### PR TITLE
Make clock enable recover stale installed systemd timer units

### DIFF
--- a/crates/orbit-core/src/routines/clock.rs
+++ b/crates/orbit-core/src/routines/clock.rs
@@ -366,11 +366,11 @@ fn install_systemd(
     runner: &dyn ClockCommandRunner,
     home: &Path,
 ) -> Result<ClockInstallReport, OrbitError> {
-    let unit_dir = home.join(".config/systemd/user");
+    let unit_dir = systemd_user_unit_dir(home);
     fs::create_dir_all(&unit_dir).map_err(|error| OrbitError::Io(error.to_string()))?;
 
-    let service_path = unit_dir.join(format!("{SYSTEMD_UNIT}.service"));
-    let timer_path = unit_dir.join(format!("{SYSTEMD_UNIT}.timer"));
+    let service_path = systemd_service_path(home);
+    let timer_path = systemd_timer_path(home);
     atomic_write_text(&service_path, &render_systemd_service(orbit_bin)).map_err(|error| {
         OrbitError::Io(format!(
             "failed to write '{}': {error}",
@@ -385,10 +385,7 @@ fn install_systemd(
         ))
     })?;
 
-    let reload = ManagerCommand {
-        program: "systemctl",
-        args: vec!["--user".into(), "daemon-reload".into()],
-    };
+    let reload = systemd_daemon_reload_command();
     let enable = systemd_enable_command();
     let restart = systemd_restart_command();
     let reloaded = runner.run(&reload).unwrap_or(false);
@@ -432,6 +429,25 @@ pub(super) fn render_systemd_timer(settings: ClockSettings) -> String {
     SYSTEMD_TIMER_TEMPLATE.replace("{{CADENCE_SECONDS}}", &settings.cadence_seconds.to_string())
 }
 
+fn systemd_user_unit_dir(home: &Path) -> PathBuf {
+    home.join(".config/systemd/user")
+}
+
+fn systemd_service_path(home: &Path) -> PathBuf {
+    systemd_user_unit_dir(home).join(format!("{SYSTEMD_UNIT}.service"))
+}
+
+fn systemd_timer_path(home: &Path) -> PathBuf {
+    systemd_user_unit_dir(home).join(format!("{SYSTEMD_UNIT}.timer"))
+}
+
+fn systemd_daemon_reload_command() -> ManagerCommand {
+    ManagerCommand {
+        program: "systemctl",
+        args: vec!["--user".into(), "daemon-reload".into()],
+    }
+}
+
 fn systemd_enable_command() -> ManagerCommand {
     ManagerCommand {
         program: "systemctl",
@@ -452,6 +468,32 @@ fn systemd_restart_command() -> ManagerCommand {
             format!("{SYSTEMD_UNIT}.timer"),
         ],
     }
+}
+
+/// Rewrite an already-installed timer when it differs from the embedded
+/// template. A missing unit is left to `systemctl enable`.
+fn migrate_stale_systemd_timer(home: &Path, settings: ClockSettings) -> Result<(), OrbitError> {
+    let timer_path = systemd_timer_path(home);
+    if !timer_path.exists() {
+        return Ok(());
+    }
+    let installed = fs::read_to_string(&timer_path).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to read '{}': {error}",
+            timer_path.display()
+        ))
+    })?;
+    let expected = render_systemd_timer(settings);
+    if installed == expected {
+        return Ok(());
+    }
+    atomic_write_text(&timer_path, &expected).map_err(|error| {
+        OrbitError::Io(format!(
+            "failed to write '{}': {error}",
+            timer_path.display()
+        ))
+    })?;
+    Ok(())
 }
 
 fn manager_status_command(platform: ClockPlatform) -> ManagerCommand {
@@ -550,12 +592,18 @@ pub(super) fn set_clock_enabled_with(
         .run(&manager_status_command(platform))
         .unwrap_or(false);
     if platform == ClockPlatform::Systemd && enabled {
+        migrate_stale_systemd_timer(home, settings)?;
+        let reload = systemd_daemon_reload_command();
+        if !runner.run(&reload)? {
+            return Err(manager_command_error(&reload));
+        }
         let enable = systemd_enable_command();
         if !runner.run(&enable)? {
             return Err(manager_command_error(&enable));
         }
         // Starting an already-active elapsed timer is a no-op. Restarting
-        // makes `enable` a repair operation as well as a paused-clock resume.
+        // after daemon-reload makes `enable` repair a stale installed unit
+        // as well as resume a paused clock.
         let restart = systemd_restart_command();
         if !runner.run(&restart)? {
             return Err(manager_command_error(&restart));
@@ -619,7 +667,7 @@ pub(super) fn clock_status_with(
                     (
                         false,
                         Some(
-                            "systemd timer is enabled but is not active with a finite future trigger; recovery: `orbit routine clock enable` re-arms the timer and verifies the result"
+                            "systemd timer is enabled but is not active with a finite future trigger; recovery: `orbit routine clock enable` rewrites a stale installed timer if needed, re-arms it, and verifies the result"
                                 .to_string(),
                         ),
                     )
@@ -628,7 +676,7 @@ pub(super) fn clock_status_with(
             Err(_) if enabled => (
                 false,
                 Some(
-                    "systemd timer is enabled but its next trigger could not be verified; recovery: inspect `systemctl --user status orbit-sweep.timer`, then run `orbit routine clock enable` to re-arm and verify it"
+                    "systemd timer is enabled but its next trigger could not be verified; recovery: inspect `systemctl --user status orbit-sweep.timer`, then run `orbit routine clock enable` to rewrite a stale unit if needed, re-arm, and verify it"
                         .to_string(),
                 ),
             ),
@@ -700,7 +748,7 @@ fn manager_command_error(command: &ManagerCommand) -> OrbitError {
 
 fn systemd_unschedulable_error(action: &str) -> OrbitError {
     OrbitError::Execution(format!(
-        "systemd timer {action}, but the manager did not report it active with a finite future trigger; inspect `systemctl --user status {SYSTEMD_UNIT}.timer` and `journalctl --user -u {SYSTEMD_UNIT}.timer -u {SYSTEMD_UNIT}.service`; after correcting the reported failure, `orbit routine clock enable` re-arms the timer and verifies the result"
+        "systemd timer {action}, but the manager did not report it active with a finite future trigger; inspect `systemctl --user status {SYSTEMD_UNIT}.timer` and `journalctl --user -u {SYSTEMD_UNIT}.timer -u {SYSTEMD_UNIT}.service`"
     ))
 }
 

--- a/crates/orbit-core/src/routines/tests/clock.rs
+++ b/crates/orbit-core/src/routines/tests/clock.rs
@@ -9,7 +9,7 @@ use orbit_common::OrbitError;
 use super::super::clock::{
     ClockCommandRunner, ClockPlatform, ClockSettings, ManagerCommand, clock_status_with,
     install_clock_with, load_clock_settings, render_systemd_service, render_systemd_timer,
-    set_clock_cadence_with, set_clock_enabled_with,
+    save_clock_settings, set_clock_cadence_with, set_clock_enabled_with,
 };
 
 struct MockRunner {
@@ -121,6 +121,10 @@ impl SystemdManagerFake {
             .lock()
             .expect("fake systemd state lock")
             .next_trigger
+    }
+
+    fn commands(&self) -> Vec<String> {
+        self.commands.lock().expect("fake command log lock").clone()
     }
 
     fn set_now(&self, now_seconds: u64) {
@@ -237,6 +241,22 @@ fn finds_launcher(path: &str, launcher: &str) -> bool {
         .any(|directory| directory.join(launcher).is_file())
 }
 
+fn write_stale_on_startup_timer(home: &Path, cadence_seconds: u64) {
+    let unit_dir = home.join(".config/systemd/user");
+    fs::create_dir_all(&unit_dir).expect("create systemd user unit dir");
+    fs::write(
+        unit_dir.join("orbit-sweep.timer"),
+        format!(
+            "# stale pre-OnActiveSec timer\n[Unit]\nDescription=Run orbit sweep every {cadence_seconds} seconds\n\n[Timer]\nOnStartupSec={cadence_seconds}s\nOnUnitActiveSec={cadence_seconds}s\nAccuracySec=5s\n\n[Install]\nWantedBy=timers.target\n"
+        ),
+    )
+    .expect("write stale OnStartupSec timer");
+}
+
+fn systemd_show_command() -> &'static str {
+    "systemctl --user show orbit-sweep.timer --property=LoadState --property=ActiveState --property=NextElapseUSecRealtime --property=NextElapseUSecMonotonic --property=LastTriggerUSec"
+}
+
 #[test]
 fn rendered_systemd_service_discovers_local_provider_launchers() {
     let home = tempdir().expect("create temporary home");
@@ -344,6 +364,98 @@ fn late_reinstall_rearms_an_active_elapsed_timer_from_timer_activation() {
         .next_trigger()
         .expect("finite trigger after reinstall");
     assert!((week + 300..=week + 305).contains(&next));
+}
+
+#[test]
+fn enable_migrates_stale_on_startup_sec_elapsed_timer() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    save_clock_settings(
+        root.path(),
+        ClockSettings {
+            cadence_seconds: 300,
+        },
+    )
+    .expect("persist cadence matching the stale unit");
+    write_stale_on_startup_timer(home.path(), 300);
+    let week = 7 * 24 * 60 * 60;
+    let runner = SystemdManagerFake::late_elapsed(home.path(), week, 60);
+
+    let status = set_clock_enabled_with(
+        root.path(),
+        true,
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("enable migrates and re-arms a stale timer");
+
+    assert!(status.enabled);
+    assert!(status.schedulable);
+    let next = runner
+        .next_trigger()
+        .expect("finite trigger after enable migration");
+    assert!((week + 300..=week + 305).contains(&next));
+
+    let timer = fs::read_to_string(home.path().join(".config/systemd/user/orbit-sweep.timer"))
+        .expect("read migrated timer");
+    assert!(timer.contains("OnActiveSec=300s"));
+    assert!(timer.contains("OnUnitActiveSec=300s"));
+    assert!(!timer.contains("OnStartupSec="));
+    assert_eq!(
+        runner.commands(),
+        vec![
+            "systemctl --user is-enabled orbit-sweep.timer".to_string(),
+            "systemctl --user daemon-reload".to_string(),
+            "systemctl --user enable orbit-sweep.timer".to_string(),
+            "systemctl --user restart orbit-sweep.timer".to_string(),
+            systemd_show_command().to_string(),
+        ]
+    );
+}
+
+#[test]
+fn enable_is_idempotent_for_current_on_active_sec_timer() {
+    let root = tempdir().expect("create global root");
+    let home = tempdir().expect("create home");
+    let runner = SystemdManagerFake::new(home.path(), 100);
+    install_clock_with(
+        root.path(),
+        "/opt/orbit/bin/orbit",
+        ClockSettings::default(),
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("install current OnActiveSec timer");
+    let before = fs::read_to_string(home.path().join(".config/systemd/user/orbit-sweep.timer"))
+        .expect("read current timer");
+    let commands_after_install = runner.commands().len();
+
+    let status = set_clock_enabled_with(
+        root.path(),
+        true,
+        ClockPlatform::Systemd,
+        &runner,
+        home.path(),
+    )
+    .expect("enable current timer");
+
+    assert!(status.enabled);
+    assert!(status.schedulable);
+    let after = fs::read_to_string(home.path().join(".config/systemd/user/orbit-sweep.timer"))
+        .expect("read timer after enable");
+    assert_eq!(before, after);
+    assert_eq!(
+        runner.commands()[commands_after_install..],
+        vec![
+            "systemctl --user is-enabled orbit-sweep.timer".to_string(),
+            "systemctl --user daemon-reload".to_string(),
+            "systemctl --user enable orbit-sweep.timer".to_string(),
+            "systemctl --user restart orbit-sweep.timer".to_string(),
+            systemd_show_command().to_string(),
+        ]
+    );
 }
 
 #[test]
@@ -573,7 +685,7 @@ fn systemd_cadence_change_and_reenable_establish_new_deadlines() {
 fn manager_failures_include_exact_recovery_command() {
     let root = tempdir().expect("create global root");
     let home = tempdir().expect("create home");
-    let runner = MockRunner::new(vec![Ok(false), Ok(false)]);
+    let runner = MockRunner::new(vec![Ok(false), Ok(true), Ok(false)]);
     let error = set_clock_enabled_with(
         root.path(),
         true,
@@ -661,6 +773,10 @@ fn systemd_install_rejects_successful_commands_without_a_finite_trigger() {
     assert!(error.to_string().contains("finite future trigger"));
     assert!(error.to_string().contains("systemctl --user status"));
     assert!(error.to_string().contains("journalctl --user"));
+    assert!(
+        !error.to_string().contains("orbit routine clock enable"),
+        "a completed enable/install that is still unschedulable must not tell the operator to repeat enable"
+    );
 }
 
 #[test]

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-08-23
-last_validated: 2026-08-23
+last_updated: 2026-08-29
+last_validated: 2026-08-29
 status: Accepted
 feature: routines
 doc_role: design
@@ -11,7 +11,7 @@ summary: Proposed contract for routine definitions, sweep dispatch, host-local s
 tags: [routines, scheduler]
 paths: ["crates/orbit-cli/src/command/routine/**", "crates/orbit-core/src/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-store/src/sqlite/routine_store/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10800, ORB-10986]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10800, ORB-10986, ORB-11082]
 ---
 
 # Routines — Design
@@ -32,7 +32,8 @@ routine definition. Its durable configuration is `~/.orbit/clock.toml`, defaults
 `orbit routine clock status` reports configured cadence, native-manager enabled state,
 and whether an enabled Linux timer is active with a finite next trigger. An enabled timer
 without that scheduling state is `unhealthy`, has no effective cadence, and reports
-`orbit routine clock enable`, which restarts the timer and verifies the resulting deadline.
+`orbit routine clock enable`, which rewrites a stale installed systemd timer if needed,
+restarts the timer, and verifies the resulting deadline.
 `orbit routine clock pause` disables only launchd/systemd
 scheduled invocations (surviving logout/reboot through the native per-user manager);
 it preserves routine cursors, fire history, and per-routine pauses, and a deliberate
@@ -277,8 +278,10 @@ renders and installs the platform unit:
   `OnUnitActiveSec=<cadence>` plus a oneshot service. Every timer activation (fresh install,
   late reinstall, cadence change, or re-enable) therefore arms a finite first sweep relative
   to that activation; successful service activations schedule subsequent sweeps at the
-  configured cadence. `AccuracySec=5s` bounds manager coalescing after each deadline
-  [ORB-10986]. These monotonic
+  configured cadence. `orbit routine clock enable` compares the installed timer with the
+  embedded template, rewrites a stale definition (for example pre-fix `OnStartupSec`), and
+  daemon-reloads before restart [ORB-11082]. `AccuracySec=5s` bounds manager coalescing
+  after each deadline [ORB-10986]. These monotonic
   triggers deliberately do not replay timer events missed while the manager or host was
   down. The first sweep after restart evaluates each routine's cursor, so `catch_up_once`
   collapses missed cron slots to one fire and `skip` waits for the next natural slot.

--- a/docs/design/routines/4_decisions.md
+++ b/docs/design/routines/4_decisions.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Decisions
 owner: claude
-last_updated: 2026-08-23
-last_validated: 2026-08-23
+last_updated: 2026-08-29
+last_validated: 2026-08-29
 status: Accepted
 feature: routines
 doc_role: decisions
@@ -11,7 +11,7 @@ summary: Decision log for the routines scheduler, including default seeding and 
 tags: [routines, scheduler]
 paths: ["crates/orbit-core/src/routines/**", "crates/orbit-cmd/src/registry_routines.rs", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-registry/src/**"]
 related_features: [routines, activity-job, host-registry]
-related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ORB-10986]
+related_artifacts: [ORB-10001, ORB-10021, ORB-10207, ORB-10270, ORB-10319, ORB-10739, ORB-10986, ORB-11082]
 ---
 
 # Routines — Decisions
@@ -162,7 +162,7 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
 
 ### Consequences
 - Clock status reports configured and effective cadence, and native-manager failures include recovery commands.
-- On Linux, enabled state and successful manager command exits are insufficient for health: installation and controls report success only when systemd exposes an active timer with a finite next trigger. An elapsed or unscheduled timer reports `orbit routine clock enable`, which restarts the timer even when already enabled and verifies the repaired state.
+- On Linux, enabled state and successful manager command exits are insufficient for health: installation and controls report success only when systemd exposes an active timer with a finite next trigger. An elapsed or unscheduled timer reports `orbit routine clock enable`, which rewrites a stale installed unit (for example a pre-fix `OnStartupSec` timer) when it differs from the embedded template, daemon-reloads, restarts the timer even when already enabled, and verifies the repaired state.
 - Linux uses monotonic timer-activation and service-activation triggers. `OnActiveSec` establishes the first deadline after every install, reinstall, cadence change, and re-enable; `OnUnitActiveSec` establishes recurrence after each sweep service activation. `AccuracySec=5s` bounds coalescing after either deadline. Missed timer ticks are not replayed, leaving catch-up versus skip behavior to each routine's persisted cursor and `missed_run` policy.
 - Cost: the host-local setting intentionally does not travel with a workspace, so operators configure each host separately.
 
@@ -182,5 +182,8 @@ Store the supported whole-minute cadence in host-local `~/.orbit/clock.toml` and
   (`GET /api/routines`), realizing the single-host half of the §7 cross-host-visibility
   vision. Read-only projection of `routine_statuses`; no new ADR (no new architectural
   constraint — mirrors the existing `orbit routine list --json` surface).
+- [ORB-11082] — Linux `orbit routine clock enable` rewrites a stale installed timer from
+  the embedded template and daemon-reloads before restart, so an `OnStartupSec` upgrade
+  leftover is recovered by the advertised command instead of looping on enable.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -148,12 +148,13 @@ orbit sweep --json
 On Linux, a healthy enabled status includes an active timer, a finite next systemd trigger,
 and an effective cadence. `clock: unhealthy` with an inactive effective cadence means the
 timer is enabled but elapsed, unscheduled, inactive, or could not be probed. Inspect the
-printed diagnostic, then run `orbit routine clock enable`: it restarts the timer even when it
-is already enabled and returns success only after verifying a finite next trigger. If that
-verification fails, inspect the `systemctl --user status` and `journalctl --user` commands in
-the error before retrying. The generated timer schedules its first sweep from every timer
-activation and then recurs from service activation; installation and cadence changes perform
-the same post-activation verification.
+printed diagnostic, then run `orbit routine clock enable`: it rewrites a stale installed
+timer if needed, restarts the timer even when it is already enabled, and returns success
+only after verifying a finite next trigger. If that verification fails, inspect the
+`systemctl --user status` and `journalctl --user` commands in the error rather than repeating
+enable. The generated timer schedules its first sweep from every timer activation and then
+recurs from service activation; installation and cadence changes perform the same
+post-activation verification.
 It does not replay every tick missed during host or manager downtime: on the next sweep,
 routine `missed_run: catch_up_once` fires once for a gap while `skip` waits for the next natural
 cron slot.


### PR DESCRIPTION
## Task

[ORB-11082](https://orbit-cli.com/tasks/ORB-11082) — Make clock enable recover stale installed systemd timer units

### Description

## Problem
After the timer template changed from `OnStartupSec` to `OnActiveSec`, an already-installed pre-fix `orbit-sweep.timer` can remain active-but-unscheduled. `orbit routine clock enable` only restarts and verifies the installed unit; it does not compare or rewrite the unit, so it repeats the failure and tells the operator to run the same ineffective command. F2026-08-122 records this exact upgrade state on dk-server-1.

## Why It Matters
The advertised self-recovery command cannot recover the most likely upgrade failure, leaving routine scheduling silently stopped until an operator knows to reinstall the clock unit.

## Constraints / Notes
- Preserve systemd fail-closed schedulability verification.
- Keep launchd behavior unchanged.
- Migration must use the authoritative embedded timer template and perform the required daemon reload before re-enabling.

### Acceptance Criteria

- On Linux, clock enable detects an installed stale timer definition and rewrites/reloads it before restart, or returns a precise command that actually performs the migration instead of telling the operator to repeat enable.
- A deterministic systemd-manager fake reproduces an OnStartupSec active-elapsed unit and proves one recovery operation installs the OnActiveSec template and yields a finite next trigger.
- Current OnActiveSec units remain idempotent, launchd behavior is unchanged, and status/error guidance matches the implemented recovery path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Linux `orbit routine clock enable` now compares the installed user timer with the embedded template, rewrites a stale definition (for example pre-fix `OnStartupSec`), daemon-reloads, then enables/restarts and fail-closed verifies a finite next trigger.
- Matching `OnActiveSec` units are not rewritten; launchd enable/pause is unchanged.
- Status recovery text points at enable as a real migration path; unschedulable errors after enable/install no longer tell the operator to repeat enable.
- `SystemdManagerFake` coverage: one enable of an active-elapsed `OnStartupSec` unit installs `OnActiveSec` and yields a finite trigger; current-template enable stays idempotent.
- Operator/design docs now describe the rewrite+reload recovery path.
- Linked `resolves: F2026-08-122`. Added context_files for the current docs that described enable as restart-only.
Assessment: Scoped to the clock enable path and its existing fake. Fail-closed schedulability verification is preserved. Workspace-wide `make ci-lint` was not run here; `make ci-fast`, orbit-core clippy `-D warnings`, and the clock unit tests passed.
Strategic decisions: Always daemon-reload on systemd enable after the template comparison so a failed reload cannot leave the manager on the old unit while the file already matches the new template.
Validation:
- cargo test -p orbit-core --lib routines::tests::clock -- --test-threads=1 (16 passed)
- cargo clippy -p orbit-core --all-targets -- -D warnings
- make ci-fast

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11082-6a9371c9`
- Behind base: 0
- Ahead of base: 1