### PR TITLE
Keep release approval probes out of commit-required delivery

### DIFF
--- a/.orbit/auto_tasks/release-prep.yaml
+++ b/.orbit/auto_tasks/release-prep.yaml
@@ -13,6 +13,16 @@ template:
     task only after the workspace is eligible. It must never edit repository
     files or release state during the gate.
 
+    ## Delivery contract
+
+    This probe carries `no-diff-expected`. Blocked, no-release, and eligible
+    probe scenarios are all successful no-diff outcomes: persist evidence in
+    this probe's `execution_summary` and stop. Never enter a commit-required delivery tail.
+    Do not drop `no-diff-expected`. Do not commit, tag, push,
+    publish, promote, merge, bump versions, or edit CHANGELOG.md from this
+    probe. If a workflow still offers `git_commit`, the tag must cause it to
+    skip rather than fail; never dispatch this probe without that tag.
+
     ## 1. Deterministic unfinished-work gate
 
     Query all tasks in `backlog`, `in-progress`, and `review` through the Orbit
@@ -57,24 +67,44 @@ template:
     title pattern `Prepare v<X.Y.Z> release` and the `release` tag. Search
     deterministically and select the lexicographically smallest matching task
     ID if more than one already exists; never create a second canonical task.
-    If none exists, create exactly one task with that title, the `release` tag,
-    type `chore`, and the candidate version and evidence in its description.
-    Carry the release runbook context selectors
-    `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`, and
+    If none exists, create exactly one task with that title, type `chore`,
+    status `proposed` (never `backlog` or `in-progress`), tags `release` and
+    `awaiting-release-approval` (never `no-diff-expected`), and the candidate
+    version and evidence in its description. Carry the release runbook context
+    selectors `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`, and
     `file:npm/package.json` onto that canonical task.
     If one exists, update only that canonical task with the fresh candidate,
-    survey evidence, and breaking-change candidates. Preserve the human review
-    boundary and do not change it to done. Report the selected or newly-created
-    task ID, and any pre-existing duplicate candidates, in this probe's
-    `execution_summary`.
+    survey evidence, and breaking-change candidates. Keep it `proposed`, keep
+    `awaiting-release-approval`, and do not move it to backlog or in-progress.
+    Preserve the human review boundary and do not change it to done. Report the
+    selected or newly-created task ID, and any pre-existing duplicate
+    candidates, in this probe's `execution_summary`.
 
-    The canonical task must instruct its executor to follow `RELEASING.md`,
-    including the release checklist and all versioned release files. The
-    handoff stops after surveying, candidate semver analysis, and creating or
-    updating that one task. It must not commit, tag, push, publish, promote or
-    merge branches, bump versions, edit `CHANGELOG.md`, or ask for or record
-    human confirmation that a breaking-change candidate is accepted. Those
-    actions require the later human-approved release task.
+    The canonical task's durable description and acceptance criteria must stay
+    report-only while classification or approval is pending: instruct its
+    executor to follow `RELEASING.md` for survey evidence only, stop at the
+    human approval boundary, and not commit, tag, push, publish, promote,
+    merge, bump versions, edit CHANGELOG.md, or record human confirmation that
+    a breaking-change candidate is accepted. The canonical task is not
+    dispatchable in this phase. Do not ship it, start it, or admit it to
+    `task_pr_pipeline`.
+
+    The probe handoff stops after surveying, candidate semver analysis, and
+    creating or updating that one proposed task. It must not commit, tag,
+    push, publish, promote or merge branches, bump versions, edit
+    `CHANGELOG.md`, or ask for or record human confirmation that a
+    breaking-change candidate is accepted.
+
+    ## 4. Approval handoff (not this probe)
+
+    A later human or operator approval handoff — not this probe — rewrites the
+    canonical task's durable description and acceptance criteria to the
+    authorized bounded diff (version bump, CHANGELOG, and task PR) and removes
+    `awaiting-release-approval` before any backlog or in-progress admission.
+    That rewrite is what makes the implementation phase dispatchable. Tag,
+    publish, promotion, and merge still require their own separate human
+    authorization and must not be granted by this probe or by the bounded
+    implementation mandate.
 
     ## Deterministic validation scenarios
 
@@ -82,24 +112,28 @@ template:
 
     - With another unfinished task, report its ID and make no release-state or
       repository changes; only exact `auto-task:release-prep` instances are
-      excluded.
+      excluded. Complete as a successful no-diff outcome.
     - With no other unfinished task and no commits after the latest reachable
       `v*` tag, report the tag and "nothing to release" and make no release
-      changes.
+      changes. Complete as a successful no-diff outcome.
     - With an eligible commit range, record the survey, candidate bump, and
       breaking candidates, then create or update exactly one canonical
-      `release` task.
+      `release` task in `proposed` with `awaiting-release-approval`. Complete
+      as a successful no-diff outcome. Do not dispatch that canonical task.
 
     A repeated pass must reuse the open `release-prep` probe via
     `skip_if_open` and reuse the one canonical release task rather than
     creating duplicates.
   acceptance_criteria:
   - The unfinished-work gate reports sorted blocking task IDs and exempts only open tasks carrying the exact auto-task:release-prep provenance tag.
-  - A blocked or no-release pass changes no repository or release state and completes with evidence in execution_summary.
+  - A blocked or no-release pass changes no repository or release state and completes with evidence in execution_summary as a successful no-diff outcome.
   - An eligible pass records the latest reachable v* tag, commit survey, candidate semver bump, and breaking-change candidates with exact evidence.
-  - An eligible pass creates or updates exactly one canonical Prepare v<X.Y.Z> release task carrying the release tag and reports its task ID.
+  - An eligible pass creates or updates exactly one canonical Prepare v<X.Y.Z> release task carrying the release and awaiting-release-approval tags, status proposed, and reports its task ID.
   - The canonical release task carries `file:npm/package.json` alongside CHANGELOG.md, Cargo.toml, and Cargo.lock.
-  - The canonical task stops before commits, tags, pushes, publishing, branch promotion, version bumps, CHANGELOG edits, or human confirmation of breaking-change classification, and points to RELEASING.md.
+  - The canonical task stays non-dispatchable while human classification or approval is pending; its durable mandate forbids commits, tags, pushes, publishing, branch promotion, version bumps, CHANGELOG edits, and human confirmation of breaking-change classification, and points to RELEASING.md.
+  - Blocked, no-release, and eligible probe scenarios complete as successful no-diff outcomes and never enter a commit-required delivery tail.
+  - Approval handoff updates the canonical task's durable description and criteria to the authorized bounded diff and removes awaiting-release-approval before backlog or in-progress admission.
+  - Tag, publish, promotion, and merge remain unauthorized without a separate explicit human approval.
   - Repeated passes do not duplicate the open probe or the canonical release-preparation task.
   task_type: chore
   tags:
@@ -111,5 +145,5 @@ template:
 dedupe: skip_if_open
 created_by: codex
 created_at: 2026-08-14T04:40:00Z
-updated_by: unknown
-updated_at: 2026-08-16T17:24:10.982767150+00:00
+updated_by: grok
+updated_at: 2026-08-30T00:00:00Z

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -630,6 +630,14 @@ fn pr_pipeline_models_handoff_phases_as_ordered_activity_checkpoints() {
         })
         .collect::<Vec<_>>();
 
+    assert!(
+        phases.iter().all(|(_, target, _)| {
+            !target.contains("git_merge")
+                && !target.contains("git_tag")
+                && !target.contains("publish")
+        }),
+        "task_pr_pipeline must not tag, publish, or merge without a separate human-authorized job: {phases:?}"
+    );
     assert_eq!(
         phases,
         vec![

--- a/crates/orbit-core/src/application/task/tests/mod.rs
+++ b/crates/orbit-core/src/application/task/tests/mod.rs
@@ -4,6 +4,7 @@ mod add;
 mod params;
 mod paths;
 mod records;
+mod release_approval;
 mod update;
 
 use crate::OrbitRuntime;

--- a/crates/orbit-core/src/application/task/tests/release_approval.rs
+++ b/crates/orbit-core/src/application/task/tests/release_approval.rs
@@ -1,0 +1,142 @@
+//! ORB-11081: report-only release tasks stay out of commit-required delivery.
+
+use orbit_types::task::{
+    AWAITING_RELEASE_APPROVAL_TAG, RELEASE_TASK_TAG, Task, TaskStatus, TaskType,
+};
+
+use super::test_runtime;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+
+const REPORT_ONLY: &str = "\
+This handoff is intentionally bounded: do not commit, tag, push, publish, \
+promote, merge, bump versions, edit CHANGELOG.md, or record human confirmation \
+that a breaking-change candidate is accepted. Stop at the human approval \
+boundary.
+";
+
+const AUTHORIZED: &str = "\
+Implement the approved release-preparation diff according to RELEASING.md: \
+add the CHANGELOG section, bump versions, commit, push, and open the task PR. \
+Do not tag, publish, promote, or merge without a separate explicit human approval.
+";
+
+fn add_release_task(
+    runtime: &crate::OrbitRuntime,
+    title: &str,
+    description: &str,
+    tags: Vec<String>,
+    status: Option<TaskStatus>,
+) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: description.to_string(),
+            acceptance_criteria: vec![
+                "Preserve the human approval boundary for tag, publish, promotion, and merge."
+                    .to_string(),
+            ],
+            tags,
+            plan: "Follow RELEASING.md.".to_string(),
+            workspace_path: Some(".".to_string()),
+            task_type: Some(TaskType::Chore),
+            status,
+            ..Default::default()
+        })
+        .expect("add release task")
+}
+
+#[test]
+fn report_only_release_task_cannot_enter_backlog_or_workflow() {
+    let (_root, runtime) = test_runtime();
+    let task = add_release_task(
+        &runtime,
+        "Prepare v0.14.0 release",
+        REPORT_ONLY,
+        vec![
+            RELEASE_TASK_TAG.to_string(),
+            AWAITING_RELEASE_APPROVAL_TAG.to_string(),
+        ],
+        Some(TaskStatus::Proposed),
+    );
+
+    let approve_err = runtime
+        .approve_task(&task.id, Some("approve classification".to_string()), None)
+        .expect_err("report-only release task must not approve into backlog");
+    assert!(
+        approve_err
+            .to_string()
+            .contains(AWAITING_RELEASE_APPROVAL_TAG),
+        "{approve_err}"
+    );
+
+    let start_err = runtime
+        .start_task(&task.id, Some("start report-only".to_string()), None)
+        .expect_err("report-only release task must not start");
+    assert!(start_err.to_string().contains("report-only"), "{start_err}");
+
+    let update_err = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            },
+        )
+        .expect_err("status-only update must not skip the mandate rewrite");
+    assert!(
+        update_err.to_string().contains("bounded diff"),
+        "{update_err}"
+    );
+
+    let admit_err = runtime
+        .ensure_task_can_enter_workflow_as_system(&task.id, "task_pr_pipeline")
+        .expect_err("report-only phase cannot reach git_commit through workflow admission");
+    assert!(
+        admit_err
+            .to_string()
+            .contains("awaiting human classification"),
+        "{admit_err}"
+    );
+    assert_eq!(
+        runtime.get_task(&task.id).expect("reload").status,
+        TaskStatus::Proposed
+    );
+}
+
+#[test]
+fn approval_handoff_rewrites_mandate_before_admission() {
+    let (_root, runtime) = test_runtime();
+    let task = add_release_task(
+        &runtime,
+        "Prepare v0.15.0 release",
+        REPORT_ONLY,
+        vec![
+            RELEASE_TASK_TAG.to_string(),
+            AWAITING_RELEASE_APPROVAL_TAG.to_string(),
+        ],
+        Some(TaskStatus::Proposed),
+    );
+
+    let updated = runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                description: Some(AUTHORIZED.to_string()),
+                acceptance_criteria: Some(vec![
+                    "Open a task-scoped PR. Stop before tag, publish, promotion, or merge."
+                        .to_string(),
+                ]),
+                tags: Some(vec![RELEASE_TASK_TAG.to_string()]),
+                status: Some(TaskStatus::Backlog),
+                ..Default::default()
+            },
+        )
+        .expect("approval handoff updates mandate and admits to backlog in one write");
+    assert_eq!(updated.status, TaskStatus::Backlog);
+    assert!(!updated.awaits_release_approval());
+
+    let admitted = runtime
+        .ensure_task_can_enter_workflow_as_system(&updated.id, "task_pr_pipeline")
+        .expect("authorized implementation phase can enter the workflow that reaches git_commit");
+    assert_eq!(admitted.status, TaskStatus::Backlog);
+}

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -61,6 +61,9 @@ impl OrbitRuntime {
         let implemented_by =
             implementation_label(&task, effective_label.as_str(), canonical_model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
+        if task.status == TaskStatus::Proposed {
+            ensure_release_task_is_dispatchable(&task)?;
+        }
 
         let result = match task.status {
             TaskStatus::Proposed => self.with_mutation(|| {
@@ -276,6 +279,7 @@ impl OrbitRuntime {
                 )));
             }
         }
+        ensure_release_task_is_dispatchable(&task)?;
         self.resolve_and_log_crew_for_task_start(
             id,
             crew_override.as_deref(),
@@ -397,6 +401,9 @@ impl OrbitRuntime {
         workflow: &str,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
+        if task.status != TaskStatus::InProgress {
+            ensure_release_task_is_dispatchable(&task)?;
+        }
         if matches!(
             task.status,
             TaskStatus::Proposed
@@ -709,6 +716,15 @@ impl OrbitRuntime {
         ensure_task_delete_allowed(&task.id, task.status, force)?;
         self.delete_task(id)
     }
+}
+
+pub(crate) fn ensure_release_task_is_dispatchable(task: &Task) -> Result<(), OrbitError> {
+    if task.awaits_release_approval() {
+        return Err(OrbitError::InvalidInput(
+            task.release_approval_block_reason(),
+        ));
+    }
+    Ok(())
 }
 
 fn ensure_task_delete_allowed(id: &str, status: TaskStatus, force: bool) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -19,7 +19,10 @@ use super::paths::{
     canonicalize_context_files_for_read, context_files_pruned_history_entry,
     context_workspace_root, normalize_context_files_for_write,
 };
-use super::transitions::{ensure_task_has_execution_plan, in_progress_transition_requires_plan};
+use super::transitions::{
+    ensure_release_task_is_dispatchable, ensure_task_has_execution_plan,
+    in_progress_transition_requires_plan,
+};
 
 impl OrbitRuntime {
     pub fn update_task(&self, id: &str, params: TaskUpdateParams) -> Result<Task, OrbitError> {
@@ -175,6 +178,21 @@ impl OrbitRuntime {
         }
 
         if let Some(target_status) = params.status {
+            if matches!(target_status, TaskStatus::Backlog | TaskStatus::InProgress)
+                && target_status != task.status
+            {
+                let mut projected = task.clone();
+                if let Some(description) = &params.description {
+                    projected.description = description.clone();
+                }
+                if let Some(criteria) = &params.acceptance_criteria {
+                    projected.acceptance_criteria = criteria.clone();
+                }
+                if let Some(tags) = &params.tags {
+                    projected.tags = tags.clone();
+                }
+                ensure_release_task_is_dispatchable(&projected)?;
+            }
             if target_status == TaskStatus::Archived {
                 return Err(OrbitError::InvalidInput(
                     "use `orbit task archive <id>` instead of setting status to archived"

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -85,6 +85,87 @@ fn repository_definitions_all_parse() {
 }
 
 #[test]
+fn release_prep_probe_stays_no_diff_and_keeps_canonical_task_non_dispatchable() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".orbit/auto_tasks/release-prep.yaml");
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let definition = parse_auto_task_yaml(&yaml).expect("parse release-prep");
+
+    assert_eq!(definition.name, "release-prep");
+    assert!(!definition.enabled, "definition must ship disabled");
+    assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
+    assert_eq!(
+        definition.template.status,
+        orbit_types::task::TaskStatus::Backlog
+    );
+    assert!(
+        definition
+            .template
+            .tags
+            .iter()
+            .any(|tag| tag == "no-diff-expected"),
+        "probe must stay a successful no-diff outcome"
+    );
+    assert!(
+        !definition
+            .template
+            .tags
+            .iter()
+            .any(|tag| tag == "release" || tag == "awaiting-release-approval"),
+        "the probe itself is not the canonical release task"
+    );
+
+    let body = definition
+        .template
+        .description
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    for required in [
+        "no-diff-expected",
+        "successful no-diff",
+        "never enter a commit-required delivery tail",
+        "status `proposed`",
+        "awaiting-release-approval",
+        "authorized bounded diff",
+        "before any backlog or in-progress admission",
+        "tag, publish, promotion, and merge",
+        "do not dispatch",
+    ] {
+        assert!(
+            body.contains(required),
+            "release-prep template should retain '{required}'"
+        );
+    }
+
+    let joined = definition
+        .template
+        .acceptance_criteria
+        .iter()
+        .map(|criterion| criterion.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+    for required in [
+        "successful no-diff outcome",
+        "never enter a commit-required delivery tail",
+        "awaiting-release-approval",
+        "status proposed",
+        "non-dispatchable",
+        "authorized bounded diff",
+        "before backlog or in-progress admission",
+        "tag, publish, promotion, and merge remain unauthorized",
+    ] {
+        assert!(
+            joined.contains(required),
+            "release-prep criteria should retain '{required}'"
+        );
+    }
+}
+
+#[test]
 fn model_price_audit_is_weekly_report_only_and_routes_to_terra() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../..")

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs
@@ -181,6 +181,11 @@ pub(super) fn commit_batch_changes<H: RuntimeHost + ?Sized>(
             batch_tasks.len()
         )));
     };
+    if task.awaits_release_approval() {
+        return Err(OrbitError::InvalidInput(
+            task.release_approval_block_reason(),
+        ));
+    }
 
     let workspace_path = resolve_workspace_path(host, input, batch_id)?;
     ensure_named_branch(&workspace_path)?;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
@@ -4,6 +4,7 @@ mod author;
 mod base_checkpoint;
 mod delivery_gate;
 mod message;
+mod release_approval;
 mod scope;
 mod summary;
 pub(in crate::executor::automation::vcs::commit) mod test_support;

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/release_approval.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/release_approval.rs
@@ -1,0 +1,112 @@
+use std::fs;
+
+use orbit_types::task::{AWAITING_RELEASE_APPROVAL_TAG, RELEASE_TASK_TAG};
+use serde_json::json;
+
+use super::super::git_commit;
+use super::test_support::*;
+
+use super::super::super::git::git_output;
+
+const REPORT_ONLY: &str = "\
+This handoff is intentionally bounded: do not commit, tag, push, publish, \
+promote, merge, bump versions, or edit CHANGELOG.md. Stop at the human \
+approval boundary.
+";
+
+const AUTHORIZED: &str = "\
+Implement the approved release-preparation diff according to RELEASING.md.
+";
+
+#[test]
+fn report_only_release_phase_cannot_reach_git_commit() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+
+    let mut task = task_with_file(
+        "ORB-10987",
+        "Prepare v0.14.0 release",
+        "CHANGELOG.md",
+        "codex",
+    );
+    task.description = REPORT_ONLY.to_string();
+    task.tags = vec![
+        RELEASE_TASK_TAG.to_string(),
+        AWAITING_RELEASE_APPROVAL_TAG.to_string(),
+    ];
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+    });
+
+    let error =
+        git_commit(&host, &input).expect_err("report-only release phase must not enter git_commit");
+    let message = error.to_string();
+    assert!(
+        message.contains("report-only release-preparation mandate"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("nothing to commit"),
+        "must not look like an empty implementation: {message}"
+    );
+    let log = git_output(workspace, &["rev-list", "--count", "HEAD"]).expect("count commits");
+    assert_eq!(log.trim(), "1", "report-only phase must create no commit");
+}
+
+#[test]
+fn authorized_release_implementation_phase_can_git_commit() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    fs::write(workspace.join("CHANGELOG.md"), "## 0.15.0\n").unwrap();
+
+    let mut task = task_with_file(
+        "ORB-11004",
+        "Prepare v0.15.0 release",
+        "CHANGELOG.md",
+        "codex",
+    );
+    task.description = AUTHORIZED.to_string();
+    task.tags = vec![RELEASE_TASK_TAG.to_string()];
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "base_sha": git_output(workspace, &["rev-parse", "HEAD"]).expect("base sha"),
+    });
+
+    let result = git_commit(&host, &input).expect("authorized implementation phase can commit");
+    assert_eq!(result["committed"], json!(true));
+    assert_eq!(result["skipped_no_diff_expected"], json!(false));
+    let log = git_output(workspace, &["rev-list", "--count", "HEAD"]).expect("count commits");
+    assert_eq!(log.trim(), "2");
+}
+
+#[test]
+fn no_diff_probe_still_skips_git_commit_without_failing() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+
+    let mut task = task_with_file(
+        "ORB-PROBE",
+        "Check whether the next Orbit release is ready to prepare",
+        "CHANGELOG.md",
+        "luna",
+    );
+    task.tags = vec![
+        "release-prep".to_string(),
+        orbit_types::task::NO_DIFF_EXPECTED_TAG.to_string(),
+    ];
+    let host = CommitTestHost::new(vec![task], workspace.to_path_buf());
+    let input = json!({
+        "scope": "all",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+    });
+
+    let result = git_commit(&host, &input).expect("probe no-diff skip succeeds");
+    assert_eq!(result["skipped_no_diff_expected"], json!(true));
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/merge.rs
@@ -81,6 +81,22 @@ fn merge_batch_pr_actorless_task_falls_back_to_system() {
 }
 
 #[test]
+fn merge_batch_pr_rejects_tasks_that_lack_separate_human_authorization() {
+    let workspace = pr_workspace();
+    let mut unauthorized = review_batch_task("T-UNAPPROVED", Some("codex"), None);
+    unauthorized.pr_status = Some("commented".to_string());
+    let host = PrOpenTestHost::new(vec![unauthorized], workspace.repo.clone());
+
+    let error = merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo))
+        .expect_err("merge still requires separate human PR approval");
+    assert!(error.to_string().contains("is not approved"), "{error}");
+    assert_eq!(
+        host.get_task("T-UNAPPROVED").expect("task").status,
+        TaskStatus::Review
+    );
+}
+
+#[test]
 fn merge_batch_pr_propagates_private_vcs_failure_before_task_updates() {
     let workspace = pr_workspace();
     let host = PrOpenTestHost::new(

--- a/crates/orbit-types/src/task/mod.rs
+++ b/crates/orbit-types/src/task/mod.rs
@@ -4,6 +4,7 @@ mod artifacts;
 mod error;
 mod model;
 mod plan;
+mod release_approval;
 mod show_fields;
 pub use error::TaskError;
 
@@ -34,6 +35,7 @@ pub use model::{
     unsatisfiable_task_dependencies, validate_task_dependencies,
 };
 pub use plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion};
+pub use release_approval::{AWAITING_RELEASE_APPROVAL_TAG, RELEASE_TASK_TAG};
 pub use show_fields::{
     TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV, is_task_show_projection_field,
     task_show_record_field_json, unknown_task_show_field_message,

--- a/crates/orbit-types/src/task/release_approval.rs
+++ b/crates/orbit-types/src/task/release_approval.rs
@@ -1,0 +1,81 @@
+//! Report-only release-preparation pause vs authorized implementation (ORB-11081).
+//!
+//! The workspace `release-prep` probe is itself a no-diff report. The canonical
+//! `Prepare v<X.Y.Z> release` task it creates must stay non-dispatchable until a
+//! human classification or approval rewrites that task's durable mandate to the
+//! bounded release diff. Shipping the report-only phase through
+//! `task_pr_pipeline` is what turned the expected pause into
+//! `nothing to commit` (F2026-08-121 / ORB-10987, ORB-11004).
+
+use super::model::Task;
+
+/// Canonical release-preparation tasks carry this tag while they wait for
+/// human classification or approval. Auto-dispatch and `git_commit` refuse
+/// the tag; approval handoff removes it only after rewriting the durable
+/// mandate to the authorized bounded diff.
+pub const AWAITING_RELEASE_APPROVAL_TAG: &str = "awaiting-release-approval";
+
+/// Tag that identifies the canonical `Prepare v<X.Y.Z> release` task.
+pub const RELEASE_TASK_TAG: &str = "release";
+
+impl Task {
+    /// Whether this task is still the report-only release-preparation pause.
+    ///
+    /// True when the task carries [`RELEASE_TASK_TAG`] and either
+    /// [`AWAITING_RELEASE_APPROVAL_TAG`] or a historical report-only mandate
+    /// that forbids the bounded diff (the ORB-10987 / ORB-11004 shape). False
+    /// once the durable description and criteria instruct the authorized
+    /// implementation and the awaiting tag is gone.
+    pub fn awaits_release_approval(&self) -> bool {
+        if !self.tags.iter().any(|tag| tag == RELEASE_TASK_TAG) {
+            return false;
+        }
+        if self
+            .tags
+            .iter()
+            .any(|tag| tag == AWAITING_RELEASE_APPROVAL_TAG)
+        {
+            return true;
+        }
+        report_only_release_mandate(&self.description, &self.acceptance_criteria)
+    }
+
+    /// Operator-facing reason a report-only release task cannot enter a
+    /// commit-required delivery tail.
+    pub fn release_approval_block_reason(&self) -> String {
+        format!(
+            "task '{}' is a report-only release-preparation mandate awaiting human classification \
+             or approval; rewrite its durable description and acceptance criteria to the authorized \
+             bounded diff and remove `{AWAITING_RELEASE_APPROVAL_TAG}` before backlog or \
+             in-progress admission",
+            self.id
+        )
+    }
+}
+
+fn report_only_release_mandate(description: &str, acceptance_criteria: &[String]) -> bool {
+    let blob = std::iter::once(description)
+        .chain(acceptance_criteria.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_lowercase();
+    if authorizes_bounded_release_diff(&blob) {
+        return false;
+    }
+    forbids_bounded_release_diff(&blob)
+}
+
+fn authorizes_bounded_release_diff(lower: &str) -> bool {
+    lower.contains("implement the approved")
+}
+
+fn forbids_bounded_release_diff(lower: &str) -> bool {
+    let no_commit = lower.contains("do not commit") || lower.contains("must not commit");
+    let no_bump_or_changelog = lower.contains("bump versions")
+        || lower.contains("edit changelog")
+        || lower.contains("edit `changelog.md`");
+    let pause = lower.contains("human approval")
+        || lower.contains("approval boundary")
+        || lower.contains("classification");
+    no_commit && (pause || no_bump_or_changelog)
+}

--- a/crates/orbit-types/src/task/tests/mod.rs
+++ b/crates/orbit-types/src/task/tests/mod.rs
@@ -1,3 +1,4 @@
 mod artifacts;
+mod release_approval;
 mod show_fields;
 mod task;

--- a/crates/orbit-types/src/task/tests/release_approval.rs
+++ b/crates/orbit-types/src/task/tests/release_approval.rs
@@ -1,0 +1,112 @@
+use chrono::Utc;
+
+use crate::task::{
+    AWAITING_RELEASE_APPROVAL_TAG, RELEASE_TASK_TAG, Task, TaskPriority, TaskStatus, TaskType,
+};
+
+fn task(description: &str, criteria: &[&str], tags: &[&str]) -> Task {
+    let now = Utc::now();
+    Task {
+        id: "ORB-10987".to_string(),
+        title: "Prepare v0.14.0 release".to_string(),
+        description: description.to_string(),
+        acceptance_criteria: criteria.iter().map(|value| (*value).to_string()).collect(),
+        tags: tags.iter().map(|value| (*value).to_string()).collect(),
+        plan: String::new(),
+        execution_summary: String::new(),
+        context_files: Vec::new(),
+        created_by: None,
+        planned_by: None,
+        implemented_by: None,
+        status: TaskStatus::Proposed,
+        priority: TaskPriority::High,
+        complexity: None,
+        task_type: TaskType::Chore,
+        pr_status: None,
+        external_refs: Vec::new(),
+        relations: Vec::new(),
+        job_run_id: None,
+        crew: None,
+        orchestrator: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+const REPORT_ONLY_MANDATE: &str = "\
+Prepare the candidate v0.14.0 release after the report-first probe.
+
+This handoff is intentionally bounded: do not commit, tag, push, publish, \
+promote, merge, bump versions, edit CHANGELOG.md, or record human confirmation \
+that a breaking-change candidate is accepted. The implementing release agent \
+must stop at the human approval boundary and report evidence before any \
+release-state action.
+";
+
+const AUTHORIZED_MANDATE: &str = "\
+Prepare the candidate v0.15.0 release as a reviewable PR targeting agent-main.
+
+The report-first survey is complete. Implement the approved release-preparation \
+diff according to RELEASING.md: add the CHANGELOG section, bump versions, \
+commit, push the task branch, and open the task PR.
+
+This task stops at an open PR. Do not create or push v0.15.0, publish \
+Cargo/npm/GitHub/Homebrew artifacts, promote agent-main to main, merge any PR, \
+or mark the release complete.
+";
+
+#[test]
+fn awaiting_tag_keeps_a_release_task_non_dispatchable() {
+    let task = task(
+        AUTHORIZED_MANDATE,
+        &["Follow RELEASING.md."],
+        &[RELEASE_TASK_TAG, AWAITING_RELEASE_APPROVAL_TAG],
+    );
+    assert!(task.awaits_release_approval());
+    assert!(
+        task.release_approval_block_reason()
+            .contains(AWAITING_RELEASE_APPROVAL_TAG)
+    );
+}
+
+#[test]
+fn historical_report_only_mandate_matches_orb_10987() {
+    let task = task(
+        REPORT_ONLY_MANDATE,
+        &[
+            "Follow RELEASING.md and its release checklist; preserve the human approval boundary for tag, publish, promotion, and merge.",
+            "The PR workflow may create its task commit, push its task branch, and open/update the PR. Do not tag, publish, promote, or merge without a separate explicit human approval.",
+        ],
+        &[RELEASE_TASK_TAG],
+    );
+    assert!(
+        task.awaits_release_approval(),
+        "ORB-10987/ORB-11004 report-only mandate must stay non-dispatchable even without the new tag"
+    );
+}
+
+#[test]
+fn authorized_implementation_mandate_is_dispatchable() {
+    let task = task(
+        AUTHORIZED_MANDATE,
+        &[
+            "Cargo.toml, Cargo.lock, and npm/package.json report version 0.15.0.",
+            "A task-scoped PR is opened against agent-main. Stop before tag creation/push, package or release publication, agent-main-to-main promotion, PR merge, or final release completion.",
+        ],
+        &[RELEASE_TASK_TAG],
+    );
+    assert!(!task.awaits_release_approval());
+}
+
+#[test]
+fn probe_and_unrelated_tasks_are_not_release_approval_pauses() {
+    let probe = task(
+        "Report-first gate. It must never edit repository files.",
+        &["A blocked or no-release pass changes no repository or release state."],
+        &["release-prep", "no-diff-expected"],
+    );
+    assert!(!probe.awaits_release_approval());
+
+    let ordinary = task("Implement a bug fix.", &["The failing test passes."], &[]);
+    assert!(!ordinary.awaits_release_approval());
+}

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-08-16
-last_validated: 2026-08-16
+last_updated: 2026-08-30
+last_validated: 2026-08-30
 status: Accepted
 feature: auto-tasks
 doc_role: design
@@ -11,7 +11,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**", "crates/orbit-web/src/api/auto_tasks.rs", "crates/orbit-web/assets/dashboard/operations.js"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876, ORB-11081]
 ---
 
 # Auto-tasks — Design
@@ -200,6 +200,17 @@ use scheduler dry-run inspection before the weekly slot. The generated task's
 observed models, checked sources, and effective periods when the table is
 accurate.
 
+The workspace-local `release-prep` definition is a no-diff probe
+(`no-diff-expected`): blocked, empty-range, and eligible passes all complete
+as successful evidence-only outcomes and must never enter a commit-required
+delivery tail. An eligible pass creates or updates one canonical
+`Prepare v<X.Y.Z> release` task in `proposed` with `release` and
+`awaiting-release-approval`. That canonical task stays non-dispatchable until
+a later approval handoff rewrites its durable mandate to the bounded
+version/changelog/PR diff and drops the awaiting tag (ORB-11081). Tag,
+publish, promotion, and merge remain behind their existing separate human
+gates.
+
 - **Definitions are not full-text indexed.** Unlike indexed docs, auto-task
   YAML is not in a SQLite/search index; discovery is a directory scan. Acceptable
   at the expected cardinality (a handful of chores per workspace).
@@ -218,5 +229,6 @@ accurate.
 - ORB-10441 — mint-time visible title provenance.
 - ORB-10472 — worktree-local, atomic definition refresh.
 - ORB-10583 — workspace-local weekly official model-price audit definition.
+- ORB-11081 — release-prep probe stays no-diff; canonical release task is non-dispatchable until approval rewrites its mandate.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11081](https://orbit-cli.com/tasks/ORB-11081) — Keep release approval probes out of commit-required delivery

### Description

## Problem
The release-prep flow mixes a report-first human approval boundary with a later diff-producing release implementation task. ORB-10987 and ORB-11004 were both dispatched through `task_pr_pipeline` while their durable mandate still required a clean-worktree report and pause; the deterministic commit step then failed with `nothing to commit`. F2026-08-127 is a duplicate incident of canonical F2026-08-121.

## Why It Matters
An expected approval pause is recorded as implementation failure and requires manual lifecycle repair. Human approval can arrive without rewriting the stale report-only mandate, so a retry can fail the same way.

## Constraints / Notes
- Keep the probe no-diff and evidence-only.
- Keep version, changelog, commit, tag, publish, promotion, and merge actions behind their existing human gates.
- The canonical release implementation task must not be dispatchable until its durable description and criteria describe the authorized diff.

### Acceptance Criteria

- Blocked, no-release, and eligible release-prep probe scenarios complete as successful no-diff outcomes and never enter a commit-required delivery tail.
- The canonical release task remains non-dispatchable while human classification or approval is pending; approval handoff updates its durable mandate to the bounded diff before backlog or in-progress admission.
- A regression covering the ORB-10987/ORB-11004 sequence proves the report-only phase cannot reach git_commit and the authorized implementation phase can.
- Existing guards still reject tag, publish, promotion, or merge actions that lack their separate human authorization.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote the workspace release-prep probe so blocked, no-release, and eligible passes complete as successful no-diff outcomes (`no-diff-expected`) and never enter a commit-required delivery tail.
- Eligible handoff now creates or updates the canonical Prepare vX.Y.Z release task as proposed with tags `release` and `awaiting-release-approval`, keeping a report-only mandate until approval rewrites the durable description/criteria to the bounded diff and drops that tag before backlog or in-progress admission.
- Added `Task::awaits_release_approval()` and refused approve/start/update-to-backlog-or-in-progress, workflow admission, and `git_commit` while the predicate holds; the authorized implementation phase can admit and commit. Tag/publish/promotion/merge remain behind existing separate human gates.
Assessment: The ORB-10987/ORB-11004 sequence is now a regression: report-only cannot reach a commit, and the rewritten mandate can. Probe no-diff skip is unchanged.
Validation:
- cargo test -p orbit-types --lib task::tests::release_approval
- cargo test -p orbit-core --lib release_approval / release_prep / pr_pipeline_models_handoff
- cargo test -p orbit-engine --lib release_approval / merge_batch_pr_rejects
- cargo clippy -p orbit-types -p orbit-core -p orbit-engine --all-targets -- -D warnings
- make ci-fast
Notes:
- No friction filed: the YAML whitespace-folding test miss was a one-off, not a recurring tooling incident.
Strategic decisions: fail closed on the awaiting tag even if the mandate was already rewritten; keep historical report-only prose as a fallback so the incident shape is blocked without the new tag.
Design weaknesses / risks:
- Severity: medium. A mandate rewrite that forgets to drop `awaiting-release-approval` stays non-dispatchable.
- Mitigation: approval handoff is specified as one update that rewrites description, criteria, tags, and status together.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11081-6a9371c9`
- Behind base: 0
- Ahead of base: 1