### PR TITLE
Isolate workspace-init tests from the managed registry root

### DIFF
--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -1061,36 +1061,76 @@ fn workspace_init_skips_mcp_by_default() {
 fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
     let home = tempdir().expect("home tempdir");
     let workspace = home.path().join("work").join("repo");
+    let managed_registry = tempdir().expect("managed registry tempdir");
     std::fs::create_dir_all(workspace.join(".git")).expect("create workspace repo");
     std::fs::create_dir_all(home.path().join(".orbit")).expect("create global orbit root");
+    let managed_registry_path = managed_registry.path().join("workspaces.json");
+    std::fs::write(&managed_registry_path, "managed registry sentinel\n")
+        .expect("seed managed registry");
 
-    let _env = EnvGuard::acquire().home(home.path()).cwd(&workspace);
+    let previous_registry_root = std::env::var_os("ORBIT_REGISTRY_ROOT");
+    let previous_managed_context = std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT");
+    let previous_run_id = std::env::var_os("ORBIT_RUN_ID");
 
-    let result = WorkspaceInitArgs {
-        name: None,
-        base_branch: Some("main".to_string()),
-        ship_mode: None,
-        role: None,
-        owner: None,
-        task_id_start: None,
-        mcp: false,
-        inject_agent_rules: false,
-        refresh_defaults: false,
-        force: false,
+    {
+        let env = EnvGuard::acquire().managed_registry_root(managed_registry.path());
+
+        assert_eq!(
+            orbit_core::runtime::resolve_global_root().expect("resolve managed registry root"),
+            managed_registry.path(),
+            "a trusted managed child must retain registry-root precedence"
+        );
+
+        let _env = env.home(home.path()).cwd(&workspace);
+
+        assert_eq!(
+            orbit_core::runtime::resolve_global_root().expect("resolve fixture registry root"),
+            home.path().join(".orbit"),
+            "the fixture must clear the managed registry locator in favor of its temporary home"
+        );
+
+        let result = WorkspaceInitArgs {
+            name: None,
+            base_branch: Some("main".to_string()),
+            ship_mode: None,
+            role: None,
+            owner: None,
+            task_id_start: None,
+            mcp: false,
+            inject_agent_rules: false,
+            refresh_defaults: false,
+            force: false,
+        }
+        .execute_without_runtime(None);
+
+        result.expect("workspace init");
+        assert!(workspace.join(".orbit").join("state").is_dir());
+        assert!(workspace.join(".orbit").join("knowledge").is_dir());
+        assert!(!workspace.join(".orbit").join("adrs").exists());
+        assert!(!home.path().join(".orbit").join("state").exists());
+        assert!(!home.path().join(".orbit").join("knowledge").exists());
+        assert!(home.path().join(".orbit/workspaces.json").is_file());
+        assert_eq!(
+            std::fs::read_to_string(&managed_registry_path).expect("read managed registry"),
+            "managed registry sentinel\n",
+            "workspace init must not write through the ambient managed registry locator"
+        );
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(".gitignore")).expect("read .gitignore"),
+            orbit_gitignore_block()
+        );
+        assert!(!orbit_gitignore_block().contains(".orbit/adrs"));
     }
-    .execute_without_runtime(None);
 
-    result.expect("workspace init");
-    assert!(workspace.join(".orbit").join("state").is_dir());
-    assert!(workspace.join(".orbit").join("knowledge").is_dir());
-    assert!(!workspace.join(".orbit").join("adrs").exists());
-    assert!(!home.path().join(".orbit").join("state").exists());
-    assert!(!home.path().join(".orbit").join("knowledge").exists());
     assert_eq!(
-        std::fs::read_to_string(workspace.join(".gitignore")).expect("read .gitignore"),
-        orbit_gitignore_block()
+        std::env::var_os("ORBIT_REGISTRY_ROOT"),
+        previous_registry_root
     );
-    assert!(!orbit_gitignore_block().contains(".orbit/adrs"));
+    assert_eq!(
+        std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT"),
+        previous_managed_context
+    );
+    assert_eq!(std::env::var_os("ORBIT_RUN_ID"), previous_run_id);
 }
 
 #[test]

--- a/crates/orbit-cli/src/tests/env_isolation.rs
+++ b/crates/orbit-cli/src/tests/env_isolation.rs
@@ -1,4 +1,5 @@
-//! Crate-wide test isolation for process-global `HOME`/`USERPROFILE`/cwd.
+//! Crate-wide test isolation for process-global roots, `HOME`/`USERPROFILE`,
+//! and cwd.
 //!
 //! Workspace-init and the adjacent init/MCP-setup tests exercise
 //! [`WorkspaceInitArgs`](crate::command::workspace) and
@@ -48,6 +49,9 @@ pub(crate) struct EnvGuard {
     home: Option<Option<OsString>>,
     userprofile: Option<Option<OsString>>,
     orbit_root: Option<Option<OsString>>,
+    orbit_registry_root: Option<Option<OsString>>,
+    managed_run_context: Option<Option<OsString>>,
+    run_id: Option<Option<OsString>>,
     cwd: Option<PathBuf>,
     // Declared last so it drops last: the lock is held until every restoration
     // in `Drop` has run.
@@ -67,20 +71,44 @@ impl EnvGuard {
             home: None,
             userprofile: None,
             orbit_root: None,
+            orbit_registry_root: None,
+            managed_run_context: None,
+            run_id: None,
             cwd: None,
             _lock: lock,
         }
     }
 
+    /// Simulate the registry locator supplied to a trusted managed child.
+    ///
+    /// This exists for fixtures that must prove they remain isolated when the
+    /// test process itself is launched by a managed run. The marker and run id
+    /// are the trust boundary required for production registry-root precedence.
+    pub(crate) fn managed_registry_root(mut self, root: &Path) -> Self {
+        if self.orbit_registry_root.is_none() {
+            self.orbit_registry_root = Some(std::env::var_os("ORBIT_REGISTRY_ROOT"));
+        }
+        if self.managed_run_context.is_none() {
+            self.managed_run_context = Some(std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT"));
+        }
+        if self.run_id.is_none() {
+            self.run_id = Some(std::env::var_os("ORBIT_RUN_ID"));
+        }
+        unsafe {
+            std::env::set_var("ORBIT_REGISTRY_ROOT", root);
+            std::env::set_var("ORBIT_MANAGED_RUN_CONTEXT", "1");
+            std::env::set_var("ORBIT_RUN_ID", "jrun-env-isolation");
+        }
+        self
+    }
+
     /// Point `HOME` and `USERPROFILE` at `home`, capturing the prior values the
     /// first time either is set.
     ///
-    /// Also clears `ORBIT_ROOT`, capturing its prior value: it is an explicit
-    /// escape hatch that outranks `HOME`/cwd-based root resolution (see
-    /// `orbit-core/src/runtime/resolve.rs`), so a process launched by Orbit's
-    /// own dispatch — which sets `ORBIT_ROOT` in the ambient environment for
-    /// audit bookkeeping — would otherwise resolve these tests' isolated
-    /// fixture root straight through to the real, non-isolated shared root.
+    /// Also clears `ORBIT_ROOT` and `ORBIT_REGISTRY_ROOT`, capturing their
+    /// prior values. The former is an explicit workspace-root escape hatch;
+    /// the latter selects a managed child's host registry. Either would
+    /// otherwise route an isolated fixture through real shared state.
     pub(crate) fn home(mut self, home: &Path) -> Self {
         if self.home.is_none() {
             self.home = Some(std::env::var_os("HOME"));
@@ -91,10 +119,14 @@ impl EnvGuard {
         if self.orbit_root.is_none() {
             self.orbit_root = Some(std::env::var_os("ORBIT_ROOT"));
         }
+        if self.orbit_registry_root.is_none() {
+            self.orbit_registry_root = Some(std::env::var_os("ORBIT_REGISTRY_ROOT"));
+        }
         unsafe {
             std::env::set_var("HOME", home);
             std::env::set_var("USERPROFILE", home);
             std::env::remove_var("ORBIT_ROOT");
+            std::env::remove_var("ORBIT_REGISTRY_ROOT");
         }
         self
     }
@@ -137,6 +169,15 @@ impl Drop for EnvGuard {
         }
         if let Some(previous) = self.orbit_root.take() {
             restore_var("ORBIT_ROOT", previous);
+        }
+        if let Some(previous) = self.orbit_registry_root.take() {
+            restore_var("ORBIT_REGISTRY_ROOT", previous);
+        }
+        if let Some(previous) = self.run_id.take() {
+            restore_var("ORBIT_RUN_ID", previous);
+        }
+        if let Some(previous) = self.managed_run_context.take() {
+            restore_var("ORBIT_MANAGED_RUN_CONTEXT", previous);
         }
     }
 }


### PR DESCRIPTION
## Task

[ORB-11085](https://orbit-cli.com/tasks/ORB-11085) — Isolate workspace-init tests from the managed registry root

### Description

## Problem
The orbit-cli workspace-init test fixture clears and restores `ORBIT_ROOT`, but managed runners now route with `ORBIT_REGISTRY_ROOT` (ORB-11066). At current HEAD inside jrun-20260829-2336-3, `cargo test -p orbit-cli --bin orbit command::workspace::tests::init:: -- --test-threads=8` fails 21 of 25 tests because fixture initialization writes through `~/.orbit/resources/executors/claude.yaml`, which is read-only in the runner. F2026-08-096 is the canonical ambient-managed-environment test isolation report.

## Why It Matters
The failures look like workspace-init regressions and touch the real machine registry instead of each test's temporary home. The same suite behaves differently in CI and in the normal Orbit development path.

## Constraints / Notes
- Extend the existing EnvGuard/test fixture; do not weaken production registry-root precedence.
- Capture, clear, and restore every managed root locator the fixture can inherit, including ORBIT_REGISTRY_ROOT.
- Keep environment mutation serialized and avoid new per-module locks.

### Acceptance Criteria

- The 25 command::workspace::tests::init tests pass inside a managed run with ORBIT_REGISTRY_ROOT pointing at the real machine registry.
- EnvGuard captures, clears, and restores ORBIT_REGISTRY_ROOT alongside ORBIT_ROOT, HOME, and USERPROFILE without leaking values between parallel tests.
- A regression test proves the fixture uses its temporary registry while the ambient managed registry remains unchanged and production managed root precedence is preserved.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended the crate-wide EnvGuard to capture, clear, and restore ORBIT_REGISTRY_ROOT whenever an isolated HOME is installed, alongside HOME, USERPROFILE, and ORBIT_ROOT.
- Added a managed-registry fixture helper that preserves the managed-run trust marker and run id under the existing crate-wide lock.
- Strengthened the existing workspace-init regression test: it verifies managed registry precedence before fixture setup, verifies the fixture resolves its temporary HOME registry after setup, preserves an ambient registry sentinel, and restores all managed environment values after drop.

Validation:
- `cargo test -p orbit-cli --bin orbit command::workspace::tests::init:: -- --test-threads=8` (25 passed; executed with ORBIT_REGISTRY_ROOT present).
- `make ci-fast` passed.
- `make ci-lint` passed.

Assessment: Focused two-file test-isolation change; no production registry resolution behavior was changed.

Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11085-6a937ebc`
- Behind base: 0
- Ahead of base: 1