### PR TITLE
Reject or qualify cross-workspace friction resolves relations

### DIFF
--- a/crates/orbit-cli/src/output/json.rs
+++ b/crates/orbit-cli/src/output/json.rs
@@ -47,6 +47,14 @@ pub fn error_payload(error: &OrbitError) -> Value {
         object.insert("path".to_string(), json!(path));
         object.insert("reason".to_string(), json!(reason));
     }
+    if let Some(details) = error.friction_not_local_details()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("friction_id".to_string(), json!(details.friction_id));
+        object.insert("task_id".to_string(), json!(details.task_id));
+        object.insert("workspace_id".to_string(), json!(details.workspace_id));
+        object.insert("found_in".to_string(), json!(details.found_in));
+    }
     payload
 }
 
@@ -94,6 +102,7 @@ fn error_code(error: &OrbitError) -> &str {
         OrbitError::AdrInvalidTransition(_) => "adr_invalid_transition",
         OrbitError::RemoteArtifactUnavailable { .. } => "remote_artifact_unavailable",
         OrbitError::ArtifactNotLocal { .. } => "artifact_not_local",
+        OrbitError::FrictionNotLocal(_) => "friction_not_local",
         OrbitError::Migration(_) => "migration_failed",
         // New OrbitError variants must remain JSON-serializable before this
         // boundary assigns them a dedicated stable code.

--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -77,6 +77,20 @@ pub struct DependencyNotDelivered {
 /// Boxed into the error enum for the same reason as
 /// [`DependencyNotDelivered`]: four inline strings for one rare refusal would
 /// widen every `Result<_, OrbitError>` in the workspace.
+/// Evidence behind [`OrbitError::FrictionNotLocal`]: an unqualified
+/// `resolves` target is missing from this workspace but present in others
+/// on the same host [ORB-11078].
+///
+/// Boxed into the error enum so the multi-field payload does not widen
+/// every `Result<_, OrbitError>`.
+#[derive(Debug, Serialize)]
+pub struct FrictionNotLocal {
+    pub friction_id: String,
+    pub task_id: String,
+    pub workspace_id: String,
+    pub found_in: Vec<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct WorkspaceClaimHeld {
     /// The governed operation that was refused, e.g. `orbit.workflow.ship`.
@@ -145,6 +159,15 @@ pub enum OrbitError {
         id: String,
         artifact_origin: ArtifactOrigin,
     },
+    /// An unqualified `resolves` friction ID belongs to another workspace
+    /// on this host, so completing the task must not count as coverage
+    /// [ORB-11078]. Distinct from a dangling miss, which is audit-visible
+    /// and does not block completion.
+    #[error(
+        "resolves target '{}' is not in workspace '{}' (found in {}); auto-resolve is workspace-local — resolve it from its owning workspace with orbit.friction.resolve, or land a covering task there",
+        .0.friction_id, .0.workspace_id, .0.found_in.join(", ")
+    )]
+    FrictionNotLocal(Box<FrictionNotLocal>),
     #[error("companion not installed: {0}")]
     CompanionNotInstalled(String),
     #[error("invalid input: {0}")]
@@ -297,6 +320,27 @@ impl OrbitError {
             kind,
             id: id.into(),
             artifact_origin,
+        }
+    }
+
+    pub fn friction_not_local(
+        friction_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workspace_id: impl Into<String>,
+        found_in: Vec<String>,
+    ) -> Self {
+        Self::FrictionNotLocal(Box::new(FrictionNotLocal {
+            friction_id: friction_id.into(),
+            task_id: task_id.into(),
+            workspace_id: workspace_id.into(),
+            found_in,
+        }))
+    }
+
+    pub fn friction_not_local_details(&self) -> Option<&FrictionNotLocal> {
+        match self {
+            Self::FrictionNotLocal(details) => Some(details),
+            _ => None,
         }
     }
 

--- a/crates/orbit-common/src/lib.rs
+++ b/crates/orbit-common/src/lib.rs
@@ -31,8 +31,8 @@ pub mod test_env;
 pub mod test_fixtures;
 
 pub use error::{
-    ArtifactOrigin, ArtifactOriginMode, DependencyNotDelivered, NotFoundKind, OrbitError,
-    WorkspaceClaimHeld,
+    ArtifactOrigin, ArtifactOriginMode, DependencyNotDelivered, FrictionNotLocal, NotFoundKind,
+    OrbitError, WorkspaceClaimHeld,
 };
 pub use fs::task_io::{prune_missing_context_files, task_artifact_from_source_file};
 pub use model::pricing::{derive_cost_usd, normalize_token_usage};

--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -27,7 +27,9 @@ use std::{borrow::Cow, sync::OnceLock};
 use regex::Regex;
 use serde_json::Value;
 
-use crate::{ArtifactOrigin, DependencyNotDelivered, OrbitError, WorkspaceClaimHeld};
+use crate::{
+    ArtifactOrigin, DependencyNotDelivered, FrictionNotLocal, OrbitError, WorkspaceClaimHeld,
+};
 
 const REDACTED_ENV_VALUE: &str = "[REDACTED_ENV]";
 static DEFAULT_PATTERN_REDACTOR: OnceLock<PatternRedactor> = OnceLock::new();
@@ -139,6 +141,9 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             id: redact_sensitive_env_text(&id),
             artifact_origin: redact_artifact_origin(artifact_origin, redact_sensitive_env_text),
         },
+        OrbitError::FrictionNotLocal(details) => OrbitError::FrictionNotLocal(
+            redact_friction_not_local(*details, redact_sensitive_env_text),
+        ),
         OrbitError::CompanionNotInstalled(m) => {
             OrbitError::CompanionNotInstalled(redact_sensitive_env_text(&m))
         }
@@ -283,6 +288,9 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             id: redact_all(&id),
             artifact_origin: redact_artifact_origin(artifact_origin, redact_all),
         },
+        OrbitError::FrictionNotLocal(details) => {
+            OrbitError::FrictionNotLocal(redact_friction_not_local(*details, redact_all))
+        }
         OrbitError::CompanionNotInstalled(m) => OrbitError::CompanionNotInstalled(redact_all(&m)),
         OrbitError::InvalidInput(m) => OrbitError::InvalidInput(redact_all(&m)),
         OrbitError::SensitiveInput { field, reason } => OrbitError::SensitiveInput {
@@ -366,6 +374,22 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
         OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_all(&m)),
         OrbitError::Migration(m) => OrbitError::Migration(redact_all(&m)),
     }
+}
+
+fn redact_friction_not_local(
+    details: FrictionNotLocal,
+    redact: fn(&str) -> String,
+) -> Box<FrictionNotLocal> {
+    Box::new(FrictionNotLocal {
+        friction_id: redact(&details.friction_id),
+        task_id: redact(&details.task_id),
+        workspace_id: redact(&details.workspace_id),
+        found_in: details
+            .found_in
+            .into_iter()
+            .map(|workspace_id| redact(&workspace_id))
+            .collect(),
+    })
 }
 
 fn redact_workspace_claim_held(

--- a/crates/orbit-core/assets/skills/orbit/references/friction.md
+++ b/crates/orbit-core/assets/skills/orbit/references/friction.md
@@ -90,11 +90,20 @@ orbit tool run orbit.friction.resolve --input '{"id":"<ID>"}'
 
 `update` also accepts `tags` and `body`.
 
-When a task fixes the underlying cause, give that task
-`relations: [{"type":"resolves","target":"<friction-id>"}]`. It auto-resolves
-the friction and records `resolved_by_task` when the task reaches `done`. Filing
-the task does not itself resolve anything — the record stays open until the fix
-lands. A dangling target is audit-visible but does not block task completion.
+When a task in the **same workspace** as the friction fixes the underlying
+cause, give that task
+`relations: [{"type":"resolves","target":"<friction-id>"}]`. Unqualified
+friction IDs are workspace-local: auto-resolve looks up that ID only in the
+task's workspace and records `resolved_by_task` when the task reaches `done`.
+IDs are not global. Filing the task does not itself resolve anything — the
+record stays open until the fix lands.
+
+A target that does not exist in this workspace and is not known to belong
+elsewhere is dangling: audit-visible, and it does not block completion. A
+target that exists only in another workspace on this host is **not**
+dangling — completing the task is rejected with `friction_not_local`. Resolve
+that friction from its owning workspace (`orbit.friction.resolve`, or a
+covering task there). Do not count a foreign `resolves` edge as coverage.
 
 ## Reading the corpus
 

--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -74,11 +74,16 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
 - `dependencies: ["<task-id>", ...]` — prerequisites must reach a satisfying
   status first.
 - `relations: [{"type": "resolves", "target": "<friction-id>"}]` — auto-resolves
-  that friction when this task reaches `done`. Other types (`produces`,
-  `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`,
-  `related_to`) are tracked but inert. Only `produces`/`resolves` accept
-  non-task targets; the rest require a task ID. A dangling target succeeds but
-  emits a `TaskRelationDangling` audit event.
+  that friction when this task reaches `done`, **only in the same workspace**.
+  Friction IDs are workspace-local; an unqualified target is never a global
+  lookup. Completing a task whose `resolves` target exists only in another
+  workspace on this host is rejected with `friction_not_local` — resolve the
+  friction from its owning workspace (`orbit.friction.resolve`, or a covering
+  task there) instead. Other types (`produces`, `blocked_by`, `child_of`,
+  `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked
+  but inert. Only `produces`/`resolves` accept non-task targets; the rest
+  require a task ID. A dangling target (unknown in every workspace this host
+  can see) succeeds but emits a `TaskRelationDangling` audit event.
 - `parent_id`, `source_task_id` (the bug-introducing task; creation-time only —
   `update` silently drops it), `tags` (reuse existing before inventing new).
 - `required_tools: ["<exact.canonical.tool>", ...]` — tools the task must add to

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -188,6 +188,9 @@ impl RuntimeHost for OrbitRuntime {
                 existing_task.plan.as_str(),
             )?;
         }
+        if update.status == Some(TaskStatus::Done) && existing_task.status != TaskStatus::Done {
+            self.ensure_resolves_are_workspace_local(&existing_task)?;
+        }
         let (agent, model) = self
             .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
         let runtime_model_identity = <Self as RuntimeHost>::actor_model_identity(self);

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -416,6 +416,20 @@ impl HubCoordinationExecutor {
                 .transpose()?;
         let artifacts = super::input::parse_artifacts(&input)?;
         let relations = super::input::parse_relations(&input)?;
+        if status == Some(TaskStatus::Done)
+            && current.status != TaskStatus::Done
+            && let Ok(frictions) = self.friction_store()
+        {
+            let mut preview = current.clone();
+            if let Some(relations) = &relations {
+                preview.relations = relations.clone();
+            }
+            crate::application::task::ensure_resolves_targets_are_workspace_local(
+                frictions.as_ref(),
+                &self.inner.workspace_id,
+                &preview,
+            )?;
+        }
         let comment = optional_string(&input, "comment")?;
         let task_type = optional_string_alias(&input, &["type", "task_type", "taskType"])?
             .map(|value| super::input::parse_task_type("type", &value))

--- a/crates/orbit-core/src/application/task/mod.rs
+++ b/crates/orbit-core/src/application/task/mod.rs
@@ -19,7 +19,8 @@ pub(crate) use paths::{
     canonicalize_context_files_for_read, compute_task_add_warnings, context_workspace_root,
 };
 pub(crate) use transitions::{
-    ensure_task_has_execution_plan, in_progress_transition_requires_plan,
+    ensure_resolves_targets_are_workspace_local, ensure_task_has_execution_plan,
+    in_progress_transition_requires_plan,
 };
 
 #[cfg(test)]

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use orbit_common::{NotFoundKind, OrbitError};
+use orbit_store::contracts::FrictionStoreBackend;
 use orbit_types::identity::is_valid_friction_id;
 use orbit_types::record::OrbitEvent;
 use orbit_types::task::{
@@ -61,6 +62,9 @@ impl OrbitRuntime {
         let implemented_by =
             implementation_label(&task, effective_label.as_str(), canonical_model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
+        if task.status == TaskStatus::Review {
+            self.ensure_resolves_are_workspace_local(&task)?;
+        }
 
         let result = match task.status {
             TaskStatus::Proposed => self.with_mutation(|| {
@@ -125,6 +129,22 @@ impl OrbitRuntime {
             self.record_event(event)?;
         }
         Ok(())
+    }
+
+    /// Refuse a done transition whose unqualified `resolves` target lives in
+    /// another workspace on this host (ORB-11078).
+    ///
+    /// Same-workspace targets and IDs that cannot be shown to belong
+    /// elsewhere stay on the existing auto-resolve / dangling path.
+    pub(crate) fn ensure_resolves_are_workspace_local(
+        &self,
+        task: &Task,
+    ) -> Result<(), OrbitError> {
+        let Ok(frictions) = crate::runtime::friction::store_for(self) else {
+            return Ok(());
+        };
+        let workspace_id = self.workspace_id()?;
+        ensure_resolves_targets_are_workspace_local(frictions.as_ref(), &workspace_id, task)
     }
 
     pub(crate) fn apply_resolves_side_effects(&self, task: &Task) -> Vec<OrbitEvent> {
@@ -709,6 +729,37 @@ impl OrbitRuntime {
         ensure_task_delete_allowed(&task.id, task.status, force)?;
         self.delete_task(id)
     }
+}
+
+/// Rejects an unqualified `resolves` friction ID that is missing locally
+/// but present in another workspace on this host.
+pub(crate) fn ensure_resolves_targets_are_workspace_local(
+    frictions: &dyn FrictionStoreBackend,
+    workspace_id: &str,
+    task: &Task,
+) -> Result<(), OrbitError> {
+    for relation in &task.relations {
+        if relation.relation_type != TaskRelationType::Resolves {
+            continue;
+        }
+        let target = relation.target.as_str();
+        if !is_valid_friction_id(target) {
+            continue;
+        }
+        if frictions.show(target)?.is_some() {
+            continue;
+        }
+        let found_in = frictions.foreign_owners_of(target)?;
+        if !found_in.is_empty() {
+            return Err(OrbitError::friction_not_local(
+                target,
+                task.id.clone(),
+                workspace_id,
+                found_in,
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn ensure_task_delete_allowed(id: &str, status: TaskStatus, force: bool) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/application/task/update.rs
+++ b/crates/orbit-core/src/application/task/update.rs
@@ -208,6 +208,13 @@ impl OrbitRuntime {
                 let effective_plan = params.plan.as_deref().unwrap_or(task.plan.as_str());
                 ensure_task_has_execution_plan(id, effective_plan)?;
             }
+            if target_status == TaskStatus::Done && task.status != TaskStatus::Done {
+                let mut preview = task.clone();
+                if let Some(relations) = &params.relations {
+                    preview.relations = relations.clone();
+                }
+                self.ensure_resolves_are_workspace_local(&preview)?;
+            }
         }
 
         if task.status == TaskStatus::InProgress && params.status == Some(TaskStatus::Review) {

--- a/crates/orbit-core/tests/relation_auto_close.rs
+++ b/crates/orbit-core/tests/relation_auto_close.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)]
 
 use chrono::{TimeZone, Utc};
+use orbit_common::OrbitError;
 use orbit_core::OrbitRuntime;
 use orbit_engine::{RuntimeHost, TaskAutomationUpdate};
 use orbit_store::friction_store::{FrictionAddParams, FrictionStore};
@@ -272,4 +273,153 @@ fn approving_proposed_task_does_not_resolve_friction() {
 
     let task = runtime.get_task(&task_id).expect("get task");
     assert_eq!(task.status, TaskStatus::Backlog);
+}
+
+fn dual_workspace_runtimes() -> (
+    TempDir,
+    OrbitRuntime,
+    std::path::PathBuf,
+    OrbitRuntime,
+    std::path::PathBuf,
+) {
+    let root = TempDir::new().expect("create tempdir");
+    let global_root = root.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+
+    let repo_a = root.path().join("repo_a");
+    let orbit_a = repo_a.join(".orbit");
+    std::fs::create_dir_all(&orbit_a).expect("create workspace a");
+    let runtime_a =
+        OrbitRuntime::from_roots(&global_root, &orbit_a).expect("build workspace a runtime");
+
+    let repo_b = root.path().join("repo_b");
+    let orbit_b = repo_b.join(".orbit");
+    std::fs::create_dir_all(&orbit_b).expect("create workspace b");
+    let runtime_b =
+        OrbitRuntime::from_roots(&global_root, &orbit_b).expect("build workspace b runtime");
+
+    (root, runtime_a, repo_a, runtime_b, repo_b)
+}
+
+fn assert_friction_not_local(error: &OrbitError, friction_id: &str, found_in: &str) {
+    let details = error
+        .friction_not_local_details()
+        .expect("structured friction_not_local error");
+    assert_eq!(details.friction_id, friction_id);
+    assert!(
+        details
+            .found_in
+            .iter()
+            .any(|workspace| workspace == found_in),
+        "expected owner {found_in}, got {:?}",
+        details.found_in
+    );
+    assert_ne!(details.workspace_id, found_in);
+}
+
+fn assert_friction_still_open(runtime: &OrbitRuntime, friction_id: &str) {
+    let stored = frictions(runtime)
+        .show(friction_id)
+        .expect("show friction")
+        .expect("friction exists");
+    assert_eq!(stored.record.status, FrictionStatus::Open);
+    assert_eq!(stored.record.resolved_by_task, None);
+}
+
+/// F2026-08-094: a done task in one workspace named an unqualified friction
+/// ID that lived in another, and auto-resolve silently no-op'd. Completing
+/// that edge must now fail with `friction_not_local` and leave the foreign
+/// friction open.
+#[test]
+fn cross_workspace_resolves_update_to_done_is_rejected() {
+    let (_root, runtime_a, _repo_a, runtime_b, repo_b) = dual_workspace_runtimes();
+    let friction_id = add_test_friction(&runtime_a);
+    let owner = runtime_a.workspace_id().expect("workspace a id");
+    let task_id = add_task_with_resolves(&runtime_b, &repo_b, &friction_id, "backlog");
+
+    let error = runtime_b
+        .run_tool(
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "status": "done",
+                "model": "codex"
+            }),
+        )
+        .expect_err("cross-workspace resolves must not complete");
+    assert_friction_not_local(&error, &friction_id, &owner);
+    assert_friction_still_open(&runtime_a, &friction_id);
+    assert_eq!(
+        runtime_b.get_task(&task_id).expect("get task").status,
+        TaskStatus::Backlog
+    );
+}
+
+#[test]
+fn cross_workspace_resolves_review_approval_is_rejected() {
+    let (_root, runtime_a, _repo_a, runtime_b, repo_b) = dual_workspace_runtimes();
+    let friction_id = add_test_friction(&runtime_a);
+    let owner = runtime_a.workspace_id().expect("workspace a id");
+    let task_id = add_task_with_resolves(&runtime_b, &repo_b, &friction_id, "backlog");
+    move_backlog_task_to_review(&runtime_b, &task_id);
+
+    let error = runtime_b
+        .run_tool(
+            "orbit.task.approve",
+            json!({ "id": task_id, "model": "codex" }),
+        )
+        .expect_err("cross-workspace resolves must not approve into done");
+    assert_friction_not_local(&error, &friction_id, &owner);
+    assert_friction_still_open(&runtime_a, &friction_id);
+    assert_eq!(
+        runtime_b.get_task(&task_id).expect("get task").status,
+        TaskStatus::Review
+    );
+}
+
+#[test]
+fn cross_workspace_resolves_automation_update_is_rejected() {
+    let (_root, runtime_a, _repo_a, runtime_b, repo_b) = dual_workspace_runtimes();
+    let friction_id = add_test_friction(&runtime_a);
+    let owner = runtime_a.workspace_id().expect("workspace a id");
+    let task_id = add_task_with_resolves(&runtime_b, &repo_b, &friction_id, "backlog");
+
+    let error = runtime_b
+        .apply_task_automation_update(
+            &task_id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::Done),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect_err("cross-workspace resolves must not complete via automation");
+    assert_friction_not_local(&error, &friction_id, &owner);
+    assert_friction_still_open(&runtime_a, &friction_id);
+    assert_eq!(
+        runtime_b.get_task(&task_id).expect("get task").status,
+        TaskStatus::Backlog
+    );
+}
+
+#[test]
+fn same_workspace_resolves_still_wins_when_another_workspace_shares_the_id() {
+    let (_root, runtime_a, _repo_a, runtime_b, repo_b) = dual_workspace_runtimes();
+    let foreign_id = add_test_friction(&runtime_a);
+    let local_id = add_test_friction(&runtime_b);
+    assert_eq!(foreign_id, local_id);
+
+    let task_id = add_task_with_resolves(&runtime_b, &repo_b, &local_id, "backlog");
+    runtime_b
+        .run_tool(
+            "orbit.task.update",
+            json!({
+                "id": task_id,
+                "status": "done",
+                "model": "codex"
+            }),
+        )
+        .expect("local resolves still completes");
+
+    assert_friction_resolved_by(&runtime_b, &local_id, &task_id);
+    assert_friction_still_open(&runtime_a, &foreign_id);
 }

--- a/crates/orbit-mcp/src/error.rs
+++ b/crates/orbit-mcp/src/error.rs
@@ -47,6 +47,14 @@ fn error_payload(err: &OrbitError) -> Value {
         object.insert("path".to_string(), json!(path));
         object.insert("reason".to_string(), json!(reason));
     }
+    if let Some(details) = err.friction_not_local_details()
+        && let Some(object) = payload.as_object_mut()
+    {
+        object.insert("friction_id".to_string(), json!(details.friction_id));
+        object.insert("task_id".to_string(), json!(details.task_id));
+        object.insert("workspace_id".to_string(), json!(details.workspace_id));
+        object.insert("found_in".to_string(), json!(details.found_in));
+    }
     payload
 }
 
@@ -90,6 +98,7 @@ fn error_code(err: &OrbitError) -> &str {
         OrbitError::WorkspaceClaimHeld(_) => "workspace_claim_held",
         OrbitError::RemoteArtifactUnavailable { .. } => "remote_artifact_unavailable",
         OrbitError::ArtifactNotLocal { .. } => "artifact_not_local",
+        OrbitError::FrictionNotLocal(_) => "friction_not_local",
         OrbitError::AgentProtocolViolation(_) => "agent_protocol_violation",
         OrbitError::UnsupportedAgentProvider(_) => "unsupported_provider",
         OrbitError::OwnerUnavailable(_) => "owner_unavailable",

--- a/crates/orbit-mcp/src/tests/error.rs
+++ b/crates/orbit-mcp/src/tests/error.rs
@@ -158,3 +158,25 @@ fn ship_run_in_flight_has_a_stable_code_and_names_both_ids() {
         "ship_run_in_flight"
     );
 }
+
+#[test]
+fn friction_not_local_has_a_stable_code_and_names_owners() {
+    let error = OrbitError::friction_not_local(
+        "F2026-08-001",
+        "ORB-00001",
+        "ws_task",
+        vec!["ws_friction".to_string()],
+    );
+    let payload = error_payload(&error);
+
+    assert_eq!(payload["code"], "friction_not_local");
+    assert_eq!(payload["friction_id"], "F2026-08-001");
+    assert_eq!(payload["task_id"], "ORB-00001");
+    assert_eq!(payload["workspace_id"], "ws_task");
+    assert_eq!(payload["found_in"], json!(["ws_friction"]));
+    assert!(payload["message"].as_str().is_some_and(|message| {
+        message.contains("F2026-08-001")
+            && message.contains("ws_task")
+            && message.contains("ws_friction")
+    }));
+}

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -157,6 +157,8 @@ pub trait FrictionStoreBackend: Send + Sync {
     fn add(&self, params: FrictionAddParams) -> Result<StoredFrictionRecord, OrbitError>;
     fn list(&self, filter: &FrictionListFilter) -> Result<Vec<StoredFrictionRecord>, OrbitError>;
     fn show(&self, id: &str) -> Result<Option<StoredFrictionRecord>, OrbitError>;
+    /// Workspace IDs other than this store's that already hold `id`.
+    fn foreign_owners_of(&self, id: &str) -> Result<Vec<String>, OrbitError>;
     fn update(
         &self,
         id: &str,

--- a/crates/orbit-store/src/repository/friction/mod.rs
+++ b/crates/orbit-store/src/repository/friction/mod.rs
@@ -132,6 +132,17 @@ impl FrictionStore {
             .with_read_connection(|conn| queries::show_record(conn, &self.workspace_id, id))
     }
 
+    /// Other workspaces on this host that already hold `id`.
+    ///
+    /// Returns IDs only — never another workspace's body — so callers can
+    /// refuse an unqualified cross-workspace `resolves` edge without treating
+    /// friction IDs as global (ORB-11078).
+    pub fn foreign_owners_of(&self, id: &str) -> Result<Vec<String>, OrbitError> {
+        validate_friction_id(id)?;
+        self.store
+            .with_read_connection(|conn| queries::foreign_owners_of(conn, &self.workspace_id, id))
+    }
+
     pub fn update(
         &self,
         id: &str,
@@ -361,6 +372,10 @@ impl crate::contracts::FrictionStoreBackend for FrictionStore {
 
     fn show(&self, id: &str) -> Result<Option<StoredFrictionRecord>, OrbitError> {
         Self::show(self, id)
+    }
+
+    fn foreign_owners_of(&self, id: &str) -> Result<Vec<String>, OrbitError> {
+        Self::foreign_owners_of(self, id)
     }
 
     fn update(

--- a/crates/orbit-store/src/repository/friction/queries.rs
+++ b/crates/orbit-store/src/repository/friction/queries.rs
@@ -183,6 +183,35 @@ pub(super) fn show_record(
     }
 }
 
+/// Workspace IDs other than `workspace_id` that already hold `friction_id`.
+///
+/// Friction IDs are workspace-local (ORB-11078). This lookup is the
+/// ownership probe that distinguishes a dangling local miss from a
+/// cross-workspace ID that must not count as coverage.
+pub(super) fn foreign_owners_of(
+    conn: &Connection,
+    workspace_id: &str,
+    friction_id: &str,
+) -> Result<Vec<String>, OrbitError> {
+    let mut statement = conn
+        .prepare(
+            "SELECT workspace_id FROM friction_records \
+             WHERE friction_id = ?1 AND workspace_id != ?2 \
+             ORDER BY workspace_id",
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let rows = statement
+        .query_map(rusqlite::params![friction_id, workspace_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let mut owners = Vec::new();
+    for row in rows {
+        owners.push(row.map_err(|error| OrbitError::Store(error.to_string()))?);
+    }
+    Ok(owners)
+}
+
 /// Writes the record row and replaces its denormalized tag rows.
 ///
 /// `friction_record_tags` exists so a tag filter is an index probe instead of

--- a/crates/orbit-store/src/repository/friction/tests/friction_store.rs
+++ b/crates/orbit-store/src/repository/friction/tests/friction_store.rs
@@ -72,6 +72,16 @@ fn identical_friction_ids_in_two_workspaces_stay_distinct() {
     assert_eq!(isolated.record.body, "Second workspace report");
     assert_eq!(one.list(&FrictionListFilter::default()).unwrap().len(), 1);
     assert_eq!(two.list(&FrictionListFilter::default()).unwrap().len(), 1);
+    assert_eq!(
+        one.foreign_owners_of(&first.record.id)
+            .expect("owners from one"),
+        vec!["ws_two".to_string()]
+    );
+    assert_eq!(
+        two.foreign_owners_of(&second.record.id)
+            .expect("owners from two"),
+        vec!["ws_one".to_string()]
+    );
 }
 
 /// The bound this task exists to establish: a fixed-size page decodes exactly

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -254,6 +254,7 @@ pub(super) fn map_runtime_error(e: orbit_core::OrbitError) -> Response {
         error @ orbit_core::OrbitError::ArtifactNotLocal { .. } => {
             artifact_conflict(error, "artifact_not_local")
         }
+        error @ orbit_core::OrbitError::FrictionNotLocal(_) => friction_not_local_conflict(error),
         error @ orbit_core::OrbitError::ShipRunInFlight { .. } => {
             ship_run_in_flight_conflict(error)
         }
@@ -315,6 +316,22 @@ fn workspace_claim_held_conflict(error: orbit_core::OrbitError) -> Response {
         "expires_at": claim.map(|claim| claim.expires_at.as_str()),
     });
     (StatusCode::CONFLICT, Json(body)).into_response()
+}
+
+fn friction_not_local_conflict(error: orbit_core::OrbitError) -> Response {
+    let details = error.friction_not_local_details();
+    (
+        StatusCode::CONFLICT,
+        Json(json!({
+            "error": error.to_string(),
+            "code": "friction_not_local",
+            "friction_id": details.map(|details| details.friction_id.as_str()),
+            "task_id": details.map(|details| details.task_id.as_str()),
+            "workspace_id": details.map(|details| details.workspace_id.as_str()),
+            "found_in": details.map(|details| details.found_in.as_slice()),
+        })),
+    )
+        .into_response()
 }
 
 fn artifact_conflict(error: orbit_core::OrbitError, code: &'static str) -> Response {

--- a/plugin/skills/orbit/references/friction.md
+++ b/plugin/skills/orbit/references/friction.md
@@ -90,11 +90,20 @@ orbit tool run orbit.friction.resolve --input '{"id":"<ID>"}'
 
 `update` also accepts `tags` and `body`.
 
-When a task fixes the underlying cause, give that task
-`relations: [{"type":"resolves","target":"<friction-id>"}]`. It auto-resolves
-the friction and records `resolved_by_task` when the task reaches `done`. Filing
-the task does not itself resolve anything — the record stays open until the fix
-lands. A dangling target is audit-visible but does not block task completion.
+When a task in the **same workspace** as the friction fixes the underlying
+cause, give that task
+`relations: [{"type":"resolves","target":"<friction-id>"}]`. Unqualified
+friction IDs are workspace-local: auto-resolve looks up that ID only in the
+task's workspace and records `resolved_by_task` when the task reaches `done`.
+IDs are not global. Filing the task does not itself resolve anything — the
+record stays open until the fix lands.
+
+A target that does not exist in this workspace and is not known to belong
+elsewhere is dangling: audit-visible, and it does not block completion. A
+target that exists only in another workspace on this host is **not**
+dangling — completing the task is rejected with `friction_not_local`. Resolve
+that friction from its owning workspace (`orbit.friction.resolve`, or a
+covering task there). Do not count a foreign `resolves` edge as coverage.
 
 ## Reading the corpus
 

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -74,11 +74,16 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
 - `dependencies: ["<task-id>", ...]` — prerequisites must reach a satisfying
   status first.
 - `relations: [{"type": "resolves", "target": "<friction-id>"}]` — auto-resolves
-  that friction when this task reaches `done`. Other types (`produces`,
-  `blocked_by`, `child_of`, `spawned_from`, `regression_from`, `supersedes`,
-  `related_to`) are tracked but inert. Only `produces`/`resolves` accept
-  non-task targets; the rest require a task ID. A dangling target succeeds but
-  emits a `TaskRelationDangling` audit event.
+  that friction when this task reaches `done`, **only in the same workspace**.
+  Friction IDs are workspace-local; an unqualified target is never a global
+  lookup. Completing a task whose `resolves` target exists only in another
+  workspace on this host is rejected with `friction_not_local` — resolve the
+  friction from its owning workspace (`orbit.friction.resolve`, or a covering
+  task there) instead. Other types (`produces`, `blocked_by`, `child_of`,
+  `spawned_from`, `regression_from`, `supersedes`, `related_to`) are tracked
+  but inert. Only `produces`/`resolves` accept non-task targets; the rest
+  require a task ID. A dangling target (unknown in every workspace this host
+  can see) succeeds but emits a `TaskRelationDangling` audit event.
 - `parent_id`, `source_task_id` (the bug-introducing task; creation-time only —
   `update` silently drops it), `tags` (reuse existing before inventing new).
 - `required_tools: ["<exact.canonical.tool>", ...]` — tools the task must add to


### PR DESCRIPTION
## Task

[ORB-11078](https://orbit-cli.com/tasks/ORB-11078) — Reject or qualify cross-workspace friction resolves relations

### Description

## Problem
Friction IDs are workspace-local, but task `resolves` relations carry only an unqualified friction ID. A task in another workspace can therefore reach `done` with a plausible `resolves:F...` edge while the intended friction remains open. Current Orbit skill text promises automatic resolution without stating the same-workspace limitation. F2026-08-094 records ORB-10715 in ws_constellation reaching done while the ws_orbit friction stayed open.

## Why It Matters
The edge looks authoritative in task history, so curation and operators can stop checking an issue that never closed. The failure is silent and can also target an unrelated same-ID record in the task-owning workspace.

## Constraints / Notes
- Preserve same-workspace auto-resolution and `resolved_by_task` stamping.
- Remove the silent cross-workspace no-op: either reject an unqualified cross-workspace relation when ownership can be determined, or introduce an explicitly workspace-qualified contract with deterministic lookup.
- Keep workspace-local friction IDs; do not make an undocumented global-ID assumption.

### Acceptance Criteria

- Same-workspace task completion still resolves the related friction and records resolved_by_task, covered by the existing relation auto-close integration tests.
- A cross-workspace resolves edge cannot silently count as actionable coverage: it is either rejected with a structured workspace-locality error or resolves an explicitly workspace-qualified target, with a regression reproducing F2026-08-094.
- The Orbit friction and task-authoring skill references state the shipped workspace-locality or qualification contract and the required manual fallback, if any.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Unqualified `resolves` friction IDs stay workspace-local. Completing a task whose target is missing locally but present in another workspace on this host is now refused with structured `OrbitError::FrictionNotLocal` (`code: friction_not_local`) before the done write, on approve, `orbit.task.update`, automation update, and the checkoutless hub path.
- `FrictionStoreBackend::foreign_owners_of` is the ownership probe (IDs only, no foreign body). Same-workspace auto-resolve and `resolved_by_task` stamping are unchanged; a miss that cannot be shown to belong elsewhere remains dangling and does not block completion.
- MCP, CLI JSON, and HTTP 409 projections carry `friction_id`, `task_id`, `workspace_id`, and `found_in`. Friction and task-authoring skill references document the locality contract and the manual fallback (`orbit.friction.resolve` or a covering task in the owning workspace); plugin skills were synced from the canonical assets.
- Regression tests in `relation_auto_close.rs` reproduce F2026-08-094 on update/approve/automation, keep existing same-workspace coverage, and confirm a shared ID still resolves only the local record.
Assessment: Smallest complete seam that removes the silent cross-workspace no-op without inventing a qualified-ID contract. Extra context_files are the tightly coupled store query, error projections, and done-transition call sites required to compile and enforce the refusal.
Strategic decisions: Reject at done rather than adding workspace-qualified friction IDs, matching the keep-IDs-workspace-local constraint. Write-time attach is still allowed (like dangling) so authors can name a target before it exists; completion is the coverage gate.
Design weaknesses / risks:
- Severity: medium. A host that cannot see the owning workspace still treats the ID as dangling and can mark the task done. Mitigation: document the manual fallback; foreign lookup is host-global SQLite, which covers the F2026-08-094 topology.
Recommended follow-ups: None required for this task. Full workspace `make ci-lint` was not run; clippy -D warnings passed on the changed crates (orbit-common, orbit-store, orbit-core, orbit-mcp, orbit-cli, orbit-web).
Validation: cargo test -p orbit-core --test relation_auto_close (10 passed); cargo test -p orbit-store --lib identical_friction_ids; cargo test -p orbit-mcp --lib friction_not_local; cargo test -p orbit-core --lib portability; cargo check -p orbit-cli -p orbit-web; cargo clippy -D warnings on changed crates; make ci-fast.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11078-6a937ebc`
- Behind base: 0
- Ahead of base: 1