### PR TITLE
Adopt task-scoped GitHub reads for CI remediation

### DIFF
--- a/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
+++ b/crates/orbit-core/assets/auto_tasks/ci-failure-remediation.yaml
@@ -179,6 +179,14 @@ template:
   - ci-failure-remediation
   - github-actions
   - no-diff-expected
+  # Exact names only. Dispatch unions these with the selected activity
+  # baseline (`agent_implement` today); a wildcard would fail admission.
+  required_tools:
+  - github.auth.status
+  - github.run.list
+  - github.run.view
+  - github.run.logs
+  - github.pr.list
   priority: high
   # The portable system lane is seeded per machine and compatibility-aliased
   # for configs written before that crew existed.

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -74,6 +74,17 @@ they do not replace it or bypass runtime capability, policy, filesystem,
 subprocess, or authentication checks. Invalid, inactive, wildcard, or
 non-agent-facing names fail dispatch before the provider starts.
 
+`ci-failure-remediation` is the worked example: its template declares exactly
+`github.auth.status`, `github.run.list`, `github.run.view`, `github.run.logs`,
+and `github.pr.list`. A minted instance therefore runs under
+`effective_tools = agent_implement baseline ∪ those five names`. Ordinary
+implementation tasks that request nothing keep the original baseline and
+cannot call GitHub tools. Inclusion is only allowlist membership — a
+structured `github.auth.status` answer may still report `available: false` or
+`authenticated: false` when the lane has no GitHub CLI or no credentials
+(DANI-10056 is failed-validation evidence of the missing-requirements bug,
+not a clean CI result).
+
 ## The five seeded definitions
 
 `orbit workspace init` seeds all five, disabled:
@@ -98,15 +109,20 @@ non-agent-facing names fail dispatch before the provider starts.
   pull-request heads, clusters by root cause, repairs repository-owned failures
   without weakening a check, and treats a clean current-head pass as a successful
   no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
-  should adapt it before enabling. **Execution-lane precondition:** all of its CI
-  discovery goes through the read-only `github.auth.status`, `github.run.list`,
+  should adapt it before enabling. The template persists those five exact
+  GitHub-read names as `required_tools` so dispatch can union them with the
+  ordinary `agent_implement` baseline; it does not widen that activity or use
+  `github.*`. **Execution-lane precondition:** all of its CI discovery goes
+  through the read-only `github.auth.status`, `github.run.list`,
   `github.run.view`, `github.run.logs`, and `github.pr.list` builtin tools, which
   run the GitHub CLI as a child of whichever process executes the tool. So the
   lane that runs the minted task needs one of: an executor whose sandbox permits
   reading the GitHub CLI's configuration directory, or a GitHub token forwarded
   through `[execution.env] pass`. Check before enabling — a lane with neither
   still completes, but every run ends at the preflight with a
-  capability-unavailable summary and no investigation.
+  capability-unavailable summary and no investigation. That structured
+  unauthenticated or unavailable answer is a legitimate capability outcome,
+  not a policy denial and not a clean pipeline.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.

--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -87,7 +87,14 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   deduplicated on write, and cannot change once the task enters `in-progress`.
   Inclusion grants only activity allowlist membership: caller role, host
   capability, tool policy, filesystem/subprocess policy, and external
-  authentication can still deny execution.
+  authentication can still deny execution. The shipped `ci-failure-remediation`
+  auto-task is the worked example: it names exactly `github.auth.status`,
+  `github.run.list`, `github.run.view`, `github.run.logs`, and `github.pr.list`,
+  so `agent_implement` stays unchanged and
+  `effective_tools = activity baseline ∪ those five`. Reaching
+  `github.auth.status` can still yield a structured `available: false` or
+  `authenticated: false` capability-unavailable result when the lane has no
+  GitHub client or credentials; that is not a clean CI pass.
 
 ## Quality bar
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_remediation.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_remediation.rs
@@ -1,0 +1,380 @@
+//! Adoption of task-scoped GitHub reads for `ci-failure-remediation` [ORB-11070].
+//!
+//! DANI-10056 failed because the minted task carried no requirements and
+//! `agent_implement` does not include GitHub reads. This file covers the
+//! mint → production baseline union → dispatch export → preflight path
+//! without a handwritten activity allowlist.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use orbit_common::OrbitError;
+use orbit_engine::activity_job::load_activity_asset;
+use orbit_engine::{RuntimeHost, V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+use orbit_types::workflow::ActivityV2Spec;
+use orbit_types::workflow::activity_job::{Provider, tool_allowed};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use crate::OrbitRuntime;
+use crate::adapter::command::override_activity_tools_for_test;
+use crate::application::task::TaskAddParams;
+use crate::auto_tasks::DEFAULT_AUTO_TASK_FILES;
+use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
+
+const CI_REMEDIATION_REQUIRED_TOOLS: [&str; 5] = [
+    "github.auth.status",
+    "github.pr.list",
+    "github.run.list",
+    "github.run.logs",
+    "github.run.view",
+];
+
+const AGENT_IMPLEMENT_BASELINE: [&str; 4] = [
+    "orbit.task.*",
+    "orbit.friction.*",
+    "orbit.search",
+    "proc.spawn",
+];
+
+fn install_shipped_ci_remediation(runtime: &OrbitRuntime) {
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "ci-failure-remediation")
+        .expect("shipped ci-failure-remediation");
+    let dest =
+        crate::auto_tasks::definition_path(&runtime.paths().local_dir, "ci-failure-remediation");
+    std::fs::create_dir_all(dest.parent().expect("auto_tasks parent"))
+        .expect("create auto_tasks dir");
+    std::fs::write(&dest, yaml).expect("install shipped definition");
+}
+
+fn agent_implement_spec() -> orbit_types::workflow::activity_job::AgentLoopSpec {
+    let (_, yaml) = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find(|(name, _)| *name == "agent_implement")
+        .expect("shipped agent_implement");
+    let asset = load_activity_asset(yaml).expect("parse agent_implement");
+    let ActivityV2Spec::AgentLoop(mut spec) = asset.spec.spec else {
+        panic!("agent_implement must remain an agent_loop activity");
+    };
+    assert_eq!(spec.tools, AGENT_IMPLEMENT_BASELINE);
+    spec.provider = Provider::Grok;
+    spec.model = Some("grok-test".to_string());
+    spec.wall_clock_timeout_seconds = 15;
+    spec
+}
+
+fn add_ordinary_task(runtime: &OrbitRuntime) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Ordinary implementation".to_string(),
+            description: "Neighboring task with empty required_tools.".to_string(),
+            ..Default::default()
+        })
+        .expect("add ordinary task")
+        .id
+}
+
+fn expected_effective_tools() -> Vec<String> {
+    AGENT_IMPLEMENT_BASELINE
+        .iter()
+        .chain(CI_REMEDIATION_REQUIRED_TOOLS.iter())
+        .map(|tool| (*tool).to_string())
+        .collect()
+}
+
+#[cfg(unix)]
+fn write_executable(path: &Path, contents: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, contents).expect("write executable");
+    let mut permissions = std::fs::metadata(path)
+        .expect("executable metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("chmod executable");
+}
+
+#[cfg(unix)]
+fn locate_orbit_cli_binary() -> Option<PathBuf> {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_orbit") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let target_root = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root.join("target"));
+    for profile in ["debug", "release"] {
+        let candidate = target_root.join(profile).join("orbit");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    std::env::var_os("ORBIT_BIN")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+}
+
+#[test]
+fn minted_ci_remediation_unions_agent_implement_baseline_and_denies_ordinary_github_reads() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    install_shipped_ci_remediation(&runtime);
+    let minted = runtime
+        .auto_task_mint("ci-failure-remediation")
+        .expect("mint");
+    let ordinary_id = add_ordinary_task(&runtime);
+    let spec = agent_implement_spec();
+
+    let ordinary = RuntimeHost::resolve_activity_tools(
+        &runtime,
+        std::slice::from_ref(&ordinary_id),
+        &spec.tools,
+    )
+    .expect("resolve ordinary task");
+    assert!(ordinary.requested_tools.is_empty());
+    assert_eq!(ordinary.effective_tools, spec.tools);
+    assert!(
+        !tool_allowed("github.auth.status", &ordinary.effective_tools),
+        "ordinary tasks must not inherit GitHub reads from agent_implement"
+    );
+
+    let remediated = RuntimeHost::resolve_activity_tools(
+        &runtime,
+        std::slice::from_ref(&minted.id),
+        &spec.tools,
+    )
+    .expect("resolve minted CI-remediation task");
+    assert_eq!(
+        remediated.requested_tools,
+        CI_REMEDIATION_REQUIRED_TOOLS.map(str::to_string)
+    );
+    assert_eq!(remediated.effective_tools, expected_effective_tools());
+
+    let _denied = override_activity_tools_for_test(ordinary.effective_tools.clone());
+    let error = runtime
+        .execute_tool_command(
+            "github.auth.status",
+            json!({}),
+            Some("grok".to_string()),
+            Some("grok-test".to_string()),
+        )
+        .expect_err("ordinary implementation must not reach GitHub reads");
+    assert!(
+        matches!(error, OrbitError::PolicyDenied(_)),
+        "expected policy_denied, got {error:?}"
+    );
+    drop(_denied);
+
+    let stub = tempdir().expect("gh stub dir");
+    let bin = stub.path().join("bin");
+    std::fs::create_dir_all(&bin).expect("create stub bin");
+    #[cfg(unix)]
+    write_executable(&bin.join("gh"), "#!/bin/sh\nexit 0\n");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let _path = orbit_common::test_env::scoped([("PATH", Some(path.as_str()))]);
+    let _allowed = override_activity_tools_for_test(remediated.effective_tools.clone());
+    let preflight = runtime
+        .execute_tool_command(
+            "github.auth.status",
+            json!({}),
+            Some("grok".to_string()),
+            Some("grok-test".to_string()),
+        )
+        .expect("CI-remediation preflight must reach tool execution");
+    assert!(
+        preflight
+            .get("available")
+            .and_then(Value::as_bool)
+            .is_some()
+    );
+    assert!(
+        preflight
+            .get("authenticated")
+            .and_then(Value::as_bool)
+            .is_some()
+    );
+    assert!(
+        preflight
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| !detail.is_empty()),
+        "preflight must carry a quotable detail: {preflight}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn mint_and_agent_implement_dispatch_export_the_computed_github_reads() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    install_shipped_ci_remediation(&runtime);
+    let minted = runtime
+        .auto_task_mint("ci-failure-remediation")
+        .expect("mint");
+    let ordinary_id = add_ordinary_task(&runtime);
+    let spec = agent_implement_spec();
+
+    let fixture = tempdir().expect("dispatch fixture");
+    let grok = fixture.path().join("grok");
+    let stdin_path = fixture.path().join("stdin.json");
+    let tools_env_path = fixture.path().join("activity_tools.txt");
+    let preflight_path = fixture.path().join("preflight.json");
+    let gh_bin = fixture.path().join("bin");
+    std::fs::create_dir_all(&gh_bin).expect("create gh stub dir");
+    write_executable(&gh_bin.join("gh"), "#!/bin/sh\nexit 0\n");
+    let nested_orbit = locate_orbit_cli_binary()
+        .map(|path| format!("'{}'", path.display()))
+        .unwrap_or_else(|| "''".to_string());
+    write_executable(
+        &grok,
+        &format!(
+            r#"#!/bin/sh
+cat > '{stdin}'
+printf '%s' "$ORBIT_ACTIVITY_TOOLS" > '{tools}'
+if [ -n {orbit} ] && [ -x {orbit} ]; then
+  {orbit} tool run github.auth.status > '{preflight}' || true
+fi
+printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"ok":true}},"error":null}}'
+"#,
+            stdin = stdin_path.display(),
+            tools = tools_env_path.display(),
+            orbit = nested_orbit,
+            preflight = preflight_path.display(),
+        ),
+    );
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{inherited_path}", gh_bin.display());
+    let grok_cmd = grok.display().to_string();
+    let mut env_pairs = vec![
+        ("ORBIT_V2_CLI_GROK", Some(grok_cmd.as_str())),
+        ("PATH", Some(path.as_str())),
+    ];
+    let orbit_bin = locate_orbit_cli_binary().map(|path| path.display().to_string());
+    if let Some(orbit_bin) = orbit_bin.as_deref() {
+        env_pairs.push(("ORBIT_BIN", Some(orbit_bin)));
+    }
+    let _env = orbit_common::test_env::scoped(env_pairs);
+
+    let audit_dir = tempdir().expect("audit dir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        Arc::new(orbit_store::Store::open_in_memory().expect("audit store")),
+        "ws_test",
+        "jrun-orb-11070",
+        "grok:grok-test".to_string(),
+        None,
+    )
+    .expect("audit writer");
+    let outcome = dispatch_v2_activity(V2DispatchInput {
+        activity_name: "agent_implement",
+        spec: &ActivityV2Spec::AgentLoop(spec.clone()),
+        fs_profile: None,
+        input: json!({
+            "task_id": minted.id,
+            "prompt": "Run the GitHub capability preflight."
+        }),
+        audit,
+        run_id: "jrun-orb-11070",
+        host: Some(&runtime),
+    })
+    .expect("dispatch agent_implement");
+    assert!(
+        outcome.success,
+        "agent_implement dispatch failed: {:?}",
+        outcome.message
+    );
+
+    let stdin = std::fs::read(&stdin_path).expect("read envelope");
+    let stdin_text = String::from_utf8_lossy(&stdin);
+    let envelope_text = stdin_text
+        .rsplit_once("Execution envelope:\n")
+        .map(|(_, rest)| rest.trim())
+        .unwrap_or(stdin_text.trim());
+    let envelope: Value = serde_json::from_str(envelope_text)
+        .unwrap_or_else(|error| panic!("envelope JSON ({error}): {stdin_text}"));
+    assert_eq!(
+        envelope["required_tools"],
+        json!(CI_REMEDIATION_REQUIRED_TOOLS)
+    );
+    assert_eq!(envelope["tools"], json!(expected_effective_tools()));
+    let exported = std::fs::read_to_string(&tools_env_path).expect("read ORBIT_ACTIVITY_TOOLS");
+    assert_eq!(exported, expected_effective_tools().join(","));
+
+    let ordinary = RuntimeHost::resolve_activity_tools(
+        &runtime,
+        std::slice::from_ref(&ordinary_id),
+        &spec.tools,
+    )
+    .expect("resolve ordinary");
+    let _denied = override_activity_tools_for_test(ordinary.effective_tools);
+    let error = runtime
+        .execute_tool_command(
+            "github.auth.status",
+            json!({}),
+            Some("grok".to_string()),
+            Some("grok-test".to_string()),
+        )
+        .expect_err("ordinary task remains GitHub-denied");
+    assert!(matches!(error, OrbitError::PolicyDenied(_)), "{error:?}");
+    drop(_denied);
+
+    let preflight = if preflight_path.is_file() {
+        let bytes = std::fs::read(&preflight_path).expect("read nested preflight");
+        serde_json::from_slice::<Value>(&bytes)
+            .ok()
+            .filter(|value| {
+                value.get("available").and_then(Value::as_bool).is_some()
+                    && value
+                        .get("authenticated")
+                        .and_then(Value::as_bool)
+                        .is_some()
+            })
+    } else {
+        None
+    };
+    let preflight = preflight.unwrap_or_else(|| {
+        let _allowed = override_activity_tools_for_test(
+            envelope["tools"]
+                .as_array()
+                .expect("effective tools")
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>(),
+        );
+        runtime
+            .execute_tool_command(
+                "github.auth.status",
+                json!({}),
+                Some("grok".to_string()),
+                Some("grok-test".to_string()),
+            )
+            .expect("preflight from dispatched effective tools")
+    });
+    assert!(
+        preflight
+            .get("available")
+            .and_then(Value::as_bool)
+            .is_some()
+    );
+    assert!(
+        preflight
+            .get("authenticated")
+            .and_then(Value::as_bool)
+            .is_some()
+    );
+    assert!(
+        preflight
+            .get("detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| !detail.is_empty()),
+        "preflight must carry a quotable detail: {preflight}"
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -1,4 +1,5 @@
 mod backlog_exclusion;
+mod ci_remediation;
 mod cli_executor;
 mod dispatch;
 mod pipeline_actions;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox_nested.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox_nested.rs
@@ -1,5 +1,5 @@
 //! Production-shaped managed nested Orbit commands under the resolved macOS
-//! child-runtime profile. [ORB-11055] [ORB-11066]
+//! child-runtime profile. [ORB-11055] [ORB-11066] [ORB-11070]
 
 #[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
@@ -17,9 +17,16 @@ use orbit_exec::{
 use serde_json::Value;
 
 #[cfg(target_os = "macos")]
+use orbit_engine::activity_job::load_activity_asset;
+#[cfg(target_os = "macos")]
+use orbit_types::workflow::ActivityV2Spec;
+
+#[cfg(target_os = "macos")]
 use crate::OrbitRuntime;
 #[cfg(target_os = "macos")]
 use crate::adapter::engine_host::v2_host::test_support::seed_executor;
+#[cfg(target_os = "macos")]
+use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
 
 /// A managed child launched from a disposable linked worktree carries the same
 /// registry locator and provenance the CLI runner emits. Both a capability
@@ -53,7 +60,27 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
         "workspace init",
     );
 
-    let add = run_orbit(
+    let minted = run_orbit(
+        &orbit_bin,
+        &repo,
+        &home,
+        &["auto-task", "mint", "ci-failure-remediation", "--json"],
+        "auto-task mint",
+    );
+    let minted: Value = serde_json::from_slice(&minted.stdout).expect("mint JSON");
+    let task_id = minted["id"].as_str().expect("task id").to_string();
+    assert_eq!(
+        minted["required_tools"],
+        serde_json::json!([
+            "github.auth.status",
+            "github.pr.list",
+            "github.run.list",
+            "github.run.logs",
+            "github.run.view"
+        ])
+    );
+
+    let ordinary = run_orbit(
         &orbit_bin,
         &repo,
         &home,
@@ -61,19 +88,27 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
             "task",
             "add",
             "--title",
-            "Nested sandbox audit write",
+            "Ordinary nested implementation",
             "--description",
-            "Registered-workspace fixture for a sandboxed orbit.task.update.",
+            "Empty required_tools neighbor proving GitHub reads stay task-scoped.",
             "--acceptance-criteria",
-            "execution summary persists under the child-runtime profile",
+            "github.auth.status remains policy-denied",
             "--complexity",
             "low",
             "--json",
         ],
-        "task add",
+        "ordinary task add",
     );
-    let added: Value = serde_json::from_slice(&add.stdout).expect("task add JSON");
-    let task_id = added["id"].as_str().expect("task id").to_string();
+    let ordinary: Value = serde_json::from_slice(&ordinary.stdout).expect("ordinary task JSON");
+    let ordinary_id = ordinary["id"]
+        .as_str()
+        .expect("ordinary task id")
+        .to_string();
+    assert!(
+        ordinary["required_tools"]
+            .as_array()
+            .is_some_and(|tools| tools.is_empty())
+    );
 
     let worktree = repo.join(".orbit/state/worktrees/jrun-orb-11066");
     let worktree_output = Command::new("git")
@@ -141,34 +176,68 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
     let _env = orbit_common::test_env::scoped([("HOME", Some(home_str.as_str()))]);
     let profile_text = compile_macos_sandbox_profile(&resolved.fs_profile, "gemini")
         .expect("compile nested orbit sandbox profile");
+    let (_, implement_yaml) = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find(|(name, _)| *name == "agent_implement")
+        .expect("shipped agent_implement");
+    let implement = load_activity_asset(implement_yaml).expect("parse agent_implement");
+    let ActivityV2Spec::AgentLoop(implement_spec) = implement.spec.spec else {
+        panic!("agent_implement must remain an agent_loop activity");
+    };
+    let minted_tools = RuntimeHost::resolve_activity_tools(
+        &runtime,
+        std::slice::from_ref(&task_id),
+        &implement_spec.tools,
+    )
+    .expect("resolve minted CI-remediation tools");
+    assert_eq!(
+        minted_tools.requested_tools,
+        [
+            "github.auth.status",
+            "github.pr.list",
+            "github.run.list",
+            "github.run.logs",
+            "github.run.view"
+        ]
+    );
+    assert!(
+        minted_tools
+            .effective_tools
+            .starts_with(implement_spec.tools.as_slice()),
+        "effective tools must keep the production agent_implement baseline: {:?}",
+        minted_tools.effective_tools
+    );
+    assert!(
+        minted_tools
+            .effective_tools
+            .iter()
+            .any(|tool| tool == "github.auth.status")
+    );
+    let ordinary_tools = RuntimeHost::resolve_activity_tools(
+        &runtime,
+        std::slice::from_ref(&ordinary_id),
+        &implement_spec.tools,
+    )
+    .expect("resolve ordinary tools");
+    assert_eq!(ordinary_tools.effective_tools, implement_spec.tools);
+    assert!(
+        !ordinary_tools
+            .effective_tools
+            .iter()
+            .any(|tool| tool.starts_with("github.")),
+        "DANI-10056 missing-requirements behavior must remain denied for ordinary tasks"
+    );
+
     let child_home_str = child_home.to_string_lossy().into_owned();
     let orbit_bin_str = orbit_bin.to_string_lossy().into_owned();
-    let env = vec![
-        ("HOME".to_string(), child_home_str.clone()),
-        ("USERPROFILE".to_string(), child_home_str),
-        (
-            "PATH".to_string(),
-            "/usr/bin:/bin:/usr/local/bin".to_string(),
-        ),
-        ("TMPDIR".to_string(), "/tmp".to_string()),
-        ("ORBIT_BIN".to_string(), orbit_bin_str),
-        ("ORBIT_REGISTRY_ROOT".to_string(), global_str.clone()),
-        ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
-        ("ORBIT_RUN_ID".to_string(), "jrun-orb-11066".to_string()),
-        ("ORBIT_TASK_ID".to_string(), task_id.clone()),
-        ("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.clone()),
-        ("ORBIT_TASK_ACTOR_KIND".to_string(), "agent".to_string()),
-        (
-            "ORBIT_ACTIVITY_TOOLS".to_string(),
-            "github.auth.status,orbit.task.show".to_string(),
-        ),
-        (
-            "ORBIT_ACTIVITY_FS_PROFILE".to_string(),
-            resolved.fs_profile.name.clone(),
-        ),
-        ("ORBIT_AGENT_NAME".to_string(), "grok".to_string()),
-        ("ORBIT_AGENT_MODEL".to_string(), "grok".to_string()),
-    ];
+    let env = managed_nested_env(
+        &child_home_str,
+        &orbit_bin_str,
+        &global_str,
+        &task_id,
+        &minted_tools.effective_tools,
+        &resolved.fs_profile.name,
+    );
 
     let output = run_sandboxed_orbit(
         &orbit_bin,
@@ -196,8 +265,46 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
             && capability
                 .get("authenticated")
                 .and_then(Value::as_bool)
-                .is_some(),
+                .is_some()
+            && capability
+                .get("detail")
+                .and_then(Value::as_str)
+                .is_some_and(|detail| !detail.is_empty()),
         "github.auth.status must return its structured capability result: {capability}"
+    );
+    assert!(
+        !stdout.contains("policy_denied") && !stderr.contains("policy_denied"),
+        "computed CI-remediation tools must not reproduce DANI-10056 policy_denied: {stderr}"
+    );
+
+    let ordinary_env = managed_nested_env(
+        &child_home_str,
+        &orbit_bin_str,
+        &global_str,
+        &ordinary_id,
+        &ordinary_tools.effective_tools,
+        &resolved.fs_profile.name,
+    );
+    let denied = run_sandboxed_orbit(
+        &orbit_bin,
+        &profile_text,
+        &ordinary_env,
+        &worktree,
+        &["tool", "run", "github.auth.status"],
+    );
+    let denied_out = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&denied.stdout),
+        String::from_utf8_lossy(&denied.stderr)
+    );
+    assert!(
+        !denied.status.success(),
+        "ordinary agent_implement baseline must deny GitHub reads\n{denied_out}"
+    );
+    assert!(
+        denied_out.contains("policy_denied")
+            || denied_out.contains("not in the activity allowlist"),
+        "DANI-10056 missing-requirements denial must stay policy_denied: {denied_out}"
     );
 
     let input = serde_json::json!({ "id": task_id, "model": "grok" }).to_string();
@@ -227,6 +334,43 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
             "managed registry discovery must not create global workspace-only path {workspace_only}"
         );
     }
+}
+
+#[cfg(target_os = "macos")]
+fn managed_nested_env(
+    child_home: &str,
+    orbit_bin: &str,
+    registry_root: &str,
+    task_id: &str,
+    effective_tools: &[String],
+    fs_profile: &str,
+) -> Vec<(String, String)> {
+    vec![
+        ("HOME".to_string(), child_home.to_string()),
+        ("USERPROFILE".to_string(), child_home.to_string()),
+        (
+            "PATH".to_string(),
+            "/usr/bin:/bin:/usr/local/bin".to_string(),
+        ),
+        ("TMPDIR".to_string(), "/tmp".to_string()),
+        ("ORBIT_BIN".to_string(), orbit_bin.to_string()),
+        ("ORBIT_REGISTRY_ROOT".to_string(), registry_root.to_string()),
+        ("ORBIT_MANAGED_RUN_CONTEXT".to_string(), "1".to_string()),
+        ("ORBIT_RUN_ID".to_string(), "jrun-orb-11066".to_string()),
+        ("ORBIT_TASK_ID".to_string(), task_id.to_string()),
+        ("ORBIT_ACTIVE_TASK_ID".to_string(), task_id.to_string()),
+        ("ORBIT_TASK_ACTOR_KIND".to_string(), "agent".to_string()),
+        (
+            "ORBIT_ACTIVITY_TOOLS".to_string(),
+            effective_tools.join(","),
+        ),
+        (
+            "ORBIT_ACTIVITY_FS_PROFILE".to_string(),
+            fs_profile.to_string(),
+        ),
+        ("ORBIT_AGENT_NAME".to_string(), "grok".to_string()),
+        ("ORBIT_AGENT_MODEL".to_string(), "grok".to_string()),
+    ]
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/orbit-core/src/auto_tasks/tests/mint.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/mint.rs
@@ -9,10 +9,23 @@ use orbit_types::workflow::{DedupePolicy, auto_task_tag};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::auto_tasks::DEFAULT_AUTO_TASK_FILES;
 use crate::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
 use crate::auto_tasks::state::cursor_state_path;
 
 use super::interval_params;
+
+fn install_shipped_ci_remediation(runtime: &OrbitRuntime) {
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "ci-failure-remediation")
+        .expect("shipped ci-failure-remediation");
+    let dest =
+        crate::auto_tasks::definition_path(&runtime.paths().local_dir, "ci-failure-remediation");
+    std::fs::create_dir_all(dest.parent().expect("auto_tasks parent"))
+        .expect("create auto_tasks dir");
+    std::fs::write(&dest, yaml).expect("install shipped definition");
+}
 
 fn runtime() -> OrbitRuntime {
     OrbitRuntime::in_memory().expect("build in-memory runtime")
@@ -103,6 +116,26 @@ fn mint_matches_a_scheduler_fire_field_for_field() {
     assert_eq!(
         minted.required_tools,
         vec!["github.auth.status", "github.run.list"]
+    );
+}
+
+#[test]
+fn mint_of_shipped_ci_failure_remediation_persists_the_five_github_reads() {
+    let runtime = runtime();
+    install_shipped_ci_remediation(&runtime);
+
+    let minted = runtime
+        .auto_task_mint("ci-failure-remediation")
+        .expect("mint shipped definition");
+    assert_eq!(
+        minted.required_tools,
+        vec![
+            "github.auth.status",
+            "github.pr.list",
+            "github.run.list",
+            "github.run.logs",
+            "github.run.view",
+        ]
     );
 }
 

--- a/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
@@ -8,6 +8,7 @@ use tempfile::tempdir;
 
 use crate::OrbitRuntime;
 use crate::application::task::TaskUpdateParams;
+use crate::auto_tasks::DEFAULT_AUTO_TASK_FILES;
 use crate::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
 
 use super::interval_params;
@@ -122,6 +123,41 @@ fn skip_if_open_never_files_a_second_open_instance() {
     let drained = fire(&runtime, t0 + Duration::minutes(240));
     assert_eq!(drained[0].0, "fired");
     assert_eq!(runtime.list_tasks().expect("tasks").len(), 2);
+}
+
+#[test]
+fn shipped_ci_failure_remediation_fire_persists_the_five_github_reads() {
+    let runtime = runtime();
+    let (_, yaml) = DEFAULT_AUTO_TASK_FILES
+        .iter()
+        .find(|(name, _)| *name == "ci-failure-remediation")
+        .expect("shipped ci-failure-remediation");
+    let dest =
+        crate::auto_tasks::definition_path(&runtime.paths().local_dir, "ci-failure-remediation");
+    std::fs::create_dir_all(dest.parent().expect("auto_tasks parent"))
+        .expect("create auto_tasks dir");
+    std::fs::write(&dest, yaml).expect("install shipped definition");
+    runtime
+        .auto_task_toggle("ci-failure-remediation", true)
+        .expect("enable for scheduled fire");
+
+    let t0 = at(2026, 1, 1, 0, 15);
+    assert_eq!(fire(&runtime, t0)[0].0, "baselined");
+    let reports = fire(&runtime, at(2026, 1, 1, 1, 16));
+    assert_eq!(reports[0].0, "fired");
+    let task = runtime
+        .get_task(&reports[0].1.clone().expect("task id"))
+        .expect("fired task");
+    assert_eq!(
+        task.required_tools,
+        vec![
+            "github.auth.status",
+            "github.pr.list",
+            "github.run.list",
+            "github.run.logs",
+            "github.run.view",
+        ]
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -541,6 +541,26 @@ fn ci_failure_remediation_default_is_portable_hourly_and_inert() {
         definition.template.task_type,
         orbit_types::task::TaskType::Bug
     );
+    assert_eq!(
+        definition.template.required_tools,
+        vec![
+            "github.auth.status",
+            "github.pr.list",
+            "github.run.list",
+            "github.run.logs",
+            "github.run.view",
+        ],
+        "minted CI-remediation tasks must persist the five exact GitHub reads"
+    );
+    assert!(
+        definition
+            .template
+            .required_tools
+            .iter()
+            .all(|tool| !tool.contains('*')),
+        "required_tools must not use a wildcard: {:?}",
+        definition.template.required_tools
+    );
     for required_tag in ["ci-failure-remediation", "no-diff-expected"] {
         assert!(
             definition

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -340,6 +340,34 @@ backend = "cli"
     }
 
     #[test]
+    fn agent_implement_tools_remain_the_implementation_baseline() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "agent_implement")
+            .expect("agent implement activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse agent implement activity");
+        let ActivityV2Spec::AgentLoop(spec) = asset.spec.spec else {
+            panic!("expected agent_loop activity");
+        };
+        assert_eq!(
+            spec.tools,
+            [
+                "orbit.task.*",
+                "orbit.friction.*",
+                "orbit.search",
+                "proc.spawn"
+            ]
+        );
+        assert!(
+            spec.tools
+                .iter()
+                .all(|tool| !tool.starts_with("github.") && !tool.contains("ceiling")),
+            "agent_implement must not widen to GitHub reads or grow a task ceiling: {:?}",
+            spec.tools
+        );
+    }
+
+    #[test]
     fn agent_implement_context_loading_reads_files_and_lists_directories() {
         let (_, yaml) = DEFAULT_ACTIVITY_FILES
             .iter()

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -107,7 +107,10 @@ definition of the same name.
   through the read-only `github.*` builtin tools, which bound log output and
   redact credentials; a `github.auth.status` preflight makes an execution lane
   that cannot authenticate report a capability-unavailable outcome instead of a
-  clean pipeline (ORB-11059).
+  clean pipeline (ORB-11059). The template persists the five exact GitHub-read
+  names as `required_tools` so dispatch unions them with the ordinary
+  `agent_implement` baseline rather than widening that activity (ORB-11070;
+  DANI-10056 is the missing-requirements incident, not a clean result).
 
 ## Workspace-authored definitions in this repo
 
@@ -143,5 +146,9 @@ encode this repository's branches and gates. Re-init preserves them:
 - ORB-11059 — Routed the default's CI discovery through the read-only
   `github.run.*` / `github.pr.list` / `github.auth.status` builtin tools and
   added the capability-unavailable outcome.
+- ORB-11070 — Adopted those five exact names as the template's `required_tools`
+  so minted CI-remediation tasks can reach them under `agent_implement`
+  without changing that activity's baseline. DANI-10056 remains cited as
+  failed-validation evidence of the missing-requirements bug.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -74,6 +74,17 @@ they do not replace it or bypass runtime capability, policy, filesystem,
 subprocess, or authentication checks. Invalid, inactive, wildcard, or
 non-agent-facing names fail dispatch before the provider starts.
 
+`ci-failure-remediation` is the worked example: its template declares exactly
+`github.auth.status`, `github.run.list`, `github.run.view`, `github.run.logs`,
+and `github.pr.list`. A minted instance therefore runs under
+`effective_tools = agent_implement baseline ∪ those five names`. Ordinary
+implementation tasks that request nothing keep the original baseline and
+cannot call GitHub tools. Inclusion is only allowlist membership — a
+structured `github.auth.status` answer may still report `available: false` or
+`authenticated: false` when the lane has no GitHub CLI or no credentials
+(DANI-10056 is failed-validation evidence of the missing-requirements bug,
+not a clean CI result).
+
 ## The five seeded definitions
 
 `orbit workspace init` seeds all five, disabled:
@@ -98,15 +109,20 @@ non-agent-facing names fail dispatch before the provider starts.
   pull-request heads, clusters by root cause, repairs repository-owned failures
   without weakening a check, and treats a clean current-head pass as a successful
   no-diff outcome. The body is GitHub-Actions-shaped; operators on other CI
-  should adapt it before enabling. **Execution-lane precondition:** all of its CI
-  discovery goes through the read-only `github.auth.status`, `github.run.list`,
+  should adapt it before enabling. The template persists those five exact
+  GitHub-read names as `required_tools` so dispatch can union them with the
+  ordinary `agent_implement` baseline; it does not widen that activity or use
+  `github.*`. **Execution-lane precondition:** all of its CI discovery goes
+  through the read-only `github.auth.status`, `github.run.list`,
   `github.run.view`, `github.run.logs`, and `github.pr.list` builtin tools, which
   run the GitHub CLI as a child of whichever process executes the tool. So the
   lane that runs the minted task needs one of: an executor whose sandbox permits
   reading the GitHub CLI's configuration directory, or a GitHub token forwarded
   through `[execution.env] pass`. Check before enabling — a lane with neither
   still completes, but every run ends at the preflight with a
-  capability-unavailable summary and no investigation.
+  capability-unavailable summary and no investigation. That structured
+  unauthenticated or unavailable answer is a legitimate capability outcome,
+  not a policy denial and not a clean pipeline.
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -87,7 +87,14 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   deduplicated on write, and cannot change once the task enters `in-progress`.
   Inclusion grants only activity allowlist membership: caller role, host
   capability, tool policy, filesystem/subprocess policy, and external
-  authentication can still deny execution.
+  authentication can still deny execution. The shipped `ci-failure-remediation`
+  auto-task is the worked example: it names exactly `github.auth.status`,
+  `github.run.list`, `github.run.view`, `github.run.logs`, and `github.pr.list`,
+  so `agent_implement` stays unchanged and
+  `effective_tools = activity baseline ∪ those five`. Reaching
+  `github.auth.status` can still yield a structured `available: false` or
+  `authenticated: false` capability-unavailable result when the lane has no
+  GitHub client or credentials; that is not a clean CI pass.
 
 ## Quality bar
 


### PR DESCRIPTION
## Task

[ORB-11070](https://orbit-cli.com/tasks/ORB-11070) — Adopt task-scoped GitHub reads for CI remediation

### Description

## Problem

DANI-10056 / `jrun-20260829-2250-3` proved the registry/bootstrap correction from ORB-11066 works on macOS, but `ci-failure-remediation` still cannot perform its mandate. Its first `orbit tool run github.auth.status` reaches Orbit dispatch and is rejected because the minted task carries no task-scoped tool requirements and the ordinary `agent_implement` baseline does not include GitHub reads.

The installed assets match landed source. This is a shipped contract contradiction from ORB-11059, not catalog drift: the auto-task mandates `github.auth.status`, `github.run.list`, `github.run.view`, `github.run.logs`, and `github.pr.list`, but cannot express those requirements in task data.

## Required Adoption

After ORB-11069 lands, declare those five exact names in the `ci-failure-remediation` auto-task template's `required_tools`. Do not modify `agent_implement`'s baseline tools, do not introduce an activity ceiling or dedicated activity, and do not use `github.*`.

The minted task's effective surface must be computed by the permanent contract:

`effective_tools = agent_implement baseline tools union task required_tools`

Ordinary tasks that request nothing must retain the existing baseline and remain unable to call GitHub tools.

Update the shipped definition, installed-asset expectations, auto-task documentation, and the production-shaped macOS regression. The regression must obtain its effective tools by minting and dispatching a real task through the normal auto-task/task-pipeline contract; it must not manually inject an allowlist.

## Incident and Handoff

- Depends on ORB-11069.
- Source regression: ORB-11059.
- Incident record: F2026-08-139.
- Fresh reproduction: dsearch DANI-10056.
- Replace ORB-11066's manual `ORBIT_ACTIVITY_TOOLS` test setup with the computed task-plus-activity contract.

A structured `github.auth.status` answer may legitimately report unavailable or unauthenticated. Success here is correct policy reachability and structured output, not forcing credentials onto a lane.

### Acceptance Criteria

- The shipped `ci-failure-remediation` auto-task template declares exactly `github.auth.status`, `github.run.list`, `github.run.view`, `github.run.logs`, and `github.pr.list` in `required_tools`, with no wildcard and no direct vendor CLI/API escape hatch.
- The shipped `agent_implement` activity remains unchanged: its baseline `tools` list is neither widened nor given a task ceiling.
- Scheduled and manual mint tests show a CI-remediation task persists the exact five requirements; dispatch computes the existing agent_implement baseline plus those five and exports that effective list into both the agent envelope and `ORBIT_ACTIVITY_TOOLS`.
- A neighboring ordinary implementation task with empty `required_tools` receives only the original baseline and a call to `github.auth.status` remains policy-denied, proving GitHub reads are task-scoped.
- An end-to-end regression uses the real auto-task mint and normal task pipeline/activity selection with deterministic GitHub stubs; the preflight reaches tool execution and returns structured `available`, `authenticated`, and `detail` fields without manually injecting an activity allowlist.
- The macOS nested-tool regression from ORB-11066 derives its effective tools from the persisted task requirements plus production activity baseline and fails against both the pre-ORB-11066 bootstrap behavior and the DANI-10056 missing-requirements behavior.
- A freshly installed candidate binary runs a new managed dsearch CI-remediation task on macOS; `github.auth.status` returns its structured capability result rather than `policy_denied` or `Operation not permitted`, and the execution summary cites the task/run ID plus the matching sandbox-log check.
- Current auto-task and task-authoring documentation explains the five exact requirements, baseline union, and why authentication can still yield a legitimate capability-unavailable outcome.
- F2026-08-139 is linked and resolved when the task reaches done; DANI-10056 remains cited as failed validation evidence rather than being relabeled as a clean CI result.
- Focused auto-task, task-pipeline, tool-policy, and macOS sandbox regressions pass followed by `make ci-fast`, `make ci-lint`, and `git diff --check`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Declared the five exact GitHub-read names on the shipped `ci-failure-remediation` template `required_tools` (`github.auth.status`, `github.run.list`, `github.run.view`, `github.run.logs`, `github.pr.list`); no wildcard and no vendor CLI/API hatch.
- Left `agent_implement` baseline unchanged (`orbit.task.*`, `orbit.friction.*`, `orbit.search`, `proc.spawn`) and locked that list in a shipped-activity test.
- Scheduled fire and manual mint of the shipped definition now persist those five names on the minted task.
- Dispatch of `agent_implement` against a minted CI-remediation task unions the production baseline with those five and exports the effective list into the agent envelope and `ORBIT_ACTIVITY_TOOLS`. A neighboring empty-`required_tools` task keeps the original baseline and `github.auth.status` is `policy_denied`.
- End-to-end mint → `agent_implement` dispatch uses a fake provider and a deterministic `gh` stub; the preflight reaches tool execution and returns structured `available`, `authenticated`, and `detail` without a handwritten allowlist.
- Replaced ORB-11066's hardcoded `ORBIT_ACTIVITY_TOOLS` macOS nested setup with mint + production baseline union. The regression fails on bootstrap denial (pre-ORB-11066) and on `policy_denied` (DANI-10056 missing requirements). This Linux host did not execute the macOS-gated test or a live dsearch candidate-binary run.
- Auto-task and task-authoring skill docs (assets + plugin sync) and `docs/design/auto-tasks/1_overview.md` now name the five requirements, the baseline union, and why a structured unauthenticated/unavailable preflight is a legitimate capability outcome. DANI-10056 remains cited as failed-validation evidence, not a clean CI result. F2026-08-139 is already linked as `resolves`.
Assessment: Scoped adoption of the ORB-11069 contract. Focused auto-task, dispatch/tool-policy, and shipped-activity tests passed; `make ci-fast`, `make ci-lint`, and `git diff --check` passed. Live macOS candidate-binary validation on a managed dsearch CI-remediation task was not run here (Linux executor).
Strategic decisions:
- Compute `effective_tools` from the persisted task plus the shipped `agent_implement` baseline rather than widening that activity or injecting an allowlist.
Design weaknesses / risks:
- Severity: low. The macOS nested regression and a freshly installed candidate binary on dsearch were not executed on this Linux host. Mitigation: unrestricted CI / a macOS lane should run `sandbox_nested` and the live nested `github.auth.status` check.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11070-6a937ebc`
- Behind base: 0
- Ahead of base: 1