### PR TITLE
Document the rejected-task revision transition in task execution guidance

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/task-execution.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-execution.md
@@ -33,8 +33,22 @@ commands, risks — if one doesn't exist.
 
 ## Step 3 — Start
 
-`orbit.task.start` with a `note`. Moves `backlog`/`proposed` → `in-progress` and
-records approval. Starting from `proposed` still requires a real plan.
+For first-time pickup or resuming eligible work, use `orbit.task.start` with a
+`note`. It moves `proposed`, `backlog`, `someday`, or `blocked` → `in-progress`
+and records approval. Starting from `proposed` still requires a real plan:
+
+```bash
+orbit tool run orbit.task.start --input '{"id":"<task-id>","note":"<why work is starting or resuming>","model":"<agent-family>"}'
+```
+
+`rejected` is not a pickup state for `orbit.task.start`. Reconsider it only
+when a reviewer or other authorized decision explicitly requests a revision;
+use `orbit.task.update` to move the task to `in-progress`, recording that
+authorization in the update:
+
+```bash
+orbit tool run orbit.task.update --input '{"id":"<task-id>","status":"in-progress","comment":"Authorized revision: <reviewer decision>","model":"<agent-family>"}'
+```
 
 ## Step 4 — Implement and validate
 
@@ -91,8 +105,13 @@ Justification), `Recommended follow-ups:`.
 
 One task per activity invocation — no multiplexing. Ask clarifying questions
 before implementing if material ambiguity remains. If approval for `proposed`
-work can't be obtained, stop after recording that state. Direct execution must
-persist a non-empty `execution_summary` before or with the review transition.
+work can't be obtained, stop after recording that state. Use `orbit.task.start`
+only for `proposed`, `backlog`, `someday`, or `blocked` pickup; an authorized
+`rejected` revision uses `orbit.task.update` to `in-progress` instead. Direct
+execution must persist a non-empty `execution_summary` before or with the
+review transition.
 
-Exit: task started via `orbit.task.start`; execution summary persisted; friction
-checkpoint considered; direct execution advanced to `review`.
+Exit: eligible work started via `orbit.task.start`, or an authorized rejected
+revision moved to `in-progress` via `orbit.task.update`; execution summary
+persisted; friction checkpoint considered; direct execution advanced to
+`review`.

--- a/plugin/skills/orbit/references/task-execution.md
+++ b/plugin/skills/orbit/references/task-execution.md
@@ -33,8 +33,22 @@ commands, risks — if one doesn't exist.
 
 ## Step 3 — Start
 
-`orbit.task.start` with a `note`. Moves `backlog`/`proposed` → `in-progress` and
-records approval. Starting from `proposed` still requires a real plan.
+For first-time pickup or resuming eligible work, use `orbit.task.start` with a
+`note`. It moves `proposed`, `backlog`, `someday`, or `blocked` → `in-progress`
+and records approval. Starting from `proposed` still requires a real plan:
+
+```bash
+orbit tool run orbit.task.start --input '{"id":"<task-id>","note":"<why work is starting or resuming>","model":"<agent-family>"}'
+```
+
+`rejected` is not a pickup state for `orbit.task.start`. Reconsider it only
+when a reviewer or other authorized decision explicitly requests a revision;
+use `orbit.task.update` to move the task to `in-progress`, recording that
+authorization in the update:
+
+```bash
+orbit tool run orbit.task.update --input '{"id":"<task-id>","status":"in-progress","comment":"Authorized revision: <reviewer decision>","model":"<agent-family>"}'
+```
 
 ## Step 4 — Implement and validate
 
@@ -91,8 +105,13 @@ Justification), `Recommended follow-ups:`.
 
 One task per activity invocation — no multiplexing. Ask clarifying questions
 before implementing if material ambiguity remains. If approval for `proposed`
-work can't be obtained, stop after recording that state. Direct execution must
-persist a non-empty `execution_summary` before or with the review transition.
+work can't be obtained, stop after recording that state. Use `orbit.task.start`
+only for `proposed`, `backlog`, `someday`, or `blocked` pickup; an authorized
+`rejected` revision uses `orbit.task.update` to `in-progress` instead. Direct
+execution must persist a non-empty `execution_summary` before or with the
+review transition.
 
-Exit: task started via `orbit.task.start`; execution summary persisted; friction
-checkpoint considered; direct execution advanced to `review`.
+Exit: eligible work started via `orbit.task.start`, or an authorized rejected
+revision moved to `in-progress` via `orbit.task.update`; execution summary
+persisted; friction checkpoint considered; direct execution advanced to
+`review`.


### PR DESCRIPTION
## Task

[ORB-11086](https://orbit-cli.com/tasks/ORB-11086) — Document the rejected-task revision transition in task execution guidance

### Description

## Problem
Orbit's lifecycle permits `rejected -> in-progress`, but `orbit.task.start` accepts only proposed, backlog, someday, and blocked. The task-execution skill currently tells an implementer to use task.start and does not explain the rejected-review revision path. During ORB-11067, task.start rejected the documented resume while direct task.update to in-progress succeeded.

## Why It Matters
A reviewer-authorized revision looks like an invalid lifecycle operation and forces the executor to discover an undocumented alternate write surface.

## Constraints / Notes
- Align guidance with the shipped transition surfaces; this task does not widen task.start or weaken lifecycle validation.
- Keep rejected-task reconsideration explicitly authorization-driven.
- Distinguish a revision from first-time pickup and from resuming blocked work.

### Acceptance Criteria

- The task-execution skill states that authorized rejected-task revision uses orbit.task.update to in-progress, while proposed/backlog/someday/blocked pickup uses orbit.task.start.
- The lifecycle table and execution steps no longer imply that task.start accepts rejected, and examples include the required model attribution.
- Existing task.start status rejection tests remain unchanged and passing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Documented `orbit.task.start` as the pickup/resume path only for `proposed`, `backlog`, `someday`, and `blocked`, with a model-attributed CLI example.
- Documented that a `rejected` task may return to `in-progress` only for an authorized revision, using `orbit.task.update` and an authorization-recording comment; updated lifecycle exit guidance accordingly.
- Kept the packaged plugin skill mirror synchronized with the canonical embedded asset (required by the repository synchronization guard).

Assessment: The guidance now matches the shipped start transition guard without changing lifecycle code or its tests.

Validation:
- `make ci-fast` passed.
- `make ci-lint` passed.
- `cargo test -p orbit-core --lib direct_start_from_proposed_still_requires_plan` passed.
- `cargo test -p orbit-core` ran 805 tests; 804 passed and one pre-existing unrelated test failed: `adapter::engine_host::v2_host::tests::cli_executor::cli_executor_selection_diagnostics_table` expected command `grok` but observed a temporary executable path.

Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11086-6a93859b`
- Behind base: 0
- Ahead of base: 1