### PR TITLE
CLI flag for required-tools is inconsistent between task/auto-task add and update

### DIFF
--- a/crates/orbit-cli/src/command/auto_task/add.rs
+++ b/crates/orbit-cli/src/command/auto_task/add.rs
@@ -39,7 +39,12 @@ pub struct AutoTaskAddArgs {
     #[arg(long = "tag", action = ArgAction::Append)]
     pub tags: Vec<String>,
     /// Exact canonical tool names copied to every minted task.
-    #[arg(long = "required-tool", action = ArgAction::Append, value_delimiter = ',')]
+    #[arg(
+        long = "required-tools",
+        alias = "required-tool",
+        action = ArgAction::Append,
+        value_delimiter = ','
+    )]
     pub required_tools: Vec<String>,
     /// Priority (defaults to medium)
     #[arg(long, value_enum, default_value_t = TaskPriority::Medium)]

--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -29,7 +29,12 @@ pub struct TaskAddArgs {
     #[arg(long = "tag", action = ArgAction::Append, value_delimiter = ',')]
     pub tags: Vec<String>,
     /// Exact canonical tool names the task adds to its agent activity baseline.
-    #[arg(long = "required-tool", action = ArgAction::Append, value_delimiter = ',')]
+    #[arg(
+        long = "required-tools",
+        alias = "required-tool",
+        action = ArgAction::Append,
+        value_delimiter = ','
+    )]
     pub required_tools: Vec<String>,
     /// Optional task plan payload. Leave blank for the executing agent or planning activity to author later.
     #[arg(long, default_value = "")]

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -33,6 +33,10 @@ fn task_add_parses_repeat_and_comma_delimited_lists() {
         "ORB-00001,ORB-00002",
         "--dependency",
         "ORB-00003",
+        "--required-tools",
+        "proc.spawn,orbit.task.show",
+        "--required-tools",
+        "orbit.task.update",
         "--context",
         "file:one.rs,file:two.rs",
         "--context",
@@ -49,12 +53,41 @@ fn task_add_parses_repeat_and_comma_delimited_lists() {
     assert_eq!(args.acceptance_criteria, ["first", "second"]);
     assert_eq!(args.tags, ["cli", "surface", "test"]);
     assert_eq!(args.dependencies, ["ORB-00001", "ORB-00002", "ORB-00003"]);
+    assert_eq!(
+        args.required_tools,
+        ["proc.spawn", "orbit.task.show", "orbit.task.update"]
+    );
     assert_eq!(args.context, ["file:one.rs", "file:two.rs", "dir:three"]);
     assert_eq!(args.description, "Plain description");
     assert_eq!(args.plan, "Plain plan");
     assert_eq!(args.priority, orbit_core::TaskPriority::High);
     assert_eq!(args.complexity, orbit_core::TaskComplexity::Hard);
     assert_eq!(args.task_type, Some(orbit_core::TaskType::Bug));
+}
+
+#[test]
+fn task_add_accepts_legacy_required_tool_alias() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "Legacy required tool",
+        "--complexity",
+        "low",
+        "--required-tool",
+        "proc.spawn",
+    ])
+    .expect("parse task add with legacy required-tool alias");
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    assert_eq!(args.required_tools, ["proc.spawn"]);
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -82,3 +82,28 @@ fn task_update_complexity_uses_add_spellings() {
         assert_eq!(args.complexity.expect("complexity").to_string(), complexity);
     }
 }
+
+#[test]
+fn task_update_accepts_required_tools() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "update",
+        "ORB-00001",
+        "--required-tools",
+        "proc.spawn,orbit.task.show",
+    ])
+    .expect("parse task update required tools");
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Update(args) = task.command else {
+        panic!("expected task update command");
+    };
+
+    assert_eq!(
+        args.required_tools.as_deref(),
+        Some("proc.spawn,orbit.task.show")
+    );
+}

--- a/crates/orbit-cli/src/command/tests/auto_task.rs
+++ b/crates/orbit-cli/src/command/tests/auto_task.rs
@@ -1,0 +1,58 @@
+use clap::Parser;
+
+use crate::command::auto_task::AutoTaskSubcommand;
+use crate::command::{Cli, Commands};
+
+#[test]
+fn auto_task_add_accepts_required_tools_and_legacy_alias() {
+    for flag in ["--required-tools", "--required-tool"] {
+        let cli = Cli::try_parse_from([
+            "orbit",
+            "auto-task",
+            "add",
+            "--name",
+            "required-tools",
+            "--every-minutes",
+            "5",
+            "--title",
+            "Required tools",
+            flag,
+            "proc.spawn,orbit.task.show",
+        ])
+        .expect("parse auto-task add required tools");
+
+        let Commands::AutoTask(auto_task) = cli.command else {
+            panic!("expected auto-task command");
+        };
+        let AutoTaskSubcommand::Add(args) = auto_task.command else {
+            panic!("expected auto-task add command");
+        };
+
+        assert_eq!(args.required_tools, ["proc.spawn", "orbit.task.show"]);
+    }
+}
+
+#[test]
+fn auto_task_update_accepts_required_tools() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "auto-task",
+        "update",
+        "required-tools",
+        "--required-tools",
+        "proc.spawn,orbit.task.show",
+    ])
+    .expect("parse auto-task update required tools");
+
+    let Commands::AutoTask(auto_task) = cli.command else {
+        panic!("expected auto-task command");
+    };
+    let AutoTaskSubcommand::Update(args) = auto_task.command else {
+        panic!("expected auto-task update command");
+    };
+
+    assert_eq!(
+        args.required_tools.as_deref(),
+        Some("proc.spawn,orbit.task.show")
+    );
+}

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -1,6 +1,7 @@
 // Content moved from inline #[cfg(test)] mod tests in command/mod.rs per ORB-00221.
 // tests/mod.rs can directly contain tests for the declaring parent module (exempt from orphan rules).
 
+mod auto_task;
 mod doctor;
 mod friction;
 mod gc;


### PR DESCRIPTION
## Task

[ORB-11093](https://orbit-cli.com/tasks/ORB-11093) — CLI flag for required-tools is inconsistent between task/auto-task add and update

### Description

ORB-11069 (commit c2b357d7, "feat: Add task-scoped required tools to activity baselines") shipped the new required-tools CLI surface with a mismatched flag name between `add` and `update` subcommands for the same field:

- `orbit task add` / `orbit auto-task add`: flag is `--required-tool` (singular), `ArgAction::Append`, repeatable or comma-delimited.
  - crates/orbit-cli/src/command/task/add.rs:32
  - crates/orbit-cli/src/command/auto_task/add.rs:42
- `orbit task update` / `orbit auto-task update`: flag is `--required-tools` (plural), single CSV string.
  - crates/orbit-cli/src/command/task/update.rs:30
  - crates/orbit-cli/src/command/auto_task/update.rs:47

The underlying field is `required_tools` everywhere (task model, MCP tool schemas for `orbit.task.add`/`orbit.task.update` both use `required_tools`), so the CLI is the only place the name diverges. A user who learns the flag from one subcommand's `--help` and reuses it on the sibling subcommand gets a hard failure.

Reproduction (built release binary, isolated `--root`):

```
$ orbit task add --title t --description d --complexity low --required-tools "proc.spawn"
error: unexpected argument '--required-tools' found
  tip: a similar argument exists: '--required-tool'
```

```
$ orbit task update QAT-00000 --required-tool "proc.spawn"
error: unexpected argument '--required-tool' found
```
(update only recognizes `--required-tools`; add only recognizes `--required-tool`)

Confirmed via `orbit task add --help` / `orbit task update --help` / `orbit auto-task add --help` / `orbit auto-task update --help` on a locally built `cargo build --release -p orbit-cli` binary — the mismatch is present on both the task and auto-task command pairs.

Suggested fix: pick one flag name (plural `--required-tools` matches the field name and the `update` behavior) and use it consistently across `task add`, `task update`, `auto-task add`, and `auto-task update`, keeping `--required-tool` as a clap alias if backward compatibility for the just-shipped `add` flag is wanted.

Note: the core feature behavior itself (recording required_tools on add, updating while proposed, freezing once in-progress with "task X required_tools are frozen once the task enters in-progress") was verified working correctly by hand.

### Acceptance Criteria



## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Standardized task add and auto-task add on repeatable, comma-delimited `--required-tools`, retaining `--required-tool` as a compatibility alias.
- Added parser coverage for canonical spelling on task/auto-task add/update and the legacy add aliases, using the repository sibling test layout.
- Extended task context selectors for the directly affected parser tests and their module registration.
Assessment: The four sibling commands now advertise the same canonical flag while preserving the previously shipped add spelling.
Validation:
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `cargo fmt --check`; all four `--help` commands expose `--required-tools`; `git diff --check`.
- Target behavior tests passed in `cargo test -p orbit-cli --bin orbit`, but the full command exits nonzero due to one unrelated existing environment-sensitive test: `workspace_init_under_home_with_global_orbit_creates_repo_orbit` observes `~/.orbit` where its fixture expects no global Orbit directory (371 passed, 1 failed).
Deviations from original plan: Added direct parser tests and context entries to cover both task families and preserve the established sibling-test layout.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11093-6a93859b`
- Behind base: 0
- Ahead of base: 1