### PR TITLE
Serialize checkoutless task updates so required_tools cannot race execution admission

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -311,6 +311,16 @@ impl HubCoordinationExecutor {
         self.task_json(&task)
     }
 
+    /// Apply a checkoutless task update, holding the task's write lock across
+    /// the whole read-modify-write.
+    ///
+    /// ORB-11092: this path used to read the snapshot, check `required_tools`
+    /// freeze against it, and persist later without `with_task_write_lock`. A
+    /// concurrent `orbit.task.start` could append `in-progress` after that
+    /// stale snapshot and still lose to the later write, mutating execution
+    /// authority after admission. The lock is re-entrant per thread, so start
+    /// (which calls this method) and the store's per-write locking still hold
+    /// underneath.
     fn update_task(
         &self,
         input: Value,
@@ -318,7 +328,57 @@ impl HubCoordinationExecutor {
         model: Option<String>,
     ) -> Result<Value, OrbitError> {
         let id = required_string(&input, &["id"], "id")?;
-        let current = self.task(&id)?;
+        // The lock hook takes `FnMut` because it is a trait object, but the
+        // body must run exactly once and consumes its inputs; `take()` makes
+        // both facts explicit rather than forcing the params to be cloneable.
+        let mut inputs = Some((input, agent, model));
+        let mut outcome: Option<(Value, TaskStatus, Task)> = None;
+        self.inner.tasks.task.with_task_write_lock(&id, &mut || {
+            let (input, agent, model) = inputs.take().ok_or_else(|| {
+                OrbitError::Execution(
+                    "checkoutless task update body was invoked more than once".to_string(),
+                )
+            })?;
+            outcome = Some(self.update_task_locked(&id, input, agent, model)?);
+            Ok(())
+        })?;
+        let (json, prior_status, updated) = outcome.ok_or_else(|| {
+            OrbitError::Execution(
+                "checkoutless task update body did not run under the task lock".to_string(),
+            )
+        })?;
+
+        // Cascading friction resolution touches *other* records, so it stays
+        // outside this task's lock.
+        if updated.status == TaskStatus::Done
+            && prior_status != TaskStatus::Done
+            && let Ok(frictions) = self.friction_store()
+        {
+            for relation in &updated.relations {
+                if relation.relation_type == orbit_types::task::TaskRelationType::Resolves
+                    && is_valid_friction_id(&relation.target)
+                    && let Err(error) = frictions.resolve_by_task(&relation.target, &id, Utc::now())
+                {
+                    tracing::warn!(
+                        task_id = id,
+                        friction_id = relation.target,
+                        error = %error,
+                        "checkoutless task completion could not apply friction side effect"
+                    );
+                }
+            }
+        }
+        Ok(json)
+    }
+
+    fn update_task_locked(
+        &self,
+        id: &str,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+    ) -> Result<(Value, TaskStatus, Task), OrbitError> {
+        let current = self.task(id)?;
         let actor = Self::actor(agent.as_deref(), model.as_deref());
         let status = optional_string(&input, "status")?
             .map(|value| super::input::parse_task_status("status", &value))
@@ -398,7 +458,7 @@ impl HubCoordinationExecutor {
         if let Some(dependencies) = dependencies.as_ref() {
             validate_task_dependencies(
                 &self.inner.tasks.task.list_tasks()?,
-                Some(&id),
+                Some(id),
                 dependencies,
             )?;
         }
@@ -470,7 +530,7 @@ impl HubCoordinationExecutor {
                     .inner
                     .tasks
                     .history
-                    .get_task_history(&id)?
+                    .get_task_history(id)?
                     .unwrap_or_default()
                     .iter()
                     .any(|entry| entry.to_status == Some(TaskStatus::InProgress));
@@ -489,7 +549,7 @@ impl HubCoordinationExecutor {
             )));
         }
         self.inner.tasks.document.update_task_document(
-            &id,
+            id,
             TaskDocumentUpdateParams {
                 actor: actor.clone(),
                 title: optional_string(&input, "title")?.map(|value| redact_all(&value)),
@@ -533,7 +593,7 @@ impl HubCoordinationExecutor {
         )?;
         if !artifacts.is_empty() {
             self.inner.tasks.artifact.upsert_task_artifacts(
-                &id,
+                id,
                 TaskArtifactUpdateParams {
                     actor: actor.clone(),
                     upsert_artifacts: artifacts,
@@ -550,7 +610,7 @@ impl HubCoordinationExecutor {
                 .into_iter()
                 .collect();
             self.inner.tasks.history.update_task_history(
-                &id,
+                id,
                 TaskHistoryUpdateParams {
                     actor,
                     status,
@@ -561,26 +621,9 @@ impl HubCoordinationExecutor {
                 },
             )?;
         }
-        let updated = self.task(&id)?;
-        if updated.status == TaskStatus::Done
-            && current.status != TaskStatus::Done
-            && let Ok(frictions) = self.friction_store()
-        {
-            for relation in &updated.relations {
-                if relation.relation_type == orbit_types::task::TaskRelationType::Resolves
-                    && is_valid_friction_id(&relation.target)
-                    && let Err(error) = frictions.resolve_by_task(&relation.target, &id, Utc::now())
-                {
-                    tracing::warn!(
-                        task_id = id,
-                        friction_id = relation.target,
-                        error = %error,
-                        "checkoutless task completion could not apply friction side effect"
-                    );
-                }
-            }
-        }
-        self.task_json(&updated)
+        let updated = self.task(id)?;
+        let json = self.task_json(&updated)?;
+        Ok((json, current.status, updated))
     }
 
     fn transition(
@@ -591,7 +634,33 @@ impl HubCoordinationExecutor {
         start: bool,
     ) -> Result<Value, OrbitError> {
         let id = required_string(&input, &["id"], "id")?;
-        let task = self.task(&id)?;
+        let mut inputs = Some((input, agent, model, start));
+        let mut result = None;
+        self.inner.tasks.task.with_task_write_lock(&id, &mut || {
+            let (input, agent, model, start) = inputs.take().ok_or_else(|| {
+                OrbitError::Execution(
+                    "checkoutless task transition body was invoked more than once".to_string(),
+                )
+            })?;
+            result = Some(self.transition_locked(&id, input, agent, model, start)?);
+            Ok(())
+        })?;
+        result.ok_or_else(|| {
+            OrbitError::Execution(
+                "checkoutless task transition body did not run under the task lock".to_string(),
+            )
+        })
+    }
+
+    fn transition_locked(
+        &self,
+        id: &str,
+        input: Value,
+        agent: Option<String>,
+        model: Option<String>,
+        start: bool,
+    ) -> Result<Value, OrbitError> {
+        let task = self.task(id)?;
         let target = if start {
             if !matches!(
                 task.status,
@@ -623,7 +692,7 @@ impl HubCoordinationExecutor {
             }
         };
         let mut update = Map::new();
-        update.insert("id".to_string(), Value::String(id));
+        update.insert("id".to_string(), Value::String(id.to_string()));
         update.insert("status".to_string(), Value::String(target.to_string()));
         if let Some(note) = optional_string(&input, "note")? {
             update.insert("comment".to_string(), Value::String(note));

--- a/crates/orbit-core/src/adapter/tool_host/tests/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/host.rs
@@ -1,0 +1,202 @@
+use std::time::Duration;
+
+use orbit_types::tool::ToolSessionContext;
+use serde_json::json;
+
+use crate::adapter::tool_host::HubCoordinationExecutor;
+
+fn executor() -> (
+    tempfile::TempDir,
+    HubCoordinationExecutor,
+    ToolSessionContext,
+) {
+    let root = tempfile::tempdir().expect("global root");
+    HubCoordinationExecutor::register_workspace(root.path(), "ws_checkoutless", "checkoutless")
+        .expect("register workspace");
+    let executor = HubCoordinationExecutor::new(root.path(), "ws_checkoutless", None)
+        .expect("coordination executor");
+    let context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    (root, executor, context)
+}
+
+/// Locate a task's bundle directory under a checkoutless hub root. The store
+/// owns the layout; the test only needs *a* path to contend on.
+fn task_bundle_dir(root: &std::path::Path, id: &str) -> std::path::PathBuf {
+    fn walk(dir: &std::path::Path, id: &str) -> Option<std::path::PathBuf> {
+        for entry in std::fs::read_dir(dir).ok()?.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if path.file_name().is_some_and(|name| name == id) && path.join("task.yaml").is_file() {
+                return Some(path);
+            }
+            if let Some(found) = walk(&path, id) {
+                return Some(found);
+            }
+        }
+        None
+    }
+    walk(root, id).unwrap_or_else(|| panic!("no bundle directory for {id} under {root:?}"))
+}
+
+/// ORB-11092: the checkoutless update path must hold the task lock across its
+/// whole read-modify-write, not just around the store write.
+///
+/// The body reads the task, decides from that snapshot whether `required_tools`
+/// may still change, and only then writes. When the lock covered the write
+/// alone, a concurrent `orbit.task.start` could commit `in-progress` inside
+/// that gap: the requirements updater had already observed a backlog task, and
+/// its write landed a new allowlist after the lifecycle freeze.
+///
+/// The other thread holds the bundle lock directly, so the window is opened
+/// deliberately rather than raced for. Sleep after the contender is announced
+/// gives a stale pre-lock read time to observe backlog before start commits.
+#[test]
+fn checkoutless_concurrent_required_tools_update_cannot_write_through_start() {
+    use std::sync::mpsc::sync_channel;
+
+    let (root, executor, context) = executor();
+    let created = executor
+        .execute_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_checkoutless",
+                "title": "Freeze under contention",
+                "description": "required_tools must not race start",
+                "complexity": "low",
+                "required_tools": ["github.run.list"],
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("add checkoutless task");
+    let id = created["id"].as_str().expect("task id").to_string();
+    executor
+        .execute_tool(
+            "orbit.task.update",
+            json!({
+                "id": id,
+                "plan": "1. Execute with the admitted tool surface.",
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("persist plan so start is legal");
+
+    let lock_target = task_bundle_dir(root.path(), &id).join("task.yaml");
+    let (locked_tx, locked_rx) = sync_channel::<()>(0);
+    let (contender_tx, contender_rx) = sync_channel::<()>(0);
+
+    let holder_executor = &executor;
+    let holder_context = &context;
+    let holder_lock_target = lock_target.as_path();
+    let holder_id = id.as_str();
+    let contended = std::thread::scope(|scope| {
+        scope.spawn(move || {
+            orbit_common::fs::io::with_exclusive_file_lock::<(), orbit_common::OrbitError, _>(
+                holder_lock_target,
+                "ORB-11092 regression",
+                || {
+                    locked_tx.send(()).expect("announce the held lock");
+                    contender_rx.recv().expect("await the contending update");
+                    std::thread::sleep(Duration::from_millis(250));
+                    holder_executor
+                        .execute_tool(
+                            "orbit.task.start",
+                            json!({"id": holder_id, "model": "codex"}),
+                            holder_context.clone(),
+                        )
+                        .expect("start under the lock");
+                    Ok(())
+                },
+            )
+            .expect("hold the task lock");
+        });
+
+        locked_rx.recv().expect("await the held lock");
+        contender_tx
+            .send(())
+            .expect("announce the contending update");
+        executor.execute_tool(
+            "orbit.task.update",
+            json!({
+                "id": id,
+                "required_tools": ["github.run.view"],
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+    });
+
+    let err = contended.expect_err("an in-progress task must refuse a required_tools change");
+    assert!(
+        err.to_string().contains("frozen"),
+        "expected the required_tools freeze, got: {err}"
+    );
+    let shown = executor
+        .execute_tool("orbit.task.show", json!({"id": id}), context)
+        .expect("show after the race");
+    assert_eq!(shown["status"], "in-progress");
+    assert_eq!(
+        shown["required_tools"],
+        json!(["github.run.list"]),
+        "the losing writer must not have changed required_tools after start"
+    );
+}
+
+#[test]
+fn checkoutless_required_tools_freeze_after_start_without_a_race() {
+    let (_root, executor, context) = executor();
+    let created = executor
+        .execute_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_checkoutless",
+                "title": "Hub required_tools freeze",
+                "description": "Sequential freeze on the checkoutless path.",
+                "complexity": "low",
+                "required_tools": ["github.run.list", "github.auth.status"],
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("add checkoutless task");
+    let id = created["id"].as_str().expect("task id");
+    executor
+        .execute_tool(
+            "orbit.task.update",
+            json!({
+                "id": id,
+                "plan": "Execute with the admitted tool surface.",
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("persist plan");
+    let started = executor
+        .execute_tool(
+            "orbit.task.start",
+            json!({"id": id, "model": "codex"}),
+            context.clone(),
+        )
+        .expect("start checkoutless task");
+    assert_eq!(started["status"], "in-progress");
+    assert_eq!(
+        started["required_tools"],
+        json!(["github.auth.status", "github.run.list"])
+    );
+
+    let error = executor
+        .execute_tool(
+            "orbit.task.update",
+            json!({"id": id, "required_tools": ["github.run.view"], "model": "codex"}),
+            context,
+        )
+        .expect_err("active task requirements are frozen");
+    assert!(error.to_string().contains("frozen"), "{error}");
+}

--- a/crates/orbit-core/src/adapter/tool_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/mod.rs
@@ -1,6 +1,7 @@
 mod auto_task_tools;
 mod command_tools;
 mod friction_tools;
+mod host;
 mod state_tools;
 mod task_tools;
 mod workflow_tools;


### PR DESCRIPTION
## Task

[ORB-11092](https://orbit-cli.com/tasks/ORB-11092) — Serialize checkoutless task updates so required_tools cannot race execution admission

### Description

## Problem
The checkoutless `HubCoordinationExecutor::update_task` reads the task snapshot at `crates/orbit-core/src/adapter/tool_host/host.rs:320-321`, checks the `required_tools` freeze against that snapshot/history at `:443-467`, and only later persists the document at `:477-519`. It never calls the task backend's `with_task_write_lock`, so the read/check/write sequence is not atomic.

A concurrent `orbit.task.start` can append the `in-progress` transition after the requirements updater has observed a backlog task but before that updater writes the new list. The stale updater then lands changed `required_tools` on an active task, allowing the current dispatch or a retry to resolve a different authority surface after admission. This violates ORB-11069's freeze contract.

The checkout-backed path already documents and prevents this exact stale-snapshot class by holding `with_task_write_lock` across its whole read/modify/write sequence at `crates/orbit-core/src/application/task/update.rs:67-100`; the backend contract explains why per-write locking is insufficient at `crates/orbit-store/src/contracts/traits.rs:79-94`. The checkoutless path needs the same boundary, including its document, artifact, and history writes.

## Why It Matters
`required_tools` is execution authority, not ordinary display metadata. Without one critical section, an actor can deliberately race task start and alter the activity allowlist after the lifecycle boundary intended to freeze it. Independent capability and filesystem checks still apply, but the task-scoped allowlist itself is mutable contrary to its contract.

## Constraints / Notes
- Preserve checkoutless routing; do not invent a second lock implementation.
- Add deterministic synchronization-based coverage rather than a probabilistic stress test.
- Source task: ORB-11069.

### Acceptance Criteria

- The checkoutless task update/start paths hold the authoritative per-task write lock across snapshot reads, lifecycle/required_tools validation, and all document/history/artifact writes derived from that snapshot.
- A deterministic concurrent regression test pauses a requirements update after its pre-state read, advances the same task to in-progress, and proves the stale update cannot change required_tools after the lifecycle boundary.
- Existing checkoutless task lifecycle, comments, artifacts, and task projection tests pass without lost updates or deadlocks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Wrapped checkoutless `HubCoordinationExecutor::update_task` and `transition` (start/approve) in `TaskStoreBackend::with_task_write_lock` so snapshot reads, lifecycle/`required_tools` freeze checks, and document/artifact/history writes derived from that snapshot are one critical section. Reused the existing backend lock; no second implementation. Friction `resolves` side effects stay outside the lock because they touch other records, matching the checkout-backed path.
- Added a deterministic concurrent regression in `crates/orbit-core/src/adapter/tool_host/tests/host.rs`: a holder thread takes the bundle lock, `orbit.task.start`s under it, and the contending `required_tools` update must fail the freeze rather than land a stale allowlist. Added a sequential checkoutless freeze test on the same surface.
Assessment: The checkoutless update/start path now has the same lock boundary as `application/task/update.rs` (ORB-10988). Context files expanded to the new sibling test module so the concurrent coverage is reserved with the production change.
Validation:
- `cargo test -p orbit-core --lib checkoutless -- --test-threads=1` (7 passed: existing hub lifecycle/comments/artifacts/projection plus the new freeze tests)
- `cargo test -p orbit-core --lib concurrent_update_cannot_write_through_a_status_change task_tools_roundtrip_required_tools_and_freeze_them_at_in_progress`
- `make ci-fast`
- `make ci-lint`
Strategic decisions: Nested start (`transition` then `update_task`) relies on existing per-thread re-entrancy of `with_exclusive_file_lock` rather than a new lock. The concurrent test opens the window by holding the bundle lock directly, same pattern as ORB-10988, instead of a probabilistic stress test.
Design weaknesses / risks: None material. Checkoutless `orbit.task.show` field projection still does not serve `required_tools` through `fields:` (pre-existing; the freeze tests assert from the full task payload).
Deviations from original plan: None.
Recommended follow-ups: None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11092-6a938596`
- Behind base: 0
- Ahead of base: 1