### PR TITLE
Persist owner-local task-publication repository bindings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,10 +75,11 @@ feature.
   Retrieval and ranking live in `orbit-search`. `orbit-core` owns the domain (corpora, records, lifecycle) and projects records into search-source structs. `orbit-search` owns lexical (BM25), semantic (cosine), and hybrid scoring. CLI verbs are presets layered on the same backend.
   It also builds `orbit-search-companion`, a separately installed search companion binary, as an additional `[[bin]]` target (folded from the standalone `orbit-search-companion` crate, ORB-10357); that target alone depends on fastembed-rs and is not linked into the default `orbit` CLI binary.
 - **orbit-registry**: machine identity and workspace registry feature crate. It
-  owns `host.toml`, the logical workspace catalog and local checkout bindings,
-  validation, and atomic file persistence. It contains no shared database,
-  command orchestration, MCP transport, or Core runtime execution. Depends only
-  on `orbit-types` and `orbit-common` among workspace crates.
+  owns `host.toml`, the logical workspace catalog, local checkout bindings,
+  owner-local task-publication repository bindings, validation, and atomic file
+  persistence. It contains no shared database, command orchestration, MCP
+  transport, or Core runtime execution. Depends only on `orbit-types` and
+  `orbit-common` among workspace crates.
 - **orbit-store**: one directional persistence crate. `contracts` owns every
   consumer-visible trait, parameter, query/filter, and result projection;
   `fs` owns narrowly named lock, path-safety, and YAML mechanics; private

--- a/crates/orbit-registry/src/lib.rs
+++ b/crates/orbit-registry/src/lib.rs
@@ -3,10 +3,10 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 //! Machine identity and workspace registry domain for Orbit.
 //!
-//! This crate owns host identity, the logical workspace catalog and local
-//! checkout bindings, and their file persistence and validation. It contains
-//! no command orchestration, MCP transport, Core runtime execution, or shared
-//! database access.
+//! This crate owns host identity, the logical workspace catalog, local
+//! checkout bindings, owner-local task-publication repository bindings, and
+//! their file persistence and validation. It contains no command orchestration,
+//! MCP transport, Core runtime execution, or shared database access.
 
 pub mod host_identity;
 pub mod workspace_registry;

--- a/crates/orbit-registry/src/tests/mod.rs
+++ b/crates/orbit-registry/src/tests/mod.rs
@@ -1,4 +1,5 @@
 #![allow(missing_docs)]
 
 mod host_identity;
+mod workspace_publication;
 mod workspace_registry;

--- a/crates/orbit-registry/src/tests/workspace_publication.rs
+++ b/crates/orbit-registry/src/tests/workspace_publication.rs
@@ -1,0 +1,394 @@
+use std::fs;
+use std::path::Path;
+
+use chrono::{TimeZone, Utc};
+use orbit_types::workspace::{
+    WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
+    WorkspaceRegistry, WorkspaceStatus,
+};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use crate::workspace_registry::{
+    bind_publication, find_publication_binding, load_registry_from, rebind_publication,
+    record_publication_success, save_registry_to, unbind_publication,
+};
+
+fn timestamp() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 29, 1, 2, 3)
+        .single()
+        .expect("fixed timestamp")
+}
+
+fn logical_workspace(id: &str, owner: &str, git_remote: &str) -> Workspace {
+    Workspace {
+        id: id.to_string(),
+        name: id.trim_start_matches("ws_").to_string(),
+        owner_machine_id: Some(owner.to_string()),
+        git_remote: Some(git_remote.to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+    }
+}
+
+fn owner_checkout(workspace_id: &str) -> WorkspaceCheckout {
+    WorkspaceCheckout::owner(
+        workspace_id.to_string(),
+        format!("/repos/{workspace_id}").into(),
+        format!("/repos/{workspace_id}/.orbit").into(),
+    )
+}
+
+fn owner_registry() -> WorkspaceRegistry {
+    WorkspaceRegistry {
+        workspaces: vec![logical_workspace(
+            "ws_orbit",
+            "hm_owner",
+            "git@github.com:example/source.git",
+        )],
+        checkouts: vec![owner_checkout("ws_orbit")],
+        ..WorkspaceRegistry::default()
+    }
+}
+
+fn write_host_identity(root: &Path, machine_id: &str) {
+    fs::write(
+        root.join("host.toml"),
+        format!(
+            "schema_version = 2\nmachine_id = \"{machine_id}\"\nhost_id = \"test-host\"\ntask_prefix = \"ORB\"\n"
+        ),
+    )
+    .expect("write host identity");
+}
+
+fn write_json(path: &Path, value: &Value) -> Vec<u8> {
+    let bytes = serde_json::to_vec_pretty(value).expect("serialize fixture");
+    fs::write(path, &bytes).expect("write fixture");
+    bytes
+}
+
+fn assert_redacted(message: &str) {
+    assert!(
+        !message.contains("ghp_s3cret")
+            && !message.contains("/repos/")
+            && !message.contains("/home/"),
+        "diagnostic leaked a secret or checkout path: {message}"
+    );
+}
+
+#[test]
+fn bind_round_trips_through_atomic_save_and_rebind_is_the_only_replace_path() {
+    let root = tempdir().expect("tempdir");
+    write_host_identity(root.path(), "hm_owner");
+    let path = root.path().join("workspaces.json");
+    let mut registry = owner_registry();
+
+    let created = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect("bind");
+    assert_eq!(created.workspace_id, "ws_orbit");
+    assert_eq!(
+        created.source_repository_fingerprint,
+        "git@github.com:example/source.git"
+    );
+    assert_eq!(created.publication_branch, "refs/heads/main");
+    assert_eq!(created.authority_machine_id, "hm_owner");
+    assert_eq!(created.last_success_generation, None);
+
+    let duplicate = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/other.git",
+        "refs/heads/main",
+        "tp_other",
+        Some("hm_owner"),
+    )
+    .expect_err("second bind must use rebind")
+    .to_string();
+    assert!(
+        duplicate.contains("already has a publication binding"),
+        "{duplicate}"
+    );
+    assert!(duplicate.contains("rebind"), "{duplicate}");
+
+    record_publication_success(
+        &mut registry,
+        "ws_orbit",
+        3,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        Some("hm_owner"),
+    )
+    .expect("record success");
+    save_registry_to(&registry, &path).expect("save binding");
+
+    let loaded = load_registry_from(&path).expect("reload");
+    let binding = find_publication_binding(&loaded, "orbit").expect("find by name");
+    assert_eq!(binding.publication_id, "tp_orbit_tasks");
+    assert_eq!(binding.last_success_generation, Some(3));
+
+    let mut rebound = loaded;
+    let replaced = rebind_publication(
+        &mut rebound,
+        "ws_orbit",
+        "https://github.com/example/tasks-v2.git",
+        "refs/heads/publication",
+        "tp_orbit_tasks_v2",
+        Some("hm_owner"),
+    )
+    .expect("rebind");
+    assert_eq!(
+        replaced.publication_remote,
+        "https://github.com/example/tasks-v2.git"
+    );
+    assert_eq!(replaced.last_success_generation, None);
+    save_registry_to(&rebound, &path).expect("save rebind");
+
+    let mut unbound = load_registry_from(&path).expect("reload rebound");
+    let removed = unbind_publication(&mut unbound, "ws_orbit", Some("hm_owner")).expect("unbind");
+    assert_eq!(removed.publication_id, "tp_orbit_tasks_v2");
+    save_registry_to(&unbound, &path).expect("save unbind");
+    let empty = load_registry_from(&path).expect("reload empty");
+    assert!(find_publication_binding(&empty, "ws_orbit").is_none());
+    let persisted: Value =
+        serde_json::from_slice(&fs::read(&path).expect("read")).expect("parse saved registry");
+    assert!(persisted.get("publication_bindings").is_none());
+}
+
+#[test]
+fn existing_registry_without_publication_bindings_loads_and_saves_without_data_loss() {
+    let root = tempdir().expect("tempdir");
+    write_host_identity(root.path(), "hm_owner");
+    let path = root.path().join("workspaces.json");
+    write_json(
+        &path,
+        &json!({
+            "schema_version": WORKSPACE_REGISTRY_SCHEMA_VERSION,
+            "workspaces": [logical_workspace(
+                "ws_orbit",
+                "hm_owner",
+                "git@github.com:example/source.git"
+            )],
+            "checkouts": [{
+                "workspace_id": "ws_orbit",
+                "repo_root": "/repos/ws_orbit",
+                "orbit_dir": "/repos/ws_orbit/.orbit",
+                "role": "owner"
+            }]
+        }),
+    );
+
+    let loaded = load_registry_from(&path).expect("load legacy registry");
+    assert!(loaded.publication_bindings.is_empty());
+    assert_eq!(loaded.workspaces[0].id, "ws_orbit");
+    assert_eq!(
+        loaded.workspaces[0].git_remote.as_deref(),
+        Some("git@github.com:example/source.git")
+    );
+    save_registry_to(&loaded, &path).expect("save without bindings");
+    let persisted: Value = serde_json::from_slice(&fs::read(&path).expect("read")).expect("parse");
+    assert!(persisted.get("publication_bindings").is_none());
+    assert_eq!(persisted["workspaces"][0]["id"], "ws_orbit");
+    assert_eq!(
+        persisted["workspaces"][0]["git_remote"],
+        "git@github.com:example/source.git"
+    );
+}
+
+#[test]
+fn malformed_publication_bindings_fail_closed_without_rewriting() {
+    let root = tempdir().expect("tempdir");
+    write_host_identity(root.path(), "hm_owner");
+    let path = root.path().join("workspaces.json");
+    let original = write_json(
+        &path,
+        &json!({
+            "schema_version": WORKSPACE_REGISTRY_SCHEMA_VERSION,
+            "workspaces": [logical_workspace(
+                "ws_orbit",
+                "hm_owner",
+                "git@github.com:example/source.git"
+            )],
+            "checkouts": [{
+                "workspace_id": "ws_orbit",
+                "repo_root": "/repos/ws_orbit",
+                "orbit_dir": "/repos/ws_orbit/.orbit",
+                "role": "owner"
+            }],
+            "publication_bindings": [{
+                "workspace_id": "ws_orbit",
+                "source_repository_fingerprint": "git@github.com:example/source.git",
+                "publication_remote": "https://x-access-token:ghp_s3cret@github.com/example/tasks.git",
+                "publication_branch": "refs/heads/main",
+                "publication_id": "tp_orbit_tasks",
+                "authority_machine_id": "hm_owner"
+            }]
+        }),
+    );
+
+    let error = load_registry_from(&path)
+        .expect_err("credential-bearing binding must fail")
+        .to_string();
+    assert!(error.contains("credentials"), "{error}");
+    assert_redacted(&error);
+    assert_eq!(fs::read(&path).expect("unchanged"), original);
+}
+
+#[test]
+fn bind_rejects_replica_equivalent_remote_credentials_branch_authority_and_reused_ids() {
+    let mut registry = owner_registry();
+    registry.workspaces.push(logical_workspace(
+        "ws_other",
+        "hm_owner",
+        "git@github.com:example/other-source.git",
+    ));
+    registry.checkouts.push(owner_checkout("ws_other"));
+
+    bind_publication(
+        &mut registry,
+        "ws_other",
+        "git@github.com:example/other-tasks.git",
+        "refs/heads/main",
+        "tp_shared",
+        Some("hm_owner"),
+    )
+    .expect("first lineage");
+
+    let replica = bind_publication(
+        &mut WorkspaceRegistry {
+            checkouts: vec![WorkspaceCheckout {
+                workspace_id: "ws_orbit".to_string(),
+                repo_root: "/repos/ws_orbit".into(),
+                orbit_dir: "/repos/ws_orbit/.orbit".into(),
+                role: Some(WorkspaceCheckoutRole::Replica),
+                owner_machine_id: Some("hm_owner".to_string()),
+                path_overrides: Vec::new(),
+            }],
+            ..owner_registry()
+        },
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "refs/heads/main",
+        "tp_replica",
+        Some("hm_other"),
+    )
+    .expect_err("replica")
+    .to_string();
+    assert!(replica.contains("replica checkout"), "{replica}");
+    assert_redacted(&replica);
+
+    let equivalent = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "https://github.com/example/source.git",
+        "refs/heads/main",
+        "tp_same_repo",
+        Some("hm_owner"),
+    )
+    .expect_err("source-equivalent remote")
+    .to_string();
+    assert!(
+        equivalent.contains("equivalent to the workspace source remote"),
+        "{equivalent}"
+    );
+    assert_redacted(&equivalent);
+
+    let credentials = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "https://x-access-token:ghp_s3cret@github.com/example/tasks.git",
+        "refs/heads/main",
+        "tp_secret",
+        Some("hm_owner"),
+    )
+    .expect_err("credentials")
+    .to_string();
+    assert!(credentials.contains("credentials"), "{credentials}");
+    assert_redacted(&credentials);
+
+    let branch = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "refs/tags/v1",
+        "tp_tag",
+        Some("hm_owner"),
+    )
+    .expect_err("tag ref")
+    .to_string();
+    assert!(branch.contains("ordinary refs/heads"), "{branch}");
+
+    let authority = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "refs/heads/main",
+        "tp_authority",
+        Some("hm_other"),
+    )
+    .expect_err("wrong machine")
+    .to_string();
+    assert!(authority.contains("declared owner machine"), "{authority}");
+    assert_redacted(&authority);
+
+    let reused = bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "refs/heads/main",
+        "tp_shared",
+        Some("hm_owner"),
+    )
+    .expect_err("reused lineage")
+    .to_string();
+    assert!(
+        reused.contains("already bound to workspace 'ws_other'"),
+        "{reused}"
+    );
+}
+
+#[test]
+fn rejected_bind_leaves_persisted_registry_byte_identical() {
+    let root = tempdir().expect("tempdir");
+    write_host_identity(root.path(), "hm_owner");
+    let path = root.path().join("workspaces.json");
+    let mut registry = owner_registry();
+    bind_publication(
+        &mut registry,
+        "ws_orbit",
+        "git@github.com:example/tasks.git",
+        "refs/heads/main",
+        "tp_orbit_tasks",
+        Some("hm_owner"),
+    )
+    .expect("bind");
+    save_registry_to(&registry, &path).expect("save");
+    let original = fs::read(&path).expect("original bytes");
+
+    let mut dirty = load_registry_from(&path).expect("load");
+    let error = rebind_publication(
+        &mut dirty,
+        "ws_orbit",
+        "/repos/ws_orbit",
+        "refs/heads/main",
+        "tp_path",
+        Some("hm_owner"),
+    )
+    .expect_err("local path")
+    .to_string();
+    assert!(error.contains("local checkout path"), "{error}");
+    assert_redacted(&error);
+    assert_eq!(
+        fs::read(&path).expect("still original"),
+        original,
+        "failed rebind must not persist"
+    );
+}

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -199,6 +199,9 @@ pub fn remove_workspace(
     registry
         .checkouts
         .retain(|checkout| checkout.workspace_id != removed.id);
+    registry
+        .publication_bindings
+        .retain(|binding| binding.workspace_id != removed.id);
     if let Some(owner) = removed.owner_machine_id.as_deref()
         && !registry
             .workspaces
@@ -624,6 +627,7 @@ pub fn validate_workspace_registry(
             }
         }
     }
+    super::publication::validate_publication_bindings(registry, context)?;
     Ok(changed)
 }
 

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -2,6 +2,7 @@
 
 mod catalog;
 mod io;
+mod publication;
 
 pub use catalog::{
     WorkspaceRegistryHostContext, assign_checkout_role, find_checkout, find_checkout_by_path,
@@ -12,6 +13,10 @@ pub use catalog::{
 pub use io::{
     global_orbit_dir, load_registry, load_registry_from, registry_path, registry_path_for,
     save_registry, save_registry_to,
+};
+pub use publication::{
+    bind_publication, find_publication_binding, rebind_publication, record_publication_success,
+    unbind_publication,
 };
 
 #[cfg(test)]

--- a/crates/orbit-registry/src/workspace_registry/publication.rs
+++ b/crates/orbit-registry/src/workspace_registry/publication.rs
@@ -1,0 +1,356 @@
+//! Owner-local task-publication repository bindings.
+
+use std::collections::HashSet;
+
+use orbit_common::{NotFoundKind, OrbitError};
+use orbit_types::identity::validate_machine_id;
+use orbit_types::workspace::{
+    Workspace, WorkspaceCheckoutRole, WorkspaceError, WorkspacePublicationBinding,
+    WorkspaceRegistry, canonicalize_publication_branch, git_remotes_equivalent, redact_git_remote,
+    validate_publication_remote,
+};
+
+use super::{WorkspaceRegistryHostContext, find_checkout, find_workspace};
+
+/// Locate the publication binding for a workspace id or name.
+pub fn find_publication_binding<'a>(
+    registry: &'a WorkspaceRegistry,
+    id_or_name: &str,
+) -> Option<&'a WorkspacePublicationBinding> {
+    let workspace = find_workspace(registry, id_or_name)?;
+    registry
+        .publication_bindings
+        .iter()
+        .find(|binding| binding.workspace_id == workspace.id)
+}
+
+/// Create a publication binding. Fails when one already exists; use
+/// [`rebind_publication`] to replace it.
+pub fn bind_publication(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    publication_remote: &str,
+    publication_branch: &str,
+    publication_id: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    if registry
+        .publication_bindings
+        .iter()
+        .any(|binding| binding.workspace_id == workspace_id)
+    {
+        return Err(publication_error(format!(
+            "workspace '{workspace_id}' already has a publication binding; use rebind to replace it"
+        )));
+    }
+    let binding = build_binding(
+        registry,
+        &workspace_id,
+        publication_remote,
+        publication_branch,
+        publication_id,
+    )?;
+    registry.publication_bindings.push(binding.clone());
+    Ok(binding)
+}
+
+/// Replace an existing publication binding. Last-success state is cleared
+/// because the lineage or remote is changing.
+pub fn rebind_publication(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    publication_remote: &str,
+    publication_branch: &str,
+    publication_id: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let index = registry
+        .publication_bindings
+        .iter()
+        .position(|binding| binding.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            publication_error(format!(
+                "workspace '{workspace_id}' has no publication binding"
+            ))
+        })?;
+    let binding = build_binding(
+        registry,
+        &workspace_id,
+        publication_remote,
+        publication_branch,
+        publication_id,
+    )?;
+    registry.publication_bindings[index] = binding.clone();
+    Ok(binding)
+}
+
+/// Remove the publication binding for a workspace.
+pub fn unbind_publication(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let index = registry
+        .publication_bindings
+        .iter()
+        .position(|binding| binding.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            publication_error(format!(
+                "workspace '{workspace_id}' has no publication binding"
+            ))
+        })?;
+    Ok(registry.publication_bindings.remove(index))
+}
+
+/// Record a successful publication generation and commit without rebinding.
+pub fn record_publication_success(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    generation: u64,
+    commit: &str,
+    local_machine_id: Option<&str>,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace_id = bindable_workspace(registry, id_or_name, local_machine_id)?.id;
+    let binding = registry
+        .publication_bindings
+        .iter_mut()
+        .find(|binding| binding.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            publication_error(format!(
+                "workspace '{workspace_id}' has no publication binding"
+            ))
+        })?;
+    if let Some(previous) = binding.last_success_generation {
+        if generation < previous {
+            return Err(publication_error(format!(
+                "workspace '{workspace_id}' publication generation {generation} is behind last success {previous}"
+            )));
+        }
+        if generation == previous {
+            if binding.last_success_commit.as_deref() == Some(commit) {
+                return Ok(binding.clone());
+            }
+            return Err(publication_error(format!(
+                "workspace '{workspace_id}' publication generation {generation} already recorded a different commit"
+            )));
+        }
+    }
+    let next = WorkspacePublicationBinding {
+        workspace_id: binding.workspace_id.clone(),
+        source_repository_fingerprint: binding.source_repository_fingerprint.clone(),
+        publication_remote: binding.publication_remote.clone(),
+        publication_branch: binding.publication_branch.clone(),
+        publication_id: binding.publication_id.clone(),
+        authority_machine_id: binding.authority_machine_id.clone(),
+        last_success_generation: Some(generation),
+        last_success_commit: Some(commit.to_ascii_lowercase()),
+    }
+    .validated()
+    .map_err(workspace_error)?;
+    *binding = next.clone();
+    Ok(next)
+}
+
+pub(crate) fn validate_publication_bindings(
+    registry: &WorkspaceRegistry,
+    context: &WorkspaceRegistryHostContext,
+) -> Result<(), OrbitError> {
+    let mut seen_workspace_ids = HashSet::new();
+    let mut seen_publication_ids = HashSet::new();
+    for binding in &registry.publication_bindings {
+        binding.validate().map_err(|error| {
+            invalid_registry(format!(
+                "publication binding for workspace '{}': {error}",
+                binding.workspace_id
+            ))
+        })?;
+        if !seen_workspace_ids.insert(binding.workspace_id.clone()) {
+            return Err(invalid_registry(format!(
+                "workspace '{}' has more than one publication binding",
+                binding.workspace_id
+            )));
+        }
+        if !seen_publication_ids.insert(binding.publication_id.clone()) {
+            return Err(invalid_registry(format!(
+                "publication id '{}' is bound to more than one workspace",
+                binding.publication_id
+            )));
+        }
+        let workspace = registry
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == binding.workspace_id)
+            .ok_or_else(|| {
+                invalid_registry(format!(
+                    "publication binding references unknown workspace '{}'",
+                    binding.workspace_id
+                ))
+            })?;
+        publisher_allowed(registry, workspace, context.machine_id.as_deref()).map_err(
+            |reason| {
+                invalid_registry(format!(
+                    "publication binding for workspace '{}': {reason}",
+                    binding.workspace_id
+                ))
+            },
+        )?;
+        match workspace.git_remote.as_deref() {
+            Some(git_remote) if git_remote == binding.source_repository_fingerprint => {}
+            Some(_) => {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' publication fingerprint does not match the registered source remote",
+                    binding.workspace_id
+                )));
+            }
+            None => {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' publication binding has no registered source remote",
+                    binding.workspace_id
+                )));
+            }
+        }
+        match workspace.owner_machine_id.as_deref() {
+            Some(owner) if owner == binding.authority_machine_id => {}
+            Some(owner) => {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' publication authority '{}' does not match declared owner '{owner}'",
+                    binding.workspace_id, binding.authority_machine_id
+                )));
+            }
+            None => {
+                return Err(invalid_registry(format!(
+                    "workspace '{}' publication binding has no declared owner",
+                    binding.workspace_id
+                )));
+            }
+        }
+        if let Some(local_machine_id) = context.machine_id.as_deref()
+            && local_machine_id != binding.authority_machine_id
+        {
+            return Err(invalid_registry(format!(
+                "workspace '{}' publication binding belongs to owner '{}', not local machine '{local_machine_id}'",
+                binding.workspace_id, binding.authority_machine_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+struct BindableWorkspace {
+    id: String,
+}
+
+fn bindable_workspace(
+    registry: &WorkspaceRegistry,
+    id_or_name: &str,
+    local_machine_id: Option<&str>,
+) -> Result<BindableWorkspace, OrbitError> {
+    if let Some(machine_id) = local_machine_id {
+        validate_machine_id(machine_id)?;
+    }
+    let workspace = find_workspace(registry, id_or_name)
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    publisher_allowed(registry, workspace, local_machine_id).map_err(publication_error)?;
+    Ok(BindableWorkspace {
+        id: workspace.id.clone(),
+    })
+}
+
+fn publisher_allowed(
+    registry: &WorkspaceRegistry,
+    workspace: &Workspace,
+    local_machine_id: Option<&str>,
+) -> Result<(), String> {
+    if let Some(checkout) = find_checkout(registry, &workspace.id) {
+        if checkout.role == Some(WorkspaceCheckoutRole::Replica) {
+            return Err(format!(
+                "workspace '{}' is a replica checkout; only the declared owner can manage a publication binding",
+                workspace.id
+            ));
+        }
+    } else {
+        return Err(format!(
+            "workspace '{}' has no local checkout; publication bindings are owner-local",
+            workspace.id
+        ));
+    }
+    let Some(owner) = workspace.owner_machine_id.as_deref() else {
+        return Err(format!(
+            "workspace '{}' has no declared owner; cannot bind a publication repository",
+            workspace.id
+        ));
+    };
+    if let Some(local_machine_id) = local_machine_id
+        && local_machine_id != owner
+    {
+        return Err(format!(
+            "workspace '{}' publication binding requires the declared owner machine '{owner}'",
+            workspace.id
+        ));
+    }
+    Ok(())
+}
+
+fn build_binding(
+    registry: &WorkspaceRegistry,
+    workspace_id: &str,
+    publication_remote: &str,
+    publication_branch: &str,
+    publication_id: &str,
+) -> Result<WorkspacePublicationBinding, OrbitError> {
+    let workspace = find_workspace(registry, workspace_id)
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.to_string()))?;
+    let Some(fingerprint) = workspace.git_remote.as_deref() else {
+        return Err(publication_error(format!(
+            "workspace '{workspace_id}' has no registered source-repository identity"
+        )));
+    };
+    let Some(authority) = workspace.owner_machine_id.as_deref() else {
+        return Err(publication_error(format!(
+            "workspace '{workspace_id}' has no declared owner; cannot bind a publication repository"
+        )));
+    };
+    if let Some(existing) = registry.publication_bindings.iter().find(|binding| {
+        binding.publication_id == publication_id && binding.workspace_id != workspace_id
+    }) {
+        return Err(publication_error(format!(
+            "publication id '{publication_id}' is already bound to workspace '{}'",
+            existing.workspace_id
+        )));
+    }
+    let branch = canonicalize_publication_branch(publication_branch).map_err(workspace_error)?;
+    validate_publication_remote(publication_remote).map_err(workspace_error)?;
+    if git_remotes_equivalent(publication_remote, fingerprint).unwrap_or(false) {
+        return Err(publication_error(format!(
+            "publication remote '{}' is equivalent to the workspace source remote",
+            redact_git_remote(publication_remote)
+        )));
+    }
+    WorkspacePublicationBinding {
+        workspace_id: workspace_id.to_string(),
+        source_repository_fingerprint: fingerprint.to_string(),
+        publication_remote: publication_remote.to_string(),
+        publication_branch: branch,
+        publication_id: publication_id.to_string(),
+        authority_machine_id: authority.to_string(),
+        last_success_generation: None,
+        last_success_commit: None,
+    }
+    .validated()
+    .map_err(workspace_error)
+}
+
+fn workspace_error(error: WorkspaceError) -> OrbitError {
+    publication_error(error.to_string())
+}
+
+fn publication_error(message: String) -> OrbitError {
+    OrbitError::WorkspaceError(message)
+}
+
+fn invalid_registry(message: String) -> OrbitError {
+    OrbitError::WorkspaceError(format!("invalid registry: {message}"))
+}

--- a/crates/orbit-types/src/workspace/mod.rs
+++ b/crates/orbit-types/src/workspace/mod.rs
@@ -1,12 +1,19 @@
 //! Domain contracts for this Orbit types module.
 
 mod error;
+mod publication;
 mod registry;
 pub use error::WorkspaceError;
 
 #[cfg(test)]
 mod tests;
 
+pub use publication::{
+    DEFAULT_PUBLICATION_BRANCH, WorkspacePublicationBinding, canonicalize_publication_branch,
+    git_remote_identity, git_remotes_equivalent, redact_git_remote, validate_git_commit_id,
+    validate_last_success, validate_publication_branch, validate_publication_id,
+    validate_publication_remote, validate_source_repository_fingerprint,
+};
 pub use registry::{
     WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
     WorkspacePaths, WorkspaceRegistry, WorkspaceStatus,

--- a/crates/orbit-types/src/workspace/publication.rs
+++ b/crates/orbit-types/src/workspace/publication.rs
@@ -1,0 +1,382 @@
+//! Machine-local task-publication repository binding contract.
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::identity::{validate_machine_id, validate_registry_identifier};
+use crate::workspace::WorkspaceError;
+
+/// Default ordinary branch for a dedicated publication repository.
+pub const DEFAULT_PUBLICATION_BRANCH: &str = "refs/heads/main";
+
+/// Owner-local binding between one workspace and its dedicated publication
+/// repository.
+///
+/// This record lives in machine-local workspace-registry state. It must not
+/// appear in a task bundle or source-controlled `.orbit/config.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkspacePublicationBinding {
+    pub workspace_id: String,
+    /// Registered portable source-repository identity, copied from the logical
+    /// workspace `git_remote`. Never inferred from a checkout path.
+    pub source_repository_fingerprint: String,
+    pub publication_remote: String,
+    pub publication_branch: String,
+    /// Opaque lineage id. Unique among publication bindings on this machine.
+    pub publication_id: String,
+    pub authority_machine_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_success_commit: Option<String>,
+}
+
+impl WorkspacePublicationBinding {
+    /// Validate field-level publication-binding rules.
+    pub fn validated(self) -> Result<Self, WorkspaceError> {
+        self.validate()?;
+        Ok(self)
+    }
+
+    pub fn validate(&self) -> Result<(), WorkspaceError> {
+        validate_registry_identifier("workspace_id", &self.workspace_id)
+            .map_err(workspace_identity_error)?;
+        validate_source_repository_fingerprint(&self.source_repository_fingerprint)?;
+        validate_publication_remote(&self.publication_remote)?;
+        validate_publication_branch(&self.publication_branch)?;
+        validate_publication_id(&self.publication_id)?;
+        validate_machine_id(&self.authority_machine_id).map_err(workspace_identity_error)?;
+        validate_last_success(
+            self.last_success_generation,
+            self.last_success_commit.as_deref(),
+        )?;
+        if git_remotes_equivalent(
+            &self.publication_remote,
+            &self.source_repository_fingerprint,
+        )? {
+            return Err(WorkspaceError::Invalid(format!(
+                "publication remote '{}' is equivalent to the workspace source remote",
+                redact_git_remote(&self.publication_remote)
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Canonical `refs/heads/<name>` form, defaulting empty input to
+/// [`DEFAULT_PUBLICATION_BRANCH`].
+pub fn canonicalize_publication_branch(branch: &str) -> Result<String, WorkspaceError> {
+    let trimmed = branch.trim();
+    let candidate = if trimmed.is_empty() {
+        DEFAULT_PUBLICATION_BRANCH.to_string()
+    } else if let Some(name) = trimmed.strip_prefix("refs/heads/") {
+        format!("refs/heads/{name}")
+    } else if trimmed.starts_with("refs/") {
+        return Err(WorkspaceError::Invalid(format!(
+            "publication branch '{trimmed}' is not an ordinary refs/heads/* branch"
+        )));
+    } else {
+        format!("refs/heads/{trimmed}")
+    };
+    validate_publication_branch(&candidate)?;
+    Ok(candidate)
+}
+
+pub fn validate_publication_branch(branch: &str) -> Result<(), WorkspaceError> {
+    let Some(name) = branch.strip_prefix("refs/heads/") else {
+        return Err(WorkspaceError::Invalid(format!(
+            "publication branch '{branch}' is not an ordinary refs/heads/* branch"
+        )));
+    };
+    if name.is_empty() {
+        return Err(WorkspaceError::Invalid(
+            "publication branch must name a refs/heads/* ref".to_string(),
+        ));
+    }
+    if !is_valid_git_ref_name(name) {
+        return Err(WorkspaceError::Invalid(format!(
+            "publication branch '{branch}' is not a valid ordinary Git branch ref"
+        )));
+    }
+    Ok(())
+}
+
+pub fn validate_publication_id(publication_id: &str) -> Result<(), WorkspaceError> {
+    validate_registry_identifier("publication_id", publication_id).map_err(workspace_identity_error)
+}
+
+pub fn validate_source_repository_fingerprint(fingerprint: &str) -> Result<(), WorkspaceError> {
+    if fingerprint.trim() != fingerprint || fingerprint.is_empty() {
+        return Err(WorkspaceError::Invalid(
+            "source_repository_fingerprint must be the registered portable Git remote".to_string(),
+        ));
+    }
+    if looks_like_local_path(fingerprint) {
+        return Err(WorkspaceError::Invalid(
+            "source_repository_fingerprint must be a portable Git remote, not a local checkout path"
+                .to_string(),
+        ));
+    }
+    if remote_has_credentials(fingerprint) {
+        return Err(WorkspaceError::Invalid(format!(
+            "source_repository_fingerprint '{}' must not contain credentials",
+            redact_git_remote(fingerprint)
+        )));
+    }
+    git_remote_identity(fingerprint).map(|_| ())
+}
+
+pub fn validate_publication_remote(remote: &str) -> Result<(), WorkspaceError> {
+    if remote.trim() != remote || remote.is_empty() {
+        return Err(WorkspaceError::Invalid(
+            "publication remote must be a non-empty Git URL".to_string(),
+        ));
+    }
+    if looks_like_local_path(remote) {
+        return Err(WorkspaceError::Invalid(
+            "publication remote must be a Git URL, not a local checkout path".to_string(),
+        ));
+    }
+    if looks_like_remote_alias(remote) {
+        return Err(WorkspaceError::Invalid(
+            "publication remote must be a Git URL, not a checkout-local alias".to_string(),
+        ));
+    }
+    if remote_has_credentials(remote) {
+        return Err(WorkspaceError::Invalid(format!(
+            "publication remote '{}' must not contain credentials",
+            redact_git_remote(remote)
+        )));
+    }
+    git_remote_identity(remote).map(|_| ())
+}
+
+pub fn validate_git_commit_id(commit: &str) -> Result<(), WorkspaceError> {
+    let valid_len = commit.len() == 40 || commit.len() == 64;
+    if valid_len && commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+    Err(WorkspaceError::Invalid(
+        "publication commit must be a 40- or 64-character Git object id".to_string(),
+    ))
+}
+
+pub fn validate_last_success(
+    generation: Option<u64>,
+    commit: Option<&str>,
+) -> Result<(), WorkspaceError> {
+    match (generation, commit) {
+        (None, None) => Ok(()),
+        (Some(generation), Some(commit)) => {
+            if generation == 0 {
+                return Err(WorkspaceError::Invalid(
+                    "publication last-success generation must be at least 1".to_string(),
+                ));
+            }
+            validate_git_commit_id(commit)
+        }
+        _ => Err(WorkspaceError::Invalid(
+            "publication last-success generation and commit must be recorded together".to_string(),
+        )),
+    }
+}
+
+/// Host/path identity used to compare Git remotes without credentials or `.git`.
+pub fn git_remote_identity(remote: &str) -> Result<String, WorkspaceError> {
+    let parsed = parse_git_remote(remote)?;
+    Ok(parsed.identity)
+}
+
+pub fn git_remotes_equivalent(left: &str, right: &str) -> Result<bool, WorkspaceError> {
+    Ok(git_remote_identity(left)? == git_remote_identity(right)?)
+}
+
+/// Replace credential userinfo with `***`. Local paths become `<local-path>`.
+pub fn redact_git_remote(remote: &str) -> String {
+    if looks_like_local_path(remote) {
+        return "<local-path>".to_string();
+    }
+    if let Some(redacted) = redact_url_userinfo(remote) {
+        return redacted;
+    }
+    redact_scp_userinfo(remote).unwrap_or_else(|| remote.to_string())
+}
+
+struct ParsedGitRemote {
+    identity: String,
+    has_credentials: bool,
+}
+
+fn parse_git_remote(remote: &str) -> Result<ParsedGitRemote, WorkspaceError> {
+    if remote.contains("://") {
+        return parse_url_remote(remote);
+    }
+    parse_scp_remote(remote)
+}
+
+fn parse_url_remote(remote: &str) -> Result<ParsedGitRemote, WorkspaceError> {
+    let url = Url::parse(remote).map_err(|_| invalid_git_url(remote))?;
+    match url.scheme() {
+        "http" | "https" | "ssh" | "git" => {}
+        "file" => {
+            return Err(WorkspaceError::Invalid(
+                "publication remote must be a Git URL, not a local checkout path".to_string(),
+            ));
+        }
+        other => {
+            return Err(WorkspaceError::Invalid(format!(
+                "Git remote '{}' uses unsupported scheme '{other}'",
+                redact_git_remote(remote)
+            )));
+        }
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| invalid_git_url(remote))?
+        .to_ascii_lowercase();
+    let path = normalize_remote_path(url.path());
+    if path.is_empty() {
+        return Err(invalid_git_url(remote));
+    }
+    let identity = match url.port() {
+        Some(port) if !is_default_port(url.scheme(), port) => {
+            format!("{host}:{port}/{path}")
+        }
+        _ => format!("{host}/{path}"),
+    };
+    let has_credentials = url.password().is_some()
+        || (!url.username().is_empty() && matches!(url.scheme(), "http" | "https"));
+    Ok(ParsedGitRemote {
+        identity,
+        has_credentials,
+    })
+}
+
+fn parse_scp_remote(remote: &str) -> Result<ParsedGitRemote, WorkspaceError> {
+    let Some((user_host, path)) = remote.split_once(':') else {
+        return Err(invalid_git_url(remote));
+    };
+    if user_host.contains('/') || path.is_empty() || path.starts_with('/') {
+        return Err(invalid_git_url(remote));
+    }
+    let (username, host) = match user_host.split_once('@') {
+        Some((username, host)) => (username, host),
+        None => ("", user_host),
+    };
+    if host.is_empty() || host.contains('@') {
+        return Err(invalid_git_url(remote));
+    }
+    let has_credentials = username.contains(':');
+    let identity = format!(
+        "{}/{}",
+        host.to_ascii_lowercase(),
+        normalize_remote_path(path)
+    );
+    if identity.ends_with('/') {
+        return Err(invalid_git_url(remote));
+    }
+    Ok(ParsedGitRemote {
+        identity,
+        has_credentials,
+    })
+}
+
+fn normalize_remote_path(path: &str) -> String {
+    let trimmed = path.trim_matches('/');
+    let without_git = trimmed
+        .strip_suffix(".git")
+        .or_else(|| trimmed.strip_suffix(".GIT"))
+        .unwrap_or(trimmed);
+    without_git.trim_matches('/').to_ascii_lowercase()
+}
+
+fn is_default_port(scheme: &str, port: u16) -> bool {
+    matches!(
+        (scheme, port),
+        ("http", 80) | ("https", 443) | ("ssh", 22) | ("git", 9418)
+    )
+}
+
+fn remote_has_credentials(remote: &str) -> bool {
+    parse_git_remote(remote)
+        .map(|parsed| parsed.has_credentials)
+        .unwrap_or(false)
+}
+
+fn looks_like_local_path(remote: &str) -> bool {
+    let trimmed = remote.trim();
+    trimmed.starts_with("file:")
+        || trimmed.starts_with('/')
+        || trimmed.starts_with('.')
+        || trimmed.starts_with('~')
+        || (trimmed.len() >= 3
+            && trimmed.as_bytes()[1] == b':'
+            && trimmed.as_bytes()[0].is_ascii_alphabetic()
+            && (trimmed.as_bytes()[2] == b'\\' || trimmed.as_bytes()[2] == b'/'))
+}
+
+fn looks_like_remote_alias(remote: &str) -> bool {
+    !remote.contains("://")
+        && !remote.contains('@')
+        && !remote.contains(':')
+        && !remote.contains('/')
+}
+
+fn is_valid_git_ref_name(name: &str) -> bool {
+    if name.is_empty()
+        || name.starts_with('/')
+        || name.ends_with('/')
+        || name.ends_with('.')
+        || name.contains("//")
+        || name.contains("..")
+        || name.contains("@{")
+        || name.ends_with(".lock")
+    {
+        return false;
+    }
+    name.split('/').all(is_valid_git_ref_component)
+}
+
+fn is_valid_git_ref_component(component: &str) -> bool {
+    if component.is_empty() || component.starts_with('.') || component.ends_with(".lock") {
+        return false;
+    }
+    component.chars().all(|ch| {
+        !ch.is_ascii_control()
+            && !matches!(
+                ch,
+                ' ' | '~' | '^' | ':' | '?' | '*' | '[' | '\\' | '\t' | '\n'
+            )
+    })
+}
+
+fn redact_url_userinfo(remote: &str) -> Option<String> {
+    let mut url = Url::parse(remote).ok()?;
+    if url.password().is_none() && url.username().is_empty() {
+        return None;
+    }
+    let _ = url.set_username("***");
+    let _ = url.set_password(None);
+    Some(url.to_string())
+}
+
+fn redact_scp_userinfo(remote: &str) -> Option<String> {
+    let (user_host, path) = remote.split_once(':')?;
+    let (username, host) = user_host.split_once('@')?;
+    if !username.contains(':') && username != "***" {
+        return None;
+    }
+    Some(format!("***@{host}:{path}"))
+}
+
+fn invalid_git_url(remote: &str) -> WorkspaceError {
+    WorkspaceError::Invalid(format!(
+        "Git remote '{}' is not a valid Git URL",
+        redact_git_remote(remote)
+    ))
+}
+
+fn workspace_identity_error(error: crate::identity::IdentityError) -> WorkspaceError {
+    WorkspaceError::Invalid(error.to_string())
+}

--- a/crates/orbit-types/src/workspace/registry.rs
+++ b/crates/orbit-types/src/workspace/registry.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use super::publication::WorkspacePublicationBinding;
+
 /// Current on-disk schema version for `~/.orbit/workspaces.json`.
 pub const WORKSPACE_REGISTRY_SCHEMA_VERSION: u32 = 1;
 
@@ -142,6 +144,10 @@ pub struct WorkspaceRegistry {
     pub workspaces: Vec<Workspace>,
     #[serde(default)]
     pub checkouts: Vec<WorkspaceCheckout>,
+    /// Owner-local bindings to dedicated task-publication repositories.
+    /// Absent from registries that have never bound a publication remote.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub publication_bindings: Vec<WorkspacePublicationBinding>,
 }
 
 impl Default for WorkspaceRegistry {
@@ -151,6 +157,7 @@ impl Default for WorkspaceRegistry {
             owner_host_ids: BTreeMap::new(),
             workspaces: Vec::new(),
             checkouts: Vec::new(),
+            publication_bindings: Vec::new(),
         }
     }
 }

--- a/crates/orbit-types/src/workspace/tests/mod.rs
+++ b/crates/orbit-types/src/workspace/tests/mod.rs
@@ -1,1 +1,2 @@
+mod publication;
 mod workspace;

--- a/crates/orbit-types/src/workspace/tests/publication.rs
+++ b/crates/orbit-types/src/workspace/tests/publication.rs
@@ -1,0 +1,174 @@
+use crate::workspace::{
+    DEFAULT_PUBLICATION_BRANCH, WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace,
+    WorkspacePublicationBinding, WorkspaceRegistry, canonicalize_publication_branch,
+    git_remote_identity, git_remotes_equivalent, redact_git_remote, validate_publication_branch,
+    validate_publication_id, validate_publication_remote,
+};
+use chrono::{TimeZone, Utc};
+
+fn binding() -> WorkspacePublicationBinding {
+    WorkspacePublicationBinding {
+        workspace_id: "ws_orbit".to_string(),
+        source_repository_fingerprint: "git@github.com:example/source.git".to_string(),
+        publication_remote: "git@github.com:example/tasks.git".to_string(),
+        publication_branch: DEFAULT_PUBLICATION_BRANCH.to_string(),
+        publication_id: "tp_orbit_tasks".to_string(),
+        authority_machine_id: "hm_owner".to_string(),
+        last_success_generation: Some(42),
+        last_success_commit: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+    }
+    .validated()
+    .expect("valid binding")
+}
+
+#[test]
+fn publication_binding_round_trips_all_lineage_fields() {
+    let now = Utc
+        .with_ymd_and_hms(2026, 8, 29, 1, 2, 3)
+        .single()
+        .expect("fixed timestamp");
+    let registry = WorkspaceRegistry {
+        workspaces: vec![Workspace {
+            id: "ws_orbit".to_string(),
+            name: "orbit".to_string(),
+            owner_machine_id: Some("hm_owner".to_string()),
+            git_remote: Some("git@github.com:example/source.git".to_string()),
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: crate::workspace::WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        }],
+        publication_bindings: vec![binding()],
+        ..WorkspaceRegistry::default()
+    };
+
+    let value = serde_json::to_value(&registry).expect("serialize");
+    assert_eq!(value["schema_version"], WORKSPACE_REGISTRY_SCHEMA_VERSION);
+    let encoded = &value["publication_bindings"][0];
+    assert_eq!(encoded["workspace_id"], "ws_orbit");
+    assert_eq!(
+        encoded["source_repository_fingerprint"],
+        "git@github.com:example/source.git"
+    );
+    assert_eq!(
+        encoded["publication_remote"],
+        "git@github.com:example/tasks.git"
+    );
+    assert_eq!(encoded["publication_branch"], "refs/heads/main");
+    assert_eq!(encoded["publication_id"], "tp_orbit_tasks");
+    assert_eq!(encoded["authority_machine_id"], "hm_owner");
+    assert_eq!(encoded["last_success_generation"], 42);
+    assert_eq!(
+        encoded["last_success_commit"],
+        "0123456789abcdef0123456789abcdef01234567"
+    );
+
+    let decoded: WorkspaceRegistry = serde_json::from_value(value).expect("deserialize");
+    assert_eq!(decoded.publication_bindings, registry.publication_bindings);
+}
+
+#[test]
+fn registry_without_publication_bindings_omits_the_field() {
+    let registry = WorkspaceRegistry::default();
+    let value = serde_json::to_value(&registry).expect("serialize");
+    assert!(value.get("publication_bindings").is_none());
+
+    let decoded: WorkspaceRegistry = serde_json::from_value(serde_json::json!({
+        "schema_version": WORKSPACE_REGISTRY_SCHEMA_VERSION,
+        "workspaces": [],
+        "checkouts": []
+    }))
+    .expect("legacy document without publication_bindings");
+    assert!(decoded.publication_bindings.is_empty());
+}
+
+#[test]
+fn git_remote_identity_treats_ssh_and_https_forms_as_equal() {
+    let identity = git_remote_identity("git@github.com:Org/Repo.git").expect("scp");
+    assert_eq!(identity, "github.com/org/repo");
+    assert!(
+        git_remotes_equivalent(
+            "git@github.com:Org/Repo.git",
+            "https://github.com/Org/Repo.git"
+        )
+        .expect("compare")
+    );
+    assert!(
+        git_remotes_equivalent(
+            "ssh://git@github.com/Org/Repo",
+            "https://github.com/Org/Repo/"
+        )
+        .expect("compare")
+    );
+}
+
+#[test]
+fn publication_remote_rejects_credentials_aliases_paths_and_source_equivalents() {
+    let secret = "https://x-access-token:ghp_s3cret@github.com/example/tasks.git";
+    let error = validate_publication_remote(secret)
+        .expect_err("credential URL")
+        .to_string();
+    assert!(error.contains("must not contain credentials"), "{error}");
+    assert!(!error.contains("ghp_s3cret"), "{error}");
+    assert_eq!(
+        redact_git_remote(secret),
+        "https://***@github.com/example/tasks.git"
+    );
+
+    assert!(
+        validate_publication_remote("/repos/orbit")
+            .expect_err("path")
+            .to_string()
+            .contains("local checkout path")
+    );
+    assert!(
+        validate_publication_remote("origin")
+            .expect_err("alias")
+            .to_string()
+            .contains("checkout-local alias")
+    );
+    assert!(
+        WorkspacePublicationBinding {
+            workspace_id: "ws_orbit".to_string(),
+            source_repository_fingerprint: "git@github.com:example/source.git".to_string(),
+            publication_remote: "https://github.com/example/source.git".to_string(),
+            publication_branch: "refs/heads/main".to_string(),
+            publication_id: "tp_dup".to_string(),
+            authority_machine_id: "hm_owner".to_string(),
+            last_success_generation: None,
+            last_success_commit: None,
+        }
+        .validated()
+        .expect_err("source-equivalent remote")
+        .to_string()
+        .contains("equivalent to the workspace source remote")
+    );
+}
+
+#[test]
+fn publication_branch_and_id_reject_malformed_refs() {
+    assert_eq!(
+        canonicalize_publication_branch("main").expect("short name"),
+        "refs/heads/main"
+    );
+    assert_eq!(
+        canonicalize_publication_branch("").expect("default"),
+        DEFAULT_PUBLICATION_BRANCH
+    );
+    assert!(
+        validate_publication_branch("refs/tags/v1")
+            .expect_err("tag")
+            .to_string()
+            .contains("ordinary refs/heads")
+    );
+    assert!(
+        validate_publication_branch("refs/heads/feature..boom")
+            .expect_err("dot-dot")
+            .to_string()
+            .contains("valid ordinary Git branch")
+    );
+    assert!(validate_publication_id("tp_orbit").is_ok());
+    assert!(validate_publication_id("tp_path/id").is_err());
+    assert!(validate_publication_id("").is_err());
+}

--- a/crates/orbit-types/src/workspace/tests/workspace.rs
+++ b/crates/orbit-types/src/workspace/tests/workspace.rs
@@ -44,4 +44,5 @@ fn registry_serialization_keeps_paths_out_of_logical_workspaces() {
     assert!(value["workspaces"][0].get("orbit_dir").is_none());
     assert_eq!(value["checkouts"][0]["role"], "replica");
     assert_eq!(value["checkouts"][0]["owner_machine_id"], "hm_owner");
+    assert!(value.get("publication_bindings").is_none());
 }


### PR DESCRIPTION
## Task

[ORB-11072](https://orbit-cli.com/tasks/ORB-11072) — Persist owner-local task-publication repository bindings

### Description

## Problem
The merged ORB-11068 design requires one machine-local binding between an owned Orbit workspace and its dedicated private publication repository, but the workspace registry has no publication lineage or remote-binding model.

## Why It Matters
Publication cannot fail closed unless Orbit persists the expected workspace, source-repository identity, publication remote and branch, lineage ID, authority machine, and last-success state independently of task bundles and source-controlled configuration.

## Constraints / Notes
- Implement the binding in machine-local registry state; never write it into a task bundle or .orbit/config.toml.
- V1 permits exactly one publication repository per workspace and one workspace per publication lineage.
- Reuse the registered portable source-repository identity and declared owner identity; do not infer either from cwd or a clone path.
- Reject credential-bearing URLs, source-equivalent remotes, invalid ordinary branch refs, duplicate lineage IDs, and binding mutations from replicas.
- Preserve backward-compatible loading and atomic writes for registries without publication fields.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- Workspace-registry types and persistence round-trip a publication binding containing workspace ID, source-repository fingerprint, publication remote, ordinary branch, opaque publication ID, authority machine ID, and optional last-success generation/commit.
- Existing workspaces.json files without publication bindings load, validate, and save without data loss; schema migration and malformed-input tests are deterministic.
- Binding validation rejects a replica caller, a publication remote equivalent to the source remote, credential-bearing URLs, malformed branch refs, mismatched authority, and reused publication lineage IDs.
- Library operations can create, read, replace only through an explicit rebind path, and remove a binding with atomic persistence; returned diagnostics redact credentials and local checkout paths.
- Focused orbit-types and orbit-registry tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added WorkspacePublicationBinding to machine-local workspace-registry state (optional publication_bindings on schema v1) with workspace ID, registered source-repository fingerprint, publication remote, ordinary refs/heads/* branch, opaque publication ID, authority machine ID, and optional last-success generation/commit.
- Library ops bind_publication / find_publication_binding / rebind_publication / unbind_publication / record_publication_success reuse declared owner identity and Workspace.git_remote; they never infer from cwd. Replace is rebind-only and clears last-success. Persistence uses the existing atomic workspaces.json write.
- Validation rejects replica callers, source-equivalent remotes, credential-bearing URLs, local paths/aliases, malformed branch refs, mismatched authority, and reused lineage IDs. Diagnostics redact userinfo and omit checkout paths. Existing registries without the field load/save without data loss.
Assessment: Focused orbit-types and orbit-registry tests pass; crate clippy -D warnings and make ci-fast pass. Unlisted files were added for the binding module split, sibling tests, and crate-responsibility docs.
Strategic decisions: Did not bump WORKSPACE_REGISTRY_SCHEMA_VERSION; a numbered bump would refuse every current v1 workspaces.json. Optional serde default + skip-if-empty preserves compatibility.
Recommended follow-ups: ORB-11074 can consume these bindings for Git transport; no CLI surface in this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11072-6a938596`
- Behind base: 0
- Ahead of base: 1