### PR TITLE
Prefix sweep-generated tasks by provenance and rename code-review auto-task

### DIFF
--- a/.orbit/auto_tasks/code-review.yaml
+++ b/.orbit/auto_tasks/code-review.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-name: code-review-sweep
+name: code-review
 description: Post-merge code review of changes merged since the last completed sweep
 enabled: true
 schedule:
@@ -15,7 +15,7 @@ template:
     ## Rules and command surfaces
 
     - Use the registered Orbit tool surface. Find the previous sweep with
-      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review-sweep","model":"<agent-family>"}'`
+      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review","model":"<agent-family>"}'`
       and read its cursor with
       `orbit tool run orbit.task.show --input '{"id":"<id>","model":"<agent-family>"}'`.
       Search existing coverage with
@@ -30,7 +30,7 @@ template:
 
     ## Determine the review window
 
-    Find the most recent done task tagged `code-review-sweep` and read the
+    Find the most recent done task tagged `code-review` and read the
     last-reviewed commit recorded in its execution summary. Review the commits from
     that point to the current HEAD of the workspace's integration branch. If no
     prior sweep task exists, record the current HEAD as the baseline and stop — the
@@ -62,7 +62,7 @@ template:
   - A window with no confirmed findings succeeds as a no-op.
   task_type: chore
   tags:
-  - code-review-sweep
+  - code-review
   - no-diff-expected
   priority: medium
   # The portable system lane is seeded per machine and compatibility-aliased

--- a/crates/orbit-core/assets/auto_tasks/code-review.yaml
+++ b/crates/orbit-core/assets/auto_tasks/code-review.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-name: code-review-sweep
+name: code-review
 description: Post-merge code review of changes merged since the last completed sweep
 enabled: false
 schedule:
@@ -15,7 +15,7 @@ template:
     ## Rules and command surfaces
 
     - Use the registered Orbit tool surface. Find the previous sweep with
-      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review-sweep","model":"<agent-family>"}'`
+      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review","model":"<agent-family>"}'`
       and read its cursor with
       `orbit tool run orbit.task.show --input '{"id":"<id>","model":"<agent-family>"}'`.
       Search existing coverage with
@@ -30,7 +30,7 @@ template:
 
     ## Determine the review window
 
-    Find the most recent done task tagged `code-review-sweep` and read the
+    Find the most recent done task tagged `code-review` and read the
     last-reviewed commit recorded in its execution summary. Review the commits from
     that point to the current HEAD of the workspace's integration branch. If no
     prior sweep task exists, record the current HEAD as the baseline and stop — the
@@ -62,7 +62,7 @@ template:
   - A window with no confirmed findings succeeds as a no-op.
   task_type: chore
   tags:
-  - code-review-sweep
+  - code-review
   - no-diff-expected
   priority: medium
   # The portable system lane is seeded per machine and compatibility-aliased

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -99,7 +99,7 @@ not a clean CI result).
   dependencies, secret handling, and configuration with evidence; files a
   durable Orbit task for each non-duplicate finding with severity and impact; a
   clean review is a successful no-op.
-- **`code-review-sweep`** — every six hours. Reviews the commits merged into the
+- **`code-review`** — every six hours. Reviews the commits merged into the
   integration branch since the previous sweep's recorded cursor, verifies each
   candidate finding against the live code, files the non-duplicate ones as tasks
   tagged `code-review`, and records the new last-reviewed commit in its execution
@@ -126,6 +126,14 @@ not a clean CI result).
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.
+
+Finding tasks tagged `qa-sweep`, `security-review`, `code-review`, or
+`friction-curation` receive the matching bracketed title prefix at the shared
+task-creation boundary. If more than one of those tags is present, the fixed
+precedence is `qa-sweep`, `security-review`, `code-review`, then
+`friction-curation`, regardless of tag order. Existing matching prefixes are
+not duplicated. Scheduler-minted parent tasks continue to use `[auto-task] `,
+which takes precedence when an `auto-task:<name>` provenance tag is present.
 
 ## Writing the body
 

--- a/crates/orbit-core/src/application/task/add.rs
+++ b/crates/orbit-core/src/application/task/add.rs
@@ -18,6 +18,17 @@ use super::paths::{
     normalize_workspace_path,
 };
 
+const AUTO_TASK_TITLE_PREFIX: &str = "[auto-task] ";
+
+/// Task-finding provenance in canonical precedence order. When several tags
+/// are present, the first mapping wins regardless of caller-provided tag order.
+const TASK_PROVENANCE_TITLE_PREFIXES: &[(&str, &str)] = &[
+    ("qa-sweep", "[qa-sweep] "),
+    ("security-review", "[security-review] "),
+    ("code-review", "[code-review] "),
+    ("friction-curation", "[friction-curation] "),
+];
+
 impl OrbitRuntime {
     pub fn add_task(&self, params: TaskAddParams) -> Result<Task, OrbitError> {
         self.add_task_with_identity(params, None, None)
@@ -41,6 +52,9 @@ impl OrbitRuntime {
             *criterion = redact_all(criterion);
         }
         params.comment = params.comment.map(|comment| redact_all(&comment));
+
+        let normalized_tags = normalize_task_tags(params.tags.clone());
+        params.title = title_with_provenance_prefix(&params.title, &normalized_tags);
 
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
@@ -91,7 +105,7 @@ impl OrbitRuntime {
                 acceptance_criteria: params.acceptance_criteria.clone(),
                 dependencies: dependencies.clone(),
                 relations: params.relations.clone(),
-                tags: normalize_task_tags(params.tags.clone()),
+                tags: normalized_tags.clone(),
                 required_tools: normalize_required_tools(params.required_tools.clone()),
                 plan: params.plan.clone(),
                 execution_summary: String::new(),
@@ -136,6 +150,29 @@ impl OrbitRuntime {
         };
 
         Ok(task)
+    }
+}
+
+/// Apply visible provenance at the shared task-creation boundary used by CLI,
+/// MCP, dashboard, scheduler, and internal callers. Auto-task provenance wins
+/// so scheduler-minted parent tasks keep their established title convention;
+/// finding provenance otherwise follows the fixed table above.
+fn title_with_provenance_prefix(title: &str, tags: &[String]) -> String {
+    let prefix = if tags.iter().any(|tag| tag.starts_with("auto-task:")) {
+        Some(AUTO_TASK_TITLE_PREFIX)
+    } else {
+        TASK_PROVENANCE_TITLE_PREFIXES
+            .iter()
+            .find_map(|(tag, prefix)| {
+                tags.iter()
+                    .any(|candidate| candidate == tag)
+                    .then_some(*prefix)
+            })
+    };
+
+    match prefix {
+        Some(prefix) if !title.starts_with(prefix) => format!("{prefix}{title}"),
+        _ => title.to_string(),
     }
 }
 

--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -218,3 +218,78 @@ fn task_add_redacts_secrets_in_stored_fields() {
         "creation comment should carry a redaction placeholder: {comments:?}"
     );
 }
+
+#[test]
+fn task_add_applies_normalized_provenance_title_prefixes() {
+    for (tag, expected_prefix) in [
+        (" qa-SWEEP ", "[qa-sweep] "),
+        ("security-review", "[security-review] "),
+        ("code-review", "[code-review] "),
+        ("friction-curation", "[friction-curation] "),
+    ] {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Confirmed finding".to_string(),
+                tags: vec![tag.to_string()],
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("task add succeeds");
+
+        assert_eq!(task.title, format!("{expected_prefix}Confirmed finding"));
+    }
+}
+
+#[test]
+fn task_add_does_not_double_the_applicable_provenance_prefix() {
+    let (_root, runtime) = test_runtime();
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "[code-review] Confirmed finding".to_string(),
+            tags: vec!["code-review".to_string()],
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("task add succeeds");
+
+    assert_eq!(task.title, "[code-review] Confirmed finding");
+}
+
+#[test]
+fn task_add_uses_fixed_provenance_precedence_independent_of_tag_order() {
+    for tags in [
+        vec!["friction-curation", "security-review", "qa-sweep"],
+        vec!["qa-sweep", "friction-curation", "security-review"],
+    ] {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: "Confirmed finding".to_string(),
+                tags: tags.into_iter().map(str::to_string).collect(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("task add succeeds");
+
+        assert_eq!(task.title, "[qa-sweep] Confirmed finding");
+    }
+}
+
+#[test]
+fn task_add_preserves_auto_task_title_prefix_behavior() {
+    for title in ["Scheduled work", "[auto-task] Scheduled work"] {
+        let (_root, runtime) = test_runtime();
+        let task = runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                tags: vec!["auto-task:qa-sweep".to_string(), "qa-sweep".to_string()],
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("task add succeeds");
+
+        assert_eq!(task.title, "[auto-task] Scheduled work");
+    }
+}

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -55,8 +55,8 @@ pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/auto_tasks/ci-failure-remediation.yaml"),
     ),
     (
-        "code-review-sweep",
-        include_str!("../../assets/auto_tasks/code-review-sweep.yaml"),
+        "code-review",
+        include_str!("../../assets/auto_tasks/code-review.yaml"),
     ),
     (
         "friction-curation",

--- a/crates/orbit-core/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/scheduler.rs
@@ -28,9 +28,6 @@ use super::loader::{AutoTaskLoadError, collect_auto_tasks};
 use super::schedule::{AutoTaskDueDecision, decide_due};
 use super::state::{AutoTaskCursor, cursor_state_path, load_cursor_state, upsert_cursor};
 
-/// Visible provenance stamped onto every task minted from an auto-task template.
-const AUTO_TASK_TITLE_PREFIX: &str = "[auto-task] ";
-
 /// Per-definition outcome of one scheduler pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AutoTaskFireReport {
@@ -214,7 +211,7 @@ pub(super) fn mint_task(
     tags.push(auto_task_tag(&definition.name));
 
     runtime.add_task(TaskAddParams {
-        title: minted_title(&template.title),
+        title: template.title.clone(),
         description: template.description.clone(),
         acceptance_criteria: template.acceptance_criteria.clone(),
         tags,
@@ -229,17 +226,6 @@ pub(super) fn mint_task(
         system_created: true,
         ..TaskAddParams::default()
     })
-}
-
-/// Stamp the human-visible auto-task provenance without changing templates that
-/// already carry it. Keeping this beside the template-to-task mapping makes
-/// every mint entry point follow the same convention.
-fn minted_title(template_title: &str) -> String {
-    if template_title.starts_with(AUTO_TASK_TITLE_PREFIX) {
-        template_title.to_string()
-    } else {
-        format!("{AUTO_TASK_TITLE_PREFIX}{template_title}")
-    }
 }
 
 /// Run one scheduler pass now and project it to the deterministic-action JSON

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -24,7 +24,7 @@ fn shipped_defaults_all_parse_and_are_disabled() {
         .collect();
     for required in [
         "ci-failure-remediation",
-        "code-review-sweep",
+        "code-review",
         "friction-curation",
         "qa-sweep",
         "security-review",
@@ -317,21 +317,21 @@ fn qa_sweep_default_preserves_hands_on_validation_contract() {
 /// than in scheduler state, so the template must keep saying so, and it must
 /// stay generic across workspaces.
 #[test]
-fn code_review_sweep_default_is_portable_cursor_driven_and_inert() {
+fn code_review_default_is_portable_cursor_driven_and_inert() {
     let (_, yaml) = DEFAULT_AUTO_TASK_FILES
         .iter()
-        .find(|(name, _)| *name == "code-review-sweep")
-        .expect("code-review-sweep default");
-    let definition = parse_auto_task_yaml(yaml).expect("parse code-review-sweep");
+        .find(|(name, _)| *name == "code-review")
+        .expect("code-review default");
+    let definition = parse_auto_task_yaml(yaml).expect("parse code-review");
 
-    assert_eq!(definition.name, "code-review-sweep");
+    assert_eq!(definition.name, "code-review");
     assert!(!definition.enabled, "definition must ship disabled");
     assert_eq!(
         definition.schedule,
         AutoTaskSchedule::Cron {
             cron: "40 */6 * * *".to_string()
         },
-        "code-review-sweep must use a documented six-hourly schedule"
+        "code-review must use a documented six-hourly schedule"
     );
     assert!(matches!(definition.dedupe, DedupePolicy::SkipIfOpen));
     assert_eq!(definition.template.crew.as_deref(), Some("system"));
@@ -343,7 +343,7 @@ fn code_review_sweep_default_is_portable_cursor_driven_and_inert() {
         definition.template.status,
         orbit_types::task::TaskStatus::Backlog
     );
-    for required_tag in ["code-review-sweep", "no-diff-expected"] {
+    for required_tag in ["code-review", "no-diff-expected"] {
         assert!(
             definition
                 .template
@@ -399,7 +399,7 @@ fn code_review_sweep_default_is_portable_cursor_driven_and_inert() {
                     && criterion.contains("last-reviewed commit")
                     && criterion.contains("execution summary")
             }),
-        "code-review-sweep must require recording the window cursor"
+        "code-review must require recording the window cursor"
     );
     assert!(
         definition
@@ -412,7 +412,7 @@ fn code_review_sweep_default_is_portable_cursor_driven_and_inert() {
                     && criterion.contains("non-duplicate")
                     && criterion.contains("file:line")
             }),
-        "code-review-sweep must require verified, evidenced, non-duplicate findings"
+        "code-review must require verified, evidenced, non-duplicate findings"
     );
 }
 

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -1,8 +1,8 @@
 ---
 title: Auto-tasks — Overview
 owner: claude
-last_updated: 2026-08-22
-last_validated: 2026-08-29
+last_updated: 2026-08-30
+last_validated: 2026-08-30
 status: Accepted
 feature: auto-tasks
 doc_role: overview
@@ -11,7 +11,7 @@ summary: Dynamically-defined recurring task templates minted by one generic sche
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ORB-10549, ORB-10950, ORB-11054]
+related_artifacts: [ORB-10149, ORB-10318, ORB-10348, ORB-10439, ORB-10446, ORB-10514, ORB-10549, ORB-10950, ORB-11054, ORB-11095]
 ---
 
 # Auto-tasks — Overview
@@ -96,7 +96,7 @@ definition of the same name.
   applicable application code, dependencies, secret handling, and configuration;
   each actionable finding is filed as a durable Orbit task, and a clean review
   is a successful no-op (ORB-10950).
-- `code-review-sweep` — disabled-by-default six-hourly review of commits merged
+- `code-review` — disabled-by-default six-hourly review of commits merged
   since the previous sweep's recorded cursor.
 - `ci-failure-remediation` — disabled-by-default hourly investigation and
   remediation of current-head GitHub Actions failures across the workspace's
@@ -123,7 +123,7 @@ encode this repository's branches and gates. Re-init preserves them:
   of the same name; managed-asset reconciliation treats the local file as
   authored.
 - `doc-duties`, `model-price-audit`, `release-prep`, and this repository's
-  enabled copies of catalog names such as `code-review-sweep` and
+  enabled copies of catalog names such as `code-review` and
   `security-review`.
 
 ## Task References
@@ -150,5 +150,7 @@ encode this repository's branches and gates. Re-init preserves them:
   so minted CI-remediation tasks can reach them under `agent_implement`
   without changing that activity's baseline. DANI-10056 remains cited as
   failed-validation evidence of the missing-requirements bug.
+- ORB-11095 — Added centralized finding-title provenance and established the
+  shipped definition's canonical `code-review` name.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-08-16
-last_validated: 2026-08-16
+last_updated: 2026-08-30
+last_validated: 2026-08-30
 status: Accepted
 feature: auto-tasks
 doc_role: design
@@ -11,7 +11,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/auto_tasks/**", "crates/orbit-web/src/api/auto_tasks.rs", "crates/orbit-web/assets/dashboard/operations.js"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876, ORB-11095]
 ---
 
 # Auto-tasks — Design
@@ -122,6 +122,13 @@ identical to a fired one: same field mapping, same `[auto-task] ` title
 convention, same `auto-task:<name>` tag, same `system_created` marker, same
 template-supplied status.
 
+Title provenance is enforced by `OrbitRuntime::add_task_with_identity`, the
+shared creation boundary used by CLI, MCP, dashboard, scheduler, and internal
+callers. An `auto-task:<name>` tag maps to `[auto-task] ` and takes precedence
+for scheduler-minted parent tasks. Otherwise finding tags use this fixed,
+input-order-independent precedence: `qa-sweep`, `security-review`,
+`code-review`, then `friction-curation`. The selected prefix is idempotent.
+
 The mint is **unconditional**. It ignores schedule due-math, `dedupe`, and
 `enabled`, and it neither reads nor writes the host-local cursor — an operator
 naming a definition explicitly means it, and a manual mint must not perturb
@@ -218,5 +225,7 @@ accurate.
 - ORB-10441 — mint-time visible title provenance.
 - ORB-10472 — worktree-local, atomic definition refresh.
 - ORB-10583 — workspace-local weekly official model-price audit definition.
+- ORB-11095 — centralized tag-derived title provenance and the canonical
+  `code-review` auto-task name.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -99,7 +99,7 @@ not a clean CI result).
   dependencies, secret handling, and configuration with evidence; files a
   durable Orbit task for each non-duplicate finding with severity and impact; a
   clean review is a successful no-op.
-- **`code-review-sweep`** — every six hours. Reviews the commits merged into the
+- **`code-review`** — every six hours. Reviews the commits merged into the
   integration branch since the previous sweep's recorded cursor, verifies each
   candidate finding against the live code, files the non-duplicate ones as tasks
   tagged `code-review`, and records the new last-reviewed commit in its execution
@@ -126,6 +126,14 @@ not a clean CI result).
 
 Read them before enabling. They are also the best worked examples of how much
 instruction a minted task's body should carry.
+
+Finding tasks tagged `qa-sweep`, `security-review`, `code-review`, or
+`friction-curation` receive the matching bracketed title prefix at the shared
+task-creation boundary. If more than one of those tags is present, the fixed
+precedence is `qa-sweep`, `security-review`, `code-review`, then
+`friction-curation`, regardless of tag order. Existing matching prefixes are
+not duplicated. Scheduler-minted parent tasks continue to use `[auto-task] `,
+which takes precedence when an `auto-task:<name>` provenance tag is present.
 
 ## Writing the body
 


### PR DESCRIPTION
## Task

[ORB-11095](https://orbit-cli.com/tasks/ORB-11095) — Prefix sweep-generated tasks by provenance and rename code-review auto-task

### Description

## Problem

Tasks filed as findings by the shipped `qa-sweep`, `security-review`, `code-review-sweep`, and `friction-curation` auto-tasks are visually indistinguishable from ordinary hand-filed tasks in task lists, the dashboard, and triage. Their provenance is already carried by tags, but those tags are not always visible where titles are scanned.

Also, the shipped auto-task name `code-review-sweep` is unnecessarily inconsistent with the finding tag and desired title prefix. Rename it to `code-review`.

## Desired behavior

At the shared task-creation boundary, inspect normalized task tags and automatically prepend the corresponding provenance prefix:

- `qa-sweep` → `[qa-sweep] `
- `security-review` → `[security-review] `
- `code-review` → `[code-review] `
- `friction-curation` → `[friction-curation] `

This should follow the centralized, idempotent approach already established for `[auto-task]` task titles in ORB-10441 rather than relying on every sweep prompt or caller to format titles correctly.

Rename the shipped `code-review-sweep` auto-task to `code-review`, including its canonical definition name, filename/catalog entry, tags or cursor lookup instructions, tests, and active documentation.

## Constraints / Notes

- Apply prefixes from task tags during creation so every supported creation surface inherits the behavior.
- Prefixing must be idempotent; callers that already supplied the applicable prefix must not produce a duplicate.
- Define deterministic behavior when more than one recognized provenance tag is present; do not depend on caller-provided tag order.
- Preserve the existing `[auto-task]` prefix behavior for scheduler-minted parent tasks.
- Do not retroactively rename or retitle existing tasks; no data migration is required.
- Treat historical references to ORB-10997 as history, but remove stale `code-review-sweep` naming from active shipped assets, behavior, tests, and docs.

### Acceptance Criteria

- Creating a task tagged `qa-sweep`, `security-review`, `code-review`, or `friction-curation` yields exactly the mapped `[qa-sweep] `, `[security-review] `, `[code-review] `, or `[friction-curation] ` title prefix.
- Prefixing is implemented at one shared task-creation seam used by supported CLI, MCP, and internal creation paths, rather than duplicated in sweep prompts or individual callers.
- A title already carrying its applicable provenance prefix is unchanged, and tests prove no double-prefixing.
- Multiple recognized provenance tags have documented, deterministic behavior covered by tests and do not depend on input tag order.
- The shipped auto-task formerly named `code-review-sweep` is canonically named `code-review` across its definition filename/name, embedded default catalog, template tags and cursor instructions, active tests, and active documentation.
- Existing `[auto-task]` title-prefix behavior remains intact and is covered by regression tests alongside all four new tag-to-prefix mappings.
- Existing persisted tasks are not retitled or migrated.
- The relevant focused tests and the repository's standard fast CI/lint validation pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Centralized title provenance in `OrbitRuntime::add_task_with_identity`, after tag normalization, so CLI, MCP, dashboard, scheduler, and internal creation paths share one idempotent rule.
- Added fixed precedence (`qa-sweep` → `security-review` → `code-review` → `friction-curation`) for multiple finding tags, independent of tag input order. `auto-task:<name>` retains highest precedence so scheduler parents keep `[auto-task] `.
- Removed scheduler-local title formatting and added task-creation regression tests for all four mappings, normalized tags, idempotence, deterministic multi-tag behavior, and existing auto-task behavior.
- Renamed the shipped and repository-local definition files, names, catalog registration, template/cursor tags, tests, and active documentation from the former name to canonical `code-review`. Existing task records are untouched; no migration or retitling path was added.
- Expanded task context only for the two new canonical `code-review.yaml` paths created by the scoped file rename.

Validation:
- `cargo test -p orbit-core application::task::tests::add --lib` — 13 passed.
- `cargo test -p orbit-core auto_tasks::tests --lib` — 43 passed.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- Final `rg` found no active `code-review-sweep` references; mirrored setup docs match and `git diff --check` passed.

Assessment: The behavior is enforced at the authoritative creation boundary with a small fixed mapping and no new dependency edge or persisted-data migration. Focused tests cover the creation seam and shipped catalog rename.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11095-6a938741`
- Behind base: 0
- Ahead of base: 1