### PR TITLE
Keep workspace auto draining after leaf child failures

### DIFF
--- a/.orbit/resources/activities/invoke_and_wait.yaml
+++ b/.orbit/resources/activities/invoke_and_wait.yaml
@@ -13,7 +13,7 @@ spec:
     `pipeline_success_guard` after any cleanup that depends on the raw
     child status. The returned `status` mirrors the child Run's terminal state:
     `succeeded`,
-    `failed`, `cancelled`, or `timeout`. A `timeout` here means the
+    `failed`, `cancelled`, `interrupted`, or `timeout`. A `timeout` here means the
     WAIT side of the activity exceeded `timeout_seconds`; the child
     Run itself may still be running — callers that care must inspect
     `run_id` to decide follow-up. Gate workflows may pass
@@ -51,7 +51,7 @@ spec:
     properties:
       status:
         type: string
-        enum: [succeeded, failed, cancelled, timeout, pending, running]
+        enum: [succeeded, failed, cancelled, interrupted, timeout, pending, running]
       run_id:
         type: string
       finished_at:

--- a/.orbit/resources/activities/pipeline_success_guard.yaml
+++ b/.orbit/resources/activities/pipeline_success_guard.yaml
@@ -7,12 +7,16 @@ spec:
   description: >
     Fail the current workflow when one or more child pipeline wait entries did
     not reach `status: succeeded`. Use this after any required cleanup steps
-    that still need access to the raw child status.
+    that still need access to the raw child status. Workspace-level sequencers
+    may opt into `allow_non_success` to validate, retain, and count exact
+    terminal child outcomes without failing solely for a non-success status.
   input_schema_json:
     type: object
     properties:
       context:
         type: string
+      allow_non_success:
+        type: boolean
       result:
         type: object
         properties:
@@ -46,9 +50,18 @@ spec:
     properties:
       succeeded:
         type: boolean
-        const: true
       checked_count:
         type: integer
         minimum: 1
+      succeeded_count:
+        type: integer
+        minimum: 0
+      non_success_count:
+        type: integer
+        minimum: 0
+      results:
+        type: array
+        items:
+          type: object
   action: pipeline_success_guard
   config: {}

--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -71,12 +71,18 @@ spec:
                 mode: all
               collect: leaf_results
 
-          - id: require_leaf_success
+          # A durably linked terminal child is an observed queue item, not a
+          # structural failure of this workspace sequencer. Retain its exact
+          # result and aggregate it, then let the next iteration reclassify
+          # unrelated work. Dispatch/wait errors still fail in ship_leaves,
+          # and malformed entries fail this recording step.
+          - id: record_leaf_outcomes
             when: "{{ steps.admissible.output.has_leaves }} == true"
             target: activity:pipeline_success_guard
             default_input:
               context: workspace auto leaf ship
               results: "{{ steps.leaf_results.output }}"
+              allow_non_success: true
 
           # Detached: the next iteration keeps shipping leaves while the epic
           # assembles its branch. `classify_workspace_auto_tasks` re-observes

--- a/crates/orbit-core/assets/activities/invoke_and_wait.yaml
+++ b/crates/orbit-core/assets/activities/invoke_and_wait.yaml
@@ -22,7 +22,7 @@ spec:
     `pipeline_success_guard` after any cleanup that depends on the raw
     child status. The returned `status` mirrors the child Run's terminal state:
     `succeeded`,
-    `failed`, `cancelled`, or `timeout`. A `timeout` here means the
+    `failed`, `cancelled`, `interrupted`, or `timeout`. A `timeout` here means the
     WAIT side of the activity exceeded `timeout_seconds`; the child
     Run itself may still be running — callers that care must inspect
     `run_id` to decide follow-up. Gate workflows may pass
@@ -60,7 +60,7 @@ spec:
     properties:
       status:
         type: string
-        enum: [succeeded, failed, cancelled, timeout, pending, running]
+        enum: [succeeded, failed, cancelled, interrupted, timeout, pending, running]
       run_id:
         type: string
       finished_at:

--- a/crates/orbit-core/assets/activities/pipeline_success_guard.yaml
+++ b/crates/orbit-core/assets/activities/pipeline_success_guard.yaml
@@ -7,12 +7,16 @@ spec:
   description: >
     Fail the current workflow when one or more child pipeline wait entries did
     not reach `status: succeeded`. Use this after any required cleanup steps
-    that still need access to the raw child status.
+    that still need access to the raw child status. Workspace-level sequencers
+    may opt into `allow_non_success` to validate, retain, and count exact
+    terminal child outcomes without failing solely for a non-success status.
   input_schema_json:
     type: object
     properties:
       context:
         type: string
+      allow_non_success:
+        type: boolean
       result:
         type: object
         properties:
@@ -46,9 +50,18 @@ spec:
     properties:
       succeeded:
         type: boolean
-        const: true
       checked_count:
         type: integer
         minimum: 1
+      succeeded_count:
+        type: integer
+        minimum: 0
+      non_success_count:
+        type: integer
+        minimum: 0
+      results:
+        type: array
+        items:
+          type: object
   action: pipeline_success_guard
   config: {}

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -71,12 +71,18 @@ spec:
                 mode: all
               collect: leaf_results
 
-          - id: require_leaf_success
+          # A durably linked terminal child is an observed queue item, not a
+          # structural failure of this workspace sequencer. Retain its exact
+          # result and aggregate it, then let the next iteration reclassify
+          # unrelated work. Dispatch/wait errors still fail in ship_leaves,
+          # and malformed entries fail this recording step.
+          - id: record_leaf_outcomes
             when: "{{ steps.admissible.output.has_leaves }} == true"
             target: activity:pipeline_success_guard
             default_input:
               context: workspace auto leaf ship
               results: "{{ steps.leaf_results.output }}"
+              allow_non_success: true
 
           # Detached: the next iteration keeps shipping leaves while the epic
           # assembles its branch. `classify_workspace_auto_tasks` re-observes

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -364,10 +364,12 @@ pub(crate) fn run_deterministic(
         CoreDeterministicAction::InvokeDetached => {
             pipeline_actions::invoke_detached(runtime, action, input, tool_context)
         }
-        // Fail a workflow if one or more child pipeline wait results did not
-        // reach `succeeded`.
+        // Fail a workflow if child wait results did not reach `succeeded`, or
+        // apply the explicit workspace-sequencer recording policy.
         CoreDeterministicAction::PipelineSuccessGuard => {
-            pipeline_actions::pipeline_success_guard(action, input)
+            let output = pipeline_actions::pipeline_success_guard(action, input)?;
+            pipeline_actions::record_pipeline_results_audit(runtime, action, input, &output)?;
+            Ok(output)
         }
         // Post-loop gate signal: the admission window never opened in
         // time. Emits a `gate.starvation` audit event with task_ids and

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -562,6 +562,19 @@ fn record_gate_stale_noop(
 }
 
 pub(super) fn pipeline_success_guard(action: &str, input: &Value) -> Result<Value, DispatchError> {
+    let allow_non_success = input
+        .get("allow_non_success")
+        .map(|value| {
+            value.as_bool().ok_or_else(|| {
+                action_failed(action, "`allow_non_success` must be a boolean".to_string())
+            })
+        })
+        .transpose()?
+        .unwrap_or(false);
+    if allow_non_success {
+        return record_pipeline_results(action, input);
+    }
+
     let context = input
         .get("context")
         .and_then(Value::as_str)
@@ -614,6 +627,150 @@ pub(super) fn pipeline_success_guard(action: &str, input: &Value) -> Result<Valu
         "succeeded": true,
         "checked_count": checked_count,
     }))
+}
+
+/// Validate and retain terminal child results without converting a child
+/// failure into a failure of the workspace-level sequencer.
+///
+/// This is deliberately an opt-in policy on the existing guard action. Gate,
+/// epic, and wrapper pipelines keep their fail-fast behavior; only a caller
+/// that explicitly asks to record terminal non-successes receives counts and
+/// the exact entries it supplied. Structural problems remain errors because a
+/// missing run id or non-terminal status is not an observed leaf outcome.
+fn record_pipeline_results(action: &str, input: &Value) -> Result<Value, DispatchError> {
+    let results = input
+        .get("results")
+        .and_then(|value| (!value.is_null()).then_some(value))
+        .ok_or_else(|| action_failed(action, "expected `results` to record".to_string()))?
+        .as_array()
+        .ok_or_else(|| action_failed(action, "`results` must be an array".to_string()))?;
+    if results.is_empty() {
+        return Err(action_failed(
+            action,
+            "expected at least one `results` entry to record".to_string(),
+        ));
+    }
+
+    let mut succeeded_count = 0usize;
+    let mut non_success_count = 0usize;
+    for (idx, entry) in results.iter().enumerate() {
+        let label = format!("results[{idx}]");
+        let run_id = entry
+            .get("run_id")
+            .and_then(Value::as_str)
+            .filter(|run_id| !run_id.trim().is_empty())
+            .ok_or_else(|| {
+                action_failed(action, format!("{label} missing non-empty string run_id"))
+            })?;
+        let status = entry
+            .get("status")
+            .and_then(Value::as_str)
+            .ok_or_else(|| action_failed(action, format!("{label} missing string status")))?;
+        if let Some(error) = entry.get("error")
+            && !error.is_null()
+            && !error.is_string()
+        {
+            return Err(action_failed(
+                action,
+                format!("{label} run {run_id} has non-string error"),
+            ));
+        }
+        match status {
+            "succeeded" => succeeded_count += 1,
+            "failed" | "cancelled" | "interrupted" | "timeout" => non_success_count += 1,
+            other => {
+                return Err(action_failed(
+                    action,
+                    format!("{label} run {run_id} has non-terminal status {other}"),
+                ));
+            }
+        }
+    }
+
+    Ok(serde_json::json!({
+        "succeeded": non_success_count == 0,
+        "checked_count": results.len(),
+        "succeeded_count": succeeded_count,
+        "non_success_count": non_success_count,
+        "results": results,
+    }))
+}
+
+/// Persist each opt-in result-accounting batch independently of the loop's
+/// same-id pipeline key, which is overwritten by the next iteration.
+/// Parent run state still owns child linkage; this audit row owns the batch's
+/// exact result list and aggregate counts for durable history readers.
+pub(super) fn record_pipeline_results_audit(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+    output: &Value,
+) -> Result<(), DispatchError> {
+    if input.get("allow_non_success").and_then(Value::as_bool) != Some(true) {
+        return Ok(());
+    }
+
+    let parent_run_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let payload = serde_json::json!({
+        "parent_run_id": parent_run_id,
+        "parent_step_id": input.get("step_id"),
+        "context": input.get("context"),
+        "checked_count": output.get("checked_count"),
+        "succeeded_count": output.get("succeeded_count"),
+        "non_success_count": output.get("non_success_count"),
+        "results": output.get("results"),
+    });
+    let arguments_json = serde_json::to_string(&payload).map_err(|error| {
+        action_failed(
+            action,
+            format!("serialize pipeline.child_results payload: {error}"),
+        )
+    })?;
+
+    runtime
+        .record_audit_event(&AuditEventInsertParams {
+            execution_id: audit_execution_id("audit-pipeline-child-results"),
+            command: "pipeline.child_results".to_string(),
+            subcommand: None,
+            tool_name: None,
+            target_type: Some("job_run".to_string()),
+            target_id: parent_run_id.clone(),
+            role: "admin".to_string(),
+            status: AuditEventStatus::Success,
+            exit_code: 0,
+            duration_ms: 0,
+            working_directory: runtime.paths().repo_root.to_string_lossy().into_owned(),
+            arguments_json: Some(arguments_json),
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: None,
+            host: std::env::var("HOSTNAME").ok(),
+            pid: std::process::id(),
+            session_id: None,
+            workspace_id: None,
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: Default::default(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            lease_id: None,
+            task_id: None,
+            job_run_id: parent_run_id,
+            activity_id: None,
+            step_index: None,
+        })
+        .map_err(|error| {
+            action_failed(
+                action,
+                format!("record pipeline.child_results audit: {error}"),
+            )
+        })
 }
 
 fn pipeline_wait_entry_failure(label: &str, entry: &Value) -> Option<String> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -78,6 +78,79 @@ fn pipeline_success_guard_rejects_mixed_results() {
 }
 
 #[test]
+fn pipeline_success_guard_records_exact_terminal_results_and_counts() {
+    let results = json!([
+        {
+            "run_id": "jrun-ok",
+            "status": "succeeded"
+        },
+        {
+            "run_id": "jrun-failed",
+            "status": "failed",
+            "error": "implementation failed"
+        },
+        {
+            "run_id": "jrun-cancelled",
+            "status": "cancelled",
+            "error": "operator cancelled"
+        },
+        {
+            "run_id": "jrun-interrupted",
+            "status": "interrupted",
+            "error": "worker disappeared"
+        },
+        {
+            "run_id": "jrun-timeout",
+            "status": "timeout",
+            "error": "wait deadline elapsed"
+        }
+    ]);
+    let output = pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({
+            "results": results,
+            "allow_non_success": true
+        }),
+    )
+    .expect("terminal child outcomes should be recorded");
+
+    assert_eq!(output["succeeded"], false);
+    assert_eq!(output["checked_count"], 5);
+    assert_eq!(output["succeeded_count"], 1);
+    assert_eq!(output["non_success_count"], 4);
+    assert_eq!(output["results"], results);
+}
+
+#[test]
+fn pipeline_success_guard_record_mode_rejects_malformed_or_non_terminal_results() {
+    for (result, expected) in [
+        (
+            json!({"status": "failed", "error": "missing linkage"}),
+            "missing non-empty string run_id",
+        ),
+        (
+            json!({"run_id": "jrun-running", "status": "running"}),
+            "has non-terminal status running",
+        ),
+        (
+            json!({"run_id": "jrun-bad-error", "status": "failed", "error": 42}),
+            "has non-string error",
+        ),
+    ] {
+        let err = pipeline_success_guard(
+            "pipeline_success_guard",
+            &json!({
+                "results": [result],
+                "allow_non_success": true
+            }),
+        )
+        .expect_err("malformed result must fail closed");
+        let message = action_failure_message(err, "pipeline_success_guard");
+        assert!(message.contains(expected), "{message}");
+    }
+}
+
+#[test]
 fn gate_starvation_fail_names_both_conflicting_files_and_unmet_dependencies() {
     // A dependency-starved gate previously reported an empty
     // `conflicting_files` list and named no blocker at all.

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -1021,7 +1021,7 @@ fn workspace_auto_pipeline_is_single_flight_and_conditionally_dispatches() {
         vec![
             "admissible",
             "ship_leaves",
-            "require_leaf_success",
+            "record_leaf_outcomes",
             "start_epic",
             "window",
             "idle_wait",
@@ -1057,12 +1057,17 @@ fn workspace_auto_pipeline_is_single_flight_and_conditionally_dispatches() {
     assert_eq!(ship_input["job_name"], "task_auto_pipeline");
     assert_eq!(ship_input["run_input"]["task_ids"], "{{ item.task_ids }}");
 
-    let JobV2StepBody::TargetRef(guard) = &drain.steps[2].body else {
-        panic!("leaf success guard must be an activity reference");
+    let JobV2StepBody::TargetRef(record) = &drain.steps[2].body else {
+        panic!("leaf outcome recorder must be an activity reference");
     };
+    assert_eq!(record.target, "activity:pipeline_success_guard");
     assert_eq!(
-        guard.default_input.as_ref().expect("guard input")["results"],
+        record.default_input.as_ref().expect("record input")["results"],
         "{{ steps.leaf_results.output }}"
+    );
+    assert_eq!(
+        record.default_input.as_ref().expect("record input")["allow_non_success"],
+        true
     );
 
     // The epic must NOT be waited on: blocking on a multi-hour epic would

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -52,7 +52,7 @@ fn test_runtime_with_workspace_config(
     (root, runtime, repo_root, global_root)
 }
 
-fn seed_default_catalogs(global_root: &Path) {
+pub(super) fn seed_default_catalogs(global_root: &Path) {
     seed_default_activities(&global_root.join("resources/activities"), true)
         .expect("seed default activities");
     seed_default_jobs(&global_root.join("resources/jobs"), true).expect("seed default jobs");
@@ -66,7 +66,11 @@ fn write_context_file(repo_root: &Path, relative_path: &str) {
     std::fs::write(path, "fixture\n").expect("write context file");
 }
 
-fn seed_gate_task(runtime: &OrbitRuntime, repo_root: &Path, status: TaskStatus) -> String {
+pub(super) fn seed_gate_task(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    status: TaskStatus,
+) -> String {
     write_context_file(repo_root, "src/lib.rs");
     runtime
         .add_task(TaskAddParams {
@@ -125,7 +129,7 @@ fn try_execute_gate_job(
     )
 }
 
-fn try_execute_named_job(
+pub(super) fn try_execute_named_job(
     runtime: &OrbitRuntime,
     repo_root: &Path,
     host: &dyn RuntimeHost,

--- a/crates/orbit-core/src/application/job/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/tests/mod.rs
@@ -1,3 +1,4 @@
 mod catalog;
 mod exec;
 mod resume;
+mod workspace_auto_pipeline;

--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -1,0 +1,593 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use orbit_engine::{DispatchError, ResolvedCliExecutor, RuntimeHost};
+use orbit_tools::{FsAuditLogger, ToolContext};
+use orbit_types::task::TaskStatus;
+use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::workflow::{ChildDispatch, ChildDispatchPhase, PipelineState};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+
+use super::exec::{seed_default_catalogs, seed_gate_task, test_runtime, try_execute_named_job};
+
+#[derive(Clone, Copy)]
+enum WorkspaceAutoScenario {
+    MixedThenLater,
+    TerminalNonSuccesses,
+    DispatchFailure,
+    MalformedResult,
+    ClassifierFailure,
+}
+
+struct ScriptedWorkspaceAutoHost<'a> {
+    runtime: &'a OrbitRuntime,
+    scenario: WorkspaceAutoScenario,
+    failed_task_id: String,
+    classify_calls: AtomicUsize,
+    window_calls: AtomicUsize,
+    calls: Mutex<Vec<(String, Value)>>,
+    dispatch_state_lock: Mutex<()>,
+}
+
+impl<'a> ScriptedWorkspaceAutoHost<'a> {
+    fn new(
+        runtime: &'a OrbitRuntime,
+        scenario: WorkspaceAutoScenario,
+        failed_task_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            runtime,
+            scenario,
+            failed_task_id: failed_task_id.into(),
+            classify_calls: AtomicUsize::new(0),
+            window_calls: AtomicUsize::new(0),
+            calls: Mutex::new(Vec::new()),
+            dispatch_state_lock: Mutex::new(()),
+        }
+    }
+
+    fn inputs_for(&self, action: &str) -> Vec<Value> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .iter()
+            .filter(|(recorded, _)| recorded == action)
+            .map(|(_, input)| input.clone())
+            .collect()
+    }
+
+    fn classification(&self) -> Value {
+        let iteration = self.classify_calls.fetch_add(1, Ordering::SeqCst);
+        let dispatches = match self.scenario {
+            WorkspaceAutoScenario::MixedThenLater if iteration == 0 => vec![
+                json!({"crew": "sol", "task_ids": ["ORB-SUCCEEDED"]}),
+                json!({"crew": "terra", "task_ids": [self.failed_task_id]}),
+            ],
+            WorkspaceAutoScenario::MixedThenLater => {
+                vec![json!({"crew": "sol", "task_ids": ["ORB-LATER"]})]
+            }
+            WorkspaceAutoScenario::TerminalNonSuccesses => vec![
+                json!({"crew": "sol", "task_ids": ["ORB-FAILED"]}),
+                json!({"crew": "terra", "task_ids": ["ORB-CANCELLED"]}),
+                json!({"crew": "luna", "task_ids": ["ORB-INTERRUPTED"]}),
+                json!({"crew": "opus", "task_ids": ["ORB-TIMEOUT"]}),
+            ],
+            WorkspaceAutoScenario::DispatchFailure => {
+                vec![json!({"crew": "sol", "task_ids": ["ORB-DISPATCH-BROKEN"]})]
+            }
+            WorkspaceAutoScenario::MalformedResult => {
+                vec![json!({"crew": "sol", "task_ids": ["ORB-MALFORMED"]})]
+            }
+            WorkspaceAutoScenario::ClassifierFailure => {
+                unreachable!("classifier failure returns before building a classification")
+            }
+        };
+        let task_ids = dispatches
+            .iter()
+            .flat_map(|dispatch| {
+                dispatch["task_ids"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .cloned()
+            })
+            .collect::<Vec<_>>();
+        json!({
+            "loose_task_ids": task_ids,
+            "loose_task_dispatches": dispatches,
+            "has_leaves": true,
+            "epic_task_id": null,
+            "has_epic": false,
+            "empty": false,
+            "active_epic_run_id": null,
+            "active_epic_task_id": null,
+        })
+    }
+
+    fn record_terminal_child(&self, input: &Value, result: &Value) {
+        let Some(parent_run_id) = input.get("run_id").and_then(Value::as_str) else {
+            return;
+        };
+        let Some(child_run_id) = result.get("run_id").and_then(Value::as_str) else {
+            return;
+        };
+        let _guard = self
+            .dispatch_state_lock
+            .lock()
+            .expect("dispatch state lock");
+        let Some(mut state) = self
+            .runtime
+            .read_run_state(parent_run_id)
+            .expect("read scripted parent state")
+        else {
+            return;
+        };
+        let status = result["status"].as_str().expect("scripted terminal status");
+        let error = result
+            .get("error")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let mut dispatch = ChildDispatch::submitted(
+            child_run_id.to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(
+            input
+                .get("step_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+        );
+        dispatch.phase = ChildDispatchPhase::Terminal;
+        dispatch.child_status = Some(status.to_string());
+        dispatch.error = error;
+        state.record_child_dispatch(dispatch);
+        self.runtime
+            .write_run_state(parent_run_id, &state)
+            .expect("write scripted parent state");
+    }
+
+    fn invoke_result(&self, input: &Value) -> Result<Value, DispatchError> {
+        let task_id = input["run_input"]["task_ids"][0]
+            .as_str()
+            .expect("scripted task id");
+        let result = if task_id == "ORB-DISPATCH-BROKEN" {
+            return Err(DispatchError::DeterministicActionFailed {
+                action: "invoke_and_wait".to_string(),
+                message: "fixture dispatch failed before durable child creation".to_string(),
+            });
+        } else if task_id == "ORB-MALFORMED" {
+            json!({
+                "status": "failed",
+                "error": "fixture omitted durable child linkage",
+            })
+        } else if task_id == self.failed_task_id {
+            json!({
+                "run_id": "jrun-scripted-failed-leaf",
+                "status": "failed",
+                "error": "fixture leaf implementation failed",
+            })
+        } else if task_id == "ORB-FAILED" {
+            json!({
+                "run_id": "jrun-scripted-failed",
+                "status": "failed",
+                "error": "fixture failed",
+            })
+        } else if task_id == "ORB-CANCELLED" {
+            json!({
+                "run_id": "jrun-scripted-cancelled",
+                "status": "cancelled",
+                "error": "fixture cancelled",
+            })
+        } else if task_id == "ORB-INTERRUPTED" {
+            json!({
+                "run_id": "jrun-scripted-interrupted",
+                "status": "interrupted",
+                "error": "fixture interrupted",
+            })
+        } else if task_id == "ORB-TIMEOUT" {
+            json!({
+                "run_id": "jrun-scripted-timeout",
+                "status": "timeout",
+                "error": "fixture timeout",
+            })
+        } else if task_id == "ORB-SUCCEEDED" {
+            json!({
+                "run_id": "jrun-scripted-succeeded-leaf",
+                "status": "succeeded",
+            })
+        } else {
+            json!({
+                "run_id": "jrun-scripted-later-leaf",
+                "status": "succeeded",
+            })
+        };
+        self.record_terminal_child(input, &result);
+        Ok(result)
+    }
+}
+
+impl RuntimeHost for ScriptedWorkspaceAutoHost<'_> {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        self.calls
+            .lock()
+            .expect("call log")
+            .push((action.to_string(), input.clone()));
+        match action {
+            "resolve_workspace_ship_input" => Ok(json!({
+                "mode": "pr",
+                "base_branch": "agent-main",
+            })),
+            "drain_window" if input.get("deadline").is_none() => Ok(json!({
+                "deadline": "2099-01-01T00:00:00Z",
+                "expired": false,
+                "remaining_seconds": 1,
+            })),
+            "drain_window" => {
+                let reread = self.window_calls.fetch_add(1, Ordering::SeqCst);
+                let expired = match self.scenario {
+                    WorkspaceAutoScenario::MixedThenLater => reread >= 1,
+                    WorkspaceAutoScenario::TerminalNonSuccesses
+                    | WorkspaceAutoScenario::DispatchFailure
+                    | WorkspaceAutoScenario::MalformedResult
+                    | WorkspaceAutoScenario::ClassifierFailure => true,
+                };
+                Ok(json!({
+                    "deadline": "2099-01-01T00:00:00Z",
+                    "expired": expired,
+                    "remaining_seconds": usize::from(!expired),
+                }))
+            }
+            "classify_workspace_auto_tasks"
+                if matches!(self.scenario, WorkspaceAutoScenario::ClassifierFailure) =>
+            {
+                self.classify_calls.fetch_add(1, Ordering::SeqCst);
+                Err(DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: "fixture workspace classification failed".to_string(),
+                })
+            }
+            "classify_workspace_auto_tasks" => Ok(self.classification()),
+            "invoke_and_wait" => self.invoke_result(input),
+            "pipeline_success_guard" => <OrbitRuntime as RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            ),
+            other => Err(DispatchError::DeterministicActionNotRegistered(
+                other.to_string(),
+            )),
+        }
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
+#[test]
+fn workspace_auto_records_failed_leaf_and_dispatches_later_work() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let failed_task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::Blocked);
+    let host = ScriptedWorkspaceAutoHost::new(
+        &runtime,
+        WorkspaceAutoScenario::MixedThenLater,
+        failed_task_id.clone(),
+    );
+    let input = json!({
+        "max_tasks": 50,
+        "for_seconds": 10,
+        "idle_sleep_seconds": 0,
+    });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "workspace_auto_pipeline",
+            1,
+            Utc::now(),
+            Some(input.clone()),
+            None,
+        )
+        .expect("insert workspace auto run");
+    runtime
+        .write_run_state(
+            &run.run_id,
+            &PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
+        )
+        .expect("write workspace auto run state");
+
+    let outcome = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "workspace_auto_pipeline",
+        input,
+        &run.run_id,
+    )
+    .expect("mixed leaf outcomes must not fail the workspace drain");
+
+    assert!(outcome.success);
+    assert_eq!(host.classify_calls.load(Ordering::SeqCst), 2);
+    let invokes = host.inputs_for("invoke_and_wait");
+    assert_eq!(invokes.len(), 3);
+    assert!(
+        invokes
+            .iter()
+            .any(|input| { input["run_input"]["task_ids"] == json!(["ORB-LATER"]) })
+    );
+
+    let state = runtime
+        .read_run_state(&run.run_id)
+        .expect("read workspace auto run state")
+        .expect("workspace auto run state exists");
+    let failed_dispatch = state
+        .child_dispatches
+        .iter()
+        .find(|dispatch| dispatch.child_run_id == "jrun-scripted-failed-leaf")
+        .expect("failed child remains linked in parent run state");
+    assert_eq!(
+        failed_dispatch.parent_step_id.as_deref(),
+        Some("leaf_invoke")
+    );
+    assert_eq!(failed_dispatch.phase, ChildDispatchPhase::Terminal);
+    assert_eq!(failed_dispatch.child_status.as_deref(), Some("failed"));
+    assert_eq!(
+        failed_dispatch.error.as_deref(),
+        Some("fixture leaf implementation failed")
+    );
+    let audit_events = runtime
+        .list_audit_events(None, None, Some(AuditEventStatus::Success), None, 64)
+        .expect("list workspace auto audit events");
+    let failed_batch = audit_events
+        .iter()
+        .filter(|event| event.command == "pipeline.child_results")
+        .filter_map(|event| event.arguments_json.as_deref())
+        .filter_map(|payload| serde_json::from_str::<Value>(payload).ok())
+        .find(|payload| payload["non_success_count"] == json!(1))
+        .expect("failed batch aggregate remains in durable audit history");
+    assert_eq!(failed_batch["checked_count"], 2);
+    assert_eq!(failed_batch["succeeded_count"], 1);
+    assert_eq!(
+        failed_batch["results"],
+        json!([
+            {
+                "run_id": "jrun-scripted-succeeded-leaf",
+                "status": "succeeded"
+            },
+            {
+                "run_id": "jrun-scripted-failed-leaf",
+                "status": "failed",
+                "error": "fixture leaf implementation failed"
+            }
+        ])
+    );
+    assert_eq!(
+        runtime
+            .get_task(&failed_task_id)
+            .expect("show failed child task")
+            .status,
+        TaskStatus::Blocked,
+        "the workspace parent must not reset or requeue the failed child task"
+    );
+}
+
+#[test]
+fn workspace_auto_records_every_terminal_non_success_without_failing() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedWorkspaceAutoHost::new(
+        &runtime,
+        WorkspaceAutoScenario::TerminalNonSuccesses,
+        "ORB-UNUSED",
+    );
+    let input = json!({
+        "max_tasks": 50,
+        "for_seconds": 0,
+        "idle_sleep_seconds": 0,
+    });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "workspace_auto_pipeline",
+            1,
+            Utc::now(),
+            Some(input.clone()),
+            None,
+        )
+        .expect("insert workspace auto run");
+    runtime
+        .write_run_state(
+            &run.run_id,
+            &PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
+        )
+        .expect("write workspace auto run state");
+
+    let outcome = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "workspace_auto_pipeline",
+        input,
+        &run.run_id,
+    )
+    .expect("terminal child outcomes are data for the workspace sequencer");
+
+    assert!(outcome.success);
+    assert_eq!(host.classify_calls.load(Ordering::SeqCst), 1);
+    let state = runtime
+        .read_run_state(&run.run_id)
+        .expect("read workspace auto run state")
+        .expect("workspace auto run state exists");
+    let observed = state
+        .child_dispatches
+        .iter()
+        .map(|dispatch| {
+            (
+                dispatch.child_run_id.as_str(),
+                dispatch.child_status.as_deref(),
+                dispatch.error.as_deref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(observed.len(), 4);
+    for expected in [
+        (
+            "jrun-scripted-failed",
+            Some("failed"),
+            Some("fixture failed"),
+        ),
+        (
+            "jrun-scripted-cancelled",
+            Some("cancelled"),
+            Some("fixture cancelled"),
+        ),
+        (
+            "jrun-scripted-interrupted",
+            Some("interrupted"),
+            Some("fixture interrupted"),
+        ),
+        (
+            "jrun-scripted-timeout",
+            Some("timeout"),
+            Some("fixture timeout"),
+        ),
+    ] {
+        assert!(
+            observed.contains(&expected),
+            "missing child outcome {expected:?}"
+        );
+    }
+    let audit_events = runtime
+        .list_audit_events(None, None, Some(AuditEventStatus::Success), None, 64)
+        .expect("list workspace auto audit events");
+    let batch = audit_events
+        .iter()
+        .filter(|event| event.command == "pipeline.child_results")
+        .filter_map(|event| event.arguments_json.as_deref())
+        .filter_map(|payload| serde_json::from_str::<Value>(payload).ok())
+        .find(|payload| payload["non_success_count"] == json!(4))
+        .expect("terminal non-success aggregate is durable");
+    assert_eq!(batch["checked_count"], 4);
+    assert_eq!(batch["succeeded_count"], 0);
+    assert_eq!(batch["results"].as_array().expect("batch results").len(), 4);
+}
+
+#[test]
+fn workspace_auto_fails_promptly_when_leaf_dispatch_has_no_durable_child() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedWorkspaceAutoHost::new(
+        &runtime,
+        WorkspaceAutoScenario::DispatchFailure,
+        "ORB-UNUSED",
+    );
+
+    let err = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "workspace_auto_pipeline",
+        json!({"max_tasks": 50, "for_seconds": 0, "idle_sleep_seconds": 0}),
+        "jrun-workspace-auto-dispatch-failure",
+    )
+    .expect_err("pre-link dispatch failure must fail the workspace drain");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("fixture dispatch failed before durable child creation"),
+        "{message}"
+    );
+    assert_eq!(host.classify_calls.load(Ordering::SeqCst), 1);
+    assert!(host.inputs_for("pipeline_success_guard").is_empty());
+}
+
+#[test]
+fn workspace_auto_fails_closed_on_malformed_collected_leaf_result() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedWorkspaceAutoHost::new(
+        &runtime,
+        WorkspaceAutoScenario::MalformedResult,
+        "ORB-UNUSED",
+    );
+
+    let err = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "workspace_auto_pipeline",
+        json!({"max_tasks": 50, "for_seconds": 0, "idle_sleep_seconds": 0}),
+        "jrun-workspace-auto-malformed-result",
+    )
+    .expect_err("malformed collected result must fail the workspace drain");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("missing non-empty string run_id"),
+        "{message}"
+    );
+    assert_eq!(host.classify_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(host.inputs_for("pipeline_success_guard").len(), 1);
+}
+
+#[test]
+fn workspace_auto_preserves_concrete_workspace_step_failure() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedWorkspaceAutoHost::new(
+        &runtime,
+        WorkspaceAutoScenario::ClassifierFailure,
+        "ORB-UNUSED",
+    );
+
+    let err = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "workspace_auto_pipeline",
+        json!({"max_tasks": 50, "for_seconds": 0, "idle_sleep_seconds": 0}),
+        "jrun-workspace-auto-classifier-failure",
+    )
+    .expect_err("workspace-level deterministic failure must fail the drain");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("fixture workspace classification failed"),
+        "{message}"
+    );
+    assert_eq!(host.classify_calls.load(Ordering::SeqCst), 1);
+    assert!(host.inputs_for("invoke_and_wait").is_empty());
+}


### PR DESCRIPTION
## Task

[ORB-11091](https://orbit-cli.com/tasks/ORB-11091) — Keep workspace auto draining after leaf child failures

### Description

## Problem

`workspace_auto_pipeline` currently sends every collected `task_auto_pipeline` result through `require_leaf_success` / `pipeline_success_guard`. A single terminal child outcome of `failed`, `cancelled`, `interrupted`, or `timeout` therefore fails the workspace drain and prevents later iterations from continuing through the eligible queue.

Incident `jrun-20260829-2356` demonstrated the operational impact: child `jrun-20260829-2356-8` was recorded failed, `task_auto_pipeline` propagated that result, and the workspace auto run terminalized instead of re-listing the backlog. `ORB-11085` and `ORB-11086` remained undispatched. The child failure happened to be a separate worker-observation race, but workspace-level queue progress should not depend on every leaf child succeeding.

## Why It Matters

`workspace_auto_pipeline` is a resident queue-drain sequencer, not a fail-fast bundle. One bad leaf must remain observable and actionable without taking down the workspace lane or starving unrelated work behind it.

## Constraints / Notes

- Treat a durably linked child's terminal non-success as a recorded leaf outcome, then continue to the window check and next backlog classification.
- The workspace run must not become failed solely because one or more leaf children failed, were cancelled, were interrupted, or timed out.
- Preserve exact parent/child linkage, terminal status, run ID, and error details in run/audit projections; do not erase or rewrite the child outcome.
- Preserve fail-closed behavior for structural dispatch failures where no durable child can be created or linked, malformed fan-in results, and failures in the workspace sequencer itself.
- Do not reset or requeue child tasks from the parent. Task lifecycle and any blocked/retry decision remain owned by the child pipeline and later triage.
- Preserve crew-homogeneous fan-out, blocking `invoke_and_wait`, the drain deadline, detached epic dispatch, and byte-identical packaged/workspace job assets.
- This intentionally revises the fail-fast leaf contract introduced by ORB-10819.

## Rollback

Revert the workspace-auto job/result-accounting changes to restore fail-fast `require_leaf_success` behavior; child task and run records remain authoritative.

### Acceptance Criteria

- A deterministic workspace_auto_pipeline fixture with one succeeded leaf child, one terminally failed leaf child, and additional eligible work proves the failed child is retained in parent/child run detail while the workspace drain performs another classification and dispatches the later work.
- A workspace_auto_pipeline run containing failed, cancelled, interrupted, or timed-out durably linked leaf results does not fail solely for those outcomes; it finishes according to its drain window and other workspace-level steps.
- Run, audit, CLI/MCP/API, or equivalent durable projections preserve each non-successful child's exact run ID, terminal status, and error while exposing aggregate succeeded/non-success counts without converting the child to success.
- A failure before durable child creation/linkage, malformed collected result, or failure in another workspace-level deterministic step still fails the workspace_auto_pipeline promptly with the concrete structural error.
- The parent does not reset, requeue, or otherwise mutate failed child task lifecycle state, and existing crew partitioning, blocking leaf waits, detached epic dispatch, and deadline semantics remain unchanged.
- The packaged and workspace workspace_auto_pipeline YAML copies remain byte-identical; focused catalog and pipeline execution tests pass together with make ci-fast and make ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced workspace_auto_pipeline's fail-fast leaf guard with an explicit result-recording policy. Durably linked failed, cancelled, interrupted, and timed-out child results now validate, retain their exact run ID/status/error, expose succeeded/non-success counts, and allow the drain loop to classify and dispatch later work.
- Added a durable `pipeline.child_results` audit projection per fan-in batch so iteration history and aggregate counts survive same-step loop-key replacement; parent PipelineState child_dispatches remains authoritative for exact lineage.
- Preserved fail-closed behavior for pre-link dispatch errors, malformed/missing linkage, non-terminal collected results, and workspace-level deterministic failures. The parent does not update child tasks.
- Kept the packaged and workspace workspace_auto_pipeline assets byte-identical and documented `interrupted` in both invoke_and_wait activity schemas.
- Added focused action, catalog, and deterministic workspace pipeline tests in a dedicated sibling test module. Extra context files were required for the tightly coupled result-policy implementation, audit dispatch, activity schemas, and direct execution coverage.

Assessment: The change is scoped to an opt-in `allow_non_success` policy, so task gates, epic pipelines, and workspace wrappers retain their existing fail-fast success-guard behavior. Crew-homogeneous fan-out, blocking leaf waits, detached epic dispatch, and deadline control are unchanged.

Validation:
- `cargo test -p orbit-core workspace_auto_ -- --nocapture`: 7 passed.
- `cargo test -p orbit-core pipeline_success_guard -- --nocapture`: 5 passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- workspace_auto_pipeline asset byte comparison: identical.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11091-6a938596`
- Behind base: 0
- Ahead of base: 1