### PR TITLE
[auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox_nested.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox_nested.rs
@@ -2,6 +2,8 @@
 //! child-runtime profile. [ORB-11055] [ORB-11066] [ORB-11070]
 
 #[cfg(target_os = "macos")]
+use std::ffi::OsStr;
+#[cfg(target_os = "macos")]
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::{Command, Stdio};
@@ -52,12 +54,22 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
     std::fs::create_dir_all(&repo).expect("create repo");
     init_git_repo(&repo);
 
+    // `workspace init` freezes crew availability from PATH. Hosted macOS
+    // runners do not provide an agent CLI, which otherwise seeds an explicit
+    // empty `[crews]` registry while the CI remediation auto-task still names
+    // the `system` crew. A disposable executable keeps this fixture
+    // deterministic without dispatching an agent.
+    let provider_bin = home.join("stub-bin");
+    plant_agent_cli_stub(&provider_bin, "codex");
+    let provider_path = stub_first_path(&provider_bin);
+
     run_orbit(
         &orbit_bin,
         &repo,
         &home,
         &["workspace", "init", "--name", "orb-11055-nested-audit"],
         "workspace init",
+        Some(&provider_path),
     );
 
     let minted = run_orbit(
@@ -66,6 +78,7 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
         &home,
         &["auto-task", "mint", "ci-failure-remediation", "--json"],
         "auto-task mint",
+        None,
     );
     let minted: Value = serde_json::from_slice(&minted.stdout).expect("mint JSON");
     let task_id = minted["id"].as_str().expect("task id").to_string();
@@ -98,6 +111,7 @@ fn managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox() {
             "--json",
         ],
         "ordinary task add",
+        None,
     );
     let ordinary: Value = serde_json::from_slice(&ordinary.stdout).expect("ordinary task JSON");
     let ordinary_id = ordinary["id"]
@@ -406,8 +420,10 @@ fn run_orbit(
     home: &Path,
     args: &[&str],
     label: &str,
+    path: Option<&OsStr>,
 ) -> std::process::Output {
-    let output = Command::new(bin)
+    let mut command = Command::new(bin);
+    command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
@@ -416,7 +432,11 @@ fn run_orbit(
         .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
         .env_remove("ORBIT_AGENT_NAME")
         .env_remove("ORBIT_AGENT_MODEL")
-        .args(args)
+        .args(args);
+    if let Some(path) = path {
+        command.env("PATH", path);
+    }
+    let output = command
         .output()
         .unwrap_or_else(|err| panic!("{label}: spawn orbit: {err}"));
     assert!(
@@ -426,6 +446,27 @@ fn run_orbit(
         String::from_utf8_lossy(&output.stderr)
     );
     output
+}
+
+#[cfg(target_os = "macos")]
+fn plant_agent_cli_stub(bin: &Path, name: &str) {
+    std::fs::create_dir_all(bin).expect("create stub CLI directory");
+    let stub = bin.join(name);
+    std::fs::write(&stub, "#!/bin/sh\nexit 0\n").expect("write stub agent CLI");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .expect("mark stub agent CLI executable");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn stub_first_path(bin: &Path) -> std::ffi::OsString {
+    let inherited = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries = vec![bin.to_path_buf()];
+    entries.extend(std::env::split_paths(&inherited));
+    std::env::join_paths(entries).expect("join PATH entries")
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Task

[ORB-11094](https://orbit-cli.com/tasks/ORB-11094) — [auto-task] Remediate current GitHub Actions failures

### Description

Investigate and remediate current GitHub Actions failures for this
repository. This task may legitimately finish with no diff: if no
current, reproducible, repository-owned failure remains, persist the
evidence described below and report a successful no-current-failure or
transient-only outcome.

## Discovery and duplicate safety

1. Enumerate this repository's workflows and recent runs with GitHub's API
   or `gh`, and enumerate open pull requests with their current head SHAs.
   Cover failures for the current heads of `agent-main`, `main`, and every
   open pull request, including informational jobs such as coverage rather
   than looking only at required checks or the main `ci` job.
2. The PR-only `Create orbit task on CI failure` step in
   `.github/workflows/ci.yml` is an input and coverage signal. Search open
   Orbit tasks for its run URL, PR number, SHA, and failure signature.
   Reference matching tasks in the execution summary; do not create
   another task for the same run or root cause. This remediation task owns
   the repair and must not fan a red-run cluster out into more failure
   tasks.
3. For every candidate run, record the run and job URLs, workflow, event,
   branch or PR, run-attempt number, reported head SHA, and the current
   branch/PR head SHA. Query the failed jobs and steps and inspect the
   exact failed-step logs.
4. Independently verify the commit that Actions actually checked out from
   the checkout step/log (`HEAD is now at`, checkout ref/SHA, or equivalent
   unambiguous evidence). Keep the event's reported head SHA, the current
   ref head, and the tested checkout commit distinct; PR merge SHAs are not
   interchangeable with PR head SHAs.
5. Ignore a failed run as stale when its branch or PR has advanced and the
   failure does not reproduce at the current head, or when a newer
   successful run of the same workflow/check at the relevant current
   commit supersedes it. Cite the advancing or superseding run and SHAs;
   age alone is not evidence that a failure is stale.

## Diagnosis and remediation

Cluster repeated runs by root cause before editing. Use the failing
command, job/step, exact error signature, tested commit, and causal
dependency between failures to distinguish one regression repeated across
push/PR runs from independent failures. Repair each current root cause
once, while retaining a mapping from every affected run/job to that
cluster.

Reproduce every current candidate at the current repository head using
the exact command or the narrowest faithful local equivalent. A
deterministic repository-owned failure is in scope and must be fixed in
this task's worktree. Classify a GitHub service, network, hosted-runner, or
other infrastructure failure as transient only with concrete evidence,
such as a successful retry at the same SHA plus logs showing the
infrastructure fault. Do not call a failure transient merely because it
fails to reproduce once.

Fix the underlying repository-owned cause. Do not disable a workflow,
weaken an assertion or lint level, add a broad allow/ignore rule, mark a
failing gate `continue-on-error`, remove an affected target from coverage,
or otherwise obtain green CI by hiding the failure. Informational checks
remain informational, but they must execute successfully.

## Validation and handoff

For each fixed root cause, rerun the exact command that formerly failed.
Then run the repository pre-handoff gate, `make ci-fast`. After the
candidate commit is published through the repository's normal workflow,
inspect its GitHub Actions runs and require a green rerun for every
affected workflow/check. This includes affected informational jobs even
though they remain non-required. Do not declare a repair validated while
an affected run is missing, queued, in progress, cancelled, or red.

Persist an `execution_summary` that maps every investigated run/job URL,
reported head SHA, actual checkout commit, and current ref head to its
root-cause cluster, disposition (fixed, stale, superseded, or transient),
change, local reproduction, exact formerly failing validation, pre-handoff
result, and green GitHub rerun URL. Also map any matching PR-hook-created
Orbit task. For a successful no-diff pass, list the queries, current heads,
superseding successes or transient evidence, and why no repository-owned
failure remained.

## Historical validation fixture

Use run 30232696219 as the calibration example for the evidence model, not
as proof of a current failure:

- `Check / Clippy / Test` → `Run CI guardrails` reported Clippy's needless
  borrow at
  `crates/orbit-store/src/file/task_store/v2_bundle/bundle_io/mod.rs:172`,
  `sync_parent_dir(&staging_dir)`.
- `Coverage (informational)` reported that
  `command::skill::tests::plugin_skill_symlinks_resolve_to_assets` found
  `plugin/skills/orbit-task/SKILL.md` different from
  `crates/orbit-core/assets/skills/orbit-task/SKILL.md`.
- The run metadata reported head
  `49a2871a480b927bb31dc7a315f5ff5d130d15d0`, while the checkout log showed
  `5cec12c53211fad3f4ca940a0565bef87787958d`. A valid investigation preserves
  that discrepancy, clusters adjacent runs by the two root causes, and
  tests whether either failure still exists at the relevant current head
  before editing.


### Acceptance Criteria

- Current-head failures across agent-main, main, and open pull requests were enumerated for every repository workflow, including informational jobs.
- Every investigated run records its reported SHA, actual checkout commit, current ref head, failed job/step, exact log evidence, and stale or superseding evidence where applicable.
- Repeated red runs are clustered by root cause, and every current repository-owned failure is reproduced and fixed without weakening or bypassing a check.
- Transient-only classifications cite infrastructure evidence and a successful same-SHA retry; a single non-reproduction is not treated as sufficient evidence.
- Each fixed cause passes the exact formerly failing validation and make ci-fast, and every affected required or informational GitHub Actions check executes successfully on the candidate commit.
- The persisted execution_summary maps each run/job URL and SHA to its root cause, disposition, change, validations, green rerun, and any matching PR-hook task.
- A no-current-failure or transient-only investigation is a successful no-diff outcome when its current-head queries and superseding or transient evidence are persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success with one scoped test-fixture change. No commit or GitHub publication was performed because AGENTS.md requires explicit human approval before committing. The required post-publication green rerun remains a downstream delivery check; no uncommitted candidate is claimed as remotely validated.

Discovery:
- Enumerated workflows from GitHub and the checkout: cargo-deny, macOS Platform, CI, release, smoke-npm-install, Website, Dependabot Updates, Dependency Graph, and CodeQL. CI's informational Coverage job and PR-only Create orbit task on CI failure hook were included.
- Current ref heads at investigation: agent-main=2d792058401c675749dd7be4e2d76f37ae3f53f6; main=f052db3d4246786628157c2bcc9f8bee7e91012c.
- Open PR heads: #959=0f14f3f2ad2c863f902c0add969ff09d10e3f15c, #958=a8b09aede0a8b6627ea5d114093c454e39c236bd, #957=e860792b47f3774a49f2eb11ba265e81fbcf58c7, #956=9089a85e7d63abf532c72e1890991c4d00c5c50f. PRs #959 and #958 were blocked on an older base; #956 and #957 had completed green current-head runs.
- All GitHub run attempts listed below were attempt 1. Checkout SHAs were independently read from each job log's git log -1 --format=%H line and are kept separate from reported and current heads.

Root-cause clusters:
1. M-current, fixed locally: macOS Platform push run https://github.com/danieljhkim/orbit/actions/runs/33285279537, reported head 2d792058401c675749dd7be4e2d76f37ae3f53f6, checkout 2d792058401c675749dd7be4e2d76f37ae3f53f6, current agent-main head 2d792058401c675749dd7be4e2d76f37ae3f53f6; failed job https://github.com/danieljhkim/orbit/actions/runs/33285279537/job/99187289491, macOS Sandbox, step Run orbit-core sandbox tests. Exact evidence: managed_nested_orbit_dispatches_from_linked_worktree_under_sandbox failed at sandbox_nested.rs:422 after auto-task mint failed with invalid input: crew 'system' is not defined in [crews.*]. ConfigSeed intentionally writes an empty [crews] when host detection sees no provider, while ci-failure-remediation explicitly selects system. The test is macOS-only, so Linux did not expose it.
   Change: sandbox_nested.rs now plants a disposable executable codex stub in the isolated fixture and supplies that directory first on PATH only to workspace init. Detection therefore seeds the deterministic system crew; no agent is dispatched and production behavior is unchanged.
   Local exact/narrow equivalent: cargo test -p orbit-core --locked sandbox passed (21 passed, 0 failed on Linux; macOS-only sandbox_nested test is compiled out on this host), cargo clippy -p orbit-core --locked --all-targets -- -D warnings passed, cargo fmt --all -- --check passed, git diff --check passed, and make ci-fast passed. The macOS target is not installed locally, so the hosted macOS compile/run remains required after publication.
2. M-predecessors, stale/superseded: repeated macOS sandbox failures at the old provider-home logging boundary:
   - https://github.com/danieljhkim/orbit/actions/runs/33280724768, reported/checkout dc64b2c1b9f089f8c9bbfd4cb0c8ecab59e934ca, current agent-main 2d792..., failed job https://github.com/danieljhkim/orbit/actions/runs/33280724768/job/99175331443. Exact evidence was Operation not permitted for provider-home JSONL log setup and sandbox_nested managed nested test failure.
   - https://github.com/danieljhkim/orbit/actions/runs/33279477540, reported/checkout f9a34c6aad5ff871ea79235feeca5a1b5327764c, current agent-main 2d792..., failed job https://github.com/danieljhkim/orbit/actions/runs/33279477540/job/99172066302 with the same provider-home JSONL log directory denial.
   - https://github.com/danieljhkim/orbit/actions/runs/33279328537, PR #1179 closed branch, reported/checkout d4bbfd7ccca690156e0fcac63a4044137f55907c, current agent-main 2d792..., failed job https://github.com/danieljhkim/orbit/actions/runs/33279328537/job/99171676928 with the same provider-home JSONL log directory denial.
   These were superseded by the already published ORB-11067 managed-log-root fix and branch advancement; the current 2d792 failure has a different crew-resolution signature and is fixed by this fixture change. No duplicate task was created.
3. P-current CI coverage was stale/superseded: CI push run https://github.com/danieljhkim/orbit/actions/runs/33285240942 reported 06e3b3db379430a03edc1bdb988c4bff56d2c532 but the Coverage job checkout log showed 2d792058401c675749dd7be4e2d76f37ae3f53f6, equal to the current agent-main head. Failed job https://github.com/danieljhkim/orbit/actions/runs/33285240942/job/99187190883, Coverage (informational), reported activity_job::cli_runner::tests::orchestrator::benign_primary_fast_forward_ignores_primary_dirt_disjoint_from_the_run failed. It is superseded by the newer successful same-workflow current-head run https://github.com/danieljhkim/orbit/actions/runs/33285279553 at 2d792... .
4. Historical agent-main contract failures, fixed by prior work and superseded here:
   - CI push run https://github.com/danieljhkim/orbit/actions/runs/33283392472 reported/checkout 6f2e0b728e1095e2a75c8542a76d996aff690309; current head 2d792... . Failed jobs: https://github.com/danieljhkim/orbit/actions/runs/33283392472/job/99182260445 (Linux Sandbox, task_add_schema_uses_trimmed_authoring_surface assertion), https://github.com/danieljhkim/orbit/actions/runs/33283392472/job/99182260485 (Check / Clippy / Test, same task-add schema mismatch), and https://github.com/danieljhkim/orbit/actions/runs/33283392472/job/99182260380 (Coverage informational, tool_list.json drift from its golden). They are superseded by successful CI run 33285279553 at current 2d792...; related task ORB-11088 already records the corresponding snapshot repair.
   - PR #11069 run https://github.com/danieljhkim/orbit/actions/runs/33283110097 reported/checkout c2b357d7e1ad70bfd2479d8c0fdafafede38be06 on a closed branch; current ref is no longer that branch. Failed jobs https://github.com/danieljhkim/orbit/actions/runs/33283110097/job/99181521609 (Linux Sandbox, task_add_schema_uses_trimmed_authoring_surface), https://github.com/danieljhkim/orbit/actions/runs/33283110097/job/99181521613 (Check / Clippy / Test, same test), and https://github.com/danieljhkim/orbit/actions/runs/33283110097/job/99181521666 (Coverage informational, tool_list.json drift). Its hook also emitted invalid_input missing complexity. Disposition stale/superseded; ORB-11088 owns the already-fixed cluster.
   - PR #11084 run https://github.com/danieljhkim/orbit/actions/runs/33282270768 reported/checkout 7f0eba51d0299b6e217ba13cbfc66acbf3f573d on a closed branch; failed job https://github.com/danieljhkim/orbit/actions/runs/33282270768/job/99179309613 failed at Install cargo-nextest with Process completed with exit code 35, and the hook emitted missing complexity. Disposition stale/superseded.
5. Open Dependabot PR historical failures:
   - PR #959 run https://github.com/danieljhkim/orbit/actions/runs/31583558682, reported/current/checkout 0f14f3f2ad2c863f902c0add969ff09d10e3f15c; failed job https://github.com/danieljhkim/orbit/actions/runs/31583558682/job/94072012355 at Run CI guardrails. Exact log evidence: cargo-deny advisories FAILED for yanked spin 0.9.8 at Cargo.lock:248; the worker test appeared PASS in the nextest log, so the cargo-deny result is the terminal cause. Green sibling jobs were 94072012462 (MSRV), 94072012489 (Linux), and 94072012514 (Coverage informational). The hook logged SHA 163043a56a1d18861d1592ff668f1afdbcfc5a14 and emitted placeholder ORB-00000.
   - PR #958 run https://github.com/danieljhkim/orbit/actions/runs/31583549786, reported/current/checkout a8b09aede0a8b6627ea5d114093c454e39c236bd; failed job https://github.com/danieljhkim/orbit/actions/runs/31583549786/job/94071981962 with the same yanked spin 0.9.8 cargo-deny evidence. Green sibling jobs were 94071981888 (MSRV), 94071981923 (Coverage informational), and 94071981953 (Linux). The hook logged SHA c99c949f0f61e63cd00d872cf7e8d941141f70ea and emitted placeholder ORB-00000.
   - PR #957 run https://github.com/danieljhkim/orbit/actions/runs/31583534457 reported e860792b47f3774a49f2eb11ba265e81fbcf58c7, but checkout log independently showed c5d14b86d37982c6305ba0ee8ab8bbf5e490a4d7; current PR head is e860792... . Failed job https://github.com/danieljhkim/orbit/actions/runs/31583534457/job/94071930566 at Run CI guardrails; exact evidence was worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic failing at job_pipeline.rs:169 because no pipeline.worker.startup audit was found. The PR's current-head CI and macOS reruns are green: https://github.com/danieljhkim/orbit/actions/runs/32625821830 and https://github.com/danieljhkim/orbit/actions/runs/32625821814, both at e860792... . The hook logged SHA 0e2b90475f6faebaba731444b1ed7c3dbf33f50f and emitted placeholder ORB-00000. Disposition superseded.
   - PR #956 run https://github.com/danieljhkim/orbit/actions/runs/31583528205 reported 9089a85e7d63abf532c72e1890991c4d00c5c50f, but checkout log independently showed f9385676c056bdb47553e580c78c79c5481abac5; current PR head is 9089a85... . Failed job https://github.com/danieljhkim/orbit/actions/runs/31583528205/job/94071911074 at Run CI guardrails; exact evidence was worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic failing at job_pipeline.rs:138. Current-head CI and Website reruns are green: https://github.com/danieljhkim/orbit/actions/runs/32625820659 and https://github.com/danieljhkim/orbit/actions/runs/32625820653, both at 9089a85... . Green sibling jobs in the old CI run were 94071911067 (Coverage), 94071911075 (Linux), and 94071911257 (MSRV). The hook logged SHA 9792422f40deaead221cf0ba9a0007cc277738e8 and emitted placeholder ORB-00000. Disposition superseded.
   The #959/#958 old cargo-deny failures are branch-specific lockfile state; current agent-main and main Cargo.lock validation is green. No unchanged PR branch was edited.
6. Main current-head success evidence: CI https://github.com/danieljhkim/orbit/actions/runs/32696216293 and macOS Platform https://github.com/danieljhkim/orbit/actions/runs/32696216352 both completed success at f052db3d4246786628157c2bcc9f8bee7e91012c. Current agent-main CI https://github.com/danieljhkim/orbit/actions/runs/33285279553 completed success at 2d792..., but its macOS sibling is the M-current failure fixed above.
7. No matching open PR-hook-created Orbit task was found by searching task records for each run URL, PR number, reported/checkout/current SHA, failure signature, and hook title. Existing related remediation records ORB-11067 (provider-home logging), ORB-11088 (required_tools snapshots), and ORB-10982/ORB-10948 (historical PR dependency/fixture work) were retained as references; no duplicate task was created. The old hook logs' ORB-00000 is not a resolvable task ID.

Calibration:
- Run 30232696219 was retained only as the required evidence-model calibration: reported 49a2871a480b927bb31dc7a315f5ff5d130d15d0 versus checkout 5cec12c53211fad3f4ca940a0565bef87787958d, with the supplied clippy needless-borrow and coverage skill-mirror findings. It was not classified as current and was not changed.

Validation/handoff:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-core --locked sandbox: passed, 21 tests; macOS-only nested test cannot execute on this Linux host.
- cargo clippy -p orbit-core --locked --all-targets -- -D warnings: passed.
- make ci-fast: passed.
- git diff --check: passed.
- No sandbox or network denial blocked these local checks. Rustup has only x86_64-unknown-linux-gnu installed, so remote macOS validation is explicitly pending.
- Friction F2026-08-145 was filed for the non-obvious host-PATH/empty-crews fixture dependency.
- Worktree contains only the intended modification to file:crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox_nested.rs; no commit was made and task status remains in-progress for pipeline handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11094-6a938596`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*