### PR TITLE
Build validated task-publication snapshots and attachment projections

### DIFF
--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -71,11 +71,19 @@ use crate::driver::sqlite::task_registry::{
 };
 
 mod archive;
+mod publication;
 mod reindex;
 
 #[cfg(test)]
 mod tests;
 
+pub use publication::{
+    AttachmentPolicy, AttachmentPolicyKind, AttachmentScanFailure, AttachmentScanInput,
+    AttachmentScanOutcome, AttachmentSensitivityScanner, OmittedAttachment,
+    PUBLICATION_ENVELOPE_FILE_NAME, PUBLICATION_TASKS_DIR_NAME, PublicationEnvelope,
+    PublicationSnapshotMetadata, PublicationSnapshotOutcome, ScannerFailureBehavior,
+    TASK_PUBLICATION_FORMAT_VERSION, build_publication_snapshot,
+};
 pub use reindex::{ReindexOutcome, reindex_workspace};
 
 /// Archive container-format version. Bumped only when the archive *layout*

--- a/crates/orbit-store/src/workflow/task/publication.rs
+++ b/crates/orbit-store/src/workflow/task/publication.rs
@@ -1,0 +1,615 @@
+//! Deterministic, validated task-publication snapshot construction.
+//!
+//! This module owns only the filesystem projection. Git transport, publication
+//! authority checks, and last-success recording are separate workflow phases.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use orbit_common::OrbitError;
+use orbit_types::identity::{validate_machine_id, validate_registry_identifier};
+use orbit_types::policy::{compile_glob_regex, match_glob};
+use orbit_types::task::{
+    ArtifactManifestFileV2, TASK_ARTIFACT_SCHEMA_VERSION, TASK_ARTIFACTS_DIR_NAME,
+    TASK_COMMENTS_FILE_NAME, TASK_EVENTS_FILE_NAME, validate_orb_task_id,
+    validate_relative_artifact_path,
+};
+use orbit_types::workspace::{validate_git_commit_id, validate_source_repository_fingerprint};
+use serde::{Deserialize, Serialize};
+
+use crate::driver::file::task_bundle::{
+    TaskBundleV2, read_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
+};
+use crate::driver::sqlite::task_registry::TaskRegistryStore;
+use crate::fs::yaml::write_yaml_atomic_with;
+
+/// Version of the publication envelope and tree contract.
+pub const TASK_PUBLICATION_FORMAT_VERSION: u32 = 1;
+/// Root envelope name in a publication snapshot.
+pub const PUBLICATION_ENVELOPE_FILE_NAME: &str = "orbit-task-publication.yaml";
+/// Root directory holding canonical task projections.
+pub const PUBLICATION_TASKS_DIR_NAME: &str = "tasks";
+
+/// Attachment projection recorded in the publication envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentPolicyKind {
+    /// Reject a workspace that contains any attachment.
+    Fail,
+    /// Validate and copy admitted attachment bytes.
+    Include,
+    /// Remove attachment manifests and blobs while recording an omission ledger.
+    Omit,
+}
+
+/// Behavior when a configured sensitivity scanner cannot produce a verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScannerFailureBehavior {
+    /// Reject publication when the scanner is missing or fails.
+    Reject,
+    /// Continue after path and size checks, explicitly accepting an unchecked file.
+    AllowUnchecked,
+}
+
+/// Attachment controls applied independently of task-artifact upload limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentPolicy {
+    pub kind: AttachmentPolicyKind,
+    pub max_file_bytes: u64,
+    pub max_total_bytes: u64,
+    pub deny_patterns: Vec<String>,
+    pub scanner_failure_behavior: ScannerFailureBehavior,
+}
+
+impl AttachmentPolicy {
+    fn validate(&self) -> Result<(), OrbitError> {
+        for pattern in &self.deny_patterns {
+            if pattern.trim() != pattern || pattern.is_empty() {
+                return Err(OrbitError::InvalidInput(
+                    "attachment deny patterns must be non-empty and trimmed".to_string(),
+                ));
+            }
+            compile_glob_regex(pattern).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "invalid attachment deny pattern '{pattern}': {error}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Caller-supplied publication identity and commit metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationSnapshotMetadata {
+    pub publication_id: String,
+    pub workspace_id: String,
+    pub source_repository_fingerprint: String,
+    pub authority_machine_id: String,
+    pub generation: u64,
+    pub published_at: DateTime<Utc>,
+    pub previous_publication: Option<String>,
+}
+
+impl PublicationSnapshotMetadata {
+    fn validate(&self) -> Result<(), OrbitError> {
+        validate_registry_identifier("publication_id", &self.publication_id)
+            .map_err(invalid_identity)?;
+        validate_registry_identifier("workspace_id", &self.workspace_id)
+            .map_err(invalid_identity)?;
+        validate_source_repository_fingerprint(&self.source_repository_fingerprint)
+            .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+        validate_machine_id(&self.authority_machine_id).map_err(invalid_identity)?;
+        if self.generation == 0 {
+            return Err(OrbitError::InvalidInput(
+                "publication generation must be at least 1".to_string(),
+            ));
+        }
+        if let Some(commit) = self.previous_publication.as_deref() {
+            validate_git_commit_id(commit)
+                .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+/// A deliberately content-free record of an attachment excluded by `omit`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OmittedAttachment {
+    pub task_id: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
+impl OmittedAttachment {
+    fn validate(&self) -> Result<(), OrbitError> {
+        validate_orb_task_id(&self.task_id)?;
+        validate_relative_artifact_path(&self.path)?;
+        if !is_sha256_hex(&self.sha256) {
+            return Err(OrbitError::InvalidInput(format!(
+                "omitted attachment '{}' for task '{}' has an invalid sha256",
+                self.path, self.task_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Versioned root document for one immutable publication snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PublicationEnvelope {
+    pub format_version: u32,
+    pub publication_id: String,
+    pub workspace_id: String,
+    pub source_repository_fingerprint: String,
+    pub authority_machine_id: String,
+    pub generation: u64,
+    pub published_at: DateTime<Utc>,
+    pub task_schema_version: u32,
+    pub previous_publication: Option<String>,
+    pub attachment_policy: AttachmentPolicyKind,
+    pub task_ids: Vec<String>,
+    #[serde(default)]
+    pub omitted_attachments: Vec<OmittedAttachment>,
+}
+
+impl PublicationEnvelope {
+    /// Validate schema support, identity fields, ordering, and projection consistency.
+    pub fn validate(&self) -> Result<(), OrbitError> {
+        if self.format_version != TASK_PUBLICATION_FORMAT_VERSION {
+            return Err(OrbitError::InvalidInput(format!(
+                "unsupported task publication format version {}; supported version is {}",
+                self.format_version, TASK_PUBLICATION_FORMAT_VERSION
+            )));
+        }
+        if self.task_schema_version != TASK_ARTIFACT_SCHEMA_VERSION {
+            return Err(OrbitError::InvalidInput(format!(
+                "unsupported task schema version {}; supported version is {}",
+                self.task_schema_version, TASK_ARTIFACT_SCHEMA_VERSION
+            )));
+        }
+        PublicationSnapshotMetadata {
+            publication_id: self.publication_id.clone(),
+            workspace_id: self.workspace_id.clone(),
+            source_repository_fingerprint: self.source_repository_fingerprint.clone(),
+            authority_machine_id: self.authority_machine_id.clone(),
+            generation: self.generation,
+            published_at: self.published_at,
+            previous_publication: self.previous_publication.clone(),
+        }
+        .validate()?;
+
+        validate_sorted_unique_task_ids(&self.task_ids)?;
+        if !self.omitted_attachments.is_sorted() {
+            return Err(OrbitError::InvalidInput(
+                "publication omitted_attachments must be sorted".to_string(),
+            ));
+        }
+        let task_ids: BTreeSet<&str> = self.task_ids.iter().map(String::as_str).collect();
+        let mut omission_keys = BTreeSet::new();
+        for omitted in &self.omitted_attachments {
+            omitted.validate()?;
+            if !task_ids.contains(omitted.task_id.as_str()) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "omitted attachment '{}' names unpublished task '{}'",
+                    omitted.path, omitted.task_id
+                )));
+            }
+            if !omission_keys.insert((omitted.task_id.as_str(), omitted.path.as_str())) {
+                return Err(OrbitError::InvalidInput(format!(
+                    "duplicate omitted attachment '{}' for task '{}'",
+                    omitted.path, omitted.task_id
+                )));
+            }
+        }
+        if self.attachment_policy != AttachmentPolicyKind::Omit
+            && !self.omitted_attachments.is_empty()
+        {
+            return Err(OrbitError::InvalidInput(
+                "only the omit attachment policy may record omitted attachments".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Deserialize and validate a publication envelope.
+    pub fn from_yaml(raw: &str) -> Result<Self, OrbitError> {
+        let envelope: Self = serde_yaml::from_str(raw).map_err(|error| {
+            OrbitError::InvalidInput(format!("invalid task publication envelope: {error}"))
+        })?;
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    /// Serialize a validated publication envelope in canonical field order.
+    pub fn to_yaml(&self) -> Result<String, OrbitError> {
+        self.validate()?;
+        serde_yaml::to_string(self).map_err(|error| OrbitError::Store(error.to_string()))
+    }
+}
+
+/// A scanner input whose bytes are never retained in the publication envelope.
+pub struct AttachmentScanInput<'a> {
+    pub task_id: &'a str,
+    pub path: &'a str,
+    pub media_type: &'a str,
+    pub bytes: &'a [u8],
+}
+
+/// Sensitivity verdict for one attachment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachmentScanOutcome {
+    Clear,
+    Sensitive,
+}
+
+/// Content-free scanner failure classes safe to surface in policy errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachmentScanFailure {
+    Unavailable,
+    Failed,
+}
+
+/// Pluggable sensitivity boundary used by `include` publication.
+pub trait AttachmentSensitivityScanner {
+    fn scan(
+        &self,
+        input: AttachmentScanInput<'_>,
+    ) -> Result<AttachmentScanOutcome, AttachmentScanFailure>;
+}
+
+/// Result of a successfully published snapshot tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationSnapshotOutcome {
+    pub destination: PathBuf,
+    pub envelope: PublicationEnvelope,
+    pub included_attachment_bytes: u64,
+    pub omitted_attachment_bytes: u64,
+}
+
+/// Build a validated publication tree into a caller-supplied empty destination.
+///
+/// Every canonical bundle is validated before its projection is staged. The
+/// destination path appears only after the envelope and all task trees have
+/// been completed successfully.
+pub fn build_publication_snapshot(
+    registry: &TaskRegistryStore,
+    destination: &Path,
+    metadata: PublicationSnapshotMetadata,
+    policy: &AttachmentPolicy,
+    scanner: Option<&dyn AttachmentSensitivityScanner>,
+) -> Result<PublicationSnapshotOutcome, OrbitError> {
+    metadata.validate()?;
+    policy.validate()?;
+    if destination.exists() {
+        return Err(OrbitError::InvalidInput(format!(
+            "task publication destination already exists: {}",
+            destination.display()
+        )));
+    }
+    let parent = destination.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "task publication destination has no parent: {}",
+            destination.display()
+        ))
+    })?;
+    fs::create_dir_all(parent).map_err(|error| OrbitError::from_write_io(parent, error))?;
+
+    let binding = registry
+        .find_workspace_binding(&metadata.workspace_id)?
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(format!(
+                "workspace '{}' is not registered in the coordination registry",
+                metadata.workspace_id
+            ))
+        })?;
+    if binding.workspace_id != metadata.workspace_id {
+        return Err(OrbitError::InvalidInput(format!(
+            "workspace selector '{}' resolved to unexpected workspace '{}'",
+            metadata.workspace_id, binding.workspace_id
+        )));
+    }
+
+    let mut task_ids: Vec<String> = registry
+        .tasks_for_workspace(&metadata.workspace_id)?
+        .into_iter()
+        .map(|task| task.task_id)
+        .collect();
+    task_ids.sort();
+    task_ids.dedup();
+    validate_sorted_unique_task_ids(&task_ids)?;
+
+    let staging = tempfile::Builder::new()
+        .prefix(".orbit-task-publication-")
+        .tempdir_in(parent)
+        .map_err(|error| OrbitError::from_write_io(parent, error))?;
+    let tasks_root = staging.path().join(PUBLICATION_TASKS_DIR_NAME);
+    fs::create_dir(&tasks_root).map_err(|error| OrbitError::from_write_io(&tasks_root, error))?;
+
+    let mut omitted_attachments = Vec::new();
+    let mut included_attachment_bytes = 0u64;
+    let mut omitted_attachment_bytes = 0u64;
+    for task_id in &task_ids {
+        let source = registry.canonical_task_bundle_path(&metadata.workspace_id, task_id)?;
+        validate_jsonl_files(task_id, &source)?;
+        let mut bundle = read_bundle_at(&source).map_err(|error| {
+            OrbitError::Store(format!(
+                "task publication validation failed for task '{task_id}' at '{}': {error}",
+                source.display()
+            ))
+        })?;
+        let files = sorted_manifest_files(&bundle);
+        validate_manifest_uniqueness(task_id, &files)?;
+        apply_attachment_policy(
+            task_id,
+            &source,
+            &files,
+            policy,
+            scanner,
+            &mut included_attachment_bytes,
+            &mut omitted_attachment_bytes,
+            &mut omitted_attachments,
+        )?;
+
+        if let Some(manifest) = &mut bundle.artifact_manifest {
+            manifest.files = files;
+        }
+        if policy.kind == AttachmentPolicyKind::Omit {
+            bundle.artifact_manifest = None;
+        }
+        let target = tasks_root.join(task_id);
+        if policy.kind == AttachmentPolicyKind::Include && bundle.artifact_manifest.is_some() {
+            write_bundle_with_artifacts_at(&target, &bundle, &source)?;
+        } else {
+            write_bundle_at(&target, &bundle)?;
+        }
+    }
+
+    omitted_attachments.sort();
+    let envelope = PublicationEnvelope {
+        format_version: TASK_PUBLICATION_FORMAT_VERSION,
+        publication_id: metadata.publication_id,
+        workspace_id: metadata.workspace_id,
+        source_repository_fingerprint: metadata.source_repository_fingerprint,
+        authority_machine_id: metadata.authority_machine_id,
+        generation: metadata.generation,
+        published_at: metadata.published_at,
+        task_schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        previous_publication: metadata.previous_publication,
+        attachment_policy: policy.kind,
+        task_ids,
+        omitted_attachments,
+    };
+    envelope.validate()?;
+    write_yaml_atomic_with(
+        &staging.path().join(PUBLICATION_ENVELOPE_FILE_NAME),
+        &envelope,
+        |error| OrbitError::Store(format!("failed to encode publication envelope: {error}")),
+    )?;
+
+    if destination.exists() {
+        return Err(OrbitError::InvalidInput(format!(
+            "task publication destination appeared during construction: {}",
+            destination.display()
+        )));
+    }
+    fs::rename(staging.path(), destination)
+        .map_err(|error| OrbitError::from_write_io(destination, error))?;
+
+    Ok(PublicationSnapshotOutcome {
+        destination: destination.to_path_buf(),
+        envelope,
+        included_attachment_bytes,
+        omitted_attachment_bytes,
+    })
+}
+
+fn validate_sorted_unique_task_ids(task_ids: &[String]) -> Result<(), OrbitError> {
+    let mut previous: Option<&str> = None;
+    for task_id in task_ids {
+        validate_orb_task_id(task_id)?;
+        if previous.is_some_and(|prior| prior >= task_id.as_str()) {
+            return Err(OrbitError::InvalidInput(
+                "publication task_ids must be sorted and unique".to_string(),
+            ));
+        }
+        previous = Some(task_id);
+    }
+    Ok(())
+}
+
+fn sorted_manifest_files(bundle: &TaskBundleV2) -> Vec<ArtifactManifestFileV2> {
+    let mut files = bundle
+        .artifact_manifest
+        .as_ref()
+        .map(|manifest| manifest.files.clone())
+        .unwrap_or_default();
+    files.sort_by(|left, right| {
+        (&left.path, &left.blob, &left.sha256).cmp(&(&right.path, &right.blob, &right.sha256))
+    });
+    files
+}
+
+fn validate_manifest_uniqueness(
+    task_id: &str,
+    files: &[ArtifactManifestFileV2],
+) -> Result<(), OrbitError> {
+    let mut paths = BTreeSet::new();
+    let mut blobs = BTreeSet::new();
+    for file in files {
+        if !paths.insert(file.path.as_str()) {
+            return Err(policy_error(
+                task_id,
+                &file.path,
+                "duplicate logical attachment path",
+            ));
+        }
+        if !blobs.insert(file.blob.as_str()) {
+            return Err(policy_error(
+                task_id,
+                &file.path,
+                "duplicate attachment blob path",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_attachment_policy(
+    task_id: &str,
+    source: &Path,
+    files: &[ArtifactManifestFileV2],
+    policy: &AttachmentPolicy,
+    scanner: Option<&dyn AttachmentSensitivityScanner>,
+    included_bytes: &mut u64,
+    omitted_bytes: &mut u64,
+    omitted: &mut Vec<OmittedAttachment>,
+) -> Result<(), OrbitError> {
+    if policy.kind == AttachmentPolicyKind::Fail
+        && let Some(file) = files.first()
+    {
+        return Err(policy_error(
+            task_id,
+            &file.path,
+            "attachments are forbidden by the fail policy",
+        ));
+    }
+
+    for file in files {
+        if policy.kind == AttachmentPolicyKind::Omit {
+            *omitted_bytes = omitted_bytes.checked_add(file.size_bytes).ok_or_else(|| {
+                policy_error(
+                    task_id,
+                    &file.path,
+                    "omitted attachment byte count overflow",
+                )
+            })?;
+            omitted.push(OmittedAttachment {
+                task_id: task_id.to_string(),
+                path: file.path.clone(),
+                size_bytes: file.size_bytes,
+                sha256: file.sha256.clone(),
+            });
+            continue;
+        }
+        if policy.kind != AttachmentPolicyKind::Include {
+            continue;
+        }
+        if file.size_bytes > policy.max_file_bytes {
+            return Err(policy_error(
+                task_id,
+                &file.path,
+                "attachment exceeds the per-file publication limit",
+            ));
+        }
+        let next_total = included_bytes.checked_add(file.size_bytes).ok_or_else(|| {
+            policy_error(
+                task_id,
+                &file.path,
+                "included attachment byte count overflow",
+            )
+        })?;
+        if next_total > policy.max_total_bytes {
+            return Err(policy_error(
+                task_id,
+                &file.path,
+                "attachments exceed the total publication limit",
+            ));
+        }
+        for pattern in &policy.deny_patterns {
+            if match_glob(pattern, &file.path)
+                .map_err(|error| OrbitError::InvalidInput(error.to_string()))?
+            {
+                return Err(policy_error(
+                    task_id,
+                    &file.path,
+                    "attachment path matches a publication deny pattern",
+                ));
+            }
+        }
+        let blob_path = source.join(TASK_ARTIFACTS_DIR_NAME).join(&file.blob);
+        let bytes = fs::read(&blob_path).map_err(|error| {
+            OrbitError::Store(format!(
+                "task publication could not read attachment for task '{task_id}' at '{}': {error}",
+                file.path
+            ))
+        })?;
+        let scan_result = scanner.map(|scanner| {
+            scanner.scan(AttachmentScanInput {
+                task_id,
+                path: &file.path,
+                media_type: &file.media_type,
+                bytes: &bytes,
+            })
+        });
+        match scan_result {
+            Some(Ok(AttachmentScanOutcome::Clear)) => {}
+            Some(Ok(AttachmentScanOutcome::Sensitive)) => {
+                return Err(policy_error(
+                    task_id,
+                    &file.path,
+                    "attachment was classified as sensitive",
+                ));
+            }
+            Some(Err(_)) | None
+                if policy.scanner_failure_behavior == ScannerFailureBehavior::Reject =>
+            {
+                return Err(policy_error(
+                    task_id,
+                    &file.path,
+                    "attachment sensitivity scanner did not produce a verdict",
+                ));
+            }
+            Some(Err(_)) | None => {}
+        }
+        *included_bytes = next_total;
+    }
+    Ok(())
+}
+
+fn validate_jsonl_files(task_id: &str, bundle_dir: &Path) -> Result<(), OrbitError> {
+    for file_name in [TASK_EVENTS_FILE_NAME, TASK_COMMENTS_FILE_NAME] {
+        let path = bundle_dir.join(file_name);
+        let raw = fs::read_to_string(&path).map_err(|error| {
+            OrbitError::Store(format!(
+                "task publication could not read task '{task_id}' path '{file_name}': {error}"
+            ))
+        })?;
+        if !raw.is_empty() && !raw.ends_with('\n') {
+            return Err(OrbitError::Store(format!(
+                "task publication rejected incomplete JSONL tail for task '{task_id}' at '{file_name}'"
+            )));
+        }
+        for line in raw.lines() {
+            if line.trim().is_empty() || serde_json::from_str::<serde_json::Value>(line).is_err() {
+                return Err(OrbitError::Store(format!(
+                    "task publication rejected invalid JSONL for task '{task_id}' at '{file_name}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn policy_error(task_id: &str, path: &str, reason: &str) -> OrbitError {
+    OrbitError::PolicyDenied(format!(
+        "task publication attachment '{path}' for task '{task_id}' was rejected: {reason}"
+    ))
+}
+
+fn invalid_identity(error: orbit_types::identity::IdentityError) -> OrbitError {
+    OrbitError::InvalidInput(error.to_string())
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -18,6 +18,8 @@ use crate::repository::task::v2_bundle::TaskBundleStoreV2;
 
 use super::*;
 
+mod publication;
+
 fn open_registry(global: &Path) -> TaskRegistryStore {
     TaskRegistryStore::open(&task_registry_path(global)).expect("open registry")
 }

--- a/crates/orbit-store/src/workflow/task/tests/publication.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publication.rs
@@ -1,0 +1,564 @@
+use std::collections::BTreeMap;
+
+use orbit_types::task::TASK_EVENTS_FILE_NAME;
+
+use super::*;
+
+struct ClearScanner;
+
+impl AttachmentSensitivityScanner for ClearScanner {
+    fn scan(
+        &self,
+        _input: AttachmentScanInput<'_>,
+    ) -> Result<AttachmentScanOutcome, AttachmentScanFailure> {
+        Ok(AttachmentScanOutcome::Clear)
+    }
+}
+
+struct SensitiveScanner;
+
+impl AttachmentSensitivityScanner for SensitiveScanner {
+    fn scan(
+        &self,
+        _input: AttachmentScanInput<'_>,
+    ) -> Result<AttachmentScanOutcome, AttachmentScanFailure> {
+        Ok(AttachmentScanOutcome::Sensitive)
+    }
+}
+
+struct FailedScanner;
+
+impl AttachmentSensitivityScanner for FailedScanner {
+    fn scan(
+        &self,
+        _input: AttachmentScanInput<'_>,
+    ) -> Result<AttachmentScanOutcome, AttachmentScanFailure> {
+        Err(AttachmentScanFailure::Failed)
+    }
+}
+
+fn metadata(workspace_id: &str) -> PublicationSnapshotMetadata {
+    PublicationSnapshotMetadata {
+        publication_id: "pub_orbit_primary".to_string(),
+        workspace_id: workspace_id.to_string(),
+        source_repository_fingerprint: "git@github.com:example/orbit-source.git".to_string(),
+        authority_machine_id: "hm_owner".to_string(),
+        generation: 7,
+        published_at: Utc.with_ymd_and_hms(2026, 8, 30, 1, 2, 3).unwrap(),
+        previous_publication: Some("a".repeat(40)),
+    }
+}
+
+fn policy(kind: AttachmentPolicyKind) -> AttachmentPolicy {
+    AttachmentPolicy {
+        kind,
+        max_file_bytes: 1024,
+        max_total_bytes: 4096,
+        deny_patterns: vec!["**/.env".to_string(), "**/*.pem".to_string()],
+        scanner_failure_behavior: ScannerFailureBehavior::Reject,
+    }
+}
+
+fn seed_artifacts(
+    store: &TaskBundleStoreV2,
+    registry: &TaskRegistryStore,
+    workspace_id: &str,
+    task_id: &str,
+    files: &[(&str, &[u8])],
+) -> Vec<ArtifactManifestFileV2> {
+    seed(
+        store,
+        registry,
+        workspace_id,
+        &make_bundle(task_id, "publication fixture", Vec::new()),
+    );
+    let entries: Vec<_> = files
+        .iter()
+        .map(|(path, bytes)| seed_artifact_blob(store, task_id, path, bytes, "codex"))
+        .collect();
+    store
+        .rewrite_artifact_manifest(
+            task_id,
+            &ArtifactManifestV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                files: entries.clone(),
+            },
+        )
+        .unwrap();
+    entries
+}
+
+fn tree_bytes(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    fn visit(root: &Path, path: &Path, output: &mut BTreeMap<String, Vec<u8>>) {
+        let mut entries: Vec<_> = fs::read_dir(path)
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            if entry.file_type().unwrap().is_dir() {
+                visit(root, &path, output);
+            } else {
+                output.insert(
+                    path.strip_prefix(root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                    fs::read(path).unwrap(),
+                );
+            }
+        }
+    }
+
+    let mut output = BTreeMap::new();
+    visit(root, root, &mut output);
+    output
+}
+
+#[test]
+fn publication_envelope_round_trips_all_identity_and_projection_fields() {
+    let envelope = PublicationEnvelope {
+        format_version: TASK_PUBLICATION_FORMAT_VERSION,
+        publication_id: "pub_orbit_primary".to_string(),
+        workspace_id: "ws_orbit".to_string(),
+        source_repository_fingerprint: "git@github.com:example/orbit-source.git".to_string(),
+        authority_machine_id: "hm_owner".to_string(),
+        generation: 7,
+        published_at: Utc.with_ymd_and_hms(2026, 8, 30, 1, 2, 3).unwrap(),
+        task_schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        previous_publication: Some("a".repeat(40)),
+        attachment_policy: AttachmentPolicyKind::Omit,
+        task_ids: vec!["ORB-00001".to_string(), "ORB-00002".to_string()],
+        omitted_attachments: vec![OmittedAttachment {
+            task_id: "ORB-00002".to_string(),
+            path: "reports/result.txt".to_string(),
+            size_bytes: 12,
+            sha256: "b".repeat(64),
+        }],
+    };
+
+    let yaml = envelope.to_yaml().unwrap();
+    assert_eq!(PublicationEnvelope::from_yaml(&yaml).unwrap(), envelope);
+    assert!(!yaml.contains("checkout"));
+    assert!(!yaml.contains("credential"));
+}
+
+#[test]
+fn no_artifact_snapshots_have_stable_sorted_host_independent_content() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_stable";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        workspace_id,
+        &make_bundle("ORB-00002", "second", Vec::new()),
+    );
+    seed(
+        &store,
+        &registry,
+        workspace_id,
+        &make_bundle("ORB-00001", "first", Vec::new()),
+    );
+
+    let first = root.path().join("snapshot-one");
+    let second = root.path().join("snapshot-two");
+    let outcome = build_publication_snapshot(
+        &registry,
+        &first,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Fail),
+        None,
+    )
+    .unwrap();
+    build_publication_snapshot(
+        &registry,
+        &second,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Fail),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(outcome.envelope.task_ids, vec!["ORB-00001", "ORB-00002"]);
+    assert_eq!(tree_bytes(&first), tree_bytes(&second));
+    assert!(first.join(PUBLICATION_ENVELOPE_FILE_NAME).is_file());
+    assert!(
+        first
+            .join(PUBLICATION_TASKS_DIR_NAME)
+            .join("ORB-00001")
+            .join("task.yaml")
+            .is_file()
+    );
+}
+
+#[test]
+fn include_copies_validated_artifacts_and_canonicalizes_manifest_order() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_include";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        &[("z.txt", b"last"), ("a.txt", b"first")],
+    );
+
+    let destination = root.path().join("included");
+    let outcome = build_publication_snapshot(
+        &registry,
+        &destination,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Include),
+        Some(&ClearScanner),
+    )
+    .unwrap();
+    assert_eq!(outcome.included_attachment_bytes, 9);
+    assert_eq!(outcome.omitted_attachment_bytes, 0);
+    let published = read_bundle_at(
+        &destination
+            .join(PUBLICATION_TASKS_DIR_NAME)
+            .join("ORB-00001"),
+    )
+    .unwrap();
+    let paths: Vec<_> = published
+        .artifact_manifest
+        .unwrap()
+        .files
+        .into_iter()
+        .map(|file| file.path)
+        .collect();
+    assert_eq!(paths, vec!["a.txt", "z.txt"]);
+}
+
+#[test]
+fn omit_removes_manifest_and_blobs_and_records_sorted_ledger() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_omit";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00002",
+        &[("z.txt", b"last"), ("a.txt", b"first")],
+    );
+    seed(
+        &store,
+        &registry,
+        workspace_id,
+        &make_bundle("ORB-00001", "without artifact", Vec::new()),
+    );
+
+    let destination = root.path().join("omitted");
+    let outcome = build_publication_snapshot(
+        &registry,
+        &destination,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Omit),
+        None,
+    )
+    .unwrap();
+    let paths: Vec<_> = outcome
+        .envelope
+        .omitted_attachments
+        .iter()
+        .map(|record| record.path.as_str())
+        .collect();
+    assert_eq!(paths, vec!["a.txt", "z.txt"]);
+    assert_eq!(outcome.omitted_attachment_bytes, 9);
+    let task_dir = destination
+        .join(PUBLICATION_TASKS_DIR_NAME)
+        .join("ORB-00002");
+    assert!(!task_dir.join("artifacts/manifest.yaml").exists());
+    assert_eq!(read_bundle_at(&task_dir).unwrap().artifact_manifest, None);
+    assert!(
+        tree_bytes(&task_dir)
+            .keys()
+            .all(|path| !path.contains("files/"))
+    );
+}
+
+#[test]
+fn fail_policy_rejects_any_attachment_without_publishing_destination() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_fail";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        &[("secret.txt", b"do-not-leak-this-content")],
+    );
+    let destination = root.path().join("rejected");
+
+    let error = build_publication_snapshot(
+        &registry,
+        &destination,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Fail),
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("ORB-00001"));
+    assert!(error.contains("secret.txt"));
+    assert!(!error.contains("do-not-leak-this-content"));
+    assert!(!destination.exists());
+}
+
+#[test]
+fn include_enforces_path_size_deny_and_sensitivity_policies() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_policy";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        &[("reports/result.txt", b"12345")],
+    );
+
+    let mut per_file = policy(AttachmentPolicyKind::Include);
+    per_file.max_file_bytes = 4;
+    assert!(
+        build_publication_snapshot(
+            &registry,
+            &root.path().join("too-large"),
+            metadata(workspace_id),
+            &per_file,
+            Some(&ClearScanner),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("per-file")
+    );
+
+    let mut total = policy(AttachmentPolicyKind::Include);
+    total.max_total_bytes = 4;
+    assert!(
+        build_publication_snapshot(
+            &registry,
+            &root.path().join("total-large"),
+            metadata(workspace_id),
+            &total,
+            Some(&ClearScanner),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("total")
+    );
+
+    let mut denied = policy(AttachmentPolicyKind::Include);
+    denied.deny_patterns = vec!["reports/**".to_string()];
+    assert!(
+        build_publication_snapshot(
+            &registry,
+            &root.path().join("denied"),
+            metadata(workspace_id),
+            &denied,
+            Some(&ClearScanner),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("deny pattern")
+    );
+
+    assert!(
+        build_publication_snapshot(
+            &registry,
+            &root.path().join("sensitive"),
+            metadata(workspace_id),
+            &policy(AttachmentPolicyKind::Include),
+            Some(&SensitiveScanner),
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("classified as sensitive")
+    );
+
+    let bundle_dir = store.bundle_path("ORB-00001").unwrap();
+    fs::write(
+        bundle_dir.join("artifacts/manifest.yaml"),
+        "schema_version: 1\nfiles:\n  - path: ../escape\n    blob: files/result.txt\n    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    media_type: text/plain\n    size_bytes: 5\n    created_by: codex\n    created_at: 2026-08-30T00:00:00Z\n",
+    )
+    .unwrap();
+    let path_error = build_publication_snapshot(
+        &registry,
+        &root.path().join("bad-path"),
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Include),
+        Some(&ClearScanner),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(path_error.contains("ORB-00001"));
+    assert!(path_error.contains("escape"));
+}
+
+#[test]
+fn scanner_unavailable_and_failed_behavior_is_explicit() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_scanner";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        &[("result.txt", b"safe")],
+    );
+
+    for (name, scanner) in [
+        ("unavailable", None),
+        (
+            "failed",
+            Some(&FailedScanner as &dyn AttachmentSensitivityScanner),
+        ),
+    ] {
+        let destination = root.path().join(name);
+        let error = build_publication_snapshot(
+            &registry,
+            &destination,
+            metadata(workspace_id),
+            &policy(AttachmentPolicyKind::Include),
+            scanner,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("did not produce a verdict"));
+        assert!(!destination.exists());
+    }
+
+    let mut allow = policy(AttachmentPolicyKind::Include);
+    allow.scanner_failure_behavior = ScannerFailureBehavior::AllowUnchecked;
+    build_publication_snapshot(
+        &registry,
+        &root.path().join("allowed-unchecked"),
+        metadata(workspace_id),
+        &allow,
+        Some(&FailedScanner),
+    )
+    .unwrap();
+}
+
+#[test]
+fn tampered_blob_and_invalid_jsonl_tail_leave_destination_unpublished() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_pub_tampered";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    let entries = seed_artifacts(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        &[("result.txt", b"original")],
+    );
+    let bundle_dir = store.bundle_path("ORB-00001").unwrap();
+    fs::write(
+        bundle_dir
+            .join(TASK_ARTIFACTS_DIR_NAME)
+            .join(&entries[0].blob),
+        b"tampered-secret-content",
+    )
+    .unwrap();
+    let tampered_destination = root.path().join("tampered");
+    let error = build_publication_snapshot(
+        &registry,
+        &tampered_destination,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Include),
+        Some(&ClearScanner),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("ORB-00001"));
+    assert!(error.contains("result.txt"));
+    assert!(!error.contains("tampered-secret-content"));
+    assert!(!tampered_destination.exists());
+
+    fs::write(
+        bundle_dir
+            .join(TASK_ARTIFACTS_DIR_NAME)
+            .join(&entries[0].blob),
+        b"original",
+    )
+    .unwrap();
+    let events = bundle_dir.join(TASK_EVENTS_FILE_NAME);
+    fs::write(
+        &events,
+        format!("{}{{", fs::read_to_string(&events).unwrap()),
+    )
+    .unwrap();
+    let jsonl_destination = root.path().join("invalid-jsonl");
+    let error = build_publication_snapshot(
+        &registry,
+        &jsonl_destination,
+        metadata(workspace_id),
+        &policy(AttachmentPolicyKind::Omit),
+        None,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("ORB-00001"));
+    assert!(error.contains("events.jsonl"));
+    assert!(!jsonl_destination.exists());
+}
+
+#[test]
+fn invalid_yaml_and_unsupported_bundle_schema_leave_destination_unpublished() {
+    for (workspace_id, task_yaml) in [
+        ("ws_pub_yaml", "not: [valid"),
+        (
+            "ws_pub_schema",
+            "schema_version: 999\nid: ORB-00001\ntitle: future\n",
+        ),
+    ] {
+        let root = TempDir::new().unwrap();
+        let registry = open_registry(root.path());
+        let binding = bind(&registry, root.path(), workspace_id);
+        let store = bundle_store(&registry, &binding);
+        seed(
+            &store,
+            &registry,
+            workspace_id,
+            &make_bundle("ORB-00001", "fixture", Vec::new()),
+        );
+        fs::write(
+            store.bundle_path("ORB-00001").unwrap().join("task.yaml"),
+            task_yaml,
+        )
+        .unwrap();
+        let destination = root.path().join("unpublished");
+        let error = build_publication_snapshot(
+            &registry,
+            &destination,
+            metadata(workspace_id),
+            &policy(AttachmentPolicyKind::Fail),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("ORB-00001"));
+        assert!(error.contains("task.yaml"));
+        assert!(!destination.exists());
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11073](https://orbit-cli.com/tasks/ORB-11073) — Build validated task-publication snapshots and attachment projections

### Description

## Problem
Orbit can export portable task archives, but it has no deterministic publication tree or versioned orbit-task-publication.yaml envelope matching the merged ORB-11068 contract.

## Why It Matters
The Git transport must receive a fully validated, self-describing snapshot whose task bundles and attachment omissions are unambiguous before any commit or push occurs.

## Constraints / Notes
- Reuse canonical task-bundle readers, schema types, checksums, and repository fingerprint types rather than inventing a second task format.
- Build into a caller-supplied temporary destination; do not touch Git, the source worktree, live indexes, or task authority.
- Capture individually consistent bundles without claiming a workspace-wide atomic read.
- Implement explicit fail/include/omit attachment policies with independent path, size, deny-pattern, sensitivity-scanner, and unavailable-scanner behavior.
- Omit must create a valid projection and a deterministic omission ledger; include must never bypass bundle checksum validation.
- Never serialize credentials, checkout paths, claim tokens, or host-private runtime state.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- A versioned publication-envelope type round-trips format version, publication/workspace/source/authority identity, generation, previous commit, publish time, task schema version, attachment policy, sorted task IDs, and deterministic omitted-attachment records.
- Snapshot construction reads and validates canonical bundles, emits the documented tasks/<task-id>/ tree, and produces stable ordering and host-independent content for identical logical input apart from explicitly supplied publication metadata.
- The fail policy rejects any attachment; include enforces canonical paths, per-file/total limits, deny patterns, sensitivity checks, and configured scanner-failure behavior; omit removes manifest/blob references consistently and records logical path, size, and hash.
- Invalid bundle YAML, JSONL tails, artifact manifests, blob checksums, unsupported schemas, and policy violations leave the destination unpublished and identify the affected task/path without exposing file contents.
- Deterministic unit tests cover no-artifact, included, omitted, rejected, scanner-unavailable, tampered, and mixed-bundle snapshots.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a versioned `orbit-task-publication.yaml` envelope with validated publication/workspace/source/authority identity, generation, previous commit, publish time, canonical task schema version, attachment policy, sorted task IDs, and deterministic omission records.
- Added an atomic snapshot builder that resolves registered canonical bundles, rejects strict JSONL-tail corruption before the canonical reader can repair it, reuses bundle schema/checksum validation, emits the documented `tasks/<task-id>/` tree, sorts task IDs and artifact manifests, and exposes only the completed caller-supplied destination.
- Added fail/include/omit attachment projections. Include applies canonical bundle path validation, per-file and publication-wide size limits, configured deny globs, scanner sensitivity verdicts, and explicit fail-closed/allow-unchecked scanner behavior. Omit removes manifest/blob references and records task ID, logical path, size, and SHA-256. Fail rejects the first attachment without exposing bytes.
- Added 9 deterministic sibling tests for envelope round-trip, no-artifact stability, included and omitted projections, fail rejection, path/size/deny/sensitivity controls, unavailable/failed scanners, tampered checksums, malformed JSONL/YAML, unsupported schemas, and mixed bundles. All changed files remained inside the declared `dir:crates/orbit-store/src/workflow/task` context.

Assessment: The implementation is scoped to snapshot construction only: it does not touch Git, source worktrees, indexes, authority, or publication last-success state. Destination publication is staged in a sibling temporary directory and renamed only after every bundle and policy check succeeds. Errors identify task/path without including attachment contents.

Validation:
- `cargo test -p orbit-store workflow::task::tests::publication`: 9 passed.
- `cargo test -p orbit-store`: 338 passed, 4 ignored.
- `make ci-fast`: passed.
- `make ci-lint`: passed workspace-wide with warnings denied.
- `git diff --check`: passed.

Friction checkpoint: no qualifying contradicted assumption, recurring failure, incident cause, or >10-minute non-obvious gotcha was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11073-6a939029`
- Behind base: 0
- Ahead of base: 1