### PR TITLE
Inspect task-publication repositories as labelled read-only state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,8 +86,9 @@ feature.
   `driver/file` and `driver/sqlite` modules implement exactly one persistence
   technology each. `repository` owns live invariants that join drivers (task
   bundles + registry indexes + checkout projections, and friction SQLite +
-  file taxonomy). `workflow` owns explicit import/export/reindex/repair and
-  layout-upgrade operations. `compose` constructs concrete implementations and
+  file taxonomy). `workflow` owns explicit import/export/reindex/repair,
+  read-only task-publication inspection, and layout-upgrade operations.
+  `compose` constructs concrete implementations and
   returns contract-facing stores. The crate retains the namespaced feature
   migration ledger and immutable historical bootstrap migrations. It depends
   on `orbit-types` and `orbit-common`; the semantic vector schema remains owned
@@ -146,8 +147,9 @@ Live task writes are committed by the composite task repository: canonical
 bundle durability is the file-driver operation, allocation/binding/index rows
 are the registry-driver operation, and `.orbit/tasks` symlinks are disposable
 checkout projections. The drivers do not call each other. Task archive
-import/export/reindex, friction Markdown import/SQLite export, legacy audit and
-job-run import, and workspace layout upgrades are explicit `workflow` modules.
+import/export/reindex, read-only task-publication inspection, friction Markdown
+import/SQLite export, legacy audit and job-run import, and workspace layout
+upgrades are explicit `workflow` modules.
 In particular, constructing a friction repository does not perform a hidden
 Markdown import; `compose::workspace_friction_store` invokes the idempotent,
 transactional workflow before opening the live repository.

--- a/crates/orbit-store/src/workflow/task/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/inspect.rs
@@ -1,0 +1,564 @@
+//! Read-only inspection of a task-publication Git repository.
+//!
+//! The consumer fetches a configured ordinary branch into an Orbit-owned cache,
+//! validates pairing and snapshot integrity, and returns labelled task
+//! projections. It never writes canonical tasks, allocators, checkout
+//! projections, claims, audit rows, or execution records.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{DateTime, Utc};
+use orbit_common::OrbitError;
+use orbit_types::identity::{validate_machine_id, validate_registry_identifier};
+use orbit_types::task::{TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACTS_DIR_NAME, TaskEnvelopeV2};
+use orbit_types::workspace::{
+    canonicalize_publication_branch, git_remotes_equivalent, redact_git_remote,
+    validate_git_commit_id, validate_source_repository_fingerprint,
+};
+
+use crate::driver::file::task_bundle::{TaskBundleV2, read_bundle_at};
+
+use super::publication::{
+    AttachmentPolicyKind, PUBLICATION_ENVELOPE_FILE_NAME, PUBLICATION_TASKS_DIR_NAME,
+    PublicationEnvelope, validate_jsonl_files,
+};
+
+/// Caller-supplied pairing and fetch inputs. Identity is never inferred from
+/// repository contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationInspectRequest {
+    pub workspace_id: String,
+    pub source_repository_fingerprint: String,
+    pub publication_id: String,
+    pub authority_machine_id: String,
+    pub publication_remote: String,
+    pub publication_branch: String,
+    pub cache_dir: PathBuf,
+    /// Inspect this commit when set; otherwise the configured branch tip.
+    pub commit: Option<String>,
+}
+
+/// How a validated snapshot relates to the fetched branch tip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationFreshness {
+    Current,
+    Stale,
+}
+
+/// Rendered results are publication snapshots, never live owner state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationRenderAuthority {
+    Snapshot,
+}
+
+/// Identity and freshness attached to every inspected task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationInspectLabel {
+    pub published_at: DateTime<Utc>,
+    pub generation: u64,
+    pub workspace_id: String,
+    pub source_repository_fingerprint: String,
+    pub authority_machine_id: String,
+    pub publication_id: String,
+    pub commit_id: String,
+    pub incomplete_attachments: bool,
+    pub freshness: PublicationFreshness,
+    pub render_authority: PublicationRenderAuthority,
+}
+
+/// One validated task rendered from a publication snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectedPublicationTask {
+    pub label: PublicationInspectLabel,
+    pub task: TaskEnvelopeV2,
+    pub description: String,
+    pub acceptance: String,
+    pub plan: String,
+    pub execution_summary: String,
+}
+
+/// A fully validated, labelled publication snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationInspection {
+    pub label: PublicationInspectLabel,
+    pub envelope: PublicationEnvelope,
+    pub git_parent: Option<String>,
+    pub tasks: Vec<InspectedPublicationTask>,
+}
+
+/// Fetch a publication branch into `request.cache_dir` and render labelled
+/// read-only task state. Fail closed before returning any task when pairing,
+/// schema, lineage, or content-integrity checks fail.
+pub fn inspect_publication(
+    request: PublicationInspectRequest,
+) -> Result<PublicationInspection, OrbitError> {
+    let request = validate_request(request)?;
+    let fetched = fetch_publication(&request)?;
+    let envelope = read_envelope(&fetched.tree_dir)?;
+    assert_pairing(&request, &envelope, &fetched.branch)?;
+    assert_parent_lineage(&envelope, fetched.git_parent.as_deref())?;
+    let tasks = read_validated_tasks(&fetched.tree_dir, &envelope)?;
+    let label = PublicationInspectLabel {
+        published_at: envelope.published_at,
+        generation: envelope.generation,
+        workspace_id: envelope.workspace_id.clone(),
+        source_repository_fingerprint: envelope.source_repository_fingerprint.clone(),
+        authority_machine_id: envelope.authority_machine_id.clone(),
+        publication_id: envelope.publication_id.clone(),
+        commit_id: fetched.commit_id,
+        incomplete_attachments: !envelope.omitted_attachments.is_empty(),
+        freshness: fetched.freshness,
+        render_authority: PublicationRenderAuthority::Snapshot,
+    };
+    Ok(PublicationInspection {
+        label: label.clone(),
+        envelope,
+        git_parent: fetched.git_parent,
+        tasks: tasks
+            .into_iter()
+            .map(|task| InspectedPublicationTask {
+                label: label.clone(),
+                task: task.envelope,
+                description: task.description,
+                acceptance: task.acceptance,
+                plan: task.plan,
+                execution_summary: task.execution_summary,
+            })
+            .collect(),
+    })
+}
+
+struct ValidatedRequest {
+    workspace_id: String,
+    source_repository_fingerprint: String,
+    publication_id: String,
+    authority_machine_id: String,
+    publication_remote: String,
+    publication_branch: String,
+    cache_dir: PathBuf,
+    commit: Option<String>,
+}
+
+struct FetchedSnapshot {
+    tree_dir: PathBuf,
+    branch: String,
+    commit_id: String,
+    git_parent: Option<String>,
+    freshness: PublicationFreshness,
+}
+
+fn validate_request(request: PublicationInspectRequest) -> Result<ValidatedRequest, OrbitError> {
+    validate_registry_identifier("workspace_id", &request.workspace_id).map_err(identity_error)?;
+    validate_source_repository_fingerprint(&request.source_repository_fingerprint)
+        .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+    validate_registry_identifier("publication_id", &request.publication_id)
+        .map_err(identity_error)?;
+    validate_machine_id(&request.authority_machine_id).map_err(identity_error)?;
+    if request.publication_remote.trim().is_empty() {
+        return Err(inspect_error("publication remote must not be empty"));
+    }
+    if remote_has_password(&request.publication_remote) {
+        return Err(inspect_error(format!(
+            "publication remote '{}' must not contain credentials",
+            redact_git_remote(&request.publication_remote)
+        )));
+    }
+    let publication_branch = canonicalize_publication_branch(&request.publication_branch)
+        .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+    if request.cache_dir.as_os_str().is_empty() {
+        return Err(inspect_error(
+            "publication inspect cache directory is required",
+        ));
+    }
+    let commit = match request.commit {
+        Some(commit) => {
+            validate_git_commit_id(&commit)
+                .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+            Some(commit.to_ascii_lowercase())
+        }
+        None => None,
+    };
+    Ok(ValidatedRequest {
+        workspace_id: request.workspace_id,
+        source_repository_fingerprint: request.source_repository_fingerprint,
+        publication_id: request.publication_id,
+        authority_machine_id: request.authority_machine_id,
+        publication_remote: request.publication_remote,
+        publication_branch,
+        cache_dir: request.cache_dir,
+        commit,
+    })
+}
+
+fn fetch_publication(request: &ValidatedRequest) -> Result<FetchedSnapshot, OrbitError> {
+    let cache = request.cache_dir.join(&request.publication_id);
+    let git_dir = cache.join("origin.git");
+    let tree_dir = cache.join("tree");
+    fs::create_dir_all(&cache).map_err(|error| OrbitError::from_write_io(&cache, error))?;
+    let git_dir_s = path_str(&git_dir)?;
+    let tree_dir_s = path_str(&tree_dir)?;
+    if git_dir.join("HEAD").is_file() {
+        assert_cache_origin(&git_dir, &request.publication_remote)?;
+        let refspec = format!(
+            "{}:{}",
+            request.publication_branch, request.publication_branch
+        );
+        git(&[
+            "--git-dir",
+            git_dir_s,
+            "fetch",
+            "--force",
+            "origin",
+            &refspec,
+        ])?;
+    } else {
+        if git_dir.exists() {
+            fs::remove_dir_all(&git_dir)
+                .map_err(|error| OrbitError::from_write_io(&git_dir, error))?;
+        }
+        git(&[
+            "clone",
+            "--bare",
+            "--single-branch",
+            "--branch",
+            short_branch(&request.publication_branch),
+            "--",
+            &request.publication_remote,
+            git_dir_s,
+        ])?;
+    }
+
+    let branch_tip = git(&[
+        "--git-dir",
+        git_dir_s,
+        "rev-parse",
+        &request.publication_branch,
+    ])?
+    .to_ascii_lowercase();
+    let commit_id = request.commit.clone().unwrap_or_else(|| branch_tip.clone());
+    if commit_id != branch_tip
+        && git(&[
+            "--git-dir",
+            git_dir_s,
+            "merge-base",
+            "--is-ancestor",
+            &commit_id,
+            &request.publication_branch,
+        ])
+        .is_err()
+    {
+        return Err(inspect_error(format!(
+            "commit {commit_id} is not on publication branch {}",
+            request.publication_branch
+        )));
+    }
+
+    if tree_dir.exists() {
+        fs::remove_dir_all(&tree_dir)
+            .map_err(|error| OrbitError::from_write_io(&tree_dir, error))?;
+    }
+    fs::create_dir_all(&tree_dir).map_err(|error| OrbitError::from_write_io(&tree_dir, error))?;
+    git(&[
+        "--git-dir",
+        git_dir_s,
+        "--work-tree",
+        tree_dir_s,
+        "checkout",
+        "--force",
+        "--detach",
+        &commit_id,
+    ])?;
+
+    let parents = git(&[
+        "--git-dir",
+        git_dir_s,
+        "rev-list",
+        "--parents",
+        "-n",
+        "1",
+        &commit_id,
+    ])?;
+    let mut tokens = parents.split_whitespace();
+    let _ = tokens.next();
+    let git_parent = tokens.next().map(str::to_ascii_lowercase);
+    if tokens.next().is_some() {
+        return Err(inspect_error(
+            "publication history must be linear; inspected commit has multiple Git parents",
+        ));
+    }
+
+    let freshness = if commit_id == branch_tip {
+        PublicationFreshness::Current
+    } else {
+        PublicationFreshness::Stale
+    };
+    Ok(FetchedSnapshot {
+        tree_dir,
+        branch: request.publication_branch.clone(),
+        commit_id,
+        git_parent,
+        freshness,
+    })
+}
+
+fn read_envelope(tree_dir: &Path) -> Result<PublicationEnvelope, OrbitError> {
+    let path = tree_dir.join(PUBLICATION_ENVELOPE_FILE_NAME);
+    let raw = fs::read_to_string(&path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            inspect_error("publication snapshot is missing orbit-task-publication.yaml")
+        } else {
+            OrbitError::from_write_io(&path, error)
+        }
+    })?;
+    PublicationEnvelope::from_yaml(&raw)
+}
+
+fn assert_pairing(
+    request: &ValidatedRequest,
+    envelope: &PublicationEnvelope,
+    fetched_branch: &str,
+) -> Result<(), OrbitError> {
+    mismatch("workspace", &request.workspace_id, &envelope.workspace_id)?;
+    mismatch(
+        "source repository fingerprint",
+        &request.source_repository_fingerprint,
+        &envelope.source_repository_fingerprint,
+    )?;
+    mismatch(
+        "publication id",
+        &request.publication_id,
+        &envelope.publication_id,
+    )?;
+    mismatch(
+        "authority",
+        &request.authority_machine_id,
+        &envelope.authority_machine_id,
+    )?;
+    mismatch("branch", &request.publication_branch, fetched_branch)?;
+    Ok(())
+}
+
+fn assert_parent_lineage(
+    envelope: &PublicationEnvelope,
+    git_parent: Option<&str>,
+) -> Result<(), OrbitError> {
+    match (envelope.previous_publication.as_deref(), git_parent) {
+        (None, None) => Ok(()),
+        (Some(previous), Some(parent)) if previous.eq_ignore_ascii_case(parent) => Ok(()),
+        (previous, parent) => Err(inspect_error(format!(
+            "Git parent/previous-publication mismatch: envelope previous_publication is {}, Git parent is {}",
+            previous.unwrap_or("null"),
+            parent.unwrap_or("null")
+        ))),
+    }
+}
+
+fn read_validated_tasks(
+    tree_dir: &Path,
+    envelope: &PublicationEnvelope,
+) -> Result<Vec<TaskBundleV2>, OrbitError> {
+    let tasks_root = tree_dir.join(PUBLICATION_TASKS_DIR_NAME);
+    let observed = published_task_ids(&tasks_root)?;
+    if observed != envelope.task_ids {
+        return Err(inspect_error(
+            "publication task list does not match the tasks/ tree",
+        ));
+    }
+    let mut bundles = Vec::with_capacity(envelope.task_ids.len());
+    for task_id in &envelope.task_ids {
+        let bundle_dir = tasks_root.join(task_id);
+        restore_empty_artifact_dir(&bundle_dir)?;
+        validate_jsonl_files(task_id, &bundle_dir)?;
+        if envelope.attachment_policy == AttachmentPolicyKind::Omit
+            && artifact_tree_has_files(&bundle_dir.join(TASK_ARTIFACTS_DIR_NAME))?
+        {
+            return Err(inspect_error(format!(
+                "omit projection for task '{task_id}' still contains artifacts"
+            )));
+        }
+        let bundle = read_bundle_at(&bundle_dir).map_err(|error| {
+            inspect_error(format!(
+                "task '{task_id}' failed publication bundle validation: {error}"
+            ))
+        })?;
+        if bundle.envelope.id != *task_id {
+            return Err(inspect_error(format!(
+                "task '{task_id}' envelope id is '{}'",
+                bundle.envelope.id
+            )));
+        }
+        bundles.push(bundle);
+    }
+    Ok(bundles)
+}
+
+fn restore_empty_artifact_dir(bundle_dir: &Path) -> Result<(), OrbitError> {
+    // Git does not store empty directories; recreate the canonical artifacts
+    // layout in the disposable inspect tree when the snapshot had no blobs.
+    let artifacts = bundle_dir.join(TASK_ARTIFACTS_DIR_NAME);
+    if !artifacts.exists() {
+        let files = artifacts.join(TASK_ARTIFACT_FILES_DIR_NAME);
+        fs::create_dir_all(&files).map_err(|error| OrbitError::from_write_io(&files, error))?;
+    }
+    Ok(())
+}
+
+fn artifact_tree_has_files(path: &Path) -> Result<bool, OrbitError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut pending = vec![path.to_path_buf()];
+    while let Some(current) = pending.pop() {
+        for entry in
+            fs::read_dir(&current).map_err(|error| OrbitError::from_write_io(&current, error))?
+        {
+            let entry = entry.map_err(|error| OrbitError::from_write_io(&current, error))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|error| OrbitError::from_write_io(&entry.path(), error))?;
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            } else {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn published_task_ids(tasks_root: &Path) -> Result<Vec<String>, OrbitError> {
+    if !tasks_root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut ids = Vec::new();
+    for entry in
+        fs::read_dir(tasks_root).map_err(|error| OrbitError::from_write_io(tasks_root, error))?
+    {
+        let entry = entry.map_err(|error| OrbitError::from_write_io(tasks_root, error))?;
+        let name = entry.file_name();
+        let Some(id) = name.to_str() else {
+            return Err(inspect_error(
+                "publication tasks/ contains a non-UTF-8 entry",
+            ));
+        };
+        if id.starts_with('.') {
+            continue;
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|error| OrbitError::from_write_io(&entry.path(), error))?;
+        if !file_type.is_dir() {
+            return Err(inspect_error(format!(
+                "publication tasks/ contains unexpected file '{id}'"
+            )));
+        }
+        ids.push(id.to_string());
+    }
+    ids.sort();
+    Ok(ids)
+}
+
+fn assert_cache_origin(git_dir: &Path, expected_remote: &str) -> Result<(), OrbitError> {
+    let observed = git(&[
+        "--git-dir",
+        path_str(git_dir)?,
+        "remote",
+        "get-url",
+        "origin",
+    ])?;
+    if remotes_match(expected_remote, &observed) {
+        return Ok(());
+    }
+    Err(inspect_error(format!(
+        "consumer cache origin '{}' does not match requested remote '{}'",
+        redact_git_remote(&observed),
+        redact_git_remote(expected_remote)
+    )))
+}
+
+fn remotes_match(expected: &str, observed: &str) -> bool {
+    if expected == observed {
+        return true;
+    }
+    let left = normalize_local_remote(expected);
+    let right = normalize_local_remote(observed);
+    if left == right {
+        return true;
+    }
+    git_remotes_equivalent(expected, observed).unwrap_or(false)
+}
+
+fn normalize_local_remote(remote: &str) -> String {
+    let trimmed = remote.trim();
+    let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);
+    Path::new(path)
+        .canonicalize()
+        .map(|canonical| canonical.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string())
+}
+
+fn mismatch(field: &str, expected: &str, observed: &str) -> Result<(), OrbitError> {
+    if expected == observed {
+        Ok(())
+    } else {
+        Err(inspect_error(format!(
+            "{field} mismatch: expected '{expected}', observed '{observed}'"
+        )))
+    }
+}
+
+fn short_branch(branch: &str) -> &str {
+    branch.strip_prefix("refs/heads/").unwrap_or(branch)
+}
+
+fn remote_has_password(remote: &str) -> bool {
+    let Some(rest) = remote.split_once("://").map(|(_, rest)| rest) else {
+        return false;
+    };
+    rest.split_once('@')
+        .is_some_and(|(userinfo, _)| userinfo.contains(':'))
+}
+
+fn git(args: &[&str]) -> Result<String, OrbitError> {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GCM_INTERACTIVE", "never")
+        .output()
+        .map_err(|error| {
+            OrbitError::Execution(format!(
+                "publication inspect failed to run `git {}`: {error}",
+                args.join(" ")
+            ))
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(inspect_error(format!(
+            "git {} failed: {}",
+            args.iter()
+                .filter(|arg| !Path::new(arg).is_absolute())
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn path_str(path: &Path) -> Result<&str, OrbitError> {
+    path.to_str()
+        .ok_or_else(|| inspect_error(format!("path '{}' is not valid UTF-8", path.display())))
+}
+
+fn inspect_error(message: impl Into<String>) -> OrbitError {
+    OrbitError::InvalidInput(format!("publication inspect: {}", message.into()))
+}
+
+fn identity_error(error: orbit_types::identity::IdentityError) -> OrbitError {
+    OrbitError::InvalidInput(error.to_string())
+}

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -1,6 +1,7 @@
-//! Task-migration tooling: export a workspace's task bundles to a portable
-//! tar.zst archive and import them into another machine's registry, resolving
-//! id collisions by renumbering through the local allocator.
+//! Task-migration and publication tooling: export a workspace's task bundles
+//! to a portable tar.zst archive, import them into another machine's registry,
+//! build validated publication snapshots, and inspect a publication repository
+//! as labelled read-only state.
 //!
 //! The engine lives in `orbit-store` because it needs the canonical bundle I/O
 //! primitives ([`read_bundle_at`]/[`write_bundle_at`]) and the private
@@ -71,12 +72,18 @@ use crate::driver::sqlite::task_registry::{
 };
 
 mod archive;
+mod inspect;
 mod publication;
 mod reindex;
 
 #[cfg(test)]
 mod tests;
 
+pub use inspect::{
+    InspectedPublicationTask, PublicationFreshness, PublicationInspectLabel,
+    PublicationInspectRequest, PublicationInspection, PublicationRenderAuthority,
+    inspect_publication,
+};
 pub use publication::{
     AttachmentPolicy, AttachmentPolicyKind, AttachmentScanFailure, AttachmentScanInput,
     AttachmentScanOutcome, AttachmentSensitivityScanner, OmittedAttachment,

--- a/crates/orbit-store/src/workflow/task/publication.rs
+++ b/crates/orbit-store/src/workflow/task/publication.rs
@@ -573,7 +573,7 @@ fn apply_attachment_policy(
     Ok(())
 }
 
-fn validate_jsonl_files(task_id: &str, bundle_dir: &Path) -> Result<(), OrbitError> {
+pub(crate) fn validate_jsonl_files(task_id: &str, bundle_dir: &Path) -> Result<(), OrbitError> {
     for file_name in [TASK_EVENTS_FILE_NAME, TASK_COMMENTS_FILE_NAME] {
         let path = bundle_dir.join(file_name);
         let raw = fs::read_to_string(&path).map_err(|error| {

--- a/crates/orbit-store/src/workflow/task/tests/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/tests/inspect.rs
@@ -1,0 +1,546 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_types::task::{ArtifactManifestV2, TASK_ARTIFACT_SCHEMA_VERSION, TASK_EVENTS_FILE_NAME};
+use tempfile::TempDir;
+
+use super::*;
+
+fn metadata(
+    workspace_id: &str,
+    generation: u64,
+    previous: Option<&str>,
+) -> PublicationSnapshotMetadata {
+    PublicationSnapshotMetadata {
+        publication_id: "pub_orbit_primary".to_string(),
+        workspace_id: workspace_id.to_string(),
+        source_repository_fingerprint: "git@github.com:example/orbit-source.git".to_string(),
+        authority_machine_id: "hm_owner".to_string(),
+        generation,
+        published_at: Utc
+            .with_ymd_and_hms(2026, 8, 30, 1, 2, generation as u32)
+            .unwrap(),
+        previous_publication: previous.map(ToOwned::to_owned),
+    }
+}
+
+fn policy(kind: AttachmentPolicyKind) -> AttachmentPolicy {
+    AttachmentPolicy {
+        kind,
+        max_file_bytes: 1024,
+        max_total_bytes: 4096,
+        deny_patterns: Vec::new(),
+        scanner_failure_behavior: ScannerFailureBehavior::AllowUnchecked,
+    }
+}
+
+fn request(
+    workspace_id: &str,
+    remote: &Path,
+    cache: &Path,
+    commit: Option<&str>,
+) -> PublicationInspectRequest {
+    PublicationInspectRequest {
+        workspace_id: workspace_id.to_string(),
+        source_repository_fingerprint: "git@github.com:example/orbit-source.git".to_string(),
+        publication_id: "pub_orbit_primary".to_string(),
+        authority_machine_id: "hm_owner".to_string(),
+        publication_remote: remote.to_string_lossy().into_owned(),
+        publication_branch: "refs/heads/main".to_string(),
+        cache_dir: cache.to_path_buf(),
+        commit: commit.map(ToOwned::to_owned),
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_AUTHOR_NAME", "orbit-test")
+        .env("GIT_AUTHOR_EMAIL", "orbit-test@example.test")
+        .env("GIT_COMMITTER_NAME", "orbit-test")
+        .env("GIT_COMMITTER_EMAIL", "orbit-test@example.test")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    git(dir, &["init", "-b", "main"]);
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dest = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &dest);
+        } else {
+            fs::copy(entry.path(), dest).unwrap();
+        }
+    }
+}
+
+fn replace_worktree(repo: &Path, snapshot: &Path) {
+    for entry in fs::read_dir(repo).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            fs::remove_dir_all(&path).unwrap();
+        } else {
+            fs::remove_file(&path).unwrap();
+        }
+    }
+    copy_tree(snapshot, repo);
+}
+
+fn commit_snapshot(repo: &Path, snapshot: &Path, message: &str) -> String {
+    replace_worktree(repo, snapshot);
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-m", message]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+fn amend_current(repo: &Path) {
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "--amend", "--no-edit"]);
+}
+
+fn tree_bytes(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    fn visit(root: &Path, path: &Path, output: &mut BTreeMap<String, Vec<u8>>) {
+        let mut entries: Vec<_> = fs::read_dir(path)
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            let path = entry.path();
+            let file_type = entry.file_type().unwrap();
+            if file_type.is_dir() || (file_type.is_symlink() && path.is_dir()) {
+                visit(root, &path, output);
+            } else if file_type.is_file() {
+                output.insert(
+                    path.strip_prefix(root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                    fs::read(path).unwrap(),
+                );
+            }
+        }
+    }
+    let mut output = BTreeMap::new();
+    visit(root, root, &mut output);
+    output
+}
+
+fn seed_one(
+    store: &TaskBundleStoreV2,
+    registry: &TaskRegistryStore,
+    workspace_id: &str,
+    task_id: &str,
+    files: &[(&str, &[u8])],
+) {
+    if files.is_empty() {
+        seed(
+            store,
+            registry,
+            workspace_id,
+            &make_bundle(task_id, task_id, Vec::new()),
+        );
+        return;
+    }
+    seed(
+        store,
+        registry,
+        workspace_id,
+        &make_bundle(task_id, task_id, Vec::new()),
+    );
+    let entries: Vec<_> = files
+        .iter()
+        .map(|(path, bytes)| seed_artifact_blob(store, task_id, path, bytes, "codex"))
+        .collect();
+    store
+        .rewrite_artifact_manifest(
+            task_id,
+            &ArtifactManifestV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                files: entries,
+            },
+        )
+        .unwrap();
+}
+
+struct LinearRepo {
+    root: TempDir,
+    remote: PathBuf,
+    cache: PathBuf,
+    source_checkout: PathBuf,
+    workspace_id: String,
+    gen1: String,
+    gen2: String,
+}
+
+fn linear_repo(workspace_id: &str, kind: AttachmentPolicyKind) -> LinearRepo {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_one(
+        &store,
+        &registry,
+        workspace_id,
+        "ORB-00001",
+        if kind == AttachmentPolicyKind::Fail {
+            &[]
+        } else {
+            &[("notes.txt", b"hello")]
+        },
+    );
+
+    let snap1 = root.path().join("snap-1");
+    build_publication_snapshot(
+        &registry,
+        &snap1,
+        metadata(workspace_id, 1, None),
+        &policy(kind),
+        None,
+    )
+    .unwrap();
+    let remote = root.path().join("publication.git");
+    init_repo(&remote);
+    let gen1 = commit_snapshot(&remote, &snap1, "generation 1");
+
+    let snap2 = root.path().join("snap-2");
+    build_publication_snapshot(
+        &registry,
+        &snap2,
+        metadata(workspace_id, 2, Some(&gen1)),
+        &policy(kind),
+        None,
+    )
+    .unwrap();
+    let gen2 = commit_snapshot(&remote, &snap2, "generation 2");
+
+    let source_checkout = root.path().join("source-checkout");
+    init_repo(&source_checkout);
+    fs::write(source_checkout.join("README.md"), "source\n").unwrap();
+    git(&source_checkout, &["add", "README.md"]);
+    git(&source_checkout, &["commit", "-m", "source"]);
+
+    LinearRepo {
+        cache: root.path().join("consumer-cache"),
+        remote,
+        source_checkout,
+        workspace_id: workspace_id.to_string(),
+        gen1,
+        gen2,
+        root,
+    }
+}
+
+fn assert_label(
+    inspection: &PublicationInspection,
+    workspace_id: &str,
+    generation: u64,
+    commit: &str,
+    freshness: PublicationFreshness,
+    incomplete: bool,
+) {
+    let label = &inspection.label;
+    assert_eq!(label.workspace_id, workspace_id);
+    assert_eq!(label.generation, generation);
+    assert_eq!(label.commit_id, commit);
+    assert_eq!(
+        label.source_repository_fingerprint,
+        "git@github.com:example/orbit-source.git"
+    );
+    assert_eq!(label.authority_machine_id, "hm_owner");
+    assert_eq!(label.publication_id, "pub_orbit_primary");
+    assert_eq!(label.freshness, freshness);
+    assert_eq!(label.incomplete_attachments, incomplete);
+    assert_eq!(label.render_authority, PublicationRenderAuthority::Snapshot);
+    assert!(!inspection.tasks.is_empty());
+    for task in &inspection.tasks {
+        assert_eq!(task.label, *label);
+        assert_eq!(
+            task.label.render_authority,
+            PublicationRenderAuthority::Snapshot
+        );
+    }
+}
+
+#[test]
+fn current_snapshot_is_labelled_and_not_live() {
+    let repo = linear_repo("ws_inspect_current", AttachmentPolicyKind::Fail);
+    let inspection =
+        inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None)).unwrap();
+    assert_label(
+        &inspection,
+        &repo.workspace_id,
+        2,
+        &repo.gen2,
+        PublicationFreshness::Current,
+        false,
+    );
+    assert_eq!(inspection.git_parent.as_deref(), Some(repo.gen1.as_str()));
+    assert_eq!(inspection.tasks[0].task.id, "ORB-00001");
+}
+
+#[test]
+fn stale_snapshot_is_labelled_with_older_generation() {
+    let repo = linear_repo("ws_inspect_stale", AttachmentPolicyKind::Fail);
+    let inspection = inspect_publication(request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache,
+        Some(&repo.gen1),
+    ))
+    .unwrap();
+    assert_label(
+        &inspection,
+        &repo.workspace_id,
+        1,
+        &repo.gen1,
+        PublicationFreshness::Stale,
+        false,
+    );
+    assert_eq!(inspection.git_parent, None);
+}
+
+#[test]
+fn omit_projection_is_labelled_incomplete() {
+    let repo = linear_repo("ws_inspect_omit", AttachmentPolicyKind::Omit);
+    let inspection =
+        inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None)).unwrap();
+    assert_label(
+        &inspection,
+        &repo.workspace_id,
+        2,
+        &repo.gen2,
+        PublicationFreshness::Current,
+        true,
+    );
+    assert!(!inspection.envelope.omitted_attachments.is_empty());
+}
+
+#[test]
+fn tampered_bundle_and_jsonl_fail_before_trusted_state() {
+    let repo = linear_repo("ws_inspect_tamper", AttachmentPolicyKind::Include);
+    let blob = repo
+        .remote
+        .join("tasks/ORB-00001/artifacts/files/notes.txt");
+    fs::write(&blob, b"tampered-secret-content").unwrap();
+    amend_current(&repo.remote);
+    let error = inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("ORB-00001"));
+    assert!(!error.contains("tampered-secret-content"));
+
+    git(&repo.remote, &["reset", "--hard", &repo.gen2]);
+    let events = repo
+        .remote
+        .join("tasks/ORB-00001")
+        .join(TASK_EVENTS_FILE_NAME);
+    let raw = fs::read_to_string(&events).unwrap();
+    fs::write(&events, format!("{raw}{{")).unwrap();
+    amend_current(&repo.remote);
+    let jsonl_error = inspect_publication(request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("jsonl"),
+        None,
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(jsonl_error.contains("ORB-00001"));
+    assert!(jsonl_error.contains("events.jsonl"));
+}
+
+#[test]
+fn mismatched_repository_and_branch_fail_closed() {
+    let repo = linear_repo("ws_inspect_mismatch", AttachmentPolicyKind::Fail);
+    let mut wrong_workspace = request(&repo.workspace_id, &repo.remote, &repo.cache, None);
+    wrong_workspace.workspace_id = "ws_other".to_string();
+    assert!(
+        inspect_publication(wrong_workspace)
+            .unwrap_err()
+            .to_string()
+            .contains("workspace mismatch")
+    );
+
+    let mut wrong_source = request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("source"),
+        None,
+    );
+    wrong_source.source_repository_fingerprint =
+        "git@github.com:example/other-source.git".to_string();
+    assert!(
+        inspect_publication(wrong_source)
+            .unwrap_err()
+            .to_string()
+            .contains("source repository fingerprint mismatch")
+    );
+
+    let mut wrong_lineage = request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("lineage"),
+        None,
+    );
+    wrong_lineage.publication_id = "pub_other".to_string();
+    assert!(
+        inspect_publication(wrong_lineage)
+            .unwrap_err()
+            .to_string()
+            .contains("publication id mismatch")
+    );
+
+    let mut wrong_authority = request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("authority"),
+        None,
+    );
+    wrong_authority.authority_machine_id = "hm_other".to_string();
+    assert!(
+        inspect_publication(wrong_authority)
+            .unwrap_err()
+            .to_string()
+            .contains("authority mismatch")
+    );
+
+    let mut wrong_branch = request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("branch"),
+        None,
+    );
+    wrong_branch.publication_branch = "refs/heads/other".to_string();
+    let branch_error = inspect_publication(wrong_branch).unwrap_err().to_string();
+    assert!(
+        branch_error.contains("branch") || branch_error.contains("git"),
+        "{branch_error}"
+    );
+}
+
+#[test]
+fn unsupported_future_schemas_fail_closed() {
+    let repo = linear_repo("ws_inspect_schema", AttachmentPolicyKind::Fail);
+    let envelope_path = repo.remote.join(PUBLICATION_ENVELOPE_FILE_NAME);
+    let yaml = fs::read_to_string(&envelope_path)
+        .unwrap()
+        .replace("format_version: 1", "format_version: 9");
+    fs::write(&envelope_path, yaml).unwrap();
+    amend_current(&repo.remote);
+    let envelope_error =
+        inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None))
+            .unwrap_err()
+            .to_string();
+    assert!(envelope_error.contains("unsupported task publication format version 9"));
+
+    git(&repo.remote, &["reset", "--hard", &repo.gen2]);
+    let task_yaml = repo.remote.join("tasks/ORB-00001/task.yaml");
+    fs::write(
+        &task_yaml,
+        "schema_version: 999\nid: ORB-00001\ntitle: future\n",
+    )
+    .unwrap();
+    amend_current(&repo.remote);
+    let task_error = inspect_publication(request(
+        &repo.workspace_id,
+        &repo.remote,
+        &repo.cache.join("task-schema"),
+        None,
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(task_error.contains("ORB-00001"));
+}
+
+#[test]
+fn parent_mismatch_fails_closed() {
+    let repo = linear_repo("ws_inspect_parent", AttachmentPolicyKind::Fail);
+    let envelope_path = repo.remote.join(PUBLICATION_ENVELOPE_FILE_NAME);
+    let yaml = fs::read_to_string(&envelope_path)
+        .unwrap()
+        .replace(&repo.gen1, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    fs::write(&envelope_path, yaml).unwrap();
+    git(&repo.remote, &["add", "-A"]);
+    git(&repo.remote, &["commit", "-m", "wrong parent"]);
+    let error = inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("previous-publication"));
+}
+
+#[test]
+fn inspect_does_not_mutate_canonical_or_source_state() {
+    let repo = linear_repo("ws_inspect_readonly", AttachmentPolicyKind::Fail);
+    let registry = open_registry(repo.root.path());
+    let before_tasks = registry
+        .tasks_for_workspace(&repo.workspace_id)
+        .unwrap()
+        .len();
+    let before_allocator = registry.allocator_next_number().unwrap();
+    let canonical = registry
+        .canonical_task_bundle_path(&repo.workspace_id, "ORB-00001")
+        .unwrap();
+    let before_bundle = tree_bytes(&canonical);
+    let before_source = tree_bytes(&repo.source_checkout);
+    let before_source_head = git(&repo.source_checkout, &["rev-parse", "HEAD"]);
+    let before_source_status = git(&repo.source_checkout, &["status", "--porcelain"]);
+    let checkout = repo
+        .root
+        .path()
+        .join("repos")
+        .join(&repo.workspace_id)
+        .join(".orbit");
+    let before_checkout = tree_bytes(&checkout);
+
+    inspect_publication(request(&repo.workspace_id, &repo.remote, &repo.cache, None)).unwrap();
+
+    assert_eq!(
+        registry
+            .tasks_for_workspace(&repo.workspace_id)
+            .unwrap()
+            .len(),
+        before_tasks
+    );
+    assert_eq!(registry.allocator_next_number().unwrap(), before_allocator);
+    assert_eq!(tree_bytes(&canonical), before_bundle);
+    assert_eq!(tree_bytes(&repo.source_checkout), before_source);
+    assert_eq!(
+        git(&repo.source_checkout, &["rev-parse", "HEAD"]),
+        before_source_head
+    );
+    assert_eq!(
+        git(&repo.source_checkout, &["status", "--porcelain"]),
+        before_source_status
+    );
+    assert_eq!(tree_bytes(&checkout), before_checkout);
+    assert!(!repo.root.path().join("claims").exists());
+    assert!(!repo.root.path().join("audit").exists());
+    assert!(!repo.root.path().join("runs").exists());
+}

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::repository::task::v2_bundle::TaskBundleStoreV2;
 
 use super::*;
 
+mod inspect;
 mod publication;
 
 fn open_registry(global: &Path) -> TaskRegistryStore {


### PR DESCRIPTION
## Task

[ORB-11075](https://orbit-cli.com/tasks/ORB-11075) — Inspect task-publication repositories as labelled read-only state

### Description

## Problem
A cloned publication repository is inspectable with Git, but Orbit has no validated read-only consumer that distinguishes a remote snapshot from live authoritative task state.

## Why It Matters
Cross-machine visibility is only safe if Orbit verifies repository pairing and bundle integrity, labels freshness and lineage, and never adopts fetched data as a writable workspace.

## Constraints / Notes
- Fetch into an Orbit-owned consumer cache, never the source checkout.
- Require explicit expected workspace, source-repository identity, publication ID, and authority lineage from a registered binding or operator input; never adopt by repository contents alone.
- Reuse the publication envelope and task-bundle validators.
- Unsupported newer schemas and any mismatch or tamper fail closed.
- Inspection may build a disposable index, but it must not mutate canonical tasks, allocators, checkout projections, ownership, claims, audit, or execution state.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- A read-only consumer fetches a configured publication branch into an Orbit-owned cache and validates its envelope, Git parent/previous-publication relation, task list, bundle schemas, JSONL tails, and included attachment checksums.
- Rendered task results are explicitly labelled with publication time, generation, workspace, source fingerprint, authority, publication ID, commit ID, and incomplete-attachment status.
- Workspace, source, lineage, authority, branch, unsupported-schema, and content-integrity mismatches fail before any task is rendered as trusted publication state.
- Inspection creates no canonical task records, allocator changes, checkout projections, workspace-role changes, claims, audit rows, or execution records.
- Tests cover current and stale snapshots, incomplete attachment projections, tampered bundles, mismatched repositories, and unsupported future envelope/task schemas.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `inspect_publication` in `crates/orbit-store/src/workflow/task/inspect.rs`. It fetches a configured ordinary branch into an Orbit-owned cache (`<cache>/<publication_id>/`), requires explicit expected workspace/source/publication-id/authority, and validates the envelope, Git parent/`previous_publication` relation, task list, bundle schemas, JSONL tails, and included attachment checksums before returning any task.
- Rendered tasks are labelled with publication time, generation, workspace, source fingerprint, authority machine, publication ID, commit ID, incomplete-attachment status, current vs stale freshness, and `PublicationRenderAuthority::Snapshot` (never live owner state).
- Workspace, source, lineage, authority, branch, unsupported-schema, parent, and content-integrity mismatches fail closed. The inspect API takes no registry, allocator, checkout, claim, audit, or execution handles.
- Added 8 local-git sibling tests covering current and stale snapshots, omit/incomplete attachments, tampered bundles and JSONL tails, mismatched identity/branch, parent mismatch, unsupported future envelope/task schemas, and a live registry plus source checkout that stay byte-identical.
- Reused `PublicationEnvelope::validate`, `validate_jsonl_files`, and `read_bundle_at`. Updated ARCHITECTURE.md workflow ownership to include read-only task-publication inspection.
Assessment: Scoped library consumer matching the ORB-11068 inspect contract. Git empty-directory loss is repaired only in the disposable cache tree. No CLI or publish-transport surface (ORB-11074 / ORB-11077).
Validation:
- `cargo test -p orbit-store workflow::task::tests`: 31 passed
- `cargo clippy -p orbit-store --all-targets -- -D warnings`: passed
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed
Strategic decisions: Identity is operator/binding input, never inferred from repository contents. Fetch uses a bare clone plus detached worktree under the consumer cache, never the source checkout.
Recommended follow-ups: ORB-11074 (owner Git compare-and-swap publish) and ORB-11077 (operator surface) can consume this inspector.
Friction checkpoint: no contradicted assumption, recurring failure, incident root cause, or >10-minute non-obvious gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11075-6a9394a9`
- Behind base: 0
- Ahead of base: 1