### PR TITLE
[code-review] Serialize checkoutless task updates across lifecycle changes

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 
 use chrono::Utc;
 use orbit_common::fs::selector::canonical_selector;
@@ -78,6 +80,18 @@ struct HubCoordinationState {
     workspace_id: String,
     legacy_friction_root: Option<PathBuf>,
     tasks: WorkspaceTaskBackends,
+    #[cfg(test)]
+    update_hooks: CheckoutlessUpdateHooks,
+}
+
+#[cfg(test)]
+pub(super) type CheckoutlessUpdateHook = Arc<dyn Fn(&Task, &Value) + Send + Sync>;
+
+#[cfg(test)]
+#[derive(Default)]
+struct CheckoutlessUpdateHooks {
+    after_pre_state_read: Mutex<Option<CheckoutlessUpdateHook>>,
+    after_locked_state_read: Mutex<Option<CheckoutlessUpdateHook>>,
 }
 
 impl HubCoordinationExecutor {
@@ -165,8 +179,41 @@ impl HubCoordinationExecutor {
                 workspace_id: workspace_id.into(),
                 legacy_friction_root,
                 tasks,
+                #[cfg(test)]
+                update_hooks: CheckoutlessUpdateHooks::default(),
             }),
         })
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_after_pre_state_read_hook(&self, hook: CheckoutlessUpdateHook) {
+        *self
+            .inner
+            .update_hooks
+            .after_pre_state_read
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_after_locked_state_read_hook(&self, hook: CheckoutlessUpdateHook) {
+        *self
+            .inner
+            .update_hooks
+            .after_locked_state_read
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(hook);
+    }
+
+    #[cfg(test)]
+    fn update_hook(hook: &Mutex<Option<CheckoutlessUpdateHook>>, task: &Task, input: &Value) {
+        let hook = hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(hook) = hook {
+            hook(task, input);
+        }
     }
 
     pub fn execute_tool(
@@ -327,8 +374,52 @@ impl HubCoordinationExecutor {
             ));
         }
         let id = required_string(&input, &["id"], "id")?;
-        let current = self.task(&id)?;
         let actor = Self::actor(agent.as_deref(), model.as_deref());
+
+        // The pre-lock snapshot exists only as a deterministic regression seam:
+        // production decisions always use the fresh snapshot read below while
+        // holding the authoritative task lock.
+        #[cfg(test)]
+        {
+            let hook = self
+                .inner
+                .update_hooks
+                .after_pre_state_read
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            if let Some(hook) = hook {
+                let pre_state = self.task(&id)?;
+                hook(&pre_state, &input);
+            }
+        }
+
+        let mut outcome = None;
+        self.inner.tasks.task.with_task_write_lock(&id, &mut || {
+            let current = self.task(&id)?;
+            #[cfg(test)]
+            Self::update_hook(
+                &self.inner.update_hooks.after_locked_state_read,
+                &current,
+                &input,
+            );
+            let updated = self.update_task_from_snapshot(&id, input.clone(), &actor, &current)?;
+            outcome = Some((current, updated));
+            Ok(())
+        })?;
+        let (current, updated) = outcome.ok_or_else(|| {
+            OrbitError::Execution(format!("task write lock did not execute update for '{id}'"))
+        })?;
+        self.finish_task_update(&id, &current, &updated)
+    }
+
+    fn update_task_from_snapshot(
+        &self,
+        id: &str,
+        input: Value,
+        actor: &str,
+        current: &Task,
+    ) -> Result<Task, OrbitError> {
         let status = optional_string(&input, "status")?
             .map(|value| super::input::parse_task_status("status", &value))
             .transpose()?;
@@ -406,7 +497,7 @@ impl HubCoordinationExecutor {
         if let Some(dependencies) = dependencies.as_ref() {
             validate_task_dependencies(
                 &self.inner.tasks.task.list_tasks()?,
-                Some(&id),
+                Some(id),
                 dependencies,
             )?;
         }
@@ -471,9 +562,9 @@ impl HubCoordinationExecutor {
             )));
         }
         self.inner.tasks.document.update_task_document(
-            &id,
+            id,
             TaskDocumentUpdateParams {
-                actor: actor.clone(),
+                actor: actor.to_string(),
                 title: optional_string(&input, "title")?.map(|value| redact_all(&value)),
                 description,
                 acceptance_criteria: optional_string_list_alias(
@@ -494,11 +585,11 @@ impl HubCoordinationExecutor {
                     .map(|value| redact_all(&value)),
                 context_files,
                 planned_by: explicit_planned_by
-                    .or_else(|| input.get("plan").is_some().then(|| Some(actor.clone()))),
+                    .or_else(|| input.get("plan").is_some().then(|| Some(actor.to_string()))),
                 implemented_by: explicit_implemented_by.or_else(|| {
                     status
                         .is_some_and(|value| matches!(value, TaskStatus::Review | TaskStatus::Done))
-                        .then(|| Some(actor.clone()))
+                        .then(|| Some(actor.to_string()))
                 }),
                 priority: None,
                 complexity: None,
@@ -514,9 +605,9 @@ impl HubCoordinationExecutor {
         )?;
         if !artifacts.is_empty() {
             self.inner.tasks.artifact.upsert_task_artifacts(
-                &id,
+                id,
                 TaskArtifactUpdateParams {
-                    actor: actor.clone(),
+                    actor: actor.to_string(),
                     upsert_artifacts: artifacts,
                 },
             )?;
@@ -525,15 +616,15 @@ impl HubCoordinationExecutor {
             let append_comments = comment
                 .map(|message| TaskComment {
                     at: Utc::now(),
-                    by: actor.clone(),
+                    by: actor.to_string(),
                     message: redact_all(message.trim()),
                 })
                 .into_iter()
                 .collect();
             self.inner.tasks.history.update_task_history(
-                &id,
+                id,
                 TaskHistoryUpdateParams {
-                    actor,
+                    actor: actor.to_string(),
                     status,
                     status_event: status.map(|_| "updated".to_string()),
                     status_note: None,
@@ -542,7 +633,15 @@ impl HubCoordinationExecutor {
                 },
             )?;
         }
-        let updated = self.task(&id)?;
+        self.task(id)
+    }
+
+    fn finish_task_update(
+        &self,
+        id: &str,
+        current: &Task,
+        updated: &Task,
+    ) -> Result<Value, OrbitError> {
         if updated.status == TaskStatus::Done
             && current.status != TaskStatus::Done
             && let Ok(frictions) = self.friction_store()
@@ -550,7 +649,7 @@ impl HubCoordinationExecutor {
             for relation in &updated.relations {
                 if relation.relation_type == orbit_types::task::TaskRelationType::Resolves
                     && is_valid_friction_id(&relation.target)
-                    && let Err(error) = frictions.resolve_by_task(&relation.target, &id, Utc::now())
+                    && let Err(error) = frictions.resolve_by_task(&relation.target, id, Utc::now())
                 {
                     tracing::warn!(
                         task_id = id,
@@ -561,7 +660,7 @@ impl HubCoordinationExecutor {
                 }
             }
         }
-        self.task_json(&updated)
+        self.task_json(updated)
     }
 
     fn transition(
@@ -572,49 +671,69 @@ impl HubCoordinationExecutor {
         start: bool,
     ) -> Result<Value, OrbitError> {
         let id = required_string(&input, &["id"], "id")?;
-        let task = self.task(&id)?;
-        let target = if start {
-            if !matches!(
-                task.status,
-                TaskStatus::Proposed
-                    | TaskStatus::Backlog
-                    | TaskStatus::Someday
-                    | TaskStatus::Blocked
-            ) {
-                return Err(OrbitError::InvalidInput(format!(
-                    "task '{id}' is in status '{}'; start requires proposed, backlog, someday, or blocked",
-                    task.status
-                )));
-            }
-            if task.plan.trim().is_empty() {
-                return Err(OrbitError::InvalidInput(format!(
-                    "task '{id}' requires a non-empty plan before entering in-progress"
-                )));
-            }
-            TaskStatus::InProgress
-        } else {
-            match task.status {
-                TaskStatus::Proposed => TaskStatus::Backlog,
-                TaskStatus::Review => TaskStatus::Done,
-                other => {
-                    return Err(OrbitError::InvalidInput(format!(
-                        "task '{id}' is in status '{other}'; approve requires proposed or review"
-                    )));
+        let actor = Self::actor(agent.as_deref(), model.as_deref());
+        let comment = optional_string(&input, "note")?.or(optional_string(&input, "comment")?);
+        let crew = optional_string(&input, "crew")?;
+        let mut outcome = None;
+        self.inner
+            .tasks
+            .task
+            .with_task_write_lock(&id, &mut || {
+                let current = self.task(&id)?;
+                let target = if start {
+                    if !matches!(
+                        current.status,
+                        TaskStatus::Proposed
+                            | TaskStatus::Backlog
+                            | TaskStatus::Someday
+                            | TaskStatus::Blocked
+                    ) {
+                        return Err(OrbitError::InvalidInput(format!(
+                            "task '{id}' is in status '{}'; start requires proposed, backlog, someday, or blocked",
+                            current.status
+                        )));
+                    }
+                    if current.plan.trim().is_empty() {
+                        return Err(OrbitError::InvalidInput(format!(
+                            "task '{id}' requires a non-empty plan before entering in-progress"
+                        )));
+                    }
+                    TaskStatus::InProgress
+                } else {
+                    match current.status {
+                        TaskStatus::Proposed => TaskStatus::Backlog,
+                        TaskStatus::Review => TaskStatus::Done,
+                        other => {
+                            return Err(OrbitError::InvalidInput(format!(
+                                "task '{id}' is in status '{other}'; approve requires proposed or review"
+                            )));
+                        }
+                    }
+                };
+                let mut update = Map::new();
+                update.insert("id".to_string(), Value::String(id.clone()));
+                update.insert("status".to_string(), Value::String(target.to_string()));
+                if let Some(comment) = &comment {
+                    update.insert("comment".to_string(), Value::String(comment.clone()));
                 }
-            }
-        };
-        let mut update = Map::new();
-        update.insert("id".to_string(), Value::String(id));
-        update.insert("status".to_string(), Value::String(target.to_string()));
-        if let Some(note) = optional_string(&input, "note")? {
-            update.insert("comment".to_string(), Value::String(note));
-        } else if let Some(comment) = optional_string(&input, "comment")? {
-            update.insert("comment".to_string(), Value::String(comment));
-        }
-        if let Some(crew) = optional_string(&input, "crew")? {
-            update.insert("crew".to_string(), Value::String(crew));
-        }
-        self.update_task(Value::Object(update), agent, model)
+                if let Some(crew) = &crew {
+                    update.insert("crew".to_string(), Value::String(crew.clone()));
+                }
+                let updated = self.update_task_from_snapshot(
+                    &id,
+                    Value::Object(update),
+                    &actor,
+                    &current,
+                )?;
+                outcome = Some((current, updated));
+                Ok(())
+            })?;
+        let (current, updated) = outcome.ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "task write lock did not execute transition for '{id}'"
+            ))
+        })?;
+        self.finish_task_update(&id, &current, &updated)
     }
 
     fn show_task(&self, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -1,12 +1,15 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::{Arc, Barrier, Mutex, MutexGuard, OnceLock};
 
-use orbit_store::maintenance::task_registry::read_workspace_config;
+use orbit_store::maintenance::task_registry::{
+    TaskRegistryStore, read_workspace_config, task_registry_path,
+};
 use orbit_types::task::TaskStatus;
 use orbit_types::tool::ToolSessionContext;
 use serde_json::{Value, json};
 
+use super::super::HubCoordinationExecutor;
 use super::super::test_support::{
     create_task, create_task_with_crew, invalid_input_message, run_tool_as_operator, test_runtime,
 };
@@ -60,6 +63,72 @@ fn assert_task_titles(output: &Value, expected: &[&str]) {
     expected.sort();
 
     assert_eq!(titles, expected);
+}
+
+fn checkoutless_executor() -> (
+    tempfile::TempDir,
+    HubCoordinationExecutor,
+    ToolSessionContext,
+) {
+    let root = tempfile::tempdir().expect("global root");
+    HubCoordinationExecutor::register_workspace(root.path(), "ws_checkoutless", "checkoutless")
+        .expect("register workspace");
+    let executor = HubCoordinationExecutor::new(root.path(), "ws_checkoutless", None)
+        .expect("coordination executor");
+    let context = ToolSessionContext::trusted_local(
+        Some("ws_checkoutless".to_string()),
+        Some("hm_hub".to_string()),
+        Some("hub".to_string()),
+    );
+    (root, executor, context)
+}
+
+fn checkoutless_review_task(
+    executor: &HubCoordinationExecutor,
+    context: &ToolSessionContext,
+    title: &str,
+) -> String {
+    let created = executor
+        .execute_tool(
+            "orbit.task.add",
+            json!({
+                "workspace": "ws_checkoutless",
+                "title": title,
+                "description": "Checkoutless review fixture",
+                "complexity": "low",
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("add checkoutless task");
+    let id = created["id"].as_str().expect("task id").to_string();
+    executor
+        .execute_tool(
+            "orbit.task.update",
+            json!({"id": id, "status": "backlog", "plan": "Execute", "model": "codex"}),
+            context.clone(),
+        )
+        .expect("move task to backlog");
+    executor
+        .execute_tool(
+            "orbit.task.start",
+            json!({"id": id, "model": "codex"}),
+            context.clone(),
+        )
+        .expect("start task");
+    executor
+        .execute_tool(
+            "orbit.task.update",
+            json!({
+                "id": id,
+                "status": "review",
+                "execution_summary": "Outcome: success",
+                "model": "codex"
+            }),
+            context.clone(),
+        )
+        .expect("move task to review");
+    id
 }
 
 #[test]
@@ -552,6 +621,146 @@ fn task_tools_roundtrip_required_tools_and_reject_updates() {
         )
         .expect_err("task requirements are creation-only");
     assert!(error.to_string().contains("immutable"), "{error}");
+}
+
+#[test]
+fn stale_checkoutless_metadata_update_cannot_mutate_a_task_approved_to_done() {
+    let (_root, executor, context) = checkoutless_executor();
+    let id = checkoutless_review_task(&executor, &context, "Terminal race fixture");
+    let snapshot_read = Arc::new(Barrier::new(2));
+    let release_update = Arc::new(Barrier::new(2));
+    executor.set_after_pre_state_read_hook(Arc::new({
+        let id = id.clone();
+        let snapshot_read = Arc::clone(&snapshot_read);
+        let release_update = Arc::clone(&release_update);
+        move |task, input| {
+            if task.id == id && input["title"] == "Stale title" {
+                assert_eq!(task.status, TaskStatus::Review);
+                snapshot_read.wait();
+                release_update.wait();
+            }
+        }
+    }));
+
+    std::thread::scope(|scope| {
+        let stale_executor = executor.clone();
+        let stale_context = context.clone();
+        let stale_id = id.clone();
+        let stale_update = scope.spawn(move || {
+            stale_executor.execute_tool(
+                "orbit.task.update",
+                json!({"id": stale_id, "title": "Stale title", "model": "codex"}),
+                stale_context,
+            )
+        });
+
+        snapshot_read.wait();
+        let approved = executor
+            .execute_tool(
+                "orbit.task.approve",
+                json!({"id": id, "note": "Approved normally", "model": "codex"}),
+                context.clone(),
+            )
+            .expect("approve review task through the normal transition surface");
+        assert_eq!(approved["status"], "done");
+        assert_eq!(
+            approved["comments"]
+                .as_array()
+                .and_then(|comments| comments.last())
+                .and_then(|comment| comment["message"].as_str()),
+            Some("Approved normally")
+        );
+        release_update.wait();
+
+        let error = stale_update
+            .join()
+            .expect("stale update thread")
+            .expect_err("the terminal task must reject the stale metadata update");
+        assert!(error.to_string().contains("done is terminal"), "{error}");
+    });
+
+    let shown = executor
+        .execute_tool(
+            "orbit.task.show",
+            json!({"id": id, "fields": ["status", "title"]}),
+            context,
+        )
+        .expect("show terminal task");
+    assert_eq!(
+        shown,
+        json!({"status": "done", "title": "Terminal race fixture"})
+    );
+}
+
+#[test]
+fn checkoutless_updates_to_distinct_tasks_remain_independent() {
+    let (root, executor, context) = checkoutless_executor();
+    let first = checkoutless_review_task(&executor, &context, "First concurrent task");
+    let second = checkoutless_review_task(&executor, &context, "Second concurrent task");
+    let registry =
+        TaskRegistryStore::open(&task_registry_path(root.path())).expect("open task registry");
+    let first_lock_path = registry
+        .canonical_task_bundle_path("ws_checkoutless", &first)
+        .expect("first task bundle")
+        .join(".task.yaml.lock");
+    let first_locked = Arc::new(Barrier::new(2));
+    let release_first = Arc::new(Barrier::new(2));
+    executor.set_after_locked_state_read_hook(Arc::new({
+        let first = first.clone();
+        let first_locked = Arc::clone(&first_locked);
+        let release_first = Arc::clone(&release_first);
+        move |task, input| {
+            if task.id == first && input["title"] == "First task updated" {
+                first_locked.wait();
+                release_first.wait();
+            }
+        }
+    }));
+
+    std::thread::scope(|scope| {
+        let first_executor = executor.clone();
+        let first_context = context.clone();
+        let first_id = first.clone();
+        let first_update = scope.spawn(move || {
+            first_executor.execute_tool(
+                "orbit.task.update",
+                json!({
+                    "id": first_id,
+                    "title": "First task updated",
+                    "model": "codex"
+                }),
+                first_context,
+            )
+        });
+
+        first_locked.wait();
+        let first_lock = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&first_lock_path)
+            .expect("open first task lock file");
+        let error = fs2::FileExt::try_lock_exclusive(&first_lock)
+            .expect_err("the updater must hold the task lock after its authoritative read");
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+        let second_updated = executor
+            .execute_tool(
+                "orbit.task.update",
+                json!({
+                    "id": second,
+                    "title": "Second task updated",
+                    "model": "codex"
+                }),
+                context.clone(),
+            )
+            .expect("a distinct task can update while the first task lock is held");
+        assert_eq!(second_updated["title"], "Second task updated");
+        release_first.wait();
+        let first_updated = first_update
+            .join()
+            .expect("first update thread")
+            .expect("first update succeeds after release");
+        assert_eq!(first_updated["title"], "First task updated");
+    });
 }
 
 /// ORB-10968: crew configuration is host-local, so a stored crew this host has


### PR DESCRIPTION
## Task

[ORB-11100](https://orbit-cli.com/tasks/ORB-11100) — [code-review] Serialize checkoutless task updates across lifecycle changes

### Description

## Problem

The checkoutless `HubCoordinationExecutor::update_task` reads a task snapshot, validates terminal/lifecycle and field-specific rules against that snapshot, and then performs separate document, artifact, and history writes. Those operations use per-write locking, but the complete read-validate-write decision is not protected by the task backend's authoritative `with_task_write_lock`.

After ORB-11099 removes existing-task `required_tools` mutation, the authority-specific race from ORB-11092 disappears. A general stale-snapshot bug remains: for example, an ordinary metadata update may observe a review task, a concurrent approval may move it to terminal `done`, and the stale updater may then mutate the now-terminal task. Concurrent lifecycle, comment, artifact, and derived-history writes can likewise be validated or assembled from a pre-state that is no longer authoritative.

## Required Change

- Implement this only after ORB-11099 so the regression and fix are independent of `required_tools`.
- Add a deterministic, synchronization-controlled checkoutless regression using an ordinary metadata/lifecycle interleaving. Pause the stale updater after its authoritative pre-state read, advance the same task to `done` through the normal checkoutless transition surface, then prove the stale mutation cannot land.
- Do not use sleeps, timing budgets, or probabilistic stress to create the interleaving.
- Reuse `TaskStoreBackend::with_task_write_lock`; do not add a second lock implementation.
- Hold the per-task lock across the snapshot read, all validation derived from it, and the document/artifact/history writes derived from that decision for checkoutless update and transition paths.
- Keep side effects that touch other records, such as friction resolution, outside the task lock.
- Preserve checkoutless routing and avoid adding another parallel lifecycle policy path.

## Why It Matters

Task terminality and lifecycle validation are store invariants. Per-write locking protects individual files but cannot make a multi-step decision atomic when its validation came from an older snapshot.

## Related Work

- ORB-10988 established the checkout-backed read-modify-write lock contract.
- ORB-11092 identified the same missing checkoutless boundary through a `required_tools` race, but its implementation and regression are being rejected in favor of the split design.
- ORB-11099 removes the mutable-authority surface first.

### Acceptance Criteria

- A deterministic checkoutless regression, with no sleep or elapsed-time assumption, pauses an ordinary metadata update after its pre-state read, advances the same review task to done through the normal approval/transition surface, and proves the stale update cannot mutate the terminal task.
- The regression fails against the unlocked checkoutless implementation and does not depend on required_tools parsing, mutation, freeze validation, or dispatch behavior.
- Checkoutless update and transition hold the existing authoritative per-task write lock across snapshot reads, lifecycle and terminal-state validation, and every document, artifact, comment, and history write derived from that snapshot.
- Cross-record side effects remain outside the task lock, same-task nested operations do not deadlock, and operations on distinct tasks retain independent concurrency.
- Focused checkoutless lifecycle, comment, artifact, projection, and concurrency tests pass, followed by make ci-fast, make ci-lint, and git diff --check.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Wrapped checkoutless task updates in the authoritative per-task write lock from snapshot read through lifecycle and terminal validation plus document, artifact, comment, and history persistence.
- Routed checkoutless start and approve transitions through the same locked snapshot/update helper while leaving friction-resolution side effects after lock release.
- Added deterministic barrier-controlled stale-snapshot and distinct-task concurrency regressions, including proof that the updater owns the same-task file lock after its authoritative read and that normal approval comments/projections persist.
Assessment: Checkoutless update decisions are now atomic per task, nested backend writes remain re-entrant, and separate task IDs retain independent concurrency.
Validation:
- cargo test -p orbit-core checkoutless: passed (8 tests)
- make ci-fast: passed
- make ci-lint: passed
- git diff --check: passed
Friction checkpoint: no qualifying friction found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11100-6a939882`
- Behind base: 0
- Ahead of base: 1