### PR TITLE
Publish task snapshots with owner-only Git compare-and-swap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,8 @@ feature.
   technology each. `repository` owns live invariants that join drivers (task
   bundles + registry indexes + checkout projections, and friction SQLite +
   file taxonomy). `workflow` owns explicit import/export/reindex/repair,
-  read-only task-publication inspection, and layout-upgrade operations.
+  owner-only task-publication transport, read-only task-publication
+  inspection, and layout-upgrade operations.
   `compose` constructs concrete implementations and
   returns contract-facing stores. The crate retains the namespaced feature
   migration ledger and immutable historical bootstrap migrations. It depends
@@ -147,9 +148,9 @@ Live task writes are committed by the composite task repository: canonical
 bundle durability is the file-driver operation, allocation/binding/index rows
 are the registry-driver operation, and `.orbit/tasks` symlinks are disposable
 checkout projections. The drivers do not call each other. Task archive
-import/export/reindex, read-only task-publication inspection, friction Markdown
-import/SQLite export, legacy audit and job-run import, and workspace layout
-upgrades are explicit `workflow` modules.
+import/export/reindex, owner-only task-publication transport and its read-only
+inspection, friction Markdown import/SQLite export, legacy audit and job-run
+import, and workspace layout upgrades are explicit `workflow` modules.
 In particular, constructing a friction repository does not perform a hidden
 Markdown import; `compose::workspace_friction_store` invokes the idempotent,
 transactional workflow before opening the live repository.

--- a/crates/orbit-store/src/workflow/task/git.rs
+++ b/crates/orbit-store/src/workflow/task/git.rs
@@ -1,0 +1,191 @@
+//! Hardened non-interactive Git plumbing shared by the task-publication
+//! transport and its read-only consumer.
+//!
+//! `orbit_common::fs::git::run_git` drives a source checkout with the
+//! operator's ambient configuration. Publication instead drives an Orbit-owned
+//! private cache: it must never prompt for credentials, read system config, run
+//! repository hooks, or let content filters rewrite snapshot bytes, and it needs
+//! per-invocation environment (index file, deterministic commit identity). That
+//! is a different contract, so it keeps its own runner here.
+
+use std::path::Path;
+use std::process::Command;
+
+use orbit_common::OrbitError;
+use orbit_types::workspace::git_remotes_equivalent;
+
+/// Result of a Git invocation that is allowed to fail.
+pub(super) struct GitAttempt {
+    pub(super) success: bool,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+}
+
+/// Runs `git` with publication-safe defaults and a caller-supplied error label.
+pub(super) struct GitRunner<'a> {
+    label: &'a str,
+    env: Vec<(&'a str, String)>,
+}
+
+impl<'a> GitRunner<'a> {
+    pub(super) fn new(label: &'a str) -> Self {
+        Self {
+            label,
+            env: Vec::new(),
+        }
+    }
+
+    /// Additional environment applied to every invocation of this runner.
+    pub(super) fn with_env(mut self, env: Vec<(&'a str, String)>) -> Self {
+        self.env = env;
+        self
+    }
+
+    /// Run `git`, mapping a non-zero exit to an error with redacted arguments.
+    pub(super) fn run(&self, args: &[&str]) -> Result<String, OrbitError> {
+        let attempt = self.try_run(args)?;
+        if !attempt.success {
+            return Err(self.error(format!(
+                "git {} failed: {}",
+                redact_args(args),
+                attempt.stderr.trim()
+            )));
+        }
+        Ok(attempt.stdout.trim().to_string())
+    }
+
+    /// Run `git` and return the outcome even when the command exits non-zero.
+    pub(super) fn try_run(&self, args: &[&str]) -> Result<GitAttempt, OrbitError> {
+        let mut command = Command::new("git");
+        command
+            .args([
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "core.excludesFile=/dev/null",
+                "-c",
+                "core.attributesFile=/dev/null",
+                "-c",
+                "core.autocrlf=false",
+                "-c",
+                "core.safecrlf=false",
+            ])
+            .args(args)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GCM_INTERACTIVE", "never");
+        for (key, value) in &self.env {
+            command.env(key, value);
+        }
+        let output = command.output().map_err(|error| {
+            OrbitError::Execution(format!(
+                "{} failed to run `git {}`: {error}",
+                self.label,
+                redact_args(args)
+            ))
+        })?;
+        Ok(GitAttempt {
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+
+    /// Single Git parent of `commit`. Publication history must stay linear, so
+    /// a merge commit is an error rather than something to pick a side of.
+    pub(super) fn single_parent(
+        &self,
+        git_dir: &str,
+        commit: &str,
+    ) -> Result<Option<String>, OrbitError> {
+        let parents = self.run(&[
+            "--git-dir",
+            git_dir,
+            "rev-list",
+            "--parents",
+            "-n",
+            "1",
+            commit,
+        ])?;
+        let mut tokens = parents.split_whitespace();
+        let _ = tokens.next();
+        let parent = tokens.next().map(str::to_ascii_lowercase);
+        if tokens.next().is_some() {
+            return Err(self.error(format!(
+                "publication history must be linear; commit {commit} has multiple Git parents"
+            )));
+        }
+        Ok(parent)
+    }
+
+    pub(super) fn error(&self, message: impl Into<String>) -> OrbitError {
+        OrbitError::InvalidInput(format!("{}: {}", self.label, message.into()))
+    }
+}
+
+/// Absolute paths are local filesystem detail; keep them out of error text.
+fn redact_args(args: &[&str]) -> String {
+    args.iter()
+        .filter(|arg| !Path::new(arg).is_absolute())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Report a binding field that disagrees with the observed publication.
+pub(super) fn field_mismatch(
+    label: &str,
+    field: &str,
+    expected: &str,
+    observed: &str,
+) -> Result<(), OrbitError> {
+    if expected == observed {
+        Ok(())
+    } else {
+        Err(OrbitError::InvalidInput(format!(
+            "{label}: {field} mismatch: expected '{expected}', observed '{observed}'"
+        )))
+    }
+}
+
+pub(super) fn short_branch(branch: &str) -> &str {
+    branch.strip_prefix("refs/heads/").unwrap_or(branch)
+}
+
+/// A publication remote must never carry embedded credentials.
+pub(super) fn remote_has_password(remote: &str) -> bool {
+    let Some(rest) = remote.split_once("://").map(|(_, rest)| rest) else {
+        return false;
+    };
+    rest.split_once('@')
+        .is_some_and(|(userinfo, _)| userinfo.contains(':'))
+}
+
+/// Compare a configured remote with one recorded in an Orbit-owned cache.
+pub(super) fn remotes_match(expected: &str, observed: &str) -> bool {
+    if expected == observed {
+        return true;
+    }
+    if normalize_local_remote(expected) == normalize_local_remote(observed) {
+        return true;
+    }
+    git_remotes_equivalent(expected, observed).unwrap_or(false)
+}
+
+fn normalize_local_remote(remote: &str) -> String {
+    let trimmed = remote.trim();
+    let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);
+    Path::new(path)
+        .canonicalize()
+        .map(|canonical| canonical.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string())
+}
+
+pub(super) fn path_str<'a>(path: &'a Path, label: &str) -> Result<&'a str, OrbitError> {
+    path.to_str().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "{label}: path '{}' is not valid UTF-8",
+            path.display()
+        ))
+    })
+}

--- a/crates/orbit-store/src/workflow/task/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/inspect.rs
@@ -7,23 +7,26 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
 use orbit_types::identity::{validate_machine_id, validate_registry_identifier};
 use orbit_types::task::{TASK_ARTIFACT_FILES_DIR_NAME, TASK_ARTIFACTS_DIR_NAME, TaskEnvelopeV2};
 use orbit_types::workspace::{
-    canonicalize_publication_branch, git_remotes_equivalent, redact_git_remote,
-    validate_git_commit_id, validate_source_repository_fingerprint,
+    canonicalize_publication_branch, redact_git_remote, validate_git_commit_id,
+    validate_source_repository_fingerprint,
 };
 
 use crate::driver::file::task_bundle::{TaskBundleV2, read_bundle_at};
 
+use super::git::{GitRunner, field_mismatch, remote_has_password, remotes_match, short_branch};
 use super::publication::{
     AttachmentPolicyKind, PUBLICATION_ENVELOPE_FILE_NAME, PUBLICATION_TASKS_DIR_NAME,
-    PublicationEnvelope, validate_jsonl_files,
+    PublicationEnvelope, assert_envelope_parent_lineage, validate_jsonl_files,
 };
+
+/// Error prefix and command label for every consumer-side failure.
+const INSPECT_LABEL: &str = "publication inspect";
 
 /// Caller-supplied pairing and fetch inputs. Identity is never inferred from
 /// repository contents.
@@ -98,7 +101,7 @@ pub fn inspect_publication(
     let fetched = fetch_publication(&request)?;
     let envelope = read_envelope(&fetched.tree_dir)?;
     assert_pairing(&request, &envelope, &fetched.branch)?;
-    assert_parent_lineage(&envelope, fetched.git_parent.as_deref())?;
+    assert_envelope_parent_lineage(&envelope, fetched.git_parent.as_deref(), INSPECT_LABEL)?;
     let tasks = read_validated_tasks(&fetched.tree_dir, &envelope)?;
     let label = PublicationInspectLabel {
         published_at: envelope.published_at,
@@ -271,23 +274,7 @@ fn fetch_publication(request: &ValidatedRequest) -> Result<FetchedSnapshot, Orbi
         &commit_id,
     ])?;
 
-    let parents = git(&[
-        "--git-dir",
-        git_dir_s,
-        "rev-list",
-        "--parents",
-        "-n",
-        "1",
-        &commit_id,
-    ])?;
-    let mut tokens = parents.split_whitespace();
-    let _ = tokens.next();
-    let git_parent = tokens.next().map(str::to_ascii_lowercase);
-    if tokens.next().is_some() {
-        return Err(inspect_error(
-            "publication history must be linear; inspected commit has multiple Git parents",
-        ));
-    }
+    let git_parent = GitRunner::new(INSPECT_LABEL).single_parent(git_dir_s, &commit_id)?;
 
     let freshness = if commit_id == branch_tip {
         PublicationFreshness::Current
@@ -320,39 +307,36 @@ fn assert_pairing(
     envelope: &PublicationEnvelope,
     fetched_branch: &str,
 ) -> Result<(), OrbitError> {
-    mismatch("workspace", &request.workspace_id, &envelope.workspace_id)?;
-    mismatch(
+    field_mismatch(
+        INSPECT_LABEL,
+        "workspace",
+        &request.workspace_id,
+        &envelope.workspace_id,
+    )?;
+    field_mismatch(
+        INSPECT_LABEL,
         "source repository fingerprint",
         &request.source_repository_fingerprint,
         &envelope.source_repository_fingerprint,
     )?;
-    mismatch(
+    field_mismatch(
+        INSPECT_LABEL,
         "publication id",
         &request.publication_id,
         &envelope.publication_id,
     )?;
-    mismatch(
+    field_mismatch(
+        INSPECT_LABEL,
         "authority",
         &request.authority_machine_id,
         &envelope.authority_machine_id,
     )?;
-    mismatch("branch", &request.publication_branch, fetched_branch)?;
-    Ok(())
-}
-
-fn assert_parent_lineage(
-    envelope: &PublicationEnvelope,
-    git_parent: Option<&str>,
-) -> Result<(), OrbitError> {
-    match (envelope.previous_publication.as_deref(), git_parent) {
-        (None, None) => Ok(()),
-        (Some(previous), Some(parent)) if previous.eq_ignore_ascii_case(parent) => Ok(()),
-        (previous, parent) => Err(inspect_error(format!(
-            "Git parent/previous-publication mismatch: envelope previous_publication is {}, Git parent is {}",
-            previous.unwrap_or("null"),
-            parent.unwrap_or("null")
-        ))),
-    }
+    field_mismatch(
+        INSPECT_LABEL,
+        "branch",
+        &request.publication_branch,
+        fetched_branch,
+    )
 }
 
 fn read_validated_tasks(
@@ -478,85 +462,16 @@ fn assert_cache_origin(git_dir: &Path, expected_remote: &str) -> Result<(), Orbi
     )))
 }
 
-fn remotes_match(expected: &str, observed: &str) -> bool {
-    if expected == observed {
-        return true;
-    }
-    let left = normalize_local_remote(expected);
-    let right = normalize_local_remote(observed);
-    if left == right {
-        return true;
-    }
-    git_remotes_equivalent(expected, observed).unwrap_or(false)
-}
-
-fn normalize_local_remote(remote: &str) -> String {
-    let trimmed = remote.trim();
-    let path = trimmed.strip_prefix("file://").unwrap_or(trimmed);
-    Path::new(path)
-        .canonicalize()
-        .map(|canonical| canonical.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| path.to_string())
-}
-
-fn mismatch(field: &str, expected: &str, observed: &str) -> Result<(), OrbitError> {
-    if expected == observed {
-        Ok(())
-    } else {
-        Err(inspect_error(format!(
-            "{field} mismatch: expected '{expected}', observed '{observed}'"
-        )))
-    }
-}
-
-fn short_branch(branch: &str) -> &str {
-    branch.strip_prefix("refs/heads/").unwrap_or(branch)
-}
-
-fn remote_has_password(remote: &str) -> bool {
-    let Some(rest) = remote.split_once("://").map(|(_, rest)| rest) else {
-        return false;
-    };
-    rest.split_once('@')
-        .is_some_and(|(userinfo, _)| userinfo.contains(':'))
-}
-
 fn git(args: &[&str]) -> Result<String, OrbitError> {
-    let output = Command::new("git")
-        .args(["-c", "core.hooksPath=/dev/null"])
-        .args(args)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GCM_INTERACTIVE", "never")
-        .output()
-        .map_err(|error| {
-            OrbitError::Execution(format!(
-                "publication inspect failed to run `git {}`: {error}",
-                args.join(" ")
-            ))
-        })?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(inspect_error(format!(
-            "git {} failed: {}",
-            args.iter()
-                .filter(|arg| !Path::new(arg).is_absolute())
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(" "),
-            stderr.trim()
-        )));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    GitRunner::new(INSPECT_LABEL).run(args)
 }
 
 fn path_str(path: &Path) -> Result<&str, OrbitError> {
-    path.to_str()
-        .ok_or_else(|| inspect_error(format!("path '{}' is not valid UTF-8", path.display())))
+    super::git::path_str(path, INSPECT_LABEL)
 }
 
 fn inspect_error(message: impl Into<String>) -> OrbitError {
-    OrbitError::InvalidInput(format!("publication inspect: {}", message.into()))
+    OrbitError::InvalidInput(format!("{INSPECT_LABEL}: {}", message.into()))
 }
 
 fn identity_error(error: orbit_types::identity::IdentityError) -> OrbitError {

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -1,7 +1,8 @@
 //! Task-migration and publication tooling: export a workspace's task bundles
 //! to a portable tar.zst archive, import them into another machine's registry,
-//! build validated publication snapshots, and inspect a publication repository
-//! as labelled read-only state.
+//! build validated publication snapshots, publish them to a dedicated
+//! publication repository, and inspect that repository as labelled read-only
+//! state.
 //!
 //! The engine lives in `orbit-store` because it needs the canonical bundle I/O
 //! primitives ([`read_bundle_at`]/[`write_bundle_at`]) and the private
@@ -72,8 +73,10 @@ use crate::driver::sqlite::task_registry::{
 };
 
 mod archive;
+mod git;
 mod inspect;
 mod publication;
+mod publish;
 mod reindex;
 
 #[cfg(test)]
@@ -90,6 +93,10 @@ pub use publication::{
     PUBLICATION_ENVELOPE_FILE_NAME, PUBLICATION_TASKS_DIR_NAME, PublicationEnvelope,
     PublicationSnapshotMetadata, PublicationSnapshotOutcome, ScannerFailureBehavior,
     TASK_PUBLICATION_FORMAT_VERSION, build_publication_snapshot,
+};
+pub use publish::{
+    PublicationCallerRole, PublicationLastSuccess, PublicationPublishOutcome,
+    PublicationPublishRequest, PublicationPublishStatus, publish_task_snapshot,
 };
 pub use reindex::{ReindexOutcome, reindex_workspace};
 

--- a/crates/orbit-store/src/workflow/task/publication.rs
+++ b/crates/orbit-store/src/workflow/task/publication.rs
@@ -573,6 +573,24 @@ fn apply_attachment_policy(
     Ok(())
 }
 
+/// The Git parent is the commit-graph authority; `previous_publication`
+/// duplicates it so a detached snapshot stays self-describing. They must agree.
+pub(crate) fn assert_envelope_parent_lineage(
+    envelope: &PublicationEnvelope,
+    parent: Option<&str>,
+    label: &str,
+) -> Result<(), OrbitError> {
+    match (envelope.previous_publication.as_deref(), parent) {
+        (None, None) => Ok(()),
+        (Some(previous), Some(parent)) if previous.eq_ignore_ascii_case(parent) => Ok(()),
+        (previous, parent) => Err(OrbitError::InvalidInput(format!(
+            "{label}: Git parent/previous-publication mismatch: envelope previous_publication is {}, Git parent is {}",
+            previous.unwrap_or("null"),
+            parent.unwrap_or("null")
+        ))),
+    }
+}
+
 pub(crate) fn validate_jsonl_files(task_id: &str, bundle_dir: &Path) -> Result<(), OrbitError> {
     for file_name in [TASK_EVENTS_FILE_NAME, TASK_COMMENTS_FILE_NAME] {
         let path = bundle_dir.join(file_name);

--- a/crates/orbit-store/src/workflow/task/publish.rs
+++ b/crates/orbit-store/src/workflow/task/publish.rs
@@ -1,0 +1,838 @@
+//! Owner-only Git transport for task-publication snapshots.
+//!
+//! Publication is explicit derived work: it never participates in canonical
+//! task-write acknowledgement, and it never becomes a second task authority.
+//! The transport therefore only ever advances one dedicated publication branch
+//! from the declared workspace owner, as a fast-forward compare-and-swap
+//! against the branch tip it actually observed. It never merges, rebases,
+//! replays task operations, force-pushes, selects by timestamp, or creates an
+//! alternate conflict branch, and it never touches the source repository, its
+//! worktree, refs, or configured remotes: all Git work happens in an
+//! Orbit-owned private cache under the caller-supplied `cache_dir`.
+//!
+//! Ownership facts (declared owner, local checkout role, binding) live in the
+//! machine-local workspace registry owned by `orbit-registry`. They are inputs
+//! here rather than lookups, so this crate keeps its narrow dependency set; the
+//! caller passes what it read, and every field is re-verified against the
+//! coordination registry and the remote envelope before anything is built.
+
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use orbit_common::OrbitError;
+use orbit_types::identity::{validate_machine_id, validate_registry_identifier};
+use orbit_types::workspace::{
+    canonicalize_publication_branch, redact_git_remote, validate_git_commit_id,
+    validate_last_success, validate_source_repository_fingerprint,
+};
+use serde::{Deserialize, Serialize};
+use tempfile::TempDir;
+
+use crate::driver::sqlite::task_registry::TaskRegistryStore;
+use crate::fs::yaml::write_yaml_atomic_with;
+
+use super::git::{
+    GitRunner, field_mismatch, path_str, remote_has_password, remotes_match, short_branch,
+};
+use super::publication::{
+    AttachmentPolicy, AttachmentSensitivityScanner, PUBLICATION_ENVELOPE_FILE_NAME,
+    PUBLICATION_TASKS_DIR_NAME, PublicationEnvelope, PublicationSnapshotMetadata,
+    assert_envelope_parent_lineage, build_publication_snapshot,
+};
+
+/// Error prefix and command label for every transport failure.
+const PUBLISH_LABEL: &str = "task publication";
+/// Private record of a push that was issued but not yet confirmed as recorded.
+const PENDING_FILE_NAME: &str = "pending-publication.yaml";
+const PENDING_FORMAT_VERSION: u32 = 1;
+
+/// Local checkout role of the caller. Only the declared owner may publish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationCallerRole {
+    Owner,
+    Replica,
+}
+
+/// Owner-local record of the last publication that was pushed *and* persisted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationLastSuccess {
+    pub generation: u64,
+    pub commit: String,
+}
+
+/// Binding facts and commit metadata for one publication attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationPublishRequest {
+    pub workspace_id: String,
+    pub source_repository_fingerprint: String,
+    pub publication_id: String,
+    pub authority_machine_id: String,
+    /// Machine running this attempt; must be the declared authority.
+    pub local_machine_id: String,
+    pub caller_role: PublicationCallerRole,
+    pub publication_remote: String,
+    pub publication_branch: String,
+    /// Orbit-owned private cache root; must be outside the source checkout.
+    pub cache_dir: PathBuf,
+    pub published_at: DateTime<Utc>,
+    pub last_success: Option<PublicationLastSuccess>,
+}
+
+/// What a publication attempt did to the publication branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationPublishStatus {
+    /// Created the configured branch in a previously empty repository.
+    Initialized,
+    /// Fast-forwarded the branch with a new generation.
+    Advanced,
+    /// The branch tip already carries this exact projection; nothing pushed.
+    Unchanged,
+    /// A previous push landed but was never recorded locally; nothing pushed.
+    Reconciled,
+}
+
+/// Result the owner records as its new last-success state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationPublishOutcome {
+    pub status: PublicationPublishStatus,
+    pub branch: String,
+    pub commit_id: String,
+    pub generation: u64,
+    pub previous_publication: Option<String>,
+    /// Branch tip observed before the compare-and-swap, if the branch existed.
+    pub observed_tip: Option<String>,
+    pub included_attachment_bytes: u64,
+    pub omitted_attachment_bytes: u64,
+}
+
+/// Publish this workspace's validated task snapshot to its dedicated
+/// publication repository.
+///
+/// Fails closed — leaving the remote branch and the caller's last-success
+/// record untouched — when the caller is not the declared owner, the registered
+/// workspace or source fingerprint disagrees, the repository is non-empty
+/// without a matching publication envelope, the branch moved, or any bundle
+/// fails validation.
+pub fn publish_task_snapshot(
+    registry: &TaskRegistryStore,
+    request: PublicationPublishRequest,
+    policy: &AttachmentPolicy,
+    scanner: Option<&dyn AttachmentSensitivityScanner>,
+) -> Result<PublicationPublishOutcome, OrbitError> {
+    let request = validate_request(request)?;
+    assert_registered_workspace(registry, &request)?;
+    let cache = PublicationCache::open(registry, &request)?;
+    let observed = cache.observe_remote(&request)?;
+    let action = decide_action(&cache, &request, &observed)?;
+    let (generation, previous) = match action {
+        PublishAction::Reconcile(outcome) => return Ok(*outcome),
+        PublishAction::Initialize => (1, None),
+        PublishAction::Advance {
+            generation,
+            previous,
+        } => (generation, Some(previous)),
+    };
+
+    let staged = cache.stage_snapshot(
+        registry,
+        &request,
+        generation,
+        previous.clone(),
+        policy,
+        scanner,
+    )?;
+    let observed_tip = observed.tip.as_ref().map(|tip| tip.commit.clone());
+    if let Some(tip) = &observed.tip
+        && tip.tasks_tree == staged.tasks_tree
+        && same_publication_content(&tip.envelope, &staged.envelope)
+    {
+        return Ok(PublicationPublishOutcome {
+            status: PublicationPublishStatus::Unchanged,
+            branch: request.publication_branch.clone(),
+            commit_id: tip.commit.clone(),
+            generation: tip.envelope.generation,
+            previous_publication: tip.envelope.previous_publication.clone(),
+            observed_tip,
+            included_attachment_bytes: staged.included_attachment_bytes,
+            omitted_attachment_bytes: staged.omitted_attachment_bytes,
+        });
+    }
+
+    let commit = cache.commit_snapshot(&request, &staged, generation, previous.as_deref())?;
+    cache.write_pending(&PendingPublication {
+        format_version: PENDING_FORMAT_VERSION,
+        publication_id: request.publication_id.clone(),
+        workspace_id: request.workspace_id.clone(),
+        publication_branch: request.publication_branch.clone(),
+        generation,
+        commit: commit.clone(),
+        previous_publication: previous.clone(),
+    })?;
+    cache.push_fast_forward(&request, &commit, observed_tip.as_deref())?;
+
+    Ok(PublicationPublishOutcome {
+        status: if previous.is_none() {
+            PublicationPublishStatus::Initialized
+        } else {
+            PublicationPublishStatus::Advanced
+        },
+        branch: request.publication_branch.clone(),
+        commit_id: commit,
+        generation,
+        previous_publication: previous,
+        observed_tip,
+        included_attachment_bytes: staged.included_attachment_bytes,
+        omitted_attachment_bytes: staged.omitted_attachment_bytes,
+    })
+}
+
+struct ValidatedRequest {
+    workspace_id: String,
+    source_repository_fingerprint: String,
+    publication_id: String,
+    authority_machine_id: String,
+    publication_remote: String,
+    publication_branch: String,
+    cache_dir: PathBuf,
+    published_at: DateTime<Utc>,
+    last_success: Option<PublicationLastSuccess>,
+}
+
+fn validate_request(request: PublicationPublishRequest) -> Result<ValidatedRequest, OrbitError> {
+    if request.caller_role != PublicationCallerRole::Owner {
+        return Err(OrbitError::PolicyDenied(format!(
+            "{PUBLISH_LABEL}: workspace '{}' is a replica checkout; only the declared owner may publish",
+            request.workspace_id
+        )));
+    }
+    validate_registry_identifier("workspace_id", &request.workspace_id).map_err(identity_error)?;
+    validate_registry_identifier("publication_id", &request.publication_id)
+        .map_err(identity_error)?;
+    validate_machine_id(&request.authority_machine_id).map_err(identity_error)?;
+    validate_machine_id(&request.local_machine_id).map_err(identity_error)?;
+    if request.local_machine_id != request.authority_machine_id {
+        return Err(OrbitError::PolicyDenied(format!(
+            "{PUBLISH_LABEL}: workspace '{}' is owned by '{}', not local machine '{}'",
+            request.workspace_id, request.authority_machine_id, request.local_machine_id
+        )));
+    }
+    validate_source_repository_fingerprint(&request.source_repository_fingerprint)
+        .map_err(workspace_error)?;
+    if request.publication_remote.trim().is_empty() {
+        return Err(publish_error("publication remote must not be empty"));
+    }
+    if remote_has_password(&request.publication_remote) {
+        return Err(publish_error(format!(
+            "publication remote '{}' must not contain credentials",
+            redact_git_remote(&request.publication_remote)
+        )));
+    }
+    let publication_branch =
+        canonicalize_publication_branch(&request.publication_branch).map_err(workspace_error)?;
+    if request.cache_dir.as_os_str().is_empty() {
+        return Err(publish_error("publication cache directory is required"));
+    }
+    let last_success = match request.last_success {
+        Some(last) => {
+            validate_last_success(Some(last.generation), Some(&last.commit))
+                .map_err(workspace_error)?;
+            Some(PublicationLastSuccess {
+                generation: last.generation,
+                commit: last.commit.to_ascii_lowercase(),
+            })
+        }
+        None => None,
+    };
+    Ok(ValidatedRequest {
+        workspace_id: request.workspace_id,
+        source_repository_fingerprint: request.source_repository_fingerprint,
+        publication_id: request.publication_id,
+        authority_machine_id: request.authority_machine_id,
+        publication_remote: request.publication_remote,
+        publication_branch,
+        cache_dir: request.cache_dir,
+        published_at: request.published_at,
+        last_success,
+    })
+}
+
+/// The coordination registry — not the caller — decides which workspace and
+/// source repository this publication belongs to.
+fn assert_registered_workspace(
+    registry: &TaskRegistryStore,
+    request: &ValidatedRequest,
+) -> Result<(), OrbitError> {
+    let binding = registry
+        .find_workspace_binding(&request.workspace_id)?
+        .ok_or_else(|| {
+            publish_error(format!(
+                "workspace '{}' is not registered in the coordination registry",
+                request.workspace_id
+            ))
+        })?;
+    if binding.workspace_id != request.workspace_id {
+        return Err(publish_error(format!(
+            "workspace selector '{}' resolved to unexpected workspace '{}'",
+            request.workspace_id, binding.workspace_id
+        )));
+    }
+    match binding.repo_fingerprint.as_deref() {
+        Some(fingerprint) if fingerprint == request.source_repository_fingerprint => Ok(()),
+        Some(_) => Err(publish_error(format!(
+            "workspace '{}' publication fingerprint does not match its registered source remote",
+            request.workspace_id
+        ))),
+        None => Err(publish_error(format!(
+            "workspace '{}' has no registered source-repository identity",
+            request.workspace_id
+        ))),
+    }
+}
+
+/// Orbit-owned private clone plus object cache for one publication lineage.
+struct PublicationCache {
+    root: PathBuf,
+    git_dir: PathBuf,
+    pending_path: PathBuf,
+}
+
+impl PublicationCache {
+    fn open(registry: &TaskRegistryStore, request: &ValidatedRequest) -> Result<Self, OrbitError> {
+        assert_outside_source_checkout(registry, request)?;
+        let root = request
+            .cache_dir
+            .join(&request.publication_id)
+            .join("publish");
+        fs::create_dir_all(&root).map_err(|error| OrbitError::from_write_io(&root, error))?;
+        let cache = Self {
+            git_dir: root.join("origin.git"),
+            pending_path: root.join(PENDING_FILE_NAME),
+            root,
+        };
+        if cache.git_dir.join("HEAD").is_file() {
+            cache.assert_cache_origin(&request.publication_remote)?;
+        } else {
+            if cache.git_dir.exists() {
+                fs::remove_dir_all(&cache.git_dir)
+                    .map_err(|error| OrbitError::from_write_io(&cache.git_dir, error))?;
+            }
+            let git_dir = cache.git_dir_str()?;
+            runner().run(&[
+                "init",
+                "--bare",
+                "--quiet",
+                "-b",
+                short_branch(&request.publication_branch),
+                git_dir,
+            ])?;
+            runner().run(&[
+                "--git-dir",
+                git_dir,
+                "remote",
+                "add",
+                "origin",
+                &request.publication_remote,
+            ])?;
+        }
+        Ok(cache)
+    }
+
+    fn git_dir_str(&self) -> Result<&str, OrbitError> {
+        path_str(&self.git_dir, PUBLISH_LABEL)
+    }
+
+    fn assert_cache_origin(&self, expected_remote: &str) -> Result<(), OrbitError> {
+        let observed = runner().run(&[
+            "--git-dir",
+            self.git_dir_str()?,
+            "remote",
+            "get-url",
+            "origin",
+        ])?;
+        if remotes_match(expected_remote, &observed) {
+            return Ok(());
+        }
+        Err(publish_error(format!(
+            "publication cache origin '{}' does not match the bound remote '{}'",
+            redact_git_remote(&observed),
+            redact_git_remote(expected_remote)
+        )))
+    }
+
+    /// Fetch the configured branch and validate the tip's envelope, pairing,
+    /// and lineage before any snapshot is built.
+    fn observe_remote(&self, request: &ValidatedRequest) -> Result<RemoteState, OrbitError> {
+        let git_dir = self.git_dir_str()?;
+        let listing = runner().run(&["--git-dir", git_dir, "ls-remote", "origin"])?;
+        let branch_present = listing
+            .lines()
+            .filter_map(|line| line.split_once('\t'))
+            .any(|(_, name)| name.trim() == request.publication_branch);
+        if !branch_present {
+            if listing.trim().is_empty() {
+                return Ok(RemoteState { tip: None });
+            }
+            return Err(publish_error(format!(
+                "publication repository is not empty and does not carry branch '{}'; refusing to initialize, adopt, or overwrite it",
+                request.publication_branch
+            )));
+        }
+
+        let refspec = format!(
+            "{}:{}",
+            request.publication_branch, request.publication_branch
+        );
+        runner().run(&["--git-dir", git_dir, "fetch", "--force", "origin", &refspec])?;
+        let commit = runner()
+            .run(&[
+                "--git-dir",
+                git_dir,
+                "rev-parse",
+                &request.publication_branch,
+            ])?
+            .to_ascii_lowercase();
+        let envelope = self.read_envelope(&commit)?;
+        let parent = runner().single_parent(self.git_dir_str()?, &commit)?;
+        assert_pairing(request, &envelope)?;
+        assert_envelope_parent_lineage(&envelope, parent.as_deref(), PUBLISH_LABEL)?;
+        Ok(RemoteState {
+            tip: Some(RemoteTip {
+                tasks_tree: self.read_tasks_tree(&commit)?,
+                commit,
+                envelope,
+            }),
+        })
+    }
+
+    fn read_envelope(&self, commit: &str) -> Result<PublicationEnvelope, OrbitError> {
+        let spec = format!("{commit}:{PUBLICATION_ENVELOPE_FILE_NAME}");
+        let attempt = runner().try_run(&["--git-dir", self.git_dir_str()?, "show", &spec])?;
+        if !attempt.success {
+            return Err(publish_error(format!(
+                "publication branch tip {commit} does not carry {PUBLICATION_ENVELOPE_FILE_NAME}; refusing to adopt or overwrite it"
+            )));
+        }
+        PublicationEnvelope::from_yaml(&attempt.stdout)
+    }
+
+    /// Object id of the `tasks/` tree, or `None` when the snapshot has no tasks.
+    fn read_tasks_tree(&self, tree_ish: &str) -> Result<Option<String>, OrbitError> {
+        let spec = format!("{tree_ish}:{PUBLICATION_TASKS_DIR_NAME}");
+        let attempt = runner().try_run(&[
+            "--git-dir",
+            self.git_dir_str()?,
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &spec,
+        ])?;
+        Ok(attempt
+            .success
+            .then(|| attempt.stdout.trim().to_ascii_lowercase())
+            .filter(|oid| !oid.is_empty()))
+    }
+
+    /// Build the snapshot tree in a disposable directory inside the private
+    /// cache and record it in a throwaway index. Nothing here can touch the
+    /// source checkout.
+    fn stage_snapshot(
+        &self,
+        registry: &TaskRegistryStore,
+        request: &ValidatedRequest,
+        generation: u64,
+        previous_publication: Option<String>,
+        policy: &AttachmentPolicy,
+        scanner: Option<&dyn AttachmentSensitivityScanner>,
+    ) -> Result<StagedSnapshot, OrbitError> {
+        let temp = tempfile::Builder::new()
+            .prefix(".orbit-publish-")
+            .tempdir_in(&self.root)
+            .map_err(|error| OrbitError::from_write_io(&self.root, error))?;
+        let tree = temp.path().join("tree");
+        let outcome = build_publication_snapshot(
+            registry,
+            &tree,
+            PublicationSnapshotMetadata {
+                publication_id: request.publication_id.clone(),
+                workspace_id: request.workspace_id.clone(),
+                source_repository_fingerprint: request.source_repository_fingerprint.clone(),
+                authority_machine_id: request.authority_machine_id.clone(),
+                generation,
+                published_at: request.published_at,
+                previous_publication,
+            },
+            policy,
+            scanner,
+        )?;
+
+        let index = temp.path().join("index");
+        let indexed = runner().with_env(vec![(
+            "GIT_INDEX_FILE",
+            path_str(&index, PUBLISH_LABEL)?.to_string(),
+        )]);
+        let git_dir = self.git_dir_str()?;
+        let work_tree = path_str(&tree, PUBLISH_LABEL)?;
+        indexed.run(&[
+            "-C",
+            work_tree,
+            "--git-dir",
+            git_dir,
+            "--work-tree",
+            work_tree,
+            "add",
+            "--all",
+            "--force",
+        ])?;
+        let tree_oid = indexed
+            .run(&["--git-dir", git_dir, "write-tree"])?
+            .to_ascii_lowercase();
+        Ok(StagedSnapshot {
+            tasks_tree: self.read_tasks_tree(&tree_oid)?,
+            tree_oid,
+            envelope: outcome.envelope,
+            included_attachment_bytes: outcome.included_attachment_bytes,
+            omitted_attachment_bytes: outcome.omitted_attachment_bytes,
+            _temp: temp,
+        })
+    }
+
+    /// Commit the staged tree with a deterministic identity and timestamp, so
+    /// an identical snapshot at the same parent always yields the same commit.
+    fn commit_snapshot(
+        &self,
+        request: &ValidatedRequest,
+        staged: &StagedSnapshot,
+        generation: u64,
+        parent: Option<&str>,
+    ) -> Result<String, OrbitError> {
+        let stamp = request
+            .published_at
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        let identity = format!("{}@orbit.invalid", request.authority_machine_id);
+        let commit_runner = runner().with_env(vec![
+            ("GIT_AUTHOR_NAME", request.authority_machine_id.clone()),
+            ("GIT_AUTHOR_EMAIL", identity.clone()),
+            ("GIT_AUTHOR_DATE", stamp.clone()),
+            ("GIT_COMMITTER_NAME", request.authority_machine_id.clone()),
+            ("GIT_COMMITTER_EMAIL", identity),
+            ("GIT_COMMITTER_DATE", stamp),
+        ]);
+        let message = format!(
+            "publication {} generation {generation}",
+            request.publication_id
+        );
+        let mut args = vec![
+            "--git-dir",
+            self.git_dir_str()?,
+            "commit-tree",
+            &staged.tree_oid,
+        ];
+        if let Some(parent) = parent {
+            args.extend_from_slice(&["-p", parent]);
+        }
+        args.extend_from_slice(&["-m", &message]);
+        Ok(commit_runner.run(&args)?.to_ascii_lowercase())
+    }
+
+    /// Push as an ordinary fast-forward. A moved branch is an authority
+    /// conflict for the operator to resolve, never something to merge or force.
+    fn push_fast_forward(
+        &self,
+        request: &ValidatedRequest,
+        commit: &str,
+        observed_tip: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        let git_dir = self.git_dir_str()?;
+        let refspec = format!("{commit}:{}", request.publication_branch);
+        let attempt =
+            runner().try_run(&["--git-dir", git_dir, "push", "--atomic", "origin", &refspec])?;
+        if !attempt.success {
+            let current = self.remote_branch_tip(request)?;
+            if current.as_deref() != observed_tip {
+                return Err(publish_error(format!(
+                    "publication branch '{}' moved during publication: observed {}, remote is now {}; resolve the publication authority before publishing again",
+                    request.publication_branch,
+                    observed_tip.unwrap_or("empty"),
+                    current.as_deref().unwrap_or("empty")
+                )));
+            }
+            return Err(publish_error(format!(
+                "publication push to '{}' failed: {}",
+                redact_git_remote(&request.publication_remote),
+                redact_remote(&attempt.stderr, &request.publication_remote)
+            )));
+        }
+        match self.remote_branch_tip(request)? {
+            Some(tip) if tip == commit => Ok(()),
+            other => Err(publish_error(format!(
+                "publication branch '{}' is {} after pushing {commit}",
+                request.publication_branch,
+                other.unwrap_or_else(|| "empty".to_string())
+            ))),
+        }
+    }
+
+    fn remote_branch_tip(&self, request: &ValidatedRequest) -> Result<Option<String>, OrbitError> {
+        let listing = runner().run(&[
+            "--git-dir",
+            self.git_dir_str()?,
+            "ls-remote",
+            "origin",
+            &request.publication_branch,
+        ])?;
+        Ok(listing
+            .lines()
+            .filter_map(|line| line.split_once('\t'))
+            .find(|(_, name)| name.trim() == request.publication_branch)
+            .map(|(oid, _)| oid.trim().to_ascii_lowercase()))
+    }
+
+    fn read_pending(
+        &self,
+        request: &ValidatedRequest,
+    ) -> Result<Option<PendingPublication>, OrbitError> {
+        let raw = match fs::read_to_string(&self.pending_path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(OrbitError::from_write_io(&self.pending_path, error)),
+        };
+        // A private cache artifact: anything unreadable or belonging to another
+        // binding is discarded, never trusted and never fatal.
+        let pending: Option<PendingPublication> = serde_yaml::from_str(&raw).ok();
+        let pending = pending.filter(|pending| {
+            pending.format_version == PENDING_FORMAT_VERSION
+                && pending.publication_id == request.publication_id
+                && pending.workspace_id == request.workspace_id
+                && pending.publication_branch == request.publication_branch
+                && validate_git_commit_id(&pending.commit).is_ok()
+        });
+        if pending.is_none() {
+            self.remove_pending()?;
+        }
+        Ok(pending)
+    }
+
+    fn write_pending(&self, pending: &PendingPublication) -> Result<(), OrbitError> {
+        write_yaml_atomic_with(&self.pending_path, pending, |error| {
+            OrbitError::Store(format!(
+                "failed to encode pending publication record: {error}"
+            ))
+        })
+    }
+
+    fn remove_pending(&self) -> Result<(), OrbitError> {
+        match fs::remove_file(&self.pending_path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(OrbitError::from_write_io(&self.pending_path, error)),
+        }
+    }
+}
+
+struct RemoteState {
+    tip: Option<RemoteTip>,
+}
+
+struct RemoteTip {
+    commit: String,
+    envelope: PublicationEnvelope,
+    tasks_tree: Option<String>,
+}
+
+struct StagedSnapshot {
+    tree_oid: String,
+    tasks_tree: Option<String>,
+    envelope: PublicationEnvelope,
+    included_attachment_bytes: u64,
+    omitted_attachment_bytes: u64,
+    /// Dropped last: removes the staged tree and throwaway index.
+    _temp: TempDir,
+}
+
+enum PublishAction {
+    Initialize,
+    Advance { generation: u64, previous: String },
+    Reconcile(Box<PublicationPublishOutcome>),
+}
+
+/// Reconcile the observed branch tip with the owner-local last-success record
+/// and any pending push, or refuse the run.
+fn decide_action(
+    cache: &PublicationCache,
+    request: &ValidatedRequest,
+    observed: &RemoteState,
+) -> Result<PublishAction, OrbitError> {
+    let pending = cache.read_pending(request)?;
+    let Some(tip) = &observed.tip else {
+        if let Some(last) = &request.last_success {
+            return Err(publish_error(format!(
+                "publication repository is empty but generation {} at commit {} was recorded locally; resolve the publication binding before publishing again",
+                last.generation, last.commit
+            )));
+        }
+        // A pending push that never landed: private state, cleaned up here.
+        cache.remove_pending()?;
+        return Ok(PublishAction::Initialize);
+    };
+
+    let pending_landed = pending
+        .as_ref()
+        .is_some_and(|pending| pending.commit == tip.commit);
+    let recorded = request
+        .last_success
+        .as_ref()
+        .is_some_and(|last| last.commit == tip.commit);
+    if pending_landed && !recorded {
+        cache.remove_pending()?;
+        return Ok(PublishAction::Reconcile(Box::new(
+            PublicationPublishOutcome {
+                status: PublicationPublishStatus::Reconciled,
+                branch: request.publication_branch.clone(),
+                commit_id: tip.commit.clone(),
+                generation: tip.envelope.generation,
+                previous_publication: tip.envelope.previous_publication.clone(),
+                observed_tip: Some(tip.commit.clone()),
+                included_attachment_bytes: 0,
+                omitted_attachment_bytes: 0,
+            },
+        )));
+    }
+
+    match &request.last_success {
+        Some(last) if recorded => {
+            if last.generation != tip.envelope.generation {
+                return Err(publish_error(format!(
+                    "publication commit {} records generation {} but the owner recorded generation {}",
+                    tip.commit, tip.envelope.generation, last.generation
+                )));
+            }
+            cache.remove_pending()?;
+        }
+        Some(last) => {
+            return Err(publish_error(format!(
+                "publication branch '{}' is at {} but the owner last published {} at generation {}; resolve the publication authority before publishing again",
+                request.publication_branch, tip.commit, last.commit, last.generation
+            )));
+        }
+        // No local record: the matching envelope is the only authority evidence,
+        // so an unmatched pending push means someone else moved the branch.
+        None if pending.is_some() => {
+            return Err(publish_error(format!(
+                "publication branch '{}' is at {}, which is not the commit this owner pushed; resolve the publication authority before publishing again",
+                request.publication_branch, tip.commit
+            )));
+        }
+        None => {}
+    }
+
+    let generation = tip.envelope.generation.checked_add(1).ok_or_else(|| {
+        publish_error("publication generation would overflow; rebind the publication lineage")
+    })?;
+    Ok(PublishAction::Advance {
+        generation,
+        previous: tip.commit.clone(),
+    })
+}
+
+fn assert_pairing(
+    request: &ValidatedRequest,
+    envelope: &PublicationEnvelope,
+) -> Result<(), OrbitError> {
+    field_mismatch(
+        PUBLISH_LABEL,
+        "workspace",
+        &request.workspace_id,
+        &envelope.workspace_id,
+    )?;
+    field_mismatch(
+        PUBLISH_LABEL,
+        "source repository fingerprint",
+        &request.source_repository_fingerprint,
+        &envelope.source_repository_fingerprint,
+    )?;
+    field_mismatch(
+        PUBLISH_LABEL,
+        "publication id",
+        &request.publication_id,
+        &envelope.publication_id,
+    )?;
+    field_mismatch(
+        PUBLISH_LABEL,
+        "authority",
+        &request.authority_machine_id,
+        &envelope.authority_machine_id,
+    )
+}
+
+/// True when two envelopes describe the same projection. `generation`,
+/// `published_at`, and `previous_publication` are lineage bookkeeping, not
+/// content, so a re-run that changed nothing must not create a commit.
+fn same_publication_content(left: &PublicationEnvelope, right: &PublicationEnvelope) -> bool {
+    left.format_version == right.format_version
+        && left.publication_id == right.publication_id
+        && left.workspace_id == right.workspace_id
+        && left.source_repository_fingerprint == right.source_repository_fingerprint
+        && left.authority_machine_id == right.authority_machine_id
+        && left.task_schema_version == right.task_schema_version
+        && left.attachment_policy == right.attachment_policy
+        && left.task_ids == right.task_ids
+        && left.omitted_attachments == right.omitted_attachments
+}
+
+/// The publication cache must never live inside the source repository.
+fn assert_outside_source_checkout(
+    registry: &TaskRegistryStore,
+    request: &ValidatedRequest,
+) -> Result<(), OrbitError> {
+    let Some(checkout) = registry.find_workspace_checkout(&request.workspace_id)? else {
+        return Ok(());
+    };
+    let cache = std::path::absolute(&request.cache_dir)
+        .map_err(|error| OrbitError::from_write_io(&request.cache_dir, error))?;
+    for source in [&checkout.repo_root, &checkout.workspace_path] {
+        let source = std::path::absolute(source)
+            .map_err(|error| OrbitError::from_write_io(source, error))?;
+        if cache.starts_with(&source) {
+            return Err(publish_error(
+                "publication cache directory must live outside the source repository and its worktree",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Private record of a push that was issued but not yet confirmed as recorded
+/// by the owner. It lets the next run reconcile by commit id instead of
+/// publishing a duplicate or divergent generation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PendingPublication {
+    format_version: u32,
+    publication_id: String,
+    workspace_id: String,
+    publication_branch: String,
+    generation: u64,
+    commit: String,
+    previous_publication: Option<String>,
+}
+
+fn runner() -> GitRunner<'static> {
+    GitRunner::new(PUBLISH_LABEL)
+}
+
+fn redact_remote(message: &str, remote: &str) -> String {
+    message.trim().replace(remote, &redact_git_remote(remote))
+}
+
+fn publish_error(message: impl Into<String>) -> OrbitError {
+    OrbitError::InvalidInput(format!("{PUBLISH_LABEL}: {}", message.into()))
+}
+
+fn workspace_error(error: orbit_types::workspace::WorkspaceError) -> OrbitError {
+    OrbitError::InvalidInput(error.to_string())
+}
+
+fn identity_error(error: orbit_types::identity::IdentityError) -> OrbitError {
+    OrbitError::InvalidInput(error.to_string())
+}

--- a/crates/orbit-store/src/workflow/task/tests/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/tests/inspect.rs
@@ -1,7 +1,5 @@
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use orbit_types::task::{ArtifactManifestV2, TASK_ARTIFACT_SCHEMA_VERSION, TASK_EVENTS_FILE_NAME};
 use tempfile::TempDir;
@@ -54,59 +52,9 @@ fn request(
     }
 }
 
-fn git(dir: &Path, args: &[&str]) -> String {
-    let output = Command::new("git")
-        .args(["-c", "core.hooksPath=/dev/null"])
-        .args(args)
-        .current_dir(dir)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_AUTHOR_NAME", "orbit-test")
-        .env("GIT_AUTHOR_EMAIL", "orbit-test@example.test")
-        .env("GIT_COMMITTER_NAME", "orbit-test")
-        .env("GIT_COMMITTER_EMAIL", "orbit-test@example.test")
-        .output()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "git {args:?} failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    String::from_utf8_lossy(&output.stdout).trim().to_string()
-}
-
 fn init_repo(dir: &Path) {
     fs::create_dir_all(dir).unwrap();
     git(dir, &["init", "-b", "main"]);
-}
-
-fn copy_tree(src: &Path, dst: &Path) {
-    fs::create_dir_all(dst).unwrap();
-    for entry in fs::read_dir(src).unwrap() {
-        let entry = entry.unwrap();
-        let dest = dst.join(entry.file_name());
-        if entry.file_type().unwrap().is_dir() {
-            copy_tree(&entry.path(), &dest);
-        } else {
-            fs::copy(entry.path(), dest).unwrap();
-        }
-    }
-}
-
-fn replace_worktree(repo: &Path, snapshot: &Path) {
-    for entry in fs::read_dir(repo).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_name() == ".git" {
-            continue;
-        }
-        let path = entry.path();
-        if path.is_dir() {
-            fs::remove_dir_all(&path).unwrap();
-        } else {
-            fs::remove_file(&path).unwrap();
-        }
-    }
-    copy_tree(snapshot, repo);
 }
 
 fn commit_snapshot(repo: &Path, snapshot: &Path, message: &str) -> String {
@@ -119,37 +67,6 @@ fn commit_snapshot(repo: &Path, snapshot: &Path, message: &str) -> String {
 fn amend_current(repo: &Path) {
     git(repo, &["add", "-A"]);
     git(repo, &["commit", "--amend", "--no-edit"]);
-}
-
-fn tree_bytes(root: &Path) -> BTreeMap<String, Vec<u8>> {
-    fn visit(root: &Path, path: &Path, output: &mut BTreeMap<String, Vec<u8>>) {
-        let mut entries: Vec<_> = fs::read_dir(path)
-            .unwrap()
-            .map(|entry| entry.unwrap())
-            .collect();
-        entries.sort_by_key(|entry| entry.file_name());
-        for entry in entries {
-            if entry.file_name() == ".git" {
-                continue;
-            }
-            let path = entry.path();
-            let file_type = entry.file_type().unwrap();
-            if file_type.is_dir() || (file_type.is_symlink() && path.is_dir()) {
-                visit(root, &path, output);
-            } else if file_type.is_file() {
-                output.insert(
-                    path.strip_prefix(root)
-                        .unwrap()
-                        .to_string_lossy()
-                        .replace('\\', "/"),
-                    fs::read(path).unwrap(),
-                );
-            }
-        }
-    }
-    let mut output = BTreeMap::new();
-    visit(root, root, &mut output);
-    output
 }
 
 fn seed_one(

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use chrono::{TimeZone, Utc};
 use orbit_types::task::{
@@ -20,6 +22,91 @@ use super::*;
 
 mod inspect;
 mod publication;
+mod publish;
+
+/// Run `git` with a deterministic, non-interactive identity. Publication tests
+/// drive only local temporary repositories: there is no network service and no
+/// ambient credential.
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_AUTHOR_NAME", "orbit-test")
+        .env("GIT_AUTHOR_EMAIL", "orbit-test@example.test")
+        .env("GIT_COMMITTER_NAME", "orbit-test")
+        .env("GIT_COMMITTER_EMAIL", "orbit-test@example.test")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let dest = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &dest);
+        } else {
+            fs::copy(entry.path(), dest).unwrap();
+        }
+    }
+}
+
+fn replace_worktree(repo: &Path, snapshot: &Path) {
+    for entry in fs::read_dir(repo).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            fs::remove_dir_all(&path).unwrap();
+        } else {
+            fs::remove_file(&path).unwrap();
+        }
+    }
+    copy_tree(snapshot, repo);
+}
+
+fn tree_bytes(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    fn visit(root: &Path, path: &Path, output: &mut BTreeMap<String, Vec<u8>>) {
+        let mut entries: Vec<_> = fs::read_dir(path)
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            let path = entry.path();
+            let file_type = entry.file_type().unwrap();
+            if file_type.is_dir() || (file_type.is_symlink() && path.is_dir()) {
+                visit(root, &path, output);
+            } else if file_type.is_file() {
+                output.insert(
+                    path.strip_prefix(root)
+                        .unwrap()
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                    fs::read(path).unwrap(),
+                );
+            }
+        }
+    }
+    let mut output = BTreeMap::new();
+    visit(root, root, &mut output);
+    output
+}
 
 fn open_registry(global: &Path) -> TaskRegistryStore {
     TaskRegistryStore::open(&task_registry_path(global)).expect("open registry")

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -1,0 +1,568 @@
+//! Publication transport tests.
+//!
+//! Every remote here is a local temporary bare repository driven with a fixed
+//! test identity, so the suite depends on no network service and no ambient
+//! credential.
+
+use std::path::{Path, PathBuf};
+
+use orbit_types::task::TASK_EVENTS_FILE_NAME;
+use tempfile::TempDir;
+
+use super::*;
+
+const FINGERPRINT: &str = "git@github.com:example/orbit-source.git";
+const AUTHORITY: &str = "hm_owner";
+const PUBLICATION_ID: &str = "pub_orbit_primary";
+const BRANCH: &str = "refs/heads/main";
+
+struct Fixture {
+    root: TempDir,
+    workspace_id: String,
+    remote: PathBuf,
+    cache: PathBuf,
+    source: PathBuf,
+}
+
+impl Fixture {
+    fn registry(&self) -> TaskRegistryStore {
+        open_registry(self.root.path())
+    }
+
+    fn remote_str(&self) -> String {
+        self.remote.to_string_lossy().into_owned()
+    }
+
+    /// Commit ids on the publication branch, newest first. Empty when the
+    /// branch does not exist.
+    fn remote_history(&self) -> Vec<String> {
+        let tip = git(
+            &self.remote,
+            &["for-each-ref", "--format=%(objectname)", BRANCH],
+        );
+        let tip = tip.trim();
+        if tip.is_empty() {
+            return Vec::new();
+        }
+        git(&self.remote, &["rev-list", tip])
+            .lines()
+            .map(|line| line.trim().to_string())
+            .filter(|line| !line.is_empty())
+            .collect()
+    }
+
+    fn remote_tip(&self) -> Option<String> {
+        self.remote_history().first().cloned()
+    }
+
+    fn remote_file(&self, commit: &str, path: &str) -> String {
+        git(&self.remote, &["show", &format!("{commit}:{path}")])
+    }
+}
+
+fn owned_workspace(
+    registry: &TaskRegistryStore,
+    global: &Path,
+    workspace_id: &str,
+) -> WorkspaceCheckoutBinding {
+    let orbit_dir = global.join("repos").join(workspace_id).join(".orbit");
+    fs::create_dir_all(&orbit_dir).expect("create orbit dir");
+    let repo_root = orbit_dir.parent().unwrap().to_path_buf();
+    registry
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(workspace_id.to_string()),
+            slug: "sample".to_string(),
+            repo_root: repo_root.clone(),
+            workspace_path: repo_root,
+            orbit_dir,
+            repo_fingerprint: Some(FINGERPRINT.to_string()),
+        })
+        .expect("bind workspace")
+}
+
+fn init_bare_remote(path: &Path) {
+    fs::create_dir_all(path).unwrap();
+    git(path, &["init", "--bare", "-b", "main"]);
+}
+
+fn fixture(workspace_id: &str) -> Fixture {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let binding = owned_workspace(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        workspace_id,
+        &make_bundle("ORB-00001", "first task", Vec::new()),
+    );
+
+    let remote = root.path().join("publication.git");
+    init_bare_remote(&remote);
+
+    // The registered source checkout is a real Git repository with its own
+    // remote; publication must never touch it.
+    let source = binding.repo_root.clone();
+    git(&source, &["init", "-b", "main"]);
+    fs::write(source.join("README.md"), "source\n").unwrap();
+    git(&source, &["add", "README.md"]);
+    git(&source, &["commit", "-m", "source"]);
+    git(
+        &source,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://example.test/orbit-source.git",
+        ],
+    );
+
+    Fixture {
+        workspace_id: workspace_id.to_string(),
+        cache: root.path().join("publication-cache"),
+        remote,
+        source,
+        root,
+    }
+}
+
+fn seed_task(fixture: &Fixture, task_id: &str) {
+    let registry = fixture.registry();
+    let binding = registry
+        .find_workspace_checkout(&fixture.workspace_id)
+        .unwrap()
+        .unwrap();
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        &fixture.workspace_id,
+        &make_bundle(task_id, task_id, Vec::new()),
+    );
+}
+
+fn publish_policy() -> AttachmentPolicy {
+    AttachmentPolicy {
+        kind: AttachmentPolicyKind::Fail,
+        max_file_bytes: 1024,
+        max_total_bytes: 4096,
+        deny_patterns: Vec::new(),
+        scanner_failure_behavior: ScannerFailureBehavior::AllowUnchecked,
+    }
+}
+
+fn request(
+    fixture: &Fixture,
+    second: u32,
+    last_success: Option<&PublicationPublishOutcome>,
+) -> PublicationPublishRequest {
+    PublicationPublishRequest {
+        workspace_id: fixture.workspace_id.clone(),
+        source_repository_fingerprint: FINGERPRINT.to_string(),
+        publication_id: PUBLICATION_ID.to_string(),
+        authority_machine_id: AUTHORITY.to_string(),
+        local_machine_id: AUTHORITY.to_string(),
+        caller_role: PublicationCallerRole::Owner,
+        publication_remote: fixture.remote_str(),
+        publication_branch: BRANCH.to_string(),
+        cache_dir: fixture.cache.clone(),
+        published_at: Utc.with_ymd_and_hms(2026, 8, 30, 1, 2, second).unwrap(),
+        last_success: last_success.map(|outcome| PublicationLastSuccess {
+            generation: outcome.generation,
+            commit: outcome.commit_id.clone(),
+        }),
+    }
+}
+
+fn publish(
+    fixture: &Fixture,
+    request: PublicationPublishRequest,
+) -> Result<PublicationPublishOutcome, OrbitError> {
+    publish_task_snapshot(&fixture.registry(), request, &publish_policy(), None)
+}
+
+/// Publish once and assert the branch was initialized.
+fn publish_first(fixture: &Fixture) -> PublicationPublishOutcome {
+    let outcome = publish(fixture, request(fixture, 1, None)).expect("first publication");
+    assert_eq!(outcome.status, PublicationPublishStatus::Initialized);
+    outcome
+}
+
+/// Commit `snapshot` into a clone of the publication remote and push it, the
+/// way a competing writer or an operator with repository access would.
+fn push_external(fixture: &Fixture, label: &str, snapshot: &Path, amend: bool) -> String {
+    let work = fixture.root.path().join(format!("external-{label}"));
+    git(
+        fixture.root.path(),
+        &[
+            "clone",
+            "--quiet",
+            &fixture.remote_str(),
+            work.to_str().unwrap(),
+        ],
+    );
+    replace_worktree(&work, snapshot);
+    git(&work, &["add", "-A"]);
+    if amend {
+        git(&work, &["commit", "--amend", "--no-edit"]);
+        git(
+            &work,
+            &["push", "--force", "origin", &format!("HEAD:{BRANCH}")],
+        );
+    } else {
+        git(&work, &["commit", "-m", label]);
+        git(&work, &["push", "origin", &format!("HEAD:{BRANCH}")]);
+    }
+    git(&work, &["rev-parse", "HEAD"])
+}
+
+/// Build a publication snapshot tree outside the transport, for tests that need
+/// a competing writer with a well-formed lineage.
+fn external_snapshot(
+    fixture: &Fixture,
+    label: &str,
+    generation: u64,
+    previous: Option<&str>,
+) -> PathBuf {
+    let destination = fixture.root.path().join(format!("snapshot-{label}"));
+    build_publication_snapshot(
+        &fixture.registry(),
+        &destination,
+        PublicationSnapshotMetadata {
+            publication_id: PUBLICATION_ID.to_string(),
+            workspace_id: fixture.workspace_id.clone(),
+            source_repository_fingerprint: FINGERPRINT.to_string(),
+            authority_machine_id: AUTHORITY.to_string(),
+            generation,
+            published_at: Utc.with_ymd_and_hms(2026, 8, 30, 9, 0, 0).unwrap(),
+            previous_publication: previous.map(ToOwned::to_owned),
+        },
+        &publish_policy(),
+        None,
+    )
+    .expect("build external snapshot");
+    destination
+}
+
+#[test]
+fn first_publication_initializes_an_empty_repository() {
+    let fixture = fixture("ws_publish_init");
+    let outcome = publish_first(&fixture);
+
+    assert_eq!(outcome.generation, 1);
+    assert_eq!(outcome.previous_publication, None);
+    assert_eq!(outcome.observed_tip, None);
+    assert_eq!(outcome.branch, BRANCH);
+    assert_eq!(
+        fixture.remote_tip().as_deref(),
+        Some(outcome.commit_id.as_str())
+    );
+    assert_eq!(fixture.remote_history().len(), 1);
+
+    let envelope = PublicationEnvelope::from_yaml(
+        &fixture.remote_file(&outcome.commit_id, PUBLICATION_ENVELOPE_FILE_NAME),
+    )
+    .expect("published envelope");
+    assert_eq!(envelope.generation, 1);
+    assert_eq!(envelope.previous_publication, None);
+    assert_eq!(envelope.workspace_id, fixture.workspace_id);
+    assert_eq!(envelope.task_ids, vec!["ORB-00001".to_string()]);
+}
+
+#[test]
+fn a_non_empty_repository_is_never_initialized_or_overwritten() {
+    let fixture = fixture("ws_publish_foreign");
+    let work = fixture.root.path().join("foreign");
+    git(
+        fixture.root.path(),
+        &[
+            "clone",
+            "--quiet",
+            &fixture.remote_str(),
+            work.to_str().unwrap(),
+        ],
+    );
+    fs::write(work.join("README.md"), "not a publication\n").unwrap();
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-m", "foreign"]);
+    git(&work, &["push", "origin", "HEAD:refs/heads/other"]);
+
+    // Refs exist, but not the configured branch.
+    let error = publish(&fixture, request(&fixture, 1, None))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("refusing to initialize, adopt, or overwrite"),
+        "{error}"
+    );
+
+    git(&work, &["push", "origin", &format!("HEAD:{BRANCH}")]);
+    let foreign_tip = git(&work, &["rev-parse", "HEAD"]);
+    let error = publish(&fixture, request(&fixture, 1, None))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains(PUBLICATION_ENVELOPE_FILE_NAME), "{error}");
+    assert_eq!(fixture.remote_tip(), Some(foreign_tip));
+    assert_eq!(fixture.remote_history().len(), 1);
+}
+
+#[test]
+fn repeat_publication_without_changes_creates_no_commit() {
+    let fixture = fixture("ws_publish_noop");
+    let first = publish_first(&fixture);
+
+    let repeat = publish(&fixture, request(&fixture, 30, Some(&first))).expect("repeat");
+    assert_eq!(repeat.status, PublicationPublishStatus::Unchanged);
+    assert_eq!(repeat.commit_id, first.commit_id);
+    assert_eq!(repeat.generation, 1);
+    assert_eq!(fixture.remote_history(), vec![first.commit_id]);
+}
+
+#[test]
+fn changed_tasks_advance_the_branch_as_a_linear_fast_forward() {
+    let fixture = fixture("ws_publish_advance");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+
+    let second = publish(&fixture, request(&fixture, 2, Some(&first))).expect("second publication");
+    assert_eq!(second.status, PublicationPublishStatus::Advanced);
+    assert_eq!(second.generation, 2);
+    assert_eq!(
+        second.previous_publication.as_deref(),
+        Some(first.commit_id.as_str())
+    );
+    assert_eq!(
+        second.observed_tip.as_deref(),
+        Some(first.commit_id.as_str())
+    );
+
+    let history = fixture.remote_history();
+    assert_eq!(
+        history,
+        vec![second.commit_id.clone(), first.commit_id.clone()]
+    );
+
+    let envelope = PublicationEnvelope::from_yaml(
+        &fixture.remote_file(&second.commit_id, PUBLICATION_ENVELOPE_FILE_NAME),
+    )
+    .expect("published envelope");
+    assert_eq!(envelope.generation, 2);
+    // The envelope's previous_publication is the Git parent, not a timestamp.
+    assert_eq!(
+        envelope.previous_publication.as_deref(),
+        Some(first.commit_id.as_str())
+    );
+    assert_eq!(
+        envelope.task_ids,
+        vec!["ORB-00001".to_string(), "ORB-00002".to_string()]
+    );
+}
+
+#[test]
+fn a_competing_writer_stops_publication_at_the_branch_boundary() {
+    let fixture = fixture("ws_publish_competing");
+    let first = publish_first(&fixture);
+
+    // Another machine publishing as the same authority moves the branch.
+    let snapshot = external_snapshot(&fixture, "gen2", 2, Some(&first.commit_id));
+    let competing = push_external(&fixture, "gen2", &snapshot, false);
+    assert_eq!(fixture.remote_tip().as_deref(), Some(competing.as_str()));
+
+    seed_task(&fixture, "ORB-00002");
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("resolve the publication authority"),
+        "{error}"
+    );
+    assert!(error.contains(&first.commit_id), "{error}");
+    assert!(error.contains(&competing), "{error}");
+
+    // The remote keeps its last good commit and gains nothing.
+    assert_eq!(fixture.remote_tip(), Some(competing));
+    assert_eq!(fixture.remote_history().len(), 2);
+}
+
+#[test]
+fn manual_tampering_and_mismatched_envelopes_are_refused() {
+    let fixture = fixture("ws_publish_tamper");
+    let first = publish_first(&fixture);
+
+    let snapshot = external_snapshot(&fixture, "tamper", 1, None);
+    let envelope_path = snapshot.join(PUBLICATION_ENVELOPE_FILE_NAME);
+    let tampered = fs::read_to_string(&envelope_path)
+        .unwrap()
+        .replace(PUBLICATION_ID, "pub_other_lineage");
+    fs::write(&envelope_path, tampered).unwrap();
+    let tampered_tip = push_external(&fixture, "tamper", &snapshot, true);
+
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("publication id mismatch"), "{error}");
+    assert_eq!(fixture.remote_tip(), Some(tampered_tip));
+    assert_eq!(fixture.remote_history().len(), 1);
+}
+
+#[test]
+fn an_invalid_snapshot_publishes_nothing() {
+    let fixture = fixture("ws_publish_invalid");
+    let first = publish_first(&fixture);
+
+    let canonical = fixture
+        .registry()
+        .canonical_task_bundle_path(&fixture.workspace_id, "ORB-00001")
+        .unwrap();
+    let events = canonical.join(TASK_EVENTS_FILE_NAME);
+    let raw = fs::read_to_string(&events).unwrap();
+    fs::write(&events, format!("{raw}{{")).unwrap();
+
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("ORB-00001"), "{error}");
+    assert_eq!(fixture.remote_history(), vec![first.commit_id]);
+    assert!(
+        !fixture
+            .cache
+            .join(PUBLICATION_ID)
+            .join("publish")
+            .join("pending-publication.yaml")
+            .exists()
+    );
+}
+
+#[test]
+fn replica_callers_and_stale_owners_may_not_publish() {
+    let fixture = fixture("ws_publish_role");
+
+    let mut replica = request(&fixture, 1, None);
+    replica.caller_role = PublicationCallerRole::Replica;
+    let error = publish(&fixture, replica).unwrap_err().to_string();
+    assert!(
+        error.contains("only the declared owner may publish"),
+        "{error}"
+    );
+
+    let mut stale_owner = request(&fixture, 1, None);
+    stale_owner.local_machine_id = "hm_other".to_string();
+    let error = publish(&fixture, stale_owner).unwrap_err().to_string();
+    assert!(error.contains("not local machine 'hm_other'"), "{error}");
+
+    let mut wrong_fingerprint = request(&fixture, 1, None);
+    wrong_fingerprint.source_repository_fingerprint =
+        "git@github.com:example/other-source.git".to_string();
+    let error = publish(&fixture, wrong_fingerprint)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("does not match its registered source remote"),
+        "{error}"
+    );
+
+    let mut unregistered = request(&fixture, 1, None);
+    unregistered.workspace_id = "ws_unregistered".to_string();
+    let error = publish(&fixture, unregistered).unwrap_err().to_string();
+    assert!(error.contains("not registered"), "{error}");
+
+    let mut inside_source = request(&fixture, 1, None);
+    inside_source.cache_dir = fixture.source.join(".orbit-publication-cache");
+    let error = publish(&fixture, inside_source).unwrap_err().to_string();
+    assert!(error.contains("outside the source repository"), "{error}");
+
+    // Nothing reached the remote.
+    assert!(fixture.remote_tip().is_none());
+}
+
+#[test]
+fn an_unreachable_remote_leaves_the_publication_untouched() {
+    let fixture = fixture("ws_publish_unreachable");
+    let first = publish_first(&fixture);
+
+    let mut unreachable = request(&fixture, 2, Some(&first));
+    unreachable.publication_remote = fixture
+        .root
+        .path()
+        .join("missing-publication.git")
+        .to_string_lossy()
+        .into_owned();
+    unreachable.cache_dir = fixture.cache.join("unreachable");
+    assert!(publish(&fixture, unreachable).is_err());
+    assert_eq!(fixture.remote_history(), vec![first.commit_id]);
+}
+
+#[test]
+fn an_unrecorded_push_reconciles_by_commit_id_instead_of_republishing() {
+    let fixture = fixture("ws_publish_reconcile");
+    let first = publish_first(&fixture);
+
+    // The push landed but the owner never persisted its last-success record.
+    let reconciled = publish(&fixture, request(&fixture, 2, None)).expect("reconcile");
+    assert_eq!(reconciled.status, PublicationPublishStatus::Reconciled);
+    assert_eq!(reconciled.commit_id, first.commit_id);
+    assert_eq!(reconciled.generation, 1);
+    assert_eq!(fixture.remote_history(), vec![first.commit_id.clone()]);
+
+    // Once recorded, publication resumes as an ordinary fast-forward.
+    seed_task(&fixture, "ORB-00002");
+    let next = publish(&fixture, request(&fixture, 3, Some(&reconciled))).expect("next generation");
+    assert_eq!(next.status, PublicationPublishStatus::Advanced);
+    assert_eq!(next.generation, 2);
+    assert_eq!(
+        next.previous_publication.as_deref(),
+        Some(first.commit_id.as_str())
+    );
+    assert_eq!(
+        fixture.remote_history(),
+        vec![next.commit_id, first.commit_id]
+    );
+}
+
+#[test]
+fn publication_never_touches_the_source_repository_or_canonical_state() {
+    let fixture = fixture("ws_publish_readonly");
+    let registry = fixture.registry();
+    let before_tasks = registry
+        .tasks_for_workspace(&fixture.workspace_id)
+        .unwrap()
+        .len();
+    let before_allocator = registry.allocator_next_number().unwrap();
+    let canonical = registry
+        .canonical_task_bundle_path(&fixture.workspace_id, "ORB-00001")
+        .unwrap();
+    let before_bundle = tree_bytes(&canonical);
+    let before_source = tree_bytes(&fixture.source);
+    let before_head = git(&fixture.source, &["rev-parse", "HEAD"]);
+    let before_refs = git(&fixture.source, &["show-ref"]);
+    let before_remotes = git(&fixture.source, &["remote", "-v"]);
+    let before_status = git(&fixture.source, &["status", "--porcelain"]);
+    let before_index = git(&fixture.source, &["diff", "--cached", "--name-status"]);
+
+    publish_first(&fixture);
+    let mut failing = request(&fixture, 2, None);
+    failing.publication_branch = "refs/heads/absent".to_string();
+    assert!(publish(&fixture, failing).is_err());
+
+    assert_eq!(
+        registry
+            .tasks_for_workspace(&fixture.workspace_id)
+            .unwrap()
+            .len(),
+        before_tasks
+    );
+    assert_eq!(registry.allocator_next_number().unwrap(), before_allocator);
+    assert_eq!(tree_bytes(&canonical), before_bundle);
+    assert_eq!(tree_bytes(&fixture.source), before_source);
+    assert_eq!(git(&fixture.source, &["rev-parse", "HEAD"]), before_head);
+    assert_eq!(git(&fixture.source, &["show-ref"]), before_refs);
+    assert_eq!(git(&fixture.source, &["remote", "-v"]), before_remotes);
+    assert_eq!(
+        git(&fixture.source, &["status", "--porcelain"]),
+        before_status
+    );
+    assert_eq!(
+        git(&fixture.source, &["diff", "--cached", "--name-status"]),
+        before_index
+    );
+}

--- a/docs/design/task-publication/2_design.md
+++ b/docs/design/task-publication/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Task Publication — Design
 owner: codex
-last_updated: 2026-08-29
-last_validated: 2026-08-29
+last_updated: 2026-08-30
+last_validated: 2026-08-30
 status: Draft
 feature: task-publication
 doc_role: design
@@ -11,7 +11,7 @@ summary: Proposed contract for publishing validated task snapshots to a dedicate
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068]
+related_artifacts: [ORB-11068, ORB-11074]
 ---
 
 # Task Publication — Design
@@ -160,6 +160,18 @@ The owner performs these phases:
 8. Record the successful generation and commit ID in owner-local publication
    state. Failed publication does not change the last-success record.
 
+Phases 6 through 8 are refined by the implemented transport [ORB-11074]. The
+snapshot is built and indexed inside the private cache, so a re-run whose
+projection is byte-identical to the branch tip creates no commit and pushes
+nothing; only `generation`, `published_at`, and `previous_publication` differ
+across such a re-run, and they are lineage bookkeeping rather than content.
+Before pushing, the owner writes a private pending record — publication id,
+workspace, branch, generation, and the commit id it is about to push — into the
+same Orbit-owned cache. That record is what phase 8's "reconcile by commit ID"
+reads on the next run: a branch tip equal to the pending commit that the owner
+never recorded is reconciled and reported without republishing, while any other
+unexpected tip is an authority conflict.
+
 Task bundles have per-bundle durability rather than one workspace-wide read
 transaction. A v1 publication is therefore a validated set of individually
 consistent bundle observations, not a claim that every task was captured at
@@ -297,5 +309,6 @@ deleting the current tree erased the data.
 ## Task References
 
 - [ORB-11068] — specified the proposed dedicated private task-publication repository protocol.
+- [ORB-11074] — implemented the owner-only Git compare-and-swap publication transport.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11074](https://orbit-cli.com/tasks/ORB-11074) — Publish task snapshots with owner-only Git compare-and-swap

### Description

## Problem
Orbit lacks the Git transport that can safely advance a dedicated publication repository from the declared workspace owner without creating another task authority.

## Why It Matters
Remote durability depends on an isolated, linear publication history. A stale owner or out-of-band writer must stop at the branch boundary instead of being merged, replayed, or force-pushed.

## Constraints / Notes
- Consume the owner-local binding and validated snapshot builder defined by the preceding task-publication foundations.
- Use an Orbit-owned private temporary clone/object cache outside the source repository and worktree.
- Initialize only an empty repository; a non-empty repository must carry a matching publication envelope and lineage.
- Fetch the configured ordinary branch, record its observed OID, create one snapshot commit, and push only as a fast-forward compare-and-swap.
- Never merge, rebase, replay task operations, force-push, select by timestamp, or create an alternate conflict branch.
- Publication is explicit derived work and never participates in canonical task-write acknowledgement.
- Reconcile push-success/local-recording-failure by commit ID before another publish.
- Integration tests must use local temporary bare repositories and deterministic credentials; no network service dependency.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- Publishing verifies the exact registered workspace, local owner role, source fingerprint, publication remote/branch, publication ID, and authority lineage before building or pushing.
- First publication succeeds only against an empty repository and creates the configured ordinary branch; subsequent publications form a linear history whose envelope previous_publication equals the Git parent.
- A moved branch, mismatched envelope, non-empty unbound repository, replica caller, authentication failure, or invalid snapshot leaves the remote last-good commit and local last-success record unchanged.
- The source repository HEAD, index, refs, configured remotes, and worktree remain byte-for-byte untouched by successful and failed publication tests.
- After a push succeeds but local success persistence is interrupted, the next run re-fetches and reconciles the exact commit instead of emitting a duplicate or divergent publication.
- Local-bare-repository integration tests cover initialization, no-op or repeat publication behavior, fast-forward update, competing writer, manual tamper, and retry reconciliation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented the owner-only Git publication transport in orbit-store.

New code
- crates/orbit-store/src/workflow/task/publish.rs: publish_task_snapshot(). Phases: validate request -> verify against the coordination registry -> open the Orbit-owned private cache -> observe the branch tip -> decide -> stage -> commit -> push. Verifies caller role (Owner vs Replica), local machine == declared authority, the exact registered workspace and its registered source fingerprint, the bound remote (cache origin) and canonical refs/heads/* branch, and the tip envelope's publication id / workspace / fingerprint / authority plus previous_publication == Git parent, all before any snapshot is built. First publication requires a repository with no refs and creates the configured ordinary branch; later publications commit-tree onto the observed tip and push as a plain (non-force) fast-forward compare-and-swap, then re-check the remote ref. No merge, rebase, replay, force-push, timestamp selection, or alternate branch anywhere.
- Outcomes: Initialized | Advanced | Unchanged | Reconciled. Unchanged is a true no-op: a re-run whose tasks/ tree oid and content-bearing envelope fields match the tip creates no commit (generation/published_at/previous_publication are lineage bookkeeping, not content).
- Push-success/local-recording-failure is reconciled by commit id: a private pending-publication.yaml (publication id, workspace, branch, generation, commit) is written in the cache before the push. The next run reconciles when the tip equals that commit and the owner has no matching last-success record, deletes it when superseded or never landed, and refuses when the tip is neither the pending nor the recorded commit.
- crates/orbit-store/src/workflow/task/git.rs (new): hardened non-interactive Git runner shared with inspect.rs (no prompts, no system config, no hooks, no excludes/attributes/crlf filters), plus single_parent, field_mismatch, short_branch, remote_has_password, remotes_match, path_str. Deduplicates the parent-parsing, pairing-mismatch and lineage checks that inspect.rs (ORB-11075) had; the envelope/Git-parent lineage rule moved to publication.rs as assert_envelope_parent_lineage.

Boundaries
- No new crate dependency edges: ownership facts (owner, checkout role, binding) are request inputs supplied by the caller from orbit-registry, then re-verified here against the task registry and the remote envelope. The publication cache is refused if it resolves inside the registered checkout, and all Git work happens in <cache>/<publication-id>/publish/{origin.git, disposable temp tree+index}.
- Commits are deterministic: authority machine id as identity, published_at as author/committer date, fixed message, so identical content at the same parent yields the same OID.

Tests: crates/orbit-store/src/workflow/task/tests/publish.rs (11 tests, local temporary bare repositories, fixed test identity, no network): initialization, no-op repeat, fast-forward advance with linear history and previous_publication == Git parent, competing writer stopped at the branch boundary, manual tamper and mismatched envelope, non-empty unbound repository (wrong branch and missing envelope), invalid snapshot, replica/stale-owner/unregistered-workspace/wrong-fingerprint/cache-inside-source refusals, unreachable remote, retry reconciliation, and a byte-for-byte assertion that the source repository worktree, HEAD, refs, index and remotes plus canonical bundles and the allocator are untouched. Shared Git test helpers moved up to tests/mod.rs.

Docs: ARCHITECTURE.md names the transport as a workflow module; docs/design/task-publication/2_design.md records the two refinements to phases 6-8 (no-op skip, pending record) and cites ORB-11074.

Validation: cargo test -p orbit-store --lib (357 passed), make ci-fast, make ci-lint all pass.

Notes for review: publish.rs is 838 lines, just over the 800-line design warning. Both candidate splits (private cache vs policy, or contract types vs transport) would invert the dependency direction or diverge from inspect.rs's layout, so it was kept as one module with one job and a linear phase flow. The push-time compare-and-swap race (branch moving between fetch and push) is enforced by the plain non-force push but is not directly unit-tested: it cannot be made deterministic without a test-only hook into the private cache. The pre-push competing-writer path is covered end-to-end.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11074-6a939949`
- Behind base: 0
- Ahead of base: 1