### PR TITLE
Restore task publications without renumbering or authority ambiguity

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -1313,6 +1313,39 @@ impl TaskRegistryStore {
         }
         tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
     }
+
+    /// Restore an allocator value after a larger workflow failed after its
+    /// final allocator advance. This is deliberately crate-private and guarded
+    /// by the exact value the workflow observed after advancing, so it cannot
+    /// rewind over a concurrent allocation.
+    pub(crate) fn restore_allocator_after_failed_restore(
+        &self,
+        expected_current: u32,
+        previous: u32,
+    ) -> Result<(), OrbitError> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let current = read_allocator_next_number(&tx)?;
+        if current != expected_current {
+            return Err(OrbitError::Store(format!(
+                "cannot roll back failed publication restore allocator: expected {expected_current}, found {current}"
+            )));
+        }
+        if previous > current {
+            return Err(OrbitError::Store(format!(
+                "invalid publication restore allocator rollback from {current} to {previous}"
+            )));
+        }
+        if previous != current {
+            set_allocator_next_number(&tx, previous)?;
+        }
+        tx.commit().map_err(|e| OrbitError::Store(e.to_string()))
+    }
 }
 
 fn read_allocator_next_number(conn: &Connection) -> Result<u32, OrbitError> {

--- a/crates/orbit-store/src/workflow/task/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/inspect.rs
@@ -97,6 +97,26 @@ pub struct PublicationInspection {
 pub fn inspect_publication(
     request: PublicationInspectRequest,
 ) -> Result<PublicationInspection, OrbitError> {
+    Ok(load_validated_publication(request)?.inspection)
+}
+
+/// Fully validated publication content retained for recovery. The public
+/// inspection surface deliberately omits append streams and attachment bytes;
+/// restore consumes this internal result so it cannot bypass the read-only
+/// consumer contract or validate a subtly different projection.
+pub(super) struct ValidatedPublicationSnapshot {
+    pub inspection: PublicationInspection,
+    pub bundles: Vec<ValidatedPublicationBundle>,
+}
+
+pub(super) struct ValidatedPublicationBundle {
+    pub bundle: TaskBundleV2,
+    pub source_dir: PathBuf,
+}
+
+pub(super) fn load_validated_publication(
+    request: PublicationInspectRequest,
+) -> Result<ValidatedPublicationSnapshot, OrbitError> {
     let request = validate_request(request)?;
     let fetched = fetch_publication(&request)?;
     let envelope = read_envelope(&fetched.tree_dir)?;
@@ -115,21 +135,25 @@ pub fn inspect_publication(
         freshness: fetched.freshness,
         render_authority: PublicationRenderAuthority::Snapshot,
     };
-    Ok(PublicationInspection {
+    let inspection = PublicationInspection {
         label: label.clone(),
         envelope,
         git_parent: fetched.git_parent,
         tasks: tasks
-            .into_iter()
+            .iter()
             .map(|task| InspectedPublicationTask {
                 label: label.clone(),
-                task: task.envelope,
-                description: task.description,
-                acceptance: task.acceptance,
-                plan: task.plan,
-                execution_summary: task.execution_summary,
+                task: task.bundle.envelope.clone(),
+                description: task.bundle.description.clone(),
+                acceptance: task.bundle.acceptance.clone(),
+                plan: task.bundle.plan.clone(),
+                execution_summary: task.bundle.execution_summary.clone(),
             })
             .collect(),
+    };
+    Ok(ValidatedPublicationSnapshot {
+        inspection,
+        bundles: tasks,
     })
 }
 
@@ -342,7 +366,7 @@ fn assert_pairing(
 fn read_validated_tasks(
     tree_dir: &Path,
     envelope: &PublicationEnvelope,
-) -> Result<Vec<TaskBundleV2>, OrbitError> {
+) -> Result<Vec<ValidatedPublicationBundle>, OrbitError> {
     let tasks_root = tree_dir.join(PUBLICATION_TASKS_DIR_NAME);
     let observed = published_task_ids(&tasks_root)?;
     if observed != envelope.task_ids {
@@ -373,7 +397,10 @@ fn read_validated_tasks(
                 bundle.envelope.id
             )));
         }
-        bundles.push(bundle);
+        bundles.push(ValidatedPublicationBundle {
+            bundle,
+            source_dir: bundle_dir,
+        });
     }
     Ok(bundles)
 }

--- a/crates/orbit-store/src/workflow/task/mod.rs
+++ b/crates/orbit-store/src/workflow/task/mod.rs
@@ -78,6 +78,7 @@ mod inspect;
 mod publication;
 mod publish;
 mod reindex;
+mod restore;
 
 #[cfg(test)]
 mod tests;
@@ -99,6 +100,10 @@ pub use publish::{
     PublicationPublishRequest, PublicationPublishStatus, publish_task_snapshot,
 };
 pub use reindex::{ReindexOutcome, reindex_workspace};
+pub use restore::{
+    PublicationRecoveryCompleteness, PublicationRestoreMode, PublicationRestoreOutcome,
+    PublicationRestoreRequest, restore_publication,
+};
 
 /// Archive container-format version. Bumped only when the archive *layout*
 /// (manifest shape / entry paths) changes incompatibly.

--- a/crates/orbit-store/src/workflow/task/restore.rs
+++ b/crates/orbit-store/src/workflow/task/restore.rs
@@ -1,0 +1,480 @@
+//! Fail-closed, same-authority recovery from a validated task publication.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+use orbit_common::fs::io::create_dir_symlink;
+
+use crate::driver::file::task_bundle::{
+    read_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
+};
+use crate::driver::sqlite::task_registry::{
+    ProjectionRebuildResult, TaskRegistryStore, parse_orb_task_number,
+};
+
+use super::inspect::{ValidatedPublicationBundle, load_validated_publication};
+use super::{OmittedAttachment, PublicationInspectRequest};
+
+const RESTORE_LABEL: &str = "publication restore";
+
+/// Destination policy for same-authority recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationRestoreMode {
+    /// Refuse any destination that already contains a canonical task.
+    EmptyDestination,
+    /// Permit existing ids only when their full canonical bundle content is
+    /// identical to the publication. Missing ids are restored normally.
+    AllowIdenticalRetry,
+}
+
+/// Whether the publication contained every task attachment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicationRecoveryCompleteness {
+    Complete,
+    IncompleteAttachments,
+}
+
+/// Pairing inputs and the explicitly selected destination policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationRestoreRequest {
+    pub publication: PublicationInspectRequest,
+    pub mode: PublicationRestoreMode,
+}
+
+/// Result of a committed restore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicationRestoreOutcome {
+    pub workspace_id: String,
+    pub publication_id: String,
+    pub generation: u64,
+    pub restored_task_ids: Vec<String>,
+    pub already_present_task_ids: Vec<String>,
+    pub projection: ProjectionRebuildResult,
+    pub omitted_attachments: Vec<OmittedAttachment>,
+    pub completeness: PublicationRecoveryCompleteness,
+}
+
+/// Restore a task publication without renumbering, implicit identity adoption,
+/// or partial canonical mutation.
+pub fn restore_publication(
+    registry: &TaskRegistryStore,
+    request: PublicationRestoreRequest,
+) -> Result<PublicationRestoreOutcome, OrbitError> {
+    restore_publication_inner(registry, request, None)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RestoreFailurePoint {
+    BundlePublication,
+    IndexRebuild,
+    ProjectionRebuild,
+    AllocatorAdvance,
+}
+
+#[cfg(test)]
+pub(super) fn restore_publication_with_failure(
+    registry: &TaskRegistryStore,
+    request: PublicationRestoreRequest,
+    failure: RestoreFailurePoint,
+) -> Result<PublicationRestoreOutcome, OrbitError> {
+    restore_publication_inner(registry, request, Some(failure))
+}
+
+fn restore_publication_inner(
+    registry: &TaskRegistryStore,
+    request: PublicationRestoreRequest,
+    failure: Option<RestoreFailurePoint>,
+) -> Result<PublicationRestoreOutcome, OrbitError> {
+    // The inspector owns repository fetch, branch/commit lineage, envelope
+    // pairing, schema support, bundle validation, JSONL validation, omission
+    // validation, and attachment checksum verification. Recovery consumes that
+    // exact result rather than recreating a second validation path.
+    let validated = load_validated_publication(request.publication.clone())?;
+    let envelope = &validated.inspection.envelope;
+    let workspace_id = envelope.workspace_id.clone();
+    assert_destination_pairing(registry, &request.publication)?;
+
+    let existing = registry.tasks_for_workspace(&workspace_id)?;
+    let destination_has_entries =
+        canonical_destination_has_entries(registry.workspaces_dir().join(&workspace_id).as_path())?;
+    if request.mode == PublicationRestoreMode::EmptyDestination
+        && (!existing.is_empty() || destination_has_entries)
+    {
+        return Err(restore_error(format!(
+            "workspace '{workspace_id}' is not an empty restore destination"
+        )));
+    }
+
+    let previous_envelopes = existing
+        .iter()
+        .map(|binding| read_bundle_at(&binding.canonical_path).map(|bundle| bundle.envelope))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut missing = Vec::new();
+    let mut already_present = Vec::new();
+    for published in &validated.bundles {
+        let task_id = &published.bundle.envelope.id;
+        match registry.find_task_binding(task_id)? {
+            None => {
+                let destination = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+                if destination.exists() {
+                    return Err(restore_error(format!(
+                        "canonical path for task '{task_id}' exists without a registry binding"
+                    )));
+                }
+                missing.push(published);
+            }
+            Some(binding) => {
+                let identical = binding.workspace_id == workspace_id
+                    && read_bundle_at(&binding.canonical_path)
+                        .is_ok_and(|bundle| bundle == published.bundle);
+                if request.mode != PublicationRestoreMode::AllowIdenticalRetry || !identical {
+                    return Err(restore_error(format!(
+                        "task id '{task_id}' collides with non-identical canonical content"
+                    )));
+                }
+                already_present.push(task_id.clone());
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        return Ok(outcome(
+            envelope,
+            Vec::new(),
+            already_present,
+            ProjectionRebuildResult {
+                projected: 0,
+                repaired: 0,
+                degraded_reason: None,
+            },
+        ));
+    }
+
+    let workspace_root = registry.workspaces_dir().join(&workspace_id);
+    fs::create_dir_all(&workspace_root)
+        .map_err(|error| OrbitError::from_write_io(&workspace_root, error))?;
+    let staging = tempfile::Builder::new()
+        .prefix(".orbit-publication-restore-")
+        .tempdir_in(&workspace_root)
+        .map_err(|error| OrbitError::from_write_io(&workspace_root, error))?;
+    for published in &missing {
+        stage_bundle(staging.path(), published)?;
+    }
+
+    let previous_allocator = registry.allocator_next_number()?;
+    let restored_ids = missing
+        .iter()
+        .map(|published| published.bundle.envelope.id.clone())
+        .collect::<Vec<_>>();
+    let mut guard = RestoreGuard::new(
+        registry,
+        workspace_id.clone(),
+        previous_envelopes,
+        previous_allocator,
+    );
+
+    for (index, published) in missing.iter().enumerate() {
+        let task_id = &published.bundle.envelope.id;
+        let source = staging.path().join(task_id);
+        let destination = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+        fs::rename(&source, &destination)
+            .map_err(|error| OrbitError::from_write_io(&destination, error))?;
+        guard.published_dirs.push(destination);
+        if index == 0 {
+            inject(failure, RestoreFailurePoint::BundlePublication)?;
+        }
+    }
+
+    for task_id in &restored_ids {
+        let path = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+        registry.register_task_bundle(task_id, &workspace_id, &path)?;
+        guard.registered_ids.push(task_id.clone());
+    }
+
+    rebuild_workspace_index(registry, &workspace_id)?;
+    inject(failure, RestoreFailurePoint::IndexRebuild)?;
+
+    let projection = if let Some(checkout) = registry.find_workspace_checkout(&workspace_id)? {
+        let swap = ProjectionSwap::publish(registry, &checkout.orbit_dir, &workspace_id)?;
+        let result = swap.result.clone();
+        guard.projection = Some(swap);
+        inject(failure, RestoreFailurePoint::ProjectionRebuild)?;
+        result
+    } else {
+        ProjectionRebuildResult {
+            projected: 0,
+            repaired: 0,
+            degraded_reason: None,
+        }
+    };
+
+    let target_allocator = restored_ids
+        .iter()
+        .filter_map(|task_id| parse_orb_task_number(task_id))
+        .max()
+        .and_then(|value| value.checked_add(1))
+        .ok_or_else(|| restore_error("publication contains no allocatable task id"))?
+        .max(previous_allocator);
+    registry.bump_allocator_to_at_least(target_allocator)?;
+    guard.advanced_allocator = Some(target_allocator);
+    inject(failure, RestoreFailurePoint::AllocatorAdvance)?;
+
+    guard.commit();
+    Ok(outcome(envelope, restored_ids, already_present, projection))
+}
+
+fn assert_destination_pairing(
+    registry: &TaskRegistryStore,
+    request: &PublicationInspectRequest,
+) -> Result<(), OrbitError> {
+    let binding = registry
+        .find_workspace_binding(&request.workspace_id)?
+        .ok_or_else(|| {
+            restore_error(format!(
+                "workspace '{}' is not registered",
+                request.workspace_id
+            ))
+        })?;
+    if binding.workspace_id != request.workspace_id {
+        return Err(restore_error(
+            "workspace selector resolved to another workspace",
+        ));
+    }
+    match binding.repo_fingerprint.as_deref() {
+        Some(fingerprint) if fingerprint == request.source_repository_fingerprint => Ok(()),
+        Some(fingerprint) => Err(restore_error(format!(
+            "source repository fingerprint mismatch: destination has '{fingerprint}', publication expects '{}'",
+            request.source_repository_fingerprint
+        ))),
+        None => Err(restore_error(format!(
+            "workspace '{}' has no registered source repository fingerprint; restore never adopts one implicitly",
+            request.workspace_id
+        ))),
+    }
+}
+
+fn canonical_destination_has_entries(workspace_root: &Path) -> Result<bool, OrbitError> {
+    let mut entries = match fs::read_dir(workspace_root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(OrbitError::from_write_io(workspace_root, error)),
+    };
+    entries
+        .next()
+        .transpose()
+        .map(|entry| entry.is_some())
+        .map_err(|error| OrbitError::from_write_io(workspace_root, error))
+}
+
+fn stage_bundle(root: &Path, published: &ValidatedPublicationBundle) -> Result<(), OrbitError> {
+    let target = root.join(&published.bundle.envelope.id);
+    if published
+        .bundle
+        .artifact_manifest
+        .as_ref()
+        .is_some_and(|manifest| !manifest.files.is_empty())
+    {
+        write_bundle_with_artifacts_at(&target, &published.bundle, &published.source_dir)
+    } else {
+        write_bundle_at(&target, &published.bundle)
+    }
+}
+
+fn rebuild_workspace_index(
+    registry: &TaskRegistryStore,
+    workspace_id: &str,
+) -> Result<(), OrbitError> {
+    let envelopes = registry
+        .tasks_for_workspace(workspace_id)?
+        .into_iter()
+        .map(|binding| read_bundle_at(&binding.canonical_path).map(|bundle| bundle.envelope))
+        .collect::<Result<Vec<_>, _>>()?;
+    registry.replace_workspace_task_indexes(workspace_id, &envelopes)
+}
+
+fn outcome(
+    envelope: &super::PublicationEnvelope,
+    restored_task_ids: Vec<String>,
+    already_present_task_ids: Vec<String>,
+    projection: ProjectionRebuildResult,
+) -> PublicationRestoreOutcome {
+    let completeness = if envelope.omitted_attachments.is_empty() {
+        PublicationRecoveryCompleteness::Complete
+    } else {
+        PublicationRecoveryCompleteness::IncompleteAttachments
+    };
+    PublicationRestoreOutcome {
+        workspace_id: envelope.workspace_id.clone(),
+        publication_id: envelope.publication_id.clone(),
+        generation: envelope.generation,
+        restored_task_ids,
+        already_present_task_ids,
+        projection,
+        omitted_attachments: envelope.omitted_attachments.clone(),
+        completeness,
+    }
+}
+
+fn inject(
+    selected: Option<RestoreFailurePoint>,
+    current: RestoreFailurePoint,
+) -> Result<(), OrbitError> {
+    if selected == Some(current) {
+        return Err(restore_error(format!("injected failure after {current:?}")));
+    }
+    Ok(())
+}
+
+struct ProjectionSwap {
+    projection_dir: PathBuf,
+    backup_dir: PathBuf,
+    _staging: tempfile::TempDir,
+    had_previous: bool,
+    result: ProjectionRebuildResult,
+    committed: bool,
+}
+
+impl ProjectionSwap {
+    fn publish(
+        registry: &TaskRegistryStore,
+        orbit_dir: &Path,
+        workspace_id: &str,
+    ) -> Result<Self, OrbitError> {
+        let staging = tempfile::Builder::new()
+            .prefix(".orbit-restore-projection-")
+            .tempdir_in(orbit_dir)
+            .map_err(|error| OrbitError::from_write_io(orbit_dir, error))?;
+        let staged_tasks = staging.path().join("tasks");
+        fs::create_dir(&staged_tasks)
+            .map_err(|error| OrbitError::from_write_io(&staged_tasks, error))?;
+        let tasks = registry.tasks_for_workspace(workspace_id)?;
+        for task in &tasks {
+            let link = staged_tasks.join(&task.task_id);
+            create_dir_symlink(&task.canonical_path, &link)
+                .map_err(|error| OrbitError::from_write_io(&link, error))?;
+        }
+
+        let projection_dir = orbit_dir.join("tasks");
+        let backup_dir = staging.path().join("previous-tasks");
+        let had_previous = projection_dir.exists();
+        if had_previous {
+            fs::rename(&projection_dir, &backup_dir)
+                .map_err(|error| OrbitError::from_write_io(&projection_dir, error))?;
+        }
+        if let Err(error) = fs::rename(&staged_tasks, &projection_dir) {
+            if had_previous {
+                let _ = fs::rename(&backup_dir, &projection_dir);
+            }
+            return Err(OrbitError::from_write_io(&projection_dir, error));
+        }
+        Ok(Self {
+            projection_dir,
+            backup_dir,
+            _staging: staging,
+            had_previous,
+            result: ProjectionRebuildResult {
+                projected: tasks.len(),
+                repaired: 0,
+                degraded_reason: None,
+            },
+            committed: false,
+        })
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+
+    fn rollback(&mut self) {
+        let _ = fs::remove_dir_all(&self.projection_dir);
+        if self.had_previous {
+            let _ = fs::rename(&self.backup_dir, &self.projection_dir);
+        }
+        self.committed = true;
+    }
+}
+
+impl Drop for ProjectionSwap {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.rollback();
+        }
+    }
+}
+
+struct RestoreGuard<'a> {
+    registry: &'a TaskRegistryStore,
+    workspace_id: String,
+    previous_envelopes: Vec<orbit_types::task::TaskEnvelopeV2>,
+    previous_allocator: u32,
+    advanced_allocator: Option<u32>,
+    published_dirs: Vec<PathBuf>,
+    registered_ids: Vec<String>,
+    projection: Option<ProjectionSwap>,
+    armed: bool,
+}
+
+impl<'a> RestoreGuard<'a> {
+    fn new(
+        registry: &'a TaskRegistryStore,
+        workspace_id: String,
+        previous_envelopes: Vec<orbit_types::task::TaskEnvelopeV2>,
+        previous_allocator: u32,
+    ) -> Self {
+        Self {
+            registry,
+            workspace_id,
+            previous_envelopes,
+            previous_allocator,
+            advanced_allocator: None,
+            published_dirs: Vec::new(),
+            registered_ids: Vec::new(),
+            projection: None,
+            armed: true,
+        }
+    }
+
+    fn commit(&mut self) {
+        if let Some(projection) = &mut self.projection {
+            projection.commit();
+        }
+        self.armed = false;
+    }
+
+    fn rollback(&mut self) {
+        if let Some(projection) = &mut self.projection {
+            projection.rollback();
+        }
+        for task_id in self.registered_ids.iter().rev() {
+            let _ = self
+                .registry
+                .unregister_task_bundle(task_id, &self.workspace_id);
+        }
+        let _ = self
+            .registry
+            .replace_workspace_task_indexes(&self.workspace_id, &self.previous_envelopes);
+        for dir in self.published_dirs.iter().rev() {
+            let _ = fs::remove_dir_all(dir);
+        }
+        if let Some(current) = self.advanced_allocator {
+            let _ = self
+                .registry
+                .restore_allocator_after_failed_restore(current, self.previous_allocator);
+        }
+        self.armed = false;
+    }
+}
+
+impl Drop for RestoreGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.rollback();
+        }
+    }
+}
+
+fn restore_error(message: impl Into<String>) -> OrbitError {
+    OrbitError::InvalidInput(format!("{RESTORE_LABEL}: {}", message.into()))
+}

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -23,6 +23,7 @@ use super::*;
 mod inspect;
 mod publication;
 mod publish;
+mod restore;
 
 /// Run `git` with a deterministic, non-interactive identity. Publication tests
 /// drive only local temporary repositories: there is no network service and no

--- a/crates/orbit-store/src/workflow/task/tests/restore.rs
+++ b/crates/orbit-store/src/workflow/task/tests/restore.rs
@@ -1,0 +1,336 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use orbit_types::task::{ArtifactManifestV2, TASK_ARTIFACT_SCHEMA_VERSION};
+use tempfile::TempDir;
+
+use super::*;
+use crate::workflow::task::restore::{RestoreFailurePoint, restore_publication_with_failure};
+
+const WORKSPACE: &str = "ws_restore";
+const FINGERPRINT: &str = "git@github.com:example/orbit-source.git";
+const PUBLICATION: &str = "pub_orbit_restore";
+const AUTHORITY: &str = "hm_owner";
+
+struct RestoreFixture {
+    _source: TempDir,
+    destination: TempDir,
+    remote: PathBuf,
+    cache: PathBuf,
+}
+
+impl RestoreFixture {
+    fn registry(&self) -> TaskRegistryStore {
+        open_registry(self.destination.path())
+    }
+
+    fn request(&self, mode: PublicationRestoreMode) -> PublicationRestoreRequest {
+        PublicationRestoreRequest {
+            publication: PublicationInspectRequest {
+                workspace_id: WORKSPACE.to_string(),
+                source_repository_fingerprint: FINGERPRINT.to_string(),
+                publication_id: PUBLICATION.to_string(),
+                authority_machine_id: AUTHORITY.to_string(),
+                publication_remote: self.remote.to_string_lossy().into_owned(),
+                publication_branch: "refs/heads/main".to_string(),
+                cache_dir: self.cache.clone(),
+                commit: None,
+            },
+            mode,
+        }
+    }
+}
+
+fn bind_restore(registry: &TaskRegistryStore, root: &Path) -> WorkspaceCheckoutBinding {
+    let orbit_dir = root.join("repos").join(WORKSPACE).join(".orbit");
+    fs::create_dir_all(&orbit_dir).unwrap();
+    registry
+        .bind_workspace(BindWorkspaceParams {
+            workspace_id: Some(WORKSPACE.to_string()),
+            slug: "restore".to_string(),
+            repo_root: orbit_dir.parent().unwrap().to_path_buf(),
+            workspace_path: orbit_dir.parent().unwrap().to_path_buf(),
+            orbit_dir,
+            repo_fingerprint: Some(FINGERPRINT.to_string()),
+        })
+        .unwrap()
+}
+
+fn fixture(kind: AttachmentPolicyKind) -> RestoreFixture {
+    let source = TempDir::new().unwrap();
+    let source_registry = open_registry(source.path());
+    let source_binding = bind_restore(&source_registry, source.path());
+    let store = bundle_store(&source_registry, &source_binding);
+    seed(
+        &store,
+        &source_registry,
+        WORKSPACE,
+        &make_bundle("ORB-00001", "first", Vec::new()),
+    );
+    seed(
+        &store,
+        &source_registry,
+        WORKSPACE,
+        &make_bundle("ORB-00007", "seventh", Vec::new()),
+    );
+    let entry = seed_artifact_blob(&store, "ORB-00007", "report.txt", b"recovery", "codex");
+    store
+        .rewrite_artifact_manifest(
+            "ORB-00007",
+            &ArtifactManifestV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                files: vec![entry],
+            },
+        )
+        .unwrap();
+
+    let snapshot = source.path().join("snapshot");
+    build_publication_snapshot(
+        &source_registry,
+        &snapshot,
+        PublicationSnapshotMetadata {
+            publication_id: PUBLICATION.to_string(),
+            workspace_id: WORKSPACE.to_string(),
+            source_repository_fingerprint: FINGERPRINT.to_string(),
+            authority_machine_id: AUTHORITY.to_string(),
+            generation: 1,
+            published_at: Utc.with_ymd_and_hms(2026, 8, 30, 4, 0, 0).unwrap(),
+            previous_publication: None,
+        },
+        &AttachmentPolicy {
+            kind,
+            max_file_bytes: 1024,
+            max_total_bytes: 4096,
+            deny_patterns: Vec::new(),
+            scanner_failure_behavior: ScannerFailureBehavior::AllowUnchecked,
+        },
+        None,
+    )
+    .unwrap();
+
+    let remote = source.path().join("publication.git");
+    fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "-b", "main"]);
+    replace_worktree(&remote, &snapshot);
+    git(&remote, &["add", "-A"]);
+    git(&remote, &["commit", "-m", "publication"]);
+
+    let destination = TempDir::new().unwrap();
+    let destination_registry = open_registry(destination.path());
+    bind_restore(&destination_registry, destination.path());
+    let cache = destination.path().join("publication-cache");
+    RestoreFixture {
+        _source: source,
+        destination,
+        remote,
+        cache,
+    }
+}
+
+#[test]
+fn empty_destination_restore_preserves_ids_rebuilds_projection_and_advances_allocator() {
+    let fixture = fixture(AttachmentPolicyKind::Include);
+    let registry = fixture.registry();
+    let outcome = restore_publication(
+        &registry,
+        fixture.request(PublicationRestoreMode::EmptyDestination),
+    )
+    .unwrap();
+
+    assert_eq!(outcome.restored_task_ids, ["ORB-00001", "ORB-00007"]);
+    assert!(outcome.already_present_task_ids.is_empty());
+    assert_eq!(
+        outcome.completeness,
+        PublicationRecoveryCompleteness::Complete
+    );
+    assert!(outcome.omitted_attachments.is_empty());
+    assert_eq!(registry.allocator_next_number().unwrap(), 8);
+    assert_eq!(registry.tasks_for_workspace(WORKSPACE).unwrap().len(), 2);
+    let checkout = registry
+        .find_workspace_checkout(WORKSPACE)
+        .unwrap()
+        .unwrap();
+    for task_id in &outcome.restored_task_ids {
+        assert!(checkout.orbit_dir.join("tasks").join(task_id).is_symlink());
+        let restored = read_bundle_at(
+            &registry
+                .canonical_task_bundle_path(WORKSPACE, task_id)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(restored.envelope.id, *task_id);
+    }
+}
+
+#[test]
+fn identical_retry_is_explicit_and_does_not_duplicate_or_advance() {
+    let fixture = fixture(AttachmentPolicyKind::Include);
+    let registry = fixture.registry();
+    restore_publication(
+        &registry,
+        fixture.request(PublicationRestoreMode::EmptyDestination),
+    )
+    .unwrap();
+    let allocator = registry.allocator_next_number().unwrap();
+    let canonical = registry
+        .canonical_task_bundle_path(WORKSPACE, "ORB-00007")
+        .unwrap();
+    let before = tree_bytes(&canonical);
+
+    let retry = restore_publication(
+        &registry,
+        fixture.request(PublicationRestoreMode::AllowIdenticalRetry),
+    )
+    .unwrap();
+    assert!(retry.restored_task_ids.is_empty());
+    assert_eq!(retry.already_present_task_ids, ["ORB-00001", "ORB-00007"]);
+    assert_eq!(registry.allocator_next_number().unwrap(), allocator);
+    assert_eq!(tree_bytes(&canonical), before);
+    assert_eq!(registry.tasks_for_workspace(WORKSPACE).unwrap().len(), 2);
+}
+
+#[test]
+fn collision_and_identity_mismatch_abort_before_mutation() {
+    let collision_fixture = fixture(AttachmentPolicyKind::Include);
+    let registry = collision_fixture.registry();
+    let binding = registry
+        .find_workspace_checkout(WORKSPACE)
+        .unwrap()
+        .unwrap();
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        WORKSPACE,
+        &make_bundle("ORB-00001", "different", Vec::new()),
+    );
+    let before = tree_bytes(registry.workspaces_dir());
+    let allocator = registry.allocator_next_number().unwrap();
+    let error = restore_publication(
+        &registry,
+        collision_fixture.request(PublicationRestoreMode::AllowIdenticalRetry),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("non-identical"), "{error}");
+    assert_eq!(tree_bytes(registry.workspaces_dir()), before);
+    assert_eq!(registry.allocator_next_number().unwrap(), allocator);
+
+    let other = fixture(AttachmentPolicyKind::Include);
+    let other_registry = other.registry();
+    let mut wrong = other.request(PublicationRestoreMode::EmptyDestination);
+    wrong.publication.authority_machine_id = "hm_other".to_string();
+    assert!(restore_publication(&other_registry, wrong).is_err());
+    assert!(
+        other_registry
+            .tasks_for_workspace(WORKSPACE)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn omitted_attachments_are_reported_as_incomplete_recovery() {
+    let fixture = fixture(AttachmentPolicyKind::Omit);
+    let outcome = restore_publication(
+        &fixture.registry(),
+        fixture.request(PublicationRestoreMode::EmptyDestination),
+    )
+    .unwrap();
+    assert_eq!(
+        outcome.completeness,
+        PublicationRecoveryCompleteness::IncompleteAttachments
+    );
+    assert_eq!(outcome.omitted_attachments.len(), 1);
+    assert_eq!(outcome.omitted_attachments[0].path, "report.txt");
+}
+
+#[test]
+fn corrupt_included_blob_and_unsupported_schema_leave_destination_empty() {
+    let corrupt_fixture = fixture(AttachmentPolicyKind::Include);
+    fs::write(
+        corrupt_fixture
+            .remote
+            .join("tasks/ORB-00007/artifacts/files/report.txt"),
+        b"corrupt",
+    )
+    .unwrap();
+    git(&corrupt_fixture.remote, &["add", "-A"]);
+    git(&corrupt_fixture.remote, &["commit", "--amend", "--no-edit"]);
+    let registry = corrupt_fixture.registry();
+    assert!(
+        restore_publication(
+            &registry,
+            corrupt_fixture.request(PublicationRestoreMode::EmptyDestination)
+        )
+        .is_err()
+    );
+    assert!(registry.tasks_for_workspace(WORKSPACE).unwrap().is_empty());
+
+    let future = fixture(AttachmentPolicyKind::Omit);
+    let envelope = future.remote.join(PUBLICATION_ENVELOPE_FILE_NAME);
+    let raw = fs::read_to_string(&envelope)
+        .unwrap()
+        .replace("format_version: 1", "format_version: 99");
+    fs::write(&envelope, raw).unwrap();
+    git(&future.remote, &["add", "-A"]);
+    git(&future.remote, &["commit", "--amend", "--no-edit"]);
+    let future_registry = future.registry();
+    assert!(
+        restore_publication(
+            &future_registry,
+            future.request(PublicationRestoreMode::EmptyDestination)
+        )
+        .is_err()
+    );
+    assert!(
+        future_registry
+            .tasks_for_workspace(WORKSPACE)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn every_mutation_phase_rolls_back_canonical_registry_projection_and_allocator() {
+    for failure in [
+        RestoreFailurePoint::BundlePublication,
+        RestoreFailurePoint::IndexRebuild,
+        RestoreFailurePoint::ProjectionRebuild,
+        RestoreFailurePoint::AllocatorAdvance,
+    ] {
+        let fixture = fixture(AttachmentPolicyKind::Include);
+        let registry = fixture.registry();
+        let allocator = registry.allocator_next_number().unwrap();
+        let checkout = registry
+            .find_workspace_checkout(WORKSPACE)
+            .unwrap()
+            .unwrap();
+        let projection_existed = checkout.orbit_dir.join("tasks").exists();
+
+        let error = restore_publication_with_failure(
+            &registry,
+            fixture.request(PublicationRestoreMode::EmptyDestination),
+            failure,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("injected failure"), "{failure:?}: {error}");
+        assert!(registry.tasks_for_workspace(WORKSPACE).unwrap().is_empty());
+        assert_eq!(registry.allocator_next_number().unwrap(), allocator);
+        assert_eq!(
+            checkout.orbit_dir.join("tasks").exists(),
+            projection_existed,
+            "{failure:?}"
+        );
+        for task_id in ["ORB-00001", "ORB-00007"] {
+            assert!(
+                !registry
+                    .canonical_task_bundle_path(WORKSPACE, task_id)
+                    .unwrap()
+                    .exists(),
+                "{failure:?}: {task_id}"
+            );
+        }
+    }
+}

--- a/docs/design/task-publication/1_overview.md
+++ b/docs/design/task-publication/1_overview.md
@@ -99,11 +99,13 @@ encrypted secret store.
 | Canonical task-bundle format | [Task Artifacts](../task-artifacts/2_design.md) | — |
 | Current live cross-machine access | [Remote Access](../remote-access/1_overview.md) | — |
 | Current host-qualified MCP routing | [Federated MCP](../federated-mcp/1_overview.md) | — |
-| Portable archive and restore primitives | [`orbit-store` task workflow](../../../crates/orbit-store/src/workflow/task/mod.rs) | — |
+| Same-authority publication recovery | [`orbit-store` restore workflow](../../../crates/orbit-store/src/workflow/task/restore.rs) | [ORB-11076] |
+| Portable migration archive primitives | [`orbit-store` task workflow](../../../crates/orbit-store/src/workflow/task/mod.rs) | — |
 | Retired source-repository registry | [Task Sync](../_archive/task-sync/1_overview.md) | — |
 
 ## Task References
 
 - [ORB-11068] — designed authority-owned task publication through a dedicated private Git repository.
+- [ORB-11076] — implemented fail-closed same-authority publication restore.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-publication/2_design.md
+++ b/docs/design/task-publication/2_design.md
@@ -16,9 +16,11 @@ related_artifacts: [ORB-11068, ORB-11074]
 
 # Task Publication — Design
 
-This document specifies a proposed v1 publication protocol. It is not a
-description of shipped behavior. V1 publishes one workspace's authority-owned
-task snapshots to one dedicated private Git repository for remote durability,
+This document specifies the v1 publication protocol. Its implemented
+`orbit-store` primitives cover snapshot construction, owner-only Git transport,
+read-only inspection, and explicit same-authority recovery; entry-point wiring
+is tracked separately. V1 publishes one workspace's authority-owned task
+snapshots to one dedicated private Git repository for remote durability,
 read-only inspection, and explicit recovery. Multi-workspace aggregation,
 authority transfer, and multi-writer synchronization remain deferred to
 [3_vision.md](./3_vision.md).
@@ -226,6 +228,13 @@ Restore is explicit and fail-closed:
 5. Report every omitted attachment; an incomplete publication cannot produce a
    "complete backup restored" result.
 
+The `orbit-store` recovery implementation follows this contract by consuming
+the inspector's validated snapshot, staging bundle and projection trees, and
+rolling back bundle publication, registry indexing, projection replacement,
+and allocator advancement as one recovery operation [ORB-11076]. Exact-content
+retries require the explicit identical-retry mode and do not replay bundle
+streams or advance the allocator.
+
 The existing task importer's `renumber` policy remains useful for migration
 between unrelated registries. It is not valid for same-authority recovery,
 because changing task IDs would break commit, relation, and audit references.
@@ -310,5 +319,6 @@ deleting the current tree erased the data.
 
 - [ORB-11068] — specified the proposed dedicated private task-publication repository protocol.
 - [ORB-11074] — implemented the owner-only Git compare-and-swap publication transport.
+- [ORB-11076] — implemented fail-closed same-authority publication restore with rollback.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11076](https://orbit-cli.com/tasks/ORB-11076) — Restore task publications without renumbering or authority ambiguity

### Description

## Problem
Orbit's generic task importer supports migration and renumbering, but same-authority disaster recovery must preserve task IDs and refuse ambiguous collisions.

## Why It Matters
A publication is only useful as a durability mechanism if it can rebuild canonical bundles, indexes, projections, and allocator state without silently merging unrelated histories or claiming omitted artifacts were recovered.

## Constraints / Notes
- Consume only a publication already validated by the read-only consumer contract.
- Require an empty destination or a deliberately selected recovery mode with exact workspace/source/publication/authority pairing.
- Same-authority restore never uses migration renumbering, skip-on-conflict, last-writer-wins, or implicit workspace/authority adoption.
- Any non-identical live task-ID collision aborts the entire restore before mutation; identical content may be treated idempotently only with proof.
- Restore canonical bundles, rebuild indexes and checkout projections, and advance the allocator beyond restored IDs.
- Preserve and report the omission ledger; incomplete publication cannot yield a complete-backup result.
- Use transactional staging/rollback so validation or persistence failure leaves the pre-restore store intact.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- Restore validates repository and envelope pairing, supported schemas, every task bundle, included attachment checksum, and omission record before mutating canonical state.
- An empty destination restore preserves task IDs, writes canonical bundles, rebuilds registry indexes and checkout projections, and advances allocation beyond the highest restored ID.
- A non-identical task-ID collision, workspace/source/lineage/authority mismatch, unsupported schema, corrupt bundle, or missing included blob aborts the whole restore with no partial canonical mutation.
- An explicitly permitted identical-content retry is idempotent and does not append duplicate events, comments, artifacts, or allocator changes.
- The outcome reports omitted artifacts and cannot label an incomplete publication as a complete recovery.
- Failure-injection tests verify rollback across bundle publication, index rebuild, projection rebuild, and allocator advancement.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added same-authority publication restore that reuses the read-only inspector validation contract for repository/envelope pairing, lineage, schemas, bundles, JSONL streams, omission records, and attachment checksums.
- Added explicit empty-destination and identical-content retry modes; collisions and workspace/source/publication/authority mismatches fail before canonical mutation, while exact retries do not replay task history or advance allocation.
- Added staged canonical bundle publication, atomic checkout-projection replacement, registry index rebuilding, allocator advancement, and rollback support including compare-guarded allocator rewind after failed recovery.
- Added complete/incomplete recovery outcomes that preserve and report the omission ledger.
- Added failure-injection coverage for bundle publication, index rebuild, projection rebuild, and allocator advancement, plus success, collision, identity, corruption, schema, retry, and omission tests.
- Updated current task-publication design documentation.
Assessment: The restore path is fail-closed, preserves task IDs, and keeps migration renumbering outside same-authority recovery. The inspector remains the single validation boundary shared by read-only rendering and restore.
Deviations from original plan:
- Expanded context to crates/orbit-store/src/driver/sqlite/task_registry/store.rs for the allocator rollback boundary and docs/design/task-publication for required live-documentation updates. No dependency edge was added.
Validation:
- cargo test -p orbit-store workflow::task::tests::restore --no-fail-fast (6 passed)
- cargo test -p orbit-store workflow::task::tests --no-fail-fast (49 passed before removal of one fixture-only test; 48 substantive tests remain)
- cargo test -p orbit-store --no-fail-fast (364 passed, 4 ignored before removal of one fixture-only test; subsequent targeted suite passed)
- make ci-fast (passed)
- make ci-lint (passed workspace-wide, all targets, warnings denied)
- git diff --check (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11076-6a93aa46`
- Behind base: 0
- Ahead of base: 1