### PR TITLE
Ship the V1 task-publication operator workflow and recovery runbook

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -207,12 +207,27 @@ impl Commands {
                 dispatch_init,
             ),
             Commands::Workspace(command) => {
+                use super::workspace::WorkspacePublicationSubcommand;
                 use super::workspace::WorkspaceSubcommand;
                 let (subcommand, runtime_need, governed) = match &command.command {
                     WorkspaceSubcommand::Init(_) => ("init", RuntimeNeed::Forbidden, false),
                     WorkspaceSubcommand::List(_) => ("list", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Show(_) => ("show", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Role(_) => ("role", RuntimeNeed::Required, false),
+                    WorkspaceSubcommand::Publication(command) => match &command.command {
+                        WorkspacePublicationSubcommand::Bind(_) => {
+                            ("publication-bind", RuntimeNeed::Required, false)
+                        }
+                        WorkspacePublicationSubcommand::Show(_) => {
+                            ("publication-show", RuntimeNeed::Required, false)
+                        }
+                        WorkspacePublicationSubcommand::Rebind(_) => {
+                            ("publication-rebind", RuntimeNeed::Required, true)
+                        }
+                        WorkspacePublicationSubcommand::Remove(args) => {
+                            ("publication-remove", RuntimeNeed::Required, args.confirm)
+                        }
+                    },
                     WorkspaceSubcommand::Remove(_) => ("remove", RuntimeNeed::Required, true),
                     WorkspaceSubcommand::Teardown(args) => {
                         ("teardown", RuntimeNeed::Required, args.confirm)
@@ -430,6 +445,7 @@ impl Commands {
             }
             Commands::Task(command) => {
                 use super::locks::LocksSubcommand;
+                use super::task::TaskPublicationSubcommand;
                 use super::task::TaskSubcommand;
                 use super::task::artifact::TaskArtifactSubcommand;
                 let (subcommand, target_type, target_id) = match &command.command {
@@ -463,6 +479,20 @@ impl Commands {
                         None,
                         Some(args.archive.to_str().unwrap_or_default()),
                     ),
+                    TaskSubcommand::Publication(command) => match &command.command {
+                        TaskPublicationSubcommand::Publish(_) => {
+                            ("publication-publish", Some("workspace"), None)
+                        }
+                        TaskPublicationSubcommand::Status(_) => {
+                            ("publication-status", Some("workspace"), None)
+                        }
+                        TaskPublicationSubcommand::Inspect(_) => {
+                            ("publication-inspect", Some("publication"), None)
+                        }
+                        TaskPublicationSubcommand::Restore(_) => {
+                            ("publication-restore", Some("workspace"), None)
+                        }
+                    },
                     TaskSubcommand::Reindex(_) => ("reindex", None, None),
                 };
                 let runtime_need = match &command.command {
@@ -480,6 +510,19 @@ impl Commands {
                     None,
                     false,
                     boxed_runtime_dispatch!(Task),
+                )
+                .governed_when(
+                    matches!(
+                        &command.command,
+                        TaskSubcommand::Publication(publication)
+                            if matches!(
+                                publication.command,
+                                TaskPublicationSubcommand::Publish(_)
+                                    | TaskPublicationSubcommand::Restore(_)
+                            )
+                    ),
+                    "task",
+                    subcommand,
                 )
             }
             Commands::Search(command) => CommandOperation::new(

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -11,6 +11,7 @@ use super::import::TaskImportArgs;
 use super::lifecycle::{TaskArchiveArgs, TaskStartArgs};
 use super::lint::TaskLintArgs;
 use super::list::TaskListArgs;
+use super::publication::TaskPublicationCommand;
 use super::reindex::TaskReindexArgs;
 use super::show::TaskShowArgs;
 use super::update::TaskUpdateArgs;
@@ -54,6 +55,8 @@ pub enum TaskSubcommand {
     Export(TaskExportArgs),
     /// Import task bundles from a tar.zst archive
     Import(TaskImportArgs),
+    /// Publish, inspect, diagnose, or deliberately restore task snapshots
+    Publication(TaskPublicationCommand),
     /// Rebuild the registry index from on-disk task bundles
     Reindex(TaskReindexArgs),
 }
@@ -72,6 +75,7 @@ impl Execute for TaskSubcommand {
             TaskSubcommand::Archive(args) => args.execute(runtime),
             TaskSubcommand::Export(args) => args.execute(runtime),
             TaskSubcommand::Import(args) => args.execute(runtime),
+            TaskSubcommand::Publication(command) => command.execute(runtime),
             TaskSubcommand::Reindex(args) => args.execute(runtime),
         }
     }

--- a/crates/orbit-cli/src/command/task/mod.rs
+++ b/crates/orbit-cli/src/command/task/mod.rs
@@ -8,11 +8,13 @@ mod lifecycle;
 mod lint;
 mod list;
 pub(crate) mod output;
+mod publication;
 mod reindex;
 pub(crate) mod show;
 mod update;
 
 pub use command::{TaskCommand, TaskSubcommand};
+pub use publication::TaskPublicationSubcommand;
 
 fn mutation_identity(model: Option<String>) -> (Option<String>, Option<String>) {
     if model.is_some() {

--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -1,0 +1,608 @@
+use std::path::PathBuf;
+
+use chrono::Utc;
+use clap::{Args, Subcommand, ValueEnum};
+use orbit_core::OrbitRuntime;
+use orbit_core::bootstrap::task_publication::{
+    AttachmentPolicy, AttachmentPolicyKind, PublicationCallerRole, PublicationFreshness,
+    PublicationInspectRequest, PublicationInspection, PublicationLastSuccess,
+    PublicationPublishOutcome, PublicationPublishRequest, PublicationPublishStatus,
+    PublicationRecoveryCompleteness, PublicationRenderAuthority, PublicationRestoreMode,
+    PublicationRestoreRequest, ScannerFailureBehavior,
+};
+use orbit_registry::{load_host_identity, workspace_registry};
+use orbit_types::workspace::{
+    DEFAULT_PUBLICATION_BRANCH, WorkspaceCheckoutRole, WorkspacePublicationBinding,
+    redact_git_remote,
+};
+use serde_json::{Value, json};
+
+use crate::command::{CommandOut, Execute, Payload, require_confirmation};
+
+const DEFAULT_MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
+const DEFAULT_MAX_TOTAL_BYTES: u64 = 100 * 1024 * 1024;
+const DEFAULT_DENY_PATTERNS: [&str; 6] = [
+    "**/.env",
+    "**/.env.*",
+    "**/*.pem",
+    "**/*.key",
+    "**/id_rsa",
+    "**/credentials.json",
+];
+
+#[derive(Args)]
+#[command(about = "Operate the explicit task-publication and recovery workflow")]
+pub struct TaskPublicationCommand {
+    #[command(subcommand)]
+    pub command: TaskPublicationSubcommand,
+}
+
+#[derive(Subcommand)]
+pub enum TaskPublicationSubcommand {
+    /// Explicitly publish the selected owned workspace's validated tasks
+    Publish(TaskPublicationPublishArgs),
+    /// Compare the owner-local last-success record with the validated branch tip
+    Status(TaskPublicationStatusArgs),
+    /// Read and validate a labelled snapshot without adopting live task state
+    Inspect(TaskPublicationInspectArgs),
+    /// Deliberately restore a same-authority snapshot into the selected workspace
+    Restore(TaskPublicationRestoreArgs),
+}
+
+impl Execute for TaskPublicationCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        match self.command {
+            TaskPublicationSubcommand::Publish(args) => args.execute(runtime),
+            TaskPublicationSubcommand::Status(args) => args.execute(runtime),
+            TaskPublicationSubcommand::Inspect(args) => args.execute(runtime),
+            TaskPublicationSubcommand::Restore(args) => args.execute(runtime),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliAttachmentPolicy {
+    Fail,
+    Include,
+    Omit,
+}
+
+impl From<CliAttachmentPolicy> for AttachmentPolicyKind {
+    fn from(value: CliAttachmentPolicy) -> Self {
+        match value {
+            CliAttachmentPolicy::Fail => Self::Fail,
+            CliAttachmentPolicy::Include => Self::Include,
+            CliAttachmentPolicy::Omit => Self::Omit,
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct TaskPublicationPublishArgs {
+    /// Attachment exposure policy. `fail` is the safe default.
+    #[arg(long = "attachments", value_enum, default_value_t = CliAttachmentPolicy::Fail)]
+    attachments: CliAttachmentPolicy,
+    /// Maximum bytes admitted for one included attachment.
+    #[arg(long, default_value_t = DEFAULT_MAX_FILE_BYTES)]
+    max_file_bytes: u64,
+    /// Maximum total bytes admitted for included attachments.
+    #[arg(long, default_value_t = DEFAULT_MAX_TOTAL_BYTES)]
+    max_total_bytes: u64,
+    /// Additional attachment path glob to reject (repeatable).
+    #[arg(long = "deny-pattern")]
+    deny_patterns: Vec<String>,
+    /// Deliberately permit `include` when no sensitivity scanner is configured.
+    #[arg(long, requires = "attachments")]
+    allow_unscanned_attachments: bool,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for TaskPublicationPublishArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        if self.allow_unscanned_attachments
+            && !matches!(self.attachments, CliAttachmentPolicy::Include)
+        {
+            return Err(orbit_core::OrbitError::InvalidInput(
+                "--allow-unscanned-attachments is valid only with --attachments include"
+                    .to_string(),
+            ));
+        }
+        let workspace_id = selected_workspace_id(runtime)?;
+        let global_root = runtime.global_root();
+        let host = load_host_identity(&global_root)?;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)
+            .cloned()
+            .ok_or_else(|| {
+                orbit_core::OrbitError::WorkspaceError(format!(
+                    "workspace '{workspace_id}' has no publication binding; run `orbit workspace publication bind` first"
+                ))
+            })?;
+        let checkout =
+            workspace_registry::find_checkout(&registry, &workspace_id).ok_or_else(|| {
+                orbit_core::OrbitError::WorkspaceError(format!(
+                    "workspace '{workspace_id}' has no local checkout"
+                ))
+            })?;
+        let caller_role = match checkout.role {
+            Some(WorkspaceCheckoutRole::Owner) => PublicationCallerRole::Owner,
+            Some(WorkspaceCheckoutRole::Replica) | None => PublicationCallerRole::Replica,
+        };
+
+        let request = publish_request(
+            &binding,
+            host.machine_id,
+            caller_role,
+            publication_cache(runtime),
+        );
+        let mut deny_patterns = DEFAULT_DENY_PATTERNS
+            .iter()
+            .map(|pattern| (*pattern).to_string())
+            .collect::<Vec<_>>();
+        deny_patterns.extend(self.deny_patterns);
+        let policy = AttachmentPolicy {
+            kind: self.attachments.into(),
+            max_file_bytes: self.max_file_bytes,
+            max_total_bytes: self.max_total_bytes,
+            deny_patterns,
+            scanner_failure_behavior: if self.allow_unscanned_attachments {
+                ScannerFailureBehavior::AllowUnchecked
+            } else {
+                ScannerFailureBehavior::Reject
+            },
+        };
+        let outcome = runtime.publish_task_publication(request, &policy)?;
+
+        workspace_registry::record_publication_success(
+            &mut registry,
+            &workspace_id,
+            outcome.generation,
+            &outcome.commit_id,
+            Some(&binding.authority_machine_id),
+        )?;
+        workspace_registry::save_registry_to(&registry, &registry_path)?;
+
+        Ok(Payload::detail(
+            publish_json(&binding, &outcome),
+            format_publish(&binding, &outcome),
+        )
+        .into())
+    }
+}
+
+#[derive(Args)]
+pub struct TaskPublicationStatusArgs {
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for TaskPublicationStatusArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let workspace_id = selected_workspace_id(runtime)?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&runtime.global_root()),
+        )?;
+        let binding = workspace_registry::find_publication_binding(&registry, &workspace_id)
+            .ok_or_else(|| {
+                orbit_core::OrbitError::WorkspaceError(format!(
+                    "workspace '{workspace_id}' has no publication binding"
+                ))
+            })?;
+        let Some(local_commit) = binding.last_success_commit.as_deref() else {
+            return Ok(Payload::detail(
+                json!({
+                    "workspace_id": binding.workspace_id,
+                    "publication_id": binding.publication_id,
+                    "state": "never-published",
+                    "last_success_generation": Value::Null,
+                    "last_success_commit": Value::Null,
+                    "publication_remote": redact_git_remote(&binding.publication_remote),
+                    "privacy": "operator-managed",
+                }),
+                format!(
+                    "publication '{}' for workspace '{}' has no recorded successful snapshot\nprivacy: operator-managed",
+                    binding.publication_id, binding.workspace_id
+                ),
+            )
+            .into());
+        };
+
+        let inspection = runtime.inspect_task_publication(inspect_request_from_binding(
+            binding,
+            publication_cache(runtime),
+            None,
+        ))?;
+        let state = if inspection.label.commit_id == local_commit {
+            "current"
+        } else {
+            "authority-conflict"
+        };
+        Ok(Payload::detail(
+            json!({
+                "workspace_id": binding.workspace_id,
+                "publication_id": binding.publication_id,
+                "state": state,
+                "last_success_generation": binding.last_success_generation,
+                "last_success_commit": local_commit,
+                "remote_generation": inspection.label.generation,
+                "remote_commit": inspection.label.commit_id,
+                "incomplete_attachments": inspection.label.incomplete_attachments,
+                "publication_remote": redact_git_remote(&binding.publication_remote),
+                "privacy": "operator-managed",
+            }),
+            format!(
+                "state:           {state}\nworkspace:       {}\npublication:     {}\nlocal_commit:    {}\nremote_commit:   {}\nremote_generation: {}\nincomplete:      {}\nprivacy:         operator-managed",
+                binding.workspace_id,
+                binding.publication_id,
+                local_commit,
+                inspection.label.commit_id,
+                inspection.label.generation,
+                inspection.label.incomplete_attachments,
+            ),
+        )
+        .into())
+    }
+}
+
+#[derive(Args, Clone)]
+struct PublicationConsumerArgs {
+    /// Expected logical workspace id carried by the publication.
+    #[arg(long)]
+    workspace_id: String,
+    /// Expected portable source-repository remote identity.
+    #[arg(long = "source-remote", value_name = "URL")]
+    source_repository_fingerprint: String,
+    /// Expected opaque publication lineage identifier.
+    #[arg(long)]
+    publication_id: String,
+    /// Expected authority machine id.
+    #[arg(long)]
+    authority_machine_id: String,
+    /// Dedicated publication repository URL.
+    #[arg(long, value_name = "URL")]
+    remote: String,
+    /// Ordinary publication branch (short name or refs/heads/*).
+    #[arg(long, default_value = DEFAULT_PUBLICATION_BRANCH)]
+    branch: String,
+    /// Inspect or restore this exact commit instead of the current branch tip.
+    #[arg(long)]
+    commit: Option<String>,
+}
+
+impl PublicationConsumerArgs {
+    fn request(&self, runtime: &OrbitRuntime, cache_leaf: &str) -> PublicationInspectRequest {
+        PublicationInspectRequest {
+            workspace_id: self.workspace_id.clone(),
+            source_repository_fingerprint: self.source_repository_fingerprint.clone(),
+            publication_id: self.publication_id.clone(),
+            authority_machine_id: self.authority_machine_id.clone(),
+            publication_remote: self.remote.clone(),
+            publication_branch: self.branch.clone(),
+            cache_dir: publication_cache(runtime).join(cache_leaf),
+            commit: self.commit.clone(),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct TaskPublicationInspectArgs {
+    #[command(flatten)]
+    publication: PublicationConsumerArgs,
+    /// Emit machine-readable JSON including validated task content.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for TaskPublicationInspectArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let inspection =
+            runtime.inspect_task_publication(self.publication.request(runtime, "inspect"))?;
+        Ok(Payload::detail(inspection_json(&inspection), format_inspection(&inspection)).into())
+    }
+}
+
+#[derive(Args)]
+pub struct TaskPublicationRestoreArgs {
+    #[command(flatten)]
+    publication: PublicationConsumerArgs,
+    /// Permit an idempotent retry only when every colliding bundle is byte-identical.
+    #[arg(long)]
+    allow_identical_retry: bool,
+    /// Confirm deliberate mutation of the destination canonical task store.
+    #[arg(long)]
+    pub confirm: bool,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for TaskPublicationRestoreArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        require_confirmation(
+            self.confirm,
+            "restoring a task publication into the canonical destination store",
+        )?;
+        assert_restore_authority(runtime, &self.publication)?;
+        runtime.record_task_publication_source(
+            &self.publication.workspace_id,
+            &self.publication.source_repository_fingerprint,
+        )?;
+        let request = PublicationRestoreRequest {
+            publication: self.publication.request(runtime, "restore"),
+            mode: if self.allow_identical_retry {
+                PublicationRestoreMode::AllowIdenticalRetry
+            } else {
+                PublicationRestoreMode::EmptyDestination
+            },
+        };
+        let outcome = runtime.restore_task_publication(request)?;
+        let completeness = match outcome.completeness {
+            PublicationRecoveryCompleteness::Complete => "complete",
+            PublicationRecoveryCompleteness::IncompleteAttachments => "incomplete-attachments",
+        };
+        let omitted = outcome
+            .omitted_attachments
+            .iter()
+            .map(|entry| {
+                json!({
+                    "task_id": entry.task_id,
+                    "path": entry.path,
+                    "size_bytes": entry.size_bytes,
+                    "sha256": entry.sha256,
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(Payload::detail(
+            json!({
+                "workspace_id": outcome.workspace_id,
+                "publication_id": outcome.publication_id,
+                "generation": outcome.generation,
+                "restored_task_ids": outcome.restored_task_ids,
+                "already_present_task_ids": outcome.already_present_task_ids,
+                "completeness": completeness,
+                "omitted_attachments": omitted,
+                "projection": {
+                    "projected": outcome.projection.projected,
+                    "repaired": outcome.projection.repaired,
+                    "degraded_reason": outcome.projection.degraded_reason,
+                },
+            }),
+            format!(
+                "restored publication '{}' generation {} into workspace '{}'\nrestored: {}\nalready present: {}\ncompleteness: {}\nomitted attachments: {}",
+                outcome.publication_id,
+                outcome.generation,
+                outcome.workspace_id,
+                outcome.restored_task_ids.len(),
+                outcome.already_present_task_ids.len(),
+                completeness,
+                outcome.omitted_attachments.len(),
+            ),
+        )
+        .into())
+    }
+}
+
+fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
+    runtime
+        .workspace_runtime_binding()
+        .map(|binding| binding.workspace_id.clone())
+        .map_or_else(|| runtime.workspace_id(), Ok)
+}
+
+fn publication_cache(runtime: &OrbitRuntime) -> PathBuf {
+    runtime.global_root().join("state").join("task-publication")
+}
+
+fn publish_request(
+    binding: &WorkspacePublicationBinding,
+    local_machine_id: String,
+    caller_role: PublicationCallerRole,
+    cache_dir: PathBuf,
+) -> PublicationPublishRequest {
+    PublicationPublishRequest {
+        workspace_id: binding.workspace_id.clone(),
+        source_repository_fingerprint: binding.source_repository_fingerprint.clone(),
+        publication_id: binding.publication_id.clone(),
+        authority_machine_id: binding.authority_machine_id.clone(),
+        local_machine_id,
+        caller_role,
+        publication_remote: binding.publication_remote.clone(),
+        publication_branch: binding.publication_branch.clone(),
+        cache_dir,
+        published_at: Utc::now(),
+        last_success: binding
+            .last_success_generation
+            .zip(binding.last_success_commit.as_ref())
+            .map(|(generation, commit)| PublicationLastSuccess {
+                generation,
+                commit: commit.clone(),
+            }),
+    }
+}
+
+fn inspect_request_from_binding(
+    binding: &WorkspacePublicationBinding,
+    cache_dir: PathBuf,
+    commit: Option<String>,
+) -> PublicationInspectRequest {
+    PublicationInspectRequest {
+        workspace_id: binding.workspace_id.clone(),
+        source_repository_fingerprint: binding.source_repository_fingerprint.clone(),
+        publication_id: binding.publication_id.clone(),
+        authority_machine_id: binding.authority_machine_id.clone(),
+        publication_remote: binding.publication_remote.clone(),
+        publication_branch: binding.publication_branch.clone(),
+        cache_dir,
+        commit,
+    }
+}
+
+fn assert_restore_authority(
+    runtime: &OrbitRuntime,
+    expected: &PublicationConsumerArgs,
+) -> Result<(), orbit_core::OrbitError> {
+    let selected = selected_workspace_id(runtime)?;
+    if selected != expected.workspace_id {
+        return Err(orbit_core::OrbitError::PolicyDenied(format!(
+            "publication restore targets workspace '{}', but the selected destination is '{selected}'",
+            expected.workspace_id
+        )));
+    }
+    let global_root = runtime.global_root();
+    let local_machine_id = load_host_identity(&global_root)?.machine_id;
+    if local_machine_id != expected.authority_machine_id {
+        return Err(orbit_core::OrbitError::PolicyDenied(format!(
+            "publication restore authority '{}' does not match local machine '{}'",
+            expected.authority_machine_id, local_machine_id
+        )));
+    }
+    let registry = workspace_registry::load_registry_from(&workspace_registry::registry_path_for(
+        &global_root,
+    ))?;
+    let workspace = workspace_registry::find_workspace(&registry, &selected).ok_or_else(|| {
+        orbit_core::OrbitError::WorkspaceError(format!("workspace '{selected}' is not registered"))
+    })?;
+    if workspace.owner_machine_id.as_deref() != Some(local_machine_id.as_str()) {
+        return Err(orbit_core::OrbitError::PolicyDenied(format!(
+            "workspace '{selected}' is not owned by local machine '{local_machine_id}'"
+        )));
+    }
+    let checkout = workspace_registry::find_checkout(&registry, &selected).ok_or_else(|| {
+        orbit_core::OrbitError::WorkspaceError(format!(
+            "workspace '{selected}' has no local checkout"
+        ))
+    })?;
+    if checkout.role != Some(WorkspaceCheckoutRole::Owner) {
+        return Err(orbit_core::OrbitError::PolicyDenied(format!(
+            "workspace '{selected}' is a replica checkout; restore requires the declared owner destination"
+        )));
+    }
+    if workspace.git_remote.as_deref() != Some(expected.source_repository_fingerprint.as_str()) {
+        return Err(orbit_core::OrbitError::PolicyDenied(format!(
+            "publication restore source remote does not match selected workspace '{selected}'"
+        )));
+    }
+    Ok(())
+}
+
+fn publication_status_label(status: PublicationPublishStatus) -> &'static str {
+    match status {
+        PublicationPublishStatus::Initialized => "initialized",
+        PublicationPublishStatus::Advanced => "advanced",
+        PublicationPublishStatus::Unchanged => "unchanged",
+        PublicationPublishStatus::Reconciled => "reconciled",
+    }
+}
+
+fn publish_json(
+    binding: &WorkspacePublicationBinding,
+    outcome: &PublicationPublishOutcome,
+) -> Value {
+    json!({
+        "status": publication_status_label(outcome.status),
+        "workspace_id": binding.workspace_id,
+        "publication_id": binding.publication_id,
+        "publication_remote": redact_git_remote(&binding.publication_remote),
+        "branch": outcome.branch,
+        "commit_id": outcome.commit_id,
+        "generation": outcome.generation,
+        "previous_publication": outcome.previous_publication,
+        "observed_tip": outcome.observed_tip,
+        "included_attachment_bytes": outcome.included_attachment_bytes,
+        "omitted_attachment_bytes": outcome.omitted_attachment_bytes,
+        "privacy": "operator-managed",
+    })
+}
+
+fn format_publish(
+    binding: &WorkspacePublicationBinding,
+    outcome: &PublicationPublishOutcome,
+) -> String {
+    format!(
+        "status:      {}\nworkspace:   {}\npublication: {}\nbranch:      {}\ncommit:      {}\ngeneration:  {}\nincluded:    {} bytes\nomitted:     {} bytes\nprivacy:     operator-managed",
+        publication_status_label(outcome.status),
+        binding.workspace_id,
+        binding.publication_id,
+        outcome.branch,
+        outcome.commit_id,
+        outcome.generation,
+        outcome.included_attachment_bytes,
+        outcome.omitted_attachment_bytes,
+    )
+}
+
+fn inspection_json(inspection: &PublicationInspection) -> Value {
+    let freshness = match inspection.label.freshness {
+        PublicationFreshness::Current => "current",
+        PublicationFreshness::Stale => "stale",
+    };
+    let render_authority = match inspection.label.render_authority {
+        PublicationRenderAuthority::Snapshot => "snapshot",
+    };
+    let tasks = inspection
+        .tasks
+        .iter()
+        .map(|task| {
+            json!({
+                "task": task.task,
+                "description": task.description,
+                "acceptance": task.acceptance,
+                "plan": task.plan,
+                "execution_summary": task.execution_summary,
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "label": {
+            "published_at": inspection.label.published_at,
+            "generation": inspection.label.generation,
+            "workspace_id": inspection.label.workspace_id,
+            "source_repository_fingerprint": redact_git_remote(&inspection.label.source_repository_fingerprint),
+            "authority_machine_id": inspection.label.authority_machine_id,
+            "publication_id": inspection.label.publication_id,
+            "commit_id": inspection.label.commit_id,
+            "incomplete_attachments": inspection.label.incomplete_attachments,
+            "freshness": freshness,
+            "render_authority": render_authority,
+        },
+        "git_parent": inspection.git_parent,
+        "attachment_policy": attachment_policy_label(inspection.envelope.attachment_policy),
+        "omitted_attachments": inspection.envelope.omitted_attachments,
+        "tasks": tasks,
+    })
+}
+
+fn attachment_policy_label(policy: AttachmentPolicyKind) -> &'static str {
+    match policy {
+        AttachmentPolicyKind::Fail => "fail",
+        AttachmentPolicyKind::Include => "include",
+        AttachmentPolicyKind::Omit => "omit",
+    }
+}
+
+fn format_inspection(inspection: &PublicationInspection) -> String {
+    let freshness = match inspection.label.freshness {
+        PublicationFreshness::Current => "current",
+        PublicationFreshness::Stale => "stale",
+    };
+    let mut output = format!(
+        "publication snapshot (not live state)\nworkspace:   {}\npublication: {}\ngeneration:  {}\ncommit:      {}\nfreshness:   {}\npublished:   {}\nauthority:   {}\nincomplete:  {}\ntasks:       {}",
+        inspection.label.workspace_id,
+        inspection.label.publication_id,
+        inspection.label.generation,
+        inspection.label.commit_id,
+        freshness,
+        inspection.label.published_at,
+        inspection.label.authority_machine_id,
+        inspection.label.incomplete_attachments,
+        inspection.tasks.len(),
+    );
+    for task in &inspection.tasks {
+        output.push_str(&format!("\n  {}  {}", task.task.id, task.task.title));
+    }
+    output
+}

--- a/crates/orbit-cli/src/command/task/tests/mod.rs
+++ b/crates/orbit-cli/src/command/task/tests/mod.rs
@@ -2,5 +2,6 @@ mod add;
 mod artifact;
 mod command;
 mod output;
+mod publication;
 mod show;
 mod update;

--- a/crates/orbit-cli/src/command/task/tests/publication.rs
+++ b/crates/orbit-cli/src/command/task/tests/publication.rs
@@ -1,0 +1,83 @@
+use clap::{CommandFactory, Parser};
+
+use crate::command::task::TaskPublicationSubcommand;
+use crate::command::{Cli, Commands};
+
+use super::super::TaskSubcommand;
+
+#[test]
+fn task_publication_help_covers_the_complete_operator_lifecycle() {
+    let command = Cli::command();
+    let publication = command
+        .find_subcommand("task")
+        .and_then(|task| task.find_subcommand("publication"))
+        .expect("task publication command");
+    let help = publication.clone().render_long_help().to_string();
+    for verb in ["publish", "status", "inspect", "restore"] {
+        assert!(help.contains(verb), "missing {verb} from help:\n{help}");
+    }
+
+    let publish = publication
+        .find_subcommand("publish")
+        .expect("publish command")
+        .clone()
+        .render_long_help()
+        .to_string();
+    assert!(publish.contains("safe default"), "{publish}");
+    assert!(publish.contains("allow-unscanned-attachments"), "{publish}");
+
+    let restore = publication
+        .find_subcommand("restore")
+        .expect("restore command")
+        .clone()
+        .render_long_help()
+        .to_string();
+    assert!(restore.contains("--confirm"), "{restore}");
+    assert!(restore.contains("--allow-identical-retry"), "{restore}");
+}
+
+#[test]
+fn task_publication_json_forms_parse_for_every_surface() {
+    for verb in ["publish", "status"] {
+        let cli = Cli::try_parse_from(["orbit", "task", "publication", verb, "--json"])
+            .expect("parse owner publication command");
+        let Commands::Task(task) = cli.command else {
+            panic!("expected task command");
+        };
+        let TaskSubcommand::Publication(_) = task.command else {
+            panic!("expected task publication command");
+        };
+    }
+
+    let pairing = [
+        "--workspace-id",
+        "ws_example",
+        "--source-remote",
+        "ssh://source.test/example.git",
+        "--publication-id",
+        "pub_example",
+        "--authority-machine-id",
+        "hm_example",
+        "--remote",
+        "ssh://publication.test/example.git",
+    ];
+    for verb in ["inspect", "restore"] {
+        let mut args = vec!["orbit", "task", "publication", verb];
+        args.extend(pairing);
+        if verb == "restore" {
+            args.push("--confirm");
+        }
+        args.push("--json");
+        let cli = Cli::try_parse_from(args).expect("parse consumer publication command");
+        let Commands::Task(task) = cli.command else {
+            panic!("expected task command");
+        };
+        let TaskSubcommand::Publication(publication) = task.command else {
+            panic!("expected task publication command");
+        };
+        assert!(matches!(
+            publication.command,
+            TaskPublicationSubcommand::Inspect(_) | TaskPublicationSubcommand::Restore(_)
+        ));
+    }
+}

--- a/crates/orbit-cli/src/command/workspace/command.rs
+++ b/crates/orbit-cli/src/command/workspace/command.rs
@@ -5,6 +5,7 @@ use crate::command::{CommandOut, Execute};
 
 use super::init::WorkspaceInitArgs;
 use super::list::WorkspaceListArgs;
+use super::publication::WorkspacePublicationCommand;
 use super::remove::WorkspaceRemoveArgs;
 use super::role::WorkspaceRoleArgs;
 use super::show::WorkspaceShowArgs;
@@ -27,6 +28,8 @@ pub enum WorkspaceSubcommand {
     Show(WorkspaceShowArgs),
     /// Validate or reassert this checkout's declared local role
     Role(WorkspaceRoleArgs),
+    /// Manage the owner-local task-publication repository binding
+    Publication(WorkspacePublicationCommand),
     /// Remove a workspace from the registry (does not delete .orbit)
     Remove(WorkspaceRemoveArgs),
     /// Remove all Orbit artifacts from this workspace
@@ -43,6 +46,7 @@ impl Execute for WorkspaceCommand {
             WorkspaceSubcommand::List(args) => args.execute(runtime),
             WorkspaceSubcommand::Show(args) => args.execute(runtime),
             WorkspaceSubcommand::Role(args) => args.execute(runtime),
+            WorkspaceSubcommand::Publication(command) => command.execute(runtime),
             WorkspaceSubcommand::Remove(args) => args.execute(runtime),
             WorkspaceSubcommand::Teardown(args) => args.execute(runtime),
         }

--- a/crates/orbit-cli/src/command/workspace/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/mod.rs
@@ -1,6 +1,7 @@
 mod command;
 mod init;
 mod list;
+mod publication;
 mod remove;
 mod role;
 mod show;
@@ -8,6 +9,7 @@ mod support;
 mod teardown;
 
 pub use command::{WorkspaceCommand, WorkspaceSubcommand};
+pub use publication::WorkspacePublicationSubcommand;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cli/src/command/workspace/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/publication.rs
@@ -1,0 +1,214 @@
+use clap::{Args, Subcommand};
+use orbit_core::OrbitRuntime;
+use orbit_registry::{load_host_identity, workspace_registry};
+use orbit_types::workspace::{
+    DEFAULT_PUBLICATION_BRANCH, WorkspacePublicationBinding, redact_git_remote,
+};
+use serde_json::{Value, json};
+
+use crate::command::{CommandOut, Execute, Payload, require_confirmation};
+
+#[derive(Args)]
+#[command(about = "Manage the owner-local task-publication repository binding")]
+pub struct WorkspacePublicationCommand {
+    #[command(subcommand)]
+    pub command: WorkspacePublicationSubcommand,
+}
+
+#[derive(Subcommand)]
+pub enum WorkspacePublicationSubcommand {
+    /// Bind the selected owned workspace to a dedicated publication repository
+    Bind(WorkspacePublicationBindArgs),
+    /// Show the selected workspace's local publication binding
+    Show(WorkspacePublicationShowArgs),
+    /// Explicitly replace the selected workspace's publication lineage
+    Rebind(WorkspacePublicationBindArgs),
+    /// Remove the local binding without deleting or changing the repository
+    Remove(WorkspacePublicationRemoveArgs),
+}
+
+impl Execute for WorkspacePublicationCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        match self.command {
+            WorkspacePublicationSubcommand::Bind(args) => args.execute_bind(runtime, false),
+            WorkspacePublicationSubcommand::Show(args) => args.execute(runtime),
+            WorkspacePublicationSubcommand::Rebind(args) => args.execute_bind(runtime, true),
+            WorkspacePublicationSubcommand::Remove(args) => args.execute(runtime),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct WorkspacePublicationBindArgs {
+    /// Dedicated publication repository URL. Credentials and source-repository reuse are refused.
+    #[arg(long, value_name = "URL")]
+    remote: String,
+    /// Stable opaque lineage identifier unique on this machine.
+    #[arg(long, value_name = "ID")]
+    publication_id: String,
+    /// Ordinary publication branch (short name or refs/heads/*).
+    #[arg(long, default_value = DEFAULT_PUBLICATION_BRANCH)]
+    branch: String,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl WorkspacePublicationBindArgs {
+    fn execute_bind(self, runtime: &OrbitRuntime, rebind: bool) -> CommandOut {
+        let workspace_id = selected_workspace_id(runtime)?;
+        let global_root = runtime.global_root();
+        let machine_id = load_host_identity(&global_root)?.machine_id;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        let binding = if rebind {
+            workspace_registry::rebind_publication(
+                &mut registry,
+                &workspace_id,
+                &self.remote,
+                &self.branch,
+                &self.publication_id,
+                Some(&machine_id),
+            )?
+        } else {
+            workspace_registry::bind_publication(
+                &mut registry,
+                &workspace_id,
+                &self.remote,
+                &self.branch,
+                &self.publication_id,
+                Some(&machine_id),
+            )?
+        };
+        runtime.record_task_publication_source(
+            &binding.workspace_id,
+            &binding.source_repository_fingerprint,
+        )?;
+        workspace_registry::save_registry_to(&registry, &registry_path)?;
+
+        let action = if rebind { "rebound" } else { "bound" };
+        Ok(Payload::detail(
+            binding_json(&binding, action),
+            format!(
+                "{action} workspace '{}' to publication '{}'\nremote:  {}\nbranch:  {}\nprivacy: operator-managed",
+                binding.workspace_id,
+                binding.publication_id,
+                redact_git_remote(&binding.publication_remote),
+                binding.publication_branch,
+            ),
+        )
+        .into())
+    }
+}
+
+#[derive(Args)]
+pub struct WorkspacePublicationShowArgs {
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for WorkspacePublicationShowArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let workspace_id = selected_workspace_id(runtime)?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&runtime.global_root()),
+        )?;
+        match workspace_registry::find_publication_binding(&registry, &workspace_id) {
+            Some(binding) => {
+                Ok(Payload::detail(binding_json(binding, "shown"), format_binding(binding)).into())
+            }
+            None => Ok(Payload::detail(
+                json!({
+                    "workspace_id": workspace_id,
+                    "bound": false,
+                    "privacy": "operator-managed",
+                }),
+                format!("workspace '{workspace_id}' has no publication binding"),
+            )
+            .into()),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct WorkspacePublicationRemoveArgs {
+    /// Confirm removal of the local lineage and last-success record.
+    #[arg(long)]
+    pub confirm: bool,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for WorkspacePublicationRemoveArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        require_confirmation(
+            self.confirm,
+            "removing a task-publication binding and its local last-success record",
+        )?;
+        let workspace_id = selected_workspace_id(runtime)?;
+        let global_root = runtime.global_root();
+        let machine_id = load_host_identity(&global_root)?.machine_id;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+        let removed = workspace_registry::unbind_publication(
+            &mut registry,
+            &workspace_id,
+            Some(&machine_id),
+        )?;
+        workspace_registry::save_registry_to(&registry, &registry_path)?;
+        Ok(Payload::detail(
+            json!({
+                "workspace_id": removed.workspace_id,
+                "publication_id": removed.publication_id,
+                "removed": true,
+                "repository_changed": false,
+            }),
+            format!(
+                "removed publication binding '{}' from workspace '{}'; the repository was not changed",
+                removed.publication_id, removed.workspace_id
+            ),
+        )
+        .into())
+    }
+}
+
+fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
+    runtime
+        .workspace_runtime_binding()
+        .map(|binding| binding.workspace_id.clone())
+        .map_or_else(|| runtime.workspace_id(), Ok)
+}
+
+fn binding_json(binding: &WorkspacePublicationBinding, action: &str) -> Value {
+    json!({
+        "action": action,
+        "bound": true,
+        "workspace_id": binding.workspace_id,
+        "source_repository_fingerprint": binding.source_repository_fingerprint,
+        "publication_remote": redact_git_remote(&binding.publication_remote),
+        "publication_branch": binding.publication_branch,
+        "publication_id": binding.publication_id,
+        "authority_machine_id": binding.authority_machine_id,
+        "last_success_generation": binding.last_success_generation,
+        "last_success_commit": binding.last_success_commit,
+        "privacy": "operator-managed",
+    })
+}
+
+fn format_binding(binding: &WorkspacePublicationBinding) -> String {
+    format!(
+        "workspace:       {}\npublication:     {}\nremote:          {}\nbranch:          {}\nsource:          {}\nauthority:       {}\nlast_generation: {}\nlast_commit:     {}\nprivacy:         operator-managed",
+        binding.workspace_id,
+        binding.publication_id,
+        redact_git_remote(&binding.publication_remote),
+        binding.publication_branch,
+        redact_git_remote(&binding.source_repository_fingerprint),
+        binding.authority_machine_id,
+        binding
+            .last_success_generation
+            .map_or_else(|| "-".to_string(), |generation| generation.to_string()),
+        binding.last_success_commit.as_deref().unwrap_or("-"),
+    )
+}

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -1,2 +1,3 @@
 mod init;
+mod publication;
 mod shared_root;

--- a/crates/orbit-cli/src/command/workspace/tests/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/publication.rs
@@ -1,0 +1,68 @@
+use clap::{CommandFactory, Parser};
+
+use crate::command::workspace::WorkspacePublicationSubcommand;
+use crate::command::{Cli, Commands};
+
+use super::super::WorkspaceSubcommand;
+
+#[test]
+fn workspace_publication_help_covers_explicit_binding_lifecycle() {
+    let command = Cli::command();
+    let publication = command
+        .find_subcommand("workspace")
+        .and_then(|workspace| workspace.find_subcommand("publication"))
+        .expect("workspace publication command");
+    let help = publication.clone().render_long_help().to_string();
+    for verb in ["bind", "show", "rebind", "remove"] {
+        assert!(help.contains(verb), "missing {verb} from help:\n{help}");
+    }
+    let remove = publication
+        .find_subcommand("remove")
+        .expect("remove command")
+        .clone()
+        .render_long_help()
+        .to_string();
+    assert!(remove.contains("--confirm"), "{remove}");
+}
+
+#[test]
+fn workspace_publication_json_forms_parse_for_every_surface() {
+    for verb in ["bind", "rebind"] {
+        let cli = Cli::try_parse_from([
+            "orbit",
+            "workspace",
+            "publication",
+            verb,
+            "--remote",
+            "ssh://publication.test/example.git",
+            "--publication-id",
+            "pub_example",
+            "--json",
+        ])
+        .expect("parse publication binding mutation");
+        let Commands::Workspace(workspace) = cli.command else {
+            panic!("expected workspace command");
+        };
+        let WorkspaceSubcommand::Publication(publication) = workspace.command else {
+            panic!("expected publication command");
+        };
+        assert!(matches!(
+            publication.command,
+            WorkspacePublicationSubcommand::Bind(_) | WorkspacePublicationSubcommand::Rebind(_)
+        ));
+    }
+
+    for args in [
+        vec!["orbit", "workspace", "publication", "show", "--json"],
+        vec![
+            "orbit",
+            "workspace",
+            "publication",
+            "remove",
+            "--confirm",
+            "--json",
+        ],
+    ] {
+        Cli::try_parse_from(args).expect("parse publication binding read/remove");
+    }
+}

--- a/crates/orbit-cli/tests/task_publication.rs
+++ b/crates/orbit-cli/tests/task_publication.rs
@@ -1,0 +1,715 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+//! Network-free operator workflow coverage for task publication and recovery.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::tempdir;
+
+const SOURCE_REMOTE: &str = "ssh://source.test/orbit.git";
+const PUBLICATION_REMOTE: &str = "ssh://publication.test/orbit-tasks.git";
+const PUBLICATION_ID: &str = "pub_network_free_e2e";
+
+#[test]
+fn operator_workflow_is_network_free_labelled_and_fail_closed() {
+    let temp = tempdir().expect("tempdir");
+    let owner_home = temp.path().join("owner-home");
+    let recovery_home = temp.path().join("recovery-home");
+    let source_repo = temp.path().join("source");
+    let recovery_repo = temp.path().join("recovery");
+    let publication_bare = temp.path().join("publication.git");
+    fs::create_dir_all(&owner_home).expect("owner home");
+    fs::create_dir_all(&recovery_home).expect("recovery home");
+    init_source_repo(&source_repo);
+    init_bare_repo(&publication_bare);
+    install_fake_ssh(temp.path());
+
+    orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "publication-owner",
+            "--task-prefix",
+            "PUB",
+        ],
+    )
+    .success();
+    orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["workspace", "init", "--name", "publication-e2e"],
+    )
+    .success();
+
+    let first = add_task(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        "First published task",
+        "first durable body",
+    );
+    let second = add_task(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        "Second published task",
+        "second durable body",
+    );
+    let attachment = temp.path().join("operator-note.txt");
+    fs::write(&attachment, "operator-only attachment\n").expect("attachment");
+    orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "task",
+            "artifact",
+            "put",
+            &first,
+            attachment.to_str().expect("attachment path"),
+            "--path",
+            "notes/operator-note.txt",
+            "--model",
+            "codex",
+            "--json",
+        ],
+    )
+    .success();
+
+    assert!(
+        branch_tip(&publication_bare).is_none(),
+        "task mutations must not publish automatically"
+    );
+    let source_before = repository_state(&source_repo);
+
+    let credential_failure = orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "workspace",
+            "publication",
+            "bind",
+            "--remote",
+            "https://operator:supersecret@publication.test/orbit.git",
+            "--publication-id",
+            PUBLICATION_ID,
+            "--json",
+        ],
+    )
+    .failure();
+    assert_output_contains(&credential_failure, "***");
+    assert_output_excludes(&credential_failure, "supersecret");
+
+    let source_remote_failure = orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "workspace",
+            "publication",
+            "bind",
+            "--remote",
+            SOURCE_REMOTE,
+            "--publication-id",
+            PUBLICATION_ID,
+            "--json",
+        ],
+    )
+    .failure();
+    assert_output_contains(
+        &source_remote_failure,
+        "equivalent to the workspace source remote",
+    );
+
+    let binding = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "workspace",
+            "publication",
+            "bind",
+            "--remote",
+            PUBLICATION_REMOTE,
+            "--publication-id",
+            PUBLICATION_ID,
+            "--json",
+        ],
+    );
+    assert_eq!(binding["bound"], true);
+    assert_eq!(binding["privacy"], "operator-managed");
+    assert_eq!(binding["publication_remote"], PUBLICATION_REMOTE);
+    let workspace_id = binding["workspace_id"]
+        .as_str()
+        .expect("workspace id")
+        .to_string();
+    let authority = binding["authority_machine_id"]
+        .as_str()
+        .expect("authority")
+        .to_string();
+
+    let published = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "task",
+            "publication",
+            "publish",
+            "--attachments",
+            "omit",
+            "--json",
+        ],
+    );
+    assert_eq!(published["status"], "initialized");
+    assert_eq!(published["generation"], 1);
+    assert!(published["omitted_attachment_bytes"].as_u64().unwrap() > 0);
+    let published_commit = published["commit_id"]
+        .as_str()
+        .expect("published commit")
+        .to_string();
+    assert_eq!(
+        branch_tip(&publication_bare).as_deref(),
+        Some(published_commit.as_str())
+    );
+
+    let status = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["task", "publication", "status", "--json"],
+    );
+    assert_eq!(status["state"], "current");
+    assert_eq!(status["remote_commit"], published_commit);
+    assert_eq!(status["incomplete_attachments"], true);
+
+    let published_paths = git_output(
+        &publication_bare,
+        &["ls-tree", "-r", "--name-only", "refs/heads/main"],
+    );
+    assert!(published_paths.contains("orbit-task-publication.yaml"));
+    assert!(published_paths.contains(&format!("tasks/{first}/task.yaml")));
+    assert!(published_paths.contains(&format!("tasks/{second}/task.yaml")));
+    for runtime_only in ["orbit.db", "state/", "claims/", "runs/", "workspaces.json"] {
+        assert!(
+            !published_paths
+                .lines()
+                .any(|path| path.contains(runtime_only)),
+            "runtime-only state leaked through {runtime_only}: {published_paths}"
+        );
+    }
+    assert_eq!(repository_state(&source_repo), source_before);
+
+    init_source_repo(&recovery_repo);
+    orbit(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &[
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "replacement-host",
+            "--task-prefix",
+            "PUB",
+        ],
+    )
+    .success();
+    fs::copy(
+        owner_home.join(".orbit/host.toml"),
+        recovery_home.join(".orbit/host.toml"),
+    )
+    .expect("preserve recovered authority identity");
+    orbit(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &["workspace", "init", "--name", "publication-e2e"],
+    )
+    .success();
+    let recovery_workspace = orbit_json(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &["workspace", "show", "--format", "json"],
+    );
+    assert_eq!(recovery_workspace["workspace"]["id"], workspace_id);
+    let recovery_before = repository_state(&recovery_repo);
+
+    let inspect_args = consumer_args(&workspace_id, &authority, "inspect");
+    let inspection = orbit_json_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &inspect_args,
+    );
+    assert_eq!(inspection["label"]["render_authority"], "snapshot");
+    assert_eq!(inspection["label"]["generation"], 1);
+    assert_eq!(inspection["label"]["freshness"], "current");
+    assert_eq!(inspection["label"]["incomplete_attachments"], true);
+    assert_eq!(inspection["label"]["workspace_id"], workspace_id);
+    assert_eq!(inspection["tasks"].as_array().expect("tasks").len(), 2);
+    assert_eq!(
+        inspection["omitted_attachments"]
+            .as_array()
+            .expect("omissions")
+            .len(),
+        1
+    );
+
+    let mut mismatch_args = consumer_args(&workspace_id, &authority, "inspect");
+    replace_arg_value(
+        &mut mismatch_args,
+        "--source-remote",
+        "ssh://source.test/other.git",
+    );
+    let mismatch = orbit_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &mismatch_args,
+    )
+    .failure();
+    assert_output_contains(&mismatch, "source repository fingerprint mismatch");
+    assert!(task_ids(&recovery_repo, &recovery_home, &publication_bare).is_empty());
+
+    let restore_without_confirmation = consumer_args(&workspace_id, &authority, "restore");
+    let confirmation_gate = orbit_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &restore_without_confirmation,
+    )
+    .failure();
+    assert_output_contains(&confirmation_gate, "--confirm");
+    assert!(task_ids(&recovery_repo, &recovery_home, &publication_bare).is_empty());
+
+    let restore_args = consumer_args(&workspace_id, &authority, "restore")
+        .into_iter()
+        .chain(["--confirm".to_string()])
+        .collect::<Vec<_>>();
+    let restored = orbit_json_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &restore_args,
+    );
+    assert_eq!(restored["completeness"], "incomplete-attachments");
+    assert_eq!(restored["omitted_attachments"].as_array().unwrap().len(), 1);
+    assert_eq!(restored["restored_task_ids"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        task_ids(&recovery_repo, &recovery_home, &publication_bare),
+        [first.clone(), second.clone()]
+    );
+    assert_eq!(repository_state(&recovery_repo), recovery_before);
+
+    let recovered_first = task_show(&recovery_repo, &recovery_home, &publication_bare, &first);
+    assert_eq!(recovered_first["title"], "First published task");
+    assert_eq!(recovered_first["description"], "first durable body");
+
+    orbit(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &[
+            "task",
+            "update",
+            &first,
+            "--title",
+            "non-identical recovery collision",
+            "--model",
+            "codex",
+        ],
+    )
+    .success();
+    let second_before_collision =
+        task_show(&recovery_repo, &recovery_home, &publication_bare, &second);
+    let collision_args = consumer_args(&workspace_id, &authority, "restore")
+        .into_iter()
+        .chain([
+            "--allow-identical-retry".to_string(),
+            "--confirm".to_string(),
+        ])
+        .collect::<Vec<_>>();
+    let collision = orbit_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &collision_args,
+    )
+    .failure();
+    assert_output_contains(&collision, "collides with non-identical canonical content");
+    assert_eq!(
+        task_show(&recovery_repo, &recovery_home, &publication_bare, &second,),
+        second_before_collision,
+        "failed recovery collision must not partially rewrite another task"
+    );
+
+    let competing = advance_valid_generation(
+        temp.path(),
+        &publication_bare,
+        &published_commit,
+        "competing",
+    );
+    assert_eq!(
+        branch_tip(&publication_bare).as_deref(),
+        Some(competing.as_str())
+    );
+    let conflict = orbit(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["task", "publication", "publish", "--json"],
+    )
+    .failure();
+    assert_output_contains(&conflict, "resolve the publication authority");
+    assert_eq!(
+        branch_tip(&publication_bare).as_deref(),
+        Some(competing.as_str())
+    );
+
+    corrupt_current_snapshot(temp.path(), &publication_bare, &first);
+    let corrupt = orbit_owned(
+        &recovery_repo,
+        &recovery_home,
+        &publication_bare,
+        &inspect_args,
+    )
+    .failure();
+    assert_output_contains(&corrupt, &first);
+
+    assert_eq!(
+        repository_state(&source_repo),
+        source_before,
+        "publication, conflict, and corrupt inspection must not dirty the source repository"
+    );
+
+    let rebound = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "workspace",
+            "publication",
+            "rebind",
+            "--remote",
+            PUBLICATION_REMOTE,
+            "--publication-id",
+            "pub_rebound_e2e",
+            "--json",
+        ],
+    );
+    assert_eq!(rebound["action"], "rebound");
+    assert_eq!(rebound["last_success_commit"], Value::Null);
+    let shown = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["workspace", "publication", "show", "--json"],
+    );
+    assert_eq!(shown["publication_id"], "pub_rebound_e2e");
+    let removed = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["workspace", "publication", "remove", "--confirm", "--json"],
+    );
+    assert_eq!(removed["removed"], true);
+    assert_eq!(removed["repository_changed"], false);
+    let unbound = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &["workspace", "publication", "show", "--json"],
+    );
+    assert_eq!(unbound["bound"], false);
+    assert_eq!(repository_state(&source_repo), source_before);
+}
+
+fn add_task(repo: &Path, home: &Path, bare: &Path, title: &str, description: &str) -> String {
+    orbit_json(
+        repo,
+        home,
+        bare,
+        &[
+            "task",
+            "add",
+            "--title",
+            title,
+            "--description",
+            description,
+            "--complexity",
+            "low",
+            "--json",
+        ],
+    )["id"]
+        .as_str()
+        .expect("task id")
+        .to_string()
+}
+
+fn consumer_args(workspace_id: &str, authority: &str, action: &str) -> Vec<String> {
+    [
+        "task",
+        "publication",
+        action,
+        "--workspace-id",
+        workspace_id,
+        "--source-remote",
+        SOURCE_REMOTE,
+        "--publication-id",
+        PUBLICATION_ID,
+        "--authority-machine-id",
+        authority,
+        "--remote",
+        PUBLICATION_REMOTE,
+        "--json",
+    ]
+    .into_iter()
+    .map(ToOwned::to_owned)
+    .collect()
+}
+
+fn replace_arg_value(args: &mut [String], flag: &str, replacement: &str) {
+    let index = args.iter().position(|arg| arg == flag).expect("flag") + 1;
+    args[index] = replacement.to_string();
+}
+
+fn task_ids(repo: &Path, home: &Path, bare: &Path) -> Vec<String> {
+    let value = orbit_json(repo, home, bare, &["task", "list", "--json"]);
+    let tasks = value
+        .as_array()
+        .or_else(|| value.get("tasks").and_then(Value::as_array))
+        .expect("task list");
+    let mut ids = tasks
+        .iter()
+        .filter_map(|task| task["id"].as_str().map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
+fn task_show(repo: &Path, home: &Path, bare: &Path, id: &str) -> Value {
+    orbit_json(repo, home, bare, &["task", "show", id, "--json"])
+}
+
+fn advance_valid_generation(root: &Path, bare: &Path, previous: &str, label: &str) -> String {
+    let checkout = root.join(label);
+    git(
+        root,
+        &["clone", bare.to_str().unwrap(), checkout.to_str().unwrap()],
+    );
+    configure_git(&checkout);
+    let envelope = checkout.join("orbit-task-publication.yaml");
+    let raw = fs::read_to_string(&envelope).expect("envelope");
+    let next = raw.replace("generation: 1", "generation: 2").replace(
+        "previous_publication: null",
+        &format!("previous_publication: {previous}"),
+    );
+    assert_ne!(raw, next, "generation envelope must change");
+    fs::write(&envelope, next).expect("advance envelope");
+    git(&checkout, &["add", "orbit-task-publication.yaml"]);
+    git(&checkout, &["commit", "-m", "competing generation"]);
+    git(&checkout, &["push", "origin", "HEAD:refs/heads/main"]);
+    git_output(&checkout, &["rev-parse", "HEAD"])
+}
+
+fn corrupt_current_snapshot(root: &Path, bare: &Path, task_id: &str) {
+    let checkout = root.join("corrupt");
+    git(
+        root,
+        &["clone", bare.to_str().unwrap(), checkout.to_str().unwrap()],
+    );
+    configure_git(&checkout);
+    let events = checkout.join("tasks").join(task_id).join("events.jsonl");
+    let mut raw = fs::read_to_string(&events).expect("events");
+    raw.push('{');
+    fs::write(&events, raw).expect("corrupt events");
+    git(&checkout, &["add", "."]);
+    git(&checkout, &["commit", "--amend", "--no-edit"]);
+    git(
+        &checkout,
+        &["push", "--force", "origin", "HEAD:refs/heads/main"],
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RepositoryState {
+    head: String,
+    status: String,
+    remotes: String,
+}
+
+fn repository_state(repo: &Path) -> RepositoryState {
+    RepositoryState {
+        head: git_output(repo, &["rev-parse", "HEAD"]),
+        status: git_output(repo, &["status", "--porcelain"]),
+        remotes: git_output(repo, &["remote", "-v"]),
+    }
+}
+
+fn init_source_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("repo");
+    git(repo, &["init", "-b", "main"]);
+    configure_git(repo);
+    fs::write(repo.join("README.md"), "source\n").expect("readme");
+    git(repo, &["add", "README.md"]);
+    git(repo, &["commit", "-m", "source"]);
+    git(repo, &["remote", "add", "origin", SOURCE_REMOTE]);
+}
+
+fn init_bare_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("bare repo");
+    git(repo, &["init", "--bare", "-b", "main"]);
+}
+
+fn install_fake_ssh(root: &Path) {
+    let path = root.join("publication-test-ssh");
+    fs::write(
+        &path,
+        "#!/bin/sh\ncase \"$*\" in\n  *git-upload-pack*) exec git-upload-pack \"$PUBLICATION_TEST_REPO\" ;;\n  *git-receive-pack*) exec git-receive-pack \"$PUBLICATION_TEST_REPO\" ;;\nesac\nexit 2\n",
+    )
+    .expect("fake ssh");
+    #[cfg(unix)]
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).expect("fake ssh executable");
+}
+
+fn configure_git(repo: &Path) {
+    git(repo, &["config", "user.name", "Orbit Publication Test"]);
+    git(
+        repo,
+        &["config", "user.email", "publication-test@example.com"],
+    );
+    git(repo, &["config", "commit.gpgsign", "false"]);
+}
+
+fn branch_tip(bare: &Path) -> Option<String> {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(bare)
+        .args(["rev-parse", "--verify", "refs/heads/main"])
+        .output()
+        .expect("branch tip");
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn orbit(
+    cwd: &Path,
+    home: &Path,
+    publication_bare: &Path,
+    args: &[&str],
+) -> assert_cmd::assert::Assert {
+    let mut command = orbit_command(cwd, home, publication_bare);
+    command.args(args);
+    command.assert()
+}
+
+fn orbit_owned(
+    cwd: &Path,
+    home: &Path,
+    publication_bare: &Path,
+    args: &[String],
+) -> assert_cmd::assert::Assert {
+    let mut command = orbit_command(cwd, home, publication_bare);
+    command.args(args);
+    command.assert()
+}
+
+fn orbit_command(cwd: &Path, home: &Path, publication_bare: &Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    let fake_ssh = publication_bare
+        .parent()
+        .expect("publication parent")
+        .join("publication-test-ssh");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("ORBIT_OPERATOR", "1")
+        .env("GIT_SSH", fake_ssh)
+        .env("GIT_SSH_VARIANT", "ssh")
+        .env("PUBLICATION_TEST_REPO", publication_bare)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_AGENT_NAME")
+        .env_remove("ORBIT_AGENT_MODEL")
+        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+        .env_remove("ORBIT_RUN_ID");
+    command
+}
+
+fn orbit_json(cwd: &Path, home: &Path, bare: &Path, args: &[&str]) -> Value {
+    let assert = orbit(cwd, home, bare, args).success();
+    serde_json::from_slice(&assert.get_output().stdout).expect("JSON output")
+}
+
+fn orbit_json_owned(cwd: &Path, home: &Path, bare: &Path, args: &[String]) -> Value {
+    let assert = orbit_owned(cwd, home, bare, args).success();
+    serde_json::from_slice(&assert.get_output().stdout).expect("JSON output")
+}
+
+fn assert_output_contains(assert: &assert_cmd::assert::Assert, expected: &str) {
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stdout.contains(expected) || stderr.contains(expected),
+        "expected '{expected}' in output\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+fn assert_output_excludes(assert: &assert_cmd::assert::Assert, forbidden: &str) {
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        !stdout.contains(forbidden) && !stderr.contains(forbidden),
+        "forbidden value '{forbidden}' leaked\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> String {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("git output");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed: {}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/crates/orbit-core/src/bootstrap/mod.rs
+++ b/crates/orbit-core/src/bootstrap/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod activity;
 pub mod init;
 pub(crate) mod policy;
 pub mod task_migration;
+pub mod task_publication;

--- a/crates/orbit-core/src/bootstrap/task_publication.rs
+++ b/crates/orbit-core/src/bootstrap/task_publication.rs
@@ -1,0 +1,67 @@
+//! Runtime facades over the `orbit-store` task-publication workflows.
+//!
+//! The CLI owns operator input and registry composition. Core keeps the
+//! existing dependency boundary by opening the coordination task registry and
+//! forwarding already-resolved publication requests to Store.
+
+use orbit_common::OrbitError;
+use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
+use orbit_store::workflow::task::{
+    inspect_publication, publish_task_snapshot, restore_publication,
+};
+
+use crate::OrbitRuntime;
+
+pub use orbit_store::workflow::task::{
+    AttachmentPolicy, AttachmentPolicyKind, InspectedPublicationTask, OmittedAttachment,
+    PublicationCallerRole, PublicationFreshness, PublicationInspectLabel,
+    PublicationInspectRequest, PublicationInspection, PublicationLastSuccess,
+    PublicationPublishOutcome, PublicationPublishRequest, PublicationPublishStatus,
+    PublicationRecoveryCompleteness, PublicationRenderAuthority, PublicationRestoreMode,
+    PublicationRestoreOutcome, PublicationRestoreRequest, ScannerFailureBehavior,
+};
+
+impl OrbitRuntime {
+    fn open_publication_task_registry(&self) -> Result<TaskRegistryStore, OrbitError> {
+        TaskRegistryStore::open(&task_registry_path(&self.global_root()))
+    }
+
+    /// Pair the coordination registry with the explicit publication binding's
+    /// portable source identity. A previously different value is refused.
+    pub fn record_task_publication_source(
+        &self,
+        workspace_id: &str,
+        source_repository_fingerprint: &str,
+    ) -> Result<(), OrbitError> {
+        self.open_publication_task_registry()?
+            .record_workspace_repo_fingerprint(workspace_id, source_repository_fingerprint)?;
+        Ok(())
+    }
+
+    /// Publish a validated snapshot with a caller-resolved owner binding.
+    pub fn publish_task_publication(
+        &self,
+        request: PublicationPublishRequest,
+        policy: &AttachmentPolicy,
+    ) -> Result<PublicationPublishOutcome, OrbitError> {
+        let registry = self.open_publication_task_registry()?;
+        publish_task_snapshot(&registry, request, policy, None)
+    }
+
+    /// Fetch, validate, and render a publication without mutating task state.
+    pub fn inspect_task_publication(
+        &self,
+        request: PublicationInspectRequest,
+    ) -> Result<PublicationInspection, OrbitError> {
+        inspect_publication(request)
+    }
+
+    /// Restore a validated publication into the selected task registry.
+    pub fn restore_task_publication(
+        &self,
+        request: PublicationRestoreRequest,
+    ) -> Result<PublicationRestoreOutcome, OrbitError> {
+        let registry = self.open_publication_task_registry()?;
+        restore_publication(&registry, request)
+    }
+}

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -342,6 +342,58 @@ impl TaskRegistryStore {
         Ok(binding)
     }
 
+    /// Record the portable source-repository identity when an existing
+    /// workspace first enables a workflow that requires it.
+    ///
+    /// Ordinary task-runtime bootstrap deliberately does not infer remote
+    /// identity. Explicit publication binding supplies the registry-validated
+    /// value instead. Once recorded, a different value is a pairing conflict,
+    /// never an implicit source move.
+    pub fn record_workspace_repo_fingerprint(
+        &self,
+        workspace_id: &str,
+        repo_fingerprint: &str,
+    ) -> Result<WorkspaceBinding, OrbitError> {
+        let workspace_id = validate_workspace_id(workspace_id)?;
+        if repo_fingerprint.trim() != repo_fingerprint || repo_fingerprint.is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "workspace repository fingerprint must be non-empty and trimmed".to_string(),
+            ));
+        }
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let existing = workspace_by_id(&tx, &workspace_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.clone()))?;
+        match existing.repo_fingerprint.as_deref() {
+            Some(current) if current == repo_fingerprint => {}
+            Some(_) => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "workspace '{workspace_id}' is registered with a different source-repository fingerprint"
+                )));
+            }
+            None => {
+                tx.execute(
+                    "UPDATE workspace_bindings
+                     SET repo_fingerprint = ?2, updated_at = ?3
+                     WHERE workspace_id = ?1",
+                    params![workspace_id, repo_fingerprint, now_string()],
+                )
+                .map_err(|error| OrbitError::Store(error.to_string()))?;
+            }
+        }
+        let binding = workspace_by_id(&tx, &workspace_id)?.ok_or_else(|| {
+            OrbitError::Store("failed to read fingerprinted workspace binding".to_string())
+        })?;
+        tx.commit()
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(binding)
+    }
+
     /// Allocate a monotonic local task ID.
     ///
     /// Allocation commits independently from bundle registration. A crash between

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -979,6 +979,37 @@ fn bind_workspace_is_idempotent_for_orbit_dir() {
 }
 
 #[test]
+fn publication_fingerprint_is_adopted_once_and_then_fails_closed() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let workspace = bind(&store, temp.path());
+    assert_eq!(
+        store
+            .find_workspace_binding(&workspace.workspace_id)
+            .expect("find workspace")
+            .expect("workspace")
+            .repo_fingerprint,
+        None
+    );
+
+    let recorded = store
+        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/orbit.git")
+        .expect("record fingerprint");
+    assert_eq!(
+        recorded.repo_fingerprint.as_deref(),
+        Some("ssh://source.test/orbit.git")
+    );
+    store
+        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/orbit.git")
+        .expect("idempotent recording");
+
+    let error = store
+        .record_workspace_repo_fingerprint(&workspace.workspace_id, "ssh://source.test/other.git")
+        .expect_err("mismatch must fail");
+    assert!(error.to_string().contains("different source-repository"));
+}
+
+#[test]
 fn bind_workspace_rebinds_same_checkout_under_a_new_orbit_dir() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,7 +27,7 @@ CLI behavior, state layout, or recovery semantics change.
 | [Check Orbit Health](./runbooks/health-checks.md) | Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health. |
 | [Inspect and Retain Logs](./runbooks/logging.md) | Locate, filter, rotate, and retain Orbit process and routine-sweep logs. |
 | [Release Orbit](./runbooks/release.md) | Cut and verify an Orbit release across agent plugins, Cargo, GitHub artifacts, Homebrew, and npm. |
-| [Inventory and Protect Orbit State](./runbooks/state-and-backup.md) | Locate Orbit state and perform WAL-safe backups, restores, and task migrations. |
+| [Inventory and Protect Orbit State](./runbooks/state-and-backup.md) | Locate Orbit state and perform WAL-safe backups, explicit task publication, restores, and task migrations. |
 | [Recover Stuck Job Runs](./runbooks/stuck-job-runs.md) | Diagnose, cancel, resume, or replay pending and running Orbit job runs. |
 | [Upgrade Orbit Safely](./runbooks/upgrades.md) | Review, apply, and verify Orbit workspace-layout and store-schema migrations safely. |
 
@@ -68,7 +68,7 @@ a conservative title/status fallback.
 | [Routines](./design/routines/1_overview.md) | Durable, git-versioned scheduler primitive that fires catalog jobs/activities on cron triggers, per host, with local state. | Accepted | claude |
 | [Task Artifacts](./design/task-artifacts/1_overview.md) | Tasks are Orbit's durable intent records: they explain what an agent or human is trying to change, how the work should be validated, what context is relevant, who acted on the work, and how the work connects to other Orbit artifacts. | Draft | codex |
 | [Task Migration](./design/task-migration/1_overview.md) | Move orbit tasks between machines with export/import (tar.zst) and disjoint id ranges, without hand-written SQL. | Draft | claude |
-| [Task Publication](./design/task-publication/1_overview.md) | Publish authority-owned task-bundle snapshots to a dedicated private Git repository for remote durability and read-only recovery. | Draft | codex |
+| [Task Publication](./design/task-publication/1_overview.md) | Explicitly publish authority-owned task snapshots to a dedicated Git repository for labelled inspection and deliberate recovery. | Accepted | codex |
 | [Terminal Interface](./design/terminal-interface/1_overview.md) | House style for orbit-cli terminal output — machine-readable first, borderless single-line tables, semantic color resolved at the sink. | Accepted | claude |
 | [User Interface](./design/user-interface/1_overview.md) | Orbit UI covers the dashboard and HTTP API owned by `orbit-web`; `orbit-cli` is the thin `orbit web serve` / `connect` command adapter. | Draft | gemini |
 | [Worktree Artifacts](./design/worktree-artifacts/1_overview.md) | Historically, worktree artifacts let decision and learning body files travel with the branch that created them while preserving one shared ID authority for the repository. | Accepted | codex |

--- a/docs/design/task-publication/1_overview.md
+++ b/docs/design/task-publication/1_overview.md
@@ -1,29 +1,30 @@
 ---
 title: Task Publication — Overview
 owner: codex
-last_updated: 2026-08-29
-last_validated: 2026-08-29
-status: Draft
+last_updated: 2026-08-30
+last_validated: 2026-08-30
+status: Accepted
 feature: task-publication
 doc_role: overview
 type: design
-summary: Publish authority-owned task-bundle snapshots to a dedicated private Git repository for remote durability and read-only recovery.
+summary: Explicitly publish authority-owned task snapshots to a dedicated Git repository for labelled inspection and deliberate recovery.
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068]
+related_artifacts: [ORB-11068, ORB-11072, ORB-11073, ORB-11074, ORB-11075, ORB-11076, ORB-11077]
 ---
 
 # Task Publication — Overview
 
-Task publication is a proposed one-way durability surface: the machine that
-owns a workspace publishes validated task-bundle snapshots to a dedicated
-private Git repository, while other machines may inspect or explicitly restore
-those snapshots without becoming competing task authorities.
+Task publication is a shipped, explicit one-way durability surface: the machine
+that owns a workspace publishes validated task-bundle snapshots to a dedicated
+Git repository, while other machines may inspect or deliberately restore those
+snapshots without becoming competing task authorities. Orbit reports repository
+privacy as operator-managed; generic Git cannot verify provider visibility.
 
-Nothing in this folder is implemented yet. The design deliberately stops short
-of the retired source-repository orphan-branch and multi-writer task-sync
-proposal.
+V1 deliberately stops short of the retired source-repository orphan-branch and
+multi-writer task-sync proposal. No task mutation, post-write hook, or default
+routine publishes automatically.
 
 ## 1. Motivation
 
@@ -53,9 +54,10 @@ separating task visibility and retention from the source-code repository.
 
 ### Publication repository
 
-A dedicated private Git repository containing publication data for exactly one
-Orbit workspace in v1. It contains no source code and uses its ordinary
-configured branch rather than an orphan branch in the source repository.
+An operator-provisioned, dedicated Git repository containing publication data
+for exactly one Orbit workspace in v1. Operators should make it private, but
+Orbit does not claim privacy unless a future provider integration proves it. It
+contains no source code and uses an ordinary configured branch.
 
 ### Publication binding
 
@@ -93,19 +95,25 @@ encrypted secret store.
 
 | Concern | File | Task |
 |---------|------|------|
-| Proposed repository binding and publication protocol | [2_design.md](./2_design.md) | [ORB-11068] |
+| Shipped repository binding, publication, inspection, and recovery protocol | [2_design.md](./2_design.md) | [ORB-11077] |
 | Evolution gates and deferred aggregation/synchronization | [3_vision.md](./3_vision.md) | [ORB-11068] |
 | Standing authority, privacy, and safety rules | [4_decisions.md](./4_decisions.md) | [ORB-11068] |
 | Canonical task-bundle format | [Task Artifacts](../task-artifacts/2_design.md) | — |
 | Current live cross-machine access | [Remote Access](../remote-access/1_overview.md) | — |
 | Current host-qualified MCP routing | [Federated MCP](../federated-mcp/1_overview.md) | — |
 | Same-authority publication recovery | [`orbit-store` restore workflow](../../../crates/orbit-store/src/workflow/task/restore.rs) | [ORB-11076] |
+| Operator CLI and network-free end-to-end contract | [`orbit-cli` publication commands](../../../crates/orbit-cli/src/command/task/publication.rs) | [ORB-11077] |
 | Portable migration archive primitives | [`orbit-store` task workflow](../../../crates/orbit-store/src/workflow/task/mod.rs) | — |
 | Retired source-repository registry | [Task Sync](../_archive/task-sync/1_overview.md) | — |
 
 ## Task References
 
 - [ORB-11068] — designed authority-owned task publication through a dedicated private Git repository.
+- [ORB-11072] — implemented owner-local publication bindings and lineage validation.
+- [ORB-11073] — implemented deterministic publication snapshots and attachment policy.
+- [ORB-11074] — implemented owner-only compare-and-swap Git publication.
+- [ORB-11075] — implemented labelled read-only publication inspection.
 - [ORB-11076] — implemented fail-closed same-authority publication restore.
+- [ORB-11077] — shipped the explicit CLI workflow, end-to-end contract, and operator runbook.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-publication/2_design.md
+++ b/docs/design/task-publication/2_design.md
@@ -3,27 +3,26 @@ title: Task Publication — Design
 owner: codex
 last_updated: 2026-08-30
 last_validated: 2026-08-30
-status: Draft
+status: Accepted
 feature: task-publication
 doc_role: design
 type: design
-summary: Proposed contract for publishing validated task snapshots to a dedicated private repository without creating a second mutation authority.
+summary: Shipped contract for explicit owner publication, labelled inspection, and deliberate same-authority task recovery.
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068, ORB-11074]
+related_artifacts: [ORB-11068, ORB-11072, ORB-11073, ORB-11074, ORB-11075, ORB-11076, ORB-11077]
 ---
 
 # Task Publication — Design
 
-This document specifies the v1 publication protocol. Its implemented
-`orbit-store` primitives cover snapshot construction, owner-only Git transport,
-read-only inspection, and explicit same-authority recovery; entry-point wiring
-is tracked separately. V1 publishes one workspace's authority-owned task
-snapshots to one dedicated private Git repository for remote durability,
-read-only inspection, and explicit recovery. Multi-workspace aggregation,
-authority transfer, and multi-writer synchronization remain deferred to
-[3_vision.md](./3_vision.md).
+This document specifies the shipped v1 publication protocol. `orbit workspace
+publication` owns explicit binding lifecycle, while `orbit task publication`
+owns publish/status, read-only inspection, and deliberate same-authority
+recovery. V1 publishes one workspace's authority-owned task snapshots to one
+dedicated Git repository. Repository privacy remains operator-managed.
+Multi-workspace aggregation, unattended triggering, authority transfer, and
+multi-writer synchronization remain deferred to [3_vision.md](./3_vision.md).
 
 ## 1. Ownership Boundary
 
@@ -87,9 +86,38 @@ repository and creates the branch's root publication commit. A non-empty
 repository without a valid matching publication envelope is refused rather than
 adopted or overwritten.
 
+### 2.1 Operator surface
+
+The shipped command taxonomy keeps machine-local repository identity under the
+workspace noun and task content movement under the task noun:
+
+| Command | Contract |
+|---|---|
+| `orbit workspace publication bind` | Owner-only initial binding; refuses replicas, credential-bearing URLs, source-remote reuse, missing source identity, and duplicate lineage. |
+| `orbit workspace publication show` | Read-only local binding and last-success inspection; repository privacy is labelled `operator-managed`. |
+| `orbit workspace publication rebind` | Operator-governed explicit replacement; clears previous lineage success rather than drifting silently. |
+| `orbit workspace publication remove --confirm` | Removes only owner-local binding state and never changes the remote repository. |
+| `orbit task publication publish` | Operator-governed explicit validation and compare-and-swap publication; the attachment default is `fail`. |
+| `orbit task publication status` | Fetches and validates the branch after a recorded success, reporting `current` or `authority-conflict`; an unused binding reports `never-published`. |
+| `orbit task publication inspect` | Fetches explicit repository/pairing inputs into a consumer cache and returns task content labelled as snapshot state, never live state. |
+| `orbit task publication restore --confirm` | Requires an owner destination with matching machine, workspace, and source identity; defaults to an empty destination. `--allow-identical-retry` admits only byte-identical collisions. |
+
+The global `--workspace <selector>` chooses the binding, publisher, status, and
+restore destination. Consumer inspection instead requires every pairing input
+(`--workspace-id`, `--source-remote`, `--publication-id`,
+`--authority-machine-id`, `--remote`, and optional branch/commit), because a
+consumer need not hold an owner-local binding. Every command returns structured
+JSON through `--json` or `--format json`; human inspection lists identity,
+freshness, task IDs, and titles without dumping task prose. Remote diagnostics
+redact credentials and local paths.
+
+No task-publication MCP mutation is registered in v1. Omitting that surface
+keeps the owner, capability, workspace-selection, and destructive-operation
+checks centralized in the operator CLI until an MCP contract can preserve them.
+
 ## 3. Tree and Manifest Contract
 
-The proposed publication branch tree is:
+The publication branch tree is:
 
 ```text
 orbit-task-publication.yaml
@@ -137,10 +165,11 @@ detached snapshot self-describing during recovery.
 
 ## 4. Snapshot Construction
 
-Publication is an explicit operation that may also be invoked by an
-operator-configured routine. It is not part of task-write acknowledgement: a
-task update commits to the canonical local store even when the publication
-repository is unavailable.
+Publication is an explicit operator operation in v1. It is not part of
+task-write acknowledgement: a task update commits to the canonical local store
+even when the publication repository is unavailable. A future routine trigger
+must be separately configurable and invoke the same publication boundary; no
+post-task-write hook or seeded routine exists.
 
 The owner performs these phases:
 
@@ -314,11 +343,20 @@ deleting the current tree erased the data.
   multi-writer design.
 - Source-repository moves may require an explicit fingerprint rebind even when
   the logical workspace is unchanged.
+- V1 has no sensitivity-scanner integration. `include` therefore refuses an
+  attachment unless the operator deliberately passes
+  `--allow-unscanned-attachments`; size limits and built-in plus operator deny
+  patterns still apply. `fail` remains the default and `omit` records incomplete
+  recovery state.
+- The operator CLI is the only mutation surface. MCP publication/restore,
+  authority transfer, multi-writer sync, and a separately configured routine
+  trigger are deferred.
 
 ## Task References
 
 - [ORB-11068] — specified the proposed dedicated private task-publication repository protocol.
 - [ORB-11074] — implemented the owner-only Git compare-and-swap publication transport.
 - [ORB-11076] — implemented fail-closed same-authority publication restore with rollback.
+- [ORB-11077] — shipped binding, publish/status, inspect/restore CLI contracts and network-free end-to-end validation.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-publication/3_vision.md
+++ b/docs/design/task-publication/3_vision.md
@@ -1,8 +1,8 @@
 ---
 title: Task Publication — Vision
 owner: codex
-last_updated: 2026-08-29
-last_validated: 2026-08-29
+last_updated: 2026-08-30
+last_validated: 2026-08-30
 status: Draft
 feature: task-publication
 doc_role: vision
@@ -11,7 +11,7 @@ summary: Evolution gates for private task-publication repositories, authority tr
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068]
+related_artifacts: [ORB-11068, ORB-11077]
 ---
 
 # Task Publication — Vision
@@ -23,9 +23,9 @@ separate capabilities with different access and safety contracts.
 
 ## 1. Open Questions
 
-1. What default publication trigger and freshness objective are justified by
-   observed task-loss and recovery needs: explicit command, post-workflow hook,
-   scheduled routine, or a combination?
+1. What separately configurable routine trigger and freshness objective are
+   justified by observed task-loss and recovery needs? V1 ships only an
+   explicit command; a post-task-write hook is excluded.
 2. Should an explicit authority transfer carry the last publication generation
    as a fencing token, and what evidence must the old owner provide before the
    new owner can publish?
@@ -121,5 +121,6 @@ authority merely because a machine can clone or push.
 ## Task References
 
 - [ORB-11068] — chose a dedicated private publication repository and deferred aggregation and synchronization.
+- [ORB-11077] — shipped the explicit-only v1 operator workflow and kept routine triggering, authority transfer, and multi-writer synchronization deferred.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/task-publication/4_decisions.md
+++ b/docs/design/task-publication/4_decisions.md
@@ -1,9 +1,9 @@
 ---
 title: Task Publication — Decisions
 owner: codex
-last_updated: 2026-08-29
-last_validated: 2026-08-29
-status: Draft
+last_updated: 2026-08-30
+last_validated: 2026-08-30
+status: Accepted
 feature: task-publication
 doc_role: decisions
 type: design
@@ -11,12 +11,12 @@ summary: Standing repository, authority, failure, and data-exposure rules for ta
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068]
+related_artifacts: [ORB-11068, ORB-11077]
 ---
 
 # Task Publication — Decisions
 
-These standing rules govern future implementation choices for task publication.
+These standing rules govern the shipped implementation and future task-publication choices.
 Task references carry provenance; superseded decisions remain in place so their
 original reasoning stays legible. See
 [CONVENTIONS.md §4](../CONVENTIONS.md#4-decisions) for the admission rule.
@@ -154,5 +154,6 @@ checks. Omission is recorded as incomplete backup state.
 ## Task References
 
 - [ORB-11068] — recorded the dedicated-repository, authority, acknowledgement, branch-conflict, and privacy rules.
+- [ORB-11077] — shipped those rules through an explicit CLI-only operator surface and deferred unattended publication.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -1,11 +1,11 @@
 ---
 type: runbook
-summary: Locate Orbit state and perform WAL-safe backups, restores, and task migrations.
-tags: [operations, backup, restore, state, sqlite]
+summary: Locate Orbit state and perform WAL-safe backups, explicit task publication, restores, and task migrations.
+tags: [operations, backup, restore, state, sqlite, task-publication]
 paths: ["crates/orbit-common/src/types/workspace.rs", "crates/orbit-config/src/**", "crates/orbit-registry/**", "crates/orbit-store/**", "crates/orbit-web/src/state.rs"]
-related_features: [orbit-core, remote-access]
-related_artifacts: [ORB-10014, ORB-10294, ORB-10473]
-last_validated: 2026-08-15
+related_features: [orbit-core, remote-access, task-publication]
+related_artifacts: [ORB-10014, ORB-10294, ORB-10473, ORB-11077]
+last_validated: 2026-08-30
 ---
 
 # Inventory and Protect Orbit State
@@ -54,6 +54,7 @@ precedence). Path layout is defined in
 | `resources/activities/`, `resources/jobs/` | managed defaults plus operator-authored activity/job YAML; hidden manifests retain managed content provenance | mixed: current defaults are regenerable, but untracked YAML and `resources/.retired-managed/` backups are **authoritative until reviewed** |
 | other `resources/`, `skills/` | default executor/policy defs and skills | regenerable (`orbit init` reseeds) |
 | `state/logs/orbit.jsonl` (+ rotated archives) | unified JSONL log sink for all Orbit processes | disposable |
+| `state/task-publication/` | private Git object/work-tree caches plus pending-push reconciliation records | regenerable after a cleanly recorded success; retain during push-success/local-record recovery |
 | `embed/` | semantic-search companion binary + models | regenerable (`orbit semantic install`) |
 | `bin/` | installed Orbit binary (when installed via `install.sh`) | reinstallable |
 
@@ -152,6 +153,97 @@ orbit task export --all -o tasks-backup.tar.zst
 
 Both `VACUUM INTO` and `.backup` produce a checkpointed, sidecar-free file. If you must
 file-copy a live DB, copy `*.db`, `*.db-wal`, and `*.db-shm` together.
+
+### Publish task snapshots to a dedicated repository
+
+Task publication is an explicit, task-only durability channel. It does not
+replace the global-root/database backup above: audit events, run history,
+claims, reservations, configuration, host identity, and runtime caches are not
+published. No task mutation publishes automatically, and v1 seeds no publication
+routine. A future routine trigger must be configured separately.
+
+Provision one empty, dedicated Git repository for the workspace. Configure its
+visibility, collaborators, retention, branch protection, and credentials with
+the Git provider. Orbit's generic Git surface always reports privacy as
+`operator-managed`; it cannot prove that a repository is private or that deleted
+history was erased.
+
+From the declared owner checkout (or with the global `--workspace <selector>`):
+
+```sh
+orbit workspace publication bind \
+  --remote ssh://git.example.com/backups/orbit-tasks.git \
+  --publication-id pub_orbit_primary
+
+orbit workspace publication show --json
+orbit task publication publish --attachments fail --json
+orbit task publication status --json
+```
+
+`bind`, `publish`, and `status` use the selected workspace; a replica, missing
+owner/source identity, credential-bearing URL, publication/source remote reuse,
+or stale lineage fails closed. Replacing a lineage is explicit with `workspace
+publication rebind`. Removing local binding state requires `workspace
+publication remove --confirm` and never deletes or rewrites the repository.
+
+The default attachment policy is `fail`. `omit` publishes core task records and
+an omission ledger, so inspection and restore report an incomplete snapshot.
+`include` enforces per-file/total limits and built-in plus operator deny patterns.
+Because v1 has no sensitivity-scanner integration, attached bytes still fail
+unless the operator deliberately adds `--allow-unscanned-attachments`. A Git
+history that ever received a secret requires provider-side history remediation
+and credential rotation; deleting the latest file is not erasure.
+
+Publication uses an Orbit-owned cache and never checks out, switches, stages, or
+changes a source-worktree branch. A moved publication branch is an authority
+conflict: Orbit neither merges nor force-pushes it. Resolve the unexpected writer
+or binding before publishing again.
+
+### Inspect and deliberately recover a publication
+
+Inspection is read-only and does not require an owner-local publication binding.
+Supply the expected pairing facts rather than trusting the repository to declare
+its own identity:
+
+```sh
+orbit --workspace <local-consumer-workspace> task publication inspect \
+  --workspace-id ws_orbit \
+  --source-remote ssh://git.example.com/team/orbit.git \
+  --publication-id pub_orbit_primary \
+  --authority-machine-id hm_example \
+  --remote ssh://git.example.com/backups/orbit-tasks.git \
+  --json
+```
+
+The result labels every record with publication time, generation, workspace,
+source identity, authority, publication ID, commit, freshness, completeness, and
+`render_authority: snapshot`. It is not live owner state. Pairing mismatch,
+unsupported schema, corrupt JSONL, changed bundle/attachment bytes, or invalid
+Git lineage returns no trusted task projection.
+
+Restore the global configuration and `host.toml`/`workspaces.json` authority
+evidence first. V1 has no authority-transfer command: the selected recovery
+workspace must be an owner checkout whose local `machine_id`, logical workspace
+ID, and source remote match the publication. Start with an empty canonical task
+destination:
+
+```sh
+orbit --workspace ws_orbit task publication restore \
+  --workspace-id ws_orbit \
+  --source-remote ssh://git.example.com/team/orbit.git \
+  --publication-id pub_orbit_primary \
+  --authority-machine-id hm_example \
+  --remote ssh://git.example.com/backups/orbit-tasks.git \
+  --confirm --json
+```
+
+The confirmation is mandatory. The default refuses any non-empty destination.
+For an interrupted or repeated recovery, `--allow-identical-retry` admits only
+byte-identical task-ID collisions; one non-identical collision aborts the whole
+restore without renumbering or partial replacement. The result names restored
+and already-present IDs, projection repair state, every omitted attachment, and
+`complete` versus `incomplete-attachments`. Use ordinary `task export/import`
+with renumbering for migration between unrelated authorities instead.
 
 ## Restore Orbit
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -11,6 +11,7 @@ sidebar:
 |---------|---------|
 | `orbit init` | Initialize the global Orbit root, skills, and skill links. |
 | `orbit workspace` | Initialize and manage workspaces. |
+| `orbit workspace publication bind/show/rebind/remove` | Manage one owner-local binding to a dedicated task-publication repository; privacy remains operator-managed. |
 | `orbit config` | Show or update Orbit configuration. |
 | `orbit semantic` | Manage the local embedding companion: `install`, `uninstall`, `stats`, and `index`. |
 
@@ -23,6 +24,9 @@ sidebar:
 | `orbit run ship --mode local [task_id ...]` | Run the local-only task path for backlog or explicitly selected tasks. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |
+| `orbit task publication publish/status` | Explicitly publish an owned workspace snapshot or validate its recorded status; task mutation never publishes automatically. |
+| `orbit task publication inspect` | Validate and render a labelled repository snapshot without adopting it as live task state. |
+| `orbit task publication restore --confirm` | Deliberately restore same-authority task IDs into an empty destination; identical retries require a separate flag. |
 | `orbit search <query>` | Search tasks, docs, learnings, and ADRs; add `--hybrid` for task/doc vector ranking, use `orbit search similar <id>` for task neighbors, or `orbit search path <path>` for applicability lookup. |
 | `orbit docs` | List, show, add, index, and migrate the docs corpus. |
 | `orbit learning` | Create, inspect, update, sync, and prune project learnings. |


### PR DESCRIPTION
## Task

[ORB-11077](https://orbit-cli.com/tasks/ORB-11077) — Ship the V1 task-publication operator workflow and recovery runbook

### Description

## Problem
The task-publication foundations need one coherent operator surface and end-to-end contract; otherwise binding, publishing, inspection, and recovery remain disconnected library capabilities.

## Why It Matters
An operator must be able to provision a dedicated private repository, bind it to one owned workspace, publish and diagnose snapshots, inspect them on another machine, and perform deliberate recovery with machine-readable evidence.

## Constraints / Notes
- Provide a coherent CLI command group for bind/show/rebind/remove, publish/status, inspect, and restore; select exact command nesting to fit Orbit's existing workspace/task taxonomy.
- Binding and restore are explicit operator actions. Do not add an unattended default routine or post-task-write hook in v1.
- Keep generic Git privacy reported as operator-managed; do not claim the repository is private unless a provider integration proves it.
- All commands support structured JSON suitable for automation and stable human diagnostics that redact credentials and content.
- Any registered MCP exposure must preserve the same ownership, workspace-selection, capability, claim, and destructive-operation gates as the CLI; omit an MCP mutation surface rather than weaken those contracts.
- Update the merged design from Draft to the accurately shipped subset, document remaining limits, and extend the state/backup runbook.
- Add one local, network-free end-to-end scenario using a source workspace, dedicated bare publication remote, owner data root, and consumer/recovery data root.
- Derived from the merged docs/design/task-publication/ design in ORB-11068.

### Acceptance Criteria

- CLI help and JSON contracts cover explicit binding lifecycle, publication/status, read-only inspection, and deliberate restore without requiring source-worktree branch changes.
- Owner/replica, workspace selector, source-remote mismatch, credential redaction, publication conflict, incomplete attachment, and destructive restore gates are consistent across every exposed surface.
- No publication runs automatically after task mutation; any future routine trigger remains a separately configurable, deferred capability.
- A network-free end-to-end test binds an owned workspace to a dedicated bare repository, publishes validated tasks, inspects the labelled snapshot from a second data root, restores into an empty destination, and proves task IDs/content while excluding runtime-only state.
- The end-to-end test also proves that repository mismatch, competing branch advancement, corrupt content, and non-identical recovery collisions fail closed without dirtying the source repository.
- Task-publication design docs, generated docs index, CLI reference/help snapshots, and state-and-backup runbook accurately distinguish shipped behavior, operator-managed privacy, incomplete attachment recovery, and deferred authority transfer/multi-writer sync.
- make ci-fast and the relevant crate integration tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `workspace publication bind/show/rebind/remove` and `task publication publish/status/inspect/restore` with structured JSON and credential-safe human diagnostics.
- Kept publication explicit and operator-governed, with owner/replica and workspace pairing checks, safe attachment defaults, compare-and-swap conflict reporting, mandatory restore confirmation, and byte-identical retry only.
- Added the Core facade and a Store-owned one-time source-fingerprint adoption seam so explicit binding/recovery can pair the existing coordination registry without a new crate dependency edge.
- Added a network-free CLI end-to-end test covering binding, explicit omit publication, status, labelled second-root inspection, incomplete recovery with exact task IDs/content, runtime-state exclusion, credential redaction, source mismatch, missing confirmation, non-identical collision, competing branch advancement, corruption, source-worktree cleanliness, rebind, and removal.
- Updated accepted task-publication design docs, deferred-trigger/authority-transfer limits, generated docs index, website CLI reference, and state/backup recovery runbook.
Assessment: The v1 operator workflow is complete at the existing CLI/Core/Store boundaries. No publication MCP mutation or automatic routine/post-task-write hook was added; those remain deferred.
Scope expansion:
- Added tightly coupled CLI operation metadata, Core facade, Store fingerprint metadata method/test, end-to-end test, task-publication design folder, generated docs index, and website CLI reference. These changes satisfy explicit criteria and preserve the existing dependency graph.
Validation:
- `make ci-fast` passed.
- `make ci-lint` passed.
- `cargo test -p orbit-store workflow::task::tests --no-fail-fast`: 48 passed.
- `cargo test -p orbit-registry workspace_publication --no-fail-fast`: 5 passed.
- `cargo test -p orbit-cli --test task_publication --no-fail-fast`: passed.
- `env -u ORBIT_ROOT cargo test -p orbit-cli --bin orbit --no-fail-fast -- --test-threads=1`: 376 passed.
- The first parallel CLI unit run exposed an existing environment-variable race in `workspace_init_under_home_with_global_orbit_creates_repo_orbit`; the isolated rerun and the full serial suite passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11077-6a93adac`
- Behind base: 0
- Ahead of base: 1