### PR TITLE
[code-review] Publication push accepts branch deletion after observing a tip

### DIFF
--- a/crates/orbit-store/src/workflow/task/publish.rs
+++ b/crates/orbit-store/src/workflow/task/publish.rs
@@ -535,18 +535,34 @@ impl PublicationCache {
         Ok(commit_runner.run(&args)?.to_ascii_lowercase())
     }
 
-    /// Push as an ordinary fast-forward. A moved branch is an authority
-    /// conflict for the operator to resolve, never something to merge or force.
+    /// Push as an exact compare-and-swap of the observed tip. Ordinary Git
+    /// fast-forward is not enough: a branch deleted or rewound after observation
+    /// can still accept a descendant and recreate or advance the ref. The lease
+    /// names the expected old object (or requires the ref to stay absent); the
+    /// refspec is not force-prefixed, so a matching lease cannot replace
+    /// non-fast-forward history. A moved branch is an authority conflict, never
+    /// something to merge or force.
     fn push_fast_forward(
         &self,
         request: &ValidatedRequest,
         commit: &str,
         observed_tip: Option<&str>,
     ) -> Result<(), OrbitError> {
+        #[cfg(test)]
+        run_before_push_hook();
+
         let git_dir = self.git_dir_str()?;
+        let lease = compare_and_swap_lease(&request.publication_branch, observed_tip);
         let refspec = format!("{commit}:{}", request.publication_branch);
-        let attempt =
-            runner().try_run(&["--git-dir", git_dir, "push", "--atomic", "origin", &refspec])?;
+        let attempt = runner().try_run(&[
+            "--git-dir",
+            git_dir,
+            "push",
+            "--atomic",
+            &lease,
+            "origin",
+            &refspec,
+        ])?;
         if !attempt.success {
             let current = self.remote_branch_tip(request)?;
             if current.as_deref() != observed_tip {
@@ -817,8 +833,43 @@ struct PendingPublication {
     previous_publication: Option<String>,
 }
 
+/// Branch-scoped expected-old-object lease. An empty expect (`<branch>:`)
+/// requires the ref to still be absent; a commit id requires that exact tip.
+fn compare_and_swap_lease(branch: &str, observed_tip: Option<&str>) -> String {
+    match observed_tip {
+        Some(oid) => format!("--force-with-lease={branch}:{oid}"),
+        None => format!("--force-with-lease={branch}:"),
+    }
+}
+
 fn runner() -> GitRunner<'static> {
     GitRunner::new(PUBLISH_LABEL)
+}
+
+#[cfg(test)]
+thread_local! {
+    static BEFORE_PUSH: std::cell::RefCell<Option<Box<dyn FnOnce() + 'static>>> =
+        std::cell::RefCell::new(None);
+}
+
+/// Install a one-shot callback that runs after the pending record is written
+/// and immediately before the compare-and-swap push. Tests use this to mutate
+/// the remote between observation and push.
+#[cfg(test)]
+pub(crate) fn set_before_push_hook(hook: impl FnOnce() + 'static) {
+    BEFORE_PUSH.with(|cell| *cell.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+pub(crate) fn clear_before_push_hook() {
+    BEFORE_PUSH.with(|cell| cell.borrow_mut().take());
+}
+
+#[cfg(test)]
+fn run_before_push_hook() {
+    if let Some(hook) = BEFORE_PUSH.with(|cell| cell.borrow_mut().take()) {
+        hook();
+    }
 }
 
 fn redact_remote(message: &str, remote: &str) -> String {

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -9,7 +9,16 @@ use std::path::{Path, PathBuf};
 use orbit_types::task::TASK_EVENTS_FILE_NAME;
 use tempfile::TempDir;
 
+use super::super::publish::{clear_before_push_hook, set_before_push_hook};
 use super::*;
+
+struct BeforePushGuard;
+
+impl Drop for BeforePushGuard {
+    fn drop(&mut self) {
+        clear_before_push_hook();
+    }
+}
 
 const FINGERPRINT: &str = "git@github.com:example/orbit-source.git";
 const AUTHORITY: &str = "hm_owner";
@@ -565,4 +574,179 @@ fn publication_never_touches_the_source_repository_or_canonical_state() {
         git(&fixture.source, &["diff", "--cached", "--name-status"]),
         before_index
     );
+}
+
+fn assert_authority_conflict(error: &str, observed: &str) {
+    assert!(
+        error.contains("resolve the publication authority"),
+        "{error}"
+    );
+    assert!(error.contains(observed), "{error}");
+}
+
+#[test]
+fn deleting_the_branch_after_observation_is_an_authority_conflict() {
+    let fixture = fixture("ws_publish_delete_race");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+
+    let _guard = BeforePushGuard;
+    let remote = fixture.remote.clone();
+    set_before_push_hook(move || {
+        git(&remote, &["update-ref", "-d", BRANCH]);
+    });
+
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert_authority_conflict(&error, &first.commit_id);
+    assert!(error.contains("moved during publication"), "{error}");
+    assert!(fixture.remote_tip().is_none(), "{}", error);
+    assert!(fixture.remote_history().is_empty());
+}
+
+#[test]
+fn rewinding_the_branch_after_observation_is_an_authority_conflict() {
+    let fixture = fixture("ws_publish_rewind_race");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+    let second = publish(&fixture, request(&fixture, 2, Some(&first))).expect("second");
+    seed_task(&fixture, "ORB-00003");
+
+    let _guard = BeforePushGuard;
+    let remote = fixture.remote.clone();
+    let rewind_to = first.commit_id.clone();
+    set_before_push_hook(move || {
+        git(&remote, &["update-ref", BRANCH, &rewind_to]);
+    });
+
+    let error = publish(&fixture, request(&fixture, 3, Some(&second)))
+        .unwrap_err()
+        .to_string();
+    assert_authority_conflict(&error, &second.commit_id);
+    assert!(error.contains("moved during publication"), "{error}");
+    assert_eq!(
+        fixture.remote_tip().as_deref(),
+        Some(first.commit_id.as_str())
+    );
+    assert_eq!(fixture.remote_history(), vec![first.commit_id.clone()]);
+}
+
+#[test]
+fn a_concurrent_fast_forward_after_observation_is_an_authority_conflict() {
+    let fixture = fixture("ws_publish_ff_race");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+
+    let snapshot = external_snapshot(&fixture, "race-ff", 2, Some(&first.commit_id));
+    let _guard = BeforePushGuard;
+    let root = fixture.root.path().to_path_buf();
+    let remote = fixture.remote_str();
+    set_before_push_hook(move || {
+        let work = root.join("external-race-ff");
+        git(
+            root.as_path(),
+            &["clone", "--quiet", &remote, work.to_str().unwrap()],
+        );
+        replace_worktree(&work, &snapshot);
+        git(&work, &["add", "-A"]);
+        git(&work, &["commit", "-m", "race-ff"]);
+        git(&work, &["push", "origin", &format!("HEAD:{BRANCH}")]);
+    });
+
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert_authority_conflict(&error, &first.commit_id);
+    let competing = fixture.remote_tip().expect("competing tip");
+    assert_ne!(competing, first.commit_id);
+    assert_eq!(fixture.remote_history().len(), 2);
+    let envelope = fixture.remote_file(&competing, PUBLICATION_ENVELOPE_FILE_NAME);
+    assert!(envelope.contains("generation: 2"), "{envelope}");
+}
+
+#[test]
+fn a_concurrent_divergent_update_after_observation_is_an_authority_conflict() {
+    let fixture = fixture("ws_publish_div_race");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+
+    let snapshot = external_snapshot(&fixture, "race-div", 1, None);
+    let _guard = BeforePushGuard;
+    let root = fixture.root.path().to_path_buf();
+    let remote = fixture.remote_str();
+    set_before_push_hook(move || {
+        let work = root.join("external-race-div");
+        git(
+            root.as_path(),
+            &["clone", "--quiet", &remote, work.to_str().unwrap()],
+        );
+        replace_worktree(&work, &snapshot);
+        git(&work, &["add", "-A"]);
+        git(&work, &["commit", "--amend", "--no-edit"]);
+        git(
+            &work,
+            &["push", "--force", "origin", &format!("HEAD:{BRANCH}")],
+        );
+    });
+
+    let error = publish(&fixture, request(&fixture, 2, Some(&first)))
+        .unwrap_err()
+        .to_string();
+    assert_authority_conflict(&error, &first.commit_id);
+    let competing = fixture.remote_tip().expect("divergent tip");
+    assert_ne!(competing, first.commit_id);
+    assert_eq!(fixture.remote_history().len(), 1);
+}
+
+#[test]
+fn an_unchanged_expected_tip_still_advances_without_rewriting_history() {
+    let fixture = fixture("ws_publish_cas_advance");
+    let first = publish_first(&fixture);
+    seed_task(&fixture, "ORB-00002");
+
+    let _guard = BeforePushGuard;
+    set_before_push_hook(|| {});
+
+    let second = publish(&fixture, request(&fixture, 2, Some(&first))).expect("cas advance");
+    assert_eq!(second.status, PublicationPublishStatus::Advanced);
+    assert_eq!(
+        second.observed_tip.as_deref(),
+        Some(first.commit_id.as_str())
+    );
+    assert_eq!(
+        fixture.remote_history(),
+        vec![second.commit_id.clone(), first.commit_id.clone()]
+    );
+}
+
+#[test]
+fn initializing_requires_the_branch_to_stay_absent() {
+    let fixture = fixture("ws_publish_init_cas");
+    let _guard = BeforePushGuard;
+    let root = fixture.root.path().to_path_buf();
+    let remote = fixture.remote_str();
+    set_before_push_hook(move || {
+        let work = root.join("external-init-cas");
+        git(
+            root.as_path(),
+            &["clone", "--quiet", &remote, work.to_str().unwrap()],
+        );
+        fs::write(work.join("README.md"), "foreign\n").unwrap();
+        git(&work, &["add", "-A"]);
+        git(&work, &["commit", "-m", "foreign"]);
+        git(&work, &["push", "origin", &format!("HEAD:{BRANCH}")]);
+    });
+
+    let error = publish(&fixture, request(&fixture, 1, None))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("resolve the publication authority"),
+        "{error}"
+    );
+    assert!(error.contains("moved during publication"), "{error}");
+    let foreign = fixture.remote_tip().expect("foreign tip");
+    assert!(!fixture.remote_file(&foreign, "README.md").is_empty());
+    assert_eq!(fixture.remote_history().len(), 1);
 }

--- a/docs/design/task-publication/2_design.md
+++ b/docs/design/task-publication/2_design.md
@@ -11,7 +11,7 @@ summary: Shipped contract for explicit owner publication, labelled inspection, a
 tags: [task-publication, task-artifacts, backup, git, multi-host]
 paths: ["crates/orbit-store/src/workflow/task/**", "crates/orbit-registry/**"]
 related_features: [task-publication, task-artifacts, remote-access, federated-mcp, host-registry]
-related_artifacts: [ORB-11068, ORB-11072, ORB-11073, ORB-11074, ORB-11075, ORB-11076, ORB-11077]
+related_artifacts: [ORB-11068, ORB-11072, ORB-11073, ORB-11074, ORB-11075, ORB-11076, ORB-11077, ORB-11110]
 ---
 
 # Task Publication — Design
@@ -187,7 +187,11 @@ The owner performs these phases:
 6. Build and commit the snapshot inside the private publication-repository
    cache. The source-code repository and its worktree are never checked out,
    switched, staged, or dirtied by publication.
-7. Push the new commit as a normal fast-forward update to the configured branch.
+7. Push the new commit as an exact compare-and-swap of the observed tip onto
+   the configured branch. The update succeeds only when that ref still names the
+   observed object, or is still absent after a verified empty-repository
+   initialization. The refspec is not force-prefixed, so a matching expected
+   object cannot replace non-fast-forward history.
 8. Record the successful generation and commit ID in owner-local publication
    state. Failed publication does not change the last-success record.
 
@@ -211,7 +215,11 @@ the same instant. A later publication converges on newer owner state.
 ## 5. Compare-and-Swap and Competing Writers
 
 The expected branch tip from phase 3 is load-bearing. The push must fail when
-the publication branch moved after it was fetched.
+the publication branch moved after it was fetched. Ordinary Git fast-forward is
+not that check: deleting or rewinding the branch after observation can still
+accept a descendant and recreate or advance the ref. The transport therefore
+compare-and-swaps the exact observed object ID, or requires the ref to stay
+absent when initialization observed an empty repository [ORB-11110].
 
 A non-fast-forward rejection means one of the following:
 
@@ -356,6 +364,7 @@ deleting the current tree erased the data.
 
 - [ORB-11068] — specified the proposed dedicated private task-publication repository protocol.
 - [ORB-11074] — implemented the owner-only Git compare-and-swap publication transport.
+- [ORB-11110] — publication push compare-and-swaps the exact observed object, so a deleted or rewound branch is an authority conflict rather than a recreate-or-advance.
 - [ORB-11076] — implemented fail-closed same-authority publication restore with rollback.
 - [ORB-11077] — shipped binding, publish/status, inspect/restore CLI contracts and network-free end-to-end validation.
 


### PR DESCRIPTION
## Task

[ORB-11110](https://orbit-cli.com/tasks/ORB-11110) — [code-review] Publication push accepts branch deletion after observing a tip

### Description

## Problem

`push_fast_forward` receives the exact `observed_tip`, but sends a plain `git push --atomic <commit>:<branch>` at `crates/orbit-store/src/workflow/task/publish.rs:538-550`. It compares the remote with `observed_tip` only after a failed push at `:550-559`. Plain fast-forward semantics are not an exact compare-and-swap: if the branch is deleted or reset backward after observation, the push can succeed and recreate or advance it, bypassing the moved-branch check.

A focused repro observed commit `d3d0d673`, created a child publication commit, deleted `refs/heads/main` on the remote, and ran the current refspec. Git exited 0 and recreated `main` at the new commit. The code then sees its own commit at `:566-573` and reports success, even though the remote tip changed from the value on which the snapshot and parent lineage decision were based.

## Why It Matters

The design makes the observed branch tip load-bearing authority evidence. Accepting a deleted or rewound branch can overwrite an operator or competing-writer action instead of surfacing the required authority conflict.

## Constraints / Notes

- Enforce an exact expected-old-object comparison without allowing non-fast-forward history replacement.
- Initialization must still require the repository to be empty and distinguish an expected absent ref from a ref deleted after observation.
- Preserve the post-push verification and pending-publication reconciliation contract.

### Acceptance Criteria

- The publication ref update succeeds only when the remote branch still equals the exact observed object ID, or is still absent for a verified empty-repository initialization.
- Deterministic local-remote regressions delete the branch and reset it backward between observation and push; both attempts fail as authority conflicts and do not recreate or advance the branch.
- A concurrent ordinary fast-forward or divergent update remains rejected, while an unchanged expected tip advances successfully without force-pushing non-fast-forward history.
- Pending-publication reconciliation and focused publish tests pass, followed by repository-required fast and lint checks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `push_fast_forward` now compare-and-swaps the exact observed object via a branch-scoped `--force-with-lease=<branch>:<oid>` (empty expect when initialization observed no ref). The refspec stays `<commit>:<branch>` with no `+`, so a matching lease still cannot replace non-fast-forward history. Deleted, rewound, or concurrently updated tips fail as authority conflicts and do not recreate or advance the branch.
- Added a test-only before-push hook so local remotes can be deleted, rewound, fast-forwarded, or diverged between observation and push. New tests cover those races plus successful advance of an unchanged expected tip and empty-repo initialization that requires the branch to stay absent.
- Aligned `docs/design/task-publication/2_design.md` phase 7 / CAS wording with the exact expected-object rule [ORB-11110].

Assessment: The observed tip is now load-bearing at push time, not only after a failed plain fast-forward. Pending-publication reconciliation is unchanged.

Validation:
- `cargo test -p orbit-store --lib workflow::task::tests::publish -- --test-threads=1`: 17 passed
- `make ci-fast`: passed
- `make ci-lint`: passed

Unlisted file: `file:docs/design/task-publication/2_design.md` was added to context_files because the live CAS contract in phase 7 described a plain fast-forward push.

Friction: none

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11110-6a93b689`
- Behind base: 0
- Ahead of base: 1