### PR TITLE
[code-review] Code-review cursor lookup selects finding tasks after tag collapse

### DIFF
--- a/.orbit/auto_tasks/code-review.yaml
+++ b/.orbit/auto_tasks/code-review.yaml
@@ -14,10 +14,16 @@ template:
 
     ## Rules and command surfaces
 
-    - Use the registered Orbit tool surface. Find the previous sweep with
-      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review","model":"<agent-family>"}'`
-      and read its cursor with
+    - Use the registered Orbit tool surface. Find the newest current-name sweep with
+      `orbit tool run orbit.task.list --input '{"status":["done"],"type":"chore","tag":["code-review","no-diff-expected"],"limit":1,"model":"<agent-family>"}'`
+      and the newest legacy-name sweep with
+      `orbit tool run orbit.task.list --input '{"status":["done"],"type":"chore","tag":["code-review-sweep","no-diff-expected"],"limit":1,"model":"<agent-family>"}'`.
+      Both tag filters use AND semantics. Compare the first result from each
+      newest-first list by `created_at`, with the lexicographically smaller task ID
+      winning an equal timestamp, and read the selected sweep's cursor with
       `orbit tool run orbit.task.show --input '{"id":"<id>","model":"<agent-family>"}'`.
+      A finding is a `bug` tagged only `code-review`, so it is never a sweep
+      candidate even when it completed after the selected sweep.
       Search existing coverage with
       `orbit tool run orbit.search --input '{"query":"<distinctive symptom, symbol, or file terms>","kind":"task","all":true,"model":"<agent-family>"}'`
       and list open review work with
@@ -30,11 +36,13 @@ template:
 
     ## Determine the review window
 
-    Find the most recent done task tagged `code-review` and read the
-    last-reviewed commit recorded in its execution summary. Review the commits from
-    that point to the current HEAD of the workspace's integration branch. If no
-    prior sweep task exists, record the current HEAD as the baseline and stop — the
-    first run seeds the cursor.
+    Run both completed-sweep queries above and select the newer result using the
+    stated ordering. Read the last-reviewed commit recorded in that sweep's
+    execution summary, then review the commits from that point to the current HEAD
+    of the workspace's integration branch. Never use a `code-review`-only finding
+    as a cursor, and never treat a selected sweep's missing cursor as a first run.
+    If neither sweep query returns a result, record the current HEAD as the baseline
+    and stop — only that case seeds the cursor.
 
     ## Review the window
 

--- a/crates/orbit-core/assets/auto_tasks/code-review.yaml
+++ b/crates/orbit-core/assets/auto_tasks/code-review.yaml
@@ -14,10 +14,16 @@ template:
 
     ## Rules and command surfaces
 
-    - Use the registered Orbit tool surface. Find the previous sweep with
-      `orbit tool run orbit.task.list --input '{"status":["done"],"tag":"code-review","model":"<agent-family>"}'`
-      and read its cursor with
+    - Use the registered Orbit tool surface. Find the newest current-name sweep with
+      `orbit tool run orbit.task.list --input '{"status":["done"],"type":"chore","tag":["code-review","no-diff-expected"],"limit":1,"model":"<agent-family>"}'`
+      and the newest legacy-name sweep with
+      `orbit tool run orbit.task.list --input '{"status":["done"],"type":"chore","tag":["code-review-sweep","no-diff-expected"],"limit":1,"model":"<agent-family>"}'`.
+      Both tag filters use AND semantics. Compare the first result from each
+      newest-first list by `created_at`, with the lexicographically smaller task ID
+      winning an equal timestamp, and read the selected sweep's cursor with
       `orbit tool run orbit.task.show --input '{"id":"<id>","model":"<agent-family>"}'`.
+      A finding is a `bug` tagged only `code-review`, so it is never a sweep
+      candidate even when it completed after the selected sweep.
       Search existing coverage with
       `orbit tool run orbit.search --input '{"query":"<distinctive symptom, symbol, or file terms>","kind":"task","all":true,"model":"<agent-family>"}'`
       and list open review work with
@@ -30,11 +36,13 @@ template:
 
     ## Determine the review window
 
-    Find the most recent done task tagged `code-review` and read the
-    last-reviewed commit recorded in its execution summary. Review the commits from
-    that point to the current HEAD of the workspace's integration branch. If no
-    prior sweep task exists, record the current HEAD as the baseline and stop — the
-    first run seeds the cursor.
+    Run both completed-sweep queries above and select the newer result using the
+    stated ordering. Read the last-reviewed commit recorded in that sweep's
+    execution summary, then review the commits from that point to the current HEAD
+    of the workspace's integration branch. Never use a `code-review`-only finding
+    as a cursor, and never treat a selected sweep's missing cursor as a first run.
+    If neither sweep query returns a result, record the current HEAD as the baseline
+    and stop — only that case seeds the cursor.
 
     ## Review the window
 

--- a/crates/orbit-core/src/auto_tasks/tests/shipped.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/shipped.rs
@@ -323,6 +323,13 @@ fn code_review_default_is_portable_cursor_driven_and_inert() {
         .find(|(name, _)| *name == "code-review")
         .expect("code-review default");
     let definition = parse_auto_task_yaml(yaml).expect("parse code-review");
+    let repository_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(".orbit/auto_tasks/code-review.yaml");
+    let repository_yaml = std::fs::read_to_string(&repository_path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", repository_path.display()));
+    let repository_definition =
+        parse_auto_task_yaml(&repository_yaml).expect("parse repository code-review");
 
     assert_eq!(definition.name, "code-review");
     assert!(!definition.enabled, "definition must ship disabled");
@@ -357,6 +364,14 @@ fn code_review_default_is_portable_cursor_driven_and_inert() {
         !yaml.contains("/home/") && !yaml.contains("/Users/"),
         "default must not contain a machine-specific path"
     );
+    assert_eq!(
+        repository_definition.template.description, definition.template.description,
+        "repository and embedded code-review instructions must stay synchronized"
+    );
+    assert_eq!(
+        repository_definition.template.acceptance_criteria, definition.template.acceptance_criteria,
+        "repository and embedded code-review criteria must stay synchronized"
+    );
     // The template ships to every workspace, so it must not name this
     // repository's branches or files.
     for repo_specific in ["agent-main", "ORB-", "CLAUDE.md", "make ci"] {
@@ -379,6 +394,11 @@ fn code_review_default_is_portable_cursor_driven_and_inert() {
         "orbit tool run orbit.task.list",
         "orbit tool run orbit.task.show",
         "orbit tool run orbit.search",
+        "code-review-sweep",
+        "both tag filters use and semantics",
+        "lexicographically smaller task id",
+        "never use a `code-review`-only finding",
+        "only that case seeds the cursor",
     ] {
         assert!(
             body.contains(required),
@@ -388,6 +408,15 @@ fn code_review_default_is_portable_cursor_driven_and_inert() {
     assert!(!body.contains("orbit task add"));
     assert!(!body.contains("orbit task list"));
     assert!(!body.contains("orbit task show"));
+    for sweep_query in [
+        r#""tag":["code-review","no-diff-expected"],"limit":1"#,
+        r#""tag":["code-review-sweep","no-diff-expected"],"limit":1"#,
+    ] {
+        assert!(
+            definition.template.description.contains(sweep_query),
+            "code-review must retain deterministic sweep query {sweep_query}"
+        );
+    }
     assert!(
         definition
             .template
@@ -414,6 +443,65 @@ fn code_review_default_is_portable_cursor_driven_and_inert() {
             }),
         "code-review must require verified, evidenced, non-duplicate findings"
     );
+}
+
+#[test]
+fn code_review_cursor_fixture_ignores_newer_finding_and_current_sweep() {
+    struct ReviewTask<'a> {
+        id: &'a str,
+        created_order: u8,
+        completed_order: Option<u8>,
+        task_type: &'a str,
+        tags: &'a [&'a str],
+        cursor: Option<&'a str>,
+    }
+
+    let tasks = [
+        ReviewTask {
+            id: "legacy-sweep",
+            created_order: 1,
+            completed_order: Some(1),
+            task_type: "chore",
+            tags: &["code-review-sweep", "no-diff-expected"],
+            cursor: Some("legacy-sweep-cursor"),
+        },
+        ReviewTask {
+            id: "newer-finding",
+            created_order: 2,
+            completed_order: Some(2),
+            task_type: "bug",
+            tags: &["code-review"],
+            cursor: None,
+        },
+        ReviewTask {
+            id: "current-sweep",
+            created_order: 3,
+            completed_order: None,
+            task_type: "chore",
+            tags: &["code-review", "no-diff-expected"],
+            cursor: None,
+        },
+    ];
+
+    let selected = tasks
+        .iter()
+        .filter(|task| {
+            let current_sweep =
+                task.tags.contains(&"code-review") && task.tags.contains(&"no-diff-expected");
+            let legacy_sweep =
+                task.tags.contains(&"code-review-sweep") && task.tags.contains(&"no-diff-expected");
+            task.completed_order.is_some()
+                && task.task_type == "chore"
+                && (current_sweep || legacy_sweep)
+        })
+        .max_by(|left, right| {
+            left.created_order
+                .cmp(&right.created_order)
+                .then_with(|| right.id.cmp(left.id))
+        })
+        .and_then(|task| task.cursor);
+
+    assert_eq!(selected, Some("legacy-sweep-cursor"));
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11108](https://orbit-cli.com/tasks/ORB-11108) — [code-review] Code-review cursor lookup selects finding tasks after tag collapse

### Description

## Problem

The renamed sweep now tags both the sweep record and every filed finding as `code-review`. The template queries the most recent completed task with that tag at `.orbit/auto_tasks/code-review.yaml:17-20` and `:31-37`, while it instructs findings to use the same tag at `:25-26` and `:46-52` and tags the sweep itself at `:63-66`.

This is already observable in the live store: ORB-11100 is the newest completed `code-review` task but is a finding whose execution summary has no last-reviewed commit; the actual prior sweep is ORB-11090 under the former `code-review-sweep` tag. An executor following the template literally can fail cursor extraction or treat the missing cursor as a first run, seed HEAD, and silently skip an unreviewed window.

## Why It Matters

The cursor is the audit boundary for post-merge review. Findings must not be eligible as sweep cursor records, and the rename must preserve access to legacy sweep history.

## Constraints / Notes

- Keep findings tagged `code-review` for existing review-work discovery.
- Preserve compatibility with completed sweeps created under `code-review-sweep`.
- Keep the repository-local and embedded auto-task assets synchronized.

### Acceptance Criteria

- Cursor discovery deterministically selects the newest completed sweep record and never a finding, even when the finding completed later and shares the `code-review` tag.
- A regression fixture with a legacy `code-review-sweep` sweep, a newer completed `code-review` finding, and a current sweep recovers the legacy sweep cursor instead of seeding current HEAD.
- The auto-task instructions expose an unambiguous registered-tool procedure for selecting prior sweeps while findings retain the `code-review` tag.
- The repository-local definition, embedded default asset, and focused shipped-auto-task tests remain synchronized and pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the repository-local and embedded code-review auto-task definitions with two registered `orbit.task.list` queries: current sweeps require `code-review` AND `no-diff-expected`, while legacy sweeps require `code-review-sweep` AND `no-diff-expected`; both are constrained to completed chores and one newest result.
- Defined deterministic cross-generation selection by `created_at` with an ascending task-ID tie break, explicitly excluded `code-review`-only findings, and limited HEAD seeding to the case where neither sweep query returns a candidate.
- Added synchronization assertions for repository and embedded instructions/criteria plus a regression fixture proving that a legacy sweep cursor survives a later completed finding while the current sweep is still active.

Assessment: Cursor discovery now distinguishes sweep records from findings without removing the shared finding tag and retains access to pre-rename sweep history. All changes remained within the three declared context files.

Validation:
- `cargo test -p orbit-core --lib auto_tasks::tests::shipped -- --nocapture`: passed, 10 tests.
- `cargo test -p orbit-core --lib code_review_ -- --nocapture`: passed, 2 tests on the final source.
- `make ci-fast`: passed.
- `make ci-lint`: passed with workspace all-target warnings denied.
- `git diff --check`: passed.
- Canonical checkout guard passed: supplied repo/workspace roots, `pwd -P`, and Git top-level all resolved to the same worktree.

Friction checkpoint: No qualifying contradicted assumption, recurring failure, incident root cause, or over-ten-minute gotcha was found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11108-6a93b94d`
- Behind base: 0
- Ahead of base: 1