### PR TITLE
[code-review] Publication Git staging rewrites attachment bytes through in-tree attributes

### DIFF
--- a/crates/orbit-store/src/workflow/task/git.rs
+++ b/crates/orbit-store/src/workflow/task/git.rs
@@ -8,11 +8,23 @@
 //! per-invocation environment (index file, deterministic commit identity). That
 //! is a different contract, so it keeps its own runner here.
 
+use std::fs;
 use std::path::Path;
 use std::process::Command;
 
 use orbit_common::OrbitError;
 use orbit_types::workspace::git_remotes_equivalent;
+
+/// Highest-precedence attributes for an Orbit-owned cache. Unsets every
+/// conversion Git would otherwise apply from a published `.gitattributes`,
+/// `$GIT_DIR/info/attributes` leftover, or ambient attributes file.
+///
+/// `core.attributesFile=/dev/null` only disables the *global* attributes
+/// file. `attr.tree` (empty or invalid) still leaves worktree attributes
+/// active on Git 2.43 during `add` and `checkout`. `info/attributes` is the
+/// layer that actually wins over `artifacts/files/.gitattributes`.
+const LITERAL_ATTRIBUTES: &str =
+    "* -text -eol -crlf -ident -filter -diff -merge -working-tree-encoding\n";
 
 /// Result of a Git invocation that is allowed to fail.
 pub(super) struct GitAttempt {
@@ -56,6 +68,9 @@ impl<'a> GitRunner<'a> {
 
     /// Run `git` and return the outcome even when the command exits non-zero.
     pub(super) fn try_run(&self, args: &[&str]) -> Result<GitAttempt, OrbitError> {
+        if let Some(git_dir) = git_dir_from_args(args) {
+            isolate_git_dir(git_dir)?;
+        }
         let mut command = Command::new("git");
         command
             .args([
@@ -70,13 +85,22 @@ impl<'a> GitRunner<'a> {
                 "-c",
                 "core.safecrlf=false",
             ])
-            .args(args)
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GCM_INTERACTIVE", "never");
+            .args(args);
         for (key, value) in &self.env {
             command.env(key, value);
         }
+        // Isolation wins over caller env and the ambient process: publication
+        // must not read operator Git config or honor GIT_CONFIG_COUNT filters.
+        command
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_ATTR_NOSYSTEM", "1")
+            .env("GCM_INTERACTIVE", "never")
+            .env_remove("GIT_CONFIG_COUNT")
+            .env_remove("GIT_CONFIG_PARAMETERS")
+            .env_remove("GIT_ATTR_SOURCE");
         let output = command.output().map_err(|error| {
             OrbitError::Execution(format!(
                 "{} failed to run `git {}`: {error}",
@@ -121,6 +145,31 @@ impl<'a> GitRunner<'a> {
     pub(super) fn error(&self, message: impl Into<String>) -> OrbitError {
         OrbitError::InvalidInput(format!("{}: {}", self.label, message.into()))
     }
+}
+
+fn git_dir_from_args<'a>(args: &'a [&'a str]) -> Option<&'a Path> {
+    let mut args = args.iter();
+    while let Some(arg) = args.next() {
+        if let Some(path) = arg.strip_prefix("--git-dir=") {
+            return Some(Path::new(path));
+        }
+        if *arg == "--git-dir" {
+            return args.next().map(Path::new);
+        }
+    }
+    None
+}
+
+fn isolate_git_dir(git_dir: &Path) -> Result<(), OrbitError> {
+    if !git_dir.is_dir() {
+        return Ok(());
+    }
+    let info = git_dir.join("info");
+    fs::create_dir_all(&info).map_err(|error| OrbitError::from_write_io(&info, error))?;
+    let path = info.join("attributes");
+    fs::write(&path, LITERAL_ATTRIBUTES)
+        .map_err(|error| OrbitError::from_write_io(&path, error))?;
+    Ok(())
 }
 
 /// Absolute paths are local filesystem detail; keep them out of error text.

--- a/crates/orbit-store/src/workflow/task/tests/inspect.rs
+++ b/crates/orbit-store/src/workflow/task/tests/inspect.rs
@@ -461,3 +461,55 @@ fn inspect_does_not_mutate_canonical_or_source_state() {
     assert!(!repo.root.path().join("audit").exists());
     assert!(!repo.root.path().join("runs").exists());
 }
+
+#[test]
+fn inspect_preserves_crlf_bytes_and_skips_configured_filters() {
+    let root = TempDir::new().unwrap();
+    let registry = open_registry(root.path());
+    let workspace_id = "ws_inspect_crlf_attr";
+    let binding = bind(&registry, root.path(), workspace_id);
+    let store = bundle_store(&registry, &binding);
+    seed_one(&store, &registry, workspace_id, "ORB-00001", &[]);
+    seed_crlf_gitattributes_attachments(&store, "ORB-00001");
+
+    let snap = root.path().join("snap");
+    build_publication_snapshot(
+        &registry,
+        &snap,
+        metadata(workspace_id, 1, None),
+        &policy(AttachmentPolicyKind::Include),
+        None,
+    )
+    .unwrap();
+
+    let remote = root.path().join("publication.git");
+    init_repo(&remote);
+    replace_worktree(&remote, &snap);
+    git_add_literal(&remote);
+    git(&remote, &["commit", "-m", "generation 1"]);
+    let commit = git(&remote, &["rev-parse", "HEAD"]);
+
+    let cache = root.path().join("consumer-cache");
+    let (env, sentinel) = poison_publication_git_filters(root.path());
+    let inspection = inspect_publication(request(workspace_id, &remote, &cache, None)).unwrap();
+    drop(env);
+
+    assert_label(
+        &inspection,
+        workspace_id,
+        1,
+        &commit,
+        PublicationFreshness::Current,
+        false,
+    );
+    assert!(
+        !sentinel.exists(),
+        "inspection executed an external Git filter"
+    );
+    let tree = cache.join("pub_orbit_primary").join("tree");
+    assert_eq!(
+        fs::read(tree.join("tasks/ORB-00001/artifacts/files/payload.txt")).unwrap(),
+        CRLF_PAYLOAD
+    );
+    read_bundle_at(&tree.join("tasks/ORB-00001")).expect("inspected bundle validates");
+}

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -49,6 +49,97 @@ fn git(dir: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
+/// Raw Git stdout, including trailing CR/LF. `git()` trims and must not be
+/// used to assert snapshot attachment bytes.
+fn git_binary(dir: &Path, args: &[&str]) -> Vec<u8> {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_AUTHOR_NAME", "orbit-test")
+        .env("GIT_AUTHOR_EMAIL", "orbit-test@example.test")
+        .env("GIT_COMMITTER_NAME", "orbit-test")
+        .env("GIT_COMMITTER_EMAIL", "orbit-test@example.test")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+/// Six-byte CRLF payload used to detect Git text conversion (`61 0d 0a 62 0d 0a`).
+const CRLF_PAYLOAD: &[u8] = b"a\r\nb\r\n";
+const GITATTRIBUTES_CRLF: &[u8] = b"payload.txt text filter=orbit-sentinel\n";
+
+fn include_attachment_policy() -> AttachmentPolicy {
+    AttachmentPolicy {
+        kind: AttachmentPolicyKind::Include,
+        max_file_bytes: 1024,
+        max_total_bytes: 4096,
+        deny_patterns: Vec::new(),
+        scanner_failure_behavior: ScannerFailureBehavior::AllowUnchecked,
+    }
+}
+
+fn seed_crlf_gitattributes_attachments(
+    store: &TaskBundleStoreV2,
+    task_id: &str,
+) -> ArtifactManifestV2 {
+    let attrs = seed_artifact_blob(
+        store,
+        task_id,
+        ".gitattributes",
+        GITATTRIBUTES_CRLF,
+        "codex",
+    );
+    let payload = seed_artifact_blob(store, task_id, "payload.txt", CRLF_PAYLOAD, "codex");
+    let manifest = ArtifactManifestV2 {
+        schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        files: vec![attrs, payload],
+    };
+    store
+        .rewrite_artifact_manifest(task_id, &manifest)
+        .expect("rewrite crlf artifact manifest");
+    manifest
+}
+
+fn git_add_literal(dir: &Path) {
+    for (rel, _) in tree_bytes(dir) {
+        let oid = git(dir, &["hash-object", "-w", "--no-filters", "--", &rel]);
+        let cacheinfo = format!("100644,{oid},{rel}");
+        git(dir, &["update-index", "--add", "--cacheinfo", &cacheinfo]);
+    }
+}
+
+fn write_sentinel_gitconfig(dir: &Path) -> (PathBuf, PathBuf) {
+    let sentinel = dir.join("orbit-sentinel-ran");
+    let config = dir.join("poisoned.gitconfig");
+    let sentinel_path = sentinel.to_str().expect("utf-8 sentinel path");
+    fs::write(
+        &config,
+        format!(
+            "[filter \"orbit-sentinel\"]\n\
+             \tclean = sh -c \"echo ran >> '{sentinel_path}'; cat\"\n\
+             \tsmudge = sh -c \"echo ran >> '{sentinel_path}'; cat\"\n\
+             \trequired = true\n"
+        ),
+    )
+    .expect("write poisoned gitconfig");
+    (config, sentinel)
+}
+
+fn poison_publication_git_filters(dir: &Path) -> (orbit_common::test_env::ScopedEnv, PathBuf) {
+    let (config, sentinel) = write_sentinel_gitconfig(dir);
+    let config_path = config.to_str().expect("utf-8 gitconfig path").to_string();
+    let env = orbit_common::test_env::scoped([("GIT_CONFIG_GLOBAL", Some(config_path.as_str()))]);
+    (env, sentinel)
+}
+
 fn copy_tree(src: &Path, dst: &Path) {
     fs::create_dir_all(dst).unwrap();
     for entry in fs::read_dir(src).unwrap() {

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -750,3 +750,86 @@ fn initializing_requires_the_branch_to_stay_absent() {
     assert!(!fixture.remote_file(&foreign, "README.md").is_empty());
     assert_eq!(fixture.remote_history().len(), 1);
 }
+
+#[test]
+fn publication_preserves_crlf_bytes_and_skips_configured_filters() {
+    let fixture = fixture("ws_publish_crlf_attr");
+    let registry = fixture.registry();
+    let binding = registry
+        .find_workspace_checkout(&fixture.workspace_id)
+        .unwrap()
+        .unwrap();
+    let store = bundle_store(&registry, &binding);
+    let manifest = seed_crlf_gitattributes_attachments(&store, "ORB-00001");
+    let expected_sha = manifest
+        .files
+        .iter()
+        .find(|file| file.path == "payload.txt")
+        .expect("payload manifest entry")
+        .sha256
+        .clone();
+
+    let (env, sentinel) = poison_publication_git_filters(fixture.root.path());
+    let outcome = publish_task_snapshot(
+        &registry,
+        request(&fixture, 1, None),
+        &include_attachment_policy(),
+        None,
+    )
+    .expect("publish crlf attachments");
+    let inspection = inspect_publication(PublicationInspectRequest {
+        workspace_id: fixture.workspace_id.clone(),
+        source_repository_fingerprint: FINGERPRINT.to_string(),
+        publication_id: PUBLICATION_ID.to_string(),
+        authority_machine_id: AUTHORITY.to_string(),
+        publication_remote: fixture.remote_str(),
+        publication_branch: BRANCH.to_string(),
+        cache_dir: fixture.root.path().join("inspect-cache"),
+        commit: None,
+    })
+    .expect("inspect published crlf snapshot");
+    drop(env);
+
+    assert_eq!(outcome.status, PublicationPublishStatus::Initialized);
+    assert_eq!(inspection.label.commit_id, outcome.commit_id);
+    assert!(
+        !sentinel.exists(),
+        "publication or inspection executed an external Git filter"
+    );
+
+    let payload_spec = format!(
+        "{}:tasks/ORB-00001/artifacts/files/payload.txt",
+        outcome.commit_id
+    );
+    assert_eq!(
+        git_binary(&fixture.remote, &["cat-file", "blob", &payload_spec]),
+        CRLF_PAYLOAD
+    );
+    let attrs_spec = format!(
+        "{}:tasks/ORB-00001/artifacts/files/.gitattributes",
+        outcome.commit_id
+    );
+    assert_eq!(
+        git_binary(&fixture.remote, &["cat-file", "blob", &attrs_spec]),
+        GITATTRIBUTES_CRLF
+    );
+    let published_manifest = fixture.remote_file(
+        &outcome.commit_id,
+        "tasks/ORB-00001/artifacts/manifest.yaml",
+    );
+    assert!(
+        published_manifest.contains(&expected_sha),
+        "{published_manifest}"
+    );
+    assert_eq!(
+        expected_sha,
+        format!("{:x}", sha2::Sha256::digest(CRLF_PAYLOAD))
+    );
+    let inspected = fixture
+        .root
+        .path()
+        .join("inspect-cache")
+        .join(PUBLICATION_ID)
+        .join("tree/tasks/ORB-00001/artifacts/files/payload.txt");
+    assert_eq!(fs::read(inspected).unwrap(), CRLF_PAYLOAD);
+}

--- a/crates/orbit-store/src/workflow/task/tests/restore.rs
+++ b/crates/orbit-store/src/workflow/task/tests/restore.rs
@@ -112,7 +112,7 @@ fn fixture(kind: AttachmentPolicyKind) -> RestoreFixture {
     fs::create_dir_all(&remote).unwrap();
     git(&remote, &["init", "-b", "main"]);
     replace_worktree(&remote, &snapshot);
-    git(&remote, &["add", "-A"]);
+    git_add_literal(&remote);
     git(&remote, &["commit", "-m", "publication"]);
 
     let destination = TempDir::new().unwrap();
@@ -187,6 +187,84 @@ fn identical_retry_is_explicit_and_does_not_duplicate_or_advance() {
     assert_eq!(registry.allocator_next_number().unwrap(), allocator);
     assert_eq!(tree_bytes(&canonical), before);
     assert_eq!(registry.tasks_for_workspace(WORKSPACE).unwrap().len(), 2);
+}
+
+#[test]
+fn restore_preserves_crlf_attachment_bytes_despite_gitattributes() {
+    let source = TempDir::new().unwrap();
+    let source_registry = open_registry(source.path());
+    let source_binding = bind_restore(&source_registry, source.path());
+    let store = bundle_store(&source_registry, &source_binding);
+    seed(
+        &store,
+        &source_registry,
+        WORKSPACE,
+        &make_bundle("ORB-00001", "crlf", Vec::new()),
+    );
+    seed_crlf_gitattributes_attachments(&store, "ORB-00001");
+
+    let snapshot = source.path().join("snapshot");
+    build_publication_snapshot(
+        &source_registry,
+        &snapshot,
+        PublicationSnapshotMetadata {
+            publication_id: PUBLICATION.to_string(),
+            workspace_id: WORKSPACE.to_string(),
+            source_repository_fingerprint: FINGERPRINT.to_string(),
+            authority_machine_id: AUTHORITY.to_string(),
+            generation: 1,
+            published_at: Utc.with_ymd_and_hms(2026, 8, 30, 4, 0, 0).unwrap(),
+            previous_publication: None,
+        },
+        &include_attachment_policy(),
+        None,
+    )
+    .unwrap();
+
+    let remote = source.path().join("publication.git");
+    fs::create_dir_all(&remote).unwrap();
+    git(&remote, &["init", "-b", "main"]);
+    replace_worktree(&remote, &snapshot);
+    git_add_literal(&remote);
+    git(&remote, &["commit", "-m", "publication"]);
+
+    let destination = TempDir::new().unwrap();
+    let destination_registry = open_registry(destination.path());
+    bind_restore(&destination_registry, destination.path());
+    let cache = destination.path().join("publication-cache");
+    let (env, sentinel) = poison_publication_git_filters(destination.path());
+    let outcome = restore_publication(
+        &destination_registry,
+        PublicationRestoreRequest {
+            publication: PublicationInspectRequest {
+                workspace_id: WORKSPACE.to_string(),
+                source_repository_fingerprint: FINGERPRINT.to_string(),
+                publication_id: PUBLICATION.to_string(),
+                authority_machine_id: AUTHORITY.to_string(),
+                publication_remote: remote.to_string_lossy().into_owned(),
+                publication_branch: "refs/heads/main".to_string(),
+                cache_dir: cache,
+                commit: None,
+            },
+            mode: PublicationRestoreMode::EmptyDestination,
+        },
+    )
+    .unwrap();
+    drop(env);
+
+    assert_eq!(outcome.restored_task_ids, ["ORB-00001"]);
+    assert!(
+        !sentinel.exists(),
+        "restore inspection executed an external Git filter"
+    );
+    let canonical = destination_registry
+        .canonical_task_bundle_path(WORKSPACE, "ORB-00001")
+        .unwrap();
+    assert_eq!(
+        fs::read(canonical.join("artifacts/files/payload.txt")).unwrap(),
+        CRLF_PAYLOAD
+    );
+    read_bundle_at(&canonical).expect("restored bundle validates");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11109](https://orbit-cli.com/tasks/ORB-11109) — [code-review] Publication Git staging rewrites attachment bytes through in-tree attributes

### Description

## Problem

Task artifact paths are projected directly beneath `artifacts/files/` at `crates/orbit-store/src/repository/task/v2/artifacts.rs:127-145`, so an admitted attachment may be named `.gitattributes`. The publication runner only sets `core.attributesFile=/dev/null` and leaves repository-tree attributes active at `crates/orbit-store/src/workflow/task/git.rs:59-76`; publication then stages the validated snapshot with ordinary `git add --all --force` at `crates/orbit-store/src/workflow/task/publish.rs:469-488`.

A focused live-code repro created `artifacts/files/.gitattributes` containing `payload.txt text` beside a six-byte CRLF payload. Running the same Git configuration and add sequence stored a four-byte LF blob (`61 0a 62 0a`) instead of the validated six-byte source (`61 0d 0a 62 0d 0a`). The publication envelope and artifact manifest still carry the original SHA-256 and size, so the pushed snapshot cannot pass its own inspection or recovery validation. Configured clean filters can also be selected by tree attributes because the runner does not isolate global Git config.

## Why It Matters

The durability path can successfully push a snapshot whose attachment bytes no longer match the canonical task bundle. A specially named attachment may also activate operator-configured Git filter programs inside the publication process, contradicting the runner contract that filters never rewrite snapshot bytes.

## Constraints / Notes

- Do not weaken attachment checksum verification.
- Preserve exact canonical bytes in both staging and inspection regardless of ambient Git configuration or published attribute files.
- Keep all Git work in the Orbit-owned cache.

### Acceptance Criteria

- A deterministic publication regression includes an `artifacts/files/.gitattributes` entry and a CRLF payload, and proves the committed blob bytes and manifest checksum remain identical to the validated canonical attachment.
- Publication and inspection do not execute or apply repository-tree, global, or local clean/smudge filters; a configured sentinel filter regression proves no external filter command runs.
- The resulting publication passes `inspect_publication` and same-authority restore with the exact original attachment bytes.
- Focused publication, inspection, and restore tests pass, followed by repository-required fast and lint checks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Hardened `GitRunner` so publication and inspection isolate operator Git config (`GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, strip `GIT_CONFIG_COUNT`/`GIT_CONFIG_PARAMETERS`/`GIT_ATTR_SOURCE`) and write `$GIT_DIR/info/attributes` unsetting text/eol/crlf/ident/filter conversions. `core.attributesFile=/dev/null` is not enough; `attr.tree` still reads worktree attributes on Git 2.43.
- Added include-policy regressions with `artifacts/files/.gitattributes` (`payload.txt text filter=orbit-sentinel`) and a six-byte CRLF payload covering committed blob bytes, manifest SHA-256, inspect worktree bytes, and same-authority restore, plus a poisoned global sentinel filter that must not run.
Assessment: Scoped to the shared publication Git runner; publish and inspect both consume it. Attachment checksum verification was not weakened.
Strategic decisions: Used `$GIT_DIR/info/attributes` rather than `attr.tree=` or replacing `git add` with `hash-object`, because Git 2.43 still applies worktree attributes during add/checkout when `attr.tree` is empty/invalid, and `info/attributes` has highest precedence while keeping the existing add/checkout flow.
Deviations from original plan: Appended `file:crates/orbit-store/src/workflow/task/tests/mod.rs` and `file:crates/orbit-store/src/workflow/task/tests/restore.rs` to context_files for shared test helpers and the restore-byte criterion.
Validation: `cargo test -p orbit-store --lib workflow::task::tests` (57 passed); `make ci-fast`; `make ci-lint`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11109-6a93bbe0`
- Behind base: 0
- Ahead of base: 1