### PR TITLE
Prefix filed CI-failure task titles with [ci-failure-sweep] and file them to the system crew

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -51,6 +51,15 @@ const SUPPORTED_SCHEMA_VERSION: u64 = 1;
 pub(crate) const CI_FAILURE_TAG: &str = "ci-failure-sweep";
 /// Prefix of the dedupe tag, completed by the failure key.
 pub(crate) const CI_FAILURE_KEY_TAG_PREFIX: &str = "ci-failure:";
+/// Title prefix on every task this step files, so a sweep-filed task is
+/// identifiable in a backlog listing without reading its tags.
+const CI_FAILURE_SWEEP_TITLE_PREFIX: &str = "[ci-failure-sweep] ";
+/// The system crew name. Filed tasks belong on the system lane, matching the
+/// shipped `ci-failure-remediation` auto-task — but this is a plain default,
+/// not a hard-coded assumption that the lane is configured: a workspace whose
+/// crew roster has no `system` entry still gets its task filed, just without
+/// a crew set.
+const SYSTEM_CREW: &str = "system";
 
 const DEFAULT_MAX_TASKS: u64 = 5;
 const MAX_MAX_TASKS: u64 = 20;
@@ -137,6 +146,14 @@ pub(crate) fn file_ci_failure_tasks(
     // Two clusters in one snapshot can share a failure key when the same root
     // cause was tested at two commits. The first filing closes the second.
     let mut filed_keys: BTreeSet<String> = BTreeSet::new();
+    // Probed once per sweep rather than assumed: a workspace whose crew
+    // roster has no `system` entry still needs filing to succeed, degrading
+    // the same way any other task with an unrecognized crew does instead of
+    // failing the sweep.
+    let system_crew = runtime
+        .validate_crew_name(Some(SYSTEM_CREW))
+        .is_ok()
+        .then(|| SYSTEM_CREW.to_string());
 
     for cluster in &clusters {
         if let Some(task_id) = open_task_for_key(runtime, &cluster.failure_key)? {
@@ -183,6 +200,7 @@ pub(crate) fn file_ci_failure_tasks(
             // Deliberately empty: the evidence is already in the description,
             // so the task ships on the ordinary agent baseline.
             required_tools: Vec::new(),
+            crew: system_crew.clone(),
             priority: TaskPriority::High,
             complexity: TaskComplexity::Unassessed,
             task_type: Some(TaskType::Bug),
@@ -249,7 +267,12 @@ impl FailureCluster {
             ("", step) => format!("{} / {step}", self.workflow),
             (job, step) => format!("{} / {job} / {step}", self.workflow),
         };
-        truncate_chars(&format!("Fix red CI: {where_}"), 120)
+        // Cap the body, not the whole string, so a long workflow/job/step
+        // never eats into the prefix and the final title still respects the
+        // existing 120-character bound.
+        let body_budget = 120usize.saturating_sub(CI_FAILURE_SWEEP_TITLE_PREFIX.chars().count());
+        let body = truncate_chars(&format!("Fix red CI: {where_}"), body_budget);
+        format!("{CI_FAILURE_SWEEP_TITLE_PREFIX}{body}")
     }
 
     fn acceptance_criteria(&self) -> Vec<String> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -8,6 +8,7 @@ use orbit_engine::RuntimeHost;
 use orbit_tools::ToolContext;
 use orbit_types::task::TaskStatus;
 use serde_json::{Value, json};
+use tempfile::tempdir;
 
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
@@ -89,6 +90,32 @@ fn filed_task_ids(output: &Value) -> Vec<String> {
         .iter()
         .map(|entry| entry["task_id"].as_str().expect("task id").to_string())
         .collect()
+}
+
+/// A workspace whose crew roster has no `system` entry: an explicit `[crews]`
+/// table naming only `sol`, with `workflow.system_crew` pointed at a name that
+/// resolves to nothing so the usual `system`-aliasing fallback does not kick
+/// in either.
+fn runtime_without_system_crew() -> (tempfile::TempDir, OrbitRuntime) {
+    let root = tempdir().expect("create tempdir");
+    let global = root.path().join("home/.orbit");
+    let workspace = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global orbit dir");
+    std::fs::create_dir_all(&workspace).expect("workspace orbit dir");
+    std::fs::write(
+        workspace.join("config.toml"),
+        r#"[workflow]
+default_crew = "sol"
+system_crew = "not-a-real-crew"
+
+[crews.sol]
+provider = "codex"
+model = "gpt-5.6-sol"
+"#,
+    )
+    .expect("write crew config with no system entry");
+    let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("build runtime");
+    (root, runtime)
 }
 
 #[test]
@@ -329,6 +356,104 @@ fn a_listed_but_uninvestigated_failure_is_not_filed_as_an_evidence_free_task() {
 
     assert_eq!(output["clusters"], json!(0));
     assert_eq!(output["outcome"], json!("no_current_failure"));
+}
+
+#[test]
+fn a_filed_task_title_carries_the_sweep_prefix_and_the_system_crew() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = "ci\ttest\t2026-08-30T01:00:00Z assertion failed: left == right\n";
+
+    let output = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "ci",
+            "test (ubuntu)",
+            "cargo test",
+            log,
+            CHECKOUT,
+        )])}),
+    );
+
+    let task_id = filed_task_ids(&output)
+        .first()
+        .cloned()
+        .expect("one filed task");
+    let task = runtime.get_task(&task_id).expect("read filed task");
+
+    assert!(
+        task.title
+            .starts_with("[ci-failure-sweep] Fix red CI: ci / test (ubuntu) / cargo test"),
+        "title must carry the sweep prefix followed by the existing rendering: {}",
+        task.title
+    );
+    assert_eq!(task.crew.as_deref(), Some("system"));
+}
+
+#[test]
+fn an_over_long_cluster_yields_an_intact_prefix_within_the_existing_bound() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let long_workflow = "w".repeat(300);
+    let log = "ci\tbuild\t2026-08-30T01:00:00Z error: boom\n";
+
+    let output = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            &long_workflow,
+            "build",
+            "cargo build",
+            log,
+            CHECKOUT,
+        )])}),
+    );
+
+    let task_id = filed_task_ids(&output)
+        .first()
+        .cloned()
+        .expect("one filed task");
+    let task = runtime.get_task(&task_id).expect("read filed task");
+
+    assert!(
+        task.title.starts_with("[ci-failure-sweep] Fix red CI: "),
+        "prefix must survive truncation intact: {}",
+        task.title
+    );
+    assert!(
+        task.title.chars().count() <= 121,
+        "title must still respect the existing length bound: {} chars",
+        task.title.chars().count()
+    );
+}
+
+#[test]
+fn filing_still_succeeds_in_a_workspace_with_no_system_crew_entry() {
+    let (_root, runtime) = runtime_without_system_crew();
+    assert!(
+        runtime.validate_crew_name(Some("system")).is_err(),
+        "fixture must genuinely lack a resolvable system crew"
+    );
+    let log = "ci\tbuild\t2026-08-30T01:00:00Z error: expected 3 arguments, found 2\n";
+
+    let output = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "ci",
+            "build",
+            "cargo build",
+            log,
+            CHECKOUT,
+        )])}),
+    );
+
+    assert_eq!(output["outcome"], json!("current_failures"));
+    let task_id = filed_task_ids(&output)
+        .first()
+        .cloned()
+        .expect("filing still succeeds without a system crew");
+    let task = runtime.get_task(&task_id).expect("read filed task");
+    assert_eq!(task.crew, None);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11112](https://orbit-cli.com/tasks/ORB-11112) — Prefix filed CI-failure task titles with [ci-failure-sweep] and file them to the system crew

### Description

Follow-up to ORB-11107 (done). Two small changes to what `file_ci_failure_tasks` writes when it mints a task from a red-CI cluster. Nothing else about the sweep changes.

Both edits are in `FailureCluster`/the `add_task` call in
`crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs`.

## 1. Title prefix

Every filed task's title is prefixed with `[ci-failure-sweep] `, so a sweep-filed
task is identifiable in a backlog listing without reading its tags.

Today `FailureCluster::title()` (around line 245) renders
`Fix red CI: <workflow> / <job> / <step>` and truncates the whole thing to 120
characters. After this change it renders
`[ci-failure-sweep] Fix red CI: <workflow> / <job> / <step>`.

The prefix must survive truncation: apply the 120-character cap to the
workflow/job/step part so the prefix is always intact and the cap still bounds
the final string. A cluster with a very long workflow name must not produce a
title with a half-eaten prefix, and must not blow past the existing bound
either.

## 2. Crew

The `add_task` call currently leaves `crew` unset, so filed tasks inherit the
workspace default crew (`sol` in `ws_orbit`). Set `crew: Some("system")` instead
— these are machine-filed chores and belong on the system lane, matching the
shipped `ci-failure-remediation` auto-task, which already uses `crew: system`.

Keep this a plain default, not a hard-coded assumption about the deployment:
filing must still succeed in a workspace whose crew roster has no `system`
entry, degrading the same way any other task with an unrecognized crew does
rather than failing the sweep.

## Not in scope

- No change to clustering, dedupe, the failure key, the tag set
  (`CI_FAILURE_TAG`, the `failure_key` tag, `github-actions`), the description
  body, acceptance criteria, priority, status, type, or `required_tools`
  (which stays empty).
- No change to `collect_ci_evidence`, `ci_failure_sweep_pipeline`, or the
  `ci_failure_sweep` routine — including its `enabled: false` default.
- Do not touch the shipped `ci-failure-remediation` auto-task.

### Acceptance Criteria

- Tasks filed by `file_ci_failure_tasks` have titles beginning with the literal `[ci-failure-sweep] `, followed by the existing `Fix red CI: ...` rendering.
- The prefix is never truncated: a cluster with an over-long workflow/job/step still yields an intact `[ci-failure-sweep] ` prefix, and the title still respects the existing length bound.
- Filed tasks carry `crew: system`, and filing still succeeds in a workspace whose crew roster has no `system` entry.
- Tests in `v2_host/tests/ci_failure_tasks.rs` cover the prefix, the truncation case, and the crew assignment.
- Nothing else about the filed task changes: tags, failure key, dedupe, description, acceptance criteria, priority, status, type, and the empty `required_tools` are all unchanged, and the routine still seeds `enabled: false`.
- The repository's documented pre-handoff gate passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented both changes in `crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs`, scoped to the two listed context files only.

1. Title prefix: `FailureCluster::title()` now applies the existing 120-char cap to the `Fix red CI: <workflow>/<job>/<step>` body only, then prepends the constant `[ci-failure-sweep] ` prefix. This guarantees the prefix is always intact (never truncated) while the overall title still respects the pre-existing bound (max 121 chars, matching the pre-existing off-by-one from the truncation ellipsis).

2. Crew: added `SYSTEM_CREW = "system"`. Before the filing loop, `file_ci_failure_tasks` probes `runtime.validate_crew_name(Some("system"))` once; if it resolves, `crew: Some("system")` is passed to every `add_task` call in that sweep, otherwise `crew: None` (task falls back to the workspace's ordinary default crew, exactly as before this change). This avoids hard-coding that the `system` crew is configured — filing still succeeds in a workspace whose registry has no `system` entry, since `add_task`'s `validate_crew_name` would otherwise hard-error on an unresolvable crew name.

Tests added in `crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs`:
- `a_filed_task_title_carries_the_sweep_prefix_and_the_system_crew` — prefix + rendering + crew on the ordinary path.
- `an_over_long_cluster_yields_an_intact_prefix_within_the_existing_bound` — 300-char workflow name still yields an intact prefix and a bounded title.
- `filing_still_succeeds_in_a_workspace_with_no_system_crew_entry` — new helper `runtime_without_system_crew()` builds a workspace with an explicit `[crews.sol]`-only registry and `workflow.system_crew = "not-a-real-crew"` (defeating the existing `alias_system_crew` fallback), asserts `validate_crew_name("system")` genuinely fails there, then asserts the sweep still files a task with `crew: None`.

Nothing else changed: tags, failure_key/cluster_key, dedupe, description body, acceptance criteria, priority, status, task_type, and empty `required_tools` are untouched; did not touch `collect_ci_evidence`, `ci_failure_sweep_pipeline`, the `ci_failure_sweep` routine (`enabled: false` default untouched), or the shipped `ci-failure-remediation` auto-task.

Validation: `cargo test -p orbit-core --lib` (832 passed, including the 11 in this module), `make ci-fast`, and `make ci-lint` all pass. No scope expansion beyond the two context files was needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11112-6a93c02f`
- Behind base: 0
- Ahead of base: 1