### PR TITLE
CI-failure tasks carry log preamble instead of the failure, and sign themselves off the wrong line

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -246,6 +246,11 @@ struct FailureCluster {
     step: String,
     tested_commit: String,
     signature: String,
+    /// True when `signature` is the failing step name because no error line
+    /// survived in the excerpt. The description must label that as a fallback
+    /// rather than a captured diagnostic; collapsing every distinct failure of
+    /// the step into one `failure_key` is the weaker identity, not a quote.
+    signature_is_step_fallback: bool,
     log_excerpt: String,
     log_truncated: bool,
     runs: Vec<Value>,
@@ -315,10 +320,18 @@ impl FailureCluster {
             "- Commit the runner actually checked out: `{}`\n",
             display(&self.tested_commit)
         ));
-        out.push_str(&format!(
-            "- Normalized error signature (the dedupe identity, not a quote): `{}`\n",
-            display(&self.signature)
-        ));
+        if self.signature_is_step_fallback {
+            out.push_str(&format!(
+                "- Normalized error signature (step-name fallback — no error line was captured; \
+                 the dedupe identity, not a quote): `{}`\n",
+                display(&self.signature)
+            ));
+        } else {
+            out.push_str(&format!(
+                "- Normalized error signature (the dedupe identity, not a quote): `{}`\n",
+                display(&self.signature)
+            ));
+        }
         if let Some(repository) = evidence.get("repository").and_then(Value::as_object) {
             if let Some(full_name) = repository.get("full_name").and_then(Value::as_str) {
                 out.push_str(&format!("- Repository: `{full_name}`\n"));
@@ -355,10 +368,31 @@ impl FailureCluster {
                 "_No log excerpt was captured for this cluster. Reproduce the failing job's \
                  command locally instead of guessing from the step name._\n",
             );
+            let relevant = relevant_log_query_errors(evidence, &self.runs);
+            if !relevant.is_empty() {
+                out.push('\n');
+                for error in relevant {
+                    out.push_str(&format!(
+                        "- `{}` for run `{}`: {}\n",
+                        display(&value_string(error, "query")),
+                        display(&value_string(error, "run_id")),
+                        truncate_chars(&value_string(error, "error"), 300),
+                    ));
+                }
+            }
         } else {
-            out.push_str("```\n");
-            out.push_str(&truncate_bytes(&self.log_excerpt, DESCRIPTION_LOG_BYTES));
-            out.push_str("\n```\n");
+            let excerpt = render_failed_step_excerpt(&self.log_excerpt, DESCRIPTION_LOG_BYTES);
+            if !excerpt.body.trim().is_empty() {
+                out.push_str("```\n");
+                out.push_str(&excerpt.body);
+                out.push_str("\n```\n");
+            }
+            if !excerpt.has_anchor {
+                out.push_str(
+                    "\n_No error anchor was present in the retained excerpt; the env/with dump \
+                     is omitted rather than shown as evidence._\n",
+                );
+            }
             if self.log_truncated {
                 out.push_str(
                     "\n_The excerpt above was truncated at collection. Head and tail are kept; \
@@ -515,8 +549,8 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
         let signature = error_signature(&log_excerpt, &step);
         let tested_commit = tested_commit(failure);
 
-        let failure_key = digest(&[&workflow, &job, &step, &signature]);
-        let cluster_key = digest(&[&workflow, &job, &step, &signature, &tested_commit]);
+        let failure_key = digest(&[&workflow, &job, &step, &signature.text]);
+        let cluster_key = digest(&[&workflow, &job, &step, &signature.text, &tested_commit]);
 
         let cluster = grouped.entry(cluster_key.clone()).or_insert_with(|| {
             order.push(cluster_key.clone());
@@ -527,7 +561,8 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
                 job,
                 step,
                 tested_commit,
-                signature,
+                signature: signature.text,
+                signature_is_step_fallback: signature.step_fallback,
                 log_excerpt,
                 log_truncated: failure
                     .get("log_truncated")
@@ -592,17 +627,231 @@ const ERROR_MARKERS: &[&str] = &[
 /// Reruns of the same regression differ in timestamps, durations, run numbers,
 /// and paths under a run-specific temp directory. Normalizing those away is
 /// what lets an hourly sweep recognize the same root cause instead of filing it
-/// again every hour. With no marker line the step name alone is the signature —
-/// weaker, but stable, and still scoped by workflow and job.
-fn error_signature(log_excerpt: &str, step: &str) -> String {
-    for line in log_excerpt.lines() {
-        let payload = log_payload(line);
-        let lowered = payload.to_ascii_lowercase();
-        if ERROR_MARKERS.iter().any(|marker| lowered.contains(marker)) {
-            return normalize_signature(&lowered);
+/// again every hour. Prefer an `##[error]`-annotated line over an unanchored
+/// marker substring, and never sign off runner-bookkeeping (checkout, group
+/// headers, `env:`/`with:` dumps). With no usable line the step name alone is
+/// the signature — weaker, but stable, and still scoped by workflow and job.
+fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
+    let lines = classify_log_lines(log_excerpt);
+    for (kind, line) in &lines {
+        if *kind == LineKind::ErrorAnnotated {
+            return ErrorSignature {
+                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                step_fallback: false,
+            };
         }
     }
-    normalize_signature(&step.to_ascii_lowercase())
+    for (kind, line) in &lines {
+        if *kind == LineKind::Marker {
+            return ErrorSignature {
+                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                step_fallback: false,
+            };
+        }
+    }
+    ErrorSignature {
+        text: normalize_signature(&step.to_ascii_lowercase()),
+        step_fallback: true,
+    }
+}
+
+struct ErrorSignature {
+    text: String,
+    step_fallback: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LineKind {
+    RunCommand,
+    ParamDump,
+    EndGroup,
+    ErrorAnnotated,
+    Marker,
+    Bookkeeping,
+    Content,
+}
+
+impl LineKind {
+    fn skip_from_excerpt(self) -> bool {
+        matches!(self, Self::ParamDump | Self::EndGroup | Self::Bookkeeping)
+    }
+}
+
+struct FailedStepExcerpt {
+    body: String,
+    has_anchor: bool,
+}
+
+/// Command line plus the failure region, never a head-biased env dump.
+///
+/// The `##[group]Run …` line is the command the runner executed and is the
+/// most actionable fact in the log. The `env:` / `with:` dump that follows it
+/// is never the evidence. The rest of the block is a bounded window around
+/// an error anchor, capped at `max_bytes` on that region rather than the
+/// log head.
+fn render_failed_step_excerpt(log: &str, max_bytes: usize) -> FailedStepExcerpt {
+    let lines = classify_log_lines(log);
+    let command = lines
+        .iter()
+        .find(|(kind, _)| *kind == LineKind::RunCommand)
+        .map(|(_, line)| *line);
+
+    let anchor = lines
+        .iter()
+        .position(|(kind, _)| *kind == LineKind::ErrorAnnotated)
+        .or_else(|| lines.iter().position(|(kind, _)| *kind == LineKind::Marker));
+
+    let Some(anchor_idx) = anchor else {
+        return FailedStepExcerpt {
+            body: command.unwrap_or("").to_string(),
+            has_anchor: false,
+        };
+    };
+
+    const LINES_BEFORE: usize = 24;
+    const LINES_AFTER: usize = 12;
+    let kept: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, (kind, _))| !kind.skip_from_excerpt())
+        .map(|(idx, _)| idx)
+        .collect();
+    let anchor_in_kept = kept.iter().position(|idx| *idx == anchor_idx).unwrap_or(0);
+    let start = anchor_in_kept.saturating_sub(LINES_BEFORE);
+    let end = (anchor_in_kept + 1 + LINES_AFTER).min(kept.len());
+    let mut window: Vec<&str> = kept[start..end].iter().map(|idx| lines[*idx].1).collect();
+    if let Some(command) = command
+        && !window.contains(&command)
+    {
+        window.insert(0, command);
+    }
+    let joined = window.join("\n");
+    FailedStepExcerpt {
+        body: cap_bytes_around_line(&joined, lines[anchor_idx].1, max_bytes),
+        has_anchor: true,
+    }
+}
+
+fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
+    let mut in_param_block = false;
+    let mut out = Vec::new();
+    for line in log.lines() {
+        let payload = log_payload(line);
+        let trimmed = payload.trim();
+        let lowered = trimmed.to_ascii_lowercase();
+        let indented = payload.starts_with(' ') || payload.starts_with('\t');
+        let kind = if is_run_command_payload(trimmed) {
+            in_param_block = false;
+            LineKind::RunCommand
+        } else if lowered.contains("##[endgroup]") {
+            in_param_block = false;
+            LineKind::EndGroup
+        } else if lowered == "env:" || lowered == "with:" {
+            in_param_block = true;
+            LineKind::ParamDump
+        } else if in_param_block && (indented || trimmed.is_empty()) {
+            LineKind::ParamDump
+        } else {
+            in_param_block = false;
+            if lowered.contains("##[error]") {
+                LineKind::ErrorAnnotated
+            } else if is_runner_bookkeeping(&lowered) || lowered.contains("##[group]") {
+                LineKind::Bookkeeping
+            } else if ERROR_MARKERS.iter().any(|marker| lowered.contains(marker)) {
+                LineKind::Marker
+            } else {
+                LineKind::Content
+            }
+        };
+        out.push((kind, line));
+    }
+    out
+}
+
+fn is_run_command_payload(payload: &str) -> bool {
+    let lowered = payload.trim().to_ascii_lowercase();
+    lowered.starts_with("##[group]run ") || lowered == "##[group]run"
+}
+
+fn is_runner_bookkeeping(lowered: &str) -> bool {
+    lowered.starts_with("head is now at") || lowered.starts_with("syncing repository")
+}
+
+/// Cap `text` at `max_bytes` while keeping `anchor_line`, not the head.
+fn cap_bytes_around_line(text: &str, anchor_line: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let Some(anchor_start) = text.find(anchor_line) else {
+        return truncate_bytes(text, max_bytes);
+    };
+    let anchor_len = anchor_line.len();
+    if anchor_len >= max_bytes {
+        return truncate_bytes(anchor_line, max_bytes);
+    }
+    let extra = max_bytes - anchor_len;
+    let want_before = extra * 2 / 3;
+    let mut start = anchor_start.saturating_sub(want_before);
+    while start > 0 && !text.is_char_boundary(start) {
+        start -= 1;
+    }
+    if start > 0
+        && let Some(newline) = text[start..anchor_start].find('\n')
+    {
+        start += newline + 1;
+    }
+    let mut end = start.saturating_add(max_bytes).min(text.len());
+    if end < anchor_start + anchor_len {
+        end = (anchor_start + anchor_len).min(text.len());
+        start = end.saturating_sub(max_bytes);
+        while start > 0 && !text.is_char_boundary(start) {
+            start -= 1;
+        }
+    }
+    while end < text.len() && !text.is_char_boundary(end) {
+        end += 1;
+    }
+    if end < text.len()
+        && let Some(newline) = text[anchor_start + anchor_len..end].rfind('\n')
+    {
+        end = anchor_start + anchor_len + newline;
+    }
+    let mut out = String::new();
+    if start > 0 {
+        out.push_str("[...]\n");
+    }
+    out.push_str(&text[start..end]);
+    if end < text.len() {
+        out.push_str(&format!(
+            "\n[... truncated at {max_bytes} B for the task description; the full excerpt is in \
+             the sweep run's step output ...]"
+        ));
+    }
+    out
+}
+
+/// `query_errors` entries for this cluster's failed-step log fetch, if any.
+fn relevant_log_query_errors<'a>(evidence: &'a Value, runs: &[Value]) -> Vec<&'a Value> {
+    let run_ids: BTreeSet<String> = runs
+        .iter()
+        .map(|run| value_string(run, "run_id"))
+        .filter(|id| !id.is_empty())
+        .collect();
+    evidence
+        .get("query_errors")
+        .and_then(Value::as_array)
+        .map(|errors| {
+            errors
+                .iter()
+                .filter(|error| {
+                    let query = value_string(error, "query");
+                    let run_id = value_string(error, "run_id");
+                    matches!(query.as_str(), "run_logs" | "run_logs_all")
+                        && run_ids.contains(&run_id)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Strip the `job<TAB>step<TAB>timestamp ` columns a runner log carries.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -488,3 +488,264 @@ fn the_filing_cap_reports_what_it_left_unfiled() {
         "a cap must be reported, never a silent truncation"
     );
 }
+
+fn signature_line(description: &str) -> String {
+    description
+        .lines()
+        .find(|line| line.contains("Normalized error signature"))
+        .expect("signature line")
+        .to_string()
+}
+
+fn excerpt_block(description: &str) -> String {
+    let start = description
+        .find("## Failed-step log excerpt")
+        .expect("excerpt heading");
+    let rest = &description[start..];
+    let end = rest.find("\n## ").unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// Realistic GitHub failed-step log: `##[group]Run …`, a large `env:` dump,
+/// then the trailing compiler diagnostic. Each env line is ~90 bytes so 50
+/// lines already sit past the 4,000-byte description budget.
+fn realistic_github_step_log(command: &str, env_lines: usize, trailing: &str) -> String {
+    let prefix = |msg: &str| format!("build\tRun go build\t2026-08-30T01:00:00Z {msg}");
+    let mut out = String::new();
+    out.push_str(&prefix(&format!("##[group]Run {command}")));
+    out.push('\n');
+    out.push_str(&prefix("env:"));
+    out.push('\n');
+    for index in 0..env_lines {
+        out.push_str(&prefix(&format!("  VAR_{index}: {}", "x".repeat(60))));
+        out.push('\n');
+    }
+    out.push_str(&prefix("##[endgroup]"));
+    out.push('\n');
+    out.push_str(trailing);
+    if !trailing.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn dani_10111_style_log(commit_subject: &str, error: Option<&str>) -> String {
+    let prefix = |msg: &str| format!("Vulnerability scan\tCheckout\t2026-08-30T01:00:00Z {msg}\n");
+    let mut out = String::new();
+    out.push_str(&prefix("##[group]Run actions/checkout@v4"));
+    out.push_str(&prefix("with:"));
+    out.push_str(&prefix("  repository: acme/monodev"));
+    out.push_str(&prefix("  token: ***"));
+    out.push_str(&prefix("env:"));
+    out.push_str(&prefix("  GITHUB_TOKEN: ***"));
+    out.push_str(&prefix("##[endgroup]"));
+    out.push_str(&prefix("Syncing repository: acme/monodev"));
+    out.push_str(&prefix(&format!("HEAD is now at e5c1dc9 {commit_subject}")));
+    if let Some(error) = error {
+        out.push_str(&prefix(error));
+    }
+    out
+}
+
+fn filed_description(runtime: &OrbitRuntime, log: &str) -> (Value, String) {
+    let output = file(
+        runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "ci",
+            "build",
+            "cargo build",
+            log,
+            CHECKOUT,
+        )])}),
+    );
+    let task_id = filed_task_ids(&output)
+        .first()
+        .cloned()
+        .expect("one filed task");
+    let task = runtime.get_task(&task_id).expect("read filed task");
+    (output, task.description)
+}
+
+#[test]
+fn excerpt_keeps_the_run_command_and_trailing_error_not_the_env_dump() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let trailing = concat!(
+        "build\tRun go build\t2026-08-30T01:00:00Z ##[command]go build ./...\n",
+        "build\tRun go build\t2026-08-30T01:00:00Z ./main.go:10:2: undefined: Foo\n",
+        "build\tRun go build\t2026-08-30T01:00:00Z ##[error]Process completed with exit code 1.\n",
+    );
+    let log = realistic_github_step_log("go build ./...", 80, trailing);
+    let error_at = log
+        .find("undefined: Foo")
+        .expect("fixture must contain the trailing error");
+    assert!(
+        error_at > 4_000,
+        "fixture must place the error past the 4,000-byte description budget, at {error_at}"
+    );
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let excerpt = excerpt_block(&description);
+    assert!(
+        excerpt.contains("##[group]Run go build ./..."),
+        "excerpt must keep the runner command:\n{excerpt}"
+    );
+    assert!(
+        excerpt.contains("undefined: Foo"),
+        "excerpt must carry the trailing error, not a head window:\n{excerpt}"
+    );
+    assert!(
+        excerpt.contains("##[error]Process completed with exit code 1."),
+        "excerpt must carry the annotated error:\n{excerpt}"
+    );
+    assert!(
+        !excerpt.contains("VAR_0:"),
+        "excerpt must drop the env dump:\n{excerpt}"
+    );
+}
+
+#[test]
+fn excerpt_without_an_error_anchor_says_so_and_still_shows_the_command() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = realistic_github_step_log("go build ./...", 80, "");
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let excerpt = excerpt_block(&description);
+    assert!(
+        excerpt.contains("##[group]Run go build ./..."),
+        "command line must still be shown:\n{excerpt}"
+    );
+    assert!(
+        excerpt.contains("No error anchor was present in the retained excerpt"),
+        "missing anchor must be stated, not implied by dumping env:\n{excerpt}"
+    );
+    assert!(
+        !excerpt.contains("VAR_0:"),
+        "env dump must not be presented as evidence:\n{excerpt}"
+    );
+}
+
+#[test]
+fn error_signature_prefers_an_annotated_error_over_a_checkout_commit_message() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = dani_10111_style_log(
+        "chore: add ci failure sweep routine",
+        Some("##[error]GO-2024-2611: yaml: vulnerable dependency"),
+    );
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let signature = signature_line(&description);
+    assert!(
+        !signature.to_ascii_lowercase().contains("head is now at"),
+        "checkout bookkeeping must not become the signature: {signature}"
+    );
+    assert!(
+        signature.contains("yaml") && signature.contains("vulnerable"),
+        "signature must come from the ##[error] line: {signature}"
+    );
+}
+
+#[test]
+fn checkout_commit_message_containing_failure_is_not_the_signature() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = dani_10111_style_log("chore: add ci failure sweep routine", None);
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let signature = signature_line(&description);
+    assert!(
+        signature.contains("step-name fallback"),
+        "bookkeeping-only excerpt must label the step-name fallback: {signature}"
+    );
+    assert!(
+        !signature.to_ascii_lowercase().contains("head is now at"),
+        "HEAD is now at <hex> chore: … failure … must not be chosen: {signature}"
+    );
+}
+
+#[test]
+fn same_failure_under_a_different_commit_message_reuses_the_failure_key() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let first_log = dani_10111_style_log(
+        "chore: add ci failure sweep routine",
+        Some("##[error]GO-2024-2611: yaml: vulnerable dependency"),
+    );
+    let second_log = dani_10111_style_log(
+        "chore: mention failure in a later commit",
+        Some("##[error]GO-2024-2611: yaml: vulnerable dependency"),
+    );
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10, "ci", "build", "cargo build", &first_log, CHECKOUT,
+        )])}),
+    );
+    let task_id = filed_task_ids(&first)
+        .first()
+        .cloned()
+        .expect("first sweep files one task");
+    let first_key = first["filed"][0]["failure_key"].clone();
+
+    let second = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            11, "ci", "build", "cargo build", &second_log, NEXT_HEAD,
+        )])}),
+    );
+
+    assert_eq!(second["filed_count"], json!(0));
+    let skipped = second["skipped_existing"].as_array().expect("skipped");
+    assert!(
+        skipped.iter().any(|entry| {
+            entry["task_id"] == json!(task_id.clone()) && entry["failure_key"] == first_key
+        }),
+        "skip_if_open must suppress the second filing under a different commit message: {skipped:?}"
+    );
+}
+
+#[test]
+fn empty_excerpt_surfaces_the_matching_log_query_error() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut missing_log = failure(10, "ci", "build", "Run CI guardrails", "", CHECKOUT);
+    missing_log["log_excerpt"] = json!("");
+    let mut evidence = snapshot(vec![missing_log]);
+    evidence["query_errors"] = json!([
+        {
+            "query": "run_logs",
+            "run_id": "10",
+            "error": "HTTP 404: Not Found — logs for this run are no longer available"
+        },
+        {
+            "query": "run_list",
+            "branch": "other",
+            "error": "unrelated list failure"
+        }
+    ]);
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+    let task_id = filed_task_ids(&output)
+        .first()
+        .cloned()
+        .expect("one filed task");
+    let description = runtime.get_task(&task_id).expect("read").description;
+    let excerpt = excerpt_block(&description);
+    assert!(
+        excerpt.contains("No log excerpt was captured"),
+        "empty excerpt must still be stated:\n{excerpt}"
+    );
+    assert!(
+        excerpt.contains("run_logs")
+            && excerpt.contains("10")
+            && excerpt.contains("logs for this run are no longer available"),
+        "relevant query_errors entry must sit next to the empty excerpt:\n{excerpt}"
+    );
+    assert!(
+        !excerpt.contains("unrelated list failure"),
+        "unrelated query errors must not be inlined into this cluster's excerpt:\n{excerpt}"
+    );
+    let signature = signature_line(&description);
+    assert!(
+        signature.contains("step-name fallback"),
+        "step-name signature must be labeled as a fallback: {signature}"
+    );
+}

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -506,6 +506,16 @@ fn investigate<Q: CiQueries + ?Sized>(
             failure["actual_checkout_shas"] = json!(log.checkout_commits);
             failure["checkout_evidence"] = json!(log.checkout_evidence);
             failure["checkout_evidence_scope"] = json!("failed");
+            // `gh` can succeed with empty stdout when the run's logs are gone
+            // (retention). That is not a captured excerpt; record it so the
+            // filed task can say why the block is empty.
+            if log.text.trim().is_empty() {
+                query_errors.push(json!({
+                    "query": "run_logs",
+                    "run_id": run_id,
+                    "error": "query returned no log text",
+                }));
+            }
         }
         Err(error) => {
             query_errors

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -216,3 +216,40 @@ fn integration_and_release_on_the_same_branch_are_scanned_once() {
     assert_eq!(evidence["heads"].as_array().expect("heads").len(), 1);
     assert_eq!(evidence["heads"][0]["kind"], json!("integration"));
 }
+
+#[test]
+fn empty_failed_step_log_is_recorded_in_query_errors() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(
+            "topic",
+            vec![vec![run(
+                10,
+                "ci",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T01:00:00Z",
+            )]],
+        )
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+    assert_eq!(failure["log_excerpt"], json!(""));
+    let errors = evidence["query_errors"].as_array().expect("query_errors");
+    assert!(
+        errors.iter().any(|error| {
+            error["query"] == json!("run_logs")
+                && error["run_id"] == json!("10")
+                && error["error"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("no log text"))
+        }),
+        "empty failed-step log must be a query error, got {errors:?}"
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11113](https://orbit-cli.com/tasks/ORB-11113) — CI-failure tasks carry log preamble instead of the failure, and sign themselves off the wrong line

### Description

The `ci_failure_sweep` routine shipped by ORB-11107 is live and filing tasks, and the filed tasks do not contain their own failure. Three defects, all observed in tasks already filed and already dispatched.

## Observed

- `DANI-10110` (monodev) — the entire `Failed-step log excerpt` block is the CodeQL `##[group]Run go build ./...` env-variable dump. The build error is not in it.
- `DANI-10111` (monodev) — the entire excerpt is the `actions/checkout` parameter dump. Its recorded signature is `head is now at <hex> chore: add ci failure sweep routine`.
- `ORB-11111` (orbit) — no excerpt at all, no reason given, signature degraded to the bare step name `run ci guardrails`.

All three were dispatched to an agent, which planned against this evidence. `DANI-10111`'s plan targets the govulncheck action's nested checkout — a guess made from a log excerpt that never showed the failure.

## 1. The excerpt must be the failure, not the head of the log

`FailureCluster::description` renders the excerpt through `truncate_bytes` at `DESCRIPTION_LOG_BYTES` (4,000), and `truncate_bytes` keeps the **first** 4,000 bytes and discards the rest.

Collection already does the right thing: `run_logs` builds a head+tail excerpt at `log_max_bytes` (16,384) and marks the omitted gap (`crates/orbit-tools/src/builtin/github/mod.rs`, the `bytes omitted` path). The description then re-truncates that head-only, throwing away exactly the tail half that holds the error.

A GitHub step log opens with `##[group]Run …` followed by a large `env:`/`with:` dump, so a head-biased 4,000-byte window is *reliably* preamble. This is not an occasional miss; it is the normal case.

The excerpt in the task description should carry **only the failure region** — not a head window, and not the whole log. Anchor on the actual error (an `##[error]` line, a non-zero exit, a panic/assertion) and keep a bounded window of surrounding context. Drop the run/env preamble entirely; it is never the evidence. If no anchor is found inside the retained excerpt, say so explicitly rather than falling back to printing the preamble.

Note the input constraint: by the time the description is built, the middle of the log is already gone (head+tail at 16 KB). Anchoring at collection time, where the full log is available, is acceptable and probably better; anchoring in the description over the retained tail is acceptable too. Either way the rendered block must be the failure.

## 2. `error_signature` matches a bare substring and takes the first hit

`error_signature` walks the excerpt in order and returns the first line whose lowercased payload contains any of `ERROR_MARKERS` (`error`, `failed`, `failure`, `panicked`, `assertion`, `exit code`, `not ok`, `fatal`) as an unanchored substring.

In `DANI-10111` that matched:

```
HEAD is now at e5c1dc9 chore: add ci failure sweep routine
```

— the word `failure` inside a commit message, on a checkout line, in a step that had not failed yet.

This is not cosmetic. `failure_key = digest(workflow, job, step, signature)` and `cluster_key` extends it, so the dedupe identity became a function of a commit message: the next push re-files the same `Vulnerability scan` failure as a new task, and the `skip_if_open` dedupe from ORB-11107 does not catch it.

Prefer a real anchor — an `##[error]`-annotated line first — over an unanchored substring hit anywhere in a line. Do not sign off runner-bookkeeping lines (`HEAD is now at …`, `Syncing repository`, `##[group]Run …`, and the `with:` / `env:` parameter blocks). Keeping the marker list as a fallback is fine; taking the first match in file order without preferring the annotated error is not.

## 3. A failed log fetch is recorded in the snapshot but dropped from the task

When `run_logs` errors, `collect.rs` pushes `{"query": "run_logs", ...}` into `query_errors`, and the snapshot carries it under the `query_errors` key. The task description renders `truncation` but never `query_errors`, so `ORB-11111` says only "No log excerpt was captured for this cluster" with no cause, while the reason sits in the snapshot the description was built from.

Surface the relevant `query_errors` entries in the description when a cluster has no excerpt, so the reader can tell an expired-log fetch from a run that genuinely produced nothing. `ORB-11111`'s run is old enough that log retention is the likely cause — confirm rather than assume.

Relatedly, when `error_signature` falls back to the step name because there was no excerpt, the description should say the signature is a step-name fallback. As written, `run ci guardrails` is presented under the same "Normalized error signature (the dedupe identity...)" heading as a real one, and it silently collapses every distinct failure of that step into one dedupe key.

## Not in scope

- Do not retro-edit `DANI-10110`, `DANI-10111`, or `ORB-11111`. They are in progress; Daniel decides what happens to them.
- No change to clustering inputs beyond the signature itself, to the tag scheme, to `collect_ci_evidence`'s query set or bounds, to the `ci_failure_sweep_pipeline` job, or to the routine's `enabled: false` default.
- Do not raise `log_max_bytes` or `DESCRIPTION_LOG_BYTES` as the fix. The problem is which region is kept, not how much.
- Do not touch the shipped `ci-failure-remediation` auto-task.

### Acceptance Criteria

- The `Failed-step log excerpt` block in a filed task keeps the `##[group]Run …` line naming the command the runner executed, drops the `env:` / `with:` dump that follows it, and carries the failure region — the error and bounded surrounding context. See the correcting comment on this task: the command line is the most actionable fact in the log and must not be stripped with the rest of the preamble.
- A step log whose error lies past the first 4,000 bytes still produces a task description containing that error; a regression test uses a realistic GitHub step log with a large env preamble and a trailing error.
- When no error anchor is present in the retained excerpt, the description says so explicitly instead of rendering the env dump as if it were evidence; the command line is still shown.
- `error_signature` prefers an `##[error]`-annotated line over an unanchored marker substring, and does not sign off runner-bookkeeping lines; a test covers the `HEAD is now at <hex> chore: … failure …` line from DANI-10111 and asserts it is not chosen.
- Because the signature feeds `failure_key`, a repeat of the same failure under a different commit message yields the same failure key, so `skip_if_open` dedupe still suppresses the second filing; a test covers this.
- When a cluster has no excerpt because a log query failed, the description surfaces the relevant `query_errors` entry so the cause is visible, as in ORB-11111.
- A signature that came from the step-name fallback is labeled as a fallback in the description rather than presented as a captured error signature.
- `log_max_bytes` and `DESCRIPTION_LOG_BYTES` are unchanged, and clustering, tags, dedupe semantics, the sweep job, and the routine's `enabled: false` default are all untouched.
- The repository's documented pre-handoff gate passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Failed-step log excerpts now keep the `##[group]Run …` command line, drop `env:`/`with:` dumps, and window around an error anchor (`##[error]` first, then non-bookkeeping marker lines) instead of head-truncating at `DESCRIPTION_LOG_BYTES`.
- When no error anchor is present, the description still shows the command and states that explicitly rather than printing the preamble as evidence.
- `error_signature` prefers `##[error]`-annotated lines, skips runner-bookkeeping (including `HEAD is now at …` commit messages), and the description labels a step-name fallback as such. `failure_key` still hashes workflow/job/step/signature, so the same diagnostic under a different checkout commit message dedupes.
- Empty excerpts inline the cluster-relevant `query_errors` (`run_logs` matching the run id). Collection now records `query returned no log text` when failed-step `run_logs` succeeds with empty stdout (the ORB-11111 shape).
- `log_max_bytes` and `DESCRIPTION_LOG_BYTES` are unchanged. Clustering, tags, sweep job, and the routine `enabled: false` default were not touched.
- Added `file:crates/orbit-engine/src/executor/automation/ci/tests/collect.rs` to context_files for the empty-log query_errors test.

Assessment: Acceptance criteria are covered by new filing tests (realistic >4k env preamble with trailing error, no-anchor message, DANI-10111 checkout-line signature, skip_if_open across commit messages, query_errors + step-name fallback) plus a collect test for empty logs. `make ci-fast` and `make ci-lint` passed.

Strategic decisions: Description-side anchoring over the already-bounded head+tail excerpt, rather than raising byte budgets or changing `bound_log_text`. Collection only gained empty-log recording so a silent successful fetch is visible.

Recommended follow-ups: None required. Already-filed DANI-10110, DANI-10111, and ORB-11111 were left untouched per scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11113-6a93c2b3`
- Behind base: 0
- Ahead of base: 1