### PR TITLE
Align task.show projections with the public task DTO

### DIFF
--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -292,6 +292,13 @@ pub(super) fn task_field_to_json(
             })?,
         ))
         .map_err(|e| OrbitError::Io(e.to_string())),
+        "relations" => serde_json::to_value(resolve_task_relations(
+            task,
+            status_by_id.ok_or_else(|| {
+                OrbitError::Execution("missing task status index for relations".to_string())
+            })?,
+        ))
+        .map_err(|e| OrbitError::Io(e.to_string())),
         "history" => serde_json::to_value(runtime.get_task_history(&task.id)?)
             .map_err(|e| OrbitError::Io(e.to_string())),
         "context_files" => {
@@ -415,6 +422,20 @@ pub(super) fn print_single_task_field(
                 })?,
             ) {
                 println!("{}", dependency);
+            }
+            Ok(())
+        }
+        "relations" => {
+            for relation in resolve_task_relations(
+                task,
+                status_by_id.ok_or_else(|| {
+                    OrbitError::Execution("missing task status index for relations".to_string())
+                })?,
+            ) {
+                println!(
+                    "{}",
+                    serde_json::to_string(&relation).map_err(|e| OrbitError::Io(e.to_string()))?
+                );
             }
             Ok(())
         }

--- a/crates/orbit-cli/src/command/task/tests/show.rs
+++ b/crates/orbit-cli/src/command/task/tests/show.rs
@@ -15,6 +15,9 @@ fn normalize_accepts_ordinary_top_level_fields() {
         "complexity".to_string(),
         "created_at".to_string(),
         "updated_at".to_string(),
+        "relations".to_string(),
+        "job_run_id".to_string(),
+        "external_refs".to_string(),
     ])
     .expect("ordinary top-level fields are projectable");
     assert_eq!(
@@ -28,8 +31,20 @@ fn normalize_accepts_ordinary_top_level_fields() {
             "complexity",
             "created_at",
             "updated_at",
+            "relations",
+            "job_run_id",
+            "external_refs",
         ]
     );
+}
+
+#[test]
+fn normalize_rejects_terminal_with_status_guidance() {
+    let error = normalize_task_show_fields(&["terminal".to_string()])
+        .expect_err("terminal is derived lifecycle state, not a field");
+    let message = error.to_string();
+    assert!(message.contains("use `status`"), "{message}");
+    assert!(message.contains(TASK_SHOW_PROJECTION_FIELDS_CSV));
 }
 
 #[test]

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1857,11 +1857,16 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
             "tags": ["mcp-roundtrip"],
             "crew": "sol",
             "orchestrator": "terra",
+            "relations": [{"type": "related_to", "target": "DK-00042"}],
         }),
     );
     let task_id = created["id"].as_str().expect("task id").to_string();
     assert_eq!(created["title"], "MCP round-trip task");
     assert_eq!(created["status"], "proposed");
+    client.call_tool_ok(
+        "orbit_task_update",
+        json!({"id": task_id, "job_run_id": "jrun-mcp-projection"}),
+    );
 
     let shown = client.call_tool_ok("orbit_task_show", json!({ "id": task_id }));
     assert_eq!(shown["id"], json!(task_id));
@@ -1870,6 +1875,7 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
     assert_eq!(shown["tags"], json!(["mcp-roundtrip"]));
     assert_eq!(shown["crew"], "sol");
     assert_eq!(shown["orchestrator"], "terra");
+    assert_eq!(shown["job_run_id"], "jrun-mcp-projection");
     assert_eq!(
         client.call_tool_ok(
             "orbit_task_show",
@@ -1887,12 +1893,33 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
     assert_eq!(
         client.call_tool_ok(
             "orbit_task_show",
-            json!({ "id": task_id, "fields": ["status", "title", "plan"] }),
+            json!({
+                "id": task_id,
+                "fields": ["status", "relations", "external_refs", "job_run_id"],
+            }),
         ),
         json!({
             "status": "proposed",
-            "title": "MCP round-trip task",
-            "plan": "",
+            "relations": [{
+                "type": "related_to",
+                "target": "DK-00042",
+                "verification": "not verifiable here",
+            }],
+            "external_refs": [],
+            "job_run_id": "jrun-mcp-projection",
+        })
+    );
+    assert_eq!(
+        client.call_tool_ok(
+            "orbit_task_show",
+            json!({ "id": task_id, "field": "relations" }),
+        ),
+        json!({
+            "items": [{
+                "type": "related_to",
+                "target": "DK-00042",
+                "verification": "not verifiable here",
+            }],
         })
     );
 
@@ -1960,6 +1987,51 @@ fn mcp_serve_round_trips_records_against_a_temp_workspace() {
     assert_eq!(
         serde_json::from_slice::<Value>(&tool_run.stdout).expect("tool-run status JSON"),
         json!("proposed")
+    );
+
+    let expected_projection = json!({
+        "status": "proposed",
+        "relations": [{
+            "type": "related_to",
+            "target": "DK-00042",
+            "verification": "not verifiable here",
+        }],
+        "external_refs": [],
+        "job_run_id": "jrun-mcp-projection",
+    });
+    let output = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "task",
+            "show",
+            &task_id,
+            "--json",
+            "--fields",
+            "status,relations,external_refs,job_run_id",
+        ])
+        .output()
+        .expect("show mixed public DTO fields through the CLI");
+    assert_command_succeeded("mixed CLI task-show projection", &output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).expect("mixed CLI projection JSON"),
+        expected_projection
+    );
+
+    let tool_run = McpWorkspace::orbit_command(&workspace.work, &workspace.home)
+        .args([
+            "tool",
+            "run",
+            "orbit.task.show",
+            "--input",
+            &format!(
+                r#"{{"id":"{task_id}","fields":["status","relations","external_refs","job_run_id"]}}"#
+            ),
+        ])
+        .output()
+        .expect("show mixed public DTO fields through orbit tool run");
+    assert_command_succeeded("mixed tool-run task-show projection", &tool_run);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&tool_run.stdout).expect("mixed tool-run projection JSON"),
+        expected_projection
     );
 
     let listed = client.call_tool_ok("orbit_task_list", json!({}));

--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -779,7 +779,7 @@
         "required": false
       },
       {
-        "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution.",
+        "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, parent_id, title, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, created_by, planned_by, implemented_by, status, priority, complexity, type, pr_status, external_refs, relations, source_task_id, job_run_id, crew, orchestrator, created_at, updated_at, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution.",
         "name": "fields",
         "param_type": "string_list",
         "required": false

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -669,7 +669,7 @@
               "type": "string"
             }
           ],
-          "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution."
+          "description": "Optional field projection as a string or array of strings. When set, returns only the requested field(s) as JSON. Valid values: id, parent_id, title, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, created_by, planned_by, implemented_by, status, priority, complexity, type, pr_status, external_refs, relations, source_task_id, job_run_id, crew, orchestrator, created_at, updated_at, comments, history, artifacts. `crew` is execution selection; `orchestrator` is separate orchestration attribution."
         },
         "id": {
           "description": "Globally unique task ID. Resolved through the host task registry by default; a workspace argument is not required.",

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -35,8 +35,8 @@ use orbit_types::record::FrictionStatus;
 use orbit_types::task::{
     Task, TaskComment, TaskPriority, TaskStatus, TaskType, normalize_required_tools,
     normalize_task_dependencies, normalize_task_tags, resolve_task_dependencies,
-    task_dependencies_ready, task_matches_tags, task_show_record_field_json,
-    unknown_task_show_field_message, validate_task_dependencies,
+    resolve_task_relations, task_dependencies_ready, task_matches_tags,
+    task_show_record_field_json, unknown_task_show_field_message, validate_task_dependencies,
 };
 use orbit_types::tool::ToolSessionContext;
 use serde_json::{Map, Value, json};
@@ -794,6 +794,7 @@ impl HubCoordinationExecutor {
                         .map(|entry| entry.label())
                         .collect::<Vec<_>>()
                 )),
+                "relations" => Ok(json!(resolve_task_relations(&task, &status))),
                 "tags" => Ok(json!(task.tags)),
                 "context_files" => Ok(json!(task.context_files)),
                 "crew" => Ok(json!(task.crew)),
@@ -1254,7 +1255,7 @@ mod checkoutless_hub_tests {
     }
 
     #[test]
-    fn task_show_projects_status_and_mixed_fields_without_checkout() {
+    fn task_show_projects_public_dto_fields_without_checkout() {
         let (_root, executor, context) = executor();
         let created = executor
             .execute_tool(
@@ -1264,6 +1265,7 @@ mod checkoutless_hub_tests {
                     "title": "Hub status projection",
                     "description": "Exercise fields:[status] on the hub.",
                     "complexity": "low",
+                    "relations": [{"type": "related_to", "target": "DK-00042"}],
                     "model": "codex"
                 }),
                 context.clone(),
@@ -1281,18 +1283,33 @@ mod checkoutless_hub_tests {
                 .expect("fields:[status] must succeed"),
             json!("proposed")
         );
+        executor
+            .execute_tool(
+                "orbit.task.update",
+                json!({"id": id, "job_run_id": "jrun-hub", "model": "codex"}),
+                context.clone(),
+            )
+            .expect("attach checkoutless job run");
         assert_eq!(
             executor
                 .execute_tool(
                     "orbit.task.show",
-                    json!({"id": id, "fields": ["status", "title", "plan"]}),
+                    json!({
+                        "id": id,
+                        "fields": ["status", "relations", "external_refs", "job_run_id"],
+                    }),
                     context,
                 )
                 .expect("mixed projection must succeed"),
             json!({
                 "status": "proposed",
-                "title": "Hub status projection",
-                "plan": "",
+                "relations": [{
+                    "type": "related_to",
+                    "target": "DK-00042",
+                    "verification": "not verifiable here",
+                }],
+                "external_refs": [],
+                "job_run_id": "jrun-hub",
             })
         );
     }

--- a/crates/orbit-core/src/adapter/tool_host/json.rs
+++ b/crates/orbit-core/src/adapter/tool_host/json.rs
@@ -96,7 +96,10 @@ pub(super) fn task_fields_to_json(
     task: &Task,
     fields: &[String],
 ) -> Result<Value, OrbitError> {
-    let status_by_id = if fields.iter().any(|field| field == "resolved_dependencies") {
+    let status_by_id = if fields
+        .iter()
+        .any(|field| matches!(field.as_str(), "resolved_dependencies" | "relations"))
+    {
         Some(runtime.task_status_index()?)
     } else {
         None
@@ -148,6 +151,13 @@ fn task_field_to_json(
             .collect::<Vec<_>>(),
         )
         .map_err(serialize_error("serialize resolved dependencies")),
+        "relations" => serde_json::to_value(resolve_task_relations(
+            task,
+            status_by_id.ok_or_else(|| {
+                OrbitError::Execution("missing task status index for relations".to_string())
+            })?,
+        ))
+        .map_err(serialize_error("serialize relations")),
         "history" => serialize_history(&runtime.get_task_history(&task.id)?),
         "context_files" => serde_json::to_value(&task.context_files)
             .map_err(serialize_error("serialize context files")),

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -5,11 +5,12 @@ use std::sync::{Arc, Barrier, Mutex, MutexGuard, OnceLock};
 use orbit_store::maintenance::task_registry::{
     TaskRegistryStore, read_workspace_config, task_registry_path,
 };
-use orbit_types::task::TaskStatus;
+use orbit_types::task::{TASK_SHOW_PUBLIC_DTO_FIELDS, TaskStatus};
 use orbit_types::tool::ToolSessionContext;
 use serde_json::{Value, json};
 
 use super::super::HubCoordinationExecutor;
+use super::super::json::task_to_json;
 use super::super::test_support::{
     create_task, create_task_with_crew, invalid_input_message, run_tool_as_operator, test_runtime,
 };
@@ -2315,12 +2316,30 @@ fn task_show_tool_projects_mixed_top_level_and_sidecar_fields() {
         &["file:src/lib.rs"],
     );
 
+    runtime
+        .execute_tool_command(
+            "orbit.task.update",
+            json!({
+                "id": task.id,
+                "relations": [{"type": "related_to", "target": "DK-00042"}],
+                "job_run_id": "jrun-projection",
+            }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+        )
+        .expect("projection fixture metadata update succeeds");
+
     let output = runtime
         .execute_tool_command(
             "orbit.task.show",
             json!({
                 "id": task.id,
-                "fields": ["status", "title", "context_files", "plan"],
+                "fields": [
+                    "status",
+                    "relations",
+                    "external_refs",
+                    "job_run_id",
+                ],
             }),
             Some("codex".to_string()),
             Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
@@ -2331,11 +2350,42 @@ fn task_show_tool_projects_mixed_top_level_and_sidecar_fields() {
         output,
         json!({
             "status": "in-progress",
-            "title": "Show mixed fields",
-            "context_files": ["file:src/lib.rs"],
-            "plan": "",
+            "relations": [{
+                "type": "related_to",
+                "target": "DK-00042",
+                "verification": "not verifiable here",
+            }],
+            "external_refs": [],
+            "job_run_id": "jrun-projection",
         })
     );
+}
+
+#[test]
+fn task_show_public_dto_and_projection_vocabulary_cannot_drift() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "DTO vocabulary drift",
+        "Keep every stable public DTO key classified.",
+        TaskStatus::Backlog,
+        &[],
+    );
+    let dto = task_to_json(
+        &task,
+        &runtime.task_status_index().expect("task status index"),
+    );
+    let mut actual = dto
+        .as_object()
+        .expect("task DTO object")
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    actual.sort_unstable();
+    let mut expected = TASK_SHOW_PUBLIC_DTO_FIELDS.to_vec();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -2364,6 +2414,27 @@ fn task_show_tool_rejects_unknown_projection_with_the_shared_vocabulary() {
         message.contains(orbit_types::task::TASK_SHOW_PROJECTION_FIELDS_CSV),
         "{message}"
     );
+}
+
+#[test]
+fn task_show_tool_rejects_terminal_with_status_guidance() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task = create_task(
+        &runtime,
+        &repo_root,
+        "Terminal projection",
+        "Exercise actionable lifecycle guidance.",
+        TaskStatus::Backlog,
+        &[],
+    );
+
+    let message = invalid_input_message(runtime.execute_tool_command(
+        "orbit.task.show",
+        json!({ "id": task.id, "field": "terminal" }),
+        Some("codex".to_string()),
+        Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+    ));
+    assert!(message.contains("use `status`"), "{message}");
 }
 
 #[test]

--- a/crates/orbit-tools/tests/public_tool_surface.rs
+++ b/crates/orbit-tools/tests/public_tool_surface.rs
@@ -472,6 +472,9 @@ fn task_show_schema_distinguishes_execution_crew_from_orchestrator() {
         "complexity",
         "created_at",
         "updated_at",
+        "relations",
+        "job_run_id",
+        "external_refs",
     ] {
         assert!(
             fields.description.contains(field),

--- a/crates/orbit-types/src/task/mod.rs
+++ b/crates/orbit-types/src/task/mod.rs
@@ -35,6 +35,7 @@ pub use model::{
 };
 pub use plan::{TaskPlan, TaskPlanCheckpoint, TaskPlanSuccessCriterion};
 pub use show_fields::{
-    TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV, is_task_show_projection_field,
+    TASK_SHOW_DERIVED_RESPONSE_FIELDS, TASK_SHOW_PROJECTION_FIELDS,
+    TASK_SHOW_PROJECTION_FIELDS_CSV, TASK_SHOW_PUBLIC_DTO_FIELDS, is_task_show_projection_field,
     task_show_record_field_json, unknown_task_show_field_message,
 };

--- a/crates/orbit-types/src/task/show_fields.rs
+++ b/crates/orbit-types/src/task/show_fields.rs
@@ -1,9 +1,11 @@
 //! Canonical `orbit.task.show` field-projection vocabulary.
 //!
 //! CLI help, MCP/tool schema text, validation errors, and JSON projectors
-//! must all draw from this list. Sidecar fields (`comments`, `history`,
-//! `artifacts`) and `resolved_dependencies` still need a runtime fetch;
-//! the Task-local scalars below are projected from the record itself.
+//! must all draw from this list. Every stable key in the public task DTO is
+//! projectable. Sidecars (`comments`, `history`, `artifacts`) and fields whose
+//! canonical form depends on other tasks (`resolved_dependencies`,
+//! `relations`) still need a runtime fetch; the remaining fields are projected
+//! from the record itself.
 
 use serde_json::{Value, json};
 
@@ -14,20 +16,15 @@ use crate::task::Task;
 #[macro_export]
 macro_rules! task_show_projection_fields_csv {
     () => {
-        "id, title, type, status, priority, complexity, created_at, updated_at, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, crew, orchestrator, comments, history, artifacts"
+        "id, parent_id, title, description, acceptance_criteria, dependencies, resolved_dependencies, tags, required_tools, plan, execution_summary, context_files, created_by, planned_by, implemented_by, status, priority, complexity, type, pr_status, external_refs, relations, source_task_id, job_run_id, crew, orchestrator, created_at, updated_at, comments, history, artifacts"
     };
 }
 
 /// Authoritative `orbit.task.show` `--fields` / `fields` / `field` vocabulary.
 pub const TASK_SHOW_PROJECTION_FIELDS: &[&str] = &[
     "id",
+    "parent_id",
     "title",
-    "type",
-    "status",
-    "priority",
-    "complexity",
-    "created_at",
-    "updated_at",
     "description",
     "acceptance_criteria",
     "dependencies",
@@ -37,11 +34,89 @@ pub const TASK_SHOW_PROJECTION_FIELDS: &[&str] = &[
     "plan",
     "execution_summary",
     "context_files",
+    "created_by",
+    "planned_by",
+    "implemented_by",
+    "status",
+    "priority",
+    "complexity",
+    "type",
+    "pr_status",
+    "external_refs",
+    "relations",
+    "source_task_id",
+    "job_run_id",
     "crew",
     "orchestrator",
+    "created_at",
+    "updated_at",
     "comments",
     "history",
     "artifacts",
+];
+
+/// Stable top-level keys in the unprojected public task DTO.
+///
+/// A projector-vs-DTO drift test compares this policy with the actual DTO.
+/// Sidecars are deliberately absent because they are attached after the base
+/// DTO is serialized, but remain projectable through the vocabulary above.
+pub const TASK_SHOW_PUBLIC_DTO_FIELDS: &[&str] = &[
+    "id",
+    "parent_id",
+    "title",
+    "description",
+    "acceptance_criteria",
+    "dependencies",
+    "resolved_dependencies",
+    "tags",
+    "required_tools",
+    "plan",
+    "execution_summary",
+    "context_files",
+    "created_by",
+    "planned_by",
+    "implemented_by",
+    "status",
+    "priority",
+    "complexity",
+    "type",
+    "pr_status",
+    "external_refs",
+    "relations",
+    "source_task_id",
+    "job_run_id",
+    "crew",
+    "orchestrator",
+    "created_at",
+    "updated_at",
+];
+
+/// Response enrichments that are intentionally not task-field projections.
+///
+/// These keys describe the read environment or an explicitly requested
+/// enrichment rather than stable task data, so asking for them alone could
+/// produce host-dependent results.
+pub const TASK_SHOW_DERIVED_RESPONSE_FIELDS: &[(&str, &str)] = &[
+    (
+        "workspace",
+        "lookup-owner metadata attached by the CLI, not task data",
+    ),
+    (
+        "related_docs",
+        "derived only when with_context is requested",
+    ),
+    (
+        "resolved_crew",
+        "conditional host-local crew configuration enrichment",
+    ),
+    (
+        "crew_model",
+        "conditional host-local crew configuration enrichment",
+    ),
+    (
+        "crew_unresolved",
+        "conditional host-local crew-resolution diagnostic",
+    ),
 ];
 
 /// Comma-separated form of [`TASK_SHOW_PROJECTION_FIELDS`].
@@ -54,21 +129,46 @@ pub fn is_task_show_projection_field(name: &str) -> bool {
 
 /// Actionable error for a name that is not in the vocabulary.
 pub fn unknown_task_show_field_message(name: &str) -> String {
-    format!("unknown field selector `{name}`. Valid values: {TASK_SHOW_PROJECTION_FIELDS_CSV}")
+    let guidance = if name == "terminal" {
+        " `terminal` is not a task field; use `status` for lifecycle state."
+    } else {
+        ""
+    };
+    format!(
+        "unknown field selector `{name}`.{guidance} Valid values: {TASK_SHOW_PROJECTION_FIELDS_CSV}"
+    )
 }
 
 /// JSON for a Task-local (non-sidecar) projection field.
 ///
-/// Returns `None` for sidecar names, `resolved_dependencies`, and unknown
-/// names so callers can keep those on their existing fetch paths.
+/// Returns `None` for sidecar names, cross-task fields (`dependencies`,
+/// `resolved_dependencies`, `relations`), and unknown names so callers can
+/// keep those on their existing fetch paths.
 pub fn task_show_record_field_json(task: &Task, field: &str) -> Option<Value> {
     match field {
         "id" => Some(json!(task.id)),
+        "parent_id" => Some(json!(task.parent_id())),
         "title" => Some(json!(task.title)),
+        "description" => Some(json!(task.description)),
+        "acceptance_criteria" => Some(json!(task.acceptance_criteria)),
+        "tags" => Some(json!(task.tags)),
+        "required_tools" => Some(json!(task.required_tools)),
+        "plan" => Some(json!(task.plan)),
+        "execution_summary" => Some(json!(task.execution_summary)),
+        "context_files" => Some(json!(task.context_files)),
+        "created_by" => Some(json!(task.created_by)),
+        "planned_by" => Some(json!(task.planned_by)),
+        "implemented_by" => Some(json!(task.implemented_by)),
         "type" => Some(json!(task.task_type.to_string())),
         "status" => Some(json!(task.status.to_string())),
         "priority" => Some(json!(task.priority.to_string())),
         "complexity" => Some(json!(task.complexity.map(|value| value.to_string()))),
+        "pr_status" => Some(json!(task.pr_status)),
+        "external_refs" => Some(json!(task.external_refs)),
+        "source_task_id" => Some(json!(task.source_task_id())),
+        "job_run_id" => Some(json!(task.job_run_id)),
+        "crew" => Some(json!(task.crew)),
+        "orchestrator" => Some(json!(task.orchestrator)),
         "created_at" => Some(json!(task.created_at.to_rfc3339())),
         "updated_at" => Some(json!(task.updated_at.to_rfc3339())),
         _ => None,

--- a/crates/orbit-types/src/task/tests/show_fields.rs
+++ b/crates/orbit-types/src/task/tests/show_fields.rs
@@ -1,5 +1,6 @@
 use crate::task::{
-    TASK_SHOW_PROJECTION_FIELDS, TASK_SHOW_PROJECTION_FIELDS_CSV, Task,
+    TASK_SHOW_DERIVED_RESPONSE_FIELDS, TASK_SHOW_PROJECTION_FIELDS,
+    TASK_SHOW_PROJECTION_FIELDS_CSV, TASK_SHOW_PUBLIC_DTO_FIELDS, Task,
     is_task_show_projection_field, task_show_record_field_json, unknown_task_show_field_message,
 };
 use serde_json::json;
@@ -18,6 +19,16 @@ status: in-progress
 priority: high
 complexity: medium
 task_type: bug
+external_refs:
+  - system: jira
+    id: ENG-11119
+    url: https://example.test/ENG-11119
+relations:
+  - type: child_of
+    target: ORB-10000
+  - type: regression_from
+    target: ORB-10001
+job_run_id: jrun-11119
 created_at: 2026-08-22T19:39:26.449604717+00:00
 updated_at: 2026-08-22T21:36:50.192298986+00:00
 "#,
@@ -54,11 +65,42 @@ fn vocabulary_includes_ordinary_top_level_fields() {
 }
 
 #[test]
+fn every_stable_public_dto_field_is_projectable() {
+    for field in TASK_SHOW_PUBLIC_DTO_FIELDS {
+        assert!(
+            is_task_show_projection_field(field),
+            "public task DTO field `{field}` must be projectable"
+        );
+    }
+}
+
+#[test]
+fn derived_response_fields_are_explicitly_excluded_with_reasons() {
+    for (field, reason) in TASK_SHOW_DERIVED_RESPONSE_FIELDS {
+        assert!(!is_task_show_projection_field(field), "{field}");
+        assert!(
+            !reason.trim().is_empty(),
+            "{field} needs an exclusion reason"
+        );
+    }
+}
+
+#[test]
 fn unknown_field_error_lists_the_vocabulary() {
     let message = unknown_task_show_field_message("not_a_field");
     assert!(message.contains("unknown field selector `not_a_field`"),);
     assert!(message.contains(TASK_SHOW_PROJECTION_FIELDS_CSV));
     assert!(message.contains("status"));
+}
+
+#[test]
+fn terminal_error_points_to_status_without_weakening_unknown_validation() {
+    let terminal = unknown_task_show_field_message("terminal");
+    assert!(terminal.contains("use `status`"), "{terminal}");
+    assert!(terminal.contains(TASK_SHOW_PROJECTION_FIELDS_CSV));
+
+    let unknown = unknown_task_show_field_message("not_a_field");
+    assert!(!unknown.contains("use `status`"), "{unknown}");
 }
 
 #[test]
@@ -96,6 +138,27 @@ fn record_field_json_uses_canonical_serialized_types() {
         task_show_record_field_json(&task, "updated_at"),
         Some(json!(task.updated_at.to_rfc3339()))
     );
+    assert_eq!(
+        task_show_record_field_json(&task, "external_refs"),
+        Some(json!([{
+            "system": "jira",
+            "id": "ENG-11119",
+            "url": "https://example.test/ENG-11119",
+        }]))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "job_run_id"),
+        Some(json!("jrun-11119"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "parent_id"),
+        Some(json!("ORB-10000"))
+    );
+    assert_eq!(
+        task_show_record_field_json(&task, "source_task_id"),
+        Some(json!("ORB-10001"))
+    );
+    assert_eq!(task_show_record_field_json(&task, "relations"), None);
     assert_eq!(task_show_record_field_json(&task, "comments"), None);
     assert_eq!(task_show_record_field_json(&task, "not_a_field"), None);
 }


### PR DESCRIPTION
## Task

[ORB-11119](https://orbit-cli.com/tasks/ORB-11119) — Align task.show projections with the public task DTO

### Description

## Problem

`orbit.task.show` rejected 24 requests for `relations`, plus requests for `job_run_id`, `external_refs`, and other fields that are present in the full public task record but absent from the projection vocabulary. Agents naturally expect stable top-level DTO fields to be projectable.

Nineteen additional calls requested `terminal`, an intuitive but invalid name for lifecycle state. The error should steer callers to canonical `status` rather than producing repeated schema-discovery retries.

ORB-10966 centralized the projection vocabulary and added ordinary scalar fields, but the shared allowlist still lags the full task DTO.

## Why It Matters

Projection is meant to reduce response size. Excluding real public fields forces full-record reads or trial-and-error retries on one of Orbit's highest-volume tools.

## Constraints / Notes

- Preserve strict validation for genuinely unknown names.
- Use the existing shared projection vocabulary; do not introduce per-surface allowlists.
- Return canonical serialized types and exact requested keys across CLI tool-run, MCP, and checkoutless/global task lookup.
- Relevant implementation includes `crates/orbit-types/src/task/show_fields.rs` and the tool-host projectors.
- Treat this as follow-up to ORB-10966.

### Acceptance Criteria

- orbit.task.show accepts relations, job_run_id, and external_refs as field or fields projections on CLI tool-run and MCP surfaces, returning their canonical serialized types.
- A documented/tested policy accounts for every stable public top-level task DTO field: it is either projectable or explicitly classified as internal/derived with a reason, and a drift test catches future DTO/vocabulary divergence.
- Mixed scalar, relation, and external-reference projections return one object containing exactly the requested keys on every supported lookup path.
- tools/list, CLI help, validation errors, and all projectors consume the same authoritative vocabulary.
- A request for terminal fails with actionable guidance to use status; other unknown names remain fail-closed and list valid values.
- Regression tests cover the observed projection calls and pass with focused task-show tests, make ci-fast, make ci-lint, and git diff --check.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Expanded the authoritative task.show projection vocabulary to every stable public task DTO key, including relations, job_run_id, external_refs, attribution, PR, and derived relation IDs.
- Added an explicit policy for host-local/derived response enrichments, a DTO-vocabulary drift guard, and terminal-specific guidance to use status while preserving fail-closed validation for other unknown names.
- Implemented canonical relation serialization and record-field projection across runtime-backed, checkoutless/global, direct CLI, tool-run, and MCP paths; mixed projections preserve exactly the requested keys.
- Updated CLI help/tools-list/MCP schema expectations and regression coverage for field/fields calls, canonical types, exact mixed objects, and checkoutless lookup.
Assessment: The shared vocabulary remains the single validation and advertising authority, and both runtime projectors now consume it without adding per-surface allowlists. No new dependency edge or persisted format was introduced.
Validation:
- cargo test -p orbit-types show_fields (passed: 8)
- cargo test -p orbit-core task_show (passed: 9)
- cargo test -p orbit-cli --bin orbit command::task::tests::show (passed: 4)
- cargo test -p orbit-tools task_show_schema_distinguishes_execution_crew_from_orchestrator (passed)
- cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_round_trips_records_against_a_temp_workspace -- --exact (passed)
- cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot -- --exact (passed)
- cargo test -p orbit-cli --test tool_list (passed: 7)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
- cargo test -p orbit-cli --test output_goldens was skipped after two attempts: the runner denied writes to ~/.orbit/resources/executors/claude.yaml with read-only filesystem (os error 30), including with an alternate ORBIT_ROOT. The affected golden was updated mechanically; the independent MCP tools/list production snapshot test passed.
Deviations from original plan:
- Added tightly coupled task module re-export, CLI projector, tool-schema test, MCP roundtrip, and snapshot files to context_files because they are required for cross-surface vocabulary parity and regression coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11119-6a93c99e`
- Behind base: 0
- Ahead of base: 1