### PR TITLE
Separate diagnostic and expected-negative events from tool failure rates

### DIFF
--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -98,7 +98,8 @@ pub use orbit_types::workflow::{MissedRunPolicy, OverlapPolicy};
 // the dashboard's incident, audit-summary, and scoreboard surfaces.
 pub use orbit_store::{
     CASCADE_WINDOW_SECS, FailureClass, FailureIncident, FailureIncidentQuery,
-    FailureIncidentReport, IncidentEventRef, PropagationLink,
+    FailureIncidentReport, IncidentEventRef, JOB_RUN_LIFECYCLE_LABEL, LIFECYCLE_DIAGNOSTIC_LABEL,
+    PropagationLink, is_failure_only_diagnostic_surface,
 };
 // Routine fire records surfaced by the dashboard's routine-health JSON API.
 pub use orbit_store::{RoutineFireRecord, RoutineFireState};

--- a/crates/orbit-store/src/contracts/audit.rs
+++ b/crates/orbit-store/src/contracts/audit.rs
@@ -85,7 +85,9 @@ pub struct AuditTopToolCall {
 pub struct AuditToolAggregate {
     pub tool_name: String,
     pub total: i64,
+    pub successes: i64,
     pub failures: i64,
+    pub denials: i64,
     pub mcp_total: i64,
     pub cli_total: i64,
     pub mcp_failures: i64,

--- a/crates/orbit-store/src/contracts/incident.rs
+++ b/crates/orbit-store/src/contracts/incident.rs
@@ -18,9 +18,10 @@
 //! Grouping runs in three passes:
 //!
 //! 1. **Classify** each failed row as [`FailureClass::Denied`],
-//!    [`FailureClass::Expected`], or [`FailureClass::Unexpected`] so a policy
-//!    refusal and a caller's invalid input stay distinguishable from a genuine
-//!    unexpected failure.
+//!    [`FailureClass::Expected`], [`FailureClass::Diagnostic`], or
+//!    [`FailureClass::Unexpected`] so a policy refusal, caller/input negative,
+//!    and lifecycle diagnostic stay distinguishable from a genuine unexpected
+//!    failure.
 //! 2. **Cluster** rows by `(run scope, signature)`, where the signature is
 //!    `class | role | surface | normalized message`. Volatile tokens (paths,
 //!    numbers, ids, timestamps, hashes, quoted literals) are replaced with
@@ -37,7 +38,7 @@
 //!    not a special-cased tool or activity name.
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Duration, Utc};
 use orbit_types::telemetry::{AuditEvent, AuditEventStatus};
@@ -62,9 +63,10 @@ const MAX_SIGNATURE_MESSAGE_CHARS: usize = 160;
 
 /// How an audit failure should be read by an operator.
 ///
-/// The three classes are kept separate at every layer: an incident never
-/// merges rows of different classes, so a policy denial can never be counted
-/// as an unexpected failure (or hide one).
+/// The four classes are kept separate at every layer: an incident never
+/// merges rows of different classes, so a policy denial, expected negative,
+/// or lifecycle diagnostic can never be counted as an unexpected failure (or
+/// hide one).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FailureClass {
@@ -73,6 +75,9 @@ pub enum FailureClass {
     /// The call ran and failed on a documented negative path — invalid input,
     /// a missing record, a validation refusal. The system behaved correctly.
     Expected,
+    /// An abnormal-path lifecycle record emitted for diagnosis. These rows
+    /// have no healthy-call population and therefore never form a tool rate.
+    Diagnostic,
     /// Everything else: a failure that is not a known negative path.
     Unexpected,
 }
@@ -82,6 +87,7 @@ impl FailureClass {
         match self {
             FailureClass::Denied => "denied",
             FailureClass::Expected => "expected",
+            FailureClass::Diagnostic => "diagnostic",
             FailureClass::Unexpected => "unexpected",
         }
     }
@@ -92,6 +98,7 @@ impl FailureClass {
         match self {
             FailureClass::Denied => "policy denial",
             FailureClass::Expected => "expected negative path",
+            FailureClass::Diagnostic => "lifecycle diagnostic",
             FailureClass::Unexpected => "unexpected failure",
         }
     }
@@ -218,6 +225,18 @@ pub const JOB_RUN_LIFECYCLE_CATEGORY: &str = "job_run_lifecycle";
 /// Operator-facing label for [`JOB_RUN_LIFECYCLE_CATEGORY`].
 pub const JOB_RUN_LIFECYCLE_LABEL: &str = "job-run lifecycle";
 
+/// Named lifecycle audit surfaces that are emitted only when an abnormal path
+/// occurs. Unlike callable tools, they cannot have a healthy-call denominator.
+pub const FAILURE_ONLY_DIAGNOSTIC_SURFACES: &[&str] = &[
+    "pipeline.run.terminal_conflict",
+    "pipeline.worker.exit",
+    "pipeline.worker.startup",
+];
+
+/// Operator-facing label for abnormal-path lifecycle records, whether they
+/// use one of [`FAILURE_ONLY_DIAGNOSTIC_SURFACES`] or have no tool identity.
+pub const LIFECYCLE_DIAGNOSTIC_LABEL: &str = "lifecycle diagnostics";
+
 /// Result of one aggregation: the incidents plus the raw denominators they
 /// were derived from, so no surface has to re-derive (or guess) them.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -229,12 +248,21 @@ pub struct FailureIncidentReport {
     pub raw_events_by_class: BTreeMap<String, u64>,
     /// Incident count per class.
     pub incidents_by_class: BTreeMap<String, u64>,
+    /// Unique affected run count per class.
+    pub affected_runs_by_class: BTreeMap<String, u64>,
     /// Unique `job_run_id`s on the grouped incidents (the affected-run count).
     pub affected_run_count: u64,
     /// Raw failed rows with no tool identity.
     pub job_run_lifecycle_events: u64,
     /// Incidents whose root had no tool identity.
     pub job_run_lifecycle_incidents: u64,
+    /// Raw diagnostic rows, including both no-tool lifecycle rows and named
+    /// failure-only diagnostic surfaces.
+    pub lifecycle_diagnostic_events: u64,
+    /// Diagnostic incidents over the same raw population.
+    pub lifecycle_diagnostic_incidents: u64,
+    /// Unique runs affected by diagnostic incidents.
+    pub lifecycle_diagnostic_affected_run_count: u64,
     /// True when the scan hit `max_events` and older rows were not read.
     pub truncated: bool,
 }
@@ -261,7 +289,8 @@ pub fn build_report(failures: &[AuditEvent], truncated: bool) -> FailureIncident
         }
     }
     let mut incidents_by_class: BTreeMap<String, u64> = BTreeMap::new();
-    let mut run_ids: BTreeMap<String, ()> = BTreeMap::new();
+    let mut run_ids: BTreeSet<String> = BTreeSet::new();
+    let mut run_ids_by_class: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     let mut job_run_lifecycle_incidents: u64 = 0;
     for incident in &incidents {
         *incidents_by_class
@@ -271,18 +300,42 @@ pub fn build_report(failures: &[AuditEvent], truncated: bool) -> FailureIncident
             job_run_lifecycle_incidents += 1;
         }
         for run_id in &incident.run_ids {
-            run_ids.insert(run_id.clone(), ());
+            run_ids.insert(run_id.clone());
+            run_ids_by_class
+                .entry(incident.class.as_str().to_string())
+                .or_default()
+                .insert(run_id.clone());
         }
     }
+    let affected_runs_by_class: BTreeMap<String, u64> = run_ids_by_class
+        .into_iter()
+        .map(|(class, ids)| (class, ids.len() as u64))
+        .collect();
+    let lifecycle_diagnostic_events = raw_events_by_class
+        .get(FailureClass::Diagnostic.as_str())
+        .copied()
+        .unwrap_or(0);
+    let lifecycle_diagnostic_incidents = incidents_by_class
+        .get(FailureClass::Diagnostic.as_str())
+        .copied()
+        .unwrap_or(0);
+    let lifecycle_diagnostic_affected_run_count = affected_runs_by_class
+        .get(FailureClass::Diagnostic.as_str())
+        .copied()
+        .unwrap_or(0);
 
     FailureIncidentReport {
         raw_failed_events: failures.len() as u64,
         raw_events_by_class,
         incidents_by_class,
+        affected_runs_by_class,
         incidents,
         affected_run_count: run_ids.len() as u64,
         job_run_lifecycle_events,
         job_run_lifecycle_incidents,
+        lifecycle_diagnostic_events,
+        lifecycle_diagnostic_incidents,
+        lifecycle_diagnostic_affected_run_count,
         truncated,
     }
 }
@@ -292,6 +345,9 @@ pub fn build_report(failures: &[AuditEvent], truncated: bool) -> FailureIncident
 /// path. Anything unmatched is treated as unexpected — the conservative
 /// direction, since under-reporting a real failure is the costlier mistake.
 pub fn classify(event: &AuditEvent) -> FailureClass {
+    if is_lifecycle_diagnostic(event) {
+        return FailureClass::Diagnostic;
+    }
     if matches!(event.status, AuditEventStatus::Denied) {
         return FailureClass::Denied;
     }
@@ -313,6 +369,23 @@ pub fn classify(event: &AuditEvent) -> FailureClass {
         return FailureClass::Expected;
     }
     FailureClass::Unexpected
+}
+
+/// True for a failure-only named diagnostic surface. Callers use the same
+/// predicate when excluding those rows from callable-tool rate rankings.
+pub fn is_failure_only_diagnostic_surface(name: &str) -> bool {
+    let name = name.trim();
+    FAILURE_ONLY_DIAGNOSTIC_SURFACES.contains(&name)
+}
+
+/// True when an audit row is a lifecycle diagnostic rather than a call whose
+/// success and failure populations can be compared.
+pub fn is_lifecycle_diagnostic(event: &AuditEvent) -> bool {
+    !has_tool_identity(event)
+        || event
+            .tool_name
+            .as_deref()
+            .is_some_and(is_failure_only_diagnostic_surface)
 }
 
 /// True when the row names a real tool. Empty/`NULL` tool names are job-run

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
@@ -849,7 +849,9 @@ impl Store {
 
         let sql = "SELECT COALESCE(tool_name, 'unknown') AS tool, \
                    COUNT(*), \
+                   COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0), \
                    COALESCE(SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END), 0), \
+                   COALESCE(SUM(CASE WHEN status = 'denied' THEN 1 ELSE 0 END), 0), \
                    COALESCE(SUM(CASE WHEN subcommand = 'run-mcp' THEN 1 ELSE 0 END), 0), \
                    COALESCE(SUM(CASE WHEN subcommand = 'run' THEN 1 ELSE 0 END), 0), \
                    COALESCE(SUM(CASE WHEN status = 'failure' AND subcommand = 'run-mcp' THEN 1 ELSE 0 END), 0), \
@@ -866,12 +868,14 @@ impl Store {
                 Ok(AuditToolAggregate {
                     tool_name: row.get(0)?,
                     total: row.get(1)?,
-                    failures: row.get(2)?,
-                    mcp_total: row.get(3)?,
-                    cli_total: row.get(4)?,
-                    mcp_failures: row.get(5)?,
-                    cli_failures: row.get(6)?,
-                    avg_duration_ms: row.get(7)?,
+                    successes: row.get(2)?,
+                    failures: row.get(3)?,
+                    denials: row.get(4)?,
+                    mcp_total: row.get(5)?,
+                    cli_total: row.get(6)?,
+                    mcp_failures: row.get(7)?,
+                    cli_failures: row.get(8)?,
+                    avg_duration_ms: row.get(9)?,
                 })
             })
             .map_err(|e| OrbitError::Store(e.to_string()))?;

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/audit_event_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/audit_event_store.rs
@@ -601,7 +601,9 @@ fn audit_event_aggregates_by_tool_splits_failures_by_surface() {
         .find(|r| r.tool_name == "orbit.search")
         .expect("orbit.search row");
     assert_eq!(search.total, 3);
+    assert_eq!(search.successes, 1);
     assert_eq!(search.failures, 2);
+    assert_eq!(search.denials, 0);
     assert_eq!(search.mcp_total, 1);
     assert_eq!(search.cli_total, 2);
     assert_eq!(search.mcp_failures, 1);
@@ -613,7 +615,9 @@ fn audit_event_aggregates_by_tool_splits_failures_by_surface() {
         .find(|r| r.tool_name == "unknown")
         .expect("unknown bucket");
     assert_eq!(unknown.total, 1);
+    assert_eq!(unknown.successes, 1);
     assert_eq!(unknown.failures, 0);
+    assert_eq!(unknown.denials, 0);
     assert_eq!(unknown.mcp_total, 0);
     assert_eq!(unknown.cli_total, 0);
 }

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/incident.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/incident.rs
@@ -12,7 +12,8 @@ use orbit_types::telemetry::{AuditEvent, AuditEventStatus};
 use crate::Store;
 use crate::driver::sqlite::audit_event_store::incident::{
     CASCADE_WINDOW_SECS, FailureClass, FailureIncidentQuery, build_report, group_failure_incidents,
-    has_tool_identity, normalize_message, signature_for,
+    has_tool_identity, is_failure_only_diagnostic_surface, is_lifecycle_diagnostic,
+    normalize_message, signature_for,
 };
 
 use super::super::AuditEventInsertParams;
@@ -316,6 +317,80 @@ fn denials_expected_negative_paths_and_unexpected_failures_never_merge() {
 }
 
 #[test]
+fn duplicate_worker_diagnostics_are_seven_incidents_not_fourteen_tool_failures() {
+    const RUN_IDS: [&str; 7] = [
+        "jrun-diagnostic-0",
+        "jrun-diagnostic-1",
+        "jrun-diagnostic-2",
+        "jrun-diagnostic-3",
+        "jrun-diagnostic-4",
+        "jrun-diagnostic-5",
+        "jrun-diagnostic-6",
+    ];
+    let mut failures = Vec::new();
+    for (index, run_id) in RUN_IDS.into_iter().enumerate() {
+        for duplicate in 0..2 {
+            failures.push(
+                FailureFixture::new(
+                    (index * 2 + duplicate) as i64,
+                    (index * 10 + duplicate) as i64,
+                    "pipeline.worker.exit",
+                )
+                .message("pipeline worker exited after claiming the persisted run")
+                .run(run_id, "worker-observer")
+                .build(),
+            );
+        }
+    }
+
+    let report = build_report(&failures, false);
+
+    assert!(is_failure_only_diagnostic_surface("pipeline.worker.exit"));
+    assert!(failures.iter().all(is_lifecycle_diagnostic));
+    assert_eq!(report.raw_failed_events, 14);
+    assert_eq!(report.incident_count(), 7);
+    assert_eq!(report.lifecycle_diagnostic_events, 14);
+    assert_eq!(report.lifecycle_diagnostic_incidents, 7);
+    assert_eq!(report.lifecycle_diagnostic_affected_run_count, 7);
+    assert_eq!(report.raw_events_by_class.get("diagnostic"), Some(&14));
+    assert_eq!(report.incidents_by_class.get("diagnostic"), Some(&7));
+    assert_eq!(report.affected_runs_by_class.get("diagnostic"), Some(&7));
+    assert!(report.incidents.iter().all(|incident| {
+        incident.class == FailureClass::Diagnostic
+            && incident.event_count == 2
+            && incident.events.len() == 2
+            && incident.events.iter().all(|event| {
+                event.tool_name.as_deref() == Some("pipeline.worker.exit")
+                    && event.run_id.is_some()
+                    && event.task_id.is_some()
+            })
+    }));
+}
+
+#[test]
+fn expected_task_show_and_update_negatives_do_not_enter_unexpected_counts() {
+    let failures = vec![
+        FailureFixture::new(1, 0, "orbit.task.show")
+            .message("not found: task REC-missing")
+            .build(),
+        FailureFixture::new(2, 1, "orbit.task.update")
+            .message("unsupported field projection: mystery")
+            .build(),
+    ];
+
+    let report = build_report(&failures, false);
+
+    assert_eq!(report.raw_events_by_class.get("expected"), Some(&2));
+    assert_eq!(report.incidents_by_class.get("expected"), Some(&2));
+    assert_eq!(report.raw_events_by_class.get("unexpected"), None);
+    assert!(report.incidents.iter().all(|incident| {
+        incident.class == FailureClass::Expected
+            && incident.events.len() == 1
+            && incident.events[0].tool_name.is_some()
+    }));
+}
+
+#[test]
 fn a_denial_recorded_with_failure_status_still_classifies_as_a_denial() {
     let failures = vec![
         FailureFixture::new(1, 0, "surface.alpha")
@@ -596,6 +671,10 @@ fn ten_unknown_rows_group_as_lifecycle_with_four_cascades_and_one_start() {
         "2 duplicate Starts collapse; 8 cascade rows from 4 leaves are 4 roots"
     );
     assert_eq!(report.job_run_lifecycle_incidents, 5);
+    assert_eq!(report.lifecycle_diagnostic_events, 10);
+    assert_eq!(report.lifecycle_diagnostic_incidents, 5);
+    assert_eq!(report.lifecycle_diagnostic_affected_run_count, 8);
+    assert_eq!(report.raw_events_by_class.get("diagnostic"), Some(&10));
     assert_eq!(
         report.affected_run_count, 8,
         "4 leaf runs + 4 parent runs; Starts carry no run id"

--- a/crates/orbit-store/src/lib.rs
+++ b/crates/orbit-store/src/lib.rs
@@ -111,9 +111,10 @@ use chrono::{DateTime, Utc};
 pub use contracts::incident::{
     CASCADE_WINDOW_SECS, DEFAULT_SCAN_LIMIT as FAILURE_INCIDENT_SCAN_LIMIT, FailureClass,
     FailureIncident, FailureIncidentQuery, FailureIncidentReport, IncidentEventRef,
-    PropagationLink, build_report as build_failure_incident_report, classify as classify_failure,
-    group_failure_incidents, normalize_message as normalize_failure_message,
-    signature_for as failure_signature_for,
+    JOB_RUN_LIFECYCLE_LABEL, LIFECYCLE_DIAGNOSTIC_LABEL, PropagationLink,
+    build_report as build_failure_incident_report, classify as classify_failure,
+    group_failure_incidents, is_failure_only_diagnostic_surface, is_lifecycle_diagnostic,
+    normalize_message as normalize_failure_message, signature_for as failure_signature_for,
 };
 pub use contracts::{
     ActiveTaskReservation, ActivityInvocationCount, ActivityInvocationMetrics,

--- a/crates/orbit-web/assets/dashboard/_preview_failures_card.html
+++ b/crates/orbit-web/assets/dashboard/_preview_failures_card.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Preview — Failures by Tool card</title>
+  <title>Preview — Unexpected Failures by Callable Tool</title>
   <link rel="stylesheet" href="dashboard.css" />
   <style>
     body { padding: 24px; max-width: 1100px; margin: 0 auto; }
@@ -10,24 +10,26 @@
   </style>
 </head>
 <body>
-  <h1>Audit tab · Failures by Tool (preview)</h1>
+  <h1>Audit tab · Unexpected Failures by Callable Tool (preview)</h1>
   <div id="mount"></div>
 
   <script type="module">
     import { el } from './common.js';
 
     const rateRows = [
-      { tool: "orbit.friction.add", rate: 0.143, failures: 1, total: 7 },
-      { tool: "orbit.task.add",   rate: 0.118, failures: 2, total: 17 },
-      { tool: "orbit.task.show",  rate: 0.114, failures: 4, total: 35 },
-      { tool: "orbit.search",     rate: 0.042, failures: 1, total: 24 },
+      { tool: "orbit.friction.add", rate: 0.143, failures: 1, successes: 6, total: 7 },
+      { tool: "orbit.task.add",   rate: 0.118, failures: 2, successes: 15, total: 17 },
+      { tool: "orbit.search",     rate: 0.042, failures: 1, successes: 23, total: 24 },
     ];
     const failuresRows = [
-      { tool: "orbit.friction.add", count: 1, mcp: 1, cli: 0 },
-      { tool: "orbit.task.add",   count: 2, mcp: 1, cli: 1 },
-      { tool: "orbit.task.show",  count: 4, mcp: 3, cli: 1 },
-      { tool: "orbit.search",     count: 1, mcp: 0, cli: 1 },
+      { tool: "orbit.friction.add", count: 1 },
+      { tool: "orbit.task.add",   count: 2 },
+      { tool: "orbit.search",     count: 1 },
     ];
+    // Accessible in the incident evidence, but deliberately absent from the
+    // reliability rate rows above.
+    const expectedNegativeFixtures = ["orbit.task.show", "orbit.task.update"];
+    const diagnosticFixtures = ["pipeline.worker.exit", "pipeline.run.terminal_conflict"];
 
     function isNamedTool(name) {
       const trimmed = String(name || "").trim();
@@ -41,7 +43,7 @@
       }
 
       const container = el("div", { class: "audit-summary-container" });
-      container.appendChild(el("h3", { class: "summary-title", text: "Failures by Tool (24H)" }));
+      container.appendChild(el("h3", { class: "summary-title", text: "Unexpected Failures by Callable Tool (24H)" }));
       const grid = el("div", { class: "tool-health-grid" });
 
       for (const row of rateRows) {
@@ -54,22 +56,16 @@
         header.appendChild(el("span", { class: "tool-name", text: row.tool }));
         header.appendChild(el("span", {
           class: "status-badge",
-          text: `${(rate * 100).toFixed(1)}% Fail Rate`,
+          text: `${(rate * 100).toFixed(1)}% Unexpected Failure Rate`,
         }));
         card.appendChild(header);
 
         const body = el("div", { class: "card-body" });
         const breakdown = failByTool.get(row.tool);
-        const mcp = breakdown ? (breakdown.mcp || 0) : 0;
-        const cli = breakdown ? (breakdown.cli || 0) : 0;
         const failures = row.failures != null ? row.failures : (breakdown ? (breakdown.count || 0) : 0);
         const total = row.total || 0;
         const failureWord = failures === 1 ? "failure" : "failures";
-
-        let trendText = `${failures} ${failureWord} / ${total} total runs`;
-        if (mcp > 0 && cli > 0) {
-          trendText = `${failures} ${failureWord} (${mcp} MCP, ${cli} CLI) / ${total} total runs`;
-        }
+        const trendText = `${failures} unexpected ${failureWord} / ${total} comparable calls (successful + unexpected failed)`;
         body.appendChild(el("span", { class: "metric-trend", text: trendText }));
         card.appendChild(body);
 
@@ -83,31 +79,31 @@
       container.appendChild(grid);
 
       const lifecycleCard = el("div", { class: "audit-summary-card lifecycle-failure-card" });
-      lifecycleCard.appendChild(el("div", { class: "card-title", text: "job-run lifecycle" }));
+      lifecycleCard.appendChild(el("div", { class: "card-title", text: "lifecycle diagnostics" }));
       const lifeBody = el("div", { class: "card-body" });
       lifeBody.appendChild(el("div", {
         class: "lifecycle-failure-counts",
-        text: "10 failed events · 5 incidents · 8 affected runs",
+        text: "7 incidents · 14 raw events · 7 affected runs",
       }));
       lifeBody.appendChild(el("div", {
         class: "metric-trend",
-        text: "Excluded from tool denominators and rates · window 24h",
+        text: "Failure-only diagnostic surfaces; excluded from callable-tool denominators and rates · window 24h",
       }));
       lifecycleCard.appendChild(lifeBody);
       container.appendChild(lifecycleCard);
 
       const incidentHead = el("section", { class: "incident-summary" }, [
         el("div", { class: "incident-summary-head" }, [
-          el("strong", { class: "incident-summary-headline", text: "5 incidents" }),
+          el("strong", { class: "incident-summary-headline", text: "2 unexpected incidents" }),
           el("span", {
             class: "incident-summary-denominator",
-            text: "10 failed events · 5 grouped incidents · 8 affected runs of 12 audited events",
+            text: "2 unexpected raw events · 2 affected runs; 11 incidents / 18 failed events / 11 affected runs across 40 audited events",
           }),
           el("span", { class: "incident-summary-window", text: "window 24h" }),
         ]),
         el("div", {
           class: "incident-lifecycle-note",
-          text: "job-run lifecycle: 10 failed events · 5 incidents (excluded from tool rates)",
+          text: `lifecycle diagnostics: 7 incidents · 14 raw events · 7 affected runs (excluded from tool rates); expected negatives: ${expectedNegativeFixtures.join(", ")}; evidence: ${diagnosticFixtures.join(", ")}`,
         }),
       ]);
       container.appendChild(incidentHead);

--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -304,14 +304,17 @@ function isNamedTool(name) {
   return trimmed.length > 0 && trimmed !== "unknown";
 }
 
-function renderFailuresByToolCard(rateRows, failuresRows, onCardClick) {
+function renderFailuresByToolCard(rateRows, failuresRows, onCardClick, window = "24h") {
   const failByTool = new Map();
   for (const f of failuresRows) {
     if (isNamedTool(f.tool)) failByTool.set(f.tool, f);
   }
 
   const container = el("div", { class: "audit-summary-container" });
-  container.appendChild(el("h3", { class: "summary-title", text: "Failures by Tool (24H)" }));
+  container.appendChild(el("h3", {
+    class: "summary-title",
+    text: `Unexpected Failures by Callable Tool (${String(window).toUpperCase()})`,
+  }));
   const grid = el("div", { class: "tool-health-grid" });
 
   for (const row of rateRows) {
@@ -324,22 +327,16 @@ function renderFailuresByToolCard(rateRows, failuresRows, onCardClick) {
     header.appendChild(el("span", { class: "tool-name", text: row.tool }));
     header.appendChild(el("span", {
       class: "status-badge",
-      text: `${(rate * 100).toFixed(1)}% Fail Rate`,
+      text: `${(rate * 100).toFixed(1)}% Unexpected Failure Rate`,
     }));
     card.appendChild(header);
 
     const body = el("div", { class: "card-body" });
     const breakdown = failByTool.get(row.tool);
-    const mcp = breakdown ? (breakdown.mcp || 0) : 0;
-    const cli = breakdown ? (breakdown.cli || 0) : 0;
     const failures = row.failures != null ? row.failures : (breakdown ? (breakdown.count || 0) : 0);
     const total = row.total || 0;
     const failureWord = failures === 1 ? "failure" : "failures";
-
-    let trendText = `${failures} ${failureWord} / ${total} total runs`;
-    if (mcp > 0 && cli > 0) {
-      trendText = `${failures} ${failureWord} (${mcp} MCP, ${cli} CLI) / ${total} total runs`;
-    }
+    const trendText = `${failures} unexpected ${failureWord} / ${total} comparable calls (successful + unexpected failed)`;
     body.appendChild(el("span", { class: "metric-trend", text: trendText }));
     card.appendChild(body);
 
@@ -412,30 +409,46 @@ function renderAuditSummary(data, ctx) {
       namedRates,
       namedFailures,
       filterByTool,
+      data.window || "24h",
     ));
-  } else if (namedFailures.length) {
-    container.appendChild(createCard("Failures by tool", renderTable(
-      namedFailures,
-      [{ key: "tool", label: "tool" }, { key: "count", label: "fails", num: true }, { key: "mcp", label: "mcp", num: true }, { key: "cli", label: "cli", num: true }],
-      filterByTool
-    )));
   }
 
-  const lifecycleFailures = Number(data.job_run_lifecycle_failures) || 0;
-  const lifecycleIncidents = Number(data.job_run_lifecycle_incidents) || 0;
+  const categoryOrder = ["unexpected", "expected", "denied", "diagnostic"];
+  const categories = data.failure_categories || {};
+  const categoryRows = categoryOrder.map((key) => ({
+    key,
+    label: (categories[key] && categories[key].label) || key,
+    incidents: Number(categories[key] && categories[key].incidents) || 0,
+    raw_events: Number(categories[key] && categories[key].raw_events) || 0,
+    affected_runs: Number(categories[key] && categories[key].affected_runs) || 0,
+  }));
+  if (categoryRows.some((row) => row.incidents || row.raw_events)) {
+    container.appendChild(createCard(
+      `Failure categories · window ${data.window || "24h"}`,
+      renderTable(categoryRows, [
+        { key: "label", label: "classification" },
+        { key: "incidents", label: "incidents", num: true },
+        { key: "raw_events", label: "raw events", num: true },
+        { key: "affected_runs", label: "affected runs", num: true },
+      ]),
+    ));
+  }
+
+  const lifecycleFailures = Number(data.lifecycle_diagnostic_events) || 0;
+  const lifecycleIncidents = Number(data.lifecycle_diagnostic_incidents) || 0;
   if (lifecycleFailures > 0 || lifecycleIncidents > 0) {
-    const label = data.job_run_lifecycle_label || "job-run lifecycle";
+    const label = data.lifecycle_diagnostic_label || "lifecycle diagnostics";
     const window = data.window || "24h";
     const lifecycleCard = el("div", { class: "audit-summary-card lifecycle-failure-card" });
     lifecycleCard.appendChild(el("div", { class: "card-title", text: label }));
     const body = el("div", { class: "card-body" });
     body.appendChild(el("div", {
       class: "lifecycle-failure-counts",
-      text: `${lifecycleFailures} failed events · ${lifecycleIncidents} incidents · ${Number(data.affected_run_count) || 0} affected runs`,
+      text: `${lifecycleIncidents} incidents · ${lifecycleFailures} raw events · ${Number(data.lifecycle_diagnostic_affected_run_count) || 0} affected runs`,
     }));
     body.appendChild(el("div", {
       class: "metric-trend",
-      text: `Excluded from tool denominators and rates · window ${window}`,
+      text: `Failure-only diagnostic surfaces; excluded from callable-tool denominators and rates · window ${window}`,
     }));
     lifecycleCard.appendChild(body);
     container.appendChild(lifecycleCard);

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4124,6 +4124,7 @@
       .incident-class-chip.unexpected { border-left-color: var(--state-failed); }
       .incident-class-chip.expected { border-left-color: var(--fg-dim); }
       .incident-class-chip.denied { border-left-color: var(--state-warn, var(--accent)); }
+      .incident-class-chip.diagnostic { border-left-color: var(--accent); }
       .incident-truncation-note { margin: 0; color: var(--state-warn, var(--fg-dim)); font: 11px/1.5 var(--font-sans); }
       .incident-lifecycle-note {
         color: var(--fg-dim); font: 11px/1.5 var(--font-sans); overflow-wrap: anywhere;
@@ -4134,6 +4135,7 @@
       .incident-row.unexpected { border-left: 2px solid var(--state-failed); }
       .incident-row.expected { border-left: 2px solid var(--fg-dim); }
       .incident-row.denied { border-left: 2px solid var(--state-warn, var(--accent)); }
+      .incident-row.diagnostic { border-left: 2px solid var(--accent); }
       .incident-head {
         display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px; width: 100%;
         padding: 0; border: 0; background: none; color: var(--fg); text-align: left; cursor: pointer;
@@ -4143,6 +4145,7 @@
       .incident-class.unexpected { color: var(--state-failed); }
       .incident-class.expected { color: var(--fg-dim); }
       .incident-class.denied { color: var(--state-warn, var(--accent)); }
+      .incident-class.diagnostic { color: var(--accent); }
       .incident-surface { font: 12px var(--font-mono); overflow-wrap: anywhere; }
       .incident-actor { color: var(--fg-dim); font: 11px var(--font-sans); }
       .incident-count { margin-left: auto; color: var(--fg); font: 11px var(--font-mono); white-space: nowrap; }
@@ -4183,9 +4186,10 @@
          scannable without clipping between 480 and 720px. */
       @media (max-width: 720px) {
         .incident-summary { padding: 10px; }
-        .incident-summary-denominator, .incident-lifecycle-note, .lifecycle-failure-counts {
+        .incident-summary-denominator, .incident-class-chip, .incident-lifecycle-note, .lifecycle-failure-counts {
           font-size: 11px; overflow-wrap: anywhere;
         }
+        .incident-class-chip { white-space: normal; }
         .tool-health-grid { grid-template-columns: minmax(0, 1fr); }
         .health-card .card-header { flex-wrap: wrap; align-items: flex-start; }
         .health-card .tool-name { white-space: normal; overflow-wrap: anywhere; }

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -165,7 +165,7 @@ function eventCountLabel(value) {
   return `${count} event${count === 1 ? "" : "s"}`;
 }
 
-const INCIDENT_CLASS_ORDER = ["unexpected", "expected", "denied"];
+const INCIDENT_CLASS_ORDER = ["unexpected", "expected", "denied", "diagnostic"];
 
 function incidentSummaryNode(payload) {
   const incidents = asCount(payload.incident_count);
@@ -173,15 +173,21 @@ function incidentSummaryNode(payload) {
   const total = asCount(payload.total_events);
   const runs = asCount(payload.affected_run_count);
   const window = payload.window || getWindow();
-  const lifecycleEvents = asCount(payload.job_run_lifecycle_events);
-  const lifecycleIncidents = asCount(payload.job_run_lifecycle_incidents);
-  const lifecycleLabel = payload.job_run_lifecycle_label || "job-run lifecycle";
+  const categories = payload.failure_categories || {};
+  const unexpected = categories.unexpected || {};
+  const unexpectedIncidents = asCount(unexpected.incidents);
+  const unexpectedEvents = asCount(unexpected.raw_events);
+  const unexpectedRuns = asCount(unexpected.affected_runs);
+  const lifecycleEvents = asCount(payload.lifecycle_diagnostic_events);
+  const lifecycleIncidents = asCount(payload.lifecycle_diagnostic_incidents);
+  const lifecycleRuns = asCount(payload.lifecycle_diagnostic_affected_run_count);
+  const lifecycleLabel = payload.lifecycle_diagnostic_label || "lifecycle diagnostics";
 
   const head = el("div", { class: "incident-summary-head" }, [
-    el("strong", { class: "incident-summary-headline", text: `${incidents} incidents` }),
+    el("strong", { class: "incident-summary-headline", text: `${unexpectedIncidents} unexpected incidents` }),
     el("span", {
       class: "incident-summary-denominator",
-      text: `${failed} failed events · ${incidents} grouped incidents · ${runs} affected runs of ${total} audited events`,
+      text: `${unexpectedEvents} unexpected raw events · ${unexpectedRuns} affected runs; ${incidents} incidents / ${failed} failed events / ${runs} affected runs across ${total} audited events`,
     }),
     el("span", { class: "incident-summary-window", text: `window ${window}` }),
   ]);
@@ -193,11 +199,13 @@ function incidentSummaryNode(payload) {
   for (const key of INCIDENT_CLASS_ORDER) {
     const count = asCount(byClass[key]);
     const events = asCount(eventsByClass[key]);
+    const category = categories[key] || {};
+    const categoryRuns = asCount(category.affected_runs);
     if (count === 0 && events === 0) continue;
     chips.appendChild(el("span", {
       class: `incident-class-chip ${key}`,
-      title: `${labels[key] || key}: ${count} incidents from ${events} raw events (window ${window})`,
-      text: `${labels[key] || key} ${count}/${events}`,
+      title: `${labels[key] || key}: ${count} incidents from ${events} raw events affecting ${categoryRuns} runs (window ${window})`,
+      text: `${labels[key] || key}: ${count} incidents · ${events} raw · ${categoryRuns} runs`,
     }));
   }
 
@@ -206,8 +214,8 @@ function incidentSummaryNode(payload) {
   if (lifecycleEvents > 0 || lifecycleIncidents > 0) {
     children.push(el("div", {
       class: "incident-lifecycle-note",
-      title: `${lifecycleLabel} rows have no tool identity and are excluded from tool denominators and rates`,
-      text: `${lifecycleLabel}: ${lifecycleEvents} failed events · ${lifecycleIncidents} incidents (excluded from tool rates)`,
+      title: `${lifecycleLabel} are failure-only event surfaces and are excluded from callable-tool denominators and rates`,
+      text: `${lifecycleLabel}: ${lifecycleIncidents} incidents · ${lifecycleEvents} raw events · ${lifecycleRuns} affected runs (excluded from tool rates)`,
     }));
   }
   if (payload.truncated) {
@@ -223,7 +231,7 @@ function incidentEvidenceTable(events, ctx) {
   const table = el("table", { class: "incident-evidence" });
   const thead = el("thead");
   const headRow = el("tr");
-  for (const label of ["event", "time", "status", "actor", "surface", "tool", "run", "task", "message"]) {
+  for (const label of ["event", "execution", "time", "status", "actor", "surface", "tool", "run", "task", "message"]) {
     headRow.appendChild(el("th", { text: label }));
   }
   thead.appendChild(headRow);
@@ -232,6 +240,7 @@ function incidentEvidenceTable(events, ctx) {
   for (const event of events) {
     const tr = el("tr");
     tr.appendChild(el("td", { class: "mono", text: event.id == null ? "-" : `#${event.id}` }));
+    tr.appendChild(el("td", { class: "mono", text: event.execution_id || "-" }));
     tr.appendChild(el("td", { text: ctx.fmtAbsTime ? ctx.fmtAbsTime(event.ts) : (event.ts || "-") }));
     tr.appendChild(el("td", { text: event.status || "-" }));
     tr.appendChild(el("td", { text: event.actor || "-" }));
@@ -397,7 +406,7 @@ function renderDiagnostics(ctx = {}) {
     // Both counts in the header: grouped incidents, and the raw failed events
     // they were derived from. Neither is inferable from the other.
     $("diag-count").textContent =
-      `${asCount(payload.incident_count)} incidents / ${asCount(payload.raw_failed_events)} failed events / ${asCount(payload.affected_run_count)} affected runs`;
+      `${asCount(payload.failure_categories && payload.failure_categories.unexpected && payload.failure_categories.unexpected.incidents)} unexpected / ${asCount(payload.incident_count)} all incidents / ${asCount(payload.raw_failed_events)} failed events`;
     renderIncidents(payload, ctx);
     renderDiagnosticsSideCard(last, ctx);
     return;

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -9,8 +9,9 @@ use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Duration, Utc};
 use orbit_core::application::job::JobRunListParams;
 use orbit_core::{
-    AuditEventFilter, AuditEventStatus, AuditToolAggregate, FailureIncidentQuery, JobRunState,
-    OrbitError, OrbitRuntime,
+    AuditEventFilter, AuditEventStatus, AuditToolAggregate, FailureClass, FailureIncidentQuery,
+    FailureIncidentReport, JOB_RUN_LIFECYCLE_LABEL, JobRunState, LIFECYCLE_DIAGNOSTIC_LABEL,
+    OrbitError, OrbitRuntime, is_failure_only_diagnostic_surface,
 };
 use orbit_types::tool::{McpCapability, McpTransport};
 use serde_json::{Value, json};
@@ -18,7 +19,7 @@ use serde_json::{Value, json};
 use super::denials::{
     collect_denial_rows, denials_by_reason_summary, denials_by_tool_summary, scan_v2_loop_denials,
 };
-use super::incidents::ROLLUP_SCAN_LIMIT;
+use super::incidents::{ROLLUP_SCAN_LIMIT, failure_category_summaries};
 use super::{
     AuditQuery, AuditSummaryQuery, DEFAULT_SUMMARY_WINDOW, HISTORY_DEFAULT_LIMIT,
     HISTORY_MAX_LIMIT, bad_request, bounded_limit, map_runtime_error, server_error,
@@ -228,10 +229,16 @@ pub(super) async fn audit_summary(Ws(runtime): Ws, Query(q): Query<AuditSummaryQ
         "failure_incidents": bundle.failure_incidents,
         "failure_incidents_by_class": bundle.failure_incidents_by_class,
         "failed_events_by_class": bundle.failed_events_by_class,
+        "affected_runs_by_class": bundle.affected_runs_by_class,
+        "failure_categories": bundle.failure_categories,
         "affected_run_count": bundle.affected_run_count,
         "job_run_lifecycle_failures": bundle.job_run_lifecycle_failures,
         "job_run_lifecycle_incidents": bundle.job_run_lifecycle_incidents,
-        "job_run_lifecycle_label": "job-run lifecycle",
+        "job_run_lifecycle_label": JOB_RUN_LIFECYCLE_LABEL,
+        "lifecycle_diagnostic_events": bundle.lifecycle_diagnostic_events,
+        "lifecycle_diagnostic_incidents": bundle.lifecycle_diagnostic_incidents,
+        "lifecycle_diagnostic_affected_run_count": bundle.lifecycle_diagnostic_affected_run_count,
+        "lifecycle_diagnostic_label": LIFECYCLE_DIAGNOSTIC_LABEL,
         "failed_runs": bundle.failed_runs,
         "active_long_runs": bundle.active_long_runs,
         "sparkline": sparkline,
@@ -259,9 +266,14 @@ struct AuditSummaryBundle {
     failure_incidents: u64,
     failure_incidents_by_class: BTreeMap<String, u64>,
     failed_events_by_class: BTreeMap<String, u64>,
+    affected_runs_by_class: BTreeMap<String, u64>,
+    failure_categories: Value,
     affected_run_count: u64,
     job_run_lifecycle_failures: u64,
     job_run_lifecycle_incidents: u64,
+    lifecycle_diagnostic_events: u64,
+    lifecycle_diagnostic_incidents: u64,
+    lifecycle_diagnostic_affected_run_count: u64,
     failed_runs: i64,
     active_long_runs: i64,
     buckets: Vec<(String, i64)>,
@@ -312,15 +324,14 @@ fn compute_audit_summary_bundle(
     let role_aggs = runtime.audit_event_aggregates_by_role(&since)?;
     let actor_aggs = runtime.audit_event_aggregates_by_actor(&since)?;
 
-    let mut failures_vec: Vec<_> = tool_aggs
+    let unexpected_by_tool = raw_failure_counts_by_tool(&incidents, FailureClass::Unexpected);
+    let mut failures_vec: Vec<_> = unexpected_by_tool
         .iter()
-        .filter(|t| t.failures > 0 && is_named_tool(&t.tool_name))
-        .map(|t| {
+        .map(|(tool, count)| {
             json!({
-                "tool": t.tool_name,
-                "count": t.failures,
-                "mcp": t.mcp_failures,
-                "cli": t.cli_failures,
+                "tool": tool,
+                "count": count,
+                "class": FailureClass::Unexpected.as_str(),
             })
         })
         .collect();
@@ -359,27 +370,28 @@ fn compute_audit_summary_bundle(
 
     let mut rate_vec: Vec<_> = tool_aggs
         .iter()
-        .filter(|t| t.total >= 5 && is_named_tool(&t.tool_name))
-        .map(|t| {
-            let rate = t.failures as f64 / t.total as f64;
-            let mcp_rate = if t.mcp_total > 0 {
-                t.mcp_failures as f64 / t.mcp_total as f64
-            } else {
-                0.0
-            };
-            let cli_rate = if t.cli_total > 0 {
-                t.cli_failures as f64 / t.cli_total as f64
-            } else {
-                0.0
-            };
-            json!({
+        .filter_map(|t| {
+            let unexpected_failures = unexpected_by_tool.get(&t.tool_name).copied().unwrap_or(0);
+            let comparison_population = t.successes + unexpected_failures;
+            let is_callable = t.mcp_total + t.cli_total > 0;
+            if !is_named_tool(&t.tool_name)
+                || is_failure_only_diagnostic_surface(&t.tool_name)
+                || !is_callable
+                || t.successes == 0
+                || unexpected_failures == 0
+                || comparison_population < 5
+            {
+                return None;
+            }
+            let rate = unexpected_failures as f64 / comparison_population as f64;
+            Some(json!({
                 "tool": t.tool_name,
                 "rate": rate,
-                "failures": t.failures,
-                "mcp_rate": mcp_rate,
-                "cli_rate": cli_rate,
-                "total": t.total,
-            })
+                "failures": unexpected_failures,
+                "successes": t.successes,
+                "total": comparison_population,
+                "denominator": "successful + unexpected failed calls",
+            }))
         })
         .collect();
     rate_vec.sort_by(|a, b| {
@@ -448,6 +460,7 @@ fn compute_audit_summary_bundle(
     let denial_rows = collect_denial_rows(runtime, Some(since), None, None)?;
     let denials_by_tool = denials_by_tool_summary(&denial_rows, 8);
     let denials_by_reason = denials_by_reason_summary(&denial_rows, 8);
+    let failure_categories = failure_category_summaries(&incidents);
 
     Ok(AuditSummaryBundle {
         total,
@@ -457,9 +470,14 @@ fn compute_audit_summary_bundle(
         failure_incidents: incidents.incident_count(),
         failure_incidents_by_class: incidents.incidents_by_class,
         failed_events_by_class: incidents.raw_events_by_class,
+        affected_runs_by_class: incidents.affected_runs_by_class,
+        failure_categories,
         affected_run_count: incidents.affected_run_count,
         job_run_lifecycle_failures: incidents.job_run_lifecycle_events,
         job_run_lifecycle_incidents: incidents.job_run_lifecycle_incidents,
+        lifecycle_diagnostic_events: incidents.lifecycle_diagnostic_events,
+        lifecycle_diagnostic_incidents: incidents.lifecycle_diagnostic_incidents,
+        lifecycle_diagnostic_affected_run_count: incidents.lifecycle_diagnostic_affected_run_count,
         failed_runs,
         active_long_runs,
         buckets,
@@ -473,6 +491,32 @@ fn compute_audit_summary_bundle(
         denials_by_tool,
         denials_by_reason,
     })
+}
+
+/// Counts raw incident evidence by tool for one class. This deliberately uses
+/// the existing incident classifier instead of maintaining a second list of
+/// expected/diagnostic message rules in the dashboard API.
+fn raw_failure_counts_by_tool(
+    report: &FailureIncidentReport,
+    class: FailureClass,
+) -> BTreeMap<String, i64> {
+    let mut counts = BTreeMap::new();
+    for event in report
+        .incidents
+        .iter()
+        .filter(|incident| incident.class == class)
+        .flat_map(|incident| &incident.events)
+    {
+        let Some(tool) = event
+            .tool_name
+            .as_deref()
+            .filter(|tool| is_named_tool(tool) && !is_failure_only_diagnostic_surface(tool))
+        else {
+            continue;
+        };
+        *counts.entry(tool.to_string()).or_insert(0) += 1;
+    }
+    counts
 }
 
 /// Builds a contiguous hourly sparkline covering `[truncate_to_hour(since), now]`,

--- a/crates/orbit-web/src/api/incidents.rs
+++ b/crates/orbit-web/src/api/incidents.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, Utc};
 use orbit_common::security::redaction::redact_all;
 use orbit_core::{
     FailureClass, FailureIncident, FailureIncidentQuery, FailureIncidentReport, IncidentEventRef,
-    OrbitError, PropagationLink,
+    JOB_RUN_LIFECYCLE_LABEL, LIFECYCLE_DIAGNOSTIC_LABEL, OrbitError, PropagationLink,
 };
 use orbit_types::identity::{infer_agent_family_from_model, normalize_attribution_label};
 use serde::Deserialize;
@@ -37,7 +37,7 @@ use crate::state::Ws;
 /// of audit rows would.
 const INCIDENTS_DEFAULT_LIMIT: usize = 50;
 
-/// `?since=<24h|7d|RFC3339>&class=<denied|expected|unexpected>&limit=`.
+/// `?since=<24h|7d|RFC3339>&class=<denied|diagnostic|expected|unexpected>&limit=`.
 #[derive(Debug, Default, Deserialize)]
 pub(super) struct IncidentsQuery {
     #[serde(default)]
@@ -81,7 +81,7 @@ pub(super) async fn list_failure_incidents(
             Some(class) => Some(class),
             None => {
                 return bad_request(format!(
-                    "unknown failure class: {value} (expected denied, expected, or unexpected)"
+                    "unknown failure class: {value} (expected denied, diagnostic, expected, or unexpected)"
                 ));
             }
         },
@@ -130,6 +130,7 @@ pub(super) async fn list_failure_incidents(
 fn parse_class(raw: &str) -> Option<FailureClass> {
     match raw {
         "denied" => Some(FailureClass::Denied),
+        "diagnostic" => Some(FailureClass::Diagnostic),
         "expected" => Some(FailureClass::Expected),
         "unexpected" => Some(FailureClass::Unexpected),
         _ => None,
@@ -159,6 +160,17 @@ pub(super) fn incidents_payload(
         .take(limit)
         .map(|incident| incident_to_json(incident))
         .collect();
+    let selected_class = class_filter.map(FailureClass::as_str);
+    let matching_raw_event_count = selected_class.map_or(report.raw_failed_events, |class| {
+        report.raw_events_by_class.get(class).copied().unwrap_or(0)
+    });
+    let matching_affected_run_count = selected_class.map_or(report.affected_run_count, |class| {
+        report
+            .affected_runs_by_class
+            .get(class)
+            .copied()
+            .unwrap_or(0)
+    });
 
     json!({
         "window": window,
@@ -174,20 +186,54 @@ pub(super) fn incidents_payload(
         "affected_run_count": report.affected_run_count,
         "job_run_lifecycle_events": report.job_run_lifecycle_events,
         "job_run_lifecycle_incidents": report.job_run_lifecycle_incidents,
-        "job_run_lifecycle_label": "job-run lifecycle",
+        "job_run_lifecycle_label": JOB_RUN_LIFECYCLE_LABEL,
+        "lifecycle_diagnostic_events": report.lifecycle_diagnostic_events,
+        "lifecycle_diagnostic_incidents": report.lifecycle_diagnostic_incidents,
+        "lifecycle_diagnostic_affected_run_count": report.lifecycle_diagnostic_affected_run_count,
+        "lifecycle_diagnostic_label": LIFECYCLE_DIAGNOSTIC_LABEL,
         "matching_incident_count": selected.len(),
+        "matching_raw_event_count": matching_raw_event_count,
+        "matching_affected_run_count": matching_affected_run_count,
         "shown_incident_count": shown.len(),
         "limit": limit,
         "raw_events_by_class": report.raw_events_by_class,
         "incidents_by_class": report.incidents_by_class,
+        "affected_runs_by_class": report.affected_runs_by_class,
+        "failure_categories": failure_category_summaries(report),
         "class_labels": {
             FailureClass::Denied.as_str(): FailureClass::Denied.label(),
+            FailureClass::Diagnostic.as_str(): FailureClass::Diagnostic.label(),
             FailureClass::Expected.as_str(): FailureClass::Expected.label(),
             FailureClass::Unexpected.as_str(): FailureClass::Unexpected.label(),
         },
         "truncated": report.truncated,
         "incidents": shown,
     })
+}
+
+/// One canonical projection for the four mutually exclusive failure classes.
+/// Both summary endpoints use it so their labels and denominators cannot
+/// drift apart.
+pub(super) fn failure_category_summaries(report: &FailureIncidentReport) -> Value {
+    let mut categories = serde_json::Map::new();
+    for class in [
+        FailureClass::Unexpected,
+        FailureClass::Expected,
+        FailureClass::Denied,
+        FailureClass::Diagnostic,
+    ] {
+        let key = class.as_str();
+        categories.insert(
+            key.to_string(),
+            json!({
+                "label": class.label(),
+                "incidents": report.incidents_by_class.get(key).copied().unwrap_or(0),
+                "raw_events": report.raw_events_by_class.get(key).copied().unwrap_or(0),
+                "affected_runs": report.affected_runs_by_class.get(key).copied().unwrap_or(0),
+            }),
+        );
+    }
+    Value::Object(categories)
 }
 
 fn incident_to_json(incident: &FailureIncident) -> Value {

--- a/crates/orbit-web/src/api/tests/audit.rs
+++ b/crates/orbit-web/src/api/tests/audit.rs
@@ -23,11 +23,31 @@ fn seed_audit_event(
     role: &str,
     error_message: Option<&str>,
 ) {
+    seed_audit_event_with_scope(
+        runtime,
+        execution_id,
+        tool_name,
+        status,
+        role,
+        error_message,
+        Some(("jrun", None)),
+    );
+}
+
+fn seed_audit_event_with_scope(
+    runtime: &OrbitRuntime,
+    execution_id: &str,
+    tool_name: &str,
+    status: AuditEventStatus,
+    role: &str,
+    error_message: Option<&str>,
+    scope: Option<(&str, Option<&str>)>,
+) {
     runtime
         .record_audit_event(&AuditEventInsertParams {
             execution_id: execution_id.to_string(),
-            command: "task".to_string(),
-            subcommand: Some("update".to_string()),
+            command: "tool".to_string(),
+            subcommand: Some("run".to_string()),
             tool_name: Some(tool_name.to_string()),
             target_type: Some("task".to_string()),
             target_id: Some("T00000000-000000".to_string()),
@@ -58,12 +78,42 @@ fn seed_audit_event(
             origin_session_id: Some("mcp-session".to_string()),
             mcp_call_id: Some("mcall".to_string()),
             lease_id: Some("lease".to_string()),
-            task_id: None,
-            job_run_id: Some("jrun".to_string()),
+            task_id: scope.and_then(|(_, task_id)| task_id).map(str::to_string),
+            job_run_id: scope.map(|(run_id, _)| run_id.to_string()),
             activity_id: None,
             step_index: None,
         })
         .expect("seed audit event");
+}
+
+fn seed_fourteen_named_diagnostic_rows(runtime: &OrbitRuntime) {
+    const RUN_IDS: [&str; 7] = [
+        "jrun-diagnostic-0",
+        "jrun-diagnostic-1",
+        "jrun-diagnostic-2",
+        "jrun-diagnostic-3",
+        "jrun-diagnostic-4",
+        "jrun-diagnostic-5",
+        "jrun-diagnostic-6",
+    ];
+    for (index, run_id) in RUN_IDS.into_iter().enumerate() {
+        let tool = if index % 2 == 0 {
+            "pipeline.worker.exit"
+        } else {
+            "pipeline.run.terminal_conflict"
+        };
+        for duplicate in 0..2 {
+            seed_audit_event_with_scope(
+                runtime,
+                &format!("exec-diagnostic-{index}-{duplicate}"),
+                tool,
+                AuditEventStatus::Failure,
+                "admin",
+                Some("pipeline worker lifecycle diagnostic"),
+                Some((run_id, Some(&format!("REC-diagnostic-{index}")))),
+            );
+        }
+    }
 }
 
 fn seed_lifecycle_audit_event(
@@ -494,4 +544,99 @@ async fn audit_summary_excludes_lifecycle_rows_from_tool_metrics() {
         rates.iter().all(|row| row["tool"] != "unknown"),
         "lifecycle rows must not form a tool rate denominator"
     );
+}
+
+/// ORB-11118: rates compare only successful calls with unexpected failed
+/// calls. Expected caller/input negatives, policy denials, and failure-only
+/// lifecycle diagnostics keep their own raw/incident/run denominators.
+#[tokio::test]
+async fn audit_summary_separates_reliability_from_negative_and_diagnostic_populations() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    seed_fourteen_named_diagnostic_rows(&runtime);
+
+    for index in 0..5 {
+        seed_audit_event_with_scope(
+            &runtime,
+            &format!("exec-search-ok-{index}"),
+            "orbit.search",
+            AuditEventStatus::Success,
+            "actor-one",
+            None,
+            None,
+        );
+    }
+    seed_audit_event_with_scope(
+        &runtime,
+        "exec-search-fail",
+        "orbit.search",
+        AuditEventStatus::Failure,
+        "actor-one",
+        Some("search backend unavailable"),
+        None,
+    );
+    for (execution_id, tool, message) in [
+        (
+            "exec-show-negative",
+            "orbit.task.show",
+            "not found: task REC-missing",
+        ),
+        (
+            "exec-update-negative",
+            "orbit.task.update",
+            "unsupported field projection: mystery",
+        ),
+    ] {
+        seed_audit_event_with_scope(
+            &runtime,
+            execution_id,
+            tool,
+            AuditEventStatus::Failure,
+            "actor-one",
+            Some(message),
+            None,
+        );
+    }
+    seed_audit_event_with_scope(
+        &runtime,
+        "exec-denied",
+        "orbit.task.update",
+        AuditEventStatus::Denied,
+        "actor-one",
+        Some("policy denied: write outside allowed scope"),
+        None,
+    );
+
+    let body = body_json(request_audit(runtime, "/audit/summary?since=24h").await).await;
+
+    assert_eq!(body["failure_categories"]["unexpected"]["raw_events"], 1);
+    assert_eq!(body["failure_categories"]["unexpected"]["incidents"], 1);
+    assert_eq!(body["failure_categories"]["expected"]["raw_events"], 2);
+    assert_eq!(body["failure_categories"]["denied"]["raw_events"], 1);
+    assert_eq!(body["failure_categories"]["diagnostic"]["raw_events"], 14);
+    assert_eq!(body["failure_categories"]["diagnostic"]["incidents"], 7);
+    assert_eq!(body["failure_categories"]["diagnostic"]["affected_runs"], 7);
+    assert_eq!(body["lifecycle_diagnostic_events"], 14);
+    assert_eq!(body["lifecycle_diagnostic_incidents"], 7);
+    assert_eq!(body["lifecycle_diagnostic_affected_run_count"], 7);
+
+    let rates = body["failure_rate_by_tool"].as_array().expect("rates");
+    assert_eq!(rates.len(), 1, "only one comparable callable surface");
+    assert_eq!(rates[0]["tool"], "orbit.search");
+    assert_eq!(rates[0]["failures"], 1);
+    assert_eq!(rates[0]["successes"], 5);
+    assert_eq!(rates[0]["total"], 6);
+    assert_eq!(rates[0]["rate"].as_f64(), Some(1.0 / 6.0));
+    assert!(rates.iter().all(|row| {
+        row["tool"] != "pipeline.worker.exit"
+            && row["tool"] != "pipeline.run.terminal_conflict"
+            && row["tool"] != "orbit.task.show"
+            && row["tool"] != "orbit.task.update"
+    }));
+
+    let unexpected = body["failures_by_tool"]
+        .as_array()
+        .expect("unexpected failures by tool");
+    assert_eq!(unexpected.len(), 1);
+    assert_eq!(unexpected[0]["tool"], "orbit.search");
+    assert_eq!(unexpected[0]["count"], 1);
 }

--- a/crates/orbit-web/src/api/tests/incidents.rs
+++ b/crates/orbit-web/src/api/tests/incidents.rs
@@ -171,6 +171,51 @@ fn seed_ten_unknown_lifecycle_rows(runtime: &OrbitRuntime) {
     }
 }
 
+fn seed_named_diagnostic(
+    runtime: &OrbitRuntime,
+    execution_id: &str,
+    tool_name: &str,
+    job_run_id: &str,
+    task_id: &str,
+) {
+    runtime
+        .record_audit_event(&AuditEventInsertParams {
+            execution_id: execution_id.to_string(),
+            command: "tool".to_string(),
+            subcommand: Some("run".to_string()),
+            tool_name: Some(tool_name.to_string()),
+            target_type: Some("job_run".to_string()),
+            target_id: Some(job_run_id.to_string()),
+            role: "admin".to_string(),
+            status: AuditEventStatus::Failure,
+            exit_code: 1,
+            duration_ms: 0,
+            working_directory: "/tmp/fixture".to_string(),
+            arguments_json: None,
+            stdout_truncated: None,
+            stderr_truncated: None,
+            error_message: Some("pipeline worker lifecycle diagnostic".to_string()),
+            host: None,
+            pid: std::process::id(),
+            session_id: None,
+            workspace_id: None,
+            caller_machine_id: None,
+            caller_host_id: None,
+            process_machine_id: None,
+            process_host_id: None,
+            transport: None,
+            effective_capabilities: Default::default(),
+            origin_session_id: None,
+            mcp_call_id: None,
+            lease_id: None,
+            task_id: Some(task_id.to_string()),
+            job_run_id: Some(job_run_id.to_string()),
+            activity_id: Some("worker-observer".to_string()),
+            step_index: None,
+        })
+        .expect("seed named diagnostic");
+}
+
 async fn request(runtime: OrbitRuntime, uri: &str) -> axum::response::Response {
     router()
         .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
@@ -472,6 +517,63 @@ async fn ten_unknown_lifecycle_rows_group_as_four_cascades_and_one_start() {
             );
             assert!(event["run_id"].as_str().is_some(), "run id is present");
             assert!(event["task_id"].as_str().is_some(), "task id is present");
+        }
+    }
+}
+
+/// ORB-11118: seven duplicate-worker incidents emit fourteen raw diagnostic
+/// rows. They remain fully expandable with run/task/tool evidence while their
+/// class-specific denominator stays separate from callable reliability.
+#[tokio::test]
+async fn named_worker_diagnostics_report_seven_incidents_and_fourteen_exact_rows() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    for index in 0..7 {
+        let run_id = format!("jrun-diagnostic-{index}");
+        let task_id = format!("REC-diagnostic-{index}");
+        let tool = if index % 2 == 0 {
+            "pipeline.worker.exit"
+        } else {
+            "pipeline.run.terminal_conflict"
+        };
+        for duplicate in 0..2 {
+            seed_named_diagnostic(
+                &runtime,
+                &format!("exec-diagnostic-{index}-{duplicate}"),
+                tool,
+                &run_id,
+                &task_id,
+            );
+        }
+    }
+
+    let body =
+        body_json(request(runtime, "/audit/incidents?since=24h&class=diagnostic").await).await;
+
+    assert_eq!(body["incident_count"], 7);
+    assert_eq!(body["raw_failed_events"], 14);
+    assert_eq!(body["matching_incident_count"], 7);
+    assert_eq!(body["matching_raw_event_count"], 14);
+    assert_eq!(body["matching_affected_run_count"], 7);
+    assert_eq!(body["failure_categories"]["diagnostic"]["incidents"], 7);
+    assert_eq!(body["failure_categories"]["diagnostic"]["raw_events"], 14);
+    assert_eq!(body["failure_categories"]["diagnostic"]["affected_runs"], 7);
+    assert_eq!(body["lifecycle_diagnostic_events"], 14);
+    assert_eq!(body["lifecycle_diagnostic_incidents"], 7);
+    assert_eq!(body["lifecycle_diagnostic_affected_run_count"], 7);
+
+    let incidents = body["incidents"].as_array().expect("incidents");
+    assert_eq!(incidents.len(), 7);
+    for incident in incidents {
+        assert_eq!(incident["class"], "diagnostic");
+        assert_eq!(incident["event_count"], 2);
+        let events = incident["events"].as_array().expect("exact evidence");
+        assert_eq!(events.len(), 2);
+        for event in events {
+            assert!(event["id"].as_i64().is_some());
+            assert!(event["run_id"].as_str().is_some());
+            assert!(event["task_id"].as_str().is_some());
+            assert!(event["tool"].as_str().is_some());
+            assert!(event["execution_id"].as_str().is_some());
         }
     }
 }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1480,12 +1480,12 @@ fn dashboard_failure_metrics_are_incident_aware_and_state_their_denominators() {
     // Both counts, both denominators, and the window are rendered — never one
     // number standing in for the other.
     assert!(
-        diagnostics.contains("${asCount(payload.incident_count)} incidents / ${asCount(payload.raw_failed_events)} failed events / ${asCount(payload.affected_run_count)} affected runs"),
-        "the panel count must show grouped incidents, raw failed events, and affected runs together"
+        diagnostics.contains("${asCount(payload.failure_categories && payload.failure_categories.unexpected && payload.failure_categories.unexpected.incidents)} unexpected / ${asCount(payload.incident_count)} all incidents / ${asCount(payload.raw_failed_events)} failed events"),
+        "the panel count must separate unexpected incidents from the all-incident and raw-event populations"
     );
     assert!(
-        diagnostics.contains("${failed} failed events · ${incidents} grouped incidents · ${runs} affected runs of ${total} audited events"),
-        "the incident count must state raw events, grouped incidents, and affected runs"
+        diagnostics.contains("${unexpectedEvents} unexpected raw events · ${unexpectedRuns} affected runs; ${incidents} incidents / ${failed} failed events / ${runs} affected runs across ${total} audited events"),
+        "the incident headline must state the unexpected and all-category denominators"
     );
     assert!(
         diagnostics.contains("`window ${window}`"),
@@ -1577,14 +1577,14 @@ fn dashboard_tool_metrics_exclude_unknown_and_label_lifecycle_failures() {
     assert!(
         audit.contains("function isNamedTool(")
             && audit.contains("trimmed !== \"unknown\"")
-            && audit.contains("job_run_lifecycle_failures")
-            && audit.contains("job-run lifecycle")
-            && audit.contains("Excluded from tool denominators and rates"),
-        "tool cards must drop `unknown` and name the job-run lifecycle category"
+            && audit.contains("lifecycle_diagnostic_events")
+            && audit.contains("lifecycle diagnostics")
+            && audit.contains("excluded from callable-tool denominators and rates"),
+        "tool cards must drop `unknown` and name the lifecycle-diagnostic category"
     );
     assert!(
-        audit.contains("${lifecycleFailures} failed events · ${lifecycleIncidents} incidents · ${Number(data.affected_run_count) || 0} affected runs"),
-        "the lifecycle card must distinguish raw events, incidents, and affected runs"
+        audit.contains("${lifecycleIncidents} incidents · ${lifecycleFailures} raw events · ${Number(data.lifecycle_diagnostic_affected_run_count) || 0} affected runs"),
+        "the lifecycle diagnostic card must distinguish incidents, raw events, and affected runs"
     );
     assert!(
         diagnostics.contains("incident.events")
@@ -1594,16 +1594,90 @@ fn dashboard_tool_metrics_exclude_unknown_and_label_lifecycle_failures() {
         "incident expansion must expose run/task/tool identifiers for every row"
     );
     assert!(
-        preview.contains("job-run lifecycle")
-            && preview.contains("10 failed events · 5 incidents · 8 affected runs")
+        preview.contains("lifecycle diagnostics")
+            && preview.contains("7 incidents · 14 raw events · 7 affected runs")
             && preview.contains("isNamedTool"),
-        "the failures-card preview must render the lifecycle category and three counts"
+        "the failures-card preview must render the diagnostic category and three counts"
     );
     assert!(
         css.contains(".lifecycle-failure-card")
             && css.contains(".lifecycle-failure-counts")
             && css.contains(".incident-lifecycle-note"),
         "lifecycle labels need their own presentation hooks"
+    );
+}
+
+/// ORB-11118: the reliability card has one honest comparison population, while
+/// expected negatives, denials, and failure-only diagnostics remain visible
+/// as separately labeled incident populations with exact evidence expansion.
+#[test]
+fn dashboard_reliability_separates_all_four_failure_populations() {
+    let audit = include_str!("../../assets/dashboard/audit.js");
+    let diagnostics = include_str!("../../assets/dashboard/diagnostics.js");
+    let preview = include_str!("../../assets/dashboard/_preview_failures_card.html");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    for needle in [
+        "Unexpected Failures by Callable Tool",
+        "Unexpected Failure Rate",
+        "comparable calls (successful + unexpected failed)",
+        "Failure categories · window",
+        "classification",
+        "raw events",
+        "affected runs",
+    ] {
+        assert!(
+            audit.contains(needle),
+            "audit summary must render `{needle}`"
+        );
+    }
+    assert!(
+        !audit.contains("} else if (namedFailures.length)"),
+        "failure-only populations must not fall back to a synthetic tool-rate card"
+    );
+    assert!(
+        diagnostics.contains(
+            r#"const INCIDENT_CLASS_ORDER = ["unexpected", "expected", "denied", "diagnostic"];"#
+        ) && diagnostics.contains(
+            "${labels[key] || key}: ${count} incidents · ${events} raw · ${categoryRuns} runs"
+        ) && diagnostics.contains("${unexpectedIncidents} unexpected incidents"),
+        "the incident view must visibly separate all four classes and headline only unexpected incidents"
+    );
+    for evidence in [
+        "event.id",
+        "event.tool || \"-\"",
+        "event.run_id || \"-\"",
+        "event.task_id || \"-\"",
+        "event.execution_id",
+    ] {
+        assert!(
+            diagnostics.contains(evidence),
+            "incident expansion must retain `{evidence}`"
+        );
+    }
+    assert!(
+        preview.contains("pipeline.worker.exit")
+            && preview.contains("pipeline.run.terminal_conflict")
+            && preview.contains("orbit.task.show")
+            && preview.contains("orbit.task.update")
+            && preview.contains("7 incidents · 14 raw events · 7 affected runs"),
+        "the deterministic preview must keep diagnostic and expected-negative fixtures outside rateRows but visible in evidence"
+    );
+    assert!(
+        css.contains(".incident-class-chip.diagnostic")
+            && css.contains(".incident-row.diagnostic")
+            && css.contains(".incident-class.diagnostic"),
+        "diagnostic rows need a distinct desktop presentation"
+    );
+    let responsive_at = css
+        .rfind("@media (max-width: 720px)")
+        .expect("720px responsive rules");
+    assert!(
+        css[responsive_at..].contains(".incident-class-chip")
+            && css[responsive_at..].contains("white-space: normal")
+            && css[responsive_at..]
+                .contains(".tool-health-grid { grid-template-columns: minmax(0, 1fr); }"),
+        "four category labels and rate cards must remain scannable at narrow viewport widths"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11118](https://orbit-cli.com/tasks/ORB-11118) — Separate diagnostic and expected-negative events from tool failure rates

### Description

## Problem

The dashboard presents synthetic diagnostic event names such as `pipeline.worker.exit` and `pipeline.run.terminal_conflict` as tools with 100% failure rates. Those event names are emitted only on abnormal paths, so they have no healthy-call denominator and a failure percentage is misleading by construction.

The same card mixes unexpected incidents with expected caller/input negatives such as unsupported field projections, missing identifiers, wrong-workspace probes, and not-found lookups. ORB-10871 and ORB-10969 added incident grouping and removed some lifecycle events from tool metrics, but the current Failures by Tool card still makes diagnostic-only categories and deterministic negative paths look like service reliability.

## Why It Matters

Operators need to see genuine unexpected incidents first, while retaining raw evidence and useful counts for diagnostics, denials, and expected negative paths. A rate is meaningful only when success and failure events share a comparable call population.

## Constraints / Notes

- Preserve every raw audit row and drill-down.
- Do not invent success denominators for failure-only diagnostic event names.
- Show diagnostic events using incident count, affected-run count, and raw-event count.
- Keep unexpected, expected-negative, denied, and lifecycle-diagnostic classes visibly distinct.
- Build on the incident contract from ORB-10871 and ORB-10969 rather than creating a second incompatible grouping system.

### Acceptance Criteria

- The Failures by Tool rate ranking includes only callable surfaces with comparable success and failure populations; failure-only lifecycle diagnostic names are excluded from percentage rankings and shown in an explicitly labeled diagnostic section.
- Unexpected failures, expected-negative caller/input outcomes, policy denials, and lifecycle diagnostics have separate visible counts and denominators for the selected window.
- A deterministic fixture matching seven duplicate-worker incidents that emit fourteen raw diagnostic rows renders seven affected-run incidents, fourteen raw events, and no synthetic 100% tool failure rate.
- Expected-negative task.show and task.update fixtures remain accessible but do not inflate the unexpected reliability headline.
- Expanding any category reaches the exact underlying audit rows and run/task/tool identifiers without dropping evidence.
- Store/API/UI tests pin the classification and denominator contract, and rendered desktop plus narrow-viewport validation confirms the labels remain scannable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a fourth incident class for lifecycle diagnostics, with one canonical list of failure-only diagnostic surfaces and per-class incident, raw-event, and affected-run counts.
- Changed callable-tool reliability rates to use only unexpected failures over successful plus unexpected failed calls, requiring both populations and excluding non-callable, expected-negative, denied, and diagnostic rows.
- Exposed the four category denominators consistently from the audit summary and incident APIs while retaining all legacy raw rows and exact event, execution, run, task, and tool evidence.
- Updated the dashboard, deterministic failures-card preview, diagnostic styling, and narrow-viewport rules so the unexpected headline, expected negatives, denials, and lifecycle diagnostics are visibly distinct.
- Added the seven-incident/fourteen-row duplicate-worker fixture plus task.show/task.update expected-negative coverage across store, API, and dashboard asset tests.
Assessment: The implementation reuses the existing incident grouping/classification boundary and preserves backward-compatible lifecycle fields while making the reliability denominator explicit. Context expanded to the existing store aggregate/incident contracts, re-export files, and dashboard CSS because those were directly required for the classification, denominator, and responsive acceptance criteria.
Validation:
- make ci-fast (pass)
- make ci-lint (pass; workspace all-target clippy with warnings denied)
- cargo test -p orbit-store --lib (375 passed, 4 ignored)
- cargo test -p orbit-web (263 passed)
- Targeted deterministic store/API/dashboard regression tests (pass)
- Desktop preview fixture and 720px/520px responsive asset assertions pass; no standalone browser executable was available for an additional screenshot run.
Friction checkpoint: considered; no qualifying recurring failure, contradicted assumption, incident root cause, or over-10-minute gotcha to file.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11118-6a93c99f`
- Behind base: 0
- Ahead of base: 1