### PR TITLE
Prevent duplicate-worker false terminalization and stale interruption conflicts

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -998,9 +998,7 @@ impl OrbitRuntime {
             let run = self
                 .get_job_run_backend(run_id)?
                 .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
-            if let Some(owner_pid) = run.pid
-                && !claimed
-            {
+            if run.pid == Some(child_pid) && !claimed {
                 let _ = self.record_pipeline_audit(
                     "pipeline.worker.claimed",
                     Some(run_id),
@@ -1009,7 +1007,7 @@ impl OrbitRuntime {
                     json!({
                         "run_id": run_id,
                         "worker_pid": child_pid,
-                        "owner_pid": owner_pid,
+                        "owner_pid": child_pid,
                         "workspace": workspace,
                         "worker_log": worker_log,
                         "state": run.state.to_string(),
@@ -1030,10 +1028,42 @@ impl OrbitRuntime {
                     .filter(|value| !value.is_empty())
                     .map(|value| format!("; worker output:\n{value}"))
                     .unwrap_or_default();
+                // [ORB-11116] A second worker can lose the atomic Start race
+                // and exit successfully while the incumbent's PID remains on
+                // the run. Only this observer's exact child PID establishes
+                // ownership; another non-null PID is a benign duplicate
+                // delivery, not evidence that this child abandoned the run.
+                if let Some(owner_pid) = run.pid.filter(|owner_pid| *owner_pid != child_pid) {
+                    tracing::info!(
+                        target: "orbit.core.job_run",
+                        run_id,
+                        worker_pid = child_pid,
+                        owner_pid,
+                        exit_status = %status,
+                        "duplicate pipeline worker exited without owning the persisted run",
+                    );
+                    let _ = self.record_pipeline_audit(
+                        "pipeline.worker.duplicate",
+                        Some(run_id),
+                        actor,
+                        AuditEventStatus::Success,
+                        json!({
+                            "run_id": run_id,
+                            "worker_pid": child_pid,
+                            "owner_pid": owner_pid,
+                            "workspace": workspace,
+                            "worker_log": worker_log,
+                            "state": run.state.to_string(),
+                            "exit_status": status.to_string(),
+                        }),
+                        None,
+                    );
+                    return Ok(());
+                }
                 if run.state.is_terminal() {
                     return Ok(());
                 }
-                let ownership = if run.pid.is_some() {
+                let ownership = if run.pid == Some(child_pid) {
                     "after claiming"
                 } else {
                     "before claiming"

--- a/crates/orbit-core/src/application/job/run/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/reconcile.rs
@@ -91,49 +91,67 @@ impl OrbitRuntime {
     }
 
     pub(crate) fn reconcile_stale_job_run(&self, run: &JobRun) -> Result<bool, OrbitError> {
+        self.reconcile_stale_job_run_before_revalidation(run, || {})
+    }
+
+    fn reconcile_stale_job_run_before_revalidation<F>(
+        &self,
+        run: &JobRun,
+        before_revalidation: F,
+    ) -> Result<bool, OrbitError>
+    where
+        F: FnOnce(),
+    {
         if terminal_run_timing_is_incomplete(run) {
             return self.repair_terminal_job_run_timing(run);
         }
-        // [ORB-10070] Orphaned queued runs (claimed worker conclusively gone,
-        // or never claimed past the grace window) finalize exactly like
-        // orphaned running runs.
-        if let Some(reason) = pending_run_stale_reason(run) {
-            return self.finalize_orphaned_job_run(
-                run,
-                reason.error_code(),
-                &stale_pending_run_message(run, reason),
-            );
-        }
-        if !running_run_owner_is_stale(run) {
+        if stale_job_run_diagnostic(run).is_none() {
             return Ok(false);
         }
-        let stale_reason = running_run_owner_stale_reason(run);
-        self.finalize_orphaned_job_run(
-            run,
-            owner_identity_error_code(stale_reason),
-            &stale_job_run_message(run, stale_reason),
-        )
+
+        before_revalidation();
+        self.finalize_orphaned_job_run(&run.run_id)
+    }
+
+    /// Deterministic seam for reproducing a terminal writer winning after the
+    /// stale snapshot was classified but before reconciliation revalidates it.
+    #[cfg(test)]
+    pub(super) fn reconcile_stale_job_run_after_classification<F>(
+        &self,
+        run: &JobRun,
+        concurrent_completion: F,
+    ) -> Result<bool, OrbitError>
+    where
+        F: FnOnce(),
+    {
+        self.reconcile_stale_job_run_before_revalidation(run, concurrent_completion)
     }
 
     /// [ORB-10002] Orphaned runs (owner process conclusively gone) become
     /// `interrupted`, not `failed`: the job did not fail, its worker died.
     /// Interrupted runs are resumable from their step checkpoints via
     /// `orbit job resume <run_id>`.
-    fn finalize_orphaned_job_run(
-        &self,
-        run: &JobRun,
-        error_code: &str,
-        message: &str,
-    ) -> Result<bool, OrbitError> {
-        let finished_at = self.orphaned_run_finished_at(run);
-        let duration_ms = run.started_at.map(|started_at| {
+    fn finalize_orphaned_job_run(&self, run_id: &str) -> Result<bool, OrbitError> {
+        // [ORB-11116] The scan's candidate snapshot can go stale while a real
+        // worker is terminalizing. Re-read at the interruption boundary and
+        // re-run both state and owner classification so a completed run never
+        // receives a later interruption attempt (or its conflict diagnostic).
+        let Some(current) = self.get_job_run_backend(run_id)? else {
+            return Ok(false);
+        };
+        let Some((error_code, message)) = stale_job_run_diagnostic(&current) else {
+            return Ok(false);
+        };
+
+        let finished_at = self.orphaned_run_finished_at(&current);
+        let duration_ms = current.started_at.map(|started_at| {
             finished_at
                 .signed_duration_since(started_at)
                 .num_milliseconds()
                 .max(0) as u64
         });
         let changed = self.finalize_job_run_with_reservation_cleanup(
-            &run.run_id,
+            &current.run_id,
             JobRunState::Interrupted,
             finished_at,
             duration_ms,
@@ -143,25 +161,25 @@ impl OrbitRuntime {
             return Ok(false);
         }
 
-        let Some(current) = self.get_job_run_backend(&run.run_id)? else {
+        let Some(finalized) = self.get_job_run_backend(&current.run_id)? else {
             return Ok(false);
         };
-        if current.state != JobRunState::Interrupted || current.finished_at.is_none() {
+        if finalized.state != JobRunState::Interrupted || finalized.finished_at.is_none() {
             return Ok(false);
         }
 
-        let step_started_at = run.started_at.unwrap_or(run.scheduled_at);
+        let step_started_at = current.started_at.unwrap_or(current.scheduled_at);
         let _ = self.record_pipeline_diagnostic_step(
-            run,
+            &current,
             step_started_at,
             finished_at,
-            Some(error_code),
-            message,
+            Some(&error_code),
+            &message,
             JobRunState::Interrupted,
         );
         self.record_event(OrbitEvent::JobRunCompleted {
-            job_id: run.job_id.clone(),
-            run_id: run.run_id.clone(),
+            job_id: current.job_id.clone(),
+            run_id: current.run_id.clone(),
             state: JobRunState::Interrupted.to_string(),
         })?;
         Ok(true)
@@ -258,6 +276,29 @@ impl OrbitRuntime {
         }
         Ok(None)
     }
+}
+
+/// The diagnostic for a currently stale non-terminal run. Keeping
+/// classification and message construction together lets reconciliation
+/// repeat the authoritative decision against a fresh durable row.
+fn stale_job_run_diagnostic(run: &JobRun) -> Option<(String, String)> {
+    // [ORB-10070] Orphaned queued runs (claimed worker conclusively gone, or
+    // never claimed past the grace window) finalize exactly like orphaned
+    // running runs.
+    if let Some(reason) = pending_run_stale_reason(run) {
+        return Some((
+            reason.error_code().to_string(),
+            stale_pending_run_message(run, reason),
+        ));
+    }
+    if !running_run_owner_is_stale(run) {
+        return None;
+    }
+    let stale_reason = running_run_owner_stale_reason(run);
+    Some((
+        owner_identity_error_code(stale_reason).to_string(),
+        stale_job_run_message(run, stale_reason),
+    ))
 }
 
 fn terminal_run_timing_is_incomplete(run: &JobRun) -> bool {

--- a/crates/orbit-core/src/application/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/tests/reconcile.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use super::super::JobRunListParams;
+use crate::application::job::TERMINAL_OUTCOME_CONFLICT_CODE;
 use chrono::{Duration, Utc};
 use orbit_types::workflow::JobRunState;
 
@@ -238,6 +239,50 @@ fn pending_run_with_dead_claimed_owner_is_reconciled() {
                 .as_deref()
                 .is_some_and(|message| message.contains("no live worker process owns it"))
     }));
+}
+
+/// [ORB-11116] A worker may terminalize after the sweep reads/classifies its
+/// stale snapshot. Each terminal outcome wins before the interruption boundary
+/// is revalidated, so reconciliation must neither interrupt nor record a
+/// first-terminal-wins conflict afterward.
+#[test]
+fn concurrent_terminal_outcomes_win_before_stale_interruption_revalidation() {
+    for terminal_state in [
+        JobRunState::Success,
+        JobRunState::Failed,
+        JobRunState::Cancelled,
+    ] {
+        let (_root, runtime) = test_runtime();
+        let run = insert_pending_run(&runtime, "qa_reconcile_terminal_race");
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(&run.run_id, Utc::now() - Duration::seconds(3), 999_999)
+            .expect("mark stale running");
+        let stale_snapshot = runtime
+            .get_job_run_backend(&run.run_id)
+            .expect("read stale snapshot")
+            .expect("stale run exists");
+
+        let reconciled = runtime
+            .reconcile_stale_job_run_after_classification(&stale_snapshot, || {
+                runtime
+                    .stores()
+                    .jobs()
+                    .finalize_job_run(&run.run_id, terminal_state, Utc::now(), Some(3_000))
+                    .expect("concurrent terminal writer wins");
+            })
+            .expect("reconcile stale snapshot");
+
+        assert!(!reconciled, "{terminal_state} must prevent interruption");
+        let stored = runtime.show_job_run(&run.run_id).expect("show winner");
+        assert_eq!(stored.state, terminal_state);
+        assert!(stored.finished_at.is_some());
+        assert!(stored.steps.iter().all(|step| {
+            step.state != JobRunState::Interrupted
+                && step.error_code.as_deref() != Some(TERMINAL_OUTCOME_CONFLICT_CODE)
+        }));
+    }
 }
 
 /// [ORB-10594] The incident shape, end to end through the sweep: a run whose

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -305,6 +305,144 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_child_reaped(worker_pid);
 }
 
+/// [ORB-11116] Two observers can watch children for the same persisted run.
+/// The duplicate exits zero after losing Start, but only the child whose exact
+/// PID is persisted may be treated as the owner by its observer.
+#[cfg(unix)]
+#[test]
+fn duplicate_worker_exit_leaves_real_owner_authoritative_and_non_terminal() {
+    let (_root, runtime) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert pending run");
+    let owner_release = runtime.paths().logs_dir.join("release-real-owner");
+
+    let mut owner_command = Command::new("sh");
+    owner_command.env("ORBIT_TEST_OWNER_RELEASE", &owner_release);
+    owner_command.args([
+        "-c",
+        "while [ ! -f \"$ORBIT_TEST_OWNER_RELEASE\" ]; do sleep 0.01; done; exit 0",
+    ]);
+    let owner_log = configure_pipeline_worker_stdio(
+        &mut owner_command,
+        &runtime.paths().logs_dir,
+        &format!("{}-owner", run.run_id),
+    )
+    .expect("configure owner worker log");
+    let owner_pid = runtime
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), owner_command, owner_log)
+        .expect("spawn real owner fixture");
+    assert!(
+        runtime
+            .stores()
+            .jobs()
+            .claim_pending_job_run_owner(&run.run_id, owner_pid)
+            .expect("claim real owner")
+    );
+    assert_eq!(
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(&run.run_id, Utc::now(), owner_pid)
+            .expect("start real owner"),
+        JobRunStartOutcome::Started
+    );
+
+    let claimed = wait_for_pipeline_audit_event(&runtime, None, "exact-owner audit", |audit| {
+        audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
+            && audit.target_id.as_deref() == Some(run.run_id.as_str())
+    });
+    let claimed_arguments: serde_json::Value = serde_json::from_str(
+        claimed
+            .arguments_json
+            .as_deref()
+            .expect("claimed audit arguments"),
+    )
+    .expect("parse claimed audit arguments");
+    assert_eq!(claimed_arguments["worker_pid"], owner_pid);
+    assert_eq!(claimed_arguments["owner_pid"], owner_pid);
+
+    let duplicate_release = runtime.paths().logs_dir.join("release-duplicate-worker");
+    let mut duplicate_command = Command::new("sh");
+    duplicate_command.env("ORBIT_TEST_DUPLICATE_RELEASE", &duplicate_release);
+    duplicate_command.args([
+        "-c",
+        "while [ ! -f \"$ORBIT_TEST_DUPLICATE_RELEASE\" ]; do sleep 0.01; done; exit 0",
+    ]);
+    let duplicate_log = configure_pipeline_worker_stdio(
+        &mut duplicate_command,
+        &runtime.paths().logs_dir,
+        &format!("{}-duplicate", run.run_id),
+    )
+    .expect("configure duplicate worker log");
+    let duplicate_pid = runtime
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), duplicate_command, duplicate_log)
+        .expect("spawn duplicate worker fixture");
+    let duplicate_start =
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(&run.run_id, Utc::now(), duplicate_pid);
+    assert!(
+        matches!(duplicate_start, Err(OrbitError::JobRunStartConflict(_))),
+        "duplicate worker must lose the atomic Start race: {duplicate_start:?}"
+    );
+    std::fs::write(&duplicate_release, "release").expect("release duplicate worker");
+
+    let duplicate =
+        wait_for_pipeline_audit_event(&runtime, None, "duplicate-worker audit", |audit| {
+            audit.tool_name.as_deref() == Some("pipeline.worker.duplicate")
+                && audit.target_id.as_deref() == Some(run.run_id.as_str())
+        });
+    let duplicate_arguments: serde_json::Value = serde_json::from_str(
+        duplicate
+            .arguments_json
+            .as_deref()
+            .expect("duplicate audit arguments"),
+    )
+    .expect("parse duplicate audit arguments");
+    assert_eq!(duplicate_arguments["worker_pid"], duplicate_pid);
+    assert_eq!(duplicate_arguments["owner_pid"], owner_pid);
+    assert_eq!(duplicate_arguments["exit_status"], "exit status: 0");
+    assert_child_reaped(duplicate_pid);
+
+    let after_duplicate = runtime
+        .show_job_run(&run.run_id)
+        .expect("show run after duplicate exit");
+    assert_eq!(after_duplicate.state, JobRunState::Running);
+    assert_eq!(after_duplicate.pid, Some(owner_pid));
+    assert!(after_duplicate.finished_at.is_none());
+    assert!(after_duplicate.steps.is_empty());
+
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&run.run_id, JobRunState::Success, Utc::now(), Some(1))
+        .expect("real owner completes run");
+    std::fs::write(&owner_release, "release").expect("release real owner");
+
+    let completed = runtime
+        .show_job_run(&run.run_id)
+        .expect("show completed run");
+    assert_eq!(completed.state, JobRunState::Success);
+    assert!(completed.finished_at.is_some());
+    assert!(completed.steps.is_empty());
+    let false_owner_exit = runtime
+        .list_audit_events(None, None, None, None, 50)
+        .expect("list worker audits")
+        .into_iter()
+        .any(|audit| {
+            audit.tool_name.as_deref() == Some("pipeline.worker.exit")
+                && audit.target_id.as_deref() == Some(run.run_id.as_str())
+        });
+    assert!(
+        !false_owner_exit,
+        "duplicate exit must not be an owner failure"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn worker_exit_after_mark_running_is_reaped_and_terminalizes_the_run() {


### PR DESCRIPTION
## Task

[ORB-11116](https://orbit-cli.com/tasks/ORB-11116) — Prevent duplicate-worker false terminalization and stale interruption conflicts

### Description

## Problem

Seven persisted pipeline runs spawned multiple worker processes. When a duplicate lost the claim race and exited successfully, the startup observer treated the presence of any owner PID as proof that its own child owned the run. It then interpreted the duplicate's clean exit as an owner exit, marked the run failed, and later conflicted with the real owner's successful completion.

The ownership path records both `worker_pid` and `owner_pid`, but tests only whether `run.pid.is_some()` instead of requiring `run.pid == child_pid`.

A separate stale-run reconciliation race produced nine interruption attempts after a run had already reached success, failure, or cancellation. First-terminal-wins prevented state corruption, but reconciliation used an earlier run snapshot and still emitted terminal-conflict diagnostics.

## Why It Matters

The observer race creates false failed runs while valid work is still executing. Both races multiply one lifecycle incident into multiple red audit rows and undermine operator trust in pipeline state.

## Constraints / Notes

- Treat a duplicate worker that did not acquire ownership as a benign loser; do not terminalize the persisted run from that child's exit.
- Preserve actionable handling for a true owner that exits before producing a terminal result.
- Re-read or conditionally compare current durable state immediately before stale-run interruption.
- Preserve first-terminal-wins as the final safety boundary.
- Add deterministic concurrency coverage; do not rely on timing-only sleeps.
- Relevant implementation includes `crates/orbit-core/src/application/job/pipeline.rs` and `crates/orbit-core/src/application/job/run/reconcile.rs`.
- Related completed work: ORB-10238, ORB-10461, and ORB-11091.

### Acceptance Criteria

- A deterministic two-worker fixture proves that when one child loses the claim race and exits with status 0, the observer verifies exact PID ownership, leaves the persisted run non-terminal, and the real owner can complete successfully without a false pipeline.worker.exit failure or terminal conflict.
- Observer ownership is established only when the persisted owner PID equals the observed child PID; a different non-null owner PID is recorded as a benign duplicate-worker outcome with enough identifiers for diagnosis.
- A true owning worker that exits before terminalizing the run still produces one actionable terminal failure with its underlying diagnostic.
- Reconciliation revalidates durable state immediately before interruption, and deterministic concurrent-completion tests cover success, failure, and cancellation winning the race without a later interruption attempt.
- First-terminal-wins remains enforced, and focused pipeline/reconciliation tests pass together with make ci-fast, make ci-lint, and git diff --check.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Detached-worker observers now establish ownership only when the persisted PID exactly matches their child PID.
- A child exiting under a different non-null owner PID is recorded as a benign `pipeline.worker.duplicate` audit with run, worker, owner, workspace, log, state, and exit-status identifiers; it cannot terminalize the run.
- Stale-run reconciliation now re-reads and reclassifies the durable run immediately before interruption.
- Added a deterministic two-child Start-race fixture, preserved owner-exit diagnostic coverage, and added deterministic success/failure/cancellation reconciliation race coverage with no later interruption conflict.
Validation:
- `cargo test -p orbit-core --lib application::tests::job_pipeline -- --nocapture` (20 passed)
- `cargo test -p orbit-core --lib application::job::run::tests::reconcile -- --nocapture` (13 passed)
- `cargo test -p orbit-core --lib application::job::run::tests::conflict -- --nocapture` (3 passed)
- `make ci-fast`
- `make ci-lint`
- `git diff --check`
Assessment: Focused lifecycle races are covered deterministically, exact-PID ownership is enforced at the observer decision, first-terminal-wins remains intact, and all required checks pass.
Friction checkpoint: no qualifying recurring failure, contradicted assumption, incident root cause, or over-10-minute non-obvious gotcha surfaced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11116-6a93cf7f`
- Behind base: 0
- Ahead of base: 1