### PR TITLE
Prepare v0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.17.0
+
+### Breaking Changes
+
+- **session_log tools withdrawn**: `orbit.session_log.append`, `orbit.session_log.list`, and `orbit.session_log.resolve` are gone from the public MCP/CLI agent surface → no public replacement. ([ORB-11097])
+- **ci-failure-remediation auto-task removed**: the shipped `ci-failure-remediation` auto-task, catalog entry, and seed file are gone; existing workspace copies stay until removed by hand. ([ORB-11115])
+- **code-review auto-task renamed**: the seeded `code-review-sweep` auto-task is now `code-review`; the old name no longer loads. ([ORB-11095])
+- **Remote MCP `--operator` ignored**: destination-side caller authorization no longer honors caller `--operator` argv; a missing `~/.orbit/mcp-callers.toml` yields `agent` only. ([ORB-11052])
+
+### Highlights
+
+- **Agent plugins restored**: Claude Code, Codex, and Cursor plugin distribution ships again after the 0.15.0 retirement. ([ORB-11038])
+- **Federated MCP includes local workspaces**: federated serve now includes the accepting machine's local workspaces automatically, so a missing destinations file is a valid local-only server. ([ORB-11044])
+- **Task publication V1**: operators can bind a private Git publication repo, publish owner-only snapshots, inspect labelled read-only state, and restore without renumbering. ([ORB-11077])
+- **Managed workspace routing**: managed CLI and MCP calls now keep the catalog workspace selector instead of inferring from a linked-worktree cwd. ([ORB-11117])
+- **Richer task.show projections**: `orbit.task.show` can project every stable public task field, including relations, job run, and attribution. ([ORB-11119])
+
 ## 0.16.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "danieljhkim",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/danieljhkim/orbit",
     "source": "github"
   },
-  "version": "0.16.0",
+  "version": "0.17.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11127](https://orbit-cli.com/tasks/ORB-11127) — Prepare v0.17.0 release

### Description

## Objective

Prepare the approved Orbit `v0.17.0` release according to `RELEASING.md`.

## Approval already recorded

The human release owner approved this candidate in the task comments with `I approve` on 2026-08-30. Treat that approval as confirmation of:

- release version `0.17.0` under the pre-1.0 policy; and
- acceptance of these four breaking changes:
  - ORB-11097: withdrawal of `orbit.session_log.*` from the public agent tool surface.
  - ORB-11115: removal of the `ci-failure-remediation` auto-task and shipped asset.
  - ORB-11095: rename of the shipped `code-review-sweep` auto-task to `code-review`.
  - ORB-11052: destination-side caller authorization replacing caller-supplied `--operator` authority.

The approval prerequisite for classifying those four changes and preparing the version bump and changelog is satisfied. Do not block or ask for another confirmation of those items.

## Remaining dependency

Consume the release survey from ORB-11128 when it is complete. If it identifies additional breaking-change candidates beyond the four already approved, request a human decision only for those new candidates; do not reopen the approved version or classifications without new contradictory evidence.

## Required work

1. Follow the complete checklist in `RELEASING.md`.
2. Update `Cargo.toml`, `Cargo.lock`, `npm/package.json`, `server.json`, and all three plugin manifests to `0.17.0`; refresh `Cargo.lock` without third-party dependency drift.
3. Update `CHANGELOG.md` with the dated `0.17.0` section, including the four approved breaking changes and the required highlights structure.
4. Confirm the npm-install and plugin-install smoke scripts remain valid, changing them only if this release cycle requires it.
5. Run the release validation required by `RELEASING.md` and record exact results or justified skips.

## Boundaries

This approval authorizes release preparation and validation. It does not authorize committing, tagging, pushing, publishing, promoting, or merging. Stop before those later release actions unless the human release owner separately authorizes them.

### Acceptance Criteria

- Cargo.toml, Cargo.lock, npm/package.json, server.json, and all three plugin manifests report 0.17.0; Cargo.lock is refreshed without third-party dependency drift.
- CHANGELOG.md contains the approved 0.17.0 section with the required breaking-change and highlights structure.
- Every human-confirmed breaking change appears under Breaking Changes, and the final classification is not inferred from this probe.
- The npm-install and plugin-install smoke scripts remain valid for this release cycle and the required release validation passes.
- Follow RELEASING.md in full; do not commit, tag, push, publish, promote, or merge until this task is explicitly approved.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Bumped Cargo.toml, Cargo.lock, npm/package.json, server.json, and all three plugin manifests from 0.16.0 to 0.17.0.
- `cargo update --workspace` relocked only the 16 workspace members; 164 third-party dependencies were unchanged.
- Wrote CHANGELOG.md `## 0.17.0` with the four approved breaking changes (ORB-11097, ORB-11115, ORB-11095, ORB-11052) and five highlights from ORB-11128 (ORB-11038, ORB-11044, ORB-11077, ORB-11117, ORB-11119).
- Left `scripts/smoke-npm-install.sh` and `scripts/smoke-plugin-install.sh` unchanged: this cycle did not change the `orbit init`, `workspace init`, or `mcp serve` contracts the npm smoke drives; the plugin smoke reads version from plugin.json.
- Did not commit, tag, push, publish, promote, or merge.

Assessment: Approved 0.17.0 preparation and validation are complete. Remaining human gates: classify ORB-11099 if it should appear under Breaking Changes, then separately authorize commit/tag/push/publish/promote/merge.

Strategic decisions:
- Consumed ORB-11128. Requested human classification only for the new candidate ORB-11099. Did not reopen version 0.17.0 or the four accepted breaking changes. ORB-11099 is not listed in CHANGELOG.md.

Validation:
- `make build`: passed (`Finished dev profile` in 49.70s).
- `make ci-fast`: passed, including `scripts/smoke-plugin-install.sh`.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `./scripts/smoke-npm-install.sh --dry-run-version-assertion`: passed.
- `bash -n` on both smoke scripts: passed.
- `git diff --check`: passed.
- `cargo update --workspace`: 16 workspace members 0.16.0 → 0.17.0; 164 third-party packages unchanged.
- `./scripts/release-check.sh`: local Cargo/npm/server.json/plugin manifests all 0.17.0. Expected pre-publish DRIFT vs latest GitHub release tag 0.16.0 (exit 1). `npm view` skipped (registry unreachable). `mcp-publisher` not on PATH; structural registry validation completed.
- Skipped: live `./scripts/smoke-npm-install.sh` (requires published `@orbit-tools/cli@0.17.0`). Skipped commit/tag/push/publish/promote/merge pending a separate human release gate.

Design weaknesses / risks:
- Severity: medium. ORB-11099 remains unclassified. Mitigation: task comment requests accept/downgrade; that bullet can be added before the commit/tag gate without changing 0.17.0.

Deviations from original plan: none.

Recommended follow-ups:
- Human: accept or downgrade ORB-11099.
- Human: authorize commit/tag/push after that decision.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11127-6a93de09`
- Behind base: 0
- Ahead of base: 1