### PR TITLE
Remove approval wait from release-prep instructions

### DIFF
--- a/.orbit/auto_tasks/release-prep.yaml
+++ b/.orbit/auto_tasks/release-prep.yaml
@@ -51,8 +51,6 @@ template:
     candidate with the commit/task evidence that caused it to be flagged.
     Apply Orbit's pre-1.0 policy from `RELEASING.md`: a candidate patch bump
     for non-breaking work and a candidate minor bump for breaking candidates.
-    The candidate is not a human-confirmed classification.
-
     Then locate the canonical open release-preparation task by the exact
     title pattern `Prepare v<X.Y.Z> release` and the `release` tag. Search
     deterministically and select the lexicographically smallest matching task
@@ -63,8 +61,8 @@ template:
     `file:CHANGELOG.md`, `file:Cargo.toml`, `file:Cargo.lock`, and
     `file:npm/package.json` onto that canonical task.
     If one exists, update only that canonical task with the fresh candidate,
-    survey evidence, and breaking-change candidates. Preserve the human review
-    boundary and do not change it to done. Report the selected or newly-created
+    survey evidence, and breaking-change candidates. Do not change it to done.
+    Report the selected or newly-created
     task ID, and any pre-existing duplicate candidates, in this probe's
     `execution_summary`.
 
@@ -72,9 +70,7 @@ template:
     including the release checklist and all versioned release files. The
     handoff stops after surveying, candidate semver analysis, and creating or
     updating that one task. It must not commit, tag, push, publish, promote or
-    merge branches, bump versions, edit `CHANGELOG.md`, or ask for or record
-    human confirmation that a breaking-change candidate is accepted. Those
-    actions require the later human-approved release task.
+    merge branches, bump versions, or edit `CHANGELOG.md`.
 
     ## Deterministic validation scenarios
 
@@ -99,7 +95,7 @@ template:
   - An eligible pass records the latest reachable v* tag, commit survey, candidate semver bump, and breaking-change candidates with exact evidence.
   - An eligible pass creates or updates exactly one canonical Prepare v<X.Y.Z> release task carrying the release tag and reports its task ID.
   - The canonical release task carries `file:npm/package.json` alongside CHANGELOG.md, Cargo.toml, and Cargo.lock.
-  - The canonical task stops before commits, tags, pushes, publishing, branch promotion, version bumps, CHANGELOG edits, or human confirmation of breaking-change classification, and points to RELEASING.md.
+  - The canonical task stops before commits, tags, pushes, publishing, branch promotion, version bumps, or CHANGELOG edits, and points to RELEASING.md.
   - Repeated passes do not duplicate the open probe or the canonical release-preparation task.
   task_type: chore
   tags:


### PR DESCRIPTION
## Task

[ORB-11129](https://orbit-cli.com/tasks/ORB-11129) — Remove approval wait from release-prep instructions

### Description

## Problem

The orbit `release-prep` auto-task tells the canonical release-task executor to stop, wait for, request, or record human approval/confirmation before performing release-preparation work. That wording causes an already-routed release task to block again instead of executing its bounded preparation mandate.

## Required change

Edit only `.orbit/auto_tasks/release-prep.yaml`.

- Remove template-description and acceptance-criteria wording that instructs the canonical release task to wait for, seek, request, or record human approval or breaking-change confirmation before doing release-preparation work.
- Remove wording that describes the executable handoff as a “later human-approved” task.
- Do not add an explanation about lifecycle status or why approval is implied; simply remove the waiting requirement.
- Keep the auto-task probe itself report-first and no-diff: its unfinished-work, baseline, no-release, survey, dedupe, and one-canonical-task handoff behavior must remain unchanged.
- Preserve non-approval safety boundaries and the release actions governed separately by `RELEASING.md`; do not broaden the probe into version edits, commits, tags, pushes, publishing, promotion, or merging.
- Preserve schedule, enabled state, dedupe policy, crew, priority, tags, task type, context selectors, and workspace-specific release evidence/targets.

## Scope boundary

This is a one-file instruction correction. Do not add lifecycle guards, new task fields/tags, workflow admission logic, or executor changes.

### Acceptance Criteria

- The release-prep template no longer tells the canonical release-task executor to wait for, seek, request, or record human approval/confirmation before performing its bounded release-preparation work.
- The definition does not add lifecycle-status or implicit-approval rationale; it simply removes the approval-wait requirement.
- The report-first probe gates, evidence capture, dedupe behavior, and exactly-one canonical release-task handoff remain unchanged.
- Schedule, enabled state, dedupe policy, crew, priority, tags, task type, context selectors, and workspace-specific release targets remain unchanged.
- The change is limited to .orbit/auto_tasks/release-prep.yaml, parses successfully, and `orbit auto-task show release-prep --json` reflects the corrected instruction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated only `.orbit/auto_tasks/release-prep.yaml` to remove approval-wait, human-confirmation, human-review, and later-human-approved wording from the canonical release-preparation handoff.
- Preserved the report-first unfinished-work/no-release gates, evidence capture, dedupe behavior, one-task handoff, safety boundaries, schedule, enabled state, metadata, and release context selectors.
Validation:
- Python PyYAML parse and targeted invariants passed, including absence of approval-related wording and presence of required probe/safety text.
- `git diff --check` passed; final status contains only `.orbit/auto_tasks/release-prep.yaml`.
- `orbit auto-task show release-prep --json` was attempted. In this managed linked-worktree runner it resolved to the registered base workspace and returned its pre-change definition; forcing the local `.orbit` root was denied when Orbit attempted to create SQLite state (`Read-only file system`). This environment limitation prevented a local JSON-loader confirmation; no code failure was observed.
Assessment: The scoped instruction correction is complete and the remaining worktree diff is intentional.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11129-6a93e087`
- Behind base: 0
- Ahead of base: 1