### PR TITLE
[code-review] CI sweep omits the agent-main integration branch

### DIFF
--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -48,7 +48,7 @@ spec:
     # ships onto a separate integration branch — set it in the workspace copy
     # of this job when they differ, the same way `task_pr_pipeline` carries
     # `base_branch`.
-    integration_branch: ""
+    integration_branch: "agent-main"
     max_tasks: 5
     max_investigated_runs: 6
 


### PR DESCRIPTION
## Task

[ORB-11131](https://orbit-cli.com/tasks/ORB-11131) — [code-review] CI sweep omits the agent-main integration branch

### Description

## Problem
The live workspace job config documents that an empty `integration_branch` is wrong when integration and release differ, but leaves it empty at `.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml:44-53`. This repository uses `agent-main` as the development integration branch and `main` as the release/default branch. In live collection, an empty input falls through to the GitHub default branch at `crates/orbit-engine/src/executor/automation/ci/collect.rs:241-249`; branch de-duplication at lines 257-258 then scans that same default only once.

## Why It Matters
The enabled hourly routine observes `main` and open PRs but never the `agent-main` head that receives task merges, so a red integration build can go unfiled indefinitely.

## Constraints / Notes
Keep the generic shipped asset portable; this finding is about the Orbit workspace configuration that knows its integration branch.

### Acceptance Criteria

- The workspace copy of `ci_failure_sweep_pipeline` explicitly identifies `agent-main` as this repository's integration branch while retaining GitHub's default branch as the release branch.
- A regression test or equivalent deterministic validation proves that the effective Orbit workspace configuration scans distinct `agent-main` and `main` heads rather than collapsing both roles onto `main`.
- The capability-unavailable and no-current-failure no-op behaviors remain unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success. Changes: Set the workspace CI-failure sweep integration branch to agent-main, so collection scans it separately from the GitHub main release/default head. The generic shipped asset and collector behavior are unchanged. Assessment: The workspace configuration now matches the repository integration/release model. Validation: deterministic config assertion; cargo test -p orbit-engine derives_release_head_from_github_and_reports_every_bound_it_hit; cargo test -p orbit-engine unauthenticated_host_stops_before_any_query; cargo test -p orbit-engine advanced_head_and_superseding_success_are_stale_not_current; make ci-fast; make ci-lint; git diff --check. Friction checkpoint: no report. Cleanup: cargo clean removed this run build artifacts. Final worktree contains only the intended workspace job configuration change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11131-6a94c512`
- Behind base: 0
- Ahead of base: 1