### PR TITLE
[code-review] Direct CLI failures are classified as lifecycle diagnostics

### DIFF
--- a/crates/orbit-store/src/contracts/incident.rs
+++ b/crates/orbit-store/src/contracts/incident.rs
@@ -139,7 +139,8 @@ pub struct IncidentEventRef {
     pub run_id: Option<String>,
     pub task_id: Option<String>,
     pub activity_id: Option<String>,
-    /// Tool name when the row had one; `None` for job-run lifecycle events.
+    /// Tool name when the row had one; `None` for direct CLI and legacy
+    /// job-run lifecycle events.
     pub tool_name: Option<String>,
     pub message: Option<String>,
 }
@@ -190,8 +191,8 @@ pub struct FailureIncident {
     /// propagation chain. Unbounded so expansion can show the full evidence
     /// set; [`Self::sample_events`] stays the bounded root preview.
     pub events: Vec<IncidentEventRef>,
-    /// False when the root row had no tool identity — a job-run lifecycle
-    /// failure, not a tool named `unknown`.
+    /// False when the root row had no tool identity — either a direct CLI
+    /// command or a job-run lifecycle failure, never a tool named `unknown`.
     pub has_tool_identity: bool,
     /// Downstream failures collapsed beneath the root, in occurrence order.
     pub propagation: Vec<PropagationLink>,
@@ -225,9 +226,12 @@ pub const JOB_RUN_LIFECYCLE_CATEGORY: &str = "job_run_lifecycle";
 /// Operator-facing label for [`JOB_RUN_LIFECYCLE_CATEGORY`].
 pub const JOB_RUN_LIFECYCLE_LABEL: &str = "job-run lifecycle";
 
-/// Named lifecycle audit surfaces that are emitted only when an abnormal path
-/// occurs. Unlike callable tools, they cannot have a healthy-call denominator.
+/// Lifecycle audit surfaces that are emitted only when an abnormal path
+/// occurs. Unlike callable tools and direct CLI commands, they cannot have a
+/// healthy-call denominator. `Start` is the legacy no-tool job-start record;
+/// the remaining surfaces carry their identity in `tool_name`.
 pub const FAILURE_ONLY_DIAGNOSTIC_SURFACES: &[&str] = &[
+    "Start",
     "pipeline.run.terminal_conflict",
     "pipeline.worker.exit",
     "pipeline.worker.startup",
@@ -371,8 +375,8 @@ pub fn classify(event: &AuditEvent) -> FailureClass {
     FailureClass::Unexpected
 }
 
-/// True for a failure-only named diagnostic surface. Callers use the same
-/// predicate when excluding those rows from callable-tool rate rankings.
+/// True for a failure-only diagnostic surface. Callers use the same predicate
+/// when excluding named rows from callable-tool rate rankings.
 pub fn is_failure_only_diagnostic_surface(name: &str) -> bool {
     let name = name.trim();
     FAILURE_ONLY_DIAGNOSTIC_SURFACES.contains(&name)
@@ -381,15 +385,12 @@ pub fn is_failure_only_diagnostic_surface(name: &str) -> bool {
 /// True when an audit row is a lifecycle diagnostic rather than a call whose
 /// success and failure populations can be compared.
 pub fn is_lifecycle_diagnostic(event: &AuditEvent) -> bool {
-    !has_tool_identity(event)
-        || event
-            .tool_name
-            .as_deref()
-            .is_some_and(is_failure_only_diagnostic_surface)
+    is_failure_only_diagnostic_surface(&surface_of(event))
 }
 
-/// True when the row names a real tool. Empty/`NULL` tool names are job-run
-/// lifecycle events, not a tool called `unknown`.
+/// True when the row names a real tool. Direct CLI and legacy job-run
+/// lifecycle rows have empty/`NULL` tool names; neither is a tool called
+/// `unknown`.
 pub fn has_tool_identity(event: &AuditEvent) -> bool {
     event
         .tool_name

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/incident.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/tests/incident.rs
@@ -368,6 +368,76 @@ fn duplicate_worker_diagnostics_are_seven_incidents_not_fourteen_tool_failures()
 }
 
 #[test]
+fn direct_cli_failure_is_unexpected_while_no_tool_start_is_diagnostic() {
+    let mut direct_success = FailureFixture::new(0, 0, "unused")
+        .no_tool()
+        .command("run")
+        .status(AuditEventStatus::Success)
+        .message("operation completed")
+        .build();
+    direct_success.subcommand = Some("show".to_string());
+    direct_success.target_id = Some("jrun-direct".to_string());
+
+    let mut direct_failure = FailureFixture::new(1, 0, "unused")
+        .no_tool()
+        .command("run")
+        .message("storage backend disconnected")
+        .build();
+    direct_failure.subcommand = Some("show".to_string());
+    direct_failure.target_id = Some("jrun-direct".to_string());
+
+    let mut lifecycle_failure = FailureFixture::new(2, 1, "unused")
+        .no_tool()
+        .command("Start")
+        .message("job run start failed")
+        .build();
+    lifecycle_failure.subcommand = None;
+
+    assert!(!is_lifecycle_diagnostic(&direct_success));
+    assert!(!is_lifecycle_diagnostic(&direct_failure));
+    assert!(is_lifecycle_diagnostic(&lifecycle_failure));
+
+    let report = build_report(&[direct_failure, lifecycle_failure], false);
+
+    assert_eq!(report.raw_events_by_class.get("unexpected"), Some(&1));
+    assert_eq!(report.raw_events_by_class.get("diagnostic"), Some(&1));
+
+    let direct = report
+        .incidents
+        .iter()
+        .find(|incident| incident.surface == "run show")
+        .expect("direct CLI incident");
+    assert_eq!(direct.class, FailureClass::Unexpected);
+    assert!(!direct.has_tool_identity);
+    assert_eq!(direct.events.len(), 1);
+    assert_eq!(direct.events[0].id, 1);
+    assert_eq!(direct.events[0].execution_id, "exec-1");
+    assert_eq!(direct.events[0].surface, "run show");
+    assert_eq!(direct.events[0].tool_name, None);
+    assert_eq!(
+        direct.events[0].message.as_deref(),
+        Some("storage backend disconnected")
+    );
+
+    let lifecycle = report
+        .incidents
+        .iter()
+        .find(|incident| incident.surface == "Start")
+        .expect("pipeline lifecycle incident");
+    assert_eq!(lifecycle.class, FailureClass::Diagnostic);
+    assert!(!lifecycle.has_tool_identity);
+    assert_eq!(lifecycle.events.len(), 1);
+    assert_eq!(lifecycle.events[0].id, 2);
+    assert_eq!(lifecycle.events[0].execution_id, "exec-2");
+    assert_eq!(lifecycle.events[0].surface, "Start");
+    assert_eq!(lifecycle.events[0].tool_name, None);
+    assert_eq!(
+        lifecycle.events[0].message.as_deref(),
+        Some("job run start failed")
+    );
+}
+
+#[test]
 fn expected_task_show_and_update_negatives_do_not_enter_unexpected_counts() {
     let failures = vec![
         FailureFixture::new(1, 0, "orbit.task.show")
@@ -650,7 +720,7 @@ fn ten_unknown_lifecycle_rows() -> Vec<AuditEvent> {
 }
 
 #[test]
-fn ten_unknown_rows_group_as_lifecycle_with_four_cascades_and_one_start() {
+fn ten_unknown_rows_keep_diagnostics_to_the_failure_only_start_surface() {
     let failures = ten_unknown_lifecycle_rows();
     assert_eq!(failures.len(), 10);
     assert!(
@@ -671,10 +741,11 @@ fn ten_unknown_rows_group_as_lifecycle_with_four_cascades_and_one_start() {
         "2 duplicate Starts collapse; 8 cascade rows from 4 leaves are 4 roots"
     );
     assert_eq!(report.job_run_lifecycle_incidents, 5);
-    assert_eq!(report.lifecycle_diagnostic_events, 10);
-    assert_eq!(report.lifecycle_diagnostic_incidents, 5);
-    assert_eq!(report.lifecycle_diagnostic_affected_run_count, 8);
-    assert_eq!(report.raw_events_by_class.get("diagnostic"), Some(&10));
+    assert_eq!(report.lifecycle_diagnostic_events, 2);
+    assert_eq!(report.lifecycle_diagnostic_incidents, 1);
+    assert_eq!(report.lifecycle_diagnostic_affected_run_count, 0);
+    assert_eq!(report.raw_events_by_class.get("diagnostic"), Some(&2));
+    assert_eq!(report.raw_events_by_class.get("unexpected"), Some(&8));
     assert_eq!(
         report.affected_run_count, 8,
         "4 leaf runs + 4 parent runs; Starts carry no run id"
@@ -686,6 +757,7 @@ fn ten_unknown_rows_group_as_lifecycle_with_four_cascades_and_one_start() {
         .find(|incident| incident.surface == "Start")
         .expect("duplicate Start incident");
     assert_eq!(start.event_count, 2);
+    assert_eq!(start.class, FailureClass::Diagnostic);
     assert!(start.propagation.is_empty());
     assert!(!start.has_tool_identity);
     assert_eq!(start.events.len(), 2);
@@ -697,6 +769,7 @@ fn ten_unknown_rows_group_as_lifecycle_with_four_cascades_and_one_start() {
         .collect();
     assert_eq!(cascades.len(), 4);
     for incident in cascades {
+        assert_eq!(incident.class, FailureClass::Unexpected);
         assert_eq!(incident.root_event_count, 1);
         assert_eq!(
             incident.propagated_event_count(),


### PR DESCRIPTION
## Task

[ORB-11133](https://orbit-cli.com/tasks/ORB-11133) — [code-review] Direct CLI failures are classified as lifecycle diagnostics

### Description

## Problem
`is_lifecycle_diagnostic` treats every audit row without a `tool_name` as a lifecycle diagnostic at `crates/orbit-store/src/contracts/incident.rs:381-397`, and `classify` applies that rule before denial, expected, or unexpected classification at lines 343-371. Ordinary direct CLI operations are intentionally audited with `tool_name: None` by `admin_meta` at `crates/orbit-cli/src/command/operation.rs:178-193`, including workspace, job, publication, and other top-level commands.

## Why It Matters
A real unexpected failure from a callable direct-command surface is labeled a lifecycle diagnostic and excluded from the callable reliability headline, even though `surface_of` can identify it from command and subcommand. This hides direct-command regressions and inflates the lifecycle counts intended for failure-only pipeline events.

## Constraints / Notes
Preserve the exact raw audit evidence and the existing explicit failure-only diagnostic surfaces.

### Acceptance Criteria

- Lifecycle-diagnostic classification is limited to known failure-only lifecycle records, not all rows lacking a tool name.
- Direct CLI success and failure rows with command or subcommand identity remain a comparable callable population, and unexpected direct-command failures classify as unexpected.
- Regression tests cover both a direct CLI failure with `tool_name: null` and a genuine no-tool pipeline lifecycle event, preserving exact raw-event drill-down for both.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the blanket no-tool lifecycle classification with explicit failure-only surface matching, preserving the three named pipeline diagnostics and the legacy no-tool `Start` lifecycle record.
- Added regression coverage proving direct `run show` CLI success/failure rows with `tool_name: null` are callable/non-diagnostic, the failed row classifies as unexpected, and both it and a genuine no-tool `Start` event retain exact raw drill-down evidence.
- Updated the existing ten-row regression to separate two failure-only Start diagnostics from eight unexpected no-tool job-command failures.
Assessment: The change is narrowly scoped to the supplied incident contract and its sibling tests. It keeps raw audit evidence unchanged and makes the conservative classification boundary explicit.
Validation:
- `cargo test -p orbit-store driver::sqlite::audit_event_store::tests::incident` (16 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `git diff --check` (passed)
Deviations from original plan: None.
Friction checkpoint: No qualifying recurring failure, contradicted assumption, incident root cause, or >10-minute non-obvious gotcha was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11133-6a94c512`
- Behind base: 0
- Ahead of base: 1