### PR TITLE
Add a Dependabot vulnerability-alert sweep: collect + file activities, job, and routine

### DIFF
--- a/crates/orbit-core/assets/activities/collect_dependabot_alerts.yaml
+++ b/crates/orbit-core/assets/activities/collect_dependabot_alerts.yaml
@@ -1,0 +1,59 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: collect_dependabot_alerts
+spec:
+  type: deterministic
+  description: >
+    Query open Dependabot vulnerability alerts and open app/dependabot pull
+    requests on the engine-private host boundary using NoSandbox, then emit one
+    bounded and redacted snapshot. Missing gh, missing credentials, a 403
+    security_events-scope response, and a 404 unavailable-alerts response are
+    capability outcomes and never a clean no-alert result.
+  input_schema_json:
+    type: object
+    properties:
+      workspace_path:
+        type: string
+      repo:
+        type: string
+      max_alerts:
+        type: number
+        minimum: 1
+        maximum: 100
+      max_pull_requests:
+        type: number
+        minimum: 1
+        maximum: 100
+  output_schema_json:
+    type: object
+    required: [phase, dependabot_snapshot]
+    properties:
+      phase:
+        type: string
+      dependabot_snapshot:
+        type: object
+        required: [schema_version, collected, capability, outcome_hint]
+        properties:
+          schema_version:
+            type: number
+          collected:
+            type: boolean
+          outcome_hint:
+            type: string
+          capability:
+            type: object
+          repository:
+            type: object
+          open_alerts:
+            type: array
+          open_dependabot_pull_requests:
+            type: array
+          query_errors:
+            type: array
+          truncation:
+            type: object
+          collected_at:
+            type: string
+  action: collect_dependabot_alerts
+  config: {}

--- a/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
@@ -1,0 +1,51 @@
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: file_dependabot_alert_tasks
+spec:
+  type: deterministic
+  description: >
+    Cluster a host-collected Dependabot snapshot by ecosystem, package, and
+    manifest path; report alerts below the severity floor; skip clusters with
+    an open Dependabot-authored pull request by default; dedupe against open
+    tasks using a digest of that stable triple; and file bounded evidence-complete
+    backlog tasks with no required tools.
+  input_schema_json:
+    type: object
+    required: [dependabot_snapshot]
+    properties:
+      dependabot_snapshot:
+        type: object
+      min_severity:
+        type: string
+        enum: [low, moderate, high, critical]
+        default: high
+      skip_when_dependabot_pr_open:
+        type: boolean
+        default: true
+      max_tasks:
+        type: number
+        minimum: 1
+        maximum: 50
+  output_schema_json:
+    type: object
+    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_dependabot_pr, excluded_below_min_severity]
+    properties:
+      outcome:
+        type: string
+      clusters:
+        type: number
+      filed_count:
+        type: number
+      filed:
+        type: array
+      skipped_existing:
+        type: array
+      skipped_dependabot_pr:
+        type: array
+      skipped_over_cap:
+        type: array
+      excluded_below_min_severity:
+        type: array
+  action: file_dependabot_alert_tasks
+  config: {}

--- a/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
@@ -1,0 +1,27 @@
+schemaVersion: 2
+kind: Job
+metadata:
+  name: dependabot_alert_sweep_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  default_input:
+    max_alerts: 100
+    max_pull_requests: 100
+    max_tasks: 10
+    min_severity: high
+    skip_when_dependabot_pr_open: true
+  steps:
+    - id: collect
+      target: activity:collect_dependabot_alerts
+      default_input:
+        max_alerts: "{{ input.max_alerts }}"
+        max_pull_requests: "{{ input.max_pull_requests }}"
+    - id: file
+      target: activity:file_dependabot_alert_tasks
+      default_input:
+        dependabot_snapshot: "{{ steps.collect.output.dependabot_snapshot }}"
+        max_tasks: "{{ input.max_tasks }}"
+        min_severity: "{{ input.min_severity }}"
+        skip_when_dependabot_pr_open: "{{ input.skip_when_dependabot_pr_open }}"

--- a/crates/orbit-core/assets/routines/dependabot_alert_sweep.yaml
+++ b/crates/orbit-core/assets/routines/dependabot_alert_sweep.yaml
@@ -1,0 +1,18 @@
+# Disabled-by-default daily Dependabot vulnerability sweep [ORB-11124].
+# The 03:25 UTC slot collides with none of the shipped :00/:05/:15/:20/:35/:40
+# defaults. The job is also single-flight, and overlap is forbidden here.
+schemaVersion: 1
+name: __ORBIT_ROUTINE_NAME__
+description: >
+  Daily host-side collection of bounded, redacted Dependabot alert evidence,
+  followed by deterministic filing of deduped dependency-remediation tasks.
+enabled: false
+hosts:
+  - __ORBIT_HOST_ID__
+trigger:
+  cron: "25 3 * * *"
+  missed_run: skip
+target: job:dependabot_alert_sweep_pipeline
+policy:
+  timeout_minutes: 30
+  overlap: forbid

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -1,0 +1,375 @@
+//! Turn a host-collected Dependabot snapshot into ordinary backlog tasks.
+
+use std::collections::BTreeMap;
+
+use orbit_common::OrbitError;
+use orbit_types::task::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::OrbitRuntime;
+use crate::application::task::TaskAddParams;
+
+const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+const TAG: &str = "dependabot-sweep";
+const KEY_PREFIX: &str = "dependabot:";
+const TITLE_PREFIX: &str = "[dependabot-sweep] ";
+const SYSTEM_CREW: &str = "system";
+const DEFAULT_MAX_TASKS: u64 = 10;
+const MAX_TASKS: u64 = 50;
+const KEY_LEN: usize = 16;
+
+pub(crate) fn file_dependabot_alert_tasks(
+    runtime: &OrbitRuntime,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let snapshot = input.get("dependabot_snapshot").ok_or_else(|| {
+        OrbitError::InvalidInput(
+            "file_dependabot_alert_tasks requires the `dependabot_snapshot` produced by collect_dependabot_alerts"
+                .to_string(),
+        )
+    })?;
+    if !snapshot.is_object() {
+        return Err(OrbitError::InvalidInput(
+            "dependabot_snapshot must be an object".to_string(),
+        ));
+    }
+    let version = snapshot
+        .get("schema_version")
+        .and_then(Value::as_u64)
+        .unwrap_or(SUPPORTED_SCHEMA_VERSION);
+    if version > SUPPORTED_SCHEMA_VERSION {
+        return Err(OrbitError::InvalidInput(format!(
+            "Dependabot snapshot schema version {version} is newer than supported version {SUPPORTED_SCHEMA_VERSION}"
+        )));
+    }
+    let capability = snapshot.get("capability").cloned().unwrap_or(Value::Null);
+    if snapshot.get("collected").and_then(Value::as_bool) != Some(true) {
+        return Ok(empty_output(
+            "capability_unavailable",
+            capability,
+            "Dependabot alerts could not be queried; this is not a clean vulnerability result",
+        ));
+    }
+
+    let floor_name = input
+        .get("min_severity")
+        .and_then(Value::as_str)
+        .unwrap_or("high")
+        .trim()
+        .to_ascii_lowercase();
+    let floor = severity_rank(&floor_name).ok_or_else(|| {
+        OrbitError::InvalidInput(
+            "input.min_severity must be one of low, moderate, high, or critical".to_string(),
+        )
+    })?;
+    let max_tasks = bounded_u64(input, "max_tasks", DEFAULT_MAX_TASKS, MAX_TASKS)? as usize;
+    let skip_pr = input
+        .get("skip_when_dependabot_pr_open")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let alerts = snapshot
+        .get("open_alerts")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+
+    let mut excluded_below_min_severity = Vec::new();
+    let mut grouped: BTreeMap<(String, String, String), Vec<Value>> = BTreeMap::new();
+    for alert in alerts {
+        let severity = field(alert, "severity").to_ascii_lowercase();
+        let rank = severity_rank(&severity).unwrap_or(0);
+        if rank < floor {
+            excluded_below_min_severity.push(json!({
+                "number": alert.get("number"),
+                "ecosystem": field(alert, "ecosystem"),
+                "package": field(alert, "package"),
+                "manifest_path": field(alert, "manifest_path"),
+                "severity": severity,
+            }));
+            continue;
+        }
+        let key = (
+            field(alert, "ecosystem"),
+            field(alert, "package"),
+            field(alert, "manifest_path"),
+        );
+        if key.0.is_empty() || key.1.is_empty() || key.2.is_empty() {
+            continue;
+        }
+        grouped.entry(key).or_default().push(alert.clone());
+    }
+
+    if grouped.is_empty() {
+        let mut output = empty_output(
+            if alerts.is_empty() {
+                "no_open_alerts"
+            } else {
+                "open_alerts"
+            },
+            capability,
+            "No open Dependabot alert met the configured severity floor",
+        );
+        output["min_severity"] = json!(floor_name);
+        output["excluded_below_min_severity"] = json!(excluded_below_min_severity);
+        return Ok(output);
+    }
+
+    let pull_requests = snapshot
+        .get("open_dependabot_pull_requests")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let system_crew = runtime
+        .validate_crew_name(Some(SYSTEM_CREW))
+        .is_ok()
+        .then(|| SYSTEM_CREW.to_string());
+    let mut filed = Vec::new();
+    let mut skipped_existing = Vec::new();
+    let mut skipped_dependabot_pr = Vec::new();
+    let mut skipped_over_cap = Vec::new();
+
+    for ((ecosystem, package, manifest_path), mut cluster_alerts) in grouped {
+        cluster_alerts
+            .sort_by_key(|alert| alert.get("number").and_then(Value::as_u64).unwrap_or(0));
+        let key = digest(&ecosystem, &package, &manifest_path);
+        if let Some(task_id) = open_task_for_key(runtime, &key)? {
+            skipped_existing.push(json!({
+                "key": key, "task_id": task_id, "ecosystem": ecosystem,
+                "package": package, "manifest_path": manifest_path,
+            }));
+            continue;
+        }
+        if skip_pr
+            && let Some(pull_request) = pull_requests
+                .iter()
+                .find(|pull_request| pull_request_mentions_package(pull_request, &package))
+        {
+            skipped_dependabot_pr.push(json!({
+                "key": key, "ecosystem": ecosystem, "package": package,
+                "manifest_path": manifest_path, "pull_request": pull_request,
+            }));
+            continue;
+        }
+        if filed.len() >= max_tasks {
+            skipped_over_cap.push(json!({
+                "key": key, "ecosystem": ecosystem, "package": package,
+                "manifest_path": manifest_path,
+            }));
+            continue;
+        }
+
+        let highest = cluster_alerts
+            .iter()
+            .filter_map(|alert| severity_rank(&field(alert, "severity").to_ascii_lowercase()))
+            .max()
+            .unwrap_or(floor);
+        let task = runtime.add_task(TaskAddParams {
+            title: task_title(&package, &manifest_path),
+            description: task_description(
+                snapshot,
+                &ecosystem,
+                &package,
+                &manifest_path,
+                &cluster_alerts,
+            ),
+            acceptance_criteria: vec![
+                format!("Bump `{package}` to a non-vulnerable version that resolves every alert listed in the task description."),
+                format!("`{manifest_path}` and the repository lockfile agree on the resolved `{package}` version."),
+                "The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.".to_string(),
+            ],
+            tags: vec![TAG.to_string(), format!("{KEY_PREFIX}{key}"), "security".to_string()],
+            required_tools: Vec::new(),
+            crew: system_crew.clone(),
+            priority: priority_for_rank(highest),
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Bug),
+            status: Some(TaskStatus::Backlog),
+            system_created: true,
+            ..TaskAddParams::default()
+        })?;
+        filed.push(json!({
+            "task_id": task.id, "key": key, "ecosystem": ecosystem,
+            "package": package, "manifest_path": manifest_path,
+            "alert_count": cluster_alerts.len(),
+        }));
+    }
+
+    Ok(json!({
+        "outcome": "open_alerts",
+        "capability": capability,
+        "clusters": filed.len() + skipped_existing.len() + skipped_dependabot_pr.len() + skipped_over_cap.len(),
+        "filed_count": filed.len(),
+        "filed": filed,
+        "skipped_existing": skipped_existing,
+        "skipped_dependabot_pr": skipped_dependabot_pr,
+        "skipped_over_cap": skipped_over_cap,
+        "excluded_below_min_severity": excluded_below_min_severity,
+        "min_severity": floor_name,
+        "skip_when_dependabot_pr_open": skip_pr,
+        "max_tasks": max_tasks,
+    }))
+}
+
+fn empty_output(outcome: &str, capability: Value, detail: &str) -> Value {
+    json!({
+        "outcome": outcome, "capability": capability, "detail": detail,
+        "clusters": 0, "filed_count": 0, "filed": [], "skipped_existing": [],
+        "skipped_dependabot_pr": [], "skipped_over_cap": [],
+        "excluded_below_min_severity": [],
+    })
+}
+
+fn task_title(package: &str, manifest_path: &str) -> String {
+    let budget = 120usize.saturating_sub(TITLE_PREFIX.chars().count());
+    let body = format!("Update {package} in {manifest_path}");
+    format!("{TITLE_PREFIX}{}", truncate_chars(&body, budget))
+}
+
+fn task_description(
+    snapshot: &Value,
+    ecosystem: &str,
+    package: &str,
+    manifest_path: &str,
+    alerts: &[Value],
+) -> String {
+    let mut patched = alerts
+        .iter()
+        .map(|alert| field(alert, "first_patched_version"))
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    patched.sort();
+    patched.dedup();
+    let patched = if patched.is_empty() {
+        "not published".to_string()
+    } else {
+        patched.join(", ")
+    };
+    let repository = snapshot
+        .pointer("/repository/full_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown repository");
+    let mut out = format!(
+        "This task was filed from a bounded, redacted Dependabot snapshot collected on the host before the task existed. The implementing agent does not need GitHub credentials.\n\n## Dependency bump\n\n- Repository: `{repository}`\n- Ecosystem: `{ecosystem}`\n- Package: `{package}`\n- Manifest path: `{manifest_path}`\n- First patched version: `{patched}`\n\n## Open alerts\n\n"
+    );
+    for alert in alerts {
+        let ghsa = field(alert, "ghsa_id");
+        let cve = field(alert, "cve_id");
+        let identifier = match (ghsa.is_empty(), cve.is_empty()) {
+            (false, false) => format!("{ghsa} / {cve}"),
+            (false, true) => ghsa,
+            (true, false) => cve,
+            (true, true) => format!("alert #{}", field(alert, "number")),
+        };
+        out.push_str(&format!(
+            "- **{}** — severity `{}`; {}; vulnerable range `{}`; first patched version `{}`; {}\n",
+            identifier,
+            display(&field(alert, "severity")),
+            display(&field(alert, "summary")),
+            display(&field(alert, "vulnerable_version_range")),
+            display(&field(alert, "first_patched_version")),
+            display(&field(alert, "html_url")),
+        ));
+    }
+    if let Some(truncation) = snapshot.get("truncation") {
+        out.push_str("\n## Collection bounds\n\n");
+        out.push_str(&format!(
+            "```json\n{}\n```\n",
+            serde_json::to_string_pretty(truncation).unwrap_or_default()
+        ));
+    }
+    out.push_str("\nUpdate the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.\n");
+    out
+}
+
+fn pull_request_mentions_package(pull_request: &Value, package: &str) -> bool {
+    let package = package.to_ascii_lowercase();
+    ["title", "body"].iter().any(|key| {
+        pull_request
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|text| text.to_ascii_lowercase().contains(&package))
+    })
+}
+
+fn open_task_for_key(runtime: &OrbitRuntime, key: &str) -> Result<Option<String>, OrbitError> {
+    let tag = format!("{KEY_PREFIX}{key}");
+    Ok(runtime
+        .list_tasks_by_tags(std::slice::from_ref(&tag))?
+        .into_iter()
+        .find(|task| {
+            !matches!(
+                task.status,
+                TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
+            )
+        })
+        .map(|task| task.id))
+}
+
+fn severity_rank(value: &str) -> Option<u8> {
+    match value {
+        "low" => Some(1),
+        "moderate" | "medium" => Some(2),
+        "high" => Some(3),
+        "critical" => Some(4),
+        _ => None,
+    }
+}
+
+fn priority_for_rank(rank: u8) -> TaskPriority {
+    match rank {
+        4.. => TaskPriority::Critical,
+        3 => TaskPriority::High,
+        _ => TaskPriority::Medium,
+    }
+}
+
+fn digest(ecosystem: &str, package: &str, manifest_path: &str) -> String {
+    let mut hasher = Sha256::new();
+    for part in [ecosystem, package, manifest_path] {
+        hasher.update(part.as_bytes());
+        hasher.update([0]);
+    }
+    format!("{:x}", hasher.finalize())
+        .chars()
+        .take(KEY_LEN)
+        .collect()
+}
+
+fn bounded_u64(input: &Value, key: &str, default: u64, max: u64) -> Result<u64, OrbitError> {
+    let Some(value) = input.get(key).filter(|value| !value.is_null()) else {
+        return Ok(default);
+    };
+    let raw = match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(text) => text.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+    .ok_or_else(|| OrbitError::InvalidInput(format!("input.{key} must be a positive integer")))?;
+    if raw == 0 {
+        return Err(OrbitError::InvalidInput(format!(
+            "input.{key} must be greater than zero"
+        )));
+    }
+    Ok(raw.min(max))
+}
+
+fn field(value: &Value, key: &str) -> String {
+    match value.get(key) {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Number(number)) => number.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn display(value: &str) -> &str {
+    if value.is_empty() { "unknown" } else { value }
+}
+
+fn truncate_chars(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        value.to_string()
+    } else {
+        value.chars().take(max).collect::<String>() + "…"
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -20,8 +20,8 @@ use crate::runtime::task::locks::{
 };
 
 use super::{
-    backlog_exclusion, ci_failure_tasks, pipeline_actions, scan_unresolved, task_pilot, triage,
-    workspace_auto,
+    backlog_exclusion, ci_failure_tasks, dependabot_alert_tasks, pipeline_actions, scan_unresolved,
+    task_pilot, triage, workspace_auto,
 };
 
 /// Whether `action` is dispatchable by this runtime — the capability probe
@@ -192,6 +192,14 @@ pub(crate) fn run_deterministic(
         // that JSON and writes tasks.
         CoreDeterministicAction::FileCiFailureTasks => {
             ci_failure_tasks::file_ci_failure_tasks(runtime, input).map_err(|error| {
+                DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: error.to_string(),
+                }
+            })
+        }
+        CoreDeterministicAction::FileDependabotAlertTasks => {
+            dependabot_alert_tasks::file_dependabot_alert_tasks(runtime, input).map_err(|error| {
                 DispatchError::DeterministicActionFailed {
                     action: action.to_string(),
                     message: error.to_string(),

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -11,6 +11,7 @@ pub(super) mod backlog_exclusion;
 pub(super) mod child_dispatch;
 pub(super) mod ci_failure_tasks;
 pub(super) mod cli_executor;
+pub(super) mod dependabot_alert_tasks;
 pub(super) mod dispatch;
 pub(super) mod pipeline_actions;
 pub(super) mod sandbox;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -1,0 +1,198 @@
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use orbit_types::task::{TaskPriority, TaskStatus};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+
+fn alert(number: u64, severity: &str, range: &str, ghsa: &str) -> Value {
+    json!({
+        "number": number, "state": "open", "ecosystem": "cargo", "package": "time",
+        "manifest_path": "Cargo.lock", "scope": "runtime", "severity": severity,
+        "ghsa_id": ghsa, "cve_id": format!("CVE-2026-{number}"),
+        "summary": format!("vulnerability {number}"), "vulnerable_version_range": range,
+        "first_patched_version": "1.2.3", "html_url": format!("https://github.test/alerts/{number}")
+    })
+}
+
+fn snapshot(alerts: Vec<Value>, pull_requests: Vec<Value>) -> Value {
+    json!({
+        "schema_version": 1, "collected": true,
+        "outcome_hint": if alerts.is_empty() { "no_open_alerts" } else { "open_alerts" },
+        "capability": {"available": true, "authenticated": true, "detail": "authenticated"},
+        "repository": {"full_name": "acme/orbit"},
+        "open_alerts": alerts,
+        "open_dependabot_pull_requests": pull_requests,
+        "query_errors": [],
+        "truncation": {"alerts_limit": 100, "alerts_at_cap": false},
+        "collected_at": "2026-08-31T00:00:00Z"
+    })
+}
+
+fn file(runtime: &OrbitRuntime, snapshot: Value, extra: Value) -> Value {
+    let mut input = json!({"dependabot_snapshot": snapshot});
+    if let (Some(target), Some(source)) = (input.as_object_mut(), extra.as_object()) {
+        target.extend(source.clone());
+    }
+    runtime
+        .run_deterministic(
+            "file_dependabot_alert_tasks",
+            &json!({}),
+            &input,
+            ToolContext::default(),
+        )
+        .expect("file Dependabot tasks")
+}
+
+fn runtime_without_system_crew() -> (tempfile::TempDir, OrbitRuntime) {
+    let root = tempdir().expect("create tempdir");
+    let global = root.path().join("home/.orbit");
+    let workspace = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global orbit dir");
+    std::fs::create_dir_all(&workspace).expect("workspace orbit dir");
+    std::fs::write(
+        workspace.join("config.toml"),
+        r#"[workflow]
+default_crew = "sol"
+system_crew = "not-a-real-crew"
+
+[crews.sol]
+provider = "codex"
+model = "gpt-5.6-sol"
+"#,
+    )
+    .expect("write crew config");
+    let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("build runtime");
+    (root, runtime)
+}
+
+#[test]
+fn several_alerts_for_one_dependency_file_exactly_one_evidence_complete_task() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let output = file(
+        &runtime,
+        snapshot(
+            vec![
+                alert(1, "high", "< 1.0.0", "GHSA-one"),
+                alert(2, "critical", "< 1.2.3", "GHSA-two"),
+            ],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["clusters"], json!(1));
+    let task_id = output["filed"][0]["task_id"].as_str().expect("task id");
+    let task = runtime.get_task(task_id).expect("filed task");
+    assert_eq!(task.status, TaskStatus::Backlog);
+    assert_eq!(task.priority, TaskPriority::Critical);
+    assert!(task.required_tools.is_empty());
+    assert!(task.title.starts_with("[dependabot-sweep] "));
+    for expected in [
+        "time",
+        "Cargo.lock",
+        "1.2.3",
+        "GHSA-one",
+        "CVE-2026-1",
+        "GHSA-two",
+        "https://github.test/alerts/2",
+    ] {
+        assert!(task.description.contains(expected), "missing {expected}");
+    }
+}
+
+#[test]
+fn dedupe_key_survives_changed_alert_number_severity_and_range() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let first = file(
+        &runtime,
+        snapshot(vec![alert(1, "high", "< 1.0.0", "GHSA-old")], Vec::new()),
+        json!({}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+    let second = file(
+        &runtime,
+        snapshot(
+            vec![alert(99, "critical", "< 9.9.9", "GHSA-new")],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(
+        second["skipped_existing"]
+            .as_array()
+            .expect("skipped")
+            .len(),
+        1
+    );
+    assert_eq!(
+        first["filed"][0]["key"],
+        second["skipped_existing"][0]["key"]
+    );
+}
+
+#[test]
+fn severity_floor_is_reported_and_dependabot_pr_skip_is_switchable() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let low = file(
+        &runtime,
+        snapshot(
+            vec![alert(1, "moderate", "< 1.0.0", "GHSA-low")],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(low["filed_count"], json!(0));
+    assert_eq!(
+        low["excluded_below_min_severity"]
+            .as_array()
+            .expect("excluded")
+            .len(),
+        1
+    );
+
+    let pr = json!({"number": 4, "title": "Bump time from 1.0.0 to 1.2.3", "body": "Updates time", "url": "https://github.test/pr/4", "author": "app/dependabot"});
+    let skipped = file(
+        &runtime,
+        snapshot(
+            vec![alert(2, "high", "< 1.2.3", "GHSA-high")],
+            vec![pr.clone()],
+        ),
+        json!({}),
+    );
+    assert_eq!(skipped["filed_count"], json!(0));
+    assert_eq!(
+        skipped["skipped_dependabot_pr"]
+            .as_array()
+            .expect("PR skips")
+            .len(),
+        1
+    );
+
+    let filed = file(
+        &runtime,
+        snapshot(vec![alert(2, "high", "< 1.2.3", "GHSA-high")], vec![pr]),
+        json!({"skip_when_dependabot_pr_open": false}),
+    );
+    assert_eq!(filed["filed_count"], json!(1));
+    assert_eq!(filed["skipped_dependabot_pr"], json!([]));
+}
+
+#[test]
+fn filing_succeeds_without_a_system_crew() {
+    let (_root, runtime) = runtime_without_system_crew();
+    let output = file(
+        &runtime,
+        snapshot(
+            vec![alert(7, "high", "< 1.2.3", "GHSA-no-crew")],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+    assert_eq!(output["filed_count"], json!(1));
+    let task_id = output["filed"][0]["task_id"].as_str().expect("task id");
+    assert_eq!(runtime.get_task(task_id).expect("task").crew, None);
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -1,6 +1,7 @@
 mod backlog_exclusion;
 mod ci_failure_tasks;
 mod cli_executor;
+mod dependabot_alert_tasks;
 mod dispatch;
 mod pipeline_actions;
 mod required_tools;

--- a/crates/orbit-core/src/application/job/catalog.rs
+++ b/crates/orbit-core/src/application/job/catalog.rs
@@ -31,6 +31,10 @@ pub(crate) const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../assets/jobs/ci_failure_sweep_pipeline.yaml"),
     ),
     (
+        "dependabot_alert_sweep_pipeline",
+        include_str!("../../../assets/jobs/dependabot_alert_sweep_pipeline.yaml"),
+    ),
+    (
         "epic_pipeline",
         include_str!("../../../assets/jobs/epic_pipeline.yaml"),
     ),

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -26,6 +26,10 @@ const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
         include_str!("../../../../assets/jobs/ci_failure_sweep_pipeline.yaml"),
     ),
     (
+        "dependabot_alert_sweep_pipeline",
+        include_str!("../../../../assets/jobs/dependabot_alert_sweep_pipeline.yaml"),
+    ),
+    (
         "epic_pipeline",
         include_str!("../../../../assets/jobs/epic_pipeline.yaml"),
     ),
@@ -234,6 +238,36 @@ fn ci_failure_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
         !yaml.contains("worktree_setup"),
         "the sweep only looks and files, so it must never build a worktree"
     );
+}
+
+#[test]
+fn dependabot_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
+    let yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "dependabot_alert_sweep_pipeline").then_some(*yaml))
+        .expect("Dependabot sweep job default exists");
+    let mut asset = load_job_asset(yaml).expect("parse Dependabot sweep pipeline");
+    let catalog = default_activity_catalog();
+    resolve_job_target_refs(&mut asset.spec, &catalog).expect("resolve sweep target refs");
+    assert_eq!(asset.spec.max_active_runs, 1);
+    assert_eq!(
+        asset
+            .spec
+            .steps
+            .iter()
+            .map(|step| step.id.as_str())
+            .collect::<Vec<_>>(),
+        ["collect", "file"]
+    );
+    assert!(
+        asset
+            .spec
+            .steps
+            .iter()
+            .all(|step| matches!(step.body, JobV2StepBody::Target(_)))
+    );
+    assert!(!yaml.contains("agent_loop"));
+    assert!(!yaml.contains("worktree_setup"));
 }
 
 #[test]

--- a/crates/orbit-core/src/application/routine.rs
+++ b/crates/orbit-core/src/application/routine.rs
@@ -39,6 +39,10 @@ pub(crate) const DEFAULT_ROUTINE_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/routines/ci_failure_sweep.yaml"),
     ),
     (
+        "dependabot_alert_sweep",
+        include_str!("../../assets/routines/dependabot_alert_sweep.yaml"),
+    ),
+    (
         "task_triage",
         include_str!("../../assets/routines/task_triage.yaml"),
     ),
@@ -155,6 +159,7 @@ mod tests {
         for (stem, target) in [
             ("auto_task_scheduler", "auto_task_scheduler_pipeline"),
             ("ci_failure_sweep", "ci_failure_sweep_pipeline"),
+            ("dependabot_alert_sweep", "dependabot_alert_sweep_pipeline"),
             ("task_triage", "task_triage_pipeline"),
             ("task_pilot", "task_pilot_pipeline"),
             ("ship_sweep", "workspace_ship_pipeline"),
@@ -228,6 +233,17 @@ mod tests {
         );
         assert_eq!(sweep.policy.overlap, OverlapPolicy::Forbid);
         parse_cron(&sweep.trigger.cron).expect("CI-failure sweep cron parses");
+
+        let dependabot = std::fs::read_to_string(routines_dir.join("dependabot_alert_sweep.yaml"))
+            .expect("read Dependabot sweep routine");
+        let dependabot = parse_routine_yaml(&dependabot).expect("Dependabot sweep routine parses");
+        assert!(!dependabot.enabled);
+        assert_eq!(dependabot.trigger.cron, "25 3 * * *");
+        assert_eq!(dependabot.policy.overlap, OverlapPolicy::Forbid);
+        for occupied in ["5 * * * *", "15 * * * *", "35 * * * *", "*/20 * * * *"] {
+            assert_ne!(dependabot.trigger.cron, occupied);
+        }
+        parse_cron(&dependabot.trigger.cron).expect("Dependabot sweep cron parses");
     }
 
     #[test]

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -37,12 +37,20 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/collect_ci_evidence.yaml"),
     ),
     (
+        "collect_dependabot_alerts",
+        include_str!("../../assets/activities/collect_dependabot_alerts.yaml"),
+    ),
+    (
         "drain_window",
         include_str!("../../assets/activities/drain_window.yaml"),
     ),
     (
         "file_ci_failure_tasks",
         include_str!("../../assets/activities/file_ci_failure_tasks.yaml"),
+    ),
+    (
+        "file_dependabot_alert_tasks",
+        include_str!("../../assets/activities/file_dependabot_alert_tasks.yaml"),
     ),
     (
         "epic_orchestrator",

--- a/crates/orbit-engine/src/executor/automation/ci/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/mod.rs
@@ -22,6 +22,8 @@
 mod collect;
 mod query;
 
+pub(in crate::executor::automation) use query::AuthStatus;
+
 use std::path::PathBuf;
 
 use orbit_common::OrbitError;

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -25,18 +25,18 @@ use serde_json::{Value, json};
 /// to report *that*, and an error return would be indistinguishable from the
 /// query itself being broken.
 #[derive(Debug, Clone)]
-pub(super) struct AuthStatus {
-    pub(super) available: bool,
-    pub(super) authenticated: bool,
-    pub(super) detail: String,
+pub(in crate::executor::automation) struct AuthStatus {
+    pub(in crate::executor::automation) available: bool,
+    pub(in crate::executor::automation) authenticated: bool,
+    pub(in crate::executor::automation) detail: String,
 }
 
 impl AuthStatus {
-    pub(super) fn usable(&self) -> bool {
+    pub(in crate::executor::automation) fn usable(&self) -> bool {
         self.available && self.authenticated
     }
 
-    pub(super) fn to_json(&self) -> Value {
+    pub(in crate::executor::automation) fn to_json(&self) -> Value {
         json!({
             "available": self.available,
             "authenticated": self.authenticated,

--- a/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
@@ -1,0 +1,135 @@
+use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
+use serde_json::{Map, Value, json};
+
+use super::query::{AlertQuery, DependabotQueries};
+use super::{OUTCOME_CAPABILITY_UNAVAILABLE, OUTCOME_NO_OPEN_ALERTS, OUTCOME_OPEN_ALERTS};
+use crate::executor::automation::ci::AuthStatus;
+use crate::executor::automation::ci::bounded_u64;
+use crate::executor::automation::ci::optional_input_string;
+
+const SCHEMA_VERSION: u64 = 1;
+const DEFAULT_LIMIT: u64 = 100;
+const MAX_LIMIT: u64 = 100;
+
+pub(super) fn collect<Q: DependabotQueries + ?Sized>(
+    queries: &Q,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let limit = bounded_u64(input, "max_alerts", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let pr_limit = bounded_u64(input, "max_pull_requests", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let repo = optional_input_string(input, "repo");
+    let auth = queries.auth_status();
+    if !auth.usable() {
+        let detail = auth.detail.clone();
+        return capability_snapshot(auth, detail);
+    }
+
+    let repository = queries.repo_view(repo.as_deref())?;
+    let alerts = match queries.open_alerts(repo.as_deref(), limit)? {
+        AlertQuery::Alerts(alerts) => alerts,
+        AlertQuery::CapabilityUnavailable(detail) => return capability_snapshot(auth, detail),
+    };
+
+    let mut query_errors = Vec::new();
+    let pull_requests = match queries.open_dependabot_pull_requests(repo.as_deref(), pr_limit) {
+        Ok(pull_requests) => pull_requests,
+        Err(error) => {
+            query_errors
+                .push(json!({"query": "dependabot_pull_requests", "error": error.to_string()}));
+            Vec::new()
+        }
+    };
+    let alerts_at_cap = alerts.len() as u64 == limit;
+    let prs_at_cap = pull_requests.len() as u64 == pr_limit;
+    let notes = [
+        alerts_at_cap.then(|| {
+            format!("open alerts were listed at the {limit}-alert cap; further alerts may exist")
+        }),
+        prs_at_cap.then(|| {
+            format!(
+                "open Dependabot pull requests were listed at the {pr_limit}-PR cap; further PRs may exist"
+            )
+        }),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    let snapshot = json!({
+        "schema_version": SCHEMA_VERSION,
+        "collected": true,
+        "outcome_hint": if alerts.is_empty() { OUTCOME_NO_OPEN_ALERTS } else { OUTCOME_OPEN_ALERTS },
+        "capability": auth.to_json(),
+        "repository": repository,
+        "open_alerts": alerts.into_iter().map(bound_alert).collect::<Vec<_>>(),
+        "open_dependabot_pull_requests": pull_requests.into_iter().map(bound_pull_request).collect::<Vec<_>>(),
+        "query_errors": query_errors,
+        "truncation": {
+            "alerts_limit": limit,
+            "alerts_at_cap": alerts_at_cap,
+            "pull_requests_limit": pr_limit,
+            "pull_requests_at_cap": prs_at_cap,
+            "notes": notes,
+        },
+        "collected_at": chrono::Utc::now().to_rfc3339(),
+    });
+    redact_snapshot(snapshot)
+}
+
+fn capability_snapshot(auth: AuthStatus, detail: String) -> Result<Value, OrbitError> {
+    redact_snapshot(json!({
+        "schema_version": SCHEMA_VERSION,
+        "collected": false,
+        "outcome_hint": OUTCOME_CAPABILITY_UNAVAILABLE,
+        "capability": {
+            "available": auth.available,
+            "authenticated": auth.authenticated,
+            "detail": detail,
+        },
+        "collected_at": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+fn bound_alert(mut alert: Value) -> Value {
+    if let Some(object) = alert.as_object_mut() {
+        for (key, value) in object.iter_mut() {
+            if let Some(text) = value.as_str() {
+                let max = if key == "summary" { 300 } else { 500 };
+                *value = Value::String(one_line(text, max));
+            }
+        }
+    }
+    alert
+}
+
+fn bound_pull_request(mut pull_request: Value) -> Value {
+    if let Some(object) = pull_request.as_object_mut() {
+        bound_field(object, "title", 300);
+        bound_field(object, "body", 1_000);
+        bound_field(object, "url", 500);
+        bound_field(object, "author", 100);
+    }
+    pull_request
+}
+
+fn bound_field(object: &mut Map<String, Value>, key: &str, max: usize) {
+    if let Some(text) = object.get(key).and_then(Value::as_str) {
+        object.insert(key.to_string(), Value::String(one_line(text, max)));
+    }
+}
+
+fn one_line(text: &str, max: usize) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    compact.chars().take(max).collect()
+}
+
+fn redact_snapshot(snapshot: Value) -> Result<Value, OrbitError> {
+    let encoded = serde_json::to_string(&snapshot).map_err(|error| {
+        OrbitError::Execution(format!("failed to encode Dependabot snapshot: {error}"))
+    })?;
+    serde_json::from_str(&redact_all(&encoded)).map_err(|error| {
+        OrbitError::Execution(format!(
+            "failed to decode redacted Dependabot snapshot: {error}"
+        ))
+    })
+}

--- a/crates/orbit-engine/src/executor/automation/dependabot/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/mod.rs
@@ -1,0 +1,43 @@
+//! Host-owned Dependabot alert discovery.
+//!
+//! All `gh` processes run here with `NoSandbox` on the engine-private
+//! deterministic boundary. Only the bounded, redacted snapshot leaves this
+//! module; no credential or follow-up query capability enters an agent lane.
+
+mod collect;
+mod query;
+
+use std::path::PathBuf;
+
+use orbit_common::OrbitError;
+use serde_json::Value;
+
+use crate::context::RuntimeHost;
+
+use super::input::{canonicalize_existing_dir, input_string_field};
+
+const OUTCOME_CAPABILITY_UNAVAILABLE: &str = "capability_unavailable";
+const OUTCOME_NO_OPEN_ALERTS: &str = "no_open_alerts";
+const OUTCOME_OPEN_ALERTS: &str = "open_alerts";
+
+fn query_root<H: RuntimeHost + ?Sized>(host: &H, input: &Value) -> Result<PathBuf, OrbitError> {
+    match input_string_field(input, "workspace_path") {
+        Some(path) => canonicalize_existing_dir(&path, "workspace_path"),
+        None => Ok(PathBuf::from(host.repo_root()?)),
+    }
+}
+
+pub(super) fn collect_dependabot_alerts<H: RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+) -> Result<Value, OrbitError> {
+    let queries = query::HostDependabotQueries::new(&query_root(host, input)?);
+    let snapshot = collect::collect(&queries, input)?;
+    Ok(serde_json::json!({
+        "phase": "collect_dependabot_alerts",
+        "dependabot_snapshot": snapshot,
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-engine/src/executor/automation/dependabot/query.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/query.rs
@@ -1,0 +1,159 @@
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
+use orbit_exec::{NoSandbox, run_process};
+use orbit_tools::{check_exec_result, github_cli};
+use serde_json::{Value, json};
+
+use super::super::ci::AuthStatus;
+
+#[derive(Debug)]
+pub(super) enum AlertQuery {
+    Alerts(Vec<Value>),
+    CapabilityUnavailable(String),
+}
+
+pub(super) trait DependabotQueries {
+    fn auth_status(&self) -> AuthStatus;
+    fn repo_view(&self, repo: Option<&str>) -> Result<Value, OrbitError>;
+    fn open_alerts(&self, repo: Option<&str>, limit: u64) -> Result<AlertQuery, OrbitError>;
+    fn open_dependabot_pull_requests(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<Vec<Value>, OrbitError>;
+}
+
+pub(super) struct HostDependabotQueries {
+    repo_root: PathBuf,
+}
+
+impl HostDependabotQueries {
+    pub(super) fn new(repo_root: &Path) -> Self {
+        Self {
+            repo_root: repo_root.to_path_buf(),
+        }
+    }
+
+    fn run_gh(
+        &self,
+        mut request: orbit_exec::ExecRequest,
+        label: &str,
+    ) -> Result<String, OrbitError> {
+        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
+        let result = run_process(&request, &NoSandbox)?;
+        check_exec_result(&result, label)?;
+        Ok(result.stdout)
+    }
+}
+
+impl DependabotQueries for HostDependabotQueries {
+    fn auth_status(&self) -> AuthStatus {
+        let mut request = match github_cli::auth_status_request(&Value::Null) {
+            Ok(request) => request,
+            Err(error) => {
+                return AuthStatus {
+                    available: false,
+                    authenticated: false,
+                    detail: format!(
+                        "GitHub CLI is unavailable on this host: {}",
+                        redact_all(&error.to_string())
+                    ),
+                };
+            }
+        };
+        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
+        match run_process(&request, &NoSandbox) {
+            Ok(result) if result.success => AuthStatus {
+                available: true,
+                authenticated: true,
+                detail: "GitHub CLI is authenticated on this host".to_string(),
+            },
+            Ok(result) => AuthStatus {
+                available: true,
+                authenticated: false,
+                detail: format!(
+                    "GitHub CLI is present but holds no usable credentials on this host: {}",
+                    redact_all(result.stderr.trim())
+                ),
+            },
+            Err(error) => AuthStatus {
+                available: false,
+                authenticated: false,
+                detail: format!(
+                    "GitHub CLI is unavailable on this host: {}",
+                    redact_all(&error.to_string())
+                ),
+            },
+        }
+    }
+
+    fn repo_view(&self, repo: Option<&str>) -> Result<Value, OrbitError> {
+        let input = repo.map_or(Value::Null, |repo| json!({"repo": repo}));
+        let request = github_cli::repo_view_request(&input)?;
+        let stdout = self.run_gh(request, "gh repo view for Dependabot sweep")?;
+        let parsed = github_cli::parse_gh_json(&stdout, "gh repo view")?;
+        Ok(github_cli::project_repo_view(&parsed))
+    }
+
+    fn open_alerts(&self, repo: Option<&str>, limit: u64) -> Result<AlertQuery, OrbitError> {
+        let input = json!({"repo": repo, "limit": limit});
+        let mut request = github_cli::dependabot_alerts_request(&input)?;
+        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
+        let result = run_process(&request, &NoSandbox)?;
+        if !result.success {
+            return classify_alert_failure(&result.stderr).map(AlertQuery::CapabilityUnavailable);
+        }
+        let parsed = github_cli::parse_gh_json(&result.stdout, "gh api Dependabot alerts")?;
+        let entries = parsed.as_array().ok_or_else(|| {
+            OrbitError::Execution(
+                "gh api Dependabot alerts returned a non-array response; refusing to report no open alerts"
+                    .to_string(),
+            )
+        })?;
+        let alerts = entries
+            .iter()
+            .map(github_cli::project_dependabot_alert)
+            .collect();
+        Ok(AlertQuery::Alerts(alerts))
+    }
+
+    fn open_dependabot_pull_requests(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<Vec<Value>, OrbitError> {
+        let input = json!({"repo": repo, "limit": limit});
+        let request = github_cli::dependabot_pull_requests_request(&input)?;
+        let stdout = self.run_gh(request, "gh pr list for Dependabot sweep")?;
+        let parsed = github_cli::parse_gh_json(&stdout, "gh pr list")?;
+        let entries = parsed.as_array().ok_or_else(|| {
+            OrbitError::Execution(
+                "gh pr list for Dependabot sweep returned a non-array response".to_string(),
+            )
+        })?;
+        Ok(entries
+            .iter()
+            .map(github_cli::project_dependabot_pull_request)
+            .collect())
+    }
+}
+
+pub(super) fn classify_alert_failure(stderr: &str) -> Result<String, OrbitError> {
+    let detail = redact_all(stderr.trim());
+    let lower = detail.to_ascii_lowercase();
+    if lower.contains("403") {
+        return Ok(format!(
+            "GitHub returned HTTP 403 for Dependabot alerts; the host token lacks the security_events scope: {detail}"
+        ));
+    }
+    if lower.contains("404") {
+        return Ok(format!(
+            "GitHub returned HTTP 404 for Dependabot alerts; alerts are disabled or unavailable for this repository: {detail}"
+        ));
+    }
+    Err(OrbitError::Execution(format!(
+        "gh api Dependabot alerts failed: {detail}"
+    )))
+}

--- a/crates/orbit-engine/src/executor/automation/dependabot/tests.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/tests.rs
@@ -1,0 +1,78 @@
+use orbit_common::OrbitError;
+use serde_json::{Value, json};
+
+use super::collect::collect;
+use super::query::{AlertQuery, DependabotQueries, classify_alert_failure};
+use crate::executor::automation::ci::AuthStatus;
+
+struct ScriptedQueries {
+    alerts: AlertQuery,
+}
+
+impl DependabotQueries for ScriptedQueries {
+    fn auth_status(&self) -> AuthStatus {
+        AuthStatus {
+            available: true,
+            authenticated: true,
+            detail: "authenticated".to_string(),
+        }
+    }
+    fn repo_view(&self, _repo: Option<&str>) -> Result<Value, OrbitError> {
+        Ok(json!({"name": "orbit", "full_name": "acme/orbit", "default_branch": "main"}))
+    }
+    fn open_alerts(&self, _repo: Option<&str>, _limit: u64) -> Result<AlertQuery, OrbitError> {
+        Ok(match &self.alerts {
+            AlertQuery::Alerts(alerts) => AlertQuery::Alerts(alerts.clone()),
+            AlertQuery::CapabilityUnavailable(detail) => {
+                AlertQuery::CapabilityUnavailable(detail.clone())
+            }
+        })
+    }
+    fn open_dependabot_pull_requests(
+        &self,
+        _repo: Option<&str>,
+        _limit: u64,
+    ) -> Result<Vec<Value>, OrbitError> {
+        Ok(Vec::new())
+    }
+}
+
+#[test]
+fn http_403_and_404_are_distinct_capability_outcomes_not_no_alerts() {
+    for (stderr, expected) in [
+        (
+            "gh: Resource not accessible by integration (HTTP 403)",
+            "security_events",
+        ),
+        (
+            "gh: Dependabot alerts are not enabled (HTTP 404)",
+            "disabled or unavailable",
+        ),
+    ] {
+        let detail = classify_alert_failure(stderr).expect("classified capability response");
+        assert!(detail.contains(expected));
+        let output = collect(
+            &ScriptedQueries {
+                alerts: AlertQuery::CapabilityUnavailable(detail),
+            },
+            &json!({}),
+        )
+        .expect("collect capability snapshot");
+        assert_eq!(output["collected"], json!(false));
+        assert_eq!(output["outcome_hint"], json!("capability_unavailable"));
+        assert_ne!(output["outcome_hint"], json!("no_open_alerts"));
+    }
+}
+
+#[test]
+fn empty_success_is_the_only_no_open_alerts_outcome() {
+    let output = collect(
+        &ScriptedQueries {
+            alerts: AlertQuery::Alerts(Vec::new()),
+        },
+        &json!({}),
+    )
+    .expect("collect empty snapshot");
+    assert_eq!(output["collected"], json!(true));
+    assert_eq!(output["outcome_hint"], json!("no_open_alerts"));
+}

--- a/crates/orbit-engine/src/executor/automation/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/mod.rs
@@ -1,4 +1,5 @@
 mod ci;
+mod dependabot;
 mod input;
 pub(crate) mod review;
 mod task_update;
@@ -62,6 +63,9 @@ pub(crate) fn execute_engine_action<
 
         // ---- generic built-in actions ----
         EngineDeterministicAction::CollectCiEvidence => ci::collect_ci_evidence(host, input),
+        EngineDeterministicAction::CollectDependabotAlerts => {
+            dependabot::collect_dependabot_alerts(host, input)
+        }
         EngineDeterministicAction::GitCommit => vcs::git_commit(host, input),
         EngineDeterministicAction::GitRebase => vcs::rebase_pr_branch(host, input),
         EngineDeterministicAction::PrFailureHandoff => vcs::pr_failure_handoff(host, input),

--- a/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
+++ b/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
@@ -1,0 +1,101 @@
+use orbit_common::OrbitError;
+use orbit_exec::ExecRequest;
+use serde_json::{Value, json};
+
+use crate::TIMEOUT_DEFAULT_MS;
+
+const DEFAULT_LIMIT: u64 = 100;
+const MAX_LIMIT: u64 = 100;
+
+fn repository_path(input: &Value) -> Result<String, OrbitError> {
+    let Some(raw) = input.get("repo").and_then(Value::as_str) else {
+        return Ok("{owner}/{repo}".to_string());
+    };
+    let repo = raw.trim();
+    let mut parts = repo.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let name = parts.next().unwrap_or_default();
+    let valid_part = |part: &str| {
+        !part.is_empty()
+            && part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    };
+    if parts.next().is_some() || !valid_part(owner) || !valid_part(name) {
+        return Err(OrbitError::InvalidInput(format!(
+            "invalid `repo`: \"{repo}\"; expected owner/name using ASCII letters, digits, '.', '-', or '_'"
+        )));
+    }
+    Ok(repo.to_string())
+}
+
+/// Build one bounded Dependabot-alert API request. This builder is deliberately
+/// unregistered: only engine-private host automation calls it.
+pub fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let endpoint = format!("repos/{}/dependabot/alerts", repository_path(input)?);
+    let limit = super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let args = vec![
+        "api".to_string(),
+        "--method".to_string(),
+        "GET".to_string(),
+        endpoint,
+        "-f".to_string(),
+        "state=open".to_string(),
+        "-F".to_string(),
+        format!("per_page={limit}"),
+    ];
+    Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+/// Build the bounded query used to discover Dependabot-authored open PRs.
+pub fn build_open_pull_requests_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let limit = super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let mut args = vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "--state".to_string(),
+        "open".to_string(),
+        "--author".to_string(),
+        "app/dependabot".to_string(),
+    ];
+    super::push_repo_flag(&mut args, input)?;
+    args.extend([
+        "--limit".to_string(),
+        limit.to_string(),
+        "--json".to_string(),
+        "number,title,url,body,author".to_string(),
+    ]);
+    Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+pub fn project_alert(alert: &Value) -> Value {
+    json!({
+        "number": alert["number"],
+        "state": alert["state"],
+        "ecosystem": alert["dependency"]["package"]["ecosystem"],
+        "package": alert["dependency"]["package"]["name"],
+        "manifest_path": alert["dependency"]["manifest_path"],
+        "scope": alert["dependency"]["scope"],
+        "severity": alert["security_advisory"]["severity"],
+        "ghsa_id": alert["security_advisory"]["ghsa_id"],
+        "cve_id": alert["security_advisory"]["cve_id"],
+        "summary": alert["security_advisory"]["summary"],
+        "vulnerable_version_range": alert["security_vulnerability"]["vulnerable_version_range"],
+        "first_patched_version": alert["security_vulnerability"]["first_patched_version"]["identifier"],
+        "created_at": alert["created_at"],
+        "updated_at": alert["updated_at"],
+        "dismissed_at": alert["dismissed_at"],
+        "fixed_at": alert["fixed_at"],
+        "html_url": alert["html_url"],
+    })
+}
+
+pub fn project_pull_request(pr: &Value) -> Value {
+    json!({
+        "number": pr["number"],
+        "title": pr["title"],
+        "url": pr["url"],
+        "body": pr["body"],
+        "author": pr["author"]["login"],
+    })
+}

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -109,6 +109,7 @@ macro_rules! gh_tool {
 pub(super) use gh_tool;
 
 pub mod auth;
+pub mod dependabot_alerts;
 pub mod pr_checkout;
 pub mod pr_checks;
 pub mod pr_close;

--- a/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
@@ -4,7 +4,48 @@
 
 use serde_json::json;
 
-use crate::builtin::github::{pr_list, run_list, run_logs, run_view};
+use crate::builtin::github::{dependabot_alerts, pr_list, run_list, run_logs, run_view};
+
+#[test]
+fn dependabot_alert_request_is_bounded_and_projects_compact_evidence() {
+    let req = dependabot_alerts::build_exec_request(&json!({
+        "repo": "openai/orbit",
+        "limit": 500,
+    }))
+    .expect("request");
+    assert_eq!(
+        req.args,
+        [
+            "api",
+            "--method",
+            "GET",
+            "repos/openai/orbit/dependabot/alerts",
+            "-f",
+            "state=open",
+            "-F",
+            "per_page=100"
+        ]
+    );
+
+    let projected = dependabot_alerts::project_alert(&json!({
+        "number": 7, "state": "open",
+        "dependency": {"package": {"ecosystem": "cargo", "name": "time"}, "manifest_path": "Cargo.lock", "scope": "runtime"},
+        "security_advisory": {"severity": "high", "ghsa_id": "GHSA-1234", "cve_id": "CVE-2026-1", "summary": "A concise summary", "description": "long prose must not escape"},
+        "security_vulnerability": {"vulnerable_version_range": "< 1.2.3", "first_patched_version": {"identifier": "1.2.3"}},
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-02T00:00:00Z",
+        "dismissed_at": null, "fixed_at": null, "html_url": "https://github.com/acme/repo/security/dependabot/7"
+    }));
+    assert_eq!(projected["package"], json!("time"));
+    assert_eq!(projected["first_patched_version"], json!("1.2.3"));
+    assert!(projected.get("description").is_none());
+}
+
+#[test]
+fn dependabot_alert_request_rejects_repository_path_injection() {
+    let error = dependabot_alerts::build_exec_request(&json!({"repo": "acme/repo?per_page=999"}))
+        .expect_err("invalid repo must fail");
+    assert!(error.to_string().contains("invalid `repo`"));
+}
 
 #[test]
 fn run_list_applies_every_filter_and_caps_the_limit() {

--- a/crates/orbit-tools/src/github_cli.rs
+++ b/crates/orbit-tools/src/github_cli.rs
@@ -17,6 +17,12 @@
 //! otherwise resolves the repository from the caller's working directory.
 
 pub use crate::builtin::github::auth::build_exec_request as auth_status_request;
+pub use crate::builtin::github::dependabot_alerts::{
+    build_exec_request as dependabot_alerts_request,
+    build_open_pull_requests_request as dependabot_pull_requests_request,
+    project_alert as project_dependabot_alert,
+    project_pull_request as project_dependabot_pull_request,
+};
 pub use crate::builtin::github::pr_list::{
     build_exec_request as pr_list_request, project_pull_request,
 };

--- a/crates/orbit-types/src/workflow/activity_job/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/mod.rs
@@ -24,6 +24,7 @@ macro_rules! deterministic_action_catalog {
                 ContextConflictCheck => "context_conflict_check",
                 DrainWindow => "drain_window",
                 FileCiFailureTasks => "file_ci_failure_tasks",
+                FileDependabotAlertTasks => "file_dependabot_alert_tasks",
                 GateStarvationFail => "gate_starvation_fail",
                 InvokeAndWait => "invoke_and_wait",
                 InvokeDetached => "invoke_detached",
@@ -45,6 +46,7 @@ macro_rules! deterministic_action_catalog {
             }
             engine {
                 CollectCiEvidence => "collect_ci_evidence",
+                CollectDependabotAlerts => "collect_dependabot_alerts",
                 GitCommit => "git_commit",
                 GitMerge => "git_merge",
                 GitPush => "git_push",


### PR DESCRIPTION
## Task

[ORB-11124](https://orbit-cli.com/tasks/ORB-11124) — Add a Dependabot vulnerability-alert sweep: collect + file activities, job, and routine

### Description

Build a Dependabot vulnerability-alert sweep as a second instance of the shipped
CI-failure sweep pattern (ORB-11107): the host collects the evidence outside any
sandbox, then a deterministic step files ordinary backlog tasks carrying that
evidence inline. No new pipeline concept, no verification stage, no GitHub
credential crossing into an agent sandbox.

## Why the CI sweep is the right template

`ci_failure_sweep` already solved the hard part. An agent cannot query GitHub
from inside its lane — the `github.*` builtins run `gh` as a child of the
executing process, and the lane denies `~/.config/gh` and forwards no token. The
sweep sidesteps that by doing the looking on the engine-private deterministic
automation boundary (`NoSandbox`, inherited environment, engine-private labels,
outside tool authorization and activity allowlists) *before* any task exists,
and writing one bounded, redacted snapshot into the task description.

Dependabot alerts have exactly the same shape: a host-only read, evidence that
fits in a description, and remediation that is ordinary repository work. Mirror
the structure rather than inventing a second one.

## What to build

Follow the existing files as the template throughout; the naming below is the
suggested mirror, not a constraint on internal structure.

**1. The `gh` read** — `crates/orbit-tools/src/builtin/github/dependabot_alerts.rs`,
re-exported from `crates/orbit-tools/src/github_cli.rs` so `orbit-tools` stays
the single owner of what a `gh` invocation looks like.

- Endpoint: `gh api --method GET repos/{owner}/{repo}/dependabot/alerts`, with
  `-f state=open`. `gh` substitutes the `{owner}` / `{repo}` placeholders from
  the working directory's remote, the same resolution the other `gh` calls in
  that module rely on; an explicit `repo` input must be charset-validated before
  interpolation because it lands in a URL path.
- Prefer one bounded page (`-F per_page=…`) over `--paginate`, and report the
  bound. `gh api --paginate` on an array endpoint emits concatenated JSON
  documents rather than one array unless `--slurp` is passed, and a caller that
  stopped looking must say so rather than present a short list as complete.
- Project the alert into stable field names: alert number, state, ecosystem,
  package, manifest path, scope, severity, GHSA id, CVE id, one-line summary,
  vulnerable version range, first patched version, timestamps, html url.
- Drop the advisory's long-form `description` from the projection. It is a
  paragraph of prose that would dominate a task description without changing
  what the fix is; the one-line `summary` plus the identifiers is what a
  remediation task acts on.
- Do **not** register a new tool in `builtin/github/mod.rs::register`. The
  sweep's whole point is that the host does the looking, and `repo.rs` is the
  existing precedent for a builder that ships unregistered. The agent-facing
  surface must not grow.

**2. The collect stage** — an engine-private deterministic action
(suggested `collect_dependabot_alerts`), as a sibling of
`crates/orbit-engine/src/executor/automation/ci/`. `bounded_u64`,
`optional_input_string` and friends in `automation/ci/mod.rs` are already
`pub(super)` = visible across `automation`, so they are reusable as-is;
`AuthStatus` in `automation/ci/query.rs` is `pub(super)` to `ci` and needs its
visibility widened to `pub(in crate::executor::automation)` rather than
duplicated.

Keep the "three endings never collapse" rule from `automation/ci/mod.rs`, and
note that Dependabot has **two distinct unavailability modes** that the CI sweep
does not have. Both are capability answers, not faults, and neither is a clean
bill of health:

- `gh` absent or unauthenticated — the existing preflight.
- `gh` present and authenticated but the token lacks the `security_events`
  scope (HTTP 403), or Dependabot alerts are disabled/unavailable for the
  repository (HTTP 404). These come back as a non-zero `gh` exit with the status
  on stderr. They must be classified into the capability outcome with a detail
  string that says which one it was — never reported as "no open alerts".

Emit one snapshot: schema version, `collected`, `outcome_hint`, `capability`,
`repository`, `open_alerts`, the open Dependabot-authored pull requests (see
below), `query_errors`, `truncation`, `collected_at`.

**3. The file stage** — a core deterministic action (suggested
`file_dependabot_alert_tasks`) alongside
`crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs`, wired
through `dispatch.rs`. A pure function of the snapshot plus the workspace's open
tasks.

- **Cluster by remediation, not by alert.** The unit of work is a dependency
  bump, and one bump usually clears several alerts on the same package. Cluster
  on `(ecosystem, package, manifest_path)` and list every alert in the cluster
  in the description. Filing one task per alert would flood the backlog with
  work items that resolve each other.
- **Dedupe key** = digest of that same triple, carried as a tag
  (e.g. `dependabot:<key>`), matched against still-open tasks exactly as
  `open_task_for_key` does. Deliberately independent of alert number, severity,
  and version range: those move as advisories are updated, and a key that moves
  with them re-files the same bump every sweep.
- **Severity floor**, `min_severity` input, defaulting to `high`. Low and
  moderate alerts filed hourly are the backlog flood this step exists to
  prevent. Report what the floor excluded in the output rather than dropping it
  silently.
- **Skip what Dependabot is already fixing.** This is the one place the mirror
  genuinely diverges from the CI sweep: Dependabot opens its own PRs, so a
  cluster whose package already has an open Dependabot-authored PR is work that
  is already in flight. Collect open PRs authored by `app/dependabot` in the
  collect stage, and skip those clusters into a distinct `skipped_dependabot_pr`
  bucket. Make it switchable (`skip_when_dependabot_pr_open`, default true) —
  the alerts worth a human-shaped task are largely the ones Dependabot could not
  auto-fix.
- Filed tasks match the shipped CI-sweep conventions on HEAD: title prefix
  (`[dependabot-sweep] `) with the cap applied to the variable part so the
  prefix survives truncation; `crew: system`, probed with `validate_crew_name`
  so a workspace with no `system` crew still gets its task filed; empty
  `required_tools`; `status: backlog`; `system_created: true`.
- Map severity to priority: `critical` → critical, `high` → high, anything
  lower that clears the floor → medium.
- Description carries the package, the manifest path, the first patched version
  (the actual fix target), every alert in the cluster with its GHSA/CVE id,
  severity, summary and url, and the truncation notes. Acceptance criteria
  should name the bump and require that the manifest and lockfile agree.

**4. Assets** — mirroring the CI sweep's four:
`assets/activities/collect_dependabot_alerts.yaml`,
`assets/activities/file_dependabot_alert_tasks.yaml`,
`assets/jobs/dependabot_alert_sweep_pipeline.yaml` (two deterministic steps,
`max_active_runs: 1`), and `assets/routines/dependabot_alert_sweep.yaml`
carrying the `__ORBIT_HOST_ID__` / `__ORBIT_ROUTINE_NAME__` placeholders and
shipping `enabled: false`.

Cadence: **daily, not hourly.** Advisories are published on a scale of days and
a dependency bump takes longer than an hour to land; an hourly alert sweep would
spend almost every run rediscovering the same open alerts. Pick a slot that
stacks with none of the shipped defaults — the existing occupants are
`ci_failure_sweep` at :05, `task_triage` at :15, `worktree_gc` at :35, and
`ship_sweep` at :00/:20/:40.

**5. Wiring** — the deterministic action catalog in
`crates/orbit-types/src/workflow/activity_job/mod.rs` (one `core` and one
`engine` entry), the `automation/mod.rs` and `dispatch.rs` match arms,
`bootstrap/activity.rs::DEFAULT_ACTIVITY_FILES`,
`application/job/catalog.rs::DEFAULT_JOB_FILES`,
`application/routine.rs::DEFAULT_ROUTINE_FILES`, and the test-side mirrors of
those lists in `application/job/tests/catalog.rs` and the
`seeded_routines_are_valid_disabled_pinned_and_workspace_unique` test.

## Out of scope

- Any change to the CI-failure sweep.
- Auto-merging or otherwise acting on Dependabot's own pull requests. This
  sweep files tasks; it does not touch GitHub state.
- Configuring `security_events` scope on any host. The sweep reports the missing
  scope as a capability outcome and that is the whole of its responsibility.
- Migrating already-seeded workspaces. The new routine ships disabled and lands
  in a workspace on its next `orbit init` reseed, the same as any other default.

## Note found while scoping

`cargo check --workspace --all-targets` on `agent-main` currently fails to
compile `orbit-cli`'s `mcp_roundtrip` test: six `E0425: cannot find function
assert_command_succeeded` at `crates/orbit-cli/tests/mcp_roundtrip.rs:2013`,
`:2031`, `:2863`, `:2883`, `:2894`, `:2949`. Pre-existing and unrelated to this
task — recorded here only so the implementer does not mistake it for their own
breakage.

### Acceptance Criteria

- A `gh api repos/{owner}/{repo}/dependabot/alerts` request builder and alert projection live in `orbit-tools` and are re-exported through `github_cli.rs`; `builtin/github/mod.rs::register` is unchanged, so no new agent-facing tool is added.
- The collect stage runs on the engine-private deterministic automation boundary (`NoSandbox`, engine-private label, outside tool authorization and activity allowlists) and emits one bounded, redacted snapshot. No GitHub credential is reachable from inside an agent sandbox at any point.
- A host that lacks `gh`, lacks credentials, holds a token without the `security_events` scope (403), or points at a repository with Dependabot alerts unavailable (404) each produce the capability outcome with a detail string naming which case occurred. A test covers 403 and 404 specifically and asserts neither is reported as `no_open_alerts`.
- Clusters are keyed on (ecosystem, package, manifest_path) and the dedupe tag is a digest of that triple alone. A test proves that a re-run over the same alerts files nothing, and that a cluster whose alert numbers, severity, or vulnerable version range changed still matches its existing open task.
- One package with several alerts against it produces exactly one task listing all of them, not one task per alert.
- Alerts below `min_severity` (default `high`) are excluded and reported in the step output rather than dropped silently.
- With `skip_when_dependabot_pr_open` true (the default), a cluster whose package has an open `app/dependabot` pull request is reported in a distinct `skipped_dependabot_pr` bucket and no task is filed; with the switch false, the task is filed. Both are covered by tests.
- Filed tasks carry the `[dependabot-sweep] ` title prefix with the cap applied to the variable part, `crew: system` where that crew resolves (and file successfully where it does not), empty `required_tools`, `status: backlog`, and a priority mapped from the cluster's highest severity.
- A filed task's description names the package, the manifest path, the first patched version, and every alert in the cluster with its GHSA/CVE id, severity, summary, and URL — enough for the implementing agent to do the bump without querying GitHub.
- The routine ships `enabled: false` with the `__ORBIT_HOST_ID__` / `__ORBIT_ROUTINE_NAME__` placeholders, fires daily on a slot that collides with none of the shipped defaults, and uses `overlap: forbid` against a job with `max_active_runs: 1`.
- The new activities, job, and routine are registered in the four default-asset lists and in their test-side mirrors; the existing catalog and seeding tests pass unchanged in intent.
- `cargo check --workspace --all-targets`, `cargo clippy`, `cargo fmt --check`, and `cargo test` pass, except for the pre-existing `orbit-cli` `mcp_roundtrip` compile failure recorded in the description.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added an unregistered, bounded gh api Dependabot alerts request/projection in orbit-tools, plus the host-only Dependabot PR request and request/projection tests. Explicit repository interpolation is charset-validated and the long advisory description is not projected.
- Added the engine-private collect_dependabot_alerts action on the existing NoSandbox host boundary. It emits one bounded/redacted snapshot, distinguishes missing gh/credentials and 403 security_events/404 unavailable capability outcomes from no open alerts, and includes open app/dependabot PR evidence and truncation/query-error metadata.
- Added the core file_dependabot_alert_tasks action with remediation-triple clustering and digest-only dedupe, severity-floor reporting, switchable Dependabot-PR skipping, severity priority mapping, system-crew probing/fallback, capped prefixed titles, empty required_tools, and evidence-complete backlog tasks.
- Added and registered both activities, the two-step single-flight job, and the disabled daily 03:25 UTC overlap-forbid routine, including default catalog and seeding test mirrors.
- Expanded task context before touching the new implementation modules and directly affected test/registration mirrors; these files were required to compile and satisfy the explicit wiring/test criteria.
Assessment: The implementation follows the shipped CI sweep boundary without adding an agent-facing GitHub tool or credential path. Focused tests cover 403/404 classification, no-alert separation, multi-alert clustering, stable dedupe across advisory changes, severity exclusions, PR skip enabled/disabled, system-crew absence, deterministic job shape, and routine seeding.
Validation:
- make ci-fast passed.
- make ci-lint passed (workspace/all-target clippy with warnings denied).
- cargo check --workspace --all-targets passed.
- Focused orbit-tools, orbit-engine, orbit-core Dependabot tests and the seeded-routine test passed.
- A full cargo test attempt hit one unrelated environment-sensitive CLI test under parallel execution; its exact rerun passed. A serial full run progressed through the unit suites but the docs integration suite could not write ~/.orbit/resources/executors/claude.yaml because the runner mounted it read-only (os error 30). This is an environment denial, not a code failure.
- git diff --check passed; generated Cargo artifacts were removed with cargo clean.
Deviations from original plan:
- Full workspace tests could not finish solely because the runner's global Orbit resource path was read-only; unrestricted CI should arbitrate the remaining integration suites.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11124-6a94c2fd`
- Behind base: 0
- Ahead of base: 1