### PR TITLE
[code-review] Generic runner trailers collapse distinct CI failures

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -628,9 +628,11 @@ const ERROR_MARKERS: &[&str] = &[
 /// and paths under a run-specific temp directory. Normalizing those away is
 /// what lets an hourly sweep recognize the same root cause instead of filing it
 /// again every hour. Prefer an `##[error]`-annotated line over an unanchored
-/// marker substring, and never sign off runner-bookkeeping (checkout, group
-/// headers, `env:`/`with:` dumps). With no usable line the step name alone is
-/// the signature — weaker, but stable, and still scoped by workflow and job.
+/// marker substring, except that GitHub's generic runner-completion annotation
+/// yields to a specific unannotated diagnostic immediately before it. Never
+/// sign off runner-bookkeeping (checkout, group headers, `env:`/`with:` dumps).
+/// With no usable line the step name alone is the signature — weaker, but
+/// stable, and still scoped by workflow and job.
 fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
     let lines = classify_log_lines(log_excerpt);
     for (kind, line) in &lines {
@@ -643,6 +645,29 @@ fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
     }
     for (kind, line) in &lines {
         if *kind == LineKind::Marker {
+            return ErrorSignature {
+                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                step_fallback: false,
+            };
+        }
+    }
+    for (index, (kind, _)) in lines.iter().enumerate() {
+        if *kind != LineKind::RunnerCompletion {
+            continue;
+        }
+        if let Some((_, line)) = lines[..index]
+            .iter()
+            .rev()
+            .find(|(kind, line)| *kind == LineKind::Content && is_diagnostic_content(line))
+        {
+            return ErrorSignature {
+                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                step_fallback: false,
+            };
+        }
+    }
+    for (kind, line) in &lines {
+        if *kind == LineKind::RunnerCompletion {
             return ErrorSignature {
                 text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
                 step_fallback: false,
@@ -666,6 +691,7 @@ enum LineKind {
     ParamDump,
     EndGroup,
     ErrorAnnotated,
+    RunnerCompletion,
     Marker,
     Bookkeeping,
     Content,
@@ -698,7 +724,7 @@ fn render_failed_step_excerpt(log: &str, max_bytes: usize) -> FailedStepExcerpt 
 
     let anchor = lines
         .iter()
-        .position(|(kind, _)| *kind == LineKind::ErrorAnnotated)
+        .position(|(kind, _)| matches!(kind, LineKind::ErrorAnnotated | LineKind::RunnerCompletion))
         .or_else(|| lines.iter().position(|(kind, _)| *kind == LineKind::Marker));
 
     let Some(anchor_idx) = anchor else {
@@ -753,7 +779,9 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
             LineKind::ParamDump
         } else {
             in_param_block = false;
-            if lowered.contains("##[error]") {
+            if is_generic_runner_completion(&lowered) {
+                LineKind::RunnerCompletion
+            } else if lowered.contains("##[error]") {
                 LineKind::ErrorAnnotated
             } else if is_runner_bookkeeping(&lowered) || lowered.contains("##[group]") {
                 LineKind::Bookkeeping
@@ -766,6 +794,25 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
         out.push((kind, line));
     }
     out
+}
+
+fn is_generic_runner_completion(lowered: &str) -> bool {
+    let Some(message) = lowered.trim().strip_prefix("##[error]") else {
+        return false;
+    };
+    let Some(exit_code) = message
+        .trim()
+        .strip_prefix("process completed with exit code ")
+    else {
+        return false;
+    };
+    let exit_code = exit_code.trim_end_matches('.');
+    !exit_code.is_empty() && exit_code.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn is_diagnostic_content(line: &str) -> bool {
+    let payload = log_payload(line).trim();
+    !payload.is_empty() && !payload.starts_with("##[")
 }
 
 fn is_run_command_payload(payload: &str) -> bool {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -646,6 +646,66 @@ fn error_signature_prefers_an_annotated_error_over_a_checkout_commit_message() {
 }
 
 #[test]
+fn generic_runner_trailer_does_not_collapse_distinct_unannotated_diagnostics() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let trailer =
+        "build\tRun go build\t2026-08-30T01:00:00Z ##[error]Process completed with exit code 1.\n";
+    let foo_log = realistic_github_step_log(
+        "go build ./...",
+        2,
+        &format!(
+            "build\tRun go build\t2026-08-30T01:00:00Z ./main.go:10:2: undefined: Foo\n{trailer}"
+        ),
+    );
+    let bar_log = realistic_github_step_log(
+        "go build ./...",
+        2,
+        &format!(
+            "build\tRun go build\t2026-08-30T01:00:00Z ./main.go:14:2: undefined: Bar\n{trailer}"
+        ),
+    );
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![
+            failure(10, "ci", "build", "go build", &foo_log, CHECKOUT),
+            failure(11, "ci", "build", "go build", &bar_log, CHECKOUT),
+        ])}),
+    );
+
+    assert_eq!(first["filed_count"], json!(2));
+    let filed = first["filed"].as_array().expect("filed");
+    assert_ne!(filed[0]["failure_key"], filed[1]["failure_key"]);
+    for (task_id, diagnostic) in filed_task_ids(&first).iter().zip(["foo", "bar"]) {
+        let description = runtime
+            .get_task(task_id)
+            .expect("read filed task")
+            .description;
+        let signature = signature_line(&description).to_ascii_lowercase();
+        assert!(
+            signature.contains(diagnostic),
+            "specific diagnostic must be the signature: {signature}"
+        );
+        assert!(
+            !signature.contains("process completed"),
+            "generic runner trailer must not be the signature: {signature}"
+        );
+    }
+
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            12, "ci", "build", "go build", &foo_log, NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(
+        repeated["skipped_existing"][0]["failure_key"], filed[0]["failure_key"],
+        "the same diagnostic must retain its failure key across commits"
+    );
+}
+
+#[test]
 fn checkout_commit_message_containing_failure_is_not_the_signature() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let log = dani_10111_style_log("chore: add ci failure sweep routine", None);


### PR DESCRIPTION
## Task

[ORB-11132](https://orbit-cli.com/tasks/ORB-11132) — [code-review] Generic runner trailers collapse distinct CI failures

### Description

## Problem
`error_signature` returns the first `##[error]` line before considering any ordinary marker-bearing diagnostic at `crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs:625-650`. GitHub commonly appends the generic annotated trailer `##[error]Process completed with exit code 1` after the real unannotated compiler or test diagnostic; the repository's own realistic fixture has `undefined: Foo` followed by that trailer at `crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs:570-599`. The generic trailer is selected and its number normalized, while `cluster_failures` hashes that result into the commit-independent dedupe key at `ci_failure_tasks.rs:546-553`.

## Why It Matters
Two unrelated failures in the same workflow, job, and step receive the same `ci-failure:<key>` tag. An open task for the first then causes the hourly sweep to suppress the second as a duplicate.

## Constraints / Notes
Preserve stable cross-commit dedupe for a true repeated diagnostic and keep runner checkout and environment bookkeeping excluded.

### Acceptance Criteria

- A generic runner-completion annotation is not used as the root-cause signature when a more specific diagnostic is present in the retained failed-step log.
- A regression test feeds two different unannotated diagnostics followed by the same `##[error]Process completed with exit code 1` trailer and proves they produce different failure keys and are both fileable.
- A true repeated failure across commits continues to reuse its failure key, and checkout or environment bookkeeping remains excluded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Classified GitHub's generic `##[error]Process completed with exit code <n>` trailer separately so specific annotated errors and ordinary marker diagnostics remain preferred.
- When that trailer is the only annotation, the nearest usable unannotated content line before it becomes the normalized root-cause signature; runner commands, checkout bookkeeping, and env/with dumps remain excluded.
- Added a regression that files two distinct diagnostics sharing the same trailer with different failure keys, then proves a repeated diagnostic reuses its key across a different checked-out commit.
Assessment: The change is scoped to CI failure signature selection and its existing test module, preserves the fallback for logs without a usable specific diagnostic, and retains stable commit-independent dedupe.

Validation:
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure_tasks` — passed (18 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.

Friction checkpoint: no recurring failure, contradicted assumption, incident root cause, or >10-minute non-obvious gotcha was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11132-6a94c84d`
- Behind base: 0
- Ahead of base: 1