### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/auditability/specs/artifact-redaction.md
+++ b/docs/design/auditability/specs/artifact-redaction.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Artifact Write Redaction"
 tags: ["auditability"]
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Artifact Write Redaction
@@ -15,12 +15,12 @@ This is the author-facing inventory for the shipped artifact-write redactor. Red
 
 | Tool | Free text (`redact_all` + `redact_home_dir`) | Path-only (`redact_home_dir`) | Skip |
 |------|----------------------------------------------|-------------------------------|------|
-| `orbit.adr.add` / `orbit.adr.update` | `title`, `body` | - | status, owner, related ids/features/tasks, legacy ids |
+| `orbit.adr.add` / `orbit.adr.restore` / `orbit.adr.update` | `title`, `body` | - | status, owner, related ids/features/tasks, legacy ids |
 | `orbit.adr.supersede` | - | - | `old_id`, `new_id` |
 | `orbit.task.add` | `title`, `description`, `plan`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context`, `external_refs[].url` | workspace, ids, enums, dependency/relation targets, crew, tags |
 | `orbit.task.update` | `title`, `description`, `plan`, `execution_summary`, `acceptance_criteria[]`, `comment` | `context_files[]`, `context` | provenance/status/identity fields, tags, raw artifacts |
 | `orbit.task.reject` | `note`, `comment` | - | `id` |
-| `orbit.friction.add` | `body` | - | `model`, `during_task`, tags |
+| `orbit.friction.add` | `body` / `description` | - | `model`, `during_task`, tags |
 | `orbit.friction.update` | `body` | - | `id`, status, tags |
 | `orbit.auto_task.add` / `orbit.auto_task.update` | `description`, `template.title`, `template.description`, `template.acceptance_criteria[]` | - | name, schedule, dedupe, template enums/tags |
 | `orbit.docs.add` | - | - | DocsAdd only registers a validated repo-relative path; it does not persist document content. |
@@ -45,11 +45,7 @@ SSH replacements are class-labelled as `[REDACTED_SSH_FINGERPRINT]`, `[REDACTED_
 
 ## Refuse vs Mask
 
-Free-text fields reject a value that is exactly one high-confidence credential token:
-
-- `^sk-[A-Za-z0-9_-]{20,}$`
-- `^ghp_[A-Za-z0-9]{36}$`
-- `^xox[baprs]-[A-Za-z0-9-]{10,}$`
+Free-text fields reject a value that is exactly one high-confidence credential token, using the shared high-confidence provider-token, secret-assignment, and credentialed-URI patterns.
 
 The rejection is a typed `OrbitError::SensitiveInput` and never includes the token value. The same token shapes embedded in larger prose are masked by the shared redaction module. Path-only fields only normalize HOME-prefixed strings; token-shaped globs and character classes are preserved.
 

--- a/docs/design/auditability/specs/coverage-matrix.md
+++ b/docs/design/auditability/specs/coverage-matrix.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: Spec: Audit Coverage Matrix
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Audit Coverage Matrix
@@ -21,14 +21,14 @@ Every Orbit operation that touches code, task state, persistent runtime state, e
 | MCP tool preflight or dispatch | Command audit row | tool, status, trusted workspace/caller/process, transport, full capability set, origin session, unique call id, optional run/lease |
 | Task lifecycle update | Command/tool audit plus task history | task id, actor, status transition or document field changed |
 | Task lock reservation/check/release | Targeted command audit row | reservation target, files payload, status, conflict/denial state |
-| Activity/job run | V2 envelope JSONL | run id, agent identity, run start/finish |
-| Activity/job step | V2 envelope JSONL | run id, step id, outcome or skip/retry reason |
-| Filesystem policy decision inside v2 run | V2 envelope JSONL | profile, op, path, allowed, matched rule |
+| Activity/job run | V2 envelope audit row | run id, agent identity, run start/finish |
+| Activity/job step | V2 envelope audit row | run id, step id, outcome or skip/retry reason |
+| Filesystem policy decision inside v2 run | V2 envelope audit row | profile, op, path, allowed, matched rule |
 | Filesystem or proc-spawn policy denial live projection | Global tracing JSONL | target, tool, path, profile, matched_rule |
 | Friction task submission live projection | Global tracing JSONL | target, task_id, agent, model, summary |
-| HTTP provider turn | Loop audit JSONL plus blob store | run id, session id, provider, model, request/response blob hashes |
-| Tool call inside HTTP loop | Loop audit JSONL plus blob store | run id, session id, tool name, input/output blob hashes, outcome |
-| CLI backend provider invocation | V2 envelope JSONL | provider, redacted argv, stdin/stdout/stderr blob refs, timeout, exit code |
+| HTTP provider turn | Loop audit row plus blob store | run id, session id, provider, model, request/response blob hashes |
+| Tool call inside HTTP loop | Loop audit row plus blob store | run id, session id, tool name, input/output blob hashes, outcome |
+| CLI backend provider invocation | V2 envelope audit row | provider, redacted argv, stdin/stdout/stderr blob refs, timeout, exit code |
 | Invocation cost/usage | Invocation store | job run id, activity id, task ids, agent, model, token usage, tool-call summary |
 | Audit export/prune | Command audit row (planned) | command, actor, target, status |
 

--- a/docs/design/auditability/specs/event-schema.md
+++ b/docs/design/auditability/specs/event-schema.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: Spec: Audit Event Schema
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Audit Event Schema
@@ -43,7 +43,7 @@ Failure modes:
 
 ### V2 Activity/Job Audit Event
 
-Activity/job audit events are JSONL entries represented by `V2AuditEvent`.
+Activity/job audit events are represented by `V2AuditEvent` and persisted by the v2 audit store.
 
 Required invariants:
 
@@ -57,13 +57,13 @@ Required invariants:
 
 Failure modes:
 
-- If JSONL persistence fails, in-memory event capture remains the load-bearing smoke-verification path.
+- If v2 audit-store persistence fails, in-memory event capture remains the load-bearing smoke-verification path.
 - If a worker thread emits events, it must install the parent stack snapshot before emission.
-- If an activity/job run fails before writer construction, no v2 JSONL is expected.
+- If an activity/job run fails before writer construction, no v2 audit event is expected.
 
 ### Loop Audit Event
 
-Loop audit events are JSONL entries represented by `LoopAuditEvent`.
+Loop audit events are sink events represented by `LoopAuditEvent`; the durable runtime sink persists them as v2 audit rows.
 
 Required invariants:
 

--- a/docs/design/auditability/specs/redaction-retention.md
+++ b/docs/design/auditability/specs/redaction-retention.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: Spec: Redaction and Retention Boundaries
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Redaction and Retention Boundaries
@@ -36,7 +36,7 @@ Command audit rows:
 Activity/job and loop traces:
 
 - Live under `.orbit/state/audit/` for workspace-local run reconstruction.
-- Use JSONL for append-friendly event streams.
+- V2 envelope and loop events are persisted through the SQLite-backed v2 audit store.
 - Use content-addressed blobs for payload bodies.
 - May be manually retained or deleted with workspace state until a first-class retention policy exists.
 
@@ -48,8 +48,8 @@ Invocation metrics:
 
 Global process tracing:
 
-- Lives under `~/.orbit/state/logs/orbit.jsonl`.
-- Is append-only and unrotated in v1.
+- Uses `~/.orbit/state/logs/orbit.jsonl` as the active file.
+- Is append-only within the active file; oversized files are renamed to dated archives and old archives are pruned at subscriber initialization.
 - Is an operational log stream, not the canonical workflow envelope.
 - Carries policy-denial path/resource strings and friction summaries after [T20260427-0023], so default tracing redaction is part of its durability boundary.
 
@@ -57,7 +57,7 @@ Global process tracing:
 
 - If a redactor misses an unknown secret shape, the audit layer may persist that value. Reviewers should treat new provider payload shapes as redaction-sensitive changes.
 - If redaction changes payload bytes, the stored hash identifies the redacted payload, not the raw provider payload.
-- If JSONL writes fail, the run may continue with in-memory audit snapshots only; durable reconstruction is incomplete.
+- If v2 audit-store writes fail, the run may continue with in-memory audit snapshots only; durable reconstruction is incomplete.
 - If pruning deletes command audit rows, file-backed run traces and blobs are not automatically pruned unless a future retention task adds that coupling.
 
 ## Migration Path

--- a/docs/design/terminal-interface/specs/color-and-styling.md
+++ b/docs/design/terminal-interface/specs/color-and-styling.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Color and Styling"
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Color and Styling
@@ -25,7 +25,7 @@ Six roles, closed set. Adding a seventh is a design change, not a call-site deci
 | `muted` | de-emphasized, archived, secondary | dim |
 | `neutral` | no signal | default |
 
-Mapping from domain values to roles is defined once, in one table, covering task status, run state, job state, priority, task type, and doctor status together. The current eight per-domain functions (`status_color`/`_cell`, `priority_color`/`_cell`, `job_state_color`/`_cell`, `doctor_status_color_cell`, `task_type_color_cell`) collapse into it.
+Mapping from domain values to roles is defined once, in one table, covering task status, run state, job state, priority, task type, doctor status, and audit status together. The current eight per-domain functions (`status_color`/`_cell`, `priority_color`/`_cell`, `job_state_color`/`_cell`, `doctor_status_color_cell`, `task_type_color_cell`) collapse into it.
 
 **Unmapped values are `neutral`, never an error.** A new status introduced elsewhere in the codebase must render plainly, not panic and not fall through to an arbitrary color.
 
@@ -35,11 +35,10 @@ Resolved once, at the sink, in this precedence:
 
 1. `--no-color` → off.
 2. `NO_COLOR` set to any non-empty value → off.
-3. `--color=always` → on.
-4. `CLICOLOR_FORCE` non-empty → on.
-5. Otherwise: on if and only if `is_tty`.
+3. `CLICOLOR_FORCE` non-empty → on.
+4. Otherwise: on if and only if `is_tty`.
 
-`TERM=dumb` forces off regardless of 3 and 4.
+`TERM=dumb` forces off regardless of 2 and 3. There are no command-line color override flags; the sink owns this environment-based policy.
 
 **Invariant:** exactly one place in the crate reads these — `output/sink.rs`, enforced by `scripts/check-terminal-state-guard.sh`. A call site that consults them itself is a defect. Because the two styling crates each ship their own probe, "one place" also means the sink must *override* them rather than agree with them: `OutputSink::apply_color_policy` sets `colored`'s global override, and `output::table` passes `enforce_styling`/`force_no_tty` per render. Neither backend is left to ask.
 
@@ -54,7 +53,7 @@ Resolved once, at the sink, in this precedence:
 
 ## 4. Interaction With Modes
 
-- `json`, `ndjson`, and the plain piped form carry **no** escape sequences under any flag. `--color=always` does not apply to them; it applies to `table` on a non-TTY sink, which is the legitimate use (`orbit task list --color=always | less -R`).
+- `json`, `ndjson`, and the plain piped form carry **no** escape sequences. Color policy applies only to human-rendered table and line output.
 - Roles are a rendering concern and never appear in a payload. A payload carries `status: "blocked"`, not `status_role: "error"`. A consumer that wants severity derives it from the value, using the same public mapping.
 
 ## 5. Accessibility

--- a/docs/design/terminal-interface/specs/output-modes.md
+++ b/docs/design/terminal-interface/specs/output-modes.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Output Modes and Sink Resolution"
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Output Modes and Sink Resolution
@@ -10,7 +10,7 @@ Every `orbit` command produces a structured payload and hands it to a renderer. 
 
 ## Why This Exists
 
-Structured output is currently a per-command opt-in on 86 of 150 argument structs, hand-written alongside the human rendering in the same function, and the two drift. Nothing detects whether stdout is a terminal, so a pipe receives box-drawing characters and ANSI escapes. Both follow from rendering decisions living in command bodies. Rationale in [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload).
+Before the migration, structured output was a per-command opt-in on 86 of 150 argument structs, hand-written alongside the human rendering in the same function, and the two drifted. Nothing detected whether stdout was a terminal, so a pipe received box-drawing characters and ANSI escapes. Both followed from rendering decisions living in command bodies. Rationale in [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload).
 
 ## 1. The Sink
 
@@ -37,7 +37,7 @@ Precedence, first match wins:
 
 `auto` resolves to `table` when `is_tty`, and to the **plain** form otherwise. Plain is `table` with the header suppressed, borders and ANSI absent, truncation disabled, and single-tab field separators — the form `cut -f` expects. Plain is a rendering of `table`, not a fourth mode a command can request.
 
-`--format` is a global argument declared once on the root command, not redeclared per subcommand. The existing per-command `--json` booleans remain accepted and hidden from help; they are not removed [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload).
+`--format` is one global user-facing argument installed across the command tree so it is accepted at the root and after subcommands; command-local `--format` arguments keep their own meaning. The existing per-command `--json` booleans remain accepted and hidden from help; they are not removed [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload).
 
 ## 3. Mode Contracts
 


### PR DESCRIPTION
## Task

[ORB-11138](https://orbit-cli.com/tasks/ORB-11138) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Selected exactly the six oldest dated in-scope docs: docs/design/auditability/specs/artifact-redaction.md, coverage-matrix.md, event-schema.md, redaction-retention.md, and docs/design/terminal-interface/specs/color-and-styling.md and output-modes.md. They were the six lexicographically stable entries tied at the oldest valid date, 2026-08-02; docs/design/terminal-interface/specs/table-rendering.md was the seventh tie and was not touched.
- artifact-redaction.md: stamped 2026-08-31; added the shipped AdrRestore action and friction.add description alias to the policy table; replaced the obsolete three-token refusal list with the shared high-confidence credential-pattern contract. Verified with rg/sed against crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs, crates/orbit-tools/src/lib.rs, and crates/orbit-common/src/security/redaction.rs.
- coverage-matrix.md: stamped 2026-08-31; changed activity/job, loop, and CLI-backend channels from JSONL wording to the current v2 audit-row/SQLite-backed sink wording. Verified with rg/sed against crates/orbit-store/src/driver/sqlite/v2_audit_store/mod.rs, crates/orbit-engine/src/activity_job/sqlite_sink.rs, and crates/orbit-engine/src/activity_job/audit_writer.rs.
- event-schema.md: stamped 2026-08-31; aligned v2 and loop persistence/failure descriptions with the current audit-store implementation. Verified with sed/rg against crates/orbit-types/src/workflow/activity_job/audit_envelope.rs, crates/orbit-engine/src/activity_job/audit_writer.rs, crates/orbit-engine/src/activity_job/sqlite_sink.rs, and crates/orbit-agent/src/loop_engine/audit/mod.rs.
- redaction-retention.md: stamped 2026-08-31; documented SQLite-backed v2 audit persistence and corrected global-log retention from unrotated to active-file rotation/archive pruning. Verified with rg/sed against crates/orbit-common/src/storage/blob_store.rs, crates/orbit-common/src/observability/logging.rs, crates/orbit-common/src/observability/log_rotation.rs, and crates/orbit-core/src/application/job/exec.rs.
- color-and-styling.md: stamped 2026-08-31; included the current AuditStatus domain and corrected the policy to the actual environment-based sink controls (there are no CLI color override flags). Verified with rg/sed against crates/orbit-cli/src/output/color.rs, crates/orbit-cli/src/output/sink.rs, and the CLI command tree.
- output-modes.md: stamped 2026-08-31; corrected the global --format implementation description to match installation across the command tree and marked the old per-command rendering description as historical. Verified with rg/sed against crates/orbit-cli/src/main.rs, crates/orbit-cli/src/output/sink.rs, crates/orbit-cli/src/output/render.rs, and crates/orbit-cli/src/output/table.rs.

Unvalidated items:
- No selected document or current-behavior claim was left unvalidated. Historical provenance references, historical migration counts, and commit-specific statements were left unchanged rather than reinterpreted as current behavior; they were not needed to establish current code alignment.
- No in-scope document was frontmatter-less, so no metadata migration was required. The remaining 2026-08-02 dated document was the intentionally excluded seventh tie.
- No files under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state were modified.

Validation:
- make ci-fast passed, including cargo fmt --check, docs index check, dependency/import/terminal guards, redaction and portability guards, plugin sync/validation checks, and installer security tests.
- git diff --check passed.
- Final git status contains only the six intended documentation files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11138-6a94cc38`
- Behind base: 0
- Ahead of base: 1