### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/operations-as-data/1_overview.md
+++ b/docs/design/operations-as-data/1_overview.md
@@ -2,14 +2,14 @@
 title: Operations as Data — Overview
 owner: claude
 last_updated: 2026-07-26
-last_validated: 2026-08-08
+last_validated: 2026-08-31
 status: Accepted
 feature: operations-as-data
 doc_role: overview
 type: design
 summary: Declaring each verb of a noun once as data so CLI, MCP, dashboard, and runtime handlers are derived adapters instead of four hand-copied layers.
 tags: [operations-as-data, architecture, adr-0209]
-paths: ["crates/orbit-common/src/operation.rs", "crates/orbit-common/src/friction/**", "crates/orbit-tools/src/builtin/orbit/operation.rs", "crates/orbit-cli/src/command/operation_args.rs"]
+paths: ["crates/orbit-common/src/governance/operation.rs", "crates/orbit-common/src/governance/friction/**", "crates/orbit-tools/src/builtin/orbit/operation.rs", "crates/orbit-cli/src/command/operation_args.rs"]
 related_features: [operations-as-data, orbit-core]
 related_artifacts: [ORB-10358]
 ---
@@ -17,7 +17,7 @@ related_artifacts: [ORB-10358]
 # Operations as Data — Overview
 
 Orbit exposes the same underlying operations through four surfaces: the CLI, MCP,
-the web dashboard, and the in-runtime tool host. Historically each surface
+the web dashboard (`orbit-web`), and the in-runtime tool host. Historically each surface
 restated every verb by hand — its name, its parameters, its help text, its
 field-to-JSON mapping — so a noun with seven verbs was written out four times and
 drifted four ways. **Operations as data** replaces that with one declaration per
@@ -59,14 +59,14 @@ exactly why it accumulated.
 
 | Concern | File | Task |
 |---------|------|------|
-| The kernel: spec, parameter, and exposure vocabulary | [crates/orbit-common/src/operation.rs](../../../crates/orbit-common/src/operation.rs) | [ORB-10358] |
-| The friction registry (single declaration site) | [crates/orbit-common/src/friction/operations.rs](../../../crates/orbit-common/src/friction/operations.rs) | [ORB-10358] |
+| The kernel: spec, parameter, and exposure vocabulary | [crates/orbit-common/src/governance/operation.rs](../../../crates/orbit-common/src/governance/operation.rs) | [ORB-10358] |
+| The friction registry (single declaration site) | [crates/orbit-common/src/governance/friction/operations.rs](../../../crates/orbit-common/src/governance/friction/operations.rs) | [ORB-10358] |
 | MCP adapter: spec → `ToolSchema` + optional workspace scope | [crates/orbit-tools/src/builtin/orbit/operation.rs](../../../crates/orbit-tools/src/builtin/orbit/operation.rs) | [ORB-10358] |
 | Friction MCP tools, derived | [crates/orbit-tools/src/builtin/orbit/friction/mod.rs](../../../crates/orbit-tools/src/builtin/orbit/friction/mod.rs) | [ORB-10358] |
 | CLI adapter: spec → `clap::Command` + tool input | [crates/orbit-cli/src/command/operation_args.rs](../../../crates/orbit-cli/src/command/operation_args.rs) | [ORB-10358] |
 | Friction CLI, derived (renderers only) | [crates/orbit-cli/src/command/friction.rs](../../../crates/orbit-cli/src/command/friction.rs) | [ORB-10358] |
 | Web handlers over registry field names | [crates/orbit-web/src/api/frictions.rs](../../../crates/orbit-web/src/api/frictions.rs) | [ORB-10358] |
-| Handler table, keyed on `FrictionVerb` | [crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs](../../../crates/orbit-core/src/runtime/orbit_tool_host/friction_tools.rs) | [ORB-10358] |
+| Handler table, keyed on `FrictionVerb` | [crates/orbit-core/src/adapter/tool_host/friction_tools.rs](../../../crates/orbit-core/src/adapter/tool_host/friction_tools.rs) | [ORB-10358] |
 | Migration cookbook | [references/cookbook.md](references/cookbook.md) | [ORB-10358] |
 
 ## Task References

--- a/docs/design/operations-as-data/3_vision.md
+++ b/docs/design/operations-as-data/3_vision.md
@@ -2,14 +2,14 @@
 title: Operations as Data — Vision
 owner: claude
 last_updated: 2026-07-26
-last_validated: 2026-08-09
+last_validated: 2026-08-31
 status: Accepted
 feature: operations-as-data
 doc_role: vision
 type: design
 summary: Open questions left by the friction pilot — which nouns migrate next, whether responses become data, and what the registry could enable beyond deduplication.
 tags: [operations-as-data, architecture, adr-0209]
-paths: ["crates/orbit-common/src/operation.rs"]
+paths: ["crates/orbit-common/src/governance/operation.rs"]
 related_features: [operations-as-data, orbit-core]
 related_artifacts: [ORB-10358]
 ---

--- a/docs/design/operations-as-data/references/cookbook.md
+++ b/docs/design/operations-as-data/references/cookbook.md
@@ -2,14 +2,14 @@
 title: Operations as Data — Migration Cookbook
 owner: claude
 last_updated: 2026-07-26
-last_validated: 2026-08-09
+last_validated: 2026-08-31
 status: Accepted
 feature: operations-as-data
 doc_role: reference
 type: design
 summary: Step-by-step procedure for migrating a noun to the operation registry, and for adding a verb to an already-migrated noun.
 tags: [operations-as-data, architecture, adr-0209, cookbook]
-paths: ["crates/orbit-common/src/friction/**", "crates/orbit-cli/src/command/operation_args.rs"]
+paths: ["crates/orbit-common/src/governance/friction/**", "crates/orbit-cli/src/command/operation_args.rs"]
 related_features: [operations-as-data]
 related_artifacts: [ORB-10358]
 ---
@@ -52,8 +52,8 @@ For a noun with verbs `v₁…vₙ`, find:
 | MCP `Tool` impls | `crates/orbit-tools/src/builtin/orbit/<noun>/*.rs` |
 | MCP registration + workspace scope | `crates/orbit-tools/src/builtin/orbit/mod.rs` |
 | Action enum variants | `crates/orbit-tools/src/lib.rs` (`OrbitBuiltinAction`) |
-| Handler dispatch | `crates/orbit-core/src/runtime/orbit_tool_host/dispatch.rs` |
-| Handlers | `crates/orbit-core/src/runtime/orbit_tool_host/<noun>_tools.rs` |
+| Handler dispatch | `crates/orbit-core/src/adapter/tool_host/dispatch.rs` |
+| Handlers | `crates/orbit-core/src/adapter/tool_host/<noun>_tools.rs` |
 | CLI args + `Execute` impls | `crates/orbit-cli/src/command/<noun>.rs` |
 | CLI audit metadata | `crates/orbit-cli/src/command/operation.rs` |
 | Web handlers | `crates/orbit-web/src/api/<noun>s.rs` |
@@ -100,7 +100,7 @@ compiler cannot:
 - subcommand order matches the shipped `--help` order (assert the literal list);
 - MCP exposure matches `docs/design/mcp-bridge/references/conformance-v1.yaml`.
 
-See `crates/orbit-common/src/friction/tests.rs`.
+See `crates/orbit-common/src/governance/friction/tests/mod.rs`.
 
 ### Step 4. Collapse the action enum
 

--- a/docs/design/terminal-interface/specs/table-rendering.md
+++ b/docs/design/terminal-interface/specs/table-rendering.md
@@ -1,7 +1,7 @@
 ---
 type: design
 summary: "Spec: Table Rendering"
-last_validated: 2026-08-02
+last_validated: 2026-08-31
 ---
 
 # Spec: Table Rendering
@@ -66,7 +66,7 @@ The path from current behavior:
 1. ~~Change the preset in `crates/orbit-cli/src/output/table.rs` to a borderless one and switch `ContentArrangement` off full-width wrapping.~~ Done [ORB-10567].
 2. ~~Make `add_single_line_row` the only exported row constructor; convert the 19 call sites that use `Table::add_row` directly.~~ Done [ORB-10567] — `output::table::Table` wraps `comfy_table`, and its `add_row` is the only constructor reachable from a command module.
 3. Move width computation behind the sink (see [./output-modes.md](./output-modes.md) §1) so it is not resolved from a terminal that may not exist. **Open**, depends on [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload). `sink_width` currently reads `COLUMNS`, falls back to the terminal query, and returns no width for a non-terminal sink — the policy of §2 consumes whatever it returns, so only the source moves.
-4. Convert `print_audit_event_line` and the other hand-padded `println!` sites to the table path. **Open** — `orbit audit list` still pads with format-string literals, and the count/summary lines that neighbor a table (`orbit doctor`, `orbit routine list`, `orbit semantic stats`, `orbit migrate status`) still print to stdout rather than stderr.
+4. Convert `print_audit_event_line` and the other hand-padded `println!` sites to the table path. **Open** — `orbit audit list` still pads with format-string literals, and some count/summary lines that neighbor a table still print to stdout rather than stderr (`orbit semantic stats` and `orbit migrate status`; `orbit doctor` prints its healthy summary to stdout, while failures and warnings go to stderr).
 5. ~~Add per-column *fixed*/*flexible* and alignment metadata at each call site.~~ Done [ORB-10567] for the 21 table call sites, via `Column::fixed` / `Column::number` / `Column::path` / `Column::filtered`.
 
 Step 3 depends on [Terminal Output Is a Rendering of a Structured Payload](../4_decisions.md#terminal-output-is-a-rendering-of-a-structured-payload). Step 4 is per-command and may proceed incrementally.


### PR DESCRIPTION
## Task

[ORB-11139](https://orbit-cli.com/tasks/ORB-11139) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Inventory command scanned authored Markdown under docs/ while excluding docs/design/_archive/; docs/design/_templates/ was treated as scaffolding because the generator excludes it and its last_validated values are YYYY-MM-DD placeholders, not validation dates.
- The six oldest valid dated docs, ordered by last_validated then path, were: docs/design/terminal-interface/specs/table-rendering.md (2026-08-02); docs/design/operations-as-data/1_overview.md, docs/design/operations-as-data/3_vision.md, docs/design/operations-as-data/references/cookbook.md, docs/design/orbit-core/4_decisions.md, and docs/design/orbit-docs-plugin/1_scope.md (all 2026-08-09).

Changes and verification:
- docs/design/terminal-interface/specs/table-rendering.md: verified the table renderer, sink behavior, row-height cap, width policy, and output tests with sed/rg against crates/orbit-cli/src/output/{table,sink}.rs, command renderers, and crates/orbit-cli/tests/table_rendering.rs. Corrected the stale Step 4 status list after checking current doctor, routine, semantic, and migrate renderers; stamped last_validated: 2026-08-31.
- docs/design/operations-as-data/1_overview.md: verified the operation registry, seven FrictionVerb entries, derived MCP/CLI adapters, web handlers, and exhaustive handler dispatch with find/rg/sed against crates/orbit-common/src/governance/{operation.rs,friction/operations.rs}, crates/orbit-tools, crates/orbit-cli, crates/orbit-web, and crates/orbit-core/src/adapter/tool_host. Corrected moved governance paths, the orbit-web name, and the handler path; stamped 2026-08-31.
- docs/design/operations-as-data/3_vision.md: verified the registry and CLI adapter references and corrected the moved operation-kernel path; stamped 2026-08-31. External/background statements and historical task references were left unchanged.
- docs/design/operations-as-data/references/cookbook.md: verified the registry, adapters, handler dispatch, test layout, inactive-tool behavior, and help/snapshot test references with find/rg/sed against current source and tests. Corrected the moved governance path, tool-host paths, and friction test path; stamped 2026-08-31.
- No frontmatter migration was needed: every selected document already had schema-compatible type and summary metadata.

Unvalidated and unchanged:
- docs/design/orbit-core/4_decisions.md was left unchanged and unstamped because it is a long mixed historical decision log whose ADR restore/reconciliation claims are not current behavior (ADR lifecycle tools are now retired); validating the historical claims would require provenance beyond the current code.
- docs/design/orbit-docs-plugin/1_scope.md was left unchanged and unstamped because it is explicitly an uncommitted future extraction proposal, while no orbit-docs or orbit-docs-cli crate exists to verify the planned design.
- No selected frontmatter-less doc or individually unverifiable current-code claim was modified or stamped.

Validation:
- scripts/generate-doc-indexes.sh --check passed.
- orbit docs show parsed each of the four stamped docs successfully.
- make ci-fast passed.
- git diff --check passed; final status contains only the four intended docs. No prohibited or generated paths changed.

Assessment: bounded documentation upkeep completed with four verified stamps, targeted corrections only, and two conservative skips reported rather than asserting unsupported validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11139-6a94ce77`
- Behind base: 0
- Ahead of base: 1