### PR TITLE
Improve Knowledge friction triage UX [ORB-11136]

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -61,6 +61,8 @@ const FRICTION_LIMIT = positiveIntParam("frictions", 100);
 
 const FRICTION_STATUSES = ["open", "triaged", "resolved"];
 const DEFAULT_FRICTION_STATUS_FILTER = "active";
+const FRICTION_ACCORDION_QUERY = "(max-width: 1000px)";
+const frictionAccordionMedia = window.matchMedia(FRICTION_ACCORDION_QUERY);
 
 const $ = (id) => document.getElementById(id);
 
@@ -424,6 +426,7 @@ function renderFrictions(payload) {
   if (!body) return;
   const items = Array.isArray(payload && payload.items) ? payload.items : [];
   const stats = (payload && payload.stats) || {};
+  const accordion = frictionAccordionMedia.matches;
   renderFrictionStats(stats);
   const available = frictionAvailableCount(stats);
   const count = $("knowledge-count");
@@ -431,7 +434,7 @@ function renderFrictions(payload) {
   count.title = `Showing ${items.length} of ${available} ${frictionFilterLabel()} frictions`;
 
   if (items.length > 0 && !items.some((item) => item.id === activeFrictionId)) {
-    activeFrictionId = items[0].id;
+    activeFrictionId = accordion ? null : items[0].id;
   }
   if (items.length === 0) activeFrictionId = null;
 
@@ -449,11 +452,14 @@ function renderFrictions(payload) {
 
   for (const friction of items) {
     const title = friction.title || friction.id;
+    const expanded = activeFrictionId === friction.id;
+    const detailId = `friction-accordion-${friction.id}`;
     const row = el("div", { class: "knowledge-row friction-row", title }, [
       el("div", { class: "top" }, [
         el("span", { class: "id", text: friction.id, title: friction.id }),
         el("span", { class: "spacer" }),
         el("span", { class: "when", text: fmtTimestamp(friction.created_at), title: fmtAbsTime(friction.created_at) }),
+        accordion ? el("span", { class: "friction-row-toggle", text: expanded ? "▾" : "▸" }) : null,
       ]),
       el("div", { class: "title", text: title }),
       el("div", { class: "summary", text: truncate(friction.body || title, 180) }),
@@ -468,23 +474,43 @@ function renderFrictions(payload) {
       ]),
     ]);
     row.dataset.key = `friction-${friction.id}`;
-    row.dataset.hash = `${friction.id}-${friction.status}-${(friction.tags || []).join(",")}-${friction.created_at}-${activeFrictionId === friction.id}`;
-    if (activeFrictionId === friction.id) row.classList.add("active");
-    row.addEventListener("click", () => {
-      activeFrictionId = friction.id;
+    row.dataset.hash = `${friction.id}-${friction.status}-${(friction.tags || []).join(",")}-${friction.created_at}-${accordion}-${expanded}`;
+    if (expanded) row.classList.add("active");
+    const toggle = () => {
+      activeFrictionId = accordion && expanded ? null : friction.id;
       renderFrictions(lastFrictionPayload);
-    });
+    };
+    row.addEventListener("click", toggle);
+    if (accordion) {
+      row.tabIndex = 0;
+      row.setAttribute("role", "button");
+      row.setAttribute("aria-expanded", String(expanded));
+      row.setAttribute("aria-controls", detailId);
+      row.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        toggle();
+      });
+    }
     frag.appendChild(row);
+    if (accordion && expanded) {
+      const inlineDetail = el("section", { class: "friction-accordion-detail" });
+      inlineDetail.id = detailId;
+      inlineDetail.dataset.key = `friction-detail-${friction.id}`;
+      inlineDetail.dataset.hash = JSON.stringify({ friction, tags: lastFrictionPayload.tags });
+      inlineDetail.setAttribute("aria-label", `Details for ${friction.id}`);
+      renderFrictionDetail(friction, inlineDetail);
+      frag.appendChild(inlineDetail);
+    }
   }
 
   syncNodes(body, Array.from(frag.children));
-  renderFrictionDetail(items.find((item) => item.id === activeFrictionId) || items[0]);
+  renderFrictionDetail(accordion ? null : items.find((item) => item.id === activeFrictionId) || items[0]);
 }
 
-function renderFrictionDetail(friction) {
-  const detail = $("friction-detail");
+function renderFrictionDetail(friction, detail = $("friction-detail")) {
   if (!detail) return;
-  const count = $("friction-detail-count");
+  const count = detail.id === "friction-detail" ? $("friction-detail-count") : null;
   if (!friction) {
     if (count) count.textContent = "-";
     syncNodes(detail, [el("div", { class: "empty-state" }, [
@@ -701,6 +727,12 @@ function wireFrictionStatusFilter() {
     frictionStatusFilter = e.target.value;
     activeFrictionId = null;
     if (activeTab === "knowledge") fetchAndRenderFrictions().catch(console.error);
+  });
+}
+
+function wireFrictionResponsiveDetail() {
+  frictionAccordionMedia.addEventListener("change", () => {
+    renderFrictions(lastFrictionPayload);
   });
 }
 
@@ -1349,6 +1381,7 @@ buildChips(tasksContext);
 wireSearch(tasksContext);
 wireFrictionSearch();
 wireFrictionStatusFilter();
+wireFrictionResponsiveDetail();
 wireGlobalTaskResolver();
 buildAuditChips(auditContext());
 wireAuditSearch(auditContext());

--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -60,6 +60,7 @@ const DIAG_LIMIT = positiveIntParam("diag", 50);
 const FRICTION_LIMIT = positiveIntParam("frictions", 100);
 
 const FRICTION_STATUSES = ["open", "triaged", "resolved"];
+const DEFAULT_FRICTION_STATUS_FILTER = "active";
 
 const $ = (id) => document.getElementById(id);
 
@@ -81,6 +82,7 @@ let activeOperationsSubtab = "routines";
 let isRefreshing = false;
 let activeFrictionId = null;
 let frictionSearchQuery = "";
+let frictionStatusFilter = DEFAULT_FRICTION_STATUS_FILTER;
 
 // Health strip state
 let lastSummary = null;
@@ -402,13 +404,31 @@ function renderFrictionStats(stats = {}) {
   $("friction-resolved-month-value").textContent = formatBigInt(stats.resolved_this_month || 0);
 }
 
+function frictionFilterLabel() {
+  return frictionStatusFilter === "all" ? "all" : frictionStatusFilter;
+}
+
+function frictionAvailableCount(stats = {}) {
+  const open = Number(stats.open) || 0;
+  const triaged = Number(stats.triaged) || 0;
+  const total = Number(stats.total) || 0;
+  if (frictionStatusFilter === "active") return open + triaged;
+  if (frictionStatusFilter === "open") return open;
+  if (frictionStatusFilter === "triaged") return triaged;
+  if (frictionStatusFilter === "resolved") return Math.max(0, total - open - triaged);
+  return total;
+}
+
 function renderFrictions(payload) {
   const body = $("frictions-body");
   if (!body) return;
   const items = Array.isArray(payload && payload.items) ? payload.items : [];
   const stats = (payload && payload.stats) || {};
   renderFrictionStats(stats);
-  $("knowledge-count").textContent = `${items.length}/${stats.total || items.length}`;
+  const available = frictionAvailableCount(stats);
+  const count = $("knowledge-count");
+  count.textContent = `${items.length}/${available}`;
+  count.title = `Showing ${items.length} of ${available} ${frictionFilterLabel()} frictions`;
 
   if (items.length > 0 && !items.some((item) => item.id === activeFrictionId)) {
     activeFrictionId = items[0].id;
@@ -416,9 +436,10 @@ function renderFrictions(payload) {
   if (items.length === 0) activeFrictionId = null;
 
   if (items.length === 0) {
+    const suffix = frictionSearchQuery ? " match the current search." : ".";
     syncNodes(body, [el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: "No frictions match the current filter." }),
+      el("div", { class: "text", text: `No ${frictionFilterLabel()} frictions${suffix}` }),
     ])]);
     renderFrictionDetail(null);
     return;
@@ -669,6 +690,17 @@ function wireFrictionSearch() {
     debounce = setTimeout(() => {
       if (activeTab === "knowledge") fetchAndRenderFrictions().catch(console.error);
     }, 200);
+  });
+}
+
+function wireFrictionStatusFilter() {
+  const select = $("friction-status-filter");
+  if (!select) return;
+  select.value = frictionStatusFilter;
+  select.addEventListener("change", (e) => {
+    frictionStatusFilter = e.target.value;
+    activeFrictionId = null;
+    if (activeTab === "knowledge") fetchAndRenderFrictions().catch(console.error);
   });
 }
 
@@ -1177,15 +1209,29 @@ function fetchAndRenderFrictions() {
     renderKnowledgeDetailPlaceholder("friction");
     return Promise.resolve();
   }
-  const sp = new URLSearchParams();
-  sp.set("limit", String(FRICTION_LIMIT));
-  if (frictionSearchQuery) sp.set("q", frictionSearchQuery);
+  const statuses = frictionStatusFilter === "active" ? ["open", "triaged"] : [frictionStatusFilter];
+  const listRequests = statuses.map((status) => {
+    const sp = new URLSearchParams();
+    sp.set("limit", String(FRICTION_LIMIT));
+    if (status !== "all") sp.set("status", status);
+    if (frictionSearchQuery) sp.set("q", frictionSearchQuery);
+    return fetchJson(`/api/frictions?${sp.toString()}`);
+  });
   return Promise.all([
-    fetchJson(`/api/frictions?${sp.toString()}`),
+    Promise.all(listRequests),
     fetchJson("/api/frictions/stats"),
-  ]).then(([payload, stats]) => {
-    lastFrictionPayload = payload || { stats: {}, tags: [], items: [] };
-    lastFrictionPayload.stats = stats || lastFrictionPayload.stats || {};
+  ]).then(([payloads, stats]) => {
+    const items = payloads
+      .flatMap((payload) => Array.isArray(payload && payload.items) ? payload.items : [])
+      .sort((a, b) => {
+        const byCreatedAt = Date.parse(b.created_at || "") - Date.parse(a.created_at || "");
+        return Number.isNaN(byCreatedAt) || byCreatedAt === 0
+          ? String(b.id || "").localeCompare(String(a.id || ""))
+          : byCreatedAt;
+      })
+      .slice(0, FRICTION_LIMIT);
+    const tags = [...new Set(payloads.flatMap((payload) => Array.isArray(payload && payload.tags) ? payload.tags : []))].sort();
+    lastFrictionPayload = { stats: stats || {}, tags, items };
     renderFrictions(lastFrictionPayload);
   });
 }
@@ -1302,6 +1348,7 @@ const tasksContext = taskContext();
 buildChips(tasksContext);
 wireSearch(tasksContext);
 wireFrictionSearch();
+wireFrictionStatusFilter();
 wireGlobalTaskResolver();
 buildAuditChips(auditContext());
 wireAuditSearch(auditContext());

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3400,6 +3400,10 @@
         background: rgba(255, 255, 255, 0.03);
         border-left-color: var(--fg-dim);
       }
+      .knowledge-row:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+      }
       .knowledge-row .top {
         display: flex;
         align-items: center;
@@ -3413,6 +3417,12 @@
         color: var(--fg-dim);
       }
       .knowledge-row .spacer { flex: 1; }
+      .friction-row-toggle {
+        display: none;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
       .knowledge-row .title {
         font-size: 13px;
         color: var(--fg);
@@ -3534,13 +3544,28 @@
         overflow-y: auto;
         min-height: 0;
       }
-      /* Stacked single-column layout: the detail pane sits below the list, so
-         pinning it to the chrome offset would only shrink it. Declared after the
-         sticky rule above so it wins the equal-specificity tie. */
+      .friction-accordion-detail {
+        display: none;
+      }
+      /* At the same breakpoint where Knowledge becomes one column, reuse the
+         Tasks interaction pattern: the selected row owns an inline detail
+         immediately beneath it, and the separate pane leaves the layout. */
       @media (max-width: 1000px) {
         #friction-detail-panel {
-          position: static;
-          max-height: none;
+          display: none;
+        }
+        .friction-row-toggle {
+          display: inline-flex;
+        }
+        .friction-accordion-detail {
+          display: flex;
+          flex-direction: column;
+          background: #050505;
+          border-bottom: 1px solid var(--hair);
+          animation: fadeIn 0.3s ease;
+        }
+        .friction-accordion-detail .knowledge-detail-body {
+          overflow-y: visible;
         }
       }
       #friction-detail {
@@ -3709,7 +3734,7 @@
         grid-template-columns: 1fr;
       }
 
-      @media (max-width: 1100px) {
+      @media (max-width: 1400px) {
         .knowledge-detail-body {
           grid-template-columns: 1fr;
         }

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3252,6 +3252,9 @@
         grid-template-columns: repeat(3, minmax(0, 1fr));
         border-bottom: 1px solid var(--border);
       }
+      .friction-stats .tile {
+        padding: 8px 16px;
+      }
       @media (max-width: 800px) {
         .friction-stats { grid-template-columns: 1fr; }
         .friction-row { grid-template-columns: 120px minmax(0, 1fr) 76px; }

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -541,6 +541,40 @@
       #friction-search:focus {
         border-color: var(--accent);
       }
+
+      .friction-filter-control {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+
+      #friction-status-filter {
+        min-width: 116px;
+        background: var(--bg-elev);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: 2px;
+        padding: 6px 28px 6px 10px;
+        font: inherit;
+        font-size: 12px;
+        outline: none;
+      }
+
+      #friction-status-filter:focus-visible {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 1px var(--accent);
+      }
+
+      @media (max-width: 520px) {
+        #friction-search { flex: 1 1 100%; }
+        .friction-filter-control { flex: 1 1 100%; }
+        #friction-status-filter { flex: 1; }
+      }
       
       #task-filter {
         display: flex;

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -370,7 +370,7 @@
     <section class="tab-pane" data-tab="knowledge">
       <main style="grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);">
         <section class="panel" id="knowledge-panel">
-          <header><span>Knowledge</span><span class="count" id="knowledge-count">-</span></header>
+          <header><span>Knowledge</span><span class="count" id="knowledge-count" role="status" aria-live="polite" aria-atomic="true">-</span></header>
           <nav class="subtabs" id="knowledge-subtabs">
             <button class="subtab active" data-subtab="frictions" type="button">Frictions</button>
           </nav>
@@ -393,6 +393,16 @@
           </div>
           <div class="controls">
             <input type="search" id="friction-search" placeholder="Search frictions..." autocomplete="off" spellcheck="false" />
+            <label class="friction-filter-control" for="friction-status-filter">
+              <span>Status</span>
+              <select id="friction-status-filter" aria-controls="frictions-body">
+                <option value="active" selected>Active</option>
+                <option value="open">Open</option>
+                <option value="triaged">Triaged</option>
+                <option value="resolved">Resolved</option>
+                <option value="all">All</option>
+              </select>
+            </label>
           </div>
           <div class="body scoreboard-table-wrap" id="frictions-body">
             <div class="skeleton-state">

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -887,6 +887,47 @@ fn dashboard_knowledge_detail_pane_is_sticky_and_internally_scrollable() {
     assert!(sticky_at < unpin_at);
 }
 
+#[test]
+fn dashboard_friction_list_defaults_to_active_and_filters_by_status() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let app = include_str!("../../assets/dashboard/app.js");
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    assert!(
+        index.contains(r#"<label class="friction-filter-control" for="friction-status-filter">"#)
+            && index
+                .contains(r#"<select id="friction-status-filter" aria-controls="frictions-body">"#),
+        "the status filter must have a visible label and name the list it controls"
+    );
+    for option in ["active", "open", "triaged", "resolved", "all"] {
+        assert!(
+            index.contains(&format!(r#"<option value="{option}""#)),
+            "the friction status filter must expose {option}"
+        );
+    }
+    assert!(
+        app.contains(r#"const DEFAULT_FRICTION_STATUS_FILTER = "active";"#)
+            && app.contains(
+                r#"frictionStatusFilter === "active" ? ["open", "triaged"] : [frictionStatusFilter]"#,
+            ),
+        "the initial list must fetch open and triaged independently so resolved history cannot consume its limit"
+    );
+    assert!(
+        app.contains(r#"if (status !== "all") sp.set("status", status);"#)
+            && app.contains(r#"if (frictionSearchQuery) sp.set("q", frictionSearchQuery);"#),
+        "status and text search must compose in every list request"
+    );
+    assert!(
+        app.contains("activeFrictionId = null;") && app.contains(".slice(0, FRICTION_LIMIT);"),
+        "filter changes must reset stale selection and the merged active view must honor the shared limit"
+    );
+    assert!(
+        css.contains("#friction-status-filter:focus-visible")
+            && css.contains(".friction-filter-control { flex: 1 1 100%; }"),
+        "the filter needs visible keyboard focus and a narrow-screen layout"
+    );
+}
+
 /// ORB-10444: the Tasks tab's two write actions. Ship is one click — the
 /// dispatch carries the task id alone, so the pipeline resolves the crew from
 /// the task and the mode from the workspace — and comments post to the

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -878,6 +878,10 @@ fn dashboard_knowledge_detail_is_sticky_on_desktop_and_inline_when_narrow() {
         !css.contains("min-height: calc(100vh - 360px)"),
         "the old fixed min-height fought the bounded sticky pane and must be gone"
     );
+    assert!(
+        css.contains(".friction-stats .tile {\n        padding: 8px 16px;"),
+        "friction summary tiles need outer breathing room at every width"
+    );
     let accordion_at = css
         .find("          display: none;\n        }\n        .friction-row-toggle")
         .expect("the narrow breakpoint must hide the separate detail pane");

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -853,12 +853,12 @@ fn dashboard_managed_execution_cost_panel_has_responsive_presentation_hooks() {
     );
 }
 
-/// ORB-10444: the friction list is long enough to scroll the detail
-/// pane out of view mid-read. The pane is pinned below the fixed chrome and
-/// bounded to the remaining viewport so its body scrolls internally rather than
-/// being clipped when the detail is taller than the screen.
+/// ORB-10444: the desktop friction pane stays in view mid-read. ORB-11136:
+/// once Knowledge collapses to one column, detail expands under its owning row
+/// instead of being stranded after the full list.
 #[test]
-fn dashboard_knowledge_detail_pane_is_sticky_and_internally_scrollable() {
+fn dashboard_knowledge_detail_is_sticky_on_desktop_and_inline_when_narrow() {
+    let app = include_str!("../../assets/dashboard/app.js");
     let css = include_str!("../../assets/dashboard/dashboard.css");
 
     let sticky_at = css
@@ -878,13 +878,20 @@ fn dashboard_knowledge_detail_pane_is_sticky_and_internally_scrollable() {
         !css.contains("min-height: calc(100vh - 360px)"),
         "the old fixed min-height fought the bounded sticky pane and must be gone"
     );
-    // The single-column breakpoint stacks the pane under the list, where
-    // pinning would only shrink it — the override must come after the sticky
-    // rule so it wins the equal-specificity tie.
-    let unpin_at = css
-        .find("          position: static;\n          max-height: none;")
-        .expect("the narrow-viewport override must exist");
-    assert!(sticky_at < unpin_at);
+    let accordion_at = css
+        .find("          display: none;\n        }\n        .friction-row-toggle")
+        .expect("the narrow breakpoint must hide the separate detail pane");
+    assert!(sticky_at < accordion_at);
+    assert!(
+        app.contains(r#"const FRICTION_ACCORDION_QUERY = "(max-width: 1000px)";"#)
+            && app.contains(r#"row.setAttribute("aria-expanded", String(expanded));"#)
+            && app.contains(r#"if (event.key !== "Enter" && event.key !== " ") return;"#)
+            && app.contains("frag.appendChild(inlineDetail);")
+            && app.contains("frictionAccordionMedia.addEventListener(\"change\"")
+            && css.contains(".friction-accordion-detail .knowledge-detail-body")
+            && css.contains("@media (max-width: 1400px) {\n        .knowledge-detail-body"),
+        "narrow friction rows must expose a keyboard-operable inline accordion that tracks viewport changes"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task
ORB-11136 — Improve Knowledge friction triage with active-by-default status filtering.

## Summary
- Default Frictions to Active by merging open and triaged results without letting resolved history consume the result limit.
- Add explicit Active, Open, Triaged, Resolved, and All filtering that composes with text search.
- Replace the narrow stacked detail pane with keyboard-accessible inline accordions matching the Tasks interaction pattern.
- Keep the adjacent sticky detail pane on wider screens, improve its mid-width readability, and add padding to the friction summary tiles.
- Add focused embedded-asset regression coverage for filtering and responsive detail behavior.

## Validation
- cargo test -p orbit-web — 264 passed
- make ci-fast — passed
- cargo clippy -p orbit-web --all-targets -- -D warnings — passed
- node --check crates/orbit-web/assets/dashboard/app.js — passed
- git diff --check origin/agent-main...HEAD — passed
- Live UI verified at narrow and desktop widths, including click and Enter/Space accordion operation.

## Known baseline issue
make ci-lint remains red on macOS-only test errors in crates/orbit-engine and crates/orbit-cli/tests/mcp_roundtrip.rs. The candidate matches origin/agent-main exactly in those paths; candidate-owned orbit-web clippy is green.