### PR TITLE
Honor logical workspace identity in task publication commands

### DIFF
--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -329,11 +329,13 @@ impl Execute for TaskPublicationRestoreArgs {
             "restoring a task publication into the canonical destination store",
         )?;
         assert_restore_authority(runtime, &self.publication)?;
+        let task_workspace_id = selected_task_workspace_id(runtime)?;
         runtime.record_task_publication_source(
-            &self.publication.workspace_id,
+            &task_workspace_id,
             &self.publication.source_repository_fingerprint,
         )?;
         let request = PublicationRestoreRequest {
+            task_workspace_id,
             publication: self.publication.request(runtime, "restore"),
             mode: if self.allow_identical_retry {
                 PublicationRestoreMode::AllowIdenticalRetry

--- a/crates/orbit-cli/src/command/task/publication.rs
+++ b/crates/orbit-cli/src/command/task/publication.rs
@@ -110,6 +110,7 @@ impl Execute for TaskPublicationPublishArgs {
             ));
         }
         let workspace_id = selected_workspace_id(runtime)?;
+        let task_workspace_id = selected_task_workspace_id(runtime)?;
         let global_root = runtime.global_root();
         let host = load_host_identity(&global_root)?;
         let registry_path = workspace_registry::registry_path_for(&global_root);
@@ -134,6 +135,7 @@ impl Execute for TaskPublicationPublishArgs {
 
         let request = publish_request(
             &binding,
+            task_workspace_id,
             host.machine_id,
             caller_role,
             publication_cache(runtime),
@@ -389,6 +391,13 @@ impl Execute for TaskPublicationRestoreArgs {
 fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
     runtime
         .workspace_runtime_binding()
+        .map(|binding| binding.logical_workspace_id.clone())
+        .map_or_else(|| runtime.workspace_id(), Ok)
+}
+
+fn selected_task_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
+    runtime
+        .workspace_runtime_binding()
         .map(|binding| binding.workspace_id.clone())
         .map_or_else(|| runtime.workspace_id(), Ok)
 }
@@ -399,12 +408,14 @@ fn publication_cache(runtime: &OrbitRuntime) -> PathBuf {
 
 fn publish_request(
     binding: &WorkspacePublicationBinding,
+    task_workspace_id: String,
     local_machine_id: String,
     caller_role: PublicationCallerRole,
     cache_dir: PathBuf,
 ) -> PublicationPublishRequest {
     PublicationPublishRequest {
         workspace_id: binding.workspace_id.clone(),
+        task_workspace_id,
         source_repository_fingerprint: binding.source_repository_fingerprint.clone(),
         publication_id: binding.publication_id.clone(),
         authority_machine_id: binding.authority_machine_id.clone(),

--- a/crates/orbit-cli/src/command/workspace/publication.rs
+++ b/crates/orbit-cli/src/command/workspace/publication.rs
@@ -57,6 +57,7 @@ pub struct WorkspacePublicationBindArgs {
 impl WorkspacePublicationBindArgs {
     fn execute_bind(self, runtime: &OrbitRuntime, rebind: bool) -> CommandOut {
         let workspace_id = selected_workspace_id(runtime)?;
+        let task_workspace_id = selected_task_workspace_id(runtime)?;
         let global_root = runtime.global_root();
         let machine_id = load_host_identity(&global_root)?.machine_id;
         let registry_path = workspace_registry::registry_path_for(&global_root);
@@ -81,7 +82,7 @@ impl WorkspacePublicationBindArgs {
             )?
         };
         runtime.record_task_publication_source(
-            &binding.workspace_id,
+            &task_workspace_id,
             &binding.source_repository_fingerprint,
         )?;
         workspace_registry::save_registry_to(&registry, &registry_path)?;
@@ -175,6 +176,13 @@ impl Execute for WorkspacePublicationRemoveArgs {
 }
 
 fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
+    runtime
+        .workspace_runtime_binding()
+        .map(|binding| binding.logical_workspace_id.clone())
+        .map_or_else(|| runtime.workspace_id(), Ok)
+}
+
+fn selected_task_workspace_id(runtime: &OrbitRuntime) -> Result<String, orbit_core::OrbitError> {
     runtime
         .workspace_runtime_binding()
         .map(|binding| binding.workspace_id.clone())

--- a/crates/orbit-cli/tests/task_publication.rs
+++ b/crates/orbit-cli/tests/task_publication.rs
@@ -17,6 +17,7 @@ const PUBLICATION_REMOTE: &str = "ssh://publication.test/orbit-tasks.git";
 const PUBLICATION_ID: &str = "pub_network_free_e2e";
 const LOGICAL_WORKSPACE_ID: &str = "ws_orbit";
 const RUNTIME_WORKSPACE_ID: &str = "ws_orbit-5c61b3";
+const RECOVERY_RUNTIME_WORKSPACE_ID: &str = "ws_orbit-recovery";
 
 #[test]
 fn operator_workflow_is_network_free_labelled_and_fail_closed() {
@@ -269,9 +270,24 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &recovery_repo,
         &recovery_home,
         &publication_bare,
-        &["workspace", "init", "--name", "orbit"],
+        &["workspace", "init", "--name", "orbit-recovery"],
     )
     .success();
+    let recovery_registry_path = recovery_home.join(".orbit").join("workspaces.json");
+    let recovery_registry =
+        fs::read_to_string(&recovery_registry_path).expect("recovery workspace registry");
+    fs::write(
+        &recovery_registry_path,
+        recovery_registry.replace(RECOVERY_RUNTIME_WORKSPACE_ID, LOGICAL_WORKSPACE_ID),
+    )
+    .expect("logical recovery workspace registry");
+    let recovery_runtime_identity =
+        fs::read_to_string(recovery_repo.join(".orbit").join("config.yaml"))
+            .expect("recovery runtime workspace identity");
+    assert!(
+        recovery_runtime_identity.contains(RECOVERY_RUNTIME_WORKSPACE_ID),
+        "recovery config.yaml must retain the task partition: {recovery_runtime_identity}"
+    );
     let recovery_workspace = orbit_json(
         &recovery_repo,
         &recovery_home,
@@ -345,6 +361,12 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
     assert_eq!(
         task_ids(&recovery_repo, &recovery_home, &publication_bare),
         [first.clone(), second.clone()]
+    );
+    assert_eq!(
+        fs::read_to_string(recovery_repo.join(".orbit").join("config.yaml"))
+            .expect("recovery runtime identity after restore"),
+        recovery_runtime_identity,
+        "restore must not rewrite the destination task partition identity"
     );
     assert_eq!(repository_state(&recovery_repo), recovery_before);
 

--- a/crates/orbit-cli/tests/task_publication.rs
+++ b/crates/orbit-cli/tests/task_publication.rs
@@ -15,6 +15,8 @@ use tempfile::tempdir;
 const SOURCE_REMOTE: &str = "ssh://source.test/orbit.git";
 const PUBLICATION_REMOTE: &str = "ssh://publication.test/orbit-tasks.git";
 const PUBLICATION_ID: &str = "pub_network_free_e2e";
+const LOGICAL_WORKSPACE_ID: &str = "ws_orbit";
+const RUNTIME_WORKSPACE_ID: &str = "ws_orbit-5c61b3";
 
 #[test]
 fn operator_workflow_is_network_free_labelled_and_fail_closed() {
@@ -48,9 +50,26 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["workspace", "init", "--name", "publication-e2e"],
+        &["workspace", "init", "--name", "orbit-5c61b3"],
     )
     .success();
+
+    // The registry's logical identity may diverge from config.yaml's task
+    // partition. Publication authority follows the former; bundle discovery
+    // must keep using the latter.
+    let registry_path = owner_home.join(".orbit").join("workspaces.json");
+    let registry = fs::read_to_string(&registry_path).expect("workspace registry");
+    fs::write(
+        &registry_path,
+        registry.replace(RUNTIME_WORKSPACE_ID, LOGICAL_WORKSPACE_ID),
+    )
+    .expect("logical workspace registry");
+    let runtime_identity = fs::read_to_string(source_repo.join(".orbit").join("config.yaml"))
+        .expect("runtime workspace identity");
+    assert!(
+        runtime_identity.contains(RUNTIME_WORKSPACE_ID),
+        "config.yaml must retain the task partition: {runtime_identity}"
+    );
 
     let first = add_task(
         &source_repo,
@@ -138,6 +157,8 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &owner_home,
         &publication_bare,
         &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
             "workspace",
             "publication",
             "bind",
@@ -149,6 +170,7 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         ],
     );
     assert_eq!(binding["bound"], true);
+    assert_eq!(binding["workspace_id"], LOGICAL_WORKSPACE_ID);
     assert_eq!(binding["privacy"], "operator-managed");
     assert_eq!(binding["publication_remote"], PUBLICATION_REMOTE);
     let workspace_id = binding["workspace_id"]
@@ -165,6 +187,8 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &owner_home,
         &publication_bare,
         &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
             "task",
             "publication",
             "publish",
@@ -174,6 +198,7 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         ],
     );
     assert_eq!(published["status"], "initialized");
+    assert_eq!(published["workspace_id"], LOGICAL_WORKSPACE_ID);
     assert_eq!(published["generation"], 1);
     assert!(published["omitted_attachment_bytes"].as_u64().unwrap() > 0);
     let published_commit = published["commit_id"]
@@ -189,9 +214,17 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["task", "publication", "status", "--json"],
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "task",
+            "publication",
+            "status",
+            "--json",
+        ],
     );
     assert_eq!(status["state"], "current");
+    assert_eq!(status["workspace_id"], LOGICAL_WORKSPACE_ID);
     assert_eq!(status["remote_commit"], published_commit);
     assert_eq!(status["incomplete_attachments"], true);
 
@@ -236,7 +269,7 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &recovery_repo,
         &recovery_home,
         &publication_bare,
-        &["workspace", "init", "--name", "publication-e2e"],
+        &["workspace", "init", "--name", "orbit"],
     )
     .success();
     let recovery_workspace = orbit_json(
@@ -371,7 +404,14 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["task", "publication", "publish", "--json"],
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "task",
+            "publication",
+            "publish",
+            "--json",
+        ],
     )
     .failure();
     assert_output_contains(&conflict, "resolve the publication authority");
@@ -401,6 +441,8 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &owner_home,
         &publication_bare,
         &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
             "workspace",
             "publication",
             "rebind",
@@ -417,14 +459,29 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["workspace", "publication", "show", "--json"],
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "workspace",
+            "publication",
+            "show",
+            "--json",
+        ],
     );
     assert_eq!(shown["publication_id"], "pub_rebound_e2e");
     let removed = orbit_json(
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["workspace", "publication", "remove", "--confirm", "--json"],
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "workspace",
+            "publication",
+            "remove",
+            "--confirm",
+            "--json",
+        ],
     );
     assert_eq!(removed["removed"], true);
     assert_eq!(removed["repository_changed"], false);
@@ -432,9 +489,36 @@ fn operator_workflow_is_network_free_labelled_and_fail_closed() {
         &source_repo,
         &owner_home,
         &publication_bare,
-        &["workspace", "publication", "show", "--json"],
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "workspace",
+            "publication",
+            "show",
+            "--json",
+        ],
     );
     assert_eq!(unbound["bound"], false);
+    let logical_workspace = orbit_json(
+        &source_repo,
+        &owner_home,
+        &publication_bare,
+        &[
+            "--workspace",
+            LOGICAL_WORKSPACE_ID,
+            "workspace",
+            "show",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(logical_workspace["workspace"]["id"], LOGICAL_WORKSPACE_ID);
+    assert_eq!(
+        fs::read_to_string(source_repo.join(".orbit").join("config.yaml"))
+            .expect("runtime identity after publication"),
+        runtime_identity,
+        "publication must not rewrite the task partition identity"
+    );
     assert_eq!(repository_state(&source_repo), source_before);
 }
 

--- a/crates/orbit-store/src/workflow/task/publication.rs
+++ b/crates/orbit-store/src/workflow/task/publication.rs
@@ -284,7 +284,30 @@ pub fn build_publication_snapshot(
     policy: &AttachmentPolicy,
     scanner: Option<&dyn AttachmentSensitivityScanner>,
 ) -> Result<PublicationSnapshotOutcome, OrbitError> {
+    let task_workspace_id = metadata.workspace_id.clone();
+    build_publication_snapshot_from_task_workspace(
+        registry,
+        destination,
+        metadata,
+        &task_workspace_id,
+        policy,
+        scanner,
+    )
+}
+
+/// Build a snapshot carrying logical publication metadata from a distinct
+/// canonical task-registry partition.
+pub(crate) fn build_publication_snapshot_from_task_workspace(
+    registry: &TaskRegistryStore,
+    destination: &Path,
+    metadata: PublicationSnapshotMetadata,
+    task_workspace_id: &str,
+    policy: &AttachmentPolicy,
+    scanner: Option<&dyn AttachmentSensitivityScanner>,
+) -> Result<PublicationSnapshotOutcome, OrbitError> {
     metadata.validate()?;
+    validate_registry_identifier("task_workspace_id", task_workspace_id)
+        .map_err(invalid_identity)?;
     policy.validate()?;
     if destination.exists() {
         return Err(OrbitError::InvalidInput(format!(
@@ -301,22 +324,21 @@ pub fn build_publication_snapshot(
     fs::create_dir_all(parent).map_err(|error| OrbitError::from_write_io(parent, error))?;
 
     let binding = registry
-        .find_workspace_binding(&metadata.workspace_id)?
+        .find_workspace_binding(task_workspace_id)?
         .ok_or_else(|| {
             OrbitError::InvalidInput(format!(
-                "workspace '{}' is not registered in the coordination registry",
-                metadata.workspace_id
+                "task workspace '{task_workspace_id}' is not registered in the coordination registry"
             ))
         })?;
-    if binding.workspace_id != metadata.workspace_id {
+    if binding.workspace_id != task_workspace_id {
         return Err(OrbitError::InvalidInput(format!(
-            "workspace selector '{}' resolved to unexpected workspace '{}'",
-            metadata.workspace_id, binding.workspace_id
+            "task workspace selector '{task_workspace_id}' resolved to unexpected workspace '{}'",
+            binding.workspace_id
         )));
     }
 
     let mut task_ids: Vec<String> = registry
-        .tasks_for_workspace(&metadata.workspace_id)?
+        .tasks_for_workspace(task_workspace_id)?
         .into_iter()
         .map(|task| task.task_id)
         .collect();
@@ -335,7 +357,7 @@ pub fn build_publication_snapshot(
     let mut included_attachment_bytes = 0u64;
     let mut omitted_attachment_bytes = 0u64;
     for task_id in &task_ids {
-        let source = registry.canonical_task_bundle_path(&metadata.workspace_id, task_id)?;
+        let source = registry.canonical_task_bundle_path(task_workspace_id, task_id)?;
         validate_jsonl_files(task_id, &source)?;
         let mut bundle = read_bundle_at(&source).map_err(|error| {
             OrbitError::Store(format!(

--- a/crates/orbit-store/src/workflow/task/publish.rs
+++ b/crates/orbit-store/src/workflow/task/publish.rs
@@ -38,7 +38,7 @@ use super::git::{
 use super::publication::{
     AttachmentPolicy, AttachmentSensitivityScanner, PUBLICATION_ENVELOPE_FILE_NAME,
     PUBLICATION_TASKS_DIR_NAME, PublicationEnvelope, PublicationSnapshotMetadata,
-    assert_envelope_parent_lineage, build_publication_snapshot,
+    assert_envelope_parent_lineage, build_publication_snapshot_from_task_workspace,
 };
 
 /// Error prefix and command label for every transport failure.
@@ -64,7 +64,10 @@ pub struct PublicationLastSuccess {
 /// Binding facts and commit metadata for one publication attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicationPublishRequest {
+    /// Logical workspace identity recorded in the publication envelope.
     pub workspace_id: String,
+    /// Existing task-registry partition to enumerate for this snapshot.
+    pub task_workspace_id: String,
     pub source_repository_fingerprint: String,
     pub publication_id: String,
     pub authority_machine_id: String,
@@ -189,6 +192,7 @@ pub fn publish_task_snapshot(
 
 struct ValidatedRequest {
     workspace_id: String,
+    task_workspace_id: String,
     source_repository_fingerprint: String,
     publication_id: String,
     authority_machine_id: String,
@@ -207,6 +211,8 @@ fn validate_request(request: PublicationPublishRequest) -> Result<ValidatedReque
         )));
     }
     validate_registry_identifier("workspace_id", &request.workspace_id).map_err(identity_error)?;
+    validate_registry_identifier("task_workspace_id", &request.task_workspace_id)
+        .map_err(identity_error)?;
     validate_registry_identifier("publication_id", &request.publication_id)
         .map_err(identity_error)?;
     validate_machine_id(&request.authority_machine_id).map_err(identity_error)?;
@@ -246,6 +252,7 @@ fn validate_request(request: PublicationPublishRequest) -> Result<ValidatedReque
     };
     Ok(ValidatedRequest {
         workspace_id: request.workspace_id,
+        task_workspace_id: request.task_workspace_id,
         source_repository_fingerprint: request.source_repository_fingerprint,
         publication_id: request.publication_id,
         authority_machine_id: request.authority_machine_id,
@@ -264,28 +271,28 @@ fn assert_registered_workspace(
     request: &ValidatedRequest,
 ) -> Result<(), OrbitError> {
     let binding = registry
-        .find_workspace_binding(&request.workspace_id)?
+        .find_workspace_binding(&request.task_workspace_id)?
         .ok_or_else(|| {
             publish_error(format!(
-                "workspace '{}' is not registered in the coordination registry",
-                request.workspace_id
+                "task workspace '{}' is not registered in the coordination registry",
+                request.task_workspace_id
             ))
         })?;
-    if binding.workspace_id != request.workspace_id {
+    if binding.workspace_id != request.task_workspace_id {
         return Err(publish_error(format!(
-            "workspace selector '{}' resolved to unexpected workspace '{}'",
-            request.workspace_id, binding.workspace_id
+            "task workspace selector '{}' resolved to unexpected workspace '{}'",
+            request.task_workspace_id, binding.workspace_id
         )));
     }
     match binding.repo_fingerprint.as_deref() {
         Some(fingerprint) if fingerprint == request.source_repository_fingerprint => Ok(()),
         Some(_) => Err(publish_error(format!(
-            "workspace '{}' publication fingerprint does not match its registered source remote",
-            request.workspace_id
+            "task workspace '{}' publication fingerprint does not match its registered source remote",
+            request.task_workspace_id
         ))),
         None => Err(publish_error(format!(
-            "workspace '{}' has no registered source-repository identity",
-            request.workspace_id
+            "task workspace '{}' has no registered source-repository identity",
+            request.task_workspace_id
         ))),
     }
 }
@@ -450,7 +457,7 @@ impl PublicationCache {
             .tempdir_in(&self.root)
             .map_err(|error| OrbitError::from_write_io(&self.root, error))?;
         let tree = temp.path().join("tree");
-        let outcome = build_publication_snapshot(
+        let outcome = build_publication_snapshot_from_task_workspace(
             registry,
             &tree,
             PublicationSnapshotMetadata {
@@ -462,6 +469,7 @@ impl PublicationCache {
                 published_at: request.published_at,
                 previous_publication,
             },
+            &request.task_workspace_id,
             policy,
             scanner,
         )?;

--- a/crates/orbit-store/src/workflow/task/publish.rs
+++ b/crates/orbit-store/src/workflow/task/publish.rs
@@ -809,7 +809,7 @@ fn assert_outside_source_checkout(
     registry: &TaskRegistryStore,
     request: &ValidatedRequest,
 ) -> Result<(), OrbitError> {
-    let Some(checkout) = registry.find_workspace_checkout(&request.workspace_id)? else {
+    let Some(checkout) = registry.find_workspace_checkout(&request.task_workspace_id)? else {
         return Ok(());
     };
     let cache = std::path::absolute(&request.cache_dir)

--- a/crates/orbit-store/src/workflow/task/restore.rs
+++ b/crates/orbit-store/src/workflow/task/restore.rs
@@ -38,6 +38,8 @@ pub enum PublicationRecoveryCompleteness {
 /// Pairing inputs and the explicitly selected destination policy.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicationRestoreRequest {
+    /// Existing task-registry partition that receives restored bundles.
+    pub task_workspace_id: String,
     pub publication: PublicationInspectRequest,
     pub mode: PublicationRestoreMode,
 }
@@ -92,17 +94,18 @@ fn restore_publication_inner(
     // exact result rather than recreating a second validation path.
     let validated = load_validated_publication(request.publication.clone())?;
     let envelope = &validated.inspection.envelope;
-    let workspace_id = envelope.workspace_id.clone();
-    assert_destination_pairing(registry, &request.publication)?;
+    let task_workspace_id = request.task_workspace_id.clone();
+    assert_destination_pairing(registry, &request)?;
 
-    let existing = registry.tasks_for_workspace(&workspace_id)?;
-    let destination_has_entries =
-        canonical_destination_has_entries(registry.workspaces_dir().join(&workspace_id).as_path())?;
+    let existing = registry.tasks_for_workspace(&task_workspace_id)?;
+    let destination_has_entries = canonical_destination_has_entries(
+        registry.workspaces_dir().join(&task_workspace_id).as_path(),
+    )?;
     if request.mode == PublicationRestoreMode::EmptyDestination
         && (!existing.is_empty() || destination_has_entries)
     {
         return Err(restore_error(format!(
-            "workspace '{workspace_id}' is not an empty restore destination"
+            "task workspace '{task_workspace_id}' is not an empty restore destination"
         )));
     }
 
@@ -117,7 +120,8 @@ fn restore_publication_inner(
         let task_id = &published.bundle.envelope.id;
         match registry.find_task_binding(task_id)? {
             None => {
-                let destination = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+                let destination =
+                    registry.canonical_task_bundle_path(&task_workspace_id, task_id)?;
                 if destination.exists() {
                     return Err(restore_error(format!(
                         "canonical path for task '{task_id}' exists without a registry binding"
@@ -126,7 +130,7 @@ fn restore_publication_inner(
                 missing.push(published);
             }
             Some(binding) => {
-                let identical = binding.workspace_id == workspace_id
+                let identical = binding.workspace_id == task_workspace_id
                     && read_bundle_at(&binding.canonical_path)
                         .is_ok_and(|bundle| bundle == published.bundle);
                 if request.mode != PublicationRestoreMode::AllowIdenticalRetry || !identical {
@@ -152,7 +156,7 @@ fn restore_publication_inner(
         ));
     }
 
-    let workspace_root = registry.workspaces_dir().join(&workspace_id);
+    let workspace_root = registry.workspaces_dir().join(&task_workspace_id);
     fs::create_dir_all(&workspace_root)
         .map_err(|error| OrbitError::from_write_io(&workspace_root, error))?;
     let staging = tempfile::Builder::new()
@@ -170,7 +174,7 @@ fn restore_publication_inner(
         .collect::<Vec<_>>();
     let mut guard = RestoreGuard::new(
         registry,
-        workspace_id.clone(),
+        task_workspace_id.clone(),
         previous_envelopes,
         previous_allocator,
     );
@@ -178,7 +182,7 @@ fn restore_publication_inner(
     for (index, published) in missing.iter().enumerate() {
         let task_id = &published.bundle.envelope.id;
         let source = staging.path().join(task_id);
-        let destination = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+        let destination = registry.canonical_task_bundle_path(&task_workspace_id, task_id)?;
         fs::rename(&source, &destination)
             .map_err(|error| OrbitError::from_write_io(&destination, error))?;
         guard.published_dirs.push(destination);
@@ -188,16 +192,16 @@ fn restore_publication_inner(
     }
 
     for task_id in &restored_ids {
-        let path = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
-        registry.register_task_bundle(task_id, &workspace_id, &path)?;
+        let path = registry.canonical_task_bundle_path(&task_workspace_id, task_id)?;
+        registry.register_task_bundle(task_id, &task_workspace_id, &path)?;
         guard.registered_ids.push(task_id.clone());
     }
 
-    rebuild_workspace_index(registry, &workspace_id)?;
+    rebuild_workspace_index(registry, &task_workspace_id)?;
     inject(failure, RestoreFailurePoint::IndexRebuild)?;
 
-    let projection = if let Some(checkout) = registry.find_workspace_checkout(&workspace_id)? {
-        let swap = ProjectionSwap::publish(registry, &checkout.orbit_dir, &workspace_id)?;
+    let projection = if let Some(checkout) = registry.find_workspace_checkout(&task_workspace_id)? {
+        let swap = ProjectionSwap::publish(registry, &checkout.orbit_dir, &task_workspace_id)?;
         let result = swap.result.clone();
         guard.projection = Some(swap);
         inject(failure, RestoreFailurePoint::ProjectionRebuild)?;
@@ -227,30 +231,32 @@ fn restore_publication_inner(
 
 fn assert_destination_pairing(
     registry: &TaskRegistryStore,
-    request: &PublicationInspectRequest,
+    request: &PublicationRestoreRequest,
 ) -> Result<(), OrbitError> {
     let binding = registry
-        .find_workspace_binding(&request.workspace_id)?
+        .find_workspace_binding(&request.task_workspace_id)?
         .ok_or_else(|| {
             restore_error(format!(
-                "workspace '{}' is not registered",
-                request.workspace_id
+                "task workspace '{}' is not registered",
+                request.task_workspace_id
             ))
         })?;
-    if binding.workspace_id != request.workspace_id {
+    if binding.workspace_id != request.task_workspace_id {
         return Err(restore_error(
-            "workspace selector resolved to another workspace",
+            "task workspace selector resolved to another workspace",
         ));
     }
     match binding.repo_fingerprint.as_deref() {
-        Some(fingerprint) if fingerprint == request.source_repository_fingerprint => Ok(()),
+        Some(fingerprint) if fingerprint == request.publication.source_repository_fingerprint => {
+            Ok(())
+        }
         Some(fingerprint) => Err(restore_error(format!(
             "source repository fingerprint mismatch: destination has '{fingerprint}', publication expects '{}'",
-            request.source_repository_fingerprint
+            request.publication.source_repository_fingerprint
         ))),
         None => Err(restore_error(format!(
-            "workspace '{}' has no registered source repository fingerprint; restore never adopts one implicitly",
-            request.workspace_id
+            "task workspace '{}' has no registered source repository fingerprint; restore never adopts one implicitly",
+            request.task_workspace_id
         ))),
     }
 }

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -477,6 +477,7 @@ fn replica_callers_and_stale_owners_may_not_publish() {
     assert!(error.contains("not registered"), "{error}");
 
     let mut inside_source = request(&fixture, 1, None);
+    inside_source.workspace_id = "ws_logical_publication".to_string();
     inside_source.cache_dir = fixture.source.join(".orbit-publication-cache");
     let error = publish(&fixture, inside_source).unwrap_err().to_string();
     assert!(error.contains("outside the source repository"), "{error}");

--- a/crates/orbit-store/src/workflow/task/tests/publish.rs
+++ b/crates/orbit-store/src/workflow/task/tests/publish.rs
@@ -167,6 +167,7 @@ fn request(
 ) -> PublicationPublishRequest {
     PublicationPublishRequest {
         workspace_id: fixture.workspace_id.clone(),
+        task_workspace_id: fixture.workspace_id.clone(),
         source_repository_fingerprint: FINGERPRINT.to_string(),
         publication_id: PUBLICATION_ID.to_string(),
         authority_machine_id: AUTHORITY.to_string(),
@@ -471,7 +472,7 @@ fn replica_callers_and_stale_owners_may_not_publish() {
     );
 
     let mut unregistered = request(&fixture, 1, None);
-    unregistered.workspace_id = "ws_unregistered".to_string();
+    unregistered.task_workspace_id = "ws_unregistered".to_string();
     let error = publish(&fixture, unregistered).unwrap_err().to_string();
     assert!(error.contains("not registered"), "{error}");
 

--- a/crates/orbit-store/src/workflow/task/tests/restore.rs
+++ b/crates/orbit-store/src/workflow/task/tests/restore.rs
@@ -8,6 +8,7 @@ use super::*;
 use crate::workflow::task::restore::{RestoreFailurePoint, restore_publication_with_failure};
 
 const WORKSPACE: &str = "ws_restore";
+const TASK_WORKSPACE: &str = "ws_restore-runtime";
 const FINGERPRINT: &str = "git@github.com:example/orbit-source.git";
 const PUBLICATION: &str = "pub_orbit_restore";
 const AUTHORITY: &str = "hm_owner";
@@ -17,6 +18,7 @@ struct RestoreFixture {
     destination: TempDir,
     remote: PathBuf,
     cache: PathBuf,
+    task_workspace_id: String,
 }
 
 impl RestoreFixture {
@@ -26,6 +28,7 @@ impl RestoreFixture {
 
     fn request(&self, mode: PublicationRestoreMode) -> PublicationRestoreRequest {
         PublicationRestoreRequest {
+            task_workspace_id: self.task_workspace_id.clone(),
             publication: PublicationInspectRequest {
                 workspace_id: WORKSPACE.to_string(),
                 source_repository_fingerprint: FINGERPRINT.to_string(),
@@ -41,12 +44,16 @@ impl RestoreFixture {
     }
 }
 
-fn bind_restore(registry: &TaskRegistryStore, root: &Path) -> WorkspaceCheckoutBinding {
-    let orbit_dir = root.join("repos").join(WORKSPACE).join(".orbit");
+fn bind_restore(
+    registry: &TaskRegistryStore,
+    root: &Path,
+    workspace_id: &str,
+) -> WorkspaceCheckoutBinding {
+    let orbit_dir = root.join("repos").join(workspace_id).join(".orbit");
     fs::create_dir_all(&orbit_dir).unwrap();
     registry
         .bind_workspace(BindWorkspaceParams {
-            workspace_id: Some(WORKSPACE.to_string()),
+            workspace_id: Some(workspace_id.to_string()),
             slug: "restore".to_string(),
             repo_root: orbit_dir.parent().unwrap().to_path_buf(),
             workspace_path: orbit_dir.parent().unwrap().to_path_buf(),
@@ -57,9 +64,16 @@ fn bind_restore(registry: &TaskRegistryStore, root: &Path) -> WorkspaceCheckoutB
 }
 
 fn fixture(kind: AttachmentPolicyKind) -> RestoreFixture {
+    fixture_with_task_workspace(kind, WORKSPACE)
+}
+
+fn fixture_with_task_workspace(
+    kind: AttachmentPolicyKind,
+    task_workspace_id: &str,
+) -> RestoreFixture {
     let source = TempDir::new().unwrap();
     let source_registry = open_registry(source.path());
-    let source_binding = bind_restore(&source_registry, source.path());
+    let source_binding = bind_restore(&source_registry, source.path(), WORKSPACE);
     let store = bundle_store(&source_registry, &source_binding);
     seed(
         &store,
@@ -117,13 +131,14 @@ fn fixture(kind: AttachmentPolicyKind) -> RestoreFixture {
 
     let destination = TempDir::new().unwrap();
     let destination_registry = open_registry(destination.path());
-    bind_restore(&destination_registry, destination.path());
+    bind_restore(&destination_registry, destination.path(), task_workspace_id);
     let cache = destination.path().join("publication-cache");
     RestoreFixture {
         _source: source,
         destination,
         remote,
         cache,
+        task_workspace_id: task_workspace_id.to_string(),
     }
 }
 
@@ -163,6 +178,43 @@ fn empty_destination_restore_preserves_ids_rebuilds_projection_and_advances_allo
 }
 
 #[test]
+fn restore_keeps_logical_identity_but_writes_to_the_runtime_task_partition() {
+    let fixture = fixture_with_task_workspace(AttachmentPolicyKind::Include, TASK_WORKSPACE);
+    let registry = fixture.registry();
+    let outcome = restore_publication(
+        &registry,
+        fixture.request(PublicationRestoreMode::EmptyDestination),
+    )
+    .unwrap();
+
+    assert_eq!(outcome.workspace_id, WORKSPACE);
+    assert_eq!(
+        registry.tasks_for_workspace(TASK_WORKSPACE).unwrap().len(),
+        2
+    );
+    assert!(registry.tasks_for_workspace(WORKSPACE).unwrap().is_empty());
+    let checkout = registry
+        .find_workspace_checkout(TASK_WORKSPACE)
+        .unwrap()
+        .unwrap();
+    for task_id in &outcome.restored_task_ids {
+        assert!(checkout.orbit_dir.join("tasks").join(task_id).is_symlink());
+        assert!(
+            registry
+                .canonical_task_bundle_path(TASK_WORKSPACE, task_id)
+                .unwrap()
+                .is_dir()
+        );
+        assert!(
+            !registry
+                .canonical_task_bundle_path(WORKSPACE, task_id)
+                .unwrap()
+                .exists()
+        );
+    }
+}
+
+#[test]
 fn identical_retry_is_explicit_and_does_not_duplicate_or_advance() {
     let fixture = fixture(AttachmentPolicyKind::Include);
     let registry = fixture.registry();
@@ -193,7 +245,7 @@ fn identical_retry_is_explicit_and_does_not_duplicate_or_advance() {
 fn restore_preserves_crlf_attachment_bytes_despite_gitattributes() {
     let source = TempDir::new().unwrap();
     let source_registry = open_registry(source.path());
-    let source_binding = bind_restore(&source_registry, source.path());
+    let source_binding = bind_restore(&source_registry, source.path(), WORKSPACE);
     let store = bundle_store(&source_registry, &source_binding);
     seed(
         &store,
@@ -230,12 +282,13 @@ fn restore_preserves_crlf_attachment_bytes_despite_gitattributes() {
 
     let destination = TempDir::new().unwrap();
     let destination_registry = open_registry(destination.path());
-    bind_restore(&destination_registry, destination.path());
+    bind_restore(&destination_registry, destination.path(), WORKSPACE);
     let cache = destination.path().join("publication-cache");
     let (env, sentinel) = poison_publication_git_filters(destination.path());
     let outcome = restore_publication(
         &destination_registry,
         PublicationRestoreRequest {
+            task_workspace_id: WORKSPACE.to_string(),
             publication: PublicationInspectRequest {
                 workspace_id: WORKSPACE.to_string(),
                 source_repository_fingerprint: FINGERPRINT.to_string(),


### PR DESCRIPTION
## Task

[ORB-11142](https://orbit-cli.com/tasks/ORB-11142) — Honor logical workspace identity in task publication commands

### Description

## Problem

The V1 task-publication CLI selects the checkout runtime/task-partition ID when looking up owner-local workspace publication state. Registered workspaces may validly keep a distinct logical catalog ID and runtime ID (L-0098). On the live Orbit workspace, the authoritative registry ID is `ws_orbit` while `.orbit/config.yaml` and canonical task storage use `orbit-5c61b3`; `workspace publication bind` therefore fails with `workspace_not_found: orbit-5c61b3` even though `ws_orbit` is active and owner-local.

## Why It Matters

This blocks publication setup for a valid production workspace and tempts operators to rewrite workspace identity or re-register checkouts, which can disconnect the existing task partition. Publication must bind authority to the logical registered workspace while continuing to snapshot tasks from the runtime partition.

## Constraints / Notes

- Preserve the intentional logical-ID/runtime-ID separation from ORB-11117 and L-0098; do not rewrite `.orbit/config.yaml`, migrate task bundles, or re-key canonical task storage.
- Keep owner/replica, source-remote, authority, publication-lineage, credential-redaction, and compare-and-swap gates fail-closed.
- The publication envelope and owner-local binding use the authoritative logical workspace identity; task enumeration and restore storage use the selected runtime partition.
- Preserve behavior where logical and runtime IDs already match.
- Reproduced on Orbit 0.17.0 with `ws_orbit` / `orbit-5c61b3` during private publication setup.

## Rollback

Revert the command-resolution change and its tests; no persisted schema migration is permitted.

### Acceptance Criteria

- `orbit --workspace ws_orbit workspace publication bind/show/rebind/remove` resolves publication bindings against logical registry ID `ws_orbit` when the selected runtime task partition is `orbit-5c61b3`.
- `orbit --workspace ws_orbit task publication publish/status` uses the logical binding and publication identity while including tasks from the existing runtime partition; it does not rewrite checkout identity, task bundles, or registry workspace IDs.
- A network-free regression fixture registers a logical workspace whose runtime ID differs, publishes at least one existing task, verifies the labelled snapshot and status, and proves both identities remain unchanged.
- Owner/replica, unknown selector, source-remote mismatch, publication conflict, and authority checks remain fail-closed; equal logical/runtime ID behavior remains covered.
- Focused publication and workspace-selection tests pass together with `make ci-fast`, `make ci-lint`, and `git diff --check`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Route workspace publication commands and task publication binding lookup through the logical workspace identity while retaining the runtime ID for task-registry operations.
- Carry the runtime task partition separately through publication staging and restore, keeping envelopes/authority logical while canonical bundles, indexes, and projections use the runtime partition.
- Resolve the cache-outside-source guard through the runtime checkout.
- Add divergent-ID regressions for publish, restore, identity preservation, and cache isolation.

Assessment: both blocking review findings are fixed without migrating or rewriting persisted workspace identity.

Validation:
- Passed Store restore tests (8) and publish tests (18).
- Passed the network-free CLI publication/recovery workflow.
- Passed task/workspace publication CLI unit tests.
- Passed `make ci-lint`, formatting, and `git diff --check`.
- `make ci-fast` is blocked only by the unchanged base `docs/INDEX.md` being stale.

</details>

## Validation

- Focused tests and workspace Clippy pass locally.
- GitHub CI is running for head `4283ccf0ea9357350a46285459f48767fa673aa5`.

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11142-6a94d49c`
- Behind base: 0
- Ahead of base: 2
