### PR TITLE
Prioritize review and defect work in automatic dispatch

### DIFF
--- a/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
+++ b/crates/orbit-core/assets/activities/list_backlog_tasks.yaml
@@ -15,11 +15,13 @@ spec:
     lock exclusions; it does not report status-based admission or `max_tasks`
     truncation. Explicit `task_ids` input is treated as an override, skips
     conflict filtering, and omits `excluded`.
-    Sorts critical → high → medium → low, then by `created_at` ascending so
-    older high-priority work ships first. Caps at `max_tasks` (default 50) to
-    keep the agent's context window bounded. Also emits conservative singleton
-    `bundles` so downstream dispatch can proceed without depending on an
-    agent's final response payload.
+    Automatic ordering puts critical tasks first, then corrective tasks (`bug`
+    type or an exact `code-review` / `security-review` tag), then all remaining
+    work. Within each band it sorts critical → high → medium → low,
+    followed by `created_at` ascending and task ID ascending. Caps at
+    `max_tasks` (default 50) to keep the agent's context window bounded. Also
+    emits conservative singleton `bundles` so downstream dispatch can proceed
+    without depending on an agent's final response payload.
   input_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use orbit_common::fs::path::workspace_relative_paths_overlap;
 use orbit_engine::DispatchError;
-use orbit_types::task::{Task, TaskStatus, task_dependencies_ready};
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType, task_dependencies_ready};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -129,7 +129,7 @@ pub(super) fn list_backlog_tasks(
                 task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
             })
             .collect();
-        sort_tasks_by_priority_age(&mut backlog);
+        sort_tasks_for_automatic_dispatch(&mut backlog);
         let mut excluded = Vec::new();
         backlog.retain(|task| {
             let Some(membership) = epic_family_membership(task, &task_lookup) else {
@@ -243,17 +243,33 @@ pub(super) fn list_backlog_tasks(
     Ok(Value::Object(payload))
 }
 
-pub(super) fn sort_tasks_by_priority_age(tasks: &mut [Task]) {
-    let rank = |priority: orbit_types::task::TaskPriority| match priority {
-        orbit_types::task::TaskPriority::Critical => 0,
-        orbit_types::task::TaskPriority::High => 1,
-        orbit_types::task::TaskPriority::Medium => 2,
-        orbit_types::task::TaskPriority::Low => 3,
+pub(super) fn sort_tasks_for_automatic_dispatch(tasks: &mut [Task]) {
+    let dispatch_band = |task: &Task| {
+        if task.priority == TaskPriority::Critical {
+            0
+        } else if task.task_type == TaskType::Bug
+            || task
+                .tags
+                .iter()
+                .any(|tag| matches!(tag.as_str(), "code-review" | "security-review"))
+        {
+            1
+        } else {
+            2
+        }
+    };
+    let priority_rank = |priority: TaskPriority| match priority {
+        TaskPriority::Critical => 0,
+        TaskPriority::High => 1,
+        TaskPriority::Medium => 2,
+        TaskPriority::Low => 3,
     };
     tasks.sort_by(|left, right| {
-        rank(left.priority)
-            .cmp(&rank(right.priority))
+        dispatch_band(left)
+            .cmp(&dispatch_band(right))
+            .then(priority_rank(left.priority).cmp(&priority_rank(right.priority)))
             .then(left.created_at.cmp(&right.created_at))
+            .then(left.id.cmp(&right.id))
     });
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
@@ -4,6 +4,7 @@ use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::backlog_exclusion::sort_tasks_for_automatic_dispatch;
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_layout, seed_list_backlog_task, write_workspace_file,
 };
@@ -135,6 +136,156 @@ fn list_backlog_tasks_preserves_existing_fields_without_conflicts() {
         ])
     );
     assert_eq!(output["excluded"], json!([]));
+}
+
+#[test]
+fn automatic_backlog_selection_prioritizes_critical_then_corrective_work() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let feature = seed_list_backlog_task(
+        &runtime,
+        "High feature",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Feature,
+        None,
+        vec![],
+    );
+    let bug = seed_list_backlog_task(
+        &runtime,
+        "Low bug",
+        TaskStatus::Backlog,
+        TaskPriority::Low,
+        TaskType::Bug,
+        None,
+        vec![],
+    );
+    let critical = seed_list_backlog_task(
+        &runtime,
+        "Critical feature",
+        TaskStatus::Backlog,
+        TaskPriority::Critical,
+        TaskType::Feature,
+        None,
+        vec![],
+    );
+
+    let output = list_backlog_tasks(&runtime, json!({ "max_tasks": 1 }));
+    assert_eq!(output["task_ids"], json!([critical.id]));
+
+    runtime
+        .update_task(
+            &critical.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            },
+        )
+        .expect("complete critical task");
+    let output = list_backlog_tasks(&runtime, json!({ "max_tasks": 1 }));
+    assert_eq!(output["task_ids"], json!([bug.id]));
+    assert_ne!(output["task_ids"], json!([feature.id]));
+}
+
+#[test]
+fn only_exact_review_tags_enter_the_corrective_band() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let title_only = runtime
+        .add_task(TaskAddParams {
+            title: "[code-review] Title provenance is not structured".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Selected deterministically".to_string()],
+            plan: "Fixture plan".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed title-only task");
+    let partial_tag = runtime
+        .add_task(TaskAddParams {
+            title: "Review sweep".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Selected deterministically".to_string()],
+            tags: vec!["code-review-sweep".to_string()],
+            plan: "Fixture plan".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed partial-tag task");
+    let unrelated_tag = runtime
+        .add_task(TaskAddParams {
+            title: "QA follow-up".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Selected deterministically".to_string()],
+            tags: vec!["review".to_string()],
+            plan: "Fixture plan".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed unrelated-tag task");
+    let code_review = runtime
+        .add_task(TaskAddParams {
+            title: "Confirmed code review finding".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Selected deterministically".to_string()],
+            tags: vec!["code-review".to_string()],
+            plan: "Fixture plan".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed code-review task");
+    let security_review = runtime
+        .add_task(TaskAddParams {
+            title: "Confirmed security review finding".to_string(),
+            description: "Fixture task".to_string(),
+            acceptance_criteria: vec!["Selected deterministically".to_string()],
+            tags: vec!["security-review".to_string()],
+            plan: "Fixture plan".to_string(),
+            status: Some(TaskStatus::Backlog),
+            task_type: Some(TaskType::Chore),
+            ..Default::default()
+        })
+        .expect("seed security-review task");
+
+    let output = list_backlog_tasks(&runtime, json!({}));
+
+    assert_eq!(
+        output_task_ids(&output),
+        vec![
+            code_review.id,
+            security_review.id,
+            title_only.id,
+            partial_tag.id,
+            unrelated_tag.id,
+        ]
+    );
+}
+
+#[test]
+fn automatic_dispatch_uses_task_id_as_the_total_tie_breaker() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut task_two = seed_list_backlog_task(
+        &runtime,
+        "Second ID",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let mut task_one = task_two.clone();
+    task_two.id = "ORB-00002".to_string();
+    task_one.id = "ORB-00001".to_string();
+    let mut tasks = vec![task_two, task_one];
+
+    sort_tasks_for_automatic_dispatch(&mut tasks);
+
+    assert_eq!(
+        tasks.into_iter().map(|task| task.id).collect::<Vec<_>>(),
+        vec!["ORB-00001", "ORB-00002"]
+    );
 }
 
 #[test]
@@ -512,11 +663,20 @@ fn list_backlog_tasks_omits_excluded_for_explicit_task_ids() {
         None,
         vec!["crates/foo/src/lib.rs"],
     );
+    let corrective = seed_list_backlog_task(
+        &runtime,
+        "Corrective task",
+        TaskStatus::Backlog,
+        TaskPriority::Low,
+        TaskType::Bug,
+        None,
+        vec![],
+    );
 
-    let output = list_backlog_tasks(&runtime, json!({ "task_ids": [backlog.id] }));
+    let output = list_backlog_tasks(&runtime, json!({ "task_ids": [backlog.id, corrective.id] }));
 
-    assert_eq!(output["task_count"], json!(1));
-    assert_eq!(output["task_ids"], json!([backlog.id]));
+    assert_eq!(output["task_count"], json!(2));
+    assert_eq!(output["task_ids"], json!([backlog.id, corrective.id]));
     assert!(output.get("excluded").is_none());
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -66,7 +66,7 @@ fn list_epic_descendants_err(
 }
 
 #[test]
-fn epic_descendants_are_dependency_then_priority_ordered_and_terminal_tasks_are_skipped() {
+fn epic_descendants_are_dependency_then_dispatch_ordered_and_terminal_tasks_are_skipped() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let epic = runtime
         .add_task(TaskAddParams {
@@ -116,6 +116,19 @@ fn epic_descendants_are_dependency_then_priority_ordered_and_terminal_tasks_are_
             ..Default::default()
         })
         .expect("seed independent");
+    let corrective = runtime
+        .add_task(TaskAddParams {
+            parent_id: Some(epic.id.clone()),
+            title: "Corrective".to_string(),
+            description: "Corrective fixture".to_string(),
+            acceptance_criteria: vec!["Done".to_string()],
+            plan: "Implement".to_string(),
+            priority: TaskPriority::Low,
+            task_type: Some(TaskType::Bug),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed corrective child");
     let done = runtime
         .add_task(TaskAddParams {
             parent_id: Some(epic.id.clone()),
@@ -131,9 +144,9 @@ fn epic_descendants_are_dependency_then_priority_ordered_and_terminal_tasks_are_
     let output = list_epic_descendants(&runtime, &epic.id);
     assert_eq!(
         output["task_ids"],
-        json!([independent.id, foundation.id, dependent.id])
+        json!([independent.id, corrective.id, foundation.id, dependent.id])
     );
-    assert_eq!(output["task_count"], 3);
+    assert_eq!(output["task_count"], 4);
     assert!(
         !output["task_ids"]
             .as_array()
@@ -322,6 +335,64 @@ fn two_loose_tasks_and_one_epic_root_are_admissible_together() {
     assert_eq!(second["epic_task_id"], epic.id);
     assert_eq!(second["loose_task_ids"], json!([]));
     assert_eq!(second["has_leaves"], false);
+}
+
+#[test]
+fn automatic_epic_root_choice_uses_the_shared_dispatch_order() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let high_feature = runtime
+        .add_task(TaskAddParams {
+            title: "High feature epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            priority: TaskPriority::High,
+            task_type: Some(TaskType::Feature),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed high feature epic");
+    let corrective = runtime
+        .add_task(TaskAddParams {
+            title: "Low security review epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string(), "security-review".to_string()],
+            plan: "Delegate children".to_string(),
+            priority: TaskPriority::Low,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed corrective epic");
+    let critical = runtime
+        .add_task(TaskAddParams {
+            title: "Critical refactor epic".to_string(),
+            description: "Epic fixture".to_string(),
+            acceptance_criteria: vec!["Supervised".to_string()],
+            tags: vec!["epic".to_string()],
+            plan: "Delegate children".to_string(),
+            priority: TaskPriority::Critical,
+            task_type: Some(TaskType::Refactor),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed critical epic");
+
+    assert_eq!(classify(&runtime)["epic_task_id"], critical.id);
+
+    runtime
+        .update_task(
+            &critical.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Done),
+                ..Default::default()
+            },
+        )
+        .expect("complete critical epic");
+    assert_eq!(classify(&runtime)["epic_task_id"], corrective.id);
+    assert_ne!(classify(&runtime)["epic_task_id"], high_feature.id);
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -8,7 +8,8 @@ use serde_json::{Value, json};
 use crate::OrbitRuntime;
 
 use super::backlog_exclusion::{
-    EpicFamilyMembership, epic_family_membership, list_backlog_tasks, sort_tasks_by_priority_age,
+    EpicFamilyMembership, epic_family_membership, list_backlog_tasks,
+    sort_tasks_for_automatic_dispatch,
 };
 
 /// The job that supervises one epic root. `classify_workspace_auto_tasks`
@@ -183,7 +184,7 @@ fn next_admissible_epic_root(
                 && task_dependencies_ready(task, &status_by_id)
         })
         .collect::<Vec<_>>();
-    sort_tasks_by_priority_age(&mut backlog_epics);
+    sort_tasks_for_automatic_dispatch(&mut backlog_epics);
     Ok(backlog_epics.into_iter().next().map(|epic| epic.id))
 }
 
@@ -367,7 +368,7 @@ pub(super) fn list_epic_descendants(
                 ),
             });
         }
-        sort_tasks_by_priority_age(&mut ready);
+        sort_tasks_for_automatic_dispatch(&mut ready);
         for task in ready {
             remaining.remove(&task.id);
             ordered.push(task.id);

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -60,7 +60,7 @@ a conservative title/status fallback.
 | [Orbit Core](./design/orbit-core/1_overview.md) | Directional application, runtime, adapter, bootstrap, and composition boundaries inside orbit-core. | Accepted | codex |
 | [Orbit Docs](./design/orbit-docs/1_overview.md) | Orbit Docs — the human-authored workspace corpus and how operators and agents retrieve from it. | Draft | claude |
 | [Orbit Docs Plugin](./design/orbit-docs-plugin/1_scope.md) | Scope: extract docs + search into a plugin-style feature crate | Draft | — |
-| [Semantic Search](./design/orbit-search/1_overview.md) | Semantic search is a local, offline-first retrieval layer over Orbit's task artifacts (phase 1) and, eventually, the knowledge-graph corpus (phase 2). | Draft | claude |
+| [Semantic Search](./design/orbit-search/1_overview.md) | Semantic search is a local, offline-first retrieval layer over Orbit's task artifacts and explicitly indexed docs. | Draft | claude |
 | [Policy & Sandboxing](./design/policy-sandbox/1_overview.md) | Policy & Sandboxing is Orbit's safety surface for filesystem access and process execution. | Draft | claude |
 | [Project Learnings](./design/project-learnings/4_decisions.md) | Project Learnings — Decisions | Superseded | claude |
 | [Remote Access](./design/remote-access/1_overview.md) | Multi-workspace Orbit Web serving and loopback-safe remote access over an SSH local forward. | Accepted | codex |


### PR DESCRIPTION
## Task

[ORB-11141](https://orbit-cli.com/tasks/ORB-11141) — Prioritize review and defect work in automatic dispatch

### Description

## Problem

Automatic backlog discovery for `orbit run ship` and `orbit run auto` currently orders ready tasks only by explicit priority and creation time. It does not distinguish corrective feedback-loop work from forward development, so features, refactors, and ordinary chores can consume bounded dispatch slots ahead of code-review findings, security-review work, or attributable defects.

## Why It Matters

Verified review, security, and defect work should close before Orbit expands product surface. This keeps automatic shipping biased toward restoring correctness and acting on feedback while retaining explicit operator control for emergencies and targeted dispatch.

## Required Policy

Use one deterministic automatic-dispatch ordering shared by `run ship` backlog discovery and `run auto`:

1. Critical tasks of any type or provenance.
2. Corrective work: `type: bug`, or an exact `code-review` or `security-review` tag.
3. All remaining feature, refactor, and ordinary chore work.

Within each band, retain priority ordering (`critical` → `high` → `medium` → `low`), then `created_at` ascending, then task ID ascending as a total deterministic tie-breaker. Exact structured task type and tags are authoritative; do not infer provenance from title prefixes.

## Constraints / Notes

- Put the rule in the shared automatic-selection seam rather than separate CLI or workflow wrappers.
- Preserve explicit task-ID dispatch as an operator override; do not reorder or subject explicit selections to automatic discovery policy.
- Preserve dependency readiness, epic-family exclusion, context-lock/group exclusion, bundling, crew partitioning, and empty-backlog behavior.
- Apply the ordering consistently to loose backlog tasks, automatic epic-root choice, and dependency-ready epic descendants, using each task's own fields.
- Precedence governs ordering and truncation under bounded capacity. It must not become a global hold that prevents otherwise admissible, conflict-free work from running concurrently.
- Keep the deterministic activity contract and current documentation synchronized. Do not add configuration or persisted schema solely for this fixed policy.

### Acceptance Criteria

- With automatic discovery capped to one task, a ready low-priority `bug` is selected ahead of a ready high-priority non-critical feature, while a critical task of any type is selected ahead of both.
- Ready chores carrying the exact `code-review` or `security-review` tag enter the corrective band; title prefixes and unrelated or partial-match tags do not affect ordering.
- Tasks within the same dispatch band sort by priority, then `created_at` ascending, then task ID ascending, with deterministic tests covering equal-priority/equal-time ties.
- `orbit run ship` with no explicit IDs and `orbit run auto` use the shared ordering for loose tasks; automatic epic-root choice and dependency-ready epic descendant ordering follow the same task-level policy.
- Explicit task-ID dispatch preserves caller control and existing explicit-selection behavior, including its ordering and admission semantics.
- Dependency readiness, context-lock and group exclusions, epic-family handling, bundling, crew partitioning, empty-backlog behavior, and conflict-free concurrency remain covered by regression tests.
- The `list_backlog_tasks` activity description documents the new ordering, and relevant targeted tests, `make ci-fast`, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced priority/age-only automatic backlog ordering with one shared deterministic dispatch policy: critical tasks, then bugs or exact code-review/security-review tags, then remaining work; ties use priority, created_at, and task ID.
- Applied the shared comparator to loose backlog discovery, automatic epic-root selection, and dependency-ready epic descendants while leaving explicit task-ID dispatch untouched.
- Added regression coverage for bounded selection, exact structured provenance, title/partial-tag non-matches, deterministic ID ties, explicit ordering/admission, epic-root choice, and descendant ordering; existing dependency, locking, epic-family, crew, concurrency, and empty-backlog tests remain passing.
- Updated the list_backlog_tasks activity contract. The required ci-fast gate also exposed a pre-existing stale generated docs index; regenerated its single changed summary line and added docs/INDEX.md to task scope.

Validation:
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::backlog_exclusion --lib (14 passed)
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::workspace_auto --lib (13 passed)
- make ci-fast (passed after regenerating docs/INDEX.md)
- make ci-lint (passed)
- git diff --check (passed)

Assessment: The policy lives at the existing shared task-level selection seam, uses only authoritative Task fields, preserves explicit operator control and existing admission paths, and introduces no schema, configuration, crate, or dependency changes.

Deviations from original plan:
- Retained the mechanically regenerated docs/INDEX.md line because the repository-required ci-fast check otherwise failed. Justification: the task acceptance criterion explicitly requires that gate to pass, and the generated change is minimal.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11141-6a94d938`
- Behind base: 0
- Ahead of base: 1