### PR TITLE
Extend Dependabot alert sweep to file Code scanning and secret scanning tasks

### DIFF
--- a/crates/orbit-core/assets/activities/collect_dependabot_alerts.yaml
+++ b/crates/orbit-core/assets/activities/collect_dependabot_alerts.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Query open Dependabot vulnerability alerts and open app/dependabot pull
-    requests on the engine-private host boundary using NoSandbox, then emit one
-    bounded and redacted snapshot. Missing gh, missing credentials, a 403
-    security_events-scope response, and a 404 unavailable-alerts response are
-    capability outcomes and never a clean no-alert result.
+    Query open Dependabot, Code scanning, and secret scanning alerts plus open
+    app/dependabot pull requests on the engine-private host boundary using
+    NoSandbox, then emit one bounded and redacted snapshot. Each security
+    family reports collection and capability independently. Secret values are
+    structurally excluded before the snapshot is encoded.
   input_schema_json:
     type: object
     properties:
@@ -22,6 +22,18 @@ spec:
         minimum: 1
         maximum: 100
       max_pull_requests:
+        type: number
+        minimum: 1
+        maximum: 100
+      max_code_scanning_alerts:
+        type: number
+        minimum: 1
+        maximum: 100
+      max_secret_scanning_alerts:
+        type: number
+        minimum: 1
+        maximum: 100
+      max_secret_locations:
         type: number
         minimum: 1
         maximum: 100
@@ -43,6 +55,8 @@ spec:
             type: string
           capability:
             type: object
+          collection_status:
+            type: string
           repository:
             type: object
           open_alerts:
@@ -55,5 +69,11 @@ spec:
             type: object
           collected_at:
             type: string
+          code_scanning:
+            type: object
+            required: [collected, collection_status, capability, outcome_hint, open_alerts]
+          secret_scanning:
+            type: object
+            required: [collected, collection_status, capability, outcome_hint, open_alerts]
   action: collect_dependabot_alerts
   config: {}

--- a/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Cluster a host-collected Dependabot snapshot by ecosystem, package, and
-    manifest path; report alerts below the severity floor; skip clusters with
-    an open Dependabot-authored pull request by default; dedupe against open
-    tasks using a digest of that stable triple; and file bounded evidence-complete
-    backlog tasks with no required tools.
+    File bounded, evidence-complete backlog tasks from a host-collected
+    Dependabot, Code scanning, and secret scanning snapshot. Preserve
+    Dependabot clustering, severity filtering, and PR skips; dedupe the other
+    families by repository and alert number; and enforce one max_tasks bound
+    across all families. Filed tasks require no tools.
   input_schema_json:
     type: object
     required: [dependabot_snapshot]
@@ -29,10 +29,14 @@ spec:
         maximum: 50
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_dependabot_pr, excluded_below_min_severity]
+    required: [outcome, collection_outcome, family_outcomes, clusters, filed_count, filed, skipped_existing, skipped_dependabot_pr, skipped_over_cap, excluded_below_min_severity]
     properties:
       outcome:
         type: string
+      collection_outcome:
+        type: string
+      family_outcomes:
+        type: object
       clusters:
         type: number
       filed_count:

--- a/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
@@ -9,6 +9,9 @@ spec:
   default_input:
     max_alerts: 100
     max_pull_requests: 100
+    max_code_scanning_alerts: 100
+    max_secret_scanning_alerts: 100
+    max_secret_locations: 20
     max_tasks: 10
     min_severity: high
     skip_when_dependabot_pr_open: true
@@ -18,6 +21,9 @@ spec:
       default_input:
         max_alerts: "{{ input.max_alerts }}"
         max_pull_requests: "{{ input.max_pull_requests }}"
+        max_code_scanning_alerts: "{{ input.max_code_scanning_alerts }}"
+        max_secret_scanning_alerts: "{{ input.max_secret_scanning_alerts }}"
+        max_secret_locations: "{{ input.max_secret_locations }}"
     - id: file
       target: activity:file_dependabot_alert_tasks
       default_input:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -1,4 +1,4 @@
-//! Turn a host-collected Dependabot snapshot into ordinary backlog tasks.
+//! Turn a host-collected repository security snapshot into ordinary backlog tasks.
 
 use std::collections::BTreeMap;
 
@@ -10,10 +10,16 @@ use sha2::{Digest, Sha256};
 use crate::OrbitRuntime;
 use crate::application::task::TaskAddParams;
 
-const SUPPORTED_SCHEMA_VERSION: u64 = 1;
-const TAG: &str = "dependabot-sweep";
-const KEY_PREFIX: &str = "dependabot:";
-const TITLE_PREFIX: &str = "[dependabot-sweep] ";
+const SUPPORTED_SCHEMA_VERSION: u64 = 2;
+const DEPENDABOT_TAG: &str = "dependabot-sweep";
+const DEPENDABOT_KEY_PREFIX: &str = "dependabot:";
+const DEPENDABOT_TITLE_PREFIX: &str = "[dependabot-sweep] ";
+const CODE_TAG: &str = "code-scanning-sweep";
+const CODE_KEY_PREFIX: &str = "code-scanning:";
+const CODE_TITLE_PREFIX: &str = "[code-scanning-sweep] ";
+const SECRET_TAG: &str = "secret-scanning-sweep";
+const SECRET_KEY_PREFIX: &str = "secret-scanning:";
+const SECRET_TITLE_PREFIX: &str = "[secret-scanning-sweep] ";
 const SYSTEM_CREW: &str = "system";
 const DEFAULT_MAX_TASKS: u64 = 10;
 const MAX_TASKS: u64 = 50;
@@ -37,19 +43,11 @@ pub(crate) fn file_dependabot_alert_tasks(
     let version = snapshot
         .get("schema_version")
         .and_then(Value::as_u64)
-        .unwrap_or(SUPPORTED_SCHEMA_VERSION);
+        .unwrap_or(1);
     if version > SUPPORTED_SCHEMA_VERSION {
         return Err(OrbitError::InvalidInput(format!(
-            "Dependabot snapshot schema version {version} is newer than supported version {SUPPORTED_SCHEMA_VERSION}"
+            "security-alert snapshot schema version {version} is newer than supported version {SUPPORTED_SCHEMA_VERSION}"
         )));
-    }
-    let capability = snapshot.get("capability").cloned().unwrap_or(Value::Null);
-    if snapshot.get("collected").and_then(Value::as_bool) != Some(true) {
-        return Ok(empty_output(
-            "capability_unavailable",
-            capability,
-            "Dependabot alerts could not be queried; this is not a clean vulnerability result",
-        ));
     }
 
     let floor_name = input
@@ -68,120 +66,179 @@ pub(crate) fn file_dependabot_alert_tasks(
         .get("skip_when_dependabot_pr_open")
         .and_then(Value::as_bool)
         .unwrap_or(true);
-    let alerts = snapshot
-        .get("open_alerts")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
-
-    let mut excluded_below_min_severity = Vec::new();
-    let mut grouped: BTreeMap<(String, String, String), Vec<Value>> = BTreeMap::new();
-    for alert in alerts {
-        let severity = field(alert, "severity").to_ascii_lowercase();
-        let rank = severity_rank(&severity).unwrap_or(0);
-        if rank < floor {
-            excluded_below_min_severity.push(json!({
-                "number": alert.get("number"),
-                "ecosystem": field(alert, "ecosystem"),
-                "package": field(alert, "package"),
-                "manifest_path": field(alert, "manifest_path"),
-                "severity": severity,
-            }));
-            continue;
-        }
-        let key = (
-            field(alert, "ecosystem"),
-            field(alert, "package"),
-            field(alert, "manifest_path"),
-        );
-        if key.0.is_empty() || key.1.is_empty() || key.2.is_empty() {
-            continue;
-        }
-        grouped.entry(key).or_default().push(alert.clone());
-    }
-
-    if grouped.is_empty() {
-        let mut output = empty_output(
-            if alerts.is_empty() {
-                "no_open_alerts"
-            } else {
-                "open_alerts"
-            },
-            capability,
-            "No open Dependabot alert met the configured severity floor",
-        );
-        output["min_severity"] = json!(floor_name);
-        output["excluded_below_min_severity"] = json!(excluded_below_min_severity);
-        return Ok(output);
-    }
-
-    let pull_requests = snapshot
-        .get("open_dependabot_pull_requests")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
     let system_crew = runtime
         .validate_crew_name(Some(SYSTEM_CREW))
         .is_ok()
         .then(|| SYSTEM_CREW.to_string());
+
     let mut filed = Vec::new();
     let mut skipped_existing = Vec::new();
     let mut skipped_dependabot_pr = Vec::new();
     let mut skipped_over_cap = Vec::new();
+    let mut excluded_below_min_severity = Vec::new();
+    let mut candidate_count = 0usize;
 
-    for ((ecosystem, package, manifest_path), mut cluster_alerts) in grouped {
-        cluster_alerts
-            .sort_by_key(|alert| alert.get("number").and_then(Value::as_u64).unwrap_or(0));
-        let key = digest(&ecosystem, &package, &manifest_path);
-        if let Some(task_id) = open_task_for_key(runtime, &key)? {
-            skipped_existing.push(json!({
-                "key": key, "task_id": task_id, "ecosystem": ecosystem,
-                "package": package, "manifest_path": manifest_path,
+    if snapshot.get("collected").and_then(Value::as_bool) == Some(true) {
+        let alerts = snapshot
+            .get("open_alerts")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let mut grouped: BTreeMap<(String, String, String), Vec<Value>> = BTreeMap::new();
+        for alert in alerts {
+            let severity = field(alert, "severity").to_ascii_lowercase();
+            let rank = severity_rank(&severity).unwrap_or(0);
+            if rank < floor {
+                excluded_below_min_severity.push(json!({
+                    "family": "dependabot",
+                    "number": alert.get("number"),
+                    "ecosystem": field(alert, "ecosystem"),
+                    "package": field(alert, "package"),
+                    "manifest_path": field(alert, "manifest_path"),
+                    "severity": severity,
+                }));
+                continue;
+            }
+            let key = (
+                field(alert, "ecosystem"),
+                field(alert, "package"),
+                field(alert, "manifest_path"),
+            );
+            if key.0.is_empty() || key.1.is_empty() || key.2.is_empty() {
+                continue;
+            }
+            grouped.entry(key).or_default().push(alert.clone());
+        }
+
+        let pull_requests = snapshot
+            .get("open_dependabot_pull_requests")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        candidate_count += grouped.len();
+        for ((ecosystem, package, manifest_path), mut cluster_alerts) in grouped {
+            cluster_alerts
+                .sort_by_key(|alert| alert.get("number").and_then(Value::as_u64).unwrap_or(0));
+            let key = digest(&[&ecosystem, &package, &manifest_path]);
+            if let Some(task_id) = open_task_for_key(runtime, DEPENDABOT_KEY_PREFIX, &key)? {
+                skipped_existing.push(json!({
+                    "family": "dependabot", "key": key, "task_id": task_id,
+                    "ecosystem": ecosystem, "package": package, "manifest_path": manifest_path,
+                }));
+                continue;
+            }
+            if skip_pr
+                && let Some(pull_request) = pull_requests
+                    .iter()
+                    .find(|pull_request| pull_request_mentions_package(pull_request, &package))
+            {
+                skipped_dependabot_pr.push(json!({
+                    "family": "dependabot", "key": key, "ecosystem": ecosystem,
+                    "package": package, "manifest_path": manifest_path,
+                    "pull_request": pull_request,
+                }));
+                continue;
+            }
+            if filed.len() >= max_tasks {
+                skipped_over_cap.push(json!({
+                    "family": "dependabot", "key": key, "ecosystem": ecosystem,
+                    "package": package, "manifest_path": manifest_path,
+                }));
+                continue;
+            }
+
+            let highest = cluster_alerts
+                .iter()
+                .filter_map(|alert| severity_rank(&field(alert, "severity").to_ascii_lowercase()))
+                .max()
+                .unwrap_or(floor);
+            let task = runtime.add_task(TaskAddParams {
+                title: dependabot_task_title(&package, &manifest_path),
+                description: dependabot_task_description(
+                    snapshot,
+                    &ecosystem,
+                    &package,
+                    &manifest_path,
+                    &cluster_alerts,
+                ),
+                acceptance_criteria: vec![
+                    format!("Bump `{package}` to a non-vulnerable version that resolves every alert listed in the task description."),
+                    format!("`{manifest_path}` and the repository lockfile agree on the resolved `{package}` version."),
+                    "The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.".to_string(),
+                ],
+                tags: vec![
+                    DEPENDABOT_TAG.to_string(),
+                    format!("{DEPENDABOT_KEY_PREFIX}{key}"),
+                    "security".to_string(),
+                ],
+                required_tools: Vec::new(),
+                crew: system_crew.clone(),
+                priority: priority_for_rank(highest),
+                complexity: TaskComplexity::Unassessed,
+                task_type: Some(TaskType::Bug),
+                status: Some(TaskStatus::Backlog),
+                system_created: true,
+                ..TaskAddParams::default()
+            })?;
+            filed.push(json!({
+                "family": "dependabot", "task_id": task.id, "key": key,
+                "ecosystem": ecosystem, "package": package, "manifest_path": manifest_path,
+                "alert_count": cluster_alerts.len(),
             }));
+        }
+    }
+
+    let repository = snapshot
+        .pointer("/repository/full_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown repository");
+    let mut code_alerts = family_alerts(snapshot, "code_scanning");
+    code_alerts.sort_by_key(alert_number);
+    candidate_count += code_alerts.len();
+    for alert in code_alerts {
+        let number = alert_number(&alert);
+        if number == 0 {
             continue;
         }
-        if skip_pr
-            && let Some(pull_request) = pull_requests
-                .iter()
-                .find(|pull_request| pull_request_mentions_package(pull_request, &package))
-        {
-            skipped_dependabot_pr.push(json!({
-                "key": key, "ecosystem": ecosystem, "package": package,
-                "manifest_path": manifest_path, "pull_request": pull_request,
+        let key = digest(&["code-scanning", repository, &number.to_string()]);
+        if let Some(task_id) = open_task_for_key(runtime, CODE_KEY_PREFIX, &key)? {
+            skipped_existing.push(json!({
+                "family": "code_scanning", "key": key, "task_id": task_id,
+                "alert_number": number,
             }));
             continue;
         }
         if filed.len() >= max_tasks {
             skipped_over_cap.push(json!({
-                "key": key, "ecosystem": ecosystem, "package": package,
-                "manifest_path": manifest_path,
+                "family": "code_scanning", "key": key, "alert_number": number,
             }));
             continue;
         }
-
-        let highest = cluster_alerts
-            .iter()
-            .filter_map(|alert| severity_rank(&field(alert, "severity").to_ascii_lowercase()))
-            .max()
-            .unwrap_or(floor);
+        let rule = field(&alert, "rule_id");
+        let path = field(&alert, "path");
+        let rank =
+            severity_rank(&field(&alert, "security_severity").to_ascii_lowercase()).unwrap_or(1);
         let task = runtime.add_task(TaskAddParams {
-            title: task_title(&package, &manifest_path),
-            description: task_description(
-                snapshot,
-                &ecosystem,
-                &package,
-                &manifest_path,
-                &cluster_alerts,
-            ),
+            title: code_task_title(&rule, &path),
+            description: code_task_description(snapshot, &alert),
             acceptance_criteria: vec![
-                format!("Bump `{package}` to a non-vulnerable version that resolves every alert listed in the task description."),
-                format!("`{manifest_path}` and the repository lockfile agree on the resolved `{package}` version."),
-                "The repository's documented pre-handoff checks pass without weakening security checks or suppressing the advisories.".to_string(),
+                format!(
+                    "Remediate Code scanning rule `{}` at `{}`{} with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.",
+                    display(&rule),
+                    display(&path),
+                    line_suffix(&alert),
+                ),
+                "Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.".to_string(),
+                "Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.".to_string(),
             ],
-            tags: vec![TAG.to_string(), format!("{KEY_PREFIX}{key}"), "security".to_string()],
+            tags: vec![
+                CODE_TAG.to_string(),
+                format!("{CODE_KEY_PREFIX}{key}"),
+                "security".to_string(),
+            ],
             required_tools: Vec::new(),
             crew: system_crew.clone(),
-            priority: priority_for_rank(highest),
+            priority: priority_for_rank(rank),
             complexity: TaskComplexity::Unassessed,
             task_type: Some(TaskType::Bug),
             status: Some(TaskStatus::Backlog),
@@ -189,16 +246,90 @@ pub(crate) fn file_dependabot_alert_tasks(
             ..TaskAddParams::default()
         })?;
         filed.push(json!({
-            "task_id": task.id, "key": key, "ecosystem": ecosystem,
-            "package": package, "manifest_path": manifest_path,
-            "alert_count": cluster_alerts.len(),
+            "family": "code_scanning", "task_id": task.id, "key": key,
+            "alert_number": number, "rule_id": rule, "path": path,
         }));
     }
 
+    let mut secret_alerts = family_alerts(snapshot, "secret_scanning");
+    secret_alerts.sort_by_key(alert_number);
+    candidate_count += secret_alerts.len();
+    for alert in secret_alerts {
+        let number = alert_number(&alert);
+        if number == 0 {
+            continue;
+        }
+        let key = digest(&["secret-scanning", repository, &number.to_string()]);
+        if let Some(task_id) = open_task_for_key(runtime, SECRET_KEY_PREFIX, &key)? {
+            skipped_existing.push(json!({
+                "family": "secret_scanning", "key": key, "task_id": task_id,
+                "alert_number": number,
+            }));
+            continue;
+        }
+        if filed.len() >= max_tasks {
+            skipped_over_cap.push(json!({
+                "family": "secret_scanning", "key": key, "alert_number": number,
+            }));
+            continue;
+        }
+        let secret_type = field(&alert, "secret_type");
+        let task = runtime.add_task(TaskAddParams {
+            title: secret_task_title(&secret_type, number),
+            description: secret_task_description(snapshot, &alert),
+            acceptance_criteria: vec![
+                "Remove the exposed credential from tracked content and repository history wherever applicable, without copying the credential into task updates, logs, commits, or artifacts.".to_string(),
+                "Replace the credential use with the repository's approved secret-management or configuration mechanism.".to_string(),
+                "Rotate or revoke the exposed credential and record explicit confirmation that rotation or revocation completed, without recording the credential value.".to_string(),
+                "Run the repository's documented validation and security checks and verify that no credential material was added to the repository.".to_string(),
+            ],
+            tags: vec![
+                SECRET_TAG.to_string(),
+                format!("{SECRET_KEY_PREFIX}{key}"),
+                "security".to_string(),
+            ],
+            required_tools: Vec::new(),
+            crew: system_crew.clone(),
+            priority: if field(&alert, "validity").eq_ignore_ascii_case("active") {
+                TaskPriority::Critical
+            } else {
+                TaskPriority::High
+            },
+            complexity: TaskComplexity::Unassessed,
+            task_type: Some(TaskType::Bug),
+            status: Some(TaskStatus::Backlog),
+            system_created: true,
+            ..TaskAddParams::default()
+        })?;
+        filed.push(json!({
+            "family": "secret_scanning", "task_id": task.id, "key": key,
+            "alert_number": number, "secret_type": secret_type,
+        }));
+    }
+
+    let family_outcomes = json!({
+        "dependabot": legacy_family_outcome(snapshot),
+        "code_scanning": nested_family_outcome(snapshot, "code_scanning"),
+        "secret_scanning": nested_family_outcome(snapshot, "secret_scanning"),
+    });
+    let collection_outcome = snapshot
+        .get("collection_status")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            if snapshot.get("collected").and_then(Value::as_bool) == Some(true) {
+                "partially_collected"
+            } else {
+                "capability_unavailable"
+            }
+        });
+    let outcome = overall_finding_outcome(&family_outcomes);
+
     Ok(json!({
-        "outcome": "open_alerts",
-        "capability": capability,
-        "clusters": filed.len() + skipped_existing.len() + skipped_dependabot_pr.len() + skipped_over_cap.len(),
+        "outcome": outcome,
+        "collection_outcome": collection_outcome,
+        "family_outcomes": family_outcomes,
+        "capability": snapshot.get("capability").cloned().unwrap_or(Value::Null),
+        "clusters": candidate_count,
         "filed_count": filed.len(),
         "filed": filed,
         "skipped_existing": skipped_existing,
@@ -211,22 +342,86 @@ pub(crate) fn file_dependabot_alert_tasks(
     }))
 }
 
-fn empty_output(outcome: &str, capability: Value, detail: &str) -> Value {
+fn family_alerts(snapshot: &Value, family: &str) -> Vec<Value> {
+    snapshot
+        .get(family)
+        .filter(|value| value.get("collected").and_then(Value::as_bool) == Some(true))
+        .and_then(|value| value.get("open_alerts"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn legacy_family_outcome(snapshot: &Value) -> Value {
+    let collected = snapshot.get("collected").and_then(Value::as_bool) == Some(true);
     json!({
-        "outcome": outcome, "capability": capability, "detail": detail,
-        "clusters": 0, "filed_count": 0, "filed": [], "skipped_existing": [],
-        "skipped_dependabot_pr": [], "skipped_over_cap": [],
-        "excluded_below_min_severity": [],
+        "collected": collected,
+        "collection": if collected {
+            if snapshot.get("query_errors").and_then(Value::as_array).is_some_and(|errors| !errors.is_empty()) {
+                "partially_collected"
+            } else { "fully_collected" }
+        } else { "capability_unavailable" },
+        "outcome": snapshot.get("outcome_hint").and_then(Value::as_str).unwrap_or("capability_unavailable"),
+        "capability": snapshot.get("capability").cloned().unwrap_or(Value::Null),
     })
 }
 
-fn task_title(package: &str, manifest_path: &str) -> String {
-    let budget = 120usize.saturating_sub(TITLE_PREFIX.chars().count());
-    let body = format!("Update {package} in {manifest_path}");
-    format!("{TITLE_PREFIX}{}", truncate_chars(&body, budget))
+fn nested_family_outcome(snapshot: &Value, family: &str) -> Value {
+    let Some(value) = snapshot.get(family) else {
+        return json!({
+            "collected": false,
+            "collection": "capability_unavailable",
+            "outcome": "capability_unavailable",
+            "capability": null,
+        });
+    };
+    json!({
+        "collected": value.get("collected").and_then(Value::as_bool).unwrap_or(false),
+        "collection": value.get("collection_status").and_then(Value::as_str).unwrap_or("capability_unavailable"),
+        "outcome": value.get("outcome_hint").and_then(Value::as_str).unwrap_or("capability_unavailable"),
+        "capability": value.get("capability").cloned().unwrap_or(Value::Null),
+    })
 }
 
-fn task_description(
+fn overall_finding_outcome(families: &Value) -> &'static str {
+    let outcomes = ["dependabot", "code_scanning", "secret_scanning"].map(|family| {
+        families
+            .get(family)
+            .and_then(|value| value.get("outcome"))
+            .and_then(Value::as_str)
+            .unwrap_or("capability_unavailable")
+    });
+    if outcomes.contains(&"open_alerts") {
+        "open_alerts"
+    } else if outcomes.contains(&"no_open_alerts") {
+        "no_open_alerts"
+    } else {
+        "capability_unavailable"
+    }
+}
+
+fn dependabot_task_title(package: &str, manifest_path: &str) -> String {
+    let budget = 120usize.saturating_sub(DEPENDABOT_TITLE_PREFIX.chars().count());
+    let body = format!("Update {package} in {manifest_path}");
+    format!("{DEPENDABOT_TITLE_PREFIX}{}", truncate_chars(&body, budget))
+}
+
+fn code_task_title(rule: &str, path: &str) -> String {
+    let budget = 120usize.saturating_sub(CODE_TITLE_PREFIX.chars().count());
+    let body = format!("Fix {} in {}", display(rule), display(path));
+    format!("{CODE_TITLE_PREFIX}{}", truncate_chars(&body, budget))
+}
+
+fn secret_task_title(secret_type: &str, number: u64) -> String {
+    let budget = 120usize.saturating_sub(SECRET_TITLE_PREFIX.chars().count());
+    let body = format!(
+        "Rotate exposed {} from alert #{number}",
+        display(secret_type)
+    );
+    format!("{SECRET_TITLE_PREFIX}{}", truncate_chars(&body, budget))
+}
+
+fn dependabot_task_description(
     snapshot: &Value,
     ecosystem: &str,
     package: &str,
@@ -245,10 +440,7 @@ fn task_description(
     } else {
         patched.join(", ")
     };
-    let repository = snapshot
-        .pointer("/repository/full_name")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown repository");
+    let repository = repository_name(snapshot);
     let mut out = format!(
         "This task was filed from a bounded, redacted Dependabot snapshot collected on the host before the task existed. The implementing agent does not need GitHub credentials.\n\n## Dependency bump\n\n- Repository: `{repository}`\n- Ecosystem: `{ecosystem}`\n- Package: `{package}`\n- Manifest path: `{manifest_path}`\n- First patched version: `{patched}`\n\n## Open alerts\n\n"
     );
@@ -271,15 +463,124 @@ fn task_description(
             display(&field(alert, "html_url")),
         ));
     }
-    if let Some(truncation) = snapshot.get("truncation") {
+    append_collection_bounds(&mut out, snapshot.get("truncation"));
+    out.push_str("\nUpdate the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.\n");
+    out
+}
+
+fn code_task_description(snapshot: &Value, alert: &Value) -> String {
+    let mut out = format!(
+        "This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.\n\n## Alert evidence\n\n- Repository: `{}`\n- Alert: `#{}`\n- Rule: `{}` ({})\n- Security severity: `{}`\n- Tool: `{}` (version `{}`, guid `{}`)\n- Message: {}\n- Ref: `{}`\n- Commit: `{}`\n- Location: `{}`{}\n- Created: `{}`\n- Updated: `{}`\n- Alert URL: {}\n",
+        repository_name(snapshot),
+        field(alert, "number"),
+        display(&field(alert, "rule_id")),
+        display(&field(alert, "rule_name")),
+        display(&field(alert, "security_severity")),
+        display(&field(alert, "tool_name")),
+        display(&field(alert, "tool_version")),
+        display(&field(alert, "tool_guid")),
+        display(&field(alert, "message")),
+        display(&field(alert, "ref")),
+        display(&field(alert, "commit_sha")),
+        display(&field(alert, "path")),
+        line_suffix(alert),
+        display(&field(alert, "created_at")),
+        display(&field(alert, "updated_at")),
+        display(&field(alert, "html_url")),
+    );
+    append_collection_bounds(&mut out, snapshot.pointer("/code_scanning/truncation"));
+    out.push_str("\nRemediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.\n");
+    out
+}
+
+fn secret_task_description(snapshot: &Value, alert: &Value) -> String {
+    let mut out = format!(
+        "This task was filed from a secret-scanning projection that structurally excluded the credential value on the engine-private host boundary. Do not attempt to recover or record the credential.\n\n## Non-secret alert evidence\n\n- Repository: `{}`\n- Alert: `#{}`\n- Secret type: `{}` ({})\n- Validity: `{}`\n- Publicly leaked: `{}`\n- Multi-repository: `{}`\n- Created: `{}`\n- Updated: `{}`\n- Alert URL: {}\n\n## Locations\n\n",
+        repository_name(snapshot),
+        field(alert, "number"),
+        display(&field(alert, "secret_type")),
+        display(&field(alert, "secret_type_display_name")),
+        display(&field(alert, "validity")),
+        display(&field(alert, "publicly_leaked")),
+        display(&field(alert, "multi_repo")),
+        display(&field(alert, "created_at")),
+        display(&field(alert, "updated_at")),
+        display(&field(alert, "html_url")),
+    );
+    let locations = alert
+        .get("locations")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    if locations.is_empty() {
+        out.push_str("- No non-secret location metadata was available; use the alert URL through an authorized human workflow.\n");
+    } else {
+        for location in locations {
+            out.push_str(&format!(
+                "- Type `{}`; path `{}`{}; commit `{}`; {}\n",
+                display(&field(location, "type")),
+                display(&field(location, "path")),
+                line_suffix(location),
+                display(&field(location, "commit_sha")),
+                display(&location_url(location)),
+            ));
+        }
+    }
+    if alert
+        .get("locations_at_cap")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        out.push_str(
+            "- Location collection reached its configured cap; further locations may exist.\n",
+        );
+    }
+    append_collection_bounds(&mut out, snapshot.pointer("/secret_scanning/truncation"));
+    out.push_str("\nClean the repository and its history where applicable, migrate use to the approved secret mechanism, and rotate or revoke the credential. Confirm rotation or revocation without recording the credential value.\n");
+    out
+}
+
+fn append_collection_bounds(out: &mut String, truncation: Option<&Value>) {
+    if let Some(truncation) = truncation {
         out.push_str("\n## Collection bounds\n\n");
         out.push_str(&format!(
             "```json\n{}\n```\n",
             serde_json::to_string_pretty(truncation).unwrap_or_default()
         ));
     }
-    out.push_str("\nUpdate the dependency and regenerate the lockfile through the repository's normal package-manager workflow. Verify that the manifest and lockfile agree and run the documented pre-handoff checks.\n");
-    out
+}
+
+fn location_url(location: &Value) -> String {
+    for key in [
+        "commit_url",
+        "blob_url",
+        "issue_url",
+        "pull_request_url",
+        "discussion_url",
+    ] {
+        let value = field(location, key);
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    "no location URL".to_string()
+}
+
+fn line_suffix(value: &Value) -> String {
+    let start = field(value, "start_line");
+    let end = field(value, "end_line");
+    match (start.is_empty(), end.is_empty(), start == end) {
+        (true, _, _) => String::new(),
+        (false, true, _) | (false, false, true) => format!(" line {start}"),
+        (false, false, false) => format!(" lines {start}-{end}"),
+    }
+}
+
+fn repository_name(snapshot: &Value) -> &str {
+    snapshot
+        .pointer("/repository/full_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown repository")
 }
 
 fn pull_request_mentions_package(pull_request: &Value, package: &str) -> bool {
@@ -292,8 +593,12 @@ fn pull_request_mentions_package(pull_request: &Value, package: &str) -> bool {
     })
 }
 
-fn open_task_for_key(runtime: &OrbitRuntime, key: &str) -> Result<Option<String>, OrbitError> {
-    let tag = format!("{KEY_PREFIX}{key}");
+fn open_task_for_key(
+    runtime: &OrbitRuntime,
+    prefix: &str,
+    key: &str,
+) -> Result<Option<String>, OrbitError> {
+    let tag = format!("{prefix}{key}");
     Ok(runtime
         .list_tasks_by_tags(std::slice::from_ref(&tag))?
         .into_iter()
@@ -308,8 +613,8 @@ fn open_task_for_key(runtime: &OrbitRuntime, key: &str) -> Result<Option<String>
 
 fn severity_rank(value: &str) -> Option<u8> {
     match value {
-        "low" => Some(1),
-        "moderate" | "medium" => Some(2),
+        "low" | "note" | "warning" => Some(1),
+        "moderate" | "medium" | "error" => Some(2),
         "high" => Some(3),
         "critical" => Some(4),
         _ => None,
@@ -320,13 +625,14 @@ fn priority_for_rank(rank: u8) -> TaskPriority {
     match rank {
         4.. => TaskPriority::Critical,
         3 => TaskPriority::High,
-        _ => TaskPriority::Medium,
+        2 => TaskPriority::Medium,
+        _ => TaskPriority::Low,
     }
 }
 
-fn digest(ecosystem: &str, package: &str, manifest_path: &str) -> String {
+fn digest(parts: &[&str]) -> String {
     let mut hasher = Sha256::new();
-    for part in [ecosystem, package, manifest_path] {
+    for part in parts {
         hasher.update(part.as_bytes());
         hasher.update([0]);
     }
@@ -354,10 +660,15 @@ fn bounded_u64(input: &Value, key: &str, default: u64, max: u64) -> Result<u64, 
     Ok(raw.min(max))
 }
 
+fn alert_number(value: &Value) -> u64 {
+    value.get("number").and_then(Value::as_u64).unwrap_or(0)
+}
+
 fn field(value: &Value, key: &str) -> String {
     match value.get(key) {
         Some(Value::String(text)) => text.trim().to_string(),
         Some(Value::Number(number)) => number.to_string(),
+        Some(Value::Bool(value)) => value.to_string(),
         _ => String::new(),
     }
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -31,6 +31,70 @@ fn snapshot(alerts: Vec<Value>, pull_requests: Vec<Value>) -> Value {
     })
 }
 
+fn expanded_snapshot(
+    dependabot: Vec<Value>,
+    code_scanning: Vec<Value>,
+    secret_scanning: Vec<Value>,
+) -> Value {
+    json!({
+        "schema_version": 2,
+        "collected": true,
+        "collection_status": "fully_collected",
+        "outcome_hint": if dependabot.is_empty() { "no_open_alerts" } else { "open_alerts" },
+        "capability": {"available": true, "authenticated": true, "detail": "authenticated"},
+        "repository": {"full_name": "acme/orbit"},
+        "open_alerts": dependabot,
+        "open_dependabot_pull_requests": [],
+        "query_errors": [],
+        "truncation": {"alerts_limit": 100, "alerts_at_cap": false},
+        "code_scanning": {
+            "collected": true,
+            "collection_status": "fully_collected",
+            "outcome_hint": if code_scanning.is_empty() { "no_open_alerts" } else { "open_alerts" },
+            "capability": {"available": true, "authenticated": true},
+            "open_alerts": code_scanning,
+            "query_errors": [],
+            "truncation": {"alerts_limit": 100, "alerts_at_cap": false}
+        },
+        "secret_scanning": {
+            "collected": true,
+            "collection_status": "fully_collected",
+            "outcome_hint": if secret_scanning.is_empty() { "no_open_alerts" } else { "open_alerts" },
+            "capability": {"available": true, "authenticated": true},
+            "open_alerts": secret_scanning,
+            "query_errors": [],
+            "truncation": {"alerts_limit": 100, "alerts_at_cap": false, "locations_limit_per_alert": 20}
+        },
+        "collected_at": "2026-08-31T00:00:00Z"
+    })
+}
+
+fn code_alert(number: u64, severity: &str) -> Value {
+    json!({
+        "number": number, "state": "open", "rule_id": "rust/sql-injection",
+        "rule_name": "SQL injection", "rule_description": "Untrusted input reaches SQL",
+        "security_severity": severity, "tool_name": "CodeQL", "tool_guid": "codeql-guid",
+        "tool_version": "2.20", "message": "User-controlled value reaches query",
+        "ref": "refs/heads/main", "commit_sha": "abc123", "path": "src/db.rs",
+        "start_line": 17, "end_line": 19, "start_column": 4, "end_column": 20,
+        "created_at": "2026-08-30T00:00:00Z", "updated_at": "2026-08-31T00:00:00Z",
+        "html_url": format!("https://github.test/code/{number}")
+    })
+}
+
+fn secret_alert(number: u64, validity: &str) -> Value {
+    json!({
+        "number": number, "state": "open", "secret_type": "example_token",
+        "secret_type_display_name": "Example token", "validity": validity,
+        "publicly_leaked": true, "multi_repo": false,
+        "created_at": "2026-08-30T00:00:00Z", "updated_at": "2026-08-31T00:00:00Z",
+        "html_url": format!("https://github.test/secret/{number}"),
+        "locations": [{"type": "commit", "path": "config/dev.env", "start_line": 3,
+            "end_line": 3, "commit_sha": "def456", "commit_url": "https://github.test/commit/def456"}],
+        "locations_at_cap": false
+    })
+}
+
 fn file(runtime: &OrbitRuntime, snapshot: Value, extra: Value) -> Value {
     let mut input = json!({"dependabot_snapshot": snapshot});
     if let (Some(target), Some(source)) = (input.as_object_mut(), extra.as_object()) {
@@ -195,4 +259,174 @@ fn filing_succeeds_without_a_system_crew() {
     assert_eq!(output["filed_count"], json!(1));
     let task_id = output["filed"][0]["task_id"].as_str().expect("task id");
     assert_eq!(runtime.get_task(task_id).expect("task").crew, None);
+}
+
+#[test]
+fn code_and_secret_alerts_file_evidence_complete_deduplicated_tasks() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let snapshot = expanded_snapshot(
+        Vec::new(),
+        vec![code_alert(8, "high")],
+        vec![secret_alert(9, "active")],
+    );
+    let first = file(&runtime, snapshot.clone(), json!({}));
+    assert_eq!(first["filed_count"], json!(2));
+    assert_eq!(first["outcome"], "open_alerts");
+    assert_eq!(first["collection_outcome"], "fully_collected");
+
+    let code_id = first["filed"]
+        .as_array()
+        .expect("filed")
+        .iter()
+        .find(|entry| entry["family"] == "code_scanning")
+        .and_then(|entry| entry["task_id"].as_str())
+        .expect("code task id");
+    let code = runtime.get_task(code_id).expect("code task");
+    assert!(code.title.starts_with("[code-scanning-sweep] "));
+    assert_eq!(code.status, TaskStatus::Backlog);
+    assert_eq!(code.priority, TaskPriority::High);
+    assert!(code.required_tools.is_empty());
+    for evidence in [
+        "rust/sql-injection",
+        "CodeQL",
+        "User-controlled value reaches query",
+        "refs/heads/main",
+        "abc123",
+        "src/db.rs",
+        "lines 17-19",
+        "https://github.test/code/8",
+    ] {
+        assert!(code.description.contains(evidence), "missing {evidence}");
+    }
+    assert!(
+        code.acceptance_criteria
+            .iter()
+            .any(|criterion| criterion.contains("do not suppress"))
+    );
+
+    let secret_id = first["filed"]
+        .as_array()
+        .expect("filed")
+        .iter()
+        .find(|entry| entry["family"] == "secret_scanning")
+        .and_then(|entry| entry["task_id"].as_str())
+        .expect("secret task id");
+    let secret = runtime.get_task(secret_id).expect("secret task");
+    assert!(secret.title.starts_with("[secret-scanning-sweep] "));
+    assert_eq!(secret.priority, TaskPriority::Critical);
+    assert!(secret.required_tools.is_empty());
+    assert!(secret.description.contains("config/dev.env"));
+    assert!(
+        secret
+            .acceptance_criteria
+            .iter()
+            .any(|criterion| criterion.contains("Rotate or revoke"))
+    );
+
+    let second = file(&runtime, snapshot, json!({}));
+    assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(
+        second["skipped_existing"]
+            .as_array()
+            .expect("existing")
+            .len(),
+        2
+    );
+    assert!(
+        second["skipped_existing"]
+            .as_array()
+            .expect("existing")
+            .iter()
+            .all(|entry| entry.get("family").is_some())
+    );
+}
+
+#[test]
+fn max_tasks_is_one_deterministic_bound_across_all_families() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let output = file(
+        &runtime,
+        expanded_snapshot(
+            vec![alert(1, "high", "< 1.2.3", "GHSA-first")],
+            vec![code_alert(2, "critical")],
+            vec![secret_alert(3, "active")],
+        ),
+        json!({"max_tasks": 1}),
+    );
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["family"], "dependabot");
+    let skipped = output["skipped_over_cap"].as_array().expect("over cap");
+    assert_eq!(skipped.len(), 2);
+    assert_eq!(skipped[0]["family"], "code_scanning");
+    assert_eq!(skipped[1]["family"], "secret_scanning");
+}
+
+#[test]
+fn sentinel_credential_never_reaches_snapshot_output_or_persisted_task_fields() {
+    const SENTINEL: &str = "orbit-sentinel-credential-2ce944";
+    let projected = orbit_tools::github_cli::project_secret_scanning_alert(&json!({
+        "number": 77, "state": "open", "secret_type": "example_token",
+        "secret_type_display_name": "Example token", "secret": SENTINEL,
+        "validity": "active", "publicly_leaked": false, "multi_repo": false,
+        "created_at": "2026-08-30T00:00:00Z", "updated_at": "2026-08-31T00:00:00Z",
+        "html_url": "https://github.test/secret/77"
+    }));
+    let mut projected = projected;
+    projected["locations"] = json!([{
+        "type": "commit", "path": "config/dev.env", "start_line": 3,
+        "end_line": 3, "commit_sha": "def456", "commit_url": "https://github.test/commit/def456"
+    }]);
+    projected["locations_at_cap"] = json!(false);
+    let snapshot = expanded_snapshot(Vec::new(), Vec::new(), vec![projected]);
+    assert!(
+        !serde_json::to_string(&snapshot)
+            .expect("snapshot")
+            .contains(SENTINEL)
+    );
+
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let output = file(&runtime, snapshot, json!({}));
+    assert!(
+        !serde_json::to_string(&output)
+            .expect("output")
+            .contains(SENTINEL)
+    );
+    let task_id = output["filed"][0]["task_id"].as_str().expect("task id");
+    let task = runtime.get_task(task_id).expect("task");
+    let persisted = json!({
+        "title": task.title,
+        "description": task.description,
+        "acceptance_criteria": task.acceptance_criteria,
+        "tags": task.tags,
+        "required_tools": task.required_tools,
+        "error": null,
+        "artifacts": [],
+        "captured_logs": [],
+    });
+    assert!(
+        !serde_json::to_string(&persisted)
+            .expect("persisted")
+            .contains(SENTINEL)
+    );
+}
+
+#[test]
+fn unavailable_family_does_not_hide_findings_from_collected_family() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let mut snapshot = expanded_snapshot(Vec::new(), vec![code_alert(15, "moderate")], Vec::new());
+    snapshot["collection_status"] = json!("partially_collected");
+    snapshot["secret_scanning"] = json!({
+        "collected": false,
+        "collection_status": "capability_unavailable",
+        "outcome_hint": "capability_unavailable",
+        "capability": {"available": false, "authenticated": true, "detail": "permission unavailable"}
+    });
+    let output = file(&runtime, snapshot, json!({}));
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["family"], "code_scanning");
+    assert_eq!(output["collection_outcome"], "partially_collected");
+    assert_eq!(
+        output["family_outcomes"]["secret_scanning"]["outcome"],
+        "capability_unavailable"
+    );
 }

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -268,6 +268,44 @@ fn dependabot_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
     );
     assert!(!yaml.contains("agent_loop"));
     assert!(!yaml.contains("worktree_setup"));
+    for expected in [
+        "max_alerts: 100",
+        "max_pull_requests: 100",
+        "max_code_scanning_alerts: 100",
+        "max_secret_scanning_alerts: 100",
+        "max_secret_locations: 20",
+        "max_tasks: 10",
+        "min_severity: high",
+        "skip_when_dependabot_pr_open: true",
+    ] {
+        assert!(yaml.contains(expected), "missing default {expected}");
+    }
+
+    let collect = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "collect_dependabot_alerts").then_some(*yaml))
+        .expect("collect activity default exists");
+    for field in [
+        "max_code_scanning_alerts:",
+        "max_secret_scanning_alerts:",
+        "max_secret_locations:",
+        "code_scanning:",
+        "secret_scanning:",
+        "collection_status:",
+    ] {
+        assert!(collect.contains(field), "collect schema missing {field}");
+    }
+    let file = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "file_dependabot_alert_tasks").then_some(*yaml))
+        .expect("file activity default exists");
+    for field in [
+        "collection_outcome:",
+        "family_outcomes:",
+        "skipped_over_cap:",
+    ] {
+        assert!(file.contains(field), "file schema missing {field}");
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
@@ -8,43 +8,165 @@ use crate::executor::automation::ci::AuthStatus;
 use crate::executor::automation::ci::bounded_u64;
 use crate::executor::automation::ci::optional_input_string;
 
-const SCHEMA_VERSION: u64 = 1;
+const SCHEMA_VERSION: u64 = 2;
 const DEFAULT_LIMIT: u64 = 100;
 const MAX_LIMIT: u64 = 100;
+const DEFAULT_LOCATION_LIMIT: u64 = 20;
+
+struct FamilyData {
+    collected: bool,
+    outcome: &'static str,
+    capability: Value,
+    alerts: Vec<Value>,
+}
+
+impl FamilyData {
+    fn collection_status(&self) -> &'static str {
+        if self.collected {
+            "fully_collected"
+        } else {
+            OUTCOME_CAPABILITY_UNAVAILABLE
+        }
+    }
+}
 
 pub(super) fn collect<Q: DependabotQueries + ?Sized>(
     queries: &Q,
     input: &Value,
 ) -> Result<Value, OrbitError> {
-    let limit = bounded_u64(input, "max_alerts", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let dependabot_limit = bounded_u64(input, "max_alerts", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let code_limit = bounded_u64(input, "max_code_scanning_alerts", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let secret_limit = bounded_u64(
+        input,
+        "max_secret_scanning_alerts",
+        DEFAULT_LIMIT,
+        MAX_LIMIT,
+    )?;
+    let location_limit = bounded_u64(
+        input,
+        "max_secret_locations",
+        DEFAULT_LOCATION_LIMIT,
+        MAX_LIMIT,
+    )?;
     let pr_limit = bounded_u64(input, "max_pull_requests", DEFAULT_LIMIT, MAX_LIMIT)?;
     let repo = optional_input_string(input, "repo");
     let auth = queries.auth_status();
     if !auth.usable() {
-        let detail = auth.detail.clone();
-        return capability_snapshot(auth, detail);
+        return unavailable_snapshot(&auth, &auth.detail);
     }
 
     let repository = queries.repo_view(repo.as_deref())?;
-    let alerts = match queries.open_alerts(repo.as_deref(), limit)? {
-        AlertQuery::Alerts(alerts) => alerts,
-        AlertQuery::CapabilityUnavailable(detail) => return capability_snapshot(auth, detail),
+    let dependabot = family_data(
+        queries.open_alerts(repo.as_deref(), dependabot_limit),
+        &auth,
+    );
+    let code_scanning = family_data(
+        queries.open_code_scanning_alerts(repo.as_deref(), code_limit),
+        &auth,
+    );
+    let mut secret_scanning = family_data(
+        queries.open_secret_scanning_alerts(repo.as_deref(), secret_limit),
+        &auth,
+    );
+
+    let mut dependabot_errors = Vec::new();
+    let pull_requests = if dependabot.collected {
+        match queries.open_dependabot_pull_requests(repo.as_deref(), pr_limit) {
+            Ok(pull_requests) => pull_requests,
+            Err(error) => {
+                dependabot_errors.push(json!({
+                    "query": "dependabot_pull_requests",
+                    "error": redact_all(&error.to_string()),
+                }));
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
     };
 
-    let mut query_errors = Vec::new();
-    let pull_requests = match queries.open_dependabot_pull_requests(repo.as_deref(), pr_limit) {
-        Ok(pull_requests) => pull_requests,
-        Err(error) => {
-            query_errors
-                .push(json!({"query": "dependabot_pull_requests", "error": error.to_string()}));
-            Vec::new()
+    let mut secret_errors = Vec::new();
+    let mut locations_at_cap = Vec::new();
+    if secret_scanning.collected {
+        for alert in &mut secret_scanning.alerts {
+            let Some(number) = alert.get("number").and_then(Value::as_u64) else {
+                secret_errors.push(json!({
+                    "query": "secret_scanning_locations",
+                    "error": "secret-scanning alert omitted its numeric identifier",
+                }));
+                continue;
+            };
+            match queries.secret_scanning_locations(repo.as_deref(), number, location_limit) {
+                Ok(locations) => {
+                    let at_cap = locations.len() as u64 == location_limit;
+                    if at_cap {
+                        locations_at_cap.push(number);
+                    }
+                    if let Some(object) = alert.as_object_mut() {
+                        object.insert(
+                            "locations".to_string(),
+                            Value::Array(locations.into_iter().map(bound_alert).collect()),
+                        );
+                        object.insert("locations_at_cap".to_string(), Value::Bool(at_cap));
+                    }
+                }
+                Err(error) => {
+                    secret_errors.push(json!({
+                        "query": "secret_scanning_locations",
+                        "alert_number": number,
+                        "error": redact_all(&error.to_string()),
+                    }));
+                    if let Some(object) = alert.as_object_mut() {
+                        object.insert("locations".to_string(), json!([]));
+                        object.insert("locations_at_cap".to_string(), Value::Bool(false));
+                    }
+                }
+            }
         }
-    };
-    let alerts_at_cap = alerts.len() as u64 == limit;
+    }
+
+    let dependabot_at_cap = dependabot.alerts.len() as u64 == dependabot_limit;
     let prs_at_cap = pull_requests.len() as u64 == pr_limit;
-    let notes = [
-        alerts_at_cap.then(|| {
-            format!("open alerts were listed at the {limit}-alert cap; further alerts may exist")
+    let code_at_cap = code_scanning.alerts.len() as u64 == code_limit;
+    let secret_at_cap = secret_scanning.alerts.len() as u64 == secret_limit;
+    let dependabot_status = if dependabot.collected && dependabot_errors.is_empty() {
+        "fully_collected"
+    } else if dependabot.collected {
+        "partially_collected"
+    } else {
+        OUTCOME_CAPABILITY_UNAVAILABLE
+    };
+    let secret_status = if secret_scanning.collected && secret_errors.is_empty() {
+        "fully_collected"
+    } else if secret_scanning.collected {
+        "partially_collected"
+    } else {
+        OUTCOME_CAPABILITY_UNAVAILABLE
+    };
+    let code_status = code_scanning.collection_status();
+    let collection_status =
+        aggregate_collection_status(&[dependabot_status, code_status, secret_status]);
+
+    let dependabot_alerts = dependabot
+        .alerts
+        .into_iter()
+        .map(bound_alert)
+        .collect::<Vec<_>>();
+    let code_alerts = code_scanning
+        .alerts
+        .into_iter()
+        .map(bound_alert)
+        .collect::<Vec<_>>();
+    let secret_alerts = secret_scanning
+        .alerts
+        .into_iter()
+        .map(bound_alert)
+        .collect::<Vec<_>>();
+    let dependabot_notes = [
+        dependabot_at_cap.then(|| {
+            format!(
+                "open alerts were listed at the {dependabot_limit}-alert cap; further alerts may exist"
+            )
         }),
         prs_at_cap.then(|| {
             format!(
@@ -55,46 +177,154 @@ pub(super) fn collect<Q: DependabotQueries + ?Sized>(
     .into_iter()
     .flatten()
     .collect::<Vec<_>>();
+    let code_notes = code_at_cap
+        .then(|| {
+            format!(
+                "open Code scanning alerts were listed at the {code_limit}-alert cap; further alerts may exist"
+            )
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut secret_notes = secret_at_cap
+        .then(|| {
+            format!(
+                "open secret scanning alerts were listed at the {secret_limit}-alert cap; further alerts may exist"
+            )
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !locations_at_cap.is_empty() {
+        secret_notes.push(format!(
+            "secret-scanning locations reached the {location_limit}-location cap for alerts {:?}; further locations may exist",
+            locations_at_cap
+        ));
+    }
+
     let snapshot = json!({
         "schema_version": SCHEMA_VERSION,
-        "collected": true,
-        "outcome_hint": if alerts.is_empty() { OUTCOME_NO_OPEN_ALERTS } else { OUTCOME_OPEN_ALERTS },
-        "capability": auth.to_json(),
+        "collected": dependabot.collected,
+        "outcome_hint": dependabot.outcome,
+        "capability": dependabot.capability,
+        "collection_status": collection_status,
         "repository": repository,
-        "open_alerts": alerts.into_iter().map(bound_alert).collect::<Vec<_>>(),
+        "open_alerts": dependabot_alerts,
         "open_dependabot_pull_requests": pull_requests.into_iter().map(bound_pull_request).collect::<Vec<_>>(),
-        "query_errors": query_errors,
+        "query_errors": dependabot_errors,
         "truncation": {
-            "alerts_limit": limit,
-            "alerts_at_cap": alerts_at_cap,
+            "alerts_limit": dependabot_limit,
+            "alerts_at_cap": dependabot_at_cap,
             "pull_requests_limit": pr_limit,
             "pull_requests_at_cap": prs_at_cap,
-            "notes": notes,
+            "notes": dependabot_notes,
+        },
+        "code_scanning": {
+            "collected": code_scanning.collected,
+            "collection_status": code_status,
+            "outcome_hint": code_scanning.outcome,
+            "capability": code_scanning.capability,
+            "open_alerts": code_alerts,
+            "query_errors": [],
+            "truncation": {"alerts_limit": code_limit, "alerts_at_cap": code_at_cap, "notes": code_notes},
+        },
+        "secret_scanning": {
+            "collected": secret_scanning.collected,
+            "collection_status": secret_status,
+            "outcome_hint": secret_scanning.outcome,
+            "capability": secret_scanning.capability,
+            "open_alerts": secret_alerts,
+            "query_errors": secret_errors,
+            "truncation": {
+                "alerts_limit": secret_limit,
+                "alerts_at_cap": secret_at_cap,
+                "locations_limit_per_alert": location_limit,
+                "locations_at_cap_alerts": locations_at_cap,
+                "notes": secret_notes,
+            },
         },
         "collected_at": chrono::Utc::now().to_rfc3339(),
     });
     redact_snapshot(snapshot)
 }
 
-fn capability_snapshot(auth: AuthStatus, detail: String) -> Result<Value, OrbitError> {
+fn family_data(result: Result<AlertQuery, OrbitError>, auth: &AuthStatus) -> FamilyData {
+    match result {
+        Ok(AlertQuery::Alerts(alerts)) => FamilyData {
+            collected: true,
+            outcome: if alerts.is_empty() {
+                OUTCOME_NO_OPEN_ALERTS
+            } else {
+                OUTCOME_OPEN_ALERTS
+            },
+            capability: auth.to_json(),
+            alerts,
+        },
+        Ok(AlertQuery::CapabilityUnavailable(detail)) => unavailable_family(auth, &detail),
+        Err(error) => unavailable_family(auth, &redact_all(&error.to_string())),
+    }
+}
+
+fn unavailable_family(auth: &AuthStatus, detail: &str) -> FamilyData {
+    FamilyData {
+        collected: false,
+        outcome: OUTCOME_CAPABILITY_UNAVAILABLE,
+        capability: json!({
+            "available": false,
+            "authenticated": auth.authenticated,
+            "detail": redact_all(detail),
+        }),
+        alerts: Vec::new(),
+    }
+}
+
+fn unavailable_snapshot(auth: &AuthStatus, detail: &str) -> Result<Value, OrbitError> {
+    let family = || {
+        json!({
+            "collected": false,
+            "collection_status": OUTCOME_CAPABILITY_UNAVAILABLE,
+            "outcome_hint": OUTCOME_CAPABILITY_UNAVAILABLE,
+            "capability": {
+                "available": auth.available,
+                "authenticated": auth.authenticated,
+                "detail": redact_all(detail),
+            },
+            "open_alerts": [],
+            "query_errors": [],
+        })
+    };
     redact_snapshot(json!({
         "schema_version": SCHEMA_VERSION,
         "collected": false,
+        "collection_status": OUTCOME_CAPABILITY_UNAVAILABLE,
         "outcome_hint": OUTCOME_CAPABILITY_UNAVAILABLE,
-        "capability": {
-            "available": auth.available,
-            "authenticated": auth.authenticated,
-            "detail": detail,
-        },
+        "capability": family()["capability"],
+        "code_scanning": family(),
+        "secret_scanning": family(),
         "collected_at": chrono::Utc::now().to_rfc3339(),
     }))
+}
+
+fn aggregate_collection_status(statuses: &[&str]) -> &'static str {
+    if statuses.iter().all(|status| *status == "fully_collected") {
+        "fully_collected"
+    } else if statuses
+        .iter()
+        .all(|status| *status == OUTCOME_CAPABILITY_UNAVAILABLE)
+    {
+        OUTCOME_CAPABILITY_UNAVAILABLE
+    } else {
+        "partially_collected"
+    }
 }
 
 fn bound_alert(mut alert: Value) -> Value {
     if let Some(object) = alert.as_object_mut() {
         for (key, value) in object.iter_mut() {
             if let Some(text) = value.as_str() {
-                let max = if key == "summary" { 300 } else { 500 };
+                let max = if matches!(key.as_str(), "summary" | "message" | "rule_description") {
+                    300
+                } else {
+                    500
+                };
                 *value = Value::String(one_line(text, max));
             }
         }
@@ -125,11 +355,11 @@ fn one_line(text: &str, max: usize) -> String {
 
 fn redact_snapshot(snapshot: Value) -> Result<Value, OrbitError> {
     let encoded = serde_json::to_string(&snapshot).map_err(|error| {
-        OrbitError::Execution(format!("failed to encode Dependabot snapshot: {error}"))
+        OrbitError::Execution(format!("failed to encode security-alert snapshot: {error}"))
     })?;
     serde_json::from_str(&redact_all(&encoded)).map_err(|error| {
         OrbitError::Execution(format!(
-            "failed to decode redacted Dependabot snapshot: {error}"
+            "failed to decode redacted security-alert snapshot: {error}"
         ))
     })
 }

--- a/crates/orbit-engine/src/executor/automation/dependabot/query.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/query.rs
@@ -18,6 +18,22 @@ pub(super) trait DependabotQueries {
     fn auth_status(&self) -> AuthStatus;
     fn repo_view(&self, repo: Option<&str>) -> Result<Value, OrbitError>;
     fn open_alerts(&self, repo: Option<&str>, limit: u64) -> Result<AlertQuery, OrbitError>;
+    fn open_code_scanning_alerts(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<AlertQuery, OrbitError>;
+    fn open_secret_scanning_alerts(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<AlertQuery, OrbitError>;
+    fn secret_scanning_locations(
+        &self,
+        repo: Option<&str>,
+        alert_number: u64,
+        limit: u64,
+    ) -> Result<Vec<Value>, OrbitError>;
     fn open_dependabot_pull_requests(
         &self,
         repo: Option<&str>,
@@ -45,6 +61,29 @@ impl HostDependabotQueries {
         let result = run_process(&request, &NoSandbox)?;
         check_exec_result(&result, label)?;
         Ok(result.stdout)
+    }
+
+    fn query_alert_family(
+        &self,
+        mut request: orbit_exec::ExecRequest,
+        family: &str,
+        project: fn(&Value) -> Value,
+    ) -> Result<AlertQuery, OrbitError> {
+        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
+        let result = run_process(&request, &NoSandbox)?;
+        if !result.success {
+            return Ok(AlertQuery::CapabilityUnavailable(classify_alert_failure(
+                family,
+                &result.stderr,
+            )));
+        }
+        let parsed = github_cli::parse_gh_json(&result.stdout, family)?;
+        let entries = parsed.as_array().ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "{family} returned a non-array response; refusing to report no open alerts"
+            ))
+        })?;
+        Ok(AlertQuery::Alerts(entries.iter().map(project).collect()))
     }
 }
 
@@ -99,24 +138,58 @@ impl DependabotQueries for HostDependabotQueries {
 
     fn open_alerts(&self, repo: Option<&str>, limit: u64) -> Result<AlertQuery, OrbitError> {
         let input = json!({"repo": repo, "limit": limit});
-        let mut request = github_cli::dependabot_alerts_request(&input)?;
-        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
-        let result = run_process(&request, &NoSandbox)?;
-        if !result.success {
-            return classify_alert_failure(&result.stderr).map(AlertQuery::CapabilityUnavailable);
-        }
-        let parsed = github_cli::parse_gh_json(&result.stdout, "gh api Dependabot alerts")?;
+        self.query_alert_family(
+            github_cli::dependabot_alerts_request(&input)?,
+            "gh api Dependabot alerts",
+            github_cli::project_dependabot_alert,
+        )
+    }
+
+    fn open_code_scanning_alerts(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<AlertQuery, OrbitError> {
+        let input = json!({"repo": repo, "limit": limit});
+        self.query_alert_family(
+            github_cli::code_scanning_alerts_request(&input)?,
+            "gh api Code scanning alerts",
+            github_cli::project_code_scanning_alert,
+        )
+    }
+
+    fn open_secret_scanning_alerts(
+        &self,
+        repo: Option<&str>,
+        limit: u64,
+    ) -> Result<AlertQuery, OrbitError> {
+        let input = json!({"repo": repo, "limit": limit});
+        self.query_alert_family(
+            github_cli::secret_scanning_alerts_request(&input)?,
+            "gh api secret scanning alerts",
+            github_cli::project_secret_scanning_alert,
+        )
+    }
+
+    fn secret_scanning_locations(
+        &self,
+        repo: Option<&str>,
+        alert_number: u64,
+        limit: u64,
+    ) -> Result<Vec<Value>, OrbitError> {
+        let input = json!({"repo": repo, "alert_number": alert_number, "limit": limit});
+        let request = github_cli::secret_scanning_locations_request(&input)?;
+        let stdout = self.run_gh(request, "gh api secret scanning alert locations")?;
+        let parsed = github_cli::parse_gh_json(&stdout, "gh api secret scanning alert locations")?;
         let entries = parsed.as_array().ok_or_else(|| {
             OrbitError::Execution(
-                "gh api Dependabot alerts returned a non-array response; refusing to report no open alerts"
-                    .to_string(),
+                "gh api secret scanning alert locations returned a non-array response".to_string(),
             )
         })?;
-        let alerts = entries
+        Ok(entries
             .iter()
-            .map(github_cli::project_dependabot_alert)
-            .collect();
-        Ok(AlertQuery::Alerts(alerts))
+            .map(github_cli::project_secret_location)
+            .collect())
     }
 
     fn open_dependabot_pull_requests(
@@ -140,20 +213,18 @@ impl DependabotQueries for HostDependabotQueries {
     }
 }
 
-pub(super) fn classify_alert_failure(stderr: &str) -> Result<String, OrbitError> {
+pub(super) fn classify_alert_failure(family: &str, stderr: &str) -> String {
     let detail = redact_all(stderr.trim());
     let lower = detail.to_ascii_lowercase();
     if lower.contains("403") {
-        return Ok(format!(
-            "GitHub returned HTTP 403 for Dependabot alerts; the host token lacks the security_events scope: {detail}"
-        ));
+        return format!(
+            "GitHub returned HTTP 403 for {family}; the host token lacks the required repository security permission: {detail}"
+        );
     }
     if lower.contains("404") {
-        return Ok(format!(
-            "GitHub returned HTTP 404 for Dependabot alerts; alerts are disabled or unavailable for this repository: {detail}"
-        ));
+        return format!(
+            "GitHub returned HTTP 404 for {family}; the feature is disabled or unavailable for this repository: {detail}"
+        );
     }
-    Err(OrbitError::Execution(format!(
-        "gh api Dependabot alerts failed: {detail}"
-    )))
+    format!("{family} could not be queried; refusing to report zero findings: {detail}")
 }

--- a/crates/orbit-engine/src/executor/automation/dependabot/tests.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/tests.rs
@@ -6,7 +6,30 @@ use super::query::{AlertQuery, DependabotQueries, classify_alert_failure};
 use crate::executor::automation::ci::AuthStatus;
 
 struct ScriptedQueries {
-    alerts: AlertQuery,
+    dependabot: AlertQuery,
+    code_scanning: AlertQuery,
+    secret_scanning: AlertQuery,
+    locations: Vec<Value>,
+    location_error: bool,
+}
+
+fn clone_query(query: &AlertQuery) -> AlertQuery {
+    match query {
+        AlertQuery::Alerts(alerts) => AlertQuery::Alerts(alerts.clone()),
+        AlertQuery::CapabilityUnavailable(detail) => {
+            AlertQuery::CapabilityUnavailable(detail.clone())
+        }
+    }
+}
+
+fn scripted(dependabot: AlertQuery) -> ScriptedQueries {
+    ScriptedQueries {
+        dependabot,
+        code_scanning: AlertQuery::Alerts(Vec::new()),
+        secret_scanning: AlertQuery::Alerts(Vec::new()),
+        locations: Vec::new(),
+        location_error: false,
+    }
 }
 
 impl DependabotQueries for ScriptedQueries {
@@ -17,17 +40,46 @@ impl DependabotQueries for ScriptedQueries {
             detail: "authenticated".to_string(),
         }
     }
+
     fn repo_view(&self, _repo: Option<&str>) -> Result<Value, OrbitError> {
         Ok(json!({"name": "orbit", "full_name": "acme/orbit", "default_branch": "main"}))
     }
+
     fn open_alerts(&self, _repo: Option<&str>, _limit: u64) -> Result<AlertQuery, OrbitError> {
-        Ok(match &self.alerts {
-            AlertQuery::Alerts(alerts) => AlertQuery::Alerts(alerts.clone()),
-            AlertQuery::CapabilityUnavailable(detail) => {
-                AlertQuery::CapabilityUnavailable(detail.clone())
-            }
-        })
+        Ok(clone_query(&self.dependabot))
     }
+
+    fn open_code_scanning_alerts(
+        &self,
+        _repo: Option<&str>,
+        _limit: u64,
+    ) -> Result<AlertQuery, OrbitError> {
+        Ok(clone_query(&self.code_scanning))
+    }
+
+    fn open_secret_scanning_alerts(
+        &self,
+        _repo: Option<&str>,
+        _limit: u64,
+    ) -> Result<AlertQuery, OrbitError> {
+        Ok(clone_query(&self.secret_scanning))
+    }
+
+    fn secret_scanning_locations(
+        &self,
+        _repo: Option<&str>,
+        _alert_number: u64,
+        _limit: u64,
+    ) -> Result<Vec<Value>, OrbitError> {
+        if self.location_error {
+            Err(OrbitError::Execution(
+                "permission unavailable for locations".to_string(),
+            ))
+        } else {
+            Ok(self.locations.clone())
+        }
+    }
+
     fn open_dependabot_pull_requests(
         &self,
         _repo: Option<&str>,
@@ -42,37 +94,92 @@ fn http_403_and_404_are_distinct_capability_outcomes_not_no_alerts() {
     for (stderr, expected) in [
         (
             "gh: Resource not accessible by integration (HTTP 403)",
-            "security_events",
+            "required repository security permission",
         ),
         (
-            "gh: Dependabot alerts are not enabled (HTTP 404)",
+            "gh: Code scanning is not enabled (HTTP 404)",
             "disabled or unavailable",
         ),
     ] {
-        let detail = classify_alert_failure(stderr).expect("classified capability response");
+        let detail = classify_alert_failure("Code scanning alerts", stderr);
         assert!(detail.contains(expected));
-        let output = collect(
-            &ScriptedQueries {
-                alerts: AlertQuery::CapabilityUnavailable(detail),
-            },
-            &json!({}),
-        )
-        .expect("collect capability snapshot");
-        assert_eq!(output["collected"], json!(false));
-        assert_eq!(output["outcome_hint"], json!("capability_unavailable"));
-        assert_ne!(output["outcome_hint"], json!("no_open_alerts"));
+        let mut queries = scripted(AlertQuery::Alerts(Vec::new()));
+        queries.code_scanning = AlertQuery::CapabilityUnavailable(detail);
+        let output = collect(&queries, &json!({})).expect("collect capability snapshot");
+        assert_eq!(output["code_scanning"]["collected"], json!(false));
+        assert_eq!(
+            output["code_scanning"]["outcome_hint"],
+            json!("capability_unavailable")
+        );
+        assert_ne!(
+            output["code_scanning"]["outcome_hint"],
+            json!("no_open_alerts")
+        );
+        assert_eq!(output["collected"], json!(true));
+        assert_eq!(output["collection_status"], json!("partially_collected"));
     }
 }
 
 #[test]
 fn empty_success_is_the_only_no_open_alerts_outcome() {
-    let output = collect(
-        &ScriptedQueries {
-            alerts: AlertQuery::Alerts(Vec::new()),
-        },
-        &json!({}),
-    )
-    .expect("collect empty snapshot");
+    let output = collect(&scripted(AlertQuery::Alerts(Vec::new())), &json!({}))
+        .expect("collect empty snapshot");
     assert_eq!(output["collected"], json!(true));
     assert_eq!(output["outcome_hint"], json!("no_open_alerts"));
+    assert_eq!(output["collection_status"], json!("fully_collected"));
+}
+
+#[test]
+fn secret_value_is_structurally_absent_and_location_truncation_is_explicit() {
+    const SENTINEL: &str = "orbit-sentinel-credential-7f21e6";
+    let mut queries = scripted(AlertQuery::Alerts(Vec::new()));
+    let projected = orbit_tools::github_cli::project_secret_scanning_alert(&json!({
+        "number": 41,
+        "state": "open",
+        "secret_type": "example_token",
+        "secret_type_display_name": "Example token",
+        "secret": SENTINEL,
+        "validity": "active",
+        "publicly_leaked": true,
+        "html_url": "https://github.test/acme/orbit/security/secret-scanning/41"
+    }));
+    queries.secret_scanning = AlertQuery::Alerts(vec![projected]);
+    queries.locations = vec![json!({
+        "type": "commit", "path": "config/dev.env", "start_line": 4,
+        "end_line": 4, "commit_sha": "abc123", "commit_url": "https://github.test/commit/abc123"
+    })];
+    let output =
+        collect(&queries, &json!({"max_secret_locations": 1})).expect("collect secret snapshot");
+    let encoded = serde_json::to_string(&output).expect("encode snapshot");
+    assert!(!encoded.contains(SENTINEL));
+    assert_eq!(
+        output["secret_scanning"]["open_alerts"][0]["locations"][0]["path"],
+        "config/dev.env"
+    );
+    assert_eq!(
+        output["secret_scanning"]["truncation"]["locations_at_cap_alerts"],
+        json!([41])
+    );
+}
+
+#[test]
+fn location_permission_failure_is_partial_not_zero_findings() {
+    let mut queries = scripted(AlertQuery::Alerts(Vec::new()));
+    queries.secret_scanning = AlertQuery::Alerts(vec![json!({
+        "number": 42, "secret_type": "example", "validity": "unknown"
+    })]);
+    queries.location_error = true;
+    let output = collect(&queries, &json!({})).expect("collect partial snapshot");
+    assert_eq!(
+        output["secret_scanning"]["collection_status"],
+        "partially_collected"
+    );
+    assert_eq!(output["secret_scanning"]["outcome_hint"], "open_alerts");
+    assert_eq!(
+        output["secret_scanning"]["query_errors"]
+            .as_array()
+            .expect("errors")
+            .len(),
+        1
+    );
 }

--- a/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
+++ b/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
@@ -32,7 +32,23 @@ fn repository_path(input: &Value) -> Result<String, OrbitError> {
 /// Build one bounded Dependabot-alert API request. This builder is deliberately
 /// unregistered: only engine-private host automation calls it.
 pub fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
-    let endpoint = format!("repos/{}/dependabot/alerts", repository_path(input)?);
+    build_alert_request(input, "dependabot")
+}
+
+/// Build one bounded Code scanning alert request. Deliberately unregistered:
+/// this is only available to engine-private host automation.
+pub fn build_code_scanning_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    build_alert_request(input, "code-scanning")
+}
+
+/// Build one bounded secret scanning alert request. Deliberately unregistered:
+/// this is only available to engine-private host automation.
+pub fn build_secret_scanning_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    build_alert_request(input, "secret-scanning")
+}
+
+fn build_alert_request(input: &Value, family: &str) -> Result<ExecRequest, OrbitError> {
+    let endpoint = format!("repos/{}/{family}/alerts", repository_path(input)?);
     let limit = super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?;
     let args = vec![
         "api".to_string(),
@@ -45,6 +61,35 @@ pub fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
         format!("per_page={limit}"),
     ];
     Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
+}
+
+/// Build a bounded request for the non-secret locations attached to one
+/// secret-scanning alert. The response is projected before it leaves the host.
+pub fn build_secret_locations_request(input: &Value) -> Result<ExecRequest, OrbitError> {
+    let number = input
+        .get("alert_number")
+        .and_then(Value::as_u64)
+        .filter(|number| *number > 0)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput("input.alert_number must be a positive integer".to_string())
+        })?;
+    let limit = super::bounded_limit(input, "limit", DEFAULT_LIMIT, MAX_LIMIT)?;
+    let endpoint = format!(
+        "repos/{}/secret-scanning/alerts/{number}/locations",
+        repository_path(input)?
+    );
+    Ok(super::gh_exec_request(
+        vec![
+            "api".to_string(),
+            "--method".to_string(),
+            "GET".to_string(),
+            endpoint,
+            "-F".to_string(),
+            format!("per_page={limit}"),
+        ],
+        None,
+        TIMEOUT_DEFAULT_MS,
+    ))
 }
 
 /// Build the bounded query used to discover Dependabot-authored open PRs.
@@ -97,5 +142,75 @@ pub fn project_pull_request(pr: &Value) -> Value {
         "url": pr["url"],
         "body": pr["body"],
         "author": pr["author"]["login"],
+    })
+}
+
+/// Project only remediation evidence from a Code scanning alert.
+pub fn project_code_scanning_alert(alert: &Value) -> Value {
+    json!({
+        "number": alert["number"],
+        "state": alert["state"],
+        "rule_id": alert["rule"]["id"],
+        "rule_name": alert["rule"]["name"],
+        "rule_description": alert["rule"]["description"],
+        "security_severity": alert["rule"]["security_severity_level"],
+        "tool_name": alert["tool"]["name"],
+        "tool_guid": alert["tool"]["guid"],
+        "tool_version": alert["tool"]["version"],
+        "message": alert["most_recent_instance"]["message"]["text"],
+        "ref": alert["most_recent_instance"]["ref"],
+        "commit_sha": alert["most_recent_instance"]["commit_sha"],
+        "path": alert["most_recent_instance"]["location"]["path"],
+        "start_line": alert["most_recent_instance"]["location"]["start_line"],
+        "end_line": alert["most_recent_instance"]["location"]["end_line"],
+        "start_column": alert["most_recent_instance"]["location"]["start_column"],
+        "end_column": alert["most_recent_instance"]["location"]["end_column"],
+        "created_at": alert["created_at"],
+        "updated_at": alert["updated_at"],
+        "html_url": alert["html_url"],
+    })
+}
+
+/// Project a secret-scanning alert without ever copying GitHub's `secret`
+/// member. This structural omission is the primary credential boundary;
+/// generic redaction remains a later defense in depth.
+pub fn project_secret_scanning_alert(alert: &Value) -> Value {
+    json!({
+        "number": alert["number"],
+        "state": alert["state"],
+        "secret_type": alert["secret_type"],
+        "secret_type_display_name": alert["secret_type_display_name"],
+        "validity": alert["validity"],
+        "publicly_leaked": alert["publicly_leaked"],
+        "multi_repo": alert["multi_repo"],
+        "created_at": alert["created_at"],
+        "updated_at": alert["updated_at"],
+        "html_url": alert["html_url"],
+    })
+}
+
+/// Project only documented, non-secret location metadata. In particular, no
+/// diff, snippet, or raw credential-shaped response member is retained.
+pub fn project_secret_location(location: &Value) -> Value {
+    let details = &location["details"];
+    json!({
+        "type": location["type"],
+        "path": details["path"],
+        "start_line": details["start_line"],
+        "end_line": details["end_line"],
+        "start_column": details["start_column"],
+        "end_column": details["end_column"],
+        "blob_sha": details["blob_sha"],
+        "blob_url": details["blob_url"],
+        "commit_sha": details["commit_sha"],
+        "commit_url": details["commit_url"],
+        "issue_title": details["issue_title"],
+        "issue_url": details["issue_url"],
+        "pull_request_title": details["pull_request_title"],
+        "pull_request_url": details["pull_request_url"],
+        "discussion_title": details["discussion_title"],
+        "discussion_url": details["discussion_url"],
+        "wiki_commit_sha": details["wiki_commit_sha"],
+        "user_login": details["user_login"],
     })
 }

--- a/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
@@ -48,6 +48,88 @@ fn dependabot_alert_request_rejects_repository_path_injection() {
 }
 
 #[test]
+fn code_and_secret_scanning_requests_are_bounded_and_validate_repository() {
+    for (request, endpoint) in [
+        (
+            dependabot_alerts::build_code_scanning_request(&json!({
+                "repo": "openai/orbit", "limit": 500
+            }))
+            .expect("code scanning request"),
+            "repos/openai/orbit/code-scanning/alerts",
+        ),
+        (
+            dependabot_alerts::build_secret_scanning_request(&json!({
+                "repo": "openai/orbit", "limit": 500
+            }))
+            .expect("secret scanning request"),
+            "repos/openai/orbit/secret-scanning/alerts",
+        ),
+    ] {
+        assert_eq!(request.args[3], endpoint);
+        assert_eq!(
+            request.args.last().map(String::as_str),
+            Some("per_page=100")
+        );
+        assert!(
+            request
+                .args
+                .windows(2)
+                .any(|pair| pair == ["-f", "state=open"])
+        );
+    }
+
+    let error = dependabot_alerts::build_secret_scanning_request(
+        &json!({"repo": "acme/repo?state=resolved"}),
+    )
+    .expect_err("invalid repo must fail");
+    assert!(error.to_string().contains("invalid `repo`"));
+}
+
+#[test]
+fn scanning_projections_retain_evidence_but_structurally_drop_secret() {
+    let code = dependabot_alerts::project_code_scanning_alert(&json!({
+        "number": 9,
+        "state": "open",
+        "rule": {"id": "rust/sql-injection", "name": "SQL injection", "description": "unsafe query", "security_severity_level": "high", "tags": ["security"]},
+        "tool": {"name": "CodeQL", "guid": "tool-guid", "version": "2.0"},
+        "most_recent_instance": {"ref": "refs/heads/main", "commit_sha": "abc123", "message": {"text": "user input reaches query"}, "location": {"path": "src/db.rs", "start_line": 17, "end_line": 19, "start_column": 4, "end_column": 20}, "classifications": ["test"]},
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-02T00:00:00Z", "html_url": "https://github.test/code/9",
+        "instances_url": "must not escape"
+    }));
+    assert_eq!(code["rule_id"], "rust/sql-injection");
+    assert_eq!(code["path"], "src/db.rs");
+    assert!(code.get("instances_url").is_none());
+
+    let sentinel = "orbit-sentinel-secret-99f0";
+    let secret = dependabot_alerts::project_secret_scanning_alert(&json!({
+        "number": 12, "state": "open", "secret_type": "example_token",
+        "secret_type_display_name": "Example token", "secret": sentinel,
+        "validity": "active", "publicly_leaked": false, "multi_repo": false,
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-02T00:00:00Z",
+        "html_url": "https://github.test/secret/12"
+    }));
+    assert_eq!(secret["secret_type"], "example_token");
+    assert!(
+        !serde_json::to_string(&secret)
+            .expect("encode")
+            .contains(sentinel)
+    );
+    assert!(secret.get("secret").is_none());
+
+    let location = dependabot_alerts::project_secret_location(&json!({
+        "type": "commit", "details": {"path": "config/dev.env", "start_line": 3,
+        "end_line": 3, "commit_sha": "def456", "commit_url": "https://github.test/commit/def456",
+        "diff": sentinel}
+    }));
+    assert_eq!(location["path"], "config/dev.env");
+    assert!(
+        !serde_json::to_string(&location)
+            .expect("encode")
+            .contains(sentinel)
+    );
+}
+
+#[test]
 fn run_list_applies_every_filter_and_caps_the_limit() {
     let req = run_list::build_exec_request(&json!({
         "branch": "release",

--- a/crates/orbit-tools/src/github_cli.rs
+++ b/crates/orbit-tools/src/github_cli.rs
@@ -18,10 +18,14 @@
 
 pub use crate::builtin::github::auth::build_exec_request as auth_status_request;
 pub use crate::builtin::github::dependabot_alerts::{
+    build_code_scanning_request as code_scanning_alerts_request,
     build_exec_request as dependabot_alerts_request,
     build_open_pull_requests_request as dependabot_pull_requests_request,
-    project_alert as project_dependabot_alert,
-    project_pull_request as project_dependabot_pull_request,
+    build_secret_locations_request as secret_scanning_locations_request,
+    build_secret_scanning_request as secret_scanning_alerts_request,
+    project_alert as project_dependabot_alert, project_code_scanning_alert,
+    project_pull_request as project_dependabot_pull_request, project_secret_location,
+    project_secret_scanning_alert,
 };
 pub use crate::builtin::github::pr_list::{
     build_exec_request as pr_list_request, project_pull_request,


### PR DESCRIPTION
## Task

[ORB-11143](https://orbit-cli.com/tasks/ORB-11143) — Extend Dependabot alert sweep to file Code scanning and secret scanning tasks

### Description

## Problem

The shipped `dependabot_alert_sweep_pipeline` collects open Dependabot vulnerability alerts and files deduplicated remediation tasks, but it does not inspect the other GitHub Security findings shown alongside Dependabot: Code scanning and secret scanning. Those open findings therefore remain outside Orbit's normal backlog and audit trail.

## Objective

Extend the existing two-stage sweep so the same scheduled pipeline also collects open repository Code scanning and secret scanning alerts on the engine-private host boundary and files ordinary evidence-complete backlog tasks for them.

Preserve the existing `dependabot_alert_sweep_pipeline`, activity names, routine, defaults, and Dependabot behavior. This is an extension of the shipped seam, not a rename, compatibility layer, new pipeline concept, or migration of already-seeded workspaces.

## Required behavior

- Add bounded host-only reads for `GET /repos/{owner}/{repo}/code-scanning/alerts?state=open` and `GET /repos/{owner}/{repo}/secret-scanning/alerts?state=open`. Keep the request builders unregistered and use the existing engine-private `NoSandbox` automation boundary; no GitHub credential or new `github.*` tool enters an agent lane.
- Project only the fields needed to remediate. Code scanning evidence should include the stable alert number, rule identity and security severity, tool, message, current ref/commit, path and line range, timestamps, and HTML URL.
- Secret scanning is a hard redaction boundary. GitHub's list response includes the actual `secret`; exclude that field before any snapshot, log, task description, output, artifact, or error can be persisted. Do not rely on generic redaction as the primary control. Collect bounded, non-secret location metadata when needed so a filed task remains actionable without exposing the credential value or requiring an agent-side GitHub query.
- Report collection and capability independently for Dependabot, Code scanning, and secret scanning. A 403, 404, disabled feature, missing repository permission, or per-family query failure must never be represented as a clean zero-findings result and must not discard successfully collected families. Preserve redaction in capability details and query errors.
- File one task per open Code scanning alert, deduped by a stable family-qualified key derived from repository identity and alert number. Carry the `[code-scanning-sweep] ` title prefix, a family-qualified dedupe tag, inline remediation evidence, `status: backlog`, empty `required_tools`, and the existing optional `system` crew behavior. Map GitHub security severity deterministically to Orbit priority.
- File one task per open secret scanning alert, deduped by a stable family-qualified key derived from repository identity and alert number. Carry the `[secret-scanning-sweep] ` title prefix, a family-qualified dedupe tag, secret type/display name, validity and public-leak metadata when present, bounded non-secret locations, timestamps, and the alert URL—but never the secret value. Active secrets map to critical priority; other open secret alerts map to high priority.
- Generated Code scanning criteria must identify the rule and affected location, require a real fix rather than suppression, and name the repository's normal validation. Generated secret scanning criteria must require removal from tracked content/history as applicable, replacement with the repository's approved secret/configuration mechanism, and explicit rotation or revocation confirmation without recording the credential.
- Keep task creation bounded by the existing `max_tasks` input across all three families. Use deterministic ordering, report every family-specific existing-task skip and over-cap skip, and make the output distinguish fully collected, partially collected, capability-unavailable, no-open-alert, and open-alert cases.
- The sweep remains read-only toward GitHub: no alert dismissal, autofix commit, secret rotation, pull-request creation, or other external mutation is in scope.

## Validation notes

Use deterministic fake responses for every API and failure mode. Include a sentinel secret value in tests and assert it is absent from the encoded snapshot, activity output, persisted task fields, errors, and captured logs. Preserve the existing Dependabot clustering, severity floor, Dependabot-PR skip, dedupe, and task-rendering tests unchanged in intent.

### Acceptance Criteria

- The existing `dependabot_alert_sweep_pipeline`, its two activity identities, its routine, and its current Dependabot defaults and behavior remain compatible; no new workflow concept, compatibility alias, or agent-facing GitHub tool is introduced.
- Bounded repository Code scanning and secret scanning request builders call the documented open-alert endpoints on the engine-private host boundary, validate any explicit repository input, project only required fields, and have focused request/projection tests.
- A secret-scanning fixture containing a unique sentinel credential proves that the `secret` field is removed before persistence and that the sentinel appears in none of the serialized snapshot, deterministic activity output, task title/description/criteria/tags, errors, artifacts, or captured logs; generic redaction remains defense in depth.
- Secret-scanning collection includes bounded non-secret location evidence sufficient to identify affected repository paths or other location types, and truncation is explicit when alert or location limits are reached.
- Dependabot, Code scanning, and secret scanning each carry an independent collected/capability outcome. Tests prove that 403, 404, disabled-feature, and permission-unavailable responses are not reported as zero findings, and that one unavailable family does not prevent tasks from successfully collected families.
- Each open Code scanning alert files at most one `[code-scanning-sweep] ` backlog task with a stable family-qualified dedupe tag, empty `required_tools`, optional validated `system` crew, deterministic severity-to-priority mapping, and inline rule/tool/message/ref/commit/location/URL evidence. Re-running the same alert files nothing.
- Each open secret scanning alert files at most one `[secret-scanning-sweep] ` backlog task with a stable family-qualified dedupe tag, empty `required_tools`, optional validated `system` crew, critical priority for active validity and high priority otherwise, and only non-secret metadata and locations. Re-running the same alert files nothing.
- Generated Code scanning tasks require remediation of the identified rule at the affected location without suppressing the finding; generated secret scanning tasks require repository cleanup plus explicit credential rotation or revocation confirmation without recording the credential.
- The existing `max_tasks` remains a deterministic bound across all task families; the filer output reports family-qualified `skipped_existing` and `skipped_over_cap` entries and distinguishes fully collected, partially collected, capability-unavailable, no-open-alert, and open-alert outcomes.
- No code path added by this task dismisses alerts, commits GitHub autofixes, rotates credentials, creates pull requests, or otherwise mutates GitHub state.
- Activity/job schemas and the embedded default-asset catalog/test mirrors cover the expanded inputs and outputs, while existing Dependabot tests remain unchanged in intent.
- `make ci-fast`, `make ci-lint`, focused orbit-tools/orbit-engine/orbit-core sweep tests, `cargo check --workspace --all-targets`, and the repository's applicable full test gate pass, with any unrelated baseline failure explicitly separated from candidate failures.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended the existing engine-private collect_dependabot_alerts seam with bounded Code scanning and secret scanning open-alert requests plus bounded secret-location reads. Repository input is validated, response projections retain only remediation evidence, and the secret projection structurally omits the GitHub secret field before serialization.
- Added independent per-family collection, capability, and outcome reporting, explicit alert/location truncation, redacted partial-query diagnostics, and continued collection when another security family is unavailable.
- Extended file_dependabot_alert_tasks without renaming the job or activities. Dependabot clustering, severity floor, PR skip, defaults, and v1 snapshot compatibility remain; Code scanning and secret scanning now file deterministic, family-deduplicated backlog tasks with empty required tools, optional validated system crew, inline safe evidence, and the required remediation criteria and priorities.
- Enforced the existing max_tasks limit across all three families and made existing and over-cap skips family-qualified.
- Expanded the shipped activity/job schemas and embedded catalog tests. Added focused request/projection, capability, truncation, dedupe, task-rendering, cross-family cap, and sentinel-credential tests.

Strategic decisions:
- Kept the existing pipeline and two activity identities as the only workflow seam and left the new GitHub builders unregistered.
- Preserved the existing top-level Dependabot snapshot contract while adding Code scanning and secret scanning as independently reported family objects.
- Used structural field projection as the primary secret boundary, with generic snapshot redaction only as defense in depth.

Validation:
- Passed focused orbit-tools discovery request/projection tests (14), orbit-engine security sweep tests (4), orbit-core filing tests (8), and the embedded Dependabot job catalog test.
- Passed make ci-lint.
- Passed cargo check --workspace --all-targets.
- Passed the full cargo test --workspace gate after removing managed activity ORBIT environment variables that otherwise alter CLI policy-preflight test fixtures.
- make ci-fast reached an unrelated baseline failure: docs/INDEX.md is stale. The task changes do not touch the docs corpus. Every remaining ci-fast guardrail was run separately and passed.
- git diff --check passed. Final status contains exactly 12 intended task-scoped modified files. Cargo-generated target artifacts were cleaned.

Assessment: The implementation satisfies the expanded read-only sweep contract while retaining established Dependabot behavior and keeping credential-bearing data out of every persisted path exercised by the tests.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11143-6a94d937`
- Behind base: 0
- Ahead of base: 1