### PR TITLE
Restrict CI failure sweep to the latest workflow run

### DIFF
--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -150,23 +150,28 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     let mut current: Vec<Value> = Vec::new();
     let mut stale: Vec<Value> = Vec::new();
     let mut in_flight: Vec<Value> = Vec::new();
-    let mut runs_listed = 0usize;
-
-    for scanned in &refs {
-        let runs = match queries.runs_for_branch(&scanned.branch, bounds.runs_per_ref) {
-            Ok(runs) => runs,
-            Err(error) => {
-                query_errors.push(json!({
-                    "query": "run_list",
-                    "branch": scanned.branch,
-                    "error": error.to_string(),
-                }));
-                continue;
-            }
-        };
-        runs_listed += runs.len();
-        partition_runs(scanned, &runs, &mut current, &mut stale, &mut in_flight);
+    // This query is deliberately repository-wide. Enumerating the integration,
+    // release, and open-PR refs separately lets an unchanged old ref keep an
+    // obsolete failure alive forever. One repository-wide list lets us choose
+    // exactly one latest run for every workflow represented in the snapshot.
+    let runs = match queries.repository_runs(bounds.runs_per_ref) {
+        Ok(runs) => runs,
+        Err(error) => {
+            query_errors.push(json!({
+                "query": "run_list",
+                "error": error.to_string(),
+            }));
+            Vec::new()
+        }
+    };
+    let runs_listed = runs.len();
+    if runs_listed as u64 == bounds.runs_per_ref {
+        notes.push(format!(
+            "repository-wide workflow runs were listed at the cap ({}); older workflows may be absent",
+            bounds.runs_per_ref
+        ));
     }
+    partition_runs(&refs, &runs, &mut current, &mut stale, &mut in_flight);
 
     sort_current_failures(&mut current);
     let discovered = current.len();
@@ -345,76 +350,78 @@ fn head_json(scanned: &ScannedRef) -> Value {
     })
 }
 
-/// Split one ref's runs into current failures, stale/superseded failures, and
-/// runs that have not produced a verdict yet.
+/// Evaluate exactly the latest repository-wide run for each workflow.
+///
+/// Older unsuccessful runs remain useful evidence, but they can never become
+/// current merely because the ref they ran on has not advanced. The latest run
+/// supersedes them regardless of branch, SHA, status, or conclusion.
 fn partition_runs(
-    scanned: &ScannedRef,
+    refs: &[ScannedRef],
     runs: &[Value],
     current: &mut Vec<Value>,
     stale: &mut Vec<Value>,
     in_flight: &mut Vec<Value>,
 ) {
+    let mut workflows = std::collections::BTreeMap::<String, Vec<&Value>>::new();
     for run in runs {
-        let reported = run.get("reported_head_sha").and_then(Value::as_str);
-        let at_current_head = match (scanned.head_sha.as_deref(), reported) {
-            (Some(head), Some(reported)) => head == reported,
-            // With no current head to compare against, staleness is unknowable;
-            // reporting the failure is the honest answer.
-            _ => true,
-        };
-        let completed = run.get("status").and_then(Value::as_str) == Some("completed");
-        let conclusion = run.get("conclusion").and_then(Value::as_str);
-
-        if !completed {
-            if at_current_head {
-                in_flight.push(run_summary(scanned, run));
-            }
-            continue;
-        }
-        if !unsuccessful_conclusion(conclusion) {
-            continue;
-        }
-        if !at_current_head {
-            let mut entry = run_summary(scanned, run);
-            entry["reason"] = json!("advanced_head");
-            entry["evidence"] = json!(format!(
-                "branch '{}' has advanced to {} since this run tested {}",
-                scanned.branch,
-                scanned.head_sha.as_deref().unwrap_or("an unknown commit"),
-                reported.unwrap_or("an unreported commit"),
-            ));
-            stale.push(entry);
-            continue;
-        }
-        if let Some(superseding) = superseding_success(runs, run) {
-            let mut entry = run_summary(scanned, run);
-            entry["reason"] = json!("superseded_by_success");
-            entry["superseded_by"] = json!({
-                "run_id": superseding.get("run_id"),
-                "url": superseding.get("url"),
-                "created_at": superseding.get("created_at"),
-            });
-            stale.push(entry);
-            continue;
-        }
-        current.push(run_summary(scanned, run));
+        let workflow = run
+            .get("workflow")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        workflows.entry(workflow).or_default().push(run);
     }
-}
 
-/// A later successful run of the same workflow at the same reported SHA.
-///
-/// Age alone is never enough to call a failure stale; this is the concrete
-/// evidence that supersedes one.
-fn superseding_success<'a>(runs: &'a [Value], failed: &Value) -> Option<&'a Value> {
-    let workflow = failed.get("workflow")?;
-    let sha = failed.get("reported_head_sha")?;
-    let order = run_order(failed);
-    runs.iter().find(|candidate| {
-        candidate.get("conclusion").and_then(Value::as_str) == Some("success")
-            && candidate.get("workflow") == Some(workflow)
-            && candidate.get("reported_head_sha") == Some(sha)
-            && run_order(candidate) > order
-    })
+    for workflow_runs in workflows.values_mut() {
+        workflow_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
+        let Some(latest) = workflow_runs.first().copied() else {
+            continue;
+        };
+
+        for older in workflow_runs.iter().skip(1).copied() {
+            let completed = older.get("status").and_then(Value::as_str) == Some("completed");
+            let conclusion = older.get("conclusion").and_then(Value::as_str);
+            if completed && unsuccessful_conclusion(conclusion) {
+                let mut entry = run_summary(ref_for_run(refs, older), older);
+                entry["reason"] = json!("superseded_by_newer_workflow_run");
+                entry["evidence"] = json!(format!(
+                    "newer run {} at {} is {} with conclusion {}",
+                    latest
+                        .get("run_id")
+                        .and_then(Value::as_u64)
+                        .map_or_else(|| "unknown".to_string(), |id| id.to_string()),
+                    latest
+                        .get("created_at")
+                        .and_then(Value::as_str)
+                        .unwrap_or("an unknown time"),
+                    latest
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("in an unknown state"),
+                    latest
+                        .get("conclusion")
+                        .and_then(Value::as_str)
+                        .unwrap_or("not yet completed"),
+                ));
+                entry["superseded_by"] = json!({
+                    "run_id": latest.get("run_id"),
+                    "url": latest.get("url"),
+                    "created_at": latest.get("created_at"),
+                    "status": latest.get("status"),
+                    "conclusion": latest.get("conclusion"),
+                });
+                stale.push(entry);
+            }
+        }
+
+        let completed = latest.get("status").and_then(Value::as_str) == Some("completed");
+        let summary = run_summary(ref_for_run(refs, latest), latest);
+        if !completed {
+            in_flight.push(summary);
+        } else if unsuccessful_conclusion(latest.get("conclusion").and_then(Value::as_str)) {
+            current.push(summary);
+        }
+    }
 }
 
 /// Sortable position of a run: creation time first, run id as the tiebreak.
@@ -428,7 +435,12 @@ fn run_order(run: &Value) -> (String, u64) {
     )
 }
 
-fn run_summary(scanned: &ScannedRef, run: &Value) -> Value {
+fn ref_for_run<'a>(refs: &'a [ScannedRef], run: &Value) -> Option<&'a ScannedRef> {
+    let branch = run.get("head_branch").and_then(Value::as_str)?;
+    refs.iter().find(|scanned| scanned.branch == branch)
+}
+
+fn run_summary(scanned: Option<&ScannedRef>, run: &Value) -> Value {
     json!({
         "run_id": run.get("run_id"),
         "workflow": run.get("workflow"),
@@ -439,14 +451,14 @@ fn run_summary(scanned: &ScannedRef, run: &Value) -> Value {
         "url": run.get("url"),
         "created_at": run.get("created_at"),
         "head_branch": run.get("head_branch"),
-        "ref_kind": scanned.kind.as_str(),
-        "pr_number": scanned.pr_number,
-        "pr_url": scanned.pr_url,
+        "ref_kind": scanned.map(|scanned| scanned.kind.as_str()).unwrap_or("other"),
+        "pr_number": scanned.and_then(|scanned| scanned.pr_number.clone()),
+        "pr_url": scanned.and_then(|scanned| scanned.pr_url.clone()),
         // Three commits that are routinely conflated and are kept apart here:
         // what the event reported, what the ref points at now, and — filled in
         // by `investigate` — what the runner actually checked out.
         "event_reported_head_sha": run.get("reported_head_sha"),
-        "current_ref_head_sha": scanned.head_sha,
+        "current_ref_head_sha": scanned.and_then(|scanned| scanned.head_sha.clone()),
         "actual_checkout_shas": Value::Array(Vec::new()),
         "investigated": false,
     })

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -91,7 +91,8 @@ pub(super) trait CiQueries {
     /// GitHub itself reports it, never inferred from a naming convention.
     fn repo_view(&self) -> Result<Value, OrbitError>;
     fn open_pull_requests(&self, limit: u64) -> Result<Vec<Value>, OrbitError>;
-    fn runs_for_branch(&self, branch: &str, limit: u64) -> Result<Vec<Value>, OrbitError>;
+    /// Recent runs across the whole repository, without a branch filter.
+    fn repository_runs(&self, limit: u64) -> Result<Vec<Value>, OrbitError>;
     fn run_view(&self, run_id: &str) -> Result<Value, OrbitError>;
     fn run_logs(
         &self,
@@ -188,8 +189,8 @@ impl CiQueries for HostCiQueries {
             .unwrap_or_default())
     }
 
-    fn runs_for_branch(&self, branch: &str, limit: u64) -> Result<Vec<Value>, OrbitError> {
-        let request = github_cli::run_list_request(&json!({"branch": branch, "limit": limit}))?;
+    fn repository_runs(&self, limit: u64) -> Result<Vec<Value>, OrbitError> {
+        let request = github_cli::run_list_request(&json!({"limit": limit}))?;
         let stdout = self.run_gh(request, "gh run list")?;
         let parsed = github_cli::parse_gh_json(&stdout, "gh run list")?;
         Ok(parsed

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1,7 +1,7 @@
 use serde_json::{Value, json};
 
 use super::super::collect::collect;
-use super::support::{FakeQueries, run};
+use super::support::{FakeQueries, run, run_on_branch};
 
 const HEAD: &str = "1111111111111111111111111111111111111111";
 const OLD: &str = "2222222222222222222222222222222222222222";
@@ -33,10 +33,14 @@ fn separates_event_sha_current_head_and_actual_checkout_commit() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
-        .with_runs(
-            "topic",
-            vec![vec![run(10, "ci", HEAD, "completed", Some("failure"), "2026-08-30T01:00:00Z")]],
-        )
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
         .with_run_view(
             "10",
             json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
@@ -68,41 +72,60 @@ fn separates_event_sha_current_head_and_actual_checkout_commit() {
 }
 
 #[test]
-fn advanced_head_and_superseding_success_are_stale_not_current() {
+fn latest_non_failing_run_supersedes_older_failures_across_refs_and_shas() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
-        .with_runs(
-            "topic",
-            vec![vec![
-                // Superseded: a later success of the same workflow at the same SHA.
-                run(
-                    30,
-                    "ci",
-                    HEAD,
-                    "completed",
-                    Some("success"),
-                    "2026-08-30T03:00:00Z",
-                ),
-                run(
-                    20,
-                    "ci",
-                    HEAD,
-                    "completed",
-                    Some("failure"),
-                    "2026-08-30T02:00:00Z",
-                ),
-                // Stale: the branch has moved past the commit this run tested.
-                run(
-                    10,
-                    "lint",
-                    OLD,
-                    "completed",
-                    Some("failure"),
-                    "2026-08-30T01:00:00Z",
-                ),
-            ]],
-        );
+        .with_runs(vec![vec![
+            // The latest CI run is successful on the release branch and a
+            // different SHA. Both older CI failures are stale even though the
+            // old topic ref still points at one failure's SHA.
+            run_on_branch(
+                30,
+                "ci",
+                "main",
+                OLD,
+                "completed",
+                Some("success"),
+                "2026-08-30T03:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T02:00:00Z",
+            ),
+            run_on_branch(
+                10,
+                "ci",
+                "old-pr",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T01:00:00Z",
+            ),
+            // A completed non-failing conclusion has the same authority as a
+            // success for another workflow.
+            run(
+                40,
+                "docs",
+                HEAD,
+                "completed",
+                Some("skipped"),
+                "2026-08-30T04:00:00Z",
+            ),
+            run(
+                35,
+                "docs",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T03:30:00Z",
+            ),
+        ]]);
 
     let evidence = collect(&queries, &input()).expect("collect");
 
@@ -114,34 +137,162 @@ fn advanced_head_and_superseding_success_are_stale_not_current() {
         .iter()
         .filter_map(|entry| entry["reason"].as_str())
         .collect();
-    assert_eq!(reasons, ["superseded_by_success", "advanced_head"]);
-    assert!(
-        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"] == json!(30),
-        "supersession must cite the run that supersedes: {evidence}"
+    assert_eq!(
+        reasons,
+        [
+            "superseded_by_newer_workflow_run",
+            "superseded_by_newer_workflow_run",
+            "superseded_by_newer_workflow_run",
+        ]
     );
+    let superseding_ids: Vec<u64> = evidence["stale_or_superseded"]
+        .as_array()
+        .expect("stale array")
+        .iter()
+        .filter_map(|entry| entry["superseded_by"]["run_id"].as_u64())
+        .collect();
+    assert_eq!(superseding_ids, [30, 30, 40]);
 }
 
 #[test]
-fn queued_runs_at_the_current_head_are_in_flight_not_failures() {
+fn latest_in_flight_run_does_not_resurrect_an_older_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
-        .with_runs(
-            "topic",
-            vec![vec![run(
-                40,
+        .with_runs(vec![vec![
+            run(40, "ci", HEAD, "in_progress", None, "2026-08-30T04:00:00Z"),
+            run(
+                30,
                 "ci",
                 HEAD,
-                "in_progress",
-                None,
-                "2026-08-30T04:00:00Z",
-            )]],
-        );
+                "completed",
+                Some("failure"),
+                "2026-08-30T03:00:00Z",
+            ),
+            run(50, "lint", HEAD, "queued", None, "2026-08-30T05:00:00Z"),
+            run(
+                45,
+                "lint",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T04:30:00Z",
+            ),
+        ]]);
 
     let evidence = collect(&queries, &input()).expect("collect");
 
     assert_eq!(evidence["current_failures"], json!([]));
-    assert_eq!(evidence["in_flight"][0]["run_id"], json!(40));
+    let in_flight_ids: Vec<u64> = evidence["in_flight"]
+        .as_array()
+        .expect("in flight")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect();
+    assert_eq!(in_flight_ids, [40, 50]);
+    let stale_ids: Vec<u64> = evidence["stale_or_superseded"]
+        .as_array()
+        .expect("stale")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect();
+    assert_eq!(stale_ids, [30, 45]);
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["superseded_by"]["status"],
+        json!("in_progress")
+    );
+}
+
+#[test]
+fn old_dependabot_failure_is_superseded_by_newer_repository_ci_run() {
+    const DEPENDABOT_SHA: &str = "0f14f3f2ad2c863f902c0add969ff09d10e3f15c";
+    const OLD_RUN_ID: u64 = 31_583_558_682;
+
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_pull_request(json!({
+            "number": 959,
+            "url": "https://github.com/acme/orbit/pull/959",
+            "head_branch": "dependabot/cargo/old",
+            "reported_head_sha": DEPENDABOT_SHA,
+        }))
+        .with_runs(vec![vec![
+            run_on_branch(
+                OLD_RUN_ID + 100,
+                "CI",
+                "main",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-08-31T02:00:00Z",
+            ),
+            run_on_branch(
+                OLD_RUN_ID,
+                "CI",
+                "dependabot/cargo/old",
+                DEPENDABOT_SHA,
+                "completed",
+                Some("failure"),
+                "2026-08-20T01:00:00Z",
+            ),
+        ]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["run_id"],
+        json!(OLD_RUN_ID)
+    );
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["ref_kind"],
+        json!("pull_request")
+    );
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["investigated"],
+        json!(false),
+        "a superseded run must never consume investigation or filing input: {evidence}"
+    );
+}
+
+#[test]
+fn latest_selection_is_independent_per_workflow_and_breaks_ties_by_run_id() {
+    let tied_at = "2026-08-30T05:00:00Z";
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![
+            // Higher run ID wins the CI tie and suppresses its failure.
+            run(52, "ci", HEAD, "completed", Some("success"), tied_at),
+            run(51, "ci", HEAD, "completed", Some("failure"), tied_at),
+            // Selecting CI must not hide lint's independently latest run.
+            run(61, "lint", HEAD, "completed", Some("failure"), tied_at),
+            run(
+                60,
+                "lint",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-08-30T04:00:00Z",
+            ),
+        ]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    let current_ids: Vec<u64> = evidence["current_failures"]
+        .as_array()
+        .expect("current failures")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect();
+    assert_eq!(current_ids, [61]);
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(51));
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
+        json!(52)
+    );
 }
 
 #[test]
@@ -149,27 +300,24 @@ fn derives_release_head_from_github_and_reports_every_bound_it_hit() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", OLD)
-        .with_runs(
-            "topic",
-            vec![vec![
-                run(
-                    51,
-                    "a",
-                    HEAD,
-                    "completed",
-                    Some("failure"),
-                    "2026-08-30T05:00:00Z",
-                ),
-                run(
-                    52,
-                    "b",
-                    HEAD,
-                    "completed",
-                    Some("failure"),
-                    "2026-08-30T05:00:00Z",
-                ),
-            ]],
-        );
+        .with_runs(vec![vec![
+            run(
+                51,
+                "a",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T05:00:00Z",
+            ),
+            run(
+                52,
+                "b",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T05:00:00Z",
+            ),
+        ]]);
 
     let evidence = collect(
         &queries,
@@ -222,17 +370,14 @@ fn empty_failed_step_log_is_recorded_in_query_errors() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
-        .with_runs(
-            "topic",
-            vec![vec![run(
-                10,
-                "ci",
-                HEAD,
-                "completed",
-                Some("failure"),
-                "2026-08-30T01:00:00Z",
-            )]],
-        )
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
         .with_run_view(
             "10",
             json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),

--- a/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
@@ -19,9 +19,9 @@ pub(super) struct FakeQueries {
     pub(super) repo: Value,
     pub(super) pull_requests: Vec<Value>,
     pub(super) branch_heads: HashMap<String, String>,
-    /// Runs per branch. A `Vec` of pages: each `runs_for_branch` call pops the
-    /// next page, so a test can make CI progress between calls.
-    pub(super) runs: Mutex<HashMap<String, Vec<Vec<Value>>>>,
+    /// Repository-wide run pages. Each `repository_runs` call pops the next
+    /// page, so a test can make CI progress between calls.
+    pub(super) runs: Mutex<Vec<Vec<Value>>>,
     pub(super) run_views: HashMap<String, Value>,
     pub(super) logs: HashMap<(String, bool), String>,
 }
@@ -60,11 +60,13 @@ impl FakeQueries {
         self
     }
 
-    pub(super) fn with_runs(self, branch: &str, pages: Vec<Vec<Value>>) -> Self {
-        self.runs
-            .lock()
-            .expect("runs lock")
-            .insert(branch.to_string(), pages);
+    pub(super) fn with_pull_request(mut self, pull_request: Value) -> Self {
+        self.pull_requests.push(pull_request);
+        self
+    }
+
+    pub(super) fn with_runs(self, pages: Vec<Vec<Value>>) -> Self {
+        *self.runs.lock().expect("runs lock") = pages;
         self
     }
 
@@ -102,15 +104,12 @@ impl CiQueries for FakeQueries {
             .collect())
     }
 
-    fn runs_for_branch(&self, branch: &str, _limit: u64) -> Result<Vec<Value>, OrbitError> {
+    fn repository_runs(&self, _limit: u64) -> Result<Vec<Value>, OrbitError> {
         let mut runs = self.runs.lock().expect("runs lock");
-        let Some(pages) = runs.get_mut(branch) else {
-            return Ok(Vec::new());
-        };
-        if pages.len() > 1 {
-            Ok(pages.remove(0))
+        if runs.len() > 1 {
+            Ok(runs.remove(0))
         } else {
-            Ok(pages.first().cloned().unwrap_or_default())
+            Ok(runs.first().cloned().unwrap_or_default())
         }
     }
 
@@ -161,4 +160,18 @@ pub(super) fn run(
         "created_at": created_at,
         "url": format!("https://github.com/acme/orbit/actions/runs/{run_id}"),
     })
+}
+
+pub(super) fn run_on_branch(
+    run_id: u64,
+    workflow: &str,
+    branch: &str,
+    sha: &str,
+    status: &str,
+    conclusion: Option<&str>,
+    created_at: &str,
+) -> Value {
+    let mut value = run(run_id, workflow, sha, status, conclusion, created_at);
+    value["head_branch"] = json!(branch);
+    value
 }


### PR DESCRIPTION
## Task

[ORB-11147](https://orbit-cli.com/tasks/ORB-11147) — Restrict CI failure sweep to the latest workflow run

### Description

## Problem

`collect_ci_evidence` currently enumerates recent runs separately for the integration branch, release branch, and every open pull-request head. `partition_runs` can therefore classify an old failed run as current indefinitely whenever that old PR/ref still points at the same SHA.

ORB-11146 is the concrete false positive: the sweep filed it on 2026-08-31 from CI run `31583558682` on Dependabot PR #959 at `0f14f3f2ad2c863f902c0add969ff09d10e3f15c`. The task snapshot reports that run as current solely because the old PR head had not advanced, even though newer repository-wide `CI` runs existed. The same stale failure has already produced ORB-11111, ORB-11120, ORB-11126, ORB-11130, ORB-11135, and ORB-11146.

## Required Behavior

For each GitHub Actions workflow, the sweep must evaluate only that workflow's latest repository-wide run according to the existing deterministic run ordering (`created_at`, then run ID). It must not fall back to an older failure from another branch or an old open PR.

- Latest completed unsuccessful run: it is eligible for investigation and task filing.
- Latest completed successful or otherwise non-failing run: report no current failure for that workflow.
- Latest queued or in-progress run: report it as in flight and do not resurrect an older completed failure.
- Every older run is stale/superseded by the newer run regardless of whether its old ref still points at the tested SHA.

Preserve distinct event-reported, current-ref, and actual-checkout SHA fields for the selected run. Preserve bounded/redacted evidence, capability-unavailable behavior, filing dedupe, single-flight scheduling, and the existing no-agent/no-worktree architecture. Do not weaken CI, alter task shipping, or add GitHub access to agent sandboxes.

## Scope / Evidence

The run-selection defect is in the host-owned CI collection seam introduced by ORB-11107, principally `crates/orbit-engine/src/executor/automation/ci/`. ORB-11146 is the regression fixture and must not be treated as a repository repair task after this fix.

Use deterministic scripted GitHub state in tests; do not depend on live GitHub or wall-clock age.

### Acceptance Criteria

- The collector evaluates exactly the latest repository-wide run for each workflow using deterministic run ordering; older runs from integration, release, or open-PR refs cannot enter current_failures.
- When a workflow's latest run succeeds or has another non-failing completed conclusion, an older failed run is recorded as stale/superseded and files no task.
- When a workflow's latest run is queued or in progress, it is reported in in_flight and the collector does not fall back to any older completed failure.
- A deterministic regression test models ORB-11146: an unchanged old Dependabot PR head with failed run 31583558682 plus a newer repository-wide CI run; the old run is absent from current_failures and is never investigated or filed.
- Tests cover multiple workflows so selecting the latest run for one workflow does not hide the latest run of another workflow, including deterministic created_at ties resolved by run ID.
- Existing bounded/redacted evidence, SHA separation, capability-unavailable/no-current-failure outcomes, task dedupe, and single-flight pipeline behavior remain intact.
- Targeted orbit-engine CI automation tests and the repository's documented pre-handoff gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced branch-by-branch GitHub Actions run enumeration with one repository-wide run query, then grouped by workflow and selected exactly the latest run using created_at followed by run ID.
- Only a latest completed unsuccessful run enters current_failures. A latest queued or in-progress run enters in_flight, and a latest successful or otherwise non-failing completed run leaves no current failure. Older completed unsuccessful runs are retained only as stale/superseded evidence naming the newer run.
- Preserved integration/release/open-PR head metadata and separate event-reported, current-ref, and actual-checkout SHA fields for selected runs; investigation remains limited to current_failures.
- Added deterministic regressions for ORB-11146 run 31583558682 on the unchanged Dependabot PR head, cross-ref and cross-SHA supersession, non-failing conclusions, queued and in-progress latest runs, independent workflows, and created_at ties resolved by run ID.

Validation:
- cargo test -p orbit-engine executor::automation::ci::tests --no-fail-fast — passed (9 tests).
- cargo test -p orbit-core ci_failure --no-fail-fast — passed (19 tests, including filing dedupe and single-flight catalog coverage).
- make ci-fast — passed.
- make ci-lint — passed.
- git diff --check — passed; final worktree contains only four intended files under the scoped CI automation directory.

Assessment: The collector now has one canonical workflow-level selection path. The ORB-11146 run is absent from current_failures, remains uninvestigated, and therefore cannot reach task filing. Existing evidence bounding/redaction, SHA separation, capability/no-failure outcomes, filing dedupe, and pipeline single-flight behavior remain intact.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11147-6a94ecc2`
- Behind base: 0
- Ahead of base: 1