### PR TITLE
Add `orbit workspace sync` for managed artifact convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,26 @@ up the machine with `orbit init` and then run `orbit workspace init` from the
 project directory. `orbit.workspace.list` is global and reports active
 workspaces that have a checkout registered on that machine.
 
+Workspace lifecycle commands have deliberately separate jobs:
+
+- `orbit workspace init` bootstraps and registers a checkout once.
+- `orbit workspace sync` converges only Orbit-managed shipped definitions for
+  an existing registered workspace. It creates newly shipped defaults,
+  refreshes or retires only content whose manifest proves Orbit wrote the
+  on-disk bytes, and preserves operator edits and name collisions with an
+  actionable path. Routine provenance records the shipped-template digest,
+  the exact rendered-instance digest, and the rendered `name`/`hosts` binding
+  separately, so a host rename or checkout-directory change is reported as
+  binding drift rather than a template update. Use `--check` for a read-only
+  inspection (nonzero when convergence or provenance migration is pending) and
+  `--json` for structured per-kind actions.
+- `orbit doctor` diagnoses health and offers only narrow, evidence-specific
+  repairs; it is not the managed-definition convergence command.
+
+`workspace sync` is local: it does not pull a repository, contact another
+host, upgrade the Orbit binary, alter workspace registration/configuration, or
+apply store/layout migrations.
+
 ### Federated MCP
 
 The opt-in federated server presents one MCP namespace over this machine's

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -211,6 +211,7 @@ impl Commands {
                 use super::workspace::WorkspaceSubcommand;
                 let (subcommand, runtime_need, governed) = match &command.command {
                     WorkspaceSubcommand::Init(_) => ("init", RuntimeNeed::Forbidden, false),
+                    WorkspaceSubcommand::Sync(_) => ("sync", RuntimeNeed::Forbidden, false),
                     WorkspaceSubcommand::List(_) => ("list", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Show(_) => ("show", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Role(_) => ("role", RuntimeNeed::Required, false),
@@ -909,6 +910,9 @@ fn dispatch_workspace(command: Commands, context: DispatchContext<'_>) -> Comman
     match command {
         Commands::Workspace(WorkspaceCommand {
             command: WorkspaceSubcommand::Init(args),
+        }) => args.execute_without_runtime(context.root_override),
+        Commands::Workspace(WorkspaceCommand {
+            command: WorkspaceSubcommand::Sync(args),
         }) => args.execute_without_runtime(context.root_override),
         Commands::Workspace(command) => command.execute(context.runtime()?),
         _ => dispatch_mismatch("Workspace"),

--- a/crates/orbit-cli/src/command/workspace/command.rs
+++ b/crates/orbit-cli/src/command/workspace/command.rs
@@ -9,6 +9,7 @@ use super::publication::WorkspacePublicationCommand;
 use super::remove::WorkspaceRemoveArgs;
 use super::role::WorkspaceRoleArgs;
 use super::show::WorkspaceShowArgs;
+use super::sync::WorkspaceSyncArgs;
 use super::teardown::WorkspaceTeardownArgs;
 
 #[derive(Args)]
@@ -22,6 +23,8 @@ pub struct WorkspaceCommand {
 pub enum WorkspaceSubcommand {
     /// Initialize a new workspace in the current directory
     Init(WorkspaceInitArgs),
+    /// Converge managed artifacts on the defaults shipped by this Orbit binary
+    Sync(WorkspaceSyncArgs),
     /// List all registered workspaces
     List(WorkspaceListArgs),
     /// Show the current workspace
@@ -42,6 +45,9 @@ impl Execute for WorkspaceCommand {
             WorkspaceSubcommand::Init(_) => {
                 // Init is handled without runtime in main.rs
                 unreachable!("workspace init should be handled before runtime initialization")
+            }
+            WorkspaceSubcommand::Sync(_) => {
+                unreachable!("workspace sync should be handled before runtime initialization")
             }
             WorkspaceSubcommand::List(args) => args.execute(runtime),
             WorkspaceSubcommand::Show(args) => args.execute(runtime),

--- a/crates/orbit-cli/src/command/workspace/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/mod.rs
@@ -6,6 +6,7 @@ mod remove;
 mod role;
 mod show;
 mod support;
+mod sync;
 mod teardown;
 
 pub use command::{WorkspaceCommand, WorkspaceSubcommand};

--- a/crates/orbit-cli/src/command/workspace/sync.rs
+++ b/crates/orbit-cli/src/command/workspace/sync.rs
@@ -1,0 +1,142 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use clap::Args;
+use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
+use orbit_core::{
+    ManagedArtifactOutcome, ManagedArtifactScope, OrbitError, WorkspaceManagedArtifactSyncReport,
+    reconcile_workspace_managed_artifacts,
+};
+use orbit_registry::workspace_registry;
+use orbit_registry::{HostIdentityState, inspect_host_identity};
+
+use crate::command::{CommandOut, Payload};
+
+#[derive(Args)]
+pub struct WorkspaceSyncArgs {
+    /// Inspect and report pending convergence without writing anything
+    #[arg(long)]
+    pub check: bool,
+    /// Emit structured JSON (equivalent to --format json)
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl WorkspaceSyncArgs {
+    pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
+        let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
+        let roots = RegisteredRuntimeFactory::try_resolve_initialized_roots(&cwd, root_override)?
+            .ok_or_else(workspace_init_required)?;
+        let bootstrap_roots =
+            RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&cwd, root_override)?;
+        let global_root = bootstrap_roots.global_root;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&global_root),
+        )?;
+        let checkout = registry
+            .checkouts
+            .iter()
+            .filter(|checkout| {
+                checkout.orbit_dir == roots.shared_root && cwd.starts_with(&checkout.repo_root)
+            })
+            .max_by_key(|checkout| checkout.repo_root.components().count())
+            .ok_or_else(workspace_init_required)?;
+        if workspace_registry::find_workspace(&registry, &checkout.workspace_id).is_none() {
+            return Err(workspace_init_required());
+        }
+        let host_id = match inspect_host_identity(&global_root)? {
+            HostIdentityState::Present(identity) => identity.host_id,
+            HostIdentityState::Legacy { .. } | HostIdentityState::Absent => {
+                return Err(OrbitError::WorkspaceError(
+                    "cannot sync workspace managed artifacts without an initialized host identity; run `orbit init`, then `orbit workspace init`".to_string(),
+                ));
+            }
+        };
+        let slug = checkout
+            .repo_root
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned());
+        let report = reconcile_workspace_managed_artifacts(
+            &global_root,
+            &checkout.orbit_dir,
+            Some(&host_id),
+            slug.as_deref(),
+            self.check,
+        )?;
+        let exit_code = if self.check && report.has_pending_changes() {
+            3
+        } else {
+            0
+        };
+        let doc = serde_json::to_value(&report)
+            .map_err(|error| OrbitError::Execution(format!("serialize workspace sync: {error}")))?;
+        Ok(Payload::detail(doc, format_report(&report))
+            .with_exit_code(exit_code)
+            .into())
+    }
+}
+
+fn workspace_init_required() -> OrbitError {
+    OrbitError::WorkspaceError(
+        "current directory is not an initialized and registered Orbit workspace; run `orbit workspace init` first".to_string(),
+    )
+}
+
+fn format_report(report: &WorkspaceManagedArtifactSyncReport) -> String {
+    let mut counts: BTreeMap<(&str, &str, &str), usize> = BTreeMap::new();
+    for action in &report.actions {
+        *counts
+            .entry((
+                scope_name(action.scope),
+                action.kind.as_str(),
+                action.outcome.as_str(),
+            ))
+            .or_default() += 1;
+    }
+    let mut output = if report.check {
+        "workspace managed-artifact sync check\n".to_string()
+    } else {
+        "workspace managed-artifact sync\n".to_string()
+    };
+    for ((scope, kind, outcome), count) in counts {
+        let _ = writeln!(output, "  {scope} {kind}: {outcome}={count}");
+    }
+    for action in report.actions.iter().filter(|action| {
+        matches!(
+            action.outcome,
+            ManagedArtifactOutcome::Preserved | ManagedArtifactOutcome::BindingDrift
+        )
+    }) {
+        let _ = writeln!(
+            output,
+            "  {} {} {}: {}{}",
+            scope_name(action.scope),
+            action.kind,
+            action.outcome.as_str(),
+            action.path.display(),
+            action
+                .detail
+                .as_deref()
+                .map(|detail| format!(" — {detail}"))
+                .unwrap_or_default()
+        );
+    }
+    if report.check && report.has_pending_changes() {
+        output.push_str(
+            "pending managed-artifact changes; run `orbit workspace sync` to apply them\n",
+        );
+    } else if report.has_pending_changes() {
+        output.push_str("managed artifacts converged\n");
+    } else {
+        output.push_str("already converged\n");
+    }
+    output
+}
+
+fn scope_name(scope: ManagedArtifactScope) -> &'static str {
+    match scope {
+        ManagedArtifactScope::HostGlobal => "host-global",
+        ManagedArtifactScope::WorkspaceLocal => "workspace-local",
+    }
+}

--- a/crates/orbit-cli/tests/workspace_sync.rs
+++ b/crates/orbit-cli/tests/workspace_sync.rs
@@ -1,0 +1,188 @@
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! Binary-level coverage for explicit workspace managed-artifact convergence.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn orbit(cwd: &Path, home: &Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env_remove("ORBIT_HOME")
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_REGISTRY_ROOT")
+        .env_remove("ORBIT_WORKSPACE");
+    command
+}
+
+fn write_host_identity(home: &Path) {
+    let global = home.join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global root");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_workspace_sync\"\nhost_id = \"sync-host\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+}
+
+fn read(path: impl Into<PathBuf>) -> Vec<u8> {
+    std::fs::read(path.into()).expect("read snapshot path")
+}
+
+fn read_optional(path: impl Into<PathBuf>) -> Option<Vec<u8>> {
+    std::fs::read(path.into()).ok()
+}
+
+#[test]
+fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_idempotent() {
+    let home = tempdir().expect("home tempdir");
+    let repo = tempdir().expect("workspace tempdir");
+    write_host_identity(home.path());
+    orbit(repo.path(), home.path())
+        .args(["workspace", "init"])
+        .assert()
+        .success();
+
+    let workspace_root = repo.path().join(".orbit");
+    let auto_tasks = workspace_root.join("auto_tasks");
+    let missing = auto_tasks.join("code-review.yaml");
+    std::fs::remove_file(&missing).expect("remove a shipped auto-task");
+
+    let locally_modified = auto_tasks.join("security-review.yaml");
+    let local_body = format!(
+        "{}# operator edit\n",
+        std::fs::read_to_string(&locally_modified).expect("read managed auto-task")
+    );
+    std::fs::write(&locally_modified, &local_body).expect("edit managed auto-task");
+
+    let collision = auto_tasks.join("qa-sweep.yaml");
+    let collision_body = "operator-authored definition using a bundled file name\n";
+    std::fs::write(&collision, collision_body).expect("write colliding auto-task");
+    let manifest_path = auto_tasks.join(".orbit-managed-assets.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&read(&manifest_path)).expect("parse manifest");
+    manifest["assets"]
+        .as_object_mut()
+        .expect("assets object")
+        .remove("qa-sweep");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize manifest")
+        ),
+    )
+    .expect("remove collision provenance");
+
+    let registry = home.path().join(".orbit/workspaces.json");
+    let identity = workspace_root.join("config.yaml");
+    let registry_before = read(&registry);
+    let identity_before = read(&identity);
+    let gitignore_before = read_optional(repo.path().join(".gitignore"));
+
+    let check = orbit(repo.path(), home.path())
+        .args(["workspace", "sync", "--check", "--json"])
+        .assert()
+        .code(3)
+        .get_output()
+        .stdout
+        .clone();
+    let checked: Value = serde_json::from_slice(&check).expect("parse check JSON");
+    assert!(checked["check"].as_bool().expect("check flag"));
+    assert!(
+        checked["actions"]
+            .as_array()
+            .expect("actions")
+            .iter()
+            .any(|action| {
+                action["outcome"] == "created"
+                    && action["kind"] == "auto_task"
+                    && action["path"]
+                        .as_str()
+                        .is_some_and(|path| path.ends_with("code-review.yaml"))
+            })
+    );
+    assert!(
+        !missing.exists(),
+        "--check must not create the missing file"
+    );
+    assert_eq!(read(&registry), registry_before);
+    assert_eq!(read(&identity), identity_before);
+    assert_eq!(
+        read_optional(repo.path().join(".gitignore")),
+        gitignore_before
+    );
+
+    let applied = orbit(repo.path(), home.path())
+        .args(["workspace", "sync", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let applied: Value = serde_json::from_slice(&applied).expect("parse apply JSON");
+    let actions = applied["actions"].as_array().expect("actions");
+    assert!(actions.iter().any(|action| {
+        action["outcome"] == "preserved"
+            && action["path"] == locally_modified.to_string_lossy().as_ref()
+    }));
+    assert!(actions.iter().any(|action| {
+        action["outcome"] == "preserved" && action["path"] == collision.to_string_lossy().as_ref()
+    }));
+    assert!(
+        missing.exists(),
+        "apply creates the missing shipped definition"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&locally_modified).expect("read local edit"),
+        local_body
+    );
+    assert_eq!(
+        std::fs::read_to_string(&collision).expect("read collision"),
+        collision_body
+    );
+    assert_eq!(read(&registry), registry_before);
+    assert_eq!(read(&identity), identity_before);
+    assert_eq!(
+        read_optional(repo.path().join(".gitignore")),
+        gitignore_before
+    );
+
+    let managed_after = read(&missing);
+    orbit(repo.path(), home.path())
+        .args(["workspace", "sync", "--check", "--json"])
+        .assert()
+        .success();
+    assert_eq!(
+        read(&missing),
+        managed_after,
+        "second run is byte-for-byte inert"
+    );
+}
+
+#[test]
+fn workspace_sync_outside_registered_workspace_fails_before_writing() {
+    let home = tempdir().expect("home tempdir");
+    let repo = tempdir().expect("workspace tempdir");
+    write_host_identity(home.path());
+    let before: Vec<_> = std::fs::read_dir(repo.path())
+        .expect("read empty repo")
+        .collect();
+    orbit(repo.path(), home.path())
+        .args(["workspace", "sync"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("orbit workspace init"));
+    let after: Vec<_> = std::fs::read_dir(repo.path())
+        .expect("reread empty repo")
+        .collect();
+    assert_eq!(after.len(), before.len());
+    assert!(!repo.path().join(".orbit").exists());
+}

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -7,7 +7,7 @@ mod run;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use catalog::seed_default_jobs;
+pub(crate) use catalog::{DEFAULT_JOB_FILES, seed_default_jobs};
 pub use catalog::{JobCatalogEntry, JobCatalogFilter};
 pub use exec::V2JobRunResult;
 pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};

--- a/crates/orbit-core/src/application/mod.rs
+++ b/crates/orbit-core/src/application/mod.rs
@@ -30,12 +30,39 @@ pub const SYSTEM_AUDIT_IDENTITY: &str = "system";
 
 pub(crate) const MANAGED_ASSET_MANIFEST_FILE: &str = ".orbit-managed-assets.json";
 const MANAGED_ASSET_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const ROUTINE_MANAGED_ASSET_MANIFEST_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ManagedAssetReconciliation {
     pub refreshed: usize,
     pub retired: usize,
     pub warnings: Vec<String>,
+    pub actions: Vec<ManagedAssetAction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManagedAssetReconcileMode {
+    Apply,
+    Check,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManagedAssetOutcome {
+    Created,
+    Refreshed,
+    Retired,
+    Migrated,
+    Preserved,
+    BindingDrift,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedAssetAction {
+    pub name: String,
+    pub path: PathBuf,
+    pub outcome: ManagedAssetOutcome,
+    pub detail: Option<String>,
 }
 
 /// How a manifest key maps to the file it manages, relative to the managed
@@ -71,6 +98,23 @@ struct ManagedAssetManifest {
     schema_version: u32,
     asset_kind: String,
     assets: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    routine_provenance: BTreeMap<String, RoutineAssetProvenance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RoutineAssetProvenance {
+    pub template_digest: String,
+    pub rendered_digest: String,
+    pub binding: RoutineMaterializationBinding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RoutineMaterializationBinding {
+    pub name: String,
+    pub hosts: Vec<String>,
 }
 
 /// Materialize the current embedded resource set and reconcile assets retired
@@ -90,6 +134,26 @@ pub(crate) fn reconcile_managed_assets<'a>(
     layout: ManagedAssetLayout,
     files: &'a [(&'a str, &'a str)],
     overwrite: bool,
+    render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
+) -> Result<ManagedAssetReconciliation, OrbitError> {
+    reconcile_managed_assets_in_mode(
+        dir,
+        asset_kind,
+        layout,
+        files,
+        overwrite,
+        ManagedAssetReconcileMode::Apply,
+        render,
+    )
+}
+
+pub(crate) fn reconcile_managed_assets_in_mode<'a>(
+    dir: &Path,
+    asset_kind: &str,
+    layout: ManagedAssetLayout,
+    files: &'a [(&'a str, &'a str)],
+    overwrite: bool,
+    mode: ManagedAssetReconcileMode,
     mut render: impl FnMut(&'a str, &'a str) -> Result<Cow<'a, str>, OrbitError>,
 ) -> Result<ManagedAssetReconciliation, OrbitError> {
     validate_managed_asset_name(asset_kind, ManagedAssetLayout::YamlStem, "asset kind")?;
@@ -109,6 +173,15 @@ pub(crate) fn reconcile_managed_assets<'a>(
             }
             let path = dir.join(layout.relative_path(name));
             if !path.exists() {
+                result.actions.push(ManagedAssetAction {
+                    name: name.clone(),
+                    path,
+                    outcome: ManagedAssetOutcome::Retired,
+                    detail: Some(
+                        "removed stale manifest provenance for an absent artifact".to_string(),
+                    ),
+                });
+                result.retired += 1;
                 continue;
             }
             let content = fs::read_to_string(&path).map_err(|error| {
@@ -118,20 +191,43 @@ pub(crate) fn reconcile_managed_assets<'a>(
                 ))
             })?;
             if sha256_hex(content.as_bytes()) == *managed_digest {
-                fs::remove_file(&path).map_err(|error| {
-                    OrbitError::Io(format!(
-                        "retire managed {asset_kind} '{}': {error}",
-                        path.display()
-                    ))
-                })?;
+                if mode == ManagedAssetReconcileMode::Apply {
+                    fs::remove_file(&path).map_err(|error| {
+                        OrbitError::Io(format!(
+                            "retire managed {asset_kind} '{}': {error}",
+                            path.display()
+                        ))
+                    })?;
+                }
             } else {
-                let preserved =
-                    preserve_modified_retired_asset(dir, asset_kind, layout, name, &path)?;
-                result.warnings.push(format!(
-                    "retired managed {asset_kind} `{name}` was locally modified; Orbit removed it from the active catalog and preserved it at '{}'. Review that file, then migrate it under a new user-authored name or delete it",
+                let preserved = if mode == ManagedAssetReconcileMode::Apply {
+                    preserve_modified_retired_asset(dir, asset_kind, layout, name, &path)?
+                } else {
+                    retired_preservation_path(dir, asset_kind, layout, name)
+                };
+                let warning = format!(
+                    "retired managed {asset_kind} `{name}` was locally modified; Orbit {} it from the active catalog and preserved it at '{}'. Review that file, then migrate it under a new user-authored name or delete it",
+                    if mode == ManagedAssetReconcileMode::Apply {
+                        "removed"
+                    } else {
+                        "would remove"
+                    },
                     preserved.display()
-                ));
+                );
+                result.warnings.push(warning.clone());
+                result.actions.push(ManagedAssetAction {
+                    name: name.clone(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Preserved,
+                    detail: Some(warning),
+                });
             }
+            result.actions.push(ManagedAssetAction {
+                name: name.clone(),
+                path,
+                outcome: ManagedAssetOutcome::Retired,
+                detail: None,
+            });
             result.retired += 1;
         }
     }
@@ -155,11 +251,27 @@ pub(crate) fn reconcile_managed_assets<'a>(
                 })?;
                 if sha256_hex(existing.as_bytes()) == rendered_digest {
                     next_assets.insert((*name).to_string(), rendered_digest);
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Migrated,
+                        detail: Some(
+                            "recorded provenance for an exact existing shipped artifact"
+                                .to_string(),
+                        ),
+                    });
                 } else if previous.is_some() {
-                    result.warnings.push(format!(
+                    let warning = format!(
                         "untracked user-authored {asset_kind} '{}' collides with bundled default `{name}` and was preserved in place. Move or rename it, then rerun `orbit init` to install the bundled default",
                         path.display()
-                    ));
+                    );
+                    result.warnings.push(warning.clone());
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Preserved,
+                        detail: Some(warning),
+                    });
                 }
                 continue;
             }
@@ -183,11 +295,35 @@ pub(crate) fn reconcile_managed_assets<'a>(
                 if sha256_hex(existing.as_bytes()) == *previous_digest
                     && previous_digest != &rendered_digest
                 {
-                    write_text_with_parent(&path, &rendered)?;
+                    if mode == ManagedAssetReconcileMode::Apply {
+                        write_text_with_parent(&path, &rendered)?;
+                    }
                     next_assets.insert((*name).to_string(), rendered_digest);
                     result.refreshed += 1;
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Refreshed,
+                        detail: None,
+                    });
                 } else {
                     next_assets.insert((*name).to_string(), previous_digest.clone());
+                    let modified = sha256_hex(existing.as_bytes()) != *previous_digest;
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: if modified {
+                            ManagedAssetOutcome::Preserved
+                        } else {
+                            ManagedAssetOutcome::Unchanged
+                        },
+                        detail: modified.then(|| {
+                            format!(
+                                "locally modified managed {asset_kind} '{}' was preserved; restore the Orbit-written bytes or move/rename the file, then rerun `orbit workspace sync`",
+                                path.display()
+                            )
+                        }),
+                    });
                 }
                 continue;
             }
@@ -199,20 +335,34 @@ pub(crate) fn reconcile_managed_assets<'a>(
             // read-only.
             if previous_digest == Some(&rendered_digest) {
                 next_assets.insert((*name).to_string(), rendered_digest);
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Unchanged,
+                    detail: None,
+                });
                 continue;
             }
         }
 
-        write_text_with_parent(&path, &rendered)?;
+        if mode == ManagedAssetReconcileMode::Apply {
+            write_text_with_parent(&path, &rendered)?;
+        }
         next_assets.insert((*name).to_string(), rendered_digest);
         result.refreshed += 1;
+        result.actions.push(ManagedAssetAction {
+            name: (*name).to_string(),
+            path,
+            outcome: ManagedAssetOutcome::Created,
+            detail: None,
+        });
     }
 
     // The legacy sweep only makes sense for the flat YAML catalogs: a skill
     // tree's untracked files are ordinary reference material inside an
     // otherwise-managed directory, not stray definitions the loader would pick
     // up.
-    if previous.is_none() && layout == ManagedAssetLayout::YamlStem {
+    if previous.is_none() && layout == ManagedAssetLayout::YamlStem && dir.exists() {
         let ambiguous = ambiguous_legacy_yaml_files(dir, &next_assets)?;
         if !ambiguous.is_empty() {
             result.warnings.push(format!(
@@ -230,8 +380,9 @@ pub(crate) fn reconcile_managed_assets<'a>(
         schema_version: MANAGED_ASSET_MANIFEST_SCHEMA_VERSION,
         asset_kind: asset_kind.to_string(),
         assets: next_assets,
+        routine_provenance: BTreeMap::new(),
     };
-    if previous.as_ref() != Some(&manifest) {
+    if mode == ManagedAssetReconcileMode::Apply && previous.as_ref() != Some(&manifest) {
         let encoded = encode_managed_asset_manifest(&manifest)?;
         record_managed_manifest_write(
             &manifest_path,
@@ -251,6 +402,20 @@ pub(crate) fn reconcile_managed_assets<'a>(
     }
 
     Ok(result)
+}
+
+fn retired_preservation_path(
+    active_dir: &Path,
+    asset_kind: &str,
+    layout: ManagedAssetLayout,
+    name: &str,
+) -> PathBuf {
+    active_dir
+        .parent()
+        .unwrap_or(active_dir)
+        .join(".retired-managed")
+        .join(managed_asset_kind_directory(asset_kind))
+        .join(layout.relative_path(name))
 }
 
 /// Persist one managed-asset manifest. Callers compare against the previous
@@ -343,12 +508,20 @@ fn load_managed_asset_manifest(
             path.display()
         ))
     })?;
-    if manifest.schema_version != MANAGED_ASSET_MANIFEST_SCHEMA_VERSION {
+    let supported_schema = manifest.schema_version == MANAGED_ASSET_MANIFEST_SCHEMA_VERSION
+        || (expected_kind == "routine"
+            && manifest.schema_version == ROUTINE_MANAGED_ASSET_MANIFEST_SCHEMA_VERSION);
+    if !supported_schema {
         return Err(OrbitError::InvalidInput(format!(
-            "managed asset manifest '{}' uses unsupported schemaVersion {}; expected {}",
+            "managed asset manifest '{}' uses unsupported schemaVersion {}; expected {}{}",
             path.display(),
             manifest.schema_version,
-            MANAGED_ASSET_MANIFEST_SCHEMA_VERSION
+            MANAGED_ASSET_MANIFEST_SCHEMA_VERSION,
+            if expected_kind == "routine" {
+                format!(" or {ROUTINE_MANAGED_ASSET_MANIFEST_SCHEMA_VERSION}")
+            } else {
+                String::new()
+            }
         )));
     }
     if manifest.asset_kind != expected_kind {
@@ -523,6 +696,7 @@ pub mod semantic;
 pub mod skill;
 pub mod task;
 pub(crate) mod workflow;
+pub mod workspace_sync;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-core/src/application/routine.rs
+++ b/crates/orbit-core/src/application/routine.rs
@@ -16,13 +16,21 @@
 //! `[routines] role = "source"`; they exist so a fresh workspace gets
 //! reviewable, opt-in schedules without silently enabling unattended work.
 
-use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
 use std::path::Path;
 
 use orbit_common::OrbitError;
 use orbit_common::protocol::yaml::parse_routine_yaml;
 
-use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets};
+use super::{
+    MANAGED_ASSET_MANIFEST_FILE, ManagedAssetAction, ManagedAssetLayout, ManagedAssetManifest,
+    ManagedAssetOutcome, ManagedAssetReconcileMode, ManagedAssetReconciliation,
+    ROUTINE_MANAGED_ASSET_MANIFEST_SCHEMA_VERSION, RoutineAssetProvenance,
+    RoutineMaterializationBinding, encode_managed_asset_manifest, load_managed_asset_manifest,
+    preserve_modified_retired_asset, sha256_hex,
+};
+use orbit_common::fs::io::{atomic_write_text, write_text_with_parent};
 
 /// Shippable default routine assets, seeded under
 /// `<workspace>/.orbit/routines/<file>.yaml` on `orbit init`. Every entry
@@ -79,39 +87,402 @@ const ROUTINE_NAME_PLACEHOLDER: &str = "__ORBIT_ROUTINE_NAME__";
 // explicit host pinning and host-unique names.
 // ADR-0366: the recorded digest covers the rendered document, so a
 // placeholder-substituting asset still gets honest provenance.
+#[cfg(test)]
 pub(crate) fn seed_default_routines(
     routines_dir: &Path,
     host_id: &str,
     workspace_slug: Option<&str>,
     overwrite: bool,
 ) -> Result<ManagedAssetReconciliation, OrbitError> {
+    reconcile_default_routines(
+        routines_dir,
+        host_id,
+        workspace_slug,
+        overwrite,
+        ManagedAssetReconcileMode::Apply,
+    )
+}
+
+pub(crate) fn reconcile_default_routines(
+    routines_dir: &Path,
+    host_id: &str,
+    workspace_slug: Option<&str>,
+    overwrite_bindings: bool,
+    mode: ManagedAssetReconcileMode,
+) -> Result<ManagedAssetReconciliation, OrbitError> {
     let host_id = host_id.trim();
     if host_id.is_empty() {
         return Err(OrbitError::InvalidInput(
-            "cannot seed default routines without a host id".to_string(),
+            "cannot reconcile default routines without a host id".to_string(),
         ));
     }
-    reconcile_managed_assets(
-        routines_dir,
-        "routine",
-        ManagedAssetLayout::YamlStem,
-        DEFAULT_ROUTINE_FILES,
-        overwrite,
-        |file_stem, template| {
-            let routine_name = routine_name_for(file_stem, workspace_slug);
-            let rendered = template
-                .replace(ROUTINE_NAME_PLACEHOLDER, &routine_name)
-                .replace(HOST_ID_PLACEHOLDER, host_id);
-            // Fail-closed: never seed a file the routine loader would reject.
-            parse_routine_yaml(&rendered).map_err(|error| {
-                OrbitError::InvalidInput(format!(
-                    "default routine `{file_stem}` failed validation after placeholder \
-                     substitution (host `{host_id}`, name `{routine_name}`): {error}"
+
+    let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+    let previous =
+        load_managed_asset_manifest(&manifest_path, "routine", ManagedAssetLayout::YamlStem)?;
+    let shipped: BTreeSet<&str> = DEFAULT_ROUTINE_FILES
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    let mut next_assets = BTreeMap::new();
+    let mut next_provenance = BTreeMap::new();
+    let mut result = ManagedAssetReconciliation::default();
+
+    if let Some(previous) = &previous {
+        for (name, rendered_digest) in &previous.assets {
+            if shipped.contains(name.as_str()) {
+                continue;
+            }
+            let path = routines_dir.join(format!("{name}.yaml"));
+            if path.exists() {
+                let existing = fs::read_to_string(&path).map_err(|error| {
+                    OrbitError::Io(format!(
+                        "read retired managed routine '{}': {error}",
+                        path.display()
+                    ))
+                })?;
+                if sha256_hex(existing.as_bytes()) == *rendered_digest {
+                    if mode == ManagedAssetReconcileMode::Apply {
+                        fs::remove_file(&path).map_err(|error| {
+                            OrbitError::Io(format!(
+                                "retire managed routine '{}': {error}",
+                                path.display()
+                            ))
+                        })?;
+                    }
+                } else {
+                    let detail = format!(
+                        "retired managed routine '{}' was locally modified; move or rename it before rerunning `orbit workspace sync`",
+                        path.display()
+                    );
+                    if mode == ManagedAssetReconcileMode::Apply {
+                        let preserved = preserve_modified_retired_asset(
+                            routines_dir,
+                            "routine",
+                            ManagedAssetLayout::YamlStem,
+                            name,
+                            &path,
+                        )?;
+                        result.warnings.push(format!(
+                            "{detail}; Orbit preserved it at '{}'",
+                            preserved.display()
+                        ));
+                    } else {
+                        result.warnings.push(detail.clone());
+                    }
+                    result.actions.push(ManagedAssetAction {
+                        name: name.clone(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Preserved,
+                        detail: Some(detail),
+                    });
+                }
+            }
+            result.actions.push(ManagedAssetAction {
+                name: name.clone(),
+                path,
+                outcome: ManagedAssetOutcome::Retired,
+                detail: None,
+            });
+            result.retired += 1;
+        }
+    }
+
+    for (name, template) in DEFAULT_ROUTINE_FILES {
+        let path = routines_dir.join(format!("{name}.yaml"));
+        let requested_binding = RoutineMaterializationBinding {
+            name: routine_name_for(name, workspace_slug),
+            hosts: vec![host_id.to_string()],
+        };
+        let template_digest = sha256_hex(template.as_bytes());
+        let previous_digest = previous.as_ref().and_then(|value| value.assets.get(*name));
+        let previous_provenance = previous
+            .as_ref()
+            .and_then(|value| value.routine_provenance.get(*name));
+
+        if let Some(provenance) = previous_provenance {
+            let binding = if overwrite_bindings {
+                requested_binding.clone()
+            } else {
+                provenance.binding.clone()
+            };
+            let rendered = render_routine_template(name, template, &binding)?;
+            let rendered_digest = sha256_hex(rendered.as_bytes());
+            if path.exists() {
+                let existing = fs::read_to_string(&path).map_err(|error| {
+                    OrbitError::Io(format!(
+                        "read managed routine '{}': {error}",
+                        path.display()
+                    ))
+                })?;
+                if sha256_hex(existing.as_bytes()) != provenance.rendered_digest
+                    && !overwrite_bindings
+                {
+                    let detail = format!(
+                        "locally modified managed routine '{}' was preserved; restore the Orbit-written bytes or move/rename the file, then rerun `orbit workspace sync`",
+                        path.display()
+                    );
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Preserved,
+                        detail: Some(detail),
+                    });
+                    next_assets.insert((*name).to_string(), provenance.rendered_digest.clone());
+                    next_provenance.insert((*name).to_string(), provenance.clone());
+                    continue;
+                }
+                if !overwrite_bindings && provenance.binding != requested_binding {
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::BindingDrift,
+                        detail: Some(format!(
+                            "current host/workspace binding would render name '{}' and hosts {:?}; preserving recorded name '{}' and hosts {:?}",
+                            requested_binding.name,
+                            requested_binding.hosts,
+                            provenance.binding.name,
+                            provenance.binding.hosts
+                        )),
+                    });
+                }
+                if provenance.template_digest == template_digest && provenance.binding == binding {
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Unchanged,
+                        detail: None,
+                    });
+                    next_assets.insert((*name).to_string(), provenance.rendered_digest.clone());
+                    next_provenance.insert((*name).to_string(), provenance.clone());
+                    continue;
+                }
+                if mode == ManagedAssetReconcileMode::Apply {
+                    write_text_with_parent(&path, &rendered)?;
+                }
+                result.refreshed += 1;
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Refreshed,
+                    detail: Some("shipped routine template changed; preserved the recorded materialization binding".to_string()),
+                });
+            } else {
+                if mode == ManagedAssetReconcileMode::Apply {
+                    write_text_with_parent(&path, &rendered)?;
+                }
+                result.refreshed += 1;
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Created,
+                    detail: Some(
+                        "recreated a missing managed routine with its recorded binding".to_string(),
+                    ),
+                });
+            }
+            next_assets.insert((*name).to_string(), rendered_digest.clone());
+            next_provenance.insert(
+                (*name).to_string(),
+                RoutineAssetProvenance {
+                    template_digest,
+                    rendered_digest,
+                    binding,
+                },
+            );
+            continue;
+        }
+
+        if let Some(legacy_digest) = previous_digest {
+            if !path.exists() {
+                let rendered = render_routine_template(name, template, &requested_binding)?;
+                let rendered_digest = sha256_hex(rendered.as_bytes());
+                if mode == ManagedAssetReconcileMode::Apply {
+                    write_text_with_parent(&path, &rendered)?;
+                }
+                result.refreshed += 1;
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Created,
+                    detail: None,
+                });
+                next_assets.insert((*name).to_string(), rendered_digest.clone());
+                next_provenance.insert(
+                    (*name).to_string(),
+                    RoutineAssetProvenance {
+                        template_digest,
+                        rendered_digest,
+                        binding: requested_binding,
+                    },
+                );
+                continue;
+            }
+            let existing = fs::read_to_string(&path).map_err(|error| {
+                OrbitError::Io(format!(
+                    "read legacy managed routine '{}': {error}",
+                    path.display()
                 ))
             })?;
-            Ok(Cow::Owned(rendered))
-        },
-    )
+            if sha256_hex(existing.as_bytes()) != *legacy_digest {
+                let detail = format!(
+                    "legacy managed routine '{}' no longer matches Orbit's recorded digest and was preserved; restore the recorded bytes or move/rename it, then rerun `orbit workspace sync`",
+                    path.display()
+                );
+                result.warnings.push(detail.clone());
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Preserved,
+                    detail: Some(detail),
+                });
+                next_assets.insert((*name).to_string(), legacy_digest.clone());
+                continue;
+            }
+            let definition = parse_routine_yaml(&existing).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "legacy managed routine '{}' matches its manifest but cannot be parsed to recover its recorded binding: {error}",
+                    path.display()
+                ))
+            })?;
+            let binding = RoutineMaterializationBinding {
+                name: definition.name,
+                hosts: definition.hosts,
+            };
+            let rendered = render_routine_template(name, template, &binding)?;
+            let rendered_digest = sha256_hex(rendered.as_bytes());
+            let changed = rendered_digest != *legacy_digest;
+            if changed && mode == ManagedAssetReconcileMode::Apply {
+                write_text_with_parent(&path, &rendered)?;
+            }
+            if changed {
+                result.refreshed += 1;
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Refreshed,
+                    detail: Some("refreshed a legacy Orbit-written routine using the binding parsed from that exact instance".to_string()),
+                });
+            }
+            result.actions.push(ManagedAssetAction {
+                name: (*name).to_string(),
+                path: path.clone(),
+                outcome: ManagedAssetOutcome::Migrated,
+                detail: Some(
+                    "migrated legacy rendered-only provenance using the exact on-disk instance"
+                        .to_string(),
+                ),
+            });
+            next_assets.insert((*name).to_string(), rendered_digest.clone());
+            next_provenance.insert(
+                (*name).to_string(),
+                RoutineAssetProvenance {
+                    template_digest,
+                    rendered_digest,
+                    binding,
+                },
+            );
+            continue;
+        }
+
+        let rendered = render_routine_template(name, template, &requested_binding)?;
+        let rendered_digest = sha256_hex(rendered.as_bytes());
+        if path.exists() {
+            let existing = fs::read_to_string(&path).map_err(|error| {
+                OrbitError::Io(format!(
+                    "read colliding routine '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            if sha256_hex(existing.as_bytes()) != rendered_digest {
+                let detail = format!(
+                    "user-authored routine '{}' collides with bundled default `{name}` and was preserved; move or rename it, then rerun `orbit workspace sync`",
+                    path.display()
+                );
+                result.warnings.push(detail.clone());
+                result.actions.push(ManagedAssetAction {
+                    name: (*name).to_string(),
+                    path: path.clone(),
+                    outcome: ManagedAssetOutcome::Preserved,
+                    detail: Some(detail),
+                });
+                continue;
+            }
+            result.actions.push(ManagedAssetAction {
+                name: (*name).to_string(),
+                path: path.clone(),
+                outcome: ManagedAssetOutcome::Migrated,
+                detail: Some(
+                    "recorded provenance for an exact existing shipped routine".to_string(),
+                ),
+            });
+        } else {
+            if mode == ManagedAssetReconcileMode::Apply {
+                write_text_with_parent(&path, &rendered)?;
+            }
+            result.refreshed += 1;
+            result.actions.push(ManagedAssetAction {
+                name: (*name).to_string(),
+                path: path.clone(),
+                outcome: ManagedAssetOutcome::Created,
+                detail: None,
+            });
+        }
+        next_assets.insert((*name).to_string(), rendered_digest.clone());
+        next_provenance.insert(
+            (*name).to_string(),
+            RoutineAssetProvenance {
+                template_digest,
+                rendered_digest,
+                binding: requested_binding,
+            },
+        );
+    }
+
+    let next = ManagedAssetManifest {
+        schema_version: ROUTINE_MANAGED_ASSET_MANIFEST_SCHEMA_VERSION,
+        asset_kind: "routine".to_string(),
+        assets: next_assets,
+        routine_provenance: next_provenance,
+    };
+    if mode == ManagedAssetReconcileMode::Apply && previous.as_ref() != Some(&next) {
+        let encoded = encode_managed_asset_manifest(&next)?;
+        atomic_write_text(&manifest_path, &encoded).map_err(|error| {
+            OrbitError::Io(format!(
+                "write managed routine asset manifest '{}': {error}",
+                manifest_path.display()
+            ))
+        })?;
+    }
+    Ok(result)
+}
+
+fn render_routine_template(
+    file_stem: &str,
+    template: &str,
+    binding: &RoutineMaterializationBinding,
+) -> Result<String, OrbitError> {
+    let [host_id] = binding.hosts.as_slice() else {
+        return Err(OrbitError::InvalidInput(format!(
+            "managed routine `{file_stem}` has a recorded hosts binding {:?}; shipped routine templates require exactly one host",
+            binding.hosts
+        )));
+    };
+    let rendered = template
+        .replace(ROUTINE_NAME_PLACEHOLDER, &binding.name)
+        .replace(HOST_ID_PLACEHOLDER, host_id);
+    let definition = parse_routine_yaml(&rendered).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "default routine `{file_stem}` failed validation with recorded name '{}' and hosts {:?}: {error}",
+            binding.name, binding.hosts
+        ))
+    })?;
+    if definition.name != binding.name || definition.hosts != binding.hosts {
+        return Err(OrbitError::InvalidInput(format!(
+            "default routine `{file_stem}` did not reproduce its recorded materialization binding"
+        )));
+    }
+    Ok(rendered)
 }
 
 /// Compose a per-workspace routine name: `<stem>-<workspace-slug>`, using

--- a/crates/orbit-core/src/application/tests/mod.rs
+++ b/crates/orbit-core/src/application/tests/mod.rs
@@ -4,3 +4,4 @@ mod job_pipeline;
 mod job_submission;
 mod managed_asset_manifest;
 mod managed_assets;
+mod workspace_sync;

--- a/crates/orbit-core/src/application/tests/workspace_sync.rs
+++ b/crates/orbit-core/src/application/tests/workspace_sync.rs
@@ -1,0 +1,277 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+use crate::application::MANAGED_ASSET_MANIFEST_FILE;
+use crate::application::workspace_sync::{
+    ManagedArtifactOutcome, reconcile_workspace_managed_artifacts,
+};
+use crate::bootstrap::init::{InitOptions, init_workspace_at_root};
+
+fn initialized_roots(base: &Path) -> (PathBuf, PathBuf) {
+    let global = base.join("global");
+    let workspace = base.join("repo/.orbit");
+    init_workspace_at_root(
+        &global,
+        InitOptions {
+            global_only: true,
+            refresh_defaults: true,
+            ..Default::default()
+        },
+    )
+    .expect("initialize global root");
+    init_workspace_at_root(
+        &workspace,
+        InitOptions {
+            global_root_override: Some(global.clone()),
+            routine_host_id: Some("host-a".to_string()),
+            refresh_defaults: true,
+            ..Default::default()
+        },
+    )
+    .expect("initialize workspace root");
+    (global, workspace)
+}
+
+fn routine_manifest(workspace: &Path) -> PathBuf {
+    workspace.join("routines").join(MANAGED_ASSET_MANIFEST_FILE)
+}
+
+fn sha256(content: &str) -> String {
+    format!("{:x}", Sha256::digest(content.as_bytes()))
+}
+
+#[test]
+fn binding_drift_does_not_claim_template_drift_or_rewrite_routines() {
+    let root = tempdir().expect("create tempdir");
+    let (global, workspace) = initialized_roots(root.path());
+    let routine = workspace.join("routines/task_triage.yaml");
+    let before_routine = std::fs::read(&routine).expect("read routine");
+    let before_manifest = std::fs::read(routine_manifest(&workspace)).expect("read manifest");
+
+    let report = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("renamed-host"),
+        Some("different-checkout"),
+        false,
+    )
+    .expect("sync with drifted current binding");
+
+    assert!(report.actions.iter().any(|action| {
+        action.kind == "routine" && action.outcome == ManagedArtifactOutcome::BindingDrift
+    }));
+    assert!(!report.has_pending_changes());
+    assert_eq!(
+        std::fs::read(&routine).expect("reread routine"),
+        before_routine
+    );
+    assert_eq!(
+        std::fs::read(routine_manifest(&workspace)).expect("reread manifest"),
+        before_manifest
+    );
+}
+
+#[test]
+fn legacy_routine_manifest_check_is_read_only_and_apply_migrates_only_exact_instances() {
+    let root = tempdir().expect("create tempdir");
+    let (global, workspace) = initialized_roots(root.path());
+    let manifest_path = routine_manifest(&workspace);
+    let raw = std::fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut manifest: Value = serde_json::from_str(&raw).expect("parse manifest");
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("routineProvenance");
+    manifest["schemaVersion"] = Value::from(1);
+    let legacy = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&manifest).expect("serialize legacy manifest")
+    );
+    std::fs::write(&manifest_path, &legacy).expect("write legacy manifest");
+    let modified = workspace.join("routines/task_triage.yaml");
+    let edited = format!(
+        "{}# operator edit\n",
+        std::fs::read_to_string(&modified).expect("read routine")
+    );
+    std::fs::write(&modified, &edited).expect("edit one legacy routine");
+
+    let checked = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("new-host"),
+        Some("new-suffix"),
+        true,
+    )
+    .expect("check legacy migration");
+    assert!(checked.has_pending_changes());
+    assert!(checked.actions.iter().any(|action| {
+        action.path == modified && action.outcome == ManagedArtifactOutcome::Preserved
+    }));
+    assert_eq!(
+        std::fs::read_to_string(&manifest_path).expect("manifest after check"),
+        legacy,
+        "--check must not migrate the manifest"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&modified).expect("routine after check"),
+        edited
+    );
+
+    let applied = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("new-host"),
+        Some("new-suffix"),
+        false,
+    )
+    .expect("apply legacy migration");
+    assert!(applied.actions.iter().any(|action| {
+        action.kind == "routine" && action.outcome == ManagedArtifactOutcome::Migrated
+    }));
+    let migrated: Value = serde_json::from_str(
+        &std::fs::read_to_string(&manifest_path).expect("read migrated manifest"),
+    )
+    .expect("parse migrated manifest");
+    let provenance = migrated["routineProvenance"]
+        .as_object()
+        .expect("routine provenance");
+    assert!(!provenance.contains_key("task_triage"));
+    let entry = &provenance["worktree_gc"];
+    assert!(entry["templateDigest"].as_str().is_some());
+    assert!(entry["renderedDigest"].as_str().is_some());
+    assert_eq!(entry["binding"]["hosts"][0], "host-a");
+    assert_eq!(
+        std::fs::read_to_string(&modified).expect("modified routine survives"),
+        edited
+    );
+}
+
+#[test]
+fn real_template_refresh_uses_recorded_binding_and_second_run_is_a_no_op() {
+    let root = tempdir().expect("create tempdir");
+    let (global, workspace) = initialized_roots(root.path());
+    let manifest_path = routine_manifest(&workspace);
+    let mut manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("parse manifest");
+    manifest["routineProvenance"]["task_triage"]["templateDigest"] =
+        Value::String("digest-from-previous-shipped-template".to_string());
+    std::fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize stale provenance")
+        ),
+    )
+    .expect("write stale template identity");
+
+    let applied = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("different-current-host"),
+        Some("different-current-suffix"),
+        false,
+    )
+    .expect("refresh true template drift");
+    assert!(applied.actions.iter().any(|action| {
+        action.name == "task_triage" && action.outcome == ManagedArtifactOutcome::Refreshed
+    }));
+    let routine = orbit_common::protocol::yaml::parse_routine_yaml(
+        &std::fs::read_to_string(workspace.join("routines/task_triage.yaml"))
+            .expect("read refreshed routine"),
+    )
+    .expect("parse refreshed routine");
+    assert_eq!(routine.name, "task-triage-repo");
+    assert_eq!(routine.hosts, vec!["host-a".to_string()]);
+
+    let before = std::fs::read(&manifest_path).expect("snapshot converged manifest");
+    let second = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("different-current-host"),
+        Some("different-current-suffix"),
+        false,
+    )
+    .expect("second sync");
+    assert!(!second.has_pending_changes());
+    assert_eq!(
+        std::fs::read(&manifest_path).expect("manifest no-op"),
+        before
+    );
+}
+
+#[test]
+fn sync_refreshes_only_provenance_clean_non_routine_assets_and_retires_safely() {
+    let root = tempdir().expect("create tempdir");
+    let (global, workspace) = initialized_roots(root.path());
+    let activities = global.join("resources/activities");
+    let current_path = activities.join("sleep.yaml");
+    let current = std::fs::read_to_string(&current_path).expect("read current activity");
+    let previous_shipped = format!("{current}# previous shipped template\n");
+    std::fs::write(&current_path, &previous_shipped).expect("write previous shipped activity");
+
+    let retired_path = activities.join("retired_sync_fixture.yaml");
+    let retired = "previous Orbit-written retired activity\n";
+    std::fs::write(&retired_path, retired).expect("write retired activity");
+    let manifest_path = activities.join(MANAGED_ASSET_MANIFEST_FILE);
+    let mut manifest: Value = serde_json::from_str(
+        &std::fs::read_to_string(&manifest_path).expect("read activity manifest"),
+    )
+    .expect("parse activity manifest");
+    manifest["assets"]["sleep"] = Value::String(sha256(&previous_shipped));
+    manifest["assets"]["retired_sync_fixture"] = Value::String(sha256(retired));
+    std::fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize activity manifest")
+        ),
+    )
+    .expect("write previous activity provenance");
+
+    let checked = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("host-a"),
+        Some("repo"),
+        true,
+    )
+    .expect("check non-routine convergence");
+    assert!(checked.actions.iter().any(|action| {
+        action.path == current_path && action.outcome == ManagedArtifactOutcome::Refreshed
+    }));
+    assert!(checked.actions.iter().any(|action| {
+        action.path == retired_path && action.outcome == ManagedArtifactOutcome::Retired
+    }));
+    assert_eq!(
+        std::fs::read_to_string(&current_path).expect("activity after check"),
+        previous_shipped
+    );
+    assert!(retired_path.exists());
+
+    reconcile_workspace_managed_artifacts(&global, &workspace, Some("host-a"), Some("repo"), false)
+        .expect("apply non-routine convergence");
+    assert_eq!(
+        std::fs::read_to_string(&current_path).expect("refreshed activity"),
+        current
+    );
+    assert!(!retired_path.exists());
+
+    let before_manifest = std::fs::read(&manifest_path).expect("snapshot converged manifest");
+    let second = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("host-a"),
+        Some("repo"),
+        false,
+    )
+    .expect("second convergence");
+    assert!(!second.has_pending_changes());
+    assert_eq!(
+        std::fs::read(&manifest_path).expect("manifest after no-op"),
+        before_manifest
+    );
+}

--- a/crates/orbit-core/src/application/workspace_sync.rs
+++ b/crates/orbit-core/src/application/workspace_sync.rs
@@ -1,0 +1,264 @@
+//! Explicit convergence of the managed definitions used by one workspace.
+
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+use orbit_common::OrbitError;
+use orbit_common::protocol::yaml::parse_auto_task_yaml;
+use serde::Serialize;
+
+use super::job::DEFAULT_JOB_FILES;
+use super::routine::reconcile_default_routines;
+use super::skill::{DEFAULT_SKILL_FILES, inject_skill_template_tokens};
+use super::{
+    ManagedAssetAction, ManagedAssetLayout, ManagedAssetOutcome, ManagedAssetReconcileMode,
+    ManagedAssetReconciliation, reconcile_managed_assets_in_mode,
+};
+use crate::auto_tasks::{DEFAULT_AUTO_TASK_FILES, auto_tasks_dir};
+use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedArtifactScope {
+    HostGlobal,
+    WorkspaceLocal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedArtifactOutcome {
+    Created,
+    Refreshed,
+    Retired,
+    Migrated,
+    Preserved,
+    BindingDrift,
+    Unchanged,
+}
+
+impl ManagedArtifactOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Refreshed => "refreshed",
+            Self::Retired => "retired",
+            Self::Migrated => "migrated",
+            Self::Preserved => "preserved",
+            Self::BindingDrift => "binding_drift",
+            Self::Unchanged => "unchanged",
+        }
+    }
+
+    pub fn requires_write(self) -> bool {
+        matches!(
+            self,
+            Self::Created | Self::Refreshed | Self::Retired | Self::Migrated
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ManagedArtifactSyncAction {
+    pub scope: ManagedArtifactScope,
+    pub kind: String,
+    pub name: String,
+    pub path: PathBuf,
+    pub outcome: ManagedArtifactOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct WorkspaceManagedArtifactSyncReport {
+    pub check: bool,
+    pub actions: Vec<ManagedArtifactSyncAction>,
+}
+
+impl WorkspaceManagedArtifactSyncReport {
+    pub fn has_pending_changes(&self) -> bool {
+        self.actions
+            .iter()
+            .any(|action| action.outcome.requires_write())
+    }
+
+    pub fn count(&self, outcome: ManagedArtifactOutcome) -> usize {
+        self.actions
+            .iter()
+            .filter(|action| action.outcome == outcome)
+            .count()
+    }
+}
+
+/// Reconcile the host-global and workspace-local managed definitions used by
+/// one already-initialized workspace. This use case deliberately knows
+/// nothing about workspace registration, identity, role, config, or runtime
+/// state, so callers cannot accidentally turn convergence into bootstrap.
+pub fn reconcile_workspace_managed_artifacts(
+    global_root: &Path,
+    workspace_orbit_root: &Path,
+    routine_host_id: Option<&str>,
+    workspace_slug: Option<&str>,
+    check: bool,
+) -> Result<WorkspaceManagedArtifactSyncReport, OrbitError> {
+    let mode = if check {
+        ManagedAssetReconcileMode::Check
+    } else {
+        ManagedAssetReconcileMode::Apply
+    };
+    let mut report = WorkspaceManagedArtifactSyncReport {
+        check,
+        actions: Vec::new(),
+    };
+
+    let skills = reconcile_managed_assets_in_mode(
+        &global_root.join("skills"),
+        "skill",
+        ManagedAssetLayout::RelativePath,
+        &DEFAULT_SKILL_FILES,
+        false,
+        mode,
+        |_, content| {
+            Ok(Cow::Owned(inject_skill_template_tokens(
+                content,
+                global_root,
+            )))
+        },
+    )?;
+    append_actions(
+        &mut report,
+        ManagedArtifactScope::HostGlobal,
+        "skill",
+        skills,
+    );
+
+    let activities = reconcile_managed_assets_in_mode(
+        &global_root.join("resources/activities"),
+        "activity",
+        ManagedAssetLayout::YamlStem,
+        DEFAULT_ACTIVITY_FILES,
+        false,
+        mode,
+        |_, content| Ok(Cow::Borrowed(content)),
+    )?;
+    append_actions(
+        &mut report,
+        ManagedArtifactScope::HostGlobal,
+        "activity",
+        activities,
+    );
+
+    let jobs = reconcile_managed_assets_in_mode(
+        &global_root.join("resources/jobs"),
+        "job",
+        ManagedAssetLayout::YamlStem,
+        DEFAULT_JOB_FILES,
+        false,
+        mode,
+        |_, content| Ok(Cow::Borrowed(content)),
+    )?;
+    append_actions(&mut report, ManagedArtifactScope::HostGlobal, "job", jobs);
+
+    let auto_tasks = reconcile_managed_assets_in_mode(
+        &auto_tasks_dir(workspace_orbit_root),
+        "auto_task",
+        ManagedAssetLayout::YamlStem,
+        DEFAULT_AUTO_TASK_FILES,
+        false,
+        mode,
+        |name, content| {
+            let definition = parse_auto_task_yaml(content).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "default auto-task `{name}` failed validation: {error}"
+                ))
+            })?;
+            if definition.name != name || definition.enabled {
+                return Err(OrbitError::InvalidInput(format!(
+                    "default auto-task `{name}` must have the matching name and ship disabled"
+                )));
+            }
+            Ok(Cow::Borrowed(content))
+        },
+    )?;
+    append_actions(
+        &mut report,
+        ManagedArtifactScope::WorkspaceLocal,
+        "auto_task",
+        auto_tasks,
+    );
+
+    if let Some(routine_host_id) = routine_host_id {
+        let routines = reconcile_default_routines(
+            &workspace_orbit_root.join("routines"),
+            routine_host_id,
+            workspace_slug,
+            false,
+            mode,
+        )?;
+        append_actions(
+            &mut report,
+            ManagedArtifactScope::WorkspaceLocal,
+            "routine",
+            routines,
+        );
+    }
+
+    report.actions.sort_by(|left, right| {
+        (
+            scope_order(left.scope),
+            left.kind.as_str(),
+            left.path.as_path(),
+            left.outcome.as_str(),
+        )
+            .cmp(&(
+                scope_order(right.scope),
+                right.kind.as_str(),
+                right.path.as_path(),
+                right.outcome.as_str(),
+            ))
+    });
+    Ok(report)
+}
+
+fn append_actions(
+    report: &mut WorkspaceManagedArtifactSyncReport,
+    scope: ManagedArtifactScope,
+    kind: &str,
+    reconciliation: ManagedAssetReconciliation,
+) {
+    report.actions.extend(
+        reconciliation
+            .actions
+            .into_iter()
+            .map(|action| map_action(scope, kind, action)),
+    );
+}
+
+fn map_action(
+    scope: ManagedArtifactScope,
+    kind: &str,
+    action: ManagedAssetAction,
+) -> ManagedArtifactSyncAction {
+    ManagedArtifactSyncAction {
+        scope,
+        kind: kind.to_string(),
+        name: action.name,
+        path: action.path,
+        outcome: match action.outcome {
+            ManagedAssetOutcome::Created => ManagedArtifactOutcome::Created,
+            ManagedAssetOutcome::Refreshed => ManagedArtifactOutcome::Refreshed,
+            ManagedAssetOutcome::Retired => ManagedArtifactOutcome::Retired,
+            ManagedAssetOutcome::Migrated => ManagedArtifactOutcome::Migrated,
+            ManagedAssetOutcome::Preserved => ManagedArtifactOutcome::Preserved,
+            ManagedAssetOutcome::BindingDrift => ManagedArtifactOutcome::BindingDrift,
+            ManagedAssetOutcome::Unchanged => ManagedArtifactOutcome::Unchanged,
+        },
+        detail: action.detail,
+    }
+}
+
+fn scope_order(scope: ManagedArtifactScope) -> u8 {
+    match scope {
+        ManagedArtifactScope::HostGlobal => 0,
+        ManagedArtifactScope::WorkspaceLocal => 1,
+    }
+}

--- a/crates/orbit-core/src/auto_tasks/mod.rs
+++ b/crates/orbit-core/src/auto_tasks/mod.rs
@@ -18,16 +18,6 @@
 //! - [`scheduler`] — the pass itself + the deterministic-action projection.
 //! - [`crud`] — the shared add/list/show/update/toggle/mint domain surface.
 
-use std::borrow::Cow;
-use std::path::Path;
-
-use orbit_common::OrbitError;
-use orbit_common::protocol::yaml::parse_auto_task_yaml;
-
-use crate::application::{
-    ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_assets,
-};
-
 pub mod crud;
 pub mod loader;
 pub mod schedule;
@@ -67,46 +57,6 @@ pub(crate) const DEFAULT_AUTO_TASK_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/auto_tasks/security-review.yaml"),
     ),
 ];
-
-/// Seed missing default auto-task definitions without changing an existing
-/// workspace-authored definition. Each asset is parsed before it is written so
-/// a release cannot install an unloadable default.
-///
-/// Seeding is manifest-aware: the digest Orbit wrote for each default is
-/// recorded so a definition dropped from a later release can be retired by
-/// content provenance instead of lingering in every existing workspace.
-// ADR-0366: auto-tasks joined the ADR-0346 managed-asset mechanism.
-pub(crate) fn seed_default_auto_tasks(
-    orbit_dir: &Path,
-) -> Result<ManagedAssetReconciliation, OrbitError> {
-    let auto_tasks_dir = auto_tasks_dir(orbit_dir);
-    reconcile_managed_assets(
-        &auto_tasks_dir,
-        "auto_task",
-        ManagedAssetLayout::YamlStem,
-        DEFAULT_AUTO_TASK_FILES,
-        false,
-        |name, content| {
-            let definition = parse_auto_task_yaml(content).map_err(|error| {
-                OrbitError::InvalidInput(format!(
-                    "default auto-task `{name}` failed validation: {error}"
-                ))
-            })?;
-            if definition.name != name {
-                return Err(OrbitError::InvalidInput(format!(
-                    "default auto-task file stem `{name}` does not match definition name `{}`",
-                    definition.name
-                )));
-            }
-            if definition.enabled {
-                return Err(OrbitError::InvalidInput(format!(
-                    "default auto-task `{name}` must ship disabled"
-                )));
-            }
-            Ok(Cow::Borrowed(content))
-        },
-    )
-}
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -11,11 +11,12 @@ use crate::OrbitRuntime;
 use crate::application::MANAGED_ASSET_MANIFEST_FILE;
 use crate::application::executor::seed_default_executors;
 use crate::application::job::seed_default_jobs;
-use crate::application::routine::seed_default_routines;
 use crate::application::skill::{
     default_skill_ids, is_default_skill_file_for_root, seed_default_skills,
 };
-use crate::auto_tasks::seed_default_auto_tasks;
+use crate::application::workspace_sync::{
+    ManagedArtifactOutcome, reconcile_workspace_managed_artifacts,
+};
 use crate::bootstrap::activity::seed_default_activities;
 use crate::bootstrap::policy::seed_default_policies;
 use orbit_common::fs::io::{create_dir_symlink, remove_path_if_exists};
@@ -269,26 +270,44 @@ pub fn init_workspace_at_root(
             // directory), so defaults seed here rather than in the global branch.
             // Host identity is owned by higher-level composition and injected;
             // Core never opens host.toml or falls back to an OS hostname.
-            if let Some(host_id) = options.routine_host_id.as_deref() {
-                let reconciliation = seed_default_routines(
-                    &orbit_root.join("routines"),
-                    host_id,
+            {
+                let reconciliation = reconcile_workspace_managed_artifacts(
+                    &global_root,
+                    &orbit_root,
+                    options.routine_host_id.as_deref(),
                     workspace_slug_from_orbit_root(&orbit_root).as_deref(),
-                    // Routine definitions become workspace-authored after
-                    // seeding. Refresh global defaults without overwriting
-                    // cadence, host pins, policy, or enabled choices here;
-                    // destructive `force` already recreated the root.
-                    options.force,
+                    false,
                 )?;
-                refreshed_default_routines = reconciliation.refreshed;
-                managed_asset_warnings.extend(reconciliation.warnings);
+                refreshed_default_routines = reconciliation
+                    .actions
+                    .iter()
+                    .filter(|action| {
+                        action.kind == "routine"
+                            && matches!(
+                                action.outcome,
+                                ManagedArtifactOutcome::Created | ManagedArtifactOutcome::Refreshed
+                            )
+                    })
+                    .count();
+                seeded_default_auto_tasks = reconciliation
+                    .actions
+                    .iter()
+                    .filter(|action| {
+                        action.kind == "auto_task"
+                            && matches!(
+                                action.outcome,
+                                ManagedArtifactOutcome::Created | ManagedArtifactOutcome::Refreshed
+                            )
+                    })
+                    .count();
+                managed_asset_warnings.extend(
+                    reconciliation
+                        .actions
+                        .into_iter()
+                        .filter(|action| action.outcome == ManagedArtifactOutcome::Preserved)
+                        .filter_map(|action| action.detail),
+                );
             }
-            // Auto-task definitions are workspace-authored after seeding. Never
-            // refresh an existing file: `workspace init --force` reconciles
-            // registration and must not overwrite an operator's definition.
-            let auto_task_reconciliation = seed_default_auto_tasks(&orbit_root)?;
-            seeded_default_auto_tasks = auto_task_reconciliation.refreshed;
-            managed_asset_warnings.extend(auto_task_reconciliation.warnings);
             (
                 global_result.refreshed_default_activities,
                 global_result.retired_default_activities,

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -72,6 +72,10 @@ pub use application::search::{
     task_selectors_contain_path,
 };
 pub use application::workflow::{ShipMode, build_ship_input, find_workflow, resolved_ship_mode};
+pub use application::workspace_sync::{
+    ManagedArtifactOutcome, ManagedArtifactScope, ManagedArtifactSyncAction,
+    WorkspaceManagedArtifactSyncReport, reconcile_workspace_managed_artifacts,
+};
 pub use context::ActorIdentity;
 pub use runtime::workspace_catalog::{FederatedWorkspaceTarget, WorkspaceCatalog, WorkspaceScope};
 // Shared domain types (owned by orbit-common) that the CLI and dashboard

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -5,7 +5,7 @@ tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
 related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986]
-last_validated: 2026-08-23
+last_validated: 2026-08-31
 ---
 
 # Check Orbit Health
@@ -82,6 +82,14 @@ There is deliberately no blanket `--fix` or resolve-all option. Configuration re
 recovery, job cancellation, graph cleanup, id-allocation retirement, filesystem lock deletion,
 task-reservation release, and retired activity-backend cleanup have different evidence and
 safety gates, so each repair remains explicit and safety-scoped.
+
+For definition convergence after installing a new Orbit binary, use `orbit workspace sync`
+rather than a doctor repair. Sync uses managed manifests to create newly shipped definitions,
+refresh or retire only provably unedited Orbit-written instances, migrate legacy routine
+provenance, and preserve operator content. `orbit workspace sync --check` is the read-only fleet
+inspection form. Doctor continues to diagnose invalid/stale artifacts and perform only the
+specific repair named by an individual flag; neither command upgrades the binary or pulls a
+remote repository.
 
 ### Repair retired activity backends
 

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -5,7 +5,7 @@ tags: [operations, upgrades, migrations, recovery]
 paths: ["crates/orbit-store/src/workflow/layout/**", "crates/orbit-store/src/driver/sqlite/migration/**"]
 related_features: [orbit-core]
 related_artifacts: [ORB-10014]
-last_validated: 2026-08-22
+last_validated: 2026-08-31
 ---
 
 # Upgrade Orbit Safely
@@ -81,10 +81,23 @@ Upgrade the binary. Never hand-edit `layout.version` to force the workspace open
 After reviewing the dry run:
 
 1. Replace or upgrade the binary.
-2. Run `orbit migrate` (or `orbit migrate --dry-run`) to review any still-pending changes.
-3. Run `orbit migrate --confirm` to apply them.
-4. Run `orbit doctor` and require all relevant checks to pass.
-5. Restart any independently managed dashboard process after swapping the binary.
+2. From each initialized, registered workspace, run `orbit workspace sync --check` to review
+   newly shipped, refreshed, retired, or manifest-migration actions. It is read-only and exits
+   nonzero when managed artifacts need convergence.
+3. Run `orbit workspace sync` to apply the provenance-safe managed-artifact actions. Operator
+   edits, user-authored name collisions, and existing routine `name`/`hosts` bindings are
+   preserved and reported with their paths.
+4. Run `orbit migrate` (or `orbit migrate --dry-run`) to review any still-pending layout/store
+   changes.
+5. Run `orbit migrate --confirm` to apply those migrations.
+6. Run `orbit doctor` and require all relevant checks to pass.
+7. Restart any independently managed dashboard process after swapping the binary.
+
+These commands are intentionally independent. `workspace sync` converges local definitions
+embedded in the installed binary; it does not install a newer binary, pull a repository, sync
+another host, or run general layout/store migrations. `workspace init` remains the one-time
+registration/bootstrap operation, while `doctor` diagnoses health and performs only its named,
+narrow repairs.
 
 Agent subprocesses inherit an `ORBIT_BIN` pinned to the Orbit executable that dispatched
 them, and that executable's directory is placed first on their `PATH`. An operator-set


### PR DESCRIPTION
## Task

[ORB-11149](https://orbit-cli.com/tasks/ORB-11149) — Add `orbit workspace sync` for managed artifact convergence

### Description

## Problem

An already-initialized workspace has no explicit command that means “converge the Orbit-managed artifacts used by this workspace on the defaults shipped by the installed Orbit binary.”

Today that behavior is fragmented:

- `orbit workspace init` mixes first-time registration and durable workspace identity concerns with asset seeding, and an existing registration requires `--force` reconciliation.
- ordinary runtime bootstrap refreshes safe host-global defaults and prepares workspace layout, but it is not an intentional operator-facing convergence surface for workspace routines and auto-tasks;
- `orbit doctor --fix-stale-artifacts` retires deprecated artifacts but is not a create/update command.

As a result, installing a newer Orbit release that adds a routine, auto-task, or other managed definition leaves operators without a clear, safe command to bring an existing workspace up to date.

## Routine Provenance Defect

The existing routine manifest at `.orbit/routines/.orbit-managed-assets.json` is not sufficient authority for template convergence. Routine seeding hashes the rendered YAML after replacing `__ORBIT_HOST_ID__` and `__ORBIT_ROUTINE_NAME__`; the latter includes a workspace-derived suffix. One digest therefore conflates three different facts:

1. which shipped routine template/version Orbit used;
2. which host and routine name were materialized for this workspace;
3. whether the on-disk rendered instance has since been edited.

A host rename, checkout/workspace-derived suffix change, or reconstruction from a different path can make a freshly rendered document differ even when the shipped template is unchanged. Conversely, the health layer cannot determine template currency from that rendered digest without the original materialization context. `workspace sync` must correct this authority model rather than treating the current single digest as reliable.

## Why It Matters

Newly shipped workspace automation should be adoptable without pretending the workspace is being initialized again or risking changes to registration, identity, configuration, or operator choices. A dedicated idempotent command also makes fleet maintenance and upgrade runbooks precise: initialize once, then sync managed artifacts as Orbit evolves.

Reliable routine provenance is a prerequisite: sync must distinguish a real shipped-template update from a changed host/workspace binding and from a user edit.

## Required Behavior

Add `orbit workspace sync` as the canonical operator-facing managed-artifact convergence command.

The command must reconcile the complete managed definition set required by the current workspace, reporting host-global and workspace-local effects distinctly. For ordinary managed assets it must reuse the existing content-provenance contract:

- create a currently shipped managed artifact when it is missing;
- refresh a current artifact only when provenance proves the on-disk copy is the unmodified file Orbit previously wrote;
- retire a no-longer-shipped managed artifact only through the existing provenance-safe retirement behavior;
- preserve locally modified, user-authored, or colliding content and emit an actionable warning naming the path;
- perform no write when the workspace is already converged.

For routines, introduce a reliable persisted provenance representation that separates:

- the digest/identity of the shipped template before placeholder substitution;
- the digest of the exact rendered instance Orbit wrote;
- the materialization inputs or equivalent stable binding data needed to explain the rendered `name` and `hosts`.

The exact schema is an implementation decision, but these questions must be independently answerable: “is the rendered file still the instance Orbit wrote?”, “has the shipped template changed?”, and “did the host/workspace binding change?” Do not infer template drift merely by rendering with today’s host or checkout-directory-derived workspace suffix.

When an unmodified managed routine needs a true template refresh, preserve its recorded rendered `name` and `hosts` bindings unless an explicit rebind operation exists. Sync itself must not silently rename routines or move their host pins.

Migrate existing single-digest routine manifests conservatively:

- a rendered file whose bytes still match the legacy digest may be recognized as the unmodified Orbit-written instance and migrated without guessing that today’s host/name inputs produced it;
- a mismatch remains locally modified or unresolved and is never overwritten;
- `--check` reports any required manifest migration but performs no migration write.

The sync must not create or alter workspace registration, workspace identity, checkout role, owner, ship mode, base branch, task state, user configuration, MCP client registration, agent-rules injection, or a workspace’s explicit routine/auto-task enablement and scheduling choices.

Keep one canonical Core-owned reconciliation path. `workspace init` may invoke that same use case after bootstrap, but CLI transports must not duplicate asset ownership, provenance, migration, or mutation rules.

## Constraints / Notes

- `sync` refers to local convergence against the installed binary, not network synchronization, repository pulls, binary installation, or schema migration outside the managed-asset manifests.
- Running it outside a valid initialized and registered workspace must fail with an actionable instruction to run `orbit workspace init`; it must not partially initialize or register anything.
- Include human-readable per-kind counts and structured JSON output.
- Provide a read-only `--check` mode suitable for CI/fleet inspection; it reports pending changes without writing and exits nonzero when convergence is required.
- Filesystem tests must use isolated temporary global and workspace roots and deterministic embedded fixtures, never the developer’s real Orbit roots.

### Acceptance Criteria

- A CLI integration test runs `orbit workspace sync` in an initialized temporary workspace and proves it creates a missing newly shipped workspace-managed routine or auto-task without changing existing operator-authored definitions.
- Routine managed provenance persists independently checkable shipped-template identity, exact rendered-instance identity, and the materialization binding data needed to explain rendered `name` and `hosts`; no template-currency decision relies only on the legacy rendered digest.
- A regression test changes the current host identity and checkout-directory/workspace suffix while keeping the shipped routine template unchanged; sync neither reports a template update nor rewrites the managed routine's existing `name` or `hosts`.
- A regression test changes the shipped routine template while the rendered file still matches the recorded Orbit-written instance; sync applies the real template update while preserving the recorded rendered `name` and `hosts` bindings.
- Legacy single-digest routine manifests migrate conservatively: exact on-disk digest matches gain the new provenance without guessing current materialization inputs, mismatches remain untouched and are reported, and `--check` plans migration without writing.
- Regression tests prove sync refreshes a stale current non-routine artifact only when the on-disk digest still matches Orbit's recorded manifest digest, retires a deprecated Orbit-written artifact through the existing safe path, and is a byte-for-byte no-op on a second run.
- A locally modified managed artifact and a user-authored name collision remain present and unchanged after sync; the result reports each preservation with its exact path and an actionable remediation.
- Sync reports created, refreshed, retired, migrated, preserved/warning, binding-drift, and unchanged outcomes by artifact kind and distinguishes host-global from workspace-local effects in both human-readable and `--json` output.
- `orbit workspace sync --check` performs no filesystem or registry writes, exits successfully when converged, and exits nonzero with the pending per-kind actions when sync or a managed-manifest migration would change anything.
- Tests snapshot workspace registration, identity, role/owner, ship mode, base branch, configuration, task state, MCP/agent integration files, and enabled or customized routine/auto-task definitions before and after sync and assert they are unchanged.
- Running sync outside a valid initialized and registered workspace fails before writing anything and names `orbit workspace init` as the bootstrap command.
- `workspace init` and `workspace sync` delegate managed-artifact decisions to one Core-owned reconciliation use case; CLI code contains no duplicate provenance, overwrite, retirement, preservation, or routine-manifest migration policy.
- Current setup and maintenance documentation explains the lifecycle distinction and routine provenance behavior: `workspace init` bootstraps, `workspace sync` converges managed artifacts, `doctor` diagnoses/repairs narrow health conditions, and neither syncs a remote nor upgrades the Orbit binary.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `orbit workspace sync [--check] [--json]` as a runtime-free command that requires an initialized, registered checkout and reports deterministic host-global/workspace-local per-kind actions.
- Added the Core-owned managed-artifact reconciliation use case used by both workspace init and sync. Ordinary assets now expose created/refreshed/retired/migrated/preserved/unchanged plans and support a write-free check mode while retaining digest-authorized refresh/retirement.
- Upgraded routine manifests to schema v2 with independent shipped-template digest, exact rendered-instance digest, and recorded name/hosts binding. Sync preserves binding drift, refreshes real template drift with the recorded binding, and conservatively migrates schema-v1 rendered-only provenance.
- Added Core regressions for binding drift, true template refresh, legacy migration/check immutability, safe ordinary refresh/retirement, and second-run byte stability; added binary CLI coverage for missing-default creation, local edit/collision preservation, structured check/apply output, state preservation, and invalid-workspace refusal.
- Updated README and upgrade/health runbooks to distinguish init, sync, doctor, binary upgrade, remote synchronization, and layout/store migration.
Assessment: The implementation centralizes mutation policy in Core, keeps CLI code to registration/identity adaptation and rendering, and preserves all non-managed workspace state. Scope expanded beyond the original selectors only for command dispatch, Core DTO export/adapters, directly affected tests, and current maintenance documentation.
Validation:
- `cargo test -p orbit-core --lib` (857 passed)
- `cargo test -p orbit-cli --test workspace_sync` (2 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `git diff --check` (passed)
Friction checkpoint: no qualifying recurring failure, contradicted assumption, incident root cause, or >10-minute non-obvious gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11149-6a94f6a1`
- Behind base: 0
- Ahead of base: 1