### PR TITLE
[code-review] Dependabot PR skip matches package names as bare substrings of PR bodies, suppressing unrelated security alerts

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -128,9 +128,9 @@ pub(crate) fn file_dependabot_alert_tasks(
                 continue;
             }
             if skip_pr
-                && let Some(pull_request) = pull_requests
-                    .iter()
-                    .find(|pull_request| pull_request_mentions_package(pull_request, &package))
+                && let Some(pull_request) = pull_requests.iter().find(|pull_request| {
+                    pull_request_bumps_package(pull_request, &ecosystem, &package)
+                })
             {
                 skipped_dependabot_pr.push(json!({
                     "family": "dependabot", "key": key, "ecosystem": ecosystem,
@@ -583,14 +583,62 @@ fn repository_name(snapshot: &Value) -> &str {
         .unwrap_or("unknown repository")
 }
 
-fn pull_request_mentions_package(pull_request: &Value, package: &str) -> bool {
+/// Match a candidate open Dependabot PR against an alert cluster using
+/// identifiers the PR actually asserts — the bumped package parsed from its
+/// title, and the package/ecosystem encoded in its `dependabot/<ecosystem>/…`
+/// head ref — rather than a free-text substring search over the title and
+/// body. A free-text search matched unrelated packages that merely appeared
+/// in another package's changelog prose.
+fn pull_request_bumps_package(pull_request: &Value, ecosystem: &str, package: &str) -> bool {
     let package = package.to_ascii_lowercase();
-    ["title", "body"].iter().any(|key| {
-        pull_request
-            .get(*key)
-            .and_then(Value::as_str)
-            .is_some_and(|text| text.to_ascii_lowercase().contains(&package))
-    })
+    if dependabot_title_package(&field(pull_request, "title"))
+        .is_some_and(|title_package| title_package == package)
+    {
+        return true;
+    }
+    dependabot_branch_names_package(&field(pull_request, "head_branch"), ecosystem, &package)
+}
+
+/// Parse the package a Dependabot PR title bumps, e.g. `Bump serde from 1.0.0
+/// to 1.0.1`. Grouped-update titles (`Bump the aws-sdk group with 3 updates`)
+/// name no single package and intentionally yield `None`.
+fn dependabot_title_package(title: &str) -> Option<String> {
+    let mut tokens = title.split_whitespace();
+    if !tokens.next()?.eq_ignore_ascii_case("Bump") {
+        return None;
+    }
+    let package = tokens.next()?;
+    if package.eq_ignore_ascii_case("the") {
+        return None;
+    }
+    let next = tokens.next()?;
+    if next.eq_ignore_ascii_case("from") || next.eq_ignore_ascii_case("to") {
+        Some(package.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+/// Dependabot head refs follow `dependabot/<ecosystem>/<manifest path…>/<package>-<version>`.
+/// Require the ecosystem segment to agree and the final path segment to name
+/// the package, so a package whose name is a substring of a sibling
+/// package's branch (e.g. `time` inside `runtime`) cannot match.
+fn dependabot_branch_names_package(head_branch: &str, ecosystem: &str, package: &str) -> bool {
+    let mut segments = head_branch.split('/');
+    if segments.next() != Some("dependabot") {
+        return false;
+    }
+    let Some(branch_ecosystem) = segments.next() else {
+        return false;
+    };
+    if !branch_ecosystem.eq_ignore_ascii_case(ecosystem) {
+        return false;
+    }
+    let Some(last) = segments.next_back() else {
+        return false;
+    };
+    let last = last.to_ascii_lowercase();
+    last == package || last.starts_with(&format!("{package}-"))
 }
 
 fn open_task_for_key(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -246,6 +246,82 @@ fn severity_floor_is_reported_and_dependabot_pr_skip_is_switchable() {
 }
 
 #[test]
+fn open_pr_for_an_unrelated_package_does_not_suppress_filing() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    // `time` is a bare substring of both the PR title's release-notes prose
+    // and this changelog-flavored body, but the PR bumps `tokio`, not `time`.
+    let pr = json!({
+        "number": 5,
+        "title": "Bump tokio from 1.28.0 to 1.28.1",
+        "body": "Bumps tokio. Release notes mention improvements to runtime scheduling and the time crate.",
+        "url": "https://github.test/pr/5",
+        "author": "app/dependabot",
+        "head_branch": "dependabot/cargo/tokio-1.28.1",
+    });
+    let output = file(
+        &runtime,
+        snapshot(vec![alert(1, "high", "< 1.2.3", "GHSA-time")], vec![pr]),
+        json!({}),
+    );
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["skipped_dependabot_pr"], json!([]));
+}
+
+#[test]
+fn open_pr_that_bumps_the_alerting_package_still_suppresses_filing() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let by_title = json!({
+        "number": 6,
+        "title": "Bump time from 1.0.0 to 1.2.3",
+        "body": "Bumps time.",
+        "url": "https://github.test/pr/6",
+        "author": "app/dependabot",
+        "head_branch": "",
+    });
+    let title_match = file(
+        &runtime,
+        snapshot(
+            vec![alert(1, "high", "< 1.2.3", "GHSA-title")],
+            vec![by_title],
+        ),
+        json!({}),
+    );
+    assert_eq!(title_match["filed_count"], json!(0));
+    assert_eq!(
+        title_match["skipped_dependabot_pr"]
+            .as_array()
+            .expect("PR skips")
+            .len(),
+        1
+    );
+
+    let by_branch = json!({
+        "number": 7,
+        "title": "Bump the cargo group with 2 updates",
+        "body": "Bumps time and another package.",
+        "url": "https://github.test/pr/7",
+        "author": "app/dependabot",
+        "head_branch": "dependabot/cargo/time-1.2.3",
+    });
+    let branch_match = file(
+        &runtime,
+        snapshot(
+            vec![alert(2, "high", "< 1.2.3", "GHSA-branch")],
+            vec![by_branch],
+        ),
+        json!({}),
+    );
+    assert_eq!(branch_match["filed_count"], json!(0));
+    assert_eq!(
+        branch_match["skipped_dependabot_pr"]
+            .as_array()
+            .expect("PR skips")
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn filing_succeeds_without_a_system_crew() {
     let (_root, runtime) = runtime_without_system_crew();
     let output = file(

--- a/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/dependabot/collect.rs
@@ -338,6 +338,7 @@ fn bound_pull_request(mut pull_request: Value) -> Value {
         bound_field(object, "body", 1_000);
         bound_field(object, "url", 500);
         bound_field(object, "author", 100);
+        bound_field(object, "head_branch", 200);
     }
     pull_request
 }

--- a/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
+++ b/crates/orbit-tools/src/builtin/github/dependabot_alerts.rs
@@ -108,7 +108,7 @@ pub fn build_open_pull_requests_request(input: &Value) -> Result<ExecRequest, Or
         "--limit".to_string(),
         limit.to_string(),
         "--json".to_string(),
-        "number,title,url,body,author".to_string(),
+        "number,title,url,body,author,headRefName".to_string(),
     ]);
     Ok(super::gh_exec_request(args, None, TIMEOUT_DEFAULT_MS))
 }
@@ -142,6 +142,7 @@ pub fn project_pull_request(pr: &Value) -> Value {
         "url": pr["url"],
         "body": pr["body"],
         "author": pr["author"]["login"],
+        "head_branch": pr["headRefName"],
     })
 }
 

--- a/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/discovery_requests.rs
@@ -41,6 +41,33 @@ fn dependabot_alert_request_is_bounded_and_projects_compact_evidence() {
 }
 
 #[test]
+fn dependabot_pull_request_discovery_requests_and_projects_the_head_branch() {
+    let req = dependabot_alerts::build_open_pull_requests_request(&json!({
+        "repo": "openai/orbit",
+    }))
+    .expect("request");
+    assert!(
+        req.args
+            .windows(2)
+            .any(|pair| pair == ["--json", "number,title,url,body,author,headRefName"])
+    );
+
+    let projected = dependabot_alerts::project_pull_request(&json!({
+        "number": 4,
+        "title": "Bump time from 1.0.0 to 1.2.3",
+        "url": "https://github.test/pr/4",
+        "body": "Bumps time from 1.0.0 to 1.2.3.",
+        "author": {"login": "app/dependabot"},
+        "headRefName": "dependabot/cargo/time-1.2.3",
+    }));
+    assert_eq!(
+        projected["head_branch"],
+        json!("dependabot/cargo/time-1.2.3")
+    );
+    assert_eq!(projected["author"], json!("app/dependabot"));
+}
+
+#[test]
 fn dependabot_alert_request_rejects_repository_path_injection() {
     let error = dependabot_alerts::build_exec_request(&json!({"repo": "acme/repo?per_page=999"}))
         .expect_err("invalid repo must fail");


### PR DESCRIPTION
## Task

[ORB-11155](https://orbit-cli.com/tasks/ORB-11155) — [code-review] Dependabot PR skip matches package names as bare substrings of PR bodies, suppressing unrelated security alerts

### Description

`skip_when_dependabot_pr_open` (default `true`) suppresses filing a dependency-remediation task when any open `app/dependabot` PR "mentions" the package. The mention test is a case-insensitive substring search over the PR's title **and body**, so an open Dependabot PR for one package routinely suppresses alerts for unrelated packages.

## Evidence

- `crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs:346-355` — `pull_request_mentions_package` lowercases the package name and returns true if either `title` or `body` `.contains(&package)`. There is no token, word, or ecosystem-qualified boundary.
- `crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs:127-140` — a match pushes the cluster to `skipped_dependabot_pr` and `continue`s, so no task is filed for that alert cluster.
- `crates/orbit-tools/src/builtin/github/dependabot_alerts.rs:95-113` — `build_open_pull_requests_request` requests `number,title,url,body,author`, i.e. the full PR body, which for Dependabot is the bumped dependency's release notes and changelog.
- `crates/orbit-engine/src/executor/automation/dependabot/collect.rs:317-324` — `bound_pull_request` keeps 1,000 characters of that body in the snapshot, so a large slice of unrelated changelog text participates in matching.
- `crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml:17` ships `skip_when_dependabot_pr_open: true`.

## Failure scenario

An open Dependabot PR bumping `tokio` carries release notes naming `bytes`, `mio`, and `hyper`. Open Dependabot alerts for any of those packages match the substring test and are silently skipped, even though no PR exists to remediate them. Short crate names make this worse: a package named `time`, `log`, `rand`, or `h2` matches almost any changelog prose (`h2` matches an `<h2>` heading; `time` matches "runtime"), so those alerts can be suppressed by essentially any open Dependabot PR. The skip is only reported inside the activity output's `skipped_dependabot_pr` array; no Orbit task records the unremediated vulnerability.

## Suggested direction

Match the PR against the alert with something the PR actually asserts: Dependabot titles follow `Bump <package> from <a> to <b>` and the PR carries a `dependabot/<ecosystem>/<path>/<package>-<version>` head ref. Match on a parsed package identifier (and ideally the manifest path/ecosystem the alert cluster is keyed on) rather than a free-text substring, and prefer requesting `headRefName` over the body for this decision.

### Acceptance Criteria

- An open Dependabot PR for package A does not suppress filing for an open alert on an unrelated package B whose name merely appears in A's title or body.
- An open Dependabot PR that genuinely bumps the alerting package still suppresses filing for that package's alert cluster.
- The match is scoped to the alert cluster's ecosystem/manifest path where the PR exposes that information, and both cases are covered by tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Replaced the free-text substring match in `pull_request_mentions_package` (orbit-core/.../dependabot_alert_tasks.rs) with `pull_request_bumps_package`, which only trusts identifiers a Dependabot PR actually asserts:

1. `dependabot_title_package` parses `Bump <package> from <a> to <b>` (or `... to <b>`) titles and returns the exact package token; grouped-update titles (`Bump the <group> group with N updates`) yield `None` rather than a false positive.
2. `dependabot_branch_names_package` parses the PR's `dependabot/<ecosystem>/<path…>/<package>-<version>` head ref, requiring the ecosystem segment to match the alert cluster's ecosystem and the final path segment to equal or hyphen-prefix-match the package — so a package name that is merely a substring of a sibling package/branch (`time` inside `runtime`, `h2` inside changelog prose) can no longer match.

Both checks replace the old title+body substring scan; PR body text is no longer used for the skip decision at all.

Plumbing to get the head ref to this decision:
- `orbit-tools/src/builtin/github/dependabot_alerts.rs`: `build_open_pull_requests_request` now requests `headRefName` from `gh pr list`; `project_pull_request` projects it as `head_branch` (matching the existing `pr_list`/`run_list`/`run_view` naming convention).
- `orbit-engine/src/executor/automation/dependabot/collect.rs`: `bound_pull_request` now bounds/truncates the new `head_branch` field (200 chars) alongside the existing title/body/url/author bounds.

Tests added:
- `orbit-core/.../tests/dependabot_alert_tasks.rs`: `open_pr_for_an_unrelated_package_does_not_suppress_filing` (title/body mentioning `time` inside `runtime`/changelog prose for a `tokio` PR no longer suppresses the `time` alert) and `open_pr_that_bumps_the_alerting_package_still_suppresses_filing` (covers both the title-parse path and the grouped-title/head-ref path).
- `orbit-tools/.../tests/discovery_requests.rs`: `dependabot_pull_request_discovery_requests_and_projects_the_head_branch` locks the new `--json` field list and the `head_branch` projection.

Validation: `cargo check -p orbit-tools -p orbit-engine -p orbit-core --tests`, `cargo test -p orbit-tools -p orbit-core -p orbit-engine dependabot` (all pass), `make ci-fast` (pass after `cargo fmt --all`), `make ci-lint` (workspace clippy, `-D warnings`, pass). No scope files added beyond the five `context_files` entries.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11155-6a950176`
- Behind base: 0
- Ahead of base: 1