### PR TITLE
[code-review] Routine reconciliation reports every customized routine as a user-authored collision when no routine manifest exists

### DIFF
--- a/crates/orbit-core/src/application/routine.rs
+++ b/crates/orbit-core/src/application/routine.rs
@@ -394,7 +394,43 @@ pub(crate) fn reconcile_default_routines(
                     path.display()
                 ))
             })?;
-            if sha256_hex(existing.as_bytes()) != rendered_digest {
+            let existing_digest = sha256_hex(existing.as_bytes());
+            if existing_digest != rendered_digest {
+                // A routines directory with no manifest at all predates managed
+                // provenance, so content alone cannot separate a routine Orbit
+                // seeded and the operator then customized — flipping `enabled`
+                // and pinning a host is the documented lifecycle — from a file
+                // the operator wrote from scratch. Adopt the on-disk instance's
+                // own binding so a later shipped-template change can be
+                // reconciled, and reserve the collision warning for a directory
+                // Orbit already tracks, where a shipped name missing from the
+                // manifest really is user-authored. Mirrors the guard in
+                // `reconcile_managed_assets`. Adoption records the bytes now on
+                // disk as Orbit's own, so a later shipped-template change
+                // refreshes them onto the adopted binding; an edit made after
+                // adoption is detected and preserved as usual.
+                if previous.is_none()
+                    && let Some(binding) = adoptable_binding(name, template, &existing)
+                {
+                    result.actions.push(ManagedAssetAction {
+                        name: (*name).to_string(),
+                        path: path.clone(),
+                        outcome: ManagedAssetOutcome::Migrated,
+                        detail: Some(
+                            "adopted a pre-provenance routine using the binding parsed from that exact instance".to_string(),
+                        ),
+                    });
+                    next_assets.insert((*name).to_string(), existing_digest.clone());
+                    next_provenance.insert(
+                        (*name).to_string(),
+                        RoutineAssetProvenance {
+                            template_digest,
+                            rendered_digest: existing_digest,
+                            binding,
+                        },
+                    );
+                    continue;
+                }
                 let detail = format!(
                     "user-authored routine '{}' collides with bundled default `{name}` and was preserved; move or rename it, then rerun `orbit workspace sync`",
                     path.display()
@@ -455,6 +491,29 @@ pub(crate) fn reconcile_default_routines(
         })?;
     }
     Ok(result)
+}
+
+/// Recover the materialization binding of an on-disk routine that predates
+/// routine provenance, so it can be adopted instead of reported as a
+/// collision forever.
+///
+/// `None` means the file is not one Orbit can manage from this template:
+/// either it does not parse as a routine, or its recorded binding could not be
+/// re-rendered later (routines v1 pins exactly one host). Refusing those keeps
+/// a future reconcile from hard-failing the whole workspace sync on a binding
+/// Orbit adopted but cannot use.
+fn adoptable_binding(
+    file_stem: &str,
+    template: &str,
+    existing: &str,
+) -> Option<RoutineMaterializationBinding> {
+    let definition = parse_routine_yaml(existing).ok()?;
+    let binding = RoutineMaterializationBinding {
+        name: definition.name,
+        hosts: definition.hosts,
+    };
+    render_routine_template(file_stem, template, &binding).ok()?;
+    Some(binding)
 }
 
 fn render_routine_template(
@@ -753,6 +812,156 @@ mod tests {
             ignoring_enabled(&rendered),
             ignoring_enabled(include_str!("../../../../.orbit/routines/task_pilot.yaml")),
             "dogfood task-pilot routine must stay aligned with the seeded template outside `enabled`"
+        );
+    }
+
+    /// A routines directory seeded before routines carried managed-asset
+    /// provenance has no manifest at all. Customizing a seeded routine —
+    /// `enabled: true` plus the host pin — is the documented lifecycle, so it
+    /// must be adopted into provenance rather than accused of colliding with
+    /// the bundled default it came from [ORB-11154].
+    #[test]
+    fn manifestless_customized_routines_are_adopted_rather_than_called_collisions() {
+        let root = tempdir().expect("create tempdir");
+        let routines_dir = root.path().join("routines");
+        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("seed a pre-provenance workspace");
+        let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+        std::fs::remove_file(&manifest_path).expect("drop the manifest to predate provenance");
+
+        let customized = routines_dir.join("task_triage.yaml");
+        let edited = std::fs::read_to_string(&customized)
+            .expect("read seeded routine")
+            .replace("enabled: false", "enabled: true");
+        assert!(
+            edited.contains("enabled: true"),
+            "fixture must opt the routine in"
+        );
+        std::fs::write(&customized, &edited).expect("simulate the documented customization");
+
+        let adopted = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("reconcile the pre-provenance directory");
+        assert!(
+            adopted.warnings.is_empty(),
+            "customizing a seeded routine must not warn: {:?}",
+            adopted.warnings
+        );
+        assert!(
+            !adopted
+                .actions
+                .iter()
+                .any(|action| action.outcome == ManagedAssetOutcome::Preserved),
+            "no routine may be reported as a user-authored collision: {:?}",
+            adopted.actions
+        );
+        assert!(adopted.actions.iter().any(|action| {
+            action.name == "task_triage" && action.outcome == ManagedAssetOutcome::Migrated
+        }));
+        assert_eq!(
+            std::fs::read_to_string(&customized).expect("reread routine"),
+            edited,
+            "adoption must not rewrite the operator's routine"
+        );
+
+        let manifest =
+            load_managed_asset_manifest(&manifest_path, "routine", ManagedAssetLayout::YamlStem)
+                .expect("load adopted manifest")
+                .expect("adoption records a manifest");
+        let provenance = manifest
+            .routine_provenance
+            .get("task_triage")
+            .expect("the customized routine gains provenance");
+        assert_eq!(provenance.rendered_digest, sha256_hex(edited.as_bytes()));
+        assert_eq!(provenance.binding.hosts, vec!["host-a".to_string()]);
+        assert_eq!(provenance.binding.name, "task-triage-workspace");
+
+        // Provenance now owns the file, so convergence is a no-op instead of
+        // repeating the same complaint on every run.
+        let second = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("second reconcile");
+        assert!(second.warnings.is_empty());
+        assert_eq!(second.refreshed, 0);
+        assert!(second.actions.iter().any(|action| {
+            action.name == "task_triage" && action.outcome == ManagedAssetOutcome::Unchanged
+        }));
+    }
+
+    /// The distinguishing condition: once Orbit tracks the directory, a shipped
+    /// name that the manifest does not claim really is user-authored, and is
+    /// still reported [ORB-11154].
+    #[test]
+    fn user_authored_collision_is_still_reported_when_the_manifest_tracks_the_directory() {
+        let root = tempdir().expect("create tempdir");
+        let routines_dir = root.path().join("routines");
+        seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("seed default routines");
+        let manifest_path = routines_dir.join(MANAGED_ASSET_MANIFEST_FILE);
+        let mut manifest =
+            load_managed_asset_manifest(&manifest_path, "routine", ManagedAssetLayout::YamlStem)
+                .expect("load manifest")
+                .expect("seeding records a manifest");
+        manifest.assets.remove("task_triage");
+        manifest.routine_provenance.remove("task_triage");
+        std::fs::write(
+            &manifest_path,
+            encode_managed_asset_manifest(&manifest).expect("encode manifest"),
+        )
+        .expect("write a manifest that never claimed this name");
+
+        let user_authored = routines_dir.join("task_triage.yaml");
+        let content = std::fs::read_to_string(&user_authored)
+            .expect("read routine")
+            .replace("task-triage-workspace", "my-own-triage");
+        std::fs::write(&user_authored, &content).expect("write a user-authored routine");
+
+        let reconciled = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("reconcile a tracked directory");
+        assert!(
+            reconciled
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("collides with bundled default")),
+            "a tracked directory must still report a user-authored collision: {:?}",
+            reconciled.warnings
+        );
+        assert!(reconciled.actions.iter().any(|action| {
+            action.name == "task_triage" && action.outcome == ManagedAssetOutcome::Preserved
+        }));
+        assert_eq!(
+            std::fs::read_to_string(&user_authored).expect("reread routine"),
+            content
+        );
+    }
+
+    /// Adoption needs a binding Orbit can re-render later. A file that does not
+    /// parse as a routine yields none, so it stays a reported collision even in
+    /// a manifest-less directory [ORB-11154].
+    #[test]
+    fn manifestless_unparseable_collision_is_still_reported() {
+        let root = tempdir().expect("create tempdir");
+        let routines_dir = root.path().join("routines");
+        std::fs::create_dir_all(&routines_dir).expect("create routines dir");
+        let path = routines_dir.join("task_triage.yaml");
+        std::fs::write(
+            &path,
+            "not: a routine
+",
+        )
+        .expect("write an unmanageable file");
+
+        let reconciled = seed_default_routines(&routines_dir, "host-a", Some("workspace"), false)
+            .expect("reconcile a manifest-less directory");
+        assert!(
+            reconciled
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("collides with bundled default")),
+            "{:?}",
+            reconciled.warnings
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("reread file"),
+            "not: a routine\n"
         );
     }
 

--- a/crates/orbit-core/src/application/tests/workspace_sync.rs
+++ b/crates/orbit-core/src/application/tests/workspace_sync.rs
@@ -203,6 +203,93 @@ fn real_template_refresh_uses_recorded_binding_and_second_run_is_a_no_op() {
     );
 }
 
+/// A workspace seeded before routines recorded provenance has no routine
+/// manifest, and its routines are customized by design. Sync must adopt them
+/// instead of reporting a collision on every run, and the adoption must leave
+/// the family reconcilable when a shipped template later changes [ORB-11154].
+#[test]
+fn manifestless_customized_routines_are_adopted_and_stay_reconcilable() {
+    let root = tempdir().expect("create tempdir");
+    let (global, workspace) = initialized_roots(root.path());
+    let manifest_path = routine_manifest(&workspace);
+    std::fs::remove_file(&manifest_path).expect("drop the pre-provenance routine manifest");
+    let customized = workspace.join("routines/task_triage.yaml");
+    let edited = std::fs::read_to_string(&customized)
+        .expect("read seeded routine")
+        .replace("enabled: false", "enabled: true");
+    std::fs::write(&customized, &edited).expect("customize the seeded routine");
+
+    let checked = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("host-a"),
+        Some("repo"),
+        true,
+    )
+    .expect("check a pre-provenance workspace");
+    assert!(
+        !checked.actions.iter().any(|action| {
+            action.kind == "routine" && action.outcome == ManagedArtifactOutcome::Preserved
+        }),
+        "customized routines must not be reported as collisions: {:?}",
+        checked.actions
+    );
+    assert!(
+        !manifest_path.exists(),
+        "--check must not write the manifest"
+    );
+
+    let applied = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("host-a"),
+        Some("repo"),
+        false,
+    )
+    .expect("adopt a pre-provenance workspace");
+    assert!(!applied.actions.iter().any(|action| {
+        action.kind == "routine" && action.outcome == ManagedArtifactOutcome::Preserved
+    }));
+    assert!(applied.actions.iter().any(|action| {
+        action.name == "task_triage" && action.outcome == ManagedArtifactOutcome::Migrated
+    }));
+    assert_eq!(
+        std::fs::read_to_string(&customized).expect("reread routine"),
+        edited,
+        "adoption must not rewrite the operator's routine"
+    );
+    let mut manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest_path).expect("read manifest"))
+            .expect("parse adopted manifest");
+    let entry = &manifest["routineProvenance"]["task_triage"];
+    assert_eq!(entry["renderedDigest"], Value::from(sha256(&edited)));
+    assert_eq!(entry["binding"]["hosts"][0], "host-a");
+
+    // Provenance now exists, so a later shipped-template change reconciles
+    // rather than repeating a collision report forever.
+    manifest["routineProvenance"]["task_triage"]["templateDigest"] =
+        Value::String("digest-from-previous-shipped-template".to_string());
+    std::fs::write(
+        &manifest_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&manifest).expect("serialize stale provenance")
+        ),
+    )
+    .expect("write stale template identity");
+    let refreshed = reconcile_workspace_managed_artifacts(
+        &global,
+        &workspace,
+        Some("host-a"),
+        Some("repo"),
+        false,
+    )
+    .expect("refresh the adopted routine");
+    assert!(refreshed.actions.iter().any(|action| {
+        action.name == "task_triage" && action.outcome == ManagedArtifactOutcome::Refreshed
+    }));
+}
+
 #[test]
 fn sync_refreshes_only_provenance_clean_non_routine_assets_and_retires_safely() {
     let root = tempdir().expect("create tempdir");

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -137,6 +137,17 @@ routine an operator has edited is never deleted: it is preserved under
 `.retired-managed/routines/`. `orbit doctor` reports routine artifacts as faulty,
 deprecated, or stale, and `orbit doctor --fix-stale-artifacts` performs the retirement.
 
+A routines directory carrying no manifest at all predates that provenance, and its routines
+are customized by design — flipping `enabled` and keeping the host pin is the lifecycle the
+templates invite. Content alone cannot separate such a routine from a file the operator wrote
+from scratch, so reconciliation adopts it [ORB-11154]: the binding is parsed from that exact
+on-disk instance, and the bytes already on disk are recorded as the ones Orbit owns. Nothing
+is rewritten, no warning is emitted, and a later shipped-template change refreshes the routine
+onto the adopted binding instead of being reported as a collision forever. Adoption is skipped
+for a file that does not parse as a routine or whose binding could not be re-rendered later,
+and once the directory has a manifest, a shipped name the manifest does not claim is genuinely
+user-authored and is still reported and preserved in place.
+
 The seeded `ci_failure_sweep` targets `job:ci_failure_sweep_pipeline` hourly at
 `5 * * * *` — deliberately clear of the other defaults' minutes — with `missed_run: skip`
 and `overlap: forbid`. Its two deterministic steps run every GitHub query on the host and


### PR DESCRIPTION
## Task

[ORB-11154](https://orbit-cli.com/tasks/ORB-11154) — [code-review] Routine reconciliation reports every customized routine as a user-authored collision when no routine manifest exists

### Description

`reconcile_default_routines` (ORB-11149) reimplements managed-asset reconciliation for routines but drops the `previous.is_some()` guard that the generic reconciler uses before accusing a file of being a user-authored collision. Because no routines directory on this host has a `.orbit-managed-assets.json` yet, that guard is exactly the one that matters, and every locally customized routine is now reported as a collision the operator should move or rename.

## Evidence

- `crates/orbit-core/src/application/routine.rs:388-409` — with no manifest entry (`previous_provenance` and `previous_digest` both `None`), an existing routine whose bytes differ from the freshly rendered template unconditionally pushes a warning and a `Preserved` action: `"user-authored routine '<path>' collides with bundled default `<name>` and was preserved; move or rename it, then rerun `orbit workspace sync`"`.
- `crates/orbit-core/src/application/mod.rs:263-275` — the generic path this replaced emits the equivalent warning only inside `} else if previous.is_some() {`, precisely because without a manifest Orbit cannot distinguish a user-authored collision from a pre-manifest Orbit-written file.
- `crates/orbit-core/src/bootstrap/init.rs:270-310` — `init_workspace_at_root` now routes routines through `reconcile_workspace_managed_artifacts` and folds every `Preserved` action's `detail` into `managed_asset_warnings`, so these lines surface on `orbit workspace init`.
- `crates/orbit-cli/src/command/workspace/sync.rs:103-121` — `format_report` prints every `Preserved` action, so `orbit workspace sync` repeats them on each invocation.

## Reproduction

On this host no routines directory contains a manifest (`ls -a <workspace>/.orbit/routines/` shows only `*.yaml`), while the shipped templates ship `enabled: false` and every adopted routine has been edited to `enabled: true` with a host pin — which is the documented lifecycle (`crates/orbit-core/src/application/routine.rs:12-17`: routines "exist so a fresh workspace gets reviewable, opt-in schedules"). Every one of those files therefore takes the collision branch. In the `orbit` workspace that is all seven routines.

## Impact

`orbit workspace init` and `orbit workspace sync` tell the operator to move or rename the routines Orbit itself seeded and the operator was expected to customize. Those routines also never receive `routine_provenance`, so `orbit workspace sync` can never adopt, refresh, or re-render them when a shipped template changes — the new convergence command is permanently inert for the routine family in every existing workspace. `has_pending_changes()` stays false (`Preserved` does not require a write), so `--check` exits 0 while the report insists something is wrong.

## Suggested direction

Mirror the generic reconciler: only claim a user-authored collision when a manifest already exists. For a manifest-less directory, decide explicitly whether to adopt the on-disk instance's binding (as the legacy branch at `routine.rs:346-385` already does by parsing the file) or to stay silent, so existing workspaces can migrate into `routine_provenance` instead of being stuck.

### Acceptance Criteria

- In a workspace whose `.orbit/routines/` has no managed-asset manifest, a shipped routine that was customized (for example `enabled: true` plus a host pin) produces no "move or rename it" warning from `orbit workspace init` or `orbit workspace sync`.
- After running `orbit workspace sync` against such a workspace, the routines have recorded provenance so a later shipped-template change can be reconciled rather than reported as a collision indefinitely.
- A genuinely user-authored file that collides with a bundled default name is still reported, and the distinguishing condition is covered by a test.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed: `reconcile_default_routines` no longer reports every customized routine as a user-authored collision when `.orbit/routines/` has no managed-asset manifest.

## Change

`crates/orbit-core/src/application/routine.rs` — in the no-manifest-entry branch, an existing routine whose bytes differ from the freshly rendered template now splits on whether Orbit already tracks the directory:

- `previous.is_none()` (pre-provenance directory): adopt the on-disk instance. `adoptable_binding()` parses the file's own `name`/`hosts` and re-renders the shipped template against that binding to prove Orbit can still materialize it later; on success the routine gets a `Migrated` action plus `RoutineAssetProvenance { template_digest, rendered_digest = digest of the bytes on disk, binding }` in both `assets` and `routineProvenance`. No warning, no write, no rewrite of the operator's file.
- `previous.is_some()`: unchanged — a shipped name the manifest never claimed really is user-authored, so the existing "collides with bundled default … move or rename it" warning and `Preserved` action still fire. This matches the guard in `reconcile_managed_assets` (`application/mod.rs:263-275`) and the `manifest.is_some()` condition doctor already uses in `application/artifact_health.rs:467`.
- Adoption is refused (falls back to the collision report) when the file does not parse as a routine or its binding cannot be re-rendered — routines v1 pins exactly one host, and adopting a multi-host binding would hard-fail a later `orbit workspace sync` for the whole workspace.

Consequence recorded next to the code and in the design doc: adoption declares the bytes now on disk to be Orbit's own, so a later shipped-template change refreshes them onto the adopted binding; an edit made *after* adoption is detected and preserved as before.

## Files

- `crates/orbit-core/src/application/routine.rs` — the guard, `adoptable_binding()`, and three unit tests (`manifestless_customized_routines_are_adopted_rather_than_called_collisions`, `user_authored_collision_is_still_reported_when_the_manifest_tracks_the_directory`, `manifestless_unparseable_collision_is_still_reported`).
- `crates/orbit-core/src/application/tests/workspace_sync.rs` — `manifestless_customized_routines_are_adopted_and_stay_reconcilable`: through `reconcile_workspace_managed_artifacts`, `--check` reports no `Preserved` routine action and writes no manifest, apply adopts (`Migrated`, file byte-identical, `renderedDigest` == digest of the customized bytes, binding host preserved), and a subsequently stale `templateDigest` then produces a `Refreshed` — proving the family is no longer permanently inert.
- `docs/design/routines/2_design.md` — new paragraph after the manifest-aware seeding section describing pre-provenance adoption, its skip conditions, and the tracked-directory collision rule (same-PR doc update).

No file outside the task's `context_files` was changed except the design doc, which documents the behavior being changed (same-PR doc rule in CLAUDE.md).

## Validation

- `make ci-fast` — pass.
- `make ci-lint` — pass (clean workspace-wide clippy).
- `cargo test -p orbit-core --lib -- application::routine application::tests::workspace_sync` — 14 passed, 0 failed.
- `cargo test -p orbit-core --lib -- application:: bootstrap::` — 317 passed, 5 failed, all environmental and unrelated: `bootstrap::init::tests::global_init_seeds_skills_and_home_level_links` fails writing the real `~/.orbit/resources/executors/claude.yaml` ("Read-only file system (os error 30); this is likely a sandbox or environment condition, not an Orbit store defect"), which poisons the shared HOME env lock and cascades into four `PoisonError` failures in the same module. None touch routine reconciliation. Unrestricted CI should arbitrate.
- `git status --short` — only the three intended files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11154-6a950176`
- Behind base: 0
- Ahead of base: 1