### PR TITLE
[code-review] CI sweep selects runs repository-wide, so any branch's run supersedes an integration-branch failure

### DIFF
--- a/.orbit/resources/activities/collect_ci_evidence.yaml
+++ b/.orbit/resources/activities/collect_ci_evidence.yaml
@@ -12,9 +12,13 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. When no GitHub client is available or authenticated the snapshot
-    carries `collected: false` and gathers nothing further, so a caller can
-    never mistake it for a clean CI result.
+    less. Workflow runs are listed repository-wide in one query but evaluated
+    per head: only a newer run of the same workflow on the same branch
+    supersedes an older failure, and a run on a branch that matches no scanned
+    head is never reported as a current failure. When no GitHub client is
+    available or authenticated the snapshot carries `collected: false` and
+    gathers nothing further, so a caller can never mistake it for a clean CI
+    result.
   input_schema_json:
     type: object
     properties:
@@ -27,8 +31,13 @@ spec:
           to the repository's GitHub default branch.
       base_branch:
         type: string
-      runs_per_ref:
+      max_runs:
         type: number
+        description: >
+          Cap on the single repository-wide workflow-run listing. This is a
+          whole-repository budget, not a per-head one; it must stay deep enough
+          that the integration head's newest run survives the pull-request runs
+          that outnumber it. Defaults to 100, maximum 300.
       max_pull_requests:
         type: number
       max_investigated_runs:

--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -12,9 +12,13 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. When no GitHub client is available or authenticated the snapshot
-    carries `collected: false` and gathers nothing further, so a caller can
-    never mistake it for a clean CI result.
+    less. Workflow runs are listed repository-wide in one query but evaluated
+    per head: only a newer run of the same workflow on the same branch
+    supersedes an older failure, and a run on a branch that matches no scanned
+    head is never reported as a current failure. When no GitHub client is
+    available or authenticated the snapshot carries `collected: false` and
+    gathers nothing further, so a caller can never mistake it for a clean CI
+    result.
   input_schema_json:
     type: object
     properties:
@@ -27,8 +31,13 @@ spec:
           to the repository's GitHub default branch.
       base_branch:
         type: string
-      runs_per_ref:
+      max_runs:
         type: number
+        description: >
+          Cap on the single repository-wide workflow-run listing. This is a
+          whole-repository budget, not a per-head one; it must stay deep enough
+          that the integration head's newest run survives the pull-request runs
+          that outnumber it. Defaults to 100, maximum 300.
       max_pull_requests:
         type: number
       max_investigated_runs:

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -6,6 +6,10 @@
 //! the commit the runner actually checked out as separate fields, and the
 //! stale/superseding evidence that says which failures are still real.
 //!
+//! "Still real" is decided per head. Runs are listed repository-wide in one
+//! query, but a run only supersedes an older one on the same branch, and a run
+//! on a branch this workspace does not track is evaluated not at all.
+//!
 //! Losing the agent's ability to ask a follow-up question mid-diagnosis is the
 //! accepted cost of that boundary. The compensation is that the snapshot is
 //! generous and that every bound it hit is reported in `truncation` — a
@@ -25,8 +29,13 @@ use super::{
 /// snapshot; `file_ci_failure_tasks` reads this field before anything else.
 pub(super) const CI_EVIDENCE_SCHEMA_VERSION: u64 = 1;
 
-const DEFAULT_RUNS_PER_REF: u64 = 20;
-const MAX_RUNS_PER_REF: u64 = 100;
+/// Cap on the single repository-wide run listing. This is a whole-repository
+/// budget, not a per-ref one: it has to be deep enough that the integration
+/// head's most recent run is still in the page after the pull-request runs
+/// that outnumber it, which is why it is far larger than the per-ref bound it
+/// replaced.
+const DEFAULT_MAX_RUNS: u64 = 100;
+const MAX_MAX_RUNS: u64 = 300;
 const DEFAULT_MAX_PULL_REQUESTS: u64 = 10;
 const MAX_PULL_REQUESTS: u64 = 50;
 const DEFAULT_MAX_INVESTIGATED_RUNS: u64 = 6;
@@ -65,7 +74,7 @@ struct ScannedRef {
 }
 
 struct Bounds {
-    runs_per_ref: u64,
+    max_runs: u64,
     max_pull_requests: u64,
     max_investigated_runs: usize,
     log_max_bytes: usize,
@@ -74,12 +83,7 @@ struct Bounds {
 
 fn bounds_from_input(input: &Value) -> Result<Bounds, OrbitError> {
     Ok(Bounds {
-        runs_per_ref: bounded_u64(
-            input,
-            "runs_per_ref",
-            DEFAULT_RUNS_PER_REF,
-            MAX_RUNS_PER_REF,
-        )?,
+        max_runs: bounded_u64(input, "max_runs", DEFAULT_MAX_RUNS, MAX_MAX_RUNS)?,
         max_pull_requests: bounded_u64(
             input,
             "max_pull_requests",
@@ -150,11 +154,11 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     let mut current: Vec<Value> = Vec::new();
     let mut stale: Vec<Value> = Vec::new();
     let mut in_flight: Vec<Value> = Vec::new();
-    // This query is deliberately repository-wide. Enumerating the integration,
-    // release, and open-PR refs separately lets an unchanged old ref keep an
-    // obsolete failure alive forever. One repository-wide list lets us choose
-    // exactly one latest run for every workflow represented in the snapshot.
-    let runs = match queries.repository_runs(bounds.runs_per_ref) {
+    // One repository-wide query rather than one per ref: a single list is what
+    // lets a newer run of a workflow supersede an older one without asking the
+    // ref it ran on whether it has advanced. The listing is repository-wide;
+    // the *evaluation* is not — `partition_runs` still answers per scanned ref.
+    let runs = match queries.repository_runs(bounds.max_runs) {
         Ok(runs) => runs,
         Err(error) => {
             query_errors.push(json!({
@@ -165,13 +169,22 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         }
     };
     let runs_listed = runs.len();
-    if runs_listed as u64 == bounds.runs_per_ref {
+    if runs_listed as u64 == bounds.max_runs {
         notes.push(format!(
-            "repository-wide workflow runs were listed at the cap ({}); older workflows may be absent",
-            bounds.runs_per_ref
+            "repository-wide workflow runs were listed at the cap ({}); a head whose runs \
+             are older than the newest {} in this repository may be absent entirely",
+            bounds.max_runs, bounds.max_runs
         ));
     }
-    partition_runs(&refs, &runs, &mut current, &mut stale, &mut in_flight);
+    let runs_on_unscanned_branches =
+        partition_runs(&refs, &runs, &mut current, &mut stale, &mut in_flight);
+    if runs_on_unscanned_branches > 0 {
+        notes.push(format!(
+            "{runs_on_unscanned_branches} of {runs_listed} listed runs were on branches that \
+             match no scanned head and were not evaluated; this workspace tracks the \
+             integration head, the release head, and open pull-request heads only"
+        ));
+    }
 
     sort_current_failures(&mut current);
     let discovered = current.len();
@@ -212,7 +225,8 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         "truncation": json!({
             "refs_scanned": refs.len(),
             "runs_listed": runs_listed,
-            "runs_per_ref": bounds.runs_per_ref,
+            "max_runs": bounds.max_runs,
+            "runs_on_unscanned_branches": runs_on_unscanned_branches,
             "pull_requests_scanned": refs
                 .iter()
                 .filter(|scanned| scanned.kind == RefKind::PullRequest)
@@ -350,42 +364,63 @@ fn head_json(scanned: &ScannedRef) -> Value {
     })
 }
 
-/// Evaluate exactly the latest repository-wide run for each workflow.
+/// Evaluate the latest run of each workflow **on each scanned head**.
 ///
-/// Older unsuccessful runs remain useful evidence, but they can never become
-/// current merely because the ref they ran on has not advanced. The latest run
-/// supersedes them regardless of branch, SHA, status, or conclusion.
+/// Grouping by workflow alone makes supersession branch-blind, and in a
+/// repository where one workflow runs both on pushes to the integration branch
+/// and on every pull request that is not a detail: the first pull-request run
+/// to finish after a broken integration push buries the integration failure,
+/// which is the head that actually gates delivery. So a run only ever speaks
+/// for the branch it ran on, and the newest run on that branch decides it —
+/// regardless of SHA, status, or conclusion, which is what keeps an unchanged
+/// old head from holding an obsolete failure open forever.
+///
+/// A run whose `head_branch` matches no scanned head speaks for nothing this
+/// workspace tracks — an abandoned feature branch, a closed pull request, an
+/// unmerged Dependabot branch. It cannot be current and it cannot supersede;
+/// it is counted, and the count is reported, so that "not tracked" never reads
+/// as "not seen". Returns how many such runs were skipped.
 fn partition_runs(
     refs: &[ScannedRef],
     runs: &[Value],
     current: &mut Vec<Value>,
     stale: &mut Vec<Value>,
     in_flight: &mut Vec<Value>,
-) {
-    let mut workflows = std::collections::BTreeMap::<String, Vec<&Value>>::new();
+) -> usize {
+    let mut unscanned = 0usize;
+    // Keyed by (workflow, branch) so the map iterates in a stable order and
+    // the snapshot is byte-identical for identical GitHub state.
+    let mut heads = std::collections::BTreeMap::<(String, String), Vec<&Value>>::new();
     for run in runs {
+        let Some(scanned) = ref_for_run(refs, run) else {
+            unscanned += 1;
+            continue;
+        };
         let workflow = run
             .get("workflow")
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        workflows.entry(workflow).or_default().push(run);
+        heads
+            .entry((workflow, scanned.branch.clone()))
+            .or_default()
+            .push(run);
     }
 
-    for workflow_runs in workflows.values_mut() {
-        workflow_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
-        let Some(latest) = workflow_runs.first().copied() else {
+    for head_runs in heads.values_mut() {
+        head_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
+        let Some(latest) = head_runs.first().copied() else {
             continue;
         };
 
-        for older in workflow_runs.iter().skip(1).copied() {
+        for older in head_runs.iter().skip(1).copied() {
             let completed = older.get("status").and_then(Value::as_str) == Some("completed");
             let conclusion = older.get("conclusion").and_then(Value::as_str);
             if completed && unsuccessful_conclusion(conclusion) {
                 let mut entry = run_summary(ref_for_run(refs, older), older);
                 entry["reason"] = json!("superseded_by_newer_workflow_run");
                 entry["evidence"] = json!(format!(
-                    "newer run {} at {} is {} with conclusion {}",
+                    "newer run {} on the same branch at {} is {} with conclusion {}",
                     latest
                         .get("run_id")
                         .and_then(Value::as_u64)
@@ -422,6 +457,8 @@ fn partition_runs(
             current.push(summary);
         }
     }
+
+    unscanned
 }
 
 /// Sortable position of a run: creation time first, run id as the tiebreak.

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -72,22 +72,22 @@ fn separates_event_sha_current_head_and_actual_checkout_commit() {
 }
 
 #[test]
-fn latest_non_failing_run_supersedes_older_failures_across_refs_and_shas() {
+fn latest_non_failing_run_supersedes_older_failures_on_the_same_head() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
         .with_runs(vec![vec![
-            // The latest CI run is successful on the release branch and a
-            // different SHA. Both older CI failures are stale even though the
-            // old topic ref still points at one failure's SHA.
+            // Newer `ci` run on the same branch, at a different SHA: the older
+            // failure is stale even though the branch still points at the SHA
+            // that failure tested.
             run_on_branch(
-                30,
+                25,
                 "ci",
-                "main",
+                "topic",
                 OLD,
                 "completed",
                 Some("success"),
-                "2026-08-30T03:00:00Z",
+                "2026-08-30T02:30:00Z",
             ),
             run_on_branch(
                 20,
@@ -98,14 +98,16 @@ fn latest_non_failing_run_supersedes_older_failures_across_refs_and_shas() {
                 Some("failure"),
                 "2026-08-30T02:00:00Z",
             ),
+            // A `ci` run on the release head. It decides that head and nothing
+            // else, so it neither creates nor clears a failure on `topic`.
             run_on_branch(
-                10,
+                30,
                 "ci",
-                "old-pr",
+                "main",
                 OLD,
                 "completed",
-                Some("failure"),
-                "2026-08-30T01:00:00Z",
+                Some("success"),
+                "2026-08-30T03:00:00Z",
             ),
             // A completed non-failing conclusion has the same authority as a
             // success for another workflow.
@@ -142,7 +144,6 @@ fn latest_non_failing_run_supersedes_older_failures_across_refs_and_shas() {
         [
             "superseded_by_newer_workflow_run",
             "superseded_by_newer_workflow_run",
-            "superseded_by_newer_workflow_run",
         ]
     );
     let superseding_ids: Vec<u64> = evidence["stale_or_superseded"]
@@ -151,7 +152,131 @@ fn latest_non_failing_run_supersedes_older_failures_across_refs_and_shas() {
         .iter()
         .filter_map(|entry| entry["superseded_by"]["run_id"].as_u64())
         .collect();
-    assert_eq!(superseding_ids, [30, 30, 40]);
+    assert_eq!(superseding_ids, [25, 40]);
+}
+
+#[test]
+fn integration_failure_survives_a_later_non_failing_run_on_another_head() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_pull_request(json!({
+            "number": 12,
+            "url": "https://github.com/acme/orbit/pull/12",
+            "head_branch": "feature-x",
+            "reported_head_sha": OLD,
+        }))
+        .with_runs(vec![vec![
+            // The pull-request run of `ci` finishes after the integration
+            // push broke, and the release run after that. Neither ran the
+            // integration head's commit, so neither may clear its failure.
+            run_on_branch(
+                40,
+                "ci",
+                "feature-x",
+                OLD,
+                "completed",
+                Some("success"),
+                "2026-08-30T04:00:00Z",
+            ),
+            run_on_branch(
+                30,
+                "ci",
+                "main",
+                OLD,
+                "completed",
+                Some("success"),
+                "2026-08-30T03:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T02:00:00Z",
+            ),
+        ]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    let current_ids: Vec<u64> = evidence["current_failures"]
+        .as_array()
+        .expect("current failures")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect();
+    assert_eq!(
+        current_ids,
+        [20],
+        "a run on another head must not supersede the integration head: {evidence}"
+    );
+    assert_eq!(
+        evidence["current_failures"][0]["ref_kind"],
+        json!("integration")
+    );
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+}
+
+#[test]
+fn run_on_a_branch_no_scanned_head_matches_is_never_current() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![
+            // Newest run in the repository, on a branch behind no open pull
+            // request. It can neither be filed nor supersede anything.
+            run_on_branch(
+                50,
+                "ci",
+                "abandoned/feature",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T05:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T02:00:00Z",
+            ),
+        ]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    let current_ids: Vec<u64> = evidence["current_failures"]
+        .as_array()
+        .expect("current failures")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect();
+    assert_eq!(
+        current_ids,
+        [20],
+        "an untracked branch must neither be filed nor supersede: {evidence}"
+    );
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["in_flight"], json!([]));
+    assert_eq!(
+        evidence["truncation"]["runs_on_unscanned_branches"],
+        json!(1)
+    );
+    assert!(
+        evidence["truncation"]["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note
+                .as_str()
+                .is_some_and(|note| note.contains("match no scanned head"))),
+        "skipped runs must be reported, not silently dropped: {evidence}"
+    );
 }
 
 #[test]
@@ -204,22 +329,54 @@ fn latest_in_flight_run_does_not_resurrect_an_older_failure() {
 }
 
 #[test]
-fn old_dependabot_failure_is_superseded_by_newer_repository_ci_run() {
+fn old_dependabot_failure_on_an_unscanned_branch_is_never_current() {
+    // ORB-11146: an eleven-day-old Dependabot run kept being filed because its
+    // branch had not advanced. Once that pull request is closed the branch is
+    // not a scanned head, so the run is skipped outright rather than depending
+    // on a newer run of the same workflow existing somewhere in the repository.
     const DEPENDABOT_SHA: &str = "0f14f3f2ad2c863f902c0add969ff09d10e3f15c";
     const OLD_RUN_ID: u64 = 31_583_558_682;
 
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
+        .with_runs(vec![vec![run_on_branch(
+            OLD_RUN_ID,
+            "CI",
+            "dependabot/cargo/old",
+            DEPENDABOT_SHA,
+            "completed",
+            Some("failure"),
+            "2026-08-20T01:00:00Z",
+        )]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(
+        evidence["truncation"]["runs_on_unscanned_branches"],
+        json!(1)
+    );
+}
+
+#[test]
+fn open_pull_request_head_failure_is_current_for_its_own_head() {
+    // The converse of the case above: while the pull request is open its head
+    // is scanned, and its own latest run decides it. No run on another branch
+    // can clear it, and it clears no other branch.
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
         .with_pull_request(json!({
             "number": 959,
             "url": "https://github.com/acme/orbit/pull/959",
-            "head_branch": "dependabot/cargo/old",
-            "reported_head_sha": DEPENDABOT_SHA,
+            "head_branch": "dependabot/cargo/current",
+            "reported_head_sha": OLD,
         }))
         .with_runs(vec![vec![
             run_on_branch(
-                OLD_RUN_ID + 100,
+                200,
                 "CI",
                 "main",
                 HEAD,
@@ -228,33 +385,25 @@ fn old_dependabot_failure_is_superseded_by_newer_repository_ci_run() {
                 "2026-08-31T02:00:00Z",
             ),
             run_on_branch(
-                OLD_RUN_ID,
+                100,
                 "CI",
-                "dependabot/cargo/old",
-                DEPENDABOT_SHA,
+                "dependabot/cargo/current",
+                OLD,
                 "completed",
                 Some("failure"),
-                "2026-08-20T01:00:00Z",
+                "2026-08-31T01:00:00Z",
             ),
         ]]);
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    assert_eq!(evidence["current_failures"], json!([]));
-    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(evidence["current_failures"][0]["run_id"], json!(100));
     assert_eq!(
-        evidence["stale_or_superseded"][0]["run_id"],
-        json!(OLD_RUN_ID)
-    );
-    assert_eq!(
-        evidence["stale_or_superseded"][0]["ref_kind"],
+        evidence["current_failures"][0]["ref_kind"],
         json!("pull_request")
     );
-    assert_eq!(
-        evidence["stale_or_superseded"][0]["investigated"],
-        json!(false),
-        "a superseded run must never consume investigation or filing input: {evidence}"
-    );
+    assert_eq!(evidence["current_failures"][0]["pr_number"], json!(959));
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
 }
 
 #[test]
@@ -336,6 +485,9 @@ fn derives_release_head_from_github_and_reports_every_bound_it_hit() {
     assert_eq!(heads[1]["current_head_sha"], json!(OLD));
 
     let truncation = &evidence["truncation"];
+    // The reported bound is the repository-wide cap that was actually applied.
+    assert_eq!(truncation["max_runs"], json!(100));
+    assert_eq!(truncation["runs_on_unscanned_branches"], json!(0));
     assert_eq!(truncation["current_failures_discovered"], json!(2));
     assert_eq!(truncation["current_failures_investigated"], json!(1));
     assert!(


### PR DESCRIPTION
## Task

[ORB-11152](https://orbit-cli.com/tasks/ORB-11152) — [code-review] CI sweep selects runs repository-wide, so any branch's run supersedes an integration-branch failure

### Description

`ORB-11147` (cbf63f89) replaced the per-ref run enumeration in `collect_ci_evidence` with a single repository-wide `gh run list`, then grouped the returned runs **only by workflow name**. The scanned refs (integration, release, open PRs) no longer constrain which runs are evaluated at all — `refs` is used solely for labelling and for the `heads`/`truncation` report.

## Evidence

- `crates/orbit-engine/src/executor/automation/ci/collect.rs:157` — `queries.repository_runs(bounds.runs_per_ref)` lists runs across the whole repository with no branch filter (`crates/orbit-engine/src/executor/automation/ci/query.rs:192-193` builds `gh run list --limit N` with the `branch` key removed).
- `crates/orbit-engine/src/executor/automation/ci/collect.rs:359-430` — `partition_runs` keys `workflows` on `run["workflow"]` alone, sorts each group newest-first, and treats `workflow_runs.first()` as authoritative: every older unsuccessful run in the group is pushed to `stale` with `reason = "superseded_by_newer_workflow_run"`, and only the single latest run can become a current failure.
- `crates/orbit-engine/src/executor/automation/ci/collect.rs:438-441` — `ref_for_run` only *labels* a run; a run whose `head_branch` matches no scanned ref still flows through with `ref_kind: "other"`.
- The intent is asserted in the test `latest_non_failing_run_supersedes_older_failures_across_refs_and_shas` (`crates/orbit-engine/src/executor/automation/ci/tests/collect.rs`), where a `ci` failure on `topic` at the current head is marked stale because a later `ci` run succeeded on `main` at a different SHA.

## Why this is wrong

A GitHub workflow named `CI` runs on pushes to `agent-main` *and* on every pull request. Because supersession is branch-blind, the first PR-branch run of `CI` that completes after a broken `agent-main` push marks that integration failure `superseded_by_newer_workflow_run`, and it is never filed. PR runs vastly outnumber integration-branch runs in this repository, so a broken integration branch is effectively invisible to the sweep. This also renders the `integration_branch` wiring fixed in ORB-11131 (`.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml:51`) inert for run selection.

The converse also holds: the newest run of a workflow may be on a branch the workspace does not track (an abandoned feature branch, a closed-PR branch, a Dependabot branch). Its failure becomes a `current_failure` with `ref_kind: "other"` and a task is filed, because nothing downstream filters on `ref_kind` (`crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs` never reads that field).

Related: the bound is still named `runs_per_ref` (`collect.rs:68,215`, `crates/orbit-core/assets/activities/collect_ci_evidence.yaml:30`) and still defaults to 20, but it is now a single repository-wide cap rather than 20 per ref. The effective look-back window shrank by roughly the number of scanned refs while the name and default were kept.

## Suggested direction

Group supersession by `(workflow, branch)` — or restrict the repository-wide listing to runs whose `head_branch` matches a scanned ref — so a newer run only supersedes an older one on the same ref, and rename/re-default the bound to match its new repository-wide meaning.

### Acceptance Criteria

- A completed failing run on the integration branch is still reported in `current_failures` when a later run of the same workflow completes non-failing on an unrelated branch (PR or release).
- A run whose `head_branch` matches none of the scanned refs never produces a `current_failure`.
- The repository-wide run bound's input name, default, and activity documentation describe the cap that is actually applied.
- Regression tests cover cross-branch supersession and the untracked-branch case at the `collect` boundary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

## Changes

**`crates/orbit-engine/src/executor/automation/ci/collect.rs`**

- `partition_runs` now groups by `(workflow, head_branch)` instead of `workflow` alone. A run only supersedes an older run on the *same* branch, so a `CI` run on a pull-request or release head can no longer bury an integration-branch failure. Within a head, selection is unchanged: newest by `created_at` then run ID; latest completed-unsuccessful is current, latest queued/in-progress is in flight, older completed-unsuccessful runs are `superseded_by_newer_workflow_run`.
- A run whose `head_branch` matches no scanned head is now skipped entirely — it can neither become a `current_failure` nor supersede anything. `partition_runs` returns the count of such runs; `collect` reports it as `truncation.runs_on_unscanned_branches` plus an explicit note. Deliberately *not* pushed into `stale_or_superseded`: `ci_failure_tasks::stale_evidence` filters that array by workflow and renders it into filed task descriptions, so untracked runs there would read as "superseded" when they were simply not evaluated.
- Renamed the bound `runs_per_ref` → `max_runs` (`Bounds` field, activity input key, `truncation` key) and re-defaulted it from 20/max 100 to **100/max 300**. It became a single repository-wide cap in ORB-11147 while keeping a per-ref name and per-ref default, which shrank the effective look-back by roughly the number of scanned heads. The new default has to be deep enough that the integration head's newest run survives the PR runs that outnumber it — which is exactly what per-head evaluation depends on.
- The at-cap note now says a whole head may be absent, not just "older workflows".
- Module doc and `partition_runs` doc state the per-head rule and why branch-blind supersession was wrong.

**`crates/orbit-core/assets/activities/collect_ci_evidence.yaml`** and its byte-identical git-tracked workspace copy **`.orbit/resources/activities/collect_ci_evidence.yaml`** — renamed the input to `max_runs` with a description naming the actual cap, default, and maximum; extended the activity description to state per-head evaluation and the untracked-branch rule.

**`crates/orbit-engine/src/executor/automation/ci/tests/collect.rs`** — 9 tests → 12.

- `integration_failure_survives_a_later_non_failing_run_on_another_head` (new, criterion 1): a `ci` failure on the integration head stays current although later `ci` runs succeeded on both the release head and an open PR head.
- `run_on_a_branch_no_scanned_head_matches_is_never_current` (new, criterion 2): the newest repository run is a failure on an untracked branch; it is neither filed nor allowed to supersede the older integration failure, and the skip is reported in `truncation`.
- `latest_non_failing_run_supersedes_older_failures_across_refs_and_shas` → `..._on_the_same_head`: its premise (cross-ref supersession) was the defect. Retains SHA-independence and the non-failing-conclusion-has-success-authority cases within a head, and adds a same-workflow run on the release head that correctly changes nothing.
- `old_dependabot_failure_is_superseded_by_newer_repository_ci_run` → `old_dependabot_failure_on_an_unscanned_branch_is_never_current`: keeps the ORB-11146 fixture (run 31583558682) but suppresses it via the untracked-branch rule rather than branch-blind supersession, with no newer run needed.
- `open_pull_request_head_failure_is_current_for_its_own_head` (new): documents the converse explicitly.
- `derives_release_head_from_github_...` now asserts `truncation.max_runs == 100` and `runs_on_unscanned_branches == 0` (criterion 3).

## Reviewer note — deliberate behavior change

ORB-11147 criterion 4 asserted that the ORB-11146 Dependabot failure on **open** PR #959 is suppressed by a newer repository-wide `CI` run. Per-head supersession cannot preserve that: an open PR's head is a scanned ref, so its own latest failing run is current for its own head. The ORB-11146 outcome is preserved through the untracked-branch rule (once #959 closes, its branch matches no scanned head and the run is skipped outright regardless of what else ran). Suppressing repeat filing while a PR is open belongs to `file_ci_failure_tasks`' `open_task_for_key` dedupe, not the collector. Recorded as a task comment as well.

## Validation

- `cargo test -p orbit-engine executor::automation::ci::tests` — 12 passed, 0 failed.
- `cargo test -p orbit-core ci_failure` — 19 passed, 0 failed (filing dedupe, cluster/failure keys, single-flight catalog).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — clean. `git status --short` shows exactly the four intended files; no caches or build artifacts created in the worktree.

## Assessment

Run *listing* stays repository-wide in one query; run *evaluation* is now per scanned head. Criteria 1, 2, and 4 are covered by tests at the `collect` boundary; criterion 3 by the rename plus the asserted `truncation.max_runs`. The `integration_branch` wiring from ORB-11131 is load-bearing for run selection again rather than only for labelling.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11152-6a9501c2`
- Behind base: 0
- Ahead of base: 1