### PR TITLE
[qa-sweep] `orbit routine list` ignores explicit roots and reads `$HOME/.orbit`

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -969,9 +969,9 @@ fn dispatch_sweep(command: Commands, _context: DispatchContext<'_>) -> CommandOu
     }
 }
 
-fn dispatch_routine(command: Commands, _context: DispatchContext<'_>) -> CommandOut {
+fn dispatch_routine(command: Commands, context: DispatchContext<'_>) -> CommandOut {
     match command {
-        Commands::Routine(command) => command.execute_without_runtime(),
+        Commands::Routine(command) => command.execute_without_runtime(context.root_override),
         _ => dispatch_mismatch("Routine"),
     }
 }

--- a/crates/orbit-cli/src/command/routine/clock.rs
+++ b/crates/orbit-cli/src/command/routine/clock.rs
@@ -1,6 +1,7 @@
+use std::path::Path;
+
 use clap::{Args, Subcommand};
 use orbit_core::routines::{clock_status, set_clock_cadence, set_clock_enabled};
-use orbit_registry::workspace_registry;
 
 use crate::command::{CommandOut, CommandOutput};
 
@@ -29,11 +30,10 @@ enum RoutineClockSubcommand {
 }
 
 impl RoutineClockArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
         match self.command {
             RoutineClockSubcommand::Status => {
-                let status = clock_status(&global_root)?;
+                let status = clock_status(global_root)?;
                 let state = if !status.enabled {
                     "paused"
                 } else if status.schedulable {
@@ -56,21 +56,21 @@ impl RoutineClockArgs {
                 }
             }
             RoutineClockSubcommand::Pause => {
-                let status = set_clock_enabled(&global_root, false)?;
+                let status = set_clock_enabled(global_root, false)?;
                 println!(
                     "host sweep clock paused ({}); manual `orbit sweep` remains available",
                     status.platform
                 );
             }
             RoutineClockSubcommand::Enable => {
-                let status = set_clock_enabled(&global_root, true)?;
+                let status = set_clock_enabled(global_root, true)?;
                 println!(
                     "host sweep clock enabled: runs every {} seconds ({})",
                     status.configured_cadence_seconds, status.platform
                 );
             }
             RoutineClockSubcommand::Set { cadence_seconds } => {
-                set_clock_cadence(&global_root, cadence_seconds)?;
+                set_clock_cadence(global_root, cadence_seconds)?;
                 println!("host sweep clock cadence set to {cadence_seconds} seconds and reloaded");
             }
         }

--- a/crates/orbit-cli/src/command/routine/command.rs
+++ b/crates/orbit-cli/src/command/routine/command.rs
@@ -4,7 +4,11 @@
 //! state, so the whole parent command dispatches without a workspace runtime
 //! (see `main.rs`), like `orbit sweep` itself.
 
+use std::path::Path;
+
 use clap::{Args, Subcommand};
+use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_registry::workspace_registry;
 
 use super::clock::RoutineClockArgs;
 use super::init::RoutineInitArgs;
@@ -29,11 +33,22 @@ pub struct RoutineCommand {
 }
 
 impl RoutineCommand {
-    /// All routine subcommands resolve state from the global root; none may
-    /// bootstrap a workspace from the caller's cwd.
-    pub fn execute_without_runtime(self) -> CommandOut {
-        self.command.execute_without_runtime()
+    /// Resolve the selected global root once for every routine subcommand;
+    /// none may bootstrap a workspace from the caller's cwd.
+    pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
+        let global_root = selected_global_root(root_override)?;
+        self.command.execute_without_runtime(&global_root)
     }
+}
+
+fn selected_global_root(root_override: Option<&Path>) -> Result<std::path::PathBuf, OrbitError> {
+    let has_env_override = std::env::var("ORBIT_ROOT").is_ok_and(|root| !root.trim().is_empty());
+    if root_override.is_some() || has_env_override {
+        let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
+        return OrbitRuntime::resolve_roots_for_cwd(&cwd, root_override)
+            .map(|roots| roots.global_root);
+    }
+    workspace_registry::global_orbit_dir()
 }
 
 #[derive(Subcommand)]
@@ -53,14 +68,14 @@ pub enum RoutineSubcommand {
 }
 
 impl RoutineSubcommand {
-    fn execute_without_runtime(self) -> CommandOut {
+    fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
         match self {
-            Self::List(args) => args.execute_without_runtime(),
-            Self::Show(args) => args.execute_without_runtime(),
-            Self::Pause(args) => args.execute_without_runtime(),
-            Self::Resume(args) => args.execute_without_runtime(),
-            Self::Clock(args) => args.execute_without_runtime(),
-            Self::Init(args) => args.execute_without_runtime(),
+            Self::List(args) => args.execute_without_runtime(global_root),
+            Self::Show(args) => args.execute_without_runtime(global_root),
+            Self::Pause(args) => args.execute_without_runtime(global_root),
+            Self::Resume(args) => args.execute_without_runtime(global_root),
+            Self::Clock(args) => args.execute_without_runtime(global_root),
+            Self::Init(args) => args.execute_without_runtime(global_root),
         }
     }
 }

--- a/crates/orbit-cli/src/command/routine/init.rs
+++ b/crates/orbit-cli/src/command/routine/init.rs
@@ -1,12 +1,13 @@
+use std::path::Path;
+
 use crate::command::{CommandOut, CommandOutput};
 use clap::Args;
 use orbit_core::routines::install_clock;
 use orbit_registry::load_host_identity;
-use orbit_registry::workspace_registry;
 
 #[derive(Args)]
 #[command(
-    after_help = "Reads the machine identity from ~/.orbit/host.toml (created by\n\
+    after_help = "Reads the machine identity from the selected Orbit root's host.toml (created by\n\
                         `orbit init`) and, with --install-clock, installs the per-user OS\n\
                         clock unit that invokes `orbit sweep` every minute (launchd on\n\
                         macOS, a systemd user timer on Linux). It never creates or rewrites\n\
@@ -19,12 +20,10 @@ pub struct RoutineInitArgs {
 }
 
 impl RoutineInitArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
-
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
         // Read-only: host identity is owned by `orbit init`. Fail closed with
         // an actionable error when it is absent or unmigrated.
-        let identity = load_host_identity(&global_root)?;
+        let identity = load_host_identity(global_root)?;
         println!(
             "host identity: host_id=\"{}\", machine_id={}",
             identity.host_id, identity.machine_id
@@ -35,7 +34,7 @@ impl RoutineInitArgs {
             return Ok(CommandOutput::Silent);
         }
 
-        let report = install_clock(&global_root)?;
+        let report = install_clock(global_root)?;
         for file in &report.files_written {
             println!("wrote {}", file.display());
         }

--- a/crates/orbit-cli/src/command/routine/list.rs
+++ b/crates/orbit-cli/src/command/routine/list.rs
@@ -1,7 +1,8 @@
+use std::path::Path;
+
 use clap::Args;
 use comfy_table::Cell;
 use orbit_cmd::registry_routines::routine_statuses;
-use orbit_registry::workspace_registry;
 use serde_json::json;
 
 use crate::command::{CommandOut, Payload};
@@ -15,9 +16,8 @@ pub struct RoutineListArgs {
 }
 
 impl RoutineListArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
-        let report = routine_statuses(&global_root)?;
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
+        let report = routine_statuses(global_root)?;
 
         let statuses: Vec<_> = report
             .statuses

--- a/crates/orbit-cli/src/command/routine/pause.rs
+++ b/crates/orbit-cli/src/command/routine/pause.rs
@@ -1,7 +1,8 @@
+use std::path::Path;
+
 use crate::command::{CommandOut, CommandOutput};
 use clap::Args;
 use orbit_core::routines::pause_routine;
-use orbit_registry::workspace_registry;
 
 #[derive(Args)]
 pub struct RoutinePauseArgs {
@@ -10,9 +11,8 @@ pub struct RoutinePauseArgs {
 }
 
 impl RoutinePauseArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
-        if pause_routine(&global_root, &self.name, "human")? {
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
+        if pause_routine(global_root, &self.name, "human")? {
             println!(
                 "paused '{}' on this host (host-local; resume with `orbit routine resume {}`)",
                 self.name, self.name

--- a/crates/orbit-cli/src/command/routine/resume.rs
+++ b/crates/orbit-cli/src/command/routine/resume.rs
@@ -1,7 +1,8 @@
+use std::path::Path;
+
 use crate::command::{CommandOut, CommandOutput};
 use clap::Args;
 use orbit_core::routines::resume_routine;
-use orbit_registry::workspace_registry;
 
 #[derive(Args)]
 pub struct RoutineResumeArgs {
@@ -10,9 +11,8 @@ pub struct RoutineResumeArgs {
 }
 
 impl RoutineResumeArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
-        if resume_routine(&global_root, &self.name)? {
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
+        if resume_routine(global_root, &self.name)? {
             println!("resumed '{}' on this host", self.name);
         } else {
             println!("'{}' was not paused on this host", self.name);

--- a/crates/orbit-cli/src/command/routine/show.rs
+++ b/crates/orbit-cli/src/command/routine/show.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
+
 use crate::command::{CommandOut, Payload};
 use clap::Args;
 use orbit_cmd::registry_routines::routine_statuses;
 use orbit_core::OrbitError;
 use orbit_core::routines::recent_fires;
-use orbit_registry::workspace_registry;
 use serde_json::json;
 
 const RECENT_FIRE_LIMIT: usize = 10;
@@ -18,9 +19,8 @@ pub struct RoutineShowArgs {
 }
 
 impl RoutineShowArgs {
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let global_root = workspace_registry::global_orbit_dir()?;
-        let report = routine_statuses(&global_root)?;
+    pub fn execute_without_runtime(self, global_root: &Path) -> CommandOut {
+        let report = routine_statuses(global_root)?;
         let Some(status) = report
             .statuses
             .iter()
@@ -31,7 +31,7 @@ impl RoutineShowArgs {
                 self.name
             )));
         };
-        let fires = recent_fires(&global_root, &self.name, RECENT_FIRE_LIMIT)?;
+        let fires = recent_fires(global_root, &self.name, RECENT_FIRE_LIMIT)?;
         let definition = &status.routine.definition;
 
         let doc = json!({

--- a/crates/orbit-cli/tests/routine_root.rs
+++ b/crates/orbit-cli/tests/routine_root.rs
@@ -1,0 +1,260 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+struct Fixture {
+    _temp: TempDir,
+    home: PathBuf,
+    repo: PathBuf,
+    root: PathBuf,
+    routine_name: String,
+}
+
+impl Fixture {
+    fn initialized() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("empty-home");
+        let repo = temp.path().join("repo");
+        let root = temp.path().join("custom-root");
+        fs::create_dir_all(&home).expect("create empty home");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_git_repo(&repo);
+
+        let root_arg = root.to_string_lossy().into_owned();
+        run_success(
+            &repo,
+            &home,
+            &[
+                "--root",
+                &root_arg,
+                "init",
+                "--non-interactive",
+                "--host-name",
+                "routine-root-host",
+                "--task-prefix",
+                "RR",
+            ],
+            None,
+        );
+        run_success(
+            &repo,
+            &home,
+            &[
+                "--root",
+                &root_arg,
+                "workspace",
+                "init",
+                "--name",
+                "routine-root",
+            ],
+            None,
+        );
+        enable_routine_source(&root);
+        assert_home_empty(&home);
+
+        let list = run_json(
+            &repo,
+            &home,
+            &["--root", &root_arg, "routine", "list", "--format", "json"],
+            None,
+        );
+        let routine_name = list["routines"]
+            .as_array()
+            .and_then(|routines| routines.first())
+            .and_then(|routine| routine["name"].as_str())
+            .unwrap_or_else(|| panic!("seeded routine name in custom-root list: {list}"))
+            .to_string();
+
+        Self {
+            _temp: temp,
+            home,
+            repo,
+            root,
+            routine_name,
+        }
+    }
+}
+
+#[test]
+fn routine_list_honors_explicit_root_over_uninitialized_home_and_environment() {
+    let fixture = Fixture::initialized();
+    let root_arg = fixture.root.to_string_lossy().into_owned();
+    let uninitialized_env_root = fixture.home.join(".orbit");
+
+    let list = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &["--root", &root_arg, "routine", "list", "--format", "json"],
+        Some(&uninitialized_env_root),
+    );
+
+    assert_eq!(list["host_id"], "routine-root-host");
+    let routines = list["routines"].as_array().expect("routine list array");
+    assert!(
+        routines.len() >= 7,
+        "expected the seeded routines from the custom root: {list}"
+    );
+    assert!(
+        routines.iter().any(|routine| {
+            routine["name"]
+                .as_str()
+                .is_some_and(|name| name.starts_with("ci-failure-sweep-"))
+        }),
+        "custom-root routine list omitted ci_failure_sweep: {list}"
+    );
+    assert_home_empty(&fixture.home);
+}
+
+#[test]
+fn routine_commands_honor_orbit_root_and_mutate_only_the_selected_root() {
+    let fixture = Fixture::initialized();
+    let root_arg = fixture.root.to_string_lossy().into_owned();
+
+    let list = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &["routine", "list", "--format", "json"],
+        Some(&fixture.root),
+    );
+    assert_eq!(list["host_id"], "routine-root-host");
+
+    run_success(
+        &fixture.repo,
+        &fixture.home,
+        &[
+            "--root",
+            &root_arg,
+            "routine",
+            "pause",
+            &fixture.routine_name,
+        ],
+        None,
+    );
+    let paused = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &["routine", "show", &fixture.routine_name, "--format", "json"],
+        Some(&fixture.root),
+    );
+    assert!(
+        paused["paused_at"].is_string(),
+        "routine was not paused: {paused}"
+    );
+
+    run_success(
+        &fixture.repo,
+        &fixture.home,
+        &["routine", "resume", &fixture.routine_name],
+        Some(&fixture.root),
+    );
+    let resumed = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &[
+            "--root",
+            &root_arg,
+            "routine",
+            "show",
+            &fixture.routine_name,
+            "--format",
+            "json",
+        ],
+        None,
+    );
+    assert!(
+        resumed["paused_at"].is_null(),
+        "routine stayed paused: {resumed}"
+    );
+    assert_home_empty(&fixture.home);
+}
+
+fn run_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT");
+    if let Some(root) = orbit_root {
+        command.env("ORBIT_ROOT", root);
+    }
+    command.args(args).assert().success();
+}
+
+fn run_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) -> Value {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT");
+    if let Some(root) = orbit_root {
+        command.env("ORBIT_ROOT", root);
+    }
+    let output = command
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap_or_else(|error| {
+        panic!(
+            "parse JSON from `orbit {}`: {error}\nstdout:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output)
+        )
+    })
+}
+
+fn assert_home_empty(home: &Path) {
+    assert!(
+        fs::read_dir(home)
+            .expect("read isolated home")
+            .next()
+            .is_none(),
+        "routine command touched isolated HOME at {}",
+        home.display()
+    );
+}
+
+fn enable_routine_source(root: &Path) {
+    let config_path = root.join("config.toml");
+    let mut config = fs::read_to_string(&config_path).expect("read workspace config");
+    config.push_str("\n[routines]\nrole = \"source\"\n");
+    fs::write(config_path, config).expect("enable routine source");
+}
+
+fn init_git_repo(repo: &Path) {
+    run_git(repo, &["init", "--quiet"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# routine root test\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11156](https://orbit-cli.com/tasks/ORB-11156) — [qa-sweep] `orbit routine list` ignores explicit roots and reads `$HOME/.orbit`

### Description

## Problem

At commit `cfd62210` (after the new CI/Dependabot routine work in `45f56630`, `ad153639`, and `7bb78f3a`), the supported custom-root bootstrap succeeds, but the user-facing routine inspection path ignores both top-level `--root` and `ORBIT_ROOT`. It resolves the default home registry instead.

This was found while hands-on validating the newly shipped `ci_failure_sweep` and `dependabot_alert_sweep` routines. The analogous `workspace list` custom-root bug was fixed by done task ORB-10928, but no open `qa-sweep` task or broader task search covers the routine command family.

## Exact reproduction

1. Create a scratch Git checkout and empty home under `/tmp`.
2. From the checkout, run:

```text
orbit --root /tmp/qa/root init --non-interactive --host-name qa-host --task-prefix QAQA
orbit --root /tmp/qa/root workspace init
HOME=/tmp/qa/empty-home orbit --root /tmp/qa/root routine list --format json
```

3. Observe:

```text
{"code":"invalid_input","error":"invalid input: no host identity at `/tmp/qa/empty-home/.orbit/host.toml`; run `orbit init` to create one"}
```

The requested root contains a valid host identity and seeded routines. Setting `ORBIT_ROOT=/tmp/qa/root` instead of passing `--root` produces the same wrong-root behavior. In the agent sandbox, where the real home registry is present but read-only, the same command instead fails against `~/.orbit/workspaces.json` with EROFS.

## Evidence / likely boundary

`RoutineCommand` is dispatched with `RuntimeNeed::Forbidden`; `dispatch_routine` discards `DispatchContext`, and `RoutineListArgs::execute_without_runtime` calls `workspace_registry::global_orbit_dir()` directly. The top-level help nevertheless advertises `--root <ROOT>` as the highest-precedence override on `orbit routine list`. Sibling routine subcommands use the same runtime-free shape and should be audited so read and mutation paths cannot target the wrong host root.

## Impact

Production: operators using a non-default Orbit root cannot reliably inspect or control routines, and mutation subcommands risk acting on the home-root host state instead of the requested root.

Validation: sandbox QA cannot exercise newly shipped routines through the prescribed isolated `/tmp` root because `routine list` reaches the read-only real home registry instead.

### Acceptance Criteria

- After initializing a scratch custom root, `orbit --root <root> routine list --format json` reads that root and lists its seeded routines even when `HOME` points at an uninitialized directory.
- `ORBIT_ROOT=<root> orbit routine list --format json` has the same custom-root behavior as `--root <root>`.
- Routine show and state-changing sibling commands consistently honor the selected custom root and do not read or mutate `$HOME/.orbit` when an explicit root is supplied.
- Regression tests isolate HOME and prove the requested custom root wins without touching the developer or CI home registry.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Threaded the top-level selected root through routine dispatch and resolved explicit --root / ORBIT_ROOT with the canonical OrbitRuntime resolver before invoking any routine subcommand.
- Made list, show, pause, resume, clock, and init consume that single selected root instead of independently reopening the HOME registry.
- Added process-level regression tests that bootstrap a custom root, isolate an empty HOME, verify --root wins over a conflicting ORBIT_ROOT, verify ORBIT_ROOT alone lists seeded routines, and prove show/pause/resume read and mutate only the selected root.
- Added file:crates/orbit-cli/tests/routine_root.rs to task context because the acceptance criteria required CLI-level root-precedence and HOME-isolation coverage.

Validation:
- cargo test -p orbit-cli --test routine_root (2 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)

Assessment: The routine command family now has one canonical root-resolution path, explicit root precedence matches the advertised CLI contract, and regression coverage exercises both read and mutation paths without touching HOME.

Deviations from original plan: None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11156-6a950176`
- Behind base: 0
- Ahead of base: 1