### PR TITLE
[code-review] `min_severity` is ignored for Code scanning alerts in the security sweep

### DIFF
--- a/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
@@ -20,6 +20,9 @@ spec:
         type: string
         enum: [low, moderate, high, critical]
         default: high
+        description: >
+          Minimum severity filed for Dependabot and Code scanning alerts.
+          Secret scanning alerts are always filed regardless of this floor.
       skip_when_dependabot_pr_open:
         type: boolean
         default: true

--- a/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml
@@ -13,6 +13,7 @@ spec:
     max_secret_scanning_alerts: 100
     max_secret_locations: 20
     max_tasks: 10
+    # Governs Dependabot and Code scanning; secret scanning is always filed.
     min_severity: high
     skip_when_dependabot_pr_open: true
   steps:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -200,6 +200,23 @@ pub(crate) fn file_dependabot_alert_tasks(
         if number == 0 {
             continue;
         }
+        let security_severity = field(&alert, "security_severity").to_ascii_lowercase();
+        let rank = severity_rank(&security_severity);
+        if rank.is_none_or(|rank| rank < floor) {
+            excluded_below_min_severity.push(json!({
+                "family": "code_scanning",
+                "alert_number": number,
+                "rule_id": field(&alert, "rule_id"),
+                "path": field(&alert, "path"),
+                "security_severity": security_severity,
+                "reason": if rank.is_some() {
+                    "below_min_severity"
+                } else {
+                    "missing_or_unrecognized_security_severity"
+                },
+            }));
+            continue;
+        }
         let key = digest(&["code-scanning", repository, &number.to_string()]);
         if let Some(task_id) = open_task_for_key(runtime, CODE_KEY_PREFIX, &key)? {
             skipped_existing.push(json!({
@@ -216,8 +233,7 @@ pub(crate) fn file_dependabot_alert_tasks(
         }
         let rule = field(&alert, "rule_id");
         let path = field(&alert, "path");
-        let rank =
-            severity_rank(&field(&alert, "security_severity").to_ascii_lowercase()).unwrap_or(1);
+        let rank = rank.unwrap_or(floor);
         let task = runtime.add_task(TaskAddParams {
             title: code_task_title(&rule, &path),
             description: code_task_description(snapshot, &alert),

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -418,6 +418,71 @@ fn code_and_secret_alerts_file_evidence_complete_deduplicated_tasks() {
 }
 
 #[test]
+fn code_scanning_severity_floor_excludes_lower_severity_alerts() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let output = file(
+        &runtime,
+        expanded_snapshot(
+            Vec::new(),
+            vec![code_alert(10, "moderate"), code_alert(11, "high")],
+            Vec::new(),
+        ),
+        json!({"min_severity": "high"}),
+    );
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["alert_number"], json!(11));
+    assert_eq!(
+        output["excluded_below_min_severity"],
+        json!([{
+            "family": "code_scanning",
+            "alert_number": 10,
+            "rule_id": "rust/sql-injection",
+            "path": "src/db.rs",
+            "security_severity": "moderate",
+            "reason": "below_min_severity",
+        }])
+    );
+}
+
+#[test]
+fn code_scanning_missing_or_unrecognized_severity_is_explicitly_excluded() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let mut missing = code_alert(12, "high");
+    missing
+        .as_object_mut()
+        .expect("code alert object")
+        .remove("security_severity");
+    let output = file(
+        &runtime,
+        expanded_snapshot(
+            Vec::new(),
+            vec![missing, code_alert(13, "informational")],
+            Vec::new(),
+        ),
+        json!({"min_severity": "low"}),
+    );
+
+    assert_eq!(output["filed_count"], json!(0));
+    let excluded = output["excluded_below_min_severity"]
+        .as_array()
+        .expect("excluded alerts");
+    assert_eq!(excluded.len(), 2);
+    assert_eq!(excluded[0]["alert_number"], json!(12));
+    assert_eq!(excluded[0]["security_severity"], "");
+    assert_eq!(
+        excluded[0]["reason"],
+        "missing_or_unrecognized_security_severity"
+    );
+    assert_eq!(excluded[1]["alert_number"], json!(13));
+    assert_eq!(excluded[1]["security_severity"], "informational");
+    assert_eq!(
+        excluded[1]["reason"],
+        "missing_or_unrecognized_security_severity"
+    );
+}
+
+#[test]
 fn max_tasks_is_one_deterministic_bound_across_all_families() {
     let (_root, runtime, _repo) = runtime_with_workspace_layout();
     let output = file(
@@ -489,7 +554,7 @@ fn sentinel_credential_never_reaches_snapshot_output_or_persisted_task_fields() 
 #[test]
 fn unavailable_family_does_not_hide_findings_from_collected_family() {
     let (_root, runtime, _repo) = runtime_with_workspace_layout();
-    let mut snapshot = expanded_snapshot(Vec::new(), vec![code_alert(15, "moderate")], Vec::new());
+    let mut snapshot = expanded_snapshot(Vec::new(), vec![code_alert(15, "high")], Vec::new());
     snapshot["collection_status"] = json!("partially_collected");
     snapshot["secret_scanning"] = json!({
         "collected": false,


### PR DESCRIPTION
## Task

[ORB-11153](https://orbit-cli.com/tasks/ORB-11153) — [code-review] `min_severity` is ignored for Code scanning alerts in the security sweep

### Description

`file_dependabot_alert_tasks` advertises and defaults `min_severity: high`, and the shipped pipeline sets it at job level, but the floor is only applied to the Dependabot family. Every open Code scanning alert is filed regardless of its severity, including alerts with no `security_severity_level` at all.

## Evidence

- `crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs:54-63` — `floor` is parsed from `input.min_severity` (default `"high"`).
- `crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs:85-98` — the Dependabot loop computes `rank` and `continue`s into `excluded_below_min_severity` when `rank < floor`.
- `crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs:196-249` — the Code scanning loop performs **no** floor comparison. `severity_rank(&field(&alert, "security_severity").to_ascii_lowercase()).unwrap_or(1)` (line ~218) is used only to pick `priority_for_rank(rank)`; a missing or unrecognized `security_severity` silently becomes rank 1 and the alert is still filed as a `bug`.
- `crates/orbit-core/assets/jobs/dependabot_alert_sweep_pipeline.yaml:16` sets `min_severity: high` as a job default and passes it to the `file` step, so an operator configuring the sweep reasonably reads it as the sweep-wide floor.
- `crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml:19-22` declares `min_severity` as a top-level input with `default: high` and no statement that it is Dependabot-only.

## Impact

A repository with CodeQL enabled and a backlog of `note`/`warning`/low-severity findings gets up to `max_tasks` (default 10) low-priority `bug` tasks filed per sweep run, every run, while `excluded_below_min_severity` reports nothing for that family. Because the `max_tasks` bound is shared across all three families and Code scanning is processed before secret scanning, low-severity Code scanning alerts can also crowd out secret-scanning tasks that the sweep considers critical.

## Suggested direction

Apply `floor` to the Code scanning family using the same `severity_rank`/`excluded_below_min_severity` path as Dependabot (deciding explicitly how an alert with no `security_severity` is treated), or narrow the advertised contract in the activity input schema and the job default so `min_severity` is unambiguously Dependabot-only.

### Acceptance Criteria

- With `min_severity: high`, a Code scanning alert whose `security_severity` is below high is not filed and is reported in `excluded_below_min_severity`.
- The handling of a Code scanning alert with an absent or unrecognized `security_severity` is explicit and covered by a test.
- The `file_dependabot_alert_tasks` activity input schema and the sweep job's `min_severity` default describe the families the floor actually governs.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Applied min_severity to Code scanning alerts before dedupe and max-task admission, so recognized severities below the floor are reported in excluded_below_min_severity and do not file tasks.
- Made absent or unrecognized Code scanning security_severity explicit by excluding it with reason missing_or_unrecognized_security_severity and preserving the observed value in the exclusion record.
- Added focused tests for below-floor, missing, and unrecognized Code scanning severity; adjusted the unrelated partial-collection test to use a severity that remains eligible under the default floor.
- Documented that min_severity governs Dependabot and Code scanning, while secret scanning is always filed, in both the activity input schema and shipped sweep job default.
Validation:
- cargo fmt --all -- --check (passed)
- cargo test -p orbit-core dependabot_alert_tasks (passed: 12 tests)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Assessment: The severity floor now has one consistent contract across the two severity-ranked families without changing secret-scanning admission. Unknown Code scanning severities fail closed and are auditable rather than silently becoming low-priority filed tasks.
Cleanup: Removed the run-created Cargo target directory with cargo clean after validation; final status contains only the four intended context-file changes.
Friction checkpoint: No qualifying friction found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11153-6a950585`
- Behind base: 0
- Ahead of base: 1