### PR TITLE
Restore CI failure sweep task filing for latest failed checks

### DIFF
--- a/.orbit/resources/activities/collect_ci_evidence.yaml
+++ b/.orbit/resources/activities/collect_ci_evidence.yaml
@@ -12,10 +12,11 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. Workflow runs are listed repository-wide in one query but evaluated
-    per head: only a newer run of the same workflow on the same branch
-    supersedes an older failure, and a run on a branch that matches no scanned
-    head is never reported as a current failure. When no GitHub client is
+    less. Workflow runs are listed repository-wide in one query and exactly
+    the latest run of each workflow is authoritative, ordered by creation time
+    then run ID. Discovery or investigation failures are bounded, redacted,
+    and emitted in `retryable_errors`; the filing step rejects such a snapshot
+    so it cannot be mistaken for a clean result. When no GitHub client is
     available or authenticated the snapshot carries `collected: false` and
     gathers nothing further, so a caller can never mistake it for a clean CI
     result.
@@ -68,14 +69,18 @@ spec:
             type: object
           heads:
             type: array
+          latest_runs:
+            type: array
           current_failures:
             type: array
           stale_or_superseded:
             type: array
           in_flight:
             type: array
-          query_errors:
+          retryable_errors:
             type: array
+          summary:
+            type: object
           truncation:
             type: object
           collected_at:

--- a/.orbit/resources/activities/file_ci_failure_tasks.yaml
+++ b/.orbit/resources/activities/file_ci_failure_tasks.yaml
@@ -21,7 +21,13 @@ spec:
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
     reports `current_failures` with what it filed, skipped as already open, or
-    left unfiled at the `max_tasks` cap.
+    left unfiled at the `max_tasks` cap. Discovery, investigation,
+    registration, dedupe lookup, or task-creation failures fail the activity
+    with a bounded `retryable_error` payload; a current failure is never
+    converted to `no_current_failure` merely because its handoff failed. Every
+    successful output includes an `audit` object with counts and identities for
+    latest runs, current and investigated failures, created tasks, and existing
+    dedupe owners.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -40,7 +46,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap]
+    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap, audit]
     properties:
       outcome:
         type: string
@@ -111,5 +117,7 @@ spec:
               type: array
               items:
                 type: string
+      audit:
+        type: object
   action: file_ci_failure_tasks
   config: {}

--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -26,6 +26,9 @@
 # - No GitHub client or no credentials on this host: `collect` reports
 #   `capability_unavailable` and `file` passes that through unchanged. That is
 #   never reported as a no-current-failure and is never a CI pass.
+# - A discovery, investigation, registration, dedupe, or task-creation error
+#   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
+#   retries the handoff; no current failure is consumed as a clean result.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -12,10 +12,11 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. Workflow runs are listed repository-wide in one query but evaluated
-    per head: only a newer run of the same workflow on the same branch
-    supersedes an older failure, and a run on a branch that matches no scanned
-    head is never reported as a current failure. When no GitHub client is
+    less. Workflow runs are listed repository-wide in one query and exactly
+    the latest run of each workflow is authoritative, ordered by creation time
+    then run ID. Discovery or investigation failures are bounded, redacted,
+    and emitted in `retryable_errors`; the filing step rejects such a snapshot
+    so it cannot be mistaken for a clean result. When no GitHub client is
     available or authenticated the snapshot carries `collected: false` and
     gathers nothing further, so a caller can never mistake it for a clean CI
     result.
@@ -68,14 +69,18 @@ spec:
             type: object
           heads:
             type: array
+          latest_runs:
+            type: array
           current_failures:
             type: array
           stale_or_superseded:
             type: array
           in_flight:
             type: array
-          query_errors:
+          retryable_errors:
             type: array
+          summary:
+            type: object
           truncation:
             type: object
           collected_at:

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -21,7 +21,13 @@ spec:
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
     reports `current_failures` with what it filed, skipped as already open, or
-    left unfiled at the `max_tasks` cap.
+    left unfiled at the `max_tasks` cap. Discovery, investigation,
+    registration, dedupe lookup, or task-creation failures fail the activity
+    with a bounded `retryable_error` payload; a current failure is never
+    converted to `no_current_failure` merely because its handoff failed. Every
+    successful output includes an `audit` object with counts and identities for
+    latest runs, current and investigated failures, created tasks, and existing
+    dedupe owners.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -40,7 +46,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap]
+    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap, audit]
     properties:
       outcome:
         type: string
@@ -111,5 +117,7 @@ spec:
               type: array
               items:
                 type: string
+      audit:
+        type: object
   action: file_ci_failure_tasks
   config: {}

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -26,6 +26,9 @@
 # - No GitHub client or no credentials on this host: `collect` reports
 #   `capability_unavailable` and `file` passes that through unchanged. That is
 #   never reported as a no-current-failure and is never a CI pass.
+# - A discovery, investigation, registration, dedupe, or task-creation error
+#   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
+#   retries the handoff; no current failure is consumed as a clean result.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -29,6 +29,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
 use orbit_types::task::{TaskComplexity, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -78,6 +79,19 @@ pub(crate) fn file_ci_failure_tasks(
     runtime: &OrbitRuntime,
     input: &Value,
 ) -> Result<Value, OrbitError> {
+    file_ci_failure_tasks_with_add(runtime, input, |params| {
+        runtime.add_task(params).map(|task| task.id)
+    })
+}
+
+pub(in crate::adapter::engine_host::v2_host) fn file_ci_failure_tasks_with_add<F>(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    mut add_task: F,
+) -> Result<Value, OrbitError>
+where
+    F: FnMut(TaskAddParams) -> Result<String, OrbitError>,
+{
     let evidence = input.get("ci_evidence").ok_or_else(|| {
         OrbitError::InvalidInput(
             "file_ci_failure_tasks requires the `ci_evidence` snapshot produced by \
@@ -107,6 +121,7 @@ pub(crate) fn file_ci_failure_tasks(
     // would read exactly like "nothing is failing" — a conclusion that needs
     // queries this host never ran.
     if evidence.get("collected").and_then(Value::as_bool) != Some(true) {
+        let audit = audit_summary(evidence, &[]);
         return Ok(json!({
             "outcome": OUTCOME_CAPABILITY_UNAVAILABLE,
             "capability": capability,
@@ -115,6 +130,7 @@ pub(crate) fn file_ci_failure_tasks(
             "filed": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
+            "audit": audit,
             "detail": "no CI evidence was gathered, so no task was filed; this is not a CI pass",
         }));
     }
@@ -125,7 +141,57 @@ pub(crate) fn file_ci_failure_tasks(
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
+    let audit = audit_summary(evidence, &failures);
+    let mut retryable_errors = evidence
+        .get("retryable_errors")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    // Version-1 snapshots emitted `query_errors`. Treat them with the repaired
+    // contract when an older collect step is still paired with this filer.
+    retryable_errors.extend(
+        evidence
+            .get("query_errors")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+    );
+    retryable_errors = retryable_errors
+        .into_iter()
+        .map(normalize_retryable_error)
+        .collect();
+    for failure in &failures {
+        if failure.get("investigated").and_then(Value::as_bool) != Some(true) {
+            retryable_errors.push(json!({
+                "stage": "registration",
+                "operation": "current_failure_not_investigated",
+                "run_id": failure.get("run_id"),
+                "retryable": true,
+                "message": "a current CI failure has no complete investigation and cannot be filed safely",
+            }));
+        }
+    }
+    if !retryable_errors.is_empty() {
+        return Err(retryable_pipeline_error(
+            "collection_or_investigation",
+            &audit,
+            retryable_errors,
+        ));
+    }
     let clusters = cluster_failures(&failures);
+
+    if !failures.is_empty() && clusters.is_empty() {
+        return Err(retryable_pipeline_error(
+            "registration",
+            &audit,
+            vec![json!({
+                "stage": "registration",
+                "operation": "cluster_failures",
+                "retryable": true,
+                "message": "current failures were discovered but none could be registered for task filing",
+            })],
+        ));
+    }
 
     if clusters.is_empty() {
         return Ok(json!({
@@ -136,6 +202,7 @@ pub(crate) fn file_ci_failure_tasks(
             "filed": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
+            "audit": audit,
             "detail": "the queries ran and found no current, non-superseded failure",
         }));
     }
@@ -156,7 +223,21 @@ pub(crate) fn file_ci_failure_tasks(
         .then(|| SYSTEM_CREW.to_string());
 
     for cluster in &clusters {
-        if let Some(task_id) = open_task_for_key(runtime, &cluster.failure_key)? {
+        if let Some(task_id) =
+            open_task_for_key(runtime, &cluster.failure_key).map_err(|error| {
+                retryable_pipeline_error(
+                    "dedupe_lookup",
+                    &audit,
+                    vec![json!({
+                        "stage": "registration",
+                        "operation": "open_task_for_key",
+                        "failure_key": cluster.failure_key,
+                        "retryable": true,
+                        "message": bounded_error(&error.to_string()),
+                    })],
+                )
+            })?
+        {
             skipped_existing.push(json!({
                 "failure_key": cluster.failure_key,
                 "cluster_key": cluster.cluster_key,
@@ -188,7 +269,7 @@ pub(crate) fn file_ci_failure_tasks(
             continue;
         }
 
-        let task = runtime.add_task(TaskAddParams {
+        let task_id = add_task(TaskAddParams {
             title: cluster.title(),
             description: cluster.description(evidence),
             acceptance_criteria: cluster.acceptance_criteria(),
@@ -207,10 +288,24 @@ pub(crate) fn file_ci_failure_tasks(
             status: Some(TaskStatus::Backlog),
             system_created: true,
             ..TaskAddParams::default()
+        })
+        .map_err(|error| {
+            retryable_pipeline_error(
+                "task_creation",
+                &audit,
+                vec![json!({
+                    "stage": "task_creation",
+                    "operation": "orbit.task.add",
+                    "failure_key": cluster.failure_key,
+                    "run_ids": cluster.run_ids(),
+                    "retryable": true,
+                    "message": bounded_error(&error.to_string()),
+                })],
+            )
         })?;
         filed_keys.insert(cluster.failure_key.clone());
         filed.push(json!({
-            "task_id": task.id,
+            "task_id": task_id,
             "failure_key": cluster.failure_key,
             "cluster_key": cluster.cluster_key,
             "workflow": cluster.workflow,
@@ -221,6 +316,7 @@ pub(crate) fn file_ci_failure_tasks(
         }));
     }
 
+    let final_audit = filing_audit(audit, &filed, &skipped_existing);
     Ok(json!({
         "outcome": OUTCOME_CURRENT_FAILURES,
         "capability": capability,
@@ -230,7 +326,96 @@ pub(crate) fn file_ci_failure_tasks(
         "skipped_existing": skipped_existing,
         "skipped_over_cap": skipped_over_cap,
         "max_tasks": max_tasks,
+        "audit": final_audit,
     }))
+}
+
+fn audit_summary(evidence: &Value, failures: &[Value]) -> Value {
+    let latest_run_ids = evidence
+        .get("latest_runs")
+        .and_then(Value::as_array)
+        .map(|runs| {
+            runs.iter()
+                .filter_map(|run| run.get("run_id").cloned())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let current_failure_run_ids = failures
+        .iter()
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    let investigated_failure_run_ids = failures
+        .iter()
+        .filter(|run| run.get("investigated").and_then(Value::as_bool) == Some(true))
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    json!({
+        "latest_runs_discovered": latest_run_ids.len(),
+        "latest_run_ids": latest_run_ids,
+        "current_failures": current_failure_run_ids.len(),
+        "current_failure_run_ids": current_failure_run_ids,
+        "investigated_failures": investigated_failure_run_ids.len(),
+        "investigated_failure_run_ids": investigated_failure_run_ids,
+        "tasks_created": 0,
+        "created_task_ids": [],
+        "existing_task_skips": 0,
+        "existing_task_owners": [],
+        "retryable_errors": 0,
+    })
+}
+
+fn filing_audit(mut audit: Value, filed: &[Value], skipped_existing: &[Value]) -> Value {
+    let created_task_ids = filed
+        .iter()
+        .filter_map(|entry| entry.get("task_id").cloned())
+        .collect::<Vec<_>>();
+    let existing_task_owners = skipped_existing
+        .iter()
+        .filter_map(|entry| entry.get("task_id").cloned())
+        .collect::<Vec<_>>();
+    audit["tasks_created"] = json!(created_task_ids.len());
+    audit["created_task_ids"] = json!(created_task_ids);
+    audit["existing_task_skips"] = json!(skipped_existing.len());
+    audit["existing_task_owners"] = json!(existing_task_owners);
+    audit
+}
+
+fn retryable_pipeline_error(stage: &str, audit: &Value, errors: Vec<Value>) -> OrbitError {
+    let mut audit = audit.clone();
+    audit["retryable_errors"] = json!(errors.len());
+    OrbitError::Execution(format!(
+        "ci_failure_sweep retryable: {}",
+        json!({
+            "outcome": "retryable_error",
+            "stage": stage,
+            "audit": audit,
+            "errors": errors,
+        })
+    ))
+}
+
+fn bounded_error(message: &str) -> String {
+    redact_all(message).chars().take(500).collect()
+}
+
+fn normalize_retryable_error(error: Value) -> Value {
+    json!({
+        "stage": error.get("stage").and_then(Value::as_str).unwrap_or("collection"),
+        "operation": error
+            .get("operation")
+            .or_else(|| error.get("query"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        "run_id": error.get("run_id").cloned().unwrap_or(Value::Null),
+        "retryable": true,
+        "message": bounded_error(
+            error
+                .get("message")
+                .or_else(|| error.get("error"))
+                .and_then(Value::as_str)
+                .unwrap_or("CI handoff operation failed"),
+        ),
+    })
 }
 
 /// One root cause, with every current run that exhibited it.
@@ -262,6 +447,13 @@ impl FailureCluster {
             .iter()
             .filter_map(|run| run.get("url").and_then(Value::as_str))
             .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn run_ids(&self) -> Vec<Value> {
+        self.runs
+            .iter()
+            .filter_map(|run| run.get("run_id").cloned())
             .collect()
     }
 
@@ -478,11 +670,13 @@ impl FailureCluster {
 
 fn render_run(run: &Value) -> String {
     let mut out = format!(
-        "- {} run `{}` ({} on `{}`)\n",
+        "- {} run `{}` ({} on `{}`) — status `{}`, conclusion `{}`\n",
         display(&value_string(run, "url")),
         display(&value_string(run, "run_id")),
         display(&value_string(run, "event")),
         display(&value_string(run, "head_branch")),
+        display(&value_string(run, "status")),
+        display(&value_string(run, "conclusion")),
     );
     out.push_str(&format!(
         "  - event-reported head SHA: `{}`\n",
@@ -522,6 +716,33 @@ fn render_run(run: &Value) -> String {
             "  - checkout evidence: `{}`\n",
             truncate_chars(line, 200)
         ));
+    }
+    for job in run
+        .get("failed_jobs")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .take(3)
+    {
+        out.push_str(&format!(
+            "  - failed job `{}` (id `{}`): {}\n",
+            display(&value_string(job, "name")),
+            display(&value_string(job, "job_id")),
+            display(&value_string(job, "url")),
+        ));
+        let steps = job
+            .get("failed_steps")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(|step| display(&value_string(step, "name")).to_owned())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !steps.is_empty() {
+            out.push_str(&format!("  - failing step(s): `{steps}`\n"));
+        }
     }
     out
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -4,6 +4,7 @@
 //! Every test drives the action through `run_deterministic`, which is the only
 //! way a job step reaches it.
 
+use orbit_common::OrbitError;
 use orbit_engine::RuntimeHost;
 use orbit_tools::ToolContext;
 use orbit_types::task::TaskStatus;
@@ -11,6 +12,7 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::ci_failure_tasks::file_ci_failure_tasks_with_add;
 use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
 use crate::application::task::TaskUpdateParams;
 
@@ -27,6 +29,18 @@ fn file(runtime: &OrbitRuntime, input: Value) -> Value {
             ToolContext::default(),
         )
         .expect("file ci failure tasks")
+}
+
+fn file_error(runtime: &OrbitRuntime, input: Value) -> String {
+    runtime
+        .run_deterministic(
+            "file_ci_failure_tasks",
+            &json!({}),
+            &input,
+            ToolContext::default(),
+        )
+        .expect_err("file ci failure tasks must remain retryable")
+        .to_string()
 }
 
 /// One current failure, shaped exactly as `collect_ci_evidence` emits it.
@@ -63,6 +77,7 @@ fn failure(run_id: u64, workflow: &str, job: &str, step: &str, log: &str, checko
 }
 
 fn snapshot(current: Vec<Value>) -> Value {
+    let latest = current.clone();
     json!({
         "schema_version": 1,
         "collected": true,
@@ -74,10 +89,11 @@ fn snapshot(current: Vec<Value>) -> Value {
         },
         "repository": {"name": "orbit", "full_name": "acme/orbit", "default_branch": "main"},
         "heads": [{"kind": "integration", "branch": "agent-main", "current_head_sha": HEAD}],
+        "latest_runs": latest,
         "current_failures": current,
         "stale_or_superseded": [],
         "in_flight": [],
-        "query_errors": [],
+        "retryable_errors": [],
         "truncation": {"runs_listed": 4, "current_failures_discovered": 1, "notes": []},
         "collected_at": "2026-08-30T02:00:00Z",
     })
@@ -260,6 +276,120 @@ fn a_filed_task_is_an_ordinary_backlog_bug_carrying_usable_evidence() {
 }
 
 #[test]
+fn live_run_fixture_files_once_with_complete_actionable_evidence() {
+    const RUN_ID: u64 = 33_358_160_088;
+    const JOB_ID: u64 = 99_384_177_985;
+    const SHA: &str = "2a4cb4e4631a856552d901b6b062fa6596475cc0";
+    const RUN_URL: &str = "https://github.com/danieljhkim/orbit/actions/runs/33358160088";
+    const JOB_URL: &str =
+        "https://github.com/danieljhkim/orbit/actions/runs/33358160088/job/99384177985";
+    const TEST: &str = "orbit-cli::routine_root::routine_commands_honor_orbit_root_and_mutate_only_the_selected_root";
+    const EXCERPT: &str = "routine command touched isolated HOME at /tmp/.tmpgNchET/empty-home";
+
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut live = failure(
+        RUN_ID,
+        "CI",
+        "Rust tests",
+        "Run Rust tests",
+        &format!(
+            "CI\tRust tests\tassertion failed: {TEST} at crates/orbit-cli/tests/routine_root.rs:218: {EXCERPT}\n"
+        ),
+        SHA,
+    );
+    live["url"] = json!(RUN_URL);
+    live["event_reported_head_sha"] = json!(SHA);
+    live["current_ref_head_sha"] = json!(SHA);
+    live["actual_checkout_shas"] = json!([SHA]);
+    live["checkout_evidence"] = json!([format!("HEAD is now at {SHA}")]);
+    live["failed_jobs"] = json!([{
+        "job_id": JOB_ID,
+        "name": "Rust tests",
+        "conclusion": "failure",
+        "url": JOB_URL,
+        "failed_steps": [{"name": "Run Rust tests", "conclusion": "failure"}],
+    }]);
+    let evidence = snapshot(vec![live]);
+
+    let first = file(&runtime, json!({"ci_evidence": evidence.clone()}));
+    assert_eq!(first["outcome"], json!("current_failures"));
+    assert_eq!(first["filed_count"], json!(1));
+    assert_eq!(first["audit"]["latest_run_ids"], json!([RUN_ID]));
+    assert_eq!(first["audit"]["current_failure_run_ids"], json!([RUN_ID]));
+    assert_eq!(
+        first["audit"]["investigated_failure_run_ids"],
+        json!([RUN_ID])
+    );
+    assert_eq!(first["audit"]["tasks_created"], json!(1));
+    let task_id = filed_task_ids(&first).remove(0);
+    let task = runtime.get_task(&task_id).expect("read filed task");
+    for expected in [
+        RUN_URL,
+        JOB_URL,
+        "33358160088",
+        "99384177985",
+        "CI",
+        "conclusion `failure`",
+        "Run Rust tests",
+        TEST,
+        "crates/orbit-cli/tests/routine_root.rs:218",
+        EXCERPT,
+        SHA,
+        "event-reported head SHA",
+        "current head of that ref",
+        "commit actually checked out",
+    ] {
+        assert!(
+            task.description.contains(expected),
+            "filed task must contain {expected:?}:\n{}",
+            task.description
+        );
+    }
+
+    let second = file(&runtime, json!({"ci_evidence": evidence}));
+    assert_eq!(second["outcome"], json!("current_failures"));
+    assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(second["skipped_existing"][0]["task_id"], json!(task_id));
+    assert_eq!(second["audit"]["existing_task_skips"], json!(1));
+    assert_eq!(second["audit"]["existing_task_owners"], json!([task_id]));
+    assert_eq!(second["audit"]["current_failure_run_ids"], json!([RUN_ID]));
+}
+
+#[test]
+fn task_add_failure_is_retryable_and_cannot_persist_a_handled_state() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let evidence = snapshot(vec![failure(
+        10,
+        "CI",
+        "Rust tests",
+        "Run Rust tests",
+        "CI\tRust tests\tassertion failed: injected filing fault\n",
+        CHECKOUT,
+    )]);
+
+    let error =
+        file_ci_failure_tasks_with_add(&runtime, &json!({"ci_evidence": evidence}), |_params| {
+            Err(OrbitError::Execution(
+                "injected orbit.task.add failure".to_string(),
+            ))
+        })
+        .expect_err("task creation failure must fail the pipeline")
+        .to_string();
+
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("task_creation"));
+    assert!(error.contains("orbit.task.add"));
+    assert!(error.contains("\"current_failure_run_ids\":[10]"));
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty(),
+        "failed task creation must not persist a dedupe owner or handled marker"
+    );
+}
+
+#[test]
 fn a_second_sweep_over_a_still_red_run_does_not_file_a_second_task() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let log = "ci\tbuild\t2026-08-30T01:00:00Z error: expected 3 arguments, found 2\n";
@@ -349,13 +479,20 @@ fn a_listed_but_uninvestigated_failure_is_not_filed_as_an_evidence_free_task() {
     uninvestigated["failed_jobs"] = json!([]);
     uninvestigated["log_excerpt"] = json!("");
 
-    let output = file(
+    let error = file_error(
         &runtime,
         json!({"ci_evidence": snapshot(vec![uninvestigated])}),
     );
 
-    assert_eq!(output["clusters"], json!(0));
-    assert_eq!(output["outcome"], json!("no_current_failure"));
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("current_failure_not_investigated"));
+    assert!(error.contains("\"current_failure_run_ids\":[10]"));
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
+    );
 }
 
 #[test]
@@ -764,7 +901,7 @@ fn same_failure_under_a_different_commit_message_reuses_the_failure_key() {
 }
 
 #[test]
-fn empty_excerpt_surfaces_the_matching_log_query_error() {
+fn query_error_prevents_filing_and_remains_retryable() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let mut missing_log = failure(10, "ci", "build", "Run CI guardrails", "", CHECKOUT);
     missing_log["log_excerpt"] = json!("");
@@ -782,30 +919,15 @@ fn empty_excerpt_surfaces_the_matching_log_query_error() {
         }
     ]);
 
-    let output = file(&runtime, json!({"ci_evidence": evidence}));
-    let task_id = filed_task_ids(&output)
-        .first()
-        .cloned()
-        .expect("one filed task");
-    let description = runtime.get_task(&task_id).expect("read").description;
-    let excerpt = excerpt_block(&description);
+    let error = file_error(&runtime, json!({"ci_evidence": evidence}));
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("run_logs"));
+    assert!(error.contains("logs for this run are no longer available"));
+    assert!(error.contains("\"current_failure_run_ids\":[10]"));
     assert!(
-        excerpt.contains("No log excerpt was captured"),
-        "empty excerpt must still be stated:\n{excerpt}"
-    );
-    assert!(
-        excerpt.contains("run_logs")
-            && excerpt.contains("10")
-            && excerpt.contains("logs for this run are no longer available"),
-        "relevant query_errors entry must sit next to the empty excerpt:\n{excerpt}"
-    );
-    assert!(
-        !excerpt.contains("unrelated list failure"),
-        "unrelated query errors must not be inlined into this cluster's excerpt:\n{excerpt}"
-    );
-    let signature = signature_line(&description);
-    assert!(
-        signature.contains("step-name fallback"),
-        "step-name signature must be labeled as a fallback: {signature}"
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
     );
 }

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -6,9 +6,9 @@
 //! the commit the runner actually checked out as separate fields, and the
 //! stale/superseding evidence that says which failures are still real.
 //!
-//! "Still real" is decided per head. Runs are listed repository-wide in one
-//! query, but a run only supersedes an older one on the same branch, and a run
-//! on a branch this workspace does not track is evaluated not at all.
+//! "Still real" is decided per workflow. Runs are listed repository-wide and
+//! exactly the newest run of each workflow is authoritative, regardless of
+//! which branch or SHA an older run used.
 //!
 //! Losing the agent's ability to ask a follow-up question mid-diagnosis is the
 //! accepted cost of that boundary. The compensation is that the snapshot is
@@ -17,12 +17,13 @@
 //! "we stopped looking".
 
 use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
 use serde_json::{Value, json};
 
 use super::query::{CiQueries, LogScope};
 use super::{
     OUTCOME_CAPABILITY_UNAVAILABLE, OUTCOME_CURRENT_FAILURES, OUTCOME_NO_CURRENT_FAILURE,
-    bounded_u64, optional_input_string, unsuccessful_conclusion,
+    OUTCOME_RETRYABLE_ERROR, bounded_u64, optional_input_string, unsuccessful_conclusion,
 };
 
 /// Snapshot schema version. Bump when a consumer would misread an older
@@ -45,6 +46,7 @@ const MAX_LOG_MAX_BYTES: u64 = 262_144;
 /// Cap on full-log reads taken purely to evidence a checkout commit. The
 /// failed-step log usually lacks it, and a full log can be tens of megabytes.
 const DEFAULT_MAX_CHECKOUT_LOG_READS: u64 = 3;
+const MAX_RETRYABLE_ERROR_CHARS: usize = 500;
 
 /// Which of the workspace's heads a run belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -131,7 +133,20 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         }));
     }
 
-    let repository = queries.repo_view()?;
+    let mut retryable_errors: Vec<Value> = Vec::new();
+    let repository = match queries.repo_view() {
+        Ok(repository) => repository,
+        Err(error) => {
+            push_retryable_error(
+                &mut retryable_errors,
+                "discovery",
+                "repo_view",
+                None,
+                &error.to_string(),
+            );
+            json!({})
+        }
+    };
     let default_branch = repository
         .get("default_branch")
         .and_then(Value::as_str)
@@ -140,65 +155,75 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         .map(ToOwned::to_owned);
 
     let mut notes: Vec<String> = Vec::new();
-    let mut query_errors: Vec<Value> = Vec::new();
-
     let refs = derive_refs(
         queries,
         input,
         default_branch.as_deref(),
         &bounds,
         &mut notes,
-        &mut query_errors,
+        &mut retryable_errors,
     )?;
 
+    let mut latest: Vec<Value> = Vec::new();
     let mut current: Vec<Value> = Vec::new();
     let mut stale: Vec<Value> = Vec::new();
     let mut in_flight: Vec<Value> = Vec::new();
     // One repository-wide query rather than one per ref: a single list is what
     // lets a newer run of a workflow supersede an older one without asking the
-    // ref it ran on whether it has advanced. The listing is repository-wide;
-    // the *evaluation* is not — `partition_runs` still answers per scanned ref.
+    // ref it ran on whether it has advanced. Selection is repository-wide too:
+    // exactly one latest run per workflow is authoritative.
     let runs = match queries.repository_runs(bounds.max_runs) {
         Ok(runs) => runs,
         Err(error) => {
-            query_errors.push(json!({
-                "query": "run_list",
-                "error": error.to_string(),
-            }));
+            push_retryable_error(
+                &mut retryable_errors,
+                "discovery",
+                "run_list",
+                None,
+                &error.to_string(),
+            );
             Vec::new()
         }
     };
     let runs_listed = runs.len();
     if runs_listed as u64 == bounds.max_runs {
         notes.push(format!(
-            "repository-wide workflow runs were listed at the cap ({}); a head whose runs \
-             are older than the newest {} in this repository may be absent entirely",
+            "repository-wide workflow runs were listed at the cap ({}); a workflow whose latest \
+             run is older than the newest {} runs in this repository may be absent entirely",
             bounds.max_runs, bounds.max_runs
         ));
     }
-    let runs_on_unscanned_branches =
-        partition_runs(&refs, &runs, &mut current, &mut stale, &mut in_flight);
-    if runs_on_unscanned_branches > 0 {
-        notes.push(format!(
-            "{runs_on_unscanned_branches} of {runs_listed} listed runs were on branches that \
-             match no scanned head and were not evaluated; this workspace tracks the \
-             integration head, the release head, and open pull-request heads only"
-        ));
-    }
+    partition_runs(
+        &refs,
+        &runs,
+        &mut latest,
+        &mut current,
+        &mut stale,
+        &mut in_flight,
+    );
 
     sort_current_failures(&mut current);
     let discovered = current.len();
-    let investigated = discovered.min(bounds.max_investigated_runs);
-    if discovered > investigated {
+    let attempted = discovered.min(bounds.max_investigated_runs);
+    if discovered > attempted {
         notes.push(format!(
             "{} of {discovered} current failures were listed but not investigated \
-             (max_investigated_runs={investigated}); their run URLs are still present",
-            discovered - investigated
+             (max_investigated_runs={attempted}); their run URLs are still present",
+            discovered - attempted
         ));
+        for failure in current.iter().skip(attempted) {
+            push_retryable_error(
+                &mut retryable_errors,
+                "investigation",
+                "investigation_budget",
+                failure.get("run_id"),
+                "current failure was not investigated because max_investigated_runs was exhausted",
+            );
+        }
     }
     let mut checkout_log_reads = 0usize;
     for (index, failure) in current.iter_mut().enumerate() {
-        if index >= investigated {
+        if index >= attempted {
             failure["investigated"] = json!(false);
             continue;
         }
@@ -207,33 +232,64 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             failure,
             &bounds,
             &mut checkout_log_reads,
-            &mut query_errors,
+            &mut retryable_errors,
         );
     }
+    let investigated_ids = current
+        .iter()
+        .filter(|failure| failure.get("investigated").and_then(Value::as_bool) == Some(true))
+        .filter_map(|failure| failure.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    let latest_ids = latest
+        .iter()
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    let current_ids = current
+        .iter()
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    let investigated_count = investigated_ids.len();
+    let retryable_error_count = retryable_errors.len();
 
     Ok(json!({
         "schema_version": CI_EVIDENCE_SCHEMA_VERSION,
         "collected": true,
-        "outcome_hint": if current.is_empty() { OUTCOME_NO_CURRENT_FAILURE } else { OUTCOME_CURRENT_FAILURES },
+        "outcome_hint": if retryable_error_count > 0 {
+            OUTCOME_RETRYABLE_ERROR
+        } else if current.is_empty() {
+            OUTCOME_NO_CURRENT_FAILURE
+        } else {
+            OUTCOME_CURRENT_FAILURES
+        },
         "capability": auth.to_json(),
         "repository": repository,
         "heads": refs.iter().map(head_json).collect::<Vec<_>>(),
+        "latest_runs": latest,
         "current_failures": current,
         "stale_or_superseded": stale,
         "in_flight": in_flight,
-        "query_errors": query_errors,
+        "retryable_errors": retryable_errors,
+        "summary": {
+            "latest_runs_discovered": latest_ids.len(),
+            "latest_run_ids": latest_ids,
+            "current_failures": current_ids.len(),
+            "current_failure_run_ids": current_ids,
+            "investigated_failures": investigated_count,
+            "investigated_failure_run_ids": investigated_ids,
+            "retryable_errors": retryable_error_count,
+        },
         "truncation": json!({
             "refs_scanned": refs.len(),
             "runs_listed": runs_listed,
             "max_runs": bounds.max_runs,
-            "runs_on_unscanned_branches": runs_on_unscanned_branches,
             "pull_requests_scanned": refs
                 .iter()
                 .filter(|scanned| scanned.kind == RefKind::PullRequest)
                 .count(),
             "max_pull_requests": bounds.max_pull_requests,
             "current_failures_discovered": discovered,
-            "current_failures_investigated": investigated,
+            "current_failures_investigation_attempted": attempted,
+            "current_failures_investigated": investigated_count,
             "log_max_bytes": bounds.log_max_bytes,
             "checkout_log_reads": checkout_log_reads,
             "max_checkout_log_reads": bounds.max_checkout_log_reads,
@@ -255,7 +311,7 @@ fn derive_refs<Q: CiQueries + ?Sized>(
     default_branch: Option<&str>,
     bounds: &Bounds,
     notes: &mut Vec<String>,
-    query_errors: &mut Vec<Value>,
+    retryable_errors: &mut Vec<Value>,
 ) -> Result<Vec<ScannedRef>, OrbitError> {
     let integration = optional_input_string(input, "integration_branch")
         .or_else(|| optional_input_string(input, "base_branch"))
@@ -279,11 +335,13 @@ fn derive_refs<Q: CiQueries + ?Sized>(
         let head_sha = match queries.remote_branch_head(&branch) {
             Ok(head) => head,
             Err(error) => {
-                query_errors.push(json!({
-                    "query": "remote_branch_head",
-                    "branch": branch,
-                    "error": error.to_string(),
-                }));
+                push_retryable_error(
+                    retryable_errors,
+                    "discovery",
+                    "remote_branch_head",
+                    None,
+                    &format!("branch {branch}: {error}"),
+                );
                 None
             }
         };
@@ -340,10 +398,13 @@ fn derive_refs<Q: CiQueries + ?Sized>(
             }
         }
         Err(error) => {
-            query_errors.push(json!({
-                "query": "pr_list",
-                "error": error.to_string(),
-            }));
+            push_retryable_error(
+                retryable_errors,
+                "discovery",
+                "pr_list",
+                None,
+                &error.to_string(),
+            );
             notes.push(
                 "open pull requests could not be listed; no pull-request head was scanned"
                     .to_string(),
@@ -364,63 +425,45 @@ fn head_json(scanned: &ScannedRef) -> Value {
     })
 }
 
-/// Evaluate the latest run of each workflow **on each scanned head**.
+/// Evaluate exactly the latest repository-wide run for each workflow.
 ///
-/// Grouping by workflow alone makes supersession branch-blind, and in a
-/// repository where one workflow runs both on pushes to the integration branch
-/// and on every pull request that is not a detail: the first pull-request run
-/// to finish after a broken integration push buries the integration failure,
-/// which is the head that actually gates delivery. So a run only ever speaks
-/// for the branch it ran on, and the newest run on that branch decides it —
-/// regardless of SHA, status, or conclusion, which is what keeps an unchanged
-/// old head from holding an obsolete failure open forever.
-///
-/// A run whose `head_branch` matches no scanned head speaks for nothing this
-/// workspace tracks — an abandoned feature branch, a closed pull request, an
-/// unmerged Dependabot branch. It cannot be current and it cannot supersede;
-/// it is counted, and the count is reported, so that "not tracked" never reads
-/// as "not seen". Returns how many such runs were skipped.
+/// Older unsuccessful runs remain useful evidence, but can never become
+/// current merely because the ref they ran on has not advanced. The latest run
+/// supersedes them regardless of branch, SHA, status, or conclusion. This is
+/// the repository-wide workflow invariant established by ORB-11147.
 fn partition_runs(
     refs: &[ScannedRef],
     runs: &[Value],
+    latest_runs: &mut Vec<Value>,
     current: &mut Vec<Value>,
     stale: &mut Vec<Value>,
     in_flight: &mut Vec<Value>,
-) -> usize {
-    let mut unscanned = 0usize;
-    // Keyed by (workflow, branch) so the map iterates in a stable order and
-    // the snapshot is byte-identical for identical GitHub state.
-    let mut heads = std::collections::BTreeMap::<(String, String), Vec<&Value>>::new();
+) {
+    let mut workflows = std::collections::BTreeMap::<String, Vec<&Value>>::new();
     for run in runs {
-        let Some(scanned) = ref_for_run(refs, run) else {
-            unscanned += 1;
-            continue;
-        };
         let workflow = run
             .get("workflow")
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        heads
-            .entry((workflow, scanned.branch.clone()))
-            .or_default()
-            .push(run);
+        workflows.entry(workflow).or_default().push(run);
     }
 
-    for head_runs in heads.values_mut() {
-        head_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
-        let Some(latest) = head_runs.first().copied() else {
+    for workflow_runs in workflows.values_mut() {
+        workflow_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
+        let Some(latest) = workflow_runs.first().copied() else {
             continue;
         };
+        latest_runs.push(run_summary(ref_for_run(refs, latest), latest));
 
-        for older in head_runs.iter().skip(1).copied() {
+        for older in workflow_runs.iter().skip(1).copied() {
             let completed = older.get("status").and_then(Value::as_str) == Some("completed");
             let conclusion = older.get("conclusion").and_then(Value::as_str);
             if completed && unsuccessful_conclusion(conclusion) {
                 let mut entry = run_summary(ref_for_run(refs, older), older);
                 entry["reason"] = json!("superseded_by_newer_workflow_run");
                 entry["evidence"] = json!(format!(
-                    "newer run {} on the same branch at {} is {} with conclusion {}",
+                    "newer repository-wide run {} at {} is {} with conclusion {}",
                     latest
                         .get("run_id")
                         .and_then(Value::as_u64)
@@ -457,8 +500,6 @@ fn partition_runs(
             current.push(summary);
         }
     }
-
-    unscanned
 }
 
 /// Sortable position of a run: creation time first, run id as the tiebreak.
@@ -524,24 +565,46 @@ fn investigate<Q: CiQueries + ?Sized>(
     failure: &mut Value,
     bounds: &Bounds,
     checkout_log_reads: &mut usize,
-    query_errors: &mut Vec<Value>,
+    retryable_errors: &mut Vec<Value>,
 ) {
     let Some(run_id) = failure
         .get("run_id")
         .and_then(Value::as_u64)
         .map(|id| id.to_string())
     else {
+        push_retryable_error(
+            retryable_errors,
+            "registration",
+            "run_identity",
+            None,
+            "current failure has no numeric run_id",
+        );
         return;
     };
-    failure["investigated"] = json!(true);
+    let errors_before = retryable_errors.len();
 
     match queries.run_view(&run_id) {
         Ok(view) => {
-            failure["failed_jobs"] = view.get("failed_jobs").cloned().unwrap_or(json!([]));
+            let failed_jobs = view.get("failed_jobs").cloned().unwrap_or(json!([]));
+            if failed_jobs.as_array().is_none_or(Vec::is_empty) {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "run_view",
+                    failure.get("run_id"),
+                    "failed run returned no failed jobs",
+                );
+            }
+            failure["failed_jobs"] = failed_jobs;
         }
         Err(error) => {
-            query_errors
-                .push(json!({"query": "run_view", "run_id": run_id, "error": error.to_string()}));
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_view",
+                failure.get("run_id"),
+                &error.to_string(),
+            );
         }
     }
 
@@ -559,16 +622,23 @@ fn investigate<Q: CiQueries + ?Sized>(
             // (retention). That is not a captured excerpt; record it so the
             // filed task can say why the block is empty.
             if log.text.trim().is_empty() {
-                query_errors.push(json!({
-                    "query": "run_logs",
-                    "run_id": run_id,
-                    "error": "query returned no log text",
-                }));
+                push_retryable_error(
+                    retryable_errors,
+                    "investigation",
+                    "run_logs",
+                    failure.get("run_id"),
+                    "query returned no failed-step log text",
+                );
             }
         }
         Err(error) => {
-            query_errors
-                .push(json!({"query": "run_logs", "run_id": run_id, "error": error.to_string()}));
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_logs",
+                failure.get("run_id"),
+                &error.to_string(),
+            );
         }
     }
 
@@ -581,10 +651,19 @@ fn investigate<Q: CiQueries + ?Sized>(
         .and_then(Value::as_array)
         .is_none_or(Vec::is_empty);
     if !needs_checkout {
+        failure["investigated"] = json!(retryable_errors.len() == errors_before);
         return;
     }
     if *checkout_log_reads >= bounds.max_checkout_log_reads {
         failure["checkout_evidence_scope"] = json!("skipped_budget_exhausted");
+        push_retryable_error(
+            retryable_errors,
+            "investigation",
+            "checkout_evidence_budget",
+            failure.get("run_id"),
+            "actual checkout SHA was not collected because max_checkout_log_reads was exhausted",
+        );
+        failure["investigated"] = json!(false);
         return;
     }
     *checkout_log_reads += 1;
@@ -593,12 +672,48 @@ fn investigate<Q: CiQueries + ?Sized>(
             failure["actual_checkout_shas"] = json!(log.checkout_commits);
             failure["checkout_evidence"] = json!(log.checkout_evidence);
             failure["checkout_evidence_scope"] = json!("all");
+            if failure
+                .get("actual_checkout_shas")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty)
+            {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "checkout_evidence",
+                    failure.get("run_id"),
+                    "run logs contained no actual checkout SHA",
+                );
+            }
         }
         Err(error) => {
             failure["checkout_evidence_scope"] = json!("unavailable");
-            query_errors.push(
-                json!({"query": "run_logs_all", "run_id": run_id, "error": error.to_string()}),
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_logs_all",
+                failure.get("run_id"),
+                &error.to_string(),
             );
         }
     }
+    failure["investigated"] = json!(retryable_errors.len() == errors_before);
+}
+
+fn push_retryable_error(
+    errors: &mut Vec<Value>,
+    stage: &str,
+    operation: &str,
+    run_id: Option<&Value>,
+    message: &str,
+) {
+    let redacted = redact_all(message);
+    let bounded: String = redacted.chars().take(MAX_RETRYABLE_ERROR_CHARS).collect();
+    errors.push(json!({
+        "stage": stage,
+        "operation": operation,
+        "run_id": run_id.cloned().unwrap_or(Value::Null),
+        "retryable": true,
+        "message": bounded,
+    }));
 }

--- a/crates/orbit-engine/src/executor/automation/ci/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/mod.rs
@@ -14,10 +14,11 @@
 //! is one bounded, redacted JSON snapshot — no token, no host configuration,
 //! and no way to run another query.
 //!
-//! Three endings stay distinct here and are never allowed to collapse into one
+//! Four endings stay distinct here and are never allowed to collapse into one
 //! another or into a clean pass: [`OUTCOME_CAPABILITY_UNAVAILABLE`] (we could
 //! not look), [`OUTCOME_NO_CURRENT_FAILURE`] (we looked and nothing is
-//! failing), and [`OUTCOME_CURRENT_FAILURES`] (we looked and something is).
+//! failing), [`OUTCOME_CURRENT_FAILURES`] (we looked and something is), and
+//! [`OUTCOME_RETRYABLE_ERROR`] (a bounded discovery or investigation failed).
 
 mod collect;
 mod query;
@@ -40,6 +41,9 @@ pub(super) const OUTCOME_CAPABILITY_UNAVAILABLE: &str = "capability_unavailable"
 pub(super) const OUTCOME_NO_CURRENT_FAILURE: &str = "no_current_failure";
 /// The queries ran and found at least one current failure to file.
 pub(super) const OUTCOME_CURRENT_FAILURES: &str = "current_failures";
+/// A discovery or investigation failed. The partial evidence remains visible,
+/// but the pipeline must retry rather than consuming it as clean.
+pub(super) const OUTCOME_RETRYABLE_ERROR: &str = "retryable_error";
 
 /// Run conclusions that are not a pass.
 ///

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -152,11 +152,11 @@ fn latest_non_failing_run_supersedes_older_failures_on_the_same_head() {
         .iter()
         .filter_map(|entry| entry["superseded_by"]["run_id"].as_u64())
         .collect();
-    assert_eq!(superseding_ids, [25, 40]);
+    assert_eq!(superseding_ids, [30, 40]);
 }
 
 #[test]
-fn integration_failure_survives_a_later_non_failing_run_on_another_head() {
+fn newer_repository_wide_success_suppresses_an_older_integration_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -167,9 +167,8 @@ fn integration_failure_survives_a_later_non_failing_run_on_another_head() {
             "reported_head_sha": OLD,
         }))
         .with_runs(vec![vec![
-            // The pull-request run of `ci` finishes after the integration
-            // push broke, and the release run after that. Neither ran the
-            // integration head's commit, so neither may clear its failure.
+            // The pull-request run of `ci` is the latest repository-wide run
+            // of this workflow, so it supersedes every older failure.
             run_on_branch(
                 40,
                 "ci",
@@ -201,33 +200,24 @@ fn integration_failure_survives_a_later_non_failing_run_on_another_head() {
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    let current_ids: Vec<u64> = evidence["current_failures"]
-        .as_array()
-        .expect("current failures")
-        .iter()
-        .filter_map(|run| run["run_id"].as_u64())
-        .collect();
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(evidence["latest_runs"][0]["run_id"], json!(40));
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(20));
     assert_eq!(
-        current_ids,
-        [20],
-        "a run on another head must not supersede the integration head: {evidence}"
+        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
+        json!(40)
     );
-    assert_eq!(
-        evidence["current_failures"][0]["ref_kind"],
-        json!("integration")
-    );
-    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
-    assert_eq!(evidence["stale_or_superseded"], json!([]));
 }
 
 #[test]
-fn run_on_a_branch_no_scanned_head_matches_is_never_current() {
+fn latest_repository_wide_failure_is_current_even_when_its_ref_is_not_scanned() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
         .with_runs(vec![vec![
-            // Newest run in the repository, on a branch behind no open pull
-            // request. It can neither be filed nor supersede anything.
+            // Eligibility is workflow-wide, not branch-by-branch. Ref
+            // metadata can be absent without reviving the older run.
             run_on_branch(
                 50,
                 "ci",
@@ -258,25 +248,12 @@ fn run_on_a_branch_no_scanned_head_matches_is_never_current() {
         .collect();
     assert_eq!(
         current_ids,
-        [20],
-        "an untracked branch must neither be filed nor supersede: {evidence}"
+        [50],
+        "exactly the repository-wide latest workflow run must be current: {evidence}"
     );
-    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["current_failures"][0]["ref_kind"], json!("other"));
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(20));
     assert_eq!(evidence["in_flight"], json!([]));
-    assert_eq!(
-        evidence["truncation"]["runs_on_unscanned_branches"],
-        json!(1)
-    );
-    assert!(
-        evidence["truncation"]["notes"]
-            .as_array()
-            .expect("notes")
-            .iter()
-            .any(|note| note
-                .as_str()
-                .is_some_and(|note| note.contains("match no scanned head"))),
-        "skipped runs must be reported, not silently dropped: {evidence}"
-    );
 }
 
 #[test]
@@ -329,42 +306,49 @@ fn latest_in_flight_run_does_not_resurrect_an_older_failure() {
 }
 
 #[test]
-fn old_dependabot_failure_on_an_unscanned_branch_is_never_current() {
+fn old_dependabot_failure_is_superseded_by_newer_repository_wide_run() {
     // ORB-11146: an eleven-day-old Dependabot run kept being filed because its
-    // branch had not advanced. Once that pull request is closed the branch is
-    // not a scanned head, so the run is skipped outright rather than depending
-    // on a newer run of the same workflow existing somewhere in the repository.
+    // branch had not advanced. Repository-wide workflow selection suppresses
+    // it once any newer CI run exists, regardless of the newer run's ref.
     const DEPENDABOT_SHA: &str = "0f14f3f2ad2c863f902c0add969ff09d10e3f15c";
     const OLD_RUN_ID: u64 = 31_583_558_682;
 
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
-        .with_runs(vec![vec![run_on_branch(
-            OLD_RUN_ID,
-            "CI",
-            "dependabot/cargo/old",
-            DEPENDABOT_SHA,
-            "completed",
-            Some("failure"),
-            "2026-08-20T01:00:00Z",
-        )]]);
+        .with_runs(vec![vec![
+            run_on_branch(
+                40_000_000_000,
+                "CI",
+                "topic",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-08-31T01:00:00Z",
+            ),
+            run_on_branch(
+                OLD_RUN_ID,
+                "CI",
+                "dependabot/cargo/old",
+                DEPENDABOT_SHA,
+                "completed",
+                Some("failure"),
+                "2026-08-20T01:00:00Z",
+            ),
+        ]]);
 
     let evidence = collect(&queries, &input()).expect("collect");
 
     assert_eq!(evidence["current_failures"], json!([]));
     assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
     assert_eq!(
-        evidence["truncation"]["runs_on_unscanned_branches"],
-        json!(1)
+        evidence["stale_or_superseded"][0]["run_id"],
+        json!(OLD_RUN_ID)
     );
 }
 
 #[test]
-fn open_pull_request_head_failure_is_current_for_its_own_head() {
-    // The converse of the case above: while the pull request is open its head
-    // is scanned, and its own latest run decides it. No run on another branch
-    // can clear it, and it clears no other branch.
+fn newer_cross_branch_success_suppresses_open_pull_request_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -397,13 +381,9 @@ fn open_pull_request_head_failure_is_current_for_its_own_head() {
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    assert_eq!(evidence["current_failures"][0]["run_id"], json!(100));
-    assert_eq!(
-        evidence["current_failures"][0]["ref_kind"],
-        json!("pull_request")
-    );
-    assert_eq!(evidence["current_failures"][0]["pr_number"], json!(959));
-    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(evidence["latest_runs"][0]["run_id"], json!(200));
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(100));
 }
 
 #[test]
@@ -487,9 +467,12 @@ fn derives_release_head_from_github_and_reports_every_bound_it_hit() {
     let truncation = &evidence["truncation"];
     // The reported bound is the repository-wide cap that was actually applied.
     assert_eq!(truncation["max_runs"], json!(100));
-    assert_eq!(truncation["runs_on_unscanned_branches"], json!(0));
     assert_eq!(truncation["current_failures_discovered"], json!(2));
-    assert_eq!(truncation["current_failures_investigated"], json!(1));
+    assert_eq!(
+        truncation["current_failures_investigation_attempted"],
+        json!(1)
+    );
+    assert_eq!(truncation["current_failures_investigated"], json!(0));
     assert!(
         truncation["notes"]
             .as_array()
@@ -500,7 +483,10 @@ fn derives_release_head_from_github_and_reports_every_bound_it_hit() {
                 .is_some_and(|note| note.contains("not investigated"))),
         "truncation must be reported explicitly: {truncation}"
     );
-    assert_eq!(evidence["current_failures"][0]["investigated"], json!(true));
+    assert_eq!(
+        evidence["current_failures"][0]["investigated"],
+        json!(false)
+    );
     assert_eq!(
         evidence["current_failures"][1]["investigated"],
         json!(false)
@@ -518,7 +504,7 @@ fn integration_and_release_on_the_same_branch_are_scanned_once() {
 }
 
 #[test]
-fn empty_failed_step_log_is_recorded_in_query_errors() {
+fn empty_failed_step_log_is_an_explicit_retryable_investigation_error() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -538,15 +524,159 @@ fn empty_failed_step_log_is_recorded_in_query_errors() {
     let evidence = collect(&queries, &input()).expect("collect");
     let failure = &evidence["current_failures"][0];
     assert_eq!(failure["log_excerpt"], json!(""));
-    let errors = evidence["query_errors"].as_array().expect("query_errors");
+    let errors = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
     assert!(
         errors.iter().any(|error| {
-            error["query"] == json!("run_logs")
-                && error["run_id"] == json!("10")
-                && error["error"]
+            error["operation"] == json!("run_logs")
+                && error["run_id"] == json!(10)
+                && error["retryable"] == json!(true)
+                && error["message"]
                     .as_str()
-                    .is_some_and(|text| text.contains("no log text"))
+                    .is_some_and(|text| text.contains("no failed-step log text"))
         }),
-        "empty failed-step log must be a query error, got {errors:?}"
+        "empty failed-step log must be retryable, got {errors:?}"
     );
+    assert_eq!(failure["investigated"], json!(false));
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+}
+
+#[test]
+fn discovery_failure_is_bounded_redacted_and_retryable() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_repository_runs_error(
+            "token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890 could not list workflow runs",
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect retryable evidence");
+
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+    assert_eq!(evidence["summary"]["retryable_errors"], json!(1));
+    let error = &evidence["retryable_errors"][0];
+    assert_eq!(error["stage"], json!("discovery"));
+    assert_eq!(error["operation"], json!("run_list"));
+    assert_eq!(error["retryable"], json!(true));
+    assert!(
+        !error["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+    );
+}
+
+#[test]
+fn investigation_failure_keeps_the_current_run_visible_and_retryable() {
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run_on_branch(
+            33_358_160_088,
+            "CI",
+            "agent-main",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-31T04:00:00Z",
+        )]])
+        .with_run_view_error("33358160088", "temporary GitHub job-view failure")
+        .with_log_error("33358160088", false, "temporary GitHub log failure")
+        .with_log_error("33358160088", true, "temporary GitHub full-log failure");
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect retryable evidence");
+
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+    assert_eq!(
+        evidence["current_failures"][0]["run_id"],
+        json!(33_358_160_088_u64)
+    );
+    assert_eq!(
+        evidence["current_failures"][0]["investigated"],
+        json!(false)
+    );
+    assert_eq!(evidence["summary"]["current_failures"], json!(1));
+    assert_eq!(evidence["summary"]["investigated_failures"], json!(0));
+    assert!(
+        evidence["summary"]["retryable_errors"]
+            .as_u64()
+            .is_some_and(|count| count >= 3)
+    );
+}
+
+#[test]
+fn live_failure_fixture_is_latest_current_and_evidence_complete() {
+    const EVENT_SHA: &str = "2a4cb4e4631a856552d901b6b062fa6596475cc0";
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", EVENT_SHA)
+        .with_head("main", OLD)
+        .with_runs(vec![vec![run_on_branch(
+            33_358_160_088,
+            "CI",
+            "agent-main",
+            EVENT_SHA,
+            "completed",
+            Some("failure"),
+            "2026-08-31T04:00:00Z",
+        )]])
+        .with_run_view(
+            "33358160088",
+            json!({"failed_jobs": [{
+                "job_id": 99_384_177_985_u64,
+                "name": "Rust tests",
+                "conclusion": "failure",
+                "url": "https://github.com/danieljhkim/orbit/actions/runs/33358160088/job/99384177985",
+                "failed_steps": [{"name": "Run Rust tests", "conclusion": "failure"}],
+            }]}),
+        )
+        .with_log(
+            "33358160088",
+            false,
+            "CI\tRust tests\tRun Rust tests orbit-cli::routine_root::routine_commands_honor_orbit_root_and_mutate_only_the_selected_root\nCI\tRust tests\tcrates/orbit-cli/tests/routine_root.rs:218 routine command touched isolated HOME at /tmp/.tmpgNchET/empty-home\n",
+        )
+        .with_log(
+            "33358160088",
+            true,
+            "CI\tCheckout\tHEAD is now at 2a4cb4e4631a856552d901b6b062fa6596475cc0\n",
+        );
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["run_id"], json!(33_358_160_088_u64));
+    assert_eq!(
+        failure["failed_jobs"][0]["job_id"],
+        json!(99_384_177_985_u64)
+    );
+    assert_eq!(failure["event_reported_head_sha"], json!(EVENT_SHA));
+    assert_eq!(failure["current_ref_head_sha"], json!(EVENT_SHA));
+    assert_eq!(failure["actual_checkout_shas"], json!([EVENT_SHA]));
+    assert!(
+        failure["log_excerpt"]
+            .as_str()
+            .is_some_and(|log| log.contains("routine command touched isolated HOME"))
+    );
+    assert_eq!(failure["investigated"], json!(true));
+    assert_eq!(
+        evidence["summary"]["latest_run_ids"],
+        json!([33_358_160_088_u64])
+    );
+    assert_eq!(
+        evidence["summary"]["current_failure_run_ids"],
+        json!([33_358_160_088_u64])
+    );
+    assert_eq!(
+        evidence["summary"]["investigated_failure_run_ids"],
+        json!([33_358_160_088_u64])
+    );
+    assert_eq!(evidence["summary"]["retryable_errors"], json!(0));
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
@@ -24,6 +24,9 @@ pub(super) struct FakeQueries {
     pub(super) runs: Mutex<Vec<Vec<Value>>>,
     pub(super) run_views: HashMap<String, Value>,
     pub(super) logs: HashMap<(String, bool), String>,
+    pub(super) repository_runs_error: Option<String>,
+    pub(super) run_view_errors: HashMap<String, String>,
+    pub(super) log_errors: HashMap<(String, bool), String>,
 }
 
 impl FakeQueries {
@@ -75,6 +78,23 @@ impl FakeQueries {
         self
     }
 
+    pub(super) fn with_repository_runs_error(mut self, message: &str) -> Self {
+        self.repository_runs_error = Some(message.to_string());
+        self
+    }
+
+    pub(super) fn with_run_view_error(mut self, run_id: &str, message: &str) -> Self {
+        self.run_view_errors
+            .insert(run_id.to_string(), message.to_string());
+        self
+    }
+
+    pub(super) fn with_log_error(mut self, run_id: &str, all_scope: bool, message: &str) -> Self {
+        self.log_errors
+            .insert((run_id.to_string(), all_scope), message.to_string());
+        self
+    }
+
     pub(super) fn with_log(mut self, run_id: &str, all_scope: bool, log: &str) -> Self {
         self.logs
             .insert((run_id.to_string(), all_scope), log.to_string());
@@ -105,6 +125,9 @@ impl CiQueries for FakeQueries {
     }
 
     fn repository_runs(&self, _limit: u64) -> Result<Vec<Value>, OrbitError> {
+        if let Some(message) = &self.repository_runs_error {
+            return Err(OrbitError::Execution(message.clone()));
+        }
         let mut runs = self.runs.lock().expect("runs lock");
         if runs.len() > 1 {
             Ok(runs.remove(0))
@@ -114,6 +137,9 @@ impl CiQueries for FakeQueries {
     }
 
     fn run_view(&self, run_id: &str) -> Result<Value, OrbitError> {
+        if let Some(message) = self.run_view_errors.get(run_id) {
+            return Err(OrbitError::Execution(message.clone()));
+        }
         Ok(self
             .run_views
             .get(run_id)
@@ -127,6 +153,12 @@ impl CiQueries for FakeQueries {
         scope: LogScope,
         max_bytes: usize,
     ) -> Result<RunLog, OrbitError> {
+        if let Some(message) = self
+            .log_errors
+            .get(&(run_id.to_string(), scope == LogScope::All))
+        {
+            return Err(OrbitError::Execution(message.clone()));
+        }
         let raw = self
             .logs
             .get(&(run_id.to_string(), scope == LogScope::All))


### PR DESCRIPTION
## Task

[ORB-11158](https://orbit-cli.com/tasks/ORB-11158) — Restore CI failure sweep task filing for latest failed checks

### Description

## Problem

The Orbit workspace's `ci_failure_sweep_pipeline` is silently missing a current failed GitHub Actions check instead of registering the failure and filing its remediation task.

## Live evidence

GitHub Actions run `33358160088` (`CI`, push to `agent-main`, commit `2a4cb4e4631a856552d901b6b062fa6596475cc0`) completed with conclusion `failure` on 2026-08-31. Job `99384177985` failed in the Rust test step:

- test: `orbit-cli::routine_root::routine_commands_honor_orbit_root_and_mutate_only_the_selected_root`
- source assertion: `crates/orbit-cli/tests/routine_root.rs:218`
- failure evidence: `routine command touched isolated HOME at /tmp/.tmpgNchET/empty-home`
- run: https://github.com/danieljhkim/orbit/actions/runs/33358160088
- job: https://github.com/danieljhkim/orbit/actions/runs/33358160088/job/99384177985

An authoritative hybrid task search and recent-task inspection found no task referencing this run or job after the check failed. This is an automation failure, independent of the underlying test defect that the sweep should have filed.

## Required behavior

Trace and repair the full host-owned path from repository-wide latest-run discovery through failure registration/investigation to `orbit.task.add`. A latest completed unsuccessful run must enter `current_failures` and produce exactly one evidence-complete remediation task when no dedupe owner exists.

Preserve ORB-11147's workflow-level latest-run semantics: do not restore branch-by-branch enumeration or resurrect stale failures. A newer successful run suppresses the older failure, and a newer queued/in-progress run remains in flight without falling back.

If discovery, investigation, failure registration, or task creation fails, the pipeline must expose a bounded, redacted, actionable error and leave the failure retryable. It must not report `no_current_failure`, advance any handled cursor, or otherwise silently consume a failure whose task was not durably created.

Keep GitHub access on the engine-private host boundary, preserve task dedupe and single-flight behavior, and do not grant GitHub access to agent sandboxes.

### Acceptance Criteria

- A deterministic end-to-end fixture modeling workflow run 33358160088 and failed job 99384177985 places the latest completed unsuccessful CI run in current_failures and files exactly one remediation task.
- The filed task contains the bounded run, job, workflow, conclusion, URL, failing step/test, failure excerpt, and distinct event-reported/current-ref/actual-checkout SHA evidence needed to act without agent-side GitHub access.
- Re-running the same failed latest run creates no duplicate and reports the existing dedupe owner; the failure remains represented rather than being misreported as a clean no-failure result.
- Fault-injection tests cover discovery, investigation/registration, and orbit.task.add failures; each produces an explicit retryable pipeline outcome, and task-creation failure cannot advance or persist a handled state for that CI failure.
- ORB-11147 behavior remains covered: only the latest repository-wide run per workflow is eligible, while a newer successful run or queued/in-progress run cannot resurrect an older failure.
- Pipeline output exposes auditable counts and identities for discovered latest runs, current failures, investigated failures, tasks created, existing-task skips, and retryable errors so a dropped handoff is observable.
- Focused CI automation and task-filing tests, make ci-fast, make ci-lint, and the repository's applicable pre-handoff checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restored ORB-11147 repository-wide latest-run-per-workflow selection (created_at, then run ID), including successful and in-flight suppression of older failures.
- Added a deterministic run 33358160088 / job 99384177985 fixture. The selected current failure carries workflow, run/job URLs and IDs, conclusion, failing step/test and source assertion, bounded failure excerpt, plus separately labelled event-reported, current-ref, and actual-checkout SHAs. The filing fixture creates exactly one remediation task and a repeat reports the existing task owner while retaining current-failure identity.
- Discovery, investigation/registration, dedupe lookup, and orbit.task.add failures now produce bounded/redacted retryable_error evidence. The filing stage rejects partial/error snapshots instead of returning no_current_failure; failed task creation persists neither a task nor a handled/dedupe state.
- Collector and filer outputs now expose auditable counts and identities for latest runs, current failures, completed investigations, created tasks, existing-task skips/owners, and retryable errors. Failed jobs, job URLs/IDs, step names, status, and conclusion are rendered into filed task descriptions.
- Updated the canonical and workspace-mirrored activity/job contracts. These files were added to task context because they are the directly coupled registration and audit contract for the changed pipeline.

Validation:
- cargo test -p orbit-engine executor::automation::ci::tests --no-fail-fast — passed (15 tests).
- cargo test -p orbit-core ci_failure --no-fail-fast — passed (21 tests, including pipeline catalog, exact live fixture, dedupe, registration failure, and task-add fault injection).
- make ci-fast — passed.
- make ci-lint — passed.
- git diff --check and mirrored-asset comparisons — passed.
- Final status contains only the 12 intended task-scoped source, test, and mirrored contract files; the 6.8 GiB Cargo target directory created by validation was removed.

Assessment: The two-stage host-owned boundary remains intact and agent sandboxes gain no GitHub access. Current failures can only become a clean no-current-failure result after complete, error-free discovery and investigation, and durable task creation/dedupe remains the only handled representation.

Deviations from original plan:
- No separate handled cursor was introduced because this pipeline has no handled-state store; retry safety is enforced at the authoritative task-add/dedupe boundary.

Friction checkpoint: considered; no qualifying recurring or over-10-minute workflow friction was found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11158-6a9509b2`
- Behind base: 0
- Ahead of base: 1