### PR TITLE
Prepare v0.17.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.1
+
+### Highlights
+
+- **Managed workspace convergence**: `orbit workspace sync` safely refreshes shipped routines and other managed artifacts while preserving local edits, identity, registration, and automation choices. ([ORB-11149])
+- **Security finding automation**: the disabled-by-default security sweep can collect Dependabot, Code scanning, and secret scanning findings into deduplicated, evidence-complete remediation tasks without exposing credentials to agent sandboxes. ([ORB-11124])
+- **Corrective work prioritized automatically**: bounded `run ship` and `run auto` discovery now selects critical, bug, code-review, and security-review tasks ahead of ordinary feature work. ([ORB-11141])
+- **Actionable friction triage**: the dashboard defaults to active frictions, adds status filtering, and provides keyboard-operable responsive detail views. ([ORB-11136])
+
 ## 0.17.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "hostname",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",
@@ -16,4 +16,3 @@
     "mcp"
   ]
 }
-

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "danieljhkim",
@@ -17,4 +17,3 @@
     "mcp"
   ]
 }
-

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/danieljhkim/orbit",
     "source": "github"
   },
-  "version": "0.17.0",
+  "version": "0.17.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11160](https://orbit-cli.com/tasks/ORB-11160) — Prepare v0.17.1 release

### Description

## Release preparation handoff

Prepare the candidate `v0.17.1` release from the reachable baseline `v0.17.0`.

Follow `RELEASING.md` in full, including the release checklist, breaking-change confirmation, and every versioned release file: `Cargo.toml`, `Cargo.lock`, `npm/package.json`, `server.json`, `plugin/.claude-plugin/plugin.json`, `plugin/.codex-plugin/plugin.json`, and `plugin/plugin.json`. Also follow the runbook requirements for `CHANGELOG.md` and the npm/plugin smoke scripts.

Survey evidence:
- Baseline: `v0.17.0` (latest reachable `v*` tag).
- 27 no-merge commits surveyed in `v0.17.0..HEAD`.
- Referenced tasks: ORB-11114, ORB-11124, ORB-11129, ORB-11131, ORB-11132, ORB-11133, ORB-11134, ORB-11136, ORB-11138, ORB-11139, ORB-11140, ORB-11141, ORB-11142, ORB-11143, ORB-11145, ORB-11147, ORB-11149, ORB-11152, ORB-11153, ORB-11154, ORB-11155, ORB-11156, ORB-11158.
- Candidate: patch bump `0.17.0 -> 0.17.1` under the pre-1.0 policy.
- Breaking-change candidates: none identified from the commit and task survey. The added `orbit workspace sync` command and new optional automation are additive; the remaining surveyed work is fixes, validation tightening, security hardening, documentation, or dashboard work.

This task is a preparation handoff only. Do not commit, tag, push, publish, promote or merge branches until the required human breaking-change confirmation and explicit approval specified by `RELEASING.md` and repository policy.

### Acceptance Criteria

- Follow RELEASING.md and confirm the final breaking-change classification with a human before release mutation.
- Cargo.toml, Cargo.lock, npm/package.json, server.json, and all three plugin manifests report the approved release version.
- CHANGELOG.md contains the consumer-facing release section and Cargo.lock is refreshed without third-party drift.
- The prescribed build and npm/plugin install smoke checks pass before release publication.
- No commit, tag, push, publish, branch promotion, or merge occurs before explicit human approval.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Confirmed the human `I approve` comment against the task survey: no breaking-change candidates were identified, so the approved pre-1.0 patch release is 0.17.1.
- Added the consumer-facing CHANGELOG.md 0.17.1 section with four highlights: managed workspace convergence (ORB-11149), security finding automation (ORB-11124), corrective-work dispatch priority (ORB-11141), and friction triage improvements (ORB-11136).
- Bumped Cargo.toml, npm/package.json, both server.json version fields, and all three plugin manifests from 0.17.0 to 0.17.1.
- Refreshed Cargo.lock with `cargo update --workspace`; only the 16 Orbit workspace members changed from 0.17.0 to 0.17.1 and all 164 third-party packages remained unchanged.
- Left both smoke scripts unchanged after inspection. This cycle does not require a change to the `orbit init`, `workspace init`, or `mcp serve` invocation contract; the plugin smoke derives its install version from plugin.json.
- Did not commit, tag, push, publish, promote, or merge.

Assessment: Approved v0.17.1 release preparation is complete and ready for human review. The remaining live npm/GitHub checks are publication-stage gates because the 0.17.1 artifacts do not exist yet.

Validation:
- `make build`: passed for the workspace at 0.17.1.
- `make ci-fast`: passed, including CHANGELOG style, plugin validators, canonical skill mirror, and plugin install smoke.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `./scripts/smoke-plugin-install.sh`: passed for isolated Claude Code, Codex, and Cursor contracts.
- `./scripts/smoke-npm-install.sh --dry-run-version-assertion`: passed.
- `bash -n scripts/smoke-npm-install.sh scripts/smoke-plugin-install.sh`: passed.
- `git diff --check`: passed.
- `./scripts/release-check.sh`: all local Cargo/npm/server/plugin versions agree on 0.17.1. It exited 1 only for the expected pre-publication drift against latest GitHub release v0.17.0; npm was unavailable on PATH and mcp-publisher was unavailable, so those remote/publisher checks were skipped.
- Skipped the live `./scripts/smoke-npm-install.sh` because it intentionally installs published `@orbit-tools/cli@0.17.1`, which cannot exist before publication. The runbook requires that live versioned smoke after npm publication.
- Removed the 5.0 GiB Cargo target artifacts created by validation. Final status contains exactly the eight intended task-scoped release files.

Strategic decisions:
- Treated the human approval as confirmation of the task-described no-breaking-change classification and patch version, consistent with the immediately preceding release task convention.
- Kept the CHANGELOG to four user-facing themes and omitted internal fixes, docs churn, and small regressions per RELEASING.md.

Recommended follow-ups:
- Human: review and separately authorize the commit/tag/push/publish/promotion sequence.
- Release operator: after publishing 0.17.1 to npm, run the live npm install smoke and the versioned GitHub Actions smoke before considering the install chain verified.

Friction checkpoint: considered; no qualifying contradicted assumption, recurring failure, incident root cause, or over-10-minute non-obvious gotcha occurred.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11160-6a950ff5`
- Behind base: 0
- Ahead of base: 1