### PR TITLE
perf: stop materializing the task population twice in backlog dispatch

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -103,16 +103,26 @@ pub(super) fn list_backlog_tasks(
         })
         .unwrap_or_default();
     let (mut tasks, excluded_entries) = if explicit_task_ids.is_empty() {
-        // FIXME: perf issue iterating over all tasks
-        let all_tasks = runtime.stores().tasks().list_tasks().map_err(|err| {
-            DispatchError::DeterministicActionFailed {
+        // The lookup must stay whole: an epic's lock set is the union over its
+        // descendants (`lock_context_files_for_task`), which is a downward walk
+        // that a status-filtered map would silently shorten — narrowing it
+        // would shrink lock coverage, not just the scan. Reducing the scan
+        // itself needs a persisted parent -> children index; until then the
+        // population is loaded once and the whole set is walked.
+        //
+        // What it must not do is materialize that population twice. Consume the
+        // list into the lookup, then clone only the backlog tasks that survive
+        // the filter — tens of clones on a large workspace instead of one per
+        // task, and one copy held rather than two.
+        let task_lookup: BTreeMap<String, Task> = runtime
+            .stores()
+            .tasks()
+            .list_tasks()
+            .map_err(|err| DispatchError::DeterministicActionFailed {
                 action: action.to_string(),
                 message: format!("list tasks: {err}"),
-            }
-        })?;
-        let task_lookup: BTreeMap<String, Task> = all_tasks
-            .iter()
-            .cloned()
+            })?
+            .into_iter()
             .map(|task| (task.id.clone(), task))
             .collect();
         let status_by_id = runtime.task_status_index().map_err(|err| {
@@ -123,11 +133,15 @@ pub(super) fn list_backlog_tasks(
         })?;
         let workspace_root = runtime.paths().repo_root.as_path();
         let lock_holders = active_task_lock_holders(&task_lookup, workspace_root);
-        let mut backlog: Vec<Task> = all_tasks
-            .into_iter()
+        // `task_lookup` iterates in task-ID order rather than the store's
+        // created-at order; `sort_tasks_for_automatic_dispatch` is a total
+        // order ending in the task ID, so the dispatch sequence is unchanged.
+        let mut backlog: Vec<Task> = task_lookup
+            .values()
             .filter(|task| {
                 task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
             })
+            .cloned()
             .collect();
         sort_tasks_for_automatic_dispatch(&mut backlog);
         let mut excluded = Vec::new();

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/backlog_exclusion.rs
@@ -735,3 +735,42 @@ fn list_backlog_tasks_excludes_epic_roots_and_descendants_with_reasons() {
         assert_eq!(excluded_entry(&output, &child.id)["conflicts"], json!([]));
     }
 }
+
+/// `list_backlog_tasks` builds its candidate list by walking the task lookup,
+/// which iterates in task-ID order rather than the store's created-at order.
+/// That is only safe because the dispatch sort is a total order, so pin it:
+/// two permutations of the same population must sort to the same sequence.
+#[test]
+fn dispatch_order_is_independent_of_the_input_order() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+    let mut tasks = vec![
+        seed_task_with_dependencies(&runtime, "Chore alpha", TaskStatus::Backlog, Vec::new()),
+        seed_task_with_dependencies(&runtime, "Chore beta", TaskStatus::Backlog, Vec::new()),
+        seed_task_with_dependencies(&runtime, "Chore gamma", TaskStatus::Backlog, Vec::new()),
+        seed_task_with_dependencies(&runtime, "Chore delta", TaskStatus::Backlog, Vec::new()),
+    ];
+    // Vary the bands so the sort has real work to do rather than falling
+    // straight through to the ID tie-breaker.
+    tasks[0].priority = TaskPriority::Critical;
+    tasks[1].task_type = TaskType::Bug;
+    tasks[2].tags.push("code-review".to_string());
+    tasks[3].priority = TaskPriority::Low;
+
+    let mut forward = tasks.clone();
+    let mut reversed = tasks;
+    reversed.reverse();
+
+    sort_tasks_for_automatic_dispatch(&mut forward);
+    sort_tasks_for_automatic_dispatch(&mut reversed);
+
+    let ids = |tasks: &[Task]| tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>();
+    assert_eq!(
+        ids(&forward),
+        ids(&reversed),
+        "dispatch order must not depend on how the population was enumerated"
+    );
+    // The critical task still leads, so the assertion above is comparing a
+    // meaningful ordering rather than two identically-sorted no-ops.
+    assert_eq!(forward[0].priority, TaskPriority::Critical);
+}


### PR DESCRIPTION
## The defect

`list_backlog_tasks` carried a standing `FIXME: perf issue iterating over all tasks`. Next to the scan it flagged was a cheaper problem it did not mention:

```rust
let all_tasks = ...list_tasks()?;
let task_lookup: BTreeMap<String, Task> = all_tasks
    .iter().cloned()                      // deep-clone of every task
    .map(|task| (task.id.clone(), task))
    .collect();
...
let mut backlog: Vec<Task> = all_tasks    // original still fully owned
    .into_iter()
    .filter(|task| task.status == TaskStatus::Backlog && ...)
    .collect();
```

Every task is deep-cloned into the map — strings, tags, history, relations — while `all_tasks` stays live to be consumed afterwards. Two full copies of the population, and one clone per task, on every dispatch cycle. On a workspace with thousands of tasks, nearly all of that work is thrown away by a filter that keeps a few dozen.

## The change

Consume the list into the lookup, then clone only the tasks that survive the backlog + dependency-readiness filter.

- Clones: one per task → one per **dispatchable** task.
- Peak memory: two copies of the population → one.

## What this does not fix

The scan stays, deliberately. An epic's lock set is the union of its descendants' context files (`lock_context_files_for_task`), and that is a downward walk over the entire lookup. A status-filtered map would silently shorten an epic's lock coverage and let conflicting work dispatch in parallel — a correctness regression wearing a performance change's clothes.

Removing the scan needs a persisted parent → children index. That is an architecture decision (`ARCHITECTURE.md` governs new persisted artifacts), not a local optimization, so I left it alone. The `FIXME` is replaced by a comment recording *why* the scan is load-bearing, so the next reader does not have to re-derive it before deciding it looks removable.

## The one behavioral question

The candidate list is now enumerated in **task-ID order** (BTreeMap) rather than the store's **created-at order**.

That is safe because `sort_tasks_for_automatic_dispatch` is a total order — band, then priority, then `created_at`, then `id` — so no pair is left to input order. The new test pins it rather than trusting the reading: it sorts two permutations of the same population and asserts an identical ID sequence, with tasks spread across bands so the sort does real work first.

This is the assumption most worth a reviewer's attention.

## Verification

- `make ci-fast` — pass
- `make ci-lint` — pass
- `cargo test -p orbit-core --lib backlog_exclusion` — 15 pass (14 pre-existing, unchanged, including the epic descendant-union and ID tie-breaker cases; 1 new)

No measured before/after numbers: the local registry is empty with the box down, so I could not build a realistic population to time against. The claim here is allocation counts from the code, not a benchmark.

## Notes

No `ORB-` task ID — filed directly at Daniel's instruction while the box is down, which also overrides the repo rule against committing before task approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)