### PR TITLE
fix: isolate PATH and fixture path resolution in orbit-cli tests

### DIFF
--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -35,8 +35,13 @@ fn non_interactive_init_against_non_global_root_leaves_home_skill_links_untouche
     let live_home = tempdir().expect("live home tempdir");
     let validation_home = tempdir().expect("validation home tempdir");
     let validation_root = tempdir().expect("validation root tempdir");
+    // Detection reads the real `PATH` otherwise, so the seeded crews below
+    // would depend on which agent CLIs this developer has installed.
+    let empty_path = tempdir().expect("empty PATH tempdir");
 
-    let env = EnvGuard::acquire().home(live_home.path());
+    let env = EnvGuard::acquire()
+        .home(live_home.path())
+        .path(empty_path.path());
     let (agents_link, agents_target) = seed_discovery_sentinel(live_home.path(), ".agents");
     let (claude_link, claude_target) = seed_discovery_sentinel(live_home.path(), ".claude");
 

--- a/crates/orbit-cli/src/command/workspace/tests/shared_root.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/shared_root.rs
@@ -24,11 +24,16 @@ fn init_args(name: &str) -> WorkspaceInitArgs {
 #[test]
 fn shared_root_registers_each_checkout_and_show_resolves_by_repo_root() {
     let fixture = tempdir().expect("fixture");
-    let home = fixture.path().join("home");
-    let shared_root = fixture.path().join("shared-orbit");
-    let repo_alpha = fixture.path().join("repo-alpha");
-    let repo_beta = fixture.path().join("repo-beta");
-    let unregistered = fixture.path().join("repo-unregistered");
+    // The registry records checkout paths as the process resolves them, and
+    // `set_current_dir` below resolves symlinks. On macOS a temp dir arrives as
+    // `/var/...` but resolves to `/private/var/...`, so fixtures built from the
+    // unresolved path would never equal what the registry stored.
+    let fixture_root = std::fs::canonicalize(fixture.path()).expect("canonical fixture root");
+    let home = fixture_root.join("home");
+    let shared_root = fixture_root.join("shared-orbit");
+    let repo_alpha = fixture_root.join("repo-alpha");
+    let repo_beta = fixture_root.join("repo-beta");
+    let unregistered = fixture_root.join("repo-unregistered");
     for directory in [&home, &repo_alpha, &repo_beta, &unregistered] {
         std::fs::create_dir_all(directory).expect("fixture directory");
     }

--- a/crates/orbit-cli/src/tests/env_isolation.rs
+++ b/crates/orbit-cli/src/tests/env_isolation.rs
@@ -54,6 +54,7 @@ pub(crate) struct EnvGuard {
     managed_run_context: Option<Option<OsString>>,
     run_id: Option<Option<OsString>>,
     cwd: Option<PathBuf>,
+    path: Option<Option<OsString>>,
     // Declared last so it drops last: the lock is held until every restoration
     // in `Drop` has run.
     _lock: MutexGuard<'static, ()>,
@@ -77,6 +78,7 @@ impl EnvGuard {
             managed_run_context: None,
             run_id: None,
             cwd: None,
+            path: None,
             _lock: lock,
         }
     }
@@ -148,6 +150,25 @@ impl EnvGuard {
         self
     }
 
+    /// Point `PATH` at `dir` alone, capturing the prior value the first time it
+    /// is set.
+    ///
+    /// `orbit init` probes `PATH` to decide which agent CLIs exist and seeds a
+    /// crew per provider it finds (`init::agent_detect`). A test that asserts
+    /// on the seeded crews therefore depends on which CLIs the developer
+    /// happens to have installed, and passes or fails by machine. Pointing
+    /// `PATH` at an empty fixture directory makes detection find nothing, which
+    /// is the same answer on every host.
+    pub(crate) fn path(mut self, dir: &Path) -> Self {
+        if self.path.is_none() {
+            self.path = Some(std::env::var_os("PATH"));
+        }
+        unsafe {
+            std::env::set_var("PATH", dir);
+        }
+        self
+    }
+
     /// Run `f` with `HOME`/`USERPROFILE` temporarily pointed at `home`,
     /// restoring the values this guard currently exposes afterward — even if
     /// `f` panics.
@@ -188,6 +209,9 @@ impl Drop for EnvGuard {
         }
         if let Some(previous) = self.managed_run_context.take() {
             restore_var("ORBIT_MANAGED_RUN_CONTEXT", previous);
+        }
+        if let Some(previous) = self.path.take() {
+            restore_var("PATH", previous);
         }
     }
 }

--- a/crates/orbit-cli/tests/workspace_sync.rs
+++ b/crates/orbit-cli/tests/workspace_sync.rs
@@ -50,7 +50,11 @@ fn workspace_sync_creates_missing_defaults_preserves_operator_content_and_is_ide
         .assert()
         .success();
 
-    let workspace_root = repo.path().join(".orbit");
+    // `workspace sync` reports each action's path as the process resolves it,
+    // so fixtures compared against those paths have to resolve the same way.
+    // A macOS temp dir arrives as `/var/...` and resolves to `/private/var/...`.
+    let repo_root = std::fs::canonicalize(repo.path()).expect("canonical workspace root");
+    let workspace_root = repo_root.join(".orbit");
     let auto_tasks = workspace_root.join("auto_tasks");
     let missing = auto_tasks.join("code-review.yaml");
     std::fs::remove_file(&missing).expect("remove a shipped auto-task");


### PR DESCRIPTION
## Summary

Two `orbit-cli` tests passed on CI and failed on a developer machine, for different reasons. Both made the outcome depend on the host rather than on the code under test.

## 1. `PATH` leaks into `orbit init` crew seeding

`non_interactive_init_against_non_global_root_leaves_home_skill_links_untouched` asserts on which crews `orbit init` seeds. Seeding is driven by `init::agent_detect`, which probes the **real `PATH`** for provider CLIs. `EnvGuard` isolates `HOME`, cwd, and the managed registry root — but not `PATH`.

So the test's result depends on which agent CLIs the developer happens to have installed. On this machine it failed with `unexpected seeded crew copilot`, because the Copilot CLI is present here and absent on CI.

`agent_detect` already documents an injectable `AgentEnvProbe` seam for exactly this — but the seam sits below `InitCommand`, which constructs `RealAgentEnvProbe` internally. Threading a probe through the command for a test's benefit seemed like the wrong trade, so instead `EnvGuard` gains a `path()` builder in the same shape as its existing `home()` and `cwd()`: capture on first set, restore in `Drop` via the same `restore_var` path every other variable uses. The test points it at an empty directory, so detection finds nothing on every host.

## 2. Fixture paths compared against resolved registry paths

`shared_root_registers_each_checkout_and_show_resolves_by_repo_root` compared registry checkout paths against fixtures built from an **unresolved** temp path. The registry records paths as the process resolves them, and `set_current_dir` resolves symlinks — so on macOS the fixture held `/var/...` while the registry held `/private/var/...`.

The fixture root is canonicalized once and every derived path built from it. Production behavior is correct and unchanged; only the expectation moved.

## Scope

Test-only. No production code paths change — `EnvGuard` lives under `src/tests/`.

## Verification

- `make ci-fast` — pass
- `make ci-lint` — pass
- `cargo test -p orbit-cli --bins` — 377 pass, 0 fail

This PR is independent of #1253 and based directly on `agent-main`, but note that `cargo test --workspace` only reaches green on macOS with both applied: #1253 fixes the compile breaks that keep `orbit-engine` and `mcp_roundtrip` from building at all.

## Notes

No `ORB-` task ID — filed directly at Daniel's instruction while the box is down, which also overrides the repo rule against committing before task approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)