### PR TITLE
fix: resolve the re-entrancy lock key after creating the parent directory

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -310,11 +310,22 @@ where
         )
     })?;
 
+    // Create the parent before resolving, not after. `resolved_lock_path`
+    // canonicalizes through the parent and falls back to the literal path when
+    // the parent is missing, so resolving first made the key depend on whether
+    // this call happened to be the one that created the directory: an outer
+    // call keyed the literal path, created the parent, and the nested call then
+    // canonicalized to a different key, missed the lock it already held, and
+    // blocked on a second descriptor to the same file. Creating the parent
+    // first makes the parent always resolvable, so every call in a nest agrees
+    // on the key. Under a path that canonicalizes to itself the two orders are
+    // indistinguishable, which is why this only ever deadlocked where a symlink
+    // sat above the target.
+    create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
     let lock_path = resolved_lock_path(target_path)?;
     let Some(_held) = claim_lock_path(&lock_path) else {
         return op();
     };
-    create_private_dir_all(parent).map_err(|e| classify_lock_io(parent, e))?;
     let mut options = OpenOptions::new();
     options.create(true).read(true).write(true).truncate(false);
     apply_private_file_mode(&mut options);

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -166,3 +166,44 @@ fn exclusive_lock_is_reentrant_across_a_symlinked_route() {
     .expect("the projected route must re-enter the canonical lock");
     assert!(reached);
 }
+
+/// The outer call is the one that creates the parent directory, so the key
+/// re-entrancy is tracked under must not depend on whether the parent existed
+/// when the call started. Reaching the target through a symlink is what makes
+/// the resolved and literal paths differ, and that difference used to leave a
+/// nested call unable to see the lock it already held — it opened a second
+/// descriptor to the same file and blocked forever.
+///
+/// The work runs on its own thread so a regression fails on the timeout rather
+/// than hanging the suite. macOS reproduces this without the explicit symlink,
+/// because its temp directories already sit under one; the symlink here is what
+/// makes the case reproduce on Linux too.
+#[cfg(unix)]
+#[test]
+fn exclusive_lock_re_enters_when_the_outer_call_creates_the_parent_under_a_symlink() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let temp = TempDir::new().expect("tempdir");
+    let real_root = temp.path().join("real");
+    std::fs::create_dir_all(&real_root).expect("real root");
+    let link_root = temp.path().join("link");
+    std::os::unix::fs::symlink(&real_root, &link_root).expect("symlink to the real root");
+
+    // `bundle` deliberately does not exist yet.
+    let target = link_root.join("bundle").join("task.yaml");
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let depth = with_exclusive_file_lock::<usize, io::Error, _>(&target, "outer", || {
+            with_exclusive_file_lock::<usize, io::Error, _>(&target, "inner", || Ok(2))
+        });
+        let _ = tx.send(depth);
+    });
+
+    let depth = rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("nested lock deadlocked instead of re-entering")
+        .expect("nested locks must re-enter");
+    assert_eq!(depth, 2);
+}


### PR DESCRIPTION
## The defect

`with_exclusive_file_lock` could **deadlock against itself**.

It resolved the lock path first and created the parent directory second. But `resolved_lock_path` canonicalizes *through* the parent, and falls back to the literal path when the parent doesn't exist. So the key depended on whether this call happened to be the one that created the directory:

```
outer: parent missing  -> key = literal path   -> claimed
                       -> creates the parent
                       -> takes the lock, runs the body
inner: parent exists   -> key = canonical path -> different key
                       -> re-entrancy bookkeeping misses the lock it already holds
                       -> opens a second descriptor and blocks on it, forever
```

This is exactly the deadlock the resolution was written to prevent. From its own doc comment:

> keying re-entrancy on the literal path would let a nested call miss its own outer lock and deadlock on a second descriptor to the same file

The fallback's reasoning — *"an unresolvable parent means the directory does not exist yet, so nothing can be holding a lock inside it"* — is sound for a single call and wrong across a nest, because the function creates that parent before running the body.

## Why nobody saw it

Where a path canonicalizes to itself, the two orderings are indistinguishable. It only bites under a symlink above the target:

- **Linux CI**: `/tmp` is a real directory. Never reproduced.
- **macOS**: temp dirs live under `/var -> /private/var`. Reproduced every run — but `exclusive_lock_is_reentrant_within_a_thread` *hung* rather than failed, so the suite never got past it to report anything. It only surfaced because the compile fixes in #1253/#1254 let the run reach `orbit-common` at all.

**This is reachable outside tests.** Orbit's checkout projections are symlinks into the store (`.orbit/tasks/ORB-xxxxx -> ~/.orbit/tasks/workspaces/...`), which is precisely the "one bundle, more than one route" case the resolution was built for. A first-time bundle write that creates its parent and then takes a nested lock deadlocks under any symlinked route.

## The fix

Create the parent before resolving. The parent is then always resolvable, so every call in a nest agrees on the key.

Side effect: the parent is now created on a re-entrant call instead of skipped. The outer call already created it, so that's a no-op in every nested case.

## The regression test

The existing test caught this only on macOS, and only by hanging. The new one:

- Builds a **deliberate symlink** above the target, so it reproduces on Linux too.
- Leaves the parent uncreated, so the outer call is the one that creates it.
- Runs the nest on its own thread with a 10s timeout, so a regression **fails** instead of hanging the suite.

Verified in both directions:

```
against the old order:  nested lock deadlocked instead of re-entering: Timeout
                        test result: FAILED. finished in 10.01s
against the new order:  test result: ok. 7 passed
```

## Verification

- `make ci-fast` — pass
- `make ci-lint` — pass
- `cargo test -p orbit-common` — 217 pass, 0 fail (was: hung indefinitely)

## Notes

No `ORB-` task ID — filed directly at Daniel's instruction while the box is down, which also overrides the repo rule against committing before task approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)