### PR TITLE
feat: add `orbit task locks contention` to show what caps parallelism

### DIFF
--- a/crates/orbit-cli/src/command/locks.rs
+++ b/crates/orbit-cli/src/command/locks.rs
@@ -1,8 +1,9 @@
 //! `orbit task locks ...` — task file-lock administration.
 //!
 //! `list` renders the file-lock projection over active (in-progress/review)
-//! tasks and any live reservations. `release` clears a stale reservation by
-//! ID.
+//! tasks and any live reservations. `contention` looks the other way, at the
+//! pending backlog, and reports which selectors will serialize it. `release`
+//! clears a stale reservation by ID.
 //!
 //! Task lock reservations auto-release in workflow pipelines; `release` is the
 //! operator escape hatch for a stale reservation that wedges a run. The
@@ -11,11 +12,12 @@
 //! `runtime.run_tool` bypass (mirrors `orbit adr list`, ORB-00289).
 
 use clap::{Args, Subcommand};
-use orbit_core::OrbitRuntime;
+use orbit_core::{OrbitRuntime, TaskStatus};
 use serde_json::{Map, Value, json};
 
 use crate::command::task::output::format_task_locks;
-use crate::command::{CommandOut, CommandOutput, Execute, Payload, require_confirmation};
+use crate::command::{Block, CommandOut, CommandOutput, Execute, Payload, require_confirmation};
+use crate::output::table::{Column, Table};
 
 #[derive(Args)]
 #[command(about = "Inspect and release task file locks")]
@@ -34,6 +36,8 @@ impl Execute for LocksCommand {
 pub enum LocksSubcommand {
     /// Show files locked by active (in-progress/review) tasks and reservations
     List(LocksListArgs),
+    /// Show which files the pending backlog collides on (what caps parallelism)
+    Contention(LocksContentionArgs),
     /// Release a stale task lock reservation (operator/admin escape hatch)
     Release(LocksReleaseArgs),
 }
@@ -42,6 +46,7 @@ impl Execute for LocksSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         match self {
             LocksSubcommand::List(args) => args.execute(runtime),
+            LocksSubcommand::Contention(args) => args.execute(runtime),
             LocksSubcommand::Release(args) => args.execute(runtime),
         }
     }
@@ -65,6 +70,107 @@ impl Execute for LocksListArgs {
             Ok(CommandOutput::Silent)
         }
     }
+}
+
+/// Hotspot rows rendered by default. Long enough to show a pattern, short
+/// enough that the tail of singletons does not bury it.
+const DEFAULT_CONTENTION_LIMIT: usize = 10;
+
+#[derive(Args)]
+#[command(
+    about = "Show which files the pending backlog collides on (what caps parallelism)",
+    after_help = "Examples:\n  orbit task locks contention\n  orbit task locks contention --limit 25\n  orbit task locks contention --json\n\n\
+                  TASKS counts pending tasks whose lock surface overlaps that selector; a\n\
+                  selector claimed by one task constrains nothing and is not listed.\n\n\
+                  GROUPS counts clusters of pending tasks linked by overlapping surfaces.\n\
+                  Tasks in different groups can never block each other, so the group count\n\
+                  is a floor on how many dispatch can admit at once — not a ceiling, since\n\
+                  two tasks inside one group are often compatible and merely linked through\n\
+                  a third.\n\n\
+                  Surfaces are the ones conflict admission reserves: declared selectors,\n\
+                  pruned of paths that no longer exist, unioned across descendants for an\n\
+                  epic root. A task declaring nothing locks nothing and is counted apart."
+)]
+pub struct LocksContentionArgs {
+    /// Maximum hotspot rows to show. Default 10.
+    #[arg(long, default_value_t = DEFAULT_CONTENTION_LIMIT)]
+    pub limit: usize,
+    /// Output the contention report as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for LocksContentionArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let report = runtime.task_lock_contention(&[TaskStatus::Backlog])?;
+
+        let mut table = Table::new(vec![
+            Column::new("SELECTOR").fixed(),
+            Column::new("TASKS").number(),
+        ])
+        .keep_all_columns()
+        .empty_message("no selector is claimed by more than one pending task");
+        for hotspot in report.hotspots.iter().take(self.limit) {
+            table.add_row(vec![hotspot.selector.clone(), hotspot.tasks().to_string()]);
+        }
+
+        let doc = json!({
+            "hotspots": report
+                .hotspots
+                .iter()
+                .map(|hotspot| json!({
+                    "selector": hotspot.selector,
+                    "tasks": hotspot.tasks(),
+                    "task_ids": hotspot.task_ids,
+                }))
+                .collect::<Vec<_>>(),
+            "pending": {
+                "total": report.pending(),
+                "constrained": report.constrained,
+                "unconstrained": report.unconstrained,
+            },
+            "groups": report.groups,
+            "largest_group": report.largest_group,
+            "parallel_floor": report.parallel_floor(),
+        });
+
+        Ok(Payload::blocks(
+            doc,
+            vec![
+                Block::table(table),
+                Block::text(contention_summary(&report, self.limit)),
+            ],
+        )
+        .into())
+    }
+}
+
+/// One line stating what the numbers mean for dispatch.
+fn contention_summary(report: &orbit_core::LockContentionReport, limit: usize) -> String {
+    if report.pending() == 0 {
+        return "no pending tasks to analyze".to_string();
+    }
+    if report.hotspots.is_empty() {
+        return format!(
+            "{} pending tasks, no contention — no selector is claimed by more than one",
+            report.pending()
+        );
+    }
+    let shown = report.hotspots.len().min(limit);
+    let elided = if shown < report.hotspots.len() {
+        format!(", top {shown} shown")
+    } else {
+        String::new()
+    };
+    format!(
+        "{} pending tasks ({} declare no files), {} contended selector(s){} — at least {} can run in parallel, largest cluster chains {}",
+        report.pending(),
+        report.unconstrained,
+        report.hotspots.len(),
+        elided,
+        report.parallel_floor(),
+        report.largest_group,
+    )
 }
 
 #[derive(Args)]

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -458,6 +458,7 @@ impl Commands {
                     },
                     TaskSubcommand::Locks(command) => match &command.command {
                         LocksSubcommand::List(_) => ("locks-list", None, None),
+                        LocksSubcommand::Contention(_) => ("locks-contention", None, None),
                         LocksSubcommand::Release(args) => (
                             "locks-release",
                             Some("reservation"),

--- a/crates/orbit-core/src/application/task/contention.rs
+++ b/crates/orbit-core/src/application/task/contention.rs
@@ -1,0 +1,195 @@
+//! Lock contention across a pending task population.
+//!
+//! Throughput under conflict-aware dispatch is bounded by how much of the
+//! backlog can hold non-overlapping locks at once. Whether the backlog is
+//! draining is a separate question from why it drains at the rate it does;
+//! this answers the second by naming the selectors pending tasks keep
+//! colliding on, and by measuring how far the population decomposes into
+//! clusters that can never block one another.
+//!
+//! Surfaces come from the same expansion conflict admission uses — declared
+//! selectors, pruned of paths that no longer exist, unioned across descendants
+//! for an epic root. A contention picture admission does not share is not
+//! worth reading.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use orbit_common::OrbitError;
+use orbit_common::fs::selector::overlaps;
+use orbit_types::task::{Task, TaskStatus};
+
+use crate::OrbitRuntime;
+use crate::runtime::task::locks::lock_context_files_for_task;
+
+/// One pending task reduced to the fields the analysis reads.
+pub(crate) struct LockSurface {
+    pub task_id: String,
+    pub selectors: Vec<String>,
+}
+
+/// A selector that more than one pending task contends for.
+pub struct LockContentionHotspot {
+    /// The contended selector, in canonical form.
+    pub selector: String,
+    /// IDs of the pending tasks whose surface overlaps it, ascending.
+    pub task_ids: Vec<String>,
+}
+
+impl LockContentionHotspot {
+    /// How many pending tasks contend for this selector.
+    pub fn tasks(&self) -> usize {
+        self.task_ids.len()
+    }
+}
+
+/// What caps parallelism across a pending population.
+pub struct LockContentionReport {
+    /// Contended selectors, most contended first, then by selector.
+    pub hotspots: Vec<LockContentionHotspot>,
+    /// Pending tasks declaring at least one surviving selector.
+    pub constrained: usize,
+    /// Pending tasks declaring nothing, which contend with no one.
+    pub unconstrained: usize,
+    /// Disjoint clusters among the constrained tasks.
+    pub groups: usize,
+    /// Task count in the largest such cluster.
+    pub largest_group: usize,
+}
+
+impl LockContentionReport {
+    /// A floor on how many pending tasks can hold locks simultaneously: one
+    /// per disjoint cluster, plus every task that locks nothing at all.
+    ///
+    /// It is a floor and not the true maximum because two tasks inside one
+    /// cluster are often compatible with each other — they are linked through
+    /// a third. Computing the exact maximum is the maximum independent set
+    /// problem; the floor is cheap, sound, and enough to act on.
+    pub fn parallel_floor(&self) -> usize {
+        self.groups + self.unconstrained
+    }
+
+    /// Total pending tasks the report covers.
+    pub fn pending(&self) -> usize {
+        self.constrained + self.unconstrained
+    }
+}
+
+impl OrbitRuntime {
+    /// Lock contention across every task whose status appears in `statuses`.
+    ///
+    /// The whole task table is loaded regardless of `statuses`, because an
+    /// epic root's lock surface is the union over its descendants and those
+    /// can sit at any status. Only the selected tasks are expanded.
+    pub fn task_lock_contention(
+        &self,
+        statuses: &[TaskStatus],
+    ) -> Result<LockContentionReport, OrbitError> {
+        let lookup: BTreeMap<String, Task> = self
+            .list_tasks()?
+            .into_iter()
+            .map(|task| (task.id.clone(), task))
+            .collect();
+        let repo_root = self.paths().repo_root.as_path();
+        let surfaces: Vec<LockSurface> = lookup
+            .values()
+            .filter(|task| statuses.contains(&task.status))
+            .map(|task| LockSurface {
+                task_id: task.id.clone(),
+                selectors: lock_context_files_for_task(task, &lookup, repo_root),
+            })
+            .collect();
+        Ok(compute_contention(&surfaces))
+    }
+}
+
+/// Whether two lock surfaces would refuse to be held at the same time.
+fn surfaces_conflict(left: &LockSurface, right: &LockSurface) -> bool {
+    left.selectors
+        .iter()
+        .any(|a| right.selectors.iter().any(|b| overlaps(a, b)))
+}
+
+/// Rank selectors by how many surfaces overlap them, and cluster the surfaces
+/// that transitively conflict.
+///
+/// Both passes are quadratic in the pending population. That is deliberate:
+/// selector overlap is a containment relation — `dir:src` covers everything
+/// beneath it — not string equality, so it cannot be bucketed by hash. The
+/// input is one workspace's pending tasks, which is the scale this is for.
+pub(crate) fn compute_contention(surfaces: &[LockSurface]) -> LockContentionReport {
+    let constrained: Vec<&LockSurface> = surfaces
+        .iter()
+        .filter(|surface| !surface.selectors.is_empty())
+        .collect();
+    let unconstrained = surfaces.len() - constrained.len();
+
+    let distinct: BTreeSet<&String> = constrained
+        .iter()
+        .flat_map(|surface| surface.selectors.iter())
+        .collect();
+    let mut hotspots: Vec<LockContentionHotspot> = distinct
+        .into_iter()
+        .filter_map(|selector| {
+            let task_ids: Vec<String> = constrained
+                .iter()
+                .filter(|surface| {
+                    surface
+                        .selectors
+                        .iter()
+                        .any(|held| overlaps(held, selector))
+                })
+                .map(|surface| surface.task_id.clone())
+                .collect();
+            // A selector only one task claims constrains nothing.
+            (task_ids.len() > 1).then(|| LockContentionHotspot {
+                selector: selector.clone(),
+                task_ids,
+            })
+        })
+        .collect();
+    // Most contended first; equal rows stay in selector order so repeated runs
+    // over an unchanged backlog render identically.
+    hotspots.sort_by(|a, b| {
+        b.tasks()
+            .cmp(&a.tasks())
+            .then_with(|| a.selector.cmp(&b.selector))
+    });
+
+    let (groups, largest_group) = cluster(&constrained);
+
+    LockContentionReport {
+        hotspots,
+        constrained: constrained.len(),
+        unconstrained,
+        groups,
+        largest_group,
+    }
+}
+
+/// Connected components over the conflict graph, as
+/// `(component count, largest component size)`.
+fn cluster(surfaces: &[&LockSurface]) -> (usize, usize) {
+    let mut seen = vec![false; surfaces.len()];
+    let mut groups = 0;
+    let mut largest = 0;
+    for start in 0..surfaces.len() {
+        if seen[start] {
+            continue;
+        }
+        groups += 1;
+        let mut size = 0;
+        let mut stack = vec![start];
+        seen[start] = true;
+        while let Some(index) = stack.pop() {
+            size += 1;
+            for (other, surface) in surfaces.iter().enumerate() {
+                if !seen[other] && surfaces_conflict(surfaces[index], surface) {
+                    seen[other] = true;
+                    stack.push(other);
+                }
+            }
+        }
+        largest = largest.max(size);
+    }
+    (groups, largest)
+}

--- a/crates/orbit-core/src/application/task/mod.rs
+++ b/crates/orbit-core/src/application/task/mod.rs
@@ -1,6 +1,7 @@
 //! Task commands and coordinated record writes.
 
 mod add;
+pub(crate) mod contention;
 mod helpers;
 mod lint;
 mod params;
@@ -10,6 +11,7 @@ mod records;
 mod transitions;
 mod update;
 
+pub use contention::{LockContentionHotspot, LockContentionReport};
 pub use lint::{TaskLintFinding, TaskLintReport, TaskLintSeverity};
 pub(crate) use params::TaskRecordUpdateParams;
 pub use params::{TaskAddParams, TaskUpdateParams};

--- a/crates/orbit-core/src/application/task/tests/contention.rs
+++ b/crates/orbit-core/src/application/task/tests/contention.rs
@@ -1,0 +1,152 @@
+use crate::application::task::contention::{LockSurface, compute_contention};
+
+fn surface(task_id: &str, selectors: &[&str]) -> LockSurface {
+    LockSurface {
+        task_id: task_id.to_string(),
+        selectors: selectors.iter().map(|s| (*s).to_string()).collect(),
+    }
+}
+
+#[test]
+fn a_selector_only_one_task_claims_is_not_contention() {
+    let report = compute_contention(&[
+        surface("T-1", &["file:src/a.rs"]),
+        surface("T-2", &["file:src/b.rs"]),
+    ]);
+
+    assert!(report.hotspots.is_empty());
+    assert_eq!(report.constrained, 2);
+    assert_eq!(report.groups, 2, "disjoint tasks are separate clusters");
+    assert_eq!(report.largest_group, 1);
+    assert_eq!(report.parallel_floor(), 2);
+}
+
+#[test]
+fn two_tasks_on_one_file_contend_and_form_a_single_cluster() {
+    let report = compute_contention(&[
+        surface("T-1", &["file:src/a.rs"]),
+        surface("T-2", &["file:src/a.rs"]),
+    ]);
+
+    assert_eq!(report.hotspots.len(), 1);
+    assert_eq!(report.hotspots[0].selector, "file:src/a.rs");
+    assert_eq!(report.hotspots[0].task_ids, vec!["T-1", "T-2"]);
+    assert_eq!(report.groups, 1);
+    assert_eq!(report.largest_group, 2);
+    assert_eq!(report.parallel_floor(), 1);
+}
+
+#[test]
+fn contention_follows_selector_containment_not_string_equality() {
+    // `dir:src` covers everything beneath it, so these two tasks conflict even
+    // though neither declares the other's selector.
+    let report = compute_contention(&[
+        surface("T-1", &["dir:src"]),
+        surface("T-2", &["file:src/nested/deep.rs"]),
+    ]);
+
+    assert_eq!(
+        report.groups, 1,
+        "a directory claim reaches its descendants"
+    );
+    assert_eq!(report.largest_group, 2);
+    assert_eq!(
+        report.hotspots.len(),
+        2,
+        "both selectors are contended: each overlaps a surface held by the other task"
+    );
+}
+
+#[test]
+fn a_cluster_links_transitively_through_a_shared_middle_task() {
+    // A and C never touch the same file; B touches both. All three land in one
+    // cluster, which is why the group count is a floor on parallelism and not
+    // the achievable maximum — A and C could in fact run together.
+    let report = compute_contention(&[
+        surface("T-A", &["file:src/a.rs"]),
+        surface("T-B", &["file:src/a.rs", "file:src/c.rs"]),
+        surface("T-C", &["file:src/c.rs"]),
+    ]);
+
+    assert_eq!(report.groups, 1);
+    assert_eq!(report.largest_group, 3);
+    assert_eq!(report.parallel_floor(), 1);
+}
+
+#[test]
+fn a_task_declaring_nothing_contends_with_no_one_and_raises_the_floor() {
+    let report = compute_contention(&[
+        surface("T-1", &["file:src/a.rs"]),
+        surface("T-2", &["file:src/a.rs"]),
+        surface("T-3", &[]),
+    ]);
+
+    assert_eq!(report.constrained, 2);
+    assert_eq!(report.unconstrained, 1);
+    assert_eq!(report.pending(), 3);
+    assert_eq!(report.groups, 1);
+    assert_eq!(
+        report.parallel_floor(),
+        2,
+        "one per cluster, plus the task that locks nothing"
+    );
+}
+
+#[test]
+fn hotspots_rank_by_contention_then_by_selector() {
+    let report = compute_contention(&[
+        surface("T-1", &["file:src/hot.rs", "file:src/b.rs"]),
+        surface("T-2", &["file:src/hot.rs", "file:src/a.rs"]),
+        surface("T-3", &["file:src/hot.rs"]),
+        surface("T-4", &["file:src/a.rs"]),
+        surface("T-5", &["file:src/b.rs"]),
+    ]);
+
+    let ranked: Vec<(&str, usize)> = report
+        .hotspots
+        .iter()
+        .map(|hotspot| (hotspot.selector.as_str(), hotspot.tasks()))
+        .collect();
+    assert_eq!(
+        ranked,
+        vec![
+            ("file:src/hot.rs", 3),
+            ("file:src/a.rs", 2),
+            ("file:src/b.rs", 2),
+        ],
+        "most contended first; the two-task rows tie and fall back to selector order"
+    );
+}
+
+#[test]
+fn an_empty_population_reports_nothing_rather_than_a_clean_bill() {
+    let report = compute_contention(&[]);
+
+    assert_eq!(report.pending(), 0);
+    assert_eq!(report.groups, 0);
+    assert_eq!(report.largest_group, 0);
+    assert_eq!(report.parallel_floor(), 0);
+    assert!(report.hotspots.is_empty());
+}
+
+#[test]
+fn every_task_sharing_one_file_collapses_the_floor_to_one() {
+    let surfaces: Vec<LockSurface> = (1..=6)
+        .map(|index| LockSurface {
+            task_id: format!("T-{index}"),
+            selectors: vec!["file:src/registry.rs".to_string()],
+        })
+        .collect();
+
+    let report = compute_contention(&surfaces);
+
+    assert_eq!(report.hotspots.len(), 1);
+    assert_eq!(report.hotspots[0].tasks(), 6);
+    assert_eq!(report.groups, 1);
+    assert_eq!(report.largest_group, 6);
+    assert_eq!(
+        report.parallel_floor(),
+        1,
+        "a single file serializes them all"
+    );
+}

--- a/crates/orbit-core/src/application/task/tests/mod.rs
+++ b/crates/orbit-core/src/application/task/tests/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 mod add;
+mod contention;
 mod params;
 mod paths;
 mod records;

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -71,6 +71,7 @@ pub use application::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, HitWorkspace, WorkspaceSearchReport,
     task_selectors_contain_path,
 };
+pub use application::task::{LockContentionHotspot, LockContentionReport};
 pub use application::workflow::{ShipMode, build_ship_input, find_workflow, resolved_ship_mode};
 pub use application::workspace_sync::{
     ManagedArtifactOutcome, ManagedArtifactScope, ManagedArtifactSyncAction,


### PR DESCRIPTION
## Why

`orbit task locks list` answers *what is locked right now*. Nothing answered the forward-looking question: of the work waiting to be dispatched, what will serialize it?

Under conflict-aware dispatch that ceiling *is* the throughput ceiling — but it was invisible until tasks were already blocking each other, at which point the cost has been paid. `orbit task flow` (#1251) says whether the backlog is draining; this says why it drains at the rate it does.

## What it reports

```
$ orbit task locks contention
dir:src            5
file:src/hot.rs    4
file:src/a.rs      3
file:src/b.rs      2

6 pending tasks (1 declare no files), 4 contended selector(s) — at least 2 can run in parallel, largest cluster chains 5
```

- **Hotspots** — selectors ranked by how many pending tasks contend for them. One file claimed by a dozen tasks is a serialization point, and splitting it is usually the cheapest throughput win available. `--json` also lists the contending task IDs.
- **Groups** — how many mutually disjoint clusters the pending population falls into. Tasks in different clusters can never block each other.

The `parallel_floor` is deliberately a *floor*, not the achievable maximum: two tasks inside one cluster are often compatible and merely linked through a third. Computing the true maximum is maximum independent set; the cheap sound bound is enough to act on. The help text and the doc comments both say which it is rather than overstating it.

Contention follows selector **containment**, not string equality — `dir:src` overlaps `file:src/nested/deep.rs`. That is what makes the fixture above collapse to a floor of 2: one `dir:src` task transitively links all five constrained tasks.

## Placement

Surfaces come from `lock_context_files_for_task` — the same expansion conflict admission performs, epic descendant union and filesystem prune included. A contention picture the dispatcher does not share would not be worth reading, so the definition is shared rather than re-derived.

The analysis lives in `orbit-core` (`application/task/contention.rs`) beside the lock code it depends on, exported the way `TaskLintReport` is. `orbit-cli` holds only the clap surface and the rendering, per the crate-boundary rule in `crates/orbit-cli/CLAUDE.md`. I first wrote the analysis in the CLI and moved it — conflict-graph computation is domain logic, not presentation.

No new tool is registered: the CLI calls the public runtime API directly, as `task flow` does. Adding an MCP tool would be speculative until an agent needs it.

## Verification

- 8 new unit tests in `orbit-core` covering containment-not-equality, transitive clustering, the unconstrained population, hotspot ranking and ties, and the empty case.
- End-to-end against a scratch workspace of six real tasks; every count in the output above was verified by hand against the fixture.
- `cargo test -p orbit-core -p orbit-cli` — all pass (869 + 386 + integration targets).
- `make ci-fast`, `make ci-lint` — pass.