### PR TITLE
feat(cli): give `task update` an `--approve` step and group the task help

### DIFF
--- a/crates/orbit-cli/src/command/task/archive.rs
+++ b/crates/orbit-cli/src/command/task/archive.rs
@@ -1,0 +1,29 @@
+use clap::Args;
+use orbit_core::OrbitRuntime;
+
+use crate::command::{CommandOut, CommandOutput, Execute, Payload};
+
+use super::output::task_to_json_for_runtime;
+
+#[derive(Args)]
+#[command(after_help = "Restore an archived task with `orbit task update <id> --status backlog`.")]
+pub struct TaskArchiveArgs {
+    /// Task ID
+    pub id: String,
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for TaskArchiveArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        runtime.archive_task(&self.id)?;
+        if self.json {
+            let task = runtime.get_task(&self.id)?;
+            Ok(Payload::document(task_to_json_for_runtime(runtime, &task)?).into())
+        } else {
+            println!("Archived task '{}'", self.id);
+            Ok(CommandOutput::Silent)
+        }
+    }
+}

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -5,20 +5,68 @@ use crate::command::locks::LocksCommand;
 use crate::command::{CommandOut, Execute};
 
 use super::add::TaskAddArgs;
+use super::archive::TaskArchiveArgs;
 use super::artifact::TaskArtifactCommand;
 use super::export::TaskExportArgs;
 use super::flow::TaskFlowArgs;
 use super::import::TaskImportArgs;
-use super::lifecycle::{TaskArchiveArgs, TaskStartArgs};
 use super::lint::TaskLintArgs;
 use super::list::TaskListArgs;
 use super::publication::TaskPublicationCommand;
 use super::reindex::TaskReindexArgs;
 use super::show::TaskShowArgs;
+use super::start::TaskStartArgs;
 use super::update::TaskUpdateArgs;
 
+/// Grouped `orbit task` help, rendered the same way `orbit run` and the root
+/// command render theirs: a hand-rolled template, because clap's derive has no
+/// per-variant `help_heading`. Fourteen ungrouped rows read as a wall; the
+/// sections say which of them you are looking for. Keep the variant order in
+/// `TaskSubcommand` matching the section order below — the order decides where
+/// a command would land if it were ever missing from the template.
+const TASK_HELP_TEMPLATE: &str = "\
+{about}
+
+{usage-heading} {usage}
+
+Tasks:
+  add          Create a new task
+  update       Update task fields; `--approve` takes the next approval step
+  archive      Archive a task
+  list         List tasks with optional filters
+  show         Show one task in detail, by ID, across registered workspaces
+  artifact     Manage task artifact files
+
+Health:
+  lint         Lint tasks for stale paths and vague acceptance criteria
+  flow         Show filed-vs-closed rates over time — is the backlog draining?
+  locks        Inspect and release the file locks that gate dispatch
+
+Bundles:
+  export       Export task bundles to a portable tar.zst archive
+  import       Import task bundles from a tar.zst archive
+  publication  Publish, inspect, diagnose, or restore task snapshots
+  reindex      Rebuild the registry index from on-disk task bundles
+
+Options:
+{options}
+{after-help}";
+
+const TASK_AFTER_HELP: &str = "\
+Lifecycle:
+  orbit task update <id> --approve                  proposed -> backlog, review -> done
+  orbit task update <id> --status in-progress       take the work
+  orbit task update <id> --status review            hand it off
+
+Run `orbit task <COMMAND> --help` for a command's own options and examples.";
+
 #[derive(Args)]
-#[command(about = "Create, update, and manage tasks")]
+#[command(
+    about = "Create, update, and manage tasks",
+    override_usage = "orbit task <COMMAND>",
+    help_template = TASK_HELP_TEMPLATE,
+    after_help = TASK_AFTER_HELP
+)]
 pub struct TaskCommand {
     #[command(subcommand)]
     pub command: TaskSubcommand,
@@ -34,26 +82,28 @@ impl Execute for TaskCommand {
 pub enum TaskSubcommand {
     /// Create a new task
     Add(TaskAddArgs),
-    /// Manage task artifact files
-    Artifact(TaskArtifactCommand),
-    /// Inspect and release task file locks
-    Locks(LocksCommand),
-    /// List tasks with optional filters
-    List(TaskListArgs),
-    /// Show filed-vs-closed rates over time — whether the backlog is draining
-    Flow(TaskFlowArgs),
-    /// Show detailed information about a task, found by ID in any registered
-    /// workspace unless `--workspace` narrows the search
-    Show(TaskShowArgs),
-    /// Lint tasks for stale paths and vague acceptance criteria; `--fix` prunes stale context files
-    Lint(TaskLintArgs),
-    /// Update task fields and perform guarded status transitions
-    /// (approve: proposed -> backlog, review -> done; reject: -> rejected; unarchive: archived -> backlog)
+    /// Update task fields, or take the next approval step with `--approve`
+    /// (proposed -> backlog, review -> done)
     Update(TaskUpdateArgs),
-    /// Start work on a task, approving proposed work when needed
+    /// Deprecated alias kept for callers that predate `orbit task update`
+    /// owning approval; hidden from help and removed after a couple releases
+    #[command(hide = true)]
     Start(TaskStartArgs),
     /// Archive a task
     Archive(TaskArchiveArgs),
+    /// List tasks with optional filters
+    List(TaskListArgs),
+    /// Show detailed information about a task, found by ID in any registered
+    /// workspace unless `--workspace` narrows the search
+    Show(TaskShowArgs),
+    /// Manage task artifact files
+    Artifact(TaskArtifactCommand),
+    /// Lint tasks for stale paths and vague acceptance criteria; `--fix` prunes stale context files
+    Lint(TaskLintArgs),
+    /// Show filed-vs-closed rates over time — whether the backlog is draining
+    Flow(TaskFlowArgs),
+    /// Inspect and release task file locks
+    Locks(LocksCommand),
     /// Export task bundles to a portable tar.zst archive
     Export(TaskExportArgs),
     /// Import task bundles from a tar.zst archive
@@ -68,15 +118,15 @@ impl Execute for TaskSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         match self {
             TaskSubcommand::Add(args) => args.execute(runtime),
-            TaskSubcommand::Artifact(cmd) => cmd.execute(runtime),
-            TaskSubcommand::Locks(cmd) => cmd.execute(runtime),
-            TaskSubcommand::List(args) => args.execute(runtime),
-            TaskSubcommand::Flow(args) => args.execute(runtime),
-            TaskSubcommand::Show(args) => args.execute(runtime),
-            TaskSubcommand::Lint(args) => args.execute(runtime),
             TaskSubcommand::Update(args) => args.execute(runtime),
             TaskSubcommand::Start(args) => args.execute(runtime),
             TaskSubcommand::Archive(args) => args.execute(runtime),
+            TaskSubcommand::List(args) => args.execute(runtime),
+            TaskSubcommand::Show(args) => args.execute(runtime),
+            TaskSubcommand::Artifact(cmd) => cmd.execute(runtime),
+            TaskSubcommand::Lint(args) => args.execute(runtime),
+            TaskSubcommand::Flow(args) => args.execute(runtime),
+            TaskSubcommand::Locks(cmd) => cmd.execute(runtime),
             TaskSubcommand::Export(args) => args.execute(runtime),
             TaskSubcommand::Import(args) => args.execute(runtime),
             TaskSubcommand::Publication(command) => command.execute(runtime),

--- a/crates/orbit-cli/src/command/task/mod.rs
+++ b/crates/orbit-cli/src/command/task/mod.rs
@@ -1,17 +1,18 @@
 mod add;
+mod archive;
 pub(crate) mod artifact;
 pub mod artifacts;
 mod command;
 mod export;
 pub(crate) mod flow;
 mod import;
-mod lifecycle;
 mod lint;
 mod list;
 pub(crate) mod output;
 mod publication;
 mod reindex;
 pub(crate) mod show;
+mod start;
 mod update;
 
 pub use command::{TaskCommand, TaskSubcommand};

--- a/crates/orbit-cli/src/command/task/start.rs
+++ b/crates/orbit-cli/src/command/task/start.rs
@@ -1,9 +1,26 @@
+//! `orbit task start` — hidden compatibility shim.
+//!
+//! Approval and the move to `in-progress` both live on `orbit task update`
+//! now (`--approve`, `--status in-progress`), so this verb is off the help
+//! surface. It still runs, unchanged, because scripts and agent prompts that
+//! predate the move are still calling it; it warns on stderr and will be
+//! removed after a couple of releases.
+//!
+//! Nothing else in the tree should reach for it. The `orbit.task.start` tool
+//! remains the pipeline's own entrypoint and is not affected.
+
 use clap::Args;
 use orbit_core::OrbitRuntime;
 
 use crate::command::{CommandOut, CommandOutput, Execute, Payload};
 
 use super::output::task_to_json_for_runtime;
+
+/// Printed once per invocation, to stderr, so a caller piping `--json` into a
+/// parser sees the notice without it corrupting the document on stdout.
+const DEPRECATION_NOTICE: &str = "note: `orbit task start` is deprecated and hidden from help. \
+Use `orbit task update <id> --approve` to approve proposed work, and \
+`orbit task update <id> --status in-progress` to take it.";
 
 #[derive(Args)]
 pub struct TaskStartArgs {
@@ -28,6 +45,7 @@ pub struct TaskStartArgs {
 
 impl Execute for TaskStartArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        eprintln!("{DEPRECATION_NOTICE}");
         let (agent, model) = super::mutation_identity(self.model);
         let task = runtime.start_task_with_identity_and_crew(
             &self.id,
@@ -41,29 +59,6 @@ impl Execute for TaskStartArgs {
             Ok(Payload::document(task_to_json_for_runtime(runtime, &task)?).into())
         } else {
             println!("Started task '{}'", task.id);
-            Ok(CommandOutput::Silent)
-        }
-    }
-}
-
-#[derive(Args)]
-#[command(after_help = "Restore an archived task with `orbit task update <id> --status backlog`.")]
-pub struct TaskArchiveArgs {
-    /// Task ID
-    pub id: String,
-    /// Output as JSON
-    #[arg(long)]
-    pub json: bool,
-}
-
-impl Execute for TaskArchiveArgs {
-    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        runtime.archive_task(&self.id)?;
-        if self.json {
-            let task = runtime.get_task(&self.id)?;
-            Ok(Payload::document(task_to_json_for_runtime(runtime, &task)?).into())
-        } else {
-            println!("Archived task '{}'", self.id);
             Ok(CommandOutput::Silent)
         }
     }

--- a/crates/orbit-cli/src/command/task/tests/command.rs
+++ b/crates/orbit-cli/src/command/task/tests/command.rs
@@ -2,11 +2,11 @@ use clap::{CommandFactory, Parser, error::ErrorKind};
 
 use crate::command::Cli;
 
-/// The trimmed `orbit task` surface has 12 subcommands. ORB-10428 returns lock
+/// The trimmed `orbit task` surface has 11 subcommands. ORB-10428 returns lock
 /// administration here.
-const EXPECTED_TASK_SUBCOMMANDS: [&str; 12] = [
-    "add", "artifact", "locks", "list", "show", "lint", "update", "start", "archive", "export",
-    "import", "reindex",
+const EXPECTED_TASK_SUBCOMMANDS: [&str; 11] = [
+    "add", "artifact", "locks", "list", "show", "lint", "update", "archive", "export", "import",
+    "reindex",
 ];
 
 const REMOVED_TASK_SUBCOMMANDS: [&str; 7] = [
@@ -52,6 +52,24 @@ fn task_help_lists_exactly_the_trimmed_subcommand_set() {
     }
 }
 
+/// `start` still parses — callers that predate `task update` owning approval
+/// keep working for a couple of releases — but it is off the help surface, so
+/// nothing new discovers it.
+#[test]
+fn deprecated_task_start_still_parses_but_is_hidden_from_help() {
+    Cli::try_parse_from(["orbit", "task", "start", "ORB-00001"])
+        .expect("deprecated `task start` still parses");
+    let help = task_help();
+    assert!(
+        !help.lines().any(|line| {
+            line.trim_start()
+                .strip_prefix("start")
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with(' '))
+        }),
+        "task help should not advertise `start`:\n{help}"
+    );
+}
+
 #[test]
 fn removed_task_subcommands_are_rejected() {
     for subcommand in REMOVED_TASK_SUBCOMMANDS {
@@ -74,8 +92,8 @@ fn removed_task_subcommands_are_rejected() {
 fn task_help_describes_update_status_transitions() {
     let help = task_help();
     assert!(
-        help.contains("guarded status transitions"),
-        "update help should mention guarded status transitions:\n{help}"
+        help.contains("--approve"),
+        "update help should advertise the approval step:\n{help}"
     );
     assert!(!help.contains("proposed → archived"), "{help}");
     assert!(!help.contains("review → backlog"), "{help}");

--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, error::ErrorKind};
 
 use crate::command::{Cli, Commands};
 
@@ -98,4 +98,77 @@ fn task_update_rejects_required_tools() {
     };
 
     assert!(error.to_string().contains("--required-tools"), "{error}");
+}
+
+#[test]
+fn task_update_approve_parses_with_note_and_comment() {
+    let cli = Cli::try_parse_from([
+        "orbit",
+        "task",
+        "update",
+        "ORB-00001",
+        "--approve",
+        "--note",
+        "looks right",
+        "--comment",
+        "shipping it",
+    ])
+    .expect("parse task update --approve");
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Update(args) = task.command else {
+        panic!("expected task update command");
+    };
+
+    assert!(args.approve);
+    assert_eq!(args.note.as_deref(), Some("looks right"));
+    assert_eq!(args.comment.as_deref(), Some("shipping it"));
+    assert!(args.status.is_none());
+}
+
+/// The transition `--approve` takes is derived from the task's current status,
+/// so pairing it with an explicit status or a field edit would be asking for
+/// two contradictory writes.
+#[test]
+fn task_update_approve_conflicts_with_status_and_field_edits() {
+    for args in [
+        vec![
+            "task",
+            "update",
+            "ORB-00001",
+            "--approve",
+            "--status",
+            "done",
+        ],
+        vec!["task", "update", "ORB-00001", "--approve", "--title", "New"],
+        vec!["task", "update", "ORB-00001", "--approve", "--tag", "chore"],
+        vec![
+            "task",
+            "update",
+            "ORB-00001",
+            "--approve",
+            "--context",
+            "file:src/lib.rs",
+        ],
+    ] {
+        let mut argv = vec!["orbit"];
+        argv.extend(args);
+        let err = match Cli::try_parse_from(&argv) {
+            Ok(_) => panic!("{argv:?} should conflict with --approve"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict, "{argv:?}");
+    }
+}
+
+/// A note only has somewhere to go on the approval's history entry.
+#[test]
+fn task_update_note_requires_approve() {
+    let err = match Cli::try_parse_from(["orbit", "task", "update", "ORB-00001", "--note", "hi"]) {
+        Ok(_) => panic!("--note without --approve should not parse"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -72,10 +72,45 @@ pub struct TaskUpdateArgs {
     /// Explicit agent model to persist on the task artifact
     #[arg(long)]
     pub model: Option<String>,
+    /// Take the task's next approval step: `proposed` -> `backlog`, or
+    /// `review` -> `done`. The transition is chosen from the current status,
+    /// so it cannot be combined with field edits or an explicit `--status`.
+    #[arg(long, conflicts_with_all = APPROVE_CONFLICTS)]
+    pub approve: bool,
+    /// Note recorded on the approval's status history entry (with `--approve`)
+    #[arg(long, requires = "approve")]
+    pub note: Option<String>,
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
 }
+
+/// Every field-mutation argument on this command. `--approve` performs a
+/// guarded transition the domain derives from the task's current status; an
+/// edit alongside it would be a second, differently-attributed write on the
+/// same invocation, and `--status` would be a direct contradiction of the
+/// transition being requested. Rejecting the combination in the parser keeps
+/// approval one write with one history entry.
+const APPROVE_CONFLICTS: [&str; 18] = [
+    "title",
+    "description",
+    "acceptance_criteria",
+    "dependencies",
+    "tags",
+    "plan",
+    "execution_summary",
+    "status",
+    "task_type",
+    "complexity",
+    "planned_by",
+    "implemented_by",
+    "pr_status",
+    "job_run_id",
+    "crew",
+    "orchestrator",
+    "context_files",
+    "artifacts",
+];
 
 impl Execute for TaskUpdateArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
@@ -101,8 +136,21 @@ impl Execute for TaskUpdateArgs {
             context_files,
             artifacts,
             model,
+            approve,
+            note,
             json,
         } = self;
+
+        if approve {
+            let (agent, model) = super::mutation_identity(model);
+            let task = runtime.approve_task_with_identity(&id, note, comment, agent, model)?;
+            return if json {
+                Ok(Payload::document(task_to_json_for_runtime(runtime, &task)?).into())
+            } else {
+                println!("Approved task '{}' -> {}", task.id, task.status);
+                Ok(CommandOutput::Silent)
+            };
+        }
 
         let pr_status = pr_status.map(|value| {
             if value.trim().is_empty() {

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -384,7 +384,7 @@ impl TestWorkspace {
     }
 
     fn drive_to_done(&self, id: &str) {
-        self.run(&["task", "update", id, "--status", "backlog"], "approve");
+        self.run(&["task", "update", id, "--approve"], "approve");
         self.run(
             &[
                 "task",

--- a/crates/orbit-core/src/runtime/task/block_on_run_failure.rs
+++ b/crates/orbit-core/src/runtime/task/block_on_run_failure.rs
@@ -12,7 +12,8 @@
 //! `blocked` is a deliberate dead end for automation: `Blocked` is not in the
 //! workflow-admission allowlist, so the ship
 //! sweep skips these tasks. The only way out is a human/orchestrator decision
-//! (`orbit task start`, which accepts `Blocked`, or moving it back to backlog).
+//! (the `orbit.task.start` tool, which accepts `Blocked`, or moving it back
+//! to backlog with `orbit task update <id> --status backlog`).
 
 use orbit_common::OrbitError;
 use orbit_engine::{RuntimeHost, blocked_workflow_failure_update};

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -408,7 +408,7 @@ Three equivalent surfaces:
 | Surface | How |
 |---|---|
 | **Web dashboard** | The crew dropdown on each task card (the chevron next to `default: <crew>` in [`orbit web serve`](../README.md#quick-start)) — selecting a crew calls `orbit.task.update` under the hood. |
-| **CLI** | `orbit task add --crew <name> …` at creation, or `orbit task update <id> --crew <name>` later. Pass `--crew ""` to `task update` to clear the field. (`orbit task start --crew <name>` exists but only validates the name and logs it — it does **not** persist onto `task.crew` or affect later `orbit run ship` dispatch. Use `task update` if you want the choice to stick.) |
+| **CLI** | `orbit task add --crew <name> …` at creation, or `orbit task update <id> --crew <name>` later. Pass `--crew ""` to `task update` to clear the field. `task update` is the only surface that persists the choice — a per-run crew override validates the name and logs it without writing `task.crew`, so later `orbit run ship` dispatch does not see it. |
 | **MCP / agent** | `orbit.task.add` and `orbit.task.update` accept a `crew` parameter; an empty string on update clears it. Useful when an agent is filing or amending tasks programmatically. |
 
 The dropdown label `default: codex` in the dashboard means *the task has no `crew` set* and will inherit `[workflow].default_crew`. Picking a named crew writes it onto the task and the label updates accordingly.


### PR DESCRIPTION
## What

`orbit task update --help` has advertised `approve: proposed -> backlog, review -> done` as a guarded transition for as long as the command has existed, but the parser had no `--approve`. The only way to take the step was `--status backlog`, which names the destination instead of the transition and bypasses the guard — approving a `done` task by writing `--status done` succeeded silently.

- **`--approve`** calls the domain's `approve_task_with_identity`, so the destination is derived from the current status: `proposed -> backlog`, `review -> done`, anything else refused with the domain's own message.
- **`--note`** lands on the approval's status-history entry, and therefore `requires = "approve"`.
- `--approve` **conflicts with `--status` and every field-edit argument**. Approval is one write with one history entry; an edit alongside it would be a second, differently-attributed write in the same invocation, and `--status` would contradict the transition being asked for.

## `orbit task start`

It bundled approval with the move to `in-progress`, both of which now live on `task update`. Per the follow-up in-thread, it is **hidden from help and kept working** — it warns on stderr and is unchanged otherwise, so scripts and agent prompts that predate the move keep running for a couple of releases. The `orbit.task.start` **tool** is the pipeline's own entrypoint and is untouched.

## Help grouping

Fourteen ungrouped rows read as a wall. `orbit task --help` now renders **Tasks / Health / Bundles** from a hand-rolled `help_template`, the same technique `orbit run` and the root command already use (clap's derive has no per-variant `help_heading`). Variant order in `TaskSubcommand` was reordered to match the sections.

```
Tasks:
  add          Create a new task
  update       Update task fields; `--approve` takes the next approval step
  archive      Archive a task
  list         List tasks with optional filters
  show         Show one task in detail, by ID, across registered workspaces
  artifact     Manage task artifact files

Health:
  lint         Lint tasks for stale paths and vague acceptance criteria
  flow         Show filed-vs-closed rates over time — is the backlog draining?
  locks        Inspect and release the file locks that gate dispatch

Bundles:
  export / import / publication / reindex
```

An after-help block spells the lifecycle out in three lines.

## Cleanup

`lifecycle.rs` held two unrelated verbs. It is now `archive.rs` and `start.rs` — one file per subcommand, per the crate guide.

## Verification

Driven end to end against a scratch workspace, not just parsed:

| step | result |
|---|---|
| `--approve` from `proposed` | `-> backlog`, history entry `proposal_approved` with the `--note` text |
| `--approve` from `review` | `-> done`, history entry `review_approved` |
| `--approve` from `done` | refused: `task '...' is in status 'done'; approve requires 'proposed' or 'review'` |
| `--approve --title X` | refused by the parser as an argument conflict |
| `task start <id>` | still runs, prints the deprecation notice on stderr |

`cargo test -p orbit-cli` — 18 test binaries, 0 failures. `make ci-fast` and `make ci-lint` both clean. `task_trimmed_surface.rs` now drives its approval step through `--approve`, so the new path has binary-level coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)