### PR TITLE
feat: onboard Claude Fable 5.1 and correct the Sonnet 5 price row

### DIFF
--- a/.orbit/config.toml
+++ b/.orbit/config.toml
@@ -29,7 +29,7 @@ provider = "claude"
 
 [crews.fable]
 backend = "cli"
-model = "claude-fable-5"
+model = "claude-fable-5-1"
 provider = "claude"
 
 [crews.sol]

--- a/crates/orbit-agent/src/providers/claude/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/claude_cli.rs
@@ -9,6 +9,9 @@ fn claude_cli_model_arg(model: &str) -> String {
     if let Some(version) = trimmed.strip_prefix("sonnet-") {
         return format!("claude-sonnet-{}", version.replace('.', "-"));
     }
+    if let Some(version) = trimmed.strip_prefix("fable-") {
+        return format!("claude-fable-{}", version.replace('.', "-"));
+    }
     trimmed.to_string()
 }
 

--- a/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
@@ -133,3 +133,24 @@ fn per_request_toggles_still_compose_with_the_schema_flag() {
         .expect("model flag");
     assert_eq!(args[model_index + 1], "claude-opus-5");
 }
+
+/// Crew configs write the short `<family>-<version>` form for every Claude
+/// tier; the transport expands each to the CLI's `claude-<family>-<version>`
+/// id, so the newest tier must not silently pass through unexpanded.
+#[test]
+fn short_model_forms_expand_to_claude_cli_ids_for_every_tier() {
+    for (short, expanded) in [
+        ("opus-5", "claude-opus-5"),
+        ("sonnet-4.6", "claude-sonnet-4-6"),
+        ("fable-5.1", "claude-fable-5-1"),
+        ("fable", "fable"),
+        ("claude-fable-5-1", "claude-fable-5-1"),
+    ] {
+        let args = ClaudeCliTransport::new(Some(short.to_string())).args(false);
+        let model_index = args
+            .iter()
+            .position(|arg| arg == "--model")
+            .expect("model flag");
+        assert_eq!(args[model_index + 1], expanded, "{short}");
+    }
+}

--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -79,25 +79,21 @@ prices:
     cache_create_1h_per_million_usd: 10.0
     output_per_million_usd: 25.0
 
-  # Sonnet 5 launched with introductory pricing through 2026-08-31; standard
-  # rates apply from 2026-09-01. Two rows, contiguous (no gap on 08-31).
+  # Sonnet 5 launched at 2/10 as "introductory" pricing through 2026-08-31 with
+  # a scheduled rise to 3/15 on 2026-09-01. Anthropic cancelled that rise
+  # before it took effect and made 2/10 the standard rate (verified 2026-09-01
+  # against the platform.claude.com/docs pricing table note "The previously
+  # scheduled increase ... will not occur"). The 3/15 row this table used to
+  # carry from 09-01 never billed a single token, so it was removed rather than
+  # closed: this row is the one open-ended Sonnet 5 rate.
   - model: "claude-sonnet-5"
     effective_from: "2026-07-17T00:00:00Z"
-    effective_until: "2026-09-01T00:00:00Z"
+    effective_until: null
     input_per_million_usd: 2.0
     cache_read_per_million_usd: 0.2
     cache_create_per_million_usd: 2.5
     cache_create_1h_per_million_usd: 4.0
     output_per_million_usd: 10.0
-
-  - model: "claude-sonnet-5"
-    effective_from: "2026-09-01T00:00:00Z"
-    effective_until: null
-    input_per_million_usd: 3.0
-    cache_read_per_million_usd: 0.3
-    cache_create_per_million_usd: 3.75
-    cache_create_1h_per_million_usd: 6.0
-    output_per_million_usd: 15.0
 
   - model: "claude-haiku-4-5-20251001"
     effective_from: "2026-07-17T00:00:00Z"
@@ -113,6 +109,20 @@ prices:
     effective_until: null
     input_per_million_usd: 10.0
     cache_read_per_million_usd: 1.0
+    cache_create_per_million_usd: 12.5
+    cache_create_1h_per_million_usd: 20.0
+    output_per_million_usd: 50.0
+
+  # Fable 5.1 released 2026-09-01 at Fable 5's input/output/cache-write rates
+  # but with cache reads at 0.025x input ($0.25/M) instead of the usual 0.1x
+  # (verified against platform.claude.com/docs/en/models/fable-5-1/overview and
+  # the pricing table footnote). `claude-fable-5` stays open-ended above: it is
+  # still a served legacy model with its own 1.0 cache-read rate.
+  - model: "claude-fable-5-1"
+    effective_from: "2026-09-01T00:00:00Z"
+    effective_until: null
+    input_per_million_usd: 10.0
+    cache_read_per_million_usd: 0.25
     cache_create_per_million_usd: 12.5
     cache_create_1h_per_million_usd: 20.0
     output_per_million_usd: 50.0

--- a/crates/orbit-common/src/model/tests/pricing.rs
+++ b/crates/orbit-common/src/model/tests/pricing.rs
@@ -155,6 +155,7 @@ fn every_fleet_model_string_is_priced() {
         "claude-sonnet-5",
         "claude-haiku-4-5-20251001",
         "claude-fable-5",
+        "claude-fable-5-1",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -170,14 +171,73 @@ fn every_fleet_model_string_is_priced() {
         output: 1_000,
         ..TokenUsage::default()
     };
-    // 2026-08-13 (not 07-24): must be on/after grok-4.6's effective_from so
-    // its row is in range too, while still covering every other open-ended
-    // row (claude-opus-5 from 07-24, grok-4.5 from 08-12).
-    let at = dt("2026-08-13T00:00:00Z");
+    // 2026-09-01: must be on/after the newest effective_from in the table
+    // (claude-fable-5-1) so its row is in range too, while still covering
+    // every other open-ended row (claude-opus-5 from 07-24, grok-4.5 from
+    // 08-12, grok-4.6 from 08-13).
+    let at = dt("2026-09-01T00:00:00Z");
     for model in FLEET_MODELS {
         assert!(
             derive_cost_usd(model, at, &usage).is_some(),
             "fleet model {model} has no covering price row in model_prices.yaml"
+        );
+    }
+}
+
+#[test]
+fn fable_5_1_cache_reads_bill_at_a_fortieth_of_input() {
+    // Official rates from platform.claude.com/docs/en/models/fable-5-1/overview
+    // (released 2026-09-01): $10 input, $0.25 cache read (0.025x, not the
+    // 0.1x every other Claude row uses), $12.50 5m write, $20 1h write, $50
+    // output. 1M of each split → 10 + 0.25 + 12.5 + 20 + 50 = 92.75.
+    let usage = TokenUsage {
+        input: 1_000_000,
+        cache_read: 1_000_000,
+        cache_create: 1_000_000,
+        cache_create_1h: 1_000_000,
+        output: 1_000_000,
+    };
+    let at = dt("2026-09-01T00:00:00Z");
+    let cost = derive_cost_usd("claude-fable-5-1", at, &usage)
+        .expect("claude-fable-5-1 is priced in the shipped table");
+    assert!((cost - 92.75).abs() < 1e-9, "cost was {cost}");
+
+    // Fable 5 keeps its own 0.1x cache-read rate; the 5.1 row must not shadow it.
+    let cache_only = TokenUsage {
+        cache_read: 1_000_000,
+        ..TokenUsage::default()
+    };
+    let legacy = derive_cost_usd("claude-fable-5", at, &cache_only).expect("priced");
+    assert!(
+        (legacy - 1.0).abs() < f64::EPSILON,
+        "fable-5 cache read was {legacy}"
+    );
+    assert!(
+        derive_cost_usd("claude-fable-5-1", dt("2026-08-31T23:59:59Z"), &usage).is_none(),
+        "no fable-5-1 row before its release"
+    );
+}
+
+#[test]
+fn sonnet_5_introductory_rate_became_the_standard_rate() {
+    // The 3/15 rise scheduled for 2026-09-01 was cancelled before it took
+    // effect; 2/10 is the one open-ended rate on both sides of that date.
+    let usage = TokenUsage {
+        input: 1_000_000,
+        output: 1_000_000,
+        ..TokenUsage::default()
+    };
+    for at in [
+        "2026-08-31T23:59:59Z",
+        "2026-09-01T00:00:00Z",
+        "2027-01-01T00:00:00Z",
+    ] {
+        let rows = covering_rows("claude-sonnet-5", dt(at));
+        assert_eq!(rows.len(), 1, "exactly one sonnet-5 row covers {at}");
+        let cost = derive_cost_usd("claude-sonnet-5", dt(at), &usage).expect("priced");
+        assert!(
+            (cost - 12.0).abs() < f64::EPSILON,
+            "cost at {at} was {cost}"
         );
     }
 }

--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -136,12 +136,19 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "audit_self_reported_actor",
         apply: super::apply_audit_self_reported_actor,
     },
+    // Alias map v2: `fable` became a family rule so versioned Fable labels
+    // resolve to `claude`. Rows stamped with the old map are re-derived.
+    Migration {
+        version: 18,
+        name: "audit_actor_alias_v2",
+        apply: super::apply_audit_actor_alias_v2,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 17;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 18;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/driver/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/mod.rs
@@ -1250,6 +1250,16 @@ fn apply_audit_self_reported_actor(conn: &Connection) -> Result<(), OrbitError> 
     .map_err(|error| OrbitError::Store(error.to_string()))
 }
 
+/// v18 `audit_actor_alias_v2` migration: the alias map moved `fable` from a
+/// shorthand entry to a family rule, so versioned Fable labels (`fable-5.1`)
+/// now resolve to `claude` instead of an unrecognized family. Re-derive every
+/// row stamped with the previous map; rows already at the current version are
+/// untouched, and `role` is never rewritten.
+fn apply_audit_actor_alias_v2(conn: &Connection) -> Result<(), OrbitError> {
+    ensure_audit_events_schema(conn)?;
+    backfill_audit_actor_identity(conn)
+}
+
 /// Derive the actor columns for every row whose stamped alias version is not
 /// the current one.
 ///

--- a/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
@@ -73,6 +73,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[16].version, 17);
     assert_eq!(applied[16].name, "audit_self_reported_actor");
     assert!(!applied[16].applied_at.is_empty());
+    assert_eq!(applied[17].version, 18);
+    assert_eq!(applied[17].name, "audit_actor_alias_v2");
+    assert!(!applied[17].applied_at.is_empty());
 }
 
 #[test]
@@ -241,6 +244,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0017".to_string(),
                 "audit_self_reported_actor".to_string()
             ),
+            (
+                "migration.v0018".to_string(),
+                "audit_actor_alias_v2".to_string()
+            ),
         ]
     );
 }
@@ -252,7 +259,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-        VALUES ('migration.v0018', 'from-the-future', '2099-01-01T00:00:00Z')",
+        VALUES ('migration.v0019', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -332,7 +339,7 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_through_latest() {
     );
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("audit_self_reported_actor")
+        Some("audit_actor_alias_v2")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");

--- a/crates/orbit-store/src/driver/sqlite/migration/tests/migration.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/tests/migration.rs
@@ -456,3 +456,36 @@ fn audit_actor_backfill_is_idempotent() {
     assert_eq!(kind, "agent");
     assert_eq!(id, "claude");
 }
+
+/// Alias map v2 (migration v18) promoted `fable` to a family rule. A row the
+/// v1 map stamped as an unrecognized-family agent must be re-derived under
+/// the current map, while `role` stays byte-identical.
+#[test]
+fn audit_actor_alias_v2_rederives_rows_stamped_under_the_old_map() {
+    let conn = Connection::open_in_memory().expect("open in-memory connection");
+    apply_schema(&conn).expect("apply schema");
+    conn.execute(
+        "INSERT INTO audit_events(
+            execution_id, timestamp, command, role, status, exit_code,
+            duration_ms, working_directory, pid, actor_kind, actor_id,
+            actor_family, actor_model, actor_alias_version
+        ) VALUES ('exec-1', '2026-08-28T00:00:00Z', 'tool', 'fable-5.1', 'success', 0, 1,
+                  '/tmp', 1, 'agent', 'fable-5.1', NULL, 'fable-5.1', 1)",
+        [],
+    )
+    .expect("insert v1-stamped row");
+
+    super::super::apply_audit_actor_alias_v2(&conn).expect("re-derive under v2");
+
+    let (role, id, family, version): (String, String, String, u32) = conn
+        .query_row(
+            "SELECT role, actor_id, actor_family, actor_alias_version FROM audit_events",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("read projection");
+    assert_eq!(role, "fable-5.1");
+    assert_eq!(id, "claude");
+    assert_eq!(family, "claude");
+    assert_eq!(version, orbit_types::telemetry::ACTOR_ALIAS_MAP_VERSION);
+}

--- a/crates/orbit-types/src/identity/actor.rs
+++ b/crates/orbit-types/src/identity/actor.rs
@@ -118,7 +118,11 @@ pub fn agent_from_model(model: &str) -> Option<&'static str> {
         return None;
     }
 
-    if model.starts_with("claude-") || model.starts_with("opus") || model.starts_with("sonnet") {
+    if model.starts_with("claude-")
+        || model.starts_with("opus")
+        || model.starts_with("sonnet")
+        || model.starts_with("fable")
+    {
         return Some("claude");
     }
     if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") {

--- a/crates/orbit-types/src/identity/agent_pair.rs
+++ b/crates/orbit-types/src/identity/agent_pair.rs
@@ -118,7 +118,11 @@ pub fn infer_agent_family_from_model(model: &str) -> Option<String> {
     if model.starts_with("gpt-") || model.starts_with("o1") || model.starts_with("o3") {
         return Some("codex".to_string());
     }
-    if model.starts_with("claude-") || model.starts_with("opus") || model.starts_with("sonnet") {
+    if model.starts_with("claude-")
+        || model.starts_with("opus")
+        || model.starts_with("sonnet")
+        || model.starts_with("fable")
+    {
         return Some("claude".to_string());
     }
     if model.starts_with("gemini-") {

--- a/crates/orbit-types/src/identity/tests/actor.rs
+++ b/crates/orbit-types/src/identity/tests/actor.rs
@@ -4,6 +4,9 @@ mod mapping {
     #[test]
     fn agent_from_model_maps_known_prefixes() {
         assert_eq!(agent_from_model("claude-opus-4-7"), Some("claude"));
+        assert_eq!(agent_from_model("claude-fable-5-1"), Some("claude"));
+        assert_eq!(agent_from_model("fable"), Some("claude"));
+        assert_eq!(agent_from_model("fable-5.1"), Some("claude"));
         assert_eq!(agent_from_model("gpt-5.5"), Some("codex"));
         assert_eq!(agent_from_model("gemini-3.1-pro-preview"), Some("gemini"));
         assert_eq!(agent_from_model("ollama:llama3.2"), Some("ollama"));

--- a/crates/orbit-types/src/identity/tests/agent_pair.rs
+++ b/crates/orbit-types/src/identity/tests/agent_pair.rs
@@ -64,6 +64,13 @@ mod resolution {
             infer_agent_family_from_model("claude-opus-4-7").as_deref(),
             Some("claude")
         );
+        for fable in ["claude-fable-5-1", "fable", "fable-5.1"] {
+            assert_eq!(
+                infer_agent_family_from_model(fable).as_deref(),
+                Some("claude"),
+                "{fable}"
+            );
+        }
         assert_eq!(
             infer_agent_family_from_model("gpt-5.5").as_deref(),
             Some("codex")

--- a/crates/orbit-types/src/telemetry/audit_actor.rs
+++ b/crates/orbit-types/src/telemetry/audit_actor.rs
@@ -42,7 +42,11 @@ use crate::identity::{agent_from_model, all_agent_families, provider_for_agent_f
 /// re-kinded label, a corrected family). Adding a model that an existing rule
 /// already resolves — any `claude-*` build, say — is not a map change and must
 /// not bump it.
-pub const ACTOR_ALIAS_MAP_VERSION: u32 = 1;
+///
+/// History: v2 moved `fable` from a shorthand alias to a family rule, so
+/// versioned Fable labels (`fable-5.1`) resolve to `claude` instead of an
+/// unrecognized family.
+pub const ACTOR_ALIAS_MAP_VERSION: u32 = 2;
 
 /// What kind of thing performed an audited invocation.
 ///
@@ -176,11 +180,7 @@ const NON_AGENT_ALIASES: &[(&str, ActorKind)] = &[
 /// not already cover.
 ///
 /// Editing this table is an alias-map change: bump [`ACTOR_ALIAS_MAP_VERSION`].
-const MODEL_SHORTHAND_ALIASES: &[(&str, &str)] = &[
-    // `orbit-common::model_defaults` ships `fable` as a bare Claude model name.
-    ("fable", "claude"),
-    ("haiku", "claude"),
-];
+const MODEL_SHORTHAND_ALIASES: &[(&str, &str)] = &[("haiku", "claude")];
 
 /// Resolve a recorded `audit_events.role` label into its canonical actor.
 ///

--- a/crates/orbit-types/src/telemetry/tests/audit_actor.rs
+++ b/crates/orbit-types/src/telemetry/tests/audit_actor.rs
@@ -10,6 +10,9 @@ fn agent_granularities_collapse_to_one_canonical_actor() {
         "sonnet",
         "claude-opus-5",
         "claude-sonnet-5",
+        "fable",
+        "fable-5.1",
+        "claude-fable-5-1",
     ] {
         let actor = canonical_actor_for_role_label(label);
         assert_eq!(actor.kind, ActorKind::Agent, "{label}");

--- a/docs/design/auditability/specs/actor-identity.md
+++ b/docs/design/auditability/specs/actor-identity.md
@@ -67,8 +67,8 @@ carry `id = "claude"` while `model` keeps the finer grain retrievable.
    distinct diagnostics stay distinct.
 3. A bare agent family name (`claude`) → agent with no model recorded.
 4. A model string whose family is inferable via `identity::agent_from_model`
-   (`claude-opus-5`, `opus`, `gpt-5.6-luna`), or a shorthand in the explicit table
-   (`fable`, `haiku`) → agent with both family and model.
+   (`claude-opus-5`, `opus`, `fable-5.1`, `gpt-5.6-luna`), or a shorthand in the
+   explicit table (`haiku`) → agent with both family and model.
 5. Anything else → an agent with unknown family, keeping the label as both `id` and
    `model`. Every label reaching this point came from an attribution path that held a
    model or family, so an unrecognized *agent* loses less than a discarded row would.
@@ -90,7 +90,8 @@ Bump the version when a label's canonical resolution changes — a new alias, a 
 label, a corrected family. Do **not** bump it for a model that an existing rule already
 resolves. A bump requires a new append-only ledger migration that calls
 `backfill_audit_actor_identity`, which re-derives exactly the rows whose stamped version
-is not current.
+is not current. Map history: v2 (migration v18 `audit_actor_alias_v2`) promoted `fable`
+from a shorthand alias to a family rule so versioned Fable labels resolve to `claude`.
 
 ## Persistence
 

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -55,7 +55,7 @@ $ orbit migrate --dry-run
 Pending migrations:
   layout v1 (baseline) — adopt the versioned .orbit/ layout (records the current shape; changes nothing)
   layout v2 (archive-friction-tasks) — rewrite removed friction statuses as archived
-  schema v1 (baseline) through schema v17 (audit_self_reported_actor)
+  schema v1 (baseline) through schema v18 (audit_actor_alias_v2)
 error: execution failed: 2 migration(s) pending; run `orbit migrate --confirm` to apply
 ```
 


### PR DESCRIPTION
## Summary

Onboards Claude Fable 5.1 (`claude-fable-5-1`, released 2026-09-01) everywhere Orbit knows about Claude models, and fixes the Sonnet 5 price row that would have started over-billing today.

- **Price table**: add `claude-fable-5-1` at $10 / $0.25 cache-read / $12.50 / $20 / $50 per M (verified against platform.claude.com pricing + the Fable 5.1 model page; cache reads are 0.025x input on this model, not the usual 0.1x). `claude-fable-5` keeps its own open-ended row.
- **Sonnet 5 correction**: the table carried a 3/15 row effective 2026-09-01 for a scheduled increase Anthropic cancelled ("will not occur" per the pricing page). That row never billed a token and was removed; 2/10 is the single open-ended rate.
- **Family inference**: `fable`, `fable-5.1`, and `claude-fable-5-1` now resolve to the `claude` family in both `identity::agent_from_model` and `infer_agent_family_from_model`, matching how `opus*`/`sonnet*` are treated.
- **Audit alias map v2**: `fable` moves from the shorthand table to the family rule, so `ACTOR_ALIAS_MAP_VERSION` is bumped to 2 with a new ledger migration v18 `audit_actor_alias_v2` that re-derives rows stamped under v1 (per the documented bump procedure in `docs/design/auditability/specs/actor-identity.md`).
- **Claude CLI transport**: `fable-<version>` short forms expand to `claude-fable-<version>` like the opus/sonnet forms already did.
- **Repo workspace config**: `[crews.fable]` now pins `claude-fable-5-1`.

## Verification

- `make ci-fast` passes.
- `make ci-lint` (workspace clippy, `-D warnings`) passes.
- `cargo test --workspace` passes; new tests cover the Fable 5.1 rates, the Sonnet 5 single-row invariant, family inference for the three Fable label shapes, the CLI short-form expansion, and the v18 re-derivation.

Not touched: the live control-plane `config.toml` on dk-server-1 (unreachable from this Mac); its `[crews.fable]` model still needs the same one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
