### PR TITLE
fix(web): page audit events in SQL and surface the newest diagnostics errors

### DIFF
--- a/crates/orbit-cli/src/command/audit/list.rs
+++ b/crates/orbit-cli/src/command/audit/list.rs
@@ -86,6 +86,7 @@ impl Execute for AuditListArgs {
             job_run_id: self.run,
             lease_id: self.lease,
             limit: self.limit,
+            offset: 0,
         })?;
 
         let values: Vec<Value> = events.iter().map(audit_event_to_json).collect();

--- a/crates/orbit-core/src/adapter/command/tests/global_dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/tests/global_dispatch.rs
@@ -42,6 +42,7 @@ fn persists_one_row_with_mcp_context() {
         .list_audit_events(&AuditEventFilter {
             tool_name: Some("orbit.workspace.list".to_string()),
             limit: 10,
+            offset: 0,
             ..AuditEventFilter::default()
         })
         .expect("list global dispatch audit");
@@ -83,6 +84,7 @@ fn audits_projection_failure_once() {
         .list_audit_events(&AuditEventFilter {
             tool_name: Some("orbit.workspace.list".to_string()),
             limit: 10,
+            offset: 0,
             ..AuditEventFilter::default()
         })
         .expect("list failed global dispatch audit");
@@ -131,6 +133,7 @@ fn audits_unknown_mcp_tool_as_denied_once() {
         .list_audit_events(&AuditEventFilter {
             tool_name: Some("orbit_unknown_raw".to_string()),
             limit: 10,
+            offset: 0,
             ..AuditEventFilter::default()
         })
         .expect("list unknown-tool audit");

--- a/crates/orbit-core/src/application/audit_event.rs
+++ b/crates/orbit-core/src/application/audit_event.rs
@@ -53,6 +53,7 @@ impl OrbitRuntime {
                 job_run_id: None,
                 lease_id: None,
                 limit,
+                offset: 0,
             })
     }
 

--- a/crates/orbit-store/src/contracts/audit.rs
+++ b/crates/orbit-store/src/contracts/audit.rs
@@ -57,6 +57,10 @@ pub struct AuditEventFilter {
     pub job_run_id: Option<String>,
     pub lease_id: Option<String>,
     pub limit: usize,
+    /// Rows to skip after ordering (newest first). Pushed into SQL so a
+    /// caller can page past the first `limit` rows without prefetching the
+    /// entire history in front of the page it wants.
+    pub offset: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/audit_event_store/mod.rs
@@ -327,11 +327,13 @@ impl Store {
 
         let sql = format!(
             "SELECT {AUDIT_EVENT_COLUMNS} \
-             FROM audit_events {where_clause} ORDER BY id DESC LIMIT ?{}",
-            param_values.len() + 1
+             FROM audit_events {where_clause} ORDER BY id DESC LIMIT ?{} OFFSET ?{}",
+            param_values.len() + 1,
+            param_values.len() + 2
         );
 
         param_values.push(Box::new(limit as i64));
+        param_values.push(Box::new(filter.offset as i64));
 
         let mut stmt = conn
             .prepare(&sql)

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -52,10 +52,6 @@ pub(super) async fn list_audit(Ws(runtime): Ws, Query(q): Query<AuditQuery>) -> 
 
     let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
     let offset = q.offset.unwrap_or(0);
-
-    // Post-query filters (run_id, q) and offset are applied after the SQLite
-    // call. Request a generous prefetch so common filtered pages are full.
-    let prefetch = HISTORY_MAX_LIMIT;
     let tool = q.tool.filter(|s| !s.is_empty());
     let role = q.role.filter(|s| !s.is_empty());
     let transport = match q
@@ -83,7 +79,7 @@ pub(super) async fn list_audit(Ws(runtime): Ws, Query(q): Query<AuditQuery>) -> 
         None => None,
     };
 
-    let events = match runtime.list_audit_events_filtered(&AuditEventFilter {
+    let mut filter = AuditEventFilter {
         since,
         tool_name: tool,
         target_type: None,
@@ -98,69 +94,124 @@ pub(super) async fn list_audit(Ws(runtime): Ws, Query(q): Query<AuditQuery>) -> 
         mcp_call_id: q.mcp_call.filter(|value| !value.is_empty()),
         job_run_id: q.job_run_id.filter(|value| !value.is_empty()),
         lease_id: q.lease.filter(|value| !value.is_empty()),
-        limit: prefetch,
-    }) {
-        Ok(events) => events,
-        Err(e) => return server_error(e),
+        limit,
+        offset,
     };
 
-    let exec_id_filter = q
-        .execution_id
-        .as_deref()
-        .or(q.run_id.as_deref())
-        .filter(|s| !s.is_empty());
-    let profile_filter = q
-        .profile
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let needle =
-        q.q.as_deref()
+    let post_filter = AuditPostFilter {
+        execution_id: q
+            .execution_id
+            .as_deref()
+            .or(q.run_id.as_deref())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        profile: q
+            .profile
+            .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty())
-            .map(str::to_lowercase);
+            .map(str::to_string),
+        needle: q
+            .q
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase),
+    };
 
-    let mut filtered: Vec<_> = events
-        .into_iter()
-        .filter(|e| {
-            if let Some(eid) = exec_id_filter
-                && e.execution_id != eid
-            {
-                return false;
-            }
-            if let Some(ref profile) = profile_filter
-                && !arguments_json_matches_profile(e.arguments_json.as_deref(), profile)
-            {
-                return false;
-            }
-            if let Some(ref needle) = needle {
-                let haystacks = [
-                    e.command.as_str(),
-                    e.subcommand.as_deref().unwrap_or(""),
-                    e.tool_name.as_deref().unwrap_or(""),
-                    e.target_id.as_deref().unwrap_or(""),
-                    e.target_type.as_deref().unwrap_or(""),
-                    e.role.as_str(),
-                    e.error_message.as_deref().unwrap_or(""),
-                ];
-                if !haystacks.iter().any(|h| h.to_lowercase().contains(needle)) {
-                    return false;
-                }
-            }
-            true
-        })
-        .collect();
+    let page = if post_filter.is_empty() {
+        // Every requested predicate has a column, so the page is exactly the
+        // SQL window: no prefetch, no Rust-side slicing.
+        match runtime.list_audit_events_filtered(&filter) {
+            Ok(events) => events,
+            Err(e) => return server_error(e),
+        }
+    } else {
+        match scan_audit_page(&runtime, &mut filter, &post_filter, offset, limit) {
+            Ok(events) => events,
+            Err(e) => return server_error(e),
+        }
+    };
 
-    if offset >= filtered.len() {
-        return Json(Value::Array(Vec::new())).into_response();
-    }
-    let end = offset.saturating_add(limit).min(filtered.len());
-    let page: Vec<Value> = filtered
-        .drain(offset..end)
-        .map(|e| audit_event_to_json(&e))
-        .collect();
+    let page: Vec<Value> = page.iter().map(audit_event_to_json).collect();
     Json(Value::Array(page)).into_response()
+}
+
+/// Predicates the SQLite schema has no column for, applied to each fetched
+/// row in Rust.
+struct AuditPostFilter {
+    execution_id: Option<String>,
+    profile: Option<String>,
+    /// Lowercased free-text needle.
+    needle: Option<String>,
+}
+
+impl AuditPostFilter {
+    fn is_empty(&self) -> bool {
+        self.execution_id.is_none() && self.profile.is_none() && self.needle.is_none()
+    }
+
+    fn matches(&self, e: &orbit_core::AuditEvent) -> bool {
+        if let Some(eid) = self.execution_id.as_deref()
+            && e.execution_id != eid
+        {
+            return false;
+        }
+        if let Some(profile) = self.profile.as_deref()
+            && !arguments_json_matches_profile(e.arguments_json.as_deref(), profile)
+        {
+            return false;
+        }
+        if let Some(needle) = self.needle.as_deref() {
+            let haystacks = [
+                e.command.as_str(),
+                e.subcommand.as_deref().unwrap_or(""),
+                e.tool_name.as_deref().unwrap_or(""),
+                e.target_id.as_deref().unwrap_or(""),
+                e.target_type.as_deref().unwrap_or(""),
+                e.role.as_str(),
+                e.error_message.as_deref().unwrap_or(""),
+            ];
+            if !haystacks.iter().any(|h| h.to_lowercase().contains(needle)) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Rows a single `/api/audit` request may pull from SQLite while satisfying
+/// a Rust-side predicate. Bounds the cost of a needle that matches nothing
+/// in a long history; a page that hits the cap simply comes back short.
+const AUDIT_POST_FILTER_SCAN_CAP: usize = 10_000;
+
+/// Walk the SQL window in `HISTORY_MAX_LIMIT` batches, keeping rows that pass
+/// `post_filter`, until `offset + limit` matches are in hand, the store runs
+/// dry, or the scan cap is reached. `filter.limit`/`filter.offset` are used
+/// as scratch for the batch window.
+fn scan_audit_page(
+    runtime: &OrbitRuntime,
+    filter: &mut AuditEventFilter,
+    post_filter: &AuditPostFilter,
+    offset: usize,
+    limit: usize,
+) -> Result<Vec<orbit_core::AuditEvent>, OrbitError> {
+    let wanted = offset.saturating_add(limit);
+    let mut matched = Vec::new();
+    let mut scanned = 0usize;
+    filter.limit = HISTORY_MAX_LIMIT;
+    filter.offset = 0;
+    while matched.len() < wanted && scanned < AUDIT_POST_FILTER_SCAN_CAP {
+        let batch = runtime.list_audit_events_filtered(filter)?;
+        let fetched = batch.len();
+        scanned += fetched;
+        matched.extend(batch.into_iter().filter(|e| post_filter.matches(e)));
+        if fetched < HISTORY_MAX_LIMIT {
+            break;
+        }
+        filter.offset += fetched;
+    }
+    Ok(matched.into_iter().skip(offset).take(limit).collect())
 }
 
 /// Best-effort match of a stringified `arguments_json` payload against a

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -23,7 +23,7 @@ use serde_json::{Value, json};
 use super::map_runtime_error;
 use super::routines::{
     OperationsQuery, authorization_denied, authorized_caller, explicit_workspace,
-    not_found_or_conflict, record_operation_audit,
+    named_entity_not_found, record_operation_audit, selection_conflict,
 };
 use crate::state::DashboardState;
 
@@ -90,7 +90,7 @@ pub(super) async fn toggle_auto_task(
     let runtime = match resolve_workspace(&state, &workspace) {
         Ok((_, runtime)) => runtime,
         Err(reason) => {
-            return not_found_or_conflict("workspace_mismatch", reason);
+            return selection_conflict("workspace_mismatch", reason);
         }
     };
     let caller = match authorized_caller(&DASHBOARD_AUTO_TASK_TOGGLE) {
@@ -115,7 +115,7 @@ pub(super) async fn toggle_auto_task(
     let current = match runtime.auto_task_show(&body.name) {
         Ok(Some(definition)) => definition,
         Ok(None) => {
-            return not_found_or_conflict(
+            return named_entity_not_found(
                 "auto_task_not_found",
                 format!("auto-task '{}' was not found", body.name),
             );
@@ -195,7 +195,7 @@ pub(super) async fn mint_auto_task(
     let runtime = match resolve_workspace(&state, &workspace) {
         Ok((_, runtime)) => runtime,
         Err(reason) => {
-            return not_found_or_conflict("workspace_mismatch", reason);
+            return selection_conflict("workspace_mismatch", reason);
         }
     };
     if !body.acknowledge_unconditional {

--- a/crates/orbit-web/src/api/diagnostics.rs
+++ b/crates/orbit-web/src/api/diagnostics.rs
@@ -369,7 +369,10 @@ fn agent_stderr_error_rows(
     let step_index_by_id = step_index_by_id(&events);
     let blob_store = audit_blob_store(runtime);
     let mut rows = Vec::new();
-    for event in events {
+    // `events` is oldest-first so the step index above numbers steps in
+    // execution order; the row scan walks newest-first because it stops at
+    // `2 * limit` rows and the caller keeps only the newest `limit` of them.
+    for event in events.iter().rev() {
         if event.get("body_kind").and_then(Value::as_str) != Some("cli_invocation_finished") {
             continue;
         }
@@ -382,7 +385,7 @@ fn agent_stderr_error_rows(
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_string();
-        let step = enclosing_step_id_for_event(&event, &by_id);
+        let step = enclosing_step_id_for_event(event, &by_id);
         let step_index = step
             .as_ref()
             .and_then(|step| step_index_by_id.get(step).copied());

--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -111,7 +111,7 @@ pub(super) async fn toggle_routine(
         .iter()
         .find(|status| status.routine.definition.name == body.name)
     else {
-        return not_found_or_conflict(
+        return named_entity_not_found(
             "routine_not_found",
             format!("routine '{}' was not found", body.name),
         );
@@ -119,7 +119,7 @@ pub(super) async fn toggle_routine(
     if status.routine.source_workspace != body.source
         || status.routine.source_orbit_dir != runtime.shared_root()
     {
-        return not_found_or_conflict(
+        return selection_conflict(
             "workspace_mismatch",
             format!(
                 "select routine source workspace '{}' before changing '{}'",
@@ -128,7 +128,7 @@ pub(super) async fn toggle_routine(
         );
     }
     if body.host_id != report.host_id || !status.pinned_to_host {
-        return not_found_or_conflict(
+        return selection_conflict(
             "host_mismatch",
             format!(
                 "select pinned host '{}' before changing '{}'",
@@ -138,7 +138,7 @@ pub(super) async fn toggle_routine(
     }
     let actual_target = status.routine.definition.target.as_ref_string();
     if body.target != actual_target {
-        return not_found_or_conflict(
+        return selection_conflict(
             "target_mismatch",
             format!("routine target changed; refresh and confirm '{actual_target}'"),
         );
@@ -247,7 +247,7 @@ pub(super) async fn control_clock(
         Err(error) => return map_runtime_error(error),
     };
     if body.host_id != report.host_id {
-        return not_found_or_conflict(
+        return selection_conflict(
             "host_mismatch",
             format!(
                 "select host '{}' before changing its sweep clock",
@@ -423,7 +423,19 @@ pub(super) fn authorization_denied(denial: AuthorizationDenial) -> Response {
         .into_response()
 }
 
-pub(super) fn not_found_or_conflict(code: &'static str, message: String) -> Response {
+/// The named routine or auto-task does not exist: a permanent 404, so a
+/// client's "409 means refresh and retry" policy does not loop on it.
+pub(super) fn named_entity_not_found(code: &'static str, message: String) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({"error": message, "code": code})),
+    )
+        .into_response()
+}
+
+/// The caller's selection (workspace, host, target) no longer matches the
+/// entity it is trying to change: a 409 the client resolves by refreshing.
+pub(super) fn selection_conflict(code: &'static str, message: String) -> Response {
     (
         StatusCode::CONFLICT,
         Json(json!({"error": message, "code": code})),

--- a/crates/orbit-web/src/api/search.rs
+++ b/crates/orbit-web/src/api/search.rs
@@ -36,9 +36,11 @@ fn parse_search_query(raw: Option<&str>) -> Result<GlobalSearchParams, String> {
                 params.kind = GlobalSearchKind::from_str(&value)?;
             }
             "limit" => {
-                params.limit = value.parse::<usize>().map_err(|_| {
+                let requested = value.parse::<usize>().map_err(|_| {
                     format!("invalid limit `{value}`; expected a non-negative integer")
                 })?;
+                // Same ceiling as every other list endpoint.
+                params.limit = super::bounded_limit(Some(requested), params.limit);
             }
             "tag" | "tags" => append_csv(&mut params.tags, &value),
             "all" => params.all = parse_bool("all", &value)?,
@@ -90,5 +92,11 @@ mod query_tests {
         assert_eq!(params.status, ["task:open"]);
         assert_eq!(params.path.as_deref(), Some("src/lib.rs"));
         assert_eq!(params.limit, 7);
+    }
+
+    #[test]
+    fn query_parser_caps_limit_like_every_other_list_endpoint() {
+        let params = parse_search_query(Some("q=a&limit=100000000")).expect("parse query");
+        assert_eq!(params.limit, super::super::HISTORY_MAX_LIMIT);
     }
 }

--- a/crates/orbit-web/src/api/tests/audit.rs
+++ b/crates/orbit-web/src/api/tests/audit.rs
@@ -12,7 +12,7 @@ use orbit_types::tool::{McpCapability, McpTransport};
 use serde_json::Value;
 use tower::ServiceExt;
 
-use super::super::router;
+use super::super::{HISTORY_MAX_LIMIT, router};
 use super::test_support::body_json;
 
 fn seed_audit_event(
@@ -306,6 +306,63 @@ async fn audit_filters_all_trusted_mcp_provenance_fields() {
     let body = body_json(response).await;
     let rows = body.as_array().expect("trusted provenance filtered rows");
     assert_eq!(execution_ids(rows), vec!["exec-trusted"]);
+}
+
+/// The page window is pushed into SQL, so paging is not capped at the first
+/// `HISTORY_MAX_LIMIT` rows of history and a needle can reach rows older
+/// than that window.
+#[tokio::test]
+async fn audit_paging_and_needle_reach_past_the_max_limit_window() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let total = HISTORY_MAX_LIMIT + 50;
+    for index in 0..total {
+        // The five oldest rows carry the only needle-matching tool name.
+        let tool = if index < 5 {
+            "orbit.needle.probe"
+        } else {
+            "orbit.task.update"
+        };
+        seed_audit_event(
+            &runtime,
+            &format!("exec-{index:04}"),
+            tool,
+            AuditEventStatus::Success,
+            "editor",
+            None,
+        );
+    }
+
+    let response = request_audit(
+        runtime.clone(),
+        &format!("/audit?limit=50&offset={HISTORY_MAX_LIMIT}"),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body.as_array().expect("page past the old prefetch cap");
+    assert_eq!(rows.len(), 50);
+    assert_eq!(execution_ids(rows)[0], "exec-0049");
+
+    let response = request_audit(runtime.clone(), "/audit?q=needle&limit=10").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body.as_array().expect("needle rows");
+    assert_eq!(
+        execution_ids(rows),
+        vec![
+            "exec-0004",
+            "exec-0003",
+            "exec-0002",
+            "exec-0001",
+            "exec-0000"
+        ]
+    );
+
+    let response = request_audit(runtime, "/audit?q=needle&limit=2&offset=3").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body.as_array().expect("offset needle rows");
+    assert_eq!(execution_ids(rows), vec!["exec-0001", "exec-0000"]);
 }
 
 #[tokio::test]

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -251,6 +251,23 @@ async fn toggle_denies_a_caller_without_operator_capability() {
     );
 }
 
+/// A missing auto-task is a permanent 404, not a 409 a client would refresh
+/// and retry forever.
+#[tokio::test]
+async fn toggle_of_an_unknown_auto_task_is_not_found() {
+    let (state, _) = state(runtime());
+    let response = as_operator(send(
+        state,
+        Method::POST,
+        "/auto-tasks/toggle?workspace=default",
+        Some(r#"{"name":"no-such-auto-task","expected_enabled":true,"enabled":false}"#),
+    ))
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let json = body_json(response).await;
+    assert_eq!(json["code"], "auto_task_not_found");
+}
+
 #[tokio::test]
 async fn toggle_rolls_back_when_expected_state_is_stale() {
     let runtime = runtime();

--- a/crates/orbit-web/src/api/tests/diagnostics.rs
+++ b/crates/orbit-web/src/api/tests/diagnostics.rs
@@ -42,6 +42,17 @@ async fn request_dashboard_errors(runtime: OrbitRuntime) -> Response {
 }
 
 fn seed_cli_invocation_audit(runtime: &OrbitRuntime, run_id: &str, stderr: &[u8]) -> String {
+    seed_cli_invocation_audit_at(runtime, run_id, stderr, 4)
+}
+
+/// Seed one run's `run.started` → `step.started` → `cli.invocation.finished`
+/// envelope at `2099-05-08T<hour>:12:2xZ`, so several runs can be ordered.
+fn seed_cli_invocation_audit_at(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    stderr: &[u8],
+    hour: u32,
+) -> String {
     let audit_root = runtime.data_root().join("state").join("audit");
     let blob_store = BlobStore::new(audit_root.join("blobs"));
     let stdout_ref = blob_store
@@ -53,8 +64,8 @@ fn seed_cli_invocation_audit(runtime: &OrbitRuntime, run_id: &str, stderr: &[u8]
         json!({
             "schemaVersion": 1,
             "event_type": "run.started",
-            "event_id": "evt-run",
-            "ts": "2099-05-08T04:12:20Z",
+            "event_id": format!("evt-run-{run_id}"),
+            "ts": format!("2099-05-08T{hour:02}:12:20Z"),
             "run_id": run_id,
             "agent_identity": "system",
             "body_kind": "run_started"
@@ -62,22 +73,22 @@ fn seed_cli_invocation_audit(runtime: &OrbitRuntime, run_id: &str, stderr: &[u8]
         json!({
             "schemaVersion": 1,
             "event_type": "step.started",
-            "event_id": "evt-step",
-            "ts": "2099-05-08T04:12:21Z",
+            "event_id": format!("evt-step-{run_id}"),
+            "ts": format!("2099-05-08T{hour:02}:12:21Z"),
             "run_id": run_id,
             "agent_identity": "system",
-            "parent_event_id": "evt-run",
+            "parent_event_id": format!("evt-run-{run_id}"),
             "body_kind": "step_started",
             "step_id": "implement"
         }),
         json!({
             "schemaVersion": 1,
             "event_type": "cli.invocation.finished",
-            "event_id": "evt-cli",
-            "ts": "2099-05-08T04:12:22Z",
+            "event_id": format!("evt-cli-{run_id}"),
+            "ts": format!("2099-05-08T{hour:02}:12:22Z"),
             "run_id": run_id,
             "agent_identity": "system",
-            "parent_event_id": "evt-step",
+            "parent_event_id": format!("evt-step-{run_id}"),
             "body_kind": "cli_invocation_finished",
             "provider": "codex",
             "stdout_blob_ref": stdout_ref,
@@ -221,6 +232,41 @@ async fn diagnostics_errors_include_codex_style_stderr_rows() {
             .as_str()
             .is_some_and(|message| message.contains("apply_patch verification failed"))
     }));
+}
+
+/// The scan stops after `2 * limit` stderr rows, so it has to walk history
+/// newest-first: walking oldest-first fills that budget with the first runs
+/// ever recorded and a failure from five minutes ago never reaches the panel.
+#[tokio::test]
+async fn diagnostics_errors_prefer_the_newest_agent_stderr_rows() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    for (run_id, hour) in [("jrun-old", 1), ("jrun-mid", 2), ("jrun-new", 3)] {
+        let stderr = format!(
+            "2099-05-08T{hour:02}:12:22.000000Z ERROR codex_core::session: failed in {run_id}\n"
+        );
+        seed_cli_invocation_audit_at(&runtime, run_id, stderr.as_bytes(), hour);
+    }
+
+    let response = Router::new()
+        .nest("/api", router())
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .uri("/api/diagnostics/errors?limit=1")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    let rows = payload.as_array().expect("rows");
+    let agent_rows = rows
+        .iter()
+        .filter(|row| row["source"] == "agent-stderr")
+        .collect::<Vec<_>>();
+    assert_eq!(agent_rows.len(), 1, "{payload}");
+    assert_eq!(agent_rows[0]["job_run"], "jrun-new");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Four dashboard API defects found in an audit of `orbit-web`, each with a regression test.

- **`/api/audit` paging was silently capped at 200 rows.** The handler prefetched the newest `HISTORY_MAX_LIMIT` rows and sliced `[offset, offset+limit)` out of them in Rust, so `offset >= 200` always returned `[]` and a `q=` text search only saw the newest 200 events. `AuditEventFilter` gains an `offset` that is pushed into the SQL `OFFSET`; when no Rust-side predicate (`execution_id`/`run_id`, `profile`, `q`) is present the page is exactly the SQL window. When one is present the handler walks the history in 200-row batches until the page is full, bounded by a 10k-row scan cap.
- **`/api/diagnostics/errors` surfaced the oldest agent-stderr errors.** `v2_audit_values` reverses the store's newest-first rows so the step index numbers steps in execution order, but `agent_stderr_error_rows` then scanned that oldest-first stream and stopped after `2 * limit` rows, so it collected errors from the first runs ever recorded. The scan now walks newest-first; the index is still built oldest-first.
- **Missing routine / auto-task answered 409, not 404.** `not_found_or_conflict` hard-coded `CONFLICT` for all five callers including the two `*_not_found` codes, so a client's "409 means refresh and retry" policy looped on a permanent miss. Split into `named_entity_not_found` (404) and `selection_conflict` (409).
- **`/api/search` accepted an unbounded `limit`.** `limit=100000000` was passed straight to the store. Now routed through `bounded_limit` like every other list endpoint.

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-web` (268 tests) and the audit-store / core / cli / cmd / engine suites pass.
- New tests: `audit_paging_and_needle_reach_past_the_max_limit_window`, `diagnostics_errors_prefer_the_newest_agent_stderr_rows`, `toggle_of_an_unknown_auto_task_is_not_found`, `query_parser_caps_limit_like_every_other_list_endpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
