### PR TITLE
fix(store): chunk invocation IN-lists, honor re-resolution, mint unique row ids

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -649,7 +649,8 @@ impl HubCoordinationExecutor {
             for relation in &updated.relations {
                 if relation.relation_type == orbit_types::task::TaskRelationType::Resolves
                     && is_valid_friction_id(&relation.target)
-                    && let Err(error) = frictions.resolve_by_task(&relation.target, id, Utc::now())
+                    && let Err(error) =
+                        frictions.auto_resolve_by_task(&relation.target, id, Utc::now())
                 {
                     tracing::warn!(
                         task_id = id,

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -176,19 +176,11 @@ impl OrbitRuntime {
             if !is_valid_friction_id(target) {
                 continue;
             }
-            match frictions.show(target) {
-                Ok(Some(_)) => match frictions.resolve_by_task(target, &task.id, Utc::now()) {
-                    Ok(_) => events.push(OrbitEvent::FrictionAutoResolved {
-                        task_id: task.id.clone(),
-                        friction_id: target.to_string(),
-                    }),
-                    Err(error) => events.push(OrbitEvent::TaskRelationSideEffectFailed {
-                        task_id: task.id.clone(),
-                        target: target.to_string(),
-                        relation: RELATION_RESOLVES.to_string(),
-                        reason: error.to_string(),
-                    }),
-                },
+            match frictions.auto_resolve_by_task(target, &task.id, Utc::now()) {
+                Ok(Some(_)) => events.push(OrbitEvent::FrictionAutoResolved {
+                    task_id: task.id.clone(),
+                    friction_id: target.to_string(),
+                }),
                 Ok(None) => events.push(OrbitEvent::TaskRelationDangling {
                     task_id: task.id.clone(),
                     target: target.to_string(),

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -175,6 +175,14 @@ pub trait FrictionStoreBackend: Send + Sync {
         task_id: &str,
         resolved_at: DateTime<Utc>,
     ) -> Result<StoredFrictionRecord, OrbitError>;
+    /// Resolve as a task-completion side effect: an already-resolved record
+    /// is returned untouched, and `Ok(None)` means the record does not exist.
+    fn auto_resolve_by_task(
+        &self,
+        id: &str,
+        task_id: &str,
+        resolved_at: DateTime<Utc>,
+    ) -> Result<Option<StoredFrictionRecord>, OrbitError>;
     fn tags(&self) -> Result<Vec<String>, OrbitError>;
     fn reported_by_model(
         &self,

--- a/crates/orbit-store/src/driver/sqlite/invocation_store/records/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/invocation_store/records/mod.rs
@@ -199,38 +199,46 @@ impl Store {
         }
 
         let conn = self.connection_handle()?;
-        let placeholders = sql_placeholders(invocation_ids.len());
-        let sql = format!(
-            "SELECT invocation_id, seq, tool_name, result_bytes FROM tool_calls WHERE invocation_id IN ({placeholders}) ORDER BY invocation_id ASC, seq ASC"
-        );
-        let params: Vec<Box<dyn ToSql>> = invocation_ids
-            .iter()
-            .map(|id| Box::new(*id) as Box<dyn ToSql>)
-            .collect();
-        let param_refs: Vec<&dyn ToSql> = params.iter().map(|value| value.as_ref()).collect();
-
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-        let rows = stmt
-            .query_map(param_refs.as_slice(), |row| {
-                Ok(InvocationToolCallRecord {
-                    invocation_id: row.get(0)?,
-                    seq: row.get::<_, i64>(1)? as u64,
-                    tool_name: row.get(2)?,
-                    result_bytes: row.get::<_, i64>(3)? as u64,
-                })
-            })
-            .map_err(|e| OrbitError::Store(e.to_string()))?;
-
         let mut grouped: HashMap<i64, Vec<InvocationToolCallRecord>> = HashMap::new();
-        for row in rows {
-            let call = row.map_err(|e| OrbitError::Store(e.to_string()))?;
-            grouped.entry(call.invocation_id).or_default().push(call);
+        for chunk in invocation_ids.chunks(SQL_IN_LIST_CHUNK) {
+            let placeholders = sql_placeholders(chunk.len());
+            let sql = format!(
+                "SELECT invocation_id, seq, tool_name, result_bytes FROM tool_calls WHERE invocation_id IN ({placeholders}) ORDER BY invocation_id ASC, seq ASC"
+            );
+            let params: Vec<Box<dyn ToSql>> = chunk
+                .iter()
+                .map(|id| Box::new(*id) as Box<dyn ToSql>)
+                .collect();
+            let param_refs: Vec<&dyn ToSql> = params.iter().map(|value| value.as_ref()).collect();
+
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            let rows = stmt
+                .query_map(param_refs.as_slice(), |row| {
+                    Ok(InvocationToolCallRecord {
+                        invocation_id: row.get(0)?,
+                        seq: row.get::<_, i64>(1)? as u64,
+                        tool_name: row.get(2)?,
+                        result_bytes: row.get::<_, i64>(3)? as u64,
+                    })
+                })
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+            for row in rows {
+                let call = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+                grouped.entry(call.invocation_id).or_default().push(call);
+            }
         }
         Ok(grouped)
     }
 }
+
+/// Ids per `IN (...)` list. SQLite caps bound parameters per statement
+/// (`SQLITE_MAX_VARIABLE_NUMBER`, 32766 on the bundled build), and the
+/// accounting path hydrates every invocation in a window in one go, so an
+/// unchunked list fails outright once the window holds more rows than that.
+const SQL_IN_LIST_CHUNK: usize = 500;
 
 fn insert_invocation_task_ids(
     tx: &rusqlite::Transaction<'_>,
@@ -453,27 +461,29 @@ fn load_grouped_strings(
         return Ok(HashMap::new());
     }
 
-    let placeholders = sql_placeholders(invocation_ids.len());
-    let sql = sql_template.replace("{placeholders}", &placeholders);
-    let params: Vec<Box<dyn ToSql>> = invocation_ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn ToSql>)
-        .collect();
-    let param_refs: Vec<&dyn ToSql> = params.iter().map(|value| value.as_ref()).collect();
-
-    let mut stmt = conn
-        .prepare(&sql)
-        .map_err(|e| OrbitError::Store(e.to_string()))?;
-    let rows = stmt
-        .query_map(param_refs.as_slice(), |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-        })
-        .map_err(|e| OrbitError::Store(e.to_string()))?;
-
     let mut grouped: HashMap<i64, Vec<String>> = HashMap::new();
-    for row in rows {
-        let (invocation_id, value) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
-        grouped.entry(invocation_id).or_default().push(value);
+    for chunk in invocation_ids.chunks(SQL_IN_LIST_CHUNK) {
+        let placeholders = sql_placeholders(chunk.len());
+        let sql = sql_template.replace("{placeholders}", &placeholders);
+        let params: Vec<Box<dyn ToSql>> = chunk
+            .iter()
+            .map(|id| Box::new(*id) as Box<dyn ToSql>)
+            .collect();
+        let param_refs: Vec<&dyn ToSql> = params.iter().map(|value| value.as_ref()).collect();
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        for row in rows {
+            let (invocation_id, value) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+            grouped.entry(invocation_id).or_default().push(value);
+        }
     }
     Ok(grouped)
 }

--- a/crates/orbit-store/src/driver/sqlite/task_reservation_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_reservation_store/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{Duration, Utc};
 use orbit_common::OrbitError;
@@ -16,6 +17,23 @@ use crate::{
 };
 
 mod workspace_claim;
+
+static ROW_ID_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+/// Mint a reservation or claim row id that cannot collide with another
+/// caller's. The wall clock alone is not enough: two agents reserving in the
+/// same nanosecond tick (or on a clock that fails and reads as 0) would both
+/// produce the same primary key and one would abort on the UNIQUE constraint
+/// instead of getting a reservation. The process id separates processes and
+/// the sequence separates threads within one.
+pub(super) fn unique_row_id(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let sequence = ROW_ID_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}{nanos}-{}-{sequence}", std::process::id())
+}
 
 impl Store {
     /// Inspect active reservations through a pooled read connection. Unlike
@@ -167,13 +185,7 @@ impl Store {
                 });
             }
 
-            let reservation_id = format!(
-                "reservation-{}",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|duration| duration.as_nanos())
-                    .unwrap_or(0)
-            );
+            let reservation_id = unique_row_id("reservation-");
             let created_at = now;
             let expires_at =
                 (Utc::now() + Duration::seconds(params.ttl_seconds as i64)).to_rfc3339();

--- a/crates/orbit-store/src/driver/sqlite/task_reservation_store/tests/task_reservation_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_reservation_store/tests/task_reservation_store.rs
@@ -274,3 +274,25 @@ fn task_reservation_owned_conflict_limit_applies_after_overlap_filter() {
         Some("jrun-target")
     );
 }
+
+/// Two reservations minted back to back must never share a primary key,
+/// even when the clock does not advance between them.
+#[test]
+fn reservation_ids_are_unique_within_a_clock_tick() {
+    let ids: std::collections::BTreeSet<String> =
+        (0..1_000).map(|_| unique_row_id("reservation-")).collect();
+    assert_eq!(ids.len(), 1_000);
+    assert!(ids.iter().all(|id| id.starts_with("reservation-")));
+
+    let store = Store::open_in_memory().expect("open store");
+    let first = store
+        .reserve_task_reservation(&reserve_params("file:src/a.rs"))
+        .expect("reserve a");
+    let mut second_params = reserve_params("file:src/b.rs");
+    second_params.task_ids = vec!["T2".to_string()];
+    let second = store
+        .reserve_task_reservation(&second_params)
+        .expect("reserve b");
+    assert!(first.reserved && second.reserved);
+    assert_ne!(first.reservation_id, second.reservation_id);
+}

--- a/crates/orbit-store/src/driver/sqlite/task_reservation_store/workspace_claim.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_reservation_store/workspace_claim.rs
@@ -62,13 +62,7 @@ impl Store {
                 });
             }
 
-            let claim_id = format!(
-                "{CLAIM_ID_PREFIX}{}",
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|duration| duration.as_nanos())
-                    .unwrap_or(0)
-            );
+            let claim_id = super::unique_row_id(CLAIM_ID_PREFIX);
             let claim_token = mint_claim_token();
             let expires_at =
                 (Utc::now() + Duration::seconds(params.ttl_seconds as i64)).to_rfc3339();

--- a/crates/orbit-store/src/driver/sqlite/tests/invocation_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/invocation_store.rs
@@ -336,3 +336,62 @@ fn accounting_facts_are_unbounded_distinct_and_half_open_without_tool_hydration(
         "until is exclusive"
     );
 }
+
+/// The accounting read hydrates every invocation in its window in one go,
+/// so its `IN (...)` lists must be chunked below SQLite's bound-parameter
+/// cap. 1,100 rows crosses several chunks; every row must still get its own
+/// task and tool-call linkage back.
+#[test]
+fn hydration_spans_several_in_list_chunks_without_losing_linkage() {
+    let store = Store::open_in_memory().expect("open store");
+    let total = 1_100;
+    for index in 0..total {
+        store
+            .insert_invocation_trace_record(&InvocationInsertParams {
+                job_run_id: format!("jrun-chunk-{index}"),
+                activity_id: "implement_one".to_string(),
+                agent: "codex".to_string(),
+                model: Some(TEST_CODEX_MODEL.to_string()),
+                task_ids: vec![format!("ORB-{index}")],
+                trace: InvocationTrace {
+                    tool_calls: vec![ToolCallTrace {
+                        seq: 0,
+                        tool_name: format!("tool-{index}"),
+                        result_bytes: 1,
+                        result_payload: None,
+                    }],
+                    ..Default::default()
+                },
+            })
+            .expect("insert invocation");
+    }
+
+    let facts = store
+        .list_invocation_accounting_facts(&InvocationAccountingQuery {
+            since: None,
+            until: Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap(),
+        })
+        .expect("accounting facts");
+    assert_eq!(facts.len(), total);
+    assert!(
+        facts.iter().all(|fact| fact.task_ids.len() == 1),
+        "every fact keeps its task linkage across chunks"
+    );
+
+    let records = store
+        .list_invocation_records(&InvocationQuery {
+            limit: total + 10,
+            ..Default::default()
+        })
+        .expect("detailed records");
+    assert_eq!(records.len(), total);
+    for record in &records {
+        let index = record
+            .job_run_id
+            .strip_prefix("jrun-chunk-")
+            .expect("fixture run id");
+        assert_eq!(record.task_ids, vec![format!("ORB-{index}")]);
+        assert_eq!(record.tool_calls.len(), 1, "{}", record.job_run_id);
+        assert_eq!(record.tool_calls[0].tool_name, format!("tool-{index}"));
+    }
+}

--- a/crates/orbit-store/src/repository/friction/mod.rs
+++ b/crates/orbit-store/src/repository/friction/mod.rs
@@ -244,6 +244,25 @@ impl FrictionStore {
         )
     }
 
+    /// Resolve `id` as a side effect of `task_id` completing, unless someone
+    /// already resolved it. A task's `resolves` relation is a claim, not an
+    /// override: an existing resolution (and the task it names) is kept and
+    /// returned untouched. `Ok(None)` means no such record exists locally.
+    pub fn auto_resolve_by_task(
+        &self,
+        id: &str,
+        task_id: &str,
+        resolved_at: DateTime<Utc>,
+    ) -> Result<Option<StoredFrictionRecord>, OrbitError> {
+        let Some(stored) = self.show(id)? else {
+            return Ok(None);
+        };
+        if stored.record.status == FrictionStatus::Resolved {
+            return Ok(Some(stored));
+        }
+        self.resolve_by_task(id, task_id, resolved_at).map(Some)
+    }
+
     pub fn tags(&self) -> Result<Vec<String>, OrbitError> {
         Ok(load_tag_taxonomy(&self.files_root)?.into_iter().collect())
     }
@@ -399,6 +418,15 @@ impl crate::contracts::FrictionStoreBackend for FrictionStore {
         resolved_at: DateTime<Utc>,
     ) -> Result<StoredFrictionRecord, OrbitError> {
         Self::resolve_by_task(self, id, task_id, resolved_at)
+    }
+
+    fn auto_resolve_by_task(
+        &self,
+        id: &str,
+        task_id: &str,
+        resolved_at: DateTime<Utc>,
+    ) -> Result<Option<StoredFrictionRecord>, OrbitError> {
+        Self::auto_resolve_by_task(self, id, task_id, resolved_at)
     }
 
     fn tags(&self) -> Result<Vec<String>, OrbitError> {

--- a/crates/orbit-store/src/repository/friction/mod.rs
+++ b/crates/orbit-store/src/repository/friction/mod.rs
@@ -184,14 +184,12 @@ impl FrictionStore {
                         }
                     };
                 }
+                // Unlike `resolved_at`, which keeps the first resolution
+                // instant, the resolving task is whatever the caller names:
+                // re-resolving against a corrected task must not silently
+                // keep the wrong one.
                 if let Some(resolved_by_task) = params.resolved_by_task.clone() {
-                    stored.record.resolved_by_task = Some(
-                        stored
-                            .record
-                            .resolved_by_task
-                            .clone()
-                            .unwrap_or(resolved_by_task),
-                    );
+                    stored.record.resolved_by_task = Some(resolved_by_task);
                 }
                 queries::upsert_record(
                     conn,

--- a/crates/orbit-store/src/repository/friction/tests/friction_store.rs
+++ b/crates/orbit-store/src/repository/friction/tests/friction_store.rs
@@ -349,6 +349,17 @@ fn resolution_records_the_resolving_task_and_reopening_clears_it() {
         Some("ORB-00042")
     );
 
+    // A later resolution against a different task replaces the first one;
+    // the original resolution instant is kept.
+    let re_resolved = frictions
+        .resolve_by_task(&stored.record.id, "ORB-00043", at(2, 12))
+        .expect("re-resolve by another task");
+    assert_eq!(
+        re_resolved.record.resolved_by_task.as_deref(),
+        Some("ORB-00043")
+    );
+    assert_eq!(re_resolved.record.resolved_at, Some(at(2, 0)));
+
     let reopened = frictions
         .update(
             &stored.record.id,

--- a/crates/orbit-store/src/repository/friction/tests/friction_store.rs
+++ b/crates/orbit-store/src/repository/friction/tests/friction_store.rs
@@ -383,6 +383,38 @@ fn resolution_records_the_resolving_task_and_reopening_clears_it() {
     assert_eq!(plain.record.resolved_by_task, None);
 }
 
+/// Task completion claims a resolution only when nobody has resolved the
+/// record yet; an explicit `resolve_by_task` still replaces the task.
+#[test]
+fn auto_resolution_yields_to_an_existing_resolution() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let frictions = friction_store(temp.path(), "ws_one");
+    let stored = frictions
+        .add(add_params(TEST_CODEX_MODEL, at(1, 0), &["tooling"]))
+        .expect("seed record");
+
+    let first = frictions
+        .auto_resolve_by_task(&stored.record.id, "ORB-00001", at(2, 0))
+        .expect("auto-resolve open record")
+        .expect("record exists");
+    assert_eq!(first.record.status, FrictionStatus::Resolved);
+    assert_eq!(first.record.resolved_by_task.as_deref(), Some("ORB-00001"));
+
+    let second = frictions
+        .auto_resolve_by_task(&stored.record.id, "ORB-00002", at(3, 0))
+        .expect("auto-resolve resolved record")
+        .expect("record exists");
+    assert_eq!(second.record.resolved_by_task.as_deref(), Some("ORB-00001"));
+    assert_eq!(second.record.resolved_at, Some(at(2, 0)));
+
+    assert!(
+        frictions
+            .auto_resolve_by_task("F2026-01-999", "ORB-00003", at(3, 0))
+            .expect("missing record is not an error")
+            .is_none()
+    );
+}
+
 /// The taxonomy stayed a file; record persistence moving does not move it.
 #[test]
 fn tag_validation_uses_the_taxonomy_file() {


### PR DESCRIPTION
## Summary

Three `orbit-store` defects found in an audit of the crate, each with a regression test.

- **Invocation hydration failed past SQLite's bind-parameter cap.** `list_invocation_accounting_facts` loads every invocation in its window and then binds one `?N` per id into a single `IN (...)`; the bundled SQLite refuses more than 32,766 parameters, so once the `invocations` table crossed that size every accounting read (`orchestrator_invocation_metrics` with no `since`) died with `Too many SQL variables`, permanently. Both IN-list loaders now query in 500-id chunks and merge.
- **Re-resolving a friction against a different task silently kept the old one.** `FrictionStore::update` copied the write-once `unwrap_or` shape from `resolved_at` onto `resolved_by_task`, so `resolve_by_task(id, "ORB-200")` on a record already resolved against `ORB-100` returned `Ok` with `ORB-100` still recorded. The caller's task now wins; the original resolution instant is still preserved. The write-once shape *was* load-bearing for task auto-close (a `resolves` relation must not override a person's resolution), so that rule now lives in one named store method, `auto_resolve_by_task`, which both completion paths call.
- **Reservation and claim ids were bare wall-clock nanoseconds.** Two agents reserving in the same clock tick (or any caller on a clock that errors and reads as `0`) minted the same primary key, and the second `INSERT` aborted the transaction with a UNIQUE violation instead of a reservation. Ids now carry the process id and an atomic sequence, the same shape `create_staging_dir` already uses.

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-store` (381 tests), the orbit-core friction suites, and `relation_auto_close` pass.
- New tests: `hydration_spans_several_in_list_chunks_without_losing_linkage` (1,100 rows across chunks), `reservation_ids_are_unique_within_a_clock_tick`, `auto_resolution_yields_to_an_existing_resolution`, and an extension of `resolution_records_the_resolving_task_and_reopening_clears_it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
