### PR TITLE
fix(engine): bound the output-reader join after a normal exit, keep GC going past a stuck branch

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -276,7 +276,13 @@ pub(super) fn spawn_with_timeout(
         }
     }
 
-    let reader_join_deadline = timed_out.then(|| Instant::now() + OUTPUT_READER_JOIN_TIMEOUT);
+    // The join is bounded on every exit path, not only after a timeout. A
+    // reader returns when the last writer closes the pipe, and a helper the
+    // agent left in its own session (`setsid`) keeps the write end open after
+    // the child itself exits and after the group kill above. An unbounded
+    // join there never returns, no finish event is emitted, and the run's
+    // reservation is never released.
+    let reader_join_deadline = Instant::now() + OUTPUT_READER_JOIN_TIMEOUT;
     if let Some(h) = stdout_reader {
         join_output_reader(h, reader_join_deadline);
     }
@@ -376,21 +382,16 @@ where
     OutputReaderHandle { finished, join }
 }
 
-fn join_output_reader(reader: OutputReaderHandle, deadline: Option<Instant>) {
+fn join_output_reader(reader: OutputReaderHandle, deadline: Instant) {
     let OutputReaderHandle { finished, join } = reader;
-    match deadline {
-        Some(deadline) => {
-            let timeout = deadline.saturating_duration_since(Instant::now());
-            match finished.recv_timeout(timeout) {
-                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    let _ = join.join();
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => {}
-            }
-        }
-        None => {
+    let timeout = deadline.saturating_duration_since(Instant::now());
+    match finished.recv_timeout(timeout) {
+        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
             let _ = join.join();
         }
+        // The reader is still blocked on a pipe some escaped process holds;
+        // the captured bytes so far are what the run gets.
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -287,6 +287,64 @@ fn spawn_with_timeout_kills_grandchild_holding_output_pipes() {
     );
 }
 
+/// A helper the agent detached into its own session outlives the child and
+/// the group kill, and keeps the stdout pipe open. The child exited normally,
+/// so the run must still finish promptly with the output it produced.
+#[cfg(unix)]
+#[test]
+fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder() {
+    if std::process::Command::new("perl")
+        .arg("-e")
+        .arg("1")
+        .output()
+        .is_err()
+    {
+        return;
+    }
+    let pid_dir = tempdir().expect("pid tempdir");
+    let pid_file = pid_dir.path().join("escaped.pid");
+    // perl re-parents itself into a new session (so the group kill misses it)
+    // and execs a sleep that inherits our stdout.
+    let script = format!(
+        "perl -MPOSIX -e 'POSIX::setsid(); open(my $f, \">\", $ARGV[0]); print $f $$; close $f; exec \"sleep\", \"30\"' {} & printf '%s\n' 'done'",
+        shell_quote(pid_file.to_string_lossy().as_ref())
+    );
+    let args = sh_args(&script);
+
+    let started = std::time::Instant::now();
+    let (stdout, _stderr, exit_code, _duration, timed_out) =
+        spawn_with_timeout(spawn_test_request(
+            "/bin/sh",
+            &args,
+            None,
+            Duration::from_secs(20),
+            SpawnTraceContext {
+                provider: "codex",
+                job_run_id: "job-escaped-holder",
+                task_id: Some("TESC"),
+                cwd: None,
+            },
+        ))
+        .expect("spawn succeeds");
+
+    assert!(
+        wait_until(Duration::from_secs(2), || pid_file.exists()),
+        "escaped helper should have recorded its pid"
+    );
+    let escaped_pid = read_pid(&pid_file);
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &escaped_pid.to_string()])
+        .status();
+
+    assert!(!timed_out);
+    assert_eq!(exit_code, Some(0));
+    assert_eq!(stdout.bytes(), b"done\n");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "a normal exit must not wait on the escaped pipe holder"
+    );
+}
+
 #[cfg(unix)]
 fn read_pid(path: &Path) -> u32 {
     std::fs::read_to_string(path)

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 
 use crate::context::RuntimeHost;
 
+use super::super::git::git_success;
 use super::cleanup::remove_worktree;
 use super::{WorktreeIdentity, resolve_shared_worktree_path};
 
@@ -251,10 +252,19 @@ fn classify_known<H: RuntimeHost + ?Sized>(
 
     // Deliberately no `--force`: a last-moment dirtying of the worktree makes
     // Git fail closed. Never replace this with raw recursive deletion.
-    let branch_to_delete = branch_exists(repo_root, &branch).then_some(branch.as_str());
-    remove_worktree(repo_root, path, branch_to_delete, false)?;
-    report.action = "removed".to_string();
+    remove_worktree(repo_root, path, None, false)?;
     report.bytes_reclaimed = estimated_bytes;
+    // The directory is gone and its bytes are reclaimed either way; a branch
+    // that cannot be deleted right now (ref lock, checked out elsewhere) is
+    // reported rather than turning the whole pass into an error that hides
+    // this removal and stops the paths after it.
+    report.action = if branch_exists(repo_root, &branch)
+        && git_success(repo_root, &["branch", "-D", &branch]).is_err()
+    {
+        "removed:branch_retained".to_string()
+    } else {
+        "removed".to_string()
+    };
     Ok(report)
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/gc.rs
@@ -196,6 +196,48 @@ fn dry_run_and_yes_share_eligibility_but_only_yes_removes() {
     assert!(applied.reports[0].bytes_reclaimed > 0);
 }
 
+/// A branch that cannot be deleted must not turn a completed removal into an
+/// error: the directory is gone, its bytes are reclaimed, and the pass keeps
+/// going. The report says the branch stayed behind.
+#[test]
+fn removed_worktree_with_an_undeletable_branch_is_reported_not_failed() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo);
+    let run = pipeline_run("jrun-locked", JobRunState::Success, &["ORB-LOCKED"]);
+    let worktree = resolved_task_worktree(&repo, &run);
+    add_worktree(&repo, &worktree, "orbit/locked");
+    let host = FakeTaskHost::new(vec![task_fixture("ORB-LOCKED", TaskStatus::Done)]);
+    // A stale ref lock makes `git branch -D` fail while the worktree itself
+    // removes cleanly.
+    let lock = repo
+        .join(".git")
+        .join("refs")
+        .join("heads")
+        .join("orbit")
+        .join("locked.lock");
+    fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    fs::write(&lock, b"").unwrap();
+
+    let applied = collect_worktrees(
+        &repo,
+        &[run],
+        &host,
+        &WorktreeGcOptions {
+            delete: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(!worktree.exists());
+    assert_eq!(applied.reports[0].action, "removed:branch_retained");
+    assert!(applied.reports[0].bytes_reclaimed > 0);
+    assert!(
+        git(&repo, &["branch", "--list", "orbit/locked"]).contains("orbit/locked"),
+        "the branch stays until the lock is cleared"
+    );
+}
+
 #[test]
 fn colliding_sanitized_run_ids_are_ambiguous_and_never_removed() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
## Summary

Two `orbit-engine` defects found in an audit of the CLI runner and worktree GC, each with a regression test.

- **A provider run could hang forever after the agent exited 0.** `spawn_with_timeout` bounded the output-reader join only when the wall-clock timeout fired; on a normal exit it joined unconditionally. The reader returns only when the last writer closes the pipe, and a helper the agent detached into its own session (`setsid`) survives `cleanup_child_process_group` and keeps stdout open, so the supervisor never returned, no `CliInvocationFinished` was emitted, and the task reservation was never released. The join is now bounded by the existing `OUTPUT_READER_JOIN_TIMEOUT` on every exit path. Test: `spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder` (perl `setsid` + `sleep 30` holding the pipe; must return in well under 5s with exit 0 and the captured output).
- **Worktree GC aborted the pass and lost the removal report when `git branch -D` failed.** `remove_worktree` deleted the directory and pruned, then `?`-propagated a branch-deletion failure (ref lock, branch checked out elsewhere), so the just-removed worktree was reported as nothing, `bytes_reclaimed` was lost, and the remaining paths were never examined. Branch deletion is now best-effort after the removal: the row reports `removed:branch_retained` and collection continues. Test: `removed_worktree_with_an_undeletable_branch_is_reported_not_failed` (stale `refs/heads/<branch>.lock`).

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-engine` (415 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
