### PR TITLE
perf(core): read the task store once per lock operation and once per stale-reservation pass

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -15,8 +15,9 @@ use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::runtime::task::locks::{
-    emit_expired_reservation_events, merge_task_lock_conflicts, parse_task_ids,
-    requested_task_files, task_lock_conflicts, workspace_orbit_dir, workspace_task_reservation_id,
+    TaskLockIndex, emit_expired_reservation_events, merge_task_lock_conflicts, parse_task_ids,
+    requested_task_files_indexed, task_lock_conflicts_indexed, workspace_orbit_dir,
+    workspace_task_reservation_id,
 };
 
 use super::{
@@ -119,17 +120,20 @@ pub(crate) fn run_deterministic(
                     message: error.to_string(),
                 }
             })?;
-            let requested_files = requested_task_files(runtime, &task_ids).map_err(|error| {
+            let index = TaskLockIndex::load(runtime).map_err(|error| {
                 DispatchError::DeterministicActionFailed {
                     action: action.to_string(),
                     message: error.to_string(),
                 }
             })?;
-            let task_conflicts = task_lock_conflicts(runtime, &task_ids, &requested_files)
+            let repo_root = runtime.paths().repo_root.as_path();
+            let requested_files = requested_task_files_indexed(&index, &task_ids, repo_root)
                 .map_err(|error| DispatchError::DeterministicActionFailed {
                     action: action.to_string(),
                     message: error.to_string(),
                 })?;
+            let task_conflicts =
+                task_lock_conflicts_indexed(&index, &task_ids, &requested_files, repo_root);
             runtime
                 .reconcile_stale_owned_reservations_for_files(&requested_files, 32)
                 .map_err(|error| DispatchError::DeterministicActionFailed {

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -33,14 +33,9 @@ pub(crate) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
         .list_active_task_reservations(&workspace_orbit_dir(runtime), workspace_id.as_deref())?;
     emit_expired_reservation_events(runtime, &reservation_result.expired_reservations)?;
 
-    let all_tasks = runtime.list_tasks()?;
-    let task_lookup = all_tasks
-        .iter()
-        .cloned()
-        .map(|task| (task.id.clone(), task))
-        .collect::<BTreeMap<_, _>>();
-    let mut tasks: Vec<_> = all_tasks
-        .into_iter()
+    let index = TaskLockIndex::from_tasks(runtime.list_tasks()?);
+    let mut tasks: Vec<&Task> = index
+        .tasks()
         .filter(|task| matches!(task.status, TaskStatus::InProgress | TaskStatus::Review))
         .collect();
     tasks.sort_by_key(|task| {
@@ -60,8 +55,8 @@ pub(crate) fn list(runtime: &OrbitRuntime) -> Result<Value, OrbitError> {
     let locked_surfaces: Vec<(Task, Vec<String>)> = tasks
         .into_iter()
         .map(|task| {
-            let files = lock_context_files_for_task(&task, &task_lookup, repo_root);
-            (task, files)
+            let files = index.lock_context_files(task, repo_root);
+            (task.clone(), files)
         })
         .collect();
 
@@ -204,14 +199,17 @@ pub(crate) fn reserve(
 
     let actor = reservation_actor_label(runtime, agent.as_deref(), model.as_deref());
     let workspace_id = workspace_task_reservation_id(runtime)?;
+    let index = TaskLockIndex::load(runtime)?;
+    let repo_root = runtime.paths().repo_root.as_path();
     let (task_ids, requested_files) = match &reservation_scope {
-        TaskLockReservationScope::TaskIds(task_ids) => {
-            (task_ids.clone(), requested_task_files(runtime, task_ids)?)
-        }
+        TaskLockReservationScope::TaskIds(task_ids) => (
+            task_ids.clone(),
+            requested_task_files_indexed(&index, task_ids, repo_root)?,
+        ),
         TaskLockReservationScope::Files(files) => (Vec::new(), files.clone()),
     };
     runtime.reconcile_stale_owned_reservations_for_files(&requested_files, 32)?;
-    let mut conflicts = task_lock_conflicts(runtime, &task_ids, &requested_files)?;
+    let mut conflicts = task_lock_conflicts_indexed(&index, &task_ids, &requested_files, repo_root);
 
     record_task_lock_audit_event(
         runtime,
@@ -475,50 +473,122 @@ fn task_is_descendant_of(
     false
 }
 
-pub(crate) fn requested_task_files(
-    runtime: &OrbitRuntime,
-    task_ids: &[String],
-) -> Result<Vec<String>, OrbitError> {
-    let tasks = runtime.stores().tasks().list_tasks()?;
-    let task_map = tasks
-        .into_iter()
-        .map(|task| (task.id.clone(), task))
-        .collect::<BTreeMap<_, _>>();
+/// The task store indexed for lock-surface expansion: the id lookup plus,
+/// for each epic root, every task below it. One operation builds it once; a
+/// reserve that inspects forty active tasks then expands forty surfaces
+/// without re-reading the store or re-walking every task's parent chain for
+/// each epic it meets.
+pub(crate) struct TaskLockIndex {
+    tasks: BTreeMap<String, Task>,
+    epic_descendants: BTreeMap<String, Vec<String>>,
+}
 
-    let mut requested_files = BTreeSet::new();
-    for task_id in task_ids {
-        let task = task_map
-            .get(task_id)
-            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.clone()))?;
-        requested_files.extend(lock_context_files_for_task(
-            task,
-            &task_map,
-            runtime.paths().repo_root.as_path(),
-        ));
+impl TaskLockIndex {
+    pub(crate) fn load(runtime: &OrbitRuntime) -> Result<Self, OrbitError> {
+        Ok(Self::from_tasks(runtime.stores().tasks().list_tasks()?))
     }
 
+    pub(crate) fn from_tasks(tasks: Vec<Task>) -> Self {
+        let tasks = tasks
+            .into_iter()
+            .map(|task| (task.id.clone(), task))
+            .collect::<BTreeMap<_, _>>();
+        let mut epic_descendants: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for task in tasks.values() {
+            for epic_id in epic_ancestor_ids(task, &tasks) {
+                epic_descendants
+                    .entry(epic_id)
+                    .or_default()
+                    .push(task.id.clone());
+            }
+        }
+        Self {
+            tasks,
+            epic_descendants,
+        }
+    }
+
+    pub(crate) fn get(&self, task_id: &str) -> Option<&Task> {
+        self.tasks.get(task_id)
+    }
+
+    pub(crate) fn tasks(&self) -> impl Iterator<Item = &Task> {
+        self.tasks.values()
+    }
+
+    /// [`lock_context_files_for_task`] over the precomputed epic families.
+    pub(crate) fn lock_context_files(&self, task: &Task, workspace_root: &Path) -> Vec<String> {
+        let mut files = existing_context_files_at_root(task, workspace_root)
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        if task.tags.iter().any(|tag| tag == "epic") {
+            for descendant in self
+                .epic_descendants
+                .get(&task.id)
+                .into_iter()
+                .flatten()
+                .filter_map(|id| self.tasks.get(id))
+            {
+                files.extend(existing_context_files_at_root(descendant, workspace_root));
+            }
+        }
+        files.into_iter().collect()
+    }
+}
+
+/// Every epic-tagged ancestor on `task`'s parent chain, under the same hop
+/// and cycle guards as [`task_is_descendant_of`].
+fn epic_ancestor_ids(task: &Task, task_lookup: &BTreeMap<String, Task>) -> Vec<String> {
+    let mut epics = Vec::new();
+    let mut visited = BTreeSet::from([task.id.clone()]);
+    let mut next_parent_id = task.parent_id();
+    for _ in 0..32 {
+        let Some(parent_id) = next_parent_id else {
+            break;
+        };
+        if !visited.insert(parent_id.to_string()) {
+            break;
+        }
+        let Some(parent) = task_lookup.get(parent_id) else {
+            break;
+        };
+        if parent.tags.iter().any(|tag| tag == "epic") {
+            epics.push(parent.id.clone());
+        }
+        next_parent_id = parent.parent_id();
+    }
+    epics
+}
+
+pub(crate) fn requested_task_files_indexed(
+    index: &TaskLockIndex,
+    task_ids: &[String],
+    workspace_root: &Path,
+) -> Result<Vec<String>, OrbitError> {
+    let mut requested_files = BTreeSet::new();
+    for task_id in task_ids {
+        let task = index
+            .get(task_id)
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.clone()))?;
+        requested_files.extend(index.lock_context_files(task, workspace_root));
+    }
     Ok(requested_files.into_iter().collect())
 }
 
-pub(crate) fn task_lock_conflicts(
-    runtime: &OrbitRuntime,
+pub(crate) fn task_lock_conflicts_indexed(
+    index: &TaskLockIndex,
     bundle_task_ids: &[String],
     requested_files: &[String],
-) -> Result<Vec<TaskLockConflict>, OrbitError> {
+    workspace_root: &Path,
+) -> Vec<TaskLockConflict> {
     let bundle_ids = bundle_task_ids.iter().cloned().collect::<BTreeSet<_>>();
     let requested_files = requested_files.iter().cloned().collect::<BTreeSet<_>>();
     if requested_files.is_empty() {
-        return Ok(Vec::new());
+        return Vec::new();
     }
 
-    let all_tasks = runtime.stores().tasks().list_tasks()?;
-    let task_lookup = all_tasks
-        .iter()
-        .cloned()
-        .map(|task| (task.id.clone(), task))
-        .collect::<BTreeMap<_, _>>();
-    let mut tasks: Vec<Task> = all_tasks
-        .into_iter()
+    let mut tasks: Vec<&Task> = index
+        .tasks()
         .filter(|task| {
             matches!(task.status, TaskStatus::InProgress | TaskStatus::Review)
                 && !bundle_ids.contains(&task.id)
@@ -534,8 +604,7 @@ pub(crate) fn task_lock_conflicts(
 
     let mut conflicts = Vec::new();
     for task in tasks {
-        let held_files =
-            lock_context_files_for_task(&task, &task_lookup, runtime.paths().repo_root.as_path());
+        let held_files = index.lock_context_files(task, workspace_root);
         for requested_file in &requested_files {
             if held_files
                 .iter()
@@ -555,7 +624,7 @@ pub(crate) fn task_lock_conflicts(
             .cmp(&right.file)
             .then(left.held_by_id.cmp(&right.held_by_id))
     });
-    Ok(conflicts)
+    conflicts
 }
 
 pub(crate) fn merge_task_lock_conflicts(

--- a/crates/orbit-core/src/runtime/task/reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task/reservation_cleanup.rs
@@ -20,6 +20,13 @@ use super::locks::{
     workspace_task_reservation_id,
 };
 
+/// Workspace-wide facts consulted while classifying stale reservations.
+struct StaleReservationContext {
+    /// Run ids the orphan classifiers already consider conclusively orphaned.
+    orphaned_run_ids: BTreeSet<String>,
+    task_statuses: BTreeMap<String, TaskStatus>,
+}
+
 /// A task reservation that Orbit can prove is no longer protecting live work.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaleTaskReservation {
@@ -38,16 +45,11 @@ impl OrbitRuntime {
     /// terminal task status). Empty/missing/mixed task associations remain
     /// ambiguous and are deliberately ignored.
     pub fn list_stale_task_reservations(&self) -> Result<Vec<StaleTaskReservation>, OrbitError> {
-        let reservations = self
-            .stores()
-            .task_reservations()
-            .inspect_active_task_reservations(
-                &workspace_orbit_dir(self),
-                workspace_task_reservation_id(self)?.as_deref(),
-            )?;
+        let reservations = self.inspect_active_reservations()?;
+        let context = self.stale_reservation_context()?;
         let mut stale = Vec::new();
         for reservation in reservations {
-            if let Some(reason) = self.classify_stale_task_reservation(&reservation)? {
+            if let Some(reason) = self.classify_stale_task_reservation(&reservation, &context)? {
                 stale.push(StaleTaskReservation {
                     reservation_id: reservation.reservation_id,
                     task_ids: reservation.task_ids,
@@ -67,21 +69,25 @@ impl OrbitRuntime {
             .into_iter()
             .map(|candidate| candidate.reservation_id)
             .collect::<Vec<_>>();
+        if candidate_ids.is_empty() {
+            return Ok(0);
+        }
+        // The orphan-run and task-status facts are read once for the pass;
+        // only the reservation row itself is re-read before each release,
+        // since that is the row another operator could have released or
+        // re-owned in the meantime.
+        let context = self.stale_reservation_context()?;
         let mut released = 0;
         for reservation_id in candidate_ids {
             let current = self
-                .stores()
-                .task_reservations()
-                .inspect_active_task_reservations(
-                    &workspace_orbit_dir(self),
-                    workspace_task_reservation_id(self)?.as_deref(),
-                )?
+                .inspect_active_reservations()?
                 .into_iter()
                 .find(|reservation| reservation.reservation_id == reservation_id);
             let Some(current) = current else {
                 continue;
             };
-            let Some(stale_reason) = self.classify_stale_task_reservation(&current)? else {
+            let Some(stale_reason) = self.classify_stale_task_reservation(&current, &context)?
+            else {
                 continue;
             };
             let result = self.stores().task_reservations().release_task_reservation(
@@ -114,9 +120,44 @@ impl OrbitRuntime {
         Ok(released)
     }
 
+    fn inspect_active_reservations(&self) -> Result<Vec<ActiveTaskReservation>, OrbitError> {
+        self.stores()
+            .task_reservations()
+            .inspect_active_task_reservations(
+                &workspace_orbit_dir(self),
+                workspace_task_reservation_id(self)?.as_deref(),
+            )
+    }
+
+    /// The workspace-wide facts stale classification consults, read once per
+    /// pass instead of once per reservation: the orphan classifier scans
+    /// every job run and the task sweep reads every task.
+    fn stale_reservation_context(&self) -> Result<StaleReservationContext, OrbitError> {
+        let mut orphaned_run_ids = self
+            .list_orphaned_running_job_runs()?
+            .into_iter()
+            .map(|orphan| orphan.run_id)
+            .collect::<BTreeSet<_>>();
+        orphaned_run_ids.extend(
+            self.list_orphaned_pending_job_runs()?
+                .into_iter()
+                .map(|orphan| orphan.run_id),
+        );
+        let task_statuses = self
+            .list_tasks()?
+            .into_iter()
+            .map(|task| (task.id, task.status))
+            .collect::<BTreeMap<_, _>>();
+        Ok(StaleReservationContext {
+            orphaned_run_ids,
+            task_statuses,
+        })
+    }
+
     fn classify_stale_task_reservation(
         &self,
         reservation: &ActiveTaskReservation,
+        context: &StaleReservationContext,
     ) -> Result<Option<String>, OrbitError> {
         if let Some(owner_run_id) = reservation.owner_run_id.as_deref() {
             let Some(run) = self.get_job_run_backend(owner_run_id)? else {
@@ -128,15 +169,7 @@ impl OrbitRuntime {
                     run.state
                 )));
             }
-            let orphaned_running = self
-                .list_orphaned_running_job_runs()?
-                .into_iter()
-                .any(|orphan| orphan.run_id == owner_run_id);
-            let orphaned_pending = self
-                .list_orphaned_pending_job_runs()?
-                .into_iter()
-                .any(|orphan| orphan.run_id == owner_run_id);
-            if orphaned_running || orphaned_pending {
+            if context.orphaned_run_ids.contains(owner_run_id) {
                 return Ok(Some(format!(
                     "owner run {owner_run_id} is conclusively orphaned ({})",
                     run.state
@@ -148,15 +181,10 @@ impl OrbitRuntime {
         if reservation.task_ids.is_empty() {
             return Ok(None);
         }
-        let statuses = self
-            .list_tasks()?
-            .into_iter()
-            .map(|task| (task.id, task.status))
-            .collect::<BTreeMap<_, _>>();
         let all_done = reservation
             .task_ids
             .iter()
-            .all(|task_id| statuses.get(task_id) == Some(&TaskStatus::Done));
+            .all(|task_id| context.task_statuses.get(task_id) == Some(&TaskStatus::Done));
         if all_done {
             Ok(Some(format!(
                 "unowned reservation references only terminal done task(s): {}",

--- a/crates/orbit-core/src/runtime/task/tests/locks.rs
+++ b/crates/orbit-core/src/runtime/task/tests/locks.rs
@@ -8,8 +8,8 @@ use crate::OrbitRuntime;
 use crate::application::task::TaskAddParams;
 
 use super::super::locks::{
-    TaskLockReservationScope, parse_task_lock_reservation_scope, requested_task_files,
-    task_lock_conflicts,
+    TaskLockIndex, TaskLockReservationScope, parse_task_lock_reservation_scope,
+    requested_task_files_indexed, task_lock_conflicts_indexed,
 };
 use crate::adapter::tool_host::test_support::{
     create_context_task, invalid_input_message, run_tool_as_operator, test_runtime,
@@ -137,8 +137,10 @@ fn requested_task_files_prune_missing_context_entries() {
         &["docs/design/groundhog.md", "docs/design/missing.md"],
     );
 
+    let index = TaskLockIndex::load(&runtime).expect("index tasks");
     let requested =
-        requested_task_files(&runtime, &[task.id]).expect("collect requested task files");
+        requested_task_files_indexed(&index, &[task.id], runtime.paths().repo_root.as_path())
+            .expect("collect requested task files");
     assert_eq!(requested, vec!["file:docs/design/groundhog.md".to_string()]);
 }
 
@@ -180,8 +182,12 @@ fn active_epic_root_holds_union_of_descendant_context_files() {
     }
 
     assert_eq!(
-        requested_task_files(&runtime, std::slice::from_ref(&epic.id))
-            .expect("collect epic lock surface"),
+        requested_task_files_indexed(
+            &TaskLockIndex::load(&runtime).expect("index tasks"),
+            std::slice::from_ref(&epic.id),
+            runtime.paths().repo_root.as_path()
+        )
+        .expect("collect epic lock surface"),
         vec![
             "file:src/one.rs".to_string(),
             "file:src/root.rs".to_string(),
@@ -217,15 +223,15 @@ fn task_lock_conflicts_ignore_missing_held_context_entries() {
         &["docs/design/groundhog.md", "src/lib.rs"],
     );
 
-    let conflicts = task_lock_conflicts(
-        &runtime,
+    let conflicts = task_lock_conflicts_indexed(
+        &TaskLockIndex::load(&runtime).expect("index tasks"),
         &[],
         &[
             "docs/design/groundhog.md".to_string(),
             "src/lib.rs".to_string(),
         ],
-    )
-    .expect("compute task lock conflicts");
+        runtime.paths().repo_root.as_path(),
+    );
 
     assert_eq!(
         conflicts,
@@ -251,12 +257,12 @@ fn task_lock_conflicts_use_selector_anchor_overlap() {
         &["symbol:src/lib.rs#ok:function"],
     );
 
-    let conflicts = task_lock_conflicts(
-        &runtime,
+    let conflicts = task_lock_conflicts_indexed(
+        &TaskLockIndex::load(&runtime).expect("index tasks"),
         &[],
         &["file:src/lib.rs".to_string(), "dir:src".to_string()],
-    )
-    .expect("compute selector-aware task lock conflicts");
+        runtime.paths().repo_root.as_path(),
+    );
 
     assert_eq!(
         conflicts,


### PR DESCRIPTION
## Summary

Two hot-path scans in `orbit-core` that grew super-linearly with store size, from an audit of the task-lock and reservation-cleanup code.

- **Task-lock reserve and the dispatch conflict check.** `reserve` called `requested_task_files` (full `list_tasks`) and then `task_lock_conflicts` (a second full `list_tasks`), and inside the conflict loop `lock_context_files_for_task` re-walked every task's parent chain for each active epic it met: O(E × N × depth) on the path every task start takes. A new `TaskLockIndex` reads the store once, builds each epic's descendant list in one pass over the parent chains, and backs `requested_task_files_indexed` / `task_lock_conflicts_indexed`. `reserve`, `list`, and the dispatch `ContextConflictCheck` share one index per operation. The runtime-facing wrappers went away with their last callers.
- **Stale-reservation release.** `release_stale_task_reservations` re-ran both orphan-run scans, a full task read, and a full reservation read for every candidate (roughly 4R job-run scans and R task-store scans for R reservations). The classifier now takes a `StaleReservationContext` built once per pass; only the reservation row is re-read immediately before its own release, which is the re-check the doc comment promises.

No behavior change: the same tests cover the epic-surface union, the selector-aware conflicts, and the doctor repair classes and idempotency.

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
