### PR TITLE
perf(web,store): count runs in SQL, hydrate steps per page, move heavy reads off the async workers

### DIFF
--- a/crates/orbit-core/src/application/job/run/query.rs
+++ b/crates/orbit-core/src/application/job/run/query.rs
@@ -35,13 +35,7 @@ impl OrbitRuntime {
             }
         }
 
-        let query = JobRunQuery {
-            job_id: params.job_id,
-            state: params.state,
-            terminal_only: params.terminal_only,
-            created_since: params.since,
-            limit: params.limit,
-        };
+        let query = job_run_query(params);
         let runs = self.list_job_runs_filtered_backend(&query)?;
         if self.reconcile_job_run_records(&runs)? > 0 {
             self.list_job_runs_filtered_backend(&query)
@@ -74,7 +68,35 @@ impl OrbitRuntime {
         self.stores().jobs().list_job_runs_filtered(query)
     }
 
+    /// How many runs match `params`, without hydrating any of them. `limit`
+    /// is ignored: a count is a count.
+    pub fn count_job_runs(&self, params: JobRunListParams) -> Result<u64, OrbitError> {
+        self.reconcile_stale_job_runs(params.job_id.as_deref())?;
+        self.stores()
+            .jobs()
+            .count_job_runs_filtered(&job_run_query(params))
+    }
+
+    /// Recorded wall-clock durations of every run matching `params`, for
+    /// percentile baselines. `limit` is ignored.
+    pub fn list_job_run_durations(&self, params: JobRunListParams) -> Result<Vec<u64>, OrbitError> {
+        self.reconcile_stale_job_runs(params.job_id.as_deref())?;
+        self.stores()
+            .jobs()
+            .list_job_run_durations_filtered(&job_run_query(params))
+    }
+
     pub(crate) fn get_job_run_backend(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
         self.stores().jobs().get_job_run(run_id)
+    }
+}
+
+fn job_run_query(params: JobRunListParams) -> JobRunQuery {
+    JobRunQuery {
+        job_id: params.job_id,
+        state: params.state,
+        terminal_only: params.terminal_only,
+        created_since: params.since,
+        limit: params.limit,
     }
 }

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -343,6 +343,11 @@ pub trait TaskReservationStoreBackend: Send + Sync {
 pub trait JobRunStoreBackend: Send + Sync {
     fn list_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn list_job_runs_filtered(&self, query: &JobRunQuery) -> Result<Vec<JobRun>, OrbitError>;
+    /// Number of runs matching `query`, ignoring its `limit`.
+    fn count_job_runs_filtered(&self, query: &JobRunQuery) -> Result<u64, OrbitError>;
+    /// Every recorded `duration_ms` among runs matching `query`, ignoring
+    /// its `limit`.
+    fn list_job_run_durations_filtered(&self, query: &JobRunQuery) -> Result<Vec<u64>, OrbitError>;
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError>;
     fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError>;
     fn insert_job_run(

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
@@ -83,6 +84,16 @@ impl JobRunStoreBackend for SqliteJobRunStore {
     fn list_job_runs_filtered(&self, query: &JobRunQuery) -> Result<Vec<JobRun>, OrbitError> {
         self.store
             .list_job_runs_for_workspace(&self.workspace_id, query)
+    }
+
+    fn count_job_runs_filtered(&self, query: &JobRunQuery) -> Result<u64, OrbitError> {
+        self.store
+            .count_job_runs_for_workspace(&self.workspace_id, query)
+    }
+
+    fn list_job_run_durations_filtered(&self, query: &JobRunQuery) -> Result<Vec<u64>, OrbitError> {
+        self.store
+            .list_job_run_durations_for_workspace(&self.workspace_id, query)
     }
 
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
@@ -425,32 +436,12 @@ impl Store {
         workspace_id: &str,
         query: &JobRunQuery,
     ) -> Result<Vec<JobRun>, OrbitError> {
-        let mut conditions = vec!["workspace_id = ?1".to_string()];
-        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
-            vec![Box::new(workspace_id.to_string())];
-        if let Some(job_id) = &query.job_id {
-            conditions.push(format!("job_id = ?{}", params.len() + 1));
-            params.push(Box::new(job_id.clone()));
-        }
-        if let Some(state) = query.state {
-            conditions.push(format!("state = ?{}", params.len() + 1));
-            params.push(Box::new(state.to_string()));
-        }
-        if query.terminal_only {
-            conditions.push(
-                "state IN ('success', 'failed', 'timeout', 'cancelled', 'interrupted')".to_string(),
-            );
-        }
-        if let Some(created_since) = query.created_since {
-            conditions.push(format!("created_at >= ?{}", params.len() + 1));
-            params.push(Box::new(created_since.to_rfc3339()));
-        }
+        let (where_clause, mut params) = job_run_filter_sql(workspace_id, query);
         let mut sql = format!(
             "SELECT run_id, job_id, attempt, state, scheduled_at, started_at, finished_at, \
              duration_ms, created_at, pid, pid_start_time, input_json, retry_source_run_id, \
              knowledge_metrics_json, resolved_crew, COALESCE(crew_model, implementer_model) \
-             FROM job_runs WHERE {} ORDER BY created_at DESC, run_id ASC",
-            conditions.join(" AND ")
+             FROM job_runs WHERE {where_clause} ORDER BY created_at DESC, run_id ASC"
         );
         if let Some(limit) = query.limit {
             sql.push_str(&format!(" LIMIT ?{}", params.len() + 1));
@@ -468,10 +459,62 @@ impl Store {
         let mut runs = rows
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| OrbitError::Store(e.to_string()))?;
+        drop(stmt);
+        let run_ids = runs
+            .iter()
+            .map(|run| run.run_id.clone())
+            .collect::<Vec<_>>();
+        let mut steps_by_run = read_steps_for_runs(&conn, workspace_id, &run_ids)?;
         for run in &mut runs {
-            run.steps = read_steps(&conn, workspace_id, &run.run_id)?;
+            run.steps = steps_by_run.remove(&run.run_id).unwrap_or_default();
         }
         Ok(runs)
+    }
+
+    /// `COUNT(*)` over the same filter `list_job_runs_for_workspace` applies,
+    /// ignoring `limit`: a tile that only needs a number must not hydrate
+    /// (and silently cap at) a page of rows to get it.
+    pub fn count_job_runs_for_workspace(
+        &self,
+        workspace_id: &str,
+        query: &JobRunQuery,
+    ) -> Result<u64, OrbitError> {
+        let (where_clause, params) = job_run_filter_sql(workspace_id, query);
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|b| b.as_ref()).collect();
+        let conn = self.read()?;
+        conn.query_row(
+            &format!("SELECT COUNT(*) FROM job_runs WHERE {where_clause}"),
+            param_refs.as_slice(),
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|count| count.max(0) as u64)
+        .map_err(|e| OrbitError::Store(e.to_string()))
+    }
+
+    /// Every recorded `duration_ms` matching the filter, ignoring `limit`.
+    /// Feeds percentile baselines without materializing whole runs.
+    pub fn list_job_run_durations_for_workspace(
+        &self,
+        workspace_id: &str,
+        query: &JobRunQuery,
+    ) -> Result<Vec<u64>, OrbitError> {
+        let (where_clause, params) = job_run_filter_sql(workspace_id, query);
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|b| b.as_ref()).collect();
+        let conn = self.read()?;
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT duration_ms FROM job_runs \
+                 WHERE {where_clause} AND duration_ms IS NOT NULL"
+            ))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| row.get::<_, i64>(0))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        rows.map(|row| row.map(|value| value.max(0) as u64))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| OrbitError::Store(e.to_string()))
     }
 
     pub fn read_job_run_state_for_workspace(
@@ -654,6 +697,81 @@ fn row_to_job_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<JobRun> {
     })
 }
 
+/// `WHERE` clause and bound parameters for a [`JobRunQuery`] on `job_runs`,
+/// shared by the list, count, and duration reads so the three cannot drift.
+fn job_run_filter_sql(
+    workspace_id: &str,
+    query: &JobRunQuery,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut conditions = vec!["workspace_id = ?1".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(workspace_id.to_string())];
+    if let Some(job_id) = &query.job_id {
+        conditions.push(format!("job_id = ?{}", params.len() + 1));
+        params.push(Box::new(job_id.clone()));
+    }
+    if let Some(state) = query.state {
+        conditions.push(format!("state = ?{}", params.len() + 1));
+        params.push(Box::new(state.to_string()));
+    }
+    if query.terminal_only {
+        conditions.push(
+            "state IN ('success', 'failed', 'timeout', 'cancelled', 'interrupted')".to_string(),
+        );
+    }
+    if let Some(created_since) = query.created_since {
+        conditions.push(format!("created_at >= ?{}", params.len() + 1));
+        params.push(Box::new(created_since.to_rfc3339()));
+    }
+    (conditions.join(" AND "), params)
+}
+
+/// Run ids per `IN (...)` list, under SQLite's bound-parameter cap.
+const STEP_RUN_ID_CHUNK: usize = 500;
+
+/// Steps for a page of runs in one query per chunk instead of one per run.
+fn read_steps_for_runs(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    run_ids: &[String],
+) -> Result<HashMap<String, Vec<JobRunStep>>, OrbitError> {
+    let mut grouped: HashMap<String, Vec<JobRunStep>> = HashMap::new();
+    for chunk in run_ids.chunks(STEP_RUN_ID_CHUNK) {
+        let placeholders = (0..chunk.len())
+            .map(|index| format!("?{}", index + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT run_id, step_index, target_type, target_id, state, started_at, \
+                 finished_at, duration_ms, exit_code, error_code, error_message, \
+                 agent_response_json FROM job_run_steps \
+                 WHERE workspace_id = ?1 AND run_id IN ({placeholders}) \
+                 ORDER BY run_id ASC, step_index ASC"
+            ))
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
+            vec![Box::new(workspace_id.to_string())];
+        params.extend(
+            chunk
+                .iter()
+                .map(|run_id| Box::new(run_id.clone()) as Box<dyn rusqlite::types::ToSql>),
+        );
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let run_id: String = row.get(0)?;
+                Ok((run_id, row_to_job_run_step_at(row, 1)?))
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+        for row in rows {
+            let (run_id, step) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+            grouped.entry(run_id).or_default().push(step);
+        }
+    }
+    Ok(grouped)
+}
+
 fn read_steps(
     conn: &rusqlite::Connection,
     workspace_id: &str,
@@ -674,24 +792,30 @@ fn read_steps(
 }
 
 fn row_to_job_run_step(row: &rusqlite::Row<'_>) -> rusqlite::Result<JobRunStep> {
-    let step_index: i64 = row.get(0)?;
-    let target_type_raw: String = row.get(1)?;
-    let state_raw: String = row.get(3)?;
-    let started_raw: Option<String> = row.get(4)?;
-    let finished_raw: Option<String> = row.get(5)?;
-    let duration_ms: Option<i64> = row.get(6)?;
-    let agent_response_json: Option<String> = row.get(10)?;
+    row_to_job_run_step_at(row, 0)
+}
+
+/// Decode a step whose columns start at `offset` (0 for the per-run read,
+/// 1 when a leading `run_id` column is selected alongside).
+fn row_to_job_run_step_at(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<JobRunStep> {
+    let step_index: i64 = row.get(offset)?;
+    let target_type_raw: String = row.get(offset + 1)?;
+    let state_raw: String = row.get(offset + 3)?;
+    let started_raw: Option<String> = row.get(offset + 4)?;
+    let finished_raw: Option<String> = row.get(offset + 5)?;
+    let duration_ms: Option<i64> = row.get(offset + 6)?;
+    let agent_response_json: Option<String> = row.get(offset + 10)?;
     Ok(JobRunStep {
         step_index: step_index as u32,
         target_type: parse_job_target_type(&target_type_raw)?,
-        target_id: row.get(2)?,
+        target_id: row.get(offset + 2)?,
         state: parse_job_run_state(&state_raw)?,
         started_at: parse_optional_timestamp(started_raw)?,
         finished_at: parse_optional_timestamp(finished_raw)?,
         duration_ms: duration_ms.map(|value| value as u64),
-        exit_code: row.get(7)?,
-        error_code: row.get(8)?,
-        error_message: row.get(9)?,
+        exit_code: row.get(offset + 7)?,
+        error_code: row.get(offset + 8)?,
+        error_message: row.get(offset + 9)?,
         agent_response_json: parse_optional_json(agent_response_json, "agent_response_json")?,
     })
 }

--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -143,12 +143,21 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "audit_actor_alias_v2",
         apply: super::apply_audit_actor_alias_v2,
     },
+    // The run listing orders by `created_at DESC, run_id` per workspace; the
+    // existing indexes cover `(workspace_id, job_id, scheduled_at)` and
+    // `(workspace_id, state)`, so every dashboard page scanned and sorted a
+    // workspace's whole run history.
+    Migration {
+        version: 19,
+        name: "job_runs_created_index",
+        apply: super::apply_job_runs_created_index,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 18;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 19;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/driver/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/mod.rs
@@ -1260,6 +1260,19 @@ fn apply_audit_actor_alias_v2(conn: &Connection) -> Result<(), OrbitError> {
     backfill_audit_actor_identity(conn)
 }
 
+/// v19 `job_runs_created_index`: cover the listing's per-workspace
+/// `ORDER BY created_at DESC, run_id ASC` so a bounded page stops scanning
+/// and sorting the whole workspace history.
+fn apply_job_runs_created_index(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        r#"
+            CREATE INDEX IF NOT EXISTS idx_job_runs_workspace_created
+            ON job_runs(workspace_id, created_at DESC, run_id ASC);
+        "#,
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))
+}
+
 /// Derive the actor columns for every row whose stamped alias version is not
 /// the current one.
 ///

--- a/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
@@ -76,6 +76,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[17].version, 18);
     assert_eq!(applied[17].name, "audit_actor_alias_v2");
     assert!(!applied[17].applied_at.is_empty());
+    assert_eq!(applied[18].version, 19);
+    assert_eq!(applied[18].name, "job_runs_created_index");
+    assert!(!applied[18].applied_at.is_empty());
 }
 
 #[test]
@@ -248,6 +251,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0018".to_string(),
                 "audit_actor_alias_v2".to_string()
             ),
+            (
+                "migration.v0019".to_string(),
+                "job_runs_created_index".to_string()
+            ),
         ]
     );
 }
@@ -259,7 +266,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-        VALUES ('migration.v0019', 'from-the-future', '2099-01-01T00:00:00Z')",
+        VALUES ('migration.v0020', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -339,7 +346,7 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_through_latest() {
     );
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("audit_actor_alias_v2")
+        Some("job_runs_created_index")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -1,0 +1,144 @@
+use chrono::{DateTime, TimeZone, Utc};
+use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType};
+
+use crate::Store;
+use crate::contracts::JobRunQuery;
+
+fn at(minute: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 1, 0, minute, 0)
+        .single()
+        .expect("valid timestamp")
+}
+
+fn run_with_steps(run_id: &str, state: JobRunState, created: DateTime<Utc>, steps: u32) -> JobRun {
+    JobRun {
+        run_id: run_id.to_string(),
+        job_id: "task_pr_pipeline".to_string(),
+        attempt: 1,
+        state,
+        scheduled_at: created,
+        started_at: Some(created),
+        finished_at: state.is_terminal().then_some(created),
+        duration_ms: state.is_terminal().then_some(u64::from(steps) * 100),
+        created_at: created,
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: (0..steps)
+            .map(|index| JobRunStep {
+                step_index: index,
+                target_type: JobTargetType::Activity,
+                target_id: format!("step-{index}"),
+                state,
+                started_at: Some(created),
+                finished_at: Some(created),
+                duration_ms: Some(100),
+                exit_code: Some(0),
+                error_code: None,
+                error_message: None,
+                agent_response_json: None,
+            })
+            .collect(),
+    }
+}
+
+/// Steps come back for every run on a page whatever its size: the page is
+/// hydrated with one query per id chunk, not one per run, so a long history
+/// must not lose or cross-wire any run's steps.
+#[test]
+fn listing_hydrates_every_runs_steps_across_id_chunks() {
+    let store = Store::open_in_memory().expect("open store");
+    let total = 1_100_u32;
+    for index in 0..total {
+        let run = run_with_steps(
+            &format!("jrun-{index:05}"),
+            JobRunState::Success,
+            at(index % 60),
+            index % 4,
+        );
+        store
+            .upsert_job_run_for_workspace("ws", &run, None)
+            .expect("insert run");
+    }
+
+    let runs = store
+        .list_job_runs_for_workspace("ws", &JobRunQuery::default())
+        .expect("list runs");
+    assert_eq!(runs.len(), total as usize);
+    for run in &runs {
+        let index: u32 = run.run_id["jrun-".len()..].parse().expect("fixture id");
+        assert_eq!(run.steps.len(), (index % 4) as usize, "{}", run.run_id);
+        for (position, step) in run.steps.iter().enumerate() {
+            assert_eq!(step.step_index, position as u32, "{}", run.run_id);
+            assert_eq!(step.target_id, format!("step-{position}"), "{}", run.run_id);
+        }
+    }
+}
+
+/// Counting and duration reads apply the list filter but ignore its limit.
+#[test]
+fn count_and_durations_ignore_the_page_limit() {
+    let store = Store::open_in_memory().expect("open store");
+    for index in 0..30_u32 {
+        let state = if index % 3 == 0 {
+            JobRunState::Failed
+        } else if index % 3 == 1 {
+            JobRunState::Success
+        } else {
+            JobRunState::Running
+        };
+        let run = run_with_steps(&format!("jrun-{index:03}"), state, at(index), 1 + index % 2);
+        store
+            .upsert_job_run_for_workspace("ws", &run, None)
+            .expect("insert run");
+    }
+    // Another workspace's rows must not leak into the count.
+    let other = run_with_steps("jrun-other", JobRunState::Failed, at(5), 1);
+    store
+        .upsert_job_run_for_workspace("other-ws", &other, None)
+        .expect("insert other run");
+
+    let failed = JobRunQuery {
+        state: Some(JobRunState::Failed),
+        limit: Some(2),
+        ..JobRunQuery::default()
+    };
+    assert_eq!(
+        store
+            .list_job_runs_for_workspace("ws", &failed)
+            .expect("page")
+            .len(),
+        2
+    );
+    assert_eq!(
+        store
+            .count_job_runs_for_workspace("ws", &failed)
+            .expect("count"),
+        10
+    );
+
+    let terminal_since = JobRunQuery {
+        terminal_only: true,
+        created_since: Some(at(15)),
+        limit: Some(1),
+        ..JobRunQuery::default()
+    };
+    let mut durations = store
+        .list_job_run_durations_for_workspace("ws", &terminal_since)
+        .expect("durations");
+    durations.sort_unstable();
+    // Terminal runs created at minute >= 15: indexes 15..30 with index % 3 != 2
+    // → 10 runs; durations are 100 * (1 + index % 2).
+    assert_eq!(durations.len(), 10);
+    assert!(durations.iter().all(|d| *d == 100 || *d == 200));
+    assert_eq!(
+        store
+            .count_job_runs_for_workspace("ws", &terminal_since)
+            .expect("count"),
+        10
+    );
+}

--- a/crates/orbit-store/src/driver/sqlite/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/mod.rs
@@ -1,4 +1,5 @@
 mod connection;
 mod invocation_store;
+mod job_run_store;
 mod read_pool;
 mod reliability_store;

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -608,22 +608,21 @@ fn count_failed_runs(
     runtime: &OrbitRuntime,
     since: DateTime<Utc>,
 ) -> Result<i64, orbit_core::OrbitError> {
-    let mut total: i64 = 0;
+    let mut total: u64 = 0;
     for state in [
         JobRunState::Failed,
         JobRunState::Timeout,
         JobRunState::Interrupted,
     ] {
-        let runs = runtime.list_job_runs(JobRunListParams {
+        total += runtime.count_job_runs(JobRunListParams {
             job_id: None,
             state: Some(state),
             terminal_only: false,
             since: Some(since),
-            limit: Some(HISTORY_MAX_LIMIT),
+            limit: None,
         })?;
-        total += runs.len() as i64;
     }
-    Ok(total)
+    Ok(i64::try_from(total).unwrap_or(i64::MAX))
 }
 
 /// Counts running runs whose start time is older than the 95th percentile of
@@ -635,27 +634,20 @@ fn count_active_long_runs(
     runtime: &OrbitRuntime,
     since: DateTime<Utc>,
 ) -> Result<i64, orbit_core::OrbitError> {
-    let mut finished_durations: Vec<i64> = Vec::new();
-    for state in [
-        JobRunState::Success,
-        JobRunState::Failed,
-        JobRunState::Timeout,
-        JobRunState::Cancelled,
-        JobRunState::Interrupted,
-    ] {
-        let runs = runtime.list_job_runs(JobRunListParams {
+    // Every finished run in the window, as durations only: the baseline is
+    // a percentile, so a capped page of hydrated rows would both drift low
+    // and cost the step reads it never looks at.
+    let mut finished_durations: Vec<i64> = runtime
+        .list_job_run_durations(JobRunListParams {
             job_id: None,
-            state: Some(state),
-            terminal_only: false,
+            state: None,
+            terminal_only: true,
             since: Some(since),
-            limit: Some(HISTORY_MAX_LIMIT),
-        })?;
-        for r in runs {
-            if let Some(d) = r.duration_ms {
-                finished_durations.push(d as i64);
-            }
-        }
-    }
+            limit: None,
+        })?
+        .into_iter()
+        .map(|d| i64::try_from(d).unwrap_or(i64::MAX))
+        .collect();
 
     if finished_durations.is_empty() {
         return Ok(0);
@@ -670,7 +662,7 @@ fn count_active_long_runs(
         state: Some(JobRunState::Running),
         terminal_only: false,
         since: None,
-        limit: Some(HISTORY_MAX_LIMIT),
+        limit: None,
     })?;
 
     let now = Utc::now();

--- a/crates/orbit-web/src/api/denials.rs
+++ b/crates/orbit-web/src/api/denials.rs
@@ -13,7 +13,7 @@ use orbit_types::workflow::activity_job::{
 };
 use serde_json::{Value, json};
 
-use super::{DEFAULT_SUMMARY_WINDOW, DenialsQuery, bad_request, map_runtime_error, server_error};
+use super::{DEFAULT_SUMMARY_WINDOW, DenialsQuery, bad_request, map_runtime_error};
 use crate::parse::parse_since;
 
 const SQLITE_DENIAL_SCAN_LIMIT: usize = 1000;
@@ -518,12 +518,29 @@ pub(super) async fn list_denials(Ws(runtime): Ws, Query(q): Query<DenialsQuery>)
         .profile
         .as_deref()
         .map(str::trim)
-        .filter(|s| !s.is_empty());
-    let agent_filter = q.agent.as_deref().map(str::trim).filter(|s| !s.is_empty());
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let agent_filter = q
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
 
-    let rows = match collect_denial_rows(&runtime, since, profile_filter, agent_filter) {
+    // One SQLite scan per denial event type plus a v2 loop scan: blocking
+    // pool, not the worker serving the request (see `blocking`).
+    let rows = match super::blocking("denials listing", move || {
+        collect_denial_rows(
+            &runtime,
+            since,
+            profile_filter.as_deref(),
+            agent_filter.as_deref(),
+        )
+    })
+    .await
+    {
         Ok(rows) => rows,
-        Err(e) => return server_error(e),
+        Err(response) => return *response,
     };
 
     Json(denials_payload(&rows, kind.as_deref(), since)).into_response()

--- a/crates/orbit-web/src/api/diagnostics.rs
+++ b/crates/orbit-web/src/api/diagnostics.rs
@@ -303,9 +303,15 @@ pub(super) async fn list_diagnostics_errors(
     Query(q): Query<DiagnosticsQuery>,
 ) -> Response {
     let limit = bounded_limit(q.limit, HISTORY_DEFAULT_LIMIT);
-    match diagnostics_errors(&runtime, limit) {
+    // Reads up to 50k audit rows and a blob per agent invocation: blocking
+    // pool, not the worker serving the request (see `blocking`).
+    match super::blocking("diagnostics errors", move || {
+        diagnostics_errors(&runtime, limit)
+    })
+    .await
+    {
         Ok(rows) => Json(Value::Array(rows)).into_response(),
-        Err(e) => map_runtime_error(e),
+        Err(response) => *response,
     }
 }
 

--- a/crates/orbit-web/src/api/tests/audit.rs
+++ b/crates/orbit-web/src/api/tests/audit.rs
@@ -12,8 +12,10 @@ use orbit_types::tool::{McpCapability, McpTransport};
 use serde_json::Value;
 use tower::ServiceExt;
 
+use orbit_types::workflow::JobRunState;
+
 use super::super::{HISTORY_MAX_LIMIT, router};
-use super::test_support::body_json;
+use super::test_support::{body_json, seed_run};
 
 fn seed_audit_event(
     runtime: &OrbitRuntime,
@@ -696,4 +698,35 @@ async fn audit_summary_separates_reliability_from_negative_and_diagnostic_popula
     assert_eq!(unexpected.len(), 1);
     assert_eq!(unexpected[0]["tool"], "orbit.search");
     assert_eq!(unexpected[0]["count"], 1);
+}
+
+/// The header tiles count runs with `COUNT(*)`, so a bad day does not read
+/// as exactly `HISTORY_MAX_LIMIT` failures once the real number passes it.
+#[tokio::test]
+async fn summary_failed_runs_counts_past_the_history_page_size() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let total = HISTORY_MAX_LIMIT + 50;
+    for index in 0..total {
+        seed_run(
+            &runtime,
+            &format!("jrun-failed-{index:04}"),
+            "task_pr_pipeline",
+            JobRunState::Failed,
+        );
+    }
+    seed_run(
+        &runtime,
+        "jrun-timeout",
+        "task_pr_pipeline",
+        JobRunState::Timeout,
+    );
+    seed_run(
+        &runtime,
+        "jrun-success",
+        "task_pr_pipeline",
+        JobRunState::Success,
+    );
+
+    let body = body_json(request_audit(runtime, "/audit/summary?since=24h").await).await;
+    assert_eq!(body["failed_runs"].as_u64(), Some((total + 1) as u64));
 }

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -55,7 +55,7 @@ $ orbit migrate --dry-run
 Pending migrations:
   layout v1 (baseline) — adopt the versioned .orbit/ layout (records the current shape; changes nothing)
   layout v2 (archive-friction-tasks) — rewrite removed friction statuses as archived
-  schema v1 (baseline) through schema v18 (audit_actor_alias_v2)
+  schema v1 (baseline) through schema v19 (job_runs_created_index)
 error: execution failed: 2 migration(s) pending; run `orbit migrate --confirm` to apply
 ```
 


### PR DESCRIPTION
## Summary

Dashboard and store performance/correctness items from the `orbit-web` and `orbit-store` audits.

- **Header tiles saturated at 200.** `count_failed_runs` summed the lengths of three `list_job_runs` pages capped at `HISTORY_MAX_LIMIT`, so once real failures passed 200 the tile stopped moving, and `count_active_long_runs` computed its p95 baseline from the same truncated, fully-hydrated pages. `JobRunStoreBackend` gains `count_job_runs_filtered` and `list_job_run_durations_filtered`, both built on the same `WHERE` builder as the listing so the three cannot drift; `OrbitRuntime::count_job_runs` / `list_job_run_durations` expose them, and the tiles call them with no limit.
- **N+1 step reads on every run listing.** `list_job_runs_for_workspace` ran one `job_run_steps` query per run. A page now hydrates its steps with one query per 500-id chunk.
- **Missing listing index.** The listing orders by `created_at DESC, run_id ASC` per workspace, but the only indexes were `(workspace_id, job_id, scheduled_at)` and `(workspace_id, state)`. Migration v19 `job_runs_created_index` adds `(workspace_id, created_at DESC, run_id ASC)`.
- **Blocking I/O on async workers.** `/api/diagnostics/errors` (up to 50k audit rows and a blob read per invocation) and `/api/denials` (one SQLite scan per denial event type) ran inline on the tokio worker, the F2026-07-119 shape the `blocking` helper exists to prevent. Both handlers now run their read on the blocking pool.

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-store -p orbit-web -p orbit-cmd` pass. New tests: `listing_hydrates_every_runs_steps_across_id_chunks` (1,100 runs), `count_and_durations_ignore_the_page_limit`, `summary_failed_runs_counts_past_the_history_page_size` (251 failed runs → 251).
- `cargo test -p orbit-core`: `sandbox_nested` needs the `orbit` binary rebuilt for schema v19 (passes after `cargo build -p orbit-cli`); `workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running` asserts a thread-dependent dispatch order and is flaky independent of this change (fix follows in its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
