### PR TITLE
fix(test): stop the workspace-auto throughput test asserting a thread order

### DIFF
--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -277,14 +277,25 @@ fn workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running() {
         .iter()
         .map(|input| input["run_input"]["task_ids"].clone())
         .collect();
+    // The first iteration fills its two slots from parallel threads, so the
+    // order in which `ORB-FIRST` and `ORB-SECOND` reach the host is whichever
+    // thread wins; only the iteration boundary is a real ordering claim.
     assert_eq!(
-        dispatched,
-        vec![
-            json!(["ORB-FIRST"]),
-            json!(["ORB-SECOND"]),
-            json!(["ORB-LATER"]),
-        ],
-        "one child per leaf, and the second iteration dispatched without waiting"
+        dispatched.len(),
+        3,
+        "one child per leaf, and the second iteration dispatched without waiting: {dispatched:?}"
+    );
+    let mut first_iteration = dispatched[..2].to_vec();
+    first_iteration.sort_by_key(Value::to_string);
+    assert_eq!(
+        first_iteration,
+        vec![json!(["ORB-FIRST"]), json!(["ORB-SECOND"])],
+        "first iteration dispatched both leaves: {dispatched:?}"
+    );
+    assert_eq!(
+        dispatched[2],
+        json!(["ORB-LATER"]),
+        "second iteration dispatched while the first two children were still running"
     );
 
     // Detached, but not lost: every child is durably linked to the parent as


### PR DESCRIPTION
## Summary

`workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running` failed twice in loaded runs this session with `[ORB-SECOND, ORB-FIRST, ORB-LATER]` vs the expected `[ORB-FIRST, ORB-SECOND, ORB-LATER]`. The first drain iteration fills its two leaf slots from parallel threads, so the order in which the two leaves reach the scripted host is whichever thread wins. The property the test exists for is the iteration boundary: both leaves dispatched in iteration one, and `ORB-LATER` in iteration two without waiting on them. The assertion now compares the first iteration as a set and keeps only that boundary as an ordering claim.

## Verification

- Passes 5/5 in isolation and with the rest of `workspace_auto_pipeline`; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)