### PR TITLE
fix: only clean a worktree this repo registered, and report an auto-task fire whose cursor write failed

### DIFF
--- a/crates/orbit-core/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/scheduler.rs
@@ -35,7 +35,8 @@ pub struct AutoTaskFireReport {
     pub name: String,
     /// One of: `fired`, `would_fire`, `baselined`, `would_baseline`, `skipped`.
     pub action: &'static str,
-    /// Why, for `skipped` rows.
+    /// Why, for `skipped` rows; for `fired` rows, only when the cursor
+    /// checkpoint after minting failed.
     pub reason: Option<String>,
     /// Scheduled slot consumed (RFC 3339, UTC), when a fire was involved.
     pub slot: Option<String>,
@@ -155,7 +156,12 @@ fn fire_definition(
             }
 
             let task = mint_task(runtime, definition)?;
-            upsert_cursor(
+            // The task exists from here on. A cursor that cannot be written
+            // must not turn this into a `skipped` row: the operator would
+            // see no fire while the backlog gained a task, and every later
+            // pass would mint another for the same slot. Report the fire
+            // with the task id and say the checkpoint is missing.
+            let reason = upsert_cursor(
                 state_path,
                 &definition.name,
                 AutoTaskCursor {
@@ -164,11 +170,15 @@ fn fire_definition(
                     last_fired_at: Some(now.to_rfc3339()),
                     last_task_id: Some(task.id.clone()),
                 },
-            )?;
+            )
+            .err()
+            .map(|error| {
+                format!("cursor not advanced; the next pass may fire this slot again: {error}")
+            });
             Ok(AutoTaskFireReport {
                 name: definition.name.clone(),
                 action: "fired",
-                reason: None,
+                reason,
                 slot: Some(slot),
                 task_id: Some(task.id),
             })

--- a/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/auto_tasks/tests/scheduler.rs
@@ -8,6 +8,7 @@ use tempfile::tempdir;
 
 use crate::OrbitRuntime;
 use crate::application::task::TaskUpdateParams;
+use crate::auto_tasks::cursor_state_path;
 use crate::auto_tasks::scheduler::{SchedulerOptions, run_auto_task_scheduler_at};
 
 use super::interval_params;
@@ -73,6 +74,50 @@ fn fires_and_stamps_provenance() {
     assert_eq!(
         task.required_tools,
         vec!["github.auth.status", "github.run.list"]
+    );
+}
+
+/// The task is minted before the cursor is advanced. When that checkpoint
+/// cannot be written the pass must still report the fire and the task it
+/// created, not a `skipped` row that hides a task the backlog now carries.
+#[cfg(unix)]
+#[test]
+fn cursor_write_failure_after_minting_is_reported_as_a_fire() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let runtime = runtime();
+    runtime
+        .auto_task_add(interval_params("chore", 60))
+        .expect("add");
+    let t0 = at(2026, 1, 1, 0, 0);
+    fire(&runtime, t0); // baseline writes the cursor file
+
+    let state_path = cursor_state_path(&runtime.paths().state_dir);
+    let writable = std::fs::metadata(&state_path)
+        .expect("state file")
+        .permissions();
+    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o444))
+        .expect("make cursor file read-only");
+
+    let outcome = run_auto_task_scheduler_at(
+        &runtime,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("scheduler pass");
+    std::fs::set_permissions(&state_path, writable).expect("restore permissions");
+
+    assert_eq!(outcome.reports.len(), 1);
+    let report = &outcome.reports[0];
+    assert_eq!(report.action, "fired", "{report:?}");
+    let task_id = report.task_id.clone().expect("minted task id");
+    assert!(runtime.get_task(&task_id).is_ok());
+    assert!(
+        report
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("cursor not advanced")),
+        "{report:?}"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
@@ -14,7 +14,7 @@ use crate::context::RuntimeHost;
 
 use super::super::git::git_success;
 use super::cleanup::remove_worktree;
-use super::{WorktreeIdentity, resolve_shared_worktree_path};
+use super::{WorktreeIdentity, is_registered_worktree, resolve_shared_worktree_path};
 
 /// Task statuses that settle the work as done — the only statuses that
 /// license discarding a run's worktree and branch. Every other status
@@ -353,24 +353,6 @@ fn branch_name(worktree: &Path) -> Result<String, OrbitError> {
 /// The literal comparison is kept as the fast path, and a registered entry
 /// whose directory has already been removed simply fails to canonicalize and
 /// does not match, which is the same answer the literal comparison gave.
-fn is_registered_worktree(repo_root: &Path, path: &Path) -> Result<bool, OrbitError> {
-    let list = git_output(repo_root, &["worktree", "list", "--porcelain"])?;
-    let expected_literal = path.to_string_lossy();
-    let expected_canonical = fs::canonicalize(path).ok();
-    Ok(list
-        .lines()
-        .filter_map(|line| line.strip_prefix("worktree "))
-        .any(|registered| {
-            if registered == expected_literal {
-                return true;
-            }
-            match (&expected_canonical, fs::canonicalize(registered).ok()) {
-                (Some(expected), Some(registered)) => *expected == registered,
-                _ => false,
-            }
-        }))
-}
-
 fn branch_exists(repo_root: &Path, branch: &str) -> bool {
     Command::new("git")
         .current_dir(repo_root)

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/mod.rs
@@ -12,6 +12,30 @@ use sha2::{Digest, Sha256};
 
 use crate::executor::automation::input::{input_string_field, required_input_string};
 
+use super::git::git_output;
+
+/// Whether `path` is one of `repo_root`'s registered worktrees (main or
+/// linked), comparing both the literal path Git recorded and its canonical
+/// form. Any other checkout that happens to live at `path` is not ours to
+/// clean or remove.
+pub(super) fn is_registered_worktree(repo_root: &Path, path: &Path) -> Result<bool, OrbitError> {
+    let list = git_output(repo_root, &["worktree", "list", "--porcelain"])?;
+    let expected_literal = path.to_string_lossy();
+    let expected_canonical = std::fs::canonicalize(path).ok();
+    Ok(list
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .any(|registered| {
+            if registered == expected_literal {
+                return true;
+            }
+            match (&expected_canonical, std::fs::canonicalize(registered).ok()) {
+                (Some(expected), Some(registered)) => *expected == registered,
+                _ => false,
+            }
+        }))
+}
+
 pub use gc::{WorktreeGcOptions, WorktreeGcResult, collect_worktrees};
 pub(in crate::executor::automation) use merge::merge_batch_worktree_into_base;
 pub(in crate::executor::automation) use setup::setup_worktree;

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -11,11 +11,11 @@ use super::super::git::{
     base_sync_mode_from_input, git_command_success, git_output, git_success,
     resolve_worktree_start_point,
 };
-use super::WorktreeIdentity;
 use super::dependency_delivery::{
     DependencyDeliveryMode, dependency_delivery_mode_from_input,
     ensure_dependencies_delivered_into_base,
 };
+use super::{WorktreeIdentity, is_registered_worktree};
 
 const DEFAULT_BASE: &str = "main";
 
@@ -151,7 +151,12 @@ pub(crate) fn ensure_worktree(
     )?;
 
     if worktree_path.exists() {
-        if git_command_success(worktree_path, &["rev-parse", "--is-inside-work-tree"])? {
+        // Only a worktree this repository registered is ours to reuse and
+        // clean. "Is some git work tree" would also match an unrelated
+        // checkout that happens to sit at the resolved path (a shared
+        // `ORBIT_WORKTREE_ROOT`, a colliding name), and `clean -fd` there
+        // deletes someone else's untracked files.
+        if is_registered_worktree(repo_root, worktree_path)? {
             let attached_branch = git_output(
                 worktree_path,
                 &["symbolic-ref", "--quiet", "--short", "HEAD"],
@@ -169,7 +174,7 @@ pub(crate) fn ensure_worktree(
             })?;
         } else {
             return Err(OrbitError::Execution(format!(
-                "worktree path '{}' exists but is not a Git worktree; move it aside or remove it before retrying",
+                "worktree path '{}' exists but is not a worktree of this repository; move it aside or remove it before retrying",
                 worktree_path.display()
             )));
         }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -33,6 +33,33 @@ fn ensure_worktree_reattaches_existing_checkout_without_resetting_its_branch() {
     assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), epic_commit);
 }
 
+/// A checkout that is a git work tree but not one this repository registered
+/// is refused and left untouched: `clean -fd` must never run on it.
+#[test]
+fn ensure_worktree_refuses_to_clean_a_foreign_checkout_at_the_resolved_path() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let worktree = temp.path().join("worktree");
+    init_repo(&repo, "agent-main");
+    let base = commit_file(&repo, "base.txt", "v1");
+    // Someone else's repository lives exactly where this run's worktree would.
+    init_repo(&worktree, "main");
+    commit_file(&worktree, "theirs.txt", "tracked");
+    fs::write(worktree.join("scratch.txt"), "untracked work").unwrap();
+
+    let error = ensure_worktree(&repo, &worktree, &base, "orbit/test").unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("not a worktree of this repository"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read_to_string(worktree.join("scratch.txt")).unwrap(),
+        "untracked work"
+    );
+}
+
 #[test]
 fn ensure_worktree_reuses_orphan_branch_from_failed_attempt() {
     let temp = tempdir().unwrap();


### PR DESCRIPTION
## Summary

Two safety items from the engine/core audit, each with a regression test.

- **`ensure_worktree` cleaned any git work tree at its path.** The reuse gate was `git rev-parse --is-inside-work-tree`, which is true for an unrelated repository that happens to sit at the resolved worktree path (a shared `ORBIT_WORKTREE_ROOT`, a colliding sanitized name), and `git clean -fd` then deleted that checkout's untracked files. Reuse now requires `is_registered_worktree(repo_root, path)`, the same check GC already applies before touching anything; the helper moved from `gc.rs` to the worktree module so setup and GC share one definition. A reattached worktree still keeps its own branch, as the existing test requires. Test: `ensure_worktree_refuses_to_clean_a_foreign_checkout_at_the_resolved_path`.
- **A cursor write failure after minting hid the minted task.** The scheduler mints the task, then advances the cursor; if `upsert_cursor` failed (state dir unwritable, lock failure) the error propagated and the pass reported `skipped` with no task id, while the task existed and the next pass re-decided the same slot. The fire is now reported as `fired` with the task id and a `reason` naming the missing checkpoint. Test: `cursor_write_failure_after_minting_is_reported_as_a_fire` (read-only cursor file).

## Verification

- `make ci-fast`, `make ci-lint` pass.
- `cargo test -p orbit-engine worktree` (61) and `cargo test -p orbit-core auto_tasks` (42) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)