### PR TITLE
fix(cli): make gc, docs, and sweep honor the global --format instead of printing prose under json

### DIFF
--- a/crates/orbit-cli/src/command/docs.rs
+++ b/crates/orbit-cli/src/command/docs.rs
@@ -6,7 +6,7 @@ use orbit_core::{DocType, OrbitError, OrbitRuntime};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::command::{CommandOut, CommandOutput, Execute, Payload};
+use crate::command::{Block, CommandOut, CommandOutput, Execute, Payload};
 
 #[derive(Args)]
 #[command(about = "List, show, and curate the indexed docs corpus")]
@@ -144,60 +144,57 @@ impl Execute for DocsListArgs {
 impl Execute for DocsShowArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let shown = runtime.show_doc(&self.path)?;
+        let doc = docs_document(&shown)?;
         if self.json {
-            {
-                print_json(&shown)?;
-                Ok(CommandOutput::Silent)
-            }
-        } else {
-            println!("Path: {}", shown.path);
-            println!("Type: {}", shown.frontmatter.doc_type);
-            println!("Summary: {}", shown.frontmatter.summary);
-            if !shown.frontmatter.tags.is_empty() {
-                println!("Tags: {}", shown.frontmatter.tags.join(", "));
-            }
-            if !shown.frontmatter.paths.is_empty() {
-                println!("Paths: {}", shown.frontmatter.paths.join(", "));
-            }
-            if !shown.frontmatter.related_features.is_empty() {
-                println!(
-                    "Related Features: {}",
-                    shown.frontmatter.related_features.join(", ")
-                );
-            }
-            if !shown.frontmatter.related_artifacts.is_empty() {
-                println!(
-                    "Related Artifacts: {}",
-                    shown
-                        .frontmatter
-                        .related_artifacts
-                        .iter()
-                        .map(|artifact| artifact.as_str().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-            }
-            println!("\n{}", shown.body);
-            Ok(CommandOutput::Silent)
+            return Ok(Payload::document(doc).into());
         }
+
+        let mut text = String::new();
+        text.push_str(&format!("Path: {}\n", shown.path));
+        text.push_str(&format!("Type: {}\n", shown.frontmatter.doc_type));
+        text.push_str(&format!("Summary: {}\n", shown.frontmatter.summary));
+        if !shown.frontmatter.tags.is_empty() {
+            text.push_str(&format!("Tags: {}\n", shown.frontmatter.tags.join(", ")));
+        }
+        if !shown.frontmatter.paths.is_empty() {
+            text.push_str(&format!("Paths: {}\n", shown.frontmatter.paths.join(", ")));
+        }
+        if !shown.frontmatter.related_features.is_empty() {
+            text.push_str(&format!(
+                "Related Features: {}\n",
+                shown.frontmatter.related_features.join(", ")
+            ));
+        }
+        if !shown.frontmatter.related_artifacts.is_empty() {
+            text.push_str(&format!(
+                "Related Artifacts: {}\n",
+                shown
+                    .frontmatter
+                    .related_artifacts
+                    .iter()
+                    .map(|artifact| artifact.as_str().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        text.push_str(&format!("\n{}", shown.body));
+        Ok(Payload::blocks(doc, vec![Block::text(text)]).into())
     }
 }
 
 impl Execute for DocsAddArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let outcome = runtime.add_docs_root(&self.path)?;
+        let doc = docs_document(&outcome)?;
         if self.json {
-            {
-                print_json(&outcome)?;
-                Ok(CommandOutput::Silent)
-            }
-        } else if outcome.added {
-            println!("Added docs root: {}", outcome.path);
-            Ok(CommandOutput::Silent)
-        } else {
-            println!("Docs root already registered: {}", outcome.path);
-            Ok(CommandOutput::Silent)
+            return Ok(Payload::document(doc).into());
         }
+        let line = if outcome.added {
+            format!("Added docs root: {}", outcome.path)
+        } else {
+            format!("Docs root already registered: {}", outcome.path)
+        };
+        Ok(Payload::blocks(doc, vec![Block::text(line)]).into())
     }
 }
 
@@ -245,32 +242,34 @@ fn print_docs_index_text(result: SemanticIndexResult) -> Result<(), OrbitError> 
 impl Execute for DocsMigrateArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let report = runtime.migrate_docs(!self.confirm)?;
+        let doc = docs_document(&report)?;
         if self.json {
-            {
-                print_json(&report)?;
-                Ok(CommandOutput::Silent)
-            }
-        } else if report.changed.is_empty() {
-            println!("No docs need migration.");
-            Ok(CommandOutput::Silent)
+            return Ok(Payload::document(doc).into());
+        }
+        let mut lines = Vec::new();
+        if report.changed.is_empty() {
+            lines.push("No docs need migration.".to_string());
         } else {
             for change in &report.changed {
-                println!("{}", change.diff);
+                lines.push(change.diff.clone());
             }
             if report.dry_run {
-                println!("{} doc(s) would be migrated.", report.changed.len());
+                lines.push(format!(
+                    "{} doc(s) would be migrated.",
+                    report.changed.len()
+                ));
             } else {
-                println!("Migrated {} doc(s).", report.changed.len());
+                lines.push(format!("Migrated {} doc(s).", report.changed.len()));
             }
-            Ok(CommandOutput::Silent)
         }
+        Ok(Payload::blocks(doc, vec![Block::text(lines.join("\n"))]).into())
     }
 }
 
-fn print_json<T: Serialize>(value: &T) -> Result<(), OrbitError> {
-    let value: Value = serde_json::to_value(value)
-        .map_err(|error| OrbitError::Execution(format!("serialize docs output: {error}")))?;
-    crate::output::json::print_pretty(&value)
+/// The `json`-mode document for a docs command result.
+fn docs_document<T: Serialize>(value: &T) -> Result<Value, OrbitError> {
+    serde_json::to_value(value)
+        .map_err(|error| OrbitError::Execution(format!("serialize docs output: {error}")))
 }
 
 /// The list's records, in the same shape `--json` has always emitted.

--- a/crates/orbit-cli/src/command/gc.rs
+++ b/crates/orbit-cli/src/command/gc.rs
@@ -3,7 +3,7 @@
 use clap::{Args, Subcommand};
 use orbit_core::{OrbitError, OrbitRuntime};
 
-use crate::command::{CommandOut, CommandOutput, Execute, Payload};
+use crate::command::{Block, CommandOut, Execute, Payload};
 
 #[derive(Args)]
 #[command(about = "Inspect and explicitly reap Orbit-managed garbage")]
@@ -60,23 +60,21 @@ pub struct WorktreeGcArgs {
 impl Execute for WorktreeGcArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         let result = runtime.gc_worktrees(self.confirm, self.run, self.older_than_hours)?;
+        let doc = serde_json::to_value(&result).map_err(|error| {
+            OrbitError::Execution(format!("failed to serialize worktree GC report: {error}"))
+        })?;
+        // `--json` keeps forcing the document even on a terminal; the global
+        // `--format` picks between the same document and the lines below.
         if self.json {
-            return Ok(
-                Payload::document(serde_json::to_value(result).map_err(|error| {
-                    OrbitError::Execution(format!(
-                        "failed to serialize worktree GC report: {error}"
-                    ))
-                })?)
-                .into(),
-            );
+            return Ok(Payload::document(doc).into());
         }
 
+        let mut lines = Vec::with_capacity(result.reports.len() + 1);
         if result.reports.is_empty() {
-            println!("No worktrees matched.");
-            return Ok(CommandOutput::Silent);
+            lines.push("No worktrees matched.".to_string());
         }
         for report in &result.reports {
-            println!(
+            lines.push(format!(
                 "path={} run_id={} run_state={} task_id={} task_status={} pr_status={} action={} bytes_reclaimed={}",
                 report.path.display(),
                 report.run_id.as_deref().unwrap_or("-"),
@@ -94,9 +92,11 @@ impl Execute for WorktreeGcArgs {
                 report.pr_status.as_deref().unwrap_or("-"),
                 report.action,
                 report.bytes_reclaimed
-            );
+            ));
         }
-        println!("total_bytes_reclaimed={}", result.bytes_reclaimed);
-        Ok(CommandOutput::Silent)
+        if !result.reports.is_empty() {
+            lines.push(format!("total_bytes_reclaimed={}", result.bytes_reclaimed));
+        }
+        Ok(Payload::blocks(doc, vec![Block::text(lines.join("\n"))]).into())
     }
 }

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -7,7 +7,7 @@
 //! errors — an unconfigured host logs one line and exits 0, because the OS
 //! clock will invoke it forever.
 
-use crate::command::{CommandOut, CommandOutput};
+use crate::command::{Block, CommandOut, Payload};
 use clap::Args;
 use orbit_cmd::registry_routines::run_sweep;
 use orbit_core::routines::{RoutineSweepReport, SweepOptions, SweepOutcome};
@@ -79,47 +79,13 @@ impl SweepCommand {
             dry_run: self.dry_run,
         })?;
 
+        let doc = outcome_json(&outcome, self.dry_run);
         if self.json {
-            crate::output::json::print_pretty(&outcome_json(&outcome, self.dry_run))?;
-            return Ok(CommandOutput::Silent);
+            return Ok(Payload::document(doc).into());
         }
 
-        if outcome.lock_busy {
-            println!("sweep: another pass holds the lock on this host; exiting");
-            return Ok(CommandOutput::Silent);
-        }
-        if outcome.reports.is_empty()
-            && outcome.load_errors.is_empty()
-            && outcome.registry.diagnostics.is_empty()
-        {
-            println!("sweep[{}]: no routines configured", outcome.host_id);
-            return Ok(CommandOutput::Silent);
-        }
-
-        // Quiet by default; a dry-run is interactive so it shows everything.
-        let show_all = self.verbose || self.dry_run;
-        let mut shown = 0usize;
-        for report in &outcome.reports {
-            if show_all
-                || report_is_noteworthy(report.action)
-                || !report.validation.diagnostics.is_empty()
-            {
-                println!("{}", format_report_line(report));
-                shown += 1;
-            }
-        }
-        if outcome.reports.is_empty() {
-            for diagnostic in &outcome.registry.diagnostics {
-                println!(
-                    "sweep[{}]: {}[{}]: {}",
-                    outcome.host_id,
-                    severity_label(diagnostic.severity),
-                    diagnostic.code,
-                    diagnostic.message
-                );
-                shown += 1;
-            }
-        }
+        // Load errors are diagnostics, not records: they stay on stderr in
+        // every mode so a `--format json` consumer still sees them.
         for error in &outcome.load_errors {
             let path = error
                 .path
@@ -131,17 +97,59 @@ impl SweepCommand {
                 error.source_workspace, path, error.message
             );
         }
+
+        let lines = self.human_lines(&outcome);
+        Ok(Payload::blocks(doc, vec![Block::text(lines.join("\n"))]).into())
+    }
+
+    /// The `table`/plain lines for one pass.
+    fn human_lines(&self, outcome: &SweepOutcome) -> Vec<String> {
+        if outcome.lock_busy {
+            return vec!["sweep: another pass holds the lock on this host; exiting".to_string()];
+        }
+        if outcome.reports.is_empty()
+            && outcome.load_errors.is_empty()
+            && outcome.registry.diagnostics.is_empty()
+        {
+            return vec![format!(
+                "sweep[{}]: no routines configured",
+                outcome.host_id
+            )];
+        }
+
+        // Quiet by default; a dry-run is interactive so it shows everything.
+        let show_all = self.verbose || self.dry_run;
+        let mut lines = Vec::new();
+        for report in &outcome.reports {
+            if show_all
+                || report_is_noteworthy(report.action)
+                || !report.validation.diagnostics.is_empty()
+            {
+                lines.push(format_report_line(report));
+            }
+        }
+        if outcome.reports.is_empty() {
+            for diagnostic in &outcome.registry.diagnostics {
+                lines.push(format!(
+                    "sweep[{}]: {}[{}]: {}",
+                    outcome.host_id,
+                    severity_label(diagnostic.severity),
+                    diagnostic.code,
+                    diagnostic.message
+                ));
+            }
+        }
         // A one-line heartbeat when a healthy pass had nothing to report, so the
         // log still shows the sweep ran (bounded by the log rotation in
         // `run_sweep`) without a row per routine.
-        if shown == 0 && outcome.load_errors.is_empty() {
-            println!(
+        if lines.is_empty() && outcome.load_errors.is_empty() {
+            lines.push(format!(
                 "sweep[{}]: {} routine(s), nothing due",
                 outcome.host_id,
                 outcome.reports.len()
-            );
+            ));
         }
-        Ok(CommandOutput::Silent)
+        lines
     }
 }
 

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -32,6 +32,37 @@ fn cli_docs_list_and_show_json() {
     assert!(shown["body"].as_str().expect("body").contains("# Guard"));
 }
 
+/// The global `--format json` must yield the same document `--json` does;
+/// before the commands built one payload, `--format json` fell through to
+/// the human `println!` lines and `jq` choked on `Path: ...`.
+#[test]
+fn cli_docs_show_and_migrate_honor_the_global_json_format() {
+    let workspace = TestWorkspace::new();
+    workspace.write(
+        "docs/pattern.md",
+        "---\ntype: pattern\nsummary: RAII guard pattern\ntags: [rust, guard]\n---\n# Guard\n\nBody\n",
+    );
+
+    let shown = workspace.run_json(
+        &["docs", "show", "docs/pattern.md", "--format", "json"],
+        "docs show --format json",
+    );
+    assert_eq!(shown["frontmatter"]["type"], "pattern");
+    assert_eq!(shown["path"], "docs/pattern.md");
+
+    let human = workspace.run(&["docs", "show", "docs/pattern.md"], "docs show");
+    let stdout = String::from_utf8_lossy(&human.stdout);
+    assert!(stdout.contains("Path: docs/pattern.md"), "{stdout}");
+    assert!(stdout.contains("# Guard"), "{stdout}");
+
+    let migrated = workspace.run_json(
+        &["docs", "migrate", "--format", "json"],
+        "docs migrate --format json",
+    );
+    assert_eq!(migrated["dry_run"], json!(true));
+    assert!(migrated["changed"].is_array(), "{migrated}");
+}
+
 #[test]
 fn cli_docs_migrate_is_dry_run_by_default_and_confirm_applies() {
     let workspace = TestWorkspace::new();


### PR DESCRIPTION
## Summary

`install_format_arg` grafts the global `--format` onto every subcommand and `render::emit` promises no command body writes records to stdout, but three commands still forked on their own `--json` boolean and otherwise `println!`-ed human lines before returning `CommandOutput::Silent`. With `--format json` that boolean is false, so `orbit gc worktrees --format json | jq .` (and `docs show`, `docs add`, `docs migrate`, `sweep`) printed `path=… action=…` / `Path: …` prose and exited 0.

Each command now builds one `Payload::blocks(doc, …)` from the same collected result: `json`/`ndjson` render the document, `table`/plain render the text block, and the legacy `--json` flag still forces the document. Sweep's load errors remain stderr diagnostics in every mode so a JSON consumer still sees them. The dead `print_json` helper in docs is replaced by a `docs_document` serializer.

## Verification

- New integration test `cli_docs_show_and_migrate_honor_the_global_json_format` (`--format json` parses; human form still prints `Path:`).
- `cargo test -p orbit-cli --test docs --test json_output_stability --test output_goldens` pass; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)