### PR TITLE
fix(store): guard the v19 index migration on legacy databases, add the invocations ts index

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/invocation_store/metrics.rs
+++ b/crates/orbit-store/src/driver/sqlite/invocation_store/metrics.rs
@@ -193,7 +193,14 @@ impl Store {
             .map_err(|e| OrbitError::Store(e.to_string()))
     }
 
-    fn load_invocation_samples(&self) -> Result<Vec<InvocationSample>, OrbitError> {
+    /// Every invocation with a resolved model, in storage order. The callers
+    /// group into ordered maps and sort each bucket before taking
+    /// percentiles, so an `ORDER BY` here would only add a full-table sort;
+    /// the model filter runs in SQL so unattributed rows are never
+    /// materialized.
+    fn load_model_attributed_invocation_samples(
+        &self,
+    ) -> Result<Vec<InvocationSample>, OrbitError> {
         let conn = self.read()?;
         let mut stmt = conn
             .prepare(
@@ -201,7 +208,7 @@ impl Store {
                 SELECT activity_id, agent, model, input_tokens, cache_read_tokens,
                        cache_create_tokens, output_tokens, tool_call_count
                 FROM invocations
-                ORDER BY activity_id ASC, agent ASC, model ASC, id ASC
+                WHERE model IS NOT NULL AND TRIM(model) <> ''
                 "#,
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
@@ -223,22 +230,6 @@ impl Store {
 
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(|e| OrbitError::Store(e.to_string()))
-    }
-
-    fn load_model_attributed_invocation_samples(
-        &self,
-    ) -> Result<Vec<InvocationSample>, OrbitError> {
-        Ok(self
-            .load_invocation_samples()?
-            .into_iter()
-            .filter(|sample| {
-                sample
-                    .model
-                    .as_deref()
-                    .map(str::trim)
-                    .is_some_and(|value| !value.is_empty())
-            })
-            .collect())
     }
 
     fn group_invocation_metrics<K, F>(

--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -152,12 +152,21 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         name: "job_runs_created_index",
         apply: super::apply_job_runs_created_index,
     },
+    // Every window filter (`ts >= ? AND ts < ?`) and the newest-first
+    // listing (`ORDER BY ts DESC, id DESC LIMIT n`) over `invocations` had
+    // only the job-run and activity indexes to work with, so each was a
+    // full scan plus a temp sort.
+    Migration {
+        version: 20,
+        name: "invocations_ts_index",
+        apply: super::apply_invocations_ts_index,
+    },
 ];
 
 /// Highest schema version this binary knows how to produce. Public for
 /// the future `orbit migrate` surface (P3.4), alongside
 /// [`AppliedMigration`] and the `Store` version accessors.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 19;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 20;
 
 const LEDGER_KEY_PREFIX: &str = "migration.v";
 

--- a/crates/orbit-store/src/driver/sqlite/migration/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/mod.rs
@@ -630,6 +630,9 @@ fn ensure_invocation_schema_v1(conn: &Connection) -> Result<(), OrbitError> {
             CREATE INDEX IF NOT EXISTS idx_invocations_activity_id
             ON invocations(activity_id);
 
+            CREATE INDEX IF NOT EXISTS idx_invocations_ts
+            ON invocations(ts DESC, id DESC);
+
             CREATE INDEX IF NOT EXISTS idx_invocation_tasks_task_id
             ON invocation_tasks(task_id);
 
@@ -697,6 +700,9 @@ fn ensure_v2_state_consolidation_schema(conn: &Connection) -> Result<(), OrbitEr
 
             CREATE INDEX IF NOT EXISTS idx_job_runs_ws_state
             ON job_runs(workspace_id, state);
+
+            CREATE INDEX IF NOT EXISTS idx_job_runs_workspace_created
+            ON job_runs(workspace_id, created_at DESC, run_id ASC);
 
             CREATE TABLE IF NOT EXISTS job_run_steps (
                 workspace_id TEXT NOT NULL,
@@ -1263,11 +1269,40 @@ fn apply_audit_actor_alias_v2(conn: &Connection) -> Result<(), OrbitError> {
 /// v19 `job_runs_created_index`: cover the listing's per-workspace
 /// `ORDER BY created_at DESC, run_id ASC` so a bounded page stops scanning
 /// and sorting the whole workspace history.
+///
+/// A legacy database may reach this entry with no `job_runs` table, or with
+/// the pre-consolidation one that has no `workspace_id`; the current table
+/// is created at open time by `ensure_v2_state_consolidation_schema`, which
+/// declares the same index. So this entry indexes the table only when it is
+/// already the current shape and otherwise leaves it to open time.
 fn apply_job_runs_created_index(conn: &Connection) -> Result<(), OrbitError> {
+    if !table_has_column(conn, "job_runs", "workspace_id")?
+        || !table_has_column(conn, "job_runs", "created_at")?
+    {
+        return Ok(());
+    }
     conn.execute_batch(
         r#"
             CREATE INDEX IF NOT EXISTS idx_job_runs_workspace_created
             ON job_runs(workspace_id, created_at DESC, run_id ASC);
+        "#,
+    )
+    .map_err(|error| OrbitError::Store(error.to_string()))
+}
+
+/// v20 `invocations_ts_index`: cover the accounting window filters and the
+/// newest-first invocation listing on `invocations(ts, id)`.
+///
+/// Guarded like v19: `ensure_invocation_schema_v1` declares the same index
+/// for a database whose `invocations` table is created or upgraded at open.
+fn apply_invocations_ts_index(conn: &Connection) -> Result<(), OrbitError> {
+    if !table_has_column(conn, "invocations", "ts")? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        r#"
+            CREATE INDEX IF NOT EXISTS idx_invocations_ts
+            ON invocations(ts DESC, id DESC);
         "#,
     )
     .map_err(|error| OrbitError::Store(error.to_string()))

--- a/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
@@ -79,6 +79,9 @@ fn fresh_db_applies_baseline_and_records_ledger() {
     assert_eq!(applied[18].version, 19);
     assert_eq!(applied[18].name, "job_runs_created_index");
     assert!(!applied[18].applied_at.is_empty());
+    assert_eq!(applied[19].version, 20);
+    assert_eq!(applied[19].name, "invocations_ts_index");
+    assert!(!applied[19].applied_at.is_empty());
 }
 
 #[test]
@@ -255,6 +258,10 @@ fn legacy_db_adopts_versioned_ledger() {
                 "migration.v0019".to_string(),
                 "job_runs_created_index".to_string()
             ),
+            (
+                "migration.v0020".to_string(),
+                "invocations_ts_index".to_string()
+            ),
         ]
     );
 }
@@ -266,7 +273,7 @@ fn refuses_db_from_a_newer_binary() {
 
     conn.execute(
         "INSERT INTO schema_meta(key, value, updated_at)
-        VALUES ('migration.v0020', 'from-the-future', '2099-01-01T00:00:00Z')",
+        VALUES ('migration.v0021', 'from-the-future', '2099-01-01T00:00:00Z')",
         [],
     )
     .expect("record future migration");
@@ -346,7 +353,7 @@ fn store_reopens_database_at_shipped_schema_v4_and_applies_through_latest() {
     );
     assert_eq!(
         applied.last().map(|migration| migration.name.as_str()),
-        Some("job_runs_created_index")
+        Some("invocations_ts_index")
     );
     let connection = store.connection();
     let conn = connection.lock().expect("connection");

--- a/crates/orbit-store/src/driver/sqlite/tests/invocation_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/invocation_store.rs
@@ -395,3 +395,29 @@ fn hydration_spans_several_in_list_chunks_without_losing_linkage() {
         assert_eq!(record.tool_calls[0].tool_name, format!("tool-{index}"));
     }
 }
+
+/// The newest-first listing and the accounting window both order and filter
+/// on `ts`; after v20 the planner must satisfy them from the index rather
+/// than scanning and sorting the table.
+#[test]
+fn ts_ordered_reads_use_the_invocations_ts_index() {
+    let store = Store::open_in_memory().expect("open store");
+    let plan = store
+        .with_read_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "EXPLAIN QUERY PLAN SELECT id FROM invocations \
+                     WHERE ts >= '2026-01-01' AND ts < '2026-02-01' ORDER BY ts DESC, id DESC LIMIT 10",
+                )
+                .map_err(|e| orbit_common::OrbitError::Store(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(3))
+                .map_err(|e| orbit_common::OrbitError::Store(e.to_string()))?;
+            rows.collect::<Result<Vec<_>, _>>()
+                .map_err(|e| orbit_common::OrbitError::Store(e.to_string()))
+        })
+        .expect("query plan");
+    let plan = plan.join("\n");
+    assert!(plan.contains("idx_invocations_ts"), "{plan}");
+    assert!(!plan.contains("USE TEMP B-TREE"), "{plan}");
+}

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -46,6 +46,18 @@ fn run_with_steps(run_id: &str, state: JobRunState, created: DateTime<Utc>, step
     }
 }
 
+/// The run upsert persists the run row only; steps are written per step.
+fn insert_run_with_steps(store: &Store, workspace_id: &str, run: &JobRun) {
+    store
+        .upsert_job_run_for_workspace(workspace_id, run, None)
+        .expect("insert run");
+    for step in &run.steps {
+        store
+            .upsert_job_run_step_for_workspace(workspace_id, &run.run_id, step)
+            .expect("insert step");
+    }
+}
+
 /// Steps come back for every run on a page whatever its size: the page is
 /// hydrated with one query per id chunk, not one per run, so a long history
 /// must not lose or cross-wire any run's steps.
@@ -60,9 +72,7 @@ fn listing_hydrates_every_runs_steps_across_id_chunks() {
             at(index % 60),
             index % 4,
         );
-        store
-            .upsert_job_run_for_workspace("ws", &run, None)
-            .expect("insert run");
+        insert_run_with_steps(&store, "ws", &run);
     }
 
     let runs = store
@@ -92,9 +102,7 @@ fn count_and_durations_ignore_the_page_limit() {
             JobRunState::Running
         };
         let run = run_with_steps(&format!("jrun-{index:03}"), state, at(index), 1 + index % 2);
-        store
-            .upsert_job_run_for_workspace("ws", &run, None)
-            .expect("insert run");
+        insert_run_with_steps(&store, "ws", &run);
     }
     // Another workspace's rows must not leak into the count.
     let other = run_with_steps("jrun-other", JobRunState::Failed, at(5), 1);

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -55,7 +55,7 @@ $ orbit migrate --dry-run
 Pending migrations:
   layout v1 (baseline) — adopt the versioned .orbit/ layout (records the current shape; changes nothing)
   layout v2 (archive-friction-tasks) — rewrite removed friction statuses as archived
-  schema v1 (baseline) through schema v19 (job_runs_created_index)
+  schema v1 (baseline) through schema v20 (invocations_ts_index)
 error: execution failed: 2 migration(s) pending; run `orbit migrate --confirm` to apply
 ```
 


### PR DESCRIPTION
## Summary

Fixes the agent-main CI failure from #1265 (`Check / Clippy / Test` and `Coverage`: every shipped-fixture upgrade test in `migration::tests::ledger` / `migration::tests::migration`, plus `listing_hydrates_every_runs_steps_across_id_chunks`).

- **v19 `job_runs_created_index` failed on legacy databases.** It created the index unconditionally, but a legacy store reaches that ledger entry with no `job_runs` table (v6 fixture) or with the pre-consolidation table that has no `workspace_id` (v4 fixture); the current table is created at open time by `ensure_v2_state_consolidation_schema`. The entry now indexes the table only when it already has the current shape, and the open-time schema block declares the same index so every database ends up with it either way.
- **The step-hydration test asserted on steps it never wrote.** `upsert_job_run_for_workspace` persists the run row only; the test now writes each step through `upsert_job_run_step_for_workspace`.
- **v20 `invocations_ts_index`** adds `invocations(ts DESC, id DESC)` for the accounting window filters and the newest-first listing (both were full scans plus a temp sort), with the same guard and open-time declaration. A plan test asserts the index is used with no temp B-tree.
- The scoreboard sample scan drops its full-table `ORDER BY` (callers group and sort per bucket anyway) and filters unattributed rows in SQL.

Why the regression shipped: my verification for #1265 ran `cargo test -p orbit-store -p orbit-web -p orbit-core -p orbit-cmd` without `--no-fail-fast`; cargo stopped at the first failing binary (the flaky orbit-core test) and the store suite never ran.

## Verification

- `cargo test --workspace --no-fail-fast` passes locally (binary rebuilt for schema v20).
- `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)