### PR TITLE
perf(store): search tasks from the bundles the listing already read

### DIFF
--- a/crates/orbit-store/src/repository/task/v2/crud.rs
+++ b/crates/orbit-store/src/repository/task/v2/crud.rs
@@ -180,14 +180,35 @@ impl TaskV2Store {
         tags: &[String],
     ) -> Result<Vec<Task>, OrbitError> {
         let lowered = query.to_lowercase();
-        let mut tasks = self.list_tasks_by_tags(tags)?;
-        let mut matches = Vec::new();
-        for task in tasks.drain(..) {
-            if self.task_matches_query(&task, &lowered)? {
-                matches.push(task);
-            }
+        let bundles = self.candidate_bundles_by_tags(tags)?;
+        self.search_bundles(bundles, &lowered)
+    }
+
+    /// The bundles `list_tasks_by_tags` would materialize, in the same order,
+    /// handed over whole so a caller that also needs the sidecars does not
+    /// read each bundle again.
+    fn candidate_bundles_by_tags(&self, tags: &[String]) -> Result<Vec<TaskBundleV2>, OrbitError> {
+        let required_tags = normalize_task_tags(tags.to_vec());
+        if let Some(bundles) = self.indexed_bundles(TaskIndexFilter {
+            status: None,
+            priority: None,
+            job_run_id: None,
+            tags: required_tags.clone(),
+        })? {
+            return Ok(bundles);
         }
-        Ok(matches)
+        let mut bundles = self.bundle_store.list_bundles()?;
+        bundles.retain(|bundle| {
+            required_tags
+                .iter()
+                .all(|required| bundle.envelope.tags.iter().any(|tag| tag == required))
+        });
+        sort_by_created_desc_id_asc(
+            &mut bundles,
+            |bundle| &bundle.envelope.created_at,
+            |bundle| &bundle.envelope.id,
+        );
+        Ok(bundles)
     }
 
     pub(crate) fn delete_task(&self, id: &str) -> Result<bool, OrbitError> {

--- a/crates/orbit-store/src/repository/task/v2/index.rs
+++ b/crates/orbit-store/src/repository/task/v2/index.rs
@@ -40,13 +40,29 @@ impl TaskV2Store {
         &self,
         filter: TaskIndexFilter,
     ) -> Result<Option<Vec<Task>>, OrbitError> {
+        let Some(bundles) = self.indexed_bundles(filter)? else {
+            return Ok(None);
+        };
+        bundles
+            .into_iter()
+            .map(|bundle| self.task_from_bundle(bundle))
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some)
+    }
+
+    /// The bundles behind an index query, in index order. `None` when the
+    /// index is not usable and the caller must scan bundles instead.
+    pub(super) fn indexed_bundles(
+        &self,
+        filter: TaskIndexFilter,
+    ) -> Result<Option<Vec<TaskBundleV2>>, OrbitError> {
         if !self.index_is_usable()? {
             return Ok(None);
         }
         let ids = self
             .registry
             .indexed_task_ids_filtered(&self.workspace_id, &filter)?;
-        self.tasks_from_ids(ids).map(Some)
+        self.bundles_from_ids(ids).map(Some)
     }
 
     /// Decide whether the generated index still matches the bundles on disk.
@@ -115,15 +131,15 @@ impl TaskV2Store {
     /// concurrent writer is publishing or removing. An id that disappears
     /// between the index query and the bundle read is a task that was deleted,
     /// not a listing failure.
-    fn tasks_from_ids(&self, ids: Vec<String>) -> Result<Vec<Task>, OrbitError> {
-        let mut tasks = Vec::with_capacity(ids.len());
+    fn bundles_from_ids(&self, ids: Vec<String>) -> Result<Vec<TaskBundleV2>, OrbitError> {
+        let mut bundles = Vec::with_capacity(ids.len());
         for id in ids {
             let Some(bundle) = self.bundle_store.read_bundle_if_settled(&id)? else {
                 continue;
             };
-            tasks.push(self.task_from_bundle(bundle)?);
+            bundles.push(bundle);
         }
-        Ok(tasks)
+        Ok(bundles)
     }
 
     pub(super) fn replace_index_best_effort(&self, envelope: &TaskEnvelopeV2, operation: &str) {

--- a/crates/orbit-store/src/repository/task/v2/query.rs
+++ b/crates/orbit-store/src/repository/task/v2/query.rs
@@ -1,45 +1,73 @@
 use super::*;
 
 impl TaskV2Store {
-    pub(super) fn task_matches_query(
+    /// Search over the bundles the candidate listing already read, so a
+    /// query costs one bundle read per task instead of three (each of which
+    /// re-hashed every artifact blob) plus a fourth read of the blobs.
+    pub(super) fn search_bundles(
         &self,
-        task: &Task,
+        bundles: Vec<TaskBundleV2>,
+        lowered: &str,
+    ) -> Result<Vec<Task>, OrbitError> {
+        let mut matches = Vec::new();
+        for bundle in bundles {
+            let comments_match = bundle
+                .comments
+                .iter()
+                .any(|comment| comment.body.to_lowercase().contains(lowered));
+            let manifest = bundle.artifact_manifest.clone();
+            let task = self.task_from_bundle(bundle)?;
+            // Cheapest evidence first: the fields already in memory, then the
+            // comments, and only then the artifact blobs on disk.
+            if task_in_memory_fields_match_query(&task, lowered)
+                || comments_match
+                || self.artifact_manifest_matches_query(&task.id, manifest.as_ref(), lowered)?
+            {
+                matches.push(task);
+            }
+        }
+        Ok(matches)
+    }
+
+    /// Phase 5 bridge: artifact search reads text artifact files on demand
+    /// until generated full-text indexes carry artifact paths, content, and
+    /// snippets. A path match needs no read; a text blob is read only when
+    /// its path did not already match.
+    fn artifact_manifest_matches_query(
+        &self,
+        id: &str,
+        manifest: Option<&ArtifactManifestV2>,
         lowered: &str,
     ) -> Result<bool, OrbitError> {
-        if task_in_memory_fields_match_query(task, lowered) {
-            return Ok(true);
-        }
-
-        if self.task_sidecars_match_query(&task.id, lowered)? {
-            return Ok(true);
-        }
-
-        // Phase 5 bridge: artifact search reads text artifact files on demand until
-        // generated full-text indexes carry artifact paths, content, and snippets.
-        self.task_artifacts_match_query(&task.id, lowered)
-    }
-
-    fn task_sidecars_match_query(&self, id: &str, lowered: &str) -> Result<bool, OrbitError> {
-        let Some(comments) = self.get_task_comments(id)? else {
+        let Some(manifest) = manifest else {
             return Ok(false);
         };
-        Ok(comments
-            .iter()
-            .any(|comment| comment.message.to_lowercase().contains(lowered)))
-    }
-
-    fn task_artifacts_match_query(&self, id: &str, lowered: &str) -> Result<bool, OrbitError> {
-        let Some(artifacts) = self.get_task_artifacts(id)? else {
-            // A task may be deleted after the indexed/listed candidate set is built.
-            return Ok(false);
-        };
-        Ok(artifacts.iter().any(|artifact| {
-            artifact.path.to_lowercase().contains(lowered)
-                || (is_text_artifact_media_type(&artifact.media_type)
-                    && artifact
-                        .text_content()
-                        .is_some_and(|content| content.to_lowercase().contains(lowered)))
-        }))
+        let artifact_dir = self
+            .bundle_store
+            .bundle_path(id)?
+            .join(TASK_ARTIFACTS_DIR_NAME);
+        for file in &manifest.files {
+            if file.path.to_lowercase().contains(lowered) {
+                return Ok(true);
+            }
+            if !is_text_artifact_media_type(&file.media_type) {
+                continue;
+            }
+            let content = match fs::read(artifact_dir.join(&file.blob)) {
+                Ok(content) => content,
+                // The bundle can be rewritten between the listing and this
+                // read; a blob that vanished is not a match, not an error.
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(OrbitError::Io(err.to_string())),
+            };
+            if String::from_utf8(content)
+                .ok()
+                .is_some_and(|text| text.to_lowercase().contains(lowered))
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
## Summary

`orbit task search` paid three full bundle reads per candidate task. `list_tasks_by_tags` read each bundle once to build the candidate `Task`s; then `task_matches_query` called `get_task_comments` (second `read_bundle`) and `get_task_artifacts` (third `read_bundle`, then a read of every blob). Every `read_bundle` runs `validate_artifact_manifest_files`, which reads and SHA-256s each artifact blob, so a workspace with a few large artifacts hashed them three times per query.

- `indexed_bundles` / `candidate_bundles_by_tags` return the candidate bundles whole, in the same order the task listing used (index order, or created-desc for the bundle scan).
- `search_bundles` checks the in-memory task fields first, then the comments already in the bundle, and reads a text artifact blob only when its path did not already match. A blob that vanished between listing and read is a non-match, not an error.
- `indexed_tasks` is now a projection over `indexed_bundles`; `get_task_comments` / `get_task_artifacts` are unchanged for their other callers.

No behavior change; the existing search tests (text artifacts, binary artifacts, tag filters, deleted-after-listing) cover the semantics.

## Verification

- `cargo test -p orbit-store task` (165 tests) passes; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)