### PR TITLE
fix(test): put every env-mutating orbit-core test behind the one shared guard

### DIFF
--- a/crates/orbit-core/src/adapter/command/tests/support.rs
+++ b/crates/orbit-core/src/adapter/command/tests/support.rs
@@ -1,15 +1,24 @@
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use orbit_common::test_env::ScopedEnv;
 
 use crate::OrbitRuntime;
 use crate::adapter::command::dispatch::take_tool_audit_recorded;
 
 /// Serializes tests that mutate `ORBIT_AGENT_*` or assert environment-derived
 /// audit roles so parallel test execution cannot race environment writers.
-pub(super) fn env_guard() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+///
+/// Holds the process-wide guard every env-mutating test in this binary
+/// shares (not a lock of its own), clears the variables these tests set or
+/// assert on, and restores whatever was there when dropped.
+pub(super) fn env_guard() -> ScopedEnv {
+    orbit_common::test_env::unset([
+        "ORBIT_AGENT_NAME",
+        "ORBIT_AGENT_MODEL",
+        "ORBIT_TASK_ID",
+        "ORBIT_RUN_ID",
+        crate::runtime::run_input::ORBIT_MANAGED_RUN_CONTEXT_ENV,
+        "ORBIT_ACTIVITY_ID",
+        "ORBIT_STEP_INDEX",
+    ])
 }
 
 pub(super) fn clear_identity_env() {

--- a/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
@@ -680,46 +680,13 @@ fn tool_name(action: OrbitBuiltinAction) -> &'static str {
 mod tests {
     use super::*;
     use std::fs;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     use crate::adapter::tool_host::test_support::test_runtime;
 
-    struct EnvVarGuard {
-        _lock: MutexGuard<'static, ()>,
-        name: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(name: &'static str, value: &str) -> Self {
-            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let previous = std::env::var(name).ok();
-            // SAFETY: this test guard serializes environment mutation and restores on drop.
-            unsafe {
-                std::env::set_var(name, value);
-            }
-            Self {
-                _lock: lock,
-                name,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: the guard holds the serialization lock for the full mutation window.
-            unsafe {
-                match &self.previous {
-                    Some(value) => std::env::set_var(self.name, value),
-                    None => std::env::remove_var(self.name),
-                }
-            }
-        }
+    /// Set one variable under the process-wide env guard shared by every
+    /// env-mutating test in this binary; restored on drop.
+    fn env_var(name: &'static str, value: &str) -> orbit_common::test_env::ScopedEnv {
+        orbit_common::test_env::scoped([(name, Some(value))])
     }
 
     #[test]
@@ -845,7 +812,7 @@ mod tests {
     #[test]
     fn dispatch_preserves_common_word_github_token_in_task_description() {
         let word = "user";
-        let _env = EnvVarGuard::set("GITHUB_TOKEN", word);
+        let _env = env_var("GITHUB_TOKEN", word);
         let (_root, runtime, _repo_root) = test_runtime();
         let description = format!("No {word}-facing CLI behavior should change.");
 
@@ -873,7 +840,7 @@ mod tests {
     #[test]
     fn dispatch_redacts_live_github_token_before_task_persistence_and_audits() {
         let token = "orbit-redaction-secret-value";
-        let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let _env = env_var("GITHUB_TOKEN", token);
         let (_root, runtime, _repo_root) = test_runtime();
 
         let output = runtime
@@ -1031,7 +998,7 @@ mod tests {
     #[test]
     fn friction_body_update_is_sanitized_but_tags_are_verbatim() {
         let token = "orbit-friction-secret-value";
-        let _env = EnvVarGuard::set("GITHUB_TOKEN", token);
+        let _env = env_var("GITHUB_TOKEN", token);
         let (_root, runtime, _repo_root) = test_runtime();
         let tag = "sk-abcdefghijklmnopqrstuvwx";
         let frictions_root = runtime.data_root().join("frictions");

--- a/crates/orbit-core/src/runtime/engine/tests/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/tests/crew.rs
@@ -1,7 +1,5 @@
 //! Sibling tests for `crew.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
-
 use chrono::Utc;
 use orbit_engine::RuntimeHost;
 use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
@@ -14,15 +12,6 @@ use crate::OrbitRuntime;
 use crate::application::task::TaskAddParams;
 
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
-
-/// Serialize the process-wide `CONSTELLATION_DEFAULT_PROVIDER` mutations so the
-/// env-default test cannot race concurrent tests.
-fn env_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
 
 fn runtime_with_named_crews() -> (TempDir, OrbitRuntime) {
     let root = tempdir().expect("create temp root");
@@ -418,22 +407,15 @@ fn select_crew_name_precedence_and_environment_default() {
 /// the env tier, a leaked value cannot affect concurrent tests.
 #[test]
 fn resolve_crew_for_task_reads_env_default_but_workspace_crew_wins() {
-    let _lock = env_lock();
-    let saved = std::env::var(CONSTELLATION_DEFAULT_PROVIDER_ENV).ok();
-    // SAFETY: serialized by env_lock(); restored before we assert or return.
-    unsafe { std::env::set_var(CONSTELLATION_DEFAULT_PROVIDER_ENV, "claude") };
+    // The process-wide guard every env-mutating test in this binary shares.
+    // A module-local lock only serialized this test against its siblings; a
+    // workspace init running elsewhere read the leaked `claude` and tried to
+    // resolve it as a crew.
+    let _env =
+        orbit_common::test_env::scoped([(CONSTELLATION_DEFAULT_PROVIDER_ENV, Some("claude"))]);
 
     let (_root, runtime) = runtime_with_named_crews();
     let resolved = runtime.resolve_crew_for_task(None, None);
-
-    // Restore the prior environment before asserting so a failure never leaks.
-    // SAFETY: same serialization lock still held.
-    unsafe {
-        match saved {
-            Some(value) => std::env::set_var(CONSTELLATION_DEFAULT_PROVIDER_ENV, value),
-            None => std::env::remove_var(CONSTELLATION_DEFAULT_PROVIDER_ENV),
-        }
-    }
 
     let crew = resolved.expect("resolve crew");
     // `[workflow].default_crew = "primary"` (workspace tier) beats the env tier.


### PR DESCRIPTION
## Summary

Follow-up to #1272. `workspace_init_leaves_repo_skills_unseeded` still failed in the full `orbit-core` lib run with `crew 'claude' is not defined in [crews.*]`. The binary held four independent environment locks — the crew tests' `env_lock`, the command tests' `env_guard`, the artifact-redaction `EnvVarGuard`, and `orbit_common::test_env` — each serializing only its own group. `resolve_crew_for_task_reads_env_default_but_workspace_crew_wins` exported `CONSTELLATION_DEFAULT_PROVIDER=claude` under its own lock while a workspace init elsewhere read it as the default crew.

All three local helpers now build on `test_env::scoped` / `test_env::unset`, which take the one process-wide lock and restore the prior values on drop: `env_guard()` returns a `ScopedEnv` that clears the `ORBIT_AGENT_*` and audit-context variables, `env_var(name, value)` replaces `EnvVarGuard`, and the crew test scopes its variable directly.

## Verification

- `cargo test -p orbit-core --lib --no-fail-fast`: 872/872, twice in a row.
- `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)