### PR TITLE
fix(agent): stop billing Gemini cached input twice and count its thoughts as output

### DIFF
--- a/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/tests/transport.rs
@@ -117,3 +117,29 @@ fn spawn_one_request_server(response_body: &'static str) -> (String, thread::Joi
 
     (format!("http://{addr}"), handle)
 }
+
+/// Thinking models report reasoning tokens beside the visible candidates;
+/// `totalTokenCount` is prompt + thoughts + candidates, so both are output.
+#[test]
+fn send_turn_counts_thought_tokens_as_output() {
+    let response_body = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":800,"thoughtsTokenCount":4200,"cachedContentTokenCount":90,"totalTokenCount":5100}}"#;
+    let (base_url, server) = spawn_one_request_server(response_body);
+    let transport = GeminiHttpTransport::new(GEMINI_API_KEY, "gemini-test", None)
+        .expect("transport")
+        .with_base_url(base_url);
+    let messages = [Message::user_text("hello")];
+    let req = TurnRequest {
+        system: None,
+        messages: &messages,
+        tools: &[],
+        cache_hint: CacheHint::None,
+        max_response_tokens: 0,
+    };
+
+    let response = transport.send_turn(&req).expect("send turn");
+    server.join().expect("server thread");
+
+    assert_eq!(response.usage.input_tokens, 100);
+    assert_eq!(response.usage.cache_read_input_tokens, 90);
+    assert_eq!(response.usage.output_tokens, 5_000);
+}

--- a/crates/orbit-agent/src/providers/gemini_http/transport.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/transport.rs
@@ -270,7 +270,10 @@ impl LoopTransport for GeminiHttpTransport {
 
         let usage = TurnUsage {
             input_tokens: parsed.usage_metadata.prompt_token_count,
-            output_tokens: parsed.usage_metadata.candidates_token_count,
+            output_tokens: parsed
+                .usage_metadata
+                .candidates_token_count
+                .saturating_add(parsed.usage_metadata.thoughts_token_count),
             cache_read_input_tokens: parsed.usage_metadata.cached_content_token_count,
             cache_creation_input_tokens: 0,
         };

--- a/crates/orbit-agent/src/providers/gemini_http/wire.rs
+++ b/crates/orbit-agent/src/providers/gemini_http/wire.rs
@@ -120,4 +120,8 @@ pub struct UsageMetadata {
     pub candidates_token_count: u64,
     #[serde(default)]
     pub cached_content_token_count: u64,
+    /// Reasoning tokens of thinking models, reported beside the visible
+    /// candidates and part of the output budget.
+    #[serde(default)]
+    pub thoughts_token_count: u64,
 }

--- a/crates/orbit-agent/src/types/response/usage.rs
+++ b/crates/orbit-agent/src/types/response/usage.rs
@@ -146,25 +146,21 @@ fn usage_from_map(map: &JsonMap, key_mode: UsageKeyMode) -> Option<TokenUsage> {
         UsageKeyMode::Standard => first_u64(map, STANDARD_CACHE_CREATE_KEYS),
         UsageKeyMode::TokenBlock => first_u64(map, STANDARD_CACHE_CREATE_KEYS),
     };
+    // Gemini reports visible output and reasoning ("thoughts") as separate
+    // counters, in the CLI token block and in `usageMetadata` alike
+    // (`totalTokenCount` is prompt + thoughts + candidates); both consume the
+    // output budget, so sum them rather than first-wins. `tool` is the small
+    // tool-call channel of the token block and is also part of the output side.
     let output = match key_mode {
-        UsageKeyMode::Standard => first_u64(map, STANDARD_OUTPUT_KEYS),
-        // Gemini reports visible output and reasoning ("thoughts") as separate
-        // counters in the same token block; both consume the output budget, so
-        // sum them rather than first-wins. `tool` is the small tool-call channel
-        // and is also part of the output side.
-        UsageKeyMode::TokenBlock => {
-            let visible = first_u64(map, TOKEN_BLOCK_OUTPUT_KEYS);
-            let thoughts = first_u64(map, TOKEN_BLOCK_THOUGHT_KEYS);
-            let tool = first_u64(map, TOKEN_BLOCK_TOOL_KEYS);
-            match (visible, thoughts, tool) {
-                (None, None, None) => None,
-                (v, t, tl) => Some(
-                    v.unwrap_or(0)
-                        .saturating_add(t.unwrap_or(0))
-                        .saturating_add(tl.unwrap_or(0)),
-                ),
-            }
-        }
+        UsageKeyMode::Standard => sum_present(&[
+            first_u64(map, STANDARD_OUTPUT_KEYS),
+            first_u64(map, THOUGHT_KEYS),
+        ]),
+        UsageKeyMode::TokenBlock => sum_present(&[
+            first_u64(map, TOKEN_BLOCK_OUTPUT_KEYS),
+            first_u64(map, THOUGHT_KEYS),
+            first_u64(map, TOKEN_BLOCK_TOOL_KEYS),
+        ]),
     };
 
     let cache_creation_split = match key_mode {
@@ -280,8 +276,18 @@ const TOKEN_BLOCK_OUTPUT_KEYS: &[&str] = &[
     "output",
 ];
 
-const TOKEN_BLOCK_THOUGHT_KEYS: &[&str] =
-    &["thoughts", "thoughtsTokenCount", "thoughts_token_count"];
+const THOUGHT_KEYS: &[&str] = &["thoughts", "thoughtsTokenCount", "thoughts_token_count"];
+
+/// `None` when no counter was present; otherwise the saturating sum of the
+/// ones that were.
+fn sum_present(parts: &[Option<u64>]) -> Option<u64> {
+    parts.iter().any(Option::is_some).then(|| {
+        parts
+            .iter()
+            .flatten()
+            .fold(0_u64, |total, value| total.saturating_add(*value))
+    })
+}
 
 const TOKEN_BLOCK_TOOL_KEYS: &[&str] = &["tool", "toolTokenCount", "tool_token_count"];
 

--- a/crates/orbit-agent/src/types/tests/response.rs
+++ b/crates/orbit-agent/src/types/tests/response.rs
@@ -404,6 +404,34 @@ mod sum {
 
     use super::super::super::response::usage::*;
 
+    /// Gemini's `usageMetadata` reports reasoning beside the candidates;
+    /// `totalTokenCount` is prompt + thoughts + candidates, so both count as
+    /// output, and `promptTokenCount` stays the gross prompt total that the
+    /// price table's gross basis later splits.
+    #[test]
+    fn gemini_usage_metadata_counts_thoughts_as_output() {
+        let documents = vec![json!({
+            "usageMetadata": {
+                "promptTokenCount": 100_000,
+                "cachedContentTokenCount": 90_000,
+                "candidatesTokenCount": 800,
+                "thoughtsTokenCount": 4_200,
+                "totalTokenCount": 105_000
+            }
+        })];
+
+        assert_eq!(
+            sum_usage(&documents),
+            TokenUsage {
+                input: 100_000,
+                cache_read: 90_000,
+                cache_create: 0,
+                cache_create_1h: 0,
+                output: 5_000,
+            }
+        );
+    }
+
     #[test]
     fn claude_cli_cache_creation_ttl_split_maps_each_ttl() {
         let documents = vec![json!({

--- a/crates/orbit-common/assets/model_prices.yaml
+++ b/crates/orbit-common/assets/model_prices.yaml
@@ -193,10 +193,17 @@ prices:
     output_per_million_usd: 1.2
 
   # ── Google / Gemini (crew: gemini) ───────────────────────────────────────
+  # Gemini's `promptTokenCount` is the total effective prompt "including the
+  # number of tokens in the cached content" (ai.google.dev/api/generate-content,
+  # UsageMetadata), and `cachedContentTokenCount` is the cached subset. Like
+  # OpenAI, the input total is gross and the cached share is removed before
+  # the full input rate applies; without `gross_includes_cache` every cached
+  # token was billed at both the input and the cache-read rate.
   # Gemini 3.5 Flash, launched Google I/O 2026 at 1.50/9.00; cached input 0.15.
   - model: "gemini-3.5-flash"
     effective_from: "2026-07-17T00:00:00Z"
     effective_until: null
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 1.5
     cache_read_per_million_usd: 0.15
     cache_create_per_million_usd: 1.5
@@ -212,6 +219,7 @@ prices:
   - model: "gemini-3.7-flash"
     effective_from: "2026-08-13T00:00:00Z"
     effective_until: "2027-01-01T00:00:00Z"
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 0.75
     cache_read_per_million_usd: 0.075
     cache_create_per_million_usd: 0.75
@@ -223,6 +231,7 @@ prices:
   - model: "gemini-3.7-flash"
     effective_from: "2027-01-01T00:00:00Z"
     effective_until: null
+    input_token_basis: gross_includes_cache
     input_per_million_usd: 1.5
     cache_read_per_million_usd: 0.15
     cache_create_per_million_usd: 1.5

--- a/crates/orbit-common/src/model/tests/pricing.rs
+++ b/crates/orbit-common/src/model/tests/pricing.rs
@@ -320,6 +320,37 @@ fn gpt_5_6_rates_change_at_the_exclusive_july_30_boundary_without_overlap() {
     }
 }
 
+/// Gemini's `promptTokenCount` is the total effective prompt including the
+/// cached content (ai.google.dev/api/generate-content, UsageMetadata), so the
+/// cached share must come out of the input bucket before the input rate
+/// applies; the old exclusive rows billed it twice.
+#[test]
+fn gemini_prompt_total_is_gross_of_cached_content() {
+    let at = dt("2026-08-14T00:00:00Z");
+    let usage = TokenUsage {
+        input: 100_000,
+        cache_read: 90_000,
+        output: 1_000,
+        ..TokenUsage::default()
+    };
+    // gemini-3.7-flash introductory: 10k uncached @ 0.75 + 90k cached @ 0.075
+    // + 1k output @ 3.75 = 0.0075 + 0.00675 + 0.00375 = 0.018.
+    let cost = derive_cost_usd("gemini-3.7-flash", at, &usage).expect("priced");
+    assert!((cost - 0.018).abs() < 1e-9, "cost was {cost}");
+    let normalized = normalize_token_usage("gemini-3.7-flash", at, &usage).expect("normalized");
+    assert_eq!(normalized.input, 10_000);
+    assert_eq!(normalized.cache_read, 90_000);
+    for model in ["gemini-3.5-flash", "gemini-3.7-flash"] {
+        for row in covering_rows(model, at) {
+            assert_eq!(
+                row.input_token_basis,
+                InputTokenBasis::GrossIncludesCache,
+                "{model}"
+            );
+        }
+    }
+}
+
 #[test]
 fn gross_openai_input_is_split_into_uncached_read_and_write_buckets() {
     let at = dt("2026-07-30T00:00:00Z");


### PR DESCRIPTION
## Summary

Two Gemini token-accounting defects from the `orbit-agent` audit, verified against the Gemini API reference (`UsageMetadata`).

- **Cached input billed twice.** `promptTokenCount` is documented as the total effective prompt "including the number of tokens in the cached content", with `cachedContentTokenCount` the cached subset; both paths (HTTP transport, CLI `usageMetadata`) feed exactly those two fields into `TokenUsage.input` / `cache_read`. The Gemini price rows defaulted to `InputTokenBasis::Exclusive`, so `cost_usd` added the full input rate on the gross total *and* the cache-read rate on the cached share. A 100k-prompt / 90k-cached turn on `gemini-3.7-flash` priced at ~$0.0743 instead of $0.018. The three Gemini rows now declare `input_token_basis: gross_includes_cache`, the mechanism the OpenAI rows already use.
- **Reasoning tokens dropped from output.** `thoughtsTokenCount` is reported beside `candidatesTokenCount` and `totalTokenCount = prompt + thoughts + candidates`. The CLI token block already summed thoughts into output; `usageMetadata` (Standard key mode) and the HTTP `UsageMetadata` struct used the visible candidates only, undercounting output (and the loop's `max_total_tokens` guard) by the whole thinking budget. Both now sum visible and thought tokens via a shared `sum_present`.

## Verification

- New tests: `gemini_prompt_total_is_gross_of_cached_content` (pricing + normalization), `gemini_usage_metadata_counts_thoughts_as_output` (CLI sum), `send_turn_counts_thought_tokens_as_output` (HTTP transport).
- `cargo test -p orbit-agent -p orbit-common` pass; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)