### PR TITLE
fix(search): match BM25 terms individually, reset the chunker counter after a split paragraph

### DIFF
--- a/crates/orbit-search/src/vector/chunker.rs
+++ b/crates/orbit-search/src/vector/chunker.rs
@@ -26,16 +26,19 @@ pub fn chunk_text(
     for paragraph in paragraphs {
         let paragraph_tokens = embedder.token_count(&paragraph)?;
         if paragraph_tokens > target_tokens {
+            // The over-long paragraph is split on its own; no overlap tail is
+            // carried into it, so the buffer and its counter reset together.
+            // (The counter used to keep the discarded tail's weight, which
+            // flushed the next paragraph early and embedded it twice.)
             if !current.is_empty() {
                 chunks.push(current.join("\n\n"));
-                current = overlap_tail(&current, embedder, overlap_tokens)?;
-                current_tokens = count_parts(&current, embedder)?;
+                current.clear();
+                current_tokens = 0;
             }
             for piece in split_long_paragraph(&paragraph, embedder, target_tokens, overlap_tokens)?
             {
                 chunks.push(piece);
             }
-            current.clear();
             continue;
         }
 

--- a/crates/orbit-search/src/vector/query/bm25.rs
+++ b/crates/orbit-search/src/vector/query/bm25.rs
@@ -22,7 +22,7 @@ pub fn bm25_top_k(
         return Ok(Vec::new());
     }
 
-    let match_query = fts_phrase_quote(query);
+    let match_query = fts_terms_query(query);
     let conn = store.connection();
     let conn = conn
         .lock()
@@ -151,7 +151,17 @@ fn snippet_by_chunk_idx(
     })
 }
 
+/// Turn a free-text query into an FTS5 `MATCH` expression: every
+/// whitespace-separated term is quoted (so `-`, `*`, `NOT`, and the like are
+/// literal), and the terms are joined with FTS5's implicit AND. Quoting the
+/// whole query as one string would make it a *phrase* query, which only hits
+/// chunks where the words are adjacent — a multi-word search returned nothing
+/// from the lexical half of hybrid ranking.
 // widened for tests per ORB-00230 sibling layout; see test_layout.md
-pub(crate) fn fts_phrase_quote(query: &str) -> String {
-    format!("\"{}\"", query.trim().replace('"', "\"\""))
+pub(crate) fn fts_terms_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/crates/orbit-search/src/vector/query/tests/bm25.rs
+++ b/crates/orbit-search/src/vector/query/tests/bm25.rs
@@ -1,6 +1,6 @@
 //! Unit tests for `bm25` — sibling layout under vector/query/tests/.
 
-use super::super::bm25::{bm25_top_k, fts_phrase_quote, snippet_for_hit};
+use super::super::bm25::{bm25_top_k, fts_terms_query, snippet_for_hit};
 
 use crate::NoopEmbedder;
 use crate::vector::{EmbeddingField, VectorStore};
@@ -64,11 +64,43 @@ fn bm25_top_k_filters_by_source_kind() {
 }
 
 #[test]
-fn bm25_phrase_quotes_embedded_double_quotes() {
+fn bm25_terms_are_quoted_individually_not_as_one_phrase() {
     assert_eq!(
-        fts_phrase_quote("foo \"bar\" baz"),
-        "\"foo \"\"bar\"\" baz\""
+        fts_terms_query("foo \"bar\" baz"),
+        "\"foo\" \"\"\"bar\"\"\" \"baz\""
     );
+    assert_eq!(
+        fts_terms_query("  neutrino   decay "),
+        "\"neutrino\" \"decay\""
+    );
+    assert_eq!(fts_terms_query("ORB-11136"), "\"ORB-11136\"");
+}
+
+/// The words of a query need not be adjacent in the chunk: `neutrino decay`
+/// must still find a chunk that says `neutrino ... decay`.
+#[test]
+fn bm25_multi_word_query_matches_non_adjacent_terms() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let embedder = NoopEmbedder::small();
+    for (id, text) in [
+        ("T1", "flaky neutrino harness on the decay path"),
+        ("T2", "neutrino only"),
+        ("T3", "unrelated gamma delta"),
+    ] {
+        store
+            .upsert_embeddings(
+                "task",
+                id,
+                &[EmbeddingField::new("purpose", text)],
+                &embedder,
+                false,
+            )
+            .unwrap();
+    }
+
+    let hits = bm25_top_k(&store, "neutrino decay", Some("task"), 5).unwrap();
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].source_id, "T1");
 }
 
 #[test]

--- a/crates/orbit-search/src/vector/tests/chunker.rs
+++ b/crates/orbit-search/src/vector/tests/chunker.rs
@@ -15,3 +15,25 @@ fn paragraph_chunker_overlaps_at_boundaries() {
     assert!(chunks[1].contains("four five six"));
     assert!(chunks[2].contains("four five six"));
 }
+
+/// Flushing the buffer ahead of an over-long paragraph must reset the token
+/// counter with it. It used to keep the weight of an overlap tail that was
+/// then discarded, so the paragraph after the long one was flushed alone as a
+/// spurious chunk and embedded twice.
+#[test]
+fn counter_resets_after_a_long_paragraph_is_split_on_its_own() {
+    let embedder = NoopEmbedder::new("noop", 3, 64);
+    let long = "l1 l2 l3 l4 l5 l6 l7 l8 l9 l10 l11 l12";
+    let text = format!("a b c d\n\n{long}\n\ne f\n\ng h\n\ni j");
+    let chunks = chunk_text(&text, &embedder, 5, 3).unwrap();
+
+    assert!(
+        !chunks.iter().any(|chunk| chunk == "e f"),
+        "the paragraph after the split one was flushed alone: {chunks:?}"
+    );
+    assert!(
+        chunks.iter().any(|chunk| chunk == "e f\n\ng h"),
+        "short paragraphs after the split one pack together again: {chunks:?}"
+    );
+    assert_eq!(chunks[0], "a b c d");
+}


### PR DESCRIPTION
## Summary

Two `orbit-search` defects from the crate audit, each with a regression test.

- **Every multi-word query was a phrase query.** `fts_phrase_quote` quoted the whole user query as one FTS5 string. That escapes operators correctly, but `MATCH "neutrino decay"` only matches chunks where the two words are adjacent, so the BM25 retriever returned nothing for most multi-word searches and hybrid ranking silently degraded to pure cosine (`bm25_rank: None` on every hit). `fts_terms_query` now quotes each whitespace-separated term and joins them with FTS5's implicit AND. Tests: `bm25_terms_are_quoted_individually_not_as_one_phrase`, `bm25_multi_word_query_matches_non_adjacent_terms`.
- **Chunker kept a stale token count after splitting a long paragraph.** The over-long branch flushed the buffer, built an overlap tail, then `current.clear()`-ed it without resetting `current_tokens`, so the discarded tail's weight made the next short paragraph flush alone (an extra chunk, its text embedded twice, a duplicate `corpus_fts` row). The buffer and counter now reset together and the dead overlap computation is gone. Test: `counter_resets_after_a_long_paragraph_is_split_on_its_own`.

## Verification

- `cargo test -p orbit-search` (60 + parity) and `cargo test -p orbit-core search` pass; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)