### PR TITLE
fix: lock registry read-modify-writes and escape the MCP callers seed label

### DIFF
--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -109,9 +109,12 @@ impl ShipSweepCommand {
     pub fn execute_without_runtime(self) -> CommandOut {
         let global_root = workspace_registry::global_orbit_dir()?;
         let registry_path = workspace_registry::registry_path_for(&global_root);
-        let mut registry = workspace_registry::load_registry_from(&registry_path)?;
-        workspace_registry::validate_workspaces(&mut registry);
-        workspace_registry::save_registry_to(&registry, &registry_path)?;
+        let registry = workspace_registry::with_registry_lock(&registry_path, || {
+            let mut registry = workspace_registry::load_registry_from(&registry_path)?;
+            workspace_registry::validate_workspaces(&mut registry);
+            workspace_registry::save_registry_to(&registry, &registry_path)?;
+            Ok(registry)
+        })?;
 
         let mode_override = self.mode.map(ShipMode::to_core);
         let reports: Vec<SweepReport> = workspace_registry::local_workspaces(&registry)

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -187,184 +187,195 @@ impl WorkspaceInitArgs {
         let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
         let id = canonical_workspace_id(&name);
         let git_remote = detect_git_remote(cwd);
-        let mut registry = workspace_registry::load_registry_from(registry_path)?;
-        let existing_workspace = registry
-            .workspaces
-            .iter()
-            .find(|workspace| workspace.id == id);
-        let existing_checkout = registry
-            .checkouts
-            .iter()
-            .find(|checkout| checkout.repo_root == cwd);
-        let reconciling_existing = existing_workspace.is_some() || existing_checkout.is_some();
-        let registered_shared_root = global_root == orbit_dir
-            && registry
-                .checkouts
-                .iter()
-                .any(|checkout| checkout.orbit_dir == orbit_dir);
-        if registered_shared_root {
-            validate_shared_root_identity(orbit_dir)?;
-        }
+        // Every read of the registry below feeds the write at the end; the lock
+        // keeps a concurrent sweep or init from saving over this registration.
+        let (reconciling_existing, registered_shared_root) =
+            workspace_registry::with_registry_lock(registry_path, || {
+                let mut registry = workspace_registry::load_registry_from(registry_path)?;
+                let existing_workspace = registry
+                    .workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == id);
+                let existing_checkout = registry
+                    .checkouts
+                    .iter()
+                    .find(|checkout| checkout.repo_root == cwd);
+                let reconciling_existing =
+                    existing_workspace.is_some() || existing_checkout.is_some();
+                let registered_shared_root = global_root == orbit_dir
+                    && registry
+                        .checkouts
+                        .iter()
+                        .any(|checkout| checkout.orbit_dir == orbit_dir);
+                if registered_shared_root {
+                    validate_shared_root_identity(orbit_dir)?;
+                }
 
-        if reconciling_existing && !self.force {
-            return Err(OrbitError::WorkspaceError(format!(
-                "workspace registration already exists for '{}' or '{}'; rerun with --force to reconcile it",
-                id,
-                cwd.display()
-            )));
-        }
+                if reconciling_existing && !self.force {
+                    return Err(OrbitError::WorkspaceError(format!(
+                        "workspace registration already exists for '{}' or '{}'; rerun with --force to reconcile it",
+                        id,
+                        cwd.display()
+                    )));
+                }
 
-        if reconciling_existing {
-            validate_existing_registration(
-                existing_workspace,
-                existing_checkout,
-                cwd,
-                orbit_dir,
-                &id,
-            )?;
-            if !registered_shared_root {
-                validate_workspace_identity(orbit_dir, &id)?;
-            }
-        } else if !registered_shared_root
-            && let Some(identity) = read_workspace_identity(orbit_dir)?
-            && identity.workspace_id != id
-        {
-            // A checkout can carry an identity the registry never recorded:
-            // any command that opens a runtime in an uninitialized checkout
-            // seeds a bootstrap id. Replacing one is explicit reconciliation,
-            // so it needs --force — but --force must not detach an identity a
-            // durable registration still claims.
-            if !self.force {
-                return Err(OrbitError::WorkspaceError(format!(
-                    "workspace identity '{}' at '{}' conflicts with requested workspace '{}'; rerun with --force to reconcile it",
-                    identity.workspace_id,
-                    orbit_dir.join("config.yaml").display(),
-                    id
-                )));
-            }
-            if registry_claims(&registry, &identity.workspace_id) {
-                return Err(OrbitError::WorkspaceError(format!(
-                    "cannot reconcile workspace '{}': checkout identity '{}' at '{}' is claimed by an existing registration",
-                    id,
-                    identity.workspace_id,
-                    orbit_dir.join("config.yaml").display()
-                )));
-            }
-        }
+                if reconciling_existing {
+                    validate_existing_registration(
+                        existing_workspace,
+                        existing_checkout,
+                        cwd,
+                        orbit_dir,
+                        &id,
+                    )?;
+                    if !registered_shared_root {
+                        validate_workspace_identity(orbit_dir, &id)?;
+                    }
+                } else if !registered_shared_root
+                    && let Some(identity) = read_workspace_identity(orbit_dir)?
+                    && identity.workspace_id != id
+                {
+                    // A checkout can carry an identity the registry never recorded:
+                    // any command that opens a runtime in an uninitialized checkout
+                    // seeds a bootstrap id. Replacing one is explicit reconciliation,
+                    // so it needs --force — but --force must not detach an identity a
+                    // durable registration still claims.
+                    if !self.force {
+                        return Err(OrbitError::WorkspaceError(format!(
+                            "workspace identity '{}' at '{}' conflicts with requested workspace '{}'; rerun with --force to reconcile it",
+                            identity.workspace_id,
+                            orbit_dir.join("config.yaml").display(),
+                            id
+                        )));
+                    }
+                    if registry_claims(&registry, &identity.workspace_id) {
+                        return Err(OrbitError::WorkspaceError(format!(
+                            "cannot reconcile workspace '{}': checkout identity '{}' at '{}' is claimed by an existing registration",
+                            id,
+                            identity.workspace_id,
+                            orbit_dir.join("config.yaml").display()
+                        )));
+                    }
+                }
 
-        init_workspace_at_root(
-            orbit_dir,
-            InitOptions {
-                refresh_defaults: true,
-                global_root_override: Some(global_root.to_path_buf()),
-                routine_host_id: local_host_id.clone(),
-                // Host detection is a CLI concern: Core seeds config from the
-                // families this adapter reports, never by probing PATH itself.
-                config_seed: Some(config_seed_from_detection(&detect(&RealAgentEnvProbe))),
-                ..Default::default()
-            },
-        )?;
-        ensure_orbit_gitignore_entry(cwd, orbit_dir)?;
-        let mut checkout_added = false;
-        if let Some(existing) = registry.workspaces.iter_mut().find(|w| w.id == id) {
-            if let Some(ship_mode) = self.ship_mode {
-                existing.ship_mode = Some(ship_mode);
-            }
-            if let Some(base_branch) = self.base_branch {
-                existing.base_branch = base_branch;
-            }
-            existing.updated_at = Utc::now();
-            if let Some(checkout) = registry
-                .checkouts
-                .iter_mut()
-                .find(|checkout| checkout.workspace_id == id)
-            {
-                checkout.repo_root = cwd.to_path_buf();
-                checkout.orbit_dir = orbit_dir.to_path_buf();
-            } else {
-                workspace_registry::register_checkout(
-                    &mut registry,
-                    unassigned_checkout(&id, cwd, orbit_dir),
+                init_workspace_at_root(
+                    orbit_dir,
+                    InitOptions {
+                        refresh_defaults: true,
+                        global_root_override: Some(global_root.to_path_buf()),
+                        routine_host_id: local_host_id.clone(),
+                        // Host detection is a CLI concern: Core seeds config from the
+                        // families this adapter reports, never by probing PATH itself.
+                        config_seed: Some(config_seed_from_detection(&detect(&RealAgentEnvProbe))),
+                        ..Default::default()
+                    },
                 )?;
-                checkout_added = true;
-            }
-        } else {
-            let now = Utc::now();
-            let ws = Workspace {
-                id: id.clone(),
-                name: name.clone(),
-                // The explicit role assignment below writes owner identity
-                // and checkout role together before this registry is saved.
-                owner_machine_id: None,
-                git_remote,
-                ship_mode: self.ship_mode,
-                base_branch: self.base_branch.unwrap_or_else(|| "main".to_string()),
-                status: WorkspaceStatus::Active,
-                created_at: now,
-                updated_at: now,
-            };
-            workspace_registry::register_workspace(&mut registry, ws)?;
-            workspace_registry::register_checkout(
-                &mut registry,
-                unassigned_checkout(&id, cwd, orbit_dir),
-            )?;
-            checkout_added = true;
-        }
-
-        // A new checkout defaults compatibly to the local owner. An explicit
-        // replica declaration supplies its stable owner in this same in-memory
-        // mutation, so no transient local-owner binding is ever persisted.
-        if checkout_added || explicit_role.is_some() {
-            let assigned_role = explicit_role.unwrap_or(WorkspaceCheckoutRole::Owner);
-            workspace_registry::assign_checkout_role(
-                &mut registry,
-                &id,
-                assigned_role,
-                self.owner.as_deref(),
-                local_machine_id.as_deref(),
-            )?;
-            match assigned_role {
-                WorkspaceCheckoutRole::Owner => {
-                    if let (Some(machine_id), Some(host_id)) =
-                        (local_machine_id.as_deref(), local_host_id.as_deref())
+                ensure_orbit_gitignore_entry(cwd, orbit_dir)?;
+                let mut checkout_added = false;
+                if let Some(existing) = registry.workspaces.iter_mut().find(|w| w.id == id) {
+                    if let Some(ship_mode) = self.ship_mode {
+                        existing.ship_mode = Some(ship_mode);
+                    }
+                    if let Some(base_branch) = self.base_branch {
+                        existing.base_branch = base_branch;
+                    }
+                    existing.updated_at = Utc::now();
+                    if let Some(checkout) = registry
+                        .checkouts
+                        .iter_mut()
+                        .find(|checkout| checkout.workspace_id == id)
                     {
-                        workspace_registry::rename_local_owner_host_id(
+                        checkout.repo_root = cwd.to_path_buf();
+                        checkout.orbit_dir = orbit_dir.to_path_buf();
+                    } else {
+                        workspace_registry::register_checkout(
                             &mut registry,
-                            machine_id,
-                            host_id,
+                            unassigned_checkout(&id, cwd, orbit_dir),
                         )?;
+                        checkout_added = true;
+                    }
+                } else {
+                    let now = Utc::now();
+                    let ws = Workspace {
+                        id: id.clone(),
+                        name: name.clone(),
+                        // The explicit role assignment below writes owner identity
+                        // and checkout role together before this registry is saved.
+                        owner_machine_id: None,
+                        git_remote,
+                        ship_mode: self.ship_mode,
+                        base_branch: self.base_branch.unwrap_or_else(|| "main".to_string()),
+                        status: WorkspaceStatus::Active,
+                        created_at: now,
+                        updated_at: now,
+                    };
+                    workspace_registry::register_workspace(&mut registry, ws)?;
+                    workspace_registry::register_checkout(
+                        &mut registry,
+                        unassigned_checkout(&id, cwd, orbit_dir),
+                    )?;
+                    checkout_added = true;
+                }
+
+                // A new checkout defaults compatibly to the local owner. An explicit
+                // replica declaration supplies its stable owner in this same in-memory
+                // mutation, so no transient local-owner binding is ever persisted.
+                if checkout_added || explicit_role.is_some() {
+                    let assigned_role = explicit_role.unwrap_or(WorkspaceCheckoutRole::Owner);
+                    workspace_registry::assign_checkout_role(
+                        &mut registry,
+                        &id,
+                        assigned_role,
+                        self.owner.as_deref(),
+                        local_machine_id.as_deref(),
+                    )?;
+                    match assigned_role {
+                        WorkspaceCheckoutRole::Owner => {
+                            if let (Some(machine_id), Some(host_id)) =
+                                (local_machine_id.as_deref(), local_host_id.as_deref())
+                            {
+                                workspace_registry::rename_local_owner_host_id(
+                                    &mut registry,
+                                    machine_id,
+                                    host_id,
+                                )?;
+                            }
+                        }
+                        WorkspaceCheckoutRole::Replica => {
+                            // v1 has no fleet lookup from stable machine id to display
+                            // name. Until the local record is enriched with a human
+                            // name, the explicit owner id is itself recognizable to
+                            // routine-pin diagnostics as a known-elsewhere owner.
+                            if let Some(owner) = self.owner.as_deref() {
+                                registry
+                                    .owner_host_ids
+                                    .entry(owner.to_string())
+                                    .or_insert_with(|| owner.to_string());
+                            }
+                        }
                     }
                 }
-                WorkspaceCheckoutRole::Replica => {
-                    // v1 has no fleet lookup from stable machine id to display
-                    // name. Until the local record is enriched with a human
-                    // name, the explicit owner id is itself recognizable to
-                    // routine-pin diagnostics as a known-elsewhere owner.
-                    if let Some(owner) = self.owner.as_deref() {
-                        registry
-                            .owner_host_ids
-                            .entry(owner.to_string())
-                            .or_insert_with(|| owner.to_string());
-                    }
+                orbit_core::adapter::HubCoordinationExecutor::register_workspace(
+                    global_root,
+                    &id,
+                    &name,
+                )?;
+                // A first checkout for this data dir must land in sqlite before the
+                // JSON catalog is saved. Shared-root follow-on checkouts reuse one
+                // orbit_dir (UNIQUE) and must not steal that row. `--force` rebinds
+                // a leftover synthetic parent(data-dir) mint.
+                if !registered_shared_root {
+                    orbit_core::adapter::HubCoordinationExecutor::bind_checkout(
+                        global_root,
+                        &id,
+                        &name,
+                        cwd,
+                        orbit_dir,
+                        self.force,
+                    )?;
                 }
-            }
-        }
-        orbit_core::adapter::HubCoordinationExecutor::register_workspace(global_root, &id, &name)?;
-        // A first checkout for this data dir must land in sqlite before the
-        // JSON catalog is saved. Shared-root follow-on checkouts reuse one
-        // orbit_dir (UNIQUE) and must not steal that row. `--force` rebinds
-        // a leftover synthetic parent(data-dir) mint.
-        if !registered_shared_root {
-            orbit_core::adapter::HubCoordinationExecutor::bind_checkout(
-                global_root,
-                &id,
-                &name,
-                cwd,
-                orbit_dir,
-                self.force,
-            )?;
-        }
-        workspace_registry::save_registry_to(&registry, registry_path)?;
+                workspace_registry::save_registry_to(&registry, registry_path)?;
+                Ok((reconciling_existing, registered_shared_root))
+            })?;
         if !reconciling_existing && !registered_shared_root {
             write_workspace_identity(orbit_dir, &id)?;
         }

--- a/crates/orbit-common/src/protocol/mod.rs
+++ b/crates/orbit-common/src/protocol/mod.rs
@@ -1,3 +1,4 @@
+pub mod toml;
 pub mod tool_input;
 pub mod tool_schema;
 pub mod yaml;

--- a/crates/orbit-common/src/protocol/tests/mod.rs
+++ b/crates/orbit-common/src/protocol/tests/mod.rs
@@ -1,1 +1,2 @@
+mod toml;
 mod yaml;

--- a/crates/orbit-common/src/protocol/tests/toml.rs
+++ b/crates/orbit-common/src/protocol/tests/toml.rs
@@ -1,0 +1,21 @@
+use super::super::toml::escape_basic_string;
+
+#[test]
+fn escapes_every_basic_string_hazard() {
+    assert_eq!(escape_basic_string("plain"), "plain");
+    assert_eq!(escape_basic_string("say \"hi\""), "say \\\"hi\\\"");
+    assert_eq!(escape_basic_string("back\\slash"), "back\\\\slash");
+    assert_eq!(escape_basic_string("a\nb\tc"), "a\\nb\\tc");
+    assert_eq!(escape_basic_string("\u{01}"), "\\u0001");
+}
+
+/// The escaped form must parse back to the original through a real TOML
+/// parser, which is the only contract that matters.
+#[test]
+fn round_trips_through_a_toml_parser() {
+    for value in ["laptop\"", "\"\"\"open", "tab\there", "x\\y", "\u{7f}"] {
+        let document = format!("label = \"{}\"\n", escape_basic_string(value));
+        let parsed: toml::Value = toml::from_str(&document).expect("valid TOML");
+        assert_eq!(parsed["label"].as_str(), Some(value), "{document}");
+    }
+}

--- a/crates/orbit-common/src/protocol/toml.rs
+++ b/crates/orbit-common/src/protocol/toml.rs
@@ -1,0 +1,28 @@
+//! TOML text helpers shared by every crate that renders a config file from
+//! strings it did not author.
+
+/// Escape `value` for embedding inside a TOML basic (double-quoted) string,
+/// per the TOML spec's basic-string escape set.
+///
+/// Anything rendered into a `"..."` literal must pass through here: a value
+/// that carries a quote, a backslash, or a control character is otherwise
+/// either invalid TOML or, worse, valid TOML with a different meaning.
+pub fn escape_basic_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            control if (control as u32) < 0x20 || control as u32 == 0x7f => {
+                escaped.push_str(&format!("\\u{:04X}", control as u32));
+            }
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}

--- a/crates/orbit-mcp/src/remote/callers.rs
+++ b/crates/orbit-mcp/src/remote/callers.rs
@@ -36,6 +36,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
+use orbit_common::protocol::toml::escape_basic_string;
 use orbit_types::identity::validate_machine_id;
 use orbit_types::tool::{CallerIdentityProof, McpCapability, RemoteCallerGrant};
 use serde::Deserialize;
@@ -677,7 +678,12 @@ pub fn render_callers_seed(callers: &[SeedCaller]) -> String {
         out.push_str("\n[[callers]]\n");
         out.push_str(&format!("machine_id   = \"{}\"\n", caller.machine_id));
         if let Some(label) = &caller.label {
-            out.push_str(&format!("label        = \"{label}\"\n"));
+            // A label comes from a peer's operator-chosen host id or an SSH
+            // destination string; a quote in it must not end the literal.
+            out.push_str(&format!(
+                "label        = \"{}\"\n",
+                escape_basic_string(label)
+            ));
         }
         out.push_str("capabilities = [\"agent\"]\n");
     }

--- a/crates/orbit-mcp/src/remote/tests/callers.rs
+++ b/crates/orbit-mcp/src/remote/tests/callers.rs
@@ -485,3 +485,23 @@ capabilities = ["agent"]
         "a machine that accepts SSH with no callers file is the Tier 1 gap the doctor reports"
     );
 }
+
+/// A label is a peer's operator-chosen host id or an SSH destination; a
+/// quote in it must be escaped, or the seed is unparseable and every remote
+/// session is refused until someone hand-edits the file.
+#[test]
+fn seed_escapes_labels_that_would_break_the_toml_literal() {
+    let seeded = render_callers_seed(&[SeedCaller {
+        machine_id: "hm_0123456789abcdef".to_string(),
+        label: Some("laptop\" # not a comment".to_string()),
+    }]);
+    assert!(
+        seeded.contains("label        = \"laptop\\\" # not a comment\""),
+        "{seeded}"
+    );
+    let parsed: toml::Value = toml::from_str(&seeded).expect("seed parses as TOML");
+    assert_eq!(
+        parsed["callers"][0]["label"].as_str(),
+        Some("laptop\" # not a comment")
+    );
+}

--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -18,6 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use orbit_common::OrbitError;
 use orbit_common::fs::io::atomic_write_text;
+use orbit_common::protocol::toml::escape_basic_string;
 use orbit_types::identity::{MACHINE_ID_PREFIX, validate_machine_id};
 use serde::Deserialize;
 
@@ -85,33 +86,11 @@ impl HostIdentity {
              host_id = \"{}\"\n\
              task_prefix = \"{}\"\n",
             self.schema_version,
-            toml_escape_basic(&self.machine_id),
-            toml_escape_basic(&self.host_id),
-            toml_escape_basic(&self.task_prefix),
+            escape_basic_string(&self.machine_id),
+            escape_basic_string(&self.host_id),
+            escape_basic_string(&self.task_prefix),
         )
     }
-}
-
-/// Escape a value for embedding inside a TOML basic (double-quoted) string,
-/// per the TOML spec's basic-string escape set.
-fn toml_escape_basic(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '"' => escaped.push_str("\\\""),
-            '\\' => escaped.push_str("\\\\"),
-            '\n' => escaped.push_str("\\n"),
-            '\r' => escaped.push_str("\\r"),
-            '\t' => escaped.push_str("\\t"),
-            '\u{08}' => escaped.push_str("\\b"),
-            '\u{0C}' => escaped.push_str("\\f"),
-            control if (control as u32) < 0x20 || control as u32 == 0x7f => {
-                escaped.push_str(&format!("\\u{:04X}", control as u32));
-            }
-            other => escaped.push(other),
-        }
-    }
-    escaped
 }
 
 /// The three actionable states of `host.toml`. Malformed, incomplete, blank,

--- a/crates/orbit-registry/src/workspace_registry/io.rs
+++ b/crates/orbit-registry/src/workspace_registry/io.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
-use orbit_common::fs::io::atomic_write_text;
+use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
 pub use orbit_common::fs::path::global_orbit_dir;
 use orbit_types::workspace::WorkspaceRegistry;
 
@@ -21,6 +21,20 @@ pub fn registry_path_for(global_root: &Path) -> PathBuf {
 /// Load the machine-global workspace registry.
 pub fn load_registry() -> Result<WorkspaceRegistry, OrbitError> {
     load_registry_from(&registry_path()?)
+}
+
+/// Run `op` while holding the exclusive lock for the registry at `path`.
+///
+/// `load_registry_from` and `save_registry_to` are each atomic on their own,
+/// but a caller that loads, edits, and saves is not: two such callers (the
+/// scheduled sweep validating checkouts, `orbit workspace init` registering a
+/// new one) interleave, and the second save silently drops the first one's
+/// edit. Wrap the whole read-modify-write in this.
+pub fn with_registry_lock<T>(
+    path: &Path,
+    op: impl FnOnce() -> Result<T, OrbitError>,
+) -> Result<T, OrbitError> {
+    with_exclusive_file_lock(path, "workspace registry", op)
 }
 
 /// Load, migrate, and validate a registry from an explicit path.

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -12,7 +12,7 @@ pub use catalog::{
 };
 pub use io::{
     global_orbit_dir, load_registry, load_registry_from, registry_path, registry_path_for,
-    save_registry, save_registry_to,
+    save_registry, save_registry_to, with_registry_lock,
 };
 pub use publication::{
     bind_publication, find_publication_binding, rebind_publication, record_publication_success,


### PR DESCRIPTION
## Summary

Two findings from the registry/MCP audit.

- **`workspaces.json` read-modify-write had no lock.** `load_registry_from` → mutate → `save_registry_to` is three steps with nothing held across them; `atomic_write_text` prevents a torn file but not a lost update. The scheduled ship sweep (load, `validate_workspaces`, save) racing `orbit workspace init` (load, `register_workspace`/`register_checkout`, save) let the later save clobber the earlier one, after `HubCoordinationExecutor::register_workspace` had already written the sqlite row, leaving the JSON catalog and sqlite inconsistent. `workspace_registry::with_registry_lock(path, op)` holds `with_exclusive_file_lock` (the same helper task bundles and the token scoreboard use) across the span; the sweep and the whole registry-touching body of `workspace init` now run inside it. Other load/save pairs are unchanged and can adopt the helper as they are touched.
- **MCP callers seed wrote an unescaped label.** `render_callers_seed` interpolated `label` straight into a TOML basic string. Labels come from a peer machine's operator-chosen `host_id` (validation allows `"`) or an SSH destination, so a peer named `laptop"` produced an unparseable `mcp-callers.toml`; `load_callers` then failed for every session and the seeder refuses to overwrite the broken file. The escaper `host.toml` already used moves from `orbit-registry` to `orbit_common::protocol::toml::escape_basic_string` and both renderers share it. Tests: `seed_escapes_labels_that_would_break_the_toml_literal` (renders and re-parses), plus round-trip tests for the escaper itself.

## Verification

- `cargo test -p orbit-common -p orbit-registry -p orbit-mcp`, and the `workspace` / `sweep` orbit-cli suites pass; `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)