### PR TITLE
fix: name the capture-limit kill, bound checkout evidence, clean up failed byte writes

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -89,14 +89,22 @@ pub fn atomic_write_bytes(path: &Path, content: &[u8]) -> io::Result<()> {
     let temp_path = temp_path_for(path);
     let mut file = create_new_private_file(&temp_path)?;
 
-    if let Ok(metadata) = fs::metadata(path) {
-        fs::set_permissions(&temp_path, metadata.permissions())?;
+    let staged = (|| {
+        if let Ok(metadata) = fs::metadata(path) {
+            fs::set_permissions(&temp_path, metadata.permissions())?;
+        }
+        file.write_all(content)?;
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp_path, path)
+    })();
+    if staged.is_err() {
+        // Every temp name is fresh, so a leftover would never be reclaimed:
+        // a failed write (ENOSPC mid-`write_all`, a rename refused) must not
+        // keep consuming the space it was short of.
+        let _ = fs::remove_file(&temp_path);
     }
-
-    file.write_all(content)?;
-    file.sync_all()?;
-    drop(file);
-    fs::rename(&temp_path, path)?;
+    staged?;
     sync_parent_dir(path)
 }
 

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -207,3 +207,29 @@ fn exclusive_lock_re_enters_when_the_outer_call_creates_the_parent_under_a_symli
         .expect("nested locks must re-enter");
     assert_eq!(depth, 2);
 }
+
+/// A byte write that cannot be committed must not leave its staging file
+/// behind: temp names are never reused, so a leftover is never reclaimed.
+#[test]
+fn atomic_write_bytes_removes_its_temp_file_when_the_rename_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A non-empty directory at the target path makes the final rename fail
+    // after the staging file has been fully written.
+    let target = dir.path().join("target");
+    std::fs::create_dir_all(target.join("occupied")).expect("occupy target");
+
+    let error =
+        super::super::io::atomic_write_bytes(&target, b"payload").expect_err("rename fails");
+    assert!(target.is_dir(), "{error}");
+
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name != "target")
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "staging files left behind: {leftovers:?}"
+    );
+}

--- a/crates/orbit-exec/src/supervision/tests/wait.rs
+++ b/crates/orbit-exec/src/supervision/tests/wait.rs
@@ -36,11 +36,52 @@ fn wait_kills_process_when_stdout_capture_limit_is_exceeded() {
         "expected None (SIGKILL) or Some(141) (SIGPIPE cascade), got {:?}",
         result.exit_code
     );
-    assert!(result.stderr.is_empty());
+    // `yes` may die of SIGPIPE before the supervisor observes the cap; only
+    // the supervisor-delivered kill carries the reason (asserted separately
+    // below with a child that survives the pipe closing).
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.is_empty() || stderr.contains("process output capture limit exceeded on stdout"),
+        "stderr was {stderr:?}"
+    );
     assert!(result.stdout.ends_with(OUTPUT_TRUNCATED_MARKER));
     assert!(result.stdout.len() <= 64 + OUTPUT_TRUNCATED_MARKER.len());
     assert!(
         started.elapsed() < Duration::from_secs(2),
         "output cap should kill the subprocess promptly"
     );
+}
+
+/// A child that ignores SIGPIPE keeps running after the drain drops the pipe,
+/// so the supervisor is the one that stops it — and it must say why, or the
+/// caller sees a bare failure with an empty stderr for a log that was merely
+/// long.
+#[cfg(unix)]
+#[test]
+fn capture_limit_kill_names_its_reason_on_stderr() {
+    let req = ExecRequest {
+        program: "/bin/sh".to_string(),
+        args: vec![
+            "-c".to_string(),
+            "trap '' PIPE; while :; do echo orbit-cap; done".to_string(),
+        ],
+        current_dir: None,
+        timeout_ms: Some(5_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::Inherit,
+        debug: false,
+    };
+    let child = crate::process::spawn(&req).expect("spawn child");
+
+    let result =
+        wait_with_timeout_and_output_limit(child, Some(5_000), false, None, 64).expect("wait");
+
+    assert!(!result.exit_success);
+    assert_eq!(result.exit_code, None, "supervisor kill, not a self-exit");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("process output capture limit exceeded on stdout"),
+        "stderr was {stderr:?}"
+    );
+    assert!(result.stdout.ends_with(OUTPUT_TRUNCATED_MARKER));
 }

--- a/crates/orbit-exec/src/supervision/wait.rs
+++ b/crates/orbit-exec/src/supervision/wait.rs
@@ -70,9 +70,11 @@ pub(super) fn wait_with_timeout_and_output_limit(
 
     let deadline = timeout_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
     let mut stdin_write_error = None;
+    let mut capture_limited: Option<&'static str> = None;
     let (timed_out, interrupted_signal, exit_success, exit_code) = loop {
-        if output_limit_rx.try_recv().is_ok() {
+        if let Ok(stream) = output_limit_rx.try_recv() {
             terminate_process_group(&mut child, termination_signal(), WAIT_POLL_INTERVAL)?;
+            capture_limited = Some(stream);
             break (false, None, false, None);
         }
 
@@ -155,6 +157,17 @@ pub(super) fn wait_with_timeout_and_output_limit(
             stderr.push(b'\n');
         }
         stderr.extend_from_slice(b"process timed out");
+    }
+    // A capture-limit stop looks like a bare failure otherwise (exit code
+    // `None`, often an empty stderr), and a tool such as `github.run.logs`
+    // then reports "failed: " with no reason for a log that was merely long.
+    if let Some(stream) = capture_limited {
+        if !stderr.is_empty() {
+            stderr.push(b'\n');
+        }
+        stderr.extend_from_slice(
+            format!("process output capture limit exceeded on {stream}").as_bytes(),
+        );
     }
     #[cfg(unix)]
     if !timed_out && let Some(signal) = interrupted_signal {

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use orbit_common::OrbitError;
 use orbit_common::security::redaction::redact_all;
 use orbit_exec::{EnvironmentMode, ExecRequest, StdinMode};
@@ -391,11 +393,21 @@ fn commit_sha_tokens(payload: &str) -> Vec<&str> {
     tokens
 }
 
-/// Scan a runner log for checkout evidence, keeping at most `max_lines` lines.
+/// Scan a runner log for checkout evidence, keeping at most `max_lines` lines
+/// and at most `max_lines` distinct commits.
+///
+/// The scan deliberately covers the whole raw log, not the bounded excerpt,
+/// so both outputs must be capped here: a matrix run whose log carries tens
+/// of thousands of fetch lines must not hand the caller an unbounded commit
+/// list, and membership is a set lookup rather than a scan per token.
 pub fn scan_checkout_evidence(log: &str, max_lines: usize) -> CheckoutEvidence {
     let mut commits: Vec<String> = Vec::new();
+    let mut seen_commits: HashSet<&str> = HashSet::new();
     let mut lines = Vec::new();
     for line in log.lines() {
+        if commits.len() >= max_lines && lines.len() >= max_lines {
+            break;
+        }
         let (step, payload) = split_log_line(line);
         let lowered = payload.to_ascii_lowercase();
         let marked = CHECKOUT_MARKERS
@@ -407,7 +419,10 @@ pub fn scan_checkout_evidence(log: &str, max_lines: usize) -> CheckoutEvidence {
             continue;
         }
         for token in commit_sha_tokens(payload) {
-            if !commits.iter().any(|sha| sha == token) {
+            if commits.len() >= max_lines {
+                break;
+            }
+            if seen_commits.insert(token) {
                 commits.push(token.to_string());
             }
         }

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -148,3 +148,31 @@ fn a_log_without_checkout_evidence_yields_nothing_rather_than_a_guess() {
     assert!(evidence.commits.is_empty());
     assert!(evidence.lines.is_empty());
 }
+
+/// The commit list is bounded like the lines are: a matrix log with tens of
+/// thousands of fetch lines must not hand the caller an unbounded array, and
+/// every commit appears once.
+#[test]
+fn checkout_evidence_caps_and_dedups_commits() {
+    let mut log = String::new();
+    for index in 0..500_u32 {
+        let sha = format!("{index:040x}");
+        // Each commit appears twice, as a fetch line and a checkout line.
+        log.push_str(&format!(
+            "setup\tRun actions/checkout@v4\t2026-01-01T00:00:00.0000000Z  * branch {sha} -> FETCH_HEAD\n"
+        ));
+        log.push_str(&format!(
+            "setup\tRun actions/checkout@v4\t2026-01-01T00:00:01.0000000Z HEAD is now at {sha} chore\n"
+        ));
+    }
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits.len(), 40, "{:?}", evidence.commits);
+    assert_eq!(evidence.lines.len(), 40);
+    let mut unique = evidence.commits.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), evidence.commits.len());
+    assert_eq!(evidence.commits[0], format!("{:040x}", 0));
+}


### PR DESCRIPTION
## Summary

Three findings from the `orbit-exec` / `orbit-tools` / `orbit-common` audit, each with a regression test.

- **Capture-limit kill was an unattributable failure.** When a drain thread hit `DEFAULT_OUTPUT_CAPTURE_LIMIT_BYTES` the supervisor SIGTERMed the group and returned `exit_code: None` with nothing appended to stderr (unlike the timeout path). `github.run.logs` on a run whose log exceeds 1 MiB — the case its own docs anticipate — therefore surfaced `gh run view --log failed: ` with an empty reason instead of the bounded head/tail excerpt. The kill now appends `process output capture limit exceeded on <stream>`. Tests: `capture_limit_kill_names_its_reason_on_stderr` (a child that ignores SIGPIPE, so the supervisor is deterministically the killer); the existing `yes`-based test tolerates the SIGPIPE cascade that may pre-empt the marker.
- **`scan_checkout_evidence` returned an unbounded commit list with O(n²) dedup.** Lines were capped at `max_lines`; commits were not, and membership was a linear scan per token over the whole raw log. Commits are now capped at the same bound with a `HashSet`, and the scan stops once both outputs are full. Test: `checkout_evidence_caps_and_dedups_commits` (500 commits × 2 lines → 40 unique).
- **`atomic_write_bytes` leaked its temp file on any error.** The text variant cleans up via `StagedTextFile::drop`; the bytes variant open-coded the sequence with no guard, so an ENOSPC mid-write or a refused rename left `.<name>.<nanos>.<n>.tmp` behind forever. The staging file is now removed on the error path. Test: `atomic_write_bytes_removes_its_temp_file_when_the_rename_fails`.

## Verification

- `cargo test -p orbit-exec -p orbit-tools -p orbit-common` pass (the capture-limit tests 3/3 repeated); `make ci-fast`, `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)