### PR TITLE
fix(mcp): cap listener sessions, survive descriptor exhaustion, bound the probe reader

### DIFF
--- a/crates/orbit-mcp/Cargo.toml
+++ b/crates/orbit-mcp/Cargo.toml
@@ -22,7 +22,7 @@ rmcp = { version = "1.5", default-features = false, features = ["server", "trans
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-tokio = { workspace = true, features = ["io-std", "net", "rt"] }
+tokio = { workspace = true, features = ["io-std", "net", "rt", "sync", "time"] }
 toml.workspace = true
 tracing.workspace = true
 

--- a/crates/orbit-mcp/src/federated/probe.rs
+++ b/crates/orbit-mcp/src/federated/probe.rs
@@ -6,10 +6,11 @@
 //! the destination, and delivers that single `tools/call`. The client speaks
 //! MCP over the same non-PTY SSH argv the v1 proxy uses.
 
+use std::io::Read;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, sync_channel};
 use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
@@ -18,6 +19,13 @@ use orbit_types::workspace::Workspace;
 use serde_json::{Value, json};
 
 use super::config::Destination;
+
+/// Lines the probe reader may queue ahead of the consumer before it blocks.
+const PROBE_LINE_QUEUE: usize = 64;
+
+/// Longest single line the probe reader accepts from a destination. Every
+/// MCP message is one JSON line; anything past this is not a message.
+const MAX_PROBE_LINE_BYTES: u64 = 64 * 1024 * 1024;
 
 /// How long one destination gets to answer everything that decides *where* a
 /// call goes.
@@ -386,11 +394,27 @@ impl DestinationSession {
             .ok_or_else(|| unreachable(&destination, "SSH session has no stdout".to_string()))?;
         // A reader thread is what makes the deadline real: a blocking read on
         // an unresponsive host cannot otherwise be abandoned, and the thread
-        // ends on its own when the killed child closes the pipe.
-        let (sender, lines) = channel();
+        // ends on its own when the killed child closes the pipe. It is also
+        // bounded in both directions: the queue applies backpressure instead
+        // of buffering whatever the destination streams while the caller
+        // waits, and a line longer than any MCP message ends the session
+        // instead of growing a string until this process is killed.
+        let (sender, lines) = sync_channel(PROBE_LINE_QUEUE);
         std::thread::spawn(move || {
-            for line in BufReader::new(stdout).lines() {
-                let Ok(line) = line else { break };
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                match reader
+                    .by_ref()
+                    .take(MAX_PROBE_LINE_BYTES)
+                    .read_line(&mut line)
+                {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+                if !line.ends_with('\n') && line.len() as u64 >= MAX_PROBE_LINE_BYTES {
+                    break;
+                }
                 if sender.send(line).is_err() {
                     break;
                 }

--- a/crates/orbit-mcp/src/federated/tests/probe.rs
+++ b/crates/orbit-mcp/src/federated/tests/probe.rs
@@ -111,3 +111,36 @@ fn routed_delivery_does_not_inherit_an_exhausted_probe_budget() {
         "{error}"
     );
 }
+
+/// A destination that streams garbage as fast as the pipe allows. The reader
+/// queue applies backpressure instead of buffering the flood while the
+/// consumer decides, and the first non-JSON line ends the session promptly.
+#[cfg(unix)]
+#[test]
+fn a_flooding_destination_is_refused_without_buffering_the_flood() {
+    let child = Command::new("yes")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn a flooding destination");
+    let mut session = DestinationSession::start(
+        destination("orbit-owner", OWNER_MACHINE),
+        child,
+        Duration::from_secs(5),
+    )
+    .expect("start a session against the flooding destination");
+
+    let started = Instant::now();
+    let error = session
+        .handshake()
+        .expect_err("a stream of `y` lines is not an MCP answer");
+    assert!(
+        matches!(error, OrbitError::UnreachableDestination(_)),
+        "{error}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "the first bad line must end the session, not the deadline"
+    );
+}

--- a/crates/orbit-mcp/src/listener.rs
+++ b/crates/orbit-mcp/src/listener.rs
@@ -9,16 +9,30 @@
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use orbit_common::OrbitError;
 use orbit_types::tool::ToolSessionContext;
 use rmcp::ServiceExt;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::{McpHost, OrbitToolServer};
 
 /// Loopback port `orbit mcp listen` binds when no address is given.
 pub const DEFAULT_MCP_LISTEN_PORT: u16 = 7879;
+
+/// Sessions one listener serves at a time. Each accepted connection holds a
+/// server instance and an rmcp session until the peer closes, and the
+/// listener authenticates no one, so without a ceiling any process that can
+/// reach the socket can pin descriptors and memory until `accept` itself
+/// fails. Beyond the ceiling new connections wait for a slot rather than
+/// being refused, so a burst of legitimate clients degrades to queueing.
+pub const DEFAULT_MAX_MCP_SESSIONS: usize = 64;
+
+/// How long the accept loop pauses after a resource-exhaustion error before
+/// trying again, instead of spinning or giving up.
+const ACCEPT_EXHAUSTION_BACKOFF: Duration = Duration::from_millis(250);
 
 /// How far a listener is allowed to be reachable.
 ///
@@ -42,6 +56,7 @@ pub struct McpListener {
     listener: TcpListener,
     host: Arc<dyn McpHost>,
     trusted_context: ToolSessionContext,
+    sessions: Arc<Semaphore>,
 }
 
 impl McpListener {
@@ -64,6 +79,7 @@ impl McpListener {
             listener,
             host,
             trusted_context,
+            sessions: Arc::new(Semaphore::new(DEFAULT_MAX_MCP_SESSIONS)),
         })
     }
 
@@ -84,6 +100,13 @@ impl McpListener {
     /// workspace.
     pub async fn serve(self) -> Result<(), OrbitError> {
         loop {
+            // Take the slot before accepting so a full listener leaves the
+            // connection in the kernel backlog instead of holding an accepted
+            // socket it cannot serve yet.
+            let permit = Arc::clone(&self.sessions)
+                .acquire_owned()
+                .await
+                .map_err(|_| OrbitError::Execution("mcp listen session gate closed".to_string()))?;
             let (stream, peer) = match self.listener.accept().await {
                 Ok(accepted) => accepted,
                 // A connection that died between the SYN and our accept is the
@@ -91,6 +114,15 @@ impl McpListener {
                 // longer usable, and spinning on it would burn the accept loop.
                 Err(error) if is_transient_accept_error(&error) => {
                     tracing::warn!(error = %error, "mcp listener skipped a connection");
+                    continue;
+                }
+                // Out of descriptors (or memory): the sessions already being
+                // served will release some. Ending the listener here would
+                // take those healthy sessions' endpoint down with the burst.
+                Err(error) if is_resource_exhaustion(&error) => {
+                    tracing::warn!(error = %error, "mcp listener backing off after resource exhaustion");
+                    drop(permit);
+                    tokio::time::sleep(ACCEPT_EXHAUSTION_BACKOFF).await;
                     continue;
                 }
                 Err(error) => {
@@ -101,7 +133,7 @@ impl McpListener {
                 Arc::clone(&self.host),
                 self.session_context_for(peer),
             );
-            tokio::spawn(serve_connection(server, stream, peer));
+            tokio::spawn(serve_connection(server, stream, peer, permit));
         }
     }
 
@@ -133,7 +165,12 @@ fn ensure_bind_allowed(addr: SocketAddr, exposure: ListenerExposure) -> Result<(
     )))
 }
 
-async fn serve_connection(server: OrbitToolServer, stream: TcpStream, peer: SocketAddr) {
+async fn serve_connection(
+    server: OrbitToolServer,
+    stream: TcpStream,
+    peer: SocketAddr,
+    _permit: OwnedSemaphorePermit,
+) {
     let running = match server.serve(stream).await {
         Ok(running) => running,
         Err(error) => {
@@ -151,6 +188,25 @@ fn is_transient_accept_error(error: &std::io::Error) -> bool {
         error.kind(),
         ErrorKind::ConnectionAborted | ErrorKind::ConnectionReset | ErrorKind::Interrupted
     )
+}
+
+/// `accept` failed for want of a descriptor or memory rather than because the
+/// socket is gone: EMFILE / ENFILE (no stable `ErrorKind` on every platform,
+/// so the raw errno is matched on Unix) or an out-of-memory report.
+fn is_resource_exhaustion(error: &std::io::Error) -> bool {
+    if error.kind() == ErrorKind::OutOfMemory {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        // ENFILE (23) and EMFILE (24) share these values on Linux and macOS;
+        // matching the errno keeps this crate free of a libc edge.
+        matches!(error.raw_os_error(), Some(23 | 24))
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two resource-bound findings from the `orbit-mcp` audit.

- **TCP listener: unbounded sessions and a fatal EMFILE.** `serve()` accepted and `tokio::spawn`ed without a ceiling; each session lives until the peer closes. The module doc already notes the listener authenticates no one, so any process that can reach the socket could open connections until `accept` returned EMFILE — which `is_transient_accept_error` did not classify, so the whole listener returned `Err` and every healthy session lost its endpoint. A `Semaphore` (`DEFAULT_MAX_MCP_SESSIONS = 64`) is acquired before `accept`, so a full listener leaves new connections in the kernel backlog rather than holding sockets it cannot serve; the permit rides with `serve_connection` and frees on exit. ENFILE/EMFILE (errno literals, no `libc` edge) and `OutOfMemory` on `accept` now back off 250 ms and retry.
- **Federated probe: unbounded reader.** The destination's stdout was read through `channel()` (unbounded) with `BufReader::lines()` (unbounded line), decoupled from the deadline, so a destination streaming without newlines could grow the mux without limit during the 900 s routed-delivery budget. The reader now uses `sync_channel(64)` (backpressure) and a 64 MiB per-line cap; an oversized line ends the session, which the consumer already reports as unreachable. Test: `a_flooding_destination_is_refused_without_buffering_the_flood` (`yes` as the destination).

## Verification

- `cargo test -p orbit-mcp` passes; `make ci-fast`, `make ci-lint` pass. tokio gains the `sync` and `time` features in this crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)