### PR TITLE
perf(exec): walk each deny-glob root once per sandbox phase instead of once per rule

### DIFF
--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -4,7 +4,7 @@
 //! `ResolvedFsProfile::modify` as ordered bind mounts. It is therefore honest
 //! write confinement, not a general read-policy implementation.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -746,31 +746,41 @@ fn non_subtree_denies(profile: &ResolvedFsProfile) -> Vec<String> {
         .collect()
 }
 
+/// Every existing path matched by any of `rules`.
+///
+/// Rules are grouped by the directory their static prefix resolves to and
+/// each such directory is walked once. The shipped default policy carries
+/// four non-subtree denies (`**/.env` and friends) whose prefix is the
+/// workspace root, and the post-run guard expands them before and after every
+/// sandboxed invocation; one walk per rule per phase made that eight full
+/// workspace traversals (including `target/` and `.git/`) per agent step.
 fn expand_rules(rules: &[String]) -> Result<BTreeSet<PathBuf>, OrbitError> {
-    let mut expanded = BTreeSet::new();
+    let mut by_root: BTreeMap<PathBuf, Vec<_>> = BTreeMap::new();
     for rule in rules {
-        expanded.extend(expand_rule(rule)?);
+        let regex = compile_glob_regex(rule).map_err(|error| {
+            OrbitError::InvalidInput(format!(
+                "invalid linux-bwrap filesystem glob `{rule}`: {error}"
+            ))
+        })?;
+        let root = nearest_existing_ancestor(&static_prefix(rule))?;
+        by_root.entry(root).or_default().push(regex);
     }
-    Ok(expanded)
-}
-
-fn expand_rule(rule: &str) -> Result<BTreeSet<PathBuf>, OrbitError> {
-    let regex = compile_glob_regex(rule).map_err(|error| {
-        OrbitError::InvalidInput(format!(
-            "invalid linux-bwrap filesystem glob `{rule}`: {error}"
-        ))
-    })?;
-    let root = nearest_existing_ancestor(&static_prefix(rule))?;
-    let mut candidates = Vec::new();
-    walk_paths(&root, &mut candidates)?;
     let mut matches = BTreeSet::new();
-    for candidate in candidates {
-        let rendered = candidate.to_string_lossy().replace('\\', "/");
-        if regex.is_match(&rendered) {
-            matches.insert(canonical_existing(&candidate, "denyModify match")?);
+    for (root, regexes) in by_root {
+        let mut candidates = Vec::new();
+        walk_paths(&root, &mut candidates)?;
+        for candidate in candidates {
+            let rendered = candidate.to_string_lossy().replace('\\', "/");
+            if regexes.iter().any(|regex| regex.is_match(&rendered)) {
+                matches.insert(canonical_existing(&candidate, "denyModify match")?);
+            }
         }
     }
     Ok(matches)
+}
+
+fn expand_rule(rule: &str) -> Result<BTreeSet<PathBuf>, OrbitError> {
+    expand_rules(std::slice::from_ref(&rule.to_string()))
 }
 
 fn static_prefix(rule: &str) -> PathBuf {
@@ -800,8 +810,15 @@ fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, OrbitError> {
     canonical_existing(&current, "glob search root")
 }
 
+/// `root` itself and everything beneath it, each path once.
 fn walk_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), OrbitError> {
     out.push(root.to_path_buf());
+    walk_children(root, out)
+}
+
+/// Every path beneath `root` (not `root`), each once: a directory is pushed
+/// by its parent's listing, never again when it is descended into.
+fn walk_children(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), OrbitError> {
     if !root.is_dir() {
         return Ok(());
     }
@@ -824,7 +841,7 @@ fn walk_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), OrbitError> {
             })?
             .is_dir()
         {
-            walk_paths(&path, out)?;
+            walk_children(&path, out)?;
         }
     }
     Ok(())
@@ -851,3 +868,7 @@ fn is_executable(path: &Path) -> bool {
 fn is_executable(path: &Path) -> bool {
     path.is_file()
 }
+
+#[cfg(test)]
+#[path = "tests/linux_sandbox.rs"]
+mod tests;

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -1,0 +1,80 @@
+//! Unit tests for `linux_sandbox` rule expansion — sibling layout under
+//! src/tests/. The filesystem walk is platform-neutral, so these run
+//! everywhere; the bwrap spawn itself is covered by the Linux-only
+//! integration tests.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use super::{expand_rule, expand_rules, walk_paths};
+
+fn tree() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    for dir in ["a", "a/deep", "b", "target/debug"] {
+        fs::create_dir_all(root.join(dir)).expect("create dir");
+    }
+    for file in [
+        ".env",
+        "a/.env",
+        "a/deep/.env.local",
+        "b/settings.env",
+        "b/env.txt",
+        "target/debug/build.env.bak",
+    ] {
+        fs::write(root.join(file), b"x").expect("write file");
+    }
+    temp
+}
+
+fn canonical(root: &std::path::Path, rel: &str) -> PathBuf {
+    root.join(rel).canonicalize().expect("canonical")
+}
+
+/// Every rule sharing a search root is matched from one walk, and the union
+/// equals what the rules would have matched one at a time.
+#[test]
+fn rules_sharing_a_root_expand_from_one_walk_to_the_same_set() {
+    let temp = tree();
+    let root = temp.path().canonicalize().expect("canonical root");
+    let prefix = root.to_string_lossy().replace('\\', "/");
+    let rules: Vec<String> = ["**/.env", "**/.env.*", "**/*.env", "**/*.env.*"]
+        .iter()
+        .map(|glob| format!("{prefix}/{glob}"))
+        .collect();
+
+    let together = expand_rules(&rules).expect("expand together");
+    let mut one_at_a_time = BTreeSet::new();
+    for rule in &rules {
+        one_at_a_time.extend(expand_rule(rule).expect("expand one"));
+    }
+    assert_eq!(together, one_at_a_time);
+
+    let expected: BTreeSet<PathBuf> = [
+        ".env",
+        "a/.env",
+        "a/deep/.env.local",
+        "b/settings.env",
+        "target/debug/build.env.bak",
+    ]
+    .iter()
+    .map(|rel| canonical(&root, rel))
+    .collect();
+    assert_eq!(together, expected);
+}
+
+/// The walk lists each path exactly once: directories used to be pushed on
+/// entry and again from their parent's listing.
+#[test]
+fn walk_lists_every_path_once() {
+    let temp = tree();
+    let root = temp.path().canonicalize().expect("canonical root");
+    let mut paths = Vec::new();
+    walk_paths(&root, &mut paths).expect("walk");
+    let unique: BTreeSet<&PathBuf> = paths.iter().collect();
+    assert_eq!(unique.len(), paths.len(), "duplicates in {paths:?}");
+    // 1 root + 4 dirs (a, a/deep, b, target, target/debug = 5) + 6 files.
+    assert_eq!(paths.len(), 1 + 5 + 6);
+    assert_eq!(paths[0], root);
+}


### PR DESCRIPTION
## Summary

`LinuxBwrapPostRunGuard::capture` / `verify` expand every non-subtree deny glob before and after each sandboxed invocation, and `expand_rule` performed its own full recursive `walk_paths` from the rule's static prefix. With the shipped default policy's four `.env` rules (all rooted at the workspace), that was eight complete workspace traversals per agent step, `target/`, `node_modules/`, and `.git/` included, materialized into `Vec<PathBuf>` before regex matching. `walk_paths` additionally pushed every directory twice (once on entry, once from its parent's listing).

- `expand_rules` groups rules by their resolved search root and walks each root once, testing every rule's compiled pattern against each candidate; `expand_rule` is the single-rule case of it.
- `walk_paths` pushes the root, then `walk_children` lists each descendant exactly once.
- Unit tests (`src/tests/linux_sandbox.rs`, platform-neutral since only the walk is exercised): the grouped expansion equals the per-rule union and the expected `.env` set; the walk lists each path once.

## Verification

- `cargo test -p orbit-exec` passes; `make ci-fast` (orphan-module guard included), `make ci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)