### PR TITLE
[code-review] Direct task-lock reservations do not canonicalize selectors against the workspace

### DIFF
--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -206,7 +206,10 @@ pub(crate) fn reserve(
             task_ids.clone(),
             requested_task_files_indexed(&index, task_ids, repo_root)?,
         ),
-        TaskLockReservationScope::Files(files) => (Vec::new(), files.clone()),
+        TaskLockReservationScope::Files(files) => (
+            Vec::new(),
+            canonicalize_file_lock_selectors(files, repo_root)?,
+        ),
     };
     runtime.reconcile_stale_owned_reservations_for_files(&requested_files, 32)?;
     let mut conflicts = task_lock_conflicts_indexed(&index, &task_ids, &requested_files, repo_root);
@@ -391,6 +394,24 @@ fn parse_file_lock_selectors(files: Vec<String>) -> Result<Vec<String>, OrbitErr
         ));
     }
     Ok(deduped.into_iter().collect())
+}
+
+fn canonicalize_file_lock_selectors(
+    files: &[String],
+    workspace_root: &Path,
+) -> Result<Vec<String>, OrbitError> {
+    files
+        .iter()
+        .map(|selector| {
+            canonical_selector_in_workspace(selector, workspace_root).map_err(|error| {
+                OrbitError::InvalidInput(format!(
+                    "`files` entries must remain inside workspace `{}`: {error}",
+                    workspace_root.display()
+                ))
+            })
+        })
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map(|selectors| selectors.into_iter().collect())
 }
 
 pub(crate) fn workspace_orbit_dir(runtime: &OrbitRuntime) -> String {

--- a/crates/orbit-core/src/runtime/task/tests/locks.rs
+++ b/crates/orbit-core/src/runtime/task/tests/locks.rs
@@ -472,7 +472,10 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
         .run_tool(
             "orbit.task.locks.reserve",
             json!({
-                "files": ["file:src/lib.rs", "dir:src/auth/"],
+                "files": [
+                    format!("file:{}", repo_root.join("src/lib.rs").display()),
+                    "dir:src/auth/",
+                ],
                 "ttl_seconds": 3600,
                 "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
             }),
@@ -551,6 +554,33 @@ fn files_shape_reservations_conflict_and_release_like_task_reservations() {
         )
         .expect("task reservation succeeds after release");
     assert_eq!(task_reserve["reserved"], true);
+}
+
+#[test]
+fn files_shape_reservations_reject_outside_workspace_before_persisting() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let error = runtime
+        .run_tool(
+            "orbit.task.locks.reserve",
+            json!({
+                "files": ["file:/outside-workspace/lib.rs"],
+                "ttl_seconds": 3600,
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL,
+            }),
+        )
+        .expect_err("outside-workspace selector is rejected");
+    let message = invalid_input_message::<Value>(Err(error));
+    assert!(
+        message.contains("must remain inside workspace"),
+        "{message}"
+    );
+
+    let locks = runtime
+        .run_tool("orbit.task.locks", json!({}))
+        .expect("list task locks");
+    assert_eq!(locks["total_reservations"], 0);
 }
 
 use orbit_tools::{ReservationOwnerContext, ToolContext};


### PR DESCRIPTION
## Task

[ORB-11163](https://orbit-cli.com/tasks/ORB-11163) — [code-review] Direct task-lock reservations do not canonicalize selectors against the workspace

### Description

## Problem
The new direct `orbit task locks reserve --file` path parses a `file:`/`dir:` selector and stores its textual form, but never applies the workspace canonicalization used by task context surfaces. As a result, a caller can reserve `file:/absolute/path/to/worktree/src/lib.rs`, while a task declares the equivalent canonical `file:src/lib.rs`; the reservation and task do not conflict. Both can proceed despite targeting the same file.

## Evidence
- `crates/orbit-core/src/runtime/task/locks.rs:368-386` accepts direct selectors through `Selector::parse()` and inserts `selector.to_string()` without `canonical_selector_in_workspace`.
- `crates/orbit-core/src/runtime/task/locks.rs:204-212` passes those raw direct selectors to stale-reservation reconciliation and conflict checks.
- Task-backed lock surfaces do canonicalize through `canonical_selector_in_workspace` at `crates/orbit-core/src/runtime/task/locks.rs:430-437`, producing workspace-relative anchors.
- Overlap compares anchors as strings at `crates/orbit-common/src/fs/selector.rs:356-378`; `/absolute/.../src/lib.rs` and `src/lib.rs` therefore do not overlap. `canonical_selector_in_workspace` at `:287-315` is the existing canonical path that rewrites an in-workspace absolute anchor to the relative form.

## Impact
A manual/direct lock can silently fail to serialize work with pipeline task locks, defeating the reservation feature’s conflict-safety promise. Out-of-workspace anchors also become durable reservation records despite context surfaces being constrained to the workspace.

## Suggested direction
Canonicalize and validate every direct `files` selector against `runtime.paths().repo_root` before reservation/conflict processing; reject anchors outside the workspace and add absolute-vs-relative conflict coverage.

### Acceptance Criteria

- Reserving an in-workspace file via an absolute selector conflicts with a task or reservation using the equivalent workspace-relative selector.
- A direct `files` reservation whose anchor is outside the workspace is rejected before a reservation is persisted.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Canonicalized direct `files` reservation selectors against the runtime repository root before stale-reservation reconciliation and conflict checks.
- Rejected selectors whose anchors resolve outside the workspace.
- Added coverage proving an in-workspace absolute selector is stored as its relative form and conflicts with a task reservation, plus coverage that an outside-workspace selector leaves no reservation behind.
Validation:
- cargo fmt --check
- cargo test -p orbit-core files_shape_reservations --lib
- cargo test -p orbit-core runtime::task::tests::locks --lib (16 passed)
- make ci-fast
- make ci-lint
Assessment: The direct reservation path now shares the existing workspace canonicalization contract used by task-backed lock surfaces; no dependency or API changes were needed.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11163-6a9a1de3`
- Behind base: 0
- Ahead of base: 1