### PR TITLE
[code-review] `orbit task flow` loses historical rejection events after a task is reopened

### DIFF
--- a/crates/orbit-cli/src/command/task/flow.rs
+++ b/crates/orbit-cli/src/command/task/flow.rs
@@ -7,15 +7,15 @@
 //! forty close a week and terminal when none do. This bucketizes both rates
 //! over the same windows so the trend is visible.
 //!
-//! Closure time is approximated by `updated_at` on a task that has reached a
-//! terminal status. `Done` is terminal, so nothing moves the timestamp
-//! afterwards, but a task edited shortly before it closed reports that edit's
-//! time. The error is bounded by the gap between a task's last edit and its
-//! close, and it does not accumulate across buckets.
+//! Terminal transitions come from task status history, so a task that is
+//! rejected and later reopened remains closed for the intervening windows and
+//! still contributes its dropped event. Legacy terminal tasks without status
+//! history retain the previous `updated_at` approximation.
 
 use chrono::{DateTime, Duration, Utc};
 use clap::{ArgAction, Args};
 use orbit_core::{OrbitError, OrbitRuntime, Task, TaskStatus, TaskType};
+use orbit_types::task::TaskHistoryEntry;
 use serde_json::json;
 
 use crate::command::{Block, CommandOut, Execute, Payload};
@@ -40,8 +40,8 @@ const DEFAULT_BUCKETS: usize = 6;
                   of the population was still open when that window closed.\n\n\
                   The verdict compares total inflow against total outflow across every\n\
                   window: draining, flat, or growing.\n\n\
-                  Closure time is approximated by a terminal task's last-updated timestamp;\n\
-                  a task edited shortly before closing reports that edit's time."
+                  Terminal transitions come from task status history, so reopened tasks retain\n\
+                  their prior CLOSED or DROPPED events in the appropriate windows."
 )]
 pub struct TaskFlowArgs {
     /// Filter by tag. Repeat for AND semantics, matching `orbit task list`.
@@ -61,14 +61,19 @@ pub struct TaskFlowArgs {
     pub json: bool,
 }
 
-/// The three task fields the report reads. Reducing to them keeps the
-/// arithmetic testable without constructing whole tasks, and makes it obvious
-/// that nothing else influences the numbers.
-#[derive(Clone, Copy)]
+/// The task creation time and status changes the report reads. Reducing to
+/// them keeps the arithmetic testable without constructing whole tasks.
+#[derive(Clone)]
 pub(crate) struct FlowPoint {
     pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    pub terminal: Option<TerminalKind>,
+    pub status_changes: Vec<StatusChange>,
+}
+
+/// A transition into a task status at a known instant.
+#[derive(Clone, Copy)]
+pub(crate) struct StatusChange {
+    pub at: DateTime<Utc>,
+    pub status: TaskStatus,
 }
 
 /// A task leaves the live backlog on `done`, `rejected`, or `archived`. The
@@ -91,18 +96,45 @@ impl TerminalKind {
 }
 
 impl FlowPoint {
-    pub(crate) fn from_task(task: &Task) -> Self {
+    pub(crate) fn from_task(task: &Task, history: &[TaskHistoryEntry]) -> Self {
+        let mut status_changes: Vec<StatusChange> = history
+            .iter()
+            .filter_map(|entry| {
+                entry.to_status.map(|status| StatusChange {
+                    at: entry.at,
+                    status,
+                })
+            })
+            .collect();
+        status_changes.sort_by_key(|change| change.at);
+
+        // Older task records may predate status history. Preserve their
+        // terminal outflow approximation rather than silently removing them
+        // from the report.
+        if status_changes.is_empty() && TerminalKind::of(task.status).is_some() {
+            status_changes.push(StatusChange {
+                at: task.updated_at,
+                status: task.status,
+            });
+        }
+
         Self {
             created_at: task.created_at,
-            updated_at: task.updated_at,
-            terminal: TerminalKind::of(task.status),
+            status_changes,
         }
     }
 
-    /// Whether the task was still open at `instant`: created by then, and
-    /// either never closed or closed afterwards.
+    /// Whether the task was still open at `instant`: created by then and not
+    /// in a terminal status at that time. A later reopen restores it to the
+    /// historical backlog population.
     fn open_at(&self, instant: DateTime<Utc>) -> bool {
-        self.created_at <= instant && (self.terminal.is_none() || self.updated_at > instant)
+        self.created_at <= instant
+            && self
+                .status_changes
+                .iter()
+                .rev()
+                .find(|change| change.at <= instant)
+                .is_none_or(|change| TerminalKind::of(change.status).is_none())
     }
 }
 
@@ -182,13 +214,15 @@ pub(crate) fn compute_flow(
             if point.created_at >= bucket.start && point.created_at < bucket.end {
                 bucket.filed += 1;
             }
-            if let Some(kind) = point.terminal
-                && point.updated_at >= bucket.start
-                && point.updated_at < bucket.end
-            {
-                match kind {
-                    TerminalKind::Closed => bucket.closed += 1,
-                    TerminalKind::Dropped => bucket.dropped += 1,
+            for change in &point.status_changes {
+                if let Some(kind) = TerminalKind::of(change.status)
+                    && change.at >= bucket.start
+                    && change.at < bucket.end
+                {
+                    match kind {
+                        TerminalKind::Closed => bucket.closed += 1,
+                        TerminalKind::Dropped => bucket.dropped += 1,
+                    }
                 }
             }
             if point.open_at(bucket.end) {
@@ -213,8 +247,12 @@ impl Execute for TaskFlowArgs {
             .list_tasks_by_tags(&self.tags)?
             .iter()
             .filter(|task| self.task_type.is_none_or(|kind| task.task_type == kind))
-            .map(FlowPoint::from_task)
-            .collect();
+            .map(|task| {
+                runtime
+                    .get_task_history(&task.id)
+                    .map(|history| FlowPoint::from_task(task, &history))
+            })
+            .collect::<Result<_, _>>()?;
 
         let report = compute_flow(&points, Utc::now(), width, self.buckets);
 

--- a/crates/orbit-cli/src/command/task/tests/flow.rs
+++ b/crates/orbit-cli/src/command/task/tests/flow.rs
@@ -2,7 +2,9 @@
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 
-use crate::command::task::flow::{FlowPoint, TerminalKind, compute_flow, format_net};
+use orbit_core::TaskStatus;
+
+use crate::command::task::flow::{FlowPoint, StatusChange, TerminalKind, compute_flow, format_net};
 
 fn at(day: u32) -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 1, day, 12, 0, 0)
@@ -13,16 +15,33 @@ fn at(day: u32) -> DateTime<Utc> {
 fn open(created: u32) -> FlowPoint {
     FlowPoint {
         created_at: at(created),
-        updated_at: at(created),
-        terminal: None,
+        status_changes: Vec::new(),
     }
 }
 
 fn terminal(created: u32, ended: u32, kind: TerminalKind) -> FlowPoint {
     FlowPoint {
         created_at: at(created),
-        updated_at: at(ended),
-        terminal: Some(kind),
+        status_changes: vec![StatusChange {
+            at: at(ended),
+            status: match kind {
+                TerminalKind::Closed => TaskStatus::Done,
+                TerminalKind::Dropped => TaskStatus::Rejected,
+            },
+        }],
+    }
+}
+
+fn status_history(created: u32, changes: &[(u32, TaskStatus)]) -> FlowPoint {
+    FlowPoint {
+        created_at: at(created),
+        status_changes: changes
+            .iter()
+            .map(|(day, status)| StatusChange {
+                at: at(*day),
+                status: *status,
+            })
+            .collect(),
     }
 }
 
@@ -73,6 +92,28 @@ fn open_at_end_reflects_the_population_still_open_when_the_window_closed() {
     assert_eq!(report.buckets[0].open_at_end, 1);
     assert_eq!(report.buckets[1].open_at_end, 0);
     assert_eq!(report.open_now, 0);
+}
+
+/// A rejected task remains out of the historical population until its later
+/// reopen, and its rejected transition is still an outflow event.
+#[test]
+fn rejection_then_reopen_preserves_dropped_event_and_historical_boundaries() {
+    let report = compute_flow(
+        &[status_history(
+            1,
+            &[(10, TaskStatus::Rejected), (16, TaskStatus::Backlog)],
+        )],
+        at(21),
+        Duration::days(7),
+        2,
+    );
+
+    assert_eq!(report.buckets[0].dropped, 1);
+    assert_eq!(report.buckets[0].open_at_end, 0);
+    assert_eq!(report.buckets[1].dropped, 0);
+    assert_eq!(report.buckets[1].open_at_end, 1);
+    assert_eq!(report.dropped, 1);
+    assert_eq!(report.open_now, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11162](https://orbit-cli.com/tasks/ORB-11162) — [code-review] `orbit task flow` loses historical rejection events after a task is reopened

### Description

## Problem
`orbit task flow` derives `TerminalKind` exclusively from each task’s *current* `status` in `crates/orbit-cli/src/command/task/flow.rs:87-102`, then counts its sole `updated_at` timestamp as the drop/close event in `compute_flow` at `:186-192`. But rejected tasks are explicitly reopenable: `crates/orbit-types/src/task/model.rs:4-26` documents that `Rejected` can be re-opened, and `TaskStatus::validate_transition` at `:254-277` permits every transition except transitions out of `Done` and direct archive.

A task rejected during a reporting window and subsequently restored to backlog/in-progress has a non-terminal current status, so `FlowPoint::from_task` makes `terminal: None`. The report then omits the rejection from `DROPPED`, reports the task as open at earlier window boundaries, and can reverse the displayed backlog trend. This is not merely an approximation of close time: the event is absent even though task history records it.

## Evidence
- `crates/orbit-cli/src/command/task/flow.rs:87-102` discards task history and classifies only current status.
- `crates/orbit-cli/src/command/task/flow.rs:186-204` counts only that derived current terminal state and uses it for all historical open-at-end values.
- `crates/orbit-types/src/task/model.rs:4-26,254-277` makes `rejected -> backlog` a supported lifecycle path.

## Suggested direction
Drive flow outflow and historical open counts from status-transition history (or clearly restrict the command to irreversible terminal statuses and avoid claiming historical dropped rates), with coverage for reject-then-reopen.

### Acceptance Criteria

- A task rejected in one flow window and reopened in a later window still contributes one dropped event to the rejection window.
- `orbit task flow` reports the task as closed/dropped at boundaries after the rejection and before its reopen, with regression coverage for the lifecycle.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Derived `orbit task flow` terminal outflow and boundary openness from recorded status transitions instead of the task's current status.
- Preserved the legacy `updated_at` fallback only for terminal tasks without status history.
- Added reject-then-reopen regression coverage: the rejection is counted once as dropped, the task is closed at the intervening boundary, and open after reopening.
- Updated flow help and module documentation to describe history-based terminal events.
Assessment: Focused implementation with no new dependency edge; task history is already available through the runtime and `orbit-cli` already depends on `orbit-types`.
Validation:
- `cargo test -p orbit-cli command::task::tests::flow` (10 passed)
- `make ci-fast` (passed)
- `make ci-lint` (passed)
- `git diff --check` (passed)
Cleanup: Removed this run's generated Cargo build artifacts with `cargo clean`; final worktree contains only the two task-scoped source/test changes.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11162-6a9a1de3`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*