### PR TITLE
[qa-sweep] orbit sweep ignores explicit custom roots

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -965,9 +965,9 @@ fn dispatch_run(command: Commands, context: DispatchContext<'_>) -> CommandOut {
     }
 }
 
-fn dispatch_sweep(command: Commands, _context: DispatchContext<'_>) -> CommandOut {
+fn dispatch_sweep(command: Commands, context: DispatchContext<'_>) -> CommandOut {
     match command {
-        Commands::Sweep(command) => command.execute_without_runtime(),
+        Commands::Sweep(command) => command.execute_without_runtime(context.root_override),
         _ => dispatch_mismatch("Sweep"),
     }
 }

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -7,10 +7,15 @@
 //! errors — an unconfigured host logs one line and exits 0, because the OS
 //! clock will invoke it forever.
 
+use std::path::Path;
+
 use crate::command::{Block, CommandOut, Payload};
 use clap::Args;
-use orbit_cmd::registry_routines::run_sweep;
-use orbit_core::application::routines::{RoutineSweepReport, SweepOptions, SweepOutcome};
+use orbit_cmd::registry_routines::{run_sweep, run_sweep_at};
+use orbit_core::{
+    OrbitError, OrbitRuntime,
+    application::routines::{RoutineSweepReport, SweepOptions, SweepOutcome},
+};
 use serde_json::json;
 
 #[derive(Args)]
@@ -74,10 +79,11 @@ impl SweepCommand {
     /// Runs without a pre-initialized runtime: the sweep resolves every
     /// workspace from the global registry (per-workspace runtimes are built
     /// inside orbit-core).
-    pub fn execute_without_runtime(self) -> CommandOut {
-        let outcome = run_sweep(SweepOptions {
+    pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
+        let options = SweepOptions {
             dry_run: self.dry_run,
-        })?;
+        };
+        let outcome = run_sweep_for_selected_root(root_override, options)?;
 
         let doc = outcome_json(&outcome, self.dry_run);
         if self.json {
@@ -151,6 +157,20 @@ impl SweepCommand {
         }
         lines
     }
+}
+
+fn run_sweep_for_selected_root(
+    root_override: Option<&Path>,
+    options: SweepOptions,
+) -> Result<SweepOutcome, OrbitError> {
+    let has_env_override = std::env::var("ORBIT_ROOT").is_ok_and(|root| !root.trim().is_empty());
+    if root_override.is_none() && !has_env_override {
+        return run_sweep(options);
+    }
+
+    let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
+    let roots = OrbitRuntime::resolve_roots_for_cwd(&cwd, root_override)?;
+    run_sweep_at(&roots.global_root, options)
 }
 
 pub(crate) fn outcome_json(outcome: &SweepOutcome, dry_run: bool) -> serde_json::Value {

--- a/crates/orbit-cli/tests/sweep_root.rs
+++ b/crates/orbit-cli/tests/sweep_root.rs
@@ -1,0 +1,219 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+struct Fixture {
+    _temp: TempDir,
+    home: PathBuf,
+    repo: PathBuf,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn initialized() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("empty-home");
+        let repo = temp.path().join("repo");
+        let root = temp.path().join("custom-root");
+        fs::create_dir_all(&home).expect("create empty home");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_git_repo(&repo);
+
+        let root_arg = root.to_string_lossy().into_owned();
+        run_success(
+            &repo,
+            &home,
+            &[
+                "--root",
+                &root_arg,
+                "init",
+                "--non-interactive",
+                "--host-name",
+                "sweep-root-host",
+                "--task-prefix",
+                "SR",
+            ],
+            None,
+        );
+        run_success(
+            &repo,
+            &home,
+            &[
+                "--root",
+                &root_arg,
+                "workspace",
+                "init",
+                "--name",
+                "sweep-root",
+            ],
+            None,
+        );
+        enable_routine_source(&root);
+        assert_home_empty(&home);
+
+        Self {
+            _temp: temp,
+            home,
+            repo,
+            root,
+        }
+    }
+}
+
+#[test]
+fn sweep_honors_explicit_root_over_uninitialized_home() {
+    let fixture = Fixture::initialized();
+    let root_arg = fixture.root.to_string_lossy().into_owned();
+
+    let outcome = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &[
+            "sweep",
+            "--root",
+            &root_arg,
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+        None,
+    );
+
+    assert_sweep_used_custom_root(&outcome);
+    assert_home_empty(&fixture.home);
+}
+
+#[test]
+fn sweep_honors_orbit_root_over_uninitialized_home() {
+    let fixture = Fixture::initialized();
+
+    let outcome = run_json(
+        &fixture.repo,
+        &fixture.home,
+        &["sweep", "--dry-run", "--format", "json"],
+        Some(&fixture.root),
+    );
+
+    assert_sweep_used_custom_root(&outcome);
+    assert_home_empty(&fixture.home);
+}
+
+fn assert_sweep_used_custom_root(outcome: &Value) {
+    assert_eq!(outcome["host_id"], "sweep-root-host");
+    assert_eq!(outcome["dry_run"], true);
+    assert!(
+        outcome["reports"]
+            .as_array()
+            .is_some_and(|reports| !reports.is_empty()),
+        "expected seeded routines from the custom root: {outcome}"
+    );
+}
+
+fn run_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) {
+    command(cwd, home, args, orbit_root)
+        .args(args)
+        .assert()
+        .success();
+}
+
+fn run_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) -> Value {
+    let output = command(cwd, home, args, orbit_root)
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    serde_json::from_slice(&output).unwrap_or_else(|error| {
+        panic!(
+            "parse JSON from `orbit {}`: {error}\nstdout:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output)
+        )
+    })
+}
+
+fn command(
+    cwd: &Path,
+    home: &Path,
+    args: &[&str],
+    orbit_root: Option<&Path>,
+) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_REGISTRY_ROOT");
+    if let Some(root) = orbit_root {
+        command.env("ORBIT_ROOT", root);
+    }
+    if let Some(root) = managed_registry_root(args, orbit_root) {
+        command
+            .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
+            .env("ORBIT_RUN_ID", "sweep-root-test")
+            .env("ORBIT_REGISTRY_ROOT", root);
+    }
+    command
+}
+
+fn managed_registry_root(args: &[&str], orbit_root: Option<&Path>) -> Option<PathBuf> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == "--root").then(|| PathBuf::from(pair[1])))
+        .or_else(|| orbit_root.map(Path::to_path_buf))
+}
+
+fn assert_home_empty(home: &Path) {
+    assert!(
+        fs::read_dir(home)
+            .expect("read isolated home")
+            .next()
+            .is_none(),
+        "sweep touched isolated HOME at {}",
+        home.display()
+    );
+}
+
+fn enable_routine_source(root: &Path) {
+    let config_path = root.join("config.toml");
+    let mut config = fs::read_to_string(&config_path).expect("read workspace config");
+    config.push_str("\n[routines]\nrole = \"source\"\n");
+    fs::write(config_path, config).expect("enable routine source");
+}
+
+fn init_git_repo(repo: &Path) {
+    run_git(repo, &["init", "--quiet"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# sweep root test\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11165](https://orbit-cli.com/tasks/ORB-11165) — [qa-sweep] orbit sweep ignores explicit custom roots

### Description

## Problem
`orbit sweep` accepts the global `--root` option but does not pass it into its runtime-free dispatch path. It instead resolves the host identity from `$HOME/.orbit`, unlike the routine commands corrected by commit `cf774ab8` (ORB-11156). This was observed while validating commits `cf774ab8..f51d848c`.

## Evidence
Built `target/debug/orbit` at `f51d848c` and initialized an isolated root and workspace under `/tmp/orbit-qa-11164`. Both placements of the documented global option fail when HOME points elsewhere:

```text
env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/tmp/orbit-qa-11164/empty-home target/debug/orbit sweep --root /tmp/orbit-qa-11164/root --format json --dry-run --verbose
{"code":"invalid_input","error":"invalid input: no host identity at `/tmp/orbit-qa-11164/empty-home/.orbit/host.toml`; run `orbit init` to create one"}
exit 1
```

`target/debug/orbit --root /tmp/orbit-qa-11164/root sweep ...` fails identically. The selected root does contain a valid `host.toml`. As a control, `orbit routine list --root /tmp/orbit-qa-11164/root --format json` succeeds and reports host `qa-host`. Code inspection shows `operation.rs` dispatches `Commands::Sweep(command) => command.execute_without_runtime()` while the sibling routine path passes `context.root_override`; `SweepCommand::execute_without_runtime` calls `run_sweep` without a selected root.

## Reproduction
1. Create a scratch Git checkout under `/tmp`.
2. Run `orbit --root /tmp/qa-root init --non-interactive --host-name qa-host --task-prefix QAQA`.
3. In the checkout, run `orbit --root /tmp/qa-root workspace init`.
4. Create an empty alternate HOME and run `env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/tmp/empty-home orbit sweep --root /tmp/qa-root --format json --dry-run`.
5. Observe that the error names `/tmp/empty-home/.orbit/host.toml` rather than `/tmp/qa-root/host.toml`.

## Impact / Scope
Production impact: custom-root installations cannot invoke the scheduler through its advertised `--root` or `ORBIT_ROOT` contract, so due routines cannot be inspected or fired by `orbit sweep` unless state is duplicated under HOME. Default-root installations are unaffected. Validation impact: custom-root hands-on scheduler validation cannot complete. This did not block the repository-prescribed `make` gates.

## Expected
The sweep dispatch resolves and uses the selected global root consistently with `orbit routine`, with CLI coverage for both `--root` and `ORBIT_ROOT` under an unrelated HOME.

### Acceptance Criteria

- `orbit sweep --root <custom-root> --dry-run --format json` reads host and workspace state from the custom root when HOME points elsewhere.
- `ORBIT_ROOT=<custom-root> orbit sweep --dry-run --format json` behaves equivalently.
- CLI integration coverage prevents sweep from falling back to `$HOME/.orbit` when an explicit root is selected.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Forwarded the global root override through the runtime-free sweep dispatch path.
- Resolved explicit `--root` and `ORBIT_ROOT` selections with the canonical runtime resolver and ran the sweep against that selected global root, while preserving the existing default-root sweep path.
- Added process-level regression coverage proving both selectors read the custom host and seeded workspace routines while an unrelated HOME remains untouched.
Assessment: The change is narrowly scoped to sweep root selection and uses the existing explicit-root scheduler seam.
Validation:
- `cargo test -p orbit-cli --test sweep_root` (2 passed)
- `cargo test -p orbit-cli command::tests::sweep` (3 passed)
- `make ci-fast`
- `make ci-lint`
Deviations from original plan:
- Added `file:crates/orbit-cli/tests/sweep_root.rs` because the acceptance criteria require full CLI process coverage; the originally listed command test file only covers pure output formatting.
Friction checkpoint: No qualifying recurring failure, contradicted assumption, incident root cause, or >10-minute non-obvious gotcha encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11165-6a9a1ed6`
- Behind base: 0
- Ahead of base: 1