### PR TITLE
docs: condense README to high-signal content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,215 +10,54 @@
 
 **Orbit takes review off the critical path, so throughput and rigor stop trading against each other. A durable task for every change, structured audit of every tool call and provider exchange, conflict-aware parallel dispatch, and continuous review sweeps that file what they find straight back into the backlog — local-first.**
 
-You drive Claude Code, Codex, Grok Build, or Gemini CLI against real code, often in parallel. Agents make it easy to skip the disciplines that keep code maintainable — no plan, no record, no audit trail, just prompt-and-merge. Six months later you can't reconstruct why an agent wrote a given line. Orbit makes those disciplines cheap enough that keeping them costs you no velocity: tasks before edits, every tool call landing in a structured audit log, parallel runs sandboxed into worktrees with file-level locks, and your team's own design docs retrievable by the agents doing the work.
+You drive Claude Code, Codex, Grok Build, or Gemini CLI against real code, often in parallel. Agents make it easy to skip the disciplines that keep code maintainable, and six months later nobody can reconstruct why an agent wrote a given line. Orbit makes those disciplines cheap: tasks before edits, every tool call in a structured audit log, parallel runs sandboxed into worktrees with file-level locks, and your own design docs retrievable by the agents doing the work.
 
-Conventional practice buys safety with blocking gates: nothing merges until a review passes. That trade caps how many agents you can run at once, because every gate holds a lock on the files it touches while a human catches up. Orbit takes the other side — merge on a quick direction check, then let scheduled `code-review`, `qa-sweep`, and `security-review` passes read the merged window and file every confirmed finding back into the backlog as an ordinary task. Review is continuous instead of blocking, so it never sits between your agents and their next change. And because every commit carries its task ID, the history of how the code came to be stays reconstructable, by you and by the agents.
+Conventional practice buys safety with blocking gates, which caps how many agents you can run at once. Orbit merges on a quick direction check, then scheduled `code-review`, `qa-sweep`, and `security-review` passes read the merged window and file every confirmed finding back into the backlog as an ordinary task. Every commit carries its task ID, so the history stays reconstructable.
 
 ---
 
-## Primary Features
+## Features
 
 - **Durable, intent-tracked task layer.** Lifecycle (`proposed → backlog → in-progress → review → done`) survives sessions and branches; every commit carries the `task_id`, so `orbit task show` reconstructs prompt, plan, execution trace, and review threads months later. → [docs/design/task-artifacts/](docs/design/task-artifacts/)
+- **Structured audit log.** Every tool call, provider exchange, and task transition is a queryable, append-only event with agent identity attached. → [docs/design/auditability/](docs/design/auditability/)
+- **Conflict-aware parallel execution.** `orbit run ship` gives each run its own git worktree and reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later. → [docs/design/activity-job/](docs/design/activity-job/)
+- **Continuous review, not blocking review.** Shipped `code-review`, `qa-sweep`, and `security-review` auto-tasks read the window since their last cursor, verify findings against live code, and file confirmed ones as tasks with `file:line` evidence. A clean window is a successful no-op. → [docs/design/auto-tasks/](docs/design/auto-tasks/)
+- **Sandboxed-by-default execution.** Dispatched agent CLIs run under `sandbox-exec` on macOS and Bubblewrap on Linux; the Linux boundary enforces writes only, leaving host reads and network open. Unsupported platforms keep the in-process filesystem guards. → [docs/design/policy-sandbox/](docs/design/policy-sandbox/)
+- **A searchable docs corpus — your conventions, not Orbit's.** Register the markdown you already write with `orbit docs add`; agents retrieve it by concept via `orbit search --kind doc`, with `--hybrid` adding embedding recall. → [docs/design/orbit-docs/](docs/design/orbit-docs/)
+- **A friction ledger for what made the work harder than it should have been.** A confusing error, a missing flag, an undocumented convention — Orbit's own tooling being one case among many — the agent files it (`orbit friction add`) instead of silently working around it. A task carrying a `resolves` relation closes its friction on reaching `done`.
+- **Dependency-ordered execution.** Tasks carry `dependencies` and typed `relations`; the pipeline gates admission on them, so declare the order once and let the queue enforce it.
+- **Recurring work as data.** `orbit auto-task` defines `.orbit/auto_tasks/*.yaml` templates with a cron or interval schedule and a dedupe policy; a seeded scheduler mints tasks from the due ones, and `orbit auto-task mint <name>` mints one on demand.
 
-- **Structured audit log.** Every tool call, provider request/response, and task transition becomes a queryable event with agent identity attached — append-only, tamper-evident, exportable. → [docs/design/auditability/](docs/design/auditability/)
-
-- **Conflict-aware parallel execution.** For `orbit run ship`, each agent run lands in its own git worktree per task, and the gate pipeline reserves task `context_files` as locks before fanning out, rejecting overlapping reservations up front instead of producing merge conflicts later (see [merge throughput chart](docs/assets/merge-throughput.png)). → [docs/design/activity-job/](docs/design/activity-job/)
-
-- **Continuous review, not blocking review.** Shipped `code-review`, `qa-sweep`, and `security-review` auto-tasks run on their own schedule against what has already merged. Each reads the window since its last recorded cursor, verifies findings against live code, and files confirmed ones as durable tasks with `file:line` evidence — reviewing the window as a whole catches interactions between separately merged changes that per-diff review structurally cannot see. A clean window is a successful no-op. → [docs/design/auto-tasks](docs/design/auto-tasks/)
-
-- **Sandboxed-by-default execution.** Dispatched agent CLIs use a platform-specific OS boundary where supported. macOS uses `sandbox-exec`; Linux uses trusted `/usr/bin/bwrap` after a capability probe to enforce writes from the resolved policy. The Linux boundary leaves host filesystem reads and host network access available, so it does not provide worktree-only reads or policy-gated network egress. Windows and other unsupported platforms have no shipped OS-level backend, while in-process FS guards still cover HTTP tools. → [docs/design/policy-sandbox](docs/design/policy-sandbox/)
-
-- **A searchable docs corpus — your conventions, not Orbit's.** Register the markdown you already write — designs, decision records, ADRs, runbooks, patterns, in whatever layout your team uses — with `orbit docs add`, and agents retrieve it by concept instead of by filename: `orbit search --kind doc <query>` ranks against locked frontmatter, and `orbit docs index` plus `--hybrid` adds body-level embedding recall. Orbit imposes no doc structure; it makes the structure you already have retrievable. → [docs/design/orbit-docs/](docs/design/orbit-docs/)
-
-- **A friction ledger for what made the work harder than it should have been.** A confusing error, a missing flag, a build step that fails for undocumented reasons, a convention nobody wrote down — Orbit's own tooling being one case among many — the agent files it (`orbit friction add`, or `orbit_friction_add` over MCP) instead of silently working around it. Records are triaged (`open → triaged → resolved`) and a task carrying `relations: [{"type": "resolves", ...}]` closes its friction on reaching `done`.
-
-- **Dependency-ordered execution.** Tasks carry `dependencies` and typed `relations` (`blocked_by`, …). The pipeline gates admission on them, so a dependent task waits for its blocker to reach `done` instead of being hand-sequenced by whoever is dispatching — declare the order once and let the queue enforce it.
-
-- **Recurring work as data, not code.** `orbit auto-task add/list/show/update/toggle` defines `.orbit/auto_tasks/*.yaml` templates with a cron or interval schedule and a dedupe policy; a seeded scheduler routine mints tasks from the due ones, collapsing catch-up runs and skipping duplicates when one is already open. `orbit auto-task mint <name>` mints one on demand — same template mapping, same provenance — so a new definition can be exercised without waiting for its slot. Provider-neutral, checked into the repo.
+Everything is incremental: the task layer and audit log work on day one; the docs corpus, friction ledger, auto-tasks, and parallel dispatch switch on as you adopt them.
 
 ---
 
 ## Quick Start
 
-### Install the Binary — Recommended
-
-One command gets you a released, signed build. Within your first fifteen minutes you have durable tasks, an audit log, MCP tools registered with your agent CLI, and the dashboard — no clone, no Rust toolchain.
-
-**Prerequisites:** at least one supported agent CLI (Codex, Claude Code, Cursor, or Gemini CLI), authenticated. For PR-based workflows (i.e., `orbit run ship` in the default `--mode pr`), `gh` installed and authenticated; otherwise use `--mode local`. On Linux, install and verify the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) after `orbit init`.
+**Prerequisites:** at least one supported agent CLI (Claude Code, Codex, Cursor, or Gemini CLI), authenticated. `orbit run ship` in its default `--mode pr` needs `gh` authenticated; otherwise use `--mode local`. On Linux, complete the [Linux sandbox runbook](docs/runbooks/linux-sandbox.md) after `orbit init`.
 
 ```bash
-# install
 curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh
 # or: brew install danieljhkim/tap/orbit
-# or, in Claude Code:
-#   /plugin marketplace add danieljhkim/orbit
-#   /plugin install orbit
-# or, in Codex CLI:
-#   codex plugin marketplace add danieljhkim/orbit --ref main
-#   codex plugin add orbit@orbit
-# or, in Cursor from an Orbit checkout:
-#   mkdir -p ~/.cursor/plugins/local
-#   ln -sfn "$(pwd)/plugin" ~/.cursor/plugins/local/orbit
-```
 
-<details>
-<summary><strong>Your first fifteen minutes</strong> — initialize, ship a task, watch it land (click to expand)</summary>
-
-```bash
-# initialize
 orbit init                                 # global state (~/.orbit)
 cd <repo> && orbit workspace init --mcp    # workspace state + operator-authorized MCP integration
 
-# create, approve, and ship a task
-TASK_ID=$(orbit task add \
-  --title "..." \
-  --description "..." \
-  --acceptance-criteria "..." \
-  --complexity medium \
-  --workspace .)
-
-# or simply ask an agent to create a task:
-# "Claude can you create an orbit task to refactor the authentication logic in ..."
-
+TASK_ID=$(orbit task add --title "..." --description "..." \
+  --acceptance-criteria "..." --complexity medium --workspace .)
 orbit task update "$TASK_ID" --status backlog   # approve into the backlog
 
-# conflict-aware, parallel flush of the backlog tasks to PRs.
-# jobs are asynchronous: this submits and returns a run id immediately.
-orbit run ship
-orbit run history -j task_auto_pipeline   # what got submitted
-orbit run show <RUN_ID>                   # step-by-step progress
-
-# launch interactive dashboard — one view over every registered workspace,
-# from any directory. The header selector preselects the workspace for the
-# directory orbit was launched from (if it's registered) and otherwise opens
-# on "All workspaces"; it shows the selected workspace's filesystem path
-# (home-abbreviated to ~) beneath the dropdown, and the aggregate task view
-# lists each task's workspace location in its Details box — so same-named
-# workspaces are easy to tell apart.
-orbit web serve
-
-# ...or view a workspace running on another machine over an SSH tunnel
-# (the dashboard stays loopback-only; auth is delegated to SSH)
-orbit web connect my-server
+orbit run ship                             # conflict-aware parallel flush of the backlog to PRs
+orbit run show <RUN_ID>                    # step-by-step progress
+orbit web serve                            # dashboard over every registered workspace
+orbit web connect my-server                # ...or a remote workspace over an SSH tunnel
 ```
 
-</details>
-<br>
+Or ask your agent: "create an orbit task to refactor the authentication logic in …". Full command reference: `orbit --help` and [orbit-cli.com](https://orbit-cli.com). Crews (which provider-model runs a task) and the base branch: [docs/CONFIG.md](docs/CONFIG.md).
 
-Everything is incremental from here: the task layer and audit log work on day one, and the docs corpus, friction ledger, auto-tasks, and parallel dispatch switch on as you adopt them — none is a prerequisite for the others.
+### Agent plugins
 
-### Clone & Customize via Agent Prompt
-
-The binary is a released build; cloning gives you a customizable framework to mold into your team's conventions. Everything `.orbit/` holds carries over, so you can start on the binary and switch later. No need to contribute back to Orbit unless you want to, you can just fork it.
-
-- If you need to build your custom workflow, ask the agent directly.
-- If you don't like any orbit conventions, ask the agent to tweak it.
-- If something doesn't work, ask the agent to fix it.
-- If you need a new feature, ask the agent to add it.
-- If you are unsure about any orbit features, ask the agent to help you.
-
-Paste the prompt below into your agent (Claude Code, Codex CLI, or Gemini CLI) **from inside the repo where you want to use Orbit**. The agent clones Orbit, builds from source, sets up MCP, and reads the key docs so it can drive the workflow on your behalf afterwards.
-
-<details>
-<summary><strong>Agent setup prompt</strong> — copy this into your agent (click to expand)</summary>
-
-> You are helping me set up Orbit, a local governance and audit layer for coding agents.
->
-> I am a staff/principal/founding engineer who already uses multiple coding agents heavily (Claude Code, Codex, Gemini, Aider, etc.) and has started to feel the long-term maintainability cost of moving fast without enough structure.
->
-> Your job is to install and configure Orbit inside this repository so that I can keep using my existing agents while gaining durable tasks, structured audit, a searchable docs corpus, and safe parallel execution.
->
-> Follow these steps carefully:
->
-> 1. Ask me where I want to clone the Orbit repository (suggest something like `~/code/orbit` or `~/dev/orbit`).
-> 2. Verify the Rust toolchain. Run `cargo --version` and `rustc --version`. Orbit declares `rust-version = "1.89"` (MSRV), so I need Rust **1.89 or newer**. If cargo is missing, or rustc is older than 1.89, **stop and ask me before installing anything** — the canonical path is `rustup` (`curl https://sh.rustup.rs | sh`), but that modifies shell profile, so I want to confirm first. If rustup is already installed but the toolchain is old, suggest `rustup update stable` and confirm before running.
-> 3. Clone `https://github.com/danieljhkim/orbit` into the location from step 1, then run `make install`. This builds with cargo and copies the `orbit` binary to `$INSTALL_BIN_DIR` (default: `~/.cargo/bin`). Confirm the install path with me before running. Verify with `orbit --version`.
-> 4. Run `orbit init` to initialize global state at `~/.orbit`. It selects the host-appropriate sandbox for the shipped executor definitions: `macos-sandbox-exec` on macOS, `linux-bwrap` on Linux, and no OS-level backend on unsupported platforms. On Linux, after `orbit init`, follow the [Linux Bubblewrap host prerequisite](#linux-bubblewrap-host-prerequisite) below and require its capability probe to pass before dispatching agents.
-> 5. From *this* repository (not the Orbit clone), run `orbit workspace init --mcp`. This creates `.orbit/` here and auto-registers Orbit's MCP server with installed agent CLIs (Claude Code, Codex, Gemini). The registered server is **operator-authorized**: it can dispatch workflows (`orbit.workflow.ship`, run observation/resume) and run `orbit.command.exec`. Tell me before running this if you'd rather it stay agent-only (`orbit mcp init` instead).
-> 6. Ask me whether to enable semantic search (**optional**). `orbit semantic install` downloads a small embedder companion plus the default bge-small model (lives under `~/.orbit/embed/`) and powers `orbit search <query> --hybrid` / `orbit search similar <task-id>` over tasks. It requires macOS arm64 or Linux x86_64/aarch64 with glibc >= 2.38; Intel macOS is unsupported for semantic search. Don't install without my OK. If I accept and tasks already exist in this workspace, also run `orbit semantic index` to backfill the corpus.
-> 7. Read the key documents so you actually understand the model:
->    - `README.md` — feature surface and install model
->    - `docs/POSITIONING.md` — what Orbit is for, what it isn't (especially "who this is for")
->    - `CLAUDE.md` — agent operating rules (commit timing, task ID convention, lint constraints)
->    - `ARCHITECTURE.md` — crate layering and dependency rules
->    - `docs/design/CONVENTIONS.md` — design-doc structure, and the admission test for what earns a decision entry
->    - `docs/CONFIG.md` — config reference: crew/workflow knobs and per-task crew override
-> 8. After setup, run `orbit task list` and `orbit semantic stats` and show me the output.
-> 9. Ask me what my first real task should be and create it properly using Orbit's task surface (use the `orbit` skill — it should be auto-discovered after step 5).
->
-> Rules:
-> - Never run destructive commands without explicit confirmation. Specifically: cloning, installing rustup, running `make install` outside `~/.cargo/bin`, and any shell-profile modification all need a confirmation prompt.
-> - If anything is unclear or fails, stop and ask me.
-> - Do not try to "make it simpler" or hide Orbit's conventions. I am choosing this because I want the discipline.
->
-> Report back what you did and the current state of the workspace.
-
-</details>
-
-### Linux Bubblewrap host prerequisite
-
-`orbit init` persists the host-appropriate sandbox into the shipped executor artifacts. On Linux that value is `linux-bwrap`, which resolves the trusted wrapper at `/usr/bin/bwrap` and fails closed if its namespace-and-mount capability probe cannot run. Install Bubblewrap before dispatching an agent. Ubuntu 24.04 (Noble) also enables AppArmor restrictions on unprivileged user namespaces; without the distro's narrow Bubblewrap profile, the probe fails with `bwrap: setting up uid map: Permission denied`.
-
-On Ubuntu 24.04, run this remediation and verification sequence. The package ships `bwrap-userns-restrict` under `/usr/share/apparmor/extra-profiles/`; copy that narrow profile into `/etc/apparmor.d/`, load it, confirm that AppArmor knows it, and run the same capability shape Orbit probes:
-
-```bash
-sudo apt-get update
-sudo apt-get install --yes bubblewrap apparmor-profiles
-test -x /usr/bin/bwrap
-test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
-sudo install -m 0644 \
-  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
-  /etc/apparmor.d/bwrap-userns-restrict
-test -f /etc/apparmor.d/bwrap-userns-restrict
-sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
-grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
-
-/usr/bin/bwrap \
-  --die-with-parent \
-  --new-session \
-  --unshare-all \
-  --share-net \
-  --ro-bind / / \
-  -- /bin/true
-```
-
-The final command must exit successfully. If it still reports the UID-map error, do not disable `kernel.apparmor_restrict_unprivileged_userns` globally and do not enable `allow_fallback`; both weaken or bypass the fail-closed boundary. Re-check the packaged profile path and load output, then rerun the probe. Non-Linux setup paths are unchanged.
-
-Full command reference: `orbit --help` and [orbit-cli.com](https://orbit-cli.com).
-
-Customizing crews (which provider-model runs a task) and the base branch: see [docs/CONFIG.md](docs/CONFIG.md).
-
----
-
-## Semantic Search (optional)
-
-`orbit search` is the unified query surface over three corpora — `--kind task`, `--kind doc`, `--kind friction`, or `--kind all`. It defaults to lexical matching. Opt into hybrid embedding ranking over task fields or indexed docs with `--hybrid`, or find cosine-neighbor tasks with `orbit search similar <task-id>`. The embedder runs as a separate companion subprocess, so semantic search has zero cost when unused.
-
-The semantic companion is released for macOS arm64 and Linux x86_64/aarch64
-with glibc >= 2.38 (Ubuntu 24.04 or equivalent). Intel macOS can run the
-Orbit CLI, but semantic search is unsupported because there is no Intel macOS
-companion asset.
-
-```bash
-orbit semantic install    # one-time: download companion + default model (bge-small)
-orbit semantic index      # backfill existing tasks
-orbit docs index          # backfill docs for --kind doc --hybrid
-orbit search "race in the scheduler when locks overlap"
-orbit search "race in the scheduler when locks overlap" --hybrid --kind task
-orbit search "why tasks serialize ORB ids" --hybrid --kind doc
-orbit search similar ORB-00042
-```
-
-After install, task writes are embedded automatically in the background; `orbit semantic index` is only needed for the initial task backfill. Docs are indexed explicitly with `orbit docs index`, which skips unchanged content hashes and sweeps stale doc paths. Companion + models live under `~/.orbit/embed/`; the per-workspace index is `.orbit/state/semantic.db`. Only tasks and docs are embedded — friction results stay lexical even when `--hybrid` is set.
-
----
-
-## Agent Plugins vs CLI
-
-Orbit ships Claude Code, Codex, and Cursor Agent Plugins 1.0 integrations. Use
-a plugin when you want Orbit's MCP tools and canonical `orbit` skill attached
-to one agent without putting the CLI on `$PATH`; use the signed CLI install for
-the dashboard and cross-agent workspace setup.
+Use a plugin to attach Orbit's MCP tools and `orbit` skill to one agent without the CLI on `$PATH`; use the CLI install for the dashboard and cross-agent workspace setup. All three load `plugin/skills/orbit` and launch `npx -y @orbit-tools/cli@latest mcp serve`.
 
 ```bash
 # Claude Code
@@ -229,154 +68,69 @@ the dashboard and cross-agent workspace setup.
 codex plugin marketplace add danieljhkim/orbit --ref main
 codex plugin add orbit@orbit
 
-# Cursor local Agent Plugin (public marketplace submission is separate)
-git clone https://github.com/danieljhkim/orbit.git
-cd orbit
-mkdir -p ~/.cursor/plugins/local
-ln -sfn "$(pwd)/plugin" ~/.cursor/plugins/local/orbit
-# Restart Cursor or run Developer: Reload Window.
+# Cursor (local plugin from a checkout)
+mkdir -p ~/.cursor/plugins/local && ln -sfn "$(pwd)/plugin" ~/.cursor/plugins/local/orbit
 ```
 
-All three plugin paths load `plugin/skills/orbit` and launch the same portable
-`npx -y @orbit-tools/cli@latest mcp serve` transport. Cursor reads the root
-`plugin/plugin.json` and `plugin/mcp.json` manifests; there is intentionally no
-`plugin/.cursor-plugin` directory. The CLI path remains `curl … | sh` or
-Homebrew, followed by `orbit workspace init --mcp`.
+### Clone and customize
 
-> **Cowork users:** Orbit advertises its canonical MCP surface independently of the
-> server's launch directory. Workspace routing comes from the server's
-> `--workspace` binding, MCP initialize/session context, or an explicit registered
-> `workspace` on the tool call — never from cwd. Do not add the global `--root`
-> flag to `orbit mcp serve`; the server rejects launch-root routing so a
-> scratchpad cwd cannot silently select the wrong workspace.
+Cloning gives you a framework to mold to your team's conventions; everything under `.orbit/` carries over from a binary install. Paste the prompt below into your agent from inside the repo where you want Orbit.
+
+<details>
+<summary><strong>Agent setup prompt</strong> (click to expand)</summary>
+
+> You are helping me set up Orbit, a local governance and audit layer for coding agents, inside this repository so I keep my existing agents while gaining durable tasks, structured audit, a searchable docs corpus, and safe parallel execution.
+>
+> 1. Ask me where to clone the Orbit repository (suggest `~/code/orbit`).
+> 2. Verify the Rust toolchain: Orbit's MSRV is `rust-version = "1.89"`. If cargo is missing or older, **stop and ask me before installing anything** (`rustup` modifies the shell profile).
+> 3. Clone `https://github.com/danieljhkim/orbit` into that location and run `make install` (copies `orbit` to `$INSTALL_BIN_DIR`, default `~/.cargo/bin`). Confirm the install path with me first. Verify with `orbit --version`.
+> 4. Run `orbit init` for global state at `~/.orbit`. On Linux, follow `docs/runbooks/linux-sandbox.md` and require its probe to pass before dispatching agents.
+> 5. From *this* repository, run `orbit workspace init --mcp`. It creates `.orbit/` and registers an **operator-authorized** MCP server with installed agent CLIs. Tell me first if you'd rather it stay agent-only (`orbit mcp init`).
+> 6. Ask me whether to enable semantic search (optional): `orbit semantic install` downloads an embedder companion plus the default model under `~/.orbit/embed/` (macOS arm64 or Linux x86_64/aarch64 with glibc >= 2.38). If I accept and tasks already exist, run `orbit semantic index`.
+> 7. Read `README.md`, `docs/POSITIONING.md`, `CLAUDE.md`, `ARCHITECTURE.md`, `docs/design/CONVENTIONS.md`, and `docs/CONFIG.md`.
+> 8. Run `orbit task list` and `orbit semantic stats` and show me the output.
+> 9. Ask me what my first real task should be and create it with the `orbit` skill.
+>
+> Rules: never run destructive commands, install rustup, install outside `~/.cargo/bin`, or modify a shell profile without confirmation. If anything is unclear or fails, stop and ask. Do not simplify or hide Orbit's conventions; I am choosing this because I want the discipline.
+
+</details>
+
+---
+
+## Search
+
+`orbit search` queries tasks, docs, and frictions (`--kind task|doc|friction|all`), lexical by default. `--hybrid` adds embedding ranking over tasks and indexed docs, and `orbit search similar <task-id>` finds cosine-neighbor tasks. The embedder is a separate companion subprocess, so semantic search costs nothing when unused.
+
+```bash
+orbit semantic install    # one-time: companion + default model (bge-small)
+orbit semantic index      # backfill existing tasks; later task writes embed automatically
+orbit docs index          # backfill docs for --kind doc --hybrid
+orbit search "race in the scheduler when locks overlap" --hybrid --kind task
+```
+
+The companion is released for macOS arm64 and Linux x86_64/aarch64 (glibc >= 2.38); Intel macOS runs the CLI without semantic search. Frictions are never embedded.
 
 ---
 
 ## Agent Skills
 
-`orbit workspace init` seeds skill files under `~/.orbit/skills/` and symlinks them into `~/.claude/skills/` and `~/.agents/skills/`, so Claude Code, Codex, and Gemini CLI discover them at session start with no per-agent configuration. The same pass removes dangling Orbit-owned links for skill IDs that left the default set (a leftover custom skill directory or a live custom symlink is left alone).
-
-Orbit ships one skill, `orbit`. Its `SKILL.md` is a router — the tool-invocation surface, the lifecycle, and a table of references that load on demand:
-
-- **Working through Orbit** — task authoring, execution, and review; search and the docs corpus; friction; orchestration and the `orbit run` surface; debugging a failed run.
-- **Setting Orbit up** — first run and host identity, configuration and crews, the routine scheduler, auto-tasks, maintenance and worktree GC, multi-host task-ID namespacing, and remote access.
-
-First-time onboarding (`.orbit/` absent) and "what is orbit" tour requests are handled by the same skill, via its bundled setup references.
-
-`orbit skill doctor` flags drift between the local copy and the upstream definition, and reports dangling or orphaned symlinks under the client skill link directories. Edit any seeded `SKILL.md` to customize behavior for your team.
+`orbit workspace init` seeds the `orbit` skill under `~/.orbit/skills/` and symlinks it into `~/.claude/skills/` and `~/.agents/skills/`, so Claude Code, Codex, and Gemini CLI discover it with no per-agent configuration. Its `SKILL.md` routes to on-demand references for working through Orbit (tasks, search, friction, `orbit run`, debugging) and setting it up (crews, routines, auto-tasks, GC, remote access). `orbit skill doctor` reports drift from the shipped copy; edit the seeded `SKILL.md` to customize it.
 
 ---
 
-## Orbit MCP Surface
+## MCP Surface
 
-`orbit workspace init --mcp` registers the Orbit MCP server with the local agent CLI (Claude Code, Codex, Gemini). The registered server launches as `orbit mcp serve --operator --workspace <ws_id>`: it holds **operator authority**, so governed operations — dispatching a workflow (`orbit.workflow.ship`), observing/resuming a run, and `orbit.command.exec` — are authorized through it. Bare `orbit mcp serve` (and every worker/agent-launched MCP session) stays agent-only and is refused those governed tools; `orbit mcp init` also stays agent-only unless you pass `--operator` at the `orbit mcp serve` layer yourself.
+`orbit workspace init --mcp` registers `orbit mcp serve --operator --workspace <ws_id>` with the local agent CLIs. That server holds **operator authority**: dispatching a workflow (`orbit.workflow.ship`), observing or resuming a run, and `orbit.command.exec` are authorized through it. Bare `orbit mcp serve`, and every agent-launched session, stays agent-only and is refused those tools. Authorization is enforced at call time, not by hiding names: `tools/list` shows every session the same surface and is the authoritative reference.
 
-`--workspace` is the workspace binding: most MCP clients cannot announce one at initialize, so the generated integration names the workspace it was registered for and workspace-scoped tools route without repeating a selector on every call. An explicit `workspace` on a tool call still overrides it, and a server launched without a binding still refuses a workspace-scoped call that names no workspace.
+`--workspace` binds the server to one workspace so scoped tools route without a selector on every call. An explicit `workspace` argument overrides it; server cwd is never a fallback, so do not pass `--root` to `orbit mcp serve`. An unbound client calls `orbit_workspace_list` first and reuses a returned `ws_*` ID.
 
-`tools/list` is the authoritative MCP reference. Orbit composes that surface from
-the explicitly MCP-registered builtins in `orbit-tools` plus the two discovery
-tools `orbit.workspace.list` and `orbit.crew.list`. `orbit tool list` remains the
-broader registry reference, including tools deliberately kept off MCP.
+`orbit workspace sync` converges Orbit-managed shipped definitions in a registered workspace (preserving operator edits; `--check` is read-only), and `orbit doctor` diagnoses health with narrow repairs. Neither pulls the repo, upgrades the binary, or applies migrations.
 
-Every advertised tool is visible to every session regardless of authority tier;
-authorization is enforced at call time, not by hiding names from `tools/list`.
-Local and SSH-originated sessions receive the same complete supported surface.
-Client permission profiles may auto-allow some names and prompt for others, but
-those settings are ergonomics, not a server security boundary. Domain
-validation, sandboxing, workspace claims, and other runtime checks still
-execute on the accepting server through Orbit Core.
-
-Workspace-scoped tools accept a registered workspace name, logical `ws_*` ID, or
-absolute path registered on the accepting server. The selector may come from the
-tool's `workspace` argument or MCP initialize metadata; server process cwd is not
-a fallback. An unbound client should first call `orbit_workspace_list`, then
-reuse a returned `ws_*` ID on workspace-scoped calls. If the list is empty, set
-up the machine with `orbit init` and then run `orbit workspace init` from the
-project directory. `orbit.workspace.list` is global and reports active
-workspaces that have a checkout registered on that machine.
-
-Workspace lifecycle commands have deliberately separate jobs:
-
-- `orbit workspace init` bootstraps and registers a checkout once.
-- `orbit workspace sync` converges only Orbit-managed shipped definitions for
-  an existing registered workspace. It creates newly shipped defaults,
-  refreshes or retires only content whose manifest proves Orbit wrote the
-  on-disk bytes, and preserves operator edits and name collisions with an
-  actionable path. Routine provenance records the shipped-template digest,
-  the exact rendered-instance digest, and the rendered `name`/`hosts` binding
-  separately, so a host rename or checkout-directory change is reported as
-  binding drift rather than a template update. Use `--check` for a read-only
-  inspection (nonzero when convergence or provenance migration is pending) and
-  `--json` for structured per-kind actions.
-- `orbit doctor` diagnoses health and offers only narrow, evidence-specific
-  repairs; it is not the managed-definition convergence command.
-
-`workspace sync` is local: it does not pull a repository, contact another
-host, upgrade the Orbit binary, alter workspace registration/configuration, or
-apply store/layout migrations.
-
-### Federated MCP
-
-The opt-in federated server presents one MCP namespace over this machine's
-workspaces plus SSH remotes listed in the operator's machine-global
-`~/.orbit/mcp-destinations.toml`. Local workspaces need no destination row; a
-missing or empty file is a valid local-only federated server. Additional remotes
-are declared as SSH destinations:
-
-```toml
-[[destinations]]
-ssh = "orbit-owner"
-machine_id = "hm_alpha"
-
-[[destinations]]
-ssh = "operator@orbit-build"
-machine_id = "hm_beta"
-```
-
-From an Orbit workspace, register that mux with a client (Codex shown here):
-
-```bash
-orbit mcp init --federated --client codex --scope home
-```
-
-This adds one client entry named `orbit-federated` that launches `orbit mcp
-serve --mode federated`. It does not replace the existing v1 `orbit` entry.
-Target another supported client with its `--client` value or use `--auto`.
-Remove only the federated entry later with `orbit mcp remove --federated`
-and the same client/scope selection.
-
-In the federated MCP session, call `orbit_workspace_list`, copy the owner row's
-host-qualified `selector`, then pass it unchanged to one workspace-scoped call:
-
-```text
-orbit_workspace_list({})
-  -> {"workspaces":[{"selector":"hm_alpha/ws_orbit", ...}]}
-
-orbit_task_list({"workspace":"hm_alpha/ws_orbit"})
-```
-
-The mux performs no placement or failover, does not detect two destinations
-that both claim Owner, and is only as available as the selected destination.
-Task reads remain owner-only, so use the owner row's selector for
-`orbit_task_list` and `orbit_task_show`; a replica selector is refused with
-`capability_refused`.
-
-Remote MCP uses one direct, byte-transparent SSH stdio hop:
-
-```text
-orbit mcp serve --mode remote <ssh-host>
-  -> ssh -T <ssh-host> orbit mcp serve --remote-caller-machine-id <audit-label>
-```
-
-SSH access is sufficient for v1. Caller labels and the best-effort SSH source IP
-are audit metadata only; future authorization belongs in Core.
+**Federated MCP** (opt-in) presents one namespace over local workspaces plus SSH remotes declared in `~/.orbit/mcp-destinations.toml`. Register it with `orbit mcp init --federated --client <client>`, then copy the owner row's host-qualified `selector` from `orbit_workspace_list` onto workspace-scoped calls. The mux does no placement or failover; task reads are owner-only. → [docs/design/federated-mcp/](docs/design/federated-mcp/)
 
 ---
 
-## Workspace Layout of `.orbit`
-
-- `orbit workspace init` creates a `.orbit/` directory at the repo root. Workspace-local state lives there; removing the directory returns the workspace to a pre-init state.
-- `orbit init` creates a `.orbit/` directory in the user's home (`~/.orbit/`). User-scoped state lives there; removing the directory returns the user environment to a pre-init state.
+## Workspace Layout
 
 ```
 .orbit/                          # workspace-local (safe to delete → clean slate)
@@ -384,65 +138,32 @@ are audit metadata only; future authorization belongs in Core.
 ├── config.yaml                  # workspace_id only
 ├── auto_tasks/                  # recurring task definitions
 ├── routines/                    # routine definitions
-├── tasks/                       # symlinks → ~/.orbit/tasks/workspaces/<id>/
+├── tasks/                       # projection of ~/.orbit/tasks/workspaces/<id>/
 ├── resources/                   # activities, jobs, executors, policies (customizable)
-└── state/
-    ├── worktrees/               # live git worktrees for agent runs
-    ├── logs/                    # captured agent stdout/stderr
-    ├── job-runs/                # per-run step state and checkpoints
-    ├── audit/                   # workspace-local audit spool
-    ├── diagnostics/             # doctor / health-check output
-    ├── scoreboard/              # rolling counters (PRs, runs, etc.)
-    ├── semantic.db              # embedding index for tasks and docs
-    └── layout.version           # layout migration marker
+└── state/                       # worktrees, logs, job-runs, audit spool, scoreboard, semantic.db
 
 ~/.orbit/                        # global (machine-level, survives repo moves)
-├── tasks/
-│   ├── index.sqlite             # authority for ORB-XXXXX IDs
-│   └── workspaces/<workspace-id>/<task-id>/   # canonical task bundles
-├── orbit.db                     # host-global store: audit events, job runs,
-│                                #   routines, frictions
+├── tasks/                       # ORB-XXXXX index + canonical task bundles per workspace
+├── orbit.db                     # host-global store: audit events, job runs, routines, frictions
 ├── workspaces.json              # workspace registry for this machine
 ├── resources/                   # shipped activities, jobs, executors, policies
-├── skills/                      # SKILL.md files (routable via MCP)
-├── embed/                       # semantic companion binary + models
+├── skills/                      # SKILL.md files
+├── embed/                       # semantic companion + models
 ├── config.toml                  # global settings
-└── host.toml                    # machine identity: machine_id, host_id,
-                                 #   task_prefix
+└── host.toml                    # machine identity: machine_id, host_id, task_prefix
 ```
 
-Couple things to note:
-- **`tasks/`** is a projection. Canonical task bundles live under `~/.orbit/tasks/workspaces/<workspace-id>/<task-id>/` so they survive repo moves; `.orbit/tasks/` is rebuildable from the canonical store. See [docs/design/task-artifacts/](docs/design/task-artifacts/).
-
-- Global state — credentials, the canonical task store, and cross-workspace config — lives under `~/.orbit/`, created by `orbit init`. The recommended `.gitignore` pattern is `.orbit/*` with `!.orbit/auto_tasks/`, `!.orbit/resources/`, `!.orbit/routines/`, and `!.orbit/config.toml` un-ignored, so local runtime state stays out of the repo while the definitions your team authors stay in. `orbit workspace init` seeds this pattern.
-
-- Operating this state day-2 — backup/restore, stuck-job debugging, corrupted-DB recovery, log rotation, health checks (`orbit doctor`, `/healthz`), and upgrades (`orbit migrate`) — is covered in the [runbook index](docs/INDEX.md#runbooks).
+`orbit workspace init` seeds a `.gitignore` that keeps runtime state out of the repo while `auto_tasks/`, `resources/`, `routines/`, and `config.toml` stay in. Day-2 operations (backup, stuck runs, DB recovery, health checks, upgrades) are in the [runbooks](docs/INDEX.md#runbooks).
 
 ---
 
-## Current Status
+## Status
 
-Pre-1.0 and under active development. Breaking changes ride a minor bump (`0.10.x → 0.11.0`); see [CHANGELOG.md](CHANGELOG.md) and [RELEASING.md](RELEASING.md).
-
-- Core local execution, workflows, MCP, tasks, docs, frictions, and audit infrastructure are usable today.
-- 0.11.0 removed two native knowledge stores: `orbit adr` / `orbit.adr.*` and
-  `orbit learning` / `orbit.learning.*` are gone. Durable know-how now lives in
-  your own markdown registered into the docs corpus, in tasks, or in friction
-  records — Orbit no longer prescribes a decision-record format. Workspaces
-  migrate on open.
-- The former parsed code-graph subsystem is also gone. Agents inspect source
-  with `grep`/`rg` and direct file reads.
-
----
+Pre-1.0 and under active development. Breaking changes ride a minor bump; see [CHANGELOG.md](CHANGELOG.md) and [RELEASING.md](RELEASING.md). 0.11.0 removed the native `orbit adr` and `orbit learning` stores and the parsed code-graph subsystem; durable know-how lives in your own markdown registered into the docs corpus.
 
 ## Contributing
 
-Contributions especially welcome on locking, worktree/session management, execution primitives, reconciliation, audit coverage, and tool-calling interfaces.
-
-Before contributing: [docs/INDEX.md](docs/INDEX.md#designs),
-[docs/design/CONVENTIONS.md](docs/design/CONVENTIONS.md), and [CLAUDE.md](CLAUDE.md).
-
----
+Contributions especially welcome on locking, worktree/session management, execution primitives, reconciliation, audit coverage, and tool-calling interfaces. Read [docs/INDEX.md](docs/INDEX.md#designs), [docs/design/CONVENTIONS.md](docs/design/CONVENTIONS.md), and [CLAUDE.md](CLAUDE.md) first.
 
 ## License
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,7 @@ CLI behavior, state layout, or recovery semantics change.
 | [Inspect the Audit Trail](./runbooks/audit-trail.md) | Query and interpret Orbit invocation, run, step, and activity audit history. |
 | [Recover a Corrupted Database](./runbooks/database-recovery.md) | Recover a corrupted Orbit SQLite database from backup, salvage, or regeneration. |
 | [Check Orbit Health](./runbooks/health-checks.md) | Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health. |
+| [Prepare a Linux Host for Sandboxed Dispatch](./runbooks/linux-sandbox.md) | Install and verify the Bubblewrap host prerequisite that Orbit's Linux sandbox fails closed without. |
 | [Inspect and Retain Logs](./runbooks/logging.md) | Locate, filter, rotate, and retain Orbit process and routine-sweep logs. |
 | [Release Orbit](./runbooks/release.md) | Cut and verify an Orbit release across agent plugins, Cargo, GitHub artifacts, Homebrew, and npm. |
 | [Inventory and Protect Orbit State](./runbooks/state-and-backup.md) | Locate Orbit state and perform WAL-safe backups, explicit task publication, restores, and task migrations. |

--- a/docs/runbooks/linux-sandbox.md
+++ b/docs/runbooks/linux-sandbox.md
@@ -1,0 +1,66 @@
+---
+type: runbook
+summary: Install and verify the Bubblewrap host prerequisite that Orbit's Linux sandbox fails closed without.
+tags: [operations, sandbox, linux, bubblewrap, apparmor]
+paths: ["crates/orbit-exec/src/**"]
+related_features: [policy-sandbox, executors]
+related_artifacts: []
+last_validated: 2026-09-03
+---
+
+# Prepare a Linux Host for Sandboxed Dispatch
+
+Use this runbook after `orbit init` on a Linux host, before dispatching any agent, or when a
+run fails with `bwrap: setting up uid map: Permission denied`.
+
+## Why the probe fails closed
+
+`orbit init` persists the host-appropriate sandbox into the shipped executor artifacts. On
+Linux that value is `linux-bwrap`, which resolves the trusted wrapper at `/usr/bin/bwrap` and
+fails closed if its namespace-and-mount capability probe cannot run. Ubuntu 24.04 (Noble) also
+enables AppArmor restrictions on unprivileged user namespaces; without the distro's narrow
+Bubblewrap profile the probe fails with the UID-map error above.
+
+The Linux boundary enforces writes from the resolved policy. It leaves host filesystem reads
+and host network access available, so it does not provide worktree-only reads or policy-gated
+network egress. See [policy-sandbox](../design/policy-sandbox/) for the design.
+
+## Install and verify on Ubuntu 24.04
+
+The package ships `bwrap-userns-restrict` under `/usr/share/apparmor/extra-profiles/`. Copy
+that narrow profile into `/etc/apparmor.d/`, load it, confirm AppArmor knows it, then run the
+same capability shape Orbit probes:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes bubblewrap apparmor-profiles
+test -x /usr/bin/bwrap
+test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+sudo install -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
+test -f /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
+
+/usr/bin/bwrap \
+  --die-with-parent \
+  --new-session \
+  --unshare-all \
+  --share-net \
+  --ro-bind / / \
+  -- /bin/true
+```
+
+The final command must exit successfully.
+
+## If the probe still fails
+
+Do not disable `kernel.apparmor_restrict_unprivileged_userns` globally and do not enable
+`allow_fallback`; both weaken or bypass the fail-closed boundary. Re-check the packaged
+profile path and the `apparmor_parser` output, then rerun the probe.
+
+Other distributions need the same two conditions: an executable `/usr/bin/bwrap` and
+permission for an unprivileged user to create user namespaces and mounts. Non-Linux hosts
+are unaffected: macOS uses `sandbox-exec`, and platforms without a shipped OS-level backend
+rely on in-process filesystem guards only.


### PR DESCRIPTION
## Summary
- README.md: 449 → 170 lines. Removed prose that restated the design docs, the duplicated plugin install blocks, and the long workspace-sync / federated-MCP walkthroughs (linked to their design docs instead). Kept the thesis, feature list, quick start, agent setup prompt, search, skills, MCP authority model, workspace layout, status, contributing.
- Moved the Ubuntu 24.04 Bubblewrap/AppArmor remediation verbatim into `docs/runbooks/linux-sandbox.md` (it existed nowhere else) and regenerated `docs/INDEX.md`.
- `docs/CONFIG.md` still links `../README.md#quick-start`; that heading is retained.

## Verification
- `scripts/generate-doc-indexes.sh --check` passes.
- Every relative link in README.md and the new runbook resolves.
- No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)