### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-core/assets/activities/step_failure_recovery.yaml
+++ b/crates/orbit-core/assets/activities/step_failure_recovery.yaml
@@ -131,7 +131,7 @@ spec:
        or change task lifecycle state. An implementation that did not complete is
        never a delivery candidate.
 
-    3. For every delivery candidate, file a friction record naming the failed
+    3. For every delivery candidate, file an Orbit friction naming the failed
        step and original error. Delivery fixes the immediate run; the friction
        preserves the root cause. The filed friction record is the durable
        artifact — do not treat reporting its id as a substitute for filing it.


### PR DESCRIPTION
## Task

[ORB-11181](https://orbit-cli.com/tasks/ORB-11181) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `26257dbc03ccee49219bbba6f4173358a6e76015`
- Normalized error signature (the dedupe identity, not a quote): `-recovery attempt of that failed\n step. you may also be invoked while repairing an already-terminal source\n run for resume. your job is to preserve the normal pipeline when possible\n and to deliver…`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-04T02:05:13.789775297+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/33827302139 run `33827302139` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `26257dbc03ccee49219bbba6f4173358a6e76015`
  - current head of that ref: `unknown`
  - commit actually checked out: `26257dbc03ccee49219bbba6f4173358a6e76015`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `26257dbc03ccee49219bbba6f4173358a6e76015`
  - failed job `Check / Clippy / Test` (id `100882587705`): https://github.com/danieljhkim/orbit/actions/runs/33827302139/job/100882587705
  - failing step(s): `Run CI guardrails`
  - failed job `Coverage (informational)` (id `100882587808`): https://github.com/danieljhkim/orbit/actions/runs/33827302139/job/100882587808
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9256437Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9256989Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-core --lib`
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9257946Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9258856Z 
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9258860Z 
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9258937Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9259269Z     application::job::tests::catalog::seeded_step_failure_recovery_asset_stays_aligned_without_retired_role
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9259576Z 
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9259790Z test result: FAILED. 879 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 83.73s
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9260069Z 
Coverage (informational)	Collect workspace coverage	2026-09-04T01:56:55.9268354Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33827296152 — superseded_by_newer_workflow_run: newer repository-wide run 33827302139 at 2026-09-04T01:50:54Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33827040033 — superseded_by_newer_workflow_run: newer repository-wide run 33827302139 at 2026-09-04T01:50:54Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33826970386 — superseded_by_newer_workflow_run: newer repository-wide run 33827302139 at 2026-09-04T01:50:54Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33582118504 — superseded_by_newer_workflow_run: newer repository-wide run 33827302139 at 2026-09-04T01:50:54Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33582116357 — superseded_by_newer_workflow_run: newer repository-wide run 33827302139 at 2026-09-04T01:50:54Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Synchronized the seeded step-failure recovery activity with the canonical dogfood resource by restoring the required "Orbit friction" wording.
- The catalog alignment assertion remains unchanged and strict.

Assessment: The CI failure was repository-owned drift between the embedded seed and `.orbit/resources`.

Validation:
- Reproduced the original failure with `cargo test -p orbit-core --lib seeded_step_failure_recovery_asset_stays_aligned_without_retired_role --locked`; it failed at the unchanged asset-alignment assertion while the stale wording was present.
- After restoration, the same command passed (1 passed).
- `make ci-fast` passed.
- `make ci-lint` passed.

Friction checkpoint: no report filed; this was a direct one-line asset drift with a clear existing regression test.

Cleanup: removed the run-created Cargo target artifacts with `cargo clean`; final worktree contains only the intended seeded asset change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11181-6a9a2832`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*