### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/orbit-core/4_decisions.md
+++ b/docs/design/orbit-core/4_decisions.md
@@ -2,7 +2,6 @@
 title: Orbit Core — Decisions
 owner: claude
 last_updated: 2026-08-11
-last_validated: 2026-08-09
 status: Accepted
 feature: orbit-core
 doc_role: decisions
@@ -12,6 +11,7 @@ tags: [orbit-core, orbit-cmd, architecture, north-star]
 paths: ["crates/orbit-core/**", "crates/orbit-cmd/**"]
 related_features: [orbit-core]
 related_artifacts: [ORB-10026, ORB-10545]
+last_validated: 2026-09-04
 ---
 
 # Orbit Core — Decisions

--- a/docs/design/orbit-docs-plugin/1_scope.md
+++ b/docs/design/orbit-docs-plugin/1_scope.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Scope: extract docs + search into a plugin-style feature crate"
 tags: [orbit-docs-plugin]
-last_validated: 2026-08-09
+last_validated: 2026-09-04
 ---
 
 # Scope: extract docs + search into a plugin-style feature crate

--- a/docs/design/orbit-docs/3_vision.md
+++ b/docs/design/orbit-docs/3_vision.md
@@ -10,7 +10,7 @@ summary: "Orbit Docs — open questions, the remaining roadmap (injection, ADR f
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00164, ORB-00165, ORB-00166, ORB-00167, ORB-00168, ORB-00169, ORB-00206]
-last_validated: 2026-08-09
+last_validated: 2026-09-04
 ---
 
 # Orbit Docs — Vision
@@ -26,14 +26,14 @@ The v1 from [ORB-00163] is the corpus and the retrieval primitive; [ORB-00206] a
 
 ## 1. Open Questions
 
-### 1.1 Should `orbit-design` retire on the same cadence as orbit-docs adoption?
+### 1.1 What remains load-bearing after `orbit-design`'s retirement?
 
-[ORB-00165] is filed but deliberately gated on three pre-flight conditions: at least two PRs using `orbit docs`, PreToolUse hook injection wired, and explicit team agreement that the 4-numbered layout is a recommendation rather than a rule. Task-time `task.show --with-context` injection is already wired. Retiring `orbit-design` too early forces a flag-day for authors who learned the old convention; retiring it too late leaves a duplicated retrieval surface (`orbit design list/show` vs `orbit docs list/show`) and a "which mental model do I use?" friction for new agents.
+[ORB-00165] is complete: the `orbit-design` skill and CLI surface were retired, and the 4-numbered layout is now a recommendation documented by `docs/design/CONVENTIONS.md`. Task-time `task.show --with-context` injection is wired; PreToolUse hook injection remains future work. The duplicated retrieval surface (`orbit design list/show` vs. `orbit docs list/show`) is no longer present.
 
-The harder sub-question: does `orbit-design` carry anything load-bearing that orbit-docs doesn't? Two candidates:
+The retirement left two load-bearing rules to keep explicit:
 
-- **ADR earning rule.** `orbit-design` documents (and the docs/design conventions enforce) that ADR headings must be allocated via `orbit.adr.add` before they appear in `4_decisions.md`. This rule belongs to `orbit-adr`, not to a docs skill. Retiring `orbit-design` should not retire the rule.
-- **`Last updated:` freshness assertion.** `orbit-design` asks authors to bump `last_updated:` when the doc materially changes. Orbit-docs has no such field; semantically, frontmatter `last_updated:` is just another tag. We chose not to lift this rule because (a) it's not enforceable without commit-graph integration, (b) it's noisy in practice (every cosmetic edit drives a debate about whether to bump), and (c) `git log -- <path>` answers the same question without an author-side assertion.
+- **ADR earning rule.** The former `orbit-design` surface documented that ADR headings must be allocated via `orbit.adr.add` before they appear in `4_decisions.md`. This rule belongs to `orbit-adr`, not to a docs skill, and remains independent of the retirement.
+- **`Last updated:` freshness assertion.** The former `orbit-design` surface asked authors to bump `last_updated:` when the doc materially changes. The current docs conventions still describe that field, while the tolerant Orbit Docs parser treats it as unmodeled metadata. We chose not to make it an Orbit Docs validation rule because (a) it is not enforceable without commit-graph integration, (b) it is noisy in practice, and (c) `git log -- <path>` answers the same question without an author-side assertion.
 
 The third condition — explicit team agreement — is what makes this an open question rather than a queued task. The answer comes from usage, not from this design doc.
 
@@ -88,7 +88,7 @@ The tradeoff is straightforward: stability of cross-references vs. human-authore
 | Discovery | Push-first (scope-glob injection) | Pull-first (search / show), with task-time context injection |
 | Cross-references | `related_features`, `evidence` | `related_features`, `related_artifacts`, `paths` |
 
-The boundary (rule-with-failure-mode vs. explanatory-context) is the load-bearing decision. Both surfaces being separate, with explicit cross-references via `related_artifacts: [L-NNNN]`, is the v1 shape.
+The boundary (rule-with-failure-mode vs. explanatory-context) is the load-bearing decision. The surfaces remain separate, with Orbit Docs cross-references using the task, friction, and retained historical ADR prefixes supported by its parser.
 
 ### 2.2 Orbit ADRs
 

--- a/docs/design/orbit-docs/4_decisions.md
+++ b/docs/design/orbit-docs/4_decisions.md
@@ -10,7 +10,7 @@ summary: "Orbit Docs decisions: locked frontmatter schema, `.orbit/` vs `docs/` 
 tags: [orbit-docs]
 related_features: [orbit-docs]
 related_artifacts: [ORB-00163, ORB-00206]
-last_validated: 2026-08-09
+last_validated: 2026-09-04
 ---
 
 # Orbit Docs — Decisions

--- a/docs/design/orbit-search/1_overview.md
+++ b/docs/design/orbit-search/1_overview.md
@@ -4,7 +4,7 @@ type: design
 title: "Semantic Search — Overview"
 owner: claude
 last_updated: 2026-08-13
-last_validated: 2026-08-09
+last_validated: 2026-09-04
 status: Draft
 feature: orbit-search
 doc_role: overview
@@ -79,7 +79,7 @@ The shipped index covers tasks plus explicitly indexed docs, including ADR desig
 | `orbit search` CLI + MCP | [2_design.md §6](./2_design.md) | [T20260510-10] |
 | Cross-workspace federated read + scope selector | [2_design.md §6.4](./2_design.md), [Federate the cross-workspace read; deny it inside a managed run](./4_decisions.md#federate-the-cross-workspace-read-deny-it-inside-a-managed-run) | [ORB-11027] |
 | Index-on-mutation + index command | [2_design.md §7](./2_design.md) | [T20260510-9] |
-| Existing task store API | [crates/orbit-store/src/file/task_store/v2/](../../../crates/orbit-store/src/file/task_store/v2/) | — |
+| Existing task store API | [crates/orbit-store/src/repository/task/v2/](../../../crates/orbit-store/src/repository/task/v2/) | — |
 | Concerns & honest limitations | [2_design.md §8](./2_design.md) | [T20260510-3] |
 | ADR log | [4_decisions.md](./4_decisions.md) | [T20260510-3] |
 | Open questions, prior work | [3_vision.md](./3_vision.md) | [T20260510-3] |

--- a/docs/runbooks/task-publication.md
+++ b/docs/runbooks/task-publication.md
@@ -5,6 +5,7 @@ tags: [operations, backup, recovery, git, task-publication]
 paths: ["crates/orbit-cli/src/command/task/publication.rs", "crates/orbit-cli/src/command/workspace/publication.rs", "crates/orbit-store/src/workflow/task/**"]
 related_features: [task-publication, task-artifacts, host-registry]
 related_artifacts: [ORB-11077, ORB-11142, ORB-11145]
+last_validated: 2026-09-04
 ---
 
 # Publish Orbit Tasks to a Dedicated Repository
@@ -26,7 +27,7 @@ Before binding a workspace, prepare:
 - one empty, dedicated Git repository for exactly one Orbit workspace;
 - provider-side private visibility, collaborators, retention, and branch protection;
 - working SSH or HTTPS credentials for that repository; and
-- the logical workspace selector returned by `orbit workspace list --all --json`.
+- the logical workspace selector returned by `orbit workspace list --all --format json`.
 
 Orbit cannot prove provider-side privacy or erase retained Git history. Never reuse the source
 repository as the publication destination, put credentials in the remote URL, or assume that a
@@ -55,7 +56,7 @@ changing anything:
 command -v orbit
 orbit --version
 git -C "$ORBIT_CHECKOUT" remote get-url origin
-orbit workspace list --all --json
+orbit workspace list --all --format json
 orbit --workspace "$ORBIT_WORKSPACE" workspace publication show --json
 ```
 
@@ -235,7 +236,7 @@ unrelated authorities.
 | Symptom | Check and response |
 | --- | --- |
 | Git reports that it cannot read a username, password, or terminal prompt. | Global credential helpers are intentionally isolated. Use SSH or pass a short-lived `GIT_ASKPASS` helper explicitly to the Orbit command. |
-| A binding appears missing or belongs to another checkout. | Run `orbit workspace list --all --json`, then repeat `workspace publication show` with the intended logical `--workspace` selector before changing the binding. |
+| A binding appears missing or belongs to another checkout. | Run `orbit workspace list --all --format json`, then repeat `workspace publication show` with the intended logical `--workspace` selector before changing the binding. |
 | The logical `ws_*` ID differs from an internal runtime task partition. | This is supported after ORB-11142. Keep selecting the logical workspace; do not rebind or rewrite task storage to make the IDs match. |
 | The publication remote is rejected during bind. | Remove credentials from the URL, confirm it differs from the source remote, and use a dedicated repository. |
 | First publication finds an unrelated or non-publication branch. | Stop. Provision an empty dedicated repository; Orbit will not adopt or overwrite unrelated history. |


### PR DESCRIPTION
## Task

[ORB-11178](https://orbit-cli.com/tasks/ORB-11178) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Selected exactly six documents using missing-then-oldest `last_validated`, with path tie-break: `docs/runbooks/task-publication.md` had no validation date; the other five were the oldest dated entries at `2026-08-09` in path order: `docs/design/orbit-core/4_decisions.md`, `docs/design/orbit-docs-plugin/1_scope.md`, `docs/design/orbit-docs/3_vision.md`, `docs/design/orbit-docs/4_decisions.md`, and `docs/design/orbit-search/1_overview.md`.
- All six already had schema-compatible frontmatter; no frontmatter migration was needed, and no frontmatter-less document was selected.

Changes and verification:
- `docs/runbooks/task-publication.md`: verified the documented workspace/publication/task-publication commands with `orbit workspace list --help`, `orbit workspace publication --help`, and `orbit task publication --help`; checked the implementation in `crates/orbit-cli/src/command/workspace/publication.rs`, `crates/orbit-cli/src/command/task/publication.rs`, and `crates/orbit-store/src/workflow/task/{publish,inspect,restore,publication,git}.rs`. Corrected the stale `orbit workspace list --all --json` examples to the current `--format json` syntax and stamped `last_validated: 2026-09-04`.
- `docs/design/orbit-core/4_decisions.md`: verified the orbit-cmd extraction and operations/friction registry claims against `crates/orbit-cmd/`, `crates/orbit-common/src/governance/friction/operations.rs`, `crates/orbit-tools/`, dependency manifests, and current history/path searches. Historical ADR entries were treated as historical records rather than rewritten; stamped `last_validated: 2026-09-04`.
- `docs/design/orbit-docs-plugin/1_scope.md`: verified the proposed plugin boundary against the absence of `crates/orbit-docs` and `crates/orbit-docs-cli`, the current docs/search modules, and current crate dependency declarations. The document remains an explicitly draft/uncommitted proposal; stamped `last_validated: 2026-09-04`.
- `docs/design/orbit-docs/3_vision.md`: verified task-time related-doc injection in `crates/orbit-core/src/application/docs/mod.rs` and the CLI/tool `with_context` surfaces; verified `orbit-design` retirement with `test ! -e crates/orbit-core/assets/skills/orbit-design`, `orbit design --help`, and the completed ORB-00165 task record. Updated the stale open-question text and obsolete `L-NNNN` cross-reference claim to describe the current retired surface and supported task/friction/retained-ADR prefixes; stamped `last_validated: 2026-09-04`.
- `docs/design/orbit-docs/4_decisions.md`: verified frontmatter inference/schema, document walking, artifact-prefix parsing, docs indexing/search, and primary-checkout claims against `crates/orbit-core/src/application/docs/`, `crates/orbit-search/src/`, `crates/orbit-cli/src/command/docs/`, and the relevant CLI help; stamped `last_validated: 2026-09-04`.
- `docs/design/orbit-search/1_overview.md`: verified embedder/companion setup, model aliases, vector schema, task fields, hybrid retrieval, and docs indexing against `crates/orbit-search/src/{embedder.rs,companion.rs,commands,vector}/`; corrected the broken task-store link from the removed `src/file/task_store/v2/` path to `src/repository/task/v2/`; stamped `last_validated: 2026-09-04`.

Unvalidated claims:
- The search overview's approximate `~30MB` companion size, MTEB/literature references, corpus-scale latency estimate, and approximate `~100 docs` corpus size have no repo-local ground truth. They were left unchanged and are not presented as code-verified facts. No selected document was otherwise skipped.

Validation and scope:
- `make ci-fast` passed.
- `git diff --check`, frontmatter-count checks, code-fence checks, and the corrected-link existence check passed.
- Final status contains only the six intended docs. No files under `.orbit/adrs/`, `CHANGELOG.md`, `docs/changelogs/`, `docs/design/_archive/`, or generated state were modified. No new metadata field, sidecar, document, or section was added.

Assessment: the bounded documentation rotation is complete with six earned validation stamps, two factual/link corrections, and the required repository guardrails passing.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11178-6a9a2832`
- Behind base: 0
- Ahead of base: 1