### PR TITLE
Prepare v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.18.0
+
+### Breaking Changes
+
+- **SSH MCP caller authorization requires a protected launcher**: `orbit mcp callers authorize` now requires `--launcher` and no longer falls back to the current executable; configure the validated protected launcher before authorizing callers. ([ORB-11184])
+
+### Highlights
+
+- **Accurate task-flow lifecycle reporting**: `orbit task flow` now derives outflow and boundary openness from recorded transitions, including rejected tasks that later reopen. ([ORB-11183])
+- **Safer direct lock reservations**: direct task-lock reservations canonicalize in-workspace selectors and reject outside-workspace paths, so they reliably conflict with task-scoped locks. ([ORB-11163])
+- **Selected roots reach sweep execution**: `orbit sweep` now honors an explicit `--root` or `ORBIT_ROOT`, including when the process HOME points elsewhere. ([ORB-11165])
+
 ## 0.17.1
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "mcpName": "io.github.danieljhkim/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "danieljhkim",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/danieljhkim/orbit",
     "source": "github"
   },
-  "version": "0.17.1",
+  "version": "0.18.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11192](https://orbit-cli.com/tasks/ORB-11192) — Prepare v0.18.0 release

### Description

Prepare the next Orbit release by following RELEASING.md, including the release checklist and every versioned release file.

Probe evidence: the unfinished-work gate is clear after exempting only ORB-11191 for the exact auto-task:release-prep provenance tag. The latest reachable release baseline is v0.17.1. The no-merge survey of v0.17.1..HEAD found 49 commits, with referenced tasks ORB-11161, ORB-11162, ORB-11163, ORB-11165, ORB-11166, ORB-11178, ORB-11181, ORB-11182, ORB-11183, ORB-11184, and ORB-11190. The candidate bump is 0.18.0 under the pre-1.0 policy because ORB-11184 changes the existing SSH MCP authorization CLI contract: commit f73739e550167a28ddcd4f8e5a9a8714b196a860 adds a required --launcher argument to orbit mcp callers authorize, removes the fallback to the current executable, and validates the new protected launcher. This is a previously valid invocation becoming invalid and is flagged for human breaking-change confirmation.

Other surveyed work was reviewed as fixes, additive CLI features, performance, refactors, docs, tests, or dependency maintenance. In particular, the task-update approval change keeps a hidden orbit task start alias, and the SQLite index migration is an additive migration for legacy databases; neither is an additional breaking candidate.

This handoff stops before commits, tags, pushes, publishing, branch promotion, version bumps, or CHANGELOG edits. Use RELEASING.md as the source of truth for the eventual release work.

### Acceptance Criteria

- Cargo, npm, server.json, and all three plugin manifests report 0.18.0.
- Cargo.lock is refreshed without third-party drift.
- The CHANGELOG section is in place.
- Both npm and plugin install smokes pass.
- The release executor follows RELEASING.md and does not commit, tag, push, publish, promote, merge, bump versions, or edit CHANGELOG.md before the approved release workflow.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Prepared the approved v0.18.0 minor release: updated the workspace Cargo version, npm metadata, MCP registry metadata, and the Claude, Codex, and agent-plugin manifests.
- Refreshed Cargo.lock; its only changes are the 16 Orbit workspace package version entries (0.17.1 -> 0.18.0), with no third-party drift.
- Added the 0.18.0 CHANGELOG section with the confirmed protected-launcher breaking change and three user-facing highlights from the release survey.
Assessment: The diff is limited to the eight release files; no commit, tag, push, publish, promotion, merge, or task review transition was performed.
Validation:
- PASS: make build.
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: scripts/smoke-plugin-install.sh.
- PASS: scripts/smoke-npm-install.sh --dry-run-version-assertion.
- PASS: release-metadata consistency check for Cargo, npm, server.json (both fields), and all three plugin manifests.
- PASS: git diff --check.
- SKIPPED BY RUNNER: scripts/smoke-npm-install.sh requires npx, which is absent from PATH (exit 2). The full versioned published-package smoke is also a post-publish release check under RELEASING.md; publishing is outside this task's permitted release-preparation scope.
Cleanup: cargo clean removed 5.1 GiB of build artifacts created by this run. Final git status contains only the eight intended release files.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11192-6a9a407c`
- Behind base: 0
- Ahead of base: 1