### PR TITLE
[code-review] Make log-follow tests synchronize readiness and terminate their workers

### DIFF
--- a/crates/orbit-cli/src/command/log/tail.rs
+++ b/crates/orbit-cli/src/command/log/tail.rs
@@ -8,6 +8,8 @@
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::thread;
 use std::time::Duration;
 
@@ -110,7 +112,66 @@ pub(super) fn run_tail<W: Write + ?Sized>(
         return Ok(());
     }
 
-    follow_file(path, initial_offset, filters, args.json, use_color, writer)
+    follow_file(
+        path,
+        initial_offset,
+        filters,
+        args.json,
+        use_color,
+        writer,
+        FollowControl::Forever,
+    )
+}
+
+#[cfg(test)]
+pub(super) struct FollowTestControl {
+    ready: Sender<()>,
+    stop: Receiver<()>,
+}
+
+#[cfg(test)]
+impl FollowTestControl {
+    pub(super) fn new(ready: Sender<()>, stop: Receiver<()>) -> Self {
+        Self { ready, stop }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn run_tail_with_test_control<W: Write + ?Sized>(
+    path: &Path,
+    args: &TailArgs,
+    filters: &Filters,
+    use_color: bool,
+    writer: &mut W,
+    control: FollowTestControl,
+) -> io::Result<()> {
+    if !path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("orbit log file not found: {}", path.display()),
+        ));
+    }
+
+    let initial_offset = print_initial_window(path, args, filters, use_color, writer)?;
+    control.ready.send(()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "follow test stopped before readiness",
+        )
+    })?;
+    if !args.follow {
+        return Ok(());
+    }
+
+    follow_file(
+        path,
+        initial_offset,
+        filters,
+        args.json,
+        use_color,
+        writer,
+        FollowControl::UntilStopped(control.stop),
+    )
 }
 
 fn print_initial_window<W: Write + ?Sized>(
@@ -156,6 +217,7 @@ fn follow_file<W: Write + ?Sized>(
     json: bool,
     use_color: bool,
     writer: &mut W,
+    control: FollowControl,
 ) -> io::Result<()> {
     let mut file = File::open(path)?;
     file.seek(SeekFrom::Start(initial_offset))?;
@@ -163,6 +225,9 @@ fn follow_file<W: Write + ?Sized>(
     let mut leftover = String::new();
 
     loop {
+        if control.should_stop() {
+            return Ok(());
+        }
         let mut buf = String::new();
         let n = reader.read_line(&mut buf)?;
         if n == 0 {
@@ -184,6 +249,22 @@ fn follow_file<W: Write + ?Sized>(
             && filters.matches(&value)
         {
             emit_line(&full_line, json, use_color, writer)?;
+        }
+    }
+}
+
+enum FollowControl {
+    Forever,
+    #[cfg(test)]
+    UntilStopped(Receiver<()>),
+}
+
+impl FollowControl {
+    fn should_stop(&self) -> bool {
+        match self {
+            Self::Forever => false,
+            #[cfg(test)]
+            Self::UntilStopped(stop) => !matches!(stop.try_recv(), Err(TryRecvError::Empty)),
         }
     }
 }

--- a/crates/orbit-cli/src/command/log/tests/tail.rs
+++ b/crates/orbit-cli/src/command/log/tests/tail.rs
@@ -2,7 +2,7 @@ use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
@@ -10,7 +10,9 @@ use serde_json::json;
 use tempfile::tempdir;
 
 use crate::command::log::format::{LevelFilter, format_message};
-use crate::command::log::tail::{TailArgs, build_filters, run_tail};
+use crate::command::log::tail::{
+    FollowTestControl, TailArgs, build_filters, run_tail, run_tail_with_test_control,
+};
 
 fn fixture_lines() -> Vec<String> {
     vec![
@@ -234,27 +236,10 @@ fn follow_mode_emits_appended_line_within_window() {
     let path = dir.path().join("orbit.jsonl");
     write_fixture(&path, &fixture_lines());
 
-    let path_clone = path.clone();
-    let (tx, rx) = mpsc::channel::<String>();
-    let handle = thread::spawn(move || {
-        let mut buf = TeeWriter::new(tx);
-        let args = TailArgs {
-            lines: 0,
-            follow: true,
-            target: None,
-            level: None,
-            since: None,
-            json: false,
-            path: Some(path_clone.clone()),
-        };
-        let filters = build_filters(&args).expect("filters");
-        // Tail should never return because of follow mode — we let the
-        // join handle leak (test process exits when done).
-        let _ = run_tail(&path_clone, &args, &filters, false, &mut buf);
-    });
-
-    // Give the follower a moment to seek to EOF and start polling.
-    thread::sleep(Duration::from_millis(75));
+    // The worker starts late on purpose: appending is nevertheless safe
+    // because readiness is the post-offset transition, not elapsed time.
+    let mut follower = spawn_follower(path.clone(), false, Duration::from_millis(100));
+    follower.wait_until_ready();
 
     let mut file = OpenOptions::new()
         .append(true)
@@ -277,7 +262,7 @@ fn follow_mode_emits_appended_line_within_window() {
     let deadline = Instant::now() + Duration::from_millis(500);
     let mut found = false;
     while Instant::now() < deadline {
-        if let Ok(line) = rx.recv_timeout(Duration::from_millis(50))
+        if let Ok(line) = follower.recv_timeout(Duration::from_millis(50))
             && line.contains("post-fixture")
         {
             found = true;
@@ -285,10 +270,8 @@ fn follow_mode_emits_appended_line_within_window() {
         }
     }
 
-    // The follower thread is intentionally not joined; the test process
-    // exits once the assertion completes.
-    drop(handle);
     assert!(found, "follow mode did not surface appended line");
+    follower.finish();
 }
 
 #[test]
@@ -299,24 +282,8 @@ fn follow_mode_with_json_flag_emits_appended_line_as_raw_jsonl() {
     let path = dir.path().join("orbit.jsonl");
     write_fixture(&path, &fixture_lines());
 
-    let path_clone = path.clone();
-    let (tx, rx) = mpsc::channel::<String>();
-    let handle = thread::spawn(move || {
-        let mut buf = TeeWriter::new(tx);
-        let args = TailArgs {
-            lines: 0,
-            follow: true,
-            target: None,
-            level: None,
-            since: None,
-            json: true,
-            path: Some(path_clone.clone()),
-        };
-        let filters = build_filters(&args).expect("filters");
-        let _ = run_tail(&path_clone, &args, &filters, false, &mut buf);
-    });
-
-    thread::sleep(Duration::from_millis(75));
+    let mut follower = spawn_follower(path.clone(), true, Duration::ZERO);
+    follower.wait_until_ready();
 
     let mut file = OpenOptions::new()
         .append(true)
@@ -339,7 +306,7 @@ fn follow_mode_with_json_flag_emits_appended_line_as_raw_jsonl() {
     let deadline = Instant::now() + Duration::from_millis(500);
     let mut got_raw = false;
     while Instant::now() < deadline {
-        if let Ok(chunk) = rx.recv_timeout(Duration::from_millis(50)) {
+        if let Ok(chunk) = follower.recv_timeout(Duration::from_millis(50)) {
             // Followed JSON output is the raw JSONL line — i.e. the same
             // string we appended, optionally followed by a newline. The
             // formatted four-column view would render `step json-followed
@@ -352,11 +319,87 @@ fn follow_mode_with_json_flag_emits_appended_line_as_raw_jsonl() {
         }
     }
 
-    drop(handle);
     assert!(
         got_raw,
         "follow mode with --json did not surface appended line as raw JSONL",
     );
+    follower.finish();
+}
+
+fn spawn_follower(path: PathBuf, json: bool, startup_delay: Duration) -> FollowWorker {
+    let (output_tx, output_rx) = mpsc::channel();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        thread::sleep(startup_delay);
+        let mut buf = TeeWriter::new(output_tx);
+        let args = TailArgs {
+            lines: 0,
+            follow: true,
+            target: None,
+            level: None,
+            since: None,
+            json,
+            path: Some(path.clone()),
+        };
+        let filters = build_filters(&args).expect("filters");
+        run_tail_with_test_control(
+            &path,
+            &args,
+            &filters,
+            false,
+            &mut buf,
+            FollowTestControl::new(ready_tx, stop_rx),
+        )
+    });
+    FollowWorker {
+        output_rx,
+        ready_rx,
+        stop_tx,
+        handle: Some(handle),
+    }
+}
+
+struct FollowWorker {
+    output_rx: mpsc::Receiver<String>,
+    ready_rx: mpsc::Receiver<()>,
+    stop_tx: mpsc::Sender<()>,
+    handle: Option<JoinHandle<io::Result<()>>>,
+}
+
+impl FollowWorker {
+    fn wait_until_ready(&self) {
+        self.ready_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("follower established its initial offset");
+    }
+
+    fn recv_timeout(&self, timeout: Duration) -> Result<String, mpsc::RecvTimeoutError> {
+        self.output_rx.recv_timeout(timeout)
+    }
+
+    fn finish(&mut self) {
+        let _ = self.stop_tx.send(());
+        self.join();
+    }
+
+    fn join(&mut self) {
+        self.handle
+            .take()
+            .expect("follower handle is present")
+            .join()
+            .expect("follower thread did not panic")
+            .expect("follower exited cleanly");
+    }
+}
+
+impl Drop for FollowWorker {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11198](https://orbit-cli.com/tasks/ORB-11198) — [code-review] Make log-follow tests synchronize readiness and terminate their workers

### Description

Inspected the clean local Orbit agent-main checkout at 4fdfabcedb87fb30835a9e649ea28212e702caab on 2026-09-04. This is a review finding, not an implemented repair. Recheck current integration HEAD before editing. 

Problem: follow_mode_emits_appended_line_within_window and follow_mode_with_json_flag_emits_appended_line_as_raw_jsonl in command/log/tests/tail.rs:232-362 start threads, sleep 75 ms to guess readiness, append a line, and drop the JoinHandle. If scheduling delays the follower, the appended row becomes part of the initial window (lines=0) and is skipped. Both tests deliberately leave run_tail's infinite follow loop alive; dropping a JoinHandle does not stop it, so threads/file handles survive until the entire test binary exits. This is confirmed from control flow; no intermittent CI failure is claimed.

Scope: use an observable ready boundary before append, and a deterministic termination/join path including failure cleanup. Keep the seam minimal and scoped to actual follow lifecycle needs, not a general clock/thread framework. Preserve raw JSON and formatted-output assertions.

### Acceptance Criteria

- Both tests append only after the follower has established its starting offset; readiness uses a signal/state transition rather than an arbitrary sleep.
- Each spawned follower terminates and is joined on success and assertion/error paths; no test relies on process exit for cleanup.
- Existing formatted and JSON appended-line behavior remains covered; a deliberately delayed startup cannot lose the test line.
- Focused log tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a test-only follow control that publishes readiness immediately after the initial window establishes its byte offset and accepts a stop signal.
- Reworked both follow tests to wait for readiness before appending, deliberately delay one worker startup, and own each worker with success-path join plus Drop cleanup for assertion/error paths.
- Preserved formatted and raw JSONL assertions for appended lines.

Assessment: The production follow path is unchanged; the test seam makes the lifecycle boundary explicit and leaves no follower alive after a test.

Validation:
- cargo test -p orbit-cli --bin orbit command::log::tests::tail (10 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)

Notes:
- An initial ci-lint run exposed an unused lifetime in the cfg(test) control enum under the non-test binary target; removed that lifetime and reran all required checks.
- Ran cargo clean before handoff, removing this run's generated target artifacts.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11198-6a9b668a`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*