### PR TITLE
[code-review] Consolidate duplicated CLI and web job-run JSON projections

### DIFF
--- a/crates/orbit-cli/src/command/run/history.rs
+++ b/crates/orbit-cli/src/command/run/history.rs
@@ -7,7 +7,7 @@ use crate::command::{Block, CommandOut, Execute, Payload};
 use crate::output::color::Domain;
 
 use super::format::{format_timestamp, format_waiting_line, summarize_error_message};
-use super::job::job_run_to_json_with_state;
+use super::job::cli_job_run_to_json;
 
 pub(crate) const DEFAULT_HISTORY_LIMIT: usize = 50;
 
@@ -60,7 +60,7 @@ pub(crate) fn run_history_payload(
     let values = runs
         .iter()
         .zip(states.iter())
-        .map(|(run, state)| job_run_to_json_with_state(run, state.as_ref()))
+        .map(|(run, state)| cli_job_run_to_json(run, state.as_ref()))
         .collect::<Vec<_>>();
     let doc = json!({ "runs": values });
 

--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -1,3 +1,4 @@
+use orbit_core::application::job::job_run_to_json;
 use orbit_core::{JobRun, OrbitError, OrbitRuntime, PipelineInvokeResult, PipelineWaitEntry};
 use orbit_types::workflow::PipelineState;
 use serde_json::{Value, json};
@@ -244,76 +245,14 @@ impl Execute for JobResumeArgs {
     }
 }
 
-/// The child Runs this run dispatched, as persisted by the dispatch
-/// checkpoint [ORB-10971]. Always an array so a reader never has to
-/// distinguish "no children" from "field absent".
-pub(crate) fn child_dispatches_json(state: Option<&PipelineState>) -> Value {
-    let dispatches = state
-        .map(|state| state.child_dispatches.as_slice())
-        .unwrap_or_default();
-    serde_json::to_value(dispatches).unwrap_or_else(|_| Value::Array(Vec::new()))
-}
-
-// Retained after the dashboard callers moved to orbit-web; the thin
-// wrapper is kept for any external re-exports or future CLI json paths.
-#[allow(dead_code)]
-pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
-    job_run_to_json_with_state(run, None)
-}
-
-pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineState>) -> Value {
-    let last = run.steps.last();
-    // [ORB-10971] Child lineage is read from the full state, before the
-    // terminal filter below: a cancelled or failed parent must still name the
-    // children it dispatched. Waiting reasons keep the old filter — they are
-    // momentary and mean nothing once the run stopped.
-    let child_dispatches = child_dispatches_json(state);
-    let state = (!run.state.is_terminal()).then_some(state).flatten();
-    let waiting_on_deps = state
-        .and_then(|state| state.waiting_on_deps.as_ref())
-        .filter(|values| !values.is_empty());
-    let waiting_on_locks = state
-        .and_then(|state| state.waiting_on_locks.as_ref())
-        .filter(|values| !values.is_empty());
-    json!({
-        "child_dispatches": child_dispatches,
-        "run_id": run.run_id,
-        "job_id": run.job_id,
-        "attempt": run.attempt,
-        "state": run.state.to_string(),
-        // Recorded owner process, when a worker claimed the run [ORB-10070].
-        // Lets operators and host automation probe whether an
-        // active run's worker is actually alive.
-        "pid": run.pid,
-        "waiting_on_deps": waiting_on_deps,
-        "waiting_on_locks": waiting_on_locks,
-        "scheduled_at": run.scheduled_at.to_rfc3339(),
-        "started_at": run.started_at.map(|v| v.to_rfc3339()),
-        "finished_at": run.finished_at.map(|v| v.to_rfc3339()),
-        "duration_ms": run.duration_ms,
-        "retry_source_run_id": run.retry_source_run_id,
-        "exit_code": last.and_then(|s| s.exit_code),
-        "agent_response_json": last.and_then(|s| s.agent_response_json.as_ref()),
-        "error_code": last.and_then(|s| s.error_code.as_deref()),
-        "error_message": last.and_then(|s| s.error_message.as_deref()),
-        "knowledge_metrics": run.knowledge_metrics,
-        "resolved_crew": run.resolved_crew,
-        "crew_model": run.crew_model,
-        "steps": run.steps.iter().map(|s| json!({
-            "step_index": s.step_index,
-            "target_type": s.target_type.to_string(),
-            "target_id": s.target_id,
-            "state": s.state.to_string(),
-            "started_at": s.started_at.map(|v| v.to_rfc3339()),
-            "finished_at": s.finished_at.map(|v| v.to_rfc3339()),
-            "duration_ms": s.duration_ms,
-            "exit_code": s.exit_code,
-            "agent_response_json": s.agent_response_json,
-            "error_code": s.error_code,
-            "error_message": s.error_message,
-        })).collect::<Vec<_>>(),
-        "created_at": run.created_at.to_rfc3339(),
-    })
+/// CLI adapter for the shared run projection.
+///
+/// The CLI has historically exposed the claimed worker PID; the web API does
+/// not. Keep that contract difference at this presentation boundary.
+pub(crate) fn cli_job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
+    let mut value = job_run_to_json(run, state);
+    value["pid"] = json!(run.pid);
+    value
 }
 
 #[derive(Args)]

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, Execute, Payload};
 
-use super::job::job_run_to_json_with_state;
+use super::job::cli_job_run_to_json;
 use super::steps::{
     filtered_steps, legacy_step_to_json, resolve_run, resolve_run_step, run_header_text,
     run_header_text_with_state, step_record_payload, step_summary_table,
@@ -57,7 +57,7 @@ pub(crate) fn run_show_payload(
     let provider_processes = runtime.collect_run_provider_processes(&run.run_id)?;
 
     let doc = json!({
-        "run": job_run_to_json_with_state(&run, state.as_ref()),
+        "run": cli_job_run_to_json(&run, state.as_ref()),
         "pipeline_state": state,
         "provider_processes": provider_processes
             .iter()

--- a/crates/orbit-cli/src/command/run/tests/job.rs
+++ b/crates/orbit-cli/src/command/run/tests/job.rs
@@ -68,10 +68,11 @@ fn job_run_json_includes_waiting_reasons_from_state() {
         Some(vec!["file:src/lib.rs".to_string()]),
     );
 
-    let value = job_run_to_json_with_state(&run, Some(&state));
+    let value = cli_job_run_to_json(&run, Some(&state));
 
     assert_eq!(value["waiting_on_deps"], json!(["ORB-1"]));
     assert_eq!(value["waiting_on_locks"], json!(["file:src/lib.rs"]));
+    assert_eq!(value["pid"], Value::Null);
 }
 
 #[test]
@@ -83,7 +84,7 @@ fn job_run_json_omits_stale_waiting_reasons_for_terminal_run() {
         Some(vec!["file:src/lib.rs".to_string()]),
     );
 
-    let value = job_run_to_json_with_state(&run, Some(&state));
+    let value = cli_job_run_to_json(&run, Some(&state));
 
     assert_eq!(value["waiting_on_deps"], Value::Null);
     assert_eq!(value["waiting_on_locks"], Value::Null);
@@ -265,7 +266,7 @@ fn job_run_json_names_the_child_a_running_parent_dispatched() {
     let run = test_run(JobRunState::Running);
     let state = state_with_child_dispatch(&run, orbit_types::workflow::ChildDispatchPhase::Waiting);
 
-    let value = job_run_to_json_with_state(&run, Some(&state));
+    let value = cli_job_run_to_json(&run, Some(&state));
 
     let dispatches = value["child_dispatches"]
         .as_array()
@@ -285,7 +286,7 @@ fn job_run_json_keeps_child_lineage_for_a_terminal_run() {
     let state =
         state_with_child_dispatch(&run, orbit_types::workflow::ChildDispatchPhase::Terminal);
 
-    let value = job_run_to_json_with_state(&run, Some(&state));
+    let value = cli_job_run_to_json(&run, Some(&state));
 
     assert_eq!(value["waiting_on_deps"], Value::Null);
     assert_eq!(
@@ -298,7 +299,7 @@ fn job_run_json_keeps_child_lineage_for_a_terminal_run() {
 fn job_run_json_always_carries_a_child_dispatch_array() {
     let run = test_run(JobRunState::Running);
 
-    let value = job_run_to_json_with_state(&run, None);
+    let value = cli_job_run_to_json(&run, None);
 
     assert_eq!(
         value["child_dispatches"],

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -13,5 +13,5 @@ pub use exec::V2JobRunResult;
 pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};
 #[cfg(test)]
 pub(crate) use run::TERMINAL_OUTCOME_CONFLICT_CODE;
-pub use run::{JobRunCancelResult, JobRunListParams};
+pub use run::{JobRunCancelResult, JobRunListParams, job_run_to_json};
 pub(crate) use run::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -11,6 +11,7 @@
 mod actions;
 mod conflict;
 mod owner;
+mod projection;
 mod query;
 mod reconcile;
 mod types;
@@ -21,4 +22,5 @@ mod tests;
 #[cfg(test)]
 pub(crate) use conflict::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub(crate) use owner::{RunOwnerLiveness, run_owner_liveness};
+pub use projection::job_run_to_json;
 pub use types::{JobRunCancelResult, JobRunListParams};

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -1,0 +1,62 @@
+//! Shared JSON projection for persisted job runs.
+
+use orbit_types::workflow::{JobRun, PipelineState};
+use serde_json::{Value, json};
+
+/// Project a job run and its optional persisted state for operator-facing APIs.
+///
+/// Child-dispatch lineage is historical and remains visible after a run reaches
+/// a terminal state. Waiting reasons are momentary, so terminal runs omit them.
+/// Presentation adapters may add intentionally surface-specific fields.
+pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
+    let last = run.steps.last();
+    let child_dispatches = serde_json::to_value(
+        state
+            .map(|state| state.child_dispatches.as_slice())
+            .unwrap_or_default(),
+    )
+    .unwrap_or_else(|_| Value::Array(Vec::new()));
+    let state = (!run.state.is_terminal()).then_some(state).flatten();
+    let waiting_on_deps = state
+        .and_then(|state| state.waiting_on_deps.as_ref())
+        .filter(|values| !values.is_empty());
+    let waiting_on_locks = state
+        .and_then(|state| state.waiting_on_locks.as_ref())
+        .filter(|values| !values.is_empty());
+
+    json!({
+        "child_dispatches": child_dispatches,
+        "run_id": run.run_id,
+        "job_id": run.job_id,
+        "attempt": run.attempt,
+        "state": run.state.to_string(),
+        "waiting_on_deps": waiting_on_deps,
+        "waiting_on_locks": waiting_on_locks,
+        "scheduled_at": run.scheduled_at.to_rfc3339(),
+        "started_at": run.started_at.map(|value| value.to_rfc3339()),
+        "finished_at": run.finished_at.map(|value| value.to_rfc3339()),
+        "duration_ms": run.duration_ms,
+        "retry_source_run_id": run.retry_source_run_id,
+        "exit_code": last.and_then(|step| step.exit_code),
+        "agent_response_json": last.and_then(|step| step.agent_response_json.as_ref()),
+        "error_code": last.and_then(|step| step.error_code.as_deref()),
+        "error_message": last.and_then(|step| step.error_message.as_deref()),
+        "knowledge_metrics": run.knowledge_metrics,
+        "resolved_crew": run.resolved_crew,
+        "crew_model": run.crew_model,
+        "steps": run.steps.iter().map(|step| json!({
+            "step_index": step.step_index,
+            "target_type": step.target_type.to_string(),
+            "target_id": step.target_id,
+            "state": step.state.to_string(),
+            "started_at": step.started_at.map(|value| value.to_rfc3339()),
+            "finished_at": step.finished_at.map(|value| value.to_rfc3339()),
+            "duration_ms": step.duration_ms,
+            "exit_code": step.exit_code,
+            "agent_response_json": step.agent_response_json,
+            "error_code": step.error_code,
+            "error_message": step.error_message,
+        })).collect::<Vec<_>>(),
+        "created_at": run.created_at.to_rfc3339(),
+    })
+}

--- a/crates/orbit-core/src/application/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/run/tests/mod.rs
@@ -5,6 +5,7 @@ use crate::OrbitRuntime;
 mod actions;
 mod conflict;
 mod owner;
+mod projection;
 mod reconcile;
 
 use chrono::{DateTime, Utc};

--- a/crates/orbit-core/src/application/job/run/tests/projection.rs
+++ b/crates/orbit-core/src/application/job/run/tests/projection.rs
@@ -1,0 +1,83 @@
+//! Regression coverage for the shared job-run JSON projection.
+
+use chrono::Utc;
+use orbit_types::workflow::{
+    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, PipelineState,
+};
+use serde_json::{Value, json};
+
+use super::super::projection::job_run_to_json;
+
+fn test_run(state: JobRunState) -> JobRun {
+    let now = Utc::now();
+    JobRun {
+        run_id: "jrun-projection".to_string(),
+        job_id: "task_auto_pipeline".to_string(),
+        attempt: 1,
+        state,
+        scheduled_at: now,
+        started_at: Some(now),
+        finished_at: None,
+        duration_ms: None,
+        created_at: now,
+        pid: Some(42),
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    }
+}
+
+fn state_with_child_dispatch(run: &JobRun) -> PipelineState {
+    let mut state = PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({}));
+    state.set_waiting_reasons(
+        Some(vec!["ORB-1".to_string()]),
+        Some(vec!["file:src/lib.rs".to_string()]),
+    );
+    state.record_child_dispatch(
+        ChildDispatch::submitted(
+            "jrun-child".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(Some("ship".to_string())),
+    );
+    state.advance_child_dispatch("jrun-child", ChildDispatchPhase::Waiting, None, None);
+    state
+}
+
+#[test]
+fn active_run_projects_waiting_reasons_and_child_dispatches() {
+    let run = test_run(JobRunState::Running);
+    let state = state_with_child_dispatch(&run);
+
+    let value = job_run_to_json(&run, Some(&state));
+
+    assert_eq!(value["waiting_on_deps"], json!(["ORB-1"]));
+    assert_eq!(value["waiting_on_locks"], json!(["file:src/lib.rs"]));
+    assert_eq!(
+        value["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child")
+    );
+}
+
+#[test]
+fn terminal_run_keeps_child_lineage_but_drops_waiting_reasons() {
+    let run = test_run(JobRunState::Cancelled);
+    let state = state_with_child_dispatch(&run);
+
+    let value = job_run_to_json(&run, Some(&state));
+
+    assert_eq!(value["waiting_on_deps"], Value::Null);
+    assert_eq!(value["waiting_on_locks"], Value::Null);
+    assert_eq!(
+        value["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child")
+    );
+}

--- a/crates/orbit-web/src/api/jobs.rs
+++ b/crates/orbit-web/src/api/jobs.rs
@@ -6,12 +6,12 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
 use orbit_core::JobRunState;
-use orbit_core::application::job::JobRunListParams;
+use orbit_core::application::job::{JobRunListParams, job_run_to_json};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::{bad_request, bounded_limit, map_runtime_error, server_error, validate_id};
-use crate::projections::{job_catalog_to_json_with_last_run, job_run_to_json};
+use crate::projections::job_catalog_to_json_with_last_run;
 
 const JOB_RUN_DEFAULT_LIMIT: usize = 25;
 
@@ -77,7 +77,7 @@ pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<JobRunListQue
     };
     match runtime.list_job_runs(params) {
         Ok(runs) => {
-            let values: Vec<Value> = runs.iter().map(job_run_to_json).collect();
+            let values: Vec<Value> = runs.iter().map(|run| job_run_to_json(run, None)).collect();
             Json(Value::Array(values)).into_response()
         }
         Err(e) => server_error(e),

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -5,6 +5,7 @@ use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::security::redaction::redact_all;
+use orbit_core::application::job::job_run_to_json;
 use orbit_core::runtime::run_audit::{RunAuditStep, RunCliInvocationRecord, RunProviderProcess};
 use orbit_core::{JobRun, OrbitRuntime, V2AuditEventFilter};
 use serde_json::{Value, json};
@@ -13,7 +14,6 @@ use super::{
     HISTORY_DEFAULT_LIMIT, LimitQuery, RunEventsQuery, bad_request, bounded_limit,
     map_runtime_error, validate_id,
 };
-use crate::projections::job_run_to_json_with_state;
 
 const RUN_EVENTS_DEFAULT_LIMIT: usize = 100;
 /// Hard cap on rows scanned from a single run's persisted v2 audit events.
@@ -150,7 +150,7 @@ pub(super) fn job_run_detail_to_json(runtime: &OrbitRuntime, run: &JobRun) -> Va
     // it entirely, so the dashboard could not see the waiting reasons or the
     // child-dispatch lineage the CLI already showed.
     let state = runtime.read_run_state(&run.run_id).ok().flatten();
-    let mut full = job_run_to_json_with_state(run, state.as_ref());
+    let mut full = job_run_to_json(run, state.as_ref());
     // Reshape into `{run, steps}` per the dashboard contract: peel the
     // `steps` array off the flat `job_run_to_json` output.
     let stored_steps = full

--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use orbit_common::storage::blob_store::BlobStore;
 use orbit_core::application::job::JobRunListParams;
 use orbit_core::application::task::TaskAddParams;
-use orbit_core::{JobRunState, OrbitRuntime, TaskStatus, V2AuditEventInsertParams};
+use orbit_core::{JobRun, JobRunState, OrbitRuntime, TaskStatus, V2AuditEventInsertParams};
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
@@ -796,13 +796,17 @@ fn seed_parent_blocked_on_child(
     run_id: &str,
     run_state: JobRunState,
     phase: ChildDispatchPhase,
-) {
+) -> JobRun {
     let run = seed_run(runtime, run_id, "workspace_auto_pipeline", run_state);
     write_seeded_run(runtime, &run);
     let mut state = PipelineState::new(
         run_id.to_string(),
         "workspace_auto_pipeline".to_string(),
         json!({}),
+    );
+    state.set_waiting_reasons(
+        Some(vec!["ORB-1".to_string()]),
+        Some(vec!["file:src/lib.rs".to_string()]),
     );
     state.record_child_dispatch(
         ChildDispatch::submitted(
@@ -819,19 +823,25 @@ fn seed_parent_blocked_on_child(
     runtime
         .write_run_state(run_id, &state)
         .expect("seed parent run state");
+    run
 }
 
 #[test]
 fn run_detail_names_the_child_a_running_parent_is_blocked_on() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let run_id = "jrun-web-child-waiting";
-    seed_parent_blocked_on_child(
+    let run = seed_parent_blocked_on_child(
         &runtime,
         run_id,
         JobRunState::Running,
         ChildDispatchPhase::Waiting,
     );
-    let run = runtime.show_job_run(run_id).expect("show run");
+    assert_eq!(run.state, JobRunState::Running);
+    let state = runtime
+        .read_run_state(run_id)
+        .expect("read run state")
+        .expect("seeded run state");
+    assert_eq!(state.waiting_on_deps, Some(vec!["ORB-1".to_string()]));
 
     let detail = job_run_detail_to_json(&runtime, &run);
     let dispatches = detail["run"]["child_dispatches"]
@@ -844,19 +854,24 @@ fn run_detail_names_the_child_a_running_parent_is_blocked_on() {
     assert_eq!(dispatches[0]["parent_step_id"], "ship_leaves");
     assert_eq!(dispatches[0]["phase"], "waiting");
     assert_eq!(dispatches[0]["queued"], false);
+    assert_eq!(detail["run"]["waiting_on_deps"], json!(["ORB-1"]));
+    assert_eq!(
+        detail["run"]["waiting_on_locks"],
+        json!(["file:src/lib.rs"])
+    );
+    assert!(detail["run"].get("pid").is_none());
 }
 
 #[test]
 fn run_detail_keeps_the_child_link_after_the_parent_terminalizes() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let run_id = "jrun-web-child-cancelled";
-    seed_parent_blocked_on_child(
+    let run = seed_parent_blocked_on_child(
         &runtime,
         run_id,
         JobRunState::Cancelled,
         ChildDispatchPhase::Terminal,
     );
-    let run = runtime.show_job_run(run_id).expect("show run");
 
     let detail = job_run_detail_to_json(&runtime, &run);
     let dispatches = detail["run"]["child_dispatches"]
@@ -869,6 +884,8 @@ fn run_detail_keeps_the_child_link_after_the_parent_terminalizes() {
         "a cancelled parent must still name the child it left behind"
     );
     assert_eq!(dispatches[0]["child_run_id"], "jrun-child-leaves");
+    assert_eq!(detail["run"]["waiting_on_deps"], Value::Null);
+    assert_eq!(detail["run"]["waiting_on_locks"], Value::Null);
 }
 
 #[test]

--- a/crates/orbit-web/src/projections.rs
+++ b/crates/orbit-web/src/projections.rs
@@ -11,7 +11,7 @@ use orbit_core::{
     resolve_task_dependencies,
 };
 use orbit_types::task::ArtifactManifestFileV2;
-use orbit_types::workflow::{JobV2Step, JobV2StepBody, PipelineState};
+use orbit_types::workflow::{JobV2Step, JobV2StepBody};
 use serde_json::{Value, json};
 
 pub(crate) fn audit_event_to_json(event: &AuditEvent) -> Value {
@@ -137,66 +137,6 @@ fn job_v2_step_to_json(step: &JobV2Step) -> Value {
         }
     }
     value
-}
-
-pub(crate) fn job_run_to_json(run: &JobRun) -> Value {
-    job_run_to_json_with_state(run, None)
-}
-
-pub(crate) fn job_run_to_json_with_state(run: &JobRun, state: Option<&PipelineState>) -> Value {
-    let last = run.steps.last();
-    // [ORB-10971] Read child lineage from the full state, before the terminal
-    // filter below: a cancelled or failed parent must still name the children
-    // it dispatched. Waiting reasons keep the filter — they are momentary and
-    // mean nothing once the run stopped.
-    let child_dispatches = serde_json::to_value(
-        state
-            .map(|state| state.child_dispatches.as_slice())
-            .unwrap_or_default(),
-    )
-    .unwrap_or_else(|_| Value::Array(Vec::new()));
-    let state = (!run.state.is_terminal()).then_some(state).flatten();
-    let waiting_on_deps = state
-        .and_then(|state| state.waiting_on_deps.as_ref())
-        .filter(|values| !values.is_empty());
-    let waiting_on_locks = state
-        .and_then(|state| state.waiting_on_locks.as_ref())
-        .filter(|values| !values.is_empty());
-    json!({
-        "child_dispatches": child_dispatches,
-        "run_id": run.run_id,
-        "job_id": run.job_id,
-        "attempt": run.attempt,
-        "state": run.state.to_string(),
-        "waiting_on_deps": waiting_on_deps,
-        "waiting_on_locks": waiting_on_locks,
-        "scheduled_at": run.scheduled_at.to_rfc3339(),
-        "started_at": run.started_at.map(|v| v.to_rfc3339()),
-        "finished_at": run.finished_at.map(|v| v.to_rfc3339()),
-        "duration_ms": run.duration_ms,
-        "retry_source_run_id": run.retry_source_run_id,
-        "exit_code": last.and_then(|s| s.exit_code),
-        "agent_response_json": last.and_then(|s| s.agent_response_json.as_ref()),
-        "error_code": last.and_then(|s| s.error_code.as_deref()),
-        "error_message": last.and_then(|s| s.error_message.as_deref()),
-        "knowledge_metrics": run.knowledge_metrics,
-        "resolved_crew": run.resolved_crew,
-        "crew_model": run.crew_model,
-        "steps": run.steps.iter().map(|s| json!({
-            "step_index": s.step_index,
-            "target_type": s.target_type.to_string(),
-            "target_id": s.target_id,
-            "state": s.state.to_string(),
-            "started_at": s.started_at.map(|v| v.to_rfc3339()),
-            "finished_at": s.finished_at.map(|v| v.to_rfc3339()),
-            "duration_ms": s.duration_ms,
-            "exit_code": s.exit_code,
-            "agent_response_json": s.agent_response_json,
-            "error_code": s.error_code,
-            "error_message": s.error_message,
-        })).collect::<Vec<_>>(),
-        "created_at": run.created_at.to_rfc3339(),
-    })
 }
 
 pub(crate) fn task_to_json(task: &Task, status_by_id: &BTreeMap<String, TaskStatus>) -> Value {


### PR DESCRIPTION
## Task

[ORB-11197](https://orbit-cli.com/tasks/ORB-11197) — [code-review] Consolidate duplicated CLI and web job-run JSON projections

### Description

Inspected the clean local Orbit agent-main checkout at 4fdfabcedb87fb30835a9e649ea28212e702caab on 2026-09-04. This is a review finding, not an implemented repair. Recheck current integration HEAD before editing. 

Problem: orbit-web/src/projections.rs:1-4 explicitly says its helpers duplicate CLI logic. The job_run_to_json_with_state implementations at web projections.rs:146-200 and CLI command/run/job.rs:264-316 duplicate terminal waiting-state filtering, child dispatch serialization, and step/run field mapping. They have already diverged: CLI includes pid while web does not. This difference is evidence of separate maintenance, not by itself a claim that both response schemas must be identical. CLI job.rs:257-262 additionally retains an unused pub(crate) wrapper under allow(dead_code) for hypothetical external re-exports/future callers; repository-wide call-site search finds none.

Scope: give the shared job-run projection rules one appropriate lower-layer owner, keep any intentional surface-specific field choices as explicit adapters, and delete the unused CLI wrapper. Do not introduce CLI/web dependency cycles, a new generic projection framework, or unrelated task/audit projection migration. Preserve shipped response contracts; document intentional differences.

### Acceptance Criteria

- One implementation owns shared child-dispatch and terminal waiting-reason projection semantics, and both CLI and HTTP run paths consume it.
- Fixtures cover active and terminal runs with child dispatches and waiting state; CLI/web response contracts and intentional field differences are preserved.
- The unused CLI job_run_to_json wrapper and its speculative dead-code allowance are removed; no forwarding layer exists solely for hypothetical callers.
- Crate layering remains valid, with ARCHITECTURE.md updated if a dependency edge changes; focused tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a core-owned job-run JSON projection that retains child-dispatch lineage for terminal runs while removing stale waiting reasons.
- Updated CLI and HTTP run paths to consume the shared projection; the CLI adds its historical pid field at its presentation boundary, while web intentionally does not.
- Removed the unused CLI job_run_to_json wrapper and dead-code allowance; added core, CLI, and web regression coverage for active and terminal child-dispatch/waiting-state behavior.
Assessment: No crate dependency edge changed; ARCHITECTURE.md remains accurate.
Validation:
- cargo test -p orbit-core projection::
- cargo test -p orbit-cli job_run_json
- cargo test -p orbit-web run_detail_
- make ci-fast
- make ci-lint
Cleanup: Removed the task-created 9.9G target build directory after validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11197-6a9b668a`
- Behind base: 0
- Ahead of base: 1