### PR TITLE
[code-review] Bound initial log-tail buffering by the requested matching window

### DIFF
--- a/crates/orbit-cli/src/command/log/tail.rs
+++ b/crates/orbit-cli/src/command/log/tail.rs
@@ -5,6 +5,7 @@
 //! default and pipeline-friendly when the sink disallows color (`--json` or
 //! plain-text without ANSI escapes).
 
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -185,29 +186,60 @@ fn print_initial_window<W: Write + ?Sized>(
     let total_bytes = file.metadata()?.len();
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
-    let mut all = Vec::new();
+    let mut matching_lines = MatchingLineWindow::new(args.lines);
     loop {
         buf.clear();
         let n = reader.read_line(&mut buf)?;
         if n == 0 {
             break;
         }
-        all.push(buf.trim_end_matches('\n').to_string());
+        if args.lines > 0
+            && let Ok(value) = serde_json::from_str::<Value>(&buf)
+            && filters.matches(&value)
+        {
+            matching_lines.push(buf.trim_end_matches('\n').to_owned());
+        }
     }
 
-    let kept: Vec<&String> = all
-        .iter()
-        .filter(|line| match serde_json::from_str::<Value>(line) {
-            Ok(value) => filters.matches(&value),
-            Err(_) => false,
-        })
-        .collect();
-
-    let start = kept.len().saturating_sub(args.lines);
-    for line in &kept[start..] {
-        emit_line(line, args.json, use_color, writer)?;
+    for line in matching_lines.into_lines() {
+        emit_line(&line, args.json, use_color, writer)?;
     }
     Ok(total_bytes)
+}
+
+/// A chronological tail window whose storage never exceeds its requested
+/// record count. The line currently being parsed is held by the caller.
+pub(super) struct MatchingLineWindow {
+    limit: usize,
+    lines: VecDeque<String>,
+}
+
+impl MatchingLineWindow {
+    pub(super) fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            lines: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn push(&mut self, line: String) {
+        if self.limit == 0 {
+            return;
+        }
+        if self.lines.len() == self.limit {
+            self.lines.pop_front();
+        }
+        self.lines.push_back(line);
+    }
+
+    fn into_lines(self) -> VecDeque<String> {
+        self.lines
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.lines.len()
+    }
 }
 
 fn follow_file<W: Write + ?Sized>(

--- a/crates/orbit-cli/src/command/log/tests/tail.rs
+++ b/crates/orbit-cli/src/command/log/tests/tail.rs
@@ -1,4 +1,4 @@
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
@@ -11,7 +11,8 @@ use tempfile::tempdir;
 
 use crate::command::log::format::{LevelFilter, format_message};
 use crate::command::log::tail::{
-    FollowTestControl, TailArgs, build_filters, run_tail, run_tail_with_test_control,
+    FollowTestControl, MatchingLineWindow, TailArgs, build_filters, run_tail,
+    run_tail_with_test_control,
 };
 
 fn fixture_lines() -> Vec<String> {
@@ -199,6 +200,78 @@ fn n_flag_limits_history() {
     let lines: Vec<&str> = output.lines().collect();
     assert!(lines[0].contains("FRC"));
     assert!(lines[1].contains("[stdout] hello world"));
+}
+
+#[test]
+fn n_zero_prints_no_initial_history_rows() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("orbit.jsonl");
+    write_fixture(&path, &fixture_lines());
+
+    let mut args = make_args(path.clone());
+    args.lines = 0;
+    assert!(capture(&path, args).is_empty());
+}
+
+#[test]
+fn initial_tail_streams_large_interleaved_log_to_last_matching_rows_in_order() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("orbit.jsonl");
+    let mut file = File::create(&path).expect("create fixture");
+    let mut expected = Vec::new();
+
+    for index in 0..4_096 {
+        match index % 5 {
+            0 => {
+                let line = json!({
+                    "timestamp": "2026-04-27T01:00:01.000000000Z",
+                    "level": "WARN",
+                    "target": "orbit.policy.deny",
+                    "fields": {"message": format!("matching-{index}")}
+                })
+                .to_string();
+                if index >= 4_065 {
+                    expected.push(line.clone());
+                }
+                writeln!(file, "{line}").expect("write matching row");
+            }
+            3 => writeln!(file, "{{malformed-{index}").expect("write malformed row"),
+            _ => writeln!(
+                file,
+                "{}",
+                json!({
+                    "timestamp": "2026-04-27T01:00:01.000000000Z",
+                    "level": "INFO",
+                    "target": "orbit.unrelated.event",
+                    "fields": {"message": format!("nonmatching-{index}")}
+                })
+            )
+            .expect("write nonmatching row"),
+        }
+    }
+
+    let mut args = make_args(path.clone());
+    args.lines = 7;
+    args.target = Some("orbit.policy".to_string());
+    args.json = true;
+
+    assert_eq!(capture(&path, args).lines().collect::<Vec<_>>(), expected);
+}
+
+#[test]
+fn matching_line_window_never_retains_more_rows_than_requested() {
+    let mut window = MatchingLineWindow::new(3);
+    for index in 0..4_096 {
+        window.push(format!("matching-{index}"));
+        assert!(
+            window.len() <= 3,
+            "the bounded window exceeded its requested capacity at row {index}"
+        );
+    }
+
+    let mut zero_window = MatchingLineWindow::new(0);
+    zero_window.push("matching".to_string());
+    assert_eq!(zero_window.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11199](https://orbit-cli.com/tasks/ORB-11199) — [code-review] Bound initial log-tail buffering by the requested matching window

### Description

Inspected the clean local Orbit agent-main checkout at 4fdfabcedb87fb30835a9e649ea28212e702caab on 2026-09-04. This is a review finding, not an implemented repair. Recheck current integration HEAD before editing. 

Problem: command/log/tail.rs:123-157 print_initial_window reads every line into Vec<String>, builds a second vector of references to all matching rows, then selects the last args.lines. The default 50-line tail therefore retains the entire log; even --lines 0 in follow mode allocates the whole history. Memory grows with accumulated log volume instead of requested output, delaying an operational diagnostic on large logs.

Scope: stream through the file and retain a bounded ring/window of only matching rows, or another equally simple bounded approach. Preserve filtering-before-limit, chronological output, malformed-line behavior, raw/formatted output, and follow offset semantics. Do not silently cap requested results or add a new service/index/cache. Coordinate with the separate follow-test lifecycle task if both modify tail.rs.

### Acceptance Criteria

- Initial-tail retained row count is bounded by requested lines (plus the current line/parser state); --lines 0 retains no history rows.
- A generated large-log fixture with interleaved matching/nonmatching/malformed rows yields the correct final N matching records in order.
- Provide allocation/peak-memory evidence or a directly observable bounded-buffer invariant showing memory does not scale with total retained history; avoid fragile timing thresholds.
- Follow-mode behavior and existing output formats remain intact; focused tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success. Changes: replaced initial whole-file and all-match collection with a VecDeque chronological window that never retains more than the requested matching rows; zero-line requests retain no history rows; added generated 4,096-row interleaved matching/nonmatching/malformed regression coverage and a directly observable bounded-window invariant. Assessment: filtering, raw/formatted output, malformed-line skipping, and follow offsets are preserved. Validation: cargo test -p orbit-cli command::log::tests::tail (13 passed); make ci-fast; make ci-lint. Friction checkpoint: no qualifying friction observed. Cleanup: removed the untracked target build artifacts created by this run. Deviation: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11199-6a9b6834`
- Behind base: 0
- Ahead of base: 1