### PR TITLE
[code-review] Apply the scoreboard time window to retries and duration metrics

### DIFF
--- a/crates/orbit-cmd/src/diagnostics.rs
+++ b/crates/orbit-cmd/src/diagnostics.rs
@@ -22,6 +22,10 @@ use orbit_core::OrbitRuntime;
 /// Diagnostics-stream read surface for [`OrbitRuntime`] (extension trait —
 /// the implementation moved out of orbit-core in [ORB-10016]).
 pub trait DiagnosticsCommands {
+    /// All `YYYY-MM` partitions that have a metrics log on disk, ascending.
+    /// Used to enumerate the lifetime population without guessing a fixed
+    /// number of trailing months.
+    fn list_metrics_months(&self) -> Result<Vec<String>, OrbitError>;
     /// All metrics entries recorded in `year_month` (`YYYY-MM`).
     fn read_metrics_entries(&self, year_month: &str) -> Result<Vec<MetricsEntry>, OrbitError>;
     /// Most recent `limit` metrics entries recorded in `year_month`.
@@ -41,6 +45,10 @@ pub trait DiagnosticsCommands {
 }
 
 impl DiagnosticsCommands for OrbitRuntime {
+    fn list_metrics_months(&self) -> Result<Vec<String>, OrbitError> {
+        list_jsonl_months(&self.data_root(), "metrics")
+    }
+
     fn read_metrics_entries(&self, year_month: &str) -> Result<Vec<MetricsEntry>, OrbitError> {
         read_jsonl_month::<MetricsEntry>(&self.data_root(), "metrics", year_month)
     }
@@ -64,6 +72,32 @@ impl DiagnosticsCommands for OrbitRuntime {
     ) -> Result<Vec<FrictionEntry>, OrbitError> {
         read_jsonl_month_limited::<FrictionEntry>(&self.data_root(), "friction", year_month, limit)
     }
+}
+
+/// Ascending list of `YYYY-MM` subdirectories under `state/diagnostics/<category>/`.
+fn list_jsonl_months(root: &Path, category: &str) -> Result<Vec<String>, OrbitError> {
+    let category_dir = root.join("state").join("diagnostics").join(category);
+    if !category_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut months: Vec<String> = fs::read_dir(&category_dir)
+        .map_err(|e| OrbitError::Io(e.to_string()))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| is_year_month(name))
+        .collect();
+    months.sort();
+    Ok(months)
+}
+
+/// `true` for a `YYYY-MM` directory name (e.g. `2026-03`).
+fn is_year_month(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() == 7
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[4] == b'-'
+        && bytes[5..].iter().all(u8::is_ascii_digit)
 }
 
 fn read_jsonl_month<T: DeserializeOwned>(
@@ -197,7 +231,7 @@ fn parse_jsonl_values<T: DeserializeOwned>(line: &str) -> Result<Vec<T>, serde_j
 mod tests {
     use serde_json::{Value, json};
 
-    use super::parse_jsonl_values;
+    use super::{is_year_month, list_jsonl_months, parse_jsonl_values};
 
     #[test]
     fn parse_jsonl_values_recovers_concatenated_objects() {
@@ -211,5 +245,40 @@ mod tests {
         let err = parse_jsonl_values::<Value>(r#"{"step":"one"}oops"#).unwrap_err();
 
         assert!(err.to_string().contains("trailing characters"));
+    }
+
+    #[test]
+    fn is_year_month_accepts_only_canonical_form() {
+        assert!(is_year_month("2026-03"));
+        assert!(!is_year_month("2026-3"));
+        assert!(!is_year_month("26-03"));
+        assert!(!is_year_month("2026/03"));
+        assert!(!is_year_month(""));
+    }
+
+    #[test]
+    fn list_jsonl_months_returns_sorted_existing_partitions() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let category_dir = root
+            .path()
+            .join("state")
+            .join("diagnostics")
+            .join("metrics");
+        std::fs::create_dir_all(category_dir.join("2026-01")).unwrap();
+        std::fs::create_dir_all(category_dir.join("2025-12")).unwrap();
+        std::fs::write(category_dir.join("not-a-month.txt"), "ignored").unwrap();
+
+        let months = list_jsonl_months(root.path(), "metrics").unwrap();
+
+        assert_eq!(months, vec!["2025-12".to_string(), "2026-01".to_string()]);
+    }
+
+    #[test]
+    fn list_jsonl_months_missing_category_dir_is_empty() {
+        let root = tempfile::tempdir().expect("tempdir");
+
+        let months = list_jsonl_months(root.path(), "metrics").unwrap();
+
+        assert!(months.is_empty());
     }
 }

--- a/crates/orbit-web/src/api/scoreboard.rs
+++ b/crates/orbit-web/src/api/scoreboard.rs
@@ -6,7 +6,7 @@ use crate::state::Ws;
 use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use orbit_cmd::DiagnosticsCommands;
 use orbit_core::scoreboard_summary::ScoreboardWindow;
 use orbit_core::{FailureIncidentQuery, OrbitRuntime};
@@ -54,10 +54,12 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
     // logged-and-swallowed so the existing scoreboard surface still renders if
     // a side log is missing or malformed.
     //
-    // Denials honor the same window as the rest of the scoreboard so the
-    // dashboard column lines up with the windowed counts.
-    let metrics_extras = compute_metrics_extras(&runtime).unwrap_or_default();
-    let since_window = window.duration().map(|d| Utc::now() - d);
+    // One `now`/`since_window` pair scopes every join below (metrics extras,
+    // denials, failure rollup) so the response mixes only compatible
+    // populations for the requested window.
+    let now = Utc::now();
+    let since_window = window.duration().map(|d| now - d);
+    let metrics_extras = compute_metrics_extras(&runtime, since_window, now).unwrap_or_default();
     let denials_by_role = runtime
         .audit_denials_by_role(since_window.as_ref())
         .unwrap_or_default();
@@ -144,27 +146,30 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
 }
 
 /// Per-agent extras derived from `MetricsEntry` JSONL.
-#[derive(Debug, Clone, Default)]
-struct MetricsExtras {
-    avg_duration_ms: i64,
-    p95_duration_ms: i64,
-    retry_count: i64,
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(super) struct MetricsExtras {
+    pub(super) avg_duration_ms: i64,
+    pub(super) p95_duration_ms: i64,
+    pub(super) retry_count: i64,
 }
 
-fn compute_metrics_extras(
+// `pub(super)`: exercised directly by the sibling `api/tests/scoreboard.rs`
+// unit tests (window/month-boundary arithmetic), per the crate's sibling
+// test-layout convention — see docs/design-patterns/test_layout.md.
+pub(super) fn compute_metrics_extras(
     runtime: &OrbitRuntime,
+    since: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
 ) -> Result<BTreeMap<String, MetricsExtras>, orbit_core::OrbitError> {
     use orbit_types::identity::ActorIdentity;
 
-    let now = Utc::now();
-    let mut months = Vec::new();
-    months.push(now.format("%Y-%m").to_string());
-    if let Some(prev) = now.checked_sub_signed(Duration::days(31)) {
-        let key = prev.format("%Y-%m").to_string();
-        if !months.contains(&key) {
-            months.push(key);
-        }
-    }
+    // A finite window only needs its own partitions; lifetime (`since ==
+    // None`) enumerates every partition that has ever been written so
+    // records older than a couple of months are still counted.
+    let months = match since {
+        Some(since) => months_in_range(since, now),
+        None => runtime.list_metrics_months()?,
+    };
 
     let mut by_actor: BTreeMap<String, Vec<u64>> = BTreeMap::new();
     let mut retries: BTreeMap<String, i64> = BTreeMap::new();
@@ -175,6 +180,12 @@ fn compute_metrics_extras(
             Err(e) => return Err(e),
         };
         for entry in entries {
+            // A month partition covers a superset of the requested range
+            // (e.g. the first/last day of the month), so re-check each
+            // record against the exact boundary.
+            if since.is_some_and(|since| entry.ts < since) || entry.ts > now {
+                continue;
+            }
             let key = match &entry.actor_identity {
                 ActorIdentity::Agent { model } if !model.is_empty() => model.clone(),
                 ActorIdentity::Human { label } if !label.is_empty() => label.clone(),
@@ -219,6 +230,30 @@ fn compute_metrics_extras(
         });
     }
     Ok(out)
+}
+
+/// Ascending `YYYY-MM` partitions spanning `since..=now`, inclusive of both
+/// endpoints' months. Steps by calendar month rather than a fixed day offset
+/// so a window whose start falls on an early-month date (e.g. subtracting 30
+/// days from March 1st) still includes every month it actually touches.
+pub(super) fn months_in_range(since: DateTime<Utc>, now: DateTime<Utc>) -> Vec<String> {
+    let (mut year, mut month) = (since.year(), since.month());
+    let (end_year, end_month) = (now.year(), now.month());
+
+    let mut months = Vec::new();
+    loop {
+        months.push(format!("{year:04}-{month:02}"));
+        if year > end_year || (year == end_year && month >= end_month) {
+            break;
+        }
+        if month == 12 {
+            month = 1;
+            year += 1;
+        } else {
+            month += 1;
+        }
+    }
+    months
 }
 
 /// Looks up an agent's grouped failure counts. The rollup is already keyed by

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -13,11 +13,14 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
+use chrono::{DateTime, Duration, Utc};
 use orbit_core::OrbitRuntime;
+use serde_json::json;
 use tower::ServiceExt;
 
+use super::super::scoreboard::{MetricsExtras, compute_metrics_extras, months_in_range};
 use super::super::*;
-use super::test_support::body_json;
+use super::test_support::{body_json, write_lines};
 
 async fn get_scoreboard(runtime: OrbitRuntime, query: Option<&str>) -> axum::response::Response {
     let uri = match query {
@@ -282,4 +285,277 @@ async fn scoreboard_reports_failure_incidents_beside_raw_failed_tool_calls() {
         "the incident states how much raw evidence it collapsed"
     );
     assert_eq!(agent["unexpected_failure_incidents"].as_u64(), Some(1));
+}
+
+// ORB-11200: `compute_metrics_extras` must scope retries/avg/p95 to the
+// scoreboard's own requested window instead of a fixed "current + prior
+// month" guess, and `months_in_range` must walk actual calendar months so an
+// early-month `now` doesn't skip the month in between.
+
+/// Writes one `MetricsEntry` JSONL line per `(year_month, ts, model,
+/// step_duration_ms, retry_count)` tuple, grouping same-month fixtures into a
+/// single file the reader can enumerate.
+fn write_metrics_entries(
+    runtime: &OrbitRuntime,
+    entries: &[(&str, DateTime<Utc>, &str, u64, u32)],
+) {
+    let mut by_month: std::collections::BTreeMap<&str, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for (month, ts, model, step_duration_ms, retry_count) in entries {
+        let line = json!({
+            "ts": ts.to_rfc3339(),
+            "job_run": "jrun-fixture",
+            "step": "implement",
+            "actor_identity": model,
+            "tool_invocations": 1,
+            "token_usage": 10,
+            "step_duration_ms": step_duration_ms,
+            "retry_count": retry_count,
+        })
+        .to_string();
+        by_month.entry(month).or_default().push(line);
+    }
+    for (month, lines) in by_month {
+        let dir = runtime
+            .data_root()
+            .join("state")
+            .join("diagnostics")
+            .join("metrics")
+            .join(month);
+        std::fs::create_dir_all(&dir).expect("create metrics month dir");
+        write_lines(&dir.join("fixture.jsonl"), &lines);
+    }
+}
+
+#[test]
+fn months_in_range_single_month_when_since_and_now_share_a_month() {
+    let since = DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let now = DateTime::parse_from_rfc3339("2026-06-15T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    assert_eq!(months_in_range(since, now), vec!["2026-06".to_string()]);
+}
+
+/// Reproduces the original bug: 31 days before an early-March `now` lands in
+/// January, so a naive "current month + prior month" guess never reads
+/// February even though the window spans it.
+#[test]
+fn months_in_range_does_not_skip_february_on_early_march_dates() {
+    let now = DateTime::parse_from_rfc3339("2026-03-01T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let since = now - Duration::days(30);
+    assert_eq!(since.format("%Y-%m").to_string(), "2026-01");
+
+    assert_eq!(
+        months_in_range(since, now),
+        vec![
+            "2026-01".to_string(),
+            "2026-02".to_string(),
+            "2026-03".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn months_in_range_walks_a_leap_year_february() {
+    let since = DateTime::parse_from_rfc3339("2028-01-30T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let now = DateTime::parse_from_rfc3339("2028-03-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    assert_eq!(
+        months_in_range(since, now),
+        vec![
+            "2028-01".to_string(),
+            "2028-02".to_string(),
+            "2028-03".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn months_in_range_spans_a_year_boundary() {
+    let since = DateTime::parse_from_rfc3339("2025-12-20T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let now = DateTime::parse_from_rfc3339("2026-01-05T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    assert_eq!(
+        months_in_range(since, now),
+        vec!["2025-12".to_string(), "2026-01".to_string()]
+    );
+}
+
+/// Fixed timestamps (no wall-clock sleeps) with a record before, inside, and
+/// after each windowed range prove only the eligible record is counted.
+#[test]
+fn compute_metrics_extras_excludes_records_outside_the_requested_window() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let now = DateTime::parse_from_rfc3339("2026-03-15T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let since = now - Duration::hours(1);
+    let month = now.format("%Y-%m").to_string();
+
+    write_metrics_entries(
+        &runtime,
+        &[
+            // Before the window: excluded.
+            (
+                &month,
+                since - Duration::minutes(1),
+                "claude-opus-5",
+                9_000,
+                5,
+            ),
+            // Inside the window: the only eligible record.
+            (
+                &month,
+                since + Duration::minutes(1),
+                "claude-opus-5",
+                400,
+                2,
+            ),
+            // After "now" (future-dated / clock skew): excluded.
+            (&month, now + Duration::minutes(10), "claude-opus-5", 500, 9),
+        ],
+    );
+
+    let extras = compute_metrics_extras(&runtime, Some(since), now).expect("compute extras");
+    let claude = extras.get("claude-opus-5").expect("claude-opus-5 row");
+    assert_eq!(
+        claude,
+        &MetricsExtras {
+            avg_duration_ms: 400,
+            p95_duration_ms: 400,
+            retry_count: 2,
+        }
+    );
+}
+
+#[test]
+fn compute_metrics_extras_windows_1h_24h_7d_30d_each_include_only_the_inside_fixture() {
+    let now = DateTime::parse_from_rfc3339("2026-03-15T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    for (label, duration) in [
+        ("1h", Duration::hours(1)),
+        ("24h", Duration::hours(24)),
+        ("7d", Duration::days(7)),
+        ("30d", Duration::days(30)),
+    ] {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let since = now - duration;
+        let model = format!("claude-opus-5-{label}");
+        write_metrics_entries(
+            &runtime,
+            &[
+                (
+                    &since.format("%Y-%m").to_string(),
+                    since - Duration::minutes(1),
+                    &model,
+                    9_000,
+                    5,
+                ),
+                (
+                    &(since + (now - since) / 2).format("%Y-%m").to_string(),
+                    since + (now - since) / 2,
+                    &model,
+                    300,
+                    1,
+                ),
+                (
+                    &now.format("%Y-%m").to_string(),
+                    now + Duration::minutes(1),
+                    &model,
+                    500,
+                    9,
+                ),
+            ],
+        );
+
+        let extras = compute_metrics_extras(&runtime, Some(since), now).expect("compute extras");
+        let row = extras
+            .get(model.as_str())
+            .unwrap_or_else(|| panic!("{label}: expected a row for {model}"));
+        assert_eq!(
+            row.retry_count, 1,
+            "{label}: only the inside-window record should count"
+        );
+        assert_eq!(
+            row.avg_duration_ms, 300,
+            "{label}: avg must ignore outside records"
+        );
+        assert_eq!(
+            row.p95_duration_ms, 300,
+            "{label}: p95 must ignore outside records"
+        );
+    }
+}
+
+/// Lifetime (`since == None`) must enumerate every metrics partition on disk,
+/// not just the current and prior month, so records older than two months
+/// are still counted.
+#[test]
+fn compute_metrics_extras_lifetime_includes_partitions_older_than_two_months() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let now = DateTime::parse_from_rfc3339("2026-03-15T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let old_ts = DateTime::parse_from_rfc3339("2025-11-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    write_metrics_entries(&runtime, &[("2025-11", old_ts, "claude-opus-5", 200, 3)]);
+
+    let extras = compute_metrics_extras(&runtime, None, now).expect("compute extras");
+    let claude = extras.get("claude-opus-5").expect("claude-opus-5 row");
+    assert_eq!(claude.retry_count, 3);
+    assert_eq!(claude.avg_duration_ms, 200);
+}
+
+/// End-to-end: the HTTP handler must thread its parsed `?window=` and a
+/// single request `now` into `compute_metrics_extras`, so a record just
+/// outside a 1h window never reaches the response.
+#[tokio::test]
+async fn scoreboard_http_response_only_reflects_metrics_inside_the_requested_window() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let now = Utc::now();
+    let month = now.format("%Y-%m").to_string();
+    write_metrics_entries(
+        &runtime,
+        &[
+            (
+                &month,
+                now - Duration::hours(2),
+                "claude-opus-5-http",
+                9_000,
+                5,
+            ),
+            (
+                &month,
+                now - Duration::minutes(10),
+                "claude-opus-5-http",
+                400,
+                2,
+            ),
+        ],
+    );
+
+    let response = get_scoreboard(runtime, Some("window=1h")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let agent = &body["agents"]["claude-opus-5-http"];
+    assert_eq!(agent["retries"].as_i64(), Some(2));
+    assert_eq!(agent["avg_step_duration_ms"].as_i64(), Some(400));
+    assert_eq!(agent["p95_wall_clock_ms"].as_i64(), Some(400));
 }


### PR DESCRIPTION
## Task

[ORB-11200](https://orbit-cli.com/tasks/ORB-11200) — [code-review] Apply the scoreboard time window to retries and duration metrics

### Description

Inspected the clean local Orbit agent-main checkout at 4fdfabcedb87fb30835a9e649ea28212e702caab on 2026-09-04. This is a review finding, not an implemented repair. Recheck current integration HEAD before editing. 

Problem: api/scoreboard.rs:59 calls compute_metrics_extras(&runtime) without the parsed ScoreboardWindow. The helper at lines 154-219 reads the current month and now-minus-31-days month and aggregates every entry without checking MetricsEntry.ts. Thus /api/scoreboard?window=1h receives retries/average/p95 from outside the requested hour, and window=all omits older metrics. Subtracting 31 days can also skip the immediately preceding month on early March dates. Core summary and denial counts use the selected window, so the response mixes incompatible populations.

Scope: use one explicit request time/range for extras and the scoreboard's existing window contract; enumerate the partitions required by that range, including all available partitions for lifetime. Put reusable metric aggregation in the existing owning layer if appropriate, keeping transport parsing thin. Do not change metric definitions or build a generic analytics framework.

### Acceptance Criteria

- Deterministic fixtures before/inside/after the requested range prove retries, average duration, and p95 only include eligible records for 1h/24h/7d/30d.
- Lifetime includes records older than the last two months, and month/leap-year boundaries do not skip eligible partitions.
- The same request clock/boundary convention is used consistently; tests use fixed timestamps without wall-clock sleeps.
- Response compatibility is preserved apart from corrected values; focused tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the scoreboard's metrics-extras join to actually respect the requested `?window=` instead of ignoring it.

Root cause: `compute_metrics_extras` read only the current month and a "now - 31 days" month, then aggregated every `MetricsEntry` in those files with no per-record timestamp check. This mixed populations across windows and, on early-month dates (e.g. March 1st), the fixed 31-day subtraction could skip the intervening month (e.g. February) entirely; `window=all` never looked past two months, silently dropping older lifetime data.

Fix (crates/orbit-web/src/api/scoreboard.rs):
- The handler now computes one `now = Utc::now()` and a matching `since_window = window.duration().map(|d| now - d)`, and threads both into `compute_metrics_extras(&runtime, since_window, now)` — the same pair already used for denials and the failure-incident rollup, so every join in the response is scoped to one consistent request clock/boundary.
- `compute_metrics_extras` now: (a) for a finite window, enumerates every calendar month from `since` to `now` via a new `months_in_range` helper (steps by real month/year arithmetic, not a fixed day offset, so it can't skip a month); (b) for lifetime (`since == None`), enumerates every metrics-month partition that exists on disk; and (c) filters every record by `since <= entry.ts <= now` regardless of which partition it came from, since a month file is a superset of the exact window.
- Added `DiagnosticsCommands::list_metrics_months` in crates/orbit-cmd/src/diagnostics.rs (the crate that already owns metrics JSONL reading) to list `YYYY-MM` partitions on disk, backing the lifetime case.
- `compute_metrics_extras`, `months_in_range`, and `MetricsExtras` widened from private to `pub(super)` so the sibling test file can exercise the window/month-boundary logic directly with fixed timestamps (no wall-clock sleeps), per this repo's structural test-layout convention.

Tests added (crates/orbit-web/src/api/tests/scoreboard.rs, 10 new + existing 4 unchanged, all passing):
- `months_in_range_*`: single-month, year-boundary, and the two bug repros (early-March skips February; leap-year February is not skipped).
- `compute_metrics_extras_excludes_records_outside_the_requested_window`: before/inside/after-now fixtures for a 1h window, asserting only the inside record contributes to retries/avg/p95.
- `compute_metrics_extras_windows_1h_24h_7d_30d_each_include_only_the_inside_fixture`: same before/inside/after pattern parametrized across all four finite windows.
- `compute_metrics_extras_lifetime_includes_partitions_older_than_two_months`: a >4-month-old fixture is counted under `window=all`.
- `scoreboard_http_response_only_reflects_metrics_inside_the_requested_window`: end-to-end HTTP check that the `?window=1h` response body only reflects the in-window fixture.
- crates/orbit-cmd/src/diagnostics.rs: unit tests for `is_year_month` and `list_jsonl_months` (sorted partitions, missing category dir).

Response shape is unchanged (same JSON fields); only the computed values are corrected. `make ci-fast` and `make ci-lint` both pass. Ran the full focused suites: `cargo test -p orbit-web --lib api::tests::scoreboard` (14 passed) and `cargo test -p orbit-cmd --lib diagnostics::tests` (5 passed).

Scope note: touched crates/orbit-cmd/src/diagnostics.rs (new read-layer capability, not in the original context_files) and crates/orbit-web/src/api/tests/scoreboard.rs (sibling test file for the modified source); both appended to context_files with rationale in a task comment. No cross-crate dependency edges added — orbit-web already depended on orbit-cmd's `DiagnosticsCommands` trait.

No friction filed: this was a straightforward, well-scoped fix once the existing month-partitioned JSONL read path was understood; no contradicted assumption or >10-minute gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11200-6a9b67fa`
- Behind base: 0
- Ahead of base: 1