### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -1,7 +1,7 @@
 ---
 type: context
 summary: "Orbit Positioning"
-last_validated: 2026-08-13
+last_validated: 2026-09-05
 ---
 
 # Orbit Positioning

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Semantic Search — Design"
 owner: claude
 last_updated: 2026-08-24
-last_validated: 2026-08-09
+last_validated: 2026-09-05
 status: Accepted
 feature: orbit-search
 doc_role: design
@@ -71,8 +71,8 @@ orbit (main binary)                          orbit-search-companion (installed b
 Lifecycle:
 
 - `SubprocessEmbedder::new()` resolves the companion path under `~/.orbit/embed/bin/orbit-search-companion-<platform>` and starts the subprocess. ~100–300ms cold-start latency for ORT init.
-- The subprocess stays alive for the duration of the parent process or until explicitly dropped. Indexing batches and multi-query interactive sessions reuse the same subprocess.
-- On process exit, the parent sends an `exit` RPC and waits up to 1s; if unresponsive, sends SIGTERM.
+- The subprocess stays alive for the duration of the parent process or until explicitly dropped. Callers that retain the embedder, including the background indexing worker, reuse the same subprocess.
+- On process exit, the parent sends an `exit` RPC, reads the response, and waits for the child to exit.
 
 ### 2.3 RPC protocol
 
@@ -99,7 +99,7 @@ The protocol is intentionally minimal — four methods, no streaming, no auth. T
 
 ### 2.4 Default model and install-time model selection
 
-`orbit semantic install` accepts `--model {bge-small | minilm-l6 | nomic-v1.5}`; default is `bge-small`. The install command probes an existing companion with `--version-info` and replaces it when the reported companion version differs from the current Orbit package version; `--force` replaces it even when the probe says it is current. Model files are downloaded into `~/.orbit/embed/models/<model_id>/`. Switching model means running `orbit semantic install --model OTHER`, which downloads the new model alongside the existing one (so the embeddings under the old `model_id` keep working until reindexed; see [§7.2](#72-backfill-and-migration)).
+`orbit semantic install` accepts `--model {bge-small | minilm-l6 | nomic-v1.5}`; default is `bge-small`. The install command validates the existing managed companion's integrity metadata and reinstalls it when the metadata is missing or stale; `--force` reinstalls it unconditionally. Model files are downloaded into `~/.orbit/embed/models/<model_id>/`. Switching model means running `orbit semantic install --model OTHER`, which downloads the new model alongside the existing one (so the embeddings under the old `model_id` keep working until reindexed; see [§7.2](#72-backfill-and-migration)).
 
 The three supported models per [3_vision.md §1](./3_vision.md):
 
@@ -116,7 +116,7 @@ On first use of any embedder-touching path, `SubprocessEmbedder::new()` checks:
 1. `~/.orbit/embed/bin/orbit-search-companion-<platform>` → standard managed-install path.
 2. `$ORBIT_SEARCH_COMPANION` → developer-only absolute path override when the explicit unsafe override gate is enabled.
 
-If none resolve, the embedder returns `OrbitError::CompanionNotInstalled` with a remediation message: `"Run \`orbit semantic install\` to enable semantic search."` Indexing-path callers log and skip (semantic search is not on the critical path of task mutation; see [§7.1](#71-on-mutation-indexing)). Query-path callers surface the error directly to the user.
+If none resolve, the embedder returns `OrbitError::CompanionNotInstalled` with the remediation message: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Indexing-path callers log and skip (semantic search is not on the critical path of task mutation; see [§7.1](#71-on-mutation-indexing)). Query-path callers surface the error directly to the user.
 
 ### 2.6 Alternative backends
 
@@ -259,13 +259,13 @@ orbit docs index         [--force] [--model MODEL]
 orbit semantic stats
 ```
 
-`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-search-companion` binary from the published release URL and the chosen model from HuggingFace, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside the existing ones. Re-running `install` after an Orbit upgrade also refreshes a stale companion automatically because the existing binary's `--version-info` output is compared to the current package version; `--force` is the explicit override for reinstalling the current version.
+`install` is the gate that enables every other subcommand. It downloads the platform-appropriate `orbit-search-companion` binary from the published release URL and the chosen model through the companion, both into `~/.orbit/embed/`. Default model is `bge-small`; users can override per [§2.4](#24-default-model-and-install-time-model-selection). Re-running `install` with a different `--model` adds that model alongside the existing ones. Re-running `install` after an Orbit upgrade refreshes a companion whose integrity metadata is missing or stale; `--force` is the explicit override for reinstalling regardless of the existing metadata.
 
 `uninstall` removes the companion binary and (by default) the currently active model. `--model M` removes only model M. `--all` removes the companion plus every installed model.
 
 `orbit search` defaults to lexical matching across tasks and docs; ADR content participates through indexed design docs. `--hybrid` blends lexical scoring with cosine over the selected corpus; `orbit search similar <task-id>` embeds the target task and runs cosine-neighbor lookup against other tasks; `orbit search path <path>` performs applicability lookup over path-scoped artifacts. `orbit semantic index` rebuilds the selected corpus (`tasks` by default, or `docs` and `all` via `--kind`); `orbit docs index` is the docs-specific alias and sweeps stale doc paths. `--force` ignores `content_hash` and re-embeds everything. `stats` reports row counts, model distribution, stale-row count, and companion-install status. The retired `learning` kind is rejected.
 
-If the companion is not installed, task-hybrid search, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Doc-hybrid search is softer: it emits a warning/note and falls back to lexical doc results.
+If the companion is not installed, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Hybrid task and doc search are softer: they emit a warning/note and fall back to lexical results.
 
 `--workspace` and `--all-workspaces` select the federated scope described in [§6.4](#64-cross-workspace-federated-search). They apply to the free-text form only; `similar` and `path` are single-workspace by construction.
 
@@ -376,7 +376,7 @@ Users who want semantic search must run two commands instead of one: install `or
 
 ### 8.2 Subprocess overhead
 
-The companion lives in a separate process and inference happens via stdio JSON-RPC. Cold-start latency is ~100–300ms (ORT init + model load). The subprocess is reused across a batch (`reindex`) and across a multi-query interactive session, so the cost is amortized for indexing and after the first search; it is fully visible on the first interactive query of a fresh `orbit` invocation. RPC serialization itself is sub-millisecond at phase-1 batch sizes (≤16 texts × ~512 tokens each); not a measurable contributor.
+The companion lives in a separate process and inference happens via stdio JSON-RPC. Cold-start latency is ~100–300ms (ORT init + model load). The background task-indexing worker reuses the subprocess across its batches, so the cost is amortized for indexing; a fresh `orbit` invocation pays the startup cost again. RPC serialization itself is sub-millisecond at phase-1 batch sizes (≤16 texts × ~512 tokens each); not a measurable contributor.
 
 ### 8.3 Default model quality is unmeasured for Orbit specifically
 

--- a/docs/design/orbit-search/3_vision.md
+++ b/docs/design/orbit-search/3_vision.md
@@ -4,7 +4,7 @@ type: design
 title: "Semantic Search — Vision"
 owner: claude
 last_updated: 2026-08-13
-last_validated: 2026-08-09
+last_validated: 2026-09-05
 status: Draft
 feature: orbit-search
 doc_role: vision
@@ -74,7 +74,7 @@ All three are useful, all three are out of scope phase 1, and all three are down
 
 ### 1.6 Review-thread granularity
 
-Phase 1 indexes each review-thread message as a separate row. The alternative — index whole threads as single documents — loses authorship signal but improves recall on multi-message threads where the decision context is spread across replies. Which granularity is more useful for "find me the thread where we decided X" is an empirical question that wants the eval harness from §1.1 to settle.
+The current task index stores title, description, plan, execution summary, and acceptance as separate rows; review-thread messages are not represented in the task embedding fields. If review threads become searchable, the alternative — index each message separately or whole threads as single documents — trades authorship signal against recall when decision context is spread across replies. Which granularity is more useful for "find me the thread where we decided X" is an empirical question that wants the eval harness from §1.1 to settle.
 
 ### 1.7 Historical phase-2 graph corpus proposal
 
@@ -146,7 +146,7 @@ The schema's `source_kind` discriminator is not future-proofing for its own sake
 
 ### 3.3 Failure-mode honesty in the score breakdown
 
-The result shape exposes `bm25_rank` and `cosine_rank` separately on every result. A consumer (especially an agent) can detect "this matched only lexically" or "this matched only semantically" and adjust confidence. Most hybrid systems hide the constituent ranks behind a fused score; surfacing both costs nothing and gives downstream tooling a real signal.
+Semantic task results expose `bm25_rank` and `cosine_rank` separately in their score breakdown. A consumer (especially an agent) can detect "this matched only lexically" or "this matched only semantically" and adjust confidence; lexical and doc results do not necessarily carry both ranks. Most hybrid systems hide the constituent ranks behind a fused score; surfacing both costs nothing and gives downstream tooling a real signal.
 
 ---
 

--- a/docs/design/orbit-search/4_decisions.md
+++ b/docs/design/orbit-search/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Semantic Search — Decisions"
 owner: claude
 last_updated: 2026-08-24
-last_validated: 2026-08-09
+last_validated: 2026-09-05
 status: Accepted
 feature: orbit-search
 doc_role: decisions

--- a/docs/design/policy-sandbox/specs/fs-profile-resolution.md
+++ b/docs/design/policy-sandbox/specs/fs-profile-resolution.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Filesystem Profile Resolution"
 tags: ["policy-sandbox"]
-last_validated: 2026-08-11
+last_validated: 2026-09-05
 ---
 
 # Spec: Filesystem Profile Resolution
@@ -17,7 +17,7 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 
 - **Schema acceptance.** Only `schemaVersion: 2` policies are accepted. v1 is rejected at load time with an explicit migration message that names `spec.denyRead`, `spec.denyModify`, and `spec.fsProfiles`.
 - **Profile lookup.** `effective_profile(profile_name)` returns the named profile if present. If absent and `profile_name == "unrestricted"`, it synthesizes `FsProfile { read: ["./**"], modify: ["./**"] }`. Any other absent name returns `OrbitError::InvalidInput`.
-- **Rule normalization.** Every rule is trimmed, has backslashes converted to forward slashes, has leading `./` stripped, and is rejected if it contains `~`, `~/`, parent traversals, or absolute paths. The normalizer also compiles the rule to its glob-equivalent regex; a rule that fails to compile is rejected at load.
+- **Rule normalization.** Every rule is trimmed, has backslashes converted to forward slashes, has leading `./` stripped, and is rejected if it is `~`/`~/…`, contains parent traversals, or is absolute. The normalizer also compiles the rule to its glob-equivalent regex; a rule that fails to compile is rejected at load.
 - **Deny injection.** Every entry of `denyRead` is appended to the resolved profile's `read` list as `!<rule>`. Ordinary `denyModify` entries append to `modify` as `!<rule>`. A `denyModify` entry already beginning with `!` is an explicit host-policy exception: it is resolved after its enclosing deny, but only through the selected profile's existing positive coverage, with nested profile rules replayed in order so profile negatives still narrow it. Injection happens after profile lookup so the implicit `unrestricted` profile is also subject to global boundaries.
 - **Validation invariants.**
   - Profile names are non-empty.
@@ -30,7 +30,7 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 
 ## Evaluation Invariants
 
-- **Path normalization.** Caller-supplied paths are normalized via `normalize_path`: trim, slash-flip, strip leading `./`. Absolute paths, `~`-anchored paths, and parent-directory components are rejected after backslash normalization.
+- **Path normalization.** Caller-supplied paths are normalized via `normalize_glob_path`: trim, slash-flip, strip leading `./`, and canonicalize redundant separators and `.` components. Absolute paths, `~`-anchored paths, and parent-directory components are rejected after backslash normalization.
 - **Empty rule list.** If the operation's rule list is empty after deny injection, the decision is `allowed = false` with `matched_rule = "[]"`.
 - **Rule walk.** The evaluator walks the rule list in order and tracks the most recent match. The decision uses the *last* match's negation flag: positive match → allow, negated match → deny.
 - **Empty positive set.** If the rule list contains no positive rules (only negated rules), the decision is `allowed = false` with `matched_rule = "[]"`.
@@ -40,7 +40,7 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 ## Glob Translator
 
 - **Supported syntax:** `*` (single-segment wildcard, anchored to `[^/]*`), `**` (cross-segment wildcard, anchored to `.*`), `**/` segment (anchored to `(?:.*/)?`), `?` (single character within a segment, anchored to `[^/]`), `<prefix>/**` directory-subtree match (anchored to `^<prefix>(?:/.*)?$`).
-- **Unsupported syntax:** character classes (`[abc]`), brace expansion (`{a,b}`), POSIX bracket expressions, leading `**/` followed by another `**`, escape sequences. Rules that need these will hit translator gaps before they hit the evaluator.
+- **Unsupported syntax:** character classes (`[abc]`), brace expansion (`{a,b}`), POSIX bracket expressions, and escape sequences are not interpreted as glob operators; they are matched literally. `**` may still be combined with other supported operators, including a `**/` segment followed by another `**`.
 - **Anchoring.** Compiled regexes are anchored at both ends (`^…$`). Partial matches do not satisfy a rule.
 
 ## Failure Modes
@@ -48,7 +48,7 @@ The resolution algorithm has multiple layered transformations (lookup, normaliza
 - **Profile missing.** `effective_profile("unknown")` (where the policy does not define `unknown` and the name is not `unrestricted`) returns `OrbitError::InvalidInput`. Callers must treat this as a configuration error, not a deny.
 - **Rule normalization failure.** A rule that escapes the workspace, is empty, or fails to compile to a regex returns `OrbitError::InvalidInput` at validation or resolution time. Loaders must surface this to the user; runtimes must treat it as a stop-the-world error rather than falling back to deny-all.
 - **Invalid modify exception.** A non-subtree exception, an exception without an earlier strict enclosing deny, or a workspace exception outside the host surface returns `OrbitError::InvalidInput`; callers must not drop the exception and continue with a broader policy.
-- **Workspace canonicalization failure.** The tool layer's `workspace_relative_path` falls back to the non-canonical workspace root when `canonicalize` fails. A path that cannot be expressed workspace-relative surfaces as `OrbitError::PolicyDenied("path is outside workspace")`, which is conservative but does not distinguish "workspace deleted" from "path actually outside."
+- **Workspace canonicalization failure.** `PolicyEngine::check_resolved` falls back to the supplied workspace root when root canonicalization fails. A path that cannot be expressed workspace-relative is returned as an outside-workspace denial, which is conservative but does not distinguish "workspace deleted" from "path actually outside."
 - **Empty `read` rule list.** A profile authored without read rules denies every read with `matched_rule = "[]"`. This is almost always a misconfiguration but is treated as a valid (if useless) profile.
 
 ## Migration Rules

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Sandboxed Exec Contract"
 tags: ["policy-sandbox"]
-last_validated: 2026-08-11
+last_validated: 2026-09-05
 ---
 
 # Spec: Sandboxed Exec Contract
@@ -28,7 +28,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 - **Background drains.** `wait_with_optional_timeout` spawns reader threads for stdout and stderr immediately after spawn. The child must never block on a full pipe buffer because the parent is not reading.
 - **Stdin writer thread.** When `StdinMode::Bytes` is set, a writer thread copies the payload to the child's stdin. A failed write terminates the child via `terminate_process_group` and surfaces as `OrbitError::Execution(<message>)`.
 - **Poll interval.** The wait loop polls with `WAIT_POLL_INTERVAL = 100ms` (or the remaining deadline, whichever is smaller). The interval is global and not per-request configurable.
-- **Signal handler installation (Unix).** A `SignalHandlerGuard` installs SIGINT and SIGTERM handlers for the duration of the wait loop. Installation acquires a process-global `Mutex` so concurrent calls cannot race. Drop restores the previous handlers in reverse order.
+- **Signal handler installation (Unix).** A `SignalHandlerGuard` installs SIGINT and SIGTERM handlers for the duration of the wait loop. Installation acquires a process-global `Mutex`; the guard holds it until drop, so concurrent supervised waits are serialized. Drop restores the previous handlers and closes the signal pipe.
 - **Timeout escalation.** When the deadline expires, `terminate_process_group(child, SIGTERM, poll_interval)` is called. If the group does not exit within `TERMINATION_GRACE_PERIOD = 5 seconds`, `kill_process_group` (SIGKILL) is invoked plus a direct `child.kill()`/`child.wait()`.
 - **Parent-signal escalation.** When the parent receives SIGINT or SIGTERM during the wait, the same termination path runs with the received signal. The result reports `exit_code = Some(128 + signal)` and `success = false`.
 - **Clean-exit reaping.** When the child exits cleanly, the wait loop calls `kill_process_group(child.id())` to reap any orphan subprocesses still holding pipe write ends, then joins the reader threads. Without this, an orphan grandchild can keep the pipes open and block reader-thread completion indefinitely.
@@ -56,7 +56,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 
 ## Concurrency Constraints
 
-- **Single signal-handler install at a time.** The global `Mutex` in `SignalHandlerGuard` serializes installs. Two concurrent `run_process` calls in the same process must take turns at install/drop boundaries; the wait loops themselves run concurrently once the handlers are active.
+- **Single signal-handler install at a time.** The global `Mutex` in `SignalHandlerGuard` serializes the complete guarded wait on Unix. Two concurrent `run_process` calls in the same process take turns from install through drop; their wait loops do not overlap.
 - **No assumption about thread-local state.** Reader threads, writer threads, and the signal handler are spawned with `'static` requirements; callers must not rely on thread-local data from the spawning thread.
 - **No retry inside `run_process`.** The runner does not retry spawn failures, wait errors, or signal-install failures. Retry policy belongs to the caller.
 


### PR DESCRIPTION
## Task

[ORB-11195](https://orbit-cli.com/tasks/ORB-11195) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- Selected exactly the six oldest dated in-scope Markdown docs by ascending last_validated (the six 2026-08-09/2026-08-11/2026-08-13 entries, with path tie-break): docs/design/orbit-search/2_design.md, docs/design/orbit-search/3_vision.md, docs/design/orbit-search/4_decisions.md, docs/design/policy-sandbox/specs/fs-profile-resolution.md, docs/design/policy-sandbox/specs/sandbox-exec-contract.md, and docs/POSITIONING.md.
- No selected document was frontmatter-less; no metadata migration was needed. All selected docs retained their existing inferred/schema-compatible type and summary.

Changes and verification:
- docs/design/orbit-search/2_design.md: corrected companion shutdown behavior, integrity-metadata reinstall behavior, exact missing-companion remediation, hybrid-search lexical fallback, and subprocess reuse wording. Verified with crates/orbit-search/Cargo.toml plus source reads of embedder.rs, companion.rs, subprocess.rs, bin/orbit-search-companion.rs, commands/install.rs, commands/reindex.rs, commands/doc_search.rs, commands/search.rs, and orbit search/semantic/docs --help.
- docs/design/orbit-search/3_vision.md: corrected review-thread indexing and score-breakdown scope. Verified against vector/task_fields.rs, commands/search.rs, commands/doc_search.rs, and application/search/convert/types code.
- docs/design/orbit-search/4_decisions.md: only advanced last_validated; historical decision entries and provenance were not rewritten.
- docs/design/policy-sandbox/specs/fs-profile-resolution.md: corrected the actual normalizer name and behavior, glob unsupported-operator semantics, and canonicalization failure owner/behavior. Verified against orbit-types policy_def.rs, orbit-common fs/glob.rs, orbit-policy engine/evaluator, and orbit-policy tests.
- docs/design/policy-sandbox/specs/sandbox-exec-contract.md: corrected signal-guard lock scope and cleanup wording. Verified against orbit-exec runner.rs, process.rs, supervision/wait.rs, cleanup.rs, signal.rs, tee.rs, and sandbox.rs.
- docs/POSITIONING.md: only advanced last_validated; positioning claims were checked against current repository guidance and remain unchanged.
- All six parse successfully via orbit docs show <path> --format json; cargo metadata and git diff --check also passed.

Unvalidated claims left unchanged:
- Empirical latency/size/recall estimates, MTEB/external benchmark assertions, and other future/design-history claims in the search docs are not reproducible from repository code; they were not rewritten.
- Historical decision rationale in 4_decisions.md and retired graph material in 2_design.md/3_vision.md were preserved as history rather than treated as current implementation claims.

Validation:
- make ci-fast passed.
- Final git status contains only the six intended documentation files; no .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state changed.

Assessment: The bounded documentation rotation is complete, with current code drift corrected only where directly evidenced and all six selected documents stamped 2026-09-05.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11195-6a9b6916`
- Behind base: 0
- Ahead of base: 1