### PR TITLE
Prevent Dependabot and CI sweeps from filing duplicate tasks

### DIFF
--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -14,9 +14,13 @@ spec:
     collected evidence rendered inline in the description, so the implementing
     agent never needs a GitHub credential; no `required_tools` are attached and
     the task ships through the ordinary pull-request route. Filing is deduped
-    against still-open tasks by a commit-independent failure key carried as a
-    `ci-failure:<key>` tag, so a repeated sweep over a run that is still red
-    does not file the same root cause twice. The three endings stay distinct
+    against still-open tasks first by a commit-independent failure key carried
+    as a `ci-failure:<key>` tag, then by a shared high-confidence material
+    coverage assessment over untagged tasks. A repeated sweep over a run that
+    is still red, or a root cause already owned by a manual task, therefore
+    does not file the same work twice. Skips name the covering task and bounded
+    match evidence; closed historical tasks and superficial similarities do
+    not suppress a current failure. The three endings stay distinct
     and none of them is a CI pass: a snapshot with `collected: false` reports
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
@@ -91,7 +95,7 @@ spec:
         type: array
         items:
           type: object
-          required: [failure_key, task_id]
+          required: [failure_key, task_id, match_kind, match_evidence]
           properties:
             failure_key:
               type: string
@@ -101,6 +105,11 @@ spec:
               type: string
             workflow:
               type: string
+            match_kind:
+              type: string
+              enum: [exact_key, material_coverage]
+            match_evidence:
+              type: object
       skipped_over_cap:
         type: array
         items:

--- a/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_dependabot_alert_tasks.yaml
@@ -9,7 +9,12 @@ spec:
     Dependabot, Code scanning, and secret scanning snapshot. Preserve
     Dependabot clustering, severity filtering, and PR skips; dedupe the other
     families by repository and alert number; and enforce one max_tasks bound
-    across all families. Filed tasks require no tools.
+    across all families. Exact generated-key tags remain the fast path, then a
+    shared high-confidence material coverage check finds untagged still-open
+    tasks. Skips name the covering task and bounded match evidence; closed
+    historical tasks and superficial similarities do not suppress a current
+    alert. Duplicate-check failures are bounded retryable errors and happen
+    before any task is filed. Filed tasks require no tools.
   input_schema_json:
     type: object
     required: [dependabot_snapshot]
@@ -48,6 +53,21 @@ spec:
         type: array
       skipped_existing:
         type: array
+        items:
+          type: object
+          required: [family, key, task_id, match_kind, match_evidence]
+          properties:
+            family:
+              type: string
+            key:
+              type: string
+            task_id:
+              type: string
+            match_kind:
+              type: string
+              enum: [exact_key, material_coverage]
+            match_evidence:
+              type: object
       skipped_dependabot_pr:
         type: array
       skipped_over_cap:

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -35,6 +35,10 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::duplicate_tasks::{
+    CoverageAnchor, CoverageFingerprint, DuplicateCandidate, DuplicateTaskLookup,
+    DuplicateTaskMatch, find_covering_task,
+};
 use crate::application::task::TaskAddParams;
 
 /// Wire contract with `collect_ci_evidence` (`orbit-engine`'s
@@ -79,17 +83,45 @@ pub(crate) fn file_ci_failure_tasks(
     runtime: &OrbitRuntime,
     input: &Value,
 ) -> Result<Value, OrbitError> {
-    file_ci_failure_tasks_with_add(runtime, input, |params| {
+    file_ci_failure_tasks_with_ops(runtime, input, runtime, |params| {
         runtime.add_task(params).map(|task| task.id)
     })
 }
 
+#[cfg(test)]
 pub(in crate::adapter::engine_host::v2_host) fn file_ci_failure_tasks_with_add<F>(
     runtime: &OrbitRuntime,
     input: &Value,
+    add_task: F,
+) -> Result<Value, OrbitError>
+where
+    F: FnMut(TaskAddParams) -> Result<String, OrbitError>,
+{
+    file_ci_failure_tasks_with_ops(runtime, input, runtime, add_task)
+}
+
+#[cfg(test)]
+pub(in crate::adapter::engine_host::v2_host) fn file_ci_failure_tasks_with_lookup<L>(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    lookup: &L,
+) -> Result<Value, OrbitError>
+where
+    L: DuplicateTaskLookup + ?Sized,
+{
+    file_ci_failure_tasks_with_ops(runtime, input, lookup, |params| {
+        runtime.add_task(params).map(|task| task.id)
+    })
+}
+
+fn file_ci_failure_tasks_with_ops<L, F>(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    lookup: &L,
     mut add_task: F,
 ) -> Result<Value, OrbitError>
 where
+    L: DuplicateTaskLookup + ?Sized,
     F: FnMut(TaskAddParams) -> Result<String, OrbitError>,
 {
     let evidence = input.get("ci_evidence").ok_or_else(|| {
@@ -222,27 +254,41 @@ where
         .is_ok()
         .then(|| SYSTEM_CREW.to_string());
 
-    for cluster in &clusters {
-        if let Some(task_id) =
-            open_task_for_key(runtime, &cluster.failure_key).map_err(|error| {
+    // Complete every external lookup before the first task write. A transient
+    // duplicate-check failure must leave no partial filing or dedupe state.
+    let duplicate_matches = clusters
+        .iter()
+        .map(|cluster| {
+            find_covering_task(lookup, &cluster.duplicate_candidate()).map_err(|error| {
                 retryable_pipeline_error(
                     "dedupe_lookup",
                     &audit,
                     vec![json!({
                         "stage": "registration",
-                        "operation": "open_task_for_key",
+                        "operation": "find_covering_task",
                         "failure_key": cluster.failure_key,
                         "retryable": true,
                         "message": bounded_error(&error.to_string()),
                     })],
                 )
-            })?
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for (cluster, duplicate_match) in clusters.iter().zip(duplicate_matches) {
+        if let Some(DuplicateTaskMatch {
+            task_id,
+            match_kind,
+            evidence,
+        }) = duplicate_match
         {
             skipped_existing.push(json!({
                 "failure_key": cluster.failure_key,
                 "cluster_key": cluster.cluster_key,
                 "task_id": task_id,
                 "workflow": cluster.workflow,
+                "match_kind": match_kind,
+                "match_evidence": evidence,
             }));
             continue;
         }
@@ -256,6 +302,14 @@ where
                     .and_then(|entry| entry["task_id"].as_str())
                     .unwrap_or_default(),
                 "workflow": cluster.workflow,
+                "match_kind": "exact_key",
+                "match_evidence": {
+                    "fingerprint": "same_sweep_key",
+                    "matched_fields": [{
+                        "field": "failure_key",
+                        "value": cluster.failure_key,
+                    }],
+                },
             }));
             continue;
         }
@@ -442,6 +496,31 @@ struct FailureCluster {
 }
 
 impl FailureCluster {
+    fn duplicate_candidate(&self) -> DuplicateCandidate {
+        let exact_tag = format!("{CI_FAILURE_KEY_TAG_PREFIX}{}", self.failure_key);
+        let fingerprints = if self.signature_is_step_fallback {
+            // A step-name fallback contains no diagnostic. It is sufficient
+            // for exact-key idempotency but too weak for broader free-text
+            // coverage, where it could suppress an unrelated failure of the
+            // same generic CI step.
+            vec![CoverageFingerprint::new(
+                "ci_failure_unmatchable_fallback",
+                vec![CoverageAnchor::new("exact_failure_key", &exact_tag)],
+            )]
+        } else {
+            vec![CoverageFingerprint::new(
+                "ci_failure_root_cause",
+                vec![
+                    CoverageAnchor::new("workflow", format!("workflow {}", self.workflow)),
+                    CoverageAnchor::new("job", format!("failing job {}", self.job)),
+                    CoverageAnchor::new("step", format!("failing step {}", self.step)),
+                    CoverageAnchor::new("normalized_error_signature", &self.signature),
+                ],
+            )]
+        };
+        DuplicateCandidate::new(exact_tag, fingerprints)
+    }
+
     fn run_urls(&self) -> Vec<String> {
         self.runs
             .iter()
@@ -1180,29 +1259,6 @@ fn digest(parts: &[&str]) -> String {
         .chars()
         .take(KEY_LEN)
         .collect()
-}
-
-/// The id of a still-open task already carrying this failure key, if any.
-fn open_task_for_key(
-    runtime: &OrbitRuntime,
-    failure_key: &str,
-) -> Result<Option<String>, OrbitError> {
-    let tag = format!("{CI_FAILURE_KEY_TAG_PREFIX}{failure_key}");
-    let tasks = runtime.list_tasks_by_tags(std::slice::from_ref(&tag))?;
-    Ok(tasks
-        .into_iter()
-        .find(|task| is_open_status(task.status))
-        .map(|task| task.id))
-}
-
-/// Statuses that count as "already being handled". Mirrors the auto-task
-/// `skip_if_open` rule: done, archived, and rejected are closed, and everything
-/// else is in flight.
-fn is_open_status(status: TaskStatus) -> bool {
-    !matches!(
-        status,
-        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
-    )
 }
 
 fn bounded_u64(input: &Value, key: &str, default: u64, max: u64) -> Result<u64, OrbitError> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks.rs
@@ -1,5 +1,7 @@
 //! Turn a host-collected repository security snapshot into ordinary backlog tasks.
 
+mod duplicates;
+
 use std::collections::BTreeMap;
 
 use orbit_common::OrbitError;
@@ -8,7 +10,15 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::duplicate_tasks::{
+    DuplicateTaskLookup, DuplicateTaskMatch, find_covering_task,
+};
 use crate::application::task::TaskAddParams;
+
+use self::duplicates::{
+    code_duplicate_candidate, dependabot_duplicate_candidate, duplicate_lookup_error,
+    secret_duplicate_candidate,
+};
 
 const SUPPORTED_SCHEMA_VERSION: u64 = 2;
 const DEPENDABOT_TAG: &str = "dependabot-sweep";
@@ -25,10 +35,26 @@ const DEFAULT_MAX_TASKS: u64 = 10;
 const MAX_TASKS: u64 = 50;
 const KEY_LEN: usize = 16;
 
+struct PendingTask {
+    params: TaskAddParams,
+    result: Value,
+}
+
 pub(crate) fn file_dependabot_alert_tasks(
     runtime: &OrbitRuntime,
     input: &Value,
 ) -> Result<Value, OrbitError> {
+    file_dependabot_alert_tasks_with_lookup(runtime, input, runtime)
+}
+
+pub(in crate::adapter::engine_host::v2_host) fn file_dependabot_alert_tasks_with_lookup<L>(
+    runtime: &OrbitRuntime,
+    input: &Value,
+    lookup: &L,
+) -> Result<Value, OrbitError>
+where
+    L: DuplicateTaskLookup + ?Sized,
+{
     let snapshot = input.get("dependabot_snapshot").ok_or_else(|| {
         OrbitError::InvalidInput(
             "file_dependabot_alert_tasks requires the `dependabot_snapshot` produced by collect_dependabot_alerts"
@@ -71,7 +97,7 @@ pub(crate) fn file_dependabot_alert_tasks(
         .is_ok()
         .then(|| SYSTEM_CREW.to_string());
 
-    let mut filed = Vec::new();
+    let mut pending_tasks = Vec::new();
     let mut skipped_existing = Vec::new();
     let mut skipped_dependabot_pr = Vec::new();
     let mut skipped_over_cap = Vec::new();
@@ -120,10 +146,20 @@ pub(crate) fn file_dependabot_alert_tasks(
             cluster_alerts
                 .sort_by_key(|alert| alert.get("number").and_then(Value::as_u64).unwrap_or(0));
             let key = digest(&[&ecosystem, &package, &manifest_path]);
-            if let Some(task_id) = open_task_for_key(runtime, DEPENDABOT_KEY_PREFIX, &key)? {
+            if let Some(DuplicateTaskMatch {
+                task_id,
+                match_kind,
+                evidence,
+            }) = find_covering_task(
+                lookup,
+                &dependabot_duplicate_candidate(&key, &package, &manifest_path),
+            )
+            .map_err(|error| duplicate_lookup_error("dependabot", &key, &error))?
+            {
                 skipped_existing.push(json!({
                     "family": "dependabot", "key": key, "task_id": task_id,
                     "ecosystem": ecosystem, "package": package, "manifest_path": manifest_path,
+                    "match_kind": match_kind, "match_evidence": evidence,
                 }));
                 continue;
             }
@@ -139,7 +175,7 @@ pub(crate) fn file_dependabot_alert_tasks(
                 }));
                 continue;
             }
-            if filed.len() >= max_tasks {
+            if pending_tasks.len() >= max_tasks {
                 skipped_over_cap.push(json!({
                     "family": "dependabot", "key": key, "ecosystem": ecosystem,
                     "package": package, "manifest_path": manifest_path,
@@ -152,7 +188,7 @@ pub(crate) fn file_dependabot_alert_tasks(
                 .filter_map(|alert| severity_rank(&field(alert, "severity").to_ascii_lowercase()))
                 .max()
                 .unwrap_or(floor);
-            let task = runtime.add_task(TaskAddParams {
+            let params = TaskAddParams {
                 title: dependabot_task_title(&package, &manifest_path),
                 description: dependabot_task_description(
                     snapshot,
@@ -179,12 +215,15 @@ pub(crate) fn file_dependabot_alert_tasks(
                 status: Some(TaskStatus::Backlog),
                 system_created: true,
                 ..TaskAddParams::default()
-            })?;
-            filed.push(json!({
-                "family": "dependabot", "task_id": task.id, "key": key,
+            };
+            pending_tasks.push(PendingTask {
+                params,
+                result: json!({
+                "family": "dependabot", "key": key,
                 "ecosystem": ecosystem, "package": package, "manifest_path": manifest_path,
                 "alert_count": cluster_alerts.len(),
-            }));
+                }),
+            });
         }
     }
 
@@ -218,14 +257,21 @@ pub(crate) fn file_dependabot_alert_tasks(
             continue;
         }
         let key = digest(&["code-scanning", repository, &number.to_string()]);
-        if let Some(task_id) = open_task_for_key(runtime, CODE_KEY_PREFIX, &key)? {
+        if let Some(DuplicateTaskMatch {
+            task_id,
+            match_kind,
+            evidence,
+        }) = find_covering_task(lookup, &code_duplicate_candidate(&key, &alert))
+            .map_err(|error| duplicate_lookup_error("code_scanning", &key, &error))?
+        {
             skipped_existing.push(json!({
                 "family": "code_scanning", "key": key, "task_id": task_id,
                 "alert_number": number,
+                "match_kind": match_kind, "match_evidence": evidence,
             }));
             continue;
         }
-        if filed.len() >= max_tasks {
+        if pending_tasks.len() >= max_tasks {
             skipped_over_cap.push(json!({
                 "family": "code_scanning", "key": key, "alert_number": number,
             }));
@@ -234,7 +280,7 @@ pub(crate) fn file_dependabot_alert_tasks(
         let rule = field(&alert, "rule_id");
         let path = field(&alert, "path");
         let rank = rank.unwrap_or(floor);
-        let task = runtime.add_task(TaskAddParams {
+        let params = TaskAddParams {
             title: code_task_title(&rule, &path),
             description: code_task_description(snapshot, &alert),
             acceptance_criteria: vec![
@@ -260,11 +306,14 @@ pub(crate) fn file_dependabot_alert_tasks(
             status: Some(TaskStatus::Backlog),
             system_created: true,
             ..TaskAddParams::default()
-        })?;
-        filed.push(json!({
-            "family": "code_scanning", "task_id": task.id, "key": key,
-            "alert_number": number, "rule_id": rule, "path": path,
-        }));
+        };
+        pending_tasks.push(PendingTask {
+            params,
+            result: json!({
+                "family": "code_scanning", "key": key,
+                "alert_number": number, "rule_id": rule, "path": path,
+            }),
+        });
     }
 
     let mut secret_alerts = family_alerts(snapshot, "secret_scanning");
@@ -276,21 +325,28 @@ pub(crate) fn file_dependabot_alert_tasks(
             continue;
         }
         let key = digest(&["secret-scanning", repository, &number.to_string()]);
-        if let Some(task_id) = open_task_for_key(runtime, SECRET_KEY_PREFIX, &key)? {
+        if let Some(DuplicateTaskMatch {
+            task_id,
+            match_kind,
+            evidence,
+        }) = find_covering_task(lookup, &secret_duplicate_candidate(&key, &alert))
+            .map_err(|error| duplicate_lookup_error("secret_scanning", &key, &error))?
+        {
             skipped_existing.push(json!({
                 "family": "secret_scanning", "key": key, "task_id": task_id,
                 "alert_number": number,
+                "match_kind": match_kind, "match_evidence": evidence,
             }));
             continue;
         }
-        if filed.len() >= max_tasks {
+        if pending_tasks.len() >= max_tasks {
             skipped_over_cap.push(json!({
                 "family": "secret_scanning", "key": key, "alert_number": number,
             }));
             continue;
         }
         let secret_type = field(&alert, "secret_type");
-        let task = runtime.add_task(TaskAddParams {
+        let params = TaskAddParams {
             title: secret_task_title(&secret_type, number),
             description: secret_task_description(snapshot, &alert),
             acceptance_criteria: vec![
@@ -316,11 +372,25 @@ pub(crate) fn file_dependabot_alert_tasks(
             status: Some(TaskStatus::Backlog),
             system_created: true,
             ..TaskAddParams::default()
-        })?;
-        filed.push(json!({
-            "family": "secret_scanning", "task_id": task.id, "key": key,
-            "alert_number": number, "secret_type": secret_type,
-        }));
+        };
+        pending_tasks.push(PendingTask {
+            params,
+            result: json!({
+                "family": "secret_scanning", "key": key,
+                "alert_number": number, "secret_type": secret_type,
+            }),
+        });
+    }
+
+    // Duplicate lookups for every candidate completed above. Only now may the
+    // action begin mutating task state, so a lookup failure cannot leave a
+    // partial sweep behind.
+    let mut filed = Vec::with_capacity(pending_tasks.len());
+    for pending in pending_tasks {
+        let task = runtime.add_task(pending.params)?;
+        let mut result = pending.result;
+        result["task_id"] = json!(task.id);
+        filed.push(result);
     }
 
     let family_outcomes = json!({
@@ -655,24 +725,6 @@ fn dependabot_branch_names_package(head_branch: &str, ecosystem: &str, package: 
     };
     let last = last.to_ascii_lowercase();
     last == package || last.starts_with(&format!("{package}-"))
-}
-
-fn open_task_for_key(
-    runtime: &OrbitRuntime,
-    prefix: &str,
-    key: &str,
-) -> Result<Option<String>, OrbitError> {
-    let tag = format!("{prefix}{key}");
-    Ok(runtime
-        .list_tasks_by_tags(std::slice::from_ref(&tag))?
-        .into_iter()
-        .find(|task| {
-            !matches!(
-                task.status,
-                TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
-            )
-        })
-        .map(|task| task.id))
 }
 
 fn severity_rank(value: &str) -> Option<u8> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/duplicates.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dependabot_alert_tasks/duplicates.rs
@@ -1,0 +1,122 @@
+//! High-confidence coverage fingerprints for security-alert task candidates.
+
+use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
+use serde_json::{Value, json};
+
+use crate::adapter::engine_host::v2_host::duplicate_tasks::{
+    CoverageAnchor, CoverageFingerprint, DuplicateCandidate,
+};
+
+use super::{
+    CODE_KEY_PREFIX, DEPENDABOT_KEY_PREFIX, SECRET_KEY_PREFIX, alert_number, field, line_suffix,
+};
+
+pub(super) fn dependabot_duplicate_candidate(
+    key: &str,
+    package: &str,
+    manifest_path: &str,
+) -> DuplicateCandidate {
+    DuplicateCandidate::new(
+        format!("{DEPENDABOT_KEY_PREFIX}{key}"),
+        vec![
+            CoverageFingerprint::new(
+                "dependency_title",
+                vec![CoverageAnchor::new(
+                    "dependency_and_manifest",
+                    format!("update {package} in {manifest_path}"),
+                )],
+            ),
+            CoverageFingerprint::new(
+                "dependency_fields",
+                vec![
+                    CoverageAnchor::new("package", format!("package {package}")),
+                    CoverageAnchor::new("manifest_path", format!("manifest path {manifest_path}")),
+                ],
+            ),
+        ],
+    )
+}
+
+pub(super) fn code_duplicate_candidate(key: &str, alert: &Value) -> DuplicateCandidate {
+    let number = alert_number(alert);
+    let rule = field(alert, "rule_id");
+    let path = field(alert, "path");
+    let alert_anchor = format!("alert {number}");
+    DuplicateCandidate::new(
+        format!("{CODE_KEY_PREFIX}{key}"),
+        vec![
+            CoverageFingerprint::new(
+                "code_scanning_title_and_alert",
+                vec![
+                    CoverageAnchor::new("rule_and_path", format!("fix {rule} in {path}")),
+                    CoverageAnchor::new("alert_number", &alert_anchor),
+                ],
+            ),
+            CoverageFingerprint::new(
+                "code_scanning_fields",
+                vec![
+                    CoverageAnchor::new("alert_number", alert_anchor),
+                    CoverageAnchor::new("rule", format!("rule {rule}")),
+                    CoverageAnchor::new(
+                        "location",
+                        format!("location {path}{}", line_suffix(alert)),
+                    ),
+                ],
+            ),
+        ],
+    )
+}
+
+pub(super) fn secret_duplicate_candidate(key: &str, alert: &Value) -> DuplicateCandidate {
+    let number = alert_number(alert);
+    let secret_type = field(alert, "secret_type");
+    let alert_anchor = format!("alert {number}");
+    let mut fingerprints = vec![CoverageFingerprint::new(
+        "secret_scanning_title",
+        vec![CoverageAnchor::new(
+            "secret_type_and_alert",
+            format!("rotate exposed {secret_type} from alert {number}"),
+        )],
+    )];
+    if let Some(location) = alert
+        .get("locations")
+        .and_then(Value::as_array)
+        .and_then(|locations| locations.first())
+    {
+        fingerprints.push(CoverageFingerprint::new(
+            "secret_scanning_fields",
+            vec![
+                CoverageAnchor::new("alert_number", alert_anchor),
+                CoverageAnchor::new("secret_type", format!("secret type {secret_type}")),
+                CoverageAnchor::new(
+                    "location",
+                    format!("path {}{}", field(location, "path"), line_suffix(location)),
+                ),
+            ],
+        ));
+    }
+    DuplicateCandidate::new(format!("{SECRET_KEY_PREFIX}{key}"), fingerprints)
+}
+
+pub(super) fn duplicate_lookup_error(family: &str, key: &str, error: &OrbitError) -> OrbitError {
+    OrbitError::Execution(format!(
+        "dependabot_alert_sweep retryable: {}",
+        json!({
+            "outcome": "retryable_error",
+            "stage": "dedupe_lookup",
+            "errors": [{
+                "stage": "registration",
+                "operation": "find_covering_task",
+                "family": family,
+                "key": key,
+                "retryable": true,
+                "message": bounded_error(&error.to_string()),
+            }],
+        })
+    ))
+}
+
+fn bounded_error(message: &str) -> String {
+    redact_all(message).chars().take(500).collect()
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
@@ -1,0 +1,246 @@
+//! Shared deterministic duplicate-task assessment for finding sweep actions.
+//!
+//! Exact generated-key tags remain the authoritative fast path. When that
+//! path misses, a candidate is compared with every still-open task using
+//! caller-supplied, high-confidence fingerprints. A fingerprint must match in
+//! full; individual keywords never carry a duplicate decision.
+
+use orbit_common::OrbitError;
+use orbit_common::security::redaction::redact_all;
+use orbit_types::task::{Task, TaskStatus};
+use serde_json::{Value, json};
+
+const MAX_EVIDENCE_FIELDS: usize = 6;
+const MAX_EVIDENCE_CHARS: usize = 160;
+
+pub(in crate::adapter::engine_host::v2_host) trait DuplicateTaskLookup {
+    fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError>;
+
+    fn list_tasks(&self) -> Result<Vec<Task>, OrbitError>;
+}
+
+impl DuplicateTaskLookup for crate::OrbitRuntime {
+    fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
+        crate::OrbitRuntime::list_tasks_by_tags(self, tags)
+    }
+
+    fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
+        crate::OrbitRuntime::list_tasks(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::adapter::engine_host::v2_host) struct DuplicateCandidate {
+    exact_tag: String,
+    fingerprints: Vec<CoverageFingerprint>,
+}
+
+impl DuplicateCandidate {
+    pub(in crate::adapter::engine_host::v2_host) fn new(
+        exact_tag: String,
+        fingerprints: Vec<CoverageFingerprint>,
+    ) -> Self {
+        Self {
+            exact_tag,
+            fingerprints,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::adapter::engine_host::v2_host) struct CoverageFingerprint {
+    name: &'static str,
+    anchors: Vec<CoverageAnchor>,
+}
+
+impl CoverageFingerprint {
+    pub(in crate::adapter::engine_host::v2_host) fn new(
+        name: &'static str,
+        anchors: Vec<CoverageAnchor>,
+    ) -> Self {
+        Self { name, anchors }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::adapter::engine_host::v2_host) struct CoverageAnchor {
+    field: &'static str,
+    value: String,
+}
+
+impl CoverageAnchor {
+    pub(in crate::adapter::engine_host::v2_host) fn new(
+        field: &'static str,
+        value: impl Into<String>,
+    ) -> Self {
+        Self {
+            field,
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::adapter::engine_host::v2_host) struct DuplicateTaskMatch {
+    pub task_id: String,
+    pub match_kind: &'static str,
+    pub evidence: Value,
+}
+
+/// Find a still-open task covering `candidate`.
+///
+/// The tag query deliberately happens before the broader task listing. An
+/// exact generated key is deterministic and sufficient by itself, so a broad
+/// lookup is neither needed nor allowed to override it.
+pub(in crate::adapter::engine_host::v2_host) fn find_covering_task<L>(
+    lookup: &L,
+    candidate: &DuplicateCandidate,
+) -> Result<Option<DuplicateTaskMatch>, OrbitError>
+where
+    L: DuplicateTaskLookup + ?Sized,
+{
+    let exact_tasks = lookup.list_tasks_by_tags(std::slice::from_ref(&candidate.exact_tag))?;
+    if let Some(task) = exact_tasks
+        .into_iter()
+        .find(|task| is_open_status(task.status))
+    {
+        return Ok(Some(DuplicateTaskMatch {
+            task_id: task.id,
+            match_kind: "exact_key",
+            evidence: bounded_evidence(
+                "generated_key",
+                &[CoverageAnchor::new("dedupe_tag", &candidate.exact_tag)],
+            ),
+        }));
+    }
+
+    validate_candidate(candidate)?;
+    let mut open_tasks = lookup
+        .list_tasks()?
+        .into_iter()
+        .filter(|task| is_open_status(task.status))
+        .collect::<Vec<_>>();
+    open_tasks.sort_by(|left, right| left.id.cmp(&right.id));
+
+    for task in open_tasks {
+        let searchable = searchable_task_text(&task);
+        if let Some(fingerprint) = candidate
+            .fingerprints
+            .iter()
+            .find(|fingerprint| fingerprint_matches(&searchable, fingerprint))
+        {
+            return Ok(Some(DuplicateTaskMatch {
+                task_id: task.id,
+                match_kind: "material_coverage",
+                evidence: bounded_evidence(fingerprint.name, &fingerprint.anchors),
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+fn validate_candidate(candidate: &DuplicateCandidate) -> Result<(), OrbitError> {
+    if candidate.exact_tag.trim().is_empty()
+        || candidate.fingerprints.is_empty()
+        || candidate
+            .fingerprints
+            .iter()
+            .any(|fingerprint| fingerprint.anchors.is_empty())
+        || candidate
+            .fingerprints
+            .iter()
+            .flat_map(|fingerprint| &fingerprint.anchors)
+            .any(|anchor| canonical_text(&anchor.value).trim().is_empty())
+    {
+        return Err(OrbitError::InvalidInput(
+            "duplicate-task candidate has an incomplete coverage fingerprint".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn fingerprint_matches(searchable: &str, fingerprint: &CoverageFingerprint) -> bool {
+    fingerprint.anchors.iter().all(|anchor| {
+        let needle = canonical_text(&anchor.value);
+        searchable.contains(&needle)
+    })
+}
+
+fn searchable_task_text(task: &Task) -> String {
+    let mut text = String::new();
+    for value in std::iter::once(task.title.as_str())
+        .chain(std::iter::once(task.description.as_str()))
+        .chain(task.acceptance_criteria.iter().map(String::as_str))
+        .chain(std::iter::once(task.plan.as_str()))
+        .chain(task.tags.iter().map(String::as_str))
+        .chain(task.context_files.iter().map(String::as_str))
+    {
+        text.push(' ');
+        text.push_str(value);
+    }
+    canonical_text(&text)
+}
+
+/// Lowercase text into a token sequence with a leading and trailing space.
+/// Searching canonical anchors in canonical task text therefore preserves
+/// token boundaries (`time` cannot match `runtime`) while tolerating normal
+/// prose and Markdown punctuation differences.
+fn canonical_text(value: &str) -> String {
+    let mut out = String::with_capacity(value.len().saturating_add(2));
+    out.push(' ');
+    let mut separated = true;
+    for character in value.chars().flat_map(char::to_lowercase) {
+        if character.is_alphanumeric() {
+            out.push(character);
+            separated = false;
+        } else if !separated {
+            out.push(' ');
+            separated = true;
+        }
+    }
+    if !out.ends_with(' ') {
+        out.push(' ');
+    }
+    out
+}
+
+fn bounded_evidence(kind: &str, anchors: &[CoverageAnchor]) -> Value {
+    let fields = anchors
+        .iter()
+        .take(MAX_EVIDENCE_FIELDS)
+        .map(|anchor| {
+            json!({
+                "field": anchor.field,
+                "value": bounded_redacted(&anchor.value),
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "fingerprint": kind,
+        "matched_fields": fields,
+    })
+}
+
+fn bounded_redacted(value: &str) -> String {
+    redact_all(value).chars().take(MAX_EVIDENCE_CHARS).collect()
+}
+
+pub(in crate::adapter::engine_host::v2_host) fn is_open_status(status: TaskStatus) -> bool {
+    !matches!(
+        status,
+        TaskStatus::Done | TaskStatus::Archived | TaskStatus::Rejected
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_text;
+
+    #[test]
+    fn canonical_text_preserves_token_boundaries() {
+        let searchable = canonical_text("Update runtime in Cargo.lock");
+        assert!(!searchable.contains(&canonical_text("time")));
+        assert!(searchable.contains(&canonical_text("runtime")));
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -13,6 +13,7 @@ pub(super) mod ci_failure_tasks;
 pub(super) mod cli_executor;
 pub(super) mod dependabot_alert_tasks;
 pub(super) mod dispatch;
+pub(super) mod duplicate_tasks;
 pub(super) mod pipeline_actions;
 pub(super) mod sandbox;
 pub(super) mod scan_unresolved;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -44,7 +44,14 @@ fn file_error(runtime: &OrbitRuntime, input: Value) -> String {
 }
 
 /// One current failure, shaped exactly as `collect_ci_evidence` emits it.
-fn failure(run_id: u64, workflow: &str, job: &str, step: &str, log: &str, checkout: &str) -> Value {
+pub(super) fn failure(
+    run_id: u64,
+    workflow: &str,
+    job: &str,
+    step: &str,
+    log: &str,
+    checkout: &str,
+) -> Value {
     json!({
         "run_id": run_id,
         "workflow": workflow,
@@ -76,7 +83,7 @@ fn failure(run_id: u64, workflow: &str, job: &str, step: &str, log: &str, checko
     })
 }
 
-fn snapshot(current: Vec<Value>) -> Value {
+pub(super) fn snapshot(current: Vec<Value>) -> Value {
     let latest = current.clone();
     json!({
         "schema_version": 1,
@@ -99,7 +106,7 @@ fn snapshot(current: Vec<Value>) -> Value {
     })
 }
 
-fn filed_task_ids(output: &Value) -> Vec<String> {
+pub(super) fn filed_task_ids(output: &Value) -> Vec<String> {
     output["filed"]
         .as_array()
         .expect("filed array")

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dependabot_alert_tasks.rs
@@ -7,7 +7,7 @@ use tempfile::tempdir;
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
 
-fn alert(number: u64, severity: &str, range: &str, ghsa: &str) -> Value {
+pub(super) fn alert(number: u64, severity: &str, range: &str, ghsa: &str) -> Value {
     json!({
         "number": number, "state": "open", "ecosystem": "cargo", "package": "time",
         "manifest_path": "Cargo.lock", "scope": "runtime", "severity": severity,
@@ -17,7 +17,7 @@ fn alert(number: u64, severity: &str, range: &str, ghsa: &str) -> Value {
     })
 }
 
-fn snapshot(alerts: Vec<Value>, pull_requests: Vec<Value>) -> Value {
+pub(super) fn snapshot(alerts: Vec<Value>, pull_requests: Vec<Value>) -> Value {
     json!({
         "schema_version": 1, "collected": true,
         "outcome_hint": if alerts.is_empty() { "no_open_alerts" } else { "open_alerts" },
@@ -31,7 +31,7 @@ fn snapshot(alerts: Vec<Value>, pull_requests: Vec<Value>) -> Value {
     })
 }
 
-fn expanded_snapshot(
+pub(super) fn expanded_snapshot(
     dependabot: Vec<Value>,
     code_scanning: Vec<Value>,
     secret_scanning: Vec<Value>,
@@ -69,7 +69,7 @@ fn expanded_snapshot(
     })
 }
 
-fn code_alert(number: u64, severity: &str) -> Value {
+pub(super) fn code_alert(number: u64, severity: &str) -> Value {
     json!({
         "number": number, "state": "open", "rule_id": "rust/sql-injection",
         "rule_name": "SQL injection", "rule_description": "Untrusted input reaches SQL",
@@ -95,7 +95,7 @@ fn secret_alert(number: u64, validity: &str) -> Value {
     })
 }
 
-fn file(runtime: &OrbitRuntime, snapshot: Value, extra: Value) -> Value {
+pub(super) fn file(runtime: &OrbitRuntime, snapshot: Value, extra: Value) -> Value {
     let mut input = json!({"dependabot_snapshot": snapshot});
     if let (Some(target), Some(source)) = (input.as_object_mut(), extra.as_object()) {
         target.extend(source.clone());
@@ -196,6 +196,7 @@ fn dedupe_key_survives_changed_alert_number_severity_and_range() {
         first["filed"][0]["key"],
         second["skipped_existing"][0]["key"]
     );
+    assert_eq!(second["skipped_existing"][0]["match_kind"], "exact_key");
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -8,6 +8,7 @@ mod required_tools;
 mod sandbox;
 mod sandbox_nested;
 mod scan_unresolved;
+mod sweep_duplicate_tasks;
 mod task_context;
 mod task_pilot;
 mod triage;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
@@ -1,0 +1,368 @@
+//! Cross-pipeline tests for the shared duplicate-task assessment contract.
+
+use std::cell::Cell;
+
+use orbit_common::OrbitError;
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::ci_failure_tasks::file_ci_failure_tasks_with_lookup;
+use crate::adapter::engine_host::v2_host::dependabot_alert_tasks::file_dependabot_alert_tasks_with_lookup;
+use crate::adapter::engine_host::v2_host::duplicate_tasks::DuplicateTaskLookup;
+use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+use crate::application::task::TaskAddParams;
+
+use super::ci_failure_tasks::{failure, filed_task_ids, snapshot as ci_snapshot};
+use super::dependabot_alert_tasks::{
+    alert, code_alert, expanded_snapshot, file as file_security, snapshot as security_snapshot,
+};
+
+const CHECKOUT: &str = "3333333333333333333333333333333333333333";
+const CI_LOG: &str = "ci\tbuild\t2026-08-30T01:00:00Z error: expected 3 arguments, found 2\n";
+
+fn file_ci(runtime: &OrbitRuntime, evidence: Value) -> Value {
+    runtime
+        .run_deterministic(
+            "file_ci_failure_tasks",
+            &json!({}),
+            &json!({"ci_evidence": evidence}),
+            ToolContext::default(),
+        )
+        .expect("file CI task")
+}
+
+fn ci_evidence() -> Value {
+    ci_snapshot(vec![failure(
+        10,
+        "ci",
+        "build",
+        "cargo build",
+        CI_LOG,
+        CHECKOUT,
+    )])
+}
+
+fn seed_manual_task(
+    runtime: &OrbitRuntime,
+    title: &str,
+    description: &str,
+    status: TaskStatus,
+) -> String {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: description.to_string(),
+            acceptance_criteria: vec!["The identified finding is remediated.".to_string()],
+            priority: TaskPriority::High,
+            task_type: Some(TaskType::Bug),
+            status: Some(status),
+            ..TaskAddParams::default()
+        })
+        .expect("seed manual task")
+        .id
+}
+
+fn seed_manual_ci_task(runtime: &OrbitRuntime, signature: &str) -> String {
+    seed_manual_task(
+        runtime,
+        "Fix red CI: ci / build / cargo build",
+        &format!(
+            "Workflow: ci\nFailing job: build\nFailing step: cargo build\n\
+             Normalized error signature: {signature}"
+        ),
+        TaskStatus::Backlog,
+    )
+}
+
+struct FailingBroadLookup<'a> {
+    runtime: &'a OrbitRuntime,
+}
+
+impl DuplicateTaskLookup for FailingBroadLookup<'_> {
+    fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
+        self.runtime.list_tasks_by_tags(tags)
+    }
+
+    fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
+        Err(injected_lookup_error())
+    }
+}
+
+struct FailingSecondBroadLookup<'a> {
+    runtime: &'a OrbitRuntime,
+    broad_calls: Cell<usize>,
+}
+
+impl DuplicateTaskLookup for FailingSecondBroadLookup<'_> {
+    fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
+        self.runtime.list_tasks_by_tags(tags)
+    }
+
+    fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
+        let call = self.broad_calls.get();
+        self.broad_calls.set(call + 1);
+        if call == 0 {
+            self.runtime.list_tasks()
+        } else {
+            Err(injected_lookup_error())
+        }
+    }
+}
+
+fn injected_lookup_error() -> OrbitError {
+    OrbitError::Store(format!(
+        "injected broad lookup failure ghp_{} {}",
+        "E".repeat(36),
+        "x".repeat(900)
+    ))
+}
+
+fn assert_retryable_redacted_lookup_error(error: &str) {
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("dedupe_lookup"));
+    assert!(error.contains("find_covering_task"));
+    assert!(!error.contains(&format!("ghp_{}", "E".repeat(36))));
+    assert!(
+        error.len() < 1_500,
+        "error must stay bounded: {}",
+        error.len()
+    );
+}
+
+#[test]
+fn ci_reports_an_untagged_manual_task_with_bounded_match_evidence() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let task_id = seed_manual_ci_task(&runtime, "error: expected <n> arguments, found <n>");
+
+    let output = file_ci(&runtime, ci_evidence());
+
+    assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["skipped_existing"][0]["task_id"], task_id);
+    assert_eq!(
+        output["skipped_existing"][0]["match_kind"],
+        "material_coverage"
+    );
+    let matched = output["skipped_existing"][0]["match_evidence"]["matched_fields"]
+        .as_array()
+        .expect("bounded match evidence");
+    assert_eq!(matched.len(), 4);
+    assert!(matched.iter().all(|entry| {
+        entry["value"]
+            .as_str()
+            .is_some_and(|value| value.chars().count() <= 160)
+    }));
+}
+
+#[test]
+fn ci_does_not_suppress_a_distinct_error_signature() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    seed_manual_ci_task(&runtime, "error: cannot find type Widget in this scope");
+
+    let output = file_ci(&runtime, ci_evidence());
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["skipped_existing"], json!([]));
+}
+
+#[test]
+fn ci_exact_key_replay_does_not_require_the_broader_lookup() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let evidence = ci_evidence();
+    let first = file_ci(&runtime, evidence.clone());
+    let task_id = filed_task_ids(&first).remove(0);
+
+    let output = file_ci_failure_tasks_with_lookup(
+        &runtime,
+        &json!({"ci_evidence": evidence}),
+        &FailingBroadLookup { runtime: &runtime },
+    )
+    .expect("the exact-key fast path must not invoke broad lookup");
+
+    assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["skipped_existing"][0]["task_id"], task_id);
+    assert_eq!(output["skipped_existing"][0]["match_kind"], "exact_key");
+}
+
+#[test]
+fn ci_duplicate_lookup_failure_is_redacted_retryable_and_writes_nothing() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+
+    let error = file_ci_failure_tasks_with_lookup(
+        &runtime,
+        &json!({"ci_evidence": ci_evidence()}),
+        &FailingBroadLookup { runtime: &runtime },
+    )
+    .expect_err("broad lookup failure must fail closed")
+    .to_string();
+
+    assert_retryable_redacted_lookup_error(&error);
+    assert!(runtime.list_tasks().expect("list tasks").is_empty());
+}
+
+#[test]
+fn security_sweep_reports_an_untagged_manual_dependency_owner() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let task_id = seed_manual_task(
+        &runtime,
+        "Update time in Cargo.lock",
+        "Bump the vulnerable time dependency and regenerate Cargo.lock.",
+        TaskStatus::Backlog,
+    );
+
+    let output = file_security(
+        &runtime,
+        security_snapshot(vec![alert(1, "high", "< 1.2.3", "GHSA-manual")], Vec::new()),
+        json!({}),
+    );
+
+    assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["skipped_existing"][0]["task_id"], task_id);
+    assert_eq!(
+        output["skipped_existing"][0]["match_kind"],
+        "material_coverage"
+    );
+    assert_eq!(
+        output["skipped_existing"][0]["match_evidence"]["fingerprint"],
+        "dependency_title"
+    );
+}
+
+#[test]
+fn security_sweep_does_not_conflate_similar_dependencies_or_manifests() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    seed_manual_task(
+        &runtime,
+        "Update runtime in Cargo.toml",
+        "Package runtime is declared at manifest path Cargo.toml.",
+        TaskStatus::Backlog,
+    );
+
+    let output = file_security(
+        &runtime,
+        security_snapshot(
+            vec![alert(1, "high", "< 1.2.3", "GHSA-distinct")],
+            Vec::new(),
+        ),
+        json!({}),
+    );
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["skipped_existing"], json!([]));
+}
+
+#[test]
+fn security_sweep_matches_only_the_same_code_alert_identity() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let task_id = seed_manual_task(
+        &runtime,
+        "Fix rust/sql-injection in src/db.rs",
+        "Code scanning alert #8 reports rule rust/sql-injection at location src/db.rs lines 17-19.",
+        TaskStatus::Review,
+    );
+
+    let duplicate = file_security(
+        &runtime,
+        expanded_snapshot(Vec::new(), vec![code_alert(8, "high")], Vec::new()),
+        json!({}),
+    );
+    assert_eq!(duplicate["filed_count"], json!(0));
+    assert_eq!(duplicate["skipped_existing"][0]["task_id"], task_id);
+
+    let distinct = file_security(
+        &runtime,
+        expanded_snapshot(Vec::new(), vec![code_alert(9, "high")], Vec::new()),
+        json!({}),
+    );
+    assert_eq!(distinct["filed_count"], json!(1));
+    assert_eq!(distinct["skipped_existing"], json!([]));
+}
+
+#[test]
+fn done_and_rejected_tasks_do_not_suppress_current_dependency_alerts() {
+    for status in [TaskStatus::Done, TaskStatus::Rejected] {
+        let (_root, runtime, _repo) = runtime_with_workspace_layout();
+        seed_manual_task(
+            &runtime,
+            "Update time in Cargo.lock",
+            "Package time at manifest path Cargo.lock.",
+            status,
+        );
+
+        let output = file_security(
+            &runtime,
+            security_snapshot(
+                vec![alert(1, "high", "< 1.2.3", "GHSA-recurrence")],
+                Vec::new(),
+            ),
+            json!({}),
+        );
+        assert_eq!(
+            output["filed_count"],
+            json!(1),
+            "{status} must be closed for dedupe"
+        );
+    }
+}
+
+#[test]
+fn every_open_status_suppresses_materially_covered_dependency_work() {
+    for status in [
+        TaskStatus::Proposed,
+        TaskStatus::Backlog,
+        TaskStatus::InProgress,
+        TaskStatus::Review,
+        TaskStatus::Blocked,
+        TaskStatus::Someday,
+    ] {
+        let (_root, runtime, _repo) = runtime_with_workspace_layout();
+        seed_manual_task(
+            &runtime,
+            "Update time in Cargo.lock",
+            "Package time at manifest path Cargo.lock.",
+            status,
+        );
+
+        let output = file_security(
+            &runtime,
+            security_snapshot(vec![alert(1, "high", "< 1.2.3", "GHSA-open")], Vec::new()),
+            json!({}),
+        );
+        assert_eq!(
+            output["filed_count"],
+            json!(0),
+            "{status} must remain open for dedupe"
+        );
+    }
+}
+
+#[test]
+fn later_security_lookup_failure_is_redacted_retryable_and_writes_nothing() {
+    let (_root, runtime, _repo) = runtime_with_workspace_layout();
+    let snapshot = expanded_snapshot(
+        vec![alert(1, "high", "< 1.2.3", "GHSA-pending")],
+        vec![code_alert(8, "high")],
+        Vec::new(),
+    );
+    let lookup = FailingSecondBroadLookup {
+        runtime: &runtime,
+        broad_calls: Cell::new(0),
+    };
+
+    let error = file_dependabot_alert_tasks_with_lookup(
+        &runtime,
+        &json!({"dependabot_snapshot": snapshot}),
+        &lookup,
+    )
+    .expect_err("the second broad lookup must fail the whole action")
+    .to_string();
+
+    assert_retryable_redacted_lookup_error(&error);
+    assert_eq!(lookup.broad_calls.get(), 2);
+    assert!(
+        runtime.list_tasks().expect("list tasks").is_empty(),
+        "the first candidate must remain pending until all lookups succeed"
+    );
+}

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -303,8 +303,18 @@ fn dependabot_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
         "collection_outcome:",
         "family_outcomes:",
         "skipped_over_cap:",
+        "match_kind:",
+        "match_evidence:",
     ] {
         assert!(file.contains(field), "file schema missing {field}");
+    }
+
+    let ci_file = DEFAULT_ACTIVITY_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "file_ci_failure_tasks").then_some(*yaml))
+        .expect("CI file activity default exists");
+    for field in ["match_kind:", "match_evidence:"] {
+        assert!(ci_file.contains(field), "CI file schema missing {field}");
     }
 }
 


### PR DESCRIPTION
## Task

[ORB-11189](https://orbit-cli.com/tasks/ORB-11189) — Prevent Dependabot and CI sweeps from filing duplicate tasks

### Description

## Problem
`dependabot_alert_sweep_pipeline` and `ci_failure_sweep_pipeline` suppress repeats only when an existing open task carries the sweep's exact alert or failure-key tag. They can still file a second task when materially equivalent work already exists under a different key or was created manually.

Add an explicit duplicate-task check before task creation in both pipelines so a candidate already covered by an open Orbit task is skipped and attributed to that task.

## Why It Matters
These sweeps run repeatedly and should improve backlog signal rather than create parallel ownership for the same dependency alert, security finding, or CI root cause.

## Constraints / Notes
- Preserve the current deterministic exact-key lookup as the fast, authoritative idempotency path.
- Add the broader coverage check at a shared seam used by both sweep pipelines; do not create two unrelated implementations.
- Compare only against still-open tasks. A completed or rejected historical task must not permanently suppress a current recurrence.
- A duplicate decision must return the covering task ID and bounded evidence explaining the match; superficial keyword similarity alone must not suppress a distinct finding.
- Duplicate-check failures are retryable pipeline failures. They must not create a task, mark a finding handled, or silently report a clean sweep.
- Keep evidence and errors bounded and redacted, and preserve each pipeline's existing task caps, ordering, and partial-capability behavior.

### Acceptance Criteria

- For both `dependabot_alert_sweep_pipeline` and `ci_failure_sweep_pipeline`, every task candidate is checked against still-open Orbit tasks before creation, including tasks that lack the sweep's generated dedupe-key tag.
- An existing open task that materially covers a candidate causes the sweep to create no new task and to report the covering task ID plus bounded match evidence in `skipped_existing` or an equally explicit result field.
- The existing exact alert/failure-key lookup remains the deterministic fast path, and both pipelines use one shared broader duplicate-check contract rather than separate ad hoc matchers.
- A merely similar but distinct dependency alert, security finding, workflow failure, job failure, or normalized error signature is not suppressed; deterministic tests cover both true duplicates and near-match non-duplicates.
- Done or rejected historical tasks do not suppress a current candidate, while proposed, backlog, in-progress, review, blocked, or someday tasks that still cover it are treated according to the repository's open-task semantics.
- If the broader duplicate lookup or assessment fails, the pipeline returns a bounded, redacted, retryable error and neither creates a task nor advances handled/dedupe state.
- Catalog and deterministic action tests exercise both pipelines, including an untagged manually created duplicate, exact-key replay, non-duplicate creation, and lookup failure; `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a shared deterministic duplicate-task assessment contract for finding sweeps. Exact generated-key tag lookup remains first and authoritative; misses compare high-confidence, token-bounded fingerprints against all still-open workspace tasks.
- Integrated coverage checks into CI, Dependabot, code-scanning, and secret-scanning candidates. Skips now report the covering task ID, match kind, and bounded redacted evidence. Done, archived, and rejected tasks are excluded under the existing open-task semantics.
- Deferred all security-sweep task writes and preflighted every CI cluster so any exact or broad duplicate lookup failure returns a bounded redacted retryable error without partial task creation or dedupe state.
- Updated both activity contracts/catalog assertions and added deterministic coverage for untagged manual owners, exact-key fast paths, open/closed statuses, near-match non-duplicates, and lookup failures in both pipelines.
- Expanded context_files with the shared matcher, the security fingerprint submodule, module registrations, and cross-pipeline tests because those files are required for the shared seam and direct validation.
Assessment: The implementation preserves task ordering, caps, partial-capability behavior, and existing exact-key idempotency while adding conservative broader matching; CI step-name fallbacks intentionally do not broad-match because they lack a diagnostic signature.
Validation:
- cargo test -p orbit-core adapter::engine_host::v2_host::tests --no-fail-fast (152 passed)
- cargo test -p orbit-core application::job::tests::catalog --no-fail-fast (30 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
- cargo clean removed the task-run target artifacts created during validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11189-6a9b668a`
- Behind base: 0
- Ahead of base: 1