### PR TITLE
[code-review] Distinguish unavailable scoreboard side metrics from real zero counts

### DIFF
--- a/crates/orbit-web/src/api/scoreboard.rs
+++ b/crates/orbit-web/src/api/scoreboard.rs
@@ -11,7 +11,7 @@ use orbit_cmd::DiagnosticsCommands;
 use orbit_core::scoreboard_summary::ScoreboardWindow;
 use orbit_core::{FailureIncidentQuery, OrbitRuntime};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::incidents::{ActorFailureRollup, ROLLUP_SCAN_LIMIT, agent_family_key, rollup_by_actor};
 use super::server_error;
@@ -50,99 +50,204 @@ pub(super) async fn scoreboard(Ws(runtime): Ws, Query(query): Query<ScoreboardQu
         Err(e) => return server_error(orbit_core::OrbitError::Store(e.to_string())),
     };
 
-    // Join MetricsEntry-derived per-actor stats and audit denials. Errors are
-    // logged-and-swallowed so the existing scoreboard surface still renders if
-    // a side log is missing or malformed.
+    // Join MetricsEntry-derived per-actor stats and audit denials. A source
+    // read/query failure is logged with full context and reported as an
+    // explicit `unavailable` coverage note plus `null` per-agent fields —
+    // never as a measured zero, which would be indistinguishable from a
+    // source that genuinely observed no activity. See ORB-11201.
     //
     // One `now`/`since_window` pair scopes every join below (metrics extras,
     // denials, failure rollup) so the response mixes only compatible
     // populations for the requested window.
     let now = Utc::now();
     let since_window = window.duration().map(|d| now - d);
-    let metrics_extras = compute_metrics_extras(&runtime, since_window, now).unwrap_or_default();
-    let denials_by_role = runtime
-        .audit_denials_by_role(since_window.as_ref())
-        .unwrap_or_default();
-    let denial_map: BTreeMap<String, i64> = denials_by_role.into_iter().collect();
+
+    let metrics_extras = match compute_metrics_extras(&runtime, since_window, now) {
+        Ok(extras) => Some(extras),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                source = "metrics_extras",
+                window = window.as_str(),
+                "scoreboard metrics-extras join failed; reporting retries/durations as unavailable"
+            );
+            None
+        }
+    };
+    let denial_map: Option<BTreeMap<String, i64>> =
+        match runtime.audit_denials_by_role(since_window.as_ref()) {
+            Ok(rows) => Some(rows.into_iter().collect()),
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    source = "audit_denials_by_role",
+                    window = window.as_str(),
+                    "scoreboard denial-count join failed; reporting denials as unavailable"
+                );
+                None
+            }
+        };
 
     // ORB-10871: a repeated failure burst is one incident, not one failure per
     // raw row. The scoreboard keeps `failed_tool_calls` (the raw count) and
     // gains the grouped counts beside it, over the same window, so an operator
     // reads "how many things went wrong" and "how much evidence there is" as
     // two distinct numbers.
-    let failure_rollup = runtime
-        .audit_failure_incidents(&FailureIncidentQuery {
-            since: since_window,
-            max_events: ROLLUP_SCAN_LIMIT,
-            ..Default::default()
-        })
-        .map(|report| rollup_by_actor(&report))
-        .unwrap_or_default();
+    let failure_rollup = match runtime.audit_failure_incidents(&FailureIncidentQuery {
+        since: since_window,
+        max_events: ROLLUP_SCAN_LIMIT,
+        ..Default::default()
+    }) {
+        Ok(report) => Some(rollup_by_actor(&report)),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                source = "audit_failure_incidents",
+                window = window.as_str(),
+                "scoreboard failure-incident join failed; reporting failure incidents as unavailable"
+            );
+            None
+        }
+    };
+
+    if let Some(coverage) = value.get_mut("coverage").and_then(|v| v.as_object_mut()) {
+        coverage.insert(
+            "metrics_extras".to_string(),
+            coverage_note(
+                metrics_extras.is_some(),
+                "Retry counts and step durations are measured for the requested window; an agent absent from the join has no recorded steps, not a read failure.",
+                "Metrics log read failed for the requested window; avg_step_duration_ms, p95_wall_clock_ms, and retries are omitted (null) rather than shown as zero.",
+            ),
+        );
+        coverage.insert(
+            "denials".to_string(),
+            coverage_note(
+                denial_map.is_some(),
+                "Denial counts are measured for the requested window; zero means no observed denials.",
+                "Audit denial-count query failed for the requested window; denials is omitted (null) rather than shown as zero.",
+            ),
+        );
+        coverage.insert(
+            "failure_incidents".to_string(),
+            coverage_note(
+                failure_rollup.is_some(),
+                "Failure incidents are measured for the requested window; zero means no observed failure incidents.",
+                "Audit failure-incident query failed for the requested window; failure_incidents, unexpected_failure_incidents, and failure_incident_events are omitted (null) rather than shown as zero.",
+            ),
+        );
+    }
 
     if let Some(agents) = value.get_mut("agents").and_then(|v| v.as_object_mut()) {
-        // Collect all agent keys upfront so we can also surface metrics rows
-        // that have no scoreboard counterpart yet.
-        let existing_keys: Vec<String> = agents.keys().cloned().collect();
-        for key in &existing_keys {
-            let extras = metrics_extras
-                .get(key.as_str())
-                .cloned()
-                .unwrap_or_default();
-            let denials = lookup_denials_for_agent(&denial_map, key);
-            let failures = lookup_failures_for_agent(&failure_rollup, key);
-            if let Some(obj) = agents.get_mut(key.as_str()).and_then(|v| v.as_object_mut()) {
-                obj.insert(
-                    "avg_step_duration_ms".to_string(),
-                    json!(extras.avg_duration_ms),
-                );
-                obj.insert("retries".to_string(), json!(extras.retry_count));
-                obj.insert(
-                    "p95_wall_clock_ms".to_string(),
-                    json!(extras.p95_duration_ms),
-                );
-                obj.insert("denials".to_string(), json!(denials));
-                obj.insert("failure_incidents".to_string(), json!(failures.incidents));
-                obj.insert(
-                    "unexpected_failure_incidents".to_string(),
-                    json!(failures.unexpected_incidents),
-                );
-                obj.insert(
-                    "failure_incident_events".to_string(),
-                    json!(failures.events),
-                );
-            }
-        }
-        // Surface metrics-only agents so retries/durations show even when no
-        // task or token row exists for them yet.
-        for (key, extras) in &metrics_extras {
-            if existing_keys.iter().any(|k| k == key) {
-                continue;
-            }
-            let denials = lookup_denials_for_agent(&denial_map, key);
-            let failures = lookup_failures_for_agent(&failure_rollup, key);
-            agents.insert(
-                key.clone(),
-                json!({
-                    "tasks_completed": 0,
-                    "tokens": { "total": 0, "output": 0 },
-                    "pr": { "review_comments": 0, "merged_clean": 0, "merged_with_revision": 0 },
-                    "task_review": { "threads": 0 },
-                    "friction": { "reported": 0 },
-                    "tool_calls": 0,
-                    "failed_tool_calls": 0,
-                    "avg_step_duration_ms": extras.avg_duration_ms,
-                    "retries": extras.retry_count,
-                    "p95_wall_clock_ms": extras.p95_duration_ms,
-                    "denials": denials,
-                    "failure_incidents": failures.incidents,
-                    "unexpected_failure_incidents": failures.unexpected_incidents,
-                    "failure_incident_events": failures.events,
-                }),
-            );
-        }
+        apply_side_source_extras(
+            agents,
+            metrics_extras.as_ref(),
+            denial_map.as_ref(),
+            failure_rollup.as_ref(),
+        );
     }
 
     Json(value).into_response()
+}
+
+/// Standard `{ "availability": ..., "detail": ... }` coverage note shape
+/// (matching [`orbit_store`]'s snapshot `CoverageNote`), used here for
+/// side-source joins that can fail independently of the primary summary.
+fn coverage_note(available: bool, observed_detail: &str, unavailable_detail: &str) -> Value {
+    if available {
+        json!({ "availability": "observed", "detail": observed_detail })
+    } else {
+        json!({ "availability": "unavailable", "detail": unavailable_detail })
+    }
+}
+
+/// Applies the three side-source joins onto each agent's JSON object.
+///
+/// `None` for a source means its upstream read/query failed (already logged
+/// with context by the caller): every field that source would have populated
+/// is set to `null`, never `0`, so a read failure can never be read as a
+/// measured zero. `Some(map)` — even an empty one — means the source
+/// succeeded, so an agent missing from it is a true, observed zero.
+pub(super) fn apply_side_source_extras(
+    agents: &mut serde_json::Map<String, Value>,
+    metrics_extras: Option<&BTreeMap<String, MetricsExtras>>,
+    denial_map: Option<&BTreeMap<String, i64>>,
+    failure_rollup: Option<&BTreeMap<String, ActorFailureRollup>>,
+) {
+    // Collect all agent keys upfront so we can also surface metrics rows
+    // that have no scoreboard counterpart yet.
+    let existing_keys: Vec<String> = agents.keys().cloned().collect();
+    for key in &existing_keys {
+        let extras = metrics_extras.map(|m| m.get(key.as_str()).cloned().unwrap_or_default());
+        let denials = denial_map.map(|m| lookup_denials_for_agent(m, key));
+        let failures = failure_rollup.map(|m| lookup_failures_for_agent(m, key));
+        if let Some(obj) = agents.get_mut(key.as_str()).and_then(|v| v.as_object_mut()) {
+            insert_extras_fields(obj, extras.as_ref(), denials, failures.as_ref());
+        }
+    }
+    // Surface metrics-only agents so retries/durations show even when no
+    // task or token row exists for them yet. Only possible when the metrics
+    // source itself succeeded — a failed source has no rows to surface.
+    if let Some(metrics_extras) = metrics_extras {
+        for (key, extras) in metrics_extras {
+            if existing_keys.iter().any(|k| k == key) {
+                continue;
+            }
+            let denials = denial_map.map(|m| lookup_denials_for_agent(m, key));
+            let failures = failure_rollup.map(|m| lookup_failures_for_agent(m, key));
+            let mut obj = serde_json::Map::new();
+            obj.insert("tasks_completed".to_string(), json!(0));
+            obj.insert("tokens".to_string(), json!({ "total": 0, "output": 0 }));
+            obj.insert(
+                "pr".to_string(),
+                json!({ "review_comments": 0, "merged_clean": 0, "merged_with_revision": 0 }),
+            );
+            obj.insert("task_review".to_string(), json!({ "threads": 0 }));
+            obj.insert("friction".to_string(), json!({ "reported": 0 }));
+            obj.insert("tool_calls".to_string(), json!(0));
+            obj.insert("failed_tool_calls".to_string(), json!(0));
+            insert_extras_fields(&mut obj, Some(extras), denials, failures.as_ref());
+            agents.insert(key.clone(), Value::Object(obj));
+        }
+    }
+}
+
+/// Writes the seven side-source-derived fields onto one agent's JSON object.
+/// `None` for a joined value means its source failed and the field becomes
+/// `null`; `Some` (including a zeroed default) means the source succeeded.
+fn insert_extras_fields(
+    obj: &mut serde_json::Map<String, Value>,
+    extras: Option<&MetricsExtras>,
+    denials: Option<i64>,
+    failures: Option<&ActorFailureRollup>,
+) {
+    obj.insert(
+        "avg_step_duration_ms".to_string(),
+        extras.map_or(Value::Null, |e| json!(e.avg_duration_ms)),
+    );
+    obj.insert(
+        "retries".to_string(),
+        extras.map_or(Value::Null, |e| json!(e.retry_count)),
+    );
+    obj.insert(
+        "p95_wall_clock_ms".to_string(),
+        extras.map_or(Value::Null, |e| json!(e.p95_duration_ms)),
+    );
+    obj.insert(
+        "denials".to_string(),
+        denials.map_or(Value::Null, |d| json!(d)),
+    );
+    obj.insert(
+        "failure_incidents".to_string(),
+        failures.map_or(Value::Null, |f| json!(f.incidents)),
+    );
+    obj.insert(
+        "unexpected_failure_incidents".to_string(),
+        failures.map_or(Value::Null, |f| json!(f.unexpected_incidents)),
+    );
+    obj.insert(
+        "failure_incident_events".to_string(),
+        failures.map_or(Value::Null, |f| json!(f.events)),
+    );
 }
 
 /// Per-agent extras derived from `MetricsEntry` JSONL.

--- a/crates/orbit-web/src/api/tests/scoreboard.rs
+++ b/crates/orbit-web/src/api/tests/scoreboard.rs
@@ -9,6 +9,7 @@
 // - schema_version is the v9 value (notable completions + coverage) with its
 //   separately-versioned managed-execution orchestration section
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -18,7 +19,10 @@ use orbit_core::OrbitRuntime;
 use serde_json::json;
 use tower::ServiceExt;
 
-use super::super::scoreboard::{MetricsExtras, compute_metrics_extras, months_in_range};
+use super::super::incidents::ActorFailureRollup;
+use super::super::scoreboard::{
+    MetricsExtras, apply_side_source_extras, compute_metrics_extras, months_in_range,
+};
 use super::super::*;
 use super::test_support::{body_json, write_lines};
 
@@ -558,4 +562,136 @@ async fn scoreboard_http_response_only_reflects_metrics_inside_the_requested_win
     assert_eq!(agent["retries"].as_i64(), Some(2));
     assert_eq!(agent["avg_step_duration_ms"].as_i64(), Some(400));
     assert_eq!(agent["p95_wall_clock_ms"].as_i64(), Some(400));
+}
+
+// ORB-11201: a side-source (metrics extras / denials / failure incidents)
+// read or query failure must surface as an explicit `unavailable` coverage
+// note plus `null` per-agent fields, never as an indistinguishable measured
+// zero. A source that succeeds — even with an empty result — still reports
+// true zeros.
+
+/// Forces a genuine, non-`InvalidInput` I/O error out of
+/// `compute_metrics_extras`'s lifetime path (`list_metrics_months`'s
+/// `fs::read_dir` over a plain file instead of a directory), proving the
+/// error actually propagates instead of being silently treated as "no
+/// partitions".
+#[test]
+fn compute_metrics_extras_surfaces_a_real_read_dir_failure() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let metrics_dir = runtime
+        .data_root()
+        .join("state")
+        .join("diagnostics")
+        .join("metrics");
+    std::fs::create_dir_all(metrics_dir.parent().expect("diagnostics dir"))
+        .expect("create diagnostics parent");
+    std::fs::write(&metrics_dir, b"not a directory").expect("block the metrics directory");
+
+    let result = compute_metrics_extras(&runtime, None, Utc::now());
+    assert!(
+        result.is_err(),
+        "read_dir over a blocking file must be a real error, not an empty partition list"
+    );
+}
+
+/// End-to-end: when the metrics log is unreadable, the scoreboard endpoint
+/// still returns 200 with the rest of the summary intact, but marks the
+/// metrics-derived fields `null` and the coverage note `unavailable` —
+/// while the independent denials/failure-incidents sources (which have no
+/// data to report) still come back as real, non-null zeros.
+#[tokio::test]
+async fn scoreboard_reports_metrics_extras_unavailable_not_zero_when_metrics_log_is_unreadable() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let metrics_dir = runtime
+        .data_root()
+        .join("state")
+        .join("diagnostics")
+        .join("metrics");
+    std::fs::create_dir_all(metrics_dir.parent().expect("diagnostics dir"))
+        .expect("create diagnostics parent");
+    std::fs::write(&metrics_dir, b"not a directory").expect("block the metrics directory");
+
+    let response = get_scoreboard(runtime, None).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a side-source failure must not fail the whole scoreboard request"
+    );
+    let body = body_json(response).await;
+
+    assert_eq!(
+        body["coverage"]["metrics_extras"]["availability"].as_str(),
+        Some("unavailable")
+    );
+    let claude = &body["agents"]["claude"];
+    assert!(
+        claude["avg_step_duration_ms"].is_null(),
+        "a failed metrics join must not report a measured zero"
+    );
+    assert!(claude["retries"].is_null());
+    assert!(claude["p95_wall_clock_ms"].is_null());
+
+    // Independent sources succeeded (nothing to read) and report true zeros.
+    assert_eq!(
+        body["coverage"]["denials"]["availability"].as_str(),
+        Some("observed")
+    );
+    assert_eq!(
+        body["coverage"]["failure_incidents"]["availability"].as_str(),
+        Some("observed")
+    );
+    assert_eq!(claude["denials"].as_i64(), Some(0));
+    assert_eq!(claude["failure_incidents"].as_i64(), Some(0));
+    assert_eq!(claude["unexpected_failure_incidents"].as_i64(), Some(0));
+    assert_eq!(claude["failure_incident_events"].as_i64(), Some(0));
+}
+
+/// Directly exercises the merge policy: a failed source (`None`) must
+/// produce `null` fields, while a succeeded-but-empty source (`Some` of an
+/// empty map) must produce real zeros. Deterministic and independent of any
+/// filesystem/SQLite failure injection.
+#[test]
+fn apply_side_source_extras_distinguishes_failed_source_from_true_zero() {
+    let mut agents = serde_json::Map::new();
+    agents.insert("claude".to_string(), json!({ "tasks_completed": 0 }));
+
+    let metrics_extras: BTreeMap<String, MetricsExtras> = BTreeMap::new();
+    let failure_rollup: BTreeMap<String, ActorFailureRollup> = BTreeMap::new();
+
+    apply_side_source_extras(
+        &mut agents,
+        Some(&metrics_extras), // succeeded, empty -> true zero
+        None,                  // failed -> null
+        Some(&failure_rollup), // succeeded, empty -> true zero
+    );
+
+    let claude = &agents["claude"];
+    assert_eq!(
+        claude["avg_step_duration_ms"],
+        json!(0),
+        "a succeeded-but-empty metrics join is a true zero"
+    );
+    assert_eq!(claude["retries"], json!(0));
+    assert_eq!(claude["p95_wall_clock_ms"], json!(0));
+    assert!(
+        claude["denials"].is_null(),
+        "a failed denials join must not report a measured zero"
+    );
+    assert_eq!(claude["failure_incidents"], json!(0));
+    assert_eq!(claude["unexpected_failure_incidents"], json!(0));
+    assert_eq!(claude["failure_incident_events"], json!(0));
+}
+
+/// When every side source fails, the metrics-only "surface a new agent" path
+/// must not fabricate a row: there is nothing observed to surface.
+#[test]
+fn apply_side_source_extras_adds_no_metrics_only_agent_when_metrics_source_failed() {
+    let mut agents = serde_json::Map::new();
+
+    apply_side_source_extras(&mut agents, None, None, None);
+
+    assert!(
+        agents.is_empty(),
+        "a failed metrics source has no rows to surface as new agents"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-11201](https://orbit-cli.com/tasks/ORB-11201) — [code-review] Distinguish unavailable scoreboard side metrics from real zero counts

### Description

Inspected the clean local Orbit agent-main checkout at 4fdfabcedb87fb30835a9e649ea28212e702caab on 2026-09-04. This is a review finding, not an implemented repair. Recheck current integration HEAD before editing. 

Problem: api/scoreboard.rs:54-78 claims side-metric errors are logged-and-swallowed, but compute_metrics_extras, audit_denials_by_role, and audit_failure_incidents errors are discarded with unwrap_or_default. The response then inserts numeric zero retry/denial/failure-incidence values for absent map entries (lines 84-112). A failed data read becomes indistinguishable from a measured zero; there is no diagnostic at these catches. Returning the rest of the scoreboard can be useful, but silently declaring zero failures is misleading operational data.

Scope: define and implement a small explicit partial-data/error policy for these three joins. Preserve usable primary summary data when appropriate, expose unavailable sections in the response and any consuming display, and log the actual failure with context. A legitimately absent optional metrics partition and an actual read/query failure must not be conflated. Coordinate with the time-window fix in the same file.

### Acceptance Criteria

- Injected side-source failures yield an explicit unavailable/partial indication (or an intentional error response), never an unqualified measured zero for the failed source.
- Successful empty queries still report true zeros; legitimately missing optional partitions follow the documented policy.
- Actual errors are preserved in structured diagnostics with source context, while successful primary summary data remains usable under the chosen partial-data policy.
- Deterministic failure-path tests, make ci-fast, and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented an explicit partial-data policy for the three side-source joins in `crates/orbit-web/src/api/scoreboard.rs` (`compute_metrics_extras`, `audit_denials_by_role`, `audit_failure_incidents`), replacing the prior `.unwrap_or_default()` swallowing.

- Each join's `Result` is now matched explicitly: `Err` logs a structured `tracing::error!` (error, source, window) and yields `None`; `Ok` yields `Some(data)` — even an empty map, which is a true observed zero, not a failure.
- Added `apply_side_source_extras` (pub(super), directly unit-tested) which writes the seven derived per-agent fields (`avg_step_duration_ms`, `retries`, `p95_wall_clock_ms`, `denials`, `failure_incidents`, `unexpected_failure_incidents`, `failure_incident_events`). A `None` source writes `null` for its fields (never `0`); a `Some` source writes the real (possibly-zero) value. The "surface metrics-only agents" pass only fires when the metrics source itself succeeded.
- Extended the existing `coverage` JSON object (already used by `orbit-store`'s snapshot coverage notes) with three new per-source notes — `coverage.metrics_extras`, `coverage.denials`, `coverage.failure_incidents` — each `{ availability: "observed"|"unavailable", detail }`, reusing the same shape the dashboard already reads for `coverage.review`.
- Added tests in the sibling `crates/orbit-web/src/api/tests/scoreboard.rs`: a genuine forced I/O failure (blocking file in place of the metrics directory) proving `compute_metrics_extras` returns a real `Err` and that the full HTTP handler still returns 200 with `coverage.metrics_extras.availability == "unavailable"` and `null` metrics fields, while the independent denials/failure-incidents sources report real (non-null) zeros; plus two deterministic unit tests against `apply_side_source_extras` directly (failed-vs-empty-source distinction, and no phantom "metrics-only" agent row when the metrics source fails).

Scope: only `crates/orbit-web/src/api/scoreboard.rs` and its sibling test file changed (context_files as declared). Did not touch `orbit-store`'s `ScoreboardCoverage` Rust struct or the dashboard JS (`assets/dashboard/scoreboard.js`) — the new coverage keys and null-vs-zero fields are added as raw JSON after struct serialization, and none of the four acceptance criteria require a UI change; a future task can teach the dashboard to render these three new coverage notes/nulls distinctly if desired.

Validation: `cargo test -p orbit-web --lib api::tests::scoreboard` (18/18 pass), `make ci-fast` (pass), `make ci-lint` (pass, zero warnings). No blockers, no friction filed (straightforward within-file change, no contradicted assumptions).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11201-6a9b6ae3`
- Behind base: 0
- Ahead of base: 1