### PR TITLE
Add `orbit host show` for local host identity

### DIFF
--- a/crates/orbit-cli/src/command/host/command.rs
+++ b/crates/orbit-cli/src/command/host/command.rs
@@ -4,6 +4,7 @@ use orbit_core::OrbitRuntime;
 use crate::command::{CommandOut, Execute};
 
 use super::rename::HostRenameArgs;
+use super::show::HostShowArgs;
 
 #[derive(Args)]
 #[command(about = "Manage this machine's local host identity")]
@@ -20,6 +21,8 @@ impl Execute for HostCommand {
 
 #[derive(Subcommand)]
 pub enum HostSubcommand {
+    /// Show this machine's local host identity without changing it
+    Show(HostShowArgs),
     /// Rename this machine in host.toml and its local workspace owner records
     Rename(HostRenameArgs),
 }
@@ -27,6 +30,7 @@ pub enum HostSubcommand {
 impl Execute for HostSubcommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         match self {
+            HostSubcommand::Show(args) => args.execute(runtime),
             HostSubcommand::Rename(args) => args.execute(runtime),
         }
     }

--- a/crates/orbit-cli/src/command/host/mod.rs
+++ b/crates/orbit-cli/src/command/host/mod.rs
@@ -2,5 +2,6 @@
 
 mod command;
 mod rename;
+mod show;
 
 pub use command::{HostCommand, HostSubcommand};

--- a/crates/orbit-cli/src/command/host/show.rs
+++ b/crates/orbit-cli/src/command/host/show.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+use orbit_core::OrbitRuntime;
+use orbit_registry::{load_host_identity, workspace_registry::global_orbit_dir};
+use serde_json::json;
+
+use crate::command::{CommandOut, Execute, Payload};
+
+#[derive(Args)]
+#[command(
+    about = "Show this machine's local host identity",
+    after_help = "Reports the stable machine_id, operator-facing host_id, and task-ID task_prefix."
+)]
+pub(crate) struct HostShowArgs {
+    /// Emit the identity as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl HostShowArgs {
+    pub(crate) fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
+        let global_root = selected_global_root(root_override)?;
+        self.execute_at(&global_root)
+    }
+
+    fn execute_at(self, global_root: &Path) -> CommandOut {
+        let identity = load_host_identity(global_root)?;
+        let doc = json!({
+            "machine_id": identity.machine_id,
+            "host_id": identity.host_id,
+            "task_prefix": identity.task_prefix,
+        });
+        let text = format!(
+            "machine_id: {}\nhost_id: {}\ntask_prefix: {}",
+            identity.machine_id, identity.host_id, identity.task_prefix
+        );
+        Ok(Payload::detail(doc, text).into())
+    }
+}
+
+impl Execute for HostShowArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let global_root = runtime.global_root();
+        self.execute_at(&global_root)
+    }
+}
+
+fn selected_global_root(root_override: Option<&Path>) -> Result<PathBuf, orbit_core::OrbitError> {
+    match root_override {
+        Some(root) => Ok(root.to_path_buf()),
+        None => global_orbit_dir(),
+    }
+}

--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -250,15 +250,16 @@ impl Commands {
             }
             Commands::Host(command) => {
                 use super::host::HostSubcommand;
-                let subcommand = match &command.command {
-                    HostSubcommand::Rename(_) => "rename",
+                let (subcommand, runtime_need, json_output) = match &command.command {
+                    HostSubcommand::Show(args) => ("show", RuntimeNeed::Forbidden, args.json),
+                    HostSubcommand::Rename(_) => ("rename", RuntimeNeed::Required, false),
                 };
                 CommandOperation::new(
-                    RuntimeNeed::Required,
+                    runtime_need,
                     Some(admin_meta("host", Some(subcommand), Some("host"), None)),
-                    None,
+                    json_output.then_some(true),
                     false,
-                    runtime_dispatch!(Host),
+                    dispatch_host,
                 )
             }
             Commands::Config(command) => {
@@ -905,6 +906,17 @@ fn dispatch_init(command: Commands, context: DispatchContext<'_>) -> CommandOut 
     match command {
         Commands::Init(command) => command.execute_without_runtime(context.root_override),
         _ => dispatch_mismatch("Init"),
+    }
+}
+
+fn dispatch_host(command: Commands, context: DispatchContext<'_>) -> CommandOut {
+    use super::host::{HostCommand, HostSubcommand};
+    match command {
+        Commands::Host(HostCommand {
+            command: HostSubcommand::Show(args),
+        }) => args.execute_without_runtime(context.root_override),
+        Commands::Host(command) => command.execute(context.runtime()?),
+        _ => dispatch_mismatch("Host"),
     }
 }
 

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -11,6 +11,7 @@ fn runtime_free_command_set_is_derived_from_operations() {
     let runtime_free: &[&[&str]] = &[
         &["orbit", "init"],
         &["orbit", "workspace", "init"],
+        &["orbit", "host", "show"],
         &["orbit", "mcp", "init"],
         &["orbit", "mcp", "remove"],
         &["orbit", "mcp", "serve"],
@@ -44,6 +45,10 @@ fn runtime_free_command_set_is_derived_from_operations() {
             "{args:?} must bootstrap a workspace runtime"
         );
     }
+    assert_eq!(
+        operation_for(&["orbit", "host", "rename", "old", "new"]).runtime_need,
+        RuntimeNeed::Required
+    );
 }
 
 #[test]
@@ -125,6 +130,10 @@ fn json_error_preferences_are_derived_from_operations() {
     );
     assert_eq!(
         operation_for(&["orbit", "friction", "list", "--json"]).json_error_preference,
+        Some(true)
+    );
+    assert_eq!(
+        operation_for(&["orbit", "host", "show", "--json"]).json_error_preference,
         Some(true)
     );
     assert_eq!(

--- a/crates/orbit-cli/tests/host_administration.rs
+++ b/crates/orbit-cli/tests/host_administration.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use serde_json::Value;
 use tempfile::tempdir;
 
 fn initialized_workspace() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -128,4 +129,120 @@ fn rename_updates_host_and_local_owner_names_without_changing_stable_identity() 
         .stderr(predicate::str::contains(
             "current host.toml names 'renamed'",
         ));
+}
+
+#[test]
+fn show_reports_the_persisted_identity_outside_a_workspace_without_writing() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("orbit-root");
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&outside).expect("create outside directory");
+    let root_arg = root.to_str().expect("utf8 root");
+    std::fs::create_dir_all(&root).expect("create root");
+    std::fs::write(
+        root.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_0123456789abcdef0123456789abcdef\"\nhost_id = \"operator-host\"\ntask_prefix = \"DE\"\n",
+    )
+    .expect("write identity");
+
+    let identity_path = root.join("host.toml");
+    let before = std::fs::read(&identity_path).expect("read identity before show");
+    let identity: toml::Value =
+        toml::from_str(std::str::from_utf8(&before).expect("identity is utf8"))
+            .expect("parse identity");
+    let machine_id = identity["machine_id"]
+        .as_str()
+        .expect("machine id")
+        .to_string();
+    let human = cargo_bin_cmd!("orbit")
+        .current_dir(&outside)
+        .args(["--root", root_arg, "host", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        String::from_utf8(human).expect("human output is utf8"),
+        format!("machine_id: {machine_id}\nhost_id: operator-host\ntask_prefix: DE\n")
+    );
+
+    let json_output = cargo_bin_cmd!("orbit")
+        .current_dir(&outside)
+        .args(["--root", root_arg, "host", "show", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let shown: Value = serde_json::from_slice(&json_output).expect("valid host JSON");
+    let object = shown.as_object().expect("host JSON object");
+    assert_eq!(object.len(), 3);
+    assert_eq!(object["machine_id"], machine_id);
+    assert_eq!(object["host_id"], "operator-host");
+    assert_eq!(object["task_prefix"], "DE");
+    assert_eq!(
+        std::fs::read(&identity_path).expect("read identity after show"),
+        before
+    );
+}
+
+#[test]
+fn show_rejects_invalid_host_identities_without_replacing_them() {
+    let cases = [
+        ("absent", None, "no host identity"),
+        (
+            "malformed",
+            Some("schema_version = [\n"),
+            "invalid host identity",
+        ),
+        (
+            "incomplete",
+            Some("schema_version = 2\nhost_id = \"operator-host\"\n"),
+            "incomplete",
+        ),
+        (
+            "future",
+            Some(
+                "schema_version = 99\nmachine_id = \"hm_0123456789abcdef0123456789abcdef\"\nhost_id = \"operator-host\"\ntask_prefix = \"DE\"\n",
+            ),
+            "unsupported schema_version",
+        ),
+    ];
+
+    for (name, contents, error_text) in cases {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join(name);
+        std::fs::create_dir_all(&root).expect("create root");
+        let identity_path = root.join("host.toml");
+        if let Some(contents) = contents {
+            std::fs::write(&identity_path, contents).expect("write identity fixture");
+        }
+        let before = std::fs::read(&identity_path).ok();
+
+        cargo_bin_cmd!("orbit")
+            .current_dir(temp.path())
+            .args(["--root", root.to_str().expect("utf8 root"), "host", "show"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(error_text));
+
+        assert_eq!(std::fs::read(&identity_path).ok(), before);
+    }
+}
+
+#[test]
+fn host_show_is_listed_in_help() {
+    cargo_bin_cmd!("orbit")
+        .args(["host", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("show"));
+    cargo_bin_cmd!("orbit")
+        .args(["host", "show", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("machine_id"))
+        .stdout(predicate::str::contains("host_id"))
+        .stdout(predicate::str::contains("task_prefix"));
 }


### PR DESCRIPTION
## Task

[ORB-11203](https://orbit-cli.com/tasks/ORB-11203) — Add `orbit host show` for local host identity

### Description

## Problem
Orbit persists a machine-level host identity containing `machine_id`, `host_id`, and `task_prefix`, but the CLI has no concise command for an operator or script to inspect those values.

## Desired Outcome
Implement:

```text
orbit host show
```

The command reads the effective local host identity and prints `machine_id`, `host_id`, and `task_prefix`.

## Constraints / Notes
- Read through the existing canonical host-identity loader and types. Do not parse `host.toml` independently or introduce another identity source.
- This is a read-only inspection command. It must not create, migrate, repair, or rewrite host identity.
- It is machine-scoped and must not depend on the current workspace or repository.
- Preserve the established meanings: `machine_id` is the stable opaque machine identity, `host_id` is the operator-facing host name, and `task_prefix` is the machine's task-ID prefix.
- Missing, malformed, incomplete, or unsupported identity must fail non-zero with the loader's actionable error; never fall back to the OS hostname or synthesize values.
- Follow existing Orbit CLI output and JSON conventions rather than adding command-specific formatting infrastructure.
- Historical ADRs are not authority; use current identity code, CLI conventions, tests, and these requirements.
- Orbit is PR-gated: implementation must use a dedicated worktree from `agent-main` and produce a reviewable PR candidate.
- Related completed identity work: ORB-10247 and ORB-10721.

### Acceptance Criteria

- `orbit host show` succeeds for a valid local identity and prints the exact field names `machine_id`, `host_id`, and `task_prefix` with their persisted values.
- If the CLI's standard JSON output flag applies to this command, `orbit host show --json` emits a valid object with exactly the keys `machine_id`, `host_id`, and `task_prefix`, using the same values as human-readable output.
- The command resolves identity through the canonical host-identity loader, works outside an Orbit workspace, and performs no write to the identity file; a test verifies the file remains byte-for-byte unchanged.
- Absent, malformed, incomplete, and future-schema host identities produce a non-zero exit with actionable errors and do not fall back to the OS hostname or generate replacement values.
- `orbit host --help` lists the `show` subcommand, and `orbit host show --help` accurately describes the three reported fields.
- Deterministic CLI tests use isolated temporary Orbit roots to cover human output, standard JSON output when supported, cwd independence, error cases, and no-write behavior.
- Targeted host/CLI tests and `make ci-fast` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit host show` with exact `machine_id`, `host_id`, and `task_prefix` human-readable and JSON payloads.
- Routed `host show` through the runtime-free operation path so it loads the machine-global identity outside an Orbit workspace, while `host rename` retains its required workspace runtime.
- Reused `orbit_registry::load_host_identity`, preserving strict missing/malformed/incomplete/future-schema errors and read-only behavior.
- Added CLI coverage for valid output, exact JSON keys/values, cwd independence, help text, absent and invalid identities, and byte-for-byte no-write behavior.

Assessment: The change is small and follows the existing command payload and global output-format conventions. No new dependency edge or persisted format was introduced.

Validation:
- `cargo test -p orbit-cli --test host_administration show_` passed (3 tests).
- `cargo test -p orbit-cli --bin orbit command::tests::operation` passed (11 tests).
- `make ci-fast` passed.
- Full `host_administration` also exercises two pre-existing init-based tests that fail in this runner because `~/.orbit/resources/executors/claude.yaml` is read-only (OS error 30); the new host-show tests are unaffected and pass.
- `git diff --check` passed; final worktree entries are task-scoped source/test changes only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11203-6a9b6a2f`
- Behind base: 0
- Ahead of base: 1