### PR TITLE
[code-review] `orbit task flow` counts a done-then-archived task as two outflow events

### DIFF
--- a/crates/orbit-cli/src/command/task/flow.rs
+++ b/crates/orbit-cli/src/command/task/flow.rs
@@ -10,7 +10,10 @@
 //! Terminal transitions come from task status history, so a task that is
 //! rejected and later reopened remains closed for the intervening windows and
 //! still contributes its dropped event. Legacy terminal tasks without status
-//! history retain the previous `updated_at` approximation.
+//! history retain the previous `updated_at` approximation. A terminal status
+//! reclassified into another terminal status without an intervening reopen
+//! (for example `Done` later `Archived`) contributes only its first outflow
+//! event — the later one is a relabeling, not a second departure.
 
 use chrono::{DateTime, Duration, Utc};
 use clap::{ArgAction, Args};
@@ -149,6 +152,24 @@ impl FlowPoint {
             .then_some(changes[1].at)
         })
     }
+
+    /// Terminal transitions that are genuine departures from the backlog.
+    ///
+    /// A terminal status immediately following another terminal status (for
+    /// example `Done` reclassified as `Archived`) never passed back through
+    /// the live backlog, so it is not a second outflow — only the first
+    /// terminal transition in a contiguous run counts.
+    fn outflow_events(&self) -> impl Iterator<Item = (DateTime<Utc>, TerminalKind)> + '_ {
+        self.status_changes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, change)| {
+                let kind = TerminalKind::of(change.status)?;
+                let follows_terminal =
+                    index > 0 && TerminalKind::of(self.status_changes[index - 1].status).is_some();
+                (!follows_terminal).then_some((change.at, kind))
+            })
+    }
 }
 
 /// One bucket's inflow and outflow, plus the population still open at its end.
@@ -239,11 +260,8 @@ pub(crate) fn compute_flow(
                 .reopen_times()
                 .filter(|at| *at >= bucket.start && *at < bucket.end)
                 .count();
-            for change in &point.status_changes {
-                if let Some(kind) = TerminalKind::of(change.status)
-                    && change.at >= bucket.start
-                    && change.at < bucket.end
-                {
+            for (at, kind) in point.outflow_events() {
+                if at >= bucket.start && at < bucket.end {
                     match kind {
                         TerminalKind::Closed => bucket.closed += 1,
                         TerminalKind::Dropped => bucket.dropped += 1,

--- a/crates/orbit-cli/src/command/task/tests/flow.rs
+++ b/crates/orbit-cli/src/command/task/tests/flow.rs
@@ -158,6 +158,43 @@ fn repeated_reopens_do_not_make_a_stable_open_task_look_draining() {
     assert!(report.verdict().starts_with("flat"), "{}", report.verdict());
 }
 
+/// A task that reaches `done` and is later `archived` (routine housekeeping,
+/// not a reopen) must contribute exactly one outflow event, not two: the
+/// archive is a reclassification of an already-departed task, not a second
+/// departure. ORB-11206.
+#[test]
+fn done_then_archived_contributes_a_single_outflow_event() {
+    let report = compute_flow(
+        &[status_history(
+            1,
+            &[(9, TaskStatus::Done), (16, TaskStatus::Archived)],
+        )],
+        at(21),
+        Duration::days(7),
+        3,
+    );
+
+    // Bucket 0: [day 0, day 7) — the task is filed.
+    assert_eq!(report.buckets[0].filed, 1);
+    assert_eq!(report.buckets[0].closed, 0);
+    assert_eq!(report.buckets[0].dropped, 0);
+    // Bucket 1: [day 7, day 14) — the `Done` transition is the one outflow event.
+    assert_eq!(report.buckets[1].closed, 1);
+    assert_eq!(report.buckets[1].dropped, 0);
+    // Bucket 2: [day 14, day 21) — the later `Archived` transition is a
+    // relabeling of the same departure, not a second one.
+    assert_eq!(report.buckets[2].closed, 0);
+    assert_eq!(report.buckets[2].dropped, 0);
+
+    assert_eq!(report.filed, 1);
+    assert_eq!(report.reopened, 0);
+    assert_eq!(report.closed, 1);
+    assert_eq!(report.dropped, 0);
+    assert_eq!(report.net(), 0);
+    assert_eq!(report.open_now, 0);
+    assert!(report.verdict().starts_with("flat"), "{}", report.verdict());
+}
+
 #[test]
 fn a_task_created_after_a_window_is_not_open_during_it() {
     let report = compute_flow(&[open(20)], at(21), Duration::days(7), 2);


### PR DESCRIPTION
## Task

[ORB-11206](https://orbit-cli.com/tasks/ORB-11206) — [code-review] `orbit task flow` counts a done-then-archived task as two outflow events

### Description

`orbit task flow` reads every terminal status transition from task history and increments an outflow counter for each one, but counts inflow only once at creation (plus, since ORB-11183, once per reopen). A task that reaches `done` and is later `archived` therefore contributes `filed=1`, `closed=1`, `dropped=1`, `reopened=0` and a NET of `-1` — one task removes two units of backlog it never added.

This is the same arithmetic class ORB-11183 fixed for reopen cycles, but terminal-to-terminal transitions were not covered by that fix.

## Evidence

- `crates/orbit-cli/src/command/task/flow.rs:242-251` — the bucket loop walks *every* `status_changes` entry and increments `closed`/`dropped` for each one whose status is terminal. Nothing suppresses a second terminal event for the same task.
- `crates/orbit-cli/src/command/task/flow.rs:145-153` — `reopen_times()` only offsets a *terminal → nonterminal* pair. A `Done → Archived` pair is terminal → terminal, so it produces no compensating inflow.
- `crates/orbit-cli/src/command/task/flow.rs:166-168` and `:181-183` — `net()` is `filed + reopened - closed - dropped`, so the extra outflow lands directly in NET and in the `draining`/`flat`/`growing` verdict at `:191-208`.
- `crates/orbit-core/src/application/task/transitions.rs:683-706` — `archive_task` rejects only an *already archived* task. Archiving a `done` task is a supported, ordinary operation.
- `crates/orbit-store/src/repository/task/v2/updates.rs:230-246` — the archive write records a `status_changed` event with `to_status = Archived`, so both the `Done` and `Archived` events are present in the history the report reads.
- `crates/orbit-cli/src/command/task/tests/flow.rs` — covers `closed`/`dropped` separation (`:65`), rejection-then-reopen (`:100`) and repeated reopens (`:128`), but has no `Done → Archived` fixture.

## Impact

Routine housekeeping that archives completed tasks silently biases the report toward a false `draining` verdict, and inflates DROPPED — the column an operator reads as "cleared without fixing anything".

## Suggested direction

Count at most one outflow per contiguous terminal run: when consecutive status changes are both terminal, the later one is a reclassification, not a second departure. The existing `reopen_times()` window-pair helper is the natural place to express the complementary rule.

### Acceptance Criteria

- A task whose history is created → done → archived contributes exactly one outflow event to `orbit task flow`, and its NET contribution over the full span is 0.
- A regression test in `crates/orbit-cli/src/command/task/tests/flow.rs` covers a done-then-archived fixture and asserts the bucket-level and total closed/dropped/net values.
- Existing reopen-cycle behavior (ORB-11183) and the closed-vs-dropped distinction are unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the double-outflow bug: `FlowPoint` gained `outflow_events()`, which yields only the first terminal transition in a contiguous terminal run (mirrors the existing `reopen_times()` window-pair pattern). `compute_flow`'s bucket loop now iterates `outflow_events()` instead of every `status_changes` entry, so a `Done -> Archived` reclassification contributes one outflow (Closed), not two (Closed + Dropped). Reopen-cycle handling and the closed/dropped kind distinction are untouched — only which events count as outflow changed, not how a counted event is classified.

Added `done_then_archived_contributes_a_single_outflow_event` to crates/orbit-cli/src/command/task/tests/flow.rs: fixture created day 1, Done day 9, Archived day 16, asserting per-bucket closed/dropped and totals filed=1, closed=1, dropped=0, net=0, open_now=0.

Updated the module doc comment to state the contiguous-terminal-run rule alongside the existing reopen-cycle note.

Validation: `cargo test -p orbit-cli --bin orbit flow` (15/15 pass, including all pre-existing reopen/closed/dropped tests unchanged), `make ci-fast` (pass), `make ci-lint` (pass, zero warnings). No new dependencies, no context_files beyond the two originally scoped.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11206-6a9b7774`
- Behind base: 0
- Ahead of base: 1