### PR TITLE
Prevent task_trimmed_surface tests from writing fixtures to the live Orbit workspace

### DIFF
--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -155,6 +156,7 @@ fn lint_fix_sweep_drops_stale_context_entries() {
 
 #[test]
 fn task_add_attributes_from_model_flag_and_managed_identity_env() {
+    let ambient = TestWorkspace::new();
     let workspace = TestWorkspace::new();
 
     let explicit = workspace.task_json(&[
@@ -172,30 +174,67 @@ fn task_add_attributes_from_model_flag_and_managed_identity_env() {
     ]);
     assert_eq!(explicit["created_by"], json!("gpt-5.6-sol"));
 
-    let output = run_orbit_with_identity(
-        &workspace.work,
-        &workspace.home,
-        &[
-            "task",
-            "add",
-            "--title",
-            "Managed identity",
-            "--description",
-            "Environment attribution",
-            "--complexity",
-            "low",
-            "--json",
-        ],
-        "codex",
-        "gpt-5.6-terra",
+    let ambient_registry = ambient.home.join(".orbit");
+    let ambient_registry = ambient_registry
+        .to_str()
+        .expect("ambient registry path is UTF-8");
+    let before = ambient.task_json(&["task", "list", "--json"]);
+    let _ambient_env = test_env::scoped([
+        ("ORBIT_ROOT", Some("/sentinel/orbit-root")),
+        ("ORBIT_SESSION_ID", Some("sentinel-session")),
+        ("ORBIT_TASK_ID", Some("sentinel-task")),
+        ("ORBIT_RUN_ID", Some("sentinel-run")),
+        ("ORBIT_ACTIVITY_ID", Some("sentinel-activity")),
+        ("ORBIT_STEP_INDEX", Some("sentinel-step")),
+        ("ORBIT_AGENT_NAME", Some("sentinel-agent")),
+        ("ORBIT_AGENT_MODEL", Some("sentinel-model")),
+        ("ORBIT_OPERATOR", Some("1")),
+        ("ORBIT_MANAGED_RUN_CONTEXT", Some("1")),
+        ("ORBIT_TASK_ACTOR_KIND", Some("sentinel-actor")),
+        ("ORBIT_REGISTRY_ROOT", Some(ambient_registry)),
+        ("ORBIT_WORKSPACE", Some("trimmed-surface-test")),
+    ]);
+
+    for _ in 0..2 {
+        let output = run_orbit_with_identity(
+            &workspace.work,
+            &workspace.home,
+            &[
+                "task",
+                "add",
+                "--title",
+                "Managed identity",
+                "--description",
+                "Environment attribution",
+                "--complexity",
+                "low",
+                "--json",
+            ],
+            "codex",
+            "gpt-5.6-terra",
+        );
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let managed: Value = serde_json::from_slice(&output.stdout).expect("managed task JSON");
+        assert_eq!(managed["created_by"], json!("gpt-5.6-terra"));
+    }
+
+    let after = ambient.task_json(&["task", "list", "--json"]);
+    assert_eq!(after, before, "ambient sentinel workspace was modified");
+
+    let fixture_tasks = workspace.task_json(&["task", "list", "--json"]);
+    let fixture_tasks = fixture_tasks.as_array().expect("fixture task list");
+    assert_eq!(fixture_tasks.len(), 3);
+    assert_eq!(
+        fixture_tasks
+            .iter()
+            .filter(|task| task["created_by"] == json!("gpt-5.6-terra"))
+            .count(),
+        2
     );
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let managed: Value = serde_json::from_slice(&output.stdout).expect("managed task JSON");
-    assert_eq!(managed["created_by"], json!("gpt-5.6-terra"));
 }
 
 #[test]
@@ -456,9 +495,18 @@ fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> Output {
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_SESSION_ID")
+        .env_remove("ORBIT_TASK_ID")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_ACTIVITY_ID")
+        .env_remove("ORBIT_STEP_INDEX")
         .env_remove("ORBIT_AGENT_NAME")
         .env_remove("ORBIT_AGENT_MODEL")
+        .env_remove("ORBIT_OPERATOR")
         .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+        .env_remove("ORBIT_TASK_ACTOR_KIND")
+        .env_remove("ORBIT_REGISTRY_ROOT")
+        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit")
 }
@@ -471,9 +519,17 @@ fn run_orbit_as_operator(cwd: &Path, home: &Path, args: &[&str]) -> Output {
         .env("USERPROFILE", home)
         .env("ORBIT_OPERATOR", "1")
         .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_SESSION_ID")
+        .env_remove("ORBIT_TASK_ID")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_ACTIVITY_ID")
+        .env_remove("ORBIT_STEP_INDEX")
         .env_remove("ORBIT_AGENT_NAME")
         .env_remove("ORBIT_AGENT_MODEL")
         .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
+        .env_remove("ORBIT_TASK_ACTOR_KIND")
+        .env_remove("ORBIT_REGISTRY_ROOT")
+        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit as operator")
 }
@@ -491,9 +547,19 @@ fn run_orbit_with_identity(
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env_remove("ORBIT_ROOT")
+        .env_remove("ORBIT_SESSION_ID")
+        .env_remove("ORBIT_TASK_ID")
+        .env_remove("ORBIT_RUN_ID")
+        .env_remove("ORBIT_ACTIVITY_ID")
+        .env_remove("ORBIT_STEP_INDEX")
         .env("ORBIT_AGENT_NAME", agent)
         .env("ORBIT_AGENT_MODEL", model)
         .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
+        .env("ORBIT_RUN_ID", "task-trimmed-surface-managed")
+        .env_remove("ORBIT_OPERATOR")
+        .env_remove("ORBIT_TASK_ACTOR_KIND")
+        .env_remove("ORBIT_REGISTRY_ROOT")
+        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit with managed identity")
 }


### PR DESCRIPTION
## Task

[ORB-11211](https://orbit-cli.com/tasks/ORB-11211) — Prevent task_trimmed_surface tests from writing fixtures to the live Orbit workspace

### Description

## Problem
`crates/orbit-cli/tests/task_trimmed_surface.rs` is not hermetic inside an Orbit-managed pipeline. Its `run_orbit_with_identity` helper sets `ORBIT_MANAGED_RUN_CONTEXT=1` while inheriting the parent process's `ORBIT_RUN_ID`, `ORBIT_REGISTRY_ROOT`, and `ORBIT_WORKSPACE`. That combination is a trusted managed-run envelope, so the nested `orbit task add` honors the live workspace selector instead of the test's temporary HOME/cwd and creates a real proposed task named `Managed identity` with description `Environment attribution`.

Confirmed leaked instances are ORB-11167, ORB-11168, ORB-11208, and ORB-11210. The Sep 5 pair came from repeated workspace test-suite invocations inside ORB-11187 / jrun-20260905-0111-3; the Sep 4 pair came from repeated suite invocations inside ORB-11166 / jrun-20260904-0133-3. The hard-coded test model `gpt-5.6-terra` makes the leaked records appear Terra-authored even when the parent worker is Opus.

## Why It Matters
Normal validation of Orbit changes mutates the authoritative production task store, consumes task IDs, creates misleading proposed work, and loses causal linkage because the leaked records have no job-run association. Re-running the suite repeats the mutation.

## Constraints / Notes
- Fix the integration-test subprocess environment; production managed workspace propagation is behaving as designed and must not be weakened.
- Follow the comprehensive environment-scrubbing pattern already used by `McpWorkspace::orbit_program_command` in `crates/orbit-cli/tests/mcp_roundtrip.rs`.
- The managed-identity assertion must continue proving that `ORBIT_AGENT_MODEL=gpt-5.6-terra` becomes `created_by`, using an explicit synthetic managed-run identity if managed context is required.
- Related prior isolation work: ORB-11085 / F2026-08-096 fixed the same ambient-registry class for the in-process workspace-init fixture, but did not cover this integration-test helper.

### Acceptance Criteria

- Running `task_add_attributes_from_model_flag_and_managed_identity_env` under a seeded ambient managed-run envelope does not create or update any task in the ambient registered workspace; the fixture task is stored only in the test's temporary workspace.
- The subprocess helpers explicitly clear inherited Orbit routing, run/task/activity/session, operator, and actor-context variables that are outside each test's intent, including `ORBIT_REGISTRY_ROOT`, `ORBIT_WORKSPACE`, and `ORBIT_RUN_ID`; the managed-identity case supplies only explicit synthetic values needed by the assertion.
- A deterministic regression test uses an isolated sentinel registry/workspace to prove ambient state remains byte-for-byte or record-for-record unchanged, without reading or writing the developer's real Orbit store.
- The managed-identity task still reports `created_by` as `gpt-5.6-terra`, and repeated executions do not escape the temporary fixture.
- `cargo test -p orbit-cli --test task_trimmed_surface`, `make ci-fast`, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Hardened every task_trimmed_surface subprocess helper by clearing inherited Orbit routing, run/task/activity/session, operator, identity, managed-context, registry, and workspace variables.
- Added a deterministic regression using two temporary workspaces: a seeded ambient sentinel registry remains record-for-record unchanged across repeated managed task additions, while fixture tasks retain created_by = gpt-5.6-terra.
- The managed helper now supplies only its explicit synthetic managed marker/run ID and requested agent identity.
Validation:
- cargo test -p orbit-cli --test task_trimmed_surface (12 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Assessment: Scoped test-only change; no production managed-workspace propagation behavior was altered. Removed the generated target/ build directory before handoff; the pre-existing ignored .orbit/config.yaml remains untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11211-6a9b7774`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*