### PR TITLE
[code-review] Dashboard scoreboard renders unavailable failure-incident metrics as a measured zero

### DIFF
--- a/crates/orbit-web/assets/dashboard/scoreboard.js
+++ b/crates/orbit-web/assets/dashboard/scoreboard.js
@@ -30,18 +30,23 @@ function fmtScoreboardCount(value) {
 }
 
 function formatScoreboardPair(agent, col) {
-  const left = asScoreboardNumber(
-    col.leftCompute ? col.leftCompute(agent) : readPath(agent, col.left),
-  );
-  const right = asScoreboardNumber(
-    col.rightCompute ? col.rightCompute(agent) : readPath(agent, col.right),
-  );
+  const rawLeft = col.leftCompute ? col.leftCompute(agent) : readPath(agent, col.left);
+  const rawRight = col.rightCompute ? col.rightCompute(agent) : readPath(agent, col.right);
+  // ORB-11201: `null` means the source read failed for this window, distinct
+  // from a genuinely observed zero. Coercing it away here would reintroduce
+  // exactly the confusion that fix eliminated in the API payload.
+  const unavailable = rawLeft === null || rawRight === null;
+  const left = asScoreboardNumber(rawLeft);
+  const right = asScoreboardNumber(rawRight);
   return {
     left,
     right,
-    text: `${fmtScoreboardCount(left)}/${fmtScoreboardCount(right)}`,
-    zero: left === 0 && right === 0,
-    title: `${col.title}: ${left} / ${right}`,
+    unavailable,
+    text: unavailable ? "unavailable" : `${fmtScoreboardCount(left)}/${fmtScoreboardCount(right)}`,
+    zero: !unavailable && left === 0 && right === 0,
+    title: unavailable
+      ? `${col.title}: unavailable (source failed for this window; not a measured zero)`
+      : `${col.title}: ${left} / ${right}`,
   };
 }
 
@@ -122,6 +127,10 @@ const OPERATIONS_SCOREBOARD_COLUMNS = [
     tone: "warn",
     title: "grouped failure incidents / raw failed events they collapsed",
     help: "grouped",
+    // ORB-11207: names the `coverage.failure_incidents` note so an
+    // unavailable source keeps this row visible instead of reading as a
+    // filtered-out measured zero.
+    coverageKey: "failure_incidents",
   },
   {
     key: "friction.reported",
@@ -543,7 +552,7 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
   for (const section of sectionList) {
     const metrics = section.columns
       .filter((candidate) => candidate.key !== "agent")
-      .filter((candidate) => metricHasActivity(rows, candidate));
+      .filter((candidate) => metricHasActivity(rows, candidate, opts.coverage));
     if (showSectionDividers) {
       const badge = metrics.length === 0
         ? emptySectionBadge(section.title, opts.coverage)
@@ -589,7 +598,13 @@ function buildLeaderboardMatrix(rows, sectionList, opts = {}) {
   return table;
 }
 
-function metricHasActivity(rows, col) {
+function metricHasActivity(rows, col, coverage) {
+  // ORB-11207: an unavailable source is not the same as an observed zero —
+  // keep the row visible so the operator sees the missing-coverage marker
+  // instead of the row silently disappearing from the table.
+  if (col.coverageKey && coverage?.[col.coverageKey]?.availability === "unavailable") {
+    return true;
+  }
   return rows.some(([, agent]) => scoreboardCellActivity(agent, col) > 0);
 }
 
@@ -652,7 +667,7 @@ function scoreboardCellNode(name, value, rowMax, isLeader, opts = {}) {
   }, [
     el("span", { class: "track" }, [fill]),
     el("span", { class: valueClass }, opts.pair
-      ? pairTextNodes(opts.pair.left, opts.pair.right, opts.pair.zero, isLeader)
+      ? pairTextNodes(opts.pair, isLeader)
       : [
           document.createTextNode(num === 0 ? "—" : fmtScoreboardCount(num)),
           ...(isLeader ? [leaderBadge()] : []),
@@ -679,7 +694,13 @@ function emptySectionBadge(title, coverage) {
     return "no observed review comments in this source";
   }
   if (title === "Delivery") return "no observed task events this window";
-  if (title === "Operations") return "no observed tool calls or friction this window";
+  if (title === "Operations") {
+    if (coverage?.failure_incidents?.availability === "unavailable") {
+      return coverage.failure_incidents.detail
+        || "failure-incident coverage is unavailable for this window; this is missing coverage, not zero activity";
+    }
+    return "no observed tool calls or friction this window";
+  }
   return "no observed events this window";
 }
 
@@ -737,12 +758,19 @@ function emptyScoreboardNode() {
   return el("span", { class: "em", text: "—" });
 }
 
-function pairTextNodes(left, right, zero, isLeader) {
-  if (zero) return [emptyScoreboardNode()];
+function pairTextNodes(pair, isLeader) {
+  if (pair.unavailable) {
+    return [el("span", {
+      class: "em unavailable",
+      text: "unavailable",
+      title: "source unavailable for this window; not a measured zero",
+    })];
+  }
+  if (pair.zero) return [emptyScoreboardNode()];
   return [
-    left === 0 ? emptyScoreboardNode() : el("span", { class: "sb-value", text: fmtScoreboardCount(left) }),
+    pair.left === 0 ? emptyScoreboardNode() : el("span", { class: "sb-value", text: fmtScoreboardCount(pair.left) }),
     el("span", { class: "pair", text: "/" }),
-    right === 0 ? emptyScoreboardNode() : el("span", { class: "sb-pair-right", text: fmtScoreboardCount(right) }),
+    pair.right === 0 ? emptyScoreboardNode() : el("span", { class: "sb-pair-right", text: fmtScoreboardCount(pair.right) }),
     ...(isLeader ? [leaderBadge()] : []),
   ];
 }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -251,7 +251,7 @@ fn dashboard_shipped_javascript_observes_history_routes_and_aggregate_requests()
         r#"
 const nodes = [];
 class Node {
-  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.hidden = false; nodes.push(this); }
+  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = { setProperty: () => {} }; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.hidden = false; nodes.push(this); }
   appendChild(child) { if (child == null) return child; this.children.push(child); child.parentNode = this; return child; }
   insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); child.parentNode = this; return child; }
   removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
@@ -1647,6 +1647,11 @@ fn dashboard_scoreboard_highlights_are_accessible_and_honest() {
         "empty Review must distinguish no events from incomplete coverage"
     );
     assert!(
+        scoreboard.contains("coverage?.failure_incidents?.availability === \"unavailable\"")
+            && scoreboard.contains("failure-incident coverage is unavailable for this window"),
+        "empty Operations must distinguish no events from incomplete failure-incident coverage"
+    );
+    assert!(
         scoreboard.contains("orbit.task.* tool-call count")
             && scoreboard.contains("raw failed tool calls over total tool calls")
             && scoreboard.contains("append-only friction reports filed by this agent")
@@ -1680,6 +1685,111 @@ fn dashboard_scoreboard_highlights_are_accessible_and_honest() {
             "scoreboard assets must stay project-agnostic; found {banned}"
         );
     }
+}
+
+/// ORB-11207: ORB-11201 made `/api/scoreboard` emit `null` (not `0`) for
+/// `failure_incidents`/`failure_incident_events` when the underlying audit
+/// query fails, plus a `coverage.failure_incidents` note. The dashboard used
+/// to coerce that `null` to `0`, rendering it as an indistinguishable `0/0`
+/// and letting the activity filter drop the row and the section badge claim
+/// observed-zero activity — reproducing exactly the confusion ORB-11201
+/// fixed. Exercised with the executable Node harness in the ORB-11196 style
+/// since the dashboard has no JS test runner.
+#[test]
+fn dashboard_scoreboard_renders_unavailable_failure_incidents_not_a_measured_zero() {
+    run_dashboard_javascript_test(
+        r#"
+const nodes = [];
+class Node {
+  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = { setProperty: () => {} }; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.hidden = false; nodes.push(this); }
+  appendChild(child) { if (child == null) return child; this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  prepend(child) { this.children.unshift(child); child.parentNode = this; }
+  remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter((child) => child !== this); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this.textContent = value; }
+  get innerHTML() { return this.textContent; }
+  get firstChild() { return this.children[0] || null; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+  get classList() { const self = this; return { add: (...c) => { self.className = `${self.className} ${c.join(" ")}`.trim(); }, remove: () => {}, toggle: (c, on) => { if (on) this.addClass(c); } }; }
+  addClass(c) { if (!this.className.split(/\\s+/).includes(c)) this.className = `${this.className} ${c}`.trim(); }
+  querySelectorAll() { return []; }
+  querySelector() { return null; }
+  contains(node) { return this === node || this.children.includes(node); }
+  focus() {}
+  closest() { return null; }
+}
+globalThis.Node = Node;
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+globalThis.document = {
+  body: new Node("body"), hidden: false,
+  getElementById: get, createElement: () => new Node(), createElementNS: () => new Node(), createTextNode: (text) => Object.assign(new Node(), { textContent: text }), createDocumentFragment: () => new Node(),
+  querySelectorAll: () => [], querySelector: () => new Node(), addEventListener: () => {},
+};
+const location = new URL("http://dashboard.test/");
+globalThis.window = { location, innerHeight: 900, addEventListener: () => {}, matchMedia: () => ({ addEventListener: () => {}, matches: false }), localStorage: { getItem: () => null, setItem: () => {} } };
+globalThis.history = { replaceState: (_, __, url) => { location.href = String(url); } };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.requestAnimationFrame = (fn) => fn();
+globalThis.setInterval = () => 0;
+globalThis.EventSource = class { constructor() {} close() {} };
+
+const { renderScoreboard } = await import("./scoreboard.js");
+
+// A quiet agent whose failure-incident fields are `null`: the audit query
+// failed for this window, so the source is unavailable, not a measured zero.
+function quietAgentWithUnavailableFailureIncidents() {
+  return {
+    tasks_created: 0, tasks_planned: 0, tasks_completed: 0,
+    tool_calls_by_surface: { graph: 0, task: 0 },
+    tool_calls: 0, failed_tool_calls: 0,
+    friction: { reported: 0 },
+    failure_incidents: null,
+    unexpected_failure_incidents: null,
+    failure_incident_events: null,
+  };
+}
+const summary = {
+  window: "24h",
+  agents: {
+    codex: quietAgentWithUnavailableFailureIncidents(),
+    claude: quietAgentWithUnavailableFailureIncidents(),
+    gemini: quietAgentWithUnavailableFailureIncidents(),
+    grok: quietAgentWithUnavailableFailureIncidents(),
+  },
+  coverage: {
+    failure_incidents: {
+      availability: "unavailable",
+      detail: "Audit failure-incident query failed for the requested window; failure_incidents, unexpected_failure_incidents, and failure_incident_events are omitted (null) rather than shown as zero.",
+    },
+  },
+};
+
+renderScoreboard(summary);
+
+const body = get("scoreboard-body");
+const table = body.children[0].children[0];
+if (!table || table.className !== "sb2-matrix") throw new Error("expected the scoreboard matrix table to render");
+const tbody = table.children[2];
+
+const failureRow = tbody.children.find((tr) => tr.dataset.key === "scoreboard-Operations-failure_incidents");
+if (!failureRow) throw new Error("the failure_incidents row must not be hidden by the activity filter when its source is unavailable");
+const rowText = failureRow.textContent;
+if (!rowText.includes("unavailable")) throw new Error(`expected an explicit unavailable indicator, got: ${rowText}`);
+if (rowText.includes("0/0")) throw new Error(`must not render an unavailable source as a measured 0/0, got: ${rowText}`);
+
+const operationsDivider = tbody.children.find((tr) => tr.className === "group" && tr.textContent.includes("Operations"));
+if (!operationsDivider) throw new Error("the Operations section divider must be present");
+if (operationsDivider.textContent.includes("no observed tool calls or friction this window")) {
+  throw new Error("the Operations badge must not assert observed-zero activity when failure-incident coverage is unavailable");
+}
+"#,
+    );
 }
 
 async fn response_body(response: Response) -> String {


### PR DESCRIPTION
## Task

[ORB-11207](https://orbit-cli.com/tasks/ORB-11207) — [code-review] Dashboard scoreboard renders unavailable failure-incident metrics as a measured zero

### Description

ORB-11201 (78c3362a) made `/api/scoreboard` emit `null` per-agent side metrics plus an explicit `coverage` note when a side source fails, so a read failure is no longer indistinguishable from an observed zero. The dashboard — the only consumer of those fields — still coerces `null` to `0` and never reads the new coverage notes, so the operator-facing surface reproduces exactly the confusion the fix targeted.

## Evidence

- `crates/orbit-web/src/api/scoreboard.rs:96-111` — when `audit_failure_incidents` fails, `failure_rollup` becomes `None`.
- `crates/orbit-web/src/api/scoreboard.rs:239-250` — `failure_incidents`, `unexpected_failure_incidents` and `failure_incident_events` are then written as `Value::Null`.
- `crates/orbit-web/src/api/scoreboard.rs:130-137` — a `coverage.failure_incidents` note with `availability: "unavailable"` is inserted alongside it (likewise `coverage.metrics_extras` at `:114-121` and `coverage.denials` at `:122-129`).
- `crates/orbit-web/assets/dashboard/scoreboard.js:23-25` — `asScoreboardNumber` returns `0` for anything that is not a finite number, so `null` becomes `0`.
- `crates/orbit-web/assets/dashboard/scoreboard.js:32-45` — the `fail inc/events` column is `format: "pair"` over `failure_incidents` / `failure_incident_events` (declared at `:115-127`), so an unavailable source renders as the literal text `0/0`.
- `crates/orbit-web/assets/dashboard/scoreboard.js:592-601` — `metricHasActivity` sums the coerced pair, so with every agent at `0/0` the `fail inc/events` row is filtered out of the table entirely.
- `crates/orbit-web/assets/dashboard/scoreboard.js:673-684` — `emptySectionBadge` consults only `coverage.review`. For the Operations section it returns the hardcoded `"no observed tool calls or friction this window"`, asserting observed absence even when the source is `unavailable`. Grepping `coverage.` across `crates/orbit-web/assets/dashboard/*.js` shows `coverage.review` is the only note ever read.

## Impact

A failing audit-failure-incident query makes the dashboard silently drop the grouped-failure row and label the section as observed-zero activity. An operator reading the dashboard concludes nothing went wrong, which is the precise misreading ORB-11201 set out to eliminate; the corrected signal exists in the JSON but reaches no user.

Only `failure_incidents` / `failure_incident_events` are currently rendered on the scoreboard grid — `denials`, `retries`, `avg_step_duration_ms` and `p95_wall_clock_ms` have no scoreboard column today — so the visible defect is scoped to the failure-incident pair, but `asScoreboardNumber` will do the same to any of the others the moment a column is added.

## Suggested direction

Teach the scoreboard renderer to distinguish `null` from `0`: render an explicit unavailable marker for a null-valued metric rather than `0`, keep the row visible when its source is unavailable, and have `emptySectionBadge` consult `coverage.failure_incidents` / `coverage.metrics_extras` / `coverage.denials` the way it already consults `coverage.review`.

### Acceptance Criteria

- When `/api/scoreboard` returns `null` for `failure_incidents`/`failure_incident_events`, the dashboard renders an explicit unavailable indicator rather than `0/0`, and the metric row is not hidden by the activity filter.
- The Operations section badge reports missing coverage (sourced from the `coverage.failure_incidents` note) instead of asserting `no observed tool calls or friction this window` when that source is unavailable.
- A test in `crates/orbit-web/src/tests/dashboard_assets.rs` exercises the null-valued payload and asserts the unavailable rendering, matching the executable-test style adopted in ORB-11196.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the null→0 coercion in the scoreboard dashboard identified by ORB-11201's follow-up review.

crates/orbit-web/assets/dashboard/scoreboard.js:
- `formatScoreboardPair` now detects `null` in the raw left/right source values (before numeric coercion) and marks the pair `unavailable`, rendering the literal text "unavailable" instead of "0/0" for that cell (with a title explaining the source failed for the window).
- Added `coverageKey: "failure_incidents"` to the `failure_incidents` column definition and threaded `opts.coverage` through `buildLeaderboardMatrix` into `metricHasActivity(rows, col, coverage)`, which now returns true immediately when the named coverage note reports `availability: "unavailable"` — so the row is never dropped by the activity filter just because every agent's null-derived value coerces to a summed zero.
- `emptySectionBadge("Operations", coverage)` now checks `coverage?.failure_incidents?.availability === "unavailable"` (mirroring the existing `coverage.review` pattern) and returns the coverage `detail` text instead of the hardcoded "no observed tool calls or friction this window" claim, for the case where the whole section would otherwise report false observed-zero activity.
- `pairTextNodes` takes the pair object directly and renders the unavailable marker before falling through to the existing zero/value rendering.

crates/orbit-web/src/tests/dashboard_assets.rs:
- Extended `dashboard_scoreboard_highlights_are_accessible_and_honest` with a static-source assertion pinning the new `coverage?.failure_incidents?.availability === "unavailable"` branch and its detail text.
- Added `dashboard_scoreboard_renders_unavailable_failure_incidents_not_a_measured_zero`, a new executable Node-harness test (same style/shim as the ORB-11196 `dashboard_shipped_javascript_observes_history_routes_and_aggregate_requests` test) that imports the real `scoreboard.js` module, renders a payload with `failure_incidents`/`failure_incident_events` set to `null` for all four canonical agents plus a `coverage.failure_incidents: { availability: "unavailable" }` note, and asserts: the `failure_incidents` row is present (not filtered out), its cell text contains "unavailable" and never "0/0", and the Operations section divider never contains the old hardcoded "no observed tool calls or friction this window" text.

Verified the new test actually catches the regression: temporarily reverted scoreboard.js to the pre-fix HEAD version and re-ran the new test — it failed with "the failure_incidents row must not be hidden by the activity filter when its source is unavailable", confirming it exercises the real bug. Restored the fix afterward.

Validation: `cargo test -p orbit-web --lib dashboard_assets::` (39/39 pass), `make ci-fast` (fmt-check + guardrail scripts, pass), `make ci-lint` (workspace clippy, all targets, warnings denied, pass — clean, no allowed-EPERM skips needed).

Scope: touched only the two context_files named on the task (scoreboard.js, dashboard_assets.rs); no other files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11207-6a9b7774`
- Behind base: 0
- Ahead of base: 1