### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/.orbit/routines/task_pilot.yaml
+++ b/.orbit/routines/task_pilot.yaml
@@ -22,7 +22,7 @@ enabled: true
 hosts:
   - dk-server-1
 trigger:
-  cron: "*/30 * * * *"
+  cron: "*/40 * * * *"
   missed_run: skip
 target: job:task_pilot_pipeline
 policy:


### PR DESCRIPTION
## Task

[ORB-11213](https://orbit-cli.com/tasks/ORB-11213) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `6708fadc8cd04986f517844801b1035306f1911b`
- Normalized error signature (the dedupe identity, not a quote): `failures:`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-05T02:03:13.394439074+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/33937245572 run `33937245572` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `6708fadc8cd04986f517844801b1035306f1911b`
  - current head of that ref: `unknown`
  - commit actually checked out: `6708fadc8cd04986f517844801b1035306f1911b`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `6708fadc8cd04986f517844801b1035306f1911b`
  - failed job `Check / Clippy / Test` (id `101227449178`): https://github.com/danieljhkim/orbit/actions/runs/33937245572/job/101227449178
  - failing step(s): `Run CI guardrails`
  - failed job `Coverage (informational)` (id `101227449360`): https://github.com/danieljhkim/orbit/actions/runs/33937245572/job/101227449360
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6322202Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6322524Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6322530Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6322611Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6323019Z     application::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6323410Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6323947Z test result: FAILED. 898 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 88.04s
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6324340Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6324771Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-core --lib`
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6346247Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-05T01:55:56.6362016Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33937177296 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33937120924 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33936254522 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33935285923 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33832409613 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33832207518 — superseded_by_newer_workflow_run: newer repository-wide run 33937245572 at 2026-09-05T01:48:18Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `.orbit/routines/task_pilot.yaml` trigger cadence from `*/30 * * * *` to the seeded default `*/40 * * * *`, fixing the dogfood/template drift. No workflow, assertion, lint level, or blocking behavior was weakened.
Validation:
- Reproduced the reported failure before the edit with `cargo test -p orbit-core --lib application::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template -- --exact` (1 failed), then reran the same command successfully (1 passed).
- `make ci-fast` passed.
- `make ci-lint` passed.
- The runner-equivalent workspace command `cargo test --tests --manifest-path "$PWD/Cargo.toml" --target-dir target/llvm-cov-target --workspace --locked` was also exercised. Its first local attempt was blocked by inherited `ORBIT_REGISTRY_ROOT`/`ORBIT_RUN_ID` test-environment state; after removing those inherited variables, the repository-owned tests passed through the CLI suite, but two unrelated GitHub capability preflight tests failed because the managed activity policy denied `github.auth.status`. The reported routine test passed, and the documented pre-handoff gates passed.
- Build artifacts created by validation were removed with `cargo clean`; final `git status --short` contains only the intended `.orbit/routines/task_pilot.yaml` change.
Assessment: Minimal repository-owned fix aligned the workspace dogfood routine with its canonical seeded template.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11213-6a9b786a`
- Behind base: 0
- Ahead of base: 1