### PR TITLE
[code-review] Epic PR-mode `--complete` fails on an empty-delivery epic because `pr_complete` demands the `no-diff-expected` tag

### DIFF
--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -220,13 +220,18 @@ spec:
 
     - id: complete_pr_no_diff
       when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ input.completion }} == done && {{ steps.commit_delivery.output.skipped_no_diff_expected }} == true"
-      target: activity:pr_complete
+      # `pr_complete`'s no_diff_expected branch asserts the no-diff-expected tag
+      # on every task, which is correct for task_pr_pipeline (where the tag is
+      # what implied skipped_no_diff_expected in the first place) but wrong
+      # here: `commit_delivery` above sets allow_empty: true unconditionally,
+      # so an ordinary untagged epic root can land this branch too. `promote_pr_no_diff`
+      # already routes around pr_promote's equivalent guard for the same
+      # reason; task_complete is the tag-agnostic status-only transition that
+      # matches it.
+      target: activity:task_complete
       default_input:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
-        completed_task_ids:
-          - "{{ input.epic_task_id }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        no_diff_expected: true
+        task_id: "{{ input.epic_task_id }}"
 
     - id: merge
       when: "{{ steps.resolve_ship_input.output.mode }} == local"

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -220,13 +220,18 @@ spec:
 
     - id: complete_pr_no_diff
       when: "{{ steps.resolve_ship_input.output.mode }} == pr && {{ input.completion }} == done && {{ steps.commit_delivery.output.skipped_no_diff_expected }} == true"
-      target: activity:pr_complete
+      # `pr_complete`'s no_diff_expected branch asserts the no-diff-expected tag
+      # on every task, which is correct for task_pr_pipeline (where the tag is
+      # what implied skipped_no_diff_expected in the first place) but wrong
+      # here: `commit_delivery` above sets allow_empty: true unconditionally,
+      # so an ordinary untagged epic root can land this branch too. `promote_pr_no_diff`
+      # already routes around pr_promote's equivalent guard for the same
+      # reason; task_complete is the tag-agnostic status-only transition that
+      # matches it.
+      target: activity:task_complete
       default_input:
         job_run_id: "{{ steps.worktree.output.job_run_id }}"
-        completed_task_ids:
-          - "{{ input.epic_task_id }}"
-        workspace_path: "{{ steps.worktree.output.workspace_path }}"
-        no_diff_expected: true
+        task_id: "{{ input.epic_task_id }}"
 
     - id: merge
       when: "{{ steps.resolve_ship_input.output.mode }} == local"

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -2084,25 +2084,25 @@ fn pr_pipelines_complete_only_when_authorized_and_handle_no_diff_without_a_pr() 
         let asset =
             load_job_asset(yaml).unwrap_or_else(|error| panic!("parse {job_name}: {error}"));
 
-        let (complete_id, no_diff_id) = if job_name == "task_pr_pipeline" {
-            ("complete_pr", "complete_no_diff")
+        let no_diff_id = if job_name == "task_pr_pipeline" {
+            "complete_no_diff"
         } else {
-            ("complete_pr", "complete_pr_no_diff")
+            "complete_pr_no_diff"
         };
 
         let complete = asset
             .spec
             .steps
             .iter()
-            .find(|step| step.id == complete_id)
-            .unwrap_or_else(|| panic!("{job_name} has a {complete_id} step"));
+            .find(|step| step.id == "complete_pr")
+            .unwrap_or_else(|| panic!("{job_name} has a complete_pr step"));
         let when = complete.when.as_deref().unwrap_or_default();
         assert!(
             when.contains("{{ input.completion }} == done"),
             "{job_name} completion must be gated on the authorization: {when}"
         );
         let JobV2StepBody::TargetRef(complete) = &complete.body else {
-            panic!("{job_name} {complete_id} must reference pr_complete");
+            panic!("{job_name} complete_pr must reference pr_complete");
         };
         assert_eq!(complete.target, "activity:pr_complete");
 
@@ -2112,14 +2112,48 @@ fn pr_pipelines_complete_only_when_authorized_and_handle_no_diff_without_a_pr() 
             .iter()
             .find(|step| step.id == no_diff_id)
             .unwrap_or_else(|| panic!("{job_name} has a {no_diff_id} step"));
-        let JobV2StepBody::TargetRef(no_diff) = &no_diff.body else {
-            panic!("{job_name} {no_diff_id} must reference pr_complete");
-        };
-        let input = no_diff.default_input.as_ref().expect("no-diff input");
-        assert_eq!(input["no_diff_expected"], true);
+        let when = no_diff.when.as_deref().unwrap_or_default();
         assert!(
-            input.get("pr_number").is_none(),
-            "{job_name} no-diff completion must not require a nonexistent PR"
+            when.contains("{{ input.completion }} == done"),
+            "{job_name} no-diff completion must be gated on the authorization: {when}"
         );
+
+        // task_pr_pipeline's `skipped_no_diff_expected` is tag-derived (its
+        // `commit` step passes no `allow_empty`), so its no-diff completion
+        // still asserts the tag through `pr_complete`, exactly like
+        // `pr_promote`'s equivalent guard. epic_pipeline's `commit_delivery`
+        // passes `allow_empty: true` unconditionally, so the same signal does
+        // NOT imply the tag there; it must route through the tag-agnostic
+        // `task_complete` instead, matching `promote_pr_no_diff` routing
+        // around `pr_promote`'s guard on the same branch.
+        if job_name == "task_pr_pipeline" {
+            let JobV2StepBody::TargetRef(no_diff) = &no_diff.body else {
+                panic!("{job_name} {no_diff_id} must reference pr_complete");
+            };
+            assert_eq!(no_diff.target, "activity:pr_complete");
+            let input = no_diff.default_input.as_ref().expect("no-diff input");
+            assert_eq!(input["no_diff_expected"], true);
+            assert!(
+                input.get("pr_number").is_none(),
+                "{job_name} no-diff completion must not require a nonexistent PR"
+            );
+        } else {
+            let JobV2StepBody::TargetRef(no_diff) = &no_diff.body else {
+                panic!("{job_name} {no_diff_id} must reference task_complete");
+            };
+            assert_eq!(
+                no_diff.target, "activity:task_complete",
+                "epic no-diff completion must not carry pr_complete's tag guard"
+            );
+            let input = no_diff.default_input.as_ref().expect("no-diff input");
+            assert!(
+                input.get("no_diff_expected").is_none(),
+                "task_complete has no tag guard to gate"
+            );
+            assert!(
+                input.get("pr_number").is_none(),
+                "{job_name} no-diff completion must not require a nonexistent PR"
+            );
+        }
     }
 }

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -6,12 +6,12 @@ use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
 use orbit_engine::{
-    DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost, V2AuditWriter,
+    DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost, TaskActivityUpdate, V2AuditWriter,
     execute_job_with_resume, resolve_job_catalog_refs_for_execution,
 };
 use orbit_store::{InvocationQuery, TaskReservationReleaseReason, V2AuditEventFilter};
 use orbit_tools::{FsAuditLogger, ToolContext};
-use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
     ActivityV2Spec, ExecutorDef, ExecutorType, JobRunState, JobV2Step, JobV2StepBody,
@@ -913,6 +913,21 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
             proc_allowed_programs,
         )
     }
+
+    // `task_complete` runs as the real production activity (it is never
+    // retargeted to a scripted action), so it needs a real task to read and
+    // mutate rather than a scripted echo.
+    fn get_task(&self, task_id: &str) -> Result<Task, orbit_common::OrbitError> {
+        self.runtime.get_task(task_id)
+    }
+
+    fn update_task_from_activity(
+        &self,
+        task_id: &str,
+        update: TaskActivityUpdate,
+    ) -> Result<Task, orbit_common::OrbitError> {
+        self.runtime.update_task_from_activity(task_id, update)
+    }
 }
 
 fn write_job(path: &Path, name: &str, action: &str) {
@@ -1386,6 +1401,54 @@ fn epic_pipeline_no_diff_skips_empty_pr_and_promotes_the_root() {
     assert_eq!(updates.len(), 1);
     assert_eq!(updates[0]["task_id"], "ORB-EPIC");
     assert_eq!(updates[0]["status"], "review");
+}
+
+/// [ORB-11214] `commit_delivery` sets `allow_empty: true` unconditionally, so
+/// an ordinary untagged epic root can report `skipped_no_diff_expected: true`
+/// with no `no-diff-expected` tag involved at all — unlike task_pr_pipeline,
+/// where the same signal is tag-derived. A `--complete` run must still finish
+/// this epic root, not fail on a tag guard the operator never asked for. This
+/// drives `complete_pr_no_diff`'s real activity (never scripted) against a
+/// real, untagged task to prove the completion itself succeeds, not just that
+/// the pipeline steps are shaped correctly.
+#[test]
+fn epic_pipeline_completes_an_untagged_no_diff_root_when_authorized() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    stub_epic_finisher(&global_root);
+    let epic_task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::Review);
+    assert!(
+        runtime
+            .get_task(&epic_task_id)
+            .expect("seeded epic root")
+            .tags
+            .is_empty(),
+        "the epic root under test must not carry the no-diff-expected tag"
+    );
+    let host = ScriptedEpicHost::new(&runtime, Vec::new()).no_diff();
+
+    let outcome = try_execute_full_epic_job(
+        &runtime,
+        &repo_root,
+        &host,
+        json!({ "epic_task_id": epic_task_id, "completion": "done" }),
+        "jrun-scripted-epic-no-diff-complete",
+    )
+    .expect(
+        "an untagged no-diff epic root must complete under authorization, not demand the \
+         no-diff-expected tag pr_complete requires",
+    );
+
+    assert!(outcome.success);
+    assert!(host.inputs_for("pr_open").is_empty());
+    assert!(host.inputs_for("git_push").is_empty());
+    assert_eq!(
+        runtime
+            .get_task(&epic_task_id)
+            .expect("completed epic root")
+            .status,
+        TaskStatus::Done
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11214](https://orbit-cli.com/tasks/ORB-11214) — [code-review] Epic PR-mode `--complete` fails on an empty-delivery epic because `pr_complete` demands the `no-diff-expected` tag

### Description

ORB-11187 (412a12ca) added `complete_pr_no_diff` to `epic_pipeline`, routing the epic root's no-diff branch through the `pr_complete` activity. That activity applies a tag guard the epic pipeline deliberately avoids on the exact same branch, so a completion-authorized PR-mode epic whose delivery commit is legitimately empty fails the run instead of completing.

## The path

`epic_pipeline` reaches the no-diff branch through `commit_delivery`, which is configured with `allow_empty: true`:

- `crates/orbit-core/assets/jobs/epic_pipeline.yaml:119-129` — `commit_delivery` passes `allow_empty: true` (and `allow_moved_head: true`).
- `crates/orbit-engine/src/executor/automation/vcs/commit/mod.rs:206` reads the tag into `no_diff_expected`, and `:254-256` returns `skipped_no_diff_expected_result(...)` when `no_diff_expected || allow_empty` and nothing staged. `skipped_no_diff_expected_result` sets `"skipped_no_diff_expected": true` (`:369-377`).

So in `epic_pipeline`, unlike `task_pr_pipeline` (whose `commit` step passes no `allow_empty`), `skipped_no_diff_expected: true` does **not** imply the task carries the `no-diff-expected` tag — `allow_empty: true` alone produces it for an ordinary, untagged epic root.

The pre-existing no-diff promotion step accounts for that. It bypasses `pr_promote` and calls plain `update_task`:

- `crates/orbit-core/assets/jobs/epic_pipeline.yaml:204-209` — `promote_pr_no_diff`, `target: activity:update_task`, `status: review`.
- Contrast `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml:157-165`, where the equivalent `promote_no_diff` step *does* use `pr_promote`, because there the tag is implied.
- `pr_promote`'s guard is at `crates/orbit-engine/src/executor/automation/vcs/pr/promote.rs:20-35`: `no_diff_expected` requires every task to carry `NO_DIFF_EXPECTED_TAG`.

The new step re-introduces exactly that guard on the branch the pipeline had routed around:

- `crates/orbit-core/assets/jobs/epic_pipeline.yaml:221-229` — `complete_pr_no_diff`, `target: activity:pr_complete`, `no_diff_expected: true`.
- `crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs:51-57` — reads `no_diff_expected` from input and calls `ensure_all_tasks_no_diff_expected(&context.tasks)?`.
- `crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs:257-267` — errors with `"pr_complete: no_diff_expected requires every task to carry the no-diff-expected tag"` when any task lacks it.

`context.tasks` here is the single epic root (`completed_task_ids: ["{{ input.epic_task_id }}"]`). Nothing in the epic flow tags an epic root `no-diff-expected`.

## Failure scenario

`orbit run auto --complete` in a `pr`-mode workspace admits an epic whose children all landed via their own child runs (`land_child` dispatches `task_local_pipeline` into separate worktrees, `epic_pipeline.yaml:60-78`) and whose own delivery worktree therefore has nothing staged and an unmoved HEAD. `commit_delivery` returns `skipped_no_diff_expected: true` via `allow_empty`. `promote_pr_no_diff` moves the untagged epic root to `review`. `complete_pr_no_diff` then fires and `pr_complete` rejects it. The epic run terminalizes `failed` with a message about a tag the operator never asked for, and the epic root is stranded at `review` — the exact outcome `--complete` was invoked to avoid, reported as an unrelated tagging error.

Without `--complete` the same run succeeds, so this is a defect introduced by the new step rather than a pre-existing condition.

## Coverage gap

`crates/orbit-core/src/application/job/tests/catalog.rs` (the ORB-11187 tests at `pr_pipelines_complete_only_when_authorized_and_handle_no_diff_without_a_pr`) asserts only the *structure* of the new steps — step presence, `when` gating, and `no_diff_expected: true` in the input. It does not execute `pr_complete` against an untagged epic root, so the guard mismatch is invisible to it. `crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs` covers `pr_complete`'s no-diff guard only with tasks that carry the tag.

## Suggested direction

Make the epic's completion branch match its promotion branch. Either give `pr_complete` a way to complete a no-diff bundle without the tag assertion when the pipeline already established the no-diff decision (the epic case), or route `complete_pr_no_diff` through the same `task_complete` activity the local pipeline uses (`crates/orbit-core/assets/jobs/task_local_pipeline.yaml:104-114`), which validates status only and has no tag requirement. The tag guard is correct for `task_pr_pipeline`, where `skipped_no_diff_expected` really is tag-derived; it is the epic pipeline's `allow_empty: true` that breaks the implication.

### Acceptance Criteria

- A PR-mode `epic_pipeline` run submitted with `completion: done`, whose `commit_delivery` reports `skipped_no_diff_expected: true` for an epic root that does NOT carry the `no-diff-expected` tag, completes the epic root to `done` instead of failing with `pr_complete: no_diff_expected requires every task to carry the no-diff-expected tag`.
- `task_pr_pipeline`'s `complete_no_diff` branch still rejects a bundle in which any task lacks the `no-diff-expected` tag, matching `pr_promote`'s existing guard.
- A test exercises the untagged-epic-root no-diff completion path end to end (not just the pipeline step structure), so the epic and PR pipelines' differing no-diff preconditions are pinned.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: epic_pipeline's `complete_pr_no_diff` step routed the no-diff completion branch through `pr_complete` with `no_diff_expected: true`, which asserts every task carries the `no-diff-expected` tag. But `commit_delivery` in epic_pipeline passes `allow_empty: true` unconditionally, so `skipped_no_diff_expected: true` is a routine outcome for any untagged epic root whose children already landed via their own child runs — unlike task_pr_pipeline, where the same signal really is tag-derived (no `allow_empty` on its `commit` step).

Fix: changed `complete_pr_no_diff` in epic_pipeline.yaml (both `crates/orbit-core/assets/jobs/epic_pipeline.yaml` and the tracked mirror `.orbit/resources/jobs/epic_pipeline.yaml`, kept byte-identical per the existing catalog test) to target `activity:task_complete` (job_run_id + task_id) instead of `activity:pr_complete`. This mirrors the pre-existing `promote_pr_no_diff` step, which already bypasses `pr_promote`'s equivalent tag guard on the same no-diff branch by calling `update_task` directly. `task_complete` performs the same guarded review->done transition without any tag assertion. task_pr_pipeline's `complete_no_diff` step is untouched and still uses `pr_complete` with the tag guard, since there the guard is correct.

Tests:
- Updated `crates/orbit-core/src/application/job/tests/catalog.rs::pr_pipelines_complete_only_when_authorized_and_handle_no_diff_without_a_pr` to assert task_pr_pipeline's no-diff completion still targets `pr_complete` with the tag guard, while epic_pipeline's targets `task_complete` with no tag guard.
- Added `crates/orbit-core/src/application/job/tests/exec.rs::epic_pipeline_completes_an_untagged_no_diff_root_when_authorized`: an end-to-end test that seeds a real, untagged task in `review`, runs the full `epic_pipeline` job with `completion: done` and a no-diff `commit_delivery`, and asserts the run succeeds and the real task reaches `done`. Extended `ScriptedEpicHost` with real `get_task`/`update_task_from_activity` forwarding to the underlying `OrbitRuntime` (task_complete is a real, never-scripted activity) so this test exercises production completion logic, not just pipeline step structure.

Validation: `cargo test -p orbit-core` (targeted: application::job::tests::exec::epic_pipeline*, application::job::tests::catalog::*) and `cargo test -p orbit-engine executor::automation::vcs::pr::tests::complete` all pass. `make ci-fast` and `make ci-lint` both pass clean.

No out-of-scope changes; no friction filed (straightforward fix, no contradicted assumptions or >10min gotchas).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11214-6a9b79d5`
- Behind base: 0
- Ahead of base: 1