### PR TITLE
Remove retired ADR authority from task-pilot instructions while preserving compatibility

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -81,15 +81,20 @@ spec:
        merely because inspection was inconclusive.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
-       `duplicate_of`, `already_landed`, `adr_conflicts`, `utility_warnings`,
-       and `surface_warnings`. Cite evidence for duplicates/already-landed work
-       and ADR conflicts. Do not choose an architecture alternative silently.
+       `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
+       name kept for consumer compatibility — populate it only with concrete
+       current-code or current-contract conflicts and their evidence; a
+       historical ADR is not by itself a reason to block or reshape work),
+       `utility_warnings`, and `surface_warnings`. Cite evidence for
+       duplicates, already-landed work, and any reported conflicts. Do not
+       choose an architecture alternative silently.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,
       invoke a pipeline, edit/delete files, commit, push, or open a PR.
     - Never inspect or report on task IDs outside the input partition except
-      when citing a concrete dependency, duplicate, or accepted ADR.
+      when citing a concrete dependency, duplicate, or recorded decision in
+      current maintained docs.
     - Preserve provider provenance: task-pilot is a role, not an actor family.
 
     Return exactly one Orbit response envelope:

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -81,15 +81,20 @@ spec:
        merely because inspection was inconclusive.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
-       `duplicate_of`, `already_landed`, `adr_conflicts`, `utility_warnings`,
-       and `surface_warnings`. Cite evidence for duplicates/already-landed work
-       and ADR conflicts. Do not choose an architecture alternative silently.
+       `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
+       name kept for consumer compatibility — populate it only with concrete
+       current-code or current-contract conflicts and their evidence; a
+       historical ADR is not by itself a reason to block or reshape work),
+       `utility_warnings`, and `surface_warnings`. Cite evidence for
+       duplicates, already-landed work, and any reported conflicts. Do not
+       choose an architecture alternative silently.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,
       invoke a pipeline, edit/delete files, commit, push, or open a PR.
     - Never inspect or report on task IDs outside the input partition except
-      when citing a concrete dependency, duplicate, or accepted ADR.
+      when citing a concrete dependency, duplicate, or recorded decision in
+      current maintained docs.
     - Preserve provider provenance: task-pilot is a role, not an actor family.
 
     Return exactly one Orbit response envelope:

--- a/plugin/agents/orbit-task-pilot.md
+++ b/plugin/agents/orbit-task-pilot.md
@@ -28,7 +28,10 @@ For each task:
    inconclusive.
 5. Report recommendations for crew, complexity, real blockers, duplicates,
    already-landed work, utility, and public surface — without applying them, and
-   without silently picking an architecture alternative.
+   without silently picking an architecture alternative. The `adr_conflicts`
+   field is a legacy output name kept for consumer compatibility, not an
+   authority: populate it only with concrete current-code or current-contract
+   conflicts and their evidence, never a historical decision by itself.
 
 ## Hard bounds
 
@@ -55,7 +58,8 @@ assessment per supplied ID, and a short summary. Each assessment carries:
 - `disposition`, plus `evidence` when the proposal is empty
 - `recommended_crew` and `recommended_complexity`
 - `blocked_by`, `duplicate_of`, `already_landed`
-- `adr_conflicts`, `utility_warnings`, `surface_warnings`
+- `adr_conflicts` (legacy compatibility spelling; see above), `utility_warnings`,
+  `surface_warnings`
 
 Fail the whole partition if any supplied task cannot be assessed. Never omit a
 task, and never summarize a failed partition as successful.


### PR DESCRIPTION
## Task

[ORB-11224](https://orbit-cli.com/tasks/ORB-11224) — Remove retired ADR authority from task-pilot instructions while preserving compatibility

### Description

## Operational finding
During the two-host preparation, deployed Mac task_pilot guidance directs agents to accepted ADRs. Linux source crates/orbit-core/assets/activities/task_pilot.yaml still asks for ADR conflict evidence and permits expanding a partition to an accepted ADR (around lines 84-92); plugin/agents/orbit-task-pilot.md has newer prose but retains the compatibility field adr_conflicts. Current root/repo instructions explicitly retire ADRs as an authority source.

## Outcome
Align shipped activity and plugin pilot instructions with current engineering evaluation: current code, observed runtime/tests, explicit requirements, and maintained explanatory docs. Historical ADRs must not force an architecture choice or block useful work. Preserve actual dependency/duplicate detection and report concrete current-contract conflicts with evidence. Audit the active shared pilot templates and related current guidance for this same instruction, not the historic ADR corpus.

Keep adr_conflicts as a legacy output field if runtime consumers/persisted formats require it, clearly separating compatibility spelling from authority; do not create a schema migration just to rename it. Validate how managed-asset sync updates unmodified installs and preserves custom overrides; do not overwrite live custom jobs in this task. This is a proposed repair; pilot before backlog. Sonnet fits medium instruction/asset integration.

### Acceptance Criteria

- No shipped pilot prompt tells an agent to search, cite, or enforce historical ADR authority; it directs judgments to current evidence and explicit constraints.
- Activity and plugin-agent boundaries remain read-only and partition-scoped, allowing only concrete current dependencies/duplicates or necessary supporting evidence.
- Existing structured-output consumers continue accepting results; any retained legacy adr_conflicts spelling is documented as compatibility and not a reason to enforce retired decisions.
- Validate shipped/mirrored assets and representative pilot output fixtures without broad prose-substring tests; required repo checks pass and managed-asset deployment behavior is documented.

## Execution Summary

<details>
<summary>Click to expand</summary>

Removed retired-ADR authority language from both shipped task-pilot prompts. In crates/orbit-core/assets/activities/task_pilot.yaml: the hard-bounds partition-expansion exception now cites 'a concrete dependency, duplicate, or recorded decision in current maintained docs' instead of 'accepted ADR', and the adr_conflicts field is annotated inline as a legacy output name kept for consumer compatibility, to be populated only with concrete current-code/current-contract conflicts (never historical ADR authority). Mirrored the identical wording change into plugin/agents/orbit-task-pilot.md (added the same compatibility framing for adr_conflicts in its step 5 and Result section) and into .orbit/resources/activities/task_pilot.yaml, which crates/orbit-core/src/bootstrap/activity.rs::task_pilot_is_read_only_bounded_and_uses_advisory_output asserts must stay byte-identical to the shipped asset (added to context_files since the change was required to keep that existing test passing, not a new mechanism). No schema/field rename: adr_conflicts remains required by the deterministic apply_task_pilot_results validator (validate_recommendations in v2_host/task_pilot.rs) and its existing fixtures/tests, satisfying the compatibility requirement. Validation: cargo test -p orbit-core task_pilot (10/10 pass, including the byte-identical mirror assertion), bash scripts/validate-codex-plugin.sh (plugin agent markers intact), make ci-fast (fmt-check + all guardrail scripts incl. sync-plugin-skills.sh, all pass), make ci-lint (workspace clippy, zero warnings). No new tests added per acceptance criterion 4 (avoid broad prose-substring tests); relied on existing narrow fixture/marker checks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11224-6a9b8b87`
- Behind base: 0
- Ahead of base: 1