### PR TITLE
Explain why auto-drain leaves backlog tasks waiting

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -31,6 +31,8 @@ pub struct CommandMeta {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeNeed {
     Required,
+    /// Read an existing workspace without stale-run reconciliation on open.
+    ReadOnly,
     Forbidden,
     /// Bind the workspace that owns this task ID rather than the one the cwd
     /// or `--workspace` walk would pick [ORB-10797] [ORB-10961].
@@ -344,6 +346,12 @@ impl Commands {
                         Some("workflow"),
                         Some("triage"),
                         RuntimeNeed::Required,
+                    ),
+                    RunSubcommand::Readiness(_) => (
+                        "readiness",
+                        Some("workspace"),
+                        Some("auto_readiness"),
+                        RuntimeNeed::ReadOnly,
                     ),
                     RunSubcommand::History(args) => (
                         "history",

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -9,6 +9,7 @@ use super::events::RunEventsArgs;
 use super::history::RunHistoryArgs;
 use super::job::JobRunArgs;
 use super::logs::RunLogsArgs;
+use super::readiness::ReadinessCommand;
 use super::ship;
 use super::show::RunShowArgs;
 use super::sweep;
@@ -52,6 +53,7 @@ Workflows:
   ship        Ship backlog or explicitly selected tasks through the gated task pipeline
   ship-sweep  Dispatch ship runs in every registered workspace with ready backlog tasks
   triage      Triage tasks blocked by failed runs; re-backlog environmental failures
+  readiness   Explain why backlog tasks are waiting in auto-drain
   job         Run an arbitrary job by ID
 
 Audits:
@@ -93,6 +95,8 @@ pub enum RunSubcommand {
     ShipSweep(sweep::ShipSweepCommand),
     /// Triage tasks blocked by failed runs; re-backlog environmental failures
     Triage(triage::TriageCommand),
+    /// Explain why backlog tasks can or cannot start in auto-drain
+    Readiness(ReadinessCommand),
     /// Show recent job runs, optionally filtered to one job
     History(RunHistoryArgs),
     /// Show structured state and step summary for a job run
@@ -119,6 +123,7 @@ impl Execute for RunSubcommand {
             // registry-driven sweep never uses the cwd-derived runtime.
             RunSubcommand::ShipSweep(command) => command.execute_without_runtime(),
             RunSubcommand::Triage(command) => command.execute(runtime),
+            RunSubcommand::Readiness(command) => command.execute(runtime),
             RunSubcommand::History(command) => command.execute(runtime),
             RunSubcommand::Show(command) => command.execute(runtime),
             RunSubcommand::Logs(command) => command.execute(runtime),

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -7,6 +7,7 @@ mod history;
 pub mod job;
 pub mod legacy_logs;
 mod logs;
+mod readiness;
 pub mod ship;
 mod show;
 mod steps;

--- a/crates/orbit-cli/src/command/run/readiness.rs
+++ b/crates/orbit-cli/src/command/run/readiness.rs
@@ -1,0 +1,108 @@
+//! `orbit run readiness` read-only auto-drain diagnostic.
+
+use clap::Args;
+use orbit_core::{OrbitError, OrbitRuntime};
+use serde_json::Value;
+
+use crate::command::{Block, CommandOut, Execute, Payload};
+
+const DEFAULT_LIMIT: usize = 50;
+
+#[derive(Args)]
+#[command(
+    about = "Explain why backlog tasks can or cannot start in auto-drain",
+    override_usage = "orbit run readiness [<TASK_ID>...] [OPTIONS]",
+    after_help = "Examples:\n  orbit run readiness\n  orbit run readiness TASK-123 TASK-124\n  orbit run readiness --concurrency 8 --json\n\nThis is a read-only snapshot. It does not reserve work, reconcile stale runs,\nsubmit a run, or mutate tasks; an eligible task is not guaranteed to start."
+)]
+pub struct ReadinessCommand {
+    /// Optional task IDs to explain. Omit to inspect a bounded backlog snapshot.
+    #[arg(value_name = "TASK_ID", num_args = 0..)]
+    pub task_ids: Vec<String>,
+    /// Leaf-run concurrency to evaluate. Defaults to auto-drain's default (5).
+    #[arg(long, value_name = "N")]
+    pub concurrency: Option<u32>,
+    /// Maximum tasks to explain, including an explicit selection (1-500).
+    #[arg(long, default_value_t = DEFAULT_LIMIT, value_name = "N")]
+    pub limit: usize,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for ReadinessCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        validate_task_ids(&self.task_ids)?;
+        let payload =
+            runtime.workspace_auto_readiness(&self.task_ids, self.concurrency, self.limit)?;
+        readiness_payload(payload)
+    }
+}
+
+fn validate_task_ids(task_ids: &[String]) -> Result<(), OrbitError> {
+    let mut seen = std::collections::BTreeSet::new();
+    for task_id in task_ids {
+        if task_id.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(
+                "task id in readiness selection must not be empty".to_string(),
+            ));
+        }
+        if !seen.insert(task_id) {
+            return Err(OrbitError::InvalidInput(format!(
+                "duplicate task id '{task_id}' in readiness selection"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn readiness_payload(payload: Value) -> CommandOut {
+    let lines = readiness_lines(&payload);
+    Ok(Payload::blocks(payload, vec![Block::text(lines.join("\n"))]).into())
+}
+
+fn readiness_lines(payload: &Value) -> Vec<String> {
+    let capacity = &payload["capacity"];
+    let mut lines = vec![format!(
+        "Snapshot only — eligible does not guarantee a task will start. Active leaf runs: {}/{}; free slots: {}.",
+        capacity["active_leaf_runs"], capacity["max_active_leaf_runs"], capacity["free_slots"],
+    )];
+    if let Some(tasks) = payload["tasks"].as_array() {
+        for task in tasks {
+            let task_id = task["task_id"].as_str().unwrap_or("-");
+            let reason = task["reason"].as_str().unwrap_or("unknown");
+            let eligible = task["eligible"].as_bool().unwrap_or(false);
+            lines.push(format!(
+                "{task_id}: {} ({reason})",
+                if eligible { "eligible" } else { "waiting" }
+            ));
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn readiness_selection_rejects_blank_and_duplicate_ids() {
+        assert!(validate_task_ids(&[" ".to_string()]).is_err());
+        assert!(validate_task_ids(&["ORB-1".to_string(), "ORB-1".to_string()]).is_err());
+    }
+
+    #[test]
+    fn readiness_payload_names_snapshot_limit_and_reason() {
+        let text = readiness_lines(&json!({
+            "capacity": { "active_leaf_runs": 5, "max_active_leaf_runs": 5, "free_slots": 0 },
+            "tasks": [{ "task_id": "ORB-1", "eligible": false, "reason": "capacity_saturated" }]
+        }))
+        .join("\n");
+        assert!(text.contains("Snapshot only"), "{text}");
+        assert!(
+            text.contains("ORB-1: waiting (capacity_saturated)"),
+            "{text}"
+        );
+    }
+}

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -140,6 +140,31 @@ fn parses_workspace_auto_drain_window() {
 }
 
 #[test]
+fn parses_readiness_selection_and_json_projection() {
+    let command = parse_run(&[
+        "orbit",
+        "run",
+        "readiness",
+        "TASK-123",
+        "TASK-124",
+        "--concurrency",
+        "8",
+        "--limit",
+        "20",
+        "--json",
+    ]);
+    match command.command {
+        RunSubcommand::Readiness(args) => {
+            assert_eq!(args.task_ids, vec!["TASK-123", "TASK-124"]);
+            assert_eq!(args.concurrency, Some(8));
+            assert_eq!(args.limit, 20);
+            assert!(args.json);
+        }
+        _ => panic!("expected readiness"),
+    }
+}
+
+#[test]
 fn parses_explicit_ship_defaults() {
     let command = parse_run(&["orbit", "run", "ship", "T1", "T2"]);
     match command.command {

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -216,6 +216,10 @@ fn main() {
             root_override.as_deref(),
             workspace_selector.as_deref(),
         ),
+        RuntimeNeed::ReadOnly => RegisteredRuntimeFactory::initialize_read_only_with_overrides(
+            root_override.as_deref(),
+            workspace_selector.as_deref(),
+        ),
         RuntimeNeed::TaskOwner { task_id } => orbit_cmd::task_owner::initialize_for_task_show(
             root_override.as_deref(),
             workspace_selector.as_deref(),

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -109,6 +109,23 @@ impl RegisteredRuntimeFactory {
         root_override: Option<&Path>,
         workspace_selector: Option<&str>,
     ) -> Result<OrbitRuntime, OrbitError> {
+        Self::initialize_with_overrides_mode(root_override, workspace_selector, false)
+    }
+
+    /// Construct a workspace runtime for an observation command without the
+    /// usual stale-run reconciliation performed during normal runtime open.
+    pub fn initialize_read_only_with_overrides(
+        root_override: Option<&Path>,
+        workspace_selector: Option<&str>,
+    ) -> Result<OrbitRuntime, OrbitError> {
+        Self::initialize_with_overrides_mode(root_override, workspace_selector, true)
+    }
+
+    fn initialize_with_overrides_mode(
+        root_override: Option<&Path>,
+        workspace_selector: Option<&str>,
+        read_only: bool,
+    ) -> Result<OrbitRuntime, OrbitError> {
         let selector = workspace_selector
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -129,7 +146,12 @@ impl RegisteredRuntimeFactory {
                 .as_ref()
                 .and_then(|selection| replica_owner_for_checkout(&selection.checkout));
             let global_root = roots.global_root.clone();
-            return OrbitRuntime::initialize_from_resolved_roots(roots, binding).map(|runtime| {
+            let runtime = if read_only {
+                OrbitRuntime::initialize_from_resolved_roots_read_only(roots, binding)
+            } else {
+                OrbitRuntime::initialize_from_resolved_roots(roots, binding)
+            };
+            return runtime.map(|runtime| {
                 attach_workspace_catalog(
                     runtime.with_coordination_write_owner(replica_owner),
                     &global_root,
@@ -139,7 +161,15 @@ impl RegisteredRuntimeFactory {
 
         let global_root = global_root_for(root_override)?;
         let selected = Self::resolve_workspace_selector(&global_root, &selector)?;
-        Self::open_registered_checkout(&global_root, &selected.workspace, &selected.checkout)
+        if read_only {
+            Self::open_registered_checkout_read_only(
+                &global_root,
+                &selected.workspace,
+                &selected.checkout,
+            )
+        } else {
+            Self::open_registered_checkout(&global_root, &selected.workspace, &selected.checkout)
+        }
     }
 
     /// Resolve a workspace selector against this machine's registry.
@@ -202,6 +232,27 @@ impl RegisteredRuntimeFactory {
                 )
             },
         )
+    }
+
+    fn open_registered_checkout_read_only(
+        global_root: &Path,
+        workspace: &Workspace,
+        checkout: &WorkspaceCheckout,
+    ) -> Result<OrbitRuntime, OrbitError> {
+        sync_task_prefix(global_root)?;
+        let binding = workspace_runtime_binding(workspace, checkout)?;
+        OrbitRuntime::from_resolved_roots_read_only_with_binding(
+            global_root,
+            &checkout.orbit_dir,
+            &checkout.orbit_dir,
+            binding,
+        )
+        .map(|runtime| {
+            attach_workspace_catalog(
+                runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
+                global_root,
+            )
+        })
     }
 
     pub fn open_resolved_checkout(

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -23,6 +23,8 @@ orbit run ship <task-id> ...        # ship exactly these
 orbit run ship --mode local         # implement in a worktree, merge to the base; no PR
 orbit run auto --for 2h             # drain the backlog for a window
 orbit run auto --for 2h --concurrency 8   # ... with 8 tasks in flight at a time
+orbit run readiness                        # explain current auto-drain eligibility, read-only
+orbit run readiness TASK-123 --json        # explain selected task IDs as JSON
 orbit run ship <task-id> --complete  # ... and also carry it through to `done`
 orbit run ship-sweep --dry-run      # what every registered workspace would ship
 orbit run triage                    # diagnose tasks blocked by failed runs
@@ -42,6 +44,14 @@ task filed mid-window starts without waiting for the batch around it.
 
 Runs are asynchronous: these commands return once the run is durable, printing a
 run ID. They do not claim the eventual outcome.
+
+`orbit run readiness` is the diagnostic counterpart to auto-drain. It reads a
+bounded snapshot of the explicit workspace and reports each selected backlog
+task as ready or waiting, naming unmet dependency IDs/statuses, context-lock
+holders, epic management, live child-run claims, and capacity saturation. It
+never creates a run, reconciles stale runs, reserves files, or mutates a task.
+Its answer can change immediately after the snapshot, so `eligible` means
+"would be admitted by this snapshot", never a guarantee that work will start.
 
 ```bash
 orbit run history -j task_auto_pipeline

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -13,15 +13,15 @@ use crate::runtime::task::locks::lock_context_files_for_task;
 const MAX_TASK_PARENT_CHAIN_DEPTH: usize = 32;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-struct BacklogTaskExclusion {
-    id: String,
-    reason: BacklogTaskExclusionReason,
-    conflicts: Vec<BacklogTaskConflict>,
+pub(super) struct BacklogTaskExclusion {
+    pub(super) id: String,
+    pub(super) reason: BacklogTaskExclusionReason,
+    pub(super) conflicts: Vec<BacklogTaskConflict>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-enum BacklogTaskExclusionReason {
+pub(super) enum BacklogTaskExclusionReason {
     ContextLockConflict,
     EpicChild,
     EpicRoot,
@@ -35,9 +35,19 @@ pub(super) enum EpicFamilyMembership {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-struct BacklogTaskConflict {
-    requested_file: String,
-    locking_task_id: String,
+pub(super) struct BacklogTaskConflict {
+    pub(super) requested_file: String,
+    pub(super) locking_task_id: String,
+}
+
+/// The task population and leaf eligibility result shared by automatic
+/// dispatch and its read-only diagnostic.  Keeping the lock/epic filter here
+/// prevents the diagnostic from becoming a second scheduler.
+pub(super) struct BacklogSnapshot {
+    pub(super) task_lookup: BTreeMap<String, Task>,
+    pub(super) status_by_id: BTreeMap<String, TaskStatus>,
+    pub(super) admissible_leaves: Vec<Task>,
+    pub(super) excluded: Vec<BacklogTaskExclusion>,
 }
 
 fn active_task_lock_holders(
@@ -114,98 +124,8 @@ pub(super) fn list_backlog_tasks(
         // list into the lookup, then clone only the backlog tasks that survive
         // the filter — tens of clones on a large workspace instead of one per
         // task, and one copy held rather than two.
-        let task_lookup: BTreeMap<String, Task> = runtime
-            .stores()
-            .tasks()
-            .list_tasks()
-            .map_err(|err| DispatchError::DeterministicActionFailed {
-                action: action.to_string(),
-                message: format!("list tasks: {err}"),
-            })?
-            .into_iter()
-            .map(|task| (task.id.clone(), task))
-            .collect();
-        let status_by_id = runtime.task_status_index().map_err(|err| {
-            DispatchError::DeterministicActionFailed {
-                action: action.to_string(),
-                message: format!("load global task status projection: {err}"),
-            }
-        })?;
-        let workspace_root = runtime.paths().repo_root.as_path();
-        let lock_holders = active_task_lock_holders(&task_lookup, workspace_root);
-        // `task_lookup` iterates in task-ID order rather than the store's
-        // created-at order; `sort_tasks_for_automatic_dispatch` is a total
-        // order ending in the task ID, so the dispatch sequence is unchanged.
-        let mut backlog: Vec<Task> = task_lookup
-            .values()
-            .filter(|task| {
-                task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
-            })
-            .cloned()
-            .collect();
-        sort_tasks_for_automatic_dispatch(&mut backlog);
-        let mut excluded = Vec::new();
-        backlog.retain(|task| {
-            let Some(membership) = epic_family_membership(task, &task_lookup) else {
-                return true;
-            };
-            excluded.push(BacklogTaskExclusion {
-                id: task.id.clone(),
-                reason: match membership {
-                    EpicFamilyMembership::Root => BacklogTaskExclusionReason::EpicRoot,
-                    EpicFamilyMembership::Child => BacklogTaskExclusionReason::EpicChild,
-                },
-                conflicts: Vec::new(),
-            });
-            false
-        });
-        if !lock_holders.is_empty() {
-            let direct_conflicts: BTreeMap<String, Vec<BacklogTaskConflict>> = backlog
-                .iter()
-                .filter_map(|task| {
-                    let conflicts =
-                        task_overlap_conflicts(task, &task_lookup, &lock_holders, workspace_root);
-                    (!conflicts.is_empty()).then(|| (task.id.clone(), conflicts))
-                })
-                .collect();
-            let mut root_trigger: BTreeMap<String, Vec<BacklogTaskConflict>> = BTreeMap::new();
-            for task in &backlog {
-                if let Some(conflicts) = direct_conflicts.get(&task.id) {
-                    let root_id = task_root_id(task, &task_lookup);
-                    // Backlog is already priority/age sorted; the first direct
-                    // conflict in that order supplies group-member attribution.
-                    root_trigger
-                        .entry(root_id)
-                        .or_insert_with(|| conflicts.clone());
-                }
-            }
-            if !root_trigger.is_empty() {
-                let mut kept = Vec::new();
-                for task in backlog {
-                    let root_id = task_root_id(&task, &task_lookup);
-                    if let Some(trigger_conflicts) = root_trigger.get(&root_id) {
-                        if let Some(conflicts) = direct_conflicts.get(&task.id) {
-                            excluded.push(BacklogTaskExclusion {
-                                id: task.id.clone(),
-                                reason: BacklogTaskExclusionReason::ContextLockConflict,
-                                conflicts: conflicts.clone(),
-                            });
-                        } else {
-                            excluded.push(BacklogTaskExclusion {
-                                id: task.id.clone(),
-                                reason: BacklogTaskExclusionReason::GroupMemberConflict,
-                                conflicts: trigger_conflicts.clone(),
-                            });
-                        }
-                    } else {
-                        kept.push(task);
-                    }
-                }
-                backlog = kept;
-            }
-        }
-        excluded.sort_by(|a, b| a.id.cmp(&b.id));
-        (backlog, Some(excluded))
+        let snapshot = backlog_snapshot(runtime, action)?;
+        (snapshot.admissible_leaves, Some(snapshot.excluded))
     } else {
         let tasks = explicit_task_ids
             .iter()
@@ -255,6 +175,107 @@ pub(super) fn list_backlog_tasks(
         );
     }
     Ok(Value::Object(payload))
+}
+
+pub(super) fn backlog_snapshot(
+    runtime: &OrbitRuntime,
+    action: &str,
+) -> Result<BacklogSnapshot, DispatchError> {
+    let task_lookup: BTreeMap<String, Task> = runtime
+        .stores()
+        .tasks()
+        .list_tasks()
+        .map_err(|err| DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("list tasks: {err}"),
+        })?
+        .into_iter()
+        .map(|task| (task.id.clone(), task))
+        .collect();
+    let status_by_id =
+        runtime
+            .task_status_index()
+            .map_err(|err| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("load global task status projection: {err}"),
+            })?;
+    let workspace_root = runtime.paths().repo_root.as_path();
+    let lock_holders = active_task_lock_holders(&task_lookup, workspace_root);
+    // `task_lookup` iterates in task-ID order rather than the store's
+    // created-at order; `sort_tasks_for_automatic_dispatch` is a total order
+    // ending in the task ID, so the dispatch sequence is unchanged.
+    let mut backlog: Vec<Task> = task_lookup
+        .values()
+        .filter(|task| {
+            task.status == TaskStatus::Backlog && task_dependencies_ready(task, &status_by_id)
+        })
+        .cloned()
+        .collect();
+    sort_tasks_for_automatic_dispatch(&mut backlog);
+    let mut excluded = Vec::new();
+    backlog.retain(|task| {
+        let Some(membership) = epic_family_membership(task, &task_lookup) else {
+            return true;
+        };
+        excluded.push(BacklogTaskExclusion {
+            id: task.id.clone(),
+            reason: match membership {
+                EpicFamilyMembership::Root => BacklogTaskExclusionReason::EpicRoot,
+                EpicFamilyMembership::Child => BacklogTaskExclusionReason::EpicChild,
+            },
+            conflicts: Vec::new(),
+        });
+        false
+    });
+    if !lock_holders.is_empty() {
+        let direct_conflicts: BTreeMap<String, Vec<BacklogTaskConflict>> = backlog
+            .iter()
+            .filter_map(|task| {
+                let conflicts =
+                    task_overlap_conflicts(task, &task_lookup, &lock_holders, workspace_root);
+                (!conflicts.is_empty()).then(|| (task.id.clone(), conflicts))
+            })
+            .collect();
+        let mut root_trigger: BTreeMap<String, Vec<BacklogTaskConflict>> = BTreeMap::new();
+        for task in &backlog {
+            if let Some(conflicts) = direct_conflicts.get(&task.id) {
+                let root_id = task_root_id(task, &task_lookup);
+                root_trigger
+                    .entry(root_id)
+                    .or_insert_with(|| conflicts.clone());
+            }
+        }
+        if !root_trigger.is_empty() {
+            let mut kept = Vec::new();
+            for task in backlog {
+                let root_id = task_root_id(&task, &task_lookup);
+                if let Some(trigger_conflicts) = root_trigger.get(&root_id) {
+                    excluded.push(BacklogTaskExclusion {
+                        id: task.id.clone(),
+                        reason: if direct_conflicts.contains_key(&task.id) {
+                            BacklogTaskExclusionReason::ContextLockConflict
+                        } else {
+                            BacklogTaskExclusionReason::GroupMemberConflict
+                        },
+                        conflicts: direct_conflicts
+                            .get(&task.id)
+                            .cloned()
+                            .unwrap_or_else(|| trigger_conflicts.clone()),
+                    });
+                } else {
+                    kept.push(task);
+                }
+            }
+            backlog = kept;
+        }
+    }
+    excluded.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(BacklogSnapshot {
+        task_lookup,
+        status_by_id,
+        admissible_leaves: backlog,
+        excluded,
+    })
 }
 
 pub(super) fn sort_tasks_for_automatic_dispatch(tasks: &mut [Task]) {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -86,6 +86,224 @@ fn list_epic_descendants_err(
         .expect_err("list epic descendants should fail")
 }
 
+fn readiness(runtime: &OrbitRuntime, task_ids: &[String], concurrency: Option<u32>) -> Value {
+    runtime
+        .workspace_auto_readiness(task_ids, concurrency, 50)
+        .expect("explain readiness")
+}
+
+fn readiness_task<'a>(output: &'a Value, task_id: &str) -> &'a Value {
+    output["tasks"]
+        .as_array()
+        .expect("readiness tasks")
+        .iter()
+        .find(|task| task["task_id"] == task_id)
+        .expect("readiness task")
+}
+
+#[test]
+fn readiness_explains_dependencies_locks_epics_claims_and_capacity() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/locked/src/lib.rs");
+    let dependency = seed_list_backlog_task(
+        &runtime,
+        "Unfinished dependency",
+        TaskStatus::Proposed,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let blocked = runtime
+        .add_task(TaskAddParams {
+            title: "Blocked leaf".to_string(),
+            description: "fixture".to_string(),
+            acceptance_criteria: vec!["fixture".to_string()],
+            plan: "fixture".to_string(),
+            dependencies: vec![dependency.id.clone()],
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed blocked leaf");
+    let missing_dependency = seed_list_backlog_task(
+        &runtime,
+        "Deleted dependency",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let missing = runtime
+        .add_task(TaskAddParams {
+            title: "Missing dependency leaf".to_string(),
+            description: "fixture".to_string(),
+            acceptance_criteria: vec!["fixture".to_string()],
+            plan: "fixture".to_string(),
+            dependencies: vec![missing_dependency.id.clone()],
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed missing dependency leaf");
+    runtime
+        .delete_task(&missing_dependency.id)
+        .expect("delete dependency for missing fixture");
+    let _holder = seed_list_backlog_task(
+        &runtime,
+        "Lock holder",
+        TaskStatus::InProgress,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["crates/locked/src/lib.rs"],
+    );
+    let locked = seed_list_backlog_task(
+        &runtime,
+        "Locked leaf",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec!["crates/locked/src/lib.rs"],
+    );
+    let epic = runtime
+        .add_task(TaskAddParams {
+            title: "Managed epic".to_string(),
+            description: "fixture".to_string(),
+            acceptance_criteria: vec!["fixture".to_string()],
+            plan: "fixture".to_string(),
+            tags: vec!["epic".to_string()],
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed epic");
+    let epic_child = seed_list_backlog_task(
+        &runtime,
+        "Managed epic child",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        Some(epic.id),
+        vec![],
+    );
+    let claimed = seed_list_backlog_task(
+        &runtime,
+        "Claimed leaf",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let claim_run = seed_live_leaf_run(&runtime, &[&claimed.id]);
+    let saturated = seed_list_backlog_task(
+        &runtime,
+        "Capacity leaf",
+        TaskStatus::Backlog,
+        TaskPriority::Low,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+
+    let ids = vec![
+        blocked.id.clone(),
+        missing.id.clone(),
+        locked.id.clone(),
+        epic_child.id.clone(),
+        claimed.id.clone(),
+        saturated.id.clone(),
+    ];
+    let output = readiness(&runtime, &ids, Some(1));
+
+    assert_eq!(
+        readiness_task(&output, &blocked.id)["reason"],
+        "unmet_dependency"
+    );
+    assert_eq!(
+        readiness_task(&output, &missing.id)["dependencies"][0]["status"],
+        "missing"
+    );
+    assert_eq!(
+        readiness_task(&output, &locked.id)["reason"],
+        "context_lock_conflict"
+    );
+    assert_eq!(
+        readiness_task(&output, &epic_child.id)["reason"],
+        "epic_managed"
+    );
+    assert_eq!(
+        readiness_task(&output, &claimed.id)["reason"],
+        "claimed_by_live_child"
+    );
+    assert_eq!(
+        readiness_task(&output, &claimed.id)["run_ids"],
+        json!([claim_run])
+    );
+    assert_eq!(
+        readiness_task(&output, &saturated.id)["reason"],
+        "capacity_saturated"
+    );
+}
+
+#[test]
+fn readiness_matches_dispatch_and_does_not_mutate_the_snapshot() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let first = seed_list_backlog_task(
+        &runtime,
+        "First ready leaf",
+        TaskStatus::Backlog,
+        TaskPriority::High,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let second = seed_list_backlog_task(
+        &runtime,
+        "Second ready leaf",
+        TaskStatus::Backlog,
+        TaskPriority::Medium,
+        TaskType::Chore,
+        None,
+        vec![],
+    );
+    let ids = vec![second.id.clone(), first.id.clone()];
+    let before_runs = runtime
+        .stores()
+        .jobs()
+        .list_pending_or_running_job_runs("task_auto_pipeline")
+        .expect("list runs");
+
+    let output = readiness(&runtime, &ids, Some(1));
+    let dispatched = classify_with(&runtime, json!({ "max_active_leaf_runs": 1 }));
+
+    assert_eq!(readiness_task(&output, &first.id)["reason"], "ready");
+    assert_eq!(readiness_task(&output, &first.id)["eligible"], true);
+    assert_eq!(
+        readiness_task(&output, &second.id)["reason"],
+        "capacity_saturated"
+    );
+    assert_eq!(dispatched["loose_task_ids"], json!([first.id]));
+    assert_eq!(
+        runtime
+            .stores()
+            .jobs()
+            .list_pending_or_running_job_runs("task_auto_pipeline")
+            .expect("list runs after"),
+        before_runs
+    );
+    assert_eq!(
+        runtime.get_task(&second.id).expect("read task").status,
+        TaskStatus::Backlog
+    );
+    assert!(
+        output["snapshot"]["limitations"]
+            .as_str()
+            .expect("limitations")
+            .contains("does not guarantee")
+    );
+}
+
 #[test]
 fn epic_descendants_are_dependency_then_dispatch_ordered_and_terminal_tasks_are_skipped() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -1,15 +1,16 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, SecondsFormat, TimeDelta, Utc};
+use orbit_common::OrbitError;
 use orbit_engine::DispatchError;
-use orbit_types::task::{Task, TaskStatus, task_dependencies_ready};
+use orbit_types::task::{Task, TaskStatus, task_dependencies_ready, unmet_task_dependencies};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
 
 use super::backlog_exclusion::{
-    EpicFamilyMembership, epic_family_membership, list_backlog_tasks,
-    sort_tasks_for_automatic_dispatch,
+    BacklogTaskExclusionReason, EpicFamilyMembership, backlog_snapshot, epic_family_membership,
+    list_backlog_tasks, sort_tasks_for_automatic_dispatch,
 };
 
 /// The job that supervises one epic root. `classify_workspace_auto_tasks`
@@ -39,6 +40,8 @@ const DEFAULT_POLL_SLEEP_SECONDS: u64 = 30;
 /// only things that can change are a task arriving or the detached epic
 /// finishing.
 const DEFAULT_IDLE_SLEEP_SECONDS: u64 = 60;
+
+const MAX_READINESS_LIMIT: usize = 500;
 
 /// Longest drain window a caller may request, in seconds (24h). The window is
 /// the caller's, not a safety property, but an unbounded deadline would let a
@@ -158,6 +161,208 @@ pub(super) fn classify_workspace_auto_tasks(
     }))
 }
 
+/// Explain the same snapshot that auto-drain uses without performing its
+/// stale-run reconciliation. This is deliberately an observation API: it
+/// neither reserves work nor creates a pipeline run, and its answer can go
+/// stale immediately after the stores are read.
+pub fn explain_workspace_auto_readiness(
+    runtime: &OrbitRuntime,
+    task_ids: &[String],
+    max_active_leaf_runs: Option<u32>,
+    limit: usize,
+) -> Result<Value, OrbitError> {
+    if !(1..=MAX_READINESS_LIMIT).contains(&limit) {
+        return Err(OrbitError::InvalidInput(format!(
+            "readiness limit must be between 1 and {MAX_READINESS_LIMIT}"
+        )));
+    }
+    let max_active_leaf_runs = max_active_leaf_runs
+        .map(u64::from)
+        .unwrap_or(DEFAULT_MAX_ACTIVE_LEAF_RUNS);
+    if max_active_leaf_runs == 0 {
+        return Err(OrbitError::InvalidInput(
+            "concurrency must be at least 1".to_string(),
+        ));
+    }
+
+    let snapshot = backlog_snapshot(runtime, "explain_workspace_auto_readiness")
+        .map_err(|error| OrbitError::Execution(format!("read readiness snapshot: {error}")))?;
+    let live_leaves = read_live_leaf_runs(runtime)?;
+    let active_epic = read_active_epic_run(runtime)?;
+    let claimed_by_task =
+        live_leaves
+            .iter()
+            .fold(BTreeMap::<String, Vec<String>>::new(), |mut claims, run| {
+                for task_id in &run.task_ids {
+                    claims
+                        .entry(task_id.clone())
+                        .or_default()
+                        .push(run.run_id.clone());
+                }
+                claims
+            });
+    let free_slots = usize::try_from(max_active_leaf_runs)
+        .unwrap_or(usize::MAX)
+        .saturating_sub(live_leaves.len());
+    let pending = snapshot
+        .admissible_leaves
+        .iter()
+        .filter(|task| !claimed_by_task.contains_key(&task.id))
+        .map(|task| task.id.clone())
+        .collect::<Vec<_>>();
+    let admitted = pending
+        .iter()
+        .take(free_slots)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let excluded_by_id = snapshot
+        .excluded
+        .iter()
+        .map(|excluded| (excluded.id.as_str(), excluded))
+        .collect::<BTreeMap<_, _>>();
+    let next_epic = if active_epic.is_none() {
+        next_admissible_epic_root(runtime, "explain_workspace_auto_readiness")
+            .map_err(|error| OrbitError::Execution(format!("read epic readiness: {error}")))?
+    } else {
+        None
+    };
+
+    let selected_ids = if task_ids.is_empty() {
+        let mut ids = snapshot
+            .task_lookup
+            .values()
+            .filter(|task| task.status == TaskStatus::Backlog)
+            .cloned()
+            .collect::<Vec<_>>();
+        sort_tasks_for_automatic_dispatch(&mut ids);
+        ids.into_iter().take(limit).map(|task| task.id).collect()
+    } else {
+        let mut ids = task_ids.to_vec();
+        ids.sort();
+        ids.dedup();
+        if let Some(missing) = ids
+            .iter()
+            .find(|id| !snapshot.task_lookup.contains_key(*id))
+        {
+            return Err(OrbitError::InvalidInput(format!(
+                "task `{missing}` was not found in this workspace"
+            )));
+        }
+        if ids.len() > limit {
+            return Err(OrbitError::InvalidInput(format!(
+                "readiness selection contains {} tasks; limit is {limit}",
+                ids.len()
+            )));
+        }
+        ids
+    };
+
+    let tasks = selected_ids
+        .iter()
+        .filter_map(|id| snapshot.task_lookup.get(id))
+        .map(|task| {
+            let mut entry = json!({
+                "task_id": task.id,
+                "status": task.status.to_string(),
+                "eligible": false,
+                "reason": "not_backlog",
+            });
+            let Some(object) = entry.as_object_mut() else {
+                unreachable!("readiness task entry is an object");
+            };
+            if task.status != TaskStatus::Backlog {
+                return Value::Object(object.clone());
+            }
+            let unmet = unmet_task_dependencies(task, &snapshot.status_by_id);
+            if !unmet.is_empty() {
+                object.insert("reason".to_string(), Value::String("unmet_dependency".to_string()));
+                object.insert(
+                    "dependencies".to_string(),
+                    json!(unmet
+                        .into_iter()
+                        .map(|dependency| json!({ "task_id": dependency.id, "status": dependency.status }))
+                        .collect::<Vec<_>>()),
+                );
+                return Value::Object(object.clone());
+            }
+            if let Some(excluded) = excluded_by_id.get(task.id.as_str()) {
+                match excluded.reason {
+                    BacklogTaskExclusionReason::EpicChild => {
+                        object.insert("reason".to_string(), Value::String("epic_managed".to_string()));
+                    }
+                    BacklogTaskExclusionReason::EpicRoot => {
+                        if active_epic.is_some() {
+                            object.insert("reason".to_string(), Value::String("epic_run_active".to_string()));
+                            object.insert("epic_run_id".to_string(), json!(active_epic.as_ref().map(|run| &run.run_id)));
+                        } else if next_epic.as_deref() == Some(task.id.as_str()) {
+                            object.insert("eligible".to_string(), Value::Bool(true));
+                            object.insert("reason".to_string(), Value::String("ready_as_epic".to_string()));
+                        } else {
+                            object.insert("reason".to_string(), Value::String("queued_behind_epic".to_string()));
+                            object.insert("next_epic_task_id".to_string(), json!(next_epic));
+                        }
+                    }
+                    BacklogTaskExclusionReason::ContextLockConflict
+                    | BacklogTaskExclusionReason::GroupMemberConflict => {
+                        object.insert(
+                            "reason".to_string(),
+                            Value::String(match excluded.reason {
+                                BacklogTaskExclusionReason::ContextLockConflict => "context_lock_conflict",
+                                BacklogTaskExclusionReason::GroupMemberConflict => "group_member_conflict",
+                                _ => unreachable!("lock exclusions are handled above"),
+                            }.to_string()),
+                        );
+                        object.insert(
+                            "conflicts".to_string(),
+                            json!(excluded.conflicts.iter().map(|conflict| json!({
+                                "requested_file": conflict.requested_file,
+                                "locking_task_id": conflict.locking_task_id,
+                            })).collect::<Vec<_>>()),
+                        );
+                    }
+                }
+                return Value::Object(object.clone());
+            }
+            if let Some(run_ids) = claimed_by_task.get(&task.id) {
+                object.insert("reason".to_string(), Value::String("claimed_by_live_child".to_string()));
+                object.insert("run_ids".to_string(), json!(run_ids));
+            } else if admitted.contains(&task.id) {
+                object.insert("eligible".to_string(), Value::Bool(true));
+                object.insert("reason".to_string(), Value::String("ready".to_string()));
+            } else {
+                object.insert("reason".to_string(), Value::String("capacity_saturated".to_string()));
+                object.insert("active_run_ids".to_string(), json!(live_leaves.iter().map(|run| &run.run_id).collect::<Vec<_>>()));
+            }
+            Value::Object(object.clone())
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "snapshot": {
+            "read_only": true,
+            "limitations": "Snapshot only: eligibility can change immediately and does not guarantee a task will start. No stale-run reconciliation, reservation, task mutation, or run submission was performed.",
+        },
+        "capacity": {
+            "max_active_leaf_runs": max_active_leaf_runs,
+            "active_leaf_runs": live_leaves.len(),
+            "free_slots": free_slots,
+        },
+        "tasks": tasks,
+    }))
+}
+
+impl OrbitRuntime {
+    /// Read-only projection of the current auto-drain admission snapshot.
+    pub fn workspace_auto_readiness(
+        &self,
+        task_ids: &[String],
+        max_active_leaf_runs: Option<u32>,
+        limit: usize,
+    ) -> Result<Value, OrbitError> {
+        explain_workspace_auto_readiness(self, task_ids, max_active_leaf_runs, limit)
+    }
+}
+
 /// A numeric loop input, tolerating the string a template renders. A step's
 /// `default_input` value goes through the template engine, so `5` arrives as
 /// `"5"`; an input the caller omitted renders as an empty string rather than
@@ -194,6 +399,7 @@ fn templated_u64(
 
 /// A live `task_auto_pipeline` run and the tasks it is carrying.
 struct LiveLeafRun {
+    run_id: String,
     task_ids: Vec<String>,
 }
 
@@ -211,14 +417,19 @@ fn live_leaf_runs(runtime: &OrbitRuntime, action: &str) -> Result<Vec<LiveLeafRu
                 format!("reconcile stale {LEAF_JOB_NAME} runs: {err}"),
             )
         })?;
+    read_live_leaf_runs(runtime)
+        .map_err(|error| action_failed(action, format!("list live {LEAF_JOB_NAME} runs: {error}")))
+}
+
+fn read_live_leaf_runs(runtime: &OrbitRuntime) -> Result<Vec<LiveLeafRun>, OrbitError> {
     let runs = runtime
         .stores()
         .jobs()
-        .list_pending_or_running_job_runs(LEAF_JOB_NAME)
-        .map_err(|err| action_failed(action, format!("list live {LEAF_JOB_NAME} runs: {err}")))?;
+        .list_pending_or_running_job_runs(LEAF_JOB_NAME)?;
     Ok(runs
         .into_iter()
         .map(|run| LiveLeafRun {
+            run_id: run.run_id,
             task_ids: run
                 .input
                 .as_ref()
@@ -258,14 +469,17 @@ fn active_epic_run(
             action: action.to_string(),
             message: format!("reconcile stale {EPIC_JOB_NAME} runs: {err}"),
         })?;
+    read_active_epic_run(runtime).map_err(|error| DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message: format!("list live {EPIC_JOB_NAME} runs: {error}"),
+    })
+}
+
+fn read_active_epic_run(runtime: &OrbitRuntime) -> Result<Option<ActiveEpicRun>, OrbitError> {
     let runs = runtime
         .stores()
         .jobs()
-        .list_pending_or_running_job_runs(EPIC_JOB_NAME)
-        .map_err(|err| DispatchError::DeterministicActionFailed {
-            action: action.to_string(),
-            message: format!("list live {EPIC_JOB_NAME} runs: {err}"),
-        })?;
+        .list_pending_or_running_job_runs(EPIC_JOB_NAME)?;
     Ok(runs.into_iter().next().map(|run| ActiveEpicRun {
         task_id: run
             .input

--- a/crates/orbit-core/src/composition.rs
+++ b/crates/orbit-core/src/composition.rs
@@ -37,6 +37,22 @@ impl OrbitRuntime {
             &roots.shared_root,
             &roots.local_root,
             binding,
+            true,
+        )
+    }
+
+    /// Open an existing workspace for an observation-only command without
+    /// reconciling stale job runs as a side effect of runtime construction.
+    pub fn initialize_from_resolved_roots_read_only(
+        roots: OrbitRuntimeRoots,
+        binding: Option<WorkspaceRuntimeBinding>,
+    ) -> Result<Self, OrbitError> {
+        build_runtime(
+            &roots.global_root,
+            &roots.shared_root,
+            &roots.local_root,
+            binding,
+            false,
         )
     }
 
@@ -99,7 +115,7 @@ impl OrbitRuntime {
         shared_root: &Path,
         local_root: &Path,
     ) -> Result<Self, OrbitError> {
-        build_runtime(global_root, shared_root, local_root, None)
+        build_runtime(global_root, shared_root, local_root, None, true)
     }
 
     pub fn from_resolved_roots_with_binding(
@@ -108,7 +124,16 @@ impl OrbitRuntime {
         local_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<Self, OrbitError> {
-        build_runtime(global_root, shared_root, local_root, Some(binding))
+        build_runtime(global_root, shared_root, local_root, Some(binding), true)
+    }
+
+    pub fn from_resolved_roots_read_only_with_binding(
+        global_root: &Path,
+        shared_root: &Path,
+        local_root: &Path,
+        binding: WorkspaceRuntimeBinding,
+    ) -> Result<Self, OrbitError> {
+        build_runtime(global_root, shared_root, local_root, Some(binding), false)
     }
 
     pub fn in_memory() -> Result<Self, OrbitError> {
@@ -127,6 +152,7 @@ fn build_runtime(
     shared_root: &Path,
     local_root: &Path,
     binding: Option<WorkspaceRuntimeBinding>,
+    reconcile_stale_runs: bool,
 ) -> Result<OrbitRuntime, OrbitError> {
     let layout_report = match orbit_store::workflow::layout::upgrade_workspace_layout(shared_root) {
         Ok(report) => report,
@@ -150,7 +176,7 @@ fn build_runtime(
         &runtime_config,
         layout_report,
     )?;
-    if !managed_run_context_from_env() {
+    if reconcile_stale_runs && !managed_run_context_from_env() {
         runtime.reconcile_stale_job_runs_on_open();
     }
     Ok(runtime)

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -23,6 +23,8 @@ orbit run ship <task-id> ...        # ship exactly these
 orbit run ship --mode local         # implement in a worktree, merge to the base; no PR
 orbit run auto --for 2h             # drain the backlog for a window
 orbit run auto --for 2h --concurrency 8   # ... with 8 tasks in flight at a time
+orbit run readiness                        # explain current auto-drain eligibility, read-only
+orbit run readiness TASK-123 --json        # explain selected task IDs as JSON
 orbit run ship <task-id> --complete  # ... and also carry it through to `done`
 orbit run ship-sweep --dry-run      # what every registered workspace would ship
 orbit run triage                    # diagnose tasks blocked by failed runs
@@ -42,6 +44,14 @@ task filed mid-window starts without waiting for the batch around it.
 
 Runs are asynchronous: these commands return once the run is durable, printing a
 run ID. They do not claim the eventual outcome.
+
+`orbit run readiness` is the diagnostic counterpart to auto-drain. It reads a
+bounded snapshot of the explicit workspace and reports each selected backlog
+task as ready or waiting, naming unmet dependency IDs/statuses, context-lock
+holders, epic management, live child-run claims, and capacity saturation. It
+never creates a run, reconciles stale runs, reserves files, or mutates a task.
+Its answer can change immediately after the snapshot, so `eligible` means
+"would be admitted by this snapshot", never a guarantee that work will start.
 
 ```bash
 orbit run history -j task_auto_pipeline


### PR DESCRIPTION
## Task

[ORB-11218](https://orbit-cli.com/tasks/ORB-11218) — Explain why auto-drain leaves backlog tasks waiting

### Description

## Problem and source evidence
At Linux HEAD d8bbab30, crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs filters dependency-unready backlog tasks before producing excluded entries. Its reasons cover locks and epic membership, not unmet dependencies. workspace_auto.rs then removes already-claimed tasks, limits to free slots, and emits counts without per-task reasons. An operator cannot distinguish a truly empty queue from blocked dependencies, active claims, lock overlap, or capacity by the drain summary alone.

## Outcome
Provide a bounded, read-only auto-readiness explanation through the existing CLI/domain surface, with structured JSON and concise human output. Share the actual dispatch eligibility rules; expose the relevant task/dependency/locking task/run IDs and capacity reason. Keep epic-managed tasks distinguishable from errors. This is diagnostic only: it must not reconcile/mutate run state, reserve files, submit work, or reorder the queue. Use a snapshot-based evaluator for the read-only path if the current classifier's stale-run reconciliation is inseparable. Do not create a second scheduler or persistent readiness cache. Pilot selects concrete targets. Medium terra is appropriate for a narrow domain/CLI projection.

Preparation only; proposed until start, pilot before backlog.

### Acceptance Criteria

- An operator can request a bounded readiness explanation in human and JSON form, scoped to an explicit workspace and optionally task IDs.
- Fixtures cover unmet/missing dependency, context lock, epic-managed task, live child claim, capacity saturation, and ready task, with actionable identifiers and deterministic ordering.
- The same settled snapshot produces eligibility consistent with actual dispatch rules; read-only explanation creates no run, task mutation, stale-run reconciliation, or reservation.
- Output explicitly states snapshot limitations and never claims a task is guaranteed to start; unavailable/corrupt inputs surface errors rather than an empty healthy queue.
- Document the command in relevant Orbit skill guidance; focused behavior tests plus make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit run readiness [TASK_ID...] [--concurrency N] [--limit N] [--json]`, with concise human output and structured snapshot JSON.
- Refactored the automatic backlog filter into a shared snapshot so readiness applies the same dependency, epic, context-lock, claim, capacity, and ordering rules as dispatch.
- Added a read-only runtime bootstrap path so the diagnostic does not reconcile stale runs while opening the workspace. It does not reserve files, submit runs, or mutate tasks.
- Added deterministic fixture coverage for unmet and missing dependencies, context locks, epic-managed tasks, live claims, capacity saturation, ready dispatch parity, and no mutation; documented the command in both distributed skill references.

Assessment: bounded diagnostic behavior is implemented with explicit snapshot limitations and actionable identifiers.

Validation:
- `cargo test -p orbit-core --lib workspace_auto --no-fail-fast`
- `cargo test -p orbit-core readiness --no-fail-fast`
- `cargo test -p orbit-cli readiness --no-fail-fast`
- `cargo test -p orbit-cli parses_readiness_selection_and_json_projection --no-fail-fast`
- `make ci-fast`
- `make ci-lint`

Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11218-6a9b8a1c`
- Behind base: 0
- Ahead of base: 1