### PR TITLE
Correct non-runnable Orbit skill examples for pilot inputs and activity inspection

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -70,7 +70,7 @@ bounded partitions, and its apply step persists only selectors it validated.
 ```bash
 orbit job show task_pilot_pipeline
 orbit run job task_pilot_pipeline                                  # zero-input discovery
-orbit run job task_pilot_pipeline --input task_ids=<id>,<id>       # audit exactly these
+orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exactly these
 ```
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
@@ -84,6 +84,8 @@ partitions concurrently, and returns selector proposals plus duplicate,
 already-landed, dependency, and conflicting-decision warnings. An enabled
 workspace routine may already run the zero-input job every few hours — an extra
 run before a large dispatch is still appropriate.
+The task-pilot pipeline never promotes tasks or dispatches them; promotion and
+shipping remain separate operator-authorized steps.
 
 ## Keeping parallel runs off each other
 

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -125,11 +125,12 @@ group and the safe termination order.
 
 ## Custom jobs and resource overrides
 
-Use `orbit job show <id>` and `orbit activity show <id>` to inspect the effective
-installed definitions before changing them. Workspace resource overrides can
-shadow shipped global resources, so the binary's version alone does not prove
-which pipeline ran. `orbit workspace sync --check` reports managed-resource
-drift; customized files are preserved for deliberate reconciliation.
+Use `orbit job show <id>` to inspect effective installed job definitions and
+`orbit activity list` to discover registered activities before changing them.
+Workspace resource overrides can shadow shipped global resources, so the
+binary's version alone does not prove which pipeline ran. `orbit workspace sync
+--check` reports managed-resource drift; customized files are preserved for
+deliberate reconciliation.
 
 A job uses `schemaVersion: 2`, `kind: Job`, `metadata.name`, and a `spec` with
 `default_input` and ordered `steps`. A simple step names an `id`, a

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -70,7 +70,7 @@ bounded partitions, and its apply step persists only selectors it validated.
 ```bash
 orbit job show task_pilot_pipeline
 orbit run job task_pilot_pipeline                                  # zero-input discovery
-orbit run job task_pilot_pipeline --input task_ids=<id>,<id>       # audit exactly these
+orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exactly these
 ```
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
@@ -84,6 +84,8 @@ partitions concurrently, and returns selector proposals plus duplicate,
 already-landed, dependency, and conflicting-decision warnings. An enabled
 workspace routine may already run the zero-input job every few hours — an extra
 run before a large dispatch is still appropriate.
+The task-pilot pipeline never promotes tasks or dispatches them; promotion and
+shipping remain separate operator-authorized steps.
 
 ## Keeping parallel runs off each other
 

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -125,11 +125,12 @@ group and the safe termination order.
 
 ## Custom jobs and resource overrides
 
-Use `orbit job show <id>` and `orbit activity show <id>` to inspect the effective
-installed definitions before changing them. Workspace resource overrides can
-shadow shipped global resources, so the binary's version alone does not prove
-which pipeline ran. `orbit workspace sync --check` reports managed-resource
-drift; customized files are preserved for deliberate reconciliation.
+Use `orbit job show <id>` to inspect effective installed job definitions and
+`orbit activity list` to discover registered activities before changing them.
+Workspace resource overrides can shadow shipped global resources, so the
+binary's version alone does not prove which pipeline ran. `orbit workspace sync
+--check` reports managed-resource drift; customized files are preserved for
+deliberate reconciliation.
 
 A job uses `schemaVersion: 2`, `kind: Job`, `metadata.name`, and a `spec` with
 `default_input` and ordered `steps`. A simple step names an `id`, a


### PR DESCRIPTION
## Task

[ORB-11223](https://orbit-cli.com/tasks/ORB-11223) — Correct non-runnable Orbit skill examples for pilot inputs and activity inspection

### Description

## Reproduction
Installed Orbit 0.18.0 on Linux: the skill references/orchestration.md shows `orbit run job task_pilot_pipeline --input task_ids=<id>,<id>`. On 2026-09-05 all four Linux workspace-local jrun-20260905-0309 attempts failed prepare_task_pilot with `task_ids must be an array`; no agent ran. JSON-array input was accepted by replacement jrun-20260905-0310 runs. references/workflows.md also recommends `orbit activity show <id>`, but `orbit activity --help` exposes only list and the documented show fails as unrecognized.

## Fix
Make zero-input task-pilot discovery the normal documented path. For intentional bounded audits, show a correctly quoted JSON array and verify it with the actual CLI parser. Replace unsupported activity show instructions with a supported read-only discovery/inspection path. Sweep the embedded Orbit skill references and plugin mirrors for these exact stale examples, updating installation assets through existing mechanisms. Do not add a new CLI command or broaden input coercion merely to preserve erroneous docs. This is an operational repair requested during run preparation; leave proposed and use task pilot before promotion.

### Acceptance Criteria

- Zero-input discovery example and optional explicit JSON-array example are correct; existing task-pilot discovery semantics and no-promotion boundary remain clear.
- No current skill guidance recommends nonexistent activity show; replacement instructions are verified against installed/source CLI help and supported asset discovery.
- Validate CLI parsing in an isolated fixture without submitting real jobs; references and plugin mirrors stay consistent, relevant skill/catalog checks and required repo checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Corrected the task-pilot examples in the embedded asset and plugin mirror: zero-input discovery is the normal path, bounded audits use a shell-quoted JSON array, and the pipeline's no-promotion/no-dispatch boundary is explicit.
- Replaced unsupported `orbit activity show` guidance with the supported read-only `orbit job show <id>` plus `orbit activity list` discovery path.
- Kept all four scoped references byte-identical between canonical assets and plugin mirrors.
Validation:
- Installed `orbit 0.18.0` help and catalog checks verified `orbit activity` exposes only `list`, `orbit job show task_pilot_pipeline` resolves the task-pilot asset, and the JSON-array `--input` form is accepted by the CLI parser in an isolated temporary root; the isolated fixture had no catalog, so no job was submitted.
- `rg` found no stale skill guidance using `orbit activity show` or the comma-separated task-id example.
- `git diff --check`, `make ci-fast`, and `make ci-lint` passed. `sync-plugin-skills --check` and both plugin validation/smoke checks passed as part of `make ci-fast`.
Assessment: Small, scoped documentation repair with canonical/plugin parity preserved; no CLI behavior or dependency changes were needed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11223-6a9b8e20`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*