### PR TITLE
Extract CI checkout identity before truncating human log excerpts

### DIFF
--- a/.orbit/resources/activities/collect_ci_evidence.yaml
+++ b/.orbit/resources/activities/collect_ci_evidence.yaml
@@ -12,7 +12,10 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. Workflow runs are listed repository-wide in one query and exactly
+    less. Checkout identity is extracted while the full runner-log stream is
+    drained, before the human excerpt is truncated; extraction scans at most
+    8 MiB per log and records incomplete evidence rather than guessing.
+    Workflow runs are listed repository-wide in one query and exactly
     the latest run of each workflow is authoritative, ordered by creation time
     then run ID. Discovery or investigation failures are bounded, redacted,
     and emitted in `retryable_errors`; the filing step rejects such a snapshot

--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -29,6 +29,10 @@
 # - A discovery, investigation, registration, dedupe, or task-creation error
 #   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
 #   retries the handoff; no current failure is consumed as a clean result.
+# - Checkout identity is read from the runner-log stream before the bounded
+#   excerpt is formed. The extractor scans no more than 8 MiB per log and
+#   marks the identity incomplete if that hard limit is reached; it never
+#   substitutes an event or PR head SHA as checkout evidence.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -12,7 +12,10 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. Workflow runs are listed repository-wide in one query and exactly
+    less. Checkout identity is extracted while the full runner-log stream is
+    drained, before the human excerpt is truncated; extraction scans at most
+    8 MiB per log and records incomplete evidence rather than guessing.
+    Workflow runs are listed repository-wide in one query and exactly
     the latest run of each workflow is authoritative, ordered by creation time
     then run ID. Discovery or investigation failures are bounded, redacted,
     and emitted in `retryable_errors`; the filing step rejects such a snapshot

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -29,6 +29,10 @@
 # - A discovery, investigation, registration, dedupe, or task-creation error
 #   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
 #   retries the handoff; no current failure is consumed as a clean result.
+# - Checkout identity is read from the runner-log stream before the bounded
+#   excerpt is formed. The extractor scans no more than 8 MiB per log and
+#   marks the identity incomplete if that hard limit is reached; it never
+#   substitutes an event or PR head SHA as checkout evidence.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -63,6 +63,12 @@ rg -n 'error|failed|panic|conflict|Validation|Outcome|execution_summary|git push
 
 Do not paste huge transcripts back to the human — summarize the decisive lines and identify the blob/command source.
 
+For CI-failure sweeps, checkout identity is separate runner-log evidence, not
+the API event or pull-request head SHA. The collector streams the full log,
+keeps only a bounded human excerpt, and scans at most 8 MiB for checkout
+evidence. Treat `checkout_identity.state: incomplete`, `missing`, or
+`ambiguous` as a diagnostic; do not fill it from another SHA field.
+
 ## Distinguish Failure Classes
 
 - **Implementation failure:** the agent loop exited nonzero or reported a failed envelope during `implement_one`.

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -618,6 +618,7 @@ fn investigate<Q: CiQueries + ?Sized>(
             failure["actual_checkout_shas"] = json!(log.checkout_commits);
             failure["checkout_evidence"] = json!(log.checkout_evidence);
             failure["checkout_evidence_scope"] = json!("failed");
+            set_checkout_identity(failure, "failed", &log);
             // `gh` can succeed with empty stdout when the run's logs are gone
             // (retention). That is not a captured excerpt; record it so the
             // filed task can say why the block is empty.
@@ -649,7 +650,11 @@ fn investigate<Q: CiQueries + ?Sized>(
     let needs_checkout = failure
         .get("actual_checkout_shas")
         .and_then(Value::as_array)
-        .is_none_or(Vec::is_empty);
+        .is_none_or(Vec::is_empty)
+        || failure
+            .get("checkout_evidence_complete")
+            .and_then(Value::as_bool)
+            != Some(true);
     if !needs_checkout {
         failure["investigated"] = json!(retryable_errors.len() == errors_before);
         return;
@@ -672,7 +677,16 @@ fn investigate<Q: CiQueries + ?Sized>(
             failure["actual_checkout_shas"] = json!(log.checkout_commits);
             failure["checkout_evidence"] = json!(log.checkout_evidence);
             failure["checkout_evidence_scope"] = json!("all");
-            if failure
+            set_checkout_identity(failure, "all", &log);
+            if !log.checkout_evidence_complete {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "checkout_evidence",
+                    failure.get("run_id"),
+                    "checkout evidence scan reached its hard limit; actual checkout identity is incomplete",
+                );
+            } else if failure
                 .get("actual_checkout_shas")
                 .and_then(Value::as_array)
                 .is_none_or(Vec::is_empty)
@@ -698,6 +712,32 @@ fn investigate<Q: CiQueries + ?Sized>(
         }
     }
     failure["investigated"] = json!(retryable_errors.len() == errors_before);
+}
+
+fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::RunLog) {
+    let state = if !log.checkout_evidence_complete {
+        "incomplete"
+    } else {
+        match log.checkout_commits.len() {
+            0 => "missing",
+            1 => "observed",
+            _ => "ambiguous",
+        }
+    };
+    failure["checkout_evidence_complete"] = json!(log.checkout_evidence_complete);
+    failure["checkout_evidence_scanned_bytes"] = json!(log.checkout_evidence_scanned_bytes);
+    failure["checkout_evidence_source_truncated"] = json!(log.checkout_evidence_source_truncated);
+    failure["checkout_identity"] = json!({
+        "state": state,
+        "observed_shas": log.checkout_commits,
+        "provenance": {
+            "source": "runner_log",
+            "scope": scope,
+            "complete": log.checkout_evidence_complete,
+            "scanned_bytes": log.checkout_evidence_scanned_bytes,
+            "source_truncated": log.checkout_evidence_source_truncated,
+        },
+    });
 }
 
 fn push_retryable_error(

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -11,11 +11,12 @@
 //! `orbit_tools::github_cli`, so the shape of a `gh` call has exactly one
 //! owner in the workspace.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
 use orbit_common::security::redaction::redact_all;
-use orbit_exec::{NoSandbox, run_process};
+use orbit_exec::{NoSandbox, run_process, run_process_streaming_stdout};
 use orbit_tools::{check_exec_result, github_cli};
 use serde_json::{Value, json};
 
@@ -65,8 +66,8 @@ impl LogScope {
     }
 }
 
-/// One run log, already bounded and redacted, plus the checkout evidence
-/// scanned out of the *unbounded* text.
+/// One run log, with a bounded human excerpt and separately bounded checkout
+/// evidence extracted while the source stream is drained.
 #[derive(Debug, Clone, Default)]
 pub(super) struct RunLog {
     pub(super) text: String,
@@ -75,6 +76,9 @@ pub(super) struct RunLog {
     pub(super) returned_bytes: usize,
     pub(super) checkout_commits: Vec<String>,
     pub(super) checkout_evidence: Vec<String>,
+    pub(super) checkout_evidence_complete: bool,
+    pub(super) checkout_evidence_scanned_bytes: usize,
+    pub(super) checkout_evidence_source_truncated: bool,
 }
 
 /// Cap on returned checkout-evidence lines, mirroring `github.run.logs`.
@@ -214,10 +218,36 @@ impl CiQueries for HostCiQueries {
         scope: LogScope,
         max_bytes: usize,
     ) -> Result<RunLog, OrbitError> {
-        let request =
+        let mut request =
             github_cli::run_logs_request(&json!({"run": run_id, "scope": scope.as_input_value()}))?;
-        let stdout = self.run_gh(request, "gh run view --log")?;
-        Ok(bounded_run_log(&stdout, max_bytes))
+        request.current_dir = Some(self.repo_root.to_string_lossy().into_owned());
+        let (result, log) =
+            run_process_streaming_stdout(&request, &NoSandbox, move |mut stdout| {
+                let mut collector =
+                    github_cli::StreamedLogCollector::new(max_bytes, MAX_EVIDENCE_LINES);
+                let mut chunk = [0_u8; 4096];
+                loop {
+                    let read = stdout.read(&mut chunk).map_err(|error| {
+                        OrbitError::Execution(format!("failed reading gh run log: {error}"))
+                    })?;
+                    if read == 0 {
+                        return Ok(collector.finish());
+                    }
+                    collector.push(&chunk[..read]);
+                }
+            })?;
+        check_exec_result(&result, "gh run view --log")?;
+        Ok(RunLog {
+            text: log.text,
+            truncated: log.truncated,
+            total_bytes: log.total_bytes,
+            returned_bytes: log.returned_bytes,
+            checkout_commits: log.checkout_evidence.commits,
+            checkout_evidence: log.checkout_evidence.lines,
+            checkout_evidence_complete: log.checkout_evidence.complete,
+            checkout_evidence_scanned_bytes: log.checkout_evidence.scanned_bytes,
+            checkout_evidence_source_truncated: log.checkout_evidence.source_truncated,
+        })
     }
 
     fn remote_branch_head(&self, branch: &str) -> Result<Option<String>, OrbitError> {
@@ -234,8 +264,10 @@ impl CiQueries for HostCiQueries {
     }
 }
 
-/// Bound and redact one raw run log, scanning the *whole* text for checkout
-/// evidence first so truncation can never hide the commit under test.
+/// Bound and redact one test fixture log, scanning it before truncation.
+/// Production log collection uses [`github_cli::StreamedLogCollector`] so it
+/// does not retain an unbounded `gh` stdout value.
+#[cfg(test)]
 pub(super) fn bounded_run_log(raw: &str, max_bytes: usize) -> RunLog {
     let bounded = github_cli::bound_log_text(raw, max_bytes);
     let evidence = github_cli::scan_checkout_evidence(raw, MAX_EVIDENCE_LINES);
@@ -246,5 +278,8 @@ pub(super) fn bounded_run_log(raw: &str, max_bytes: usize) -> RunLog {
         returned_bytes: bounded.returned_bytes,
         checkout_commits: evidence.commits,
         checkout_evidence: evidence.lines,
+        checkout_evidence_complete: evidence.complete,
+        checkout_evidence_scanned_bytes: evidence.scanned_bytes,
+        checkout_evidence_source_truncated: evidence.source_truncated,
     }
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -72,6 +72,129 @@ fn separates_event_sha_current_head_and_actual_checkout_commit() {
 }
 
 #[test]
+fn checkout_identity_is_observed_from_the_middle_of_a_bounded_full_log() {
+    let checkout = "3333333333333333333333333333333333333333";
+    let full_log = format!(
+        "head\n{}\nci\tCheckout\tHEAD is now at {checkout}\n{}\ntail\n",
+        "x".repeat(500),
+        "y".repeat(500),
+    );
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log("10", true, &full_log);
+
+    let evidence = collect(
+        &queries,
+        &json!({
+            "integration_branch": "topic", "log_max_bytes": 64, "max_checkout_log_reads": 1,
+        }),
+    )
+    .expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert!(failure["log_truncated"].as_bool().is_some());
+    assert_eq!(failure["actual_checkout_shas"], json!([checkout]));
+    assert_eq!(failure["checkout_identity"]["state"], json!("observed"));
+    assert_eq!(
+        failure["checkout_identity"]["provenance"]["scope"],
+        json!("all")
+    );
+    assert_eq!(
+        failure["checkout_identity"]["provenance"]["source"],
+        json!("runner_log")
+    );
+}
+
+#[test]
+fn contradictory_checkout_steps_are_ambiguous_not_a_confident_identity() {
+    let first = "3333333333333333333333333333333333333333";
+    let second = "4444444444444444444444444444444444444444";
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log(
+            "10",
+            true,
+            &format!(
+                "ci\tCheckout\tHEAD is now at {first}\nci\tCheckout\tHEAD is now at {second}\n"
+            ),
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+    assert_eq!(failure["checkout_identity"]["state"], json!("ambiguous"));
+    assert_eq!(failure["actual_checkout_shas"], json!([first, second]));
+}
+
+#[test]
+fn pull_request_head_and_runner_merge_checkout_remain_separate() {
+    let merge = "5555555555555555555555555555555555555555";
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", OLD)
+        .with_pull_request(json!({
+            "number": 12,
+            "url": "https://github.com/acme/orbit/pull/12",
+            "head_branch": "feature-x",
+            "reported_head_sha": HEAD,
+        }))
+        .with_runs(vec![vec![run_on_branch(
+            10,
+            "ci",
+            "feature-x",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log(
+            "10",
+            true,
+            &format!("ci\tCheckout\tHEAD is now at {merge}\n"),
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+    assert_eq!(failure["ref_kind"], json!("pull_request"));
+    assert_eq!(failure["event_reported_head_sha"], json!(HEAD));
+    assert_eq!(failure["current_ref_head_sha"], json!(HEAD));
+    assert_eq!(failure["actual_checkout_shas"], json!([merge]));
+    assert_eq!(failure["checkout_identity"]["state"], json!("observed"));
+}
+
+#[test]
 fn latest_non_failing_run_supersedes_older_failures_on_the_same_head() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)

--- a/crates/orbit-exec/src/lib.rs
+++ b/crates/orbit-exec/src/lib.rs
@@ -57,5 +57,7 @@ pub use macos_sandbox::{
     sandbox_exec_unavailable_message, spawn_under_macos_sandbox,
 };
 pub use result::ExecutionResult;
-pub use runner::{EnvironmentMode, ExecRequest, StdinMode, run_process};
+pub use runner::{
+    EnvironmentMode, ExecRequest, StdinMode, run_process, run_process_streaming_stdout,
+};
 pub use sandbox::{NoSandbox, Sandbox};

--- a/crates/orbit-exec/src/runner.rs
+++ b/crates/orbit-exec/src/runner.rs
@@ -1,3 +1,5 @@
+use std::process::ChildStdout;
+use std::thread;
 use std::time::Instant;
 
 use orbit_common::OrbitError;
@@ -90,4 +92,57 @@ pub fn run_process(
         duration_ms: started.elapsed().as_millis() as u64,
         output: None,
     })
+}
+
+/// Run a process while consuming stdout incrementally instead of retaining it.
+///
+/// Callers that need to inspect a potentially large stream should keep their
+/// own accumulator bounded in `consume`. Stderr remains subject to Orbit's
+/// normal output-capture limit, and the returned `stdout` is intentionally
+/// empty because the stream was handed to the consumer.
+pub fn run_process_streaming_stdout<T, F>(
+    req: &ExecRequest,
+    sandbox: &dyn Sandbox,
+    consume: F,
+) -> Result<(ExecutionResult, T), OrbitError>
+where
+    T: Send + 'static,
+    F: FnOnce(ChildStdout) -> Result<T, OrbitError> + Send + 'static,
+{
+    sandbox.validate(req)?;
+
+    let started = Instant::now();
+    let mut child = crate::process::spawn(req)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| OrbitError::Execution("process stdout was not piped".to_string()))?;
+    let stdout_thread = thread::spawn(move || consume(stdout));
+    let stdin_payload = match &req.stdin_mode {
+        StdinMode::Bytes(bytes) => Some(bytes.clone()),
+        StdinMode::Inherit | StdinMode::Null => None,
+    };
+    // `stdout` was deliberately removed above. The standard supervisor still
+    // drains stderr, enforces timeouts, and cleans up the child process group.
+    let result = crate::supervision::wait_with_optional_timeout(
+        child,
+        req.timeout_ms,
+        req.debug,
+        stdin_payload,
+    )?;
+    let consumed = stdout_thread
+        .join()
+        .map_err(|_| OrbitError::Execution("stdout consumer thread panicked".to_string()))??;
+
+    Ok((
+        ExecutionResult {
+            success: result.exit_success,
+            stdout: String::new(),
+            stderr: String::from_utf8_lossy(&result.stderr).to_string(),
+            exit_code: result.exit_code,
+            duration_ms: started.elapsed().as_millis() as u64,
+            output: None,
+        },
+        consumed,
+    ))
 }

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -317,6 +317,10 @@ const CHECKOUT_MARKERS: &[&str] = &[
 
 const MIN_SHA_LEN: usize = 7;
 const MAX_SHA_LEN: usize = 40;
+/// The most source bytes checkout extraction will inspect from one log. The
+/// rest is still drained so `gh` can exit, but identity is marked incomplete.
+pub const MAX_CHECKOUT_LOG_SCAN_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CHECKOUT_EVIDENCE_LINE_BYTES: usize = 16 * 1024;
 
 /// The commit a runner actually checked out, read out of the runner's own log.
 ///
@@ -327,6 +331,187 @@ const MAX_SHA_LEN: usize = 40;
 pub struct CheckoutEvidence {
     pub commits: Vec<String>,
     pub lines: Vec<String>,
+    pub complete: bool,
+    pub scanned_bytes: usize,
+    pub source_truncated: bool,
+}
+
+/// A bounded excerpt and checkout evidence collected while a log is drained.
+/// No complete copy of the source log is retained.
+pub struct StreamedLog {
+    pub text: String,
+    pub truncated: bool,
+    pub total_bytes: usize,
+    pub returned_bytes: usize,
+    pub checkout_evidence: CheckoutEvidence,
+}
+
+/// Incrementally retain the head/tail excerpt and checkout evidence from a
+/// potentially large log. `scan_limit` makes incomplete identity explicit
+/// instead of retaining an unbounded source stream.
+pub struct StreamedLogCollector {
+    max_bytes: usize,
+    head: Vec<u8>,
+    tail: Vec<u8>,
+    total_bytes: usize,
+    evidence: CheckoutEvidenceCollector,
+}
+
+impl StreamedLogCollector {
+    pub fn new(max_bytes: usize, max_evidence_lines: usize) -> Self {
+        Self {
+            max_bytes,
+            head: Vec::with_capacity(max_bytes / 2),
+            tail: Vec::with_capacity(max_bytes.saturating_sub(max_bytes / 2)),
+            total_bytes: 0,
+            evidence: CheckoutEvidenceCollector::new(
+                max_evidence_lines,
+                MAX_CHECKOUT_LOG_SCAN_BYTES,
+            ),
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) {
+        self.total_bytes = self.total_bytes.saturating_add(chunk.len());
+        self.evidence.push(chunk);
+
+        let head_limit = self.max_bytes / 2;
+        let head_take = head_limit.saturating_sub(self.head.len()).min(chunk.len());
+        self.head.extend_from_slice(&chunk[..head_take]);
+        let tail_limit = self.max_bytes.saturating_sub(head_limit);
+        self.tail.extend_from_slice(&chunk[head_take..]);
+        if self.tail.len() > tail_limit {
+            self.tail.drain(..self.tail.len() - tail_limit);
+        }
+    }
+
+    pub fn finish(mut self) -> StreamedLog {
+        let evidence = self.evidence.finish();
+        let truncated = self.total_bytes > self.max_bytes;
+        let text = if truncated {
+            let omitted = self
+                .total_bytes
+                .saturating_sub(self.head.len() + self.tail.len());
+            format!(
+                "{}\n[... {omitted} bytes omitted; raise the byte budget for more ...]\n{}",
+                redact_all(&String::from_utf8_lossy(&self.head)),
+                redact_all(&String::from_utf8_lossy(&self.tail)),
+            )
+        } else {
+            // When the source is short, all bytes are in `tail` except the
+            // initial head window, so join the two retained halves.
+            self.head.extend_from_slice(&self.tail);
+            redact_all(&String::from_utf8_lossy(&self.head))
+        };
+        StreamedLog {
+            returned_bytes: text.len(),
+            text,
+            truncated,
+            total_bytes: self.total_bytes,
+            checkout_evidence: evidence,
+        }
+    }
+}
+
+struct CheckoutEvidenceCollector {
+    max_lines: usize,
+    scan_limit: usize,
+    scanned_bytes: usize,
+    source_truncated: bool,
+    pending_line: String,
+    dropping_line: bool,
+    commits: Vec<String>,
+    seen_commits: HashSet<String>,
+    lines: Vec<String>,
+    complete: bool,
+}
+
+impl CheckoutEvidenceCollector {
+    fn new(max_lines: usize, scan_limit: usize) -> Self {
+        Self {
+            max_lines,
+            scan_limit,
+            scanned_bytes: 0,
+            source_truncated: false,
+            pending_line: String::new(),
+            dropping_line: false,
+            commits: Vec::new(),
+            seen_commits: HashSet::new(),
+            lines: Vec::new(),
+            complete: true,
+        }
+    }
+
+    fn push(&mut self, chunk: &[u8]) {
+        let remaining = self.scan_limit.saturating_sub(self.scanned_bytes);
+        let scanned = &chunk[..chunk.len().min(remaining)];
+        self.scanned_bytes += scanned.len();
+        if scanned.len() < chunk.len() {
+            self.source_truncated = true;
+            self.complete = false;
+        }
+        for part in String::from_utf8_lossy(scanned).split_inclusive('\n') {
+            if self.dropping_line {
+                if part.ends_with('\n') {
+                    self.dropping_line = false;
+                }
+                continue;
+            }
+            if self.pending_line.len() + part.len() > MAX_CHECKOUT_EVIDENCE_LINE_BYTES {
+                self.pending_line.clear();
+                self.dropping_line = !part.ends_with('\n');
+                self.complete = false;
+                continue;
+            }
+            self.pending_line.push_str(part);
+            if self.pending_line.ends_with('\n') {
+                self.observe_pending_line();
+            }
+        }
+    }
+
+    fn finish(mut self) -> CheckoutEvidence {
+        if !self.pending_line.is_empty() && !self.dropping_line {
+            self.observe_pending_line();
+        }
+        CheckoutEvidence {
+            commits: self.commits,
+            lines: self.lines,
+            complete: self.complete,
+            scanned_bytes: self.scanned_bytes,
+            source_truncated: self.source_truncated,
+        }
+    }
+
+    fn observe_pending_line(&mut self) {
+        let line = std::mem::take(&mut self.pending_line);
+        let (step, payload) = split_log_line(&line);
+        let lowered = payload.to_ascii_lowercase();
+        let marked = CHECKOUT_MARKERS
+            .iter()
+            .any(|marker| lowered.contains(marker));
+        let in_checkout_step = step.to_ascii_lowercase().contains("checkout");
+        if !(marked || in_checkout_step && is_bare_commit_sha(payload)) {
+            return;
+        }
+        if self.lines.len() < self.max_lines {
+            self.lines.push(redact_all(payload.trim()));
+        } else {
+            self.complete = false;
+        }
+        for token in commit_sha_tokens(payload) {
+            if self.seen_commits.contains(token) {
+                continue;
+            }
+            if self.commits.len() == self.max_lines {
+                self.complete = false;
+                continue;
+            }
+            let token = token.to_string();
+            self.seen_commits.insert(token.clone());
+            self.commits.push(token);
+        }
+    }
 }
 
 /// Split one `gh run view --log` line into its step column and its payload.
@@ -401,36 +586,9 @@ fn commit_sha_tokens(payload: &str) -> Vec<&str> {
 /// of thousands of fetch lines must not hand the caller an unbounded commit
 /// list, and membership is a set lookup rather than a scan per token.
 pub fn scan_checkout_evidence(log: &str, max_lines: usize) -> CheckoutEvidence {
-    let mut commits: Vec<String> = Vec::new();
-    let mut seen_commits: HashSet<&str> = HashSet::new();
-    let mut lines = Vec::new();
-    for line in log.lines() {
-        if commits.len() >= max_lines && lines.len() >= max_lines {
-            break;
-        }
-        let (step, payload) = split_log_line(line);
-        let lowered = payload.to_ascii_lowercase();
-        let marked = CHECKOUT_MARKERS
-            .iter()
-            .any(|marker| lowered.contains(marker));
-        let in_checkout_step = step.to_ascii_lowercase().contains("checkout");
-        let is_evidence = marked || (in_checkout_step && is_bare_commit_sha(payload));
-        if !is_evidence {
-            continue;
-        }
-        for token in commit_sha_tokens(payload) {
-            if commits.len() >= max_lines {
-                break;
-            }
-            if seen_commits.insert(token) {
-                commits.push(token.to_string());
-            }
-        }
-        if lines.len() < max_lines {
-            lines.push(redact_all(payload.trim()));
-        }
-    }
-    CheckoutEvidence { commits, lines }
+    let mut collector = CheckoutEvidenceCollector::new(max_lines, log.len());
+    collector.push(log.as_bytes());
+    collector.finish()
 }
 
 #[cfg(test)]

--- a/crates/orbit-tools/src/builtin/github/run_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/run_logs.rs
@@ -1,5 +1,7 @@
+use std::io::Read;
+
 use orbit_common::OrbitError;
-use orbit_exec::ExecRequest;
+use orbit_exec::{ExecRequest, NoSandbox, run_process_streaming_stdout};
 use serde_json::{Value, json};
 
 use crate::{TIMEOUT_LONG_MS, check_exec_result};
@@ -48,41 +50,78 @@ pub fn build_exec_request(input: &Value) -> Result<ExecRequest, OrbitError> {
     Ok(super::gh_exec_request(args, None, TIMEOUT_LONG_MS))
 }
 
-super::gh_tool! {
-    pub struct GithubRunLogsTool;
-    name: "github.run.logs";
-    description: "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.";
-    parameters: [
-        super::tool_param("run", "Numeric workflow-run ID", "string", true),
-        super::tool_param("job", "Numeric job ID to narrow the log to one job", "string", false),
-        super::tool_param("scope", "\"failed\" (default) for failed-step logs, or \"all\" for the full run log — use \"all\" to evidence the checked-out commit, since the checkout step usually succeeds", "string", false),
-        super::tool_param("max_bytes", "Maximum log bytes to return (default 16384, capped at 262144). The excerpt keeps the head and the tail and marks the omitted gap.", "integer", false),
-        super::tool_param("repo", "Repository in owner/name format (uses current directory if omitted)", "string", false),
-    ];
-    request: |_ctx, input| {
-        build_exec_request(input)
-    }
-    response: |_ctx, input, result| {
-        check_exec_result(result, "gh run view --log")?;
+pub struct GithubRunLogsTool;
 
+impl crate::Tool for GithubRunLogsTool {
+    fn schema(&self) -> orbit_types::tool::ToolSchema {
+        super::gh_schema(
+            "github.run.logs",
+            "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is drained incrementally; checkout extraction stops after 8 MiB and reports incomplete evidence rather than retaining an unbounded log.",
+            vec![
+                super::tool_param("run", "Numeric workflow-run ID", "string", true),
+                super::tool_param(
+                    "job",
+                    "Numeric job ID to narrow the log to one job",
+                    "string",
+                    false,
+                ),
+                super::tool_param(
+                    "scope",
+                    "\"failed\" (default) for failed-step logs, or \"all\" for the full run log — use \"all\" to evidence the checked-out commit, since the checkout step usually succeeds",
+                    "string",
+                    false,
+                ),
+                super::tool_param(
+                    "max_bytes",
+                    "Maximum log bytes to return (default 16384, capped at 262144). The excerpt keeps the head and the tail and marks the omitted gap.",
+                    "integer",
+                    false,
+                ),
+                super::tool_param(
+                    "repo",
+                    "Repository in owner/name format (uses current directory if omitted)",
+                    "string",
+                    false,
+                ),
+            ],
+        )
+    }
+
+    fn execute(&self, _ctx: &crate::ToolContext, input: Value) -> Result<Value, OrbitError> {
+        let request = build_exec_request(&input)?;
         let max_bytes =
-            super::bounded_limit(input, "max_bytes", DEFAULT_MAX_BYTES, MAX_MAX_BYTES)? as usize;
-        let bounded = super::bound_log_text(&result.stdout, max_bytes);
-        // Scan the whole log, not the excerpt: truncation must not be able to
-        // hide the checkout evidence the caller came for.
-        let evidence = super::scan_checkout_evidence(&result.stdout, MAX_EVIDENCE_LINES);
+            super::bounded_limit(&input, "max_bytes", DEFAULT_MAX_BYTES, MAX_MAX_BYTES)? as usize;
+        let (result, log) =
+            run_process_streaming_stdout(&request, &NoSandbox, move |mut stdout| {
+                let mut collector = super::StreamedLogCollector::new(max_bytes, MAX_EVIDENCE_LINES);
+                let mut chunk = [0_u8; 4096];
+                loop {
+                    let read = stdout.read(&mut chunk).map_err(|error| {
+                        OrbitError::Execution(format!("failed reading gh run log: {error}"))
+                    })?;
+                    if read == 0 {
+                        return Ok(collector.finish());
+                    }
+                    collector.push(&chunk[..read]);
+                }
+            })?;
+        check_exec_result(&result, "gh run view --log")?;
+        let evidence = log.checkout_evidence;
 
         Ok(json!({
             "run_id": input.get("run"),
             "scope": input.get("scope").and_then(Value::as_str).unwrap_or("failed"),
-            "log": bounded.text,
-            "truncated": bounded.truncated,
-            "returned_bytes": bounded.returned_bytes,
-            "total_bytes": bounded.total_bytes,
+            "log": log.text,
+            "truncated": log.truncated,
+            "returned_bytes": log.returned_bytes,
+            "total_bytes": log.total_bytes,
             // Distinct from any run's `reported_head_sha`: this is what the
             // runner checked out, read from the runner's own output.
             "checkout_commits": evidence.commits,
             "checkout_evidence": evidence.lines,
+            "checkout_evidence_complete": evidence.complete,
+            "checkout_evidence_scanned_bytes": evidence.scanned_bytes,
+            "checkout_evidence_source_truncated": evidence.source_truncated,
         }))
     }
 }

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -1,7 +1,9 @@
 //! Bounding and redaction of runner-log excerpts, plus the checkout-evidence
 //! scan that keeps the tested commit distinct from a run's reported head SHA.
 
-use crate::builtin::github::{bound_log_text, scan_checkout_evidence};
+use crate::builtin::github::{
+    MAX_CHECKOUT_LOG_SCAN_BYTES, StreamedLogCollector, bound_log_text, scan_checkout_evidence,
+};
 
 #[test]
 fn a_short_log_is_returned_whole_and_unmarked() {
@@ -175,4 +177,39 @@ fn checkout_evidence_caps_and_dedups_commits() {
     unique.dedup();
     assert_eq!(unique.len(), evidence.commits.len());
     assert_eq!(evidence.commits[0], format!("{:040x}", 0));
+}
+
+#[test]
+fn streaming_log_finds_middle_checkout_without_retaining_it_in_the_excerpt() {
+    let sha = "2d773a649844b168c5cfce4c80feadb8b025bb69";
+    let mut collector = StreamedLogCollector::new(96, 40);
+    collector.push(b"head-marker\n");
+    collector.push(&vec![b'x'; 400]);
+    collector.push(format!("\nsetup\tCheckout\tHEAD is now at {sha}\n").as_bytes());
+    collector.push(&vec![b'y'; 400]);
+    collector.push(b"\ntail-marker\n");
+    let log = collector.finish();
+
+    assert!(log.truncated);
+    assert!(log.text.contains("head-marker"));
+    assert!(log.text.contains("tail-marker"));
+    assert!(
+        !log.text.contains(sha),
+        "checkout belongs in evidence, not excerpt"
+    );
+    assert_eq!(log.checkout_evidence.commits, [sha]);
+    assert!(log.checkout_evidence.complete);
+}
+
+#[test]
+fn streaming_log_marks_identity_incomplete_after_the_hard_scan_limit() {
+    let sha = "2d773a649844b168c5cfce4c80feadb8b025bb69";
+    let mut collector = StreamedLogCollector::new(64, 40);
+    collector.push(&vec![b'x'; MAX_CHECKOUT_LOG_SCAN_BYTES]);
+    collector.push(format!("\nsetup\tCheckout\tHEAD is now at {sha}\n").as_bytes());
+    let log = collector.finish();
+
+    assert!(log.checkout_evidence.source_truncated);
+    assert!(!log.checkout_evidence.complete);
+    assert!(log.checkout_evidence.commits.is_empty());
 }

--- a/crates/orbit-tools/src/github_cli.rs
+++ b/crates/orbit-tools/src/github_cli.rs
@@ -39,5 +39,6 @@ pub use crate::builtin::github::run_view::{
     build_exec_request as run_view_request, project_run_view,
 };
 pub use crate::builtin::github::{
-    BoundedLog, CheckoutEvidence, bound_log_text, parse_gh_json, scan_checkout_evidence,
+    BoundedLog, CheckoutEvidence, StreamedLog, StreamedLogCollector, bound_log_text, parse_gh_json,
+    scan_checkout_evidence,
 };

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -63,6 +63,12 @@ rg -n 'error|failed|panic|conflict|Validation|Outcome|execution_summary|git push
 
 Do not paste huge transcripts back to the human — summarize the decisive lines and identify the blob/command source.
 
+For CI-failure sweeps, checkout identity is separate runner-log evidence, not
+the API event or pull-request head SHA. The collector streams the full log,
+keeps only a bounded human excerpt, and scans at most 8 MiB for checkout
+evidence. Treat `checkout_identity.state: incomplete`, `missing`, or
+`ambiguous` as a diagnostic; do not fill it from another SHA field.
+
 ## Distinguish Failure Classes
 
 - **Implementation failure:** the agent loop exited nonzero or reported a failed envelope during `implement_one`.


### PR DESCRIPTION
## Task

[ORB-11226](https://orbit-cli.com/tasks/ORB-11226) — Extract CI checkout identity before truncating human log excerpts

### Description

## Reproduction
Mac dsearch ci_failure_sweep_pipeline jrun-20260905-0316-6 failed checkout_evidence: `run logs contained no actual checkout SHA` for Actions runs 33852651599, 33832979876, and 33832979829. Manual `gh run view 33852651599 --log` has `git log -1 --format=%H` at line115 followed by actual checkout 2d773a649844b168c5cfce4c80feadb8b025bb69 at line116. The bounded head/tail excerpt loses this middle evidence.

crates/orbit-engine/src/executor/automation/ci/collect.rs calls queries.run_logs(LogScope::All, bounds.log_max_bytes) before extracting identity around lines670-685. The collector activity supports log_max_bytes/max_checkout_log_reads, while the ordinary installed sweep job does not forward tuning inputs. Raising every log cap is not a durable fix.

## Outcome
Preserve bounded output/memory while extracting actual checkout identity from the relevant full stream or checkout-step scope before human-excerpt truncation. Preserve distinction among API head SHA, PR merge SHA, and actually checked-out SHA; missing/ambiguous/conflicting evidence remains explicit. Don't infer actual checkout from API head solely to turn CI green. A malformed run should remain a per-run diagnostic and should not discard independent valid findings if the collection contract permits partial evidence.

Leave proposed until task pilot prepares context.

### Acceptance Criteria

- A fixture with actual checkout SHA in the middle beyond the excerpt bounds succeeds and reports exact observed SHA and provenance, while human output stays bounded.
- Cover PR merge/head mismatch, multiple checkout steps, missing evidence, and contradictory SHAs; no false confident identity is returned.
- Source ingestion/extraction is bounded or streamed with a documented hard limit and honest truncation/incomplete state; don't retain whole unbounded logs.
- Existing CI collector regression tests plus make ci-fast and make ci-lint pass, with affected guidance updated.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a streaming stdout execution path and bounded GitHub log collector: it keeps a head/tail human excerpt, scans checkout evidence before excerpt truncation, and retains no whole runner log.
- Checkout extraction has an explicit 8 MiB source scan limit. Evidence now records completeness, scanned bytes, source truncation, and an observed/missing/ambiguous/incomplete identity with runner-log provenance.
- Updated the agent-facing GitHub log tool, CI collector, mirrored activity/job guidance, and run-debugging guidance.
- Added regression coverage for middle-of-log SHA evidence, scan-limit incompleteness, PR head versus runner merge checkout, and contradictory checkout steps.
Assessment: Scoped implementation preserves the existing engine → tools → exec layering and does not infer checkout identity from API metadata.
Validation:
- cargo test -p orbit-tools bounded_logs --no-default-features
- cargo test -p orbit-engine executor::automation::ci::tests::collect --no-default-features
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11226-6a9b8e20`
- Behind base: 0
- Ahead of base: 1