### PR TITLE
Make targeted run cancellation race safely with worker terminalization

### DIFF
--- a/crates/orbit-cli/src/command/run/cancel.rs
+++ b/crates/orbit-cli/src/command/run/cancel.rs
@@ -8,12 +8,13 @@ use crate::command::{CommandOut, CommandOutput, Execute, Payload, require_confir
 
 #[derive(Args)]
 #[command(
-    about = "Cancel a pending or running job run",
+    about = "Cancel a job run, or report its existing terminal outcome",
     after_help = "Cancels a job run that has not reached a terminal state: signals the \
 owner process of a running run (TERM then KILL), releases the run's task \
 reservations, and finalizes the run as `cancelled`. The primary remediation \
 for a stuck `pending` run with no live worker (orphan reconciliation also \
-clears those on workspace open).\n\nExamples:\n  orbit run cancel jrun-20260706-0120-2 --confirm\n  orbit run cancel jrun-20260706-0120-2 --confirm --json"
+clears those on workspace open). A run that already finished returns a stable \
+`already_terminal` result without replacing its outcome.\n\nExamples:\n  orbit run cancel jrun-20260706-0120-2 --confirm\n  orbit run cancel jrun-20260706-0120-2 --confirm --json"
 )]
 pub struct RunCancelArgs {
     /// Job run ID to cancel
@@ -35,6 +36,7 @@ impl Execute for RunCancelArgs {
         if self.json {
             return Ok(Payload::document(json!({
                 "run_id": result.run_id,
+                "outcome": result.outcome,
                 "previous_state": result.previous_state,
                 "final_state": result.final_state,
                 "signal_attempted": result.signal_attempted,
@@ -42,10 +44,17 @@ impl Execute for RunCancelArgs {
             }))
             .into());
         }
-        println!(
-            "cancelled job run {} ({} -> {})",
-            result.run_id, result.previous_state, result.final_state
-        );
+        if result.outcome == "already_terminal" {
+            println!(
+                "job run {} was already terminal ({})",
+                result.run_id, result.final_state
+            );
+        } else {
+            println!(
+                "cancelled job run {} ({} -> {})",
+                result.run_id, result.previous_state, result.final_state
+            );
+        }
         if let Some(outcome) = &result.signal_outcome {
             println!("owner process signal outcome: {outcome}");
         }

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -98,6 +98,14 @@ fn cancel_requires_confirmation_before_terminalizing_pending_run() {
             .state,
         JobRunState::Cancelled
     );
+
+    RunCancelArgs {
+        run_id: run.run_id.clone(),
+        json: true,
+        confirm: true,
+    }
+    .execute(&runtime)
+    .expect("duplicate cancellation reports already-terminal success");
 }
 
 #[test]

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -33,6 +33,11 @@ use crate::application::job::resume::ResumePlan;
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+
+#[cfg(unix)]
+use super::run::CANCELLATION_WORKER_EXIT_AUDIT;
 
 const PIPELINE_WAIT_DEFAULT_TIMEOUT_SECONDS: u64 = 3600;
 const PIPELINE_WAIT_MAX_TIMEOUT_SECONDS: u64 = 7200;
@@ -1099,6 +1104,24 @@ impl OrbitRuntime {
                     );
                     return Ok(());
                 }
+                #[cfg(unix)]
+                if let Some(signal) = status
+                    .signal()
+                    .filter(|signal| matches!(*signal, libc::SIGTERM | libc::SIGKILL))
+                    && self.record_pipeline_worker_cancellation_exit(
+                        &run,
+                        signal,
+                        &status.to_string(),
+                        actor,
+                    )?
+                {
+                    // The cancelling caller owns terminalization after it has
+                    // verified both the recorded leader and process group are
+                    // gone. Reaping the worker proves only the leader exited;
+                    // finalizing here could release reservations while a
+                    // run-owned child remains alive.
+                    return Ok(());
+                }
                 if run.state.is_terminal() {
                     return Ok(());
                 }
@@ -1121,6 +1144,41 @@ impl OrbitRuntime {
 
             thread::sleep(Duration::from_millis(25));
         }
+    }
+
+    /// Record a TERM/KILL worker exit that belongs to an outstanding
+    /// cancellation request, without terminalizing the run. The signalling
+    /// caller performs the authoritative liveness verification and then
+    /// finalizes `cancelled`; this observer only preserves the completion
+    /// cause and suppresses the misleading generic worker-failure path.
+    #[cfg(unix)]
+    pub(crate) fn record_pipeline_worker_cancellation_exit(
+        &self,
+        run: &JobRun,
+        signal: i32,
+        exit_status: &str,
+        actor: Option<&str>,
+    ) -> Result<bool, OrbitError> {
+        let Some(request_id) = self.active_job_run_cancellation_request(&run.run_id)? else {
+            return Ok(false);
+        };
+        self.record_pipeline_audit(
+            CANCELLATION_WORKER_EXIT_AUDIT,
+            Some(&run.run_id),
+            actor,
+            AuditEventStatus::Success,
+            json!({
+                "request_id": request_id,
+                "run_id": run.run_id,
+                "owner_pid": run.pid,
+                "signal": signal,
+                "signal_name": worker_cancellation_signal_name(signal),
+                "exit_status": exit_status,
+                "observed_at": Utc::now().to_rfc3339(),
+            }),
+            None,
+        )?;
+        Ok(true)
     }
 
     /// Terminalize a worker process that exited while it still owned a
@@ -1325,6 +1383,15 @@ impl OrbitRuntime {
             activity_id: None,
             step_index: None,
         })
+    }
+}
+
+#[cfg(unix)]
+fn worker_cancellation_signal_name(signal: i32) -> &'static str {
+    match signal {
+        libc::SIGTERM => "SIGTERM",
+        libc::SIGKILL => "SIGKILL",
+        _ => "unknown",
     }
 }
 

--- a/crates/orbit-core/src/application/job/run/actions.rs
+++ b/crates/orbit-core/src/application/job/run/actions.rs
@@ -1,9 +1,16 @@
 //! Cancellation, archive, delete, and run-state helpers for job runs.
 
+#[cfg(unix)]
+use std::collections::{HashMap, HashSet};
+
 use chrono::Utc;
+use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::{NotFoundKind, OrbitError};
+#[cfg(unix)]
+use orbit_store::contracts::AuditEventFilter;
 use orbit_store::contracts::TaskReservationReleaseReason;
 use orbit_types::record::OrbitEvent;
+use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
     ChildCancellation, ChildCancellationPolicy, JobRun, JobRunState, PipelineState,
 };
@@ -18,6 +25,11 @@ use super::types::JobRunCancelResult;
 const CHILD_CASCADE_SOURCE: &str = "parent_cascade";
 /// Backstop against a cycle in persisted dispatch records.
 const MAX_CHILD_CANCEL_CASCADE_DEPTH: usize = 8;
+pub(crate) const CANCELLATION_REQUEST_AUDIT: &str = "pipeline.run.cancel.requested";
+pub(crate) const CANCELLATION_SIGNAL_AUDIT: &str = "pipeline.run.cancel.signal_acknowledged";
+pub(crate) const CANCELLATION_COMPLETION_AUDIT: &str = "pipeline.run.cancel.completed";
+#[cfg(unix)]
+pub(crate) const CANCELLATION_WORKER_EXIT_AUDIT: &str = "pipeline.run.cancel.worker_exit";
 
 impl OrbitRuntime {
     pub fn cancel_job_run(&self, run_id: &str) -> Result<JobRunCancelResult, OrbitError> {
@@ -62,17 +74,75 @@ impl OrbitRuntime {
         let run = self
             .get_job_run_backend(run_id)?
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
+        let request_id = audit_execution_id("cancel");
+
+        if run.state.is_terminal() {
+            self.record_cancellation_request(&run, &request_id, actor, source)?;
+            self.record_cancellation_completion(&run, &request_id, "already_terminal", None, None)?;
+            return Ok(cancellation_result(
+                &run,
+                "already_terminal",
+                run.state,
+                false,
+                None,
+                actor,
+                source,
+            ));
+        }
         run.state
             .try_transition(orbit_types::workflow::RunEvent::Cancel)
             .map_err(|msg| {
                 OrbitError::JobValidation(format!("cannot cancel job run '{}': {}", run_id, msg))
             })?;
+        self.record_cancellation_request(&run, &request_id, actor, source)?;
         let signal_attempted = run.state == JobRunState::Running && run.pid.is_some();
         let signal_outcome = if signal_attempted {
-            Some(signal(&run)?)
+            match signal(&run) {
+                Ok(outcome) => {
+                    self.record_cancellation_signal_acknowledgement(&run, &request_id, &outcome)?;
+                    Some(outcome)
+                }
+                Err(error) => {
+                    let _ = self.record_cancellation_completion(
+                        &run,
+                        &request_id,
+                        "failed",
+                        None,
+                        Some(&error.to_string()),
+                    );
+                    return Err(error);
+                }
+            }
         } else {
             None
         };
+
+        // The worker can reach a real terminal outcome while its owner is
+        // being signalled. That outcome is authoritative: cancellation lost
+        // the race and is an idempotent already-terminal result, not a second
+        // terminalization attempt or a terminal-outcome conflict.
+        let after_signal = self
+            .get_job_run_backend(run_id)?
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
+        if after_signal.state.is_terminal() {
+            self.record_cancellation_completion(
+                &after_signal,
+                &request_id,
+                "already_terminal",
+                signal_outcome.as_deref(),
+                None,
+            )?;
+            return Ok(cancellation_result(
+                &run,
+                "already_terminal",
+                after_signal.state,
+                signal_attempted,
+                signal_outcome,
+                actor,
+                source,
+            ));
+        }
+
         let now = chrono::Utc::now();
         let duration_ms = run
             .started_at
@@ -88,6 +158,24 @@ impl OrbitRuntime {
             .get_job_run_backend(run_id)?
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
         if cancelled_run.state != JobRunState::Cancelled {
+            if cancelled_run.state.is_terminal() {
+                self.record_cancellation_completion(
+                    &cancelled_run,
+                    &request_id,
+                    "already_terminal",
+                    signal_outcome.as_deref(),
+                    None,
+                )?;
+                return Ok(cancellation_result(
+                    &run,
+                    "already_terminal",
+                    cancelled_run.state,
+                    signal_attempted,
+                    signal_outcome,
+                    actor,
+                    source,
+                ));
+            }
             let detail = cancelled_run
                 .state
                 .try_transition(orbit_types::workflow::RunEvent::Cancel)
@@ -115,15 +203,156 @@ impl OrbitRuntime {
             signal_attempted: Some(signal_attempted),
             signal_outcome: signal_outcome.clone(),
         })?;
-        Ok(JobRunCancelResult {
-            run_id: run_id.to_string(),
-            previous_state: run.state.to_string(),
-            final_state: JobRunState::Cancelled.to_string(),
-            actor: actor.to_string(),
-            source: source.to_string(),
+        self.record_cancellation_completion(
+            &cancelled_run,
+            &request_id,
+            "cancelled",
+            signal_outcome.as_deref(),
+            None,
+        )?;
+        Ok(cancellation_result(
+            &run,
+            "cancelled",
+            JobRunState::Cancelled,
             signal_attempted,
             signal_outcome,
-        })
+            actor,
+            source,
+        ))
+    }
+
+    fn record_cancellation_request(
+        &self,
+        run: &JobRun,
+        request_id: &str,
+        actor: &str,
+        source: &str,
+    ) -> Result<(), OrbitError> {
+        self.record_pipeline_audit(
+            CANCELLATION_REQUEST_AUDIT,
+            Some(&run.run_id),
+            Some(actor),
+            AuditEventStatus::Success,
+            serde_json::json!({
+                "request_id": request_id,
+                "run_id": run.run_id,
+                "requested_state": run.state.to_string(),
+                "owner_pid": run.pid,
+                "owner_pid_start_time": run.pid_start_time,
+                "actor": actor,
+                "source": source,
+                "requested_at": Utc::now().to_rfc3339(),
+            }),
+            None,
+        )
+    }
+
+    fn record_cancellation_signal_acknowledgement(
+        &self,
+        run: &JobRun,
+        request_id: &str,
+        signal_outcome: &str,
+    ) -> Result<(), OrbitError> {
+        self.record_pipeline_audit(
+            CANCELLATION_SIGNAL_AUDIT,
+            Some(&run.run_id),
+            None,
+            AuditEventStatus::Success,
+            serde_json::json!({
+                "request_id": request_id,
+                "run_id": run.run_id,
+                "signal_outcome": signal_outcome,
+                "acknowledged_at": Utc::now().to_rfc3339(),
+            }),
+            None,
+        )
+    }
+
+    fn record_cancellation_completion(
+        &self,
+        run: &JobRun,
+        request_id: &str,
+        outcome: &str,
+        signal_outcome: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        self.record_pipeline_audit(
+            CANCELLATION_COMPLETION_AUDIT,
+            Some(&run.run_id),
+            None,
+            if outcome == "failed" {
+                AuditEventStatus::Failure
+            } else {
+                AuditEventStatus::Success
+            },
+            serde_json::json!({
+                "request_id": request_id,
+                "run_id": run.run_id,
+                "outcome": outcome,
+                "observed_state": run.state.to_string(),
+                "signal_outcome": signal_outcome,
+                "completed_at": Utc::now().to_rfc3339(),
+            }),
+            error.map(str::to_string),
+        )
+    }
+
+    /// The newest cancellation request that has not conclusively failed or
+    /// observed a pre-existing terminal outcome. Worker observers use this to
+    /// avoid converting an expected TERM/KILL exit into a run failure before
+    /// the signalling caller verifies that every owned target stopped.
+    #[cfg(unix)]
+    pub(crate) fn active_job_run_cancellation_request(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<String>, OrbitError> {
+        let audits = self.list_audit_events_filtered(&AuditEventFilter {
+            job_run_id: Some(run_id.to_string()),
+            limit: 200,
+            ..AuditEventFilter::default()
+        })?;
+        let mut completions = HashMap::<String, String>::new();
+        let mut requests = Vec::new();
+        for audit in audits {
+            let Some(tool) = audit.tool_name.as_deref() else {
+                continue;
+            };
+            if !matches!(
+                tool,
+                CANCELLATION_REQUEST_AUDIT | CANCELLATION_COMPLETION_AUDIT
+            ) {
+                continue;
+            }
+            let Some(arguments) = audit
+                .arguments_json
+                .as_deref()
+                .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            else {
+                continue;
+            };
+            let Some(request_id) = arguments.get("request_id").and_then(Value::as_str) else {
+                continue;
+            };
+            if tool == CANCELLATION_COMPLETION_AUDIT {
+                if let Some(outcome) = arguments.get("outcome").and_then(Value::as_str) {
+                    completions
+                        .entry(request_id.to_string())
+                        .or_insert_with(|| outcome.to_string());
+                }
+            } else {
+                requests.push(request_id.to_string());
+            }
+        }
+        let inactive: HashSet<&str> = completions
+            .iter()
+            .filter_map(|(request_id, outcome)| {
+                matches!(outcome.as_str(), "failed" | "already_terminal")
+                    .then_some(request_id.as_str())
+            })
+            .collect();
+        Ok(requests
+            .into_iter()
+            .find(|request_id| !inactive.contains(request_id.as_str())))
     }
 
     pub fn archive_job_run(&self, run_id: &str) -> Result<(), OrbitError> {
@@ -272,7 +501,14 @@ impl OrbitRuntime {
             signal_run_owner_process,
             depth + 1,
         ) {
-            Ok(_) => ("cancelled".to_string(), None),
+            Ok(result) if result.outcome == "already_terminal" => (
+                result.outcome,
+                Some(format!(
+                    "job run '{}' was already terminal ({})",
+                    result.run_id, result.final_state
+                )),
+            ),
+            Ok(result) => (result.outcome, None),
             // A child that reached a terminal state on its own is the ordinary
             // race, not a fault: the parent simply lost it to the finish line.
             Err(OrbitError::JobValidation(message))
@@ -325,5 +561,26 @@ impl OrbitRuntime {
             self.write_run_state(&run.run_id, &state)?;
         }
         Ok(())
+    }
+}
+
+fn cancellation_result(
+    run: &JobRun,
+    outcome: &str,
+    final_state: JobRunState,
+    signal_attempted: bool,
+    signal_outcome: Option<String>,
+    actor: &str,
+    source: &str,
+) -> JobRunCancelResult {
+    JobRunCancelResult {
+        run_id: run.run_id.clone(),
+        outcome: outcome.to_string(),
+        previous_state: run.state.to_string(),
+        final_state: final_state.to_string(),
+        actor: actor.to_string(),
+        source: source.to_string(),
+        signal_attempted,
+        signal_outcome,
     }
 }

--- a/crates/orbit-core/src/application/job/run/conflict.rs
+++ b/crates/orbit-core/src/application/job/run/conflict.rs
@@ -27,6 +27,11 @@
 //! What was actually missing is not a winner rule but a *record*: the operator
 //! needs to know the two outcomes disagreed. So the terminal state stands and
 //! the conflicting outcome is recorded durably and loudly instead of dropped.
+//! A cancellation request that loses to a terminal worker outcome is the one
+//! exception: cancellation reports `already_terminal` and does not manufacture
+//! a conflict by attempting to replace the worker's outcome. The inverse is
+//! still a real conflict — a worker outcome reported after `cancelled` remains
+//! explicit here.
 //!
 //! ## Where a reader sees it
 //!

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -19,6 +19,8 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+#[cfg(unix)]
+pub(crate) use actions::CANCELLATION_WORKER_EXIT_AUDIT;
 #[cfg(test)]
 pub(crate) use conflict::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub(crate) use owner::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/run/tests/actions.rs
+++ b/crates/orbit-core/src/application/job/run/tests/actions.rs
@@ -52,6 +52,7 @@ fn cancel_job_run_marks_pending_cancelled_without_signal() {
         .expect("cancel pending");
 
     assert_eq!(result.previous_state, "pending");
+    assert_eq!(result.outcome, "cancelled");
     assert_eq!(result.final_state, "cancelled");
     assert!(!result.signal_attempted);
     assert_eq!(result.signal_outcome, None);
@@ -156,7 +157,7 @@ fn cancelled_run_wait_status_reports_cancelled() {
 }
 
 #[test]
-fn cancel_job_run_rejects_terminal_run_without_mutating_bundle() {
+fn cancel_job_run_reports_terminal_run_idempotently_without_mutating_bundle() {
     let (_root, runtime) = test_runtime();
     let run = insert_pending_run(&runtime, "qa_cancel_terminal");
     let started_at = Utc::now() - Duration::seconds(2);
@@ -173,14 +174,14 @@ fn cancel_job_run_rejects_terminal_run_without_mutating_bundle() {
         .expect("finalize success");
     let before = runtime.show_job_run(&run.run_id).expect("show before");
 
-    let error = runtime
+    let result = runtime
         .cancel_job_run(&run.run_id)
-        .expect_err("terminal cancellation must fail");
+        .expect("terminal cancellation is an idempotent observation");
 
-    assert!(
-        error.to_string().contains("cannot cancel job run"),
-        "{error}"
-    );
+    assert_eq!(result.outcome, "already_terminal");
+    assert_eq!(result.previous_state, "success");
+    assert_eq!(result.final_state, "success");
+    assert!(!result.signal_attempted);
     let after = runtime.show_job_run(&run.run_id).expect("show after");
     assert_eq!(after, before);
     let events = runtime.list_session_events(20).expect("events");
@@ -432,6 +433,13 @@ fn cancellation_survivor_returns_typed_evidence_without_finalizing_run() {
         runtime.show_job_run(&run.run_id).expect("show run").state,
         JobRunState::Running,
         "a failed liveness verification must not finalize the run"
+    );
+    assert!(
+        runtime
+            .active_job_run_cancellation_request(&run.run_id)
+            .expect("read cancellation audit")
+            .is_none(),
+        "a failed signal attempt must not make a later worker exit look cancellation-induced"
     );
     assert!(
         runtime

--- a/crates/orbit-core/src/application/job/run/tests/cancellation_race.rs
+++ b/crates/orbit-core/src/application/job/run/tests/cancellation_race.rs
@@ -1,0 +1,219 @@
+//! Deterministic cancellation-versus-worker terminalization interleavings.
+
+use super::*;
+
+use orbit_engine::RuntimeHost;
+#[cfg(unix)]
+use orbit_store::TaskReservationReserveParams;
+
+fn mark_running(runtime: &OrbitRuntime, run: &JobRun) {
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("mark running");
+}
+
+fn has_conflict(runtime: &OrbitRuntime, run_id: &str) -> bool {
+    runtime
+        .show_job_run(run_id)
+        .expect("show run")
+        .steps
+        .iter()
+        .any(|step| {
+            step.error_code.as_deref()
+                == Some(crate::application::job::TERMINAL_OUTCOME_CONFLICT_CODE)
+        })
+}
+
+#[cfg(unix)]
+fn reserve_for_run(runtime: &OrbitRuntime, owner_run_id: &str, file: &str) {
+    runtime
+        .stores()
+        .task_reservations()
+        .reserve_task_reservation(TaskReservationReserveParams {
+            workspace_orbit_dir: runtime.paths().orbit_dir.to_string_lossy().into_owned(),
+            workspace_id: Some(runtime.workspace_id().expect("workspace id")),
+            task_ids: Vec::new(),
+            requested_files: vec![file.to_string()],
+            actor: "test".to_string(),
+            ttl_seconds: 3_600,
+            owner_run_id: Some(owner_run_id.to_string()),
+            owner_metadata_json: None,
+        })
+        .expect("reserve for run");
+}
+
+#[cfg(unix)]
+fn active_reservation_owners(runtime: &OrbitRuntime) -> Vec<String> {
+    let workspace_orbit_dir = runtime.paths().orbit_dir.to_string_lossy().into_owned();
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    runtime
+        .stores()
+        .task_reservations()
+        .list_active_task_reservations(&workspace_orbit_dir, Some(&workspace_id))
+        .expect("list active reservations")
+        .reservations
+        .into_iter()
+        .filter_map(|reservation| reservation.owner_run_id)
+        .collect()
+}
+
+/// Exact incident interleaving, without wall-clock sleeps: cancellation intent
+/// is durable, the worker observer sees SIGTERM, and the signaller has not yet
+/// returned from authoritative process-group verification.
+#[cfg(unix)]
+#[test]
+fn signal_induced_worker_exit_defers_to_verified_cancellation() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_signal_race");
+    mark_running(&runtime, &run);
+    reserve_for_run(&runtime, &run.run_id, "file:src/cancelled.rs");
+    reserve_for_run(&runtime, "jrun-unrelated", "file:src/unrelated.rs");
+
+    let result = runtime
+        .cancel_job_run_with_signaller(&run.run_id, "tester", "unit", |owned| {
+            assert_eq!(owned.pid, Some(std::process::id()));
+            assert!(
+                runtime
+                    .active_job_run_cancellation_request(&run.run_id)
+                    .expect("read cancellation intent")
+                    .is_some(),
+                "intent must be durable before any signal is sent"
+            );
+            assert!(
+                runtime
+                    .record_pipeline_worker_cancellation_exit(
+                        owned,
+                        libc::SIGTERM,
+                        "signal: 15 (SIGTERM)",
+                        Some("test-observer"),
+                    )
+                    .expect("record signal-induced exit")
+            );
+            assert_eq!(
+                runtime.show_job_run(&run.run_id).expect("show run").state,
+                JobRunState::Running,
+                "reaping only the leader must not release terminal-owned resources"
+            );
+            let owners = active_reservation_owners(&runtime);
+            assert!(owners.iter().any(|owner| owner == &run.run_id));
+            assert!(owners.iter().any(|owner| owner == "jrun-unrelated"));
+            Ok("terminated_process_group".to_string())
+        })
+        .expect("cancel after verified termination");
+
+    assert_eq!(result.outcome, "cancelled");
+    assert_eq!(result.final_state, "cancelled");
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Cancelled
+    );
+    assert!(!has_conflict(&runtime, &run.run_id));
+    assert_eq!(
+        active_reservation_owners(&runtime),
+        vec!["jrun-unrelated".to_string()],
+        "only the cancelled run's reservation is released after verified termination"
+    );
+    let audit_tools: Vec<String> = runtime
+        .list_audit_events(None, None, None, None, 20)
+        .expect("list cancellation audits")
+        .into_iter()
+        .filter_map(|event| event.tool_name)
+        .collect();
+    for expected in [
+        super::super::actions::CANCELLATION_REQUEST_AUDIT,
+        super::super::actions::CANCELLATION_WORKER_EXIT_AUDIT,
+        super::super::actions::CANCELLATION_SIGNAL_AUDIT,
+        super::super::actions::CANCELLATION_COMPLETION_AUDIT,
+    ] {
+        assert!(
+            audit_tools.iter().any(|tool| tool == expected),
+            "{expected}"
+        );
+    }
+}
+
+#[test]
+fn natural_success_racing_cancellation_remains_success() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_success_race");
+    mark_running(&runtime, &run);
+
+    let result = runtime
+        .cancel_job_run_with_signaller(&run.run_id, "tester", "unit", |_| {
+            runtime
+                .finalize_job_run(&run.run_id, JobRunState::Success, Utc::now(), Some(1))
+                .expect("worker succeeds");
+            Ok("already_exited".to_string())
+        })
+        .expect("observe terminal winner");
+
+    assert_eq!(result.outcome, "already_terminal");
+    assert_eq!(result.final_state, "success");
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Success
+    );
+    assert!(!has_conflict(&runtime, &run.run_id));
+}
+
+#[test]
+fn real_failure_racing_cancellation_remains_failed() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_failure_race");
+    mark_running(&runtime, &run);
+
+    let result = runtime
+        .cancel_job_run_with_signaller(&run.run_id, "tester", "unit", |_| {
+            runtime
+                .finalize_job_run(&run.run_id, JobRunState::Failed, Utc::now(), Some(1))
+                .expect("worker fails");
+            Ok("already_exited".to_string())
+        })
+        .expect("observe terminal winner");
+
+    assert_eq!(result.outcome, "already_terminal");
+    assert_eq!(result.final_state, "failed");
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Failed
+    );
+    assert!(!has_conflict(&runtime, &run.run_id));
+}
+
+#[test]
+fn duplicate_cancellation_requests_converge_without_conflict() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_duplicate_race");
+    mark_running(&runtime, &run);
+
+    let first = runtime
+        .cancel_job_run_with_signaller(&run.run_id, "first", "unit", |_| {
+            let second = runtime
+                .cancel_job_run_with_signaller(&run.run_id, "second", "unit", |_| {
+                    Ok("terminated_process_group".to_string())
+                })
+                .expect("second cancellation wins");
+            assert_eq!(second.outcome, "cancelled");
+            Ok("already_exited".to_string())
+        })
+        .expect("first cancellation observes winner");
+
+    assert_eq!(first.outcome, "already_terminal");
+    assert_eq!(first.final_state, "cancelled");
+    assert!(!has_conflict(&runtime, &run.run_id));
+}
+
+#[test]
+fn worker_failure_after_committed_cancellation_remains_an_explicit_conflict() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_genuine_conflict");
+    runtime.cancel_job_run(&run.run_id).expect("cancel run");
+
+    runtime
+        .finalize_job_run(&run.run_id, JobRunState::Failed, Utc::now(), Some(1))
+        .expect("deliver contradictory worker result");
+
+    assert!(has_conflict(&runtime, &run.run_id));
+}

--- a/crates/orbit-core/src/application/job/run/tests/conflict.rs
+++ b/crates/orbit-core/src/application/job/run/tests/conflict.rs
@@ -144,3 +144,33 @@ fn identical_refinalization_is_not_a_conflict() {
         "an idempotent replay is not a conflicting outcome"
     );
 }
+
+/// A cancellation request can lose the terminalization race after its final
+/// state snapshot. That is an already-terminal result, not evidence that the
+/// worker produced two contradictory outcomes.
+#[test]
+fn cancelled_report_after_worker_terminalization_is_not_a_conflict() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_cancel_lost_race");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("mark running");
+
+    let finished_at = Utc::now();
+    finalize(&runtime, &run, JobRunState::Success, finished_at);
+    finalize(
+        &runtime,
+        &run,
+        JobRunState::Cancelled,
+        finished_at + Duration::milliseconds(1),
+    );
+
+    let shown = runtime.show_job_run(&run.run_id).expect("show run");
+    assert_eq!(shown.state, JobRunState::Success);
+    assert!(
+        conflict_step(&runtime, &run.run_id).is_none(),
+        "a losing cancellation request must not manufacture a conflict"
+    );
+}

--- a/crates/orbit-core/src/application/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/run/tests/mod.rs
@@ -3,6 +3,7 @@
 use crate::OrbitRuntime;
 
 mod actions;
+mod cancellation_race;
 mod conflict;
 mod owner;
 mod projection;

--- a/crates/orbit-core/src/application/job/run/types.rs
+++ b/crates/orbit-core/src/application/job/run/types.rs
@@ -20,6 +20,10 @@ pub struct JobRunListParams {
 #[derive(Debug, Clone, Serialize)]
 pub struct JobRunCancelResult {
     pub run_id: String,
+    /// `cancelled` when this request terminalized the run, or
+    /// `already_terminal` when the run reached a durable terminal outcome
+    /// before this request could do so.
+    pub outcome: String,
     pub previous_state: String,
     pub final_state: String,
     pub actor: String,

--- a/crates/orbit-core/src/runtime/task/reservation_cleanup.rs
+++ b/crates/orbit-core/src/runtime/task/reservation_cleanup.rs
@@ -220,8 +220,14 @@ impl OrbitRuntime {
         // a run condemned to `interrupted` while it was still working and then
         // reporting the success it actually reached. That must not vanish, so
         // it is recorded on the run instead of discarded. See
-        // `command::job::run::conflict` for why the recorded state still wins.
-        if let Some(prior) = prior_state.filter(|prior| prior.is_terminal() && *prior != state) {
+        // `application::job::run::conflict` for why the recorded state still wins.
+        // A cancellation request that loses to a worker's terminal outcome is
+        // reported to the caller as `already_terminal`; it did not produce a
+        // second durable outcome. The inverse remains a real contradiction: a
+        // worker reporting success/failure after `cancelled` is still recorded.
+        if let Some(prior) = prior_state.filter(|prior| {
+            prior.is_terminal() && *prior != state && state != JobRunState::Cancelled
+        }) {
             self.record_terminal_outcome_conflict(run_id, prior, state, finished_at);
         }
         if state.is_terminal() {

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -122,6 +122,7 @@ pub(super) async fn cancel_run_action(Ws(runtime): Ws, Path(id): Path<String>) -
     match runtime.cancel_job_run_with_context(id, "dashboard", "web") {
         Ok(result) => Json(json!({
             "run_id": result.run_id,
+            "outcome": result.outcome,
             "previous_state": result.previous_state,
             "final_state": result.final_state,
             "actor": result.actor,

--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -403,6 +403,7 @@ async fn cancel_run_endpoint_cancels_pending_run() {
     assert_eq!(response.status(), StatusCode::OK);
     let payload = body_json(response).await;
     assert_eq!(payload["run_id"], run.run_id);
+    assert_eq!(payload["outcome"], "cancelled");
     assert_eq!(payload["previous_state"], "pending");
     assert_eq!(payload["final_state"], "cancelled");
     assert_eq!(payload["signal_attempted"], false);
@@ -412,7 +413,7 @@ async fn cancel_run_endpoint_cancels_pending_run() {
 }
 
 #[tokio::test]
-async fn cancel_run_endpoint_rejects_terminal_run_without_mutating_bundle() {
+async fn cancel_run_endpoint_reports_terminal_run_idempotently_without_mutating_bundle() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let run = seed_run(
         &runtime,
@@ -425,13 +426,12 @@ async fn cancel_run_endpoint_rejects_terminal_run_without_mutating_bundle() {
     let response =
         request_cancel(runtime.clone(), &run.run_id, Some("http://localhost:3000")).await;
 
-    assert_eq!(response.status(), StatusCode::CONFLICT);
+    assert_eq!(response.status(), StatusCode::OK);
     let payload = body_json(response).await;
-    assert!(
-        payload["error"]
-            .as_str()
-            .is_some_and(|message| message.contains("cannot cancel job run"))
-    );
+    assert_eq!(payload["outcome"], "already_terminal");
+    assert_eq!(payload["previous_state"], "success");
+    assert_eq!(payload["final_state"], "success");
+    assert_eq!(payload["signal_attempted"], false);
     let after = runtime.show_job_run(&run.run_id).expect("show after");
     assert_eq!(after, before);
 }


### PR DESCRIPTION
## Task

[ORB-11228](https://orbit-cli.com/tasks/ORB-11228) — Make targeted run cancellation race safely with worker terminalization

### Description

## Reproduction
On Mac local-data-platform, Daniel explicitly approved cancellation of duplicate DANI-10199 child run jrun-20260905-0317-3. Supported cancel --confirm stopped its verified child processes, but returned exit1 terminal_outcome_conflict: worker SIGTERM recorded failed at 2026-09-05T03:20:33.730935Z, then cancellation attempted cancelled at 03:20:33.767814Z. The parent auto-drain remained alive. This makes a successful stop appear as an unexplained failed rescue.

## Outcome
Make the cancellation/worker-completion race converge on one truthful durable outcome and idempotent result. Record cancellation intent/acknowledgment at the authoritative lifecycle boundary and reconcile expected signal-induced termination; do not overwrite a genuine prior completed result or release reservations while owned processes remain live. Preserve evidence of real failures and successful completion racing cancellation. Reuse existing terminal-outcome rules; no retries that mask arbitrary conflicts.

Read prior completed ORB-10597 before implementation and extend its liveness guarantees rather than regressing them. No global process kill, no parent drain cancellation, no changes to task approval semantics. Leave proposed; pilot first.

### Acceptance Criteria

- Deterministic synchronized tests force cancel-intent versus signal-induced worker failure, natural success, real failure, and duplicate cancel interleavings without timing sleeps.
- Operator receives a truthful stable cancellation/already-terminal result; expected SIGTERM race does not surface terminal_outcome_conflict, and a genuine conflicting outcome remains explicit.
- Only verified run-owned processes are targeted; reservations and active slots remain until authoritative liveness/terminal rules allow release. Parent and unrelated runs remain live.
- Durable audit retains cancellation request and observed completion cause; focused lifecycle tests plus make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Cancellation now writes a durable pipeline.run.cancel.requested audit before signalling and correlated signal acknowledgement and completion audits afterward.
- The exact-owner worker observer recognizes SIGTERM or SIGKILL while a cancellation request is active, records pipeline.run.cancel.worker_exit with the observed signal, and defers terminalization until the cancelling caller verifies the leader and process group are gone. This preserves run-owned reservations and overlap slots during the gap; unrelated reservations and detached child runs remain untouched.
- Cancellation re-reads the durable run after signalling. Natural success, genuine failure, and duplicate cancellation winners return a stable already_terminal result with the actual final state instead of attempting a conflicting cancelled write. A worker outcome reported after cancellation has committed still records terminal_outcome_conflict.
- CLI JSON and Web responses expose outcome as cancelled or already_terminal; terminal repeats are successful and do not replace the recorded state. CLI text and help describe the same contract.
- Added synchronized, no-sleep lifecycle tests for signal-induced exit, natural success, real failure, duplicate cancellation, reservation retention and scoped release, and the genuine inverse conflict. Existing process identity, process-group termination, detached-child, routine overlap, and reservation cleanup tests remain green.
Strategic decisions:
- Reused the existing durable audit store rather than adding a new persisted schema. Correlated request IDs make intent, signal acknowledgement, observed worker exit, and final resolution inspectable after the fact.
- Reused first-writer-wins terminal rules. Only a losing cancellation report is non-conflicting; a later worker result after cancelled remains explicit.
Scope additions:
- runtime/task/reservation_cleanup.rs was required because the shared finalization boundary classifies terminal conflicts.
- application/job/run/mod.rs, tests/mod.rs, and tests/cancellation_race.rs were required for the tightly coupled observer re-export and a focused sibling test module.
Assessment: The incident race now converges without masking real terminal outcomes or releasing ownership before verified termination. No new crate dependency edge or migration was introduced.
Validation:
- cargo test -p orbit-core application::job::run::tests -- --nocapture: 55 passed.
- cargo test -p orbit-core application::tests::job_pipeline -- --nocapture: 20 passed.
- cargo test -p orbit-core application::routines::tests::sweep -- --nocapture: 13 passed.
- cargo test -p orbit-core runtime::task::tests::reservation_cleanup -- --nocapture: 6 passed.
- Focused orbit-cli cancellation test passed.
- Focused orbit-web cancellation endpoint tests passed: 3 passed.
- make ci-fast passed.
- make ci-lint passed.
- git diff --check passed.
Cleanup:
- Removed the worktree-local Cargo target artifacts created during validation.
Friction checkpoint: no qualifying friction was encountered.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11228-6a9b8e40`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*