### PR TITLE
Show actual activity model selection alongside the requested workflow crew

### DIFF
--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -1,5 +1,9 @@
-use orbit_core::application::job::job_run_to_json;
-use orbit_core::{JobRun, OrbitError, OrbitRuntime, PipelineInvokeResult, PipelineWaitEntry};
+use orbit_core::application::job::{
+    ActivityInvocationEvidence, job_run_to_json_with_activity_provenance,
+};
+use orbit_core::{
+    InvocationQuery, JobRun, OrbitError, OrbitRuntime, PipelineInvokeResult, PipelineWaitEntry,
+};
 use orbit_types::workflow::PipelineState;
 use serde_json::{Value, json};
 
@@ -250,7 +254,36 @@ impl Execute for JobResumeArgs {
 /// The CLI has historically exposed the claimed worker PID; the web API does
 /// not. Keep that contract difference at this presentation boundary.
 pub(crate) fn cli_job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
-    let mut value = job_run_to_json(run, state);
+    let evidence = Vec::new();
+    let mut value = job_run_to_json_with_activity_provenance(run, state, &evidence);
+    value["pid"] = json!(run.pid);
+    value
+}
+
+/// CLI run inspection enriches the compatible shared projection with durable
+/// invocation evidence. Older runs or unavailable telemetry stores remain
+/// inspectable; their activity status is explicitly `unavailable` instead of
+/// borrowing the requested run crew as an actual model claim.
+pub(crate) fn cli_job_run_to_json_with_activity_provenance(
+    runtime: &OrbitRuntime,
+    run: &JobRun,
+    state: Option<&PipelineState>,
+) -> Value {
+    let evidence = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(run.run_id.clone()),
+            limit: 1_000,
+            ..InvocationQuery::default()
+        })
+        .unwrap_or_default()
+        .into_iter()
+        .map(|record| ActivityInvocationEvidence {
+            activity_id: record.activity_id,
+            provider: record.agent,
+            model: record.model,
+        })
+        .collect::<Vec<_>>();
+    let mut value = job_run_to_json_with_activity_provenance(run, state, &evidence);
     value["pid"] = json!(run.pid);
     value
 }

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -5,10 +5,10 @@ use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, Execute, Payload};
 
-use super::job::cli_job_run_to_json;
+use super::job::cli_job_run_to_json_with_activity_provenance;
 use super::steps::{
-    filtered_steps, legacy_step_to_json, resolve_run, resolve_run_step, run_header_text,
-    run_header_text_with_state, step_record_payload, step_summary_table,
+    activity_provenance_lines, filtered_steps, legacy_step_to_json, resolve_run, resolve_run_step,
+    run_header_text, run_header_text_with_state, step_record_payload, step_summary_table,
 };
 
 #[derive(Args)]
@@ -56,8 +56,10 @@ pub(crate) fn run_show_payload(
     // of the Worker daemon, so this is the only place it is observable.
     let provider_processes = runtime.collect_run_provider_processes(&run.run_id)?;
 
+    let run_projection =
+        cli_job_run_to_json_with_activity_provenance(runtime, &run, state.as_ref());
     let doc = json!({
-        "run": cli_job_run_to_json(&run, state.as_ref()),
+        "run": run_projection,
         "pipeline_state": state,
         "provider_processes": provider_processes
             .iter()
@@ -74,6 +76,13 @@ pub(crate) fn run_show_payload(
             state.step_outputs.len(),
             state.updated_at.to_rfc3339(),
         ));
+    }
+    header.push_str(&activity_provenance_lines(&doc["run"]["activity_provenance"]).join("\n"));
+    if doc["run"]["activity_provenance"]
+        .as_array()
+        .is_some_and(|values| !values.is_empty())
+    {
+        header.push('\n');
     }
     header.push_str(&live_provider_process_lines(&provider_processes));
     header.push('\n');

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -183,11 +183,76 @@ pub(crate) fn run_header_text_with_state(run: &JobRun, state: Option<&PipelineSt
         ),
         format!("{} {}", bold("Duration:"), format_duration(run.duration_ms)),
     ];
+    if let Some(requested_crew) = run
+        .input
+        .as_ref()
+        .and_then(|input| input.get("crew"))
+        .and_then(Value::as_str)
+    {
+        lines.push(format!("{} {}", bold("Requested Crew:"), requested_crew));
+    }
+    if run.resolved_crew.is_some() || run.crew_model.is_some() {
+        lines.push(format!(
+            "{} {} ({})",
+            bold("Resolved Run Crew:"),
+            run.resolved_crew.as_deref().unwrap_or("-"),
+            run.crew_model.as_deref().unwrap_or("model unavailable"),
+        ));
+    }
     if let Some(line) = format_waiting_line(run.state, state) {
         lines.push(line);
     }
     lines.extend(format_child_dispatch_lines(state));
     lines.join("\n")
+}
+
+/// Compact actual provider/model evidence for ordinary human run inspection.
+/// The JSON projection keeps the complete invocation list, including retries.
+pub(crate) fn activity_provenance_lines(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|activity| {
+            let id = activity
+                .get("activity_id")
+                .and_then(Value::as_str)
+                .unwrap_or("-");
+            let status = activity
+                .get("actual_status")
+                .and_then(Value::as_str)
+                .unwrap_or("unavailable");
+            let values = activity
+                .get("invocations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .map(|invocation| {
+                    let provider = invocation
+                        .get("provider")
+                        .and_then(Value::as_str)
+                        .unwrap_or("-");
+                    let model = invocation
+                        .get("model")
+                        .and_then(Value::as_str)
+                        .unwrap_or("model unavailable");
+                    format!("{provider}/{model}")
+                })
+                .collect::<Vec<_>>();
+            format!(
+                "Activity {} actual={} {}",
+                id,
+                status,
+                if values.is_empty() {
+                    "".to_string()
+                } else {
+                    values.join(", ")
+                }
+            )
+            .trim_end()
+            .to_string()
+        })
+        .collect()
 }
 
 pub(crate) fn step_summary_table(steps: &[&JobRunStep]) -> crate::output::table::Table {

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -38,6 +38,24 @@ orbit run trace <run_id>
 orbit run logs <run_id> --json
 ```
 
+### Verify model routing before reading logs
+
+`orbit run show <run_id> --json` separates three identities: `requested_crew`
+is the submitted `crew` input, `resolved_run_crew` is the run-level routing
+decision, and `activity_provenance` is durable provider/model evidence for
+each agent activity. The latter is the source for actual model routing; it can
+be mixed within one run. `actual_status: "not_started"` means no activity has
+begun, while `"unavailable"` means it began but no invocation evidence is
+available. Do not infer provider usage or token cost from the requested or
+resolved crew, and do not charge deterministic workflow wrapper steps to a
+model.
+
+Activities with `system_crew: true` are routed through `[workflow].system_crew`
+(which overwrites an activity `crew` during dispatch). Other activities use an
+explicit activity `crew` when present, otherwise the run's resolved crew.
+Check `activity_provenance` after execution to verify the effective route,
+especially after changing crew configuration.
+
 Step-scoped variants when the failing step is known: `orbit run show|logs|events <run_id> -s <step_id> --json`.
 
 If these commands fail or omit needed detail, fall back to files under `.orbit/state/` and mention the fallback in your report.

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -13,5 +13,8 @@ pub use exec::V2JobRunResult;
 pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};
 #[cfg(test)]
 pub(crate) use run::TERMINAL_OUTCOME_CONFLICT_CODE;
-pub use run::{JobRunCancelResult, JobRunListParams, job_run_to_json};
+pub use run::{
+    ActivityInvocationEvidence, JobRunCancelResult, JobRunListParams, job_run_to_json,
+    job_run_to_json_with_activity_provenance,
+};
 pub(crate) use run::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -24,5 +24,7 @@ pub(crate) use actions::CANCELLATION_WORKER_EXIT_AUDIT;
 #[cfg(test)]
 pub(crate) use conflict::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub(crate) use owner::{RunOwnerLiveness, run_owner_liveness};
-pub use projection::job_run_to_json;
+pub use projection::{
+    ActivityInvocationEvidence, job_run_to_json, job_run_to_json_with_activity_provenance,
+};
 pub use types::{JobRunCancelResult, JobRunListParams};

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -3,6 +3,18 @@
 use orbit_types::workflow::{JobRun, PipelineState};
 use serde_json::{Value, json};
 
+/// Durable provider/model evidence for one completed agent invocation.
+///
+/// This is intentionally separate from a run's resolved crew: the crew is the
+/// routing decision made before dispatch, while this evidence says what the
+/// provider actually reported after an activity ran.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActivityInvocationEvidence {
+    pub activity_id: String,
+    pub provider: String,
+    pub model: Option<String>,
+}
+
 /// Project a job run and its optional persisted state for operator-facing APIs.
 ///
 /// Child-dispatch lineage is historical and remains visible after a run reaches
@@ -23,6 +35,11 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let waiting_on_locks = state
         .and_then(|state| state.waiting_on_locks.as_ref())
         .filter(|values| !values.is_empty());
+    let requested_crew = run
+        .input
+        .as_ref()
+        .and_then(|input| input.get("crew"))
+        .and_then(Value::as_str);
 
     json!({
         "child_dispatches": child_dispatches,
@@ -42,8 +59,13 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         "error_code": last.and_then(|step| step.error_code.as_deref()),
         "error_message": last.and_then(|step| step.error_message.as_deref()),
         "knowledge_metrics": run.knowledge_metrics,
+        "requested_crew": requested_crew,
         "resolved_crew": run.resolved_crew,
         "crew_model": run.crew_model,
+        "resolved_run_crew": {
+            "crew": run.resolved_crew,
+            "model": run.crew_model,
+        },
         "steps": run.steps.iter().map(|step| json!({
             "step_index": step.step_index,
             "target_type": step.target_type.to_string(),
@@ -59,4 +81,51 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         })).collect::<Vec<_>>(),
         "created_at": run.created_at.to_rfc3339(),
     })
+}
+
+/// Add activity-level provider/model evidence to the stable job-run projection.
+///
+/// Missing evidence is explicit. It is not filled from the resolved run crew,
+/// because that would turn a requested route into a false claim about token
+/// usage. A deterministic workflow wrapper has no activity evidence of its
+/// own.
+pub fn job_run_to_json_with_activity_provenance(
+    run: &JobRun,
+    state: Option<&PipelineState>,
+    evidence: &[ActivityInvocationEvidence],
+) -> Value {
+    let mut value = job_run_to_json(run, state);
+    let activities = run
+        .steps
+        .iter()
+        .filter(|step| step.target_type.to_string() == "activity")
+        .map(|step| {
+            let invocations = evidence
+                .iter()
+                .filter(|record| record.activity_id == step.target_id)
+                .map(|record| {
+                    json!({
+                        "provider": record.provider,
+                        "model": record.model,
+                    })
+                })
+                .collect::<Vec<_>>();
+            let status = if invocations.is_empty() {
+                if step.started_at.is_some() {
+                    "unavailable"
+                } else {
+                    "not_started"
+                }
+            } else {
+                "recorded"
+            };
+            json!({
+                "activity_id": step.target_id,
+                "actual_status": status,
+                "invocations": invocations,
+            })
+        })
+        .collect::<Vec<_>>();
+    value["activity_provenance"] = Value::Array(activities);
+    value
 }

--- a/crates/orbit-core/src/application/job/run/tests/projection.rs
+++ b/crates/orbit-core/src/application/job/run/tests/projection.rs
@@ -2,11 +2,14 @@
 
 use chrono::Utc;
 use orbit_types::workflow::{
-    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, PipelineState,
+    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, JobRunStep, JobTargetType,
+    PipelineState,
 };
 use serde_json::{Value, json};
 
-use super::super::projection::job_run_to_json;
+use super::super::projection::{
+    ActivityInvocationEvidence, job_run_to_json, job_run_to_json_with_activity_provenance,
+};
 
 fn test_run(state: JobRunState) -> JobRun {
     let now = Utc::now();
@@ -79,5 +82,91 @@ fn terminal_run_keeps_child_lineage_but_drops_waiting_reasons() {
     assert_eq!(
         value["child_dispatches"][0]["child_run_id"],
         json!("jrun-child")
+    );
+}
+
+#[test]
+fn projection_separates_requested_resolved_and_actual_activity_identity() {
+    let mut run = test_run(JobRunState::Success);
+    run.input = Some(json!({ "crew": "luna" }));
+    run.resolved_crew = Some("luna".to_string());
+    run.crew_model = Some("gpt-5.6-luna".to_string());
+    run.steps = vec![
+        JobRunStep {
+            step_index: 0,
+            target_type: JobTargetType::Activity,
+            target_id: "system".to_string(),
+            state: JobRunState::Success,
+            started_at: Some(Utc::now()),
+            finished_at: Some(Utc::now()),
+            duration_ms: Some(1),
+            exit_code: Some(0),
+            agent_response_json: None,
+            error_code: None,
+            error_message: None,
+        },
+        JobRunStep {
+            step_index: 1,
+            target_type: JobTargetType::Activity,
+            target_id: "implement".to_string(),
+            state: JobRunState::Success,
+            started_at: Some(Utc::now()),
+            finished_at: Some(Utc::now()),
+            duration_ms: Some(1),
+            exit_code: Some(0),
+            agent_response_json: None,
+            error_code: None,
+            error_message: None,
+        },
+        JobRunStep {
+            step_index: 2,
+            target_type: JobTargetType::Activity,
+            target_id: "queued".to_string(),
+            state: JobRunState::Pending,
+            started_at: None,
+            finished_at: None,
+            duration_ms: None,
+            exit_code: None,
+            agent_response_json: None,
+            error_code: None,
+            error_message: None,
+        },
+    ];
+
+    let value = job_run_to_json_with_activity_provenance(
+        &run,
+        None,
+        &[
+            ActivityInvocationEvidence {
+                activity_id: "system".to_string(),
+                provider: "claude".to_string(),
+                model: Some("fable".to_string()),
+            },
+            ActivityInvocationEvidence {
+                activity_id: "implement".to_string(),
+                provider: "codex".to_string(),
+                model: Some("gpt-5.6-luna".to_string()),
+            },
+        ],
+    );
+
+    assert_eq!(value["requested_crew"], "luna");
+    assert_eq!(value["resolved_run_crew"]["model"], "gpt-5.6-luna");
+    assert_eq!(value["activity_provenance"][0]["actual_status"], "recorded");
+    assert_eq!(
+        value["activity_provenance"][0]["invocations"][0]["provider"],
+        "claude"
+    );
+    assert_eq!(
+        value["activity_provenance"][0]["invocations"][0]["model"],
+        "fable"
+    );
+    assert_eq!(
+        value["activity_provenance"][1]["invocations"][0]["provider"],
+        "codex"
+    );
+    assert_eq!(
+        value["activity_provenance"][2]["actual_status"],
+        "not_started"
     );
 }

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -5,9 +5,11 @@ use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_common::security::redaction::redact_all;
-use orbit_core::application::job::job_run_to_json;
+use orbit_core::application::job::{
+    ActivityInvocationEvidence, job_run_to_json_with_activity_provenance,
+};
 use orbit_core::runtime::run_audit::{RunAuditStep, RunCliInvocationRecord, RunProviderProcess};
-use orbit_core::{JobRun, OrbitRuntime, V2AuditEventFilter};
+use orbit_core::{InvocationQuery, JobRun, OrbitRuntime, V2AuditEventFilter};
 use serde_json::{Value, json};
 
 use super::{
@@ -155,7 +157,21 @@ pub(super) fn job_run_detail_to_json(runtime: &OrbitRuntime, run: &JobRun) -> Va
     // it entirely, so the dashboard could not see the waiting reasons or the
     // child-dispatch lineage the CLI already showed.
     let state = runtime.read_run_state(&run.run_id).ok().flatten();
-    let mut full = job_run_to_json(run, state.as_ref());
+    let evidence = runtime
+        .invocation_records(InvocationQuery {
+            job_run_id: Some(run.run_id.clone()),
+            limit: 1_000,
+            ..InvocationQuery::default()
+        })
+        .unwrap_or_default()
+        .into_iter()
+        .map(|record| ActivityInvocationEvidence {
+            activity_id: record.activity_id,
+            provider: record.agent,
+            model: record.model,
+        })
+        .collect::<Vec<_>>();
+    let mut full = job_run_to_json_with_activity_provenance(run, state.as_ref(), &evidence);
     // Reshape into `{run, steps}` per the dashboard contract: peel the
     // `steps` array off the flat `job_run_to_json` output.
     let stored_steps = full

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -38,6 +38,24 @@ orbit run trace <run_id>
 orbit run logs <run_id> --json
 ```
 
+### Verify model routing before reading logs
+
+`orbit run show <run_id> --json` separates three identities: `requested_crew`
+is the submitted `crew` input, `resolved_run_crew` is the run-level routing
+decision, and `activity_provenance` is durable provider/model evidence for
+each agent activity. The latter is the source for actual model routing; it can
+be mixed within one run. `actual_status: "not_started"` means no activity has
+begun, while `"unavailable"` means it began but no invocation evidence is
+available. Do not infer provider usage or token cost from the requested or
+resolved crew, and do not charge deterministic workflow wrapper steps to a
+model.
+
+Activities with `system_crew: true` are routed through `[workflow].system_crew`
+(which overwrites an activity `crew` during dispatch). Other activities use an
+explicit activity `crew` when present, otherwise the run's resolved crew.
+Check `activity_provenance` after execution to verify the effective route,
+especially after changing crew configuration.
+
 Step-scoped variants when the failing step is known: `orbit run show|logs|events <run_id> -s <step_id> --json`.
 
 If these commands fail or omit needed detail, fall back to files under `.orbit/state/` and mention the fallback in your report.


### PR DESCRIPTION
## Task

[ORB-11227](https://orbit-cli.com/tasks/ORB-11227) — Show actual activity model selection alongside the requested workflow crew

### Description

## Incident
Linux Astrolabe and Principia task_pilot_pipeline jrun-20260905-0310 were submitted with crew=luna; MCP run show returned resolved_crew=luna and crew_model=gpt-5.6-luna. Detailed CLI run show exposed pilot_results argv running claude --model fable, with provider usage confirming Fable. The hardcoded system-activity resolution selected Fable because crews.system was absent. This violated the operator's cost expectation even though the top-level run metadata appeared compliant. Explicit workspace crews.system Luna settings were subsequently approved and applied.

## Outcome
Make run inspection expose requested/run crew and the actual provider/model used by each agent activity, including system overrides, so an orchestrator need not retrieve huge raw stdout/argv blobs to determine cost routing. Keep the canonical per-invocation provenance and existing routing semantics; do not pretend a deterministic workflow wrapper itself spent model tokens. Explain override precedence and mixed-model runs succinctly in CLI/MCP projections. Include a preflight-readable explanation of effective system crew where existing discovery permits it, without creating a new policy framework or silently rewriting configs.

Leave proposed; task pilot before backlog.

### Acceptance Criteria

- A fixture with run crew Luna and activity system Fable shows both distinctly in ordinary structured run inspection; a mixed-provider run lists per-activity actual provider/model without exposing secrets.
- Actual values come from durable invocation evidence, with unavailable/not-yet-started explicitly represented rather than inferred from task or wrapper crew.
- Existing projection consumers remain compatible; display distinguishes requested, resolved wrapper and executed activity identities and avoids false model-cost claims.
- Focused projection tests and required Orbit checks pass; skill guidance teaches how to verify actual model routing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added requested-run crew, resolved-run crew, and activity-level actual provider/model projections; actual values are read only from durable invocation records and explicitly report recorded, unavailable, or not-started status.
- Enriched CLI `run show` and dashboard run detail while preserving the existing base projection, and rendered compact actual routing lines for human CLI output.
- Added a Luna-requested/Fable-actual mixed-provider regression fixture plus guidance explaining system-crew precedence and how to verify routing.
- Added `crates/orbit-core/src/application/job/mod.rs` and `run/mod.rs` exports as tightly coupled projection API registration required by CLI and web consumers.
Assessment: Scoped compatible projection change with no cost fields or inference from requested/resolved crews.
Validation:
- `cargo test -p orbit-core application::job::run::tests::projection --lib`
- `cargo test -p orbit-web api::tests::runs --lib`
- `cargo check -p orbit-cli`
- `make ci-fast`
- `make ci-lint`
All passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11227-6a9b942b`
- Behind base: 0
- Ahead of base: 1