### PR TITLE
Pilot and revalidate CI-sweep findings before exposing them to auto-drain

### DIFF
--- a/.orbit/resources/activities/apply_task_pilot_results.yaml
+++ b/.orbit/resources/activities/apply_task_pilot_results.yaml
@@ -4,27 +4,40 @@ metadata:
   name: apply_task_pilot_results
 spec:
   type: deterministic
-  description: Validate all task-pilot proposals, then replace only context_files.
+  description: >
+    Fail-closed task-pilot apply boundary. It validates complete partition
+    coverage, exact before snapshots, dispositions, canonical in-workspace
+    file/dir/symbol selectors, and target existence before the first mutation.
+    It then replaces context_files on the prepared tasks. Every other task
+    field, lifecycle state, dispatch state, and recommendation remains unchanged
+    unless a CI sweep supplies its exact filing record and explicit promotion
+    authority. In that mode only a proposed, selector-backed task with no
+    duplicate, already-landed, conflict, or warning finding advances to backlog;
+    all other findings remain proposed and are classified in the output.
   input_schema_json:
     type: object
-    required: [prepared, results, workspace_path, crew]
+    required: [prepared, results, workspace_path]
     properties:
       prepared: {type: object}
       results: {type: array, items: {type: object}}
       workspace_path: {type: string}
-      crew: {type: string}
+      promotion_authorized: {type: boolean}
+      ci_sweep_filing:
+        oneOf:
+          - type: object
+          - type: "null"
   output_schema_json:
     type: object
-    required: [status, mode, crew, workspace_path, discovery, partition_decisions, partition_count, failed_partitions, tasks]
+    required: [status, mode, workspace_path, discovery, partition_decisions, partition_count, failed_partitions, tasks, ci_sweep_admission]
     properties:
       status: {type: string, enum: [success]}
       mode: {type: string, enum: [automatic, explicit]}
-      crew: {type: string}
       workspace_path: {type: string}
       discovery: {type: object}
       partition_decisions: {type: array, items: {type: object}}
       partition_count: {type: number}
       failed_partitions: {type: array, items: {type: object}}
       tasks: {type: array, items: {type: object}}
+      ci_sweep_admission: {type: array, items: {type: object}}
   action: apply_task_pilot_results
   config: {}

--- a/.orbit/resources/activities/file_ci_failure_tasks.yaml
+++ b/.orbit/resources/activities/file_ci_failure_tasks.yaml
@@ -5,15 +5,17 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Turn one `collect_ci_evidence` snapshot into ordinary backlog bug tasks.
+    Turn one `collect_ci_evidence` snapshot into quarantined proposed bug tasks.
     Clusters the snapshot's current, non-stale failures by root cause
     (workflow, failing job, failing step, normalized error signature, and the
     commit the runner actually tested) so one regression repeated across a push
     run and a pull-request run of the same commit becomes one task rather than
-    several. Each surviving cluster is filed at `status: backlog` with the
+    several. Each surviving cluster is filed at `status: proposed` with the
     collected evidence rendered inline in the description, so the implementing
     agent never needs a GitHub credential; no `required_tools` are attached and
-    the task ships through the ordinary pull-request route. Filing is deduped
+    the task can later ship through the ordinary pull-request route only after
+    task-pilot validation and explicit CI-sweep admission. Filing itself never
+    promotes or dispatches implementation. It is deduped
     against still-open tasks by a commit-independent failure key carried as a
     `ci-failure:<key>` tag, so a repeated sweep over a run that is still red
     does not file the same root cause twice. The three endings stay distinct
@@ -27,7 +29,8 @@ spec:
     converted to `no_current_failure` merely because its handoff failed. Every
     successful output includes an `audit` object with counts and identities for
     latest runs, current and investigated failures, created tasks, and existing
-    dedupe owners.
+    dedupe owners. The filing entries retain workflow, job, step, runner-tested
+    commit, and source run URLs for the later pilot/admission audit.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -46,7 +49,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, audit]
     properties:
       outcome:
         type: string
@@ -87,6 +90,15 @@ spec:
               type: array
               items:
                 type: string
+      pilot_candidates:
+        type: array
+        description: >
+          Newly filed proposed tasks plus matching proposed CI tasks whose
+          earlier pilot did not admit them. Each entry carries the current
+          sweep provenance used by the pilot/admission boundary.
+        items:
+          type: object
+          required: [task_id, failure_key, workflow, job, step, tested_commit, run_urls]
       skipped_existing:
         type: array
         items:

--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -69,6 +69,9 @@ spec:
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
        workspace Git top-level, inspect `base_branch`, and determine every real
        file, directory, or symbol the stated change would modify or delete.
+       If `base_branch` is empty, resolve the repository's default remote branch
+       (and cross-check the release branch recorded in CI evidence) instead of
+       treating the empty string as a Git ref.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
@@ -79,6 +82,12 @@ spec:
        `evidence`. For host-operational work use `host_operational` with
        evidence. Otherwise use disposition `selectors`. Never use an empty list
        merely because inspection was inconclusive.
+       For a `ci-failure-sweep` task, compare the runner-tested commit and
+       original run evidence in the task description with `base_branch` as it
+       exists now. Inspect relevant history and current code. A failure from an
+       old release whose repair is already present must be `verified_no_diff`
+       with `already_landed` set to an object containing concrete `evidence`;
+       do not return executable selectors for it.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
@@ -88,6 +97,13 @@ spec:
        `utility_warnings`, and `surface_warnings`. Cite evidence for
        duplicates, already-landed work, and any reported conflicts. Do not
        choose an architecture alternative silently.
+       A prior done repair is evidence to inspect, not blanket immunity: when
+       the failure is from the current integration revision and the defect is
+       still present, leave `duplicate_of` and `already_landed` null and return
+       the selectors for the current repair. Use
+       `{"task_id":"...","evidence":"..."}` for a duplicate and
+       `{"evidence":"..."}` for already-landed work; a bare boolean is not
+       auditable.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,

--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -1,7 +1,8 @@
 # CI-failure sweep pipeline [ORB-11107].
 #
-# Two deterministic steps and nothing else. This pipeline looks and files; it
-# never repairs, so it launches no agent and builds no worktree.
+# Safe intake pipeline. It looks and files into proposed quarantine, then runs
+# the existing read-only task-pilot pipeline before any task can enter backlog.
+# It never implements a repair and builds no worktree.
 #
 # Shape
 # - `collect` (deterministic, host-owned): runs the GitHub capability preflight
@@ -9,15 +10,22 @@
 #   bounded, redacted evidence snapshot. The credential never has to cross into
 #   a sandbox, because the looking happens before any task exists.
 # - `file` (deterministic): clusters the snapshot's current, non-stale failures
-#   by root cause and files each surviving cluster as an ordinary `backlog` bug
-#   task carrying that evidence inline. Filing is deduped against still-open
-#   tasks by failure key.
+#   by root cause and files each surviving cluster as a `proposed` bug task
+#   carrying that evidence inline. Filing is deduped against still-open tasks
+#   by failure key. Proposed is the quarantine boundary: an active auto-drain
+#   cannot see the finding yet.
+# - `pilots` (bounded fan-out): invokes the existing task_pilot_pipeline once
+#   for each newly filed task and each still-proposed matching task from an
+#   earlier failed or withheld pilot. The child applies validated selectors,
+#   assesses current integration relevance, and promotes only warning-free actionable
+#   repairs. A failed pilot, invalid/missing selectors, duplicate or
+#   already-landed finding remains proposed without holding independent pilots.
 #
-# Filed tasks are unremarkable: they ship through `task_pr_pipeline` on the
-# ordinary `agent_implement` baseline with no `required_tools`, because the
-# evidence they need is already in the description. Verification needs no extra
-# stage — the fix opens a normal pull request, CI runs on it, and if the failure
-# is still current the next sweep observes it again.
+# Filing by itself carries no promotion authority. This named pipeline passes a
+# literal authorization only after it has selected the exact filed task for its
+# pilot; task_pilot_pipeline defaults that authority to false for every other
+# caller. Enabling the shipped CI routine or invoking this job is therefore the
+# explicit sweep-admission decision. It is not completion authorization.
 #
 # Empty and unavailable behavior
 # - No current failure: `file` reports `no_current_failure` and the run succeeds
@@ -58,6 +66,7 @@ spec:
     integration_branch: "agent-main"
     max_tasks: 5
     max_investigated_runs: 6
+    workspace_path: .
 
   steps:
     - id: collect
@@ -71,3 +80,28 @@ spec:
       default_input:
         ci_evidence: "{{ steps.collect.output.ci_evidence }}"
         max_tasks: "{{ input.max_tasks }}"
+
+    - id: pilots
+      fan_out:
+        items: "{{ steps.file.output.pilot_candidates }}"
+        max_workers: 3
+        worker:
+          id: pilot
+          target: activity:invoke_and_wait
+          default_input:
+            job_name: task_pilot_pipeline
+            run_input:
+              task_ids:
+                - "{{ item.task_id }}"
+              workspace_path: "{{ input.workspace_path }}"
+              base_branch: "{{ input.integration_branch }}"
+              max_tasks: 1
+              max_partition_size: 1
+              ci_sweep_filing: "{{ item }}"
+              # Explicit authority belongs to this intake pipeline, not to the
+              # filing activity or generic task-pilot callers.
+              promotion_authorized: true
+      fan_in:
+        join:
+          mode: all
+        collect: pilot_results

--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -7,7 +7,10 @@
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. Each read-only pilot
 # receives at most five tasks. The all-join makes any failed partition
-# fail the run before the context-only deterministic apply step can execute.
+# fail the run before the deterministic apply step can execute. Apply normally
+# changes only context_files. A CI sweep may pass its exact filing record plus
+# literal promotion authority; only then can apply promote a warning-free,
+# selector-backed proposed repair to backlog.
 #
 # Crew resolution
 # - The pilot step names the `system` crew directly, so this definition states
@@ -36,6 +39,8 @@ spec:
     base_branch: agent-main
     max_tasks: 50
     max_partition_size: 5
+    promotion_authorized: false
+    ci_sweep_filing: null
 
   steps:
     - id: prepare
@@ -71,3 +76,5 @@ spec:
         prepared: "{{ steps.prepare.output }}"
         results: "{{ steps.pilot_results.output }}"
         workspace_path: "{{ steps.prepare.output.workspace_path }}"
+        promotion_authorized: "{{ input.promotion_authorized }}"
+        ci_sweep_filing: "{{ input.ci_sweep_filing }}"

--- a/.orbit/routines/ci_failure_sweep.yaml
+++ b/.orbit/routines/ci_failure_sweep.yaml
@@ -5,9 +5,11 @@
 # false when seeded: turning on unattended CI-failure filing is an explicit,
 # reviewed, per-workspace decision.
 #
-# This routine is a scheduling surface only. All discovery, clustering, dedupe,
-# and filing live in the job's two deterministic steps, so an operator-triggered
-# run of `ci_failure_sweep_pipeline` behaves identically to a scheduled fire.
+# This routine is a scheduling surface only. Discovery, filing, task-pilot, and
+# guarded admission live in the target job, so an operator-triggered run of
+# `ci_failure_sweep_pipeline` behaves identically to a scheduled fire. Enabling
+# this routine explicitly authorizes that job to promote only pilot-ready
+# repairs from proposed to backlog; it does not authorize task completion.
 #
 # Cadence is hourly, on a minute that stacks with none of the other shipped
 # defaults (the triage routine holds :15, worktree GC :35, and the ship sweep
@@ -24,9 +26,9 @@ schemaVersion: 1
 name: ci-failure-sweep-orbit
 description: >
   Hourly sweep of this repository's current GitHub Actions failures: collect
-  bounded, redacted evidence on the host, then file each current, non-stale
-  failure cluster as an ordinary backlog bug task carrying that evidence
-  inline. Deduped against still-open tasks by failure key.
+  bounded, redacted evidence on the host, file each current failure cluster as
+  a proposed task, and promote only pilot-validated current repairs to backlog.
+  Deduped against still-open tasks by failure key.
 enabled: true
 hosts:
   - dk-server-1

--- a/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
+++ b/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
@@ -8,8 +8,12 @@ spec:
     Fail-closed task-pilot apply boundary. It validates complete partition
     coverage, exact before snapshots, dispositions, canonical in-workspace
     file/dir/symbol selectors, and target existence before the first mutation.
-    It then replaces only context_files on the prepared tasks. Every other task
-    field, lifecycle state, dispatch state, and recommendation remains unchanged.
+    It then replaces context_files on the prepared tasks. Every other task
+    field, lifecycle state, dispatch state, and recommendation remains unchanged
+    unless a CI sweep supplies its exact filing record and explicit promotion
+    authority. In that mode only a proposed, selector-backed task with no
+    duplicate, already-landed, conflict, or warning finding advances to backlog;
+    all other findings remain proposed and are classified in the output.
   input_schema_json:
     type: object
     # No `crew`: this apply step is deterministic and runs no agent, so it has
@@ -24,11 +28,17 @@ spec:
           type: object
       workspace_path:
         type: string
+      promotion_authorized:
+        type: boolean
+      ci_sweep_filing:
+        oneOf:
+          - type: object
+          - type: "null"
   output_schema_json:
     type: object
     required:
       [status, mode, workspace_path, discovery, partition_decisions,
-       partition_count, failed_partitions, tasks]
+       partition_count, failed_partitions, tasks, ci_sweep_admission]
     properties:
       status:
         type: string
@@ -51,6 +61,10 @@ spec:
         items:
           type: object
       tasks:
+        type: array
+        items:
+          type: object
+      ci_sweep_admission:
         type: array
         items:
           type: object

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -5,15 +5,17 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Turn one `collect_ci_evidence` snapshot into ordinary backlog bug tasks.
+    Turn one `collect_ci_evidence` snapshot into quarantined proposed bug tasks.
     Clusters the snapshot's current, non-stale failures by root cause
     (workflow, failing job, failing step, normalized error signature, and the
     commit the runner actually tested) so one regression repeated across a push
     run and a pull-request run of the same commit becomes one task rather than
-    several. Each surviving cluster is filed at `status: backlog` with the
+    several. Each surviving cluster is filed at `status: proposed` with the
     collected evidence rendered inline in the description, so the implementing
     agent never needs a GitHub credential; no `required_tools` are attached and
-    the task ships through the ordinary pull-request route. Filing is deduped
+    the task can later ship through the ordinary pull-request route only after
+    task-pilot validation and explicit CI-sweep admission. Filing itself never
+    promotes or dispatches implementation. It is deduped
     against still-open tasks first by a commit-independent failure key carried
     as a `ci-failure:<key>` tag, then by a shared high-confidence material
     coverage assessment over untagged tasks. A repeated sweep over a run that
@@ -31,7 +33,8 @@ spec:
     converted to `no_current_failure` merely because its handoff failed. Every
     successful output includes an `audit` object with counts and identities for
     latest runs, current and investigated failures, created tasks, and existing
-    dedupe owners.
+    dedupe owners. The filing entries retain workflow, job, step, runner-tested
+    commit, and source run URLs for the later pilot/admission audit.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -50,7 +53,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, skipped_existing, skipped_over_cap, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, audit]
     properties:
       outcome:
         type: string
@@ -91,6 +94,15 @@ spec:
               type: array
               items:
                 type: string
+      pilot_candidates:
+        type: array
+        description: >
+          Newly filed proposed tasks plus matching proposed CI tasks whose
+          earlier pilot did not admit them. Each entry carries the current
+          sweep provenance used by the pilot/admission boundary.
+        items:
+          type: object
+          required: [task_id, failure_key, workflow, job, step, tested_commit, run_urls]
       skipped_existing:
         type: array
         items:

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -69,6 +69,9 @@ spec:
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
        workspace Git top-level, inspect `base_branch`, and determine every real
        file, directory, or symbol the stated change would modify or delete.
+       If `base_branch` is empty, resolve the repository's default remote branch
+       (and cross-check the release branch recorded in CI evidence) instead of
+       treating the empty string as a Git ref.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
@@ -79,6 +82,12 @@ spec:
        `evidence`. For host-operational work use `host_operational` with
        evidence. Otherwise use disposition `selectors`. Never use an empty list
        merely because inspection was inconclusive.
+       For a `ci-failure-sweep` task, compare the runner-tested commit and
+       original run evidence in the task description with `base_branch` as it
+       exists now. Inspect relevant history and current code. A failure from an
+       old release whose repair is already present must be `verified_no_diff`
+       with `already_landed` set to an object containing concrete `evidence`;
+       do not return executable selectors for it.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
        `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
@@ -88,6 +97,13 @@ spec:
        `utility_warnings`, and `surface_warnings`. Cite evidence for
        duplicates, already-landed work, and any reported conflicts. Do not
        choose an architecture alternative silently.
+       A prior done repair is evidence to inspect, not blanket immunity: when
+       the failure is from the current integration revision and the defect is
+       still present, leave `duplicate_of` and `already_landed` null and return
+       the selectors for the current repair. Use
+       `{"task_id":"...","evidence":"..."}` for a duplicate and
+       `{"evidence":"..."}` for already-landed work; a bare boolean is not
+       auditable.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -1,7 +1,8 @@
 # CI-failure sweep pipeline [ORB-11107].
 #
-# Two deterministic steps and nothing else. This pipeline looks and files; it
-# never repairs, so it launches no agent and builds no worktree.
+# Safe intake pipeline. It looks and files into proposed quarantine, then runs
+# the existing read-only task-pilot pipeline before any task can enter backlog.
+# It never implements a repair and builds no worktree.
 #
 # Shape
 # - `collect` (deterministic, host-owned): runs the GitHub capability preflight
@@ -9,15 +10,22 @@
 #   bounded, redacted evidence snapshot. The credential never has to cross into
 #   a sandbox, because the looking happens before any task exists.
 # - `file` (deterministic): clusters the snapshot's current, non-stale failures
-#   by root cause and files each surviving cluster as an ordinary `backlog` bug
-#   task carrying that evidence inline. Filing is deduped against still-open
-#   tasks by failure key.
+#   by root cause and files each surviving cluster as a `proposed` bug task
+#   carrying that evidence inline. Filing is deduped against still-open tasks
+#   by failure key. Proposed is the quarantine boundary: an active auto-drain
+#   cannot see the finding yet.
+# - `pilots` (bounded fan-out): invokes the existing task_pilot_pipeline once
+#   for each newly filed task and each still-proposed matching task from an
+#   earlier failed or withheld pilot. The child applies validated selectors,
+#   assesses current integration relevance, and promotes only warning-free actionable
+#   repairs. A failed pilot, invalid/missing selectors, duplicate or
+#   already-landed finding remains proposed without holding independent pilots.
 #
-# Filed tasks are unremarkable: they ship through `task_pr_pipeline` on the
-# ordinary `agent_implement` baseline with no `required_tools`, because the
-# evidence they need is already in the description. Verification needs no extra
-# stage — the fix opens a normal pull request, CI runs on it, and if the failure
-# is still current the next sweep observes it again.
+# Filing by itself carries no promotion authority. This named pipeline passes a
+# literal authorization only after it has selected the exact filed task for its
+# pilot; task_pilot_pipeline defaults that authority to false for every other
+# caller. Enabling the shipped CI routine or invoking this job is therefore the
+# explicit sweep-admission decision. It is not completion authorization.
 #
 # Empty and unavailable behavior
 # - No current failure: `file` reports `no_current_failure` and the run succeeds
@@ -58,6 +66,7 @@ spec:
     integration_branch: ""
     max_tasks: 5
     max_investigated_runs: 6
+    workspace_path: .
 
   steps:
     - id: collect
@@ -71,3 +80,28 @@ spec:
       default_input:
         ci_evidence: "{{ steps.collect.output.ci_evidence }}"
         max_tasks: "{{ input.max_tasks }}"
+
+    - id: pilots
+      fan_out:
+        items: "{{ steps.file.output.pilot_candidates }}"
+        max_workers: 3
+        worker:
+          id: pilot
+          target: activity:invoke_and_wait
+          default_input:
+            job_name: task_pilot_pipeline
+            run_input:
+              task_ids:
+                - "{{ item.task_id }}"
+              workspace_path: "{{ input.workspace_path }}"
+              base_branch: "{{ input.integration_branch }}"
+              max_tasks: 1
+              max_partition_size: 1
+              ci_sweep_filing: "{{ item }}"
+              # Explicit authority belongs to this intake pipeline, not to the
+              # filing activity or generic task-pilot callers.
+              promotion_authorized: true
+      fan_in:
+        join:
+          mode: all
+        collect: pilot_results

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -7,7 +7,10 @@
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. Each read-only pilot
 # receives at most five tasks. The all-join makes any failed partition
-# fail the run before the context-only deterministic apply step can execute.
+# fail the run before the deterministic apply step can execute. Apply normally
+# changes only context_files. A CI sweep may pass its exact filing record plus
+# literal promotion authority; only then can apply promote a warning-free,
+# selector-backed proposed repair to backlog.
 #
 # Crew resolution
 # - The pilot step names the `system` crew directly, so this definition states
@@ -36,6 +39,8 @@ spec:
     base_branch: agent-main
     max_tasks: 50
     max_partition_size: 5
+    promotion_authorized: false
+    ci_sweep_filing: null
 
   steps:
     - id: prepare
@@ -71,3 +76,5 @@ spec:
         prepared: "{{ steps.prepare.output }}"
         results: "{{ steps.pilot_results.output }}"
         workspace_path: "{{ steps.prepare.output.workspace_path }}"
+        promotion_authorized: "{{ input.promotion_authorized }}"
+        ci_sweep_filing: "{{ input.ci_sweep_filing }}"

--- a/crates/orbit-core/assets/routines/ci_failure_sweep.yaml
+++ b/crates/orbit-core/assets/routines/ci_failure_sweep.yaml
@@ -5,9 +5,12 @@
 # false when seeded: turning on unattended CI-failure filing is an explicit,
 # reviewed, per-workspace decision.
 #
-# This routine is a scheduling surface only. All discovery, clustering, dedupe,
-# and filing live in the job's two deterministic steps, so an operator-triggered
-# run of `ci_failure_sweep_pipeline` behaves identically to a scheduled fire.
+# This routine is a scheduling surface only. Discovery, filing, task-pilot, and
+# guarded admission live in the target job, so an operator-triggered run of
+# `ci_failure_sweep_pipeline` behaves identically to a scheduled fire. Enabling
+# this inert-by-default routine explicitly authorizes that job to promote only
+# pilot-ready repairs from proposed to backlog; it does not authorize task
+# completion.
 #
 # Cadence is hourly, on a minute that stacks with none of the other shipped
 # defaults (the triage routine holds :15, worktree GC :35, and the ship sweep
@@ -17,15 +20,16 @@
 # any case.
 #
 # Discovery runs on the host, not inside an execution sandbox: the job collects
-# bounded, redacted GitHub Actions evidence first, then files ordinary backlog
-# bug tasks for current non-stale failure clusters.
+# bounded, redacted GitHub Actions evidence first, files proposed tasks, and
+# uses read-only pilots to prevent stale or already-landed failures from
+# reaching auto-drain.
 schemaVersion: 1
 name: __ORBIT_ROUTINE_NAME__
 description: >
   Hourly sweep of this repository's current GitHub Actions failures: collect
-  bounded, redacted evidence on the host, then file each current, non-stale
-  failure cluster as an ordinary backlog bug task carrying that evidence
-  inline. Deduped against still-open tasks by failure key.
+  bounded, redacted evidence on the host, file each current failure cluster as
+  a proposed task, and promote only pilot-validated current repairs to backlog.
+  Deduped against still-open tasks by failure key.
 enabled: false
 hosts:
   - __ORBIT_HOST_ID__

--- a/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
@@ -67,7 +67,7 @@ workspace-unique name (`<base>-<workspace>`) resolved at seed time. Run
 | `task-pilot` | every 4h | `task_pilot_pipeline` | Preflights proposed/backlog tasks with empty `context_files` and fills in validated selectors. |
 | `task-triage` | hourly | `task_triage_pipeline` | Diagnoses tasks blocked by failed runs; re-backlogs environmental casualties, leaves real failures blocked with a diagnosis. |
 | `auto-task-scheduler` | every minute | `auto_task_scheduler_pipeline` | Mints tasks from every due, enabled auto-task definition. → [auto-tasks.md](auto-tasks.md) |
-| `ci-failure-sweep` | hourly at :05 | `ci_failure_sweep_pipeline` | Collects GitHub Actions evidence and files deduped backlog bug tasks. |
+| `ci-failure-sweep` | hourly at :05 | `ci_failure_sweep_pipeline` | Files deduped proposed CI findings, pilots them, and admits only current warning-free repairs to backlog. |
 | `dependabot-alert-sweep` | daily at 03:25 host-local time | `dependabot_alert_sweep_pipeline` | Collects Dependabot, code-scanning, and secret-scanning findings and files remediation tasks. |
 | `ship-sweep` | every 20m | `workspace_ship_pipeline` | Ships this workspace's ready backlog through the gated pipeline, unattended. |
 
@@ -173,7 +173,13 @@ orbit job show dependabot_alert_sweep_pipeline
 orbit run job dependabot_alert_sweep_pipeline --input min_severity=high --input max_tasks=10
 ```
 
-These commands can create backlog tasks; they are not dry runs. Set the CI
+These commands can create and pilot proposed tasks; they are not dry runs.
+The CI job promotes only tasks whose pilot applied non-empty canonical
+selectors and reported no duplicate, already-landed, conflict, or warning
+finding. Pilot failure and stale/no-diff findings remain proposed, so an active
+auto-drain cannot claim them. Invoking this named job, or enabling its shipped
+inert routine, is explicit promotion authorization; the filing activity and a
+standalone `task_pilot_pipeline` run carry no such authority. Set the CI
 integration branch explicitly when it differs from GitHub's default branch.
 CI defaults bound investigation to six runs and filing to five tasks. The
 security job defaults to high-severity Dependabot/code-scanning findings and
@@ -185,5 +191,9 @@ A missing GitHub client, authentication, or API permission is a capability gap,
 not evidence of a clean repository. Read the collect/file step outcomes. CI
 failure-key dedupe and security alert identity suppress already-covered work;
 they do not promise general semantic duplicate detection. Discovery and filing
-errors must remain visible and retryable. Choose these routines independently
-of `ship-sweep`; filing does not authorize unattended repair.
+errors must remain visible and retryable. A previous done repair is evidence to
+inspect, not blanket dedupe: an old failed release already fixed on the current
+integration branch stays proposed as already-landed, while a distinct defect
+that still reproduces at the current revision remains eligible. Choose these
+routines independently of `ship-sweep`; admission to backlog does not authorize
+implementation or completion.

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -58,17 +58,27 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus a deterministic apply step that writes validated `context_files`. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |
 | `auto_task_scheduler_pipeline` | Mint tasks from due auto-task definitions. |
-| `ci_failure_sweep_pipeline` | Collect GitHub Actions failures and file evidence-backed tasks, without implementing repairs. |
+| `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.
+
+CI-sweep filing is deliberately non-executable: `file_ci_failure_tasks` always
+creates `proposed` tasks. The CI job invokes `task_pilot_pipeline` for each new
+task and retries matching tasks that a prior pilot left proposed, carrying
+explicit promotion authority into its deterministic apply boundary. Invalid or
+empty selectors, pilot failure, duplicates, already-landed
+work, conflicts, and warnings leave that task proposed without blocking other
+pilot children. A standalone task-pilot run has no promotion authority. The
+source run/job/SHA/step remains in the task description, while parent and child
+run state retain the pilot run ID, result, and admission decision.
 
 ### The `completion` input
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
@@ -1,0 +1,197 @@
+//! CI-sweep-specific admission policy after task-pilot validation.
+//!
+//! Filing and pilot inspection are intentionally separate. This module owns
+//! the narrow bridge from a validated pilot assessment to a backlog admission
+//! decision, including correlation with the current sweep's immutable source
+//! evidence and the proposed task's generated identity.
+
+use orbit_engine::DispatchError;
+use orbit_types::task::{Task, TaskStatus};
+use serde_json::{Value, json};
+
+const CI_FAILURE_TAG: &str = "ci-failure-sweep";
+const CI_FAILURE_KEY_TAG_PREFIX: &str = "ci-failure:";
+
+pub(super) fn assess(
+    action: &str,
+    task_id: &str,
+    task: &Task,
+    assessment: &Value,
+    selectors: &[String],
+    filing: &Value,
+    promotion_authorized: bool,
+) -> Result<Value, DispatchError> {
+    let filed_task_id = required_string(filing, "task_id", action)?;
+    if filed_task_id != task_id {
+        return Err(action_failed(
+            action,
+            format!("CI-sweep filing names task {filed_task_id}, expected {task_id}"),
+        ));
+    }
+    let failure_key = required_string(filing, "failure_key", action)?;
+    let tested_commit = required_string(filing, "tested_commit", action)?;
+    let workflow = required_string(filing, "workflow", action)?;
+    let job = required_string(filing, "job", action)?;
+    let step = required_string(filing, "step", action)?;
+    let run_urls = required_string_array(filing, "run_urls", action)?;
+    if run_urls.is_empty() {
+        return Err(action_failed(
+            action,
+            format!("CI-sweep filing for task {task_id} has no source run URLs"),
+        ));
+    }
+    let failure_tag = format!("{CI_FAILURE_KEY_TAG_PREFIX}{failure_key}");
+    if !task.tags.iter().any(|tag| tag == CI_FAILURE_TAG)
+        || !task.tags.iter().any(|tag| tag == &failure_tag)
+    {
+        return Err(action_failed(
+            action,
+            format!("task {task_id} does not match its CI-sweep filing identity"),
+        ));
+    }
+    if task.status != TaskStatus::Proposed {
+        return Err(action_failed(
+            action,
+            format!(
+                "CI-sweep task {task_id} changed to {} before admission; refusing stale pilot output",
+                task.status
+            ),
+        ));
+    }
+
+    let disposition = required_string(assessment, "disposition", action)?;
+    let duplicate_of = assessment
+        .get("duplicate_of")
+        .ok_or_else(|| action_failed(action, format!("task {task_id} is missing duplicate_of")))?;
+    let already_landed = assessment.get("already_landed").ok_or_else(|| {
+        action_failed(action, format!("task {task_id} is missing already_landed"))
+    })?;
+    for (field, value) in [
+        ("duplicate_of", duplicate_of),
+        ("already_landed", already_landed),
+    ] {
+        if !value.is_null() && !recommendation_has_evidence(value) {
+            return Err(action_failed(
+                action,
+                format!("task {task_id} {field} finding must include concrete evidence"),
+            ));
+        }
+    }
+
+    let warning_fields = [
+        "blocked_by",
+        "adr_conflicts",
+        "utility_warnings",
+        "surface_warnings",
+    ];
+    let warnings = warning_fields
+        .iter()
+        .flat_map(|field| {
+            assessment
+                .get(*field)
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .map(move |value| json!({ "field": field, "value": value }))
+        })
+        .collect::<Vec<_>>();
+
+    let (decision, classification, evidence) = if !already_landed.is_null() {
+        ("withhold", "already_landed", already_landed.clone())
+    } else if !duplicate_of.is_null() {
+        ("withhold", "duplicate", duplicate_of.clone())
+    } else if !warnings.is_empty() {
+        ("withhold", "warnings", json!(warnings))
+    } else if disposition != "selectors" || selectors.is_empty() {
+        (
+            "withhold",
+            "no_actionable_selectors",
+            assessment.get("evidence").cloned().unwrap_or(Value::Null),
+        )
+    } else if !promotion_authorized {
+        (
+            "withhold",
+            "promotion_not_authorized",
+            json!(
+                "pilot results were applied, but this run carried no CI-sweep promotion authority"
+            ),
+        )
+    } else {
+        (
+            "promote",
+            "current_actionable_regression",
+            json!(
+                "pilot validated non-empty canonical selectors with no duplicate, already-landed, conflict, or warning finding"
+            ),
+        )
+    };
+
+    Ok(json!({
+        "task_id": task_id,
+        "decision": decision,
+        "classification": classification,
+        "promotion_authorized": promotion_authorized,
+        "failure_key": failure_key,
+        "source": {
+            "workflow": workflow,
+            "job": job,
+            "step": step,
+            "tested_commit": tested_commit,
+            "run_urls": run_urls,
+        },
+        "evidence": evidence,
+    }))
+}
+
+fn recommendation_has_evidence(value: &Value) -> bool {
+    match value {
+        Value::String(text) => !text.trim().is_empty(),
+        Value::Object(fields) => fields
+            .get("evidence")
+            .is_some_and(recommendation_has_evidence),
+        Value::Array(values) => {
+            !values.is_empty() && values.iter().all(recommendation_has_evidence)
+        }
+        _ => false,
+    }
+}
+
+fn required_string<'a>(
+    value: &'a Value,
+    field: &str,
+    action: &str,
+) -> Result<&'a str, DispatchError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| action_failed(action, format!("{field} must be a non-empty string")))
+}
+
+fn required_string_array(
+    value: &Value,
+    field: &str,
+    action: &str,
+) -> Result<Vec<String>, DispatchError> {
+    let values = value
+        .get(field)
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, format!("{field} must be an array")))?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| action_failed(action, format!("{field} must contain strings")))
+        })
+        .collect()
+}
+
+fn action_failed(action: &str, message: impl Into<String>) -> DispatchError {
+    DispatchError::DeterministicActionFailed {
+        action: action.to_string(),
+        message: message.into(),
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1,19 +1,19 @@
-//! `file_ci_failure_tasks` — turn one CI evidence snapshot into ordinary
-//! backlog tasks.
+//! `file_ci_failure_tasks` — turn one CI evidence snapshot into quarantined
+//! proposed tasks.
 //!
 //! The snapshot arrives from the host-owned `collect_ci_evidence` step, which
 //! ran `gh` outside any agent sandbox. Everything below is a pure function of
 //! that JSON plus the workspace's open tasks: cluster the current failures by
 //! root cause, drop the clusters a still-open task already covers, and file
-//! what is left as `backlog` bug tasks whose descriptions carry the evidence
-//! inline.
+//! what is left as `proposed` bug tasks whose descriptions carry the evidence
+//! inline. The CI sweep then pilots and revalidates those tasks before a
+//! separate admission boundary may expose them to backlog auto-drain.
 //!
-//! A filed task is deliberately unremarkable. It ships through the existing
-//! task PR pipeline with the ordinary agent baseline and no `required_tools`:
-//! the agent never has to query GitHub, because the answer is already in the
-//! description. Verification needs no new stage either — the fix opens a normal
-//! PR, CI runs on it, and if the failure is still current the next sweep sees
-//! it again.
+//! A filed task deliberately has no `required_tools`: the pilot and eventual
+//! implementation never have to query GitHub, because the original evidence
+//! is already in the description. It is not executable until a successful
+//! pilot has applied valid selectors, found the failure relevant to current
+//! integration code, and exercised explicit sweep promotion authority.
 //!
 //! # Two keys, on purpose
 //!
@@ -160,6 +160,7 @@ where
             "clusters": 0,
             "filed_count": 0,
             "filed": [],
+            "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
             "audit": audit,
@@ -232,6 +233,7 @@ where
             "clusters": 0,
             "filed_count": 0,
             "filed": [],
+            "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
             "audit": audit,
@@ -240,6 +242,8 @@ where
     }
 
     let mut filed = Vec::new();
+    let mut pilot_candidates = Vec::new();
+    let mut pilot_candidate_ids = BTreeSet::new();
     let mut skipped_existing = Vec::new();
     let mut skipped_over_cap = Vec::new();
     // Two clusters in one snapshot can share a failure key when the same root
@@ -274,14 +278,50 @@ where
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let duplicate_tasks = duplicate_matches
+        .iter()
+        .map(|duplicate_match| {
+            duplicate_match
+                .as_ref()
+                .map(|matched| {
+                    runtime.get_task(&matched.task_id).map_err(|error| {
+                        retryable_pipeline_error(
+                            "pilot_candidate_lookup",
+                            &audit,
+                            vec![json!({
+                                "stage": "registration",
+                                "operation": "reload_duplicate_task",
+                                "task_id": matched.task_id,
+                                "retryable": true,
+                                "message": bounded_error(&error.to_string()),
+                            })],
+                        )
+                    })
+                })
+                .transpose()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-    for (cluster, duplicate_match) in clusters.iter().zip(duplicate_matches) {
+    for ((cluster, duplicate_match), duplicate_task) in
+        clusters.iter().zip(duplicate_matches).zip(duplicate_tasks)
+    {
         if let Some(DuplicateTaskMatch {
             task_id,
             match_kind,
             evidence,
         }) = duplicate_match
         {
+            if let Some(existing) = duplicate_task {
+                let expected_key_tag =
+                    format!("{CI_FAILURE_KEY_TAG_PREFIX}{}", cluster.failure_key);
+                if existing.status == TaskStatus::Proposed
+                    && existing.tags.iter().any(|tag| tag == CI_FAILURE_TAG)
+                    && existing.tags.iter().any(|tag| tag == &expected_key_tag)
+                    && pilot_candidate_ids.insert(task_id.clone())
+                {
+                    pilot_candidates.push(cluster.filing_entry(&task_id));
+                }
+            }
             skipped_existing.push(json!({
                 "failure_key": cluster.failure_key,
                 "cluster_key": cluster.cluster_key,
@@ -339,7 +379,10 @@ where
             priority: TaskPriority::High,
             complexity: TaskComplexity::Unassessed,
             task_type: Some(TaskType::Bug),
-            status: Some(TaskStatus::Backlog),
+            // Filing is quarantine, not dispatch authorization. The
+            // task-pilot apply boundary is the only CI-sweep path that may
+            // promote a relevant, selector-backed repair to backlog.
+            status: Some(TaskStatus::Proposed),
             system_created: true,
             ..TaskAddParams::default()
         })
@@ -358,16 +401,10 @@ where
             )
         })?;
         filed_keys.insert(cluster.failure_key.clone());
-        filed.push(json!({
-            "task_id": task_id,
-            "failure_key": cluster.failure_key,
-            "cluster_key": cluster.cluster_key,
-            "workflow": cluster.workflow,
-            "job": cluster.job,
-            "step": cluster.step,
-            "tested_commit": cluster.tested_commit,
-            "run_urls": cluster.run_urls(),
-        }));
+        let filing = cluster.filing_entry(&task_id);
+        pilot_candidate_ids.insert(task_id);
+        pilot_candidates.push(filing.clone());
+        filed.push(filing);
     }
 
     let final_audit = filing_audit(audit, &filed, &skipped_existing);
@@ -377,6 +414,7 @@ where
         "clusters": clusters.len(),
         "filed_count": filed.len(),
         "filed": filed,
+        "pilot_candidates": pilot_candidates,
         "skipped_existing": skipped_existing,
         "skipped_over_cap": skipped_over_cap,
         "max_tasks": max_tasks,
@@ -534,6 +572,19 @@ impl FailureCluster {
             .iter()
             .filter_map(|run| run.get("run_id").cloned())
             .collect()
+    }
+
+    fn filing_entry(&self, task_id: &str) -> Value {
+        json!({
+            "task_id": task_id,
+            "failure_key": self.failure_key,
+            "cluster_key": self.cluster_key,
+            "workflow": self.workflow,
+            "job": self.job,
+            "step": self.step,
+            "tested_commit": self.tested_commit,
+            "run_urls": self.run_urls(),
+        })
     }
 
     fn title(&self) -> String {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -9,6 +9,7 @@
 
 pub(super) mod backlog_exclusion;
 pub(super) mod child_dispatch;
+pub(super) mod ci_failure_admission;
 pub(super) mod ci_failure_tasks;
 pub(super) mod cli_executor;
 pub(super) mod dependabot_alert_tasks;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -1,8 +1,11 @@
 //! Deterministic support actions for the task-pilot workflow [ORB-10510].
 //!
 //! The agent leg only proposes task metadata. These actions own discovery,
-//! partitioning, canonical selector validation, and the sole permitted write:
-//! replacing `context_files` on the exact tasks prepared for the run.
+//! partitioning and canonical selector validation. Ordinarily the sole write
+//! is replacing `context_files` on the exact tasks prepared for the run. A
+//! CI-failure sweep may additionally request explicit admission: after the
+//! selectors and every recommendation validate, this boundary promotes only a
+//! current, warning-free repair from `proposed` to `backlog`.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -15,6 +18,7 @@ use orbit_types::task::{Task, TaskStatus};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::ci_failure_admission;
 use crate::application::task::TaskUpdateParams;
 
 const DEFAULT_MAX_PARTITION_SIZE: usize = 5;
@@ -194,6 +198,25 @@ pub(super) fn apply(
     // Validate every partition and every selector before the first mutation.
     // A malformed or failed partition therefore cannot partially apply the
     // otherwise-valid partitions that happened to precede it.
+    let ci_sweep_filing = input
+        .get("ci_sweep_filing")
+        .filter(|value| !value.is_null());
+    let promotion_authorized = input
+        .get("promotion_authorized")
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| action_failed(action, "promotion_authorized must be a boolean"))
+        })
+        .transpose()?
+        .unwrap_or(false);
+    if ci_sweep_filing.is_some() && prepared_before.len() != 1 {
+        return Err(action_failed(
+            action,
+            "CI-sweep admission requires exactly one prepared task",
+        ));
+    }
+
     let mut validated = Vec::with_capacity(prepared_before.len());
     let mut seen_task_ids = BTreeSet::new();
     for (position, (expected, result)) in expected_partitions.iter().zip(results).enumerate() {
@@ -326,6 +349,7 @@ pub(super) fn apply(
                 expected_before.clone(),
                 after,
                 (*assessment).clone(),
+                current,
             ));
         }
     }
@@ -338,14 +362,36 @@ pub(super) fn apply(
     }
 
     let mut task_results = Vec::with_capacity(validated.len());
-    for (task_id, before, after, mut assessment) in validated {
+    let mut ci_sweep_admission = Vec::new();
+    for (task_id, before, after, mut assessment, current) in validated {
         let changed = before != after;
-        if changed {
+        let admission = ci_sweep_filing
+            .map(|filing| {
+                ci_failure_admission::assess(
+                    action,
+                    &task_id,
+                    &current,
+                    &assessment,
+                    &after,
+                    filing,
+                    promotion_authorized,
+                )
+            })
+            .transpose()?;
+        let promote = admission
+            .as_ref()
+            .is_some_and(|decision| decision["decision"] == "promote");
+        if changed || promote {
             runtime
                 .update_task(
                     &task_id,
                     TaskUpdateParams {
-                        context_files: Some(after.clone()),
+                        context_files: changed.then_some(after.clone()),
+                        status: promote.then_some(TaskStatus::Backlog),
+                        comment: promote.then(|| {
+                            "CI-sweep admission: task-pilot validated current relevance and selectors; promoted proposed repair to backlog."
+                                .to_string()
+                        }),
                         ..TaskUpdateParams::default()
                     },
                 )
@@ -358,6 +404,12 @@ pub(super) fn apply(
         }
         if let Value::Object(fields) = &mut assessment {
             fields.insert("applied".to_string(), Value::Bool(changed));
+            if let Some(admission) = admission.clone() {
+                fields.insert("ci_sweep_admission".to_string(), admission);
+            }
+        }
+        if let Some(admission) = admission {
+            ci_sweep_admission.push(admission);
         }
         task_results.push(assessment);
     }
@@ -374,6 +426,7 @@ pub(super) fn apply(
         "partition_count": expected_partitions.len(),
         "failed_partitions": [],
         "tasks": task_results,
+        "ci_sweep_admission": ci_sweep_admission,
     }))
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -1,0 +1,345 @@
+//! CI-sweep quarantine and post-pilot admission regressions.
+
+use orbit_engine::RuntimeHost;
+use orbit_tools::ToolContext;
+use orbit_types::task::TaskStatus;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_layout, write_workspace_file,
+};
+use crate::application::task::TaskAddParams;
+
+use super::ci_failure_tasks::{failure, snapshot};
+
+const CHECKOUT: &str = "3333333333333333333333333333333333333333";
+const NEXT_HEAD: &str = "4444444444444444444444444444444444444444";
+
+fn file(runtime: &OrbitRuntime, failures: Vec<Value>) -> Value {
+    runtime
+        .run_deterministic(
+            "file_ci_failure_tasks",
+            &json!({}),
+            &json!({"ci_evidence": snapshot(failures)}),
+            ToolContext::default(),
+        )
+        .expect("file CI task")
+}
+
+struct Assessment<'a> {
+    selectors: Vec<&'a str>,
+    disposition: &'a str,
+    duplicate_of: Value,
+    already_landed: Value,
+    warnings: Vec<&'a str>,
+    authorized: bool,
+}
+
+impl<'a> Assessment<'a> {
+    fn actionable(selector: &'a str, authorized: bool) -> Self {
+        Self {
+            selectors: vec![selector],
+            disposition: "selectors",
+            duplicate_of: Value::Null,
+            already_landed: Value::Null,
+            warnings: Vec::new(),
+            authorized,
+        }
+    }
+
+    fn already_landed(evidence: String) -> Self {
+        Self {
+            selectors: Vec::new(),
+            disposition: "verified_no_diff",
+            duplicate_of: Value::Null,
+            already_landed: json!({"evidence": evidence}),
+            warnings: Vec::new(),
+            authorized: true,
+        }
+    }
+
+    fn duplicate() -> Self {
+        Self {
+            selectors: Vec::new(),
+            disposition: "verified_no_diff",
+            duplicate_of: json!({
+                "task_id": "ORB-EXISTING",
+                "evidence": "an open task already owns the same current repair",
+            }),
+            already_landed: Value::Null,
+            warnings: vec!["duplicate task must be inspected before reconsideration"],
+            authorized: true,
+        }
+    }
+}
+
+fn apply_pilot(
+    runtime: &OrbitRuntime,
+    repo_root: &std::path::Path,
+    filing: &Value,
+    assessment: Assessment<'_>,
+) -> Result<Value, String> {
+    let task_id = filing["task_id"].as_str().expect("filed task id");
+    let prepared = runtime
+        .run_deterministic(
+            "prepare_task_pilot",
+            &json!({}),
+            &json!({
+                "task_ids": [task_id],
+                "workspace_path": repo_root,
+                "max_tasks": 1,
+                "max_partition_size": 1,
+            }),
+            ToolContext::default(),
+        )
+        .expect("prepare CI pilot");
+    let before = prepared["tasks"][0]["context_files_before"].clone();
+    runtime
+        .run_deterministic(
+            "apply_task_pilot_results",
+            &json!({}),
+            &json!({
+                "prepared": prepared,
+                "results": [{
+                    "partition_index": 0,
+                    "task_ids": [task_id],
+                    "tasks": [{
+                        "task_id": task_id,
+                        "context_files_before": before,
+                        "context_files_after": assessment.selectors,
+                        "disposition": assessment.disposition,
+                        "evidence": "compared runner-tested and current integration revisions",
+                        "recommended_crew": "system",
+                        "recommended_complexity": "medium",
+                        "blocked_by": [],
+                        "duplicate_of": assessment.duplicate_of,
+                        "already_landed": assessment.already_landed,
+                        "adr_conflicts": [],
+                        "utility_warnings": assessment.warnings,
+                        "surface_warnings": [],
+                    }],
+                }],
+                "workspace_path": repo_root,
+                "ci_sweep_filing": filing,
+                "promotion_authorized": assessment.authorized,
+            }),
+            ToolContext::default(),
+        )
+        .map_err(|error| error.to_string())
+}
+
+fn backlog_task_ids(runtime: &OrbitRuntime) -> Vec<String> {
+    runtime
+        .run_deterministic(
+            "list_backlog_tasks",
+            &json!({}),
+            &json!({"max_tasks": 50}),
+            ToolContext::default(),
+        )
+        .expect("list backlog")["task_ids"]
+        .as_array()
+        .expect("task ids")
+        .iter()
+        .filter_map(Value::as_str)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[test]
+fn active_auto_drain_cannot_see_finding_before_pilot_apply_and_authorization() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/current_regression.rs");
+    let filed = file(
+        &runtime,
+        vec![failure(
+            10,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\terror: current regression\n",
+            CHECKOUT,
+        )],
+    );
+    let filing = &filed["filed"][0];
+    let task_id = filing["task_id"].as_str().expect("task id");
+    assert!(!backlog_task_ids(&runtime).contains(&task_id.to_string()));
+
+    let unauthorized = apply_pilot(
+        &runtime,
+        &repo_root,
+        filing,
+        Assessment::actionable("file:src/current_regression.rs", false),
+    )
+    .expect("apply selectors without promotion authority");
+    assert_eq!(
+        unauthorized["ci_sweep_admission"][0]["classification"],
+        "promotion_not_authorized"
+    );
+    assert_eq!(
+        runtime.get_task(task_id).expect("task").status,
+        TaskStatus::Proposed
+    );
+    assert!(!backlog_task_ids(&runtime).contains(&task_id.to_string()));
+
+    let authorized = apply_pilot(
+        &runtime,
+        &repo_root,
+        filing,
+        Assessment::actionable("file:src/current_regression.rs", true),
+    )
+    .expect("authorize successfully applied pilot");
+    assert_eq!(
+        authorized["ci_sweep_admission"][0]["classification"],
+        "current_actionable_regression"
+    );
+    assert!(backlog_task_ids(&runtime).contains(&task_id.to_string()));
+}
+
+#[test]
+fn already_landed_release_stays_proposed_but_distinct_current_regression_advances() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/current_regression.rs");
+    let prior = runtime
+        .add_task(TaskAddParams {
+            title: "Repair Homebrew on_arm release failure".to_string(),
+            description: "Release/Homebrew/on_arm fixed by 49740da.".to_string(),
+            acceptance_criteria: vec!["The Homebrew ARM formula works.".to_string()],
+            status: Some(TaskStatus::Done),
+            ..TaskAddParams::default()
+        })
+        .expect("seed completed repair");
+    let old = file(
+        &runtime,
+        vec![failure(
+            10,
+            "release",
+            "homebrew",
+            "on arm",
+            "release\thomebrew\terror: old arm formula\n",
+            CHECKOUT,
+        )],
+    );
+    let old_filing = &old["filed"][0];
+    let result = apply_pilot(
+        &runtime,
+        &repo_root,
+        old_filing,
+        Assessment::already_landed(format!(
+            "done repair {} landed as 49740da on current integration",
+            prior.id
+        )),
+    )
+    .expect("classify already-landed release failure");
+    assert_eq!(
+        result["ci_sweep_admission"][0]["classification"],
+        "already_landed"
+    );
+    assert_eq!(
+        runtime
+            .get_task(old_filing["task_id"].as_str().expect("old id"))
+            .expect("old task")
+            .status,
+        TaskStatus::Proposed
+    );
+
+    let current = file(
+        &runtime,
+        vec![failure(
+            11,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\terror: distinct current type failure\n",
+            NEXT_HEAD,
+        )],
+    );
+    let current_filing = &current["filed"][0];
+    apply_pilot(
+        &runtime,
+        &repo_root,
+        current_filing,
+        Assessment::actionable("file:src/current_regression.rs", true),
+    )
+    .expect("admit distinct current regression");
+    assert_eq!(
+        runtime
+            .get_task(current_filing["task_id"].as_str().expect("current id"))
+            .expect("current task")
+            .status,
+        TaskStatus::Backlog
+    );
+}
+
+#[test]
+fn failed_or_warned_pilot_does_not_block_an_independent_eligible_fix() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/eligible.rs");
+    let filed = file(
+        &runtime,
+        vec![
+            failure(
+                10,
+                "ci-a",
+                "build",
+                "cargo build",
+                "a\terror: duplicate\n",
+                CHECKOUT,
+            ),
+            failure(
+                11,
+                "ci-b",
+                "test",
+                "cargo test",
+                "b\terror: current\n",
+                CHECKOUT,
+            ),
+            failure(
+                12,
+                "ci-c",
+                "lint",
+                "cargo clippy",
+                "c\terror: invalid\n",
+                CHECKOUT,
+            ),
+        ],
+    );
+    let filings = filed["filed"].as_array().expect("three filings");
+    let warning = apply_pilot(&runtime, &repo_root, &filings[0], Assessment::duplicate())
+        .expect("withhold duplicate warning");
+    assert_eq!(warning["ci_sweep_admission"][0]["decision"], "withhold");
+
+    let invalid = apply_pilot(
+        &runtime,
+        &repo_root,
+        &filings[2],
+        Assessment::actionable("file:src/missing.rs", true),
+    )
+    .expect_err("invalid selector fails only its pilot apply");
+    assert!(invalid.contains("does not resolve"), "{invalid}");
+
+    let eligible = apply_pilot(
+        &runtime,
+        &repo_root,
+        &filings[1],
+        Assessment::actionable("file:src/eligible.rs", true),
+    )
+    .expect("independent eligible fix advances");
+    assert_eq!(eligible["ci_sweep_admission"][0]["decision"], "promote");
+    for (index, status) in [
+        TaskStatus::Proposed,
+        TaskStatus::Backlog,
+        TaskStatus::Proposed,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        assert_eq!(
+            runtime
+                .get_task(filings[index]["task_id"].as_str().expect("task id"))
+                .expect("task")
+                .status,
+            status
+        );
+    }
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -223,7 +223,7 @@ fn one_regression_across_push_and_pull_request_runs_becomes_one_task() {
 }
 
 #[test]
-fn a_filed_task_is_an_ordinary_backlog_bug_carrying_usable_evidence() {
+fn a_filed_task_is_a_proposed_bug_carrying_usable_evidence() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let log = "ci\ttest\t2026-08-30T01:00:00Z assertion failed: left == right\n";
 
@@ -245,7 +245,7 @@ fn a_filed_task_is_an_ordinary_backlog_bug_carrying_usable_evidence() {
         .expect("one filed task");
     let task = runtime.get_task(&task_id).expect("read filed task");
 
-    assert_eq!(task.status, TaskStatus::Backlog);
+    assert_eq!(task.status, TaskStatus::Proposed);
     assert_eq!(task.task_type, orbit_types::task::TaskType::Bug);
     // No `github.*` requirement: the evidence is in the description, so the
     // task ships on the ordinary agent baseline.
@@ -427,6 +427,11 @@ fn a_second_sweep_over_a_still_red_run_does_not_file_a_second_task() {
 
     assert_eq!(second["outcome"], json!("current_failures"));
     assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(
+        second["pilot_candidates"][0]["task_id"],
+        json!(task_id.clone()),
+        "a proposed task whose prior pilot did not admit it must remain retryable"
+    );
     let skipped = second["skipped_existing"].as_array().expect("skipped");
     assert!(!skipped.is_empty());
     assert!(
@@ -462,6 +467,15 @@ fn a_closed_task_does_not_suppress_a_recurrence() {
         .first()
         .cloned()
         .expect("first sweep files one task");
+    runtime
+        .update_task(
+            &task_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Backlog),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("admit the first task before completing it");
     runtime
         .update_task(
             &task_id,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -1,4 +1,5 @@
 mod backlog_exclusion;
+mod ci_failure_admission;
 mod ci_failure_tasks;
 mod cli_executor;
 mod dependabot_alert_tasks;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
@@ -168,6 +168,29 @@ fn ci_does_not_suppress_a_distinct_error_signature() {
 }
 
 #[test]
+fn completed_ci_repair_is_evidence_not_blanket_immunity_for_a_current_failure() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let completed = seed_manual_task(
+        &runtime,
+        "Fix red CI: ci / build / cargo build",
+        "Workflow: ci\nFailing job: build\nFailing step: cargo build\n\
+         Normalized error signature: error: expected <n> arguments, found <n>",
+        TaskStatus::Done,
+    );
+
+    let output = file_ci(&runtime, ci_evidence());
+
+    assert_eq!(output["filed_count"], json!(1));
+    let filed = filed_task_ids(&output);
+    assert_ne!(filed[0], completed);
+    assert_eq!(
+        runtime.get_task(&filed[0]).expect("current task").status,
+        TaskStatus::Proposed,
+        "the fresh finding must be quarantined for current-relevance pilot assessment"
+    );
+}
+
+#[test]
 fn ci_exact_key_replay_does_not_require_the_broader_lookup() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let evidence = ci_evidence();

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -198,18 +198,17 @@ fn default_activity_catalog() -> V2ActivityCatalog {
     catalog
 }
 
-/// The CI-failure sweep only looks and files. An agent step or a worktree in
-/// this pipeline would mean an agent had been handed the credentialed side of
-/// the sweep, or that the sweep had started building checkouts it never needs.
+/// The CI-failure sweep quarantines first, then delegates read-only inspection
+/// to the existing pilot job. It must never invoke an implementation pipeline
+/// or build a worktree itself.
 #[test]
-fn ci_failure_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
+fn ci_failure_sweep_pipeline_pilots_proposed_findings_before_authorized_admission() {
     let yaml = DEFAULT_JOB_FILES
         .iter()
         .find_map(|(name, yaml)| (*name == "ci_failure_sweep_pipeline").then_some(*yaml))
         .expect("CI-failure sweep job default exists");
-    let mut asset = load_job_asset(yaml).expect("parse CI-failure sweep pipeline");
+    let asset = load_job_asset(yaml).expect("parse CI-failure sweep pipeline");
     let catalog = default_activity_catalog();
-    resolve_job_target_refs(&mut asset.spec, &catalog).expect("resolve sweep target refs");
 
     assert_eq!(asset.spec.max_active_runs, 1);
 
@@ -219,25 +218,54 @@ fn ci_failure_sweep_pipeline_is_two_deterministic_steps_and_single_flight() {
         .iter()
         .map(|step| step.id.as_str())
         .collect();
-    assert_eq!(step_ids, ["collect", "file"], "collect must precede file");
+    assert_eq!(
+        step_ids,
+        ["collect", "file", "pilots"],
+        "proposed filing must precede pilot admission"
+    );
 
-    for step in &asset.spec.steps {
-        let JobV2StepBody::Target(target) = &step.body else {
-            panic!(
-                "sweep step `{}` must be a resolved activity target",
-                step.id
-            );
+    for step in &asset.spec.steps[..2] {
+        let JobV2StepBody::TargetRef(target) = &step.body else {
+            panic!("sweep step `{}` must reference an activity", step.id);
         };
         assert!(
-            matches!(target.spec, ActivityV2Spec::Deterministic(_)),
-            "sweep step `{}` must be deterministic; this sweep launches no agent",
-            step.id
+            matches!(
+                target.target.as_str(),
+                "activity:collect_ci_evidence" | "activity:file_ci_failure_tasks"
+            ),
+            "unexpected pre-pilot step {}",
+            target.target
         );
     }
+    let JobV2StepBody::FanOut { fan_out, fan_in } = &asset.spec.steps[2].body else {
+        panic!("new CI findings must fan out into independent pilots");
+    };
+    assert_eq!(fan_out.items, "{{ steps.file.output.pilot_candidates }}");
+    assert_eq!(fan_out.max_workers, 3);
+    assert_eq!(fan_in.collect.as_deref(), Some("pilot_results"));
+    let JobV2StepBody::TargetRef(pilot) = &fan_out.worker.body else {
+        panic!("pilot worker must invoke the existing task-pilot job");
+    };
+    assert_eq!(pilot.target, "activity:invoke_and_wait");
+    let input = pilot
+        .default_input
+        .as_ref()
+        .expect("pilot invocation input");
+    assert_eq!(input["job_name"], "task_pilot_pipeline");
+    assert_eq!(
+        input["run_input"]["task_ids"],
+        json!(["{{ item.task_id }}"])
+    );
+    assert_eq!(input["run_input"]["ci_sweep_filing"], "{{ item }}");
+    assert_eq!(input["run_input"]["promotion_authorized"], true);
+
+    let mut resolved = asset.clone();
+    resolve_job_target_refs(&mut resolved.spec, &catalog).expect("resolve sweep target refs");
     assert!(
         !yaml.contains("worktree_setup"),
-        "the sweep only looks and files, so it must never build a worktree"
+        "the sweep never implements, so it must never build a worktree"
     );
+    assert!(!yaml.contains("job_name: task_auto_pipeline"));
 }
 
 #[test]
@@ -406,6 +434,8 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     let defaults = asset.spec.default_input.as_ref().expect("default input");
     assert_eq!(defaults["task_ids"], json!([]));
     assert_eq!(defaults["max_partition_size"], 5);
+    assert_eq!(defaults["promotion_authorized"], false);
+    assert_eq!(defaults["ci_sweep_filing"], Value::Null);
     assert!(
         defaults.get("crew").is_none(),
         "a job-input crew would be dead: the system-crew marker overwrites it before resolution"
@@ -452,6 +482,14 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     let apply_input = apply.default_input.as_ref().expect("apply input");
     assert_eq!(apply_input["prepared"], "{{ steps.prepare.output }}");
     assert_eq!(apply_input["results"], "{{ steps.pilot_results.output }}");
+    assert_eq!(
+        apply_input["promotion_authorized"],
+        "{{ input.promotion_authorized }}"
+    );
+    assert_eq!(
+        apply_input["ci_sweep_filing"],
+        "{{ input.ci_sweep_filing }}"
+    );
     assert!(
         apply_input.get("crew").is_none() && apply_input.get("system_crew").is_none(),
         "the deterministic apply step must carry no crew key: it cannot receive the \

--- a/plugin/skills/orbit/references/setup/automation.md
+++ b/plugin/skills/orbit/references/setup/automation.md
@@ -67,7 +67,7 @@ workspace-unique name (`<base>-<workspace>`) resolved at seed time. Run
 | `task-pilot` | every 4h | `task_pilot_pipeline` | Preflights proposed/backlog tasks with empty `context_files` and fills in validated selectors. |
 | `task-triage` | hourly | `task_triage_pipeline` | Diagnoses tasks blocked by failed runs; re-backlogs environmental casualties, leaves real failures blocked with a diagnosis. |
 | `auto-task-scheduler` | every minute | `auto_task_scheduler_pipeline` | Mints tasks from every due, enabled auto-task definition. → [auto-tasks.md](auto-tasks.md) |
-| `ci-failure-sweep` | hourly at :05 | `ci_failure_sweep_pipeline` | Collects GitHub Actions evidence and files deduped backlog bug tasks. |
+| `ci-failure-sweep` | hourly at :05 | `ci_failure_sweep_pipeline` | Files deduped proposed CI findings, pilots them, and admits only current warning-free repairs to backlog. |
 | `dependabot-alert-sweep` | daily at 03:25 host-local time | `dependabot_alert_sweep_pipeline` | Collects Dependabot, code-scanning, and secret-scanning findings and files remediation tasks. |
 | `ship-sweep` | every 20m | `workspace_ship_pipeline` | Ships this workspace's ready backlog through the gated pipeline, unattended. |
 
@@ -173,7 +173,13 @@ orbit job show dependabot_alert_sweep_pipeline
 orbit run job dependabot_alert_sweep_pipeline --input min_severity=high --input max_tasks=10
 ```
 
-These commands can create backlog tasks; they are not dry runs. Set the CI
+These commands can create and pilot proposed tasks; they are not dry runs.
+The CI job promotes only tasks whose pilot applied non-empty canonical
+selectors and reported no duplicate, already-landed, conflict, or warning
+finding. Pilot failure and stale/no-diff findings remain proposed, so an active
+auto-drain cannot claim them. Invoking this named job, or enabling its shipped
+inert routine, is explicit promotion authorization; the filing activity and a
+standalone `task_pilot_pipeline` run carry no such authority. Set the CI
 integration branch explicitly when it differs from GitHub's default branch.
 CI defaults bound investigation to six runs and filing to five tasks. The
 security job defaults to high-severity Dependabot/code-scanning findings and
@@ -185,5 +191,9 @@ A missing GitHub client, authentication, or API permission is a capability gap,
 not evidence of a clean repository. Read the collect/file step outcomes. CI
 failure-key dedupe and security alert identity suppress already-covered work;
 they do not promise general semantic duplicate detection. Discovery and filing
-errors must remain visible and retryable. Choose these routines independently
-of `ship-sweep`; filing does not authorize unattended repair.
+errors must remain visible and retryable. A previous done repair is evidence to
+inspect, not blanket dedupe: an old failed release already fixed on the current
+integration branch stays proposed as already-landed, while a distinct defect
+that still reproduces at the current revision remains eligible. Choose these
+routines independently of `ship-sweep`; admission to backlog does not authorize
+implementation or completion.

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -58,17 +58,27 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus a deterministic apply step that writes validated `context_files`. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |
 | `auto_task_scheduler_pipeline` | Mint tasks from due auto-task definitions. |
-| `ci_failure_sweep_pipeline` | Collect GitHub Actions failures and file evidence-backed tasks, without implementing repairs. |
+| `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.
+
+CI-sweep filing is deliberately non-executable: `file_ci_failure_tasks` always
+creates `proposed` tasks. The CI job invokes `task_pilot_pipeline` for each new
+task and retries matching tasks that a prior pilot left proposed, carrying
+explicit promotion authority into its deterministic apply boundary. Invalid or
+empty selectors, pilot failure, duplicates, already-landed
+work, conflicts, and warnings leave that task proposed without blocking other
+pilot children. A standalone task-pilot run has no promotion authority. The
+source run/job/SHA/step remains in the task description, while parent and child
+run state retain the pilot run ID, result, and admission decision.
 
 ### The `completion` input
 


### PR DESCRIPTION
## Task

[ORB-11225](https://orbit-cli.com/tasks/ORB-11225) — Pilot and revalidate CI-sweep findings before exposing them to auto-drain

### Description

## Incident
During the authorized two-host throughput run, Mac local-data-platform ci_failure_sweep_pipeline jrun-20260905-0316-7 created DANI-10199 directly as backlog with context_files=[]; the running auto-drain immediately started child jrun-20260905-0317-3. DANI-10199 repeated the old v0.4.0 Homebrew on_arm issue already fixed by done DANI-10179. The duplicate implementation confirmed current base 3609412 contains fix 49740da and needed no diff. Daniel approved cancellation; the duplicate was rejected. This consumed a worker slot and bypassed the explicit pilot-before-backlog requirement.

## Current boundary
crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml and adapter/engine_host/v2_host/ci_failure_tasks.rs explicitly file backlog tasks. There is no proposed-status job override in the installed activity. Existing ORB-11189 dedupe must remain effective, but matching only open tasks is insufficient to justify repairing an old failed release on current code.

## Outcome
Make CI remediation intake safe for continuous dispatch: file proposed, run existing task_pilot_pipeline on new actionable tasks, verify validated selectors/no-diff and inspect already-landed/duplicate/current-relevance findings, then promote ready repairs under the authorized sweep policy. Reuse existing lifecycle and pilot machinery; don't add a parallel scheduler or hold unrelated tasks. Retain retryability: a previous done repair is not blanket immunity if a current failed revision still reproduces the defect. Require current relevance evidence, distinguish stale release failures from current regressions, and retain original run/job/SHA/step provenance.

Do not dispatch implementation from the filing activity or blindly promote warnings. A pilot failure must leave tasks proposed. Completion and promotion authorization remain explicit; ordinary standalone filing without promotion authority should stop at proposed. Scope the repair to CI-sweep intake; other automated producers may be separately assessed. Leave proposed until pilot applies context.

### Acceptance Criteria

- Deterministic regression reproduces a sweep finding arriving while an auto-drain is active: it cannot be admitted before successful pilot application and readiness assessment.
- Old failed release already fixed on current integration code is classified already-landed/stale with evidence and does not mint an executable duplicate; a distinct current regression remains eligible despite a prior done repair.
- Pilot failure, duplicate/already-landed warning, invalid/missing selectors, and lack of promotion authorization keep work out of backlog; eligible fixes advance without blocking independent work.
- Original CI evidence and pilot run/result are auditable. Avoid new polling services, duplicate schedulers, or static filename allowlists.
- Existing sweep/pilot/admission behavior tests plus make ci-fast and make ci-lint pass; update shipped jobs, activity guidance, and Orbit skill docs in the same change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- CI failure filing now creates proposed tasks, never executable backlog work, and emits retryable pilot candidates for both newly filed findings and matching proposed findings left by earlier failed or withheld pilots.
- The CI sweep job now fans those candidates into singleton runs of the existing task_pilot_pipeline. The generic pilot job defaults promotion authority to false; the explicitly enabled/invoked CI intake job passes literal authority.
- Added a fail-closed CI admission policy at the validated pilot apply boundary. It correlates task identity and source workflow/job/step/tested-SHA/run URLs, requires proposed status and canonical non-empty selectors, and withholds duplicate, already-landed, blocked, conflict, warning, no-diff, invalid, or unauthorized findings. Eligible repairs atomically receive selectors and advance to backlog.
- Parent/child run state retains pilot run IDs, pilot results, current CI provenance, and admission classifications. Proposed retry candidates preserve retryability without a parallel scheduler or static filename allowlist.
- Updated dogfood and embedded activities, jobs, routine guidance, and mirrored Orbit skill documentation. Split the CI admission policy and regressions into cohesive sibling modules to keep task_pilot.rs below the repository line-count warning.
- Added deterministic regressions for an active auto-drain race, explicit promotion authority, stale/already-landed repairs with done-task evidence, distinct current recurrence, invalid selectors, duplicate/warning withholding, independent eligible work, and proposed-task pilot retries.
Assessment: The implementation reuses the existing task lifecycle, task-pilot pipeline, invoke-and-wait child audit, and backlog drain. Filing cannot dispatch implementation, failed child pilots leave tasks proposed for a later sweep, and one failed pilot does not block independent singleton pilots.
Validation:
- cargo test -p orbit-core ci_failure --lib (24 passed)
- cargo test -p orbit-core sweep_duplicate_tasks --lib (11 passed)
- cargo test -p orbit-core task_pilot --lib (10 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Deviations from original plan:
- Added tightly coupled task-pilot apply/job/activity and CI routine files plus new focused source/test modules because lifecycle admission must be enforced at the validated pilot boundary and current shipped guidance had to remain accurate.
- No commit was created; repository policy requires human approval before commit.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11225-6a9b90be`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*