### PR TITLE
Show workspace-attributed runs in the dashboard All workspaces view

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -10,7 +10,7 @@ import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
 import { renderDiagnostics } from './diagnostics.js';
 import { renderMarkdown } from './markdown.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
-import { initRuns, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
+import { initRuns, getRunFilter, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
 import { fetchAndRenderOperations, initOperations } from './operations.js';
 import {
   renderRunDetailEmpty,
@@ -75,6 +75,8 @@ let lastTasks = [];
 // `/api/tasks/all` view, which answers a bare array with no such metadata.
 let lastTasksMeta = null;
 let lastRuns = [];
+let lastRunsMeta = null;
+let lastRunSourcesUnavailable = [];
 let lastDiagnostics = { metrics: [], errors: [], incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
@@ -198,7 +200,18 @@ function routerContext() {
 }
 
 function runsContext() {
-  return { navigateToRun: nTR, fetchAndRenderRuns, fetchAndRenderRunDetail, fetchAndRenderRunEvents, getActiveRunId, getLastRuns: () => lastRuns, fmtTimestamp, fmtDuration };
+  return {
+    navigateToRun: nTR,
+    fetchAndRenderRuns,
+    fetchAndRenderRunDetail,
+    fetchAndRenderRunEvents,
+    getActiveRunId,
+    getLastRuns: () => lastRuns,
+    getRunsMeta: () => lastRunsMeta,
+    getRunSourcesUnavailable: () => lastRunSourcesUnavailable,
+    fmtTimestamp,
+    fmtDuration,
+  };
 }
 
 function runDetailContext() {
@@ -843,15 +856,12 @@ function renderAggregatePlaceholders() {
   resetHealthStrip();
 }
 
-// ORB-00044: the Diagnostics tab is fed exclusively by per-workspace endpoints
-// (/api/job-runs, /api/scoreboard, and
-// /api/diagnostics/{metrics,errors,friction,implement_one}), so in aggregate
-// mode every diagnostics panel — all subtab bodies (ORB-10444 folded the
-// scoreboard in as one) and the implement_one side card — shows the placeholder
-// and the count is neutralized.
+// Most Diagnostics panels are fed exclusively by per-workspace endpoints and
+// remain unavailable in aggregate mode. Runs is the exception: its body is
+// managed by the bounded /api/job-runs/all response and must not be overwritten
+// by these placeholders.
 function renderDiagnosticsPlaceholders() {
   renderPanelPlaceholder("diag-body");
-  renderPanelPlaceholder("runs-body");
   renderPanelPlaceholder("scoreboard-body");
   renderPanelPlaceholder("diag-implement-one-body");
   const diagCount = $("diag-count");
@@ -995,6 +1005,12 @@ function buildWorkspaceSelector() {
   select.addEventListener("change", () => {
     setWorkspace(select.value);
     persistScopeToUrl();
+    // Clear the prior scope synchronously. A slower request from that scope is
+    // also discarded in fetchAndRenderRuns, so it cannot repaint stale rows.
+    lastRuns = [];
+    lastRunsMeta = null;
+    lastRunSourcesUnavailable = [];
+    renderRuns(lastRuns);
     refreshDashboard();
   });
 
@@ -1082,11 +1098,9 @@ function activeRefreshJobs() {
   }
 
   if (activeTab === "diagnostics") {
-    // ORB-00044: every diagnostics fetch is per-workspace — /api/job-runs and
-    // all four /api/diagnostics/* endpoints (metrics, errors, friction,
-    // implement_one) take the backend `Ws` extractor and 400 without a concrete
-    // workspace — so in aggregate mode skip the whole tab and show placeholders
-    // (subtab switches are likewise guarded in router.js setDiagSubtabImpl).
+    // Most diagnostics fetches are per-workspace. Runs has a bounded aggregate
+    // endpoint; metrics, errors, friction, implement_one and Scoreboard still
+    // require a concrete workspace and show placeholders without one.
     // ORB-10588: /api/metrics/reliability takes the whole DashboardState, not
     // the `Ws` extractor, so it answers in aggregate mode too — it is fetched
     // ahead of the guard below rather than being placeheld with the rest.
@@ -1095,6 +1109,11 @@ function activeRefreshJobs() {
         fetchAndRenderReliability()
           .catch((e) => console.error("Failed to fetch reliability metrics", e))
       );
+      return jobs;
+    }
+    if (aggregate && activeDiagSubtab === "runs") {
+      renderDiagnosticsPlaceholders();
+      jobs.push(fetchAndRenderRuns());
       return jobs;
     }
     if (aggregate) {
@@ -1173,12 +1192,44 @@ function activeRefreshJobs() {
 }
 
 function fetchAndRenderRuns() {
-  return Promise.all([
-    fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`),
-    fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`),
-  ]).then(([runs, frictionRows]) => {
+  const requestedWorkspace = getWorkspace();
+  const requestedAggregate = isAggregateView();
+  const runFilter = getRunFilter();
+  const scopeIsCurrent = () =>
+    requestedWorkspace === getWorkspace() &&
+    requestedAggregate === isAggregateView() &&
+    runFilter === getRunFilter();
+  const request = requestedAggregate
+    ? fetchJson(`/api/job-runs/all?limit=${JOB_RUN_LIMIT}&state=${encodeURIComponent(runFilter)}`).then((payload) => ({
+        runs: listItems(payload),
+        frictionRows: [],
+        meta: payload,
+        unavailable: Array.isArray(payload && payload.unavailable) ? payload.unavailable : [],
+      }))
+    : Promise.all([
+        fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`),
+        fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`),
+      ]).then(([runs, frictionRows]) => ({ runs, frictionRows, meta: null, unavailable: [] }));
+
+  return request.then(({ runs, frictionRows, meta, unavailable }) => {
+    if (!scopeIsCurrent()) return;
     lastRuns = mergeRunsWithFriction(runs, frictionRows);
+    lastRunsMeta = meta;
+    lastRunSourcesUnavailable = unavailable;
     renderRuns(lastRuns);
+  }).catch((error) => {
+    if (scopeIsCurrent()) {
+      const workspace = dashboardWorkspaces.find((entry) => entry.id === requestedWorkspace);
+      lastRuns = [];
+      lastRunsMeta = null;
+      lastRunSourcesUnavailable = [{
+        workspace_id: requestedWorkspace,
+        workspace_name: requestedAggregate ? "All workspaces" : (workspace && workspace.name) || requestedWorkspace || "workspace",
+        error: error.message || "run query failed",
+      }];
+      renderRuns(lastRuns);
+    }
+    throw error;
   });
 }
 

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -1434,6 +1434,51 @@
         align-items: center;
         border-bottom: 1px solid rgba(255, 255, 255, 0.03);
       }
+      #runs-body { overflow-x: auto; }
+      .runs-row.workspace-attributed {
+        grid-template-columns:
+          80px minmax(90px, 0.65fr) minmax(100px, 1fr) minmax(100px, 0.7fr)
+          58px 74px 86px 80px 72px;
+      }
+      .runs-row .run-workspace {
+        color: var(--accent);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .runs-filter {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+      .runs-filter-label { color: var(--fg-dim); margin-right: 2px; }
+      .runs-filter-button {
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        padding: 3px 9px;
+        background: transparent;
+        color: var(--fg-dim);
+        font: inherit;
+        cursor: pointer;
+      }
+      .runs-filter-button:hover,
+      .runs-filter-button.active {
+        border-color: var(--accent);
+        color: var(--accent);
+        background: var(--accent-dim);
+      }
+      .runs-source-warning {
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border);
+        color: var(--state-failed);
+        background: rgba(239, 68, 68, 0.08);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
       
       .runs-row:last-child {
         border-bottom: none;
@@ -1524,6 +1569,17 @@
         cursor: pointer;
       }
       .runs-sort.active { color: var(--fg); }
+
+      @media (max-width: 760px) {
+        .runs-row { min-width: 790px; }
+        .runs-row.workspace-attributed { min-width: 900px; }
+        .runs-filter,
+        .runs-source-warning {
+          min-width: max-content;
+          position: sticky;
+          left: 0;
+        }
+      }
       
       .scoreboard-row {
         display: grid;

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -17,7 +17,7 @@
 //
 // Also exports parseHashRoute for symmetry (used only internally today).
 
-import { el, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, parseDashboardWindow, persistScopeToUrl, syncWindowSelectors } from './common.js';
+import { el, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, setWorkspace, parseDashboardWindow, persistScopeToUrl, syncWindowSelectors } from './common.js';
 import { renderRuns } from './runs.js';
 
 const $ = (id) => document.getElementById(id);
@@ -126,18 +126,12 @@ function setDiagSubtabImpl(ctx, name) {
     return;
   }
 
-  // ORB-00044: in the aggregate "All workspaces" view the diagnostics fetches
-  // are skipped (activeRefreshJobs), so a subtab switch must not repaint the
-  // previous workspace's stale rows over the placeholder — render the
-  // placeholder for the now-visible body instead.
+  // Runs remains live in the aggregate view. Other per-workspace diagnostics
+  // must keep their placeholder and never repaint a prior workspace's rows.
   if (name === "runs") {
     $("diag-body").style.display = "none";
     $("runs-body").style.display = "block";
-    if (isAggregateView()) {
-      renderPanelPlaceholder("runs-body");
-    } else {
-      renderRuns(ctx.getLastRuns ? ctx.getLastRuns() : []);
-    }
+    renderRuns(ctx.getLastRuns ? ctx.getLastRuns() : []);
   } else {
     $("diag-body").style.display = "block";
     $("runs-body").style.display = "none";
@@ -299,7 +293,13 @@ function setActiveTabImpl(ctx, raw, opts = {}) {
   if (opts.refresh !== false && (!hashChanged || !shouldUpdateHash)) ctx.refreshDashboard();
 }
 
-function navigateToRunImpl(ctx, runId) {
+function navigateToRunImpl(ctx, runId, workspaceId = null) {
+  if (workspaceId) {
+    setWorkspace(workspaceId);
+    persistScopeToUrl();
+    const selector = $("workspace-select");
+    if (selector) selector.value = workspaceId;
+  }
   ctx.setRunId(runId);
   ctx.setExpandedSteps(new Set());
   ctx.setRunDetail(null);
@@ -368,9 +368,9 @@ export function setActiveTab(raw, opts = {}) {
   return setActiveTabImpl(ctx, raw, opts);
 }
 
-export function navigateToRun(runId) {
+export function navigateToRun(runId, workspaceId = null) {
   const ctx = getCtx();
-  return navigateToRunImpl(ctx, runId);
+  return navigateToRunImpl(ctx, runId, workspaceId);
 }
 
 export function initTabs() {

--- a/crates/orbit-web/assets/dashboard/runs.js
+++ b/crates/orbit-web/assets/dashboard/runs.js
@@ -17,6 +17,8 @@ const $ = (id) => document.getElementById(id);
 
 const CANCELLABLE_RUN_STATES = new Set(["pending", "running"]);
 const RESUMABLE_RUN_STATES = new Set(["failed", "interrupted", "timeout"]);
+const ACTIVE_RUN_STATES = new Set(["pending", "running"]);
+const RUN_FILTERS = new Set(["all", "active", "failed"]);
 
 const RUN_SORT_DEFAULT_DIR = {
   when: "desc",
@@ -30,6 +32,10 @@ const RUN_SORT_DEFAULT_DIR = {
 
 let runSort = { key: "when", dir: "desc" };
 const resumedRunIdsBySource = new Map();
+let runFilter = (() => {
+  const value = new URL(window.location.href).searchParams.get("run_state") || "all";
+  return RUN_FILTERS.has(value) ? value : "all";
+})();
 
 let _runsCtx = null;
 
@@ -42,9 +48,9 @@ function getActiveRunId() {
   return hasCtx("getActiveRunId") ? _runsCtx.getActiveRunId() : null;
 }
 
-function doNavigateToRun(runId) {
+function doNavigateToRun(runId, workspaceId = null) {
   if (hasCtx("navigateToRun")) {
-    try { _runsCtx.navigateToRun(runId); } catch (_) {}
+    try { _runsCtx.navigateToRun(runId, workspaceId); } catch (_) {}
   }
 }
 
@@ -98,7 +104,7 @@ function buildCancelRunButton(run, host) {
   btn.disabled = !runIsCancellable(run);
   btn.addEventListener("click", (e) => {
     e.stopPropagation();
-    cancelRun(run.run_id, btn, host);
+    cancelRun(run, btn, host);
   });
   return btn;
 }
@@ -129,7 +135,18 @@ function buildResumeRunButton(run, host) {
   return btn;
 }
 
-async function cancelRun(runId, btn, host) {
+function runScopedPath(path, run) {
+  if (!run || !run.workspace_id) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}workspace=${encodeURIComponent(run.workspace_id)}`;
+}
+
+function runIdentity(run) {
+  return `${run && run.workspace_id ? run.workspace_id : ""}:${run && run.run_id ? run.run_id : ""}`;
+}
+
+async function cancelRun(run, btn, host) {
+  const runId = run && run.run_id;
   if (!runId) return;
   const old = btn.textContent;
   btn.disabled = true;
@@ -138,11 +155,12 @@ async function cancelRun(runId, btn, host) {
     for (const node of host.querySelectorAll(".action-error")) node.remove();
   }
   try {
-    await postJson(`/api/runs/${encodeURIComponent(runId)}/cancel`);
+    await postJson(runScopedPath(`/api/runs/${encodeURIComponent(runId)}/cancel`, run));
+    const refreshActiveDetail = !run.workspace_id && getActiveRunId() === runId;
     await Promise.all([
       doFetchAndRenderRuns(),
-      getActiveRunId() === runId ? doFetchAndRenderRunDetail() : Promise.resolve(),
-      getActiveRunId() === runId ? doFetchAndRenderRunEvents() : Promise.resolve(),
+      refreshActiveDetail ? doFetchAndRenderRunDetail() : Promise.resolve(),
+      refreshActiveDetail ? doFetchAndRenderRunEvents() : Promise.resolve(),
     ]);
   } catch (e) {
     if (host) {
@@ -166,9 +184,9 @@ async function replayRun(run, btn, host) {
     for (const node of host.querySelectorAll(".action-error")) node.remove();
   }
   try {
-    const payload = await postJson(`/api/runs/${encodeURIComponent(runId)}/replay`);
+    const payload = await postJson(runScopedPath(`/api/runs/${encodeURIComponent(runId)}/replay`, run));
     if (!payload.run_id) throw new Error("replay response did not include run_id");
-    doNavigateToRun(payload.run_id);
+    doNavigateToRun(payload.run_id, run.workspace_id);
     doFetchAndRenderRuns().catch(console.error);
   } catch (e) {
     if (host) {
@@ -193,9 +211,9 @@ async function resumeRun(run, btn, host) {
     for (const node of host.querySelectorAll(".action-error")) node.remove();
   }
   try {
-    const payload = await postJson(`/api/job-runs/${encodeURIComponent(runId)}/resume`);
+    const payload = await postJson(runScopedPath(`/api/job-runs/${encodeURIComponent(runId)}/resume`, run));
     if (!payload.run_id) throw new Error("resume response did not include run_id");
-    resumedRunIdsBySource.set(runId, payload.run_id);
+    resumedRunIdsBySource.set(runIdentity(run), payload.run_id);
     await doFetchAndRenderRuns();
   } catch (e) {
     if (host) {
@@ -390,6 +408,57 @@ function sortedRunsForDisplay(runs) {
   return rows;
 }
 
+function runMatchesFilter(run) {
+  if (runFilter === "active") return ACTIVE_RUN_STATES.has(run && run.state);
+  if (runFilter === "failed") return run && run.state === "failed";
+  return true;
+}
+
+function setRunFilter(value) {
+  runFilter = RUN_FILTERS.has(value) ? value : "all";
+  const url = new URL(window.location.href);
+  if (runFilter === "all") url.searchParams.delete("run_state");
+  else url.searchParams.set("run_state", runFilter);
+  if (url.href !== window.location.href) history.replaceState(null, "", url);
+  renderRuns(hasCtx("getLastRuns") ? _runsCtx.getLastRuns() : []);
+  doFetchAndRenderRuns().catch((error) => console.error(error));
+}
+
+export function getRunFilter() {
+  return runFilter;
+}
+
+function runFilterControls() {
+  const controls = el("div", { class: "runs-filter", title: "Filter Recent Runs by state" });
+  controls.dataset.key = "runs-filter";
+  controls.dataset.hash = `runs-filter-${runFilter}`;
+  controls.appendChild(el("span", { class: "runs-filter-label", text: "state" }));
+  for (const [value, label] of [["all", "all"], ["active", "active"], ["failed", "failed"]]) {
+    const button = el("button", {
+      class: `runs-filter-button${runFilter === value ? " active" : ""}`,
+      text: label,
+    });
+    button.type = "button";
+    button.setAttribute("aria-pressed", runFilter === value ? "true" : "false");
+    button.addEventListener("click", () => setRunFilter(value));
+    controls.appendChild(button);
+  }
+  return controls;
+}
+
+function unavailableSourcesNode(unavailable) {
+  if (!Array.isArray(unavailable) || unavailable.length === 0) return null;
+  const names = unavailable.map((source) => source.workspace_name || source.workspace_id || "unknown");
+  const node = el("div", {
+    class: "runs-source-warning",
+    text: `Unavailable workspace${names.length === 1 ? "" : "s"}: ${names.join(", ")}`,
+    title: unavailable.map((source) => `${source.workspace_name || source.workspace_id}: ${source.error || "unavailable"}`).join("\n"),
+  });
+  node.dataset.key = "runs-source-warning";
+  node.dataset.hash = `${names.join("|")}-${unavailable.map((source) => source.error || "").join("|")}`;
+  return node;
+}
+
 function setRunSort(key) {
   if (runSort.key === key) {
     runSort = { key, dir: runSort.dir === "asc" ? "desc" : "asc" };
@@ -443,21 +512,29 @@ function runDurationCell(run) {
 export function renderRuns(runs) {
   const body = $("runs-body");
   const frag = document.createDocumentFragment();
-  
-  const sorted = sortedRunsForDisplay(runs);
+  const unavailable = hasCtx("getRunSourcesUnavailable") ? _runsCtx.getRunSourcesUnavailable() : [];
+  const meta = hasCtx("getRunsMeta") ? _runsCtx.getRunsMeta() : null;
+  const attributed = (runs || []).some((run) => !!run.workspace_id);
+  const sorted = sortedRunsForDisplay((runs || []).filter(runMatchesFilter));
   const top = sorted.slice(0, 20);
   if ($("diag-count")) {
-    $("diag-count").textContent = `${top.length}/${sorted.length}`;
+    const bounded = meta && meta.truncated ? "+" : "";
+    $("diag-count").textContent = `${top.length}/${sorted.length}${bounded}`;
   }
+  frag.appendChild(runFilterControls());
+  const unavailableNode = unavailableSourcesNode(unavailable);
+  if (unavailableNode) frag.appendChild(unavailableNode);
   if (top.length === 0) {
-    syncNodes(body, [el("div", { class: "empty-state" }, [
+    frag.appendChild(el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: "No job runs yet." })
-    ])]);
+      el("div", { class: "text", text: runFilter === "all" ? "No job runs yet." : `No ${runFilter} job runs.` })
+    ]));
+    syncNodes(body, Array.from(frag.children));
     return;
   }
-  const header = el("div", { class: "runs-row runs-header" }, [
+  const headerCells = [
     runHeaderCell("when", "when"),
+    attributed ? el("span", { text: "workspace" }) : null,
     runHeaderCell("job", "job"),
     runHeaderCell("run id", "run_id"),
     runHeaderCell("denials", "denials", { num: true }),
@@ -465,9 +542,10 @@ export function renderRuns(runs) {
     runHeaderCell("duration", "duration", { style: { textAlign: "right" } }),
     runHeaderCell("state", "state", { style: { textAlign: "right" } }),
     el("span", { text: "" }),
-  ]);
+  ];
+  const header = el("div", { class: `runs-row runs-header${attributed ? " workspace-attributed" : ""}` }, headerCells);
   header.dataset.key = "runs-header";
-  header.dataset.hash = `header-${runSort.key}-${runSort.dir}`;
+  header.dataset.hash = `header-${runSort.key}-${runSort.dir}-${attributed ? "workspace" : "scoped"}`;
   frag.appendChild(header);
   for (const r of top) {
     const ts = r.finished_at || r.started_at || r.scheduled_at || r.created_at;
@@ -494,11 +572,11 @@ export function renderRuns(runs) {
       });
       lineage.addEventListener("click", (e) => {
         e.stopPropagation();
-        doNavigateToRun(sourceId);
+        doNavigateToRun(sourceId, r.workspace_id);
       });
       runIdCell.appendChild(lineage);
     }
-    const resumedAsId = resumedRunIdsBySource.get(r.run_id);
+    const resumedAsId = resumedRunIdsBySource.get(runIdentity(r));
     if (resumedAsId) {
       const lineage = el("button", {
         class: "run-lineage resumed-as",
@@ -507,12 +585,13 @@ export function renderRuns(runs) {
       });
       lineage.addEventListener("click", (e) => {
         e.stopPropagation();
-        doNavigateToRun(resumedAsId);
+        doNavigateToRun(resumedAsId, r.workspace_id);
       });
       runIdCell.appendChild(lineage);
     }
-    const row = el("div", { class: "runs-row", title: `${r.run_id} (click to inspect)` }, [
+    const rowCells = [
       el("span", { class: "when", text: fmtTimestampValue(ts) }),
+      attributed ? el("span", { class: "run-workspace", text: r.workspace_name || r.workspace_id, title: r.workspace_id }) : null,
       el("span", { class: "id", text: r.job_id }),
       runIdCell,
       runCountCell(friction.denials),
@@ -523,11 +602,12 @@ export function renderRuns(runs) {
         runIsCancellable(r) ? buildCancelRunButton(r, body) : null,
         runIsResumable(r) ? buildResumeRunButton(r, body) : null,
       ]),
-    ]);
-    row.dataset.key = `run-${r.run_id}`;
-    row.dataset.hash = `${r.run_id}-${ts}-${r.duration_ms}-${r.state}-${r.retry_source_run_id || ""}-${resumedAsId || ""}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
+    ];
+    const row = el("div", { class: `runs-row${attributed ? " workspace-attributed" : ""}`, title: `${r.run_id} (click to inspect)` }, rowCells);
+    row.dataset.key = `run-${runIdentity(r)}`;
+    row.dataset.hash = `${runIdentity(r)}-${ts}-${r.duration_ms}-${r.state}-${r.retry_source_run_id || ""}-${resumedAsId || ""}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
     row.style.cursor = "pointer";
-    row.addEventListener("click", () => doNavigateToRun(r.run_id));
+    row.addEventListener("click", () => doNavigateToRun(r.run_id, r.workspace_id));
     frag.appendChild(row);
   }
   syncNodes(body, Array.from(frag.children));

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -430,6 +430,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
             get(tasks::completion_by_complexity),
         )
         .route("/tasks/all", get(workspaces::list_all_tasks))
+        .route("/job-runs/all", get(workspaces::list_all_job_runs))
         .route("/workspaces", get(workspaces::list_workspaces))
         .route(
             "/tasks/:id",

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Barrier, Mutex};
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use orbit_core::application::task::TaskAddParams;
 use orbit_core::runtime::WorkspaceRuntimeBinding;
-use orbit_core::{ActorIdentity, OrbitRuntime, ShipMode, TaskStatus};
+use orbit_core::{ActorIdentity, JobRunState, OrbitRuntime, ShipMode, TaskStatus};
 use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
 use serde_json::json;
 use tower::ServiceExt;
@@ -19,7 +19,7 @@ use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 
 use super::super::*;
-use super::test_support::body_json;
+use super::test_support::{body_json, seed_run, write_seeded_run};
 use crate::state::{DashboardState, RegistrySource, WsEntry};
 
 fn get(uri: &str) -> Request<Body> {
@@ -198,6 +198,105 @@ async fn tasks_all_aggregates_active_workspaces_and_skips_inactive() {
         alpha["orbit_dir"]
             .as_str()
             .is_some_and(|dir| dir.ends_with(".orbit"))
+    );
+}
+
+#[tokio::test]
+async fn job_runs_all_preserves_workspace_identity_order_bounds_and_unavailable_sources() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    let (alpha_orbit, alpha_repo) = seed_workspace(&global_root, tmp.path(), "alpha");
+    let (beta_orbit, beta_repo) = seed_workspace(&global_root, tmp.path(), "beta");
+
+    let alpha = OrbitRuntime::from_roots(&global_root, &alpha_orbit).expect("alpha runtime");
+    let beta = OrbitRuntime::from_roots(&global_root, &beta_orbit).expect("beta runtime");
+    let shared_time = Utc::now();
+    let mut alpha_duplicate = seed_run(&alpha, "jrun-shared", "aggregate", JobRunState::Pending);
+    alpha_duplicate.created_at = shared_time;
+    alpha_duplicate.scheduled_at = shared_time;
+    alpha_duplicate.started_at = None;
+    write_seeded_run(&alpha, &alpha_duplicate);
+    let mut beta_duplicate = seed_run(&beta, "jrun-shared", "aggregate", JobRunState::Failed);
+    beta_duplicate.created_at = shared_time;
+    beta_duplicate.scheduled_at = shared_time;
+    beta_duplicate.started_at = Some(shared_time);
+    beta_duplicate.finished_at = Some(shared_time);
+    write_seeded_run(&beta, &beta_duplicate);
+    let mut old = seed_run(&alpha, "jrun-old", "aggregate", JobRunState::Success);
+    old.created_at = shared_time - Duration::days(1);
+    old.scheduled_at = old.created_at;
+    old.started_at = Some(old.created_at);
+    old.finished_at = Some(old.created_at);
+    write_seeded_run(&alpha, &old);
+
+    let entries = vec![
+        workspace_entry("alpha", alpha_repo, alpha_orbit, true),
+        workspace_entry("beta", beta_repo, beta_orbit, true),
+        workspace_entry(
+            "gone",
+            tmp.path().join("missing"),
+            tmp.path().join("missing/.orbit"),
+            false,
+        ),
+    ];
+    let state = DashboardState::global(global_root, entries, Some("alpha".to_string()));
+    let bounded = router()
+        .with_state(state.clone())
+        .oneshot(get("/job-runs/all?limit=999"))
+        .await
+        .expect("bounded response");
+    let bounded = body_json(bounded).await;
+    assert_eq!(bounded["limit"], json!(HISTORY_MAX_LIMIT));
+    assert_eq!(bounded["items"].as_array().expect("bounded items").len(), 3);
+
+    let active = router()
+        .with_state(state.clone())
+        .oneshot(get("/job-runs/all?state=active&limit=2"))
+        .await
+        .expect("active response");
+    let active = body_json(active).await;
+    assert_eq!(active["state"], json!("active"));
+    assert_eq!(active["items"].as_array().expect("active items").len(), 1);
+    assert_eq!(active["items"][0]["workspace_id"], json!("alpha"));
+
+    let failed = router()
+        .with_state(state.clone())
+        .oneshot(get("/job-runs/all?state=failed&limit=2"))
+        .await
+        .expect("failed response");
+    let failed = body_json(failed).await;
+    assert_eq!(failed["state"], json!("failed"));
+    assert_eq!(failed["items"].as_array().expect("failed items").len(), 1);
+    assert_eq!(failed["items"][0]["workspace_id"], json!("beta"));
+
+    let invalid = router()
+        .with_state(state.clone())
+        .oneshot(get("/job-runs/all?state=terminal"))
+        .await
+        .expect("invalid response");
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/job-runs/all?limit=2"))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    assert_eq!(body["limit"], json!(2));
+    assert_eq!(body["truncated"], json!(true));
+    let rows = body["items"].as_array().expect("items");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["run_id"], json!("jrun-shared"));
+    assert_eq!(rows[0]["workspace_id"], json!("alpha"));
+    assert_eq!(rows[1]["run_id"], json!("jrun-shared"));
+    assert_eq!(rows[1]["workspace_id"], json!("beta"));
+    assert!(rows.iter().all(|run| run["workspace_name"].is_string()));
+    assert_eq!(body["unavailable"][0]["workspace_id"], json!("gone"));
+    assert_eq!(
+        body["unavailable"][0]["error"],
+        json!("workspace is unavailable")
     );
 }
 

--- a/crates/orbit-web/src/api/workspaces.rs
+++ b/crates/orbit-web/src/api/workspaces.rs
@@ -10,10 +10,13 @@ use std::path::{Path, PathBuf};
 
 use axum::extract::State;
 use axum::response::{IntoResponse, Json, Response};
-use orbit_core::DEFAULT_TASK_LIST_LIMIT;
+use chrono::{DateTime, Utc};
+use orbit_core::application::job::{JobRunListParams, job_run_to_json};
+use orbit_core::{DEFAULT_TASK_LIST_LIMIT, JobRun, JobRunState, OrbitRuntime};
+use serde::Deserialize;
 use serde_json::{Value, json};
 
-use super::{blocking, server_error};
+use super::{HISTORY_DEFAULT_LIMIT, bad_request, blocking, bounded_limit, server_error};
 use crate::projections::task_row_to_json;
 use crate::state::DashboardState;
 use orbit_core::application::task::TaskListFilter;
@@ -61,6 +64,163 @@ pub(super) async fn list_all_tasks(State(state): State<DashboardState>) -> Respo
         Ok(Err(error)) => server_error(error),
         Err(response) => *response,
     }
+}
+
+#[derive(Deserialize, Default)]
+pub(super) struct AllJobRunsQuery {
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum AllJobRunsState {
+    All,
+    Active,
+    Failed,
+}
+
+impl AllJobRunsState {
+    fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value {
+            None | Some("all") => Ok(Self::All),
+            Some("active") => Ok(Self::Active),
+            Some("failed") => Ok(Self::Failed),
+            Some(_) => Err("invalid state; expected one of: all, active, failed".to_string()),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Active => "active",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// `GET /api/job-runs/all` — a bounded run list across every visible workspace.
+///
+/// Run ids are workspace-local, so every item carries its workspace identity.
+/// Unavailable sources remain in the response instead of being represented as
+/// an empty workspace, allowing the dashboard to distinguish partial data from
+/// a genuine zero-run result.
+pub(super) async fn list_all_job_runs(
+    State(state): State<DashboardState>,
+    axum::extract::Query(query): axum::extract::Query<AllJobRunsQuery>,
+) -> Response {
+    let limit = bounded_limit(query.limit, HISTORY_DEFAULT_LIMIT);
+    let state_filter = match AllJobRunsState::parse(query.state.as_deref()) {
+        Ok(filter) => filter,
+        Err(message) => return bad_request(message),
+    };
+    match blocking("aggregate job run list", move || {
+        Ok::<_, orbit_core::OrbitError>(all_job_runs_json(&state, limit, state_filter))
+    })
+    .await
+    {
+        Ok(value) => Json(value).into_response(),
+        Err(response) => *response,
+    }
+}
+
+fn all_job_runs_json(state: &DashboardState, limit: usize, state_filter: AllJobRunsState) -> Value {
+    let pinned = state.pin();
+    let mut candidates = Vec::new();
+    let mut unavailable = Vec::new();
+    let mut source_truncated = false;
+
+    for entry in pinned.entries() {
+        if !entry.active {
+            unavailable.push(json!({
+                "workspace_id": entry.id,
+                "workspace_name": entry.name,
+                "error": "workspace is unavailable",
+            }));
+            continue;
+        }
+        let runtime = match pinned.runtime_for(&entry.id) {
+            Ok(runtime) => runtime,
+            Err(_) => {
+                unavailable.push(json!({
+                    "workspace_id": entry.id,
+                    "workspace_name": entry.name,
+                    "error": "failed to open workspace",
+                }));
+                continue;
+            }
+        };
+        match workspace_job_runs(&runtime, limit, state_filter) {
+            Ok(runs) => {
+                source_truncated |= runs.len() == limit;
+                candidates.extend(
+                    runs.into_iter()
+                        .map(|run| (run, entry.id.clone(), entry.name.clone())),
+                );
+            }
+            Err(error) => unavailable.push(json!({
+                "workspace_id": entry.id,
+                "workspace_name": entry.name,
+                "error": error.to_string(),
+            })),
+        }
+    }
+
+    candidates.sort_by(|(left, left_workspace, _), (right, right_workspace, _)| {
+        run_timestamp(right)
+            .cmp(&run_timestamp(left))
+            .then_with(|| left_workspace.cmp(right_workspace))
+            .then_with(|| left.run_id.cmp(&right.run_id))
+    });
+    let truncated = source_truncated || candidates.len() > limit;
+    candidates.truncate(limit);
+    let items = candidates
+        .into_iter()
+        .map(|(run, workspace_id, workspace_name)| {
+            let mut value = job_run_to_json(&run, None);
+            if let Value::Object(map) = &mut value {
+                map.insert("workspace_id".to_string(), json!(workspace_id));
+                map.insert("workspace_name".to_string(), json!(workspace_name));
+            }
+            value
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "items": items,
+        "limit": limit,
+        "state": state_filter.label(),
+        "truncated": truncated,
+        "unavailable": unavailable,
+    })
+}
+
+fn workspace_job_runs(
+    runtime: &OrbitRuntime,
+    limit: usize,
+    state_filter: AllJobRunsState,
+) -> Result<Vec<JobRun>, orbit_core::OrbitError> {
+    let list = |state| {
+        runtime.list_job_runs(JobRunListParams {
+            state,
+            limit: Some(limit),
+            ..Default::default()
+        })
+    };
+    match state_filter {
+        AllJobRunsState::All => list(None),
+        AllJobRunsState::Failed => list(Some(JobRunState::Failed)),
+        AllJobRunsState::Active => {
+            let mut runs = list(Some(JobRunState::Pending))?;
+            runs.extend(list(Some(JobRunState::Running))?);
+            Ok(runs)
+        }
+    }
+}
+
+fn run_timestamp(run: &JobRun) -> DateTime<Utc> {
+    run.finished_at.or(run.started_at).unwrap_or(run.created_at)
 }
 
 fn all_tasks_json(state: &DashboardState) -> Result<Vec<Value>, orbit_core::OrbitError> {

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1792,6 +1792,105 @@ if (operationsDivider.textContent.includes("no observed tool calls or friction t
     );
 }
 
+#[test]
+fn dashboard_aggregate_runs_keep_workspace_identity_filters_and_action_scope() {
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+    let router = include_str!("../../assets/dashboard/router.js");
+    assert!(css.contains(".runs-row.workspace-attributed"));
+    assert!(css.contains("@media (max-width: 760px)"));
+    assert!(css.contains("min-width: 900px"));
+    assert!(router.contains("function navigateToRunImpl(ctx, runId, workspaceId = null)"));
+    assert!(router.contains("setWorkspace(workspaceId);"));
+    assert!(router.contains("persistScopeToUrl();"));
+
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.disabled = false; }
+  appendChild(child) { if (child == null) return child; if (child.parentNode) child.parentNode.removeChild(child); this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { if (child.parentNode) child.parentNode.removeChild(child); const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  remove() { if (this.parentNode) this.parentNode.removeChild(this); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this.textContent = value; }
+  get innerHTML() { return this.textContent; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+  get classList() { const self = this; return { add: (...classes) => { for (const c of classes) if (!self.className.split(/\s+/).includes(c)) self.className = `${self.className} ${c}`.trim(); }, toggle: (c, on) => { if (on) this.addClass(c); } }; }
+  addClass(c) { if (!this.className.split(/\s+/).includes(c)) this.className = `${this.className} ${c}`.trim(); }
+  querySelectorAll(selector) { const found = []; const visit = (node) => { for (const child of node.children) { if (selector === ".action-error" && child.className.split(/\s+/).includes("action-error")) found.push(child); visit(child); } }; visit(this); return found; }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+globalThis.document = {
+  getElementById: get,
+  createElement: () => new Node(),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+};
+const location = new URL("http://dashboard.test/?run_state=active");
+globalThis.window = { location, innerWidth: 1200, confirm: () => true };
+globalThis.history = { replaceState: (_, __, url) => { location.href = String(url); } };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+const requests = [];
+globalThis.fetch = async (path) => {
+  requests.push(String(path));
+  const payload = { run_id: "jrun-next" };
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+};
+
+const runs = [
+  { workspace_id: "alpha", workspace_name: "Alpha", run_id: "jrun-shared", job_id: "ship", state: "running", created_at: "2026-09-05T03:00:00Z" },
+  { workspace_id: "beta", workspace_name: "Beta", run_id: "jrun-shared", job_id: "ship", state: "failed", created_at: "2026-09-05T03:00:00Z" },
+];
+let navigated = null;
+const { initRuns, renderRuns, buildReplayRunButton } = await import("./runs.js");
+initRuns({
+  getLastRuns: () => runs,
+  getRunsMeta: () => ({ truncated: false }),
+  getRunSourcesUnavailable: () => [{ workspace_id: "gone", workspace_name: "Gone", error: "query failed" }],
+  navigateToRun: (runId, workspaceId) => { navigated = { runId, workspaceId }; },
+  fetchAndRenderRuns: () => Promise.resolve(),
+  getActiveRunId: () => null,
+});
+renderRuns(runs);
+const body = get("runs-body");
+let rows = body.children.filter((node) => node.className.includes("runs-row workspace-attributed") && !node.className.includes("runs-header"));
+if (rows.length !== 1 || !rows[0].textContent.includes("Alpha")) throw new Error(`active filter rendered wrong rows: ${body.textContent}`);
+if (!body.textContent.includes("Unavailable workspace: Gone")) throw new Error("partial workspace failure was hidden");
+
+let controls = body.children.find((node) => node.className.includes("runs-filter"));
+controls.children.find((node) => node.textContent === "all").listeners.click();
+rows = body.children.filter((node) => node.className.includes("runs-row workspace-attributed") && !node.className.includes("runs-header"));
+if (rows.length !== 2) throw new Error("all filter did not render both duplicate run ids");
+if (new Set(rows.map((row) => row.dataset.key)).size !== 2) throw new Error("duplicate run ids collided across workspaces");
+rows.find((row) => row.textContent.includes("Beta")).listeners.click();
+if (!navigated || navigated.runId !== "jrun-shared" || navigated.workspaceId !== "beta") throw new Error(`wrong detail identity: ${JSON.stringify(navigated)}`);
+
+const betaActions = rows.find((row) => row.textContent.includes("Beta")).children.at(-1);
+betaActions.children.find((node) => node.className.includes("run-resume")).listeners.click({ stopPropagation() {} });
+const alphaActions = rows.find((row) => row.textContent.includes("Alpha")).children.at(-1);
+alphaActions.children.find((node) => node.className.includes("run-cancel")).listeners.click({ stopPropagation() {} });
+const replay = buildReplayRunButton(runs[1], new Node());
+replay.listeners.click({ stopPropagation() {} });
+await new Promise((resolve) => setTimeout(resolve, 0));
+if (!requests.includes("/api/job-runs/jrun-shared/resume?workspace=beta")) throw new Error(`resume lost workspace scope: ${requests}`);
+if (!requests.includes("/api/runs/jrun-shared/cancel?workspace=alpha")) throw new Error(`cancel lost workspace scope: ${requests}`);
+if (!requests.includes("/api/runs/jrun-shared/replay?workspace=beta")) throw new Error(`replay lost workspace scope: ${requests}`);
+
+controls = body.children.find((node) => node.className.includes("runs-filter"));
+controls.children.find((node) => node.textContent === "failed").listeners.click();
+if (new URL(location.href).searchParams.get("run_state") !== "failed") throw new Error("run filter was not persisted in reload-safe URL state");
+window.innerWidth = 480;
+renderRuns(runs);
+rows = body.children.filter((node) => node.className.includes("runs-row workspace-attributed") && !node.className.includes("runs-header"));
+if (rows.length !== 1 || !rows[0].textContent.includes("Beta")) throw new Error("narrow-screen render lost the filtered workspace row");
+"#,
+    );
+}
+
 async fn response_body(response: Response) -> String {
     let bytes = match to_bytes(response.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,


### PR DESCRIPTION
## Task

[ORB-11229](https://orbit-cli.com/tasks/ORB-11229) — Show workspace-attributed runs in the dashboard All workspaces view

### Description

During the authorized multi-workspace throughput run, operators must switch workspaces to discover active or failed runs. Current crates/orbit-web/assets/dashboard/router.js setDiagSubtabImpl explicitly replaces Runs with a placeholder in isAggregateView(), and its comment says activeRefreshJobs skips these fetches. Add a bounded aggregate run list for workspaces visible to this dashboard server, with explicit workspace attribution, state filtering and correct scoped drill-down. Reuse existing run list/projection and blocking-work seams; do not add a separate telemetry store or remote-host federation. A run ID can repeat across workspaces (this run has jrun-20260905-0255 in three Linux workspaces), so row identity, detail links and any mutation must retain workspace identity. Keep existing scoped behavior and honest partial-source errors. This is distinct from completed ORB-10872 scope-consistency work and ORB-11205 task-list hydration; do not reimplement either. Inspect current API routes before choosing the smallest shared aggregation seam. No new dashboard design framework.

### Acceptance Criteria

- All workspaces shows bounded, deterministically ordered runs with workspace name and run state; active/failed filtering is usable and scope/filter state survives reload and navigation.
- Two workspaces with the same run ID have distinct rows and open the correct detail; cancel/replay/resume never target another workspace, and aggregate view does not gain authority.
- A failed workspace query is visibly unavailable rather than silently zero; stale scoped rows cannot leak when switching scope.
- Exercise rendered desktop and narrow-screen flows plus meaningful API identity, bounds and partial-failure checks; report validation and preserve existing scoped routes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added GET /api/job-runs/all as a bounded, deterministic cross-workspace projection with workspace id/name attribution, server-side all/active/failed filters, and explicit unavailable-source reporting.
- Enabled Runs in All workspaces, added reload-safe state filters and responsive workspace attribution, and discarded stale responses during scope/filter changes.
- Made duplicate run row identity, drill-down, lineage, cancel, replay, and resume workspace-aware while preserving the existing scoped routes and preventing aggregate requests from becoming unscoped mutations.
- Added API and rendered JavaScript coverage for duplicate IDs, order, limits, filter-before-limit behavior, partial failures, action routing, URL persistence, and desktop/narrow layouts.
Assessment: The implementation reuses existing runtime run-list and projection seams, adds no store or dependency edge, and keeps all mutations bound to a concrete workspace.
Validation:
- cargo test -p orbit-web: 286 passed, 0 failed, 1 ignored.
- make ci-fast: passed.
- make ci-lint: passed with workspace all-target warnings denied.
- git diff --check: passed.
Friction checkpoint: no qualifying recurring failure or non-obvious gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11229-6a9b9153`
- Behind base: 0
- Ahead of base: 1