### PR TITLE
Refresh CLI tool-list goldens for streaming GitHub log evidence

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -91,7 +91,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.",
+    "description": "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is drained incrementally; checkout extraction stops after 8 MiB and reports incomplete evidence rather than retaining an unbounded log.",
     "enabled": true,
     "name": "github.run.logs",
     "parameters": [

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -1,7 +1,7 @@
 github.auth.status	-	Preflight the GitHub CLI surface: whether a GitHub CLI is present on this execution lane (`available`) and whether it holds usable credentials there (`authenticated`). Neither absence nor a missing credential is an error — both are reported so a caller can record a capability-unavailable outcome instead of mistaking it for a clean result.
 github.pr.list	-	List pull requests with their current head SHAs. Defaults to open pull requests.
 github.run.list	-	List recent GitHub Actions workflow runs with each run's reported head SHA. Filter by branch, workflow, status/conclusion, and event.
-github.run.logs	run:string	Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus the commit the runner actually checked out, parsed from the log's own checkout evidence. Output is capped so a large log cannot exhaust the caller's context; `truncated` reports when it was.
+github.run.logs	run:string	Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is drained incrementally; checkout extraction stops after 8 MiB and reports incomplete evidence rather than retaining an unbounded log.
 github.run.view	run:string	Inspect one GitHub Actions workflow run: its reported head SHA, event, branch, and every job with its URL, steps, and conclusions. Unsuccessful jobs and steps are also collected separately.
 orbit.auto_task.list	-	List every auto-task definition in this workspace.
 orbit.auto_task.mint	name:string	Mint one task now from an auto-task definition. Unconditional: the schedule, dedupe policy, and enabled flag are ignored, and the scheduler's own cursor is left untouched.


### PR DESCRIPTION
## Task

[ORB-11237](https://orbit-cli.com/tasks/ORB-11237) — Refresh CLI tool-list goldens for streaming GitHub log evidence

### Description

Postmerge CI regression from ORB-11226/PR1315 at4bc42160eade6c25a65e473ba0205e4becc9b185. CI run https://github.com/danieljhkim/orbit/actions/runs/33942805974 fails Check/Clippy/Test and Coverage. Coverage job101243343440 checkout log independently confirms that SHA; output_goldens::plain_and_json_forms_match_their_goldens fails at crates/orbit-cli/tests/output_goldens.rs:267 because tool_list.plain.txt still contains old github.run.logs description. Live output now documents streamed checkout evidence and8MiB extraction bound, while golden still promises only capped output plus parsed checkout. Current primary at4bc42160 retains old description at tool_list.plain.txt:4. Regenerate and review affected plain/JSON goldens using ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens. Keep the intended new streaming behavior and wording; do not revert production feature or weaken tests. Review any additional regenerated differences against current source and keep repair narrow. Inspect job101243343318 separately if it names another root cause; coverage gives confirmed evidence for this cause. Prior golden tasks are completed unrelated tool changes.

### Acceptance Criteria

- All affected tool-list plain/JSON golden changes match the intended current github.run.logs description; no unrelated snapshot drift is accepted blindly.
- Run output_goldens without update flag after regeneration, plus make ci-fast and make ci-lint.
- Candidate CI runs affected checks successfully; source behavior remains streamed and bounded with honest incomplete evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Regenerated and reviewed the scoped plain and JSON tool-list goldens so github.run.logs documents incremental source-stream draining, the 8 MiB checkout-extraction bound, and incomplete evidence.
- Confirmed no unrelated snapshot drift remains; final worktree contains only the two intended golden files.
Validation:
- `env -u ORBIT_REGISTRY_ROOT -u ORBIT_WORKSPACE cargo test -p orbit-cli --test output_goldens` — passed (2 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
Assessment: Narrow fixture-only repair; production streaming behavior and bounded/incomplete evidence semantics are unchanged.
Design weaknesses / risks:
- The output_goldens test initially used inherited managed-run `ORBIT_WORKSPACE`/`ORBIT_REGISTRY_ROOT` and failed while creating its isolated fixture workspace. Re-running with those harness-routing variables unset passed; this is an execution-environment issue, not a source or golden mismatch.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11237-6a9b972b`
- Behind base: 0
- Ahead of base: 1