### PR TITLE
Respect repository merge methods in --complete and preserve completion failure semantics

### DIFF
--- a/crates/orbit-core/assets/activities/pr_failure_handoff.yaml
+++ b/crates/orbit-core/assets/activities/pr_failure_handoff.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Terminal task-PR recovery hook. Commits any dirty candidate, restores and
-    pushes the pre-rebase branch, opens or reuses a blocked PR, and records
-    manual conflict resolution details without replacing the original failure.
+    Terminal task-PR recovery hook. Before publication it commits any dirty
+    candidate, restores and pushes the pre-rebase branch, and opens or reuses a
+    blocked PR. After publication it preserves the existing PR and review state
+    with truthful merge diagnostics for a safe completion retry.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -66,6 +67,8 @@ spec:
         type:
           - string
           - "null"
+      candidate_preserved:
+        type: boolean
       task_status:
         type: string
   action: pr_failure_handoff

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -7,11 +7,10 @@
 #   failure that the run recovers from does not block anything. Commit, branch
 #   preparation, base synchronization, push, PR creation/reuse, and promotion
 #   are independent durable steps, so recovery resumes at the failed phase.
-# - When the run itself terminalizes as `failed` (also `cancelled`/`timeout`),
-#   every task coupled to it (stamped with its `job_run_id` by `worktree_setup`)
-#   is moved to `blocked` with a `workflow_run_failed` status event — a dead end
-#   for automation that requires a human/orchestrator decision to clear. Tasks
-#   already in `review`/`done` are left untouched.
+# - When the run itself terminalizes before PR completion, its recoverable
+#   candidate is published and the task is blocked for reconciliation. Once a
+#   PR was published and the task promoted to review, a completion-stage merge
+#   failure preserves that exact candidate and review state for a safe retry.
 #
 schemaVersion: 2
 kind: Job
@@ -21,8 +20,9 @@ spec:
   state: enabled
   kind: workflow
   max_active_runs: 10
-  # ADR-0246: preserve and publish recoverable work after any terminal step
-  # failure while keeping the original failure authoritative.
+  # Preserve recoverable work after terminal failures while keeping the
+  # original error authoritative. Completion-stage failures retain the
+  # already-published PR instead of fabricating a conflict handoff.
   failure_activity: pr_failure_handoff
   default_input:
     task_ids: []

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -4,6 +4,8 @@ use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+mod completion;
+
 use chrono::Utc;
 use orbit_engine::{
     DispatchError, JobOutcome, ResolvedCliExecutor, RuntimeHost, TaskActivityUpdate, V2AuditWriter,
@@ -138,6 +140,17 @@ pub(super) fn try_execute_named_job(
     run_id: &str,
 ) -> Result<JobOutcome, DispatchError> {
     let job = resolved_job(runtime, job_name);
+    try_execute_job(runtime, repo_root, host, job, input, run_id)
+}
+
+pub(super) fn try_execute_job(
+    runtime: &OrbitRuntime,
+    repo_root: &Path,
+    host: &dyn RuntimeHost,
+    job: orbit_types::workflow::activity_job::JobV2,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, DispatchError> {
     let writer = V2AuditWriter::with_disk_sinks(
         &runtime.paths().audit_dir,
         runtime

--- a/crates/orbit-core/src/application/job/tests/exec/completion.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/completion.rs
@@ -1,0 +1,227 @@
+use std::sync::{Arc, Mutex};
+
+use orbit_engine::{DispatchError, ResolvedCliExecutor, RuntimeHost};
+use orbit_tools::{FsAuditLogger, ToolContext};
+use orbit_types::task::{ExternalRef, Task, TaskPriority, TaskStatus};
+use orbit_types::workflow::JobV2StepBody;
+use serde_json::{Value, json};
+
+use super::{resolved_job, seed_default_catalogs, test_runtime, try_execute_job};
+use crate::OrbitRuntime;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+
+/// Exercises the actual job executor's terminal-failure routing from
+/// `complete_pr` into `pr_failure_handoff`, while the same host boundary
+/// scripts the private VCS status/capability/merge calls. This is deliberately
+/// broader than a direct `pr_complete` unit test: the pipeline must preserve
+/// the published candidate after the real merge step fails.
+#[test]
+fn completion_merge_failure_routes_to_review_recovery_without_republishing() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let run_id = "jrun-completion-merge-failure";
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Published completion candidate".to_string(),
+            description: "Fixture already published and promoted to review.".to_string(),
+            acceptance_criteria: vec!["Completion retry remains safe.".to_string()],
+            plan: "Exercise completion failure recovery.".to_string(),
+            context_files: vec!["src/lib.rs".to_string()],
+            workspace_path: Some(".".to_string()),
+            status: Some(TaskStatus::Review),
+            external_refs: vec![
+                ExternalRef::try_new(
+                    "github-pr".to_string(),
+                    "42".to_string(),
+                    Some("https://github.com/example/orbit/pull/42".to_string()),
+                )
+                .expect("github PR ref"),
+            ],
+            ..Default::default()
+        })
+        .expect("seed published task");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                job_run_id: Some(Some(run_id.to_string())),
+                execution_summary: Some(
+                    "Outcome: success\n\nChanges:\n- Published candidate is ready.".to_string(),
+                ),
+                ..Default::default()
+            },
+        )
+        .expect("attach task to run");
+
+    let mut job = resolved_job(&runtime, "task_pr_pipeline");
+    job.steps.retain(|step| step.id == "complete_pr");
+    let complete = job.steps.first_mut().expect("complete_pr step");
+    complete.when = None;
+    complete.recovery_activity = None;
+    complete.resolved_recovery_activity = None;
+    let JobV2StepBody::Target(complete) = &mut complete.body else {
+        panic!("resolved complete_pr target");
+    };
+    complete.default_input = Some(json!({
+        "job_run_id": run_id,
+        "completed_task_ids": [task.id],
+        "workspace_path": repo_root,
+        "pr_number": "42",
+        "poll_interval_seconds": 0,
+        "max_wait_seconds": 0,
+    }));
+    let host = CompletionFailureHost::new(&runtime);
+
+    let error = try_execute_job(
+        &runtime,
+        &repo_root,
+        &host,
+        job,
+        json!({ "task_ids": [task.id] }),
+        run_id,
+    )
+    .expect_err("private merge denial must fail the pipeline");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("could not request rebase merge"),
+        "{message}"
+    );
+    assert!(message.contains("merge permission denied"), "{message}");
+    let persisted = runtime.get_task(&task.id).expect("preserved task");
+    assert_eq!(persisted.status, TaskStatus::Review);
+    assert_eq!(persisted.github_pr_number(), Some("42"));
+    assert_eq!(
+        persisted
+            .external_refs
+            .iter()
+            .find(|reference| reference.system == "github-pr")
+            .and_then(|reference| reference.url.as_deref()),
+        Some("https://github.com/example/orbit/pull/42")
+    );
+    assert_eq!(
+        host.operations(),
+        vec!["pr.status", "pr.merge_capabilities", "pr.merge"],
+        "completion must read status and policy before the denied merge"
+    );
+    let comments = runtime.get_task_comments(&task.id).expect("task comments");
+    let recovery = comments.last().expect("completion recovery comment");
+    assert!(recovery.message.contains("preserved PR #42"));
+    assert!(!recovery.message.contains("Manual resolution required"));
+}
+
+struct CompletionFailureHost<'a> {
+    runtime: &'a OrbitRuntime,
+    operations: Mutex<Vec<String>>,
+}
+
+impl<'a> CompletionFailureHost<'a> {
+    fn new(runtime: &'a OrbitRuntime) -> Self {
+        Self {
+            runtime,
+            operations: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn operations(&self) -> Vec<String> {
+        self.operations.lock().expect("operations lock").clone()
+    }
+}
+
+impl RuntimeHost for CompletionFailureHost<'_> {
+    fn get_task(&self, task_id: &str) -> Result<Task, orbit_common::OrbitError> {
+        self.runtime.get_task(task_id)
+    }
+
+    fn get_task_comments(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<orbit_types::task::TaskComment>, orbit_common::OrbitError> {
+        self.runtime.get_task_comments(task_id)
+    }
+
+    fn list_tasks_filtered(
+        &self,
+        status: Option<TaskStatus>,
+        priority: Option<TaskPriority>,
+        parent_id: Option<&str>,
+        job_run_id: Option<&str>,
+        external_ref: Option<&ExternalRef>,
+        has_external_ref_system: Option<&str>,
+    ) -> Result<Vec<Task>, orbit_common::OrbitError> {
+        RuntimeHost::list_tasks_filtered(
+            self.runtime,
+            status,
+            priority,
+            parent_id,
+            job_run_id,
+            external_ref,
+            has_external_ref_system,
+        )
+    }
+
+    fn apply_task_automation_update(
+        &self,
+        task_id: &str,
+        update: orbit_engine::TaskAutomationUpdate,
+    ) -> Result<(), orbit_common::OrbitError> {
+        RuntimeHost::apply_task_automation_update(self.runtime, task_id, update)
+    }
+
+    fn run_private_vcs_operation(
+        &self,
+        operation: &str,
+        _input: Value,
+    ) -> Result<Value, orbit_common::OrbitError> {
+        self.operations
+            .lock()
+            .expect("operations lock")
+            .push(operation.to_string());
+        match operation {
+            "pr.status" => Ok(json!({
+                "pull_request": {
+                    "number": 42,
+                    "state": "OPEN",
+                    "mergedAt": Value::Null,
+                    "mergeStateStatus": "CLEAN",
+                }
+            })),
+            "pr.merge_capabilities" => Ok(json!({
+                "repository": {
+                    "name_with_owner": "example/orbit",
+                    "base_branch": "agent-main",
+                    "allow_squash_merge": false,
+                    "allow_rebase_merge": true,
+                    "allow_merge_commit": true,
+                    "requires_linear_history": true,
+                }
+            })),
+            "pr.merge" => Err(orbit_common::OrbitError::Execution(
+                "gh: merge permission denied".to_string(),
+            )),
+            other => Err(orbit_common::OrbitError::Execution(format!(
+                "unexpected private VCS operation {other}"
+            ))),
+        }
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -21,12 +21,12 @@ use super::push::push_batch_changes_inner;
 const CONFLICT_BLOCKED_EVENT: &str = "pr_conflict_blocked";
 const FAILURE_HANDOFF_EVENT: &str = "pr_failure_handoff";
 
-/// ADR-0246 terminal hook for `task_pr_pipeline`.
+/// Terminal hook for `task_pr_pipeline`.
 ///
-/// The original job error remains authoritative. This action only makes the
-/// candidate recoverable: restore the pre-rebase branch, commit dirtiness,
-/// push without rewriting unknown remote history, publish a blocked PR, and
-/// leave the task in `blocked` rather than `review`.
+/// The original job error remains authoritative. Failures before publication
+/// make the candidate recoverable and block the task for reconciliation.
+/// Completion failures after publication preserve that exact PR and keep the
+/// task in review so an operator can fix the named merge gate and safely retry.
 pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync + ?Sized>(
     host: &H,
     input: &Value,
@@ -63,6 +63,20 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
             "pr_failure_handoff: task '{}' no longer belongs to run '{}'",
             task.id, run_id
         )));
+    }
+
+    if failed_step_id == "complete_pr"
+        && let Some(pr_number) = task.github_pr_number().map(ToOwned::to_owned)
+    {
+        return preserve_completion_failure(
+            host,
+            &task,
+            run_id,
+            failed_step_id,
+            error_code,
+            error_message,
+            &pr_number,
+        );
     }
 
     let worktree = pipeline_step(input, "worktree")?;
@@ -184,6 +198,51 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
         "pr_url": pr_url,
         "pr_created": pr_created,
         "task_status": "blocked",
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn preserve_completion_failure<H: RuntimeHost + ?Sized>(
+    host: &H,
+    task: &orbit_types::task::Task,
+    run_id: &str,
+    failed_step_id: &str,
+    error_code: &str,
+    error_message: &str,
+    pr_number: &str,
+) -> Result<Value, OrbitError> {
+    let pr_url = task
+        .external_refs
+        .iter()
+        .find(|external_ref| external_ref.system == "github-pr" && external_ref.id == pr_number)
+        .and_then(|external_ref| external_ref.url.clone());
+    let note = format!(
+        "PR completion failed after publication; preserved PR #{pr_number} and task status '{}' \
+         for a safe completion retry. No candidate, PR body, branch, or repository setting was \
+         changed.\n\n- Run: `{run_id}`\n- Failed step: `{failed_step_id}`\n- Error code: \
+         `{error_code}`\n\nFailure:\n```text\n{error_message}\n```",
+        task.status
+    );
+    host.apply_task_automation_update(
+        &task.id,
+        TaskAutomationUpdate {
+            append_comments: vec![TaskComment {
+                at: Utc::now(),
+                by: "system".to_string(),
+                message: note,
+            }],
+            ..TaskAutomationUpdate::default()
+        },
+    )?;
+
+    Ok(json!({
+        "phase": "failure_handoff",
+        "decision": "review_completion_failure",
+        "failed_step_id": failed_step_id,
+        "pr_number": pr_number,
+        "pr_url": pr_url,
+        "candidate_preserved": true,
+        "task_status": task.status.to_string(),
     }))
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/operations.rs
@@ -9,6 +9,7 @@ pub(crate) const PR_LIST: &str = "pr.list";
 pub(crate) const PR_CREATE: &str = "pr.create";
 pub(crate) const PR_VIEW: &str = "pr.view";
 pub(crate) const PR_MERGE: &str = "pr.merge";
+pub(crate) const PR_MERGE_CAPABILITIES: &str = "pr.merge_capabilities";
 pub(crate) const PR_STATUS: &str = "pr.status";
 
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
@@ -27,6 +28,7 @@ pub(crate) fn run(operation: &str, input: &Value) -> Result<Value, OrbitError> {
         PR_CREATE => pr_create(input),
         PR_VIEW => pr_view(input),
         PR_MERGE => pr_merge(input),
+        PR_MERGE_CAPABILITIES => pr_merge_capabilities(input),
         PR_STATUS => pr_status(input),
         other => Err(OrbitError::InvalidInput(format!(
             "unknown private automation VCS operation '{other}'"
@@ -201,6 +203,157 @@ fn pr_merge(input: &Value) -> Result<Value, OrbitError> {
     }))
 }
 
+/// Read the repository merge methods and the target branch's linear-history
+/// rule in one GraphQL snapshot. Completion resolves a method from this live
+/// state before asking GitHub to merge; it never mutates repository settings.
+fn pr_merge_capabilities(input: &Value) -> Result<Value, OrbitError> {
+    let selector = required_string(input, "pr")?;
+    let workspace_path = required_string(input, "workspace_path")?;
+    let pr_number = pr_number_from_selector(selector).ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "invalid private automation VCS PR selector '{selector}'; expected a number or GitHub PR URL"
+        ))
+    })?;
+
+    let repository = execute(
+        "gh",
+        vec![
+            "repo".to_string(),
+            "view".to_string(),
+            "--json".to_string(),
+            "nameWithOwner".to_string(),
+        ],
+        Some(Path::new(workspace_path)),
+        DEFAULT_TIMEOUT_MS,
+        "repository identity",
+    )?;
+    let repository: Value = serde_json::from_str(&repository.stdout).map_err(|error| {
+        OrbitError::Execution(format!(
+            "private automation VCS repository identity returned invalid JSON: {error}"
+        ))
+    })?;
+    let name_with_owner = repository
+        .get("nameWithOwner")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            OrbitError::Execution(
+                "private automation VCS repository identity omitted nameWithOwner".to_string(),
+            )
+        })?;
+    let (owner, name) = name_with_owner.split_once('/').ok_or_else(|| {
+        OrbitError::Execution(format!(
+            "private automation VCS repository identity '{name_with_owner}' is not owner/name"
+        ))
+    })?;
+
+    let query = "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){mergeCommitAllowed rebaseMergeAllowed squashMergeAllowed pullRequest(number:$number){baseRefName baseRef{branchProtectionRule{requiresLinearHistory}}}}}";
+    let response = execute(
+        "gh",
+        vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={owner}"),
+            "-F".to_string(),
+            format!("name={name}"),
+            "-F".to_string(),
+            format!("number={pr_number}"),
+        ],
+        Some(Path::new(workspace_path)),
+        DEFAULT_TIMEOUT_MS,
+        "merge capabilities",
+    )?;
+    let response: Value = serde_json::from_str(&response.stdout).map_err(|error| {
+        OrbitError::Execution(format!(
+            "private automation VCS merge capabilities returned invalid JSON: {error}"
+        ))
+    })?;
+    normalize_merge_capabilities(&response, name_with_owner)
+}
+
+pub(super) fn normalize_merge_capabilities(
+    response: &Value,
+    name_with_owner: &str,
+) -> Result<Value, OrbitError> {
+    let repository = response
+        .pointer("/data/repository")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            OrbitError::Execution(
+                "private automation VCS merge capabilities omitted data.repository".to_string(),
+            )
+        })?;
+    let pull_request = repository
+        .get("pullRequest")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            OrbitError::Execution(
+                "private automation VCS merge capabilities could not resolve the pull request"
+                    .to_string(),
+            )
+        })?;
+    let required_bool = |key: &str| {
+        repository.get(key).and_then(Value::as_bool).ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "private automation VCS merge capabilities omitted boolean {key}"
+            ))
+        })
+    };
+    let base_branch = pull_request
+        .get("baseRefName")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            OrbitError::Execution(
+                "private automation VCS merge capabilities omitted the PR base branch".to_string(),
+            )
+        })?;
+    let base_ref = pull_request.get("baseRef").ok_or_else(|| {
+        OrbitError::Execution(
+            "private automation VCS merge capabilities omitted PR baseRef policy data".to_string(),
+        )
+    })?;
+    if base_ref.is_null() {
+        return Err(OrbitError::Execution(
+            "private automation VCS merge capabilities could not resolve the PR base ref"
+                .to_string(),
+        ));
+    }
+    let branch_protection_rule = base_ref.get("branchProtectionRule").ok_or_else(|| {
+        OrbitError::Execution(
+            "private automation VCS merge capabilities omitted branchProtectionRule policy data"
+                .to_string(),
+        )
+    })?;
+    let requires_linear_history = if branch_protection_rule.is_null() {
+        false
+    } else {
+        branch_protection_rule
+            .get("requiresLinearHistory")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| {
+                OrbitError::Execution(
+                    "private automation VCS merge capabilities omitted boolean requiresLinearHistory"
+                        .to_string(),
+                )
+            })?
+    };
+
+    Ok(json!({
+        "repository": {
+            "name_with_owner": name_with_owner,
+            "base_branch": base_branch,
+            "allow_squash_merge": required_bool("squashMergeAllowed")?,
+            "allow_rebase_merge": required_bool("rebaseMergeAllowed")?,
+            "allow_merge_commit": required_bool("mergeCommitAllowed")?,
+            "requires_linear_history": requires_linear_history,
+        }
+    }))
+}
+
 /// Read the merge-relevant state of a PR.
 ///
 /// Separate from [`pr_view`], whose field set is fixed to the review-body
@@ -297,10 +450,18 @@ fn valid_expected_remote_sha(value: Option<&str>) -> bool {
 }
 
 fn valid_pr_selector(value: &str) -> bool {
-    value.bytes().all(|byte| byte.is_ascii_digit())
-        || (value.contains("github.com/")
-            && value.contains("/pull/")
-            && value.rsplit('/').next().is_some_and(|number| {
-                !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
-            }))
+    pr_number_from_selector(value).is_some()
+}
+
+fn pr_number_from_selector(value: &str) -> Option<&str> {
+    if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Some(value);
+    }
+    if !value.contains("github.com/") || !value.contains("/pull/") {
+        return None;
+    }
+    value
+        .rsplit('/')
+        .next()
+        .filter(|number| !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
@@ -30,6 +30,7 @@ use super::super::super::input::input_string_field;
 use super::super::super::task_update::{authorization_note, complete_tasks};
 use super::super::handoff::load_handoff_context;
 use super::super::operations;
+use super::merge::{MergeStrategy, resolve_merge_strategy};
 
 /// Default budget for waiting out required checks before giving up.
 const DEFAULT_MAX_WAIT_SECONDS: u64 = 3600;
@@ -93,6 +94,7 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
     let mut waited_seconds = 0_u64;
     let mut auto_merge_requested = false;
     let mut merge_requested = false;
+    let mut merge_strategy = None;
 
     loop {
         let status = read_pr_status(host, workspace_path, pr_number)?;
@@ -101,6 +103,7 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                 return Ok(json!({
                     "merged": true,
                     "pr_number": pr_number,
+                    "strategy": merge_strategy.map(MergeStrategy::as_str),
                     "auto_merge_requested": auto_merge_requested,
                     "waited_seconds": waited_seconds,
                 }));
@@ -120,7 +123,17 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
             }
             PrMergeState::Mergeable => {
                 if !merge_requested {
-                    request_merge(host, workspace_path, pr_number, false)?;
+                    let strategy =
+                        resolved_strategy(host, workspace_path, pr_number, &mut merge_strategy)?;
+                    request_merge(host, workspace_path, pr_number, strategy, false).map_err(
+                        |error| {
+                            OrbitError::Execution(format!(
+                                "pr_complete: could not request {} merge on pull request \
+                                 #{pr_number}: {error}; the task stays in review",
+                                strategy.as_str()
+                            ))
+                        },
+                    )?;
                     merge_requested = true;
                     // Re-read rather than assuming the request landed.
                     continue;
@@ -131,12 +144,17 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                     // Required checks are still running. Hand the merge to
                     // GitHub's auto-merge so it lands the moment they pass,
                     // then keep polling: enabling it is not success.
-                    request_merge(host, workspace_path, pr_number, true).map_err(|error| {
-                        OrbitError::Execution(format!(
-                            "pr_complete: could not enable auto-merge on pull request \
-                             #{pr_number}: {error}; the task stays in review"
-                        ))
-                    })?;
+                    let strategy =
+                        resolved_strategy(host, workspace_path, pr_number, &mut merge_strategy)?;
+                    request_merge(host, workspace_path, pr_number, strategy, true).map_err(
+                        |error| {
+                            OrbitError::Execution(format!(
+                                "pr_complete: could not enable auto-merge using {} on pull request \
+                                 #{pr_number}: {error}; the task stays in review",
+                                strategy.as_str()
+                            ))
+                        },
+                    )?;
                     auto_merge_requested = true;
                 }
             }
@@ -223,18 +241,38 @@ fn request_merge<H: RuntimeHost + ?Sized>(
     host: &H,
     workspace_path: &str,
     pr_number: &str,
+    strategy: MergeStrategy,
     auto: bool,
 ) -> Result<(), OrbitError> {
     host.run_private_vcs_operation(
         operations::PR_MERGE,
         json!({
             "pr": pr_number,
-            "strategy": "squash",
+            "strategy": strategy.as_str(),
             "auto": auto,
             "workspace_path": workspace_path,
         }),
     )
     .map(|_| ())
+}
+
+fn resolved_strategy<H: RuntimeHost + ?Sized>(
+    host: &H,
+    workspace_path: &str,
+    pr_number: &str,
+    selected: &mut Option<MergeStrategy>,
+) -> Result<MergeStrategy, OrbitError> {
+    if let Some(strategy) = *selected {
+        return Ok(strategy);
+    }
+    let strategy = resolve_merge_strategy(host, workspace_path, pr_number).map_err(|error| {
+        OrbitError::Execution(format!(
+            "pr_complete: could not resolve a permitted merge method for pull request \
+             #{pr_number}: {error}; the task stays in review"
+        ))
+    })?;
+    *selected = Some(strategy);
+    Ok(strategy)
 }
 
 fn resolve_pr_number(input: &Value, tasks: &[Task]) -> Result<String, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
@@ -15,6 +15,79 @@ use super::super::git::{base_sync_mode_from_input, git_command_success, git_outp
 use super::super::operations;
 use super::attribution::ship_done_attribution;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MergeStrategy {
+    Squash,
+    Rebase,
+    Merge,
+}
+
+impl MergeStrategy {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Squash => "squash",
+            Self::Rebase => "rebase",
+            Self::Merge => "merge",
+        }
+    }
+}
+
+pub(super) fn resolve_merge_strategy<H: RuntimeHost + ?Sized>(
+    host: &H,
+    workspace_path: &str,
+    pr_number: &str,
+) -> Result<MergeStrategy, OrbitError> {
+    let response = host.run_private_vcs_operation(
+        operations::PR_MERGE_CAPABILITIES,
+        json!({
+            "pr": pr_number,
+            "workspace_path": workspace_path,
+        }),
+    )?;
+    let repository = response.get("repository").ok_or_else(|| {
+        OrbitError::Execution(
+            "merge strategy resolution: private VCS response omitted repository capabilities"
+                .to_string(),
+        )
+    })?;
+    let capability = |key: &str| {
+        repository.get(key).and_then(Value::as_bool).ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "merge strategy resolution: repository capabilities omitted boolean {key}"
+            ))
+        })
+    };
+    let squash = capability("allow_squash_merge")?;
+    let rebase = capability("allow_rebase_merge")?;
+    let merge = capability("allow_merge_commit")?;
+    let linear = capability("requires_linear_history")?;
+
+    if squash {
+        return Ok(MergeStrategy::Squash);
+    }
+    if rebase {
+        return Ok(MergeStrategy::Rebase);
+    }
+    if merge && !linear {
+        return Ok(MergeStrategy::Merge);
+    }
+
+    let repository_name = repository
+        .get("name_with_owner")
+        .and_then(Value::as_str)
+        .unwrap_or("repository");
+    let base_branch = repository
+        .get("base_branch")
+        .and_then(Value::as_str)
+        .unwrap_or("target branch");
+    Err(OrbitError::Execution(format!(
+        "no permitted merge method for pull request #{pr_number} in {repository_name}: \
+         squash={squash}, rebase={rebase}, merge_commit={merge}, \
+         {base_branch}.requires_linear_history={linear}; repository settings were not changed \
+         and no administrative bypass was attempted"
+    )))
+}
+
 pub(in crate::executor::automation) fn git_merge<H: RuntimeHost + Sync + ?Sized>(
     host: &H,
     input: &Value,
@@ -96,11 +169,13 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + ?Sized>(
 
     ensure_branch_fresh_against_base(&workspace_path, &head, &base, base_sync_mode)?;
 
+    let merge_strategy =
+        resolve_merge_strategy(host, &workspace_path.to_string_lossy(), &pr_number)?;
     host.run_private_vcs_operation(
         operations::PR_MERGE,
         json!({
             "pr": pr_number,
-            "strategy": "squash",
+            "strategy": merge_strategy.as_str(),
             "workspace_path": workspace_path,
         }),
     )?;
@@ -147,7 +222,10 @@ pub(super) fn merge_batch_pr<H: RuntimeHost + ?Sized>(
         };
     }
 
-    Ok(json!({ "merged": true }))
+    Ok(json!({
+        "merged": true,
+        "strategy": merge_strategy.as_str(),
+    }))
 }
 
 fn resolve_batch_workspace_path<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
@@ -12,7 +12,8 @@ use tempfile::tempdir;
 use super::super::super::super::task_update::task_complete;
 use super::super::complete::pr_complete;
 use super::test_support::{
-    PR_MERGE_OPERATION, PR_STATUS_OPERATION, PrOpenTestHost, review_batch_task,
+    PR_MERGE_CAPABILITIES_OPERATION, PR_MERGE_OPERATION, PR_STATUS_OPERATION, PrOpenTestHost,
+    review_batch_task,
 };
 
 fn host(tasks: Vec<orbit_types::task::Task>) -> (tempfile::TempDir, PrOpenTestHost) {
@@ -80,6 +81,8 @@ fn a_mergeable_pr_is_merged_and_then_verified_before_completing() {
     let merges = merge_calls(&host);
     assert_eq!(merges.len(), 1, "exactly one merge request");
     assert_eq!(merges[0]["auto"], false);
+    assert_eq!(merges[0]["strategy"], "squash");
+    assert_eq!(output["merge"]["strategy"], "squash");
     assert_eq!(host.task_status("T1"), TaskStatus::Done);
 }
 
@@ -103,11 +106,105 @@ fn pending_checks_use_auto_merge_and_completion_waits_for_the_merged_state() {
         "auto-merge is requested once, not per poll"
     );
     assert_eq!(merges[0]["auto"], true);
+    assert_eq!(merges[0]["strategy"], "squash");
     assert!(
         merges[0].get("admin").is_none(),
         "completion must never request an administrative bypass"
     );
     assert_eq!(host.task_status("T1"), TaskStatus::Done);
+}
+
+/// The live incident shape: squash is disabled while rebase and merge commits
+/// are enabled. Linear history keeps merge commits out, so both immediate and
+/// auto merge must select rebase and retain that method in completion evidence.
+#[test]
+fn squash_disabled_repository_uses_rebase_for_direct_and_auto_merge() {
+    for (initial, auto) in [("CLEAN", false), ("PENDING", true)] {
+        let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+        host.queue_pr_status([state(initial), merged_state()]);
+        host.queue_merge_capabilities(false, true, true, true);
+        let mut input = complete_input(root.path(), &["T1"]);
+        input["max_wait_seconds"] = json!(1);
+
+        let output = pr_complete(&host, &input).expect("rebase completion");
+
+        let merges = merge_calls(&host);
+        assert_eq!(merges.len(), 1);
+        assert_eq!(merges[0]["strategy"], "rebase");
+        assert_eq!(merges[0]["auto"], auto);
+        assert_eq!(output["merge"]["strategy"], "rebase");
+        assert_eq!(host.task_status("T1"), TaskStatus::Done);
+    }
+}
+
+#[test]
+fn merge_only_repository_uses_merge_commit_when_linear_history_allows_it() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("CLEAN"), merged_state()]);
+    host.queue_merge_capabilities(false, false, true, false);
+
+    let output = pr_complete(&host, &complete_input(root.path(), &["T1"]))
+        .expect("merge-only repository completion");
+
+    assert_eq!(merge_calls(&host)[0]["strategy"], "merge");
+    assert_eq!(output["merge"]["strategy"], "merge");
+}
+
+#[test]
+fn no_policy_permitted_merge_method_fails_without_request_or_bypass() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("CLEAN")]);
+    host.queue_merge_capabilities(false, false, true, true);
+
+    let error = pr_complete(&host, &complete_input(root.path(), &["T1"]))
+        .expect_err("linear-history merge-only repository has no permitted method");
+
+    let message = error.to_string();
+    assert!(message.contains("no permitted merge method"), "{message}");
+    assert!(
+        message.contains("requires_linear_history=true"),
+        "{message}"
+    );
+    assert!(merge_calls(&host).is_empty());
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
+}
+
+#[test]
+fn repository_capability_api_failure_is_explicit_and_precedes_merge() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("CLEAN")]);
+    host.fail_vcs(
+        PR_MERGE_CAPABILITIES_OPERATION,
+        "gh: Resource not accessible by integration",
+    );
+
+    let error = pr_complete(&host, &complete_input(root.path(), &["T1"]))
+        .expect_err("capability permission failure must propagate");
+
+    let message = error.to_string();
+    assert!(message.contains("could not resolve a permitted merge method"));
+    assert!(message.contains("Resource not accessible by integration"));
+    assert!(merge_calls(&host).is_empty());
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
+}
+
+#[test]
+fn direct_merge_api_failure_names_the_selected_method_and_keeps_review() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("CLEAN")]);
+    host.queue_merge_capabilities(false, true, true, true);
+    host.fail_vcs(PR_MERGE_OPERATION, "gh: merge permission denied");
+
+    let error = pr_complete(&host, &complete_input(root.path(), &["T1"]))
+        .expect_err("merge permission failure must propagate");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("could not request rebase merge"),
+        "{message}"
+    );
+    assert!(message.contains("merge permission denied"), "{message}");
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
 }
 
 /// Enabling auto-merge is not terminal success: if the PR never reaches the

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -411,6 +411,50 @@ fn conflicting_rebase_publishes_clean_pre_rebase_branch_and_blocks_task() {
 }
 
 #[test]
+fn completion_failure_preserves_published_candidate_and_review_state() {
+    let workspace = pr_workspace();
+    let task_id = "ORB-COMPLETE-RECOVERY";
+    let host = PrOpenTestHost::new(
+        vec![review_batch_task(task_id, Some("codex"), None)],
+        workspace.repo.clone(),
+    );
+    let head_before = git(&workspace.repo, &["rev-parse", "HEAD"]);
+
+    let recovered = pr_failure_handoff(
+        &host,
+        &json!({
+            "failed_step_id": "complete_pr",
+            "activity_name": "pr_complete",
+            "error_code": "pipeline_step_failed",
+            "error_message": "GraphQL: Squash merges are not allowed on this repository",
+            "run_id": "batch-1",
+            "job_input": { "task_ids": [task_id] },
+            "pipeline": {},
+        }),
+    )
+    .expect("completion failure recovery");
+
+    assert_eq!(recovered["decision"], "review_completion_failure");
+    assert_eq!(recovered["pr_number"], "42");
+    assert_eq!(recovered["candidate_preserved"], true);
+    assert_eq!(host.task_status(task_id), TaskStatus::Review);
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), head_before);
+    assert!(
+        host.vcs_calls().is_empty(),
+        "recovery must not rewrite the PR"
+    );
+    let task = host.get_task(task_id).expect("task");
+    assert_eq!(task.github_pr_number(), Some("42"));
+    let comment = host
+        .comments_for(task_id)
+        .pop()
+        .expect("diagnostic comment");
+    assert!(comment.message.contains("preserved PR #42"));
+    assert!(comment.message.contains("Squash merges are not allowed"));
+    assert!(!comment.message.contains("Manual resolution required"));
+}
+
+#[test]
 fn non_fast_forward_drift_handoff_commits_dirty_work_and_raises_pr() {
     let workspace = no_diff_pr_workspace();
     fs::create_dir_all(workspace.repo.join("src")).expect("create source dir");

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/merge.rs
@@ -24,6 +24,7 @@ fn merge_batch_pr_preserves_task_attribution_per_task() {
         merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo)).expect("merge batch pr");
 
     assert_eq!(result["merged"], json!(true));
+    assert_eq!(result["strategy"], json!("squash"));
     for (task_id, expected) in cases {
         let task = host.get_task(task_id).expect("updated task");
         assert_eq!(task.status, TaskStatus::Done, "{task_id}");
@@ -98,4 +99,25 @@ fn merge_batch_pr_propagates_private_vcs_failure_before_task_updates() {
         host.get_task("T-MERGE-FAILURE").expect("task").status,
         TaskStatus::Review
     );
+}
+
+#[test]
+fn merge_batch_pr_uses_the_repository_permitted_strategy() {
+    let workspace = pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![review_batch_task("T-REBASE", Some("codex"), None)],
+        workspace.repo.clone(),
+    );
+    host.queue_merge_capabilities(false, true, true, true);
+
+    let result =
+        merge_batch_pr(&host, &merge_batch_pr_input(&workspace.repo)).expect("merge batch PR");
+
+    assert_eq!(result["strategy"], "rebase");
+    let request = host
+        .vcs_calls()
+        .into_iter()
+        .find(|call| call.operation == PR_MERGE_OPERATION)
+        .expect("merge request");
+    assert_eq!(request.input["strategy"], "rebase");
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -27,6 +27,7 @@ pub const PR_LIST_OPERATION: &str = operations::PR_LIST;
 pub const PR_CREATE_OPERATION: &str = operations::PR_CREATE;
 pub const PR_VIEW_OPERATION: &str = operations::PR_VIEW;
 pub const PR_MERGE_OPERATION: &str = operations::PR_MERGE;
+pub const PR_MERGE_CAPABILITIES_OPERATION: &str = operations::PR_MERGE_CAPABILITIES;
 pub const PR_STATUS_OPERATION: &str = operations::PR_STATUS;
 
 #[derive(Clone, Debug)]
@@ -139,6 +140,28 @@ impl PrOpenTestHost {
         for state in states {
             self.queue_vcs_result(operations::PR_STATUS, json!({ "pull_request": state }));
         }
+    }
+
+    pub fn queue_merge_capabilities(
+        &self,
+        squash: bool,
+        rebase: bool,
+        merge: bool,
+        requires_linear_history: bool,
+    ) {
+        self.queue_vcs_result(
+            operations::PR_MERGE_CAPABILITIES,
+            json!({
+                "repository": {
+                    "name_with_owner": "orbit/test",
+                    "base_branch": "agent-main",
+                    "allow_squash_merge": squash,
+                    "allow_rebase_merge": rebase,
+                    "allow_merge_commit": merge,
+                    "requires_linear_history": requires_linear_history,
+                }
+            }),
+        );
     }
 
     pub fn activity_updates(&self) -> Vec<(String, TaskActivityUpdate)> {
@@ -377,6 +400,16 @@ impl RuntimeHost for PrOpenTestHost {
         match operation {
             operations::PUSH => Ok(json!({})),
             operations::PR_MERGE => Ok(json!({})),
+            operations::PR_MERGE_CAPABILITIES => Ok(json!({
+                "repository": {
+                    "name_with_owner": "orbit/test",
+                    "base_branch": "agent-main",
+                    "allow_squash_merge": true,
+                    "allow_rebase_merge": true,
+                    "allow_merge_commit": true,
+                    "requires_linear_history": true,
+                }
+            })),
             operations::PR_LIST => {
                 let head = input.get("head").and_then(Value::as_str).ok_or_else(|| {
                     OrbitError::InvalidInput("private PR list requires a head branch".to_string())

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
@@ -2,3 +2,4 @@
 
 mod base_obsolescence;
 mod git;
+mod operations;

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
@@ -1,0 +1,84 @@
+use serde_json::json;
+
+use super::super::operations::normalize_merge_capabilities;
+
+#[test]
+fn private_vcs_boundary_normalizes_repository_and_branch_merge_policy() {
+    let output = normalize_merge_capabilities(
+        &json!({
+            "data": {
+                "repository": {
+                    "squashMergeAllowed": false,
+                    "rebaseMergeAllowed": true,
+                    "mergeCommitAllowed": true,
+                    "pullRequest": {
+                        "baseRefName": "agent-main",
+                        "baseRef": {
+                            "branchProtectionRule": {
+                                "requiresLinearHistory": true
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+        "danieljhkim/orbit",
+    )
+    .expect("normalize capability response");
+
+    assert_eq!(
+        output,
+        json!({
+            "repository": {
+                "name_with_owner": "danieljhkim/orbit",
+                "base_branch": "agent-main",
+                "allow_squash_merge": false,
+                "allow_rebase_merge": true,
+                "allow_merge_commit": true,
+                "requires_linear_history": true,
+            }
+        })
+    );
+}
+
+#[test]
+fn private_vcs_boundary_fails_closed_on_incomplete_capability_data() {
+    let error = normalize_merge_capabilities(
+        &json!({
+            "data": {
+                "repository": {
+                    "squashMergeAllowed": false,
+                    "rebaseMergeAllowed": true,
+                    "pullRequest": {
+                        "baseRefName": "agent-main",
+                        "baseRef": { "branchProtectionRule": null }
+                    }
+                }
+            }
+        }),
+        "danieljhkim/orbit",
+    )
+    .expect_err("missing mergeCommitAllowed must not be guessed");
+
+    assert!(error.to_string().contains("mergeCommitAllowed"));
+}
+
+#[test]
+fn private_vcs_boundary_does_not_guess_when_base_policy_data_is_missing() {
+    let error = normalize_merge_capabilities(
+        &json!({
+            "data": {
+                "repository": {
+                    "squashMergeAllowed": false,
+                    "rebaseMergeAllowed": true,
+                    "mergeCommitAllowed": true,
+                    "pullRequest": { "baseRefName": "agent-main" }
+                }
+            }
+        }),
+        "danieljhkim/orbit",
+    )
+    .expect_err("missing baseRef policy data must not imply no protection");
+
+    assert!(error.to_string().contains("baseRef policy data"));
+}


### PR DESCRIPTION
## Task

[ORB-11231](https://orbit-cli.com/tasks/ORB-11231) — Respect repository merge methods in --complete and preserve completion failure semantics

### Description

Confirmed live failure in ORB-11224 run jrun-20260905-0324-4 at complete_pr, PR https://github.com/danieljhkim/orbit/pull/1312: GraphQL Squash merges are not allowed on this repository. GitHub repository API reports allow_squash_merge=false, allow_rebase_merge=true, allow_merge_commit=true. crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs request_merge hardcodes strategy:squash for immediate and auto merge. Therefore --complete cannot deliver this repository despite valid completion authorization. Select an allowed merge method using live repository capabilities and applicable existing configuration/branch policy; do not blindly replace squash with another globally hardcoded method or change GitHub repository settings. Preserve linear-history constraints, ordinary GitHub gates and no admin bypass. Persist selected strategy in completion evidence. A second confirmed defect is failure routing: completion failure invoked generic vcs/failure.rs handoff, rewrote PR text as a preserved pre-rebase candidate with manual conflict reconciliation required and marked task blocked, despite same original/target base c549b5f4209d01a88daca7085bdec8b00f815f25 and no conflicts. Completion failures after successful PR publication must retain accurate published candidate identity and actionable merge reason, not fabricate rebase/conflict state. Keep task in the documented review recovery state and support safe retry/already-merged recovery without republishing candidate. Inspect original ORB-11187 behavior/tests; this is a repair, not new completion authorization.

### Acceptance Criteria

- Completion succeeds for squash-disabled/rebase-enabled repositories using a permitted method, verifies MERGED before done, and records selected method; cover merge-only and no-permitted-method cases without administrative bypass.
- Both direct and auto merge paths use resolved strategy; permission/API failures remain explicit, and pending checks are not declared completion.
- A merge-stage failure preserves existing PR body/candidate and review recovery state with truthful diagnostics; actual rebase conflict handoff remains intact.
- Regression exercises the real pipeline failure routing plus private VCS boundary, not only a mocked successful pr_complete unit; required Orbit CI checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added an engine-private GitHub capability read that captures repository merge-method settings plus the target branch's linear-history rule without changing settings or exposing an administrative bypass.
- Added one canonical merge-strategy resolver used by immediate completion, auto-merge completion, and the existing PR merge path. It prefers squash when permitted, otherwise rebase, and uses merge commits only when permitted and compatible with linear-history policy.
- Completion now records the selected strategy in checkpoint evidence, still re-reads GitHub until MERGED, and leaves pending/permission/API failures explicit with tasks in review.
- Split terminal failure recovery at the published-PR boundary: complete_pr failures preserve the existing PR identity/body/candidate and review/done state, append truthful retry diagnostics, and perform no rebase, push, or PR rewrite. Existing pre-publication and actual rebase-conflict recovery remains unchanged.
- Updated shipped activity/job descriptions and added regression coverage for squash-disabled/rebase-enabled direct and auto paths, merge-only repositories, no policy-permitted method, capability/merge API errors, private-boundary normalization, already-merged recovery, conflict handoff, and real job-executor failure routing.

Assessment: The completion path now derives merge behavior from live GitHub repository and branch policy at the authoritative private VCS boundary. Completion remains fail-closed: a task reaches done only after GitHub reports MERGED.

Validation:
- cargo test -p orbit-engine executor::automation::vcs:: --lib (168 passed)
- cargo test -p orbit-engine executor::automation::vcs::tests::operations --lib (3 passed)
- cargo test -p orbit-core application::job::tests::exec:: --lib (26 passed)
- make ci-fast (passed)
- make ci-lint (passed, workspace/all-targets, warnings denied)
- Read-only live gh GraphQL query confirmed the capability query and branchProtectionRule selection are accepted by GitHub.
- git diff --check (passed); generated target/ build artifacts removed with cargo clean.

Deviations from original plan:
- Added the shipped task_pr_pipeline and pr_failure_handoff asset descriptions because their prior all-failures-block wording became inaccurate.
- Added a focused exec/completion.rs child test module to avoid further growing the already-large exec.rs while exercising real pipeline failure routing.

Friction checkpoint: No new friction record. The encountered issue is the product defect already captured by ORB-11231; implementation and validation introduced no separate tooling/process friction.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11231-6a9b942f`
- Behind base: 0
- Ahead of base: 1