### PR TITLE
Synchronize escaped-pipe-holder test before the parent exits

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -1,6 +1,9 @@
 #![allow(missing_docs)]
 
 use std::path::Path;
+
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::time::Duration;
 
 use tempfile::tempdir;
@@ -303,11 +306,17 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
     }
     let pid_dir = tempdir().expect("pid tempdir");
     let pid_file = pid_dir.path().join("escaped.pid");
-    // perl re-parents itself into a new session (so the group kill misses it)
-    // and execs a sleep that inherits our stdout.
+    let ready_file = pid_dir.path().join("escaped.ready");
+    let escaped_helper = EscapedProcessGuard::new(pid_file.clone());
+    // The delayed helper establishes its detached session and records its PID
+    // before telling the parent it may exit. That makes the parent wait for a
+    // verified escaped pipe holder instead of racing the supervisor's group
+    // cleanup against helper startup.
     let script = format!(
-        "perl -MPOSIX -e 'POSIX::setsid(); open(my $f, \">\", $ARGV[0]); print $f $$; close $f; exec \"sleep\", \"30\"' {} & printf '%s\n' 'done'",
-        shell_quote(pid_file.to_string_lossy().as_ref())
+        "perl -MPOSIX -e 'select(undef, undef, undef, 0.2); POSIX::setsid(); open(my $pid, \">\", $ARGV[0]); print $pid $$; close $pid; open(my $ready, \">\", $ARGV[1]); print $ready \"ready\"; close $ready; exec \"sleep\", \"30\"' {} {} & while [ ! -s {} ]; do sleep 0.01; done; printf '%s\n' 'done'",
+        shell_quote(pid_file.to_string_lossy().as_ref()),
+        shell_quote(ready_file.to_string_lossy().as_ref()),
+        shell_quote(ready_file.to_string_lossy().as_ref()),
     );
     let args = sh_args(&script);
 
@@ -327,14 +336,11 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
         ))
         .expect("spawn succeeds");
 
-    assert!(
-        wait_until(Duration::from_secs(2), || pid_file.exists()),
-        "escaped helper should have recorded its pid"
-    );
     let escaped_pid = read_pid(&pid_file);
-    let _ = std::process::Command::new("kill")
-        .args(["-9", &escaped_pid.to_string()])
-        .status();
+    assert!(
+        process_is_live(escaped_pid),
+        "the escaped helper must remain live after the parent exits"
+    );
 
     assert!(!timed_out);
     assert_eq!(exit_code, Some(0));
@@ -343,6 +349,41 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
         started.elapsed() < Duration::from_secs(5),
         "a normal exit must not wait on the escaped pipe holder"
     );
+    drop(escaped_helper);
+    assert!(
+        wait_until(Duration::from_secs(2), || !process_is_live(escaped_pid)),
+        "escaped helper {escaped_pid} should be gone after test cleanup"
+    );
+}
+
+#[cfg(unix)]
+struct EscapedProcessGuard {
+    pid_file: PathBuf,
+}
+
+#[cfg(unix)]
+impl EscapedProcessGuard {
+    fn new(pid_file: PathBuf) -> Self {
+        Self { pid_file }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for EscapedProcessGuard {
+    fn drop(&mut self) {
+        let Ok(contents) = std::fs::read_to_string(&self.pid_file) else {
+            return;
+        };
+        let Ok(pid) = contents.trim().parse::<u32>() else {
+            return;
+        };
+        if pid > 0 && pid <= i32::MAX as u32 {
+            // SAFETY: the PID comes from the test helper, which we own.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Task

[ORB-11235](https://orbit-cli.com/tasks/ORB-11235) — Synchronize escaped-pipe-holder test before the parent exits

### Description

Confirmed CI failure: https://github.com/danieljhkim/orbit/actions/runs/33941196572/job/101238840189, Coverage (informational), Collect workspace coverage. Reported SHA and checkout log both4630aa2f51cefd4326bf9ccfbe4f7fa63fe73017 (ORB-11205 candidate); failure at crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs:330: escaped helper should have recorded its pid. Current source still has same race at295-345: parent shell starts Perl in background, immediately prints done and exits; helper must subsequently call setsid and record PID. Supervisor can clean up original process group before helper escapes, so waiting for PID only after spawn_with_timeout returns cannot guarantee scenario was established. This is test setup/liveness evidence, not proof production supervisor failed. Repair with explicit readiness synchronization before parent exits, proving child has entered detached session and holds inherited pipe. Preserve the regression's purpose: normal exit returns promptly even if escaped descendant retains stdout; timeout/group cleanup guarantees stay unchanged. Ensure helper cleanup even on assertion failure with existing guard patterns. No blanket sleep, larger timeout as primary fix, retry-until-pass, disabled test, or weakening process cleanup. Dedup search escaped pipe found no covering task. Current ordinary CI passed this candidate; coverage exposed scheduling race. Recheck current source/head before editing and run meaningful delayed-helper interleaving so bug is deterministic.

### Acceptance Criteria

- Fixture cannot let parent exit until verified detached helper owns inherited pipe and records its identity; explicit delayed-helper schedule proves readiness ordering.
- The real supervisor returns normal exit and expected output within bounded cleanup behavior while escaped holder remains live; helper is cleaned on success and failure.
- Focused test and relevant supervisor suite pass, including coverage-instrumented execution or justified faithful equivalent, plus make ci-fast and ci-lint.
- Record exact CI evidence and successful candidate check; do not characterize a later green retry as proof the race was absent.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reworked the escaped-pipe-holder shell fixture so its deliberately delayed Perl helper calls setsid, records its PID, and signals a readiness file before the parent can print done and exit.
- Added an RAII cleanup guard that kills the escaped helper on assertion failure and verifies cleanup on the success path; the test also proves the escaped helper remains live when the normal-exit supervisor result returns.
Assessment: The fixture now deterministically establishes the escaped inherited-pipe scenario before process-group cleanup can run, while retaining the bounded normal-exit assertion.
Validation:
- cargo test -p orbit-engine --lib activity_job::cli_runner::tests::supervisor -- --nocapture (7 passed)
- RUSTFLAGS='-C instrument-coverage' LLVM_PROFILE_FILE=/tmp/orb11235-final-%p.profraw cargo test -p orbit-engine --lib activity_job::cli_runner::tests::supervisor::spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder -- --exact --nocapture (1 passed); generated profiles removed. cargo-llvm-cov is not installed, so this is the faithful coverage-instrumented equivalent.
- make ci-fast (passed)
- make ci-lint (passed)
CI evidence:
- The reported failure was informational Coverage / Collect workspace coverage at https://github.com/danieljhkim/orbit/actions/runs/33941196572/job/101238840189 on reported SHA 2b4630aa2f51cefd4326bf9ccfbe4f7fa63fe73017 (ORB-11205 candidate). Ordinary CI had passed that candidate; that later green result is not treated as evidence that the scheduling race was absent.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11235-6a9b9841`
- Behind base: 0
- Ahead of base: 1