### PR TITLE
Add a website guide for preparing and operating continuous delivery

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
             { slug: 'how-to/write-activity', label: 'Write an Activity' },
             { slug: 'how-to/scoping-rules', label: 'Choose Scopes' },
             { slug: 'how-to/mcp-integration', label: 'Set Up MCP' },
+            { slug: 'how-to/continuous-delivery', label: 'Run Continuous Delivery' },
           ],
         },
         {

--- a/website/src/content/docs/getting-started/workflows.md
+++ b/website/src/content/docs/getting-started/workflows.md
@@ -13,7 +13,7 @@ different branch.
 
 ## `orbit run ship`
 
-Submit backlog tasks or one or more named tasks through the gated shipment pipeline. The default mode opens PRs; `--mode local` ships in-place. The command returns a run ID immediately, while dependency and lock waits happen inside the job.
+Submit backlog tasks or one or more named tasks through the gated shipment pipeline. The default mode opens PRs; `--mode local` uses the local-only delivery path. The command returns a run ID immediately, while dependency and lock waits happen inside the job.
 
 ```bash
 orbit run ship
@@ -66,6 +66,10 @@ Two limits are worth knowing:
 Submission stays asynchronous either way: the command prints the durable run ID
 and returns without knowing the eventual outcome. Follow it with
 `orbit run show <RUN_ID>`.
+
+For an operator workflow that prepares pilot context, explicitly authorizes
+backlog work, runs a bounded drain, and handles recovery, see [Run a Continuous
+Delivery Window](../how-to/continuous-delivery/).
 
 ## Direct Job Execution
 

--- a/website/src/content/docs/how-to/continuous-delivery.md
+++ b/website/src/content/docs/how-to/continuous-delivery.md
@@ -1,0 +1,109 @@
+---
+title: Run a Continuous Delivery Window
+description: "Prepare tasks, authorize a bounded backlog drain, inspect its runs, and recover safely."
+sidebar:
+  order: 6
+---
+
+Use this guide when you want a deliberate, time-bounded period of automatic delivery. It separates preparation, human approval, delivery, and recovery so an asynchronous run ID is never mistaken for a completed change.
+
+## 1. Prepare proposed work
+
+Start with the zero-input pilot. It discovers only `proposed` and `backlog`
+tasks that have no `context_files`, then prepares bounded pilot groups.
+
+```bash
+orbit run job task_pilot_pipeline --wait
+```
+
+The pilot applies validated `context_files` selectors, but it does not approve
+or dispatch work. Review both the pilot run and the task's applied selectors:
+
+```bash
+orbit run history -j task_pilot_pipeline
+orbit run show <PILOT_RUN_ID>
+orbit task show "$TASK_ID" --fields status,context_files
+```
+
+Use an explicit task list only when you intend to inspect those exact tasks;
+the job input is a JSON array, not a space-separated list:
+
+```bash
+orbit run job task_pilot_pipeline --input 'task_ids=["TASK-123","TASK-456"]' --wait
+```
+
+## 2. Authorize the backlog
+
+After reviewing a proposed task's pilot result, explicitly approve that task:
+
+```bash
+orbit task update "$TASK_ID" --approve --note "Pilot context reviewed for this delivery window."
+```
+
+That approval moves a `proposed` task to `backlog`. Pilot preparation itself
+does not grant approval. If the task is already in `backlog`, do not approve it
+again: once its pilot has applied the context you need, it is ready for the
+next delivery run.
+
+Dependencies and active locks are not bypassed by approval or by the drain.
+They keep affected work in the backlog until it is eligible, so a submitted
+window may legitimately leave some tasks unfinished.
+
+## 3. Start a bounded delivery window
+
+Choose the duration and whether this one run may complete delivery. The
+following window lasts three hours and gives the run blanket `--complete`
+authorization:
+
+```bash
+orbit run auto --for 3h --complete
+```
+
+`--complete` is opt-in authorization to move work from `review` to `done`; it
+does not approve `proposed` tasks into the backlog. It applies to every task
+the drain admits during this window, including a task admitted after the
+command starts. Omit it when a separate operator should approve completion.
+
+The command returns a durable parent run ID after submission, not a statement
+that its tasks have completed. Record that ID as `<AUTO_RUN_ID>` and inspect
+the parent and its child runs:
+
+```bash
+orbit run show <AUTO_RUN_ID>
+orbit run trace <AUTO_RUN_ID>
+orbit run show <CHILD_RUN_ID>
+orbit run logs <CHILD_RUN_ID>
+```
+
+`orbit run trace` shows the run tree; use the child IDs it reports when a
+particular task needs investigation. Also inspect the task directly to
+distinguish its submitted run from its actual lifecycle state:
+
+```bash
+orbit task show "$TASK_ID" --fields status,job_run_id,comments
+```
+
+## 4. Recover from a failed delivery
+
+First inspect the failed child run and its task. Fix a real code, review, or
+dependency problem before creating or authorizing corrective work; do not
+re-run blindly. For a task blocked by an attributable failed run, use bounded
+triage to re-backlog only an environmental failure:
+
+```bash
+orbit run show <CHILD_RUN_ID>
+orbit run logs <CHILD_RUN_ID>
+orbit run triage "$TASK_ID"
+orbit run history -j task_triage_pipeline
+```
+
+Triage never changes a task a human blocked by hand, and it leaves a
+non-environmental diagnosis blocked for an operator decision. Inspect the
+triage run before reopening the delivery window.
+
+For task-state durability and same-authority recovery, use the [task
+publication commands](../reference/cli/) and the [task-publication
+runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/task-publication.md).
+For an operator working across hosts, the existing [federated MCP
+setup](./mcp-integration/#register-the-federated-mux) explains how to select
+the owning workspace without implying automatic failover.

--- a/website/src/content/docs/how-to/index.md
+++ b/website/src/content/docs/how-to/index.md
@@ -24,4 +24,8 @@ sidebar:
     <h3>Set Up MCP</h3>
     <p>Connect Orbit tools to agent clients.</p>
   </a>
+  <a class="orbit-card" href="./continuous-delivery/">
+    <h3>Run Continuous Delivery</h3>
+    <p>Prepare tasks, authorize a bounded delivery window, and recover safely.</p>
+  </a>
 </div>


### PR DESCRIPTION
## Task

[ORB-11230](https://orbit-cli.com/tasks/ORB-11230) — Add a website guide for preparing and operating continuous delivery

### Description

The public website documents individual workflows and --complete but does not connect preparation, pilot context, backlog authorization, a bounded auto window, inspection and corrective work into a usable operator journey. website/src/content/docs/getting-started/workflows.md also says local mode ships in-place, inconsistent with its own committed/merged/pushed completion explanation. Add a focused public how-to for running a continuous delivery window, linked from getting-started/workflows and the how-to index. Show verified current commands for zero-input task_pilot_pipeline discovery, checking applied context_files, explicitly authorized backlog promotion, orbit run auto --for 3h --complete, following parent and child runs, and CI/triage recovery. Explain policies as choices: --complete is opt-in blanket completion authorization but does not approve proposed tasks; pilot prepares context rather than granting approval. Once the operator has authorized promotion and pilot applies context, avoid prescribing an extra waiting stage. Explain dependencies/locks remain in backlog and distinguish submission from completion. Include safe operational boundaries and link task publication/recovery and multi-host material only where current public pages exist, adding concise relevant links to canonical public runbooks rather than copying internal skill text wholesale. ORB-11216 owns the separate orbit-orchestrate agent skill; this task owns the human-facing website. Follow website/README.md: generated architecture/design pages must be changed at source, not edited directly. No internal task IDs or this session's private details in public docs.

### Acceptance Criteria

- A new user can follow the guide from proposed tasks through verified pilot preparation and authorized auto delivery, inspect actual outcomes, and choose a documented recovery path without reading source.
- Every command, flag, default and status claim is checked against current CLI help/job definitions; zero-input pilot examples are runnable and explicit IDs, if shown, use a JSON array.
- Correct the stale local-mode wording and link the guide from existing navigation without duplicating --complete reference semantics.
- Website build passes and rendered guide navigation, code snippets and links are checked; no edits to generated design outputs or unrelated product code.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a public continuous-delivery how-to covering zero-input pilot discovery, selector inspection, explicit proposed-to-backlog approval, a bounded authorized auto window, parent/child run inspection, and failed-run triage.
- Added the guide to the how-to landing cards and sidebar, linked it from workflow documentation, and corrected local-mode wording.
- Linked only existing public recovery and multi-host material; added file:website/astro.config.mjs to context_files because it owns sidebar navigation.
Validation:
- Audited cited commands and options against current CLI help plus job definitions.
- npm run build passed after npm ci with a workspace-local cache; rendered guide, navigation, snippets, and links were checked.
- make ci-fast and make ci-lint passed; git diff --check passed.
Assessment: focused documentation-only change; generated website, npm cache, and Rust build artifacts were removed after validation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11230-6a9b993a`
- Behind base: 0
- Ahead of base: 1