### PR TITLE
Keep overlapping pilot preparation from discarding unrelated valid partitions

### DIFF
--- a/.orbit/resources/activities/apply_task_pilot_results.yaml
+++ b/.orbit/resources/activities/apply_task_pilot_results.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Fail-closed task-pilot apply boundary. It validates complete partition
-    coverage, exact before snapshots, dispositions, canonical in-workspace
-    file/dir/symbol selectors, and target existence before the first mutation.
-    It then replaces context_files on the prepared tasks. Every other task
+    Partition-isolated, fail-closed task-pilot apply boundary. It validates each
+    partition's exact before snapshots, dispositions, canonical in-workspace
+    file/dir/symbol selectors, and target existence before mutating that
+    partition. Stale or malformed partitions are reported without writes while
+    independently valid partitions still apply. Every other task
     field, lifecycle state, dispatch state, and recommendation remains unchanged
     unless a CI sweep supplies its exact filing record and explicit promotion
     authority. In that mode only a proposed, selector-backed task with no
@@ -28,15 +29,21 @@ spec:
           - type: "null"
   output_schema_json:
     type: object
-    required: [status, mode, workspace_path, discovery, partition_decisions, partition_count, failed_partitions, tasks, ci_sweep_admission]
+    required: [status, error, mode, workspace_path, discovery, partition_decisions, partition_count, received_partition_count, failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
     properties:
-      status: {type: string, enum: [success]}
+      status: {type: string, enum: [succeeded, failed]}
+      error:
+        oneOf:
+          - type: string
+          - type: "null"
       mode: {type: string, enum: [automatic, explicit]}
       workspace_path: {type: string}
       discovery: {type: object}
       partition_decisions: {type: array, items: {type: object}}
       partition_count: {type: number}
+      received_partition_count: {type: number}
       failed_partitions: {type: array, items: {type: object}}
+      skipped_stale_partitions: {type: array, items: {type: object}}
       tasks: {type: array, items: {type: object}}
       ci_sweep_admission: {type: array, items: {type: object}}
   action: apply_task_pilot_results

--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -6,9 +6,10 @@
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. Each read-only pilot
-# receives at most five tasks. The all-join makes any failed partition
-# fail the run before the deterministic apply step can execute. Apply normally
-# changes only context_files. A CI sweep may pass its exact filing record plus
+# receives at most five tasks. Agent dispatch failures still stop at the
+# all-join. Apply isolates stale or malformed assessments by partition, applies
+# every independently valid partition, then a guard fails the total run when
+# any partition did not apply. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
 # literal promotion authority; only then can apply promote a warning-free,
 # selector-backed proposed repair to backlog.
 #
@@ -78,3 +79,9 @@ spec:
         workspace_path: "{{ steps.prepare.output.workspace_path }}"
         promotion_authorized: "{{ input.promotion_authorized }}"
         ci_sweep_filing: "{{ input.ci_sweep_filing }}"
+
+    - id: require_apply_success
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task-pilot partition apply
+        result: "{{ steps.apply.output }}"

--- a/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
+++ b/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   type: deterministic
   description: >
-    Fail-closed task-pilot apply boundary. It validates complete partition
-    coverage, exact before snapshots, dispositions, canonical in-workspace
-    file/dir/symbol selectors, and target existence before the first mutation.
-    It then replaces context_files on the prepared tasks. Every other task
+    Partition-isolated, fail-closed task-pilot apply boundary. It validates each
+    partition's exact before snapshots, dispositions, canonical in-workspace
+    file/dir/symbol selectors, and target existence before mutating that
+    partition. Stale or malformed partitions are reported without writes while
+    independently valid partitions still apply. Every other task
     field, lifecycle state, dispatch state, and recommendation remains unchanged
     unless a CI sweep supplies its exact filing record and explicit promotion
     authority. In that mode only a proposed, selector-backed task with no
@@ -37,12 +38,17 @@ spec:
   output_schema_json:
     type: object
     required:
-      [status, mode, workspace_path, discovery, partition_decisions,
-       partition_count, failed_partitions, tasks, ci_sweep_admission]
+      [status, error, mode, workspace_path, discovery,
+       partition_decisions, partition_count, received_partition_count,
+       failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
     properties:
       status:
         type: string
-        enum: [success]
+        enum: [succeeded, failed]
+      error:
+        oneOf:
+          - type: string
+          - type: "null"
       mode:
         type: string
         enum: [automatic, explicit]
@@ -56,7 +62,13 @@ spec:
           type: object
       partition_count:
         type: number
+      received_partition_count:
+        type: number
       failed_partitions:
+        type: array
+        items:
+          type: object
+      skipped_stale_partitions:
         type: array
         items:
           type: object

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -6,9 +6,10 @@
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. Each read-only pilot
-# receives at most five tasks. The all-join makes any failed partition
-# fail the run before the deterministic apply step can execute. Apply normally
-# changes only context_files. A CI sweep may pass its exact filing record plus
+# receives at most five tasks. Agent dispatch failures still stop at the
+# all-join. Apply isolates stale or malformed assessments by partition, applies
+# every independently valid partition, then a guard fails the total run when
+# any partition did not apply. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
 # literal promotion authority; only then can apply promote a warning-free,
 # selector-backed proposed repair to backlog.
 #
@@ -78,3 +79,9 @@ spec:
         workspace_path: "{{ steps.prepare.output.workspace_path }}"
         promotion_authorized: "{{ input.promotion_authorized }}"
         ci_sweep_filing: "{{ input.ci_sweep_filing }}"
+
+    - id: require_apply_success
+      target: activity:pipeline_success_guard
+      default_input:
+        context: task-pilot partition apply
+        result: "{{ steps.apply.output }}"

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -75,8 +75,12 @@ orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exa
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
 workspace whose `context_files` is empty, and skips tasks tagged as needing no
-diff. Explicit `task_ids` audits exactly the named tasks, including ones that
-already have selectors.
+diff. It also excludes a task already named by the durable prepare checkpoint
+of an active pilot run and reports the owning run ID, so a later discovery run
+can inspect new work without repeating the expensive assessment. Explicit
+`task_ids` audits exactly the named tasks, including ones that already have
+selectors, but refuses an ID already prepared by an active run; inspect or
+resume the named run instead.
 
 The pilot agent inspection is read-only; its deterministic apply step mutates
 validated task selectors. It runs five
@@ -86,6 +90,15 @@ workspace routine may already run the zero-input job every few hours — an extr
 run before a large dispatch is still appropriate.
 The task-pilot pipeline never promotes tasks or dispatches them; promotion and
 shipping remain separate operator-authorized steps.
+
+Apply is isolated by partition. A stale task snapshot or malformed assessment
+leaves that whole partition untouched while independently valid partitions are
+still applied. The run then fails deliberately, and its durable apply output
+lists each partition as `applied`, `skipped_stale`, or `failed`, plus the exact
+task IDs actually applied. `orbit run show <run_id>` is therefore the recovery
+source of truth. Resuming the failed run reuses its successful prepare, pilot,
+and apply checkpoints (it does not rerun those agents); start a fresh zero-input
+pilot only for tasks that remain empty after reviewing the recorded outcomes.
 
 ## Keeping parallel runs off each other
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -14,18 +14,23 @@ use orbit_common::fs::selector::{
     anchor_path, canonical_selector_in_workspace, exists_in_workspace,
 };
 use orbit_engine::DispatchError;
+use orbit_store::contracts::JobRunQuery;
 use orbit_types::task::{Task, TaskStatus};
+use orbit_types::workflow::JobRunState;
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
-use crate::adapter::engine_host::v2_host::ci_failure_admission;
-use crate::application::task::TaskUpdateParams;
+
+mod apply;
+
+pub(super) use apply::apply;
 
 const DEFAULT_MAX_PARTITION_SIZE: usize = 5;
 const HARD_MAX_PARTITION_SIZE: usize = 5;
 const DEFAULT_MAX_TASKS: usize = 50;
 const HARD_MAX_TASKS: usize = 500;
 const NO_DIFF_TAGS: [&str; 2] = ["no-diff-needed", "no-diff-expected"];
+const TASK_PILOT_JOB_ID: &str = "task_pilot_pipeline";
 
 pub(super) fn prepare(
     runtime: &OrbitRuntime,
@@ -49,6 +54,7 @@ pub(super) fn prepare(
     )?;
     let explicit_task_ids = string_array(input, "task_ids", action)?;
     let explicit_mode = !explicit_task_ids.is_empty();
+    let active_preparations = active_task_pilot_preparations(runtime, action, &workspace_root)?;
     let all_tasks = runtime
         .list_tasks()
         .map_err(|error| action_failed(action, format!("list workspace tasks: {error}")))?;
@@ -73,6 +79,18 @@ pub(super) fn prepare(
                         action,
                         format!("task {task_id} does not exist in the selected workspace"),
                     )
+                }).and_then(|task| {
+                    if let Some(run_ids) = active_preparations.get(task_id) {
+                        Err(action_failed(
+                            action,
+                            format!(
+                                "task {task_id} is already prepared by active task-pilot run(s) {}; inspect or resume that durable run instead of starting duplicate pilot work",
+                                run_ids.iter().cloned().collect::<Vec<_>>().join(", ")
+                            ),
+                        ))
+                    } else {
+                        Ok(task)
+                    }
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -90,6 +108,12 @@ pub(super) fn prepare(
             let reason = automatic_exclusion_reason(task);
             if let Some(reason) = reason {
                 excluded.push(json!({ "task_id": task.id, "reason": reason }));
+            } else if let Some(run_ids) = active_preparations.get(&task.id) {
+                excluded.push(json!({
+                    "task_id": task.id,
+                    "reason": "active_pilot_prepared",
+                    "prepared_by_run_ids": run_ids,
+                }));
             } else {
                 selected.push(task);
             }
@@ -135,299 +159,83 @@ pub(super) fn prepare(
     }))
 }
 
-pub(super) fn apply(
+fn active_task_pilot_preparations(
     runtime: &OrbitRuntime,
     action: &str,
-    input: &Value,
-) -> Result<Value, DispatchError> {
-    let workspace_root = requested_workspace_root(runtime, action, input)?;
-    let prepared = input
-        .get("prepared")
-        .and_then(Value::as_object)
-        .ok_or_else(|| action_failed(action, "`prepared` must be an object"))?;
-    let prepared_workspace = prepared
-        .get("workspace_path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| action_failed(action, "prepared.workspace_path must be a string"))?;
-    if Path::new(prepared_workspace) != workspace_root {
-        return Err(action_failed(
-            action,
-            format!(
-                "prepared workspace {prepared_workspace} does not match active workspace {}",
-                workspace_root.display()
-            ),
-        ));
+    workspace_root: &Path,
+) -> Result<BTreeMap<String, BTreeSet<String>>, DispatchError> {
+    let mut prepared_by_task = BTreeMap::<String, BTreeSet<String>>::new();
+    for state in [
+        JobRunState::Pending,
+        JobRunState::Running,
+        JobRunState::Retrying,
+    ] {
+        let runs = runtime
+            .stores()
+            .jobs()
+            .list_job_runs_filtered(&JobRunQuery {
+                job_id: Some(TASK_PILOT_JOB_ID.to_string()),
+                state: Some(state),
+                terminal_only: false,
+                created_since: None,
+                limit: None,
+            })
+            .map_err(|error| {
+                action_failed(action, format!("list active task-pilot runs: {error}"))
+            })?;
+        for run in runs {
+            let run = runtime.show_job_run(&run.run_id).map_err(|error| {
+                action_failed(
+                    action,
+                    format!("reconcile active task-pilot run {}: {error}", run.run_id),
+                )
+            })?;
+            if run.state.is_terminal() {
+                continue;
+            }
+            let Some(state) = runtime.read_run_state(&run.run_id).map_err(|error| {
+                action_failed(
+                    action,
+                    format!("read active task-pilot run {} state: {error}", run.run_id),
+                )
+            })?
+            else {
+                continue;
+            };
+            let Some(task_ids) = state.step_outputs.iter().find_map(|(step_index, output)| {
+                (state.step_states.get(step_index) == Some(&JobRunState::Success))
+                    .then(|| prepared_task_ids(output, workspace_root))
+                    .flatten()
+            }) else {
+                continue;
+            };
+            for task_id in task_ids {
+                prepared_by_task
+                    .entry(task_id)
+                    .or_default()
+                    .insert(run.run_id.clone());
+            }
+        }
     }
-    let mode = prepared
-        .get("mode")
-        .and_then(Value::as_str)
-        .ok_or_else(|| action_failed(action, "prepared.mode must be a string"))?;
-    let expected_partitions = prepared
-        .get("partitions")
-        .and_then(Value::as_array)
-        .ok_or_else(|| action_failed(action, "prepared.partitions must be an array"))?;
-    let prepared_tasks = prepared
-        .get("tasks")
-        .and_then(Value::as_array)
-        .ok_or_else(|| action_failed(action, "prepared.tasks must be an array"))?;
-    let results = input
-        .get("results")
-        .and_then(Value::as_array)
-        .ok_or_else(|| action_failed(action, "`results` must be an array"))?;
+    Ok(prepared_by_task)
+}
 
-    if results.len() != expected_partitions.len() {
-        return Err(action_failed(
-            action,
-            format!(
-                "expected {} task-pilot partition results, received {}",
-                expected_partitions.len(),
-                results.len()
-            ),
-        ));
+fn prepared_task_ids(output: &Value, workspace_root: &Path) -> Option<Vec<String>> {
+    let object = output.as_object()?;
+    let prepared_workspace = object.get("workspace_path")?.as_str()?;
+    if Path::new(prepared_workspace) != workspace_root
+        || !object.get("partitions")?.is_array()
+        || !object.get("tasks")?.is_array()
+        || !matches!(object.get("mode")?.as_str(), Some("automatic" | "explicit"))
+    {
+        return None;
     }
-
-    let prepared_before = prepared_tasks
+    object
+        .get("task_ids")?
+        .as_array()?
         .iter()
-        .map(|entry| {
-            let task_id = required_string(entry, "task_id", action)?;
-            let before = required_string_array(entry, "context_files_before", action)?;
-            Ok((task_id.to_string(), before))
-        })
-        .collect::<Result<BTreeMap<_, _>, DispatchError>>()?;
-
-    // Validate every partition and every selector before the first mutation.
-    // A malformed or failed partition therefore cannot partially apply the
-    // otherwise-valid partitions that happened to precede it.
-    let ci_sweep_filing = input
-        .get("ci_sweep_filing")
-        .filter(|value| !value.is_null());
-    let promotion_authorized = input
-        .get("promotion_authorized")
-        .map(|value| {
-            value
-                .as_bool()
-                .ok_or_else(|| action_failed(action, "promotion_authorized must be a boolean"))
-        })
-        .transpose()?
-        .unwrap_or(false);
-    if ci_sweep_filing.is_some() && prepared_before.len() != 1 {
-        return Err(action_failed(
-            action,
-            "CI-sweep admission requires exactly one prepared task",
-        ));
-    }
-
-    let mut validated = Vec::with_capacity(prepared_before.len());
-    let mut seen_task_ids = BTreeSet::new();
-    for (position, (expected, result)) in expected_partitions.iter().zip(results).enumerate() {
-        let expected_index = expected
-            .get("partition_index")
-            .and_then(Value::as_u64)
-            .ok_or_else(|| {
-                action_failed(
-                    action,
-                    format!("prepared.partitions[{position}].partition_index is invalid"),
-                )
-            })?;
-        let expected_ids = required_string_array(expected, "task_ids", action)?;
-        let result_object = result.as_object().ok_or_else(|| {
-            action_failed(
-                action,
-                format!("partition {expected_index} failed or returned no structured result"),
-            )
-        })?;
-        let result_index = result_object
-            .get("partition_index")
-            .and_then(Value::as_u64)
-            .ok_or_else(|| {
-                action_failed(
-                    action,
-                    format!("partition result {position} is missing partition_index"),
-                )
-            })?;
-        if result_index != expected_index {
-            return Err(action_failed(
-                action,
-                format!(
-                    "partition result {position} reports index {result_index}, expected {expected_index}"
-                ),
-            ));
-        }
-        let result_ids = result_object
-            .get("task_ids")
-            .ok_or_else(|| action_failed(action, "`task_ids` must be an array"))
-            .and_then(|value| string_array_value(value, "task_ids", action))?;
-        if result_ids != expected_ids {
-            return Err(action_failed(
-                action,
-                format!("partition {expected_index} task_ids do not match the prepared partition"),
-            ));
-        }
-        let assessments = result_object
-            .get("tasks")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                action_failed(
-                    action,
-                    format!("partition {expected_index}.tasks must be an array"),
-                )
-            })?;
-        if assessments.len() != expected_ids.len() {
-            return Err(action_failed(
-                action,
-                format!(
-                    "partition {expected_index} returned {} task assessments for {} tasks",
-                    assessments.len(),
-                    expected_ids.len()
-                ),
-            ));
-        }
-        let assessments_by_id = assessments
-            .iter()
-            .map(|assessment| {
-                let task_id = required_string(assessment, "task_id", action)?;
-                Ok((task_id.to_string(), assessment))
-            })
-            .collect::<Result<BTreeMap<_, _>, DispatchError>>()?;
-        if assessments_by_id.len() != assessments.len() {
-            return Err(action_failed(
-                action,
-                format!("partition {expected_index} contains duplicate task assessments"),
-            ));
-        }
-
-        for task_id in expected_ids {
-            if !seen_task_ids.insert(task_id.clone()) {
-                return Err(action_failed(
-                    action,
-                    format!("task {task_id} appears in more than one partition result"),
-                ));
-            }
-            let assessment = assessments_by_id.get(&task_id).ok_or_else(|| {
-                action_failed(
-                    action,
-                    format!("partition {expected_index} omitted task {task_id}"),
-                )
-            })?;
-            let expected_before = prepared_before.get(&task_id).ok_or_else(|| {
-                action_failed(action, format!("task {task_id} was not in prepared.tasks"))
-            })?;
-            let reported_before =
-                required_string_array(assessment, "context_files_before", action)?;
-            if &reported_before != expected_before {
-                return Err(action_failed(
-                    action,
-                    format!(
-                        "task {task_id} context_files_before does not match the prepared snapshot"
-                    ),
-                ));
-            }
-            let current = runtime.get_task(&task_id).map_err(|error| {
-                action_failed(action, format!("reload task {task_id}: {error}"))
-            })?;
-            if current.context_files != *expected_before {
-                return Err(action_failed(
-                    action,
-                    format!(
-                        "task {task_id} context_files changed after preparation; refusing stale pilot output"
-                    ),
-                ));
-            }
-            let disposition = required_string(assessment, "disposition", action)?;
-            let after = required_string_array(assessment, "context_files_after", action)?;
-            validate_after_selectors(
-                action,
-                &task_id,
-                disposition,
-                assessment,
-                &after,
-                &workspace_root,
-            )?;
-            validate_recommendations(action, &task_id, assessment)?;
-            validated.push((
-                task_id,
-                expected_before.clone(),
-                after,
-                (*assessment).clone(),
-                current,
-            ));
-        }
-    }
-
-    if seen_task_ids.len() != prepared_before.len() {
-        return Err(action_failed(
-            action,
-            "partition results did not cover every prepared task",
-        ));
-    }
-
-    let mut task_results = Vec::with_capacity(validated.len());
-    let mut ci_sweep_admission = Vec::new();
-    for (task_id, before, after, mut assessment, current) in validated {
-        let changed = before != after;
-        let admission = ci_sweep_filing
-            .map(|filing| {
-                ci_failure_admission::assess(
-                    action,
-                    &task_id,
-                    &current,
-                    &assessment,
-                    &after,
-                    filing,
-                    promotion_authorized,
-                )
-            })
-            .transpose()?;
-        let promote = admission
-            .as_ref()
-            .is_some_and(|decision| decision["decision"] == "promote");
-        if changed || promote {
-            runtime
-                .update_task(
-                    &task_id,
-                    TaskUpdateParams {
-                        context_files: changed.then_some(after.clone()),
-                        status: promote.then_some(TaskStatus::Backlog),
-                        comment: promote.then(|| {
-                            "CI-sweep admission: task-pilot validated current relevance and selectors; promoted proposed repair to backlog."
-                                .to_string()
-                        }),
-                        ..TaskUpdateParams::default()
-                    },
-                )
-                .map_err(|error| {
-                    action_failed(
-                        action,
-                        format!("apply validated context_files for task {task_id}: {error}"),
-                    )
-                })?;
-        }
-        if let Value::Object(fields) = &mut assessment {
-            fields.insert("applied".to_string(), Value::Bool(changed));
-            if let Some(admission) = admission.clone() {
-                fields.insert("ci_sweep_admission".to_string(), admission);
-            }
-        }
-        if let Some(admission) = admission {
-            ci_sweep_admission.push(admission);
-        }
-        task_results.push(assessment);
-    }
-
-    Ok(json!({
-        "status": "success",
-        "mode": mode,
-        "workspace_path": workspace_root,
-        "discovery": {
-            "task_ids": prepared.get("task_ids").cloned().unwrap_or_else(|| json!([])),
-            "excluded": prepared.get("excluded").cloned().unwrap_or_else(|| json!([])),
-        },
-        "partition_decisions": expected_partitions,
-        "partition_count": expected_partitions.len(),
-        "failed_partitions": [],
-        "tasks": task_results,
-        "ci_sweep_admission": ci_sweep_admission,
-    }))
+        .map(|task_id| task_id.as_str().map(ToOwned::to_owned))
+        .collect()
 }
 
 fn automatic_exclusion_reason(task: &Task) -> Option<&'static str> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -1,0 +1,596 @@
+//! Partition-isolated validation and compare-and-set application for task pilots.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use orbit_common::OrbitError;
+use orbit_engine::DispatchError;
+use orbit_types::task::{Task, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::ci_failure_admission;
+use crate::application::task::TaskUpdateParams;
+
+use super::{
+    action_failed, requested_workspace_root, required_string, required_string_array,
+    string_array_value, validate_after_selectors, validate_recommendations,
+};
+
+#[derive(Clone)]
+struct PreparedTaskSnapshot {
+    context_files: Vec<String>,
+    status: TaskStatus,
+    title: String,
+    tags: Vec<String>,
+}
+
+struct ValidatedTask {
+    task_id: String,
+    after: Vec<String>,
+    assessment: Value,
+    admission: Option<Value>,
+    promote: bool,
+}
+
+pub(in super::super) fn apply(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
+    let workspace_root = requested_workspace_root(runtime, action, input)?;
+    let prepared = input
+        .get("prepared")
+        .and_then(Value::as_object)
+        .ok_or_else(|| action_failed(action, "`prepared` must be an object"))?;
+    let prepared_workspace = prepared
+        .get("workspace_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| action_failed(action, "prepared.workspace_path must be a string"))?;
+    if Path::new(prepared_workspace) != workspace_root {
+        return Err(action_failed(
+            action,
+            format!(
+                "prepared workspace {prepared_workspace} does not match active workspace {}",
+                workspace_root.display()
+            ),
+        ));
+    }
+    let mode = prepared
+        .get("mode")
+        .and_then(Value::as_str)
+        .ok_or_else(|| action_failed(action, "prepared.mode must be a string"))?;
+    let expected_partitions = prepared
+        .get("partitions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "prepared.partitions must be an array"))?;
+    let prepared_tasks = prepared
+        .get("tasks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "prepared.tasks must be an array"))?;
+    let results = input
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| action_failed(action, "`results` must be an array"))?;
+
+    let prepared_before = prepared_tasks
+        .iter()
+        .map(|entry| {
+            let task_id = required_string(entry, "task_id", action)?;
+            let context_files = required_string_array(entry, "context_files_before", action)?;
+            let status = serde_json::from_value::<TaskStatus>(
+                entry
+                    .get("status")
+                    .cloned()
+                    .ok_or_else(|| action_failed(action, "prepared task is missing status"))?,
+            )
+            .map_err(|error| {
+                action_failed(action, format!("prepared task status is invalid: {error}"))
+            })?;
+            let title = required_string(entry, "title", action)?.to_string();
+            let tags = required_string_array(entry, "tags", action)?;
+            Ok((
+                task_id.to_string(),
+                PreparedTaskSnapshot {
+                    context_files,
+                    status,
+                    title,
+                    tags,
+                },
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, DispatchError>>()?;
+    if prepared_before.len() != prepared_tasks.len() {
+        return Err(action_failed(
+            action,
+            "prepared.tasks contains duplicate task snapshots",
+        ));
+    }
+
+    // Each partition is its own validation boundary. A malformed or stale
+    // partition mutates none of its tasks, but it cannot discard an unrelated
+    // partition whose agent result and prepared snapshot are still current.
+    let ci_sweep_filing = input
+        .get("ci_sweep_filing")
+        .filter(|value| !value.is_null());
+    let promotion_authorized = input
+        .get("promotion_authorized")
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| action_failed(action, "promotion_authorized must be a boolean"))
+        })
+        .transpose()?
+        .unwrap_or(false);
+    if ci_sweep_filing.is_some() && prepared_before.len() != 1 {
+        return Err(action_failed(
+            action,
+            "CI-sweep admission requires exactly one prepared task",
+        ));
+    }
+
+    let mut seen_task_ids = BTreeSet::new();
+    let mut partition_decisions = Vec::with_capacity(expected_partitions.len());
+    let mut task_results = Vec::with_capacity(prepared_before.len());
+    let mut ci_sweep_admission = Vec::new();
+
+    for (position, expected) in expected_partitions.iter().enumerate() {
+        let expected_index = expected
+            .get("partition_index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    format!("prepared.partitions[{position}].partition_index is invalid"),
+                )
+            })?;
+        let expected_ids = required_string_array(expected, "task_ids", action)?;
+        for task_id in &expected_ids {
+            if !seen_task_ids.insert(task_id.clone()) {
+                return Err(action_failed(
+                    action,
+                    format!("task {task_id} appears in more than one prepared partition"),
+                ));
+            }
+            if !prepared_before.contains_key(task_id) {
+                return Err(action_failed(
+                    action,
+                    format!("task {task_id} was not in prepared.tasks"),
+                ));
+            }
+        }
+
+        let Some(result) = results.get(position) else {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!("partition result {position} is missing"),
+            ));
+            continue;
+        };
+        let Some(result_object) = result.as_object() else {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!("partition {expected_index} failed or returned no structured result"),
+            ));
+            continue;
+        };
+        let result_index = result_object
+            .get("partition_index")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| format!("partition result {position} is missing partition_index"));
+        let result_index = match result_index {
+            Ok(index) => index,
+            Err(error) => {
+                partition_decisions.push(failed_partition(expected_index, &expected_ids, error));
+                continue;
+            }
+        };
+        if result_index != expected_index {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!(
+                    "partition result {position} reports index {result_index}, expected {expected_index}"
+                ),
+            ));
+            continue;
+        }
+        let result_ids = match result_object
+            .get("task_ids")
+            .ok_or_else(|| action_failed(action, "`task_ids` must be an array"))
+            .and_then(|value| string_array_value(value, "task_ids", action))
+        {
+            Ok(ids) => ids,
+            Err(error) => {
+                partition_decisions.push(failed_partition(
+                    expected_index,
+                    &expected_ids,
+                    error.to_string(),
+                ));
+                continue;
+            }
+        };
+        if result_ids != expected_ids {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!("partition {expected_index} task_ids do not match the prepared partition"),
+            ));
+            continue;
+        }
+        let Some(assessments) = result_object.get("tasks").and_then(Value::as_array) else {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!("partition {expected_index}.tasks must be an array"),
+            ));
+            continue;
+        };
+        if assessments.len() != expected_ids.len() {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!(
+                    "partition {expected_index} returned {} task assessments for {} tasks",
+                    assessments.len(),
+                    expected_ids.len()
+                ),
+            ));
+            continue;
+        }
+        let assessments_by_id = match assessments
+            .iter()
+            .map(|assessment| {
+                let task_id = required_string(assessment, "task_id", action)?;
+                Ok((task_id.to_string(), assessment))
+            })
+            .collect::<Result<BTreeMap<_, _>, DispatchError>>()
+        {
+            Ok(by_id) => by_id,
+            Err(error) => {
+                partition_decisions.push(failed_partition(
+                    expected_index,
+                    &expected_ids,
+                    error.to_string(),
+                ));
+                continue;
+            }
+        };
+        if assessments_by_id.len() != assessments.len() {
+            partition_decisions.push(failed_partition(
+                expected_index,
+                &expected_ids,
+                format!("partition {expected_index} contains duplicate task assessments"),
+            ));
+            continue;
+        }
+
+        let mut validated = Vec::with_capacity(expected_ids.len());
+        let mut stale = Vec::new();
+        let mut validation_error = None;
+        for task_id in &expected_ids {
+            let Some(assessment) = assessments_by_id.get(task_id) else {
+                validation_error =
+                    Some(format!("partition {expected_index} omitted task {task_id}"));
+                break;
+            };
+            let snapshot = &prepared_before[task_id];
+            let reported_before =
+                match required_string_array(assessment, "context_files_before", action) {
+                    Ok(before) => before,
+                    Err(error) => {
+                        validation_error = Some(error.to_string());
+                        break;
+                    }
+                };
+            if reported_before != snapshot.context_files {
+                stale.push(stale_task(
+                    task_id,
+                    "reported_context_snapshot_mismatch",
+                    "agent context_files_before does not match this run's prepared snapshot",
+                ));
+                continue;
+            }
+            let disposition = match required_string(assessment, "disposition", action) {
+                Ok(value) => value,
+                Err(error) => {
+                    validation_error = Some(error.to_string());
+                    break;
+                }
+            };
+            let after = match required_string_array(assessment, "context_files_after", action) {
+                Ok(value) => value,
+                Err(error) => {
+                    validation_error = Some(error.to_string());
+                    break;
+                }
+            };
+            if let Err(error) = validate_after_selectors(
+                action,
+                task_id,
+                disposition,
+                assessment,
+                &after,
+                &workspace_root,
+            ) {
+                validation_error = Some(error.to_string());
+                break;
+            }
+            if let Err(error) = validate_recommendations(action, task_id, assessment) {
+                validation_error = Some(error.to_string());
+                break;
+            }
+            let current = match runtime.get_task(task_id) {
+                Ok(task) => task,
+                Err(OrbitError::NotFound { .. }) => {
+                    stale.push(stale_task(
+                        task_id,
+                        "task_deleted",
+                        "task no longer exists after preparation",
+                    ));
+                    continue;
+                }
+                Err(error) => {
+                    validation_error = Some(format!("reload task {task_id}: {error}"));
+                    break;
+                }
+            };
+            if let Some(reason) = task_snapshot_drift(&current, snapshot) {
+                stale.push(stale_task(task_id, reason.0, reason.1));
+                continue;
+            }
+            let admission = match ci_sweep_filing
+                .map(|filing| {
+                    ci_failure_admission::assess(
+                        action,
+                        task_id,
+                        &current,
+                        assessment,
+                        &after,
+                        filing,
+                        promotion_authorized,
+                    )
+                })
+                .transpose()
+            {
+                Ok(admission) => admission,
+                Err(error) => {
+                    validation_error = Some(error.to_string());
+                    break;
+                }
+            };
+            let promote = admission
+                .as_ref()
+                .is_some_and(|decision| decision["decision"] == "promote");
+            validated.push(ValidatedTask {
+                task_id: task_id.clone(),
+                after,
+                assessment: (*assessment).clone(),
+                admission,
+                promote,
+            });
+        }
+        if let Some(error) = validation_error {
+            partition_decisions.push(failed_partition(expected_index, &expected_ids, error));
+            continue;
+        }
+        if !stale.is_empty() {
+            partition_decisions.push(stale_partition(expected_index, &expected_ids, stale));
+            continue;
+        }
+
+        match apply_partition(runtime, &prepared_before, &validated) {
+            Ok(ApplyPartitionOutcome::Applied) => {
+                let mut applied_task_ids = Vec::with_capacity(validated.len());
+                for mut task in validated {
+                    let changed = prepared_before[&task.task_id].context_files != task.after;
+                    if let Value::Object(fields) = &mut task.assessment {
+                        fields.insert("applied".to_string(), Value::Bool(changed || task.promote));
+                        if let Some(admission) = task.admission.clone() {
+                            fields.insert("ci_sweep_admission".to_string(), admission);
+                        }
+                    }
+                    if let Some(admission) = task.admission {
+                        ci_sweep_admission.push(admission);
+                    }
+                    applied_task_ids.push(task.task_id);
+                    task_results.push(task.assessment);
+                }
+                partition_decisions.push(json!({
+                    "partition_index": expected_index,
+                    "task_ids": expected_ids,
+                    "outcome": "applied",
+                    "applied_task_ids": applied_task_ids,
+                }));
+            }
+            Ok(ApplyPartitionOutcome::Stale(stale)) => {
+                partition_decisions.push(stale_partition(expected_index, &expected_ids, stale));
+            }
+            Err(error) => {
+                partition_decisions.push(failed_partition(
+                    expected_index,
+                    &expected_ids,
+                    error.to_string(),
+                ));
+            }
+        }
+    }
+
+    if seen_task_ids.len() != prepared_before.len() {
+        return Err(action_failed(
+            action,
+            "prepared partitions did not cover every prepared task",
+        ));
+    }
+    for position in expected_partitions.len()..results.len() {
+        partition_decisions.push(json!({
+            "partition_index": Value::Null,
+            "task_ids": [],
+            "outcome": "failed",
+            "error": format!("unexpected extra partition result at position {position}"),
+        }));
+    }
+
+    let failed_partitions = partition_decisions
+        .iter()
+        .filter(|decision| decision["outcome"] == "failed")
+        .cloned()
+        .collect::<Vec<_>>();
+    let skipped_stale_partitions = partition_decisions
+        .iter()
+        .filter(|decision| decision["outcome"] == "skipped_stale")
+        .cloned()
+        .collect::<Vec<_>>();
+    let succeeded = failed_partitions.is_empty() && skipped_stale_partitions.is_empty();
+    let status = if succeeded { "succeeded" } else { "failed" };
+    let error = (!succeeded).then(|| {
+        format!(
+            "{} partition(s) failed and {} partition(s) were skipped as stale; valid partitions were applied",
+            failed_partitions.len(),
+            skipped_stale_partitions.len()
+        )
+    });
+
+    Ok(json!({
+        "status": status,
+        "error": error,
+        "mode": mode,
+        "workspace_path": workspace_root,
+        "discovery": {
+            "task_ids": prepared.get("task_ids").cloned().unwrap_or_else(|| json!([])),
+            "excluded": prepared.get("excluded").cloned().unwrap_or_else(|| json!([])),
+        },
+        "partition_decisions": partition_decisions,
+        "partition_count": expected_partitions.len(),
+        "received_partition_count": results.len(),
+        "failed_partitions": failed_partitions,
+        "skipped_stale_partitions": skipped_stale_partitions,
+        "tasks": task_results,
+        "ci_sweep_admission": ci_sweep_admission,
+    }))
+}
+
+enum ApplyPartitionOutcome {
+    Applied,
+    Stale(Vec<Value>),
+}
+
+fn apply_partition(
+    runtime: &OrbitRuntime,
+    snapshots: &BTreeMap<String, PreparedTaskSnapshot>,
+    tasks: &[ValidatedTask],
+) -> Result<ApplyPartitionOutcome, OrbitError> {
+    let mut task_ids = tasks
+        .iter()
+        .map(|task| task.task_id.clone())
+        .collect::<Vec<_>>();
+    task_ids.sort();
+    let mut outcome = None;
+    let mut operation = || {
+        let mut stale = Vec::new();
+        for task_id in &task_ids {
+            match runtime.get_task(task_id) {
+                Ok(current) => {
+                    if let Some(reason) = task_snapshot_drift(&current, &snapshots[task_id]) {
+                        stale.push(stale_task(task_id, reason.0, reason.1));
+                    }
+                }
+                Err(OrbitError::NotFound { .. }) => stale.push(stale_task(
+                    task_id,
+                    "task_deleted",
+                    "task no longer exists at the write boundary",
+                )),
+                Err(error) => return Err(error),
+            }
+        }
+        if !stale.is_empty() {
+            outcome = Some(ApplyPartitionOutcome::Stale(stale));
+            return Ok(());
+        }
+
+        for task in tasks.iter() {
+            let changed = snapshots[&task.task_id].context_files != task.after;
+            if changed || task.promote {
+                runtime.update_task(
+                    &task.task_id,
+                    TaskUpdateParams {
+                        context_files: changed.then_some(task.after.clone()),
+                        status: task.promote.then_some(TaskStatus::Backlog),
+                        comment: task.promote.then(|| {
+                            "CI-sweep admission: task-pilot validated current relevance and selectors; promoted proposed repair to backlog."
+                                .to_string()
+                        }),
+                        ..TaskUpdateParams::default()
+                    },
+                )?;
+            }
+        }
+        outcome = Some(ApplyPartitionOutcome::Applied);
+        Ok(())
+    };
+    with_task_locks(runtime, &task_ids, 0, &mut operation)?;
+    outcome.ok_or_else(|| {
+        OrbitError::Execution("task-pilot partition operation did not run".to_string())
+    })
+}
+
+fn with_task_locks(
+    runtime: &OrbitRuntime,
+    task_ids: &[String],
+    index: usize,
+    operation: &mut dyn FnMut() -> Result<(), OrbitError>,
+) -> Result<(), OrbitError> {
+    let Some(task_id) = task_ids.get(index) else {
+        return operation();
+    };
+    let mut nested = || with_task_locks(runtime, task_ids, index + 1, operation);
+    runtime
+        .stores()
+        .tasks()
+        .with_task_write_lock(task_id, &mut nested)
+}
+
+fn task_snapshot_drift(
+    current: &Task,
+    snapshot: &PreparedTaskSnapshot,
+) -> Option<(&'static str, &'static str)> {
+    if current.context_files != snapshot.context_files {
+        Some((
+            "context_files_changed",
+            "task context_files changed after preparation",
+        ))
+    } else if current.status != snapshot.status {
+        Some(("status_changed", "task status changed after preparation"))
+    } else if current.title != snapshot.title {
+        Some(("title_changed", "task title changed after preparation"))
+    } else if current.tags != snapshot.tags {
+        Some(("tags_changed", "task tags changed after preparation"))
+    } else {
+        None
+    }
+}
+
+fn stale_task(task_id: &str, reason: &str, detail: &str) -> Value {
+    json!({ "task_id": task_id, "reason": reason, "detail": detail })
+}
+
+fn failed_partition(partition_index: u64, task_ids: &[String], error: String) -> Value {
+    json!({
+        "partition_index": partition_index,
+        "task_ids": task_ids,
+        "outcome": "failed",
+        "error": error,
+    })
+}
+
+fn stale_partition(partition_index: u64, task_ids: &[String], stale: Vec<Value>) -> Value {
+    json!({
+        "partition_index": partition_index,
+        "task_ids": task_ids,
+        "outcome": "skipped_stale",
+        "stale_tasks": stale,
+        "applied_task_ids": [],
+    })
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -1,4 +1,6 @@
+use chrono::Utc;
 use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::{JobRunState, PipelineState};
 use serde_json::{Value, json};
 
 use super::super::task_pilot::{apply, prepare};
@@ -6,7 +8,7 @@ use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_layout, write_workspace_file,
 };
-use crate::application::task::TaskAddParams;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
 
 fn seed_task(
     runtime: &OrbitRuntime,
@@ -36,15 +38,48 @@ fn seed_task(
 }
 
 fn prepared(runtime: &OrbitRuntime, repo_root: &std::path::Path, task_ids: &[String]) -> Value {
+    prepared_with_partition_size(runtime, repo_root, task_ids, 5)
+}
+
+fn prepared_with_partition_size(
+    runtime: &OrbitRuntime,
+    repo_root: &std::path::Path,
+    task_ids: &[String],
+    max_partition_size: usize,
+) -> Value {
     prepare(
         runtime,
         "prepare_task_pilot",
         &json!({
             "task_ids": task_ids,
             "workspace_path": repo_root,
+            "max_partition_size": max_partition_size,
         }),
     )
     .expect("prepare explicit task-pilot selection")
+}
+
+fn seed_active_preparation(runtime: &OrbitRuntime, prepared: Value) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_pilot_pipeline", 1, Utc::now(), Some(json!({})), None)
+        .expect("insert active pilot run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("mark pilot run running");
+    let mut state = PipelineState::new(
+        run.run_id.clone(),
+        "task_pilot_pipeline".to_string(),
+        json!({}),
+    );
+    state.record_step(0, JobRunState::Success, Some(prepared), None);
+    runtime
+        .write_run_state(&run.run_id, &state)
+        .expect("checkpoint prepared pilot output");
+    run.run_id
 }
 
 fn selector_assessment(task: &Task, after: Vec<&str>) -> Value {
@@ -163,6 +198,60 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
 }
 
 #[test]
+fn discovery_reuses_active_preparation_evidence_and_selects_only_new_work() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let already_prepared = seed_task(&runtime, "already prepared", TaskStatus::Backlog, &[], &[]);
+    let first_snapshot = prepared(
+        &runtime,
+        &repo_root,
+        std::slice::from_ref(&already_prepared.id),
+    );
+    let active_run_id = seed_active_preparation(&runtime, first_snapshot);
+    let new_task = seed_task(
+        &runtime,
+        "new after preparation",
+        TaskStatus::Backlog,
+        &[],
+        &[],
+    );
+
+    let output = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({ "workspace_path": repo_root }),
+    )
+    .expect("automatic discovery excludes durable active preparation");
+
+    assert_eq!(output["task_ids"], json!([new_task.id]));
+    assert!(output["excluded"].as_array().unwrap().iter().any(|entry| {
+        entry["task_id"] == already_prepared.id
+            && entry["reason"] == "active_pilot_prepared"
+            && entry["prepared_by_run_ids"] == json!([active_run_id])
+    }));
+}
+
+#[test]
+fn explicit_discovery_refuses_duplicate_active_preparation() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let task = seed_task(&runtime, "already prepared", TaskStatus::Backlog, &[], &[]);
+    let first_snapshot = prepared(&runtime, &repo_root, std::slice::from_ref(&task.id));
+    let active_run_id = seed_active_preparation(&runtime, first_snapshot);
+
+    let error = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": [task.id],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect_err("explicit overlap must not launch duplicate pilot work");
+
+    assert!(error.to_string().contains("already prepared"));
+    assert!(error.to_string().contains(&active_run_id));
+}
+
+#[test]
 fn explicit_mode_selects_exact_ids_even_with_nonempty_context_or_active_status() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "src/existing.rs");
@@ -250,7 +339,8 @@ fn apply_validates_all_results_then_mutates_context_files_only() {
     assert_eq!(after_alpha.plan, before_alpha.plan);
     assert_eq!(after_operational.title, before_operational.title);
     assert_eq!(after_operational.status, before_operational.status);
-    assert_eq!(output["status"], "success");
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "applied");
     assert_eq!(output["tasks"][0]["context_files_before"], json!([]));
     assert_eq!(
         output["tasks"][0]["context_files_after"],
@@ -281,7 +371,7 @@ fn invalid_selector_in_later_assessment_prevents_every_mutation() {
         ],
     );
 
-    let error = apply(
+    let output = apply(
         &runtime,
         "apply_task_pilot_results",
         &json!({
@@ -290,9 +380,16 @@ fn invalid_selector_in_later_assessment_prevents_every_mutation() {
             "workspace_path": repo_root,
         }),
     )
-    .expect_err("missing selector target must fail closed");
+    .expect("invalid partition is reported as durable output");
 
-    assert!(error.to_string().contains("does not resolve"));
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "failed");
+    assert!(
+        output["partition_decisions"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("does not resolve")
+    );
     assert!(
         runtime
             .get_task(&alpha.id)
@@ -301,6 +398,167 @@ fn invalid_selector_in_later_assessment_prevents_every_mutation() {
             .is_empty()
     );
     assert!(runtime.get_task(&beta.id).unwrap().context_files.is_empty());
+}
+
+#[test]
+fn stale_partition_does_not_discard_independent_valid_partition() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/first.rs");
+    write_workspace_file(&repo_root, "src/new.rs");
+    let first = seed_task(&runtime, "first pilot", TaskStatus::Backlog, &[], &[]);
+    let new_task = seed_task(&runtime, "new pilot", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![first.id.clone(), new_task.id.clone()];
+    let snapshot = prepared_with_partition_size(&runtime, &repo_root, &task_ids, 1);
+
+    runtime
+        .update_task(
+            &first.id,
+            TaskUpdateParams {
+                context_files: Some(vec!["file:src/first.rs".to_string()]),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("overlapping pilot applies the first task");
+
+    let mut stale_assessment = selector_assessment(&first, vec!["file:src/new.rs"]);
+    stale_assessment["context_files_before"] = json!(["file:src/first.rs"]);
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": snapshot,
+            "results": [
+                partition_result(
+                    0,
+                    std::slice::from_ref(&first.id),
+                    vec![stale_assessment],
+                ),
+                partition_result(
+                    1,
+                    std::slice::from_ref(&new_task.id),
+                    vec![selector_assessment(&new_task, vec!["file:src/new.rs"])],
+                ),
+            ],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("partition outcomes remain durable even when the run must fail");
+
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "skipped_stale");
+    assert_eq!(
+        output["partition_decisions"][0]["stale_tasks"][0]["reason"],
+        "reported_context_snapshot_mismatch"
+    );
+    assert_eq!(output["partition_decisions"][1]["outcome"], "applied");
+    assert_eq!(
+        runtime.get_task(&first.id).unwrap().context_files,
+        vec!["file:src/first.rs"]
+    );
+    assert_eq!(
+        runtime.get_task(&new_task.id).unwrap().context_files,
+        vec!["file:src/new.rs"]
+    );
+}
+
+#[test]
+fn malformed_partition_does_not_discard_independent_valid_partition() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/new.rs");
+    let malformed = seed_task(&runtime, "malformed", TaskStatus::Backlog, &[], &[]);
+    let valid = seed_task(&runtime, "valid", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![malformed.id.clone(), valid.id.clone()];
+    let snapshot = prepared_with_partition_size(&runtime, &repo_root, &task_ids, 1);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": snapshot,
+            "results": [
+                {"partition_index": 0, "task_ids": [malformed.id], "tasks": "invalid"},
+                partition_result(
+                    1,
+                    std::slice::from_ref(&valid.id),
+                    vec![selector_assessment(&valid, vec!["file:src/new.rs"])],
+                ),
+            ],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("malformed partition remains a durable failed decision");
+
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "failed");
+    assert_eq!(output["partition_decisions"][1]["outcome"], "applied");
+    assert!(
+        runtime
+            .get_task(&malformed.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+    assert_eq!(
+        runtime.get_task(&valid.id).unwrap().context_files,
+        vec!["file:src/new.rs"]
+    );
+}
+
+#[test]
+fn task_status_change_and_deletion_are_explicit_stale_outcomes() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/new.rs");
+    let changed = seed_task(&runtime, "status changed", TaskStatus::Backlog, &[], &[]);
+    let deleted = seed_task(&runtime, "deleted", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![changed.id.clone(), deleted.id.clone()];
+    let snapshot = prepared_with_partition_size(&runtime, &repo_root, &task_ids, 1);
+    runtime
+        .update_task(
+            &changed.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("operator advances task status");
+    runtime
+        .delete_task(&deleted.id)
+        .expect("operator deletes task");
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": snapshot,
+            "results": [
+                partition_result(
+                    0,
+                    std::slice::from_ref(&changed.id),
+                    vec![selector_assessment(&changed, vec!["file:src/new.rs"])],
+                ),
+                partition_result(
+                    1,
+                    std::slice::from_ref(&deleted.id),
+                    vec![selector_assessment(&deleted, vec!["file:src/new.rs"])],
+                ),
+            ],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("stale outcomes are structured instead of overwriting live state");
+
+    assert_eq!(
+        output["partition_decisions"][0]["stale_tasks"][0]["reason"],
+        "status_changed"
+    );
+    assert_eq!(
+        output["partition_decisions"][1]["stale_tasks"][0]["reason"],
+        "task_deleted"
+    );
+    assert_eq!(
+        runtime.get_task(&changed.id).unwrap().status,
+        TaskStatus::InProgress
+    );
 }
 
 #[test]
@@ -320,7 +578,7 @@ fn empty_context_requires_verified_no_diff_or_host_operational_evidence() {
         })],
     );
 
-    let error = apply(
+    let invalid_output = apply(
         &runtime,
         "apply_task_pilot_results",
         &json!({
@@ -329,8 +587,14 @@ fn empty_context_requires_verified_no_diff_or_host_operational_evidence() {
             "workspace_path": repo_root,
         }),
     )
-    .expect_err("unverified empty result must fail");
-    assert!(error.to_string().contains("verified_no_diff"));
+    .expect("invalid partition is retained as a failed decision");
+    assert_eq!(invalid_output["status"], "failed");
+    assert!(
+        invalid_output["partition_decisions"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("verified_no_diff")
+    );
 
     let valid_prepared = prepared(&runtime, &repo_root, &task_ids);
     let valid = partition_result(
@@ -385,7 +649,7 @@ fn out_of_workspace_selector_is_rejected_before_mutation() {
         })],
     );
 
-    let error = apply(
+    let output = apply(
         &runtime,
         "apply_task_pilot_results",
         &json!({
@@ -394,7 +658,13 @@ fn out_of_workspace_selector_is_rejected_before_mutation() {
             "workspace_path": repo_root,
         }),
     )
-    .expect_err("out-of-workspace selector must fail");
-    assert!(error.to_string().contains("inside workspace"));
+    .expect("out-of-workspace selector is retained as a failed decision");
+    assert_eq!(output["status"], "failed");
+    assert!(
+        output["partition_decisions"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("inside workspace")
+    );
     assert!(runtime.get_task(&task.id).unwrap().context_files.is_empty());
 }

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -440,7 +440,7 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
         defaults.get("crew").is_none(),
         "a job-input crew would be dead: the system-crew marker overwrites it before resolution"
     );
-    assert_eq!(asset.spec.steps.len(), 3);
+    assert_eq!(asset.spec.steps.len(), 4);
 
     let JobV2StepBody::TargetRef(prepare) = &asset.spec.steps[0].body else {
         panic!("task pilot preparation must be deterministic activity reference");
@@ -494,6 +494,15 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
         apply_input.get("crew").is_none() && apply_input.get("system_crew").is_none(),
         "the deterministic apply step must carry no crew key: it cannot receive the \
          system-crew injection, which only runs for agent-loop targets"
+    );
+
+    let JobV2StepBody::TargetRef(require_success) = &asset.spec.steps[3].body else {
+        panic!("task pilot must guard the durable partition apply result");
+    };
+    assert_eq!(require_success.target, "activity:pipeline_success_guard");
+    assert_eq!(
+        require_success.default_input.as_ref().expect("guard input")["result"],
+        "{{ steps.apply.output }}"
     );
     assert!(
         !yaml.contains("crew: luna") && !yaml.contains("{{ input.crew }}"),

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -75,8 +75,12 @@ orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exa
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
 workspace whose `context_files` is empty, and skips tasks tagged as needing no
-diff. Explicit `task_ids` audits exactly the named tasks, including ones that
-already have selectors.
+diff. It also excludes a task already named by the durable prepare checkpoint
+of an active pilot run and reports the owning run ID, so a later discovery run
+can inspect new work without repeating the expensive assessment. Explicit
+`task_ids` audits exactly the named tasks, including ones that already have
+selectors, but refuses an ID already prepared by an active run; inspect or
+resume the named run instead.
 
 The pilot agent inspection is read-only; its deterministic apply step mutates
 validated task selectors. It runs five
@@ -86,6 +90,15 @@ workspace routine may already run the zero-input job every few hours — an extr
 run before a large dispatch is still appropriate.
 The task-pilot pipeline never promotes tasks or dispatches them; promotion and
 shipping remain separate operator-authorized steps.
+
+Apply is isolated by partition. A stale task snapshot or malformed assessment
+leaves that whole partition untouched while independently valid partitions are
+still applied. The run then fails deliberately, and its durable apply output
+lists each partition as `applied`, `skipped_stale`, or `failed`, plus the exact
+task IDs actually applied. `orbit run show <run_id>` is therefore the recovery
+source of truth. Resuming the failed run reuses its successful prepare, pilot,
+and apply checkpoints (it does not rerun those agents); start a fresh zero-input
+pilot only for tasks that remain empty after reviewing the recorded outcomes.
 
 ## Keeping parallel runs off each other
 


### PR DESCRIPTION
## Task

[ORB-11233](https://orbit-cli.com/tasks/ORB-11233) — Keep overlapping pilot preparation from discarding unrelated valid partitions

### Description

Live incident: task_pilot_pipeline jrun-20260905-0324 prepared11225-11228; a later zero-input0334 prepared those still-empty tasks plus11229-11231 while0324 remained live.0324 applied at03:35:18.0334 partition0 finished501657ms and partition1 (new website/completion repair11230/31) finished252120ms, but whole apply failed03:43:16: task ORB-11225 context_files_before does not match the prepared snapshot. Thus unrelated valid new critical work lost its application after8min despite successful read-only assessments. Preserve stale-snapshot/CAS safeguards absolutely: never overwrite task context or statuses changed by another pilot, worker, or operator. Improve the existing preparation/apply flow so overlapping preparation is prevented or detected cheaply, and a stale task/partition cannot discard independently valid partition results. Reuse durable run/partition evidence; do not introduce another scheduler, broad leases, or blind retries. Report per-partition applied/skipped-stale/failed outcomes truthfully, including any total run failure, so an orchestrator can promote only tasks actually prepared/applied. Keep invalid/malformed output fail-closed within its declared atomicity boundary. Existing live drift must not be treated as permission to write. Current recovery is fresh zero-input0344, which excludes already-prepared tasks. Inspect current task-pilot tests and contract before choosing minimal behavior.

### Acceptance Criteria

- Synchronized fixture with overlapping pilots reproduces current interference; changed task context is never overwritten.
- Independent valid partition containing a new task can be applied or safely resumed without rerunning its agent when another partition is stale; durable output clearly identifies what did and did not apply.
- Discovery handles already-running preparation without duplicate expensive work where existing durable state permits; no fabricated prepared status or invisible approval.
- Malformed/invalid output and actual task deletion/status/context changes remain explicit and fail closed; required Orbit checks pass and operator guidance covers recovery.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Automatic and explicit preparation now consult successful prepare checkpoints from active task-pilot runs. Automatic discovery excludes already-prepared tasks with owning run IDs while still selecting newly arrived work; explicit overlap fails with recovery guidance before dispatching duplicate agents.
- Apply now validates and writes per partition. Stale context, status, title, tags, deletion, malformed assessments, and selector failures leave that partition untouched while independent valid partitions apply. Sorted nested task locks recheck the complete snapshot at the write boundary.
- Apply emits durable applied/skipped_stale/failed partition decisions and the pipeline guard deliberately fails a partial total run after the apply checkpoint, so resume reuses agent and apply checkpoints instead of repeating expensive pilots.
- Seeded/workspace activity and job contracts plus mirrored orchestration guidance describe outcome inspection and recovery. Regression fixtures reproduce the overlapping-pilot incident and verify valid new work survives stale or malformed siblings.
- Added file:crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs beyond the initial inventory to keep discovery and apply responsibilities below the repository file-size warning.
Assessment: The stale-snapshot safeguards remain fail-closed at each partition and are rechecked under task locks; no task field is overwritten after observed drift. Active-run suppression relies only on successful durable prepare checkpoints and does not fabricate claims when no checkpoint exists.
Validation:
- cargo test -p orbit-core task_pilot -- --nocapture
- cargo test -p orbit-core application::job::tests::catalog -- --nocapture
- cargo test -p orbit-core bootstrap::activity::tests -- --nocapture
- make ci-fast
- make ci-lint
All passed. Removed the run-created 5.2 GiB target directory with cargo clean after validation.
Friction: Filed F2026-09-007 for the live overlap incident root cause.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11233-6a9b9861`
- Behind base: 0
- Ahead of base: 1