### PR TITLE
Continue --complete polling when repository auto-merge is disabled

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/operations.rs
@@ -247,7 +247,7 @@ fn pr_merge_capabilities(input: &Value) -> Result<Value, OrbitError> {
         ))
     })?;
 
-    let query = "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){mergeCommitAllowed rebaseMergeAllowed squashMergeAllowed pullRequest(number:$number){baseRefName baseRef{branchProtectionRule{requiresLinearHistory}}}}}";
+    let query = "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){autoMergeAllowed mergeCommitAllowed rebaseMergeAllowed squashMergeAllowed pullRequest(number:$number){baseRefName baseRef{branchProtectionRule{requiresLinearHistory}}}}}";
     let response = execute(
         "gh",
         vec![
@@ -349,6 +349,7 @@ pub(super) fn normalize_merge_capabilities(
             "allow_squash_merge": required_bool("squashMergeAllowed")?,
             "allow_rebase_merge": required_bool("rebaseMergeAllowed")?,
             "allow_merge_commit": required_bool("mergeCommitAllowed")?,
+            "allow_auto_merge": required_bool("autoMergeAllowed")?,
             "requires_linear_history": requires_linear_history,
         }
     }))

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
@@ -30,7 +30,7 @@ use super::super::super::input::input_string_field;
 use super::super::super::task_update::{authorization_note, complete_tasks};
 use super::super::handoff::load_handoff_context;
 use super::super::operations;
-use super::merge::{MergeStrategy, resolve_merge_strategy};
+use super::merge::{MergeCapabilities, MergeStrategy, resolve_merge_capabilities};
 
 /// Default budget for waiting out required checks before giving up.
 const DEFAULT_MAX_WAIT_SECONDS: u64 = 3600;
@@ -94,7 +94,7 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
     let mut waited_seconds = 0_u64;
     let mut auto_merge_requested = false;
     let mut merge_requested = false;
-    let mut merge_strategy = None;
+    let mut merge_capabilities: Option<MergeCapabilities> = None;
 
     loop {
         let status = read_pr_status(host, workspace_path, pr_number)?;
@@ -103,7 +103,7 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                 return Ok(json!({
                     "merged": true,
                     "pr_number": pr_number,
-                    "strategy": merge_strategy.map(MergeStrategy::as_str),
+                    "strategy": merge_capabilities.map(|capabilities| capabilities.strategy.as_str()),
                     "auto_merge_requested": auto_merge_requested,
                     "waited_seconds": waited_seconds,
                 }));
@@ -123,17 +123,26 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
             }
             PrMergeState::Mergeable => {
                 if !merge_requested {
-                    let strategy =
-                        resolved_strategy(host, workspace_path, pr_number, &mut merge_strategy)?;
-                    request_merge(host, workspace_path, pr_number, strategy, false).map_err(
-                        |error| {
-                            OrbitError::Execution(format!(
-                                "pr_complete: could not request {} merge on pull request \
-                                 #{pr_number}: {error}; the task stays in review",
-                                strategy.as_str()
-                            ))
-                        },
+                    let capabilities = resolved_capabilities(
+                        host,
+                        workspace_path,
+                        pr_number,
+                        &mut merge_capabilities,
                     )?;
+                    request_merge(
+                        host,
+                        workspace_path,
+                        pr_number,
+                        capabilities.strategy,
+                        false,
+                    )
+                    .map_err(|error| {
+                        OrbitError::Execution(format!(
+                            "pr_complete: could not request {} merge on pull request \
+                                 #{pr_number}: {error}; the task stays in review",
+                            capabilities.strategy.as_str()
+                        ))
+                    })?;
                     merge_requested = true;
                     // Re-read rather than assuming the request landed.
                     continue;
@@ -142,20 +151,28 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
             PrMergeState::Pending => {
                 if !auto_merge_requested {
                     // Required checks are still running. Hand the merge to
-                    // GitHub's auto-merge so it lands the moment they pass,
-                    // then keep polling: enabling it is not success.
-                    let strategy =
-                        resolved_strategy(host, workspace_path, pr_number, &mut merge_strategy)?;
-                    request_merge(host, workspace_path, pr_number, strategy, true).map_err(
-                        |error| {
-                            OrbitError::Execution(format!(
-                                "pr_complete: could not enable auto-merge using {} on pull request \
-                                 #{pr_number}: {error}; the task stays in review",
-                                strategy.as_str()
-                            ))
-                        },
+                    // GitHub's auto-merge when this repository allows it, then
+                    // keep polling: enabling it is not success. Repositories
+                    // with auto-merge disabled instead wait for a normally
+                    // mergeable state, at which point the ordinary merge path
+                    // above makes the same permitted request.
+                    let capabilities = resolved_capabilities(
+                        host,
+                        workspace_path,
+                        pr_number,
+                        &mut merge_capabilities,
                     )?;
-                    auto_merge_requested = true;
+                    if capabilities.auto_merge_allowed {
+                        request_merge(host, workspace_path, pr_number, capabilities.strategy, true)
+                            .map_err(|error| {
+                                OrbitError::Execution(format!(
+                                    "pr_complete: could not enable auto-merge using {} on pull request \
+                                     #{pr_number}: {error}; the task stays in review",
+                                    capabilities.strategy.as_str()
+                                ))
+                            })?;
+                        auto_merge_requested = true;
+                    }
                 }
             }
         }
@@ -256,23 +273,24 @@ fn request_merge<H: RuntimeHost + ?Sized>(
     .map(|_| ())
 }
 
-fn resolved_strategy<H: RuntimeHost + ?Sized>(
+fn resolved_capabilities<H: RuntimeHost + ?Sized>(
     host: &H,
     workspace_path: &str,
     pr_number: &str,
-    selected: &mut Option<MergeStrategy>,
-) -> Result<MergeStrategy, OrbitError> {
-    if let Some(strategy) = *selected {
-        return Ok(strategy);
+    selected: &mut Option<MergeCapabilities>,
+) -> Result<MergeCapabilities, OrbitError> {
+    if let Some(capabilities) = *selected {
+        return Ok(capabilities);
     }
-    let strategy = resolve_merge_strategy(host, workspace_path, pr_number).map_err(|error| {
-        OrbitError::Execution(format!(
-            "pr_complete: could not resolve a permitted merge method for pull request \
+    let capabilities =
+        resolve_merge_capabilities(host, workspace_path, pr_number).map_err(|error| {
+            OrbitError::Execution(format!(
+                "pr_complete: could not resolve a permitted merge method for pull request \
              #{pr_number}: {error}; the task stays in review"
-        ))
-    })?;
-    *selected = Some(strategy);
-    Ok(strategy)
+            ))
+        })?;
+    *selected = Some(capabilities);
+    Ok(capabilities)
 }
 
 fn resolve_pr_number(input: &Value, tasks: &[Task]) -> Result<String, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/merge.rs
@@ -22,6 +22,13 @@ pub(super) enum MergeStrategy {
     Merge,
 }
 
+/// Repository capabilities needed to request a permitted PR merge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MergeCapabilities {
+    pub(super) strategy: MergeStrategy,
+    pub(super) auto_merge_allowed: bool,
+}
+
 impl MergeStrategy {
     pub(super) const fn as_str(self) -> &'static str {
         match self {
@@ -37,6 +44,14 @@ pub(super) fn resolve_merge_strategy<H: RuntimeHost + ?Sized>(
     workspace_path: &str,
     pr_number: &str,
 ) -> Result<MergeStrategy, OrbitError> {
+    Ok(resolve_merge_capabilities(host, workspace_path, pr_number)?.strategy)
+}
+
+pub(super) fn resolve_merge_capabilities<H: RuntimeHost + ?Sized>(
+    host: &H,
+    workspace_path: &str,
+    pr_number: &str,
+) -> Result<MergeCapabilities, OrbitError> {
     let response = host.run_private_vcs_operation(
         operations::PR_MERGE_CAPABILITIES,
         json!({
@@ -61,15 +76,25 @@ pub(super) fn resolve_merge_strategy<H: RuntimeHost + ?Sized>(
     let rebase = capability("allow_rebase_merge")?;
     let merge = capability("allow_merge_commit")?;
     let linear = capability("requires_linear_history")?;
+    let auto_merge_allowed = capability("allow_auto_merge")?;
 
     if squash {
-        return Ok(MergeStrategy::Squash);
+        return Ok(MergeCapabilities {
+            strategy: MergeStrategy::Squash,
+            auto_merge_allowed,
+        });
     }
     if rebase {
-        return Ok(MergeStrategy::Rebase);
+        return Ok(MergeCapabilities {
+            strategy: MergeStrategy::Rebase,
+            auto_merge_allowed,
+        });
     }
     if merge && !linear {
-        return Ok(MergeStrategy::Merge);
+        return Ok(MergeCapabilities {
+            strategy: MergeStrategy::Merge,
+            auto_merge_allowed,
+        });
     }
 
     let repository_name = repository

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
@@ -23,6 +23,44 @@ fn host(tasks: Vec<orbit_types::task::Task>) -> (tempfile::TempDir, PrOpenTestHo
     (root, host)
 }
 
+/// Without repository auto-merge, settling checks are polled until GitHub
+/// reports a normal mergeable state, then the permitted ordinary merge is used.
+#[test]
+fn pending_checks_with_auto_merge_disabled_wait_for_an_ordinary_merge() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("PENDING"), state("CLEAN"), merged_state()]);
+    host.queue_merge_capabilities_with_auto_merge(true, true, true, true, false);
+
+    let mut input = complete_input(root.path(), &["T1"]);
+    input["max_wait_seconds"] = json!(1);
+    let output = pr_complete(&host, &input).expect("complete after checks settle");
+
+    assert_eq!(output["merge"]["merged"], true);
+    assert_eq!(output["merge"]["auto_merge_requested"], false);
+    let merges = merge_calls(&host);
+    assert_eq!(merges.len(), 1, "only the ordinary merge is requested");
+    assert_eq!(merges[0]["auto"], false);
+    assert_eq!(merges[0]["strategy"], "squash");
+    assert_eq!(host.task_status("T1"), TaskStatus::Done);
+}
+
+#[test]
+fn pending_checks_with_auto_merge_disabled_time_out_in_review() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("PENDING")]);
+    host.queue_merge_capabilities_with_auto_merge(true, true, true, true, false);
+
+    let error = pr_complete(&host, &complete_input(root.path(), &["T1"]))
+        .expect_err("pending checks must respect the completion deadline");
+
+    assert!(error.to_string().contains("timed out"), "{error}");
+    assert!(
+        merge_calls(&host).is_empty(),
+        "disabled auto-merge is never requested"
+    );
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
+}
+
 fn complete_input(workspace_path: &std::path::Path, task_ids: &[&str]) -> Value {
     json!({
         "job_run_id": "batch-1",

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -149,6 +149,23 @@ impl PrOpenTestHost {
         merge: bool,
         requires_linear_history: bool,
     ) {
+        self.queue_merge_capabilities_with_auto_merge(
+            squash,
+            rebase,
+            merge,
+            requires_linear_history,
+            true,
+        );
+    }
+
+    pub fn queue_merge_capabilities_with_auto_merge(
+        &self,
+        squash: bool,
+        rebase: bool,
+        merge: bool,
+        requires_linear_history: bool,
+        allow_auto_merge: bool,
+    ) {
         self.queue_vcs_result(
             operations::PR_MERGE_CAPABILITIES,
             json!({
@@ -158,6 +175,7 @@ impl PrOpenTestHost {
                     "allow_squash_merge": squash,
                     "allow_rebase_merge": rebase,
                     "allow_merge_commit": merge,
+                    "allow_auto_merge": allow_auto_merge,
                     "requires_linear_history": requires_linear_history,
                 }
             }),
@@ -407,6 +425,7 @@ impl RuntimeHost for PrOpenTestHost {
                     "allow_squash_merge": true,
                     "allow_rebase_merge": true,
                     "allow_merge_commit": true,
+                    "allow_auto_merge": true,
                     "requires_linear_history": true,
                 }
             })),

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
@@ -8,6 +8,7 @@ fn private_vcs_boundary_normalizes_repository_and_branch_merge_policy() {
         &json!({
             "data": {
                 "repository": {
+                    "autoMergeAllowed": true,
                     "squashMergeAllowed": false,
                     "rebaseMergeAllowed": true,
                     "mergeCommitAllowed": true,
@@ -35,6 +36,7 @@ fn private_vcs_boundary_normalizes_repository_and_branch_merge_policy() {
                 "allow_squash_merge": false,
                 "allow_rebase_merge": true,
                 "allow_merge_commit": true,
+                "allow_auto_merge": true,
                 "requires_linear_history": true,
             }
         })


### PR DESCRIPTION
## Task

[ORB-11247](https://orbit-cli.com/tasks/ORB-11247) — Continue --complete polling when repository auto-merge is disabled

### Description

Live failure ORB-11230 jrun-20260905-0423-3 at complete_pr for PR1323: GraphQL Auto merge is not allowed for this repository (enablePullRequestAutoMerge). Implementation and website checks passed; PR subsequently reported MERGEABLE/UNSTABLE. Current crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs drive_pr_to_merged classifies pending/UNKNOWN then unconditionally requests GitHub auto-merge and fails immediately if disabled. ORB-11231 fixed permitted merge strategies and truthful failure handoff, but still has this unconditional pending branch. --complete already owns a bounded poll loop, so it must be able to wait for normal mergeability and issue an ordinary allowed merge without requiring repository auto-merge enablement. Query applicable capability through existing private VCS seam. Distinguish settling UNKNOWN from genuinely blocked gates; do not weaken required checks/reviews, turn on repository settings, or retry arbitrary permission/API errors as if success. Preserve verified-MERGED-before-done, allowed method selection and deadline semantics.

### Acceptance Criteria

- With auto-merge disabled, a settling/pending PR that becomes normally mergeable completes with the permitted ordinary strategy and verified MERGED.
- A genuinely blocked PR remains explicitly blocked/review recovery; disabled auto-merge is distinct from unrelated API/permission failure.
- Deterministic regressions cover pending-to-mergeable, pending timeout, already merged and enabled auto-merge paths; no real sleeps or live GitHub writes in tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extended the existing private PR merge-capabilities query with GitHub repository auto-merge availability and preserved fail-closed capability parsing.
- When a PR is PENDING/UNKNOWN and auto-merge is disabled, completion now keeps its bounded poll loop alive; once normally mergeable, it issues the already-selected ordinary permitted merge and still verifies MERGED before task completion.
- Added deterministic fake-VCS regressions for disabled-auto-merge pending-to-mergeable and deadline timeout; retained enabled auto-merge, already-merged, blocked, and API/permission failure coverage.
Assessment: Completion does not mutate repository settings or bypass protection. Disabled auto-merge is a capability branch, while failed capability/merge operations remain explicit failures that leave work in review.
Validation:
- cargo fmt --check
- cargo test -p orbit-engine executor::automation::vcs::pr::tests::complete --lib (21 passed)
- cargo test -p orbit-engine executor::automation::vcs::tests::operations --lib (3 passed)
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11247-6a9b9d80`
- Behind base: 0
- Ahead of base: 1