### PR TITLE
[code-review] CI-failure sweep files nothing when checkout-evidence hits any bound, including display caps

### DIFF
--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -678,6 +678,13 @@ fn investigate<Q: CiQueries + ?Sized>(
             failure["checkout_evidence"] = json!(log.checkout_evidence);
             failure["checkout_evidence_scope"] = json!("all");
             set_checkout_identity(failure, "all", &log);
+            // A genuinely incomplete scan (the source-byte cap, or a dropped
+            // overlong line that could have carried checkout identity) stays
+            // fail-closed even when one SHA was already found: it cannot rule
+            // out a later, conflicting identity past whatever it didn't
+            // manage to read. Only a *display* cap (evidence line/commit
+            // count, or an overlong line unrelated to checkout) is exempt —
+            // that never touches `checkout_evidence_complete`.
             if !log.checkout_evidence_complete {
                 push_retryable_error(
                     retryable_errors,
@@ -686,11 +693,7 @@ fn investigate<Q: CiQueries + ?Sized>(
                     failure.get("run_id"),
                     "checkout evidence scan reached its hard limit; actual checkout identity is incomplete",
                 );
-            } else if failure
-                .get("actual_checkout_shas")
-                .and_then(Value::as_array)
-                .is_none_or(Vec::is_empty)
-            {
+            } else if log.checkout_commits.is_empty() {
                 push_retryable_error(
                     retryable_errors,
                     "registration",
@@ -727,6 +730,7 @@ fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::R
     failure["checkout_evidence_complete"] = json!(log.checkout_evidence_complete);
     failure["checkout_evidence_scanned_bytes"] = json!(log.checkout_evidence_scanned_bytes);
     failure["checkout_evidence_source_truncated"] = json!(log.checkout_evidence_source_truncated);
+    failure["checkout_evidence_display_truncated"] = json!(log.checkout_evidence_display_truncated);
     failure["checkout_identity"] = json!({
         "state": state,
         "observed_shas": log.checkout_commits,
@@ -736,6 +740,10 @@ fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::R
             "complete": log.checkout_evidence_complete,
             "scanned_bytes": log.checkout_evidence_scanned_bytes,
             "source_truncated": log.checkout_evidence_source_truncated,
+            // Display caps (evidence line/commit count, or an unrelated
+            // overlong line) reduce what is reported without bearing on
+            // whether identity itself was captured; see `complete` for that.
+            "display_truncated": log.checkout_evidence_display_truncated,
         },
     });
 }

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -79,6 +79,7 @@ pub(super) struct RunLog {
     pub(super) checkout_evidence_complete: bool,
     pub(super) checkout_evidence_scanned_bytes: usize,
     pub(super) checkout_evidence_source_truncated: bool,
+    pub(super) checkout_evidence_display_truncated: bool,
 }
 
 /// Cap on returned checkout-evidence lines, mirroring `github.run.logs`.
@@ -247,6 +248,7 @@ impl CiQueries for HostCiQueries {
             checkout_evidence_complete: log.checkout_evidence.complete,
             checkout_evidence_scanned_bytes: log.checkout_evidence.scanned_bytes,
             checkout_evidence_source_truncated: log.checkout_evidence.source_truncated,
+            checkout_evidence_display_truncated: log.checkout_evidence.display_truncated,
         })
     }
 
@@ -281,5 +283,6 @@ pub(super) fn bounded_run_log(raw: &str, max_bytes: usize) -> RunLog {
         checkout_evidence_complete: evidence.complete,
         checkout_evidence_scanned_bytes: evidence.scanned_bytes,
         checkout_evidence_source_truncated: evidence.source_truncated,
+        checkout_evidence_display_truncated: evidence.display_truncated,
     }
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -732,6 +732,187 @@ fn investigation_failure_keeps_the_current_run_visible_and_retryable() {
     );
 }
 
+/// ORB-11248: a matrix workflow with enough jobs pushes the checkout-evidence
+/// line/commit display cap without the scan itself missing anything. That
+/// alone must not stop the failure from being filed.
+#[test]
+fn checkout_evidence_display_cap_alone_does_not_block_filing() {
+    let sha = "3".repeat(40);
+    let mut full_log = format!("ci\tCheckout\t2026-08-30T01:00:00Z HEAD is now at {sha}\n");
+    for _ in 0..45 {
+        full_log.push_str("ci\tCheckout\t2026-08-30T01:00:00Z Checking out the ref\n");
+    }
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log("10", true, &full_log);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["actual_checkout_shas"], json!([sha]));
+    assert_eq!(failure["checkout_identity"]["state"], json!("observed"));
+    assert_eq!(failure["checkout_evidence_display_truncated"], json!(true));
+    assert_eq!(failure["checkout_evidence_complete"], json!(true));
+    assert_eq!(failure["investigated"], json!(true));
+    assert_eq!(evidence["retryable_errors"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+}
+
+/// A dropped overlong line that could have carried checkout identity leaves
+/// the scan genuinely incomplete. A SHA found elsewhere in the same log does
+/// not lift that: the scan cannot rule out a later, conflicting identity past
+/// whatever it failed to read, so this must stay fail-closed (retryable), not
+/// be filed on a partial read.
+#[test]
+fn a_genuinely_incomplete_scan_stays_retryable_even_when_a_sha_was_found() {
+    let sha = "4".repeat(40);
+    let overlong = "x".repeat(20_000);
+    let full_log = format!(
+        "ci\tCheckout\t2026-08-30T01:00:00Z HEAD is now at {sha}\n\
+         ci\tCheckout\t2026-08-30T01:00:01Z {overlong}\n"
+    );
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log("10", true, &full_log);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["actual_checkout_shas"], json!([sha]));
+    assert_eq!(failure["checkout_evidence_complete"], json!(false));
+    assert_eq!(failure["checkout_identity"]["state"], json!("incomplete"));
+    assert_eq!(failure["investigated"], json!(false));
+    let errors = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
+    assert!(
+        errors.iter().any(|error| {
+            error["operation"] == json!("checkout_evidence")
+                && error["message"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("identity is incomplete"))
+        }),
+        "a genuine partial scan must stay retryable even with a SHA found: {errors:?}"
+    );
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+}
+
+/// The other half of the same distinction: when the scan is incomplete *and*
+/// no SHA was found anywhere, there is genuinely insufficient evidence and
+/// the failure must stay retryable rather than being filed on a guess.
+#[test]
+fn an_incomplete_scan_with_no_sha_found_stays_retryable() {
+    let overlong = "z".repeat(20_000);
+    let full_log = format!("ci\tCheckout\t2026-08-30T01:00:00Z {overlong}\n");
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log("10", true, &full_log);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["actual_checkout_shas"], json!([]));
+    assert_eq!(failure["checkout_identity"]["state"], json!("incomplete"));
+    assert_eq!(failure["investigated"], json!(false));
+    let errors = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
+    assert!(
+        errors.iter().any(|error| {
+            error["operation"] == json!("checkout_evidence")
+                && error["message"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("identity is incomplete"))
+        }),
+        "insufficient evidence must stay retryable and auditable: {errors:?}"
+    );
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+}
+
+/// A completely absent checkout step (no markers anywhere in the full log) is
+/// a distinct, complete-scan case: it must be reported as "missing" identity,
+/// not conflated with an incomplete scan, and still stays retryable since
+/// there is no evidence at all to file on.
+#[test]
+fn a_complete_scan_with_no_checkout_step_reports_missing_identity() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            10,
+            "ci",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T01:00:00Z",
+        )]])
+        .with_run_view(
+            "10",
+            json!({"failed_jobs": [{"job_id": 5, "name": "build", "conclusion": "failure"}]}),
+        )
+        .with_log("10", false, "ci\tbuild\tassertion failed\n")
+        .with_log("10", true, "ci\tbuild\tno checkout markers here\n");
+
+    let evidence = collect(&queries, &input()).expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["checkout_evidence_complete"], json!(true));
+    assert_eq!(failure["checkout_identity"]["state"], json!("missing"));
+    assert_eq!(failure["investigated"], json!(false));
+    let errors = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
+    assert!(
+        errors.iter().any(|error| {
+            error["operation"] == json!("checkout_evidence")
+                && error["message"] == json!("run logs contained no actual checkout SHA")
+        }),
+        "{errors:?}"
+    );
+}
+
 #[test]
 fn live_failure_fixture_is_latest_current_and_evidence_complete() {
     const EVENT_SHA: &str = "2a4cb4e4631a856552d901b6b062fa6596475cc0";

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -331,9 +331,18 @@ const MAX_CHECKOUT_EVIDENCE_LINE_BYTES: usize = 16 * 1024;
 pub struct CheckoutEvidence {
     pub commits: Vec<String>,
     pub lines: Vec<String>,
+    /// False only when identity itself may have been missed: the source byte
+    /// cap (`source_truncated`) was hit, or a dropped overlong line could
+    /// plausibly have carried checkout identity. A reduced *display* — the
+    /// evidence line/commit count cap, or an overlong line unrelated to
+    /// checkout — does not clear this; see `display_truncated`.
     pub complete: bool,
     pub scanned_bytes: usize,
     pub source_truncated: bool,
+    /// True when what is reported was capped for display reasons that do not
+    /// bear on checkout identity: the evidence line or commit count limit was
+    /// reached, or an overlong line unrelated to checkout was dropped.
+    pub display_truncated: bool,
 }
 
 /// A bounded excerpt and checkout evidence collected while a log is drained.
@@ -424,6 +433,7 @@ struct CheckoutEvidenceCollector {
     seen_commits: HashSet<String>,
     lines: Vec<String>,
     complete: bool,
+    display_truncated: bool,
 }
 
 impl CheckoutEvidenceCollector {
@@ -439,6 +449,7 @@ impl CheckoutEvidenceCollector {
             seen_commits: HashSet::new(),
             lines: Vec::new(),
             complete: true,
+            display_truncated: false,
         }
     }
 
@@ -458,9 +469,14 @@ impl CheckoutEvidenceCollector {
                 continue;
             }
             if self.pending_line.len() + part.len() > MAX_CHECKOUT_EVIDENCE_LINE_BYTES {
+                let identity_bearing = overlong_line_is_identity_bearing(&self.pending_line, part);
                 self.pending_line.clear();
                 self.dropping_line = !part.ends_with('\n');
-                self.complete = false;
+                if identity_bearing {
+                    self.complete = false;
+                } else {
+                    self.display_truncated = true;
+                }
                 continue;
             }
             self.pending_line.push_str(part);
@@ -480,6 +496,7 @@ impl CheckoutEvidenceCollector {
             complete: self.complete,
             scanned_bytes: self.scanned_bytes,
             source_truncated: self.source_truncated,
+            display_truncated: self.display_truncated,
         }
     }
 
@@ -497,14 +514,14 @@ impl CheckoutEvidenceCollector {
         if self.lines.len() < self.max_lines {
             self.lines.push(redact_all(payload.trim()));
         } else {
-            self.complete = false;
+            self.display_truncated = true;
         }
         for token in commit_sha_tokens(payload) {
             if self.seen_commits.contains(token) {
                 continue;
             }
             if self.commits.len() == self.max_lines {
-                self.complete = false;
+                self.display_truncated = true;
                 continue;
             }
             let token = token.to_string();
@@ -533,6 +550,30 @@ fn split_log_line(line: &str) -> (&str, &str) {
         _ => rest,
     };
     (step, payload)
+}
+
+/// Whether a line dropped for exceeding [`MAX_CHECKOUT_EVIDENCE_LINE_BYTES`]
+/// could plausibly have carried checkout identity, judged from whatever
+/// prefix was captured before the drop.
+///
+/// The job/step columns and runner timestamp sit at the very start of a
+/// `gh run view --log` line, long before any payload could reach this
+/// threshold, so the accumulated prefix (or, when nothing had accumulated yet,
+/// a short probe from the start of the new part) is enough to classify it
+/// without buffering the whole overlong line.
+fn overlong_line_is_identity_bearing(pending: &str, part: &str) -> bool {
+    let probe = if pending.is_empty() {
+        let cap = ceil_char_boundary(part, part.len().min(512));
+        &part[..cap]
+    } else {
+        pending
+    };
+    let (step, payload) = split_log_line(probe);
+    let lowered = payload.to_ascii_lowercase();
+    step.to_ascii_lowercase().contains("checkout")
+        || CHECKOUT_MARKERS
+            .iter()
+            .any(|marker| lowered.contains(marker))
 }
 
 fn is_hex(byte: u8) -> bool {

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -177,6 +177,56 @@ fn checkout_evidence_caps_and_dedups_commits() {
     unique.dedup();
     assert_eq!(unique.len(), evidence.commits.len());
     assert_eq!(evidence.commits[0], format!("{:040x}", 0));
+    // The display cap reduces what is reported, but every commit up to the
+    // cap was still seen — this is not the same as missing identity.
+    assert!(
+        evidence.complete,
+        "a display-count cap alone must not mark identity incomplete"
+    );
+    assert!(evidence.display_truncated);
+}
+
+/// An overlong line that has nothing to do with checkout (ordinary build
+/// spam) is dropped for display reasons only: it could never have carried
+/// checkout identity, so losing it must not taint the identity verdict.
+#[test]
+fn an_overlong_line_unrelated_to_checkout_is_dropped_without_marking_identity_incomplete() {
+    let sha = "5".repeat(40);
+    let overlong = "x".repeat(20_000);
+    let log = format!(
+        "build\tRun tests\t2026-01-01T00:00:00.0000000Z {overlong}\n\
+         ci\tCheckout\t2026-01-01T00:00:01.0000000Z HEAD is now at {sha}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert!(
+        evidence.complete,
+        "an unrelated overlong line must not mark identity incomplete"
+    );
+    assert!(evidence.display_truncated);
+    assert_eq!(evidence.commits, vec![sha]);
+}
+
+/// An overlong line inside a checkout step could have carried the checked-out
+/// commit; dropping it must leave identity marked incomplete rather than
+/// silently reporting whatever else was found.
+#[test]
+fn an_overlong_checkout_line_is_dropped_and_marks_identity_incomplete() {
+    let overlong = "z".repeat(20_000);
+    let log = format!("ci\tCheckout\t2026-01-01T00:00:00.0000000Z {overlong}\n");
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert!(
+        !evidence.complete,
+        "a dropped checkout-step line must mark identity incomplete"
+    );
+    assert!(evidence.commits.is_empty());
+    assert!(
+        !evidence.display_truncated,
+        "identity incompleteness is distinct from a display-only cap"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11248](https://orbit-cli.com/tasks/ORB-11248) — [code-review] CI-failure sweep files nothing when checkout-evidence hits any bound, including display caps

### Description

ORB-11226 (`4bc42160`) introduced `CheckoutEvidenceCollector::complete` and wired it into the CI-failure sweep as a hard, blocking retryable error. Three unrelated conditions all clear that one flag, and the CI sweep then refuses to file any task at all for the whole window.

## Where the flag is cleared

`crates/orbit-tools/src/builtin/github/mod.rs`:

- `:451` — the 8 MiB identity-scan hard limit (`MAX_CHECKOUT_LOG_SCAN_BYTES`, `:322`) was reached. This is the condition the downstream error message actually describes.
- `:463` — **any** log line longer than `MAX_CHECKOUT_EVIDENCE_LINE_BYTES` (16 KiB, `:323`) was seen anywhere in the run log. This check runs on every line, not only on checkout-evidence lines, so one long CI output line is enough.
- `:500` / `:507` — more than `max_lines` (40, `run_logs.rs:20` / `ci/query.rs:85`) evidence *lines* or unique commit tokens were collected. This is a presentation cap on the returned list, not a statement about identity.

Only the first is a real gap in checkout identity. The last two are display/parsing caps that say nothing about whether the checked-out SHA was found — and in a multi-job workflow the 40-line cap is reached at roughly 8 jobs (measured: 5 evidence lines per job on this repo's CI).

## How it becomes a total sweep failure

`crates/orbit-engine/src/executor/automation/ci/collect.rs:681-688` — after the full-log read, `if !log.checkout_evidence_complete` pushes a retryable error, *before* and instead of checking whether `actual_checkout_shas` is non-empty. So even when every job's checkout SHA was captured, the failure is marked uninvestigated at `:709`.

`crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs:196-211` — any failure with `investigated != true` appends `current_failure_not_investigated`, and `:207-212` turns a non-empty `retryable_errors` list into `retryable_pipeline_error("collection_or_investigation", ...)`, which fails the whole `file_ci_failure_tasks` step. Nothing is filed, and the hourly `ci-failure-sweep` routine (`.orbit/routines/ci_failure_sweep.yaml`, enabled on `dk-server-1`) repeats the same failure every hour because the log does not shrink.

Second-order cost: `collect.rs:650-658` folds `checkout_evidence_complete != Some(true)` into `needs_checkout`, so any of these conditions also forces a second, full-run `gh run view --log` read per failure and consumes the `max_checkout_log_reads` budget, before failing anyway.

## Status: latent on this repo today, not guarded

Measured against three current failed `ci.yml` runs (33944400608, 33944247360, 33944244776): ~480 KB full logs, longest line 4162 bytes, 15 checkout-evidence lines. All three bounds are currently clear, so this is not firing yet — but nothing guards it, and each bound is within ordinary reach (a wider job matrix, one long linker/assertion line, or a larger workspace log).

## Suggested direction

Separate the concerns rather than widening the caps: keep `source_truncated` (the 8 MiB case) as the only input to `checkout_identity.state == "incomplete"`, report the list/line caps as their own non-blocking markers, and in `collect.rs:681` only raise a retryable error when the scan is genuinely incomplete *and* `actual_checkout_shas` is empty. Recording `checkout_identity` (which `set_checkout_identity` already writes at `:714-740`) is enough to keep the filed task honest without suppressing the entire sweep.

### Acceptance Criteria

- Evidence display truncation alone does not make an otherwise complete and unambiguous checkout-identity scan fail; record explicit reduced-display markers.
- A genuinely incomplete source scan or potentially identity-bearing overlong line remains incomplete even when one SHA was seen. Do not promote a partial scan to verified current identity or allow automatic backlog admission from insufficient evidence.
- Independent failures with complete current evidence can still be processed where the existing intake contract supports safe isolation; insufficient evidence stays retryable and auditable.
- Deterministic tests separate display-line cap, unrelated overlong lines, overlong identity-bearing lines, source-byte cap, missing SHA and conflicting identities; preserve bounded memory.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `CheckoutEvidenceCollector` (crates/orbit-tools/src/builtin/github/mod.rs) cleared its single `complete` flag on three unrelated conditions — the genuine 8 MiB source-scan cap, the 40-line/commit display cap, and *any* overlong line regardless of whether it was checkout-related. `collect.rs::investigate` then raised a blocking retryable error whenever `!complete`, so a pure display cap (routinely reached at ~8 jobs on this repo's CI) marked the failure un-investigated, which cascaded into `ci_failure_tasks.rs` failing the whole CI-failure sweep for the window.

Fix, scoped to the five listed context_files:
1. `github/mod.rs`: split the signal on `CheckoutEvidence` into `complete` (now cleared only by the genuine 8 MiB source-byte cap or a dropped overlong line that could plausibly have carried checkout identity — judged via a new `overlong_line_is_identity_bearing` helper that inspects the accumulated line prefix for a `checkout`-named step or a `CHECKOUT_MARKERS` match) and a new non-blocking `display_truncated` (set by the evidence line/commit count cap, and by an overlong line *unrelated* to checkout).
2. `query.rs`: threaded `checkout_evidence_display_truncated` through `RunLog` (production path and the `bounded_run_log` test helper).
3. `collect.rs`: `set_checkout_identity` now records `checkout_evidence_display_truncated` alongside the existing fields (flat field and `checkout_identity.provenance`). The blocking check in `investigate` is otherwise UNCHANGED in shape (`!complete` → retryable; else empty commits → retryable) — the fix is that `complete` itself is now computed correctly, so a pure display cap no longer trips it.

Important correction during implementation: an earlier orchestrator refinement comment on this task explicitly rejected gating the retryable error on `incomplete && shas.is_empty()` — a genuinely incomplete scan (source cap or an identity-bearing overlong-line drop) must stay fail-closed/retryable even when one SHA was already found, since it cannot rule out a later conflicting identity past whatever it failed to read. My first pass got this wrong (gated on emptiness alone); corrected to preserve the original fail-closed shape and confirmed against a dedicated test (`a_genuinely_incomplete_scan_stays_retryable_even_when_a_sha_was_found`).

Deterministic tests added, separating each condition per acceptance criteria: display-line/commit cap alone → filed, `investigated: true`, no retryable errors (bounded_logs.rs + collect.rs regression test `checkout_evidence_display_cap_alone_does_not_block_filing`, the exact reported bug scenario); an unrelated overlong line (non-blocking); an identity-bearing overlong line (marks `complete: false`); the existing source-byte-cap test (untouched, still passes); a genuinely incomplete scan with a SHA found (stays retryable/fail-closed, new); incomplete + no SHA found (stays retryable, existing shape); and a complete-scan/no-checkout-step "missing" case (retryable, previously untested).

Validation: `cargo test -p orbit-tools --lib builtin::github` (14 tests) and `cargo test -p orbit-engine --lib executor::automation::ci` (22 tests, 5 new) pass; `make ci-fast` and `make ci-lint` (workspace clippy, warnings denied) both pass. No files outside the five listed context_files were touched; `orbit-core/ci_failure_tasks.rs` (the batch-wide "any uninvestigated failure fails everything" aggregation) was deliberately left alone — out of scope, and the corrected `complete` computation already resolves the reported bug since pure display truncation no longer trips it.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11248-6a9b9f0c`
- Behind base: 0
- Ahead of base: 1