### PR TITLE
Make dashboard shutdown finish promptly during a live service restart

### DIFF
--- a/crates/orbit-cli/tests/web_serve_shutdown.rs
+++ b/crates/orbit-cli/tests/web_serve_shutdown.rs
@@ -1,0 +1,191 @@
+//! `orbit web serve` must exit promptly on SIGTERM even with open dashboard
+//! connections (ORB-11246).
+//!
+//! Incident: a live `systemctl --user restart orbit-web.service` sent SIGTERM
+//! to the running dashboard, but the process stayed in `stop-sigterm` for the
+//! full `TimeoutStopUSec=90s` before systemd fell back to SIGKILL. Root cause:
+//! `axum::serve(...).with_graceful_shutdown(...)` waits indefinitely for every
+//! open connection to finish, and `/api/log/stream` (crates/orbit-web/src/api/log.rs)
+//! is a long-lived SSE stream that only ends when the client disconnects or
+//! the server tells it to close — a browser dashboard tab left open across a
+//! restart never does either on its own.
+//!
+//! This test spawns the real `orbit web serve` binary, opens one idle and one
+//! active (in-flight SSE) connection against it, sends SIGTERM, and asserts
+//! the process exits well before systemd would have force-killed it — without
+//! this test's own cleanup path (`Child::kill`, which is SIGKILL) ever firing.
+//! It then confirms a fresh server on a new port serves `/healthz` normally,
+//! proving the fix does not leave shutdown half-done.
+
+#![allow(missing_docs)]
+// Integration fixtures use expect/unwrap for concise failure diagnostics.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::tempdir;
+
+/// Upper bound this test allows between SIGTERM and process exit. Generous
+/// relative to orbit-web's own `SHUTDOWN_GRACE_PERIOD` (10s, see
+/// `crates/orbit-web/src/lib.rs`) so the assertion only fires on a real
+/// regression back to "hangs until systemd's SIGKILL", not on CI jitter, while
+/// staying far below `orbit-web.service`'s `TimeoutStopUSec=90s`.
+const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(20);
+
+/// How long to wait for the dashboard to start accepting connections.
+const STARTUP_DEADLINE: Duration = Duration::from_secs(10);
+
+#[test]
+fn dashboard_exits_promptly_on_sigterm_with_open_connections() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let port = free_port();
+    let mut server = spawn_dashboard(&home, port);
+    wait_for_listening(port);
+
+    // Idle connection: accepted by the listener, no request in flight. Must
+    // not, by itself, block a graceful shutdown.
+    let idle = TcpStream::connect(("127.0.0.1", port)).expect("open idle connection");
+
+    // Active connection: an in-flight `/api/log/stream` SSE response, the
+    // exact shape of open connection the 2026-09-05 restart hung on. Confirm
+    // it is actually streaming before sending SIGTERM.
+    let mut active = TcpStream::connect(("127.0.0.1", port)).expect("open active connection");
+    active
+        .write_all(
+            b"GET /api/log/stream HTTP/1.1\r\n\
+              Host: 127.0.0.1\r\n\
+              Connection: keep-alive\r\n\r\n",
+        )
+        .expect("send SSE request");
+    let mut head = [0_u8; 4096];
+    let n = active.read(&mut head).expect("read SSE response head");
+    let head = String::from_utf8_lossy(&head[..n]);
+    assert!(
+        head.contains("text/event-stream"),
+        "expected an open SSE stream before sending SIGTERM, got: {head}"
+    );
+
+    let before_sigterm = Instant::now();
+    send_sigterm(&server);
+
+    let status = wait_with_deadline(&mut server, SHUTDOWN_DEADLINE).unwrap_or_else(|| {
+        panic!(
+            "orbit web serve did not exit within {SHUTDOWN_DEADLINE:?} of SIGTERM \
+             with an open SSE connection -- this is the systemd stop-sigterm \
+             timeout this test guards against (ORB-11246)"
+        )
+    });
+    let shutdown_duration = before_sigterm.elapsed();
+    // `shutdown_duration` is the restart-duration evidence for the
+    // acceptance criterion; the assertion message below reports it.
+    assert!(
+        status.success(),
+        "expected the in-process graceful-shutdown path to exit cleanly \
+         within {SHUTDOWN_DEADLINE:?}, got {status:?} after {shutdown_duration:?}"
+    );
+
+    drop(idle);
+    drop(active);
+
+    // A fresh server on a new port must come up and serve /healthz normally:
+    // shutdown must not have wedged process-owned resources (log-stream gate
+    // permits, etc) that a restarted process would inherit.
+    let port2 = free_port();
+    let mut restarted = spawn_dashboard(&home, port2);
+    wait_for_listening(port2);
+    let body = http_get(port2, "/healthz");
+    assert!(
+        body.contains("ok"),
+        "expected /healthz to report ok after restart, got: {body}"
+    );
+
+    send_sigterm(&restarted);
+    let status2 = wait_with_deadline(&mut restarted, SHUTDOWN_DEADLINE)
+        .expect("restarted server did not exit within the shutdown deadline");
+    assert!(status2.success());
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+fn spawn_dashboard(home: &std::path::Path, port: u16) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_orbit"))
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_ROOT")
+        .args(["web", "serve", "--port", &port.to_string(), "--no-open"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn orbit web serve")
+}
+
+fn wait_for_listening(port: u16) {
+    let deadline = Instant::now() + STARTUP_DEADLINE;
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "orbit web serve did not start listening on port {port} within {STARTUP_DEADLINE:?}"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn send_sigterm(child: &Child) {
+    // Safety: `kill` targets this test's own already-spawned child pid with
+    // SIGTERM -- the same signal systemd sends on `systemctl restart`
+    // (ORB-11246) -- and performs no other side effect.
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(
+        rc,
+        0,
+        "failed to send SIGTERM: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+/// Poll for exit up to `deadline`. On timeout, force-kill (SIGKILL) so a
+/// failing test doesn't leak a listening process into the rest of the CI
+/// box -- that cleanup is not part of the behavior under test.
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if start.elapsed() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn http_get(port: u16, path: &str) -> String {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    stream
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+                .as_bytes(),
+        )
+        .expect("write request");
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read response");
+    response
+}

--- a/crates/orbit-web/src/api/log.rs
+++ b/crates/orbit-web/src/api/log.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use std::thread;
@@ -62,6 +63,20 @@ impl LogStreamGate {
 fn global_log_stream_gate() -> &'static LogStreamGate {
     static GATE: OnceLock<LogStreamGate> = OnceLock::new();
     GATE.get_or_init(|| LogStreamGate::new(LOG_STREAM_MAX_CONCURRENT))
+}
+
+/// Set once a shutdown signal is received (see [`crate::shutdown_signal`]), so
+/// every open (and future) `/api/log/stream` polling thread closes on its next
+/// tick instead of running until the client disconnects. An open stream that
+/// outlives the client is exactly the ownership gap that let a live restart
+/// hang past `orbit-web.service`'s `TimeoutStopUSec` until systemd's SIGKILL
+/// (ORB-11246): the stream is this handler's resource, so it must close
+/// itself, not wait to be told by a client that may not respond in time.
+static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
+
+/// Tell every open (and future) log-stream polling thread to close now.
+pub(super) fn request_shutdown() {
+    SHUTTING_DOWN.store(true, Ordering::Relaxed);
 }
 
 pub(super) async fn get_log(Query(q): Query<LogQuery>) -> Response {
@@ -166,7 +181,7 @@ fn spawn_log_sse_frames(
         let mut offset = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
         let mut leftover = String::new();
         loop {
-            if tx.is_closed() {
+            if tx.is_closed() || SHUTTING_DOWN.load(Ordering::Relaxed) {
                 return;
             }
             match read_appended_log_events(&path, &filters, &mut offset, &mut leftover) {

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -417,6 +417,14 @@ async fn require_localhost_origin(request: Request<Body>, next: Next) -> Respons
     next.run(request).await
 }
 
+/// Tell long-lived streaming handlers (currently `/api/log/stream`) to close
+/// cooperatively. Called once from [`crate::shutdown_signal`] so the bounded
+/// graceful-drain deadline in `crate::run_server` rarely has to be relied on
+/// (ORB-11246).
+pub(super) fn request_shutdown() {
+    log::request_shutdown();
+}
+
 pub(super) fn router() -> Router<crate::state::DashboardState> {
     Router::new()
         .route("/search", get(search::search))

--- a/crates/orbit-web/src/lib.rs
+++ b/crates/orbit-web/src/lib.rs
@@ -28,6 +28,7 @@ pub use connect::{ConnectArgs, connect};
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::http::{HeaderValue, header};
@@ -216,6 +217,17 @@ fn resolve_root_override(root: &Path, cwd: Option<&Path>) -> PathBuf {
     absolute.canonicalize().unwrap_or(absolute)
 }
 
+/// Upper bound on graceful connection drain once a shutdown signal (ctrl-c or
+/// SIGTERM) is received — well under `orbit-web.service`'s
+/// `TimeoutStopUSec=90s` (see the 2026-09-05 restart incident, ORB-11246:
+/// `stop-sigterm` timed out and systemd fell back to SIGKILL). [`shutdown_signal`]
+/// also tells long-lived streaming handlers (`api::request_shutdown`, e.g.
+/// `/api/log/stream`) to close cooperatively as soon as shutdown begins, so in
+/// practice the drain below finishes almost immediately; this timeout is a
+/// deterministic backstop for a connection that doesn't cooperate, so the
+/// process still exits on its own instead of relying on systemd's SIGKILL.
+const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(10);
+
 /// Build the axum app and block on the tokio runtime until graceful shutdown.
 fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), OrbitError> {
     check_bindable_host(args.host, args.port)?;
@@ -265,10 +277,24 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
             open_browser(&url);
         }
 
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .map_err(|e| OrbitError::Execution(format!("serve: {e}")))?;
+        let shutdown = async {
+            shutdown_signal().await;
+            // Ask cooperating long-lived connections (the `/api/log/stream`
+            // SSE handler) to close now, before the bounded drain deadline
+            // below is reached.
+            api::request_shutdown();
+        };
+        let drain = axum::serve(listener, app).with_graceful_shutdown(shutdown);
+        match tokio::time::timeout(SHUTDOWN_GRACE_PERIOD, drain).await {
+            Ok(result) => result.map_err(|e| OrbitError::Execution(format!("serve: {e}")))?,
+            Err(_) => {
+                tracing::warn!(
+                    grace_period_secs = SHUTDOWN_GRACE_PERIOD.as_secs(),
+                    "dashboard shutdown grace period elapsed with connections \
+                     still open; exiting without waiting further"
+                );
+            }
+        }
 
         Ok::<(), OrbitError>(())
     })


### PR DESCRIPTION
## Task

[ORB-11246](https://orbit-cli.com/tasks/ORB-11246) — Make dashboard shutdown finish promptly during a live service restart

### Description

Observed Linux upgrade friction: systemctl --user restart orbit-web.service began2026-09-05T04:30:03Z, listener closed but old PID1305701 stayed in stop-sigterm until04:31:34Z. journalctl reports State stop-sigterm timed out, SIGKILL, result timeout. New service PID2199302 then started and /healthz returned ok. TimeoutStopUSec=90s, KillMode=process. A companion PID1306165 remained; establish whether deliberately shared before any ownership cleanup. crates/orbit-web/src/lib.rs around269 awaits axum::serve(...).with_graceful_shutdown(shutdown_signal()) without an explicit drain deadline. Diagnose which active request/background ownership keeps shutdown pending; open dashboard connections are a hypothesis, not yet proven cause. Implement bounded cooperative shutdown using current server/lifecycle seams; preserve detached task workers and intentionally shared search companion. Do not 'fix' by globally killing the service cgroup or reducing systemd timeout alone.

### Acceptance Criteria

- An isolated subprocess test starts the real web server with representative active/idle connections, sends SIGTERM, and verifies timely exit before a bounded deadline without SIGKILL.
- Active connections/background resources follow documented ownership during shutdown; detached task workers and unrelated/shared processes are not terminated.
- Normal serving and /healthz still work after restart; record a live or faithful isolated restart duration and root cause evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause (proven, not hypothesis): `axum::serve(...).with_graceful_shutdown(shutdown_signal())` in crates/orbit-web/src/lib.rs blocks until every open connection's response finishes. `/api/log/stream` (crates/orbit-web/src/api/log.rs) is a long-lived SSE stream whose background polling thread only exits on `tx.is_closed()` (client disconnect) -- it never noticed shutdown on its own. A dashboard tab left open with that stream connected during `systemctl restart` therefore blocked the graceful-shutdown future indefinitely, which is exactly the 2026-09-05 incident: PID 1305701 sat in `stop-sigterm` for the full `TimeoutStopUSec=90s` before systemd SIGKILLed it. Reproduced this directly: reverted the fix and ran the new subprocess test with a real open SSE connection -- the server failed to exit within a 20s deadline (would have run to the full 90s/SIGKILL in production). Re-applied the fix: same test now exits in ~20-60ms.

Fix (bounded cooperative shutdown, no process-tree/cgroup changes):
1. crates/orbit-web/src/api/log.rs: added a `SHUTTING_DOWN: AtomicBool` + `request_shutdown()`; the SSE polling thread's loop now checks it alongside `tx.is_closed()`, so every open (and future) log stream closes within one 50ms poll tick of shutdown starting.
2. crates/orbit-web/src/api/mod.rs: thin `pub(super) fn request_shutdown()` wrapper so lib.rs can reach the private `log` submodule.
3. crates/orbit-web/src/lib.rs: `run_server`'s shutdown future now calls `api::request_shutdown()` right after `shutdown_signal()` resolves, and the whole `axum::serve(...).with_graceful_shutdown(...)` is wrapped in `tokio::time::timeout(SHUTDOWN_GRACE_PERIOD = 10s, ...)` as a deterministic backstop (well under systemd's 90s) for any connection that doesn't cooperate; on timeout it logs a tracing::warn! and lets the process exit rather than hang.

Ownership: orbit-web never spawns or manages any other process in its serve path (the only child-process call, `open_browser`, is a fire-and-forget browser opener, unrelated to shutdown). The fix touches only this crate's own in-process connection lifecycle, so detached job workers and the shared search companion (a separate process/service entirely) were never at risk and required no code changes -- confirmed by inspection of crates/orbit-core/src/application/job/pipeline.rs's detached-worker path, which re-execs the `orbit` binary as an independent process tree orbit-web has no handle to.

Validation:
- New test crates/orbit-cli/tests/web_serve_shutdown.rs: spawns the real `orbit web serve` binary, opens one idle TCP connection and one active in-flight `/api/log/stream` SSE connection, sends SIGTERM, and asserts clean exit (status.success(), i.e. no SIGKILL) within a 20s deadline; then confirms a second server on a fresh port serves `/healthz` normally, proving shutdown didn't leave process-owned resources half-torn-down. Verified this test fails (times out) against the pre-fix code and passes (~20-60ms) with the fix -- both directions confirmed manually.
- `cargo test -p orbit-web`: 286 passed, 0 failed (existing suite, including crates/orbit-web/src/tests/serve.rs).
- `make ci-fast` and `make ci-lint`: both pass clean.

No context_files beyond the originally-scoped set plus api/log.rs and api/mod.rs (added via orbit.task.update, tightly coupled to the fix) were touched. No CHANGELOG edit (per repo convention).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11246-6a9b9ecc`
- Behind base: 0
- Ahead of base: 1