### PR TITLE
Prepare pilot context against a consistent current landing-branch snapshot

### DIFF
--- a/.orbit/resources/activities/apply_task_pilot_results.yaml
+++ b/.orbit/resources/activities/apply_task_pilot_results.yaml
@@ -7,9 +7,9 @@ spec:
   description: >
     Partition-isolated, fail-closed task-pilot apply boundary. It validates each
     partition's exact before snapshots, dispositions, canonical in-workspace
-    file/dir/symbol selectors, and target existence before mutating that
-    partition. Stale or malformed partitions are reported without writes while
-    independently valid partitions still apply. Every other task
+    file/dir/symbol selectors, and target existence against the prepared source
+    revision when one was pinned. Stale or malformed partitions are reported
+    without writes while independently valid partitions still apply. Every other task
     field, lifecycle state, dispatch state, and recommendation remains unchanged
     unless a CI sweep supplies its exact filing record and explicit promotion
     authority. In that mode only a proposed, selector-backed task with no
@@ -29,7 +29,7 @@ spec:
           - type: "null"
   output_schema_json:
     type: object
-    required: [status, error, mode, workspace_path, discovery, partition_decisions, partition_count, received_partition_count, failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
+    required: [status, error, mode, workspace_path, source, discovery, partition_decisions, partition_count, received_partition_count, failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
     properties:
       status: {type: string, enum: [succeeded, failed]}
       error:
@@ -38,6 +38,10 @@ spec:
           - type: "null"
       mode: {type: string, enum: [automatic, explicit]}
       workspace_path: {type: string}
+      source:
+        oneOf:
+          - type: object
+          - type: "null"
       discovery: {type: object}
       partition_decisions: {type: array, items: {type: object}}
       partition_count: {type: number}

--- a/.orbit/resources/activities/prepare_task_pilot.yaml
+++ b/.orbit/resources/activities/prepare_task_pilot.yaml
@@ -10,7 +10,11 @@ spec:
     workspace tasks, including tasks with non-empty context_files. Without
     task_ids it selects only proposed/backlog tasks whose context_files are
     empty, excluding no-diff-needed/no-diff-expected tasks and every active,
-    review, or terminal status. This action never promotes or dispatches work.
+    review, or terminal status. In a Git workspace this step also fetches the
+    landing branch, pins one verified source revision, and fast-forwards a
+    clean primary on that branch when it is behind. Dirty, divergent, or
+    unfetchable checkouts fail closed as source-staleness before any agent
+    call. This action never promotes or dispatches work.
   input_schema_json:
     type: object
     properties:
@@ -19,6 +23,8 @@ spec:
         items:
           type: string
       workspace_path:
+        type: string
+      base_branch:
         type: string
       max_tasks:
         type: number
@@ -30,10 +36,14 @@ spec:
         maximum: 5
   output_schema_json:
     type: object
-    required: [mode, workspace_path, task_count, task_ids, tasks, partition_size, partition_count, partitions, excluded]
+    required: [mode, workspace_path, source, task_count, task_ids, tasks, partition_size, partition_count, partitions, excluded]
     properties:
       mode: {type: string, enum: [automatic, explicit]}
       workspace_path: {type: string}
+      source:
+        oneOf:
+          - type: object
+          - type: "null"
       task_count: {type: number}
       task_ids: {type: array, items: {type: string}}
       tasks: {type: array, items: {type: object}}

--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -11,9 +11,10 @@ spec:
   fsProfile: reviewer
   description: >
     Read-only task preflight for one explicit bounded partition. The pilot
-    inspects the selected workspace and target branch, returns exact canonical
-    context_files proposals plus orchestration recommendations, and has no
-    repository-write, task-update, lifecycle, dispatch, or scheduling grant.
+    inspects the selected workspace at the prepared source revision of the
+    target branch, returns exact canonical context_files proposals plus
+    orchestration recommendations, and has no repository-write, task-update,
+    lifecycle, dispatch, or scheduling grant.
   input_schema_json:
     type: object
     # `crew` is optional here: the pipeline names `system` on the pilot step so
@@ -30,6 +31,8 @@ spec:
       workspace_path:
         type: string
       base_branch:
+        type: string
+      source_revision:
         type: string
       partition_index:
         type: number
@@ -57,8 +60,9 @@ spec:
     You are Orbit's task-pilot for one explicit, bounded partition.
 
     Input contains `task_ids` (one to five exact IDs), `workspace_path`,
-    `base_branch`, and `partition_index`. Work only on those task IDs and
-    treat the workspace as read-only.
+    `base_branch`, `source_revision` (the prepared landing-branch commit),
+    and `partition_index`. Work only on those task IDs and treat the
+    workspace as read-only.
 
     For every task:
 
@@ -67,16 +71,21 @@ spec:
        `context_files`. Use `orbit.search` for the task ID and relevant design
        terms; inspect linked decision docs when a result points to one.
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
-       workspace Git top-level, inspect `base_branch`, and determine every real
-       file, directory, or symbol the stated change would modify or delete.
-       If `base_branch` is empty, resolve the repository's default remote branch
-       (and cross-check the release branch recorded in CI evidence) instead of
-       treating the empty string as a Git ref.
+       workspace Git top-level. If `source_revision` is a commit id, inspect
+       that exact snapshot (`git rev-parse`, `git ls-tree`, `git show
+       <source_revision>:<path>`) and treat it as the source of truth for
+       whether a modification target exists. `base_branch` names the landing
+       branch that snapshot belongs to. If `source_revision` is empty, inspect
+       `base_branch` as it exists in this checkout. If `base_branch` is also
+       empty, resolve the repository's default remote branch (and cross-check
+       the release branch recorded in CI evidence) instead of treating the
+       empty string as a Git ref.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
-       `workspace_path`; omit read-for-context files. Preserve the exact current
-       list as `context_files_before`.
+       `workspace_path` at `source_revision` when that field is set; omit
+       read-for-context files and working-tree-only or later-commit paths.
+       Preserve the exact current list as `context_files_before`.
     4. If the task genuinely requires no repository diff, return an empty
        `context_files_after`, disposition `verified_no_diff`, and concrete
        `evidence`. For host-operational work use `host_operational` with

--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -5,11 +5,16 @@
 # proposed/backlog tasks in the active workspace with empty context_files,
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
-# Preparation never promotes or dispatches a task. Each read-only pilot
-# receives at most five tasks. Agent dispatch failures still stop at the
+# Preparation never promotes or dispatches a task. In a Git workspace it
+# fetches the landing branch, pins one source revision, and fast-forwards a
+# clean primary on that branch when it is behind; dirty or unfetchable
+# checkouts fail as source-staleness before any agent call. Each read-only
+# pilot receives at most five tasks and inspects that pinned revision.
+# Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
-# any partition did not apply. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
+# any partition did not apply. Selector existence is validated against the
+# prepared source revision, not a later checkout. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
 # literal promotion authority; only then can apply promote a warning-free,
 # selector-backed proposed repair to backlog.
 #
@@ -49,6 +54,7 @@ spec:
       default_input:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ input.workspace_path }}"
+        base_branch: "{{ input.base_branch }}"
         max_tasks: "{{ input.max_tasks }}"
         max_partition_size: "{{ input.max_partition_size }}"
 
@@ -63,7 +69,8 @@ spec:
             task_ids: "{{ item.task_ids }}"
             partition_index: "{{ item.partition_index }}"
             workspace_path: "{{ steps.prepare.output.workspace_path }}"
-            base_branch: "{{ input.base_branch }}"
+            base_branch: "{{ steps.prepare.output.source.base_branch }}"
+            source_revision: "{{ steps.prepare.output.source.source_revision }}"
             # See the crew-resolution note at the top of this file.
             crew: system
       fan_in:

--- a/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
+++ b/crates/orbit-core/assets/activities/apply_task_pilot_results.yaml
@@ -7,9 +7,9 @@ spec:
   description: >
     Partition-isolated, fail-closed task-pilot apply boundary. It validates each
     partition's exact before snapshots, dispositions, canonical in-workspace
-    file/dir/symbol selectors, and target existence before mutating that
-    partition. Stale or malformed partitions are reported without writes while
-    independently valid partitions still apply. Every other task
+    file/dir/symbol selectors, and target existence against the prepared source
+    revision when one was pinned. Stale or malformed partitions are reported
+    without writes while independently valid partitions still apply. Every other task
     field, lifecycle state, dispatch state, and recommendation remains unchanged
     unless a CI sweep supplies its exact filing record and explicit promotion
     authority. In that mode only a proposed, selector-backed task with no
@@ -38,7 +38,7 @@ spec:
   output_schema_json:
     type: object
     required:
-      [status, error, mode, workspace_path, discovery,
+      [status, error, mode, workspace_path, source, discovery,
        partition_decisions, partition_count, received_partition_count,
        failed_partitions, skipped_stale_partitions, tasks, ci_sweep_admission]
     properties:
@@ -54,6 +54,10 @@ spec:
         enum: [automatic, explicit]
       workspace_path:
         type: string
+      source:
+        oneOf:
+          - type: object
+          - type: "null"
       discovery:
         type: object
       partition_decisions:

--- a/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
@@ -10,7 +10,11 @@ spec:
     workspace tasks, including tasks with non-empty context_files. Without
     task_ids it selects only proposed/backlog tasks whose context_files are
     empty, excluding no-diff-needed/no-diff-expected tasks and every active,
-    review, or terminal status. This action never promotes or dispatches work.
+    review, or terminal status. In a Git workspace this step also fetches the
+    landing branch, pins one verified source revision, and fast-forwards a
+    clean primary on that branch when it is behind. Dirty, divergent, or
+    unfetchable checkouts fail closed as source-staleness before any agent
+    call. This action never promotes or dispatches work.
   input_schema_json:
     type: object
     properties:
@@ -19,6 +23,8 @@ spec:
         items:
           type: string
       workspace_path:
+        type: string
+      base_branch:
         type: string
       max_tasks:
         type: number
@@ -31,7 +37,7 @@ spec:
   output_schema_json:
     type: object
     required:
-      [mode, workspace_path, task_count, task_ids, tasks, partition_size,
+      [mode, workspace_path, source, task_count, task_ids, tasks, partition_size,
        partition_count, partitions, excluded]
     properties:
       mode:
@@ -39,6 +45,10 @@ spec:
         enum: [automatic, explicit]
       workspace_path:
         type: string
+      source:
+        oneOf:
+          - type: object
+          - type: "null"
       task_count:
         type: number
       task_ids:

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -11,9 +11,10 @@ spec:
   fsProfile: reviewer
   description: >
     Read-only task preflight for one explicit bounded partition. The pilot
-    inspects the selected workspace and target branch, returns exact canonical
-    context_files proposals plus orchestration recommendations, and has no
-    repository-write, task-update, lifecycle, dispatch, or scheduling grant.
+    inspects the selected workspace at the prepared source revision of the
+    target branch, returns exact canonical context_files proposals plus
+    orchestration recommendations, and has no repository-write, task-update,
+    lifecycle, dispatch, or scheduling grant.
   input_schema_json:
     type: object
     # `crew` is optional here: the pipeline names `system` on the pilot step so
@@ -30,6 +31,8 @@ spec:
       workspace_path:
         type: string
       base_branch:
+        type: string
+      source_revision:
         type: string
       partition_index:
         type: number
@@ -57,8 +60,9 @@ spec:
     You are Orbit's task-pilot for one explicit, bounded partition.
 
     Input contains `task_ids` (one to five exact IDs), `workspace_path`,
-    `base_branch`, and `partition_index`. Work only on those task IDs and
-    treat the workspace as read-only.
+    `base_branch`, `source_revision` (the prepared landing-branch commit),
+    and `partition_index`. Work only on those task IDs and treat the
+    workspace as read-only.
 
     For every task:
 
@@ -67,16 +71,21 @@ spec:
        `context_files`. Use `orbit.search` for the task ID and relevant design
        terms; inspect linked decision docs when a result points to one.
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
-       workspace Git top-level, inspect `base_branch`, and determine every real
-       file, directory, or symbol the stated change would modify or delete.
-       If `base_branch` is empty, resolve the repository's default remote branch
-       (and cross-check the release branch recorded in CI evidence) instead of
-       treating the empty string as a Git ref.
+       workspace Git top-level. If `source_revision` is a commit id, inspect
+       that exact snapshot (`git rev-parse`, `git ls-tree`, `git show
+       <source_revision>:<path>`) and treat it as the source of truth for
+       whether a modification target exists. `base_branch` names the landing
+       branch that snapshot belongs to. If `source_revision` is empty, inspect
+       `base_branch` as it exists in this checkout. If `base_branch` is also
+       empty, resolve the repository's default remote branch (and cross-check
+       the release branch recorded in CI evidence) instead of treating the
+       empty string as a Git ref.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
-       `workspace_path`; omit read-for-context files. Preserve the exact current
-       list as `context_files_before`.
+       `workspace_path` at `source_revision` when that field is set; omit
+       read-for-context files and working-tree-only or later-commit paths.
+       Preserve the exact current list as `context_files_before`.
     4. If the task genuinely requires no repository diff, return an empty
        `context_files_after`, disposition `verified_no_diff`, and concrete
        `evidence`. For host-operational work use `host_operational` with

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -5,11 +5,16 @@
 # proposed/backlog tasks in the active workspace with empty context_files,
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
-# Preparation never promotes or dispatches a task. Each read-only pilot
-# receives at most five tasks. Agent dispatch failures still stop at the
+# Preparation never promotes or dispatches a task. In a Git workspace it
+# fetches the landing branch, pins one source revision, and fast-forwards a
+# clean primary on that branch when it is behind; dirty or unfetchable
+# checkouts fail as source-staleness before any agent call. Each read-only
+# pilot receives at most five tasks and inspects that pinned revision.
+# Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
-# any partition did not apply. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
+# any partition did not apply. Selector existence is validated against the
+# prepared source revision, not a later checkout. Apply normally changes only context_files. A CI sweep may pass its exact filing record plus
 # literal promotion authority; only then can apply promote a warning-free,
 # selector-backed proposed repair to backlog.
 #
@@ -49,6 +54,7 @@ spec:
       default_input:
         task_ids: "{{ input.task_ids }}"
         workspace_path: "{{ input.workspace_path }}"
+        base_branch: "{{ input.base_branch }}"
         max_tasks: "{{ input.max_tasks }}"
         max_partition_size: "{{ input.max_partition_size }}"
 
@@ -63,7 +69,8 @@ spec:
             task_ids: "{{ item.task_ids }}"
             partition_index: "{{ item.partition_index }}"
             workspace_path: "{{ steps.prepare.output.workspace_path }}"
-            base_branch: "{{ input.base_branch }}"
+            base_branch: "{{ steps.prepare.output.source.base_branch }}"
+            source_revision: "{{ steps.prepare.output.source.source_revision }}"
             # See the crew-resolution note at the top of this file.
             crew: system
       fan_in:

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -82,6 +82,16 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
+The prepare step fetches the landing branch (`base_branch`, defaulting to
+`workflow.base_branch`) and pins one `source_revision`. A clean primary that
+already sits on that branch and is behind origin is fast-forwarded so inspection
+sees the landed tree; a dirty, divergent, or unfetchable checkout fails as
+source-staleness *before* any agent call. The pilot inspects that pinned
+revision. Apply validates selector existence against the same snapshot, not a
+later working tree, so a newly merged file is not reported as missing merely
+because the primary lagged origin, and a later origin advance cannot admit a
+path that did not exist at prepare.
+
 The pilot agent inspection is read-only; its deterministic apply step mutates
 validated task selectors. It runs five
 partitions concurrently, and returns selector proposals plus duplicate,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -22,8 +22,10 @@ use serde_json::{Value, json};
 use crate::OrbitRuntime;
 
 mod apply;
+mod source;
 
 pub(super) use apply::apply;
+use source::{GitPathKind, SourceSnapshot, requested_base_branch, resolve_source_snapshot};
 
 const DEFAULT_MAX_PARTITION_SIZE: usize = 5;
 const HARD_MAX_PARTITION_SIZE: usize = 5;
@@ -38,6 +40,7 @@ pub(super) fn prepare(
     input: &Value,
 ) -> Result<Value, DispatchError> {
     let workspace_root = requested_workspace_root(runtime, action, input)?;
+    let source = resolve_source_snapshot(runtime, action, input, &workspace_root)?;
     let max_partition_size = bounded_usize(
         action,
         input,
@@ -149,6 +152,14 @@ pub(super) fn prepare(
     Ok(json!({
         "mode": mode,
         "workspace_path": workspace_root,
+        "source": source.as_ref().map(SourceSnapshot::to_json).unwrap_or_else(|| {
+            json!({
+                "base_branch": requested_base_branch(runtime, input),
+                "source_ref": Value::Null,
+                "source_revision": Value::Null,
+                "fast_forwarded": false,
+            })
+        }),
         "task_count": selected.len(),
         "task_ids": selected.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
         "tasks": task_snapshots,
@@ -272,6 +283,7 @@ fn validate_after_selectors(
     assessment: &Value,
     selectors: &[String],
     workspace_root: &Path,
+    source: Option<&SourceSnapshot>,
 ) -> Result<(), DispatchError> {
     if selectors.is_empty() {
         if !matches!(disposition, "verified_no_diff" | "host_operational") {
@@ -321,15 +333,19 @@ fn validate_after_selectors(
                 ),
             ));
         }
-        if !exists_in_workspace(&canonical, workspace_root) {
-            return Err(action_failed(
-                action,
-                format!(
-                    "task {task_id} selector {selector:?} does not resolve to an existing in-workspace target"
-                ),
-            ));
+        if let Some(source) = source {
+            validate_selector_at_source(action, task_id, &canonical, workspace_root, source)?;
+        } else {
+            if !exists_in_workspace(&canonical, workspace_root) {
+                return Err(action_failed(
+                    action,
+                    format!(
+                        "task {task_id} selector {selector:?} does not resolve to an existing in-workspace target"
+                    ),
+                ));
+            }
+            validate_selector_target_kind(action, task_id, &canonical, workspace_root)?;
         }
-        validate_selector_target_kind(action, task_id, &canonical, workspace_root)?;
         if !seen.insert(canonical) {
             return Err(action_failed(
                 action,
@@ -376,6 +392,40 @@ fn validate_recommendations(
         }
     }
     Ok(())
+}
+
+fn validate_selector_at_source(
+    action: &str,
+    task_id: &str,
+    selector: &str,
+    workspace_root: &Path,
+    source: &SourceSnapshot,
+) -> Result<(), DispatchError> {
+    let anchor = anchor_path(selector).map_err(|error| {
+        action_failed(
+            action,
+            format!("task {task_id} selector {selector:?} has no filesystem anchor: {error}"),
+        )
+    })?;
+    let kind = source.path_kind(action, workspace_root, &anchor)?;
+    let expected_dir = selector.starts_with("dir:");
+    match (kind, expected_dir) {
+        (GitPathKind::Tree, true) | (GitPathKind::Blob, false) => Ok(()),
+        (GitPathKind::Missing, _) => Err(action_failed(
+            action,
+            format!(
+                "task {task_id} selector {selector:?} does not resolve to an existing in-workspace target at source revision {} ({})",
+                source.source_revision, source.source_ref
+            ),
+        )),
+        _ => Err(action_failed(
+            action,
+            format!(
+                "task {task_id} selector {selector:?} does not match the target's file/directory kind at source revision {} ({})",
+                source.source_revision, source.source_ref
+            ),
+        )),
+    }
 }
 
 fn validate_selector_target_kind(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -12,6 +12,7 @@ use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::ci_failure_admission;
 use crate::application::task::TaskUpdateParams;
 
+use super::source::SourceSnapshot;
 use super::{
     action_failed, requested_workspace_root, required_string, required_string_array,
     string_array_value, validate_after_selectors, validate_recommendations,
@@ -39,9 +40,11 @@ pub(in super::super) fn apply(
     input: &Value,
 ) -> Result<Value, DispatchError> {
     let workspace_root = requested_workspace_root(runtime, action, input)?;
-    let prepared = input
+    let prepared_value = input
         .get("prepared")
-        .and_then(Value::as_object)
+        .ok_or_else(|| action_failed(action, "`prepared` must be an object"))?;
+    let prepared = prepared_value
+        .as_object()
         .ok_or_else(|| action_failed(action, "`prepared` must be an object"))?;
     let prepared_workspace = prepared
         .get("workspace_path")
@@ -72,6 +75,10 @@ pub(in super::super) fn apply(
         .get("results")
         .and_then(Value::as_array)
         .ok_or_else(|| action_failed(action, "`results` must be an array"))?;
+    let source = SourceSnapshot::from_prepared(prepared_value, action)?;
+    if let Some(source) = &source {
+        source.ensure_commit(action, &workspace_root)?;
+    }
 
     let prepared_before = prepared_tasks
         .iter()
@@ -314,6 +321,7 @@ pub(in super::super) fn apply(
                 assessment,
                 &after,
                 &workspace_root,
+                source.as_ref(),
             ) {
                 validation_error = Some(error.to_string());
                 break;
@@ -458,6 +466,7 @@ pub(in super::super) fn apply(
         "error": error,
         "mode": mode,
         "workspace_path": workspace_root,
+        "source": prepared.get("source").cloned().unwrap_or(Value::Null),
         "discovery": {
             "task_ids": prepared.get("task_ids").cloned().unwrap_or_else(|| json!([])),
             "excluded": prepared.get("excluded").cloned().unwrap_or_else(|| json!([])),

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
@@ -1,0 +1,475 @@
+//! Landing-branch source snapshot for task-pilot prepare/apply.
+//!
+//! Inspection and deterministic selector validation share one pinned revision
+//! so a newly merged target is not reported as missing when the primary
+//! checkout lags origin. The only Git write this module will perform is a
+//! fast-forward of a clean primary that already sits on the landing branch.
+
+use std::path::Path;
+use std::process::Command;
+
+use orbit_common::fs::git::{CurrentBranchStatus, current_branch, run_git};
+use orbit_engine::DispatchError;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+
+use super::action_failed;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SourceSnapshot {
+    pub base_branch: String,
+    pub source_ref: String,
+    pub source_revision: String,
+    pub fast_forwarded: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum GitPathKind {
+    Blob,
+    Tree,
+    Missing,
+    Other,
+}
+
+impl SourceSnapshot {
+    pub(super) fn to_json(&self) -> Value {
+        json!({
+            "base_branch": self.base_branch,
+            "source_ref": self.source_ref,
+            "source_revision": self.source_revision,
+            "fast_forwarded": self.fast_forwarded,
+        })
+    }
+
+    pub(super) fn from_prepared(
+        prepared: &Value,
+        action: &str,
+    ) -> Result<Option<Self>, DispatchError> {
+        let Some(source) = prepared.get("source") else {
+            return Ok(None);
+        };
+        if source.is_null() {
+            return Ok(None);
+        }
+        let object = source
+            .as_object()
+            .ok_or_else(|| action_failed(action, "prepared.source must be an object or null"))?;
+        let source_revision = object
+            .get("source_revision")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let Some(source_revision) = source_revision else {
+            return Ok(None);
+        };
+        if !is_commit_id(source_revision) {
+            return Err(action_failed(
+                action,
+                format!(
+                    "prepared.source.source_revision {source_revision:?} is not a full commit id"
+                ),
+            ));
+        }
+        let base_branch = object
+            .get("base_branch")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    "prepared.source.base_branch must be a non-empty string",
+                )
+            })?;
+        let source_ref = object
+            .get("source_ref")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                action_failed(
+                    action,
+                    "prepared.source.source_ref must be a non-empty string",
+                )
+            })?;
+        Ok(Some(Self {
+            base_branch: base_branch.to_string(),
+            source_ref: source_ref.to_string(),
+            source_revision: source_revision.to_string(),
+            fast_forwarded: object
+                .get("fast_forwarded")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        }))
+    }
+
+    pub(super) fn ensure_commit(
+        &self,
+        action: &str,
+        workspace: &Path,
+    ) -> Result<(), DispatchError> {
+        let spec = format!("{}^{{commit}}", self.source_revision);
+        let output = git(action, workspace, &["rev-parse", "--verify", &spec])?;
+        if output.success {
+            Ok(())
+        } else {
+            Err(action_failed(
+                action,
+                format!(
+                    "prepared source revision {} ({}) is not a commit in this repository: {}",
+                    self.source_revision,
+                    self.source_ref,
+                    output.stderr.trim()
+                ),
+            ))
+        }
+    }
+
+    pub(super) fn path_kind(
+        &self,
+        action: &str,
+        workspace: &Path,
+        anchor: &Path,
+    ) -> Result<GitPathKind, DispatchError> {
+        let relative = git_tree_path(anchor).ok_or_else(|| {
+            action_failed(
+                action,
+                format!(
+                    "selector anchor {} is not a repository-relative path",
+                    anchor.display()
+                ),
+            )
+        })?;
+        let object = format!("{}:{relative}", self.source_revision);
+        let output = git(action, workspace, &["cat-file", "-t", &object])?;
+        if !output.success {
+            return Ok(GitPathKind::Missing);
+        }
+        Ok(match output.stdout.trim() {
+            "blob" => GitPathKind::Blob,
+            "tree" => GitPathKind::Tree,
+            _ => GitPathKind::Other,
+        })
+    }
+}
+
+pub(super) fn resolve_source_snapshot(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+    workspace_root: &Path,
+) -> Result<Option<SourceSnapshot>, DispatchError> {
+    if !is_git_work_tree(action, workspace_root)? {
+        return Ok(None);
+    }
+
+    let base_branch = requested_base_branch(runtime, input);
+    let base_branch = normalize_base_branch(action, &base_branch)?;
+    let (source_ref, fetched_remote) = if has_origin_remote(action, workspace_root)? {
+        fetch_origin_branch(action, workspace_root, &base_branch)?;
+        (format!("origin/{base_branch}"), true)
+    } else {
+        (base_branch.clone(), false)
+    };
+    let source_revision = rev_parse_commit(action, workspace_root, &source_ref)?;
+    let head = rev_parse_commit(action, workspace_root, "HEAD")?;
+    let fast_forwarded = align_clean_primary(
+        action,
+        workspace_root,
+        &base_branch,
+        &source_ref,
+        &source_revision,
+        &head,
+        fetched_remote,
+    )?;
+
+    Ok(Some(SourceSnapshot {
+        base_branch,
+        source_ref,
+        source_revision,
+        fast_forwarded,
+    }))
+}
+
+pub(super) fn requested_base_branch(runtime: &OrbitRuntime, input: &Value) -> String {
+    input
+        .get("base_branch")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| runtime.workflow_base_branch().to_string())
+}
+
+fn normalize_base_branch(action: &str, base: &str) -> Result<String, DispatchError> {
+    let branch = base
+        .trim()
+        .strip_prefix("origin/")
+        .unwrap_or_else(|| base.trim())
+        .trim();
+    if branch.is_empty() {
+        return Err(action_failed(
+            action,
+            "base_branch must be a non-empty branch name",
+        ));
+    }
+    if branch.starts_with('-') {
+        return Err(action_failed(
+            action,
+            format!("base_branch {base:?} must not start with '-'"),
+        ));
+    }
+    Ok(branch.to_string())
+}
+
+fn align_clean_primary(
+    action: &str,
+    workspace: &Path,
+    base_branch: &str,
+    source_ref: &str,
+    source_revision: &str,
+    head: &str,
+    fetched_remote: bool,
+) -> Result<bool, DispatchError> {
+    if head == source_revision {
+        return Ok(false);
+    }
+
+    let dirty = working_tree_status(action, workspace)?;
+    let branch = current_branch(workspace)
+        .map_err(|error| action_failed(action, format!("read current branch: {error}")))?;
+    let on_landing_branch =
+        matches!(branch, CurrentBranchStatus::Named(ref name) if name == base_branch);
+    let can_fast_forward = is_ancestor(action, workspace, head, source_revision)?;
+
+    if dirty.is_empty() && on_landing_branch && can_fast_forward {
+        let merge = git(
+            action,
+            workspace,
+            &["merge", "--ff-only", "--no-edit", source_revision],
+        )?;
+        if !merge.success {
+            return Err(source_stale(
+                action,
+                base_branch,
+                source_ref,
+                source_revision,
+                head,
+                fetched_remote,
+                &format!("clean fast-forward failed: {}", merge.stderr.trim()),
+            ));
+        }
+        let after = rev_parse_commit(action, workspace, "HEAD")?;
+        if after != source_revision {
+            return Err(source_stale(
+                action,
+                base_branch,
+                source_ref,
+                source_revision,
+                &after,
+                fetched_remote,
+                "fast-forward completed but HEAD is not the pinned source revision",
+            ));
+        }
+        return Ok(true);
+    }
+
+    let reason = if !dirty.is_empty() {
+        format!(
+            "primary working tree is dirty or has untracked files ({}); refusing checkout, pull, or reset",
+            dirty.join(", ")
+        )
+    } else if !on_landing_branch {
+        format!(
+            "primary is not on landing branch {base_branch} (current: {}); refusing to switch branches",
+            match branch {
+                CurrentBranchStatus::Named(name) => name,
+                CurrentBranchStatus::DetachedHead => "detached HEAD".to_string(),
+                CurrentBranchStatus::NoCurrentBranch => "no current branch".to_string(),
+            }
+        )
+    } else if !can_fast_forward {
+        "primary HEAD is not an ancestor of the landing-branch revision; refusing a non-fast-forward update"
+            .to_string()
+    } else {
+        "primary is not at the verified landing-branch revision".to_string()
+    };
+    Err(source_stale(
+        action,
+        base_branch,
+        source_ref,
+        source_revision,
+        head,
+        fetched_remote,
+        &reason,
+    ))
+}
+
+fn source_stale(
+    action: &str,
+    base_branch: &str,
+    source_ref: &str,
+    source_revision: &str,
+    head: &str,
+    fetched_remote: bool,
+    reason: &str,
+) -> DispatchError {
+    let sync_hint = if fetched_remote {
+        format!(
+            "make the primary clean and fast-forward `{base_branch}` to `{source_ref}` ({source_revision}) before piloting"
+        )
+    } else {
+        format!("update the local `{base_branch}` checkout to {source_revision} before piloting")
+    };
+    action_failed(
+        action,
+        format!(
+            "source-staleness: landing branch `{base_branch}` is {source_revision} at `{source_ref}`, primary HEAD is {head}. {reason}. {sync_hint}"
+        ),
+    )
+}
+
+fn is_git_work_tree(action: &str, workspace: &Path) -> Result<bool, DispatchError> {
+    let output = git(action, workspace, &["rev-parse", "--is-inside-work-tree"])?;
+    Ok(output.success && output.stdout.trim() == "true")
+}
+
+fn has_origin_remote(action: &str, workspace: &Path) -> Result<bool, DispatchError> {
+    let remotes = git(action, workspace, &["remote"])?;
+    if !remotes.success {
+        return Ok(false);
+    }
+    Ok(remotes
+        .stdout
+        .lines()
+        .map(str::trim)
+        .any(|name| name == "origin"))
+}
+
+fn fetch_origin_branch(action: &str, workspace: &Path, branch: &str) -> Result<(), DispatchError> {
+    let spec = format!("+refs/heads/{branch}:refs/remotes/origin/{branch}");
+    let output = Command::new("git")
+        .args(["fetch", "origin", &spec])
+        .current_dir(workspace)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .map_err(|error| {
+            action_failed(
+                action,
+                format!(
+                    "failed to fetch origin/{branch} in '{}': {error}",
+                    workspace.display()
+                ),
+            )
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(action_failed(
+        action,
+        format!(
+            "remote failure: could not fetch origin/{branch} in '{}': {}",
+            workspace.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    ))
+}
+
+fn rev_parse_commit(action: &str, workspace: &Path, rev: &str) -> Result<String, DispatchError> {
+    let spec = format!("{rev}^{{commit}}");
+    let output = git(action, workspace, &["rev-parse", "--verify", &spec])?;
+    if !output.success {
+        return Err(action_failed(
+            action,
+            format!(
+                "unable to resolve source revision `{rev}`: {}",
+                output.stderr.trim()
+            ),
+        ));
+    }
+    let sha = output.stdout.trim();
+    if !is_commit_id(sha) {
+        return Err(action_failed(
+            action,
+            format!("resolved `{rev}` to a non-commit id {sha:?}"),
+        ));
+    }
+    Ok(sha.to_string())
+}
+
+fn is_ancestor(
+    action: &str,
+    workspace: &Path,
+    ancestor: &str,
+    descendant: &str,
+) -> Result<bool, DispatchError> {
+    let output = git(
+        action,
+        workspace,
+        &["merge-base", "--is-ancestor", ancestor, descendant],
+    )?;
+    Ok(output.success)
+}
+
+fn working_tree_status(action: &str, workspace: &Path) -> Result<Vec<String>, DispatchError> {
+    let output = git(action, workspace, &["status", "--porcelain=v1", "-uall"])?;
+    if !output.success {
+        return Err(action_failed(
+            action,
+            format!(
+                "unable to read git status in '{}': {}",
+                workspace.display(),
+                output.stderr.trim()
+            ),
+        ));
+    }
+    Ok(output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(8)
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn git_tree_path(anchor: &Path) -> Option<String> {
+    if anchor.is_absolute() {
+        return None;
+    }
+    let mut parts = Vec::new();
+    for component in anchor.components() {
+        match component {
+            std::path::Component::Normal(part) => parts.push(part.to_string_lossy().into_owned()),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
+fn is_commit_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn git(
+    action: &str,
+    workspace: &Path,
+    args: &[&str],
+) -> Result<orbit_common::fs::git::GitCommandOutput, DispatchError> {
+    run_git(workspace, args).map_err(|error| {
+        action_failed(
+            action,
+            format!(
+                "git {} failed in '{}': {error}",
+                args.join(" "),
+                workspace.display()
+            ),
+        )
+    })
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -315,8 +315,15 @@ fn failed_or_warned_pilot_does_not_block_an_independent_eligible_fix() {
         &filings[2],
         Assessment::actionable("file:src/missing.rs", true),
     )
-    .expect_err("invalid selector fails only its pilot apply");
-    assert!(invalid.contains("does not resolve"), "{invalid}");
+    .expect("invalid selector is a durable failed partition");
+    assert_eq!(invalid["status"], "failed");
+    assert!(
+        invalid["partition_decisions"][0]["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("does not resolve"),
+        "{invalid}"
+    );
 
     let eligible = apply_pilot(
         &runtime,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -12,6 +12,7 @@ mod scan_unresolved;
 mod sweep_duplicate_tasks;
 mod task_context;
 mod task_pilot;
+mod task_pilot_source;
 mod triage;
 mod v2_host;
 mod workspace_auto;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -1,0 +1,397 @@
+//! Git source-snapshot fixtures for task-pilot prepare/apply [ORB-11236].
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::super::task_pilot::{apply, prepare};
+use crate::OrbitRuntime;
+use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+use crate::application::task::TaskAddParams;
+
+const LANDING: &str = "agent-main";
+
+struct RemoteLandingFixture {
+    _root: TempDir,
+    runtime: OrbitRuntime,
+    repo: PathBuf,
+    seed: PathBuf,
+    stale_sha: String,
+    current_sha: String,
+    task: Task,
+}
+
+fn seed_task(runtime: &OrbitRuntime, title: &str) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: format!("Fixture task: {title}"),
+            acceptance_criteria: vec!["The fixture outcome is observable.".to_string()],
+            plan: "Inspect and update the fixture.".to_string(),
+            workspace_path: Some(".".to_string()),
+            priority: TaskPriority::Medium,
+            task_type: Some(TaskType::Chore),
+            status: Some(TaskStatus::Backlog),
+            ..TaskAddParams::default()
+        })
+        .expect("seed task")
+}
+
+fn selector_assessment(task: &Task, after: Vec<&str>) -> Value {
+    json!({
+        "task_id": task.id,
+        "context_files_before": task.context_files,
+        "context_files_after": after,
+        "disposition": "selectors",
+        "recommended_crew": "luna",
+        "recommended_complexity": "medium",
+        "blocked_by": [],
+        "duplicate_of": null,
+        "already_landed": null,
+        "adr_conflicts": [],
+        "utility_warnings": [],
+        "surface_warnings": [],
+    })
+}
+
+fn apply_selectors(
+    runtime: &OrbitRuntime,
+    prepared: &Value,
+    task: &Task,
+    after: Vec<&str>,
+) -> Value {
+    apply(
+        runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared,
+            "results": [{
+                "partition_index": 0,
+                "task_ids": [task.id.clone()],
+                "tasks": [selector_assessment(task, after)],
+                "summary": "fixture partition",
+            }],
+            "workspace_path": prepared["workspace_path"],
+        }),
+    )
+    .expect("apply partition is a durable output")
+}
+
+fn git(current_dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn git_allow_fail(current_dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")))
+}
+
+fn init_repo(path: &Path, branch: &str) {
+    fs::create_dir_all(path).expect("create repo dir");
+    git(path, &["init"]);
+    git(path, &["checkout", "-b", branch]);
+    git(path, &["config", "user.name", "Orbit Test"]);
+    git(path, &["config", "user.email", "orbit-test@example.com"]);
+    git(path, &["config", "commit.gpgsign", "false"]);
+}
+
+fn commit_file(repo: &Path, relative: &str, contents: &str) -> String {
+    let path = repo.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(&path, contents).expect("write file");
+    git(repo, &["add", relative]);
+    git(repo, &["commit", "-m", &format!("write {relative}")]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+fn remote_landing_fixture() -> RemoteLandingFixture {
+    let (root, runtime, repo) = runtime_with_workspace_layout();
+    let remote = root.path().join("remote.git");
+    let seed = root.path().join("seed");
+    git(root.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    init_repo(&repo, LANDING);
+    fs::create_dir_all(repo.join("src")).expect("src dir");
+    fs::write(repo.join(".gitignore"), ".orbit/\n").expect("ignore orbit store");
+    fs::write(repo.join("src/existing.rs"), "existing\n").expect("write existing");
+    git(&repo, &["add", ".gitignore", "src/existing.rs"]);
+    git(&repo, &["commit", "-m", "existing target"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&repo, &["push", "-u", "origin", LANDING]);
+    let stale_sha = git(&repo, &["rev-parse", "HEAD"]);
+
+    git(
+        root.path(),
+        &[
+            "clone",
+            "--branch",
+            LANDING,
+            remote.to_str().unwrap(),
+            seed.to_str().unwrap(),
+        ],
+    );
+    git(&seed, &["config", "user.name", "Orbit Test"]);
+    git(&seed, &["config", "user.email", "orbit-test@example.com"]);
+    git(&seed, &["config", "commit.gpgsign", "false"]);
+    let current_sha = commit_file(&seed, "src/merged.rs", "newly merged\n");
+    git(&seed, &["push", "origin", LANDING]);
+
+    assert_eq!(git(&repo, &["rev-parse", "HEAD"]), stale_sha);
+    assert!(!repo.join("src/merged.rs").exists());
+
+    let task = seed_task(&runtime, "merged target");
+    RemoteLandingFixture {
+        _root: root,
+        runtime,
+        repo,
+        seed,
+        stale_sha,
+        current_sha,
+        task,
+    }
+}
+
+fn prepare_landing(fixture: &RemoteLandingFixture) -> Result<Value, String> {
+    prepare(
+        &fixture.runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": [fixture.task.id.clone()],
+            "workspace_path": fixture.repo,
+            "base_branch": LANDING,
+        }),
+    )
+    .map_err(|error| error.to_string())
+}
+
+#[test]
+fn clean_stale_primary_fast_forwards_and_apply_admits_newly_merged_file() {
+    let fixture = remote_landing_fixture();
+    let prepared = prepare_landing(&fixture).expect("clean stale primary prepares");
+
+    assert_eq!(prepared["source"]["base_branch"], LANDING);
+    assert_eq!(
+        prepared["source"]["source_ref"],
+        format!("origin/{LANDING}")
+    );
+    assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
+    assert_eq!(prepared["source"]["fast_forwarded"], true);
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", "HEAD"]),
+        fixture.current_sha
+    );
+    assert!(fixture.repo.join("src/merged.rs").exists());
+
+    let output = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["file:src/merged.rs"],
+    );
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["source"]["source_revision"], fixture.current_sha);
+    assert_eq!(
+        fixture
+            .runtime
+            .get_task(&fixture.task.id)
+            .unwrap()
+            .context_files,
+        vec!["file:src/merged.rs"]
+    );
+}
+
+#[test]
+fn dirty_primary_reports_source_staleness_without_moving_head() {
+    let fixture = remote_landing_fixture();
+    fs::write(fixture.repo.join("src/existing.rs"), "dirty local edit\n")
+        .expect("dirty tracked file");
+    let before = git(&fixture.repo, &["rev-parse", "HEAD"]);
+
+    let error = prepare_landing(&fixture).expect_err("dirty primary must not spend an agent call");
+    assert!(
+        error.contains("source-staleness"),
+        "expected source-staleness, got {error}"
+    );
+    assert!(error.contains(&fixture.current_sha));
+    assert!(error.contains(&fixture.stale_sha));
+    assert_eq!(git(&fixture.repo, &["rev-parse", "HEAD"]), before);
+    assert!(!fixture.repo.join("src/merged.rs").exists());
+}
+
+#[test]
+fn untracked_file_on_stale_primary_does_not_reset_or_admit_later_paths() {
+    let fixture = remote_landing_fixture();
+    fs::write(fixture.repo.join("scratch.txt"), "untracked\n").expect("untracked file");
+    let before = git(&fixture.repo, &["rev-parse", "HEAD"]);
+
+    let error = prepare_landing(&fixture).expect_err("untracked files block fast-forward");
+    assert!(error.contains("source-staleness"), "{error}");
+    assert!(
+        error.contains("untracked") || error.contains("dirty"),
+        "{error}"
+    );
+    assert_eq!(git(&fixture.repo, &["rev-parse", "HEAD"]), before);
+    assert!(
+        git_allow_fail(&fixture.repo, &["status", "--porcelain"])
+            .status
+            .success()
+    );
+    let status_output = git_allow_fail(&fixture.repo, &["status", "--porcelain"]);
+    let status = String::from_utf8_lossy(&status_output.stdout);
+    assert!(status.contains("scratch.txt"));
+}
+
+#[test]
+fn remote_failure_is_closed_without_git_writes() {
+    let fixture = remote_landing_fixture();
+    git(
+        &fixture.repo,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "/no/such/orbit-pilot-remote.git",
+        ],
+    );
+    let before = git(&fixture.repo, &["rev-parse", "HEAD"]);
+
+    let error = prepare_landing(&fixture).expect_err("broken origin must fail closed");
+    assert!(
+        error.contains("remote failure") || error.contains("could not fetch"),
+        "{error}"
+    );
+    assert_eq!(git(&fixture.repo, &["rev-parse", "HEAD"]), before);
+    assert!(!fixture.repo.join("src/merged.rs").exists());
+}
+
+#[test]
+fn apply_uses_pinned_revision_after_concurrent_branch_advancement() {
+    let fixture = remote_landing_fixture();
+    let prepared = prepare_landing(&fixture).expect("prepare pins current landing tip");
+    let pinned = prepared["source"]["source_revision"]
+        .as_str()
+        .expect("pinned sha")
+        .to_string();
+    assert_eq!(pinned, fixture.current_sha);
+
+    commit_file(&fixture.seed, "src/later.rs", "landed after prepare\n");
+    git(&fixture.seed, &["push", "origin", LANDING]);
+    git(&fixture.repo, &["fetch", "origin", LANDING]);
+    git(
+        &fixture.repo,
+        &["merge", "--ff-only", &format!("origin/{LANDING}")],
+    );
+    assert!(fixture.repo.join("src/later.rs").exists());
+
+    let later = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["file:src/later.rs"],
+    );
+    assert_eq!(later["status"], "failed");
+    let error = later["partition_decisions"][0]["error"]
+        .as_str()
+        .expect("failed partition error");
+    assert!(error.contains("does not resolve"), "{error}");
+    assert!(error.contains(&pinned), "{error}");
+    assert!(
+        fixture
+            .runtime
+            .get_task(&fixture.task.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+
+    let merged = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["file:src/merged.rs"],
+    );
+    assert_eq!(merged["status"], "succeeded");
+    assert_eq!(
+        fixture
+            .runtime
+            .get_task(&fixture.task.id)
+            .unwrap()
+            .context_files,
+        vec!["file:src/merged.rs"]
+    );
+}
+
+#[test]
+fn untracked_workspace_file_is_not_admitted_against_the_source_snapshot() {
+    let fixture = remote_landing_fixture();
+    let prepared = prepare_landing(&fixture).expect("fast-forward to landing tip");
+    fs::write(fixture.repo.join("src/ghost.rs"), "working tree only\n").expect("untracked ghost");
+
+    let output = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["file:src/ghost.rs"],
+    );
+    assert_eq!(output["status"], "failed");
+    assert!(
+        output["partition_decisions"][0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("does not resolve")
+    );
+    assert!(
+        fixture
+            .runtime
+            .get_task(&fixture.task.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+}
+
+#[test]
+fn non_git_workspace_still_uses_filesystem_existence() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    fs::create_dir_all(repo_root.join("src")).expect("src");
+    fs::write(repo_root.join("src/alpha.rs"), "fn alpha() {}\n").expect("alpha");
+    let task = seed_task(&runtime, "filesystem fallback");
+    let prepared = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({
+            "task_ids": [task.id.clone()],
+            "workspace_path": repo_root,
+            "base_branch": LANDING,
+        }),
+    )
+    .expect("non-git prepare");
+    assert_eq!(prepared["source"]["source_revision"], Value::Null);
+
+    let output = apply_selectors(&runtime, &prepared, &task, vec!["file:src/alpha.rs"]);
+    assert_eq!(output["status"], "succeeded");
+}

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -448,6 +448,7 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     assert_eq!(prepare.target, "activity:prepare_task_pilot");
     let prepare_input = prepare.default_input.as_ref().expect("prepare input");
     assert_eq!(prepare_input["task_ids"], "{{ input.task_ids }}");
+    assert_eq!(prepare_input["base_branch"], "{{ input.base_branch }}");
 
     let JobV2StepBody::FanOut { fan_out, fan_in } = &asset.spec.steps[1].body else {
         panic!("task pilot agent work must fan out");
@@ -465,6 +466,14 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     assert_eq!(pilot.target, "activity:task_pilot");
     let pilot_input = pilot.default_input.as_ref().expect("pilot input");
     assert_eq!(pilot_input["task_ids"], "{{ item.task_ids }}");
+    assert_eq!(
+        pilot_input["base_branch"],
+        "{{ steps.prepare.output.source.base_branch }}"
+    );
+    assert_eq!(
+        pilot_input["source_revision"],
+        "{{ steps.prepare.output.source.source_revision }}"
+    );
     assert_eq!(
         pilot_input["crew"],
         json!("system"),

--- a/plugin/agents/orbit-task-pilot.md
+++ b/plugin/agents/orbit-task-pilot.md
@@ -8,20 +8,25 @@ You are Orbit's task-pilot agent.
 
 ## Contract
 
-Accept an explicit target workspace, a target branch, and a partition of one to
+Accept an explicit target workspace, a target branch, a prepared
+`source_revision` when the pipeline pinned one, and a partition of one to
 five Orbit task IDs. Inspect those tasks and return proposals. Do not apply them.
 
 For each task:
 
 1. Read the complete record and preserve the current selector list exactly as
    `context_files_before`.
-2. Inspect the target branch, modification and deletion targets, related tasks,
-   and any recorded decisions governing the code in scope, using read-only tools
-   only. Decisions are titled sections inside a feature's design docs — reach
-   them through the docs corpus, not a separate decision store.
+2. Inspect the target branch at `source_revision` when that commit is supplied,
+   modification and deletion targets, related tasks, and any recorded decisions
+   governing the code in scope, using read-only tools only. The pinned revision
+   is the source of truth for whether a path exists; do not propose
+   working-tree-only or later-commit files. Decisions are titled sections
+   inside a feature's design docs — reach them through the docs corpus, not a
+   separate decision store.
 3. Return `context_files_after` using only canonical `file:`, `dir:`, or
-   `symbol:` selectors whose anchors already exist inside the target workspace.
-   Modification and deletion targets only — never read-for-context files.
+   `symbol:` selectors whose anchors already exist inside the target workspace
+   at that source revision. Modification and deletion targets only — never
+   read-for-context files.
 4. Use disposition `selectors` for a non-empty proposal. An empty proposal is
    valid only with `verified_no_diff` or `host_operational`, plus concrete
    evidence. Never return an empty list merely because inspection was

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -82,6 +82,16 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
+The prepare step fetches the landing branch (`base_branch`, defaulting to
+`workflow.base_branch`) and pins one `source_revision`. A clean primary that
+already sits on that branch and is behind origin is fast-forwarded so inspection
+sees the landed tree; a dirty, divergent, or unfetchable checkout fails as
+source-staleness *before* any agent call. The pilot inspects that pinned
+revision. Apply validates selector existence against the same snapshot, not a
+later working tree, so a newly merged file is not reported as missing merely
+because the primary lagged origin, and a later origin advance cannot admit a
+path that did not exist at prepare.
+
 The pilot agent inspection is read-only; its deterministic apply step mutates
 validated task selectors. It runs five
 partitions concurrently, and returns selector proposals plus duplicate,


### PR DESCRIPTION
## Task

[ORB-11236](https://orbit-cli.com/tasks/ORB-11236) — Prepare pilot context against a consistent current landing-branch snapshot

### Description

Mac kvDB incident reported by supervising subagent: pilot jrun-20260905-0353-2 for DANI-10206 failed apply with selector file:golang/kvcli/cmd/cli_test.go does not resolve to an existing in-workspace target. File was already merged in CLI PR66; primary local main remained77a7655 while origin/main advanced6682327. Verified clean primary and ff-only synchronization to6682327 allowed zero-input retry0357 to proceed. Task execution advances remote landing branch but pilot inspection/apply can validate different or stale checkout snapshots. Make the existing pilot preparation and selector application use one explicit verified source revision appropriate to the landing branch and preserve it in evidence; diagnose drift instead of falsely saying a newly merged target does not exist. Decide the smallest consistent snapshot mechanism from current Git/runtime seams, without unconditional checkout/pull/reset of a dirty primary and without silently widening selector rules to nonexistent new files. Context selectors still name real modification targets. Keep snapshot safety/CAS against task changes; separate working-tree changes from task-state changes. ORB-11233 covers overlapping task snapshots/partitions; this task covers code revision consistency after remote delivery.

### Acceptance Criteria

- Fixture with remote landing branch advanced and clean stale primary correctly prepares a newly merged modification target against the declared source revision, or reports actionable explicit source-staleness before spending an agent call.
- Inspection and deterministic selector validation share the same source snapshot; revision appears in durable pilot evidence.
- Dirty primary, untracked files, remote failure and concurrent branch advancement are handled without destructive Git writes or admitting genuinely nonexistent targets.
- Existing selector semantics and managed-run authority are preserved; targeted Git/snapshot tests and required Orbit checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `prepare_task_pilot` now fetches the landing branch (`base_branch`, else `workflow.base_branch`), pins one `source_revision`, and fast-forwards a clean primary that already sits on that branch and is behind origin. Dirty, untracked, divergent, or unfetchable checkouts fail closed as explicit source-staleness before any agent call; no checkout/pull/reset of a dirty primary.
- `apply_task_pilot_results` validates `file:`/`dir:`/`symbol:` anchors with `git cat-file` at the prepared SHA when one was pinned, so a later working-tree or origin advance cannot admit a path that did not exist at prepare, and a newly merged file is not reported as missing merely because the primary lagged origin. Task-state CAS is unchanged. Non-git fixtures keep filesystem existence.
- Pipeline wiring passes `base_branch` into prepare and the pinned `source_revision` into the read-only pilot. Durable prepare/apply output includes `source` (`base_branch`, `source_ref`, `source_revision`, `fast_forwarded`). Agent instruction and orchestration docs describe the snapshot.
- Git fixtures cover clean stale primary + newly merged file, dirty/untracked/remote-failure without HEAD movement, concurrent advancement, and untracked working-tree files not admitted against the snapshot.

Assessment: Smallest consistent seam from `orbit_common::fs::git` plus optional ff-only; selector grammar is unchanged.
Strategic decisions: Pin the fetched commit at prepare and validate apply against that object, rather than a detached inspection worktree. Fast-forward only when the primary is clean, on the landing branch, and an ancestor of the pinned SHA.
Design weaknesses / risks:
- Severity: medium. Fetch of `origin/<base>` can fail a scheduled zero-input pilot when the network or remote ref is unavailable. Mitigation: fail closed with `remote failure` instead of inspecting a stale tree (the incident mode).
- Severity: low. Dirty primary behind origin still requires an operator/clean-up before piloting. Mitigation: the error names both SHAs and the ff-only recovery.
Validation: `cargo test -p orbit-core --lib -- task_pilot ci_failure_admission` (25 passed); `make ci-fast`; `make ci-lint`.
Recommended follow-ups: none for this snapshot seam; ORB-11233 remains the overlapping-task partition work.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11236-6a9b9d7f`
- Behind base: 0
- Ahead of base: 1