### PR TITLE
[BLOCKED] [auto-task] Remediate current GitHub Actions failures

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -315,8 +315,15 @@ fn failed_or_warned_pilot_does_not_block_an_independent_eligible_fix() {
         &filings[2],
         Assessment::actionable("file:src/missing.rs", true),
     )
-    .expect_err("invalid selector fails only its pilot apply");
-    assert!(invalid.contains("does not resolve"), "{invalid}");
+    .expect("invalid selector is isolated to its pilot apply");
+    assert_eq!(invalid["status"], "failed");
+    assert_eq!(invalid["failed_partitions"][0]["outcome"], "failed");
+    assert!(
+        invalid["failed_partitions"][0]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("does not resolve")),
+        "{invalid}"
+    );
 
     let eligible = apply_pilot(
         &runtime,

--- a/crates/orbit-core/src/application/job/tests/exec/completion.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/completion.rs
@@ -194,6 +194,7 @@ impl RuntimeHost for CompletionFailureHost<'_> {
                     "allow_rebase_merge": true,
                     "allow_merge_commit": true,
                     "requires_linear_history": true,
+                    "allow_auto_merge": false,
                 }
             })),
             "pr.merge" => Err(orbit_common::OrbitError::Execution(


### PR DESCRIPTION
## Manual resolution required

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline stopped. This PR is intentionally blocked and must be reconciled manually before merge.

- Task: `ORB-11186`
- Run: `jrun-20260905-0440-3`
- Failed step: `sync_base`
- Error code: `pipeline_step_failed`
- Original base: `caf7f890827b344954ea0c92f3cda5fd1e1b82f9`
- Target base: `65a2e65831ea7c5740ef036013e0f6fc20543b80`

## Conflicting paths

- `crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs`

## Failure

```text
deterministic action `git_rebase` failed: execution failed: git_rebase: rebase of 'orbit/ORB-11186-6a9b9d42' onto checkpoint '65a2e65831ea7c5740ef036013e0f6fc20543b80' stopped with conflicts; conflicting paths: crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
```