### PR TITLE
Update completion pipeline fixture for required auto-merge capability

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec/completion.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/completion.rs
@@ -193,6 +193,7 @@ impl RuntimeHost for CompletionFailureHost<'_> {
                     "allow_squash_merge": false,
                     "allow_rebase_merge": true,
                     "allow_merge_commit": true,
+                    "allow_auto_merge": true,
                     "requires_linear_history": true,
                 }
             })),


### PR DESCRIPTION
## Task

[ORB-11252](https://orbit-cli.com/tasks/ORB-11252) — Update completion pipeline fixture for required auto-merge capability

### Description

Confirmed current CI33945478293, tested/head cc00ce1739c78e7531f20e107b15cbd3662e668a, Coverage job101250653399: application::job::tests::exec::completion::completion_merge_failure_routes_to_review_recovery_without_republishing fails at crates/orbit-core/src/application/job/tests/exec/completion.rs86. Actual error `merge strategy resolution: repository capabilities omitted boolean allow_auto_merge`; expected deliberately injected `could not request rebase merge` / `merge permission denied`. ORB-11247 correctly made the private capability shape include allow_auto_merge, but the cross-crate CompletionFailureHost fixture still emits the older shape. Update this isolated fake capability response so the regression reaches and asserts the intended merge-denial recovery, retaining review state, unchanged PR/candidate, and no republish assertions. Do not relax production capability parsing or weaken the failure-semantics test. ORB-11186 currently repairs a different stale CI-admission expectation in ci_failure_admission.rs; keep this later, separate fixture repair scoped.

### Acceptance Criteria

- The real-job-executor completion failure regression reaches its intentional merge-permission denial and all existing recovery assertions pass.
- The fake repository capability response matches the current private contract, with no production-code relaxation.
- Run the focused completion test and relevant core execution suite, then required checks; verify the formerly failing CI job at the merged candidate.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/job/tests/exec/completion.rs` so the `CompletionFailureHost` fake repository capability response includes the required `allow_auto_merge: true` field.
- Kept production capability parsing, merge-denial semantics, and all recovery assertions unchanged.

Assessment: The focused regression now reaches the intentional `gh: merge permission denied` path and preserves review state, the existing PR/candidate, and no-republish behavior. The relevant execution suite and repository checks pass.

Validation:
- `cargo test -p orbit-core completion_merge_failure_routes_to_review_recovery_without_republishing --lib` — passed (1 test).
- `cargo test -p orbit-core application::job::tests::exec --lib` — passed (26 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed with warnings denied.
- `git diff --check` — passed; final worktree contains only the intended fixture change.
- Removed the worktree-local `target/` artifacts created by this run. Merged-candidate CI verification remains with the delivery pipeline because this activity has no merged candidate yet.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11252-6a9ba4f6`
- Behind base: 0
- Ahead of base: 1