### PR TITLE
Start a bounded auto-delivery window from the Orbit dashboard

### DIFF
--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -179,6 +179,15 @@ pub const DASHBOARD_AUTO_TASK_MINT: GovernedOperation = GovernedOperation {
     rationale: "manual mint ignores schedule, enabled state, and scheduler dedupe",
 };
 
+/// Opt-in `CompletionPolicy::Done` for a dashboard-submitted bounded
+/// auto-drain window (the `--complete` equivalent of `orbit run auto`).
+pub const DASHBOARD_AUTO_DRAIN_COMPLETE: GovernedOperation = GovernedOperation {
+    id: "auto_drain.complete",
+    surface: OperationSurface::Dashboard,
+    allowed: &[McpCapability::Operator],
+    rationale: "opting into automatic completion authorizes review -> done for every task the drain window ships, not only the ones visible at submission",
+};
+
 /// Every governed operation, declared exactly once.
 ///
 /// This is the single enumerable place the required capability lives. A call
@@ -293,6 +302,7 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
     DASHBOARD_CLOCK_CADENCE,
     DASHBOARD_AUTO_TASK_TOGGLE,
     DASHBOARD_AUTO_TASK_MINT,
+    DASHBOARD_AUTO_DRAIN_COMPLETE,
 ];
 
 /// Look up the governed tool operation for `tool_name`, if any.

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4147,7 +4147,7 @@
         grid-template-columns: minmax(0, 2fr) minmax(300px, 1fr);
         align-items: start;
       }
-      .operations-auto-tasks-layout { grid-template-columns: minmax(0, 1fr); }
+      .operations-auto-tasks-layout, .operations-auto-drain-layout { grid-template-columns: minmax(0, 1fr); }
       body.operations-active { height: auto; min-height: 100vh; overflow-y: auto; }
       .operations-layout .panel { min-width: 0; }
       .tab-pane[data-tab="operations"] .subtabs { border-bottom: 1px solid var(--border); }
@@ -4159,7 +4159,7 @@
       .operation-feedback.pending { color: var(--priority-medium); }
       .operation-feedback.success { color: var(--state-success); }
       .operation-feedback.error { color: var(--state-failed); }
-      #routines-body, #clock-body, #auto-tasks-body { padding: 12px; background: var(--bg); }
+      #routines-body, #clock-body, #auto-tasks-body, #auto-drain-body { padding: 12px; background: var(--bg); }
       .operation-card {
         padding: 12px; margin-bottom: 10px; border: 1px solid var(--border);
         border-radius: 4px; background: var(--bg-elev);

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -334,6 +334,7 @@
       <nav class="subtabs" id="operations-subtabs">
         <button class="subtab active" data-subtab="routines" type="button">Routines</button>
         <button class="subtab" data-subtab="auto-tasks" type="button">Auto-tasks</button>
+        <button class="subtab" data-subtab="auto-drain" type="button">Auto-drain</button>
       </nav>
       <main class="operations-layout" id="operations-routines-main">
         <section class="panel" id="routines-panel">
@@ -362,6 +363,18 @@
           </header>
           <div class="operation-feedback" id="auto-task-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="auto-tasks-body">
+            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+          </div>
+        </section>
+      </main>
+      <main class="operations-layout operations-auto-drain-layout" id="operations-auto-drain-main" hidden>
+        <section class="panel" id="auto-drain-panel">
+          <header>
+            <span>Bounded Auto-delivery Window</span>
+            <span class="count" id="auto-drain-count">-</span>
+          </header>
+          <div class="operation-feedback" id="auto-drain-operation-feedback" role="status" aria-live="polite"></div>
+          <div class="body" id="auto-drain-body">
             <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,12 +1,20 @@
 // Routine-definition, host sweep-clock, and auto-task operations [ORB-10875, ORB-10876].
 
 import { el, fetchJson, getWorkspace, postJson } from './common.js';
+import { navigateToRun } from './router.js';
 
 const $ = (id) => document.getElementById(id);
 const pendingOperations = new Set();
 const UNCONDITIONAL_MINT_WARNING = "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.";
+const AUTO_DRAIN_DURATIONS = ["15m", "30m", "1h", "2h", "4h", "8h"];
+const AUTO_DRAIN_COMPLETE_WARNING = "Also marks every task this window ships as done (review -> done), not only the ones eligible right now.";
 let lastOperations = null;
 let lastAutoTasks = null;
+let lastAutoDrain = null;
+let autoDrainDuration = "1h";
+let autoDrainConcurrency = "";
+let autoDrainComplete = false;
+let lastAutoDrainRun = null;
 let context = null;
 
 export function initOperations(nextContext) {
@@ -404,11 +412,174 @@ function fetchAndRenderAutoTasks() {
   return fetchJson("/api/auto-tasks").then(renderAutoTasks);
 }
 
+// ORB-11250: bounded backlog auto-drain window ("orbit run auto --for
+// <duration> [--complete]" from the dashboard). One workspace-scoped action,
+// not a per-row one, so it follows the mint/clock in-flight idiom (a single
+// fixed `pendingOperations` key, guard released in `finally`) rather than
+// tasks.js's per-task Ship guard.
+function autoDrainReasons(payload) {
+  const workspaceReason = workspaceReadOnlyReason();
+  return {
+    submit: workspaceReason,
+    complete: workspaceReason || (payload.controls_authorized === false
+      ? "Automatic completion requires an authorized operator session; the window can still start with default review completion."
+      : ""),
+  };
+}
+
+function autoDrainCounts(payload) {
+  const tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+  const eligible = tasks.filter((task) => task.eligible).length;
+  return { eligible, waiting: tasks.length - eligible };
+}
+
+function autoDrainStartButton(payload) {
+  const key = "auto-drain:start";
+  const reasons = autoDrainReasons(payload);
+  const pending = pendingOperations.has(key);
+  const button = el("button", {
+    class: "operation-button secondary",
+    text: pending ? "Starting…" : "Start bounded window",
+    title: reasons.submit || "Submit orbit.workflow.auto with this duration and concurrency",
+  });
+  button.type = "button";
+  button.disabled = Boolean(reasons.submit) || pending || autoDrainComplete && Boolean(reasons.complete);
+  button.addEventListener("click", async () => {
+    if (pendingOperations.has(key)) return;
+    const workspace = selectedWorkspace();
+    const counts = autoDrainCounts(payload);
+    const completeLine = autoDrainComplete
+      ? `WARNING: ${AUTO_DRAIN_COMPLETE_WARNING}`
+      : "Shipped tasks stay in review; a separate action completes them.";
+    const confirmText = [
+      `Start a bounded auto-delivery window in workspace "${workspace?.name || workspace?.id}"?`,
+      `Duration: ${autoDrainDuration} · Concurrency: ${autoDrainConcurrency || "runtime default"}`,
+      `Currently eligible: ${counts.eligible} · waiting: ${counts.waiting}`,
+      "",
+      completeLine,
+    ].join("\n");
+    if (!window.confirm(confirmText)) return;
+    pendingOperations.add(key);
+    feedback("auto-drain-operation-feedback", "pending", `Starting a ${autoDrainDuration} auto-delivery window…`);
+    renderAutoDrain(payload);
+    try {
+      const body = { for_duration: autoDrainDuration, complete: autoDrainComplete };
+      if (autoDrainConcurrency) body.concurrency = Number(autoDrainConcurrency);
+      const result = await postJson("/api/workflows/auto", body);
+      const runId = result?.run_id ?? null;
+      const state = result?.state ?? "submitted";
+      const completion = result?.completion ?? "review";
+      feedback("auto-drain-operation-feedback", "success", `Run ${runId ?? "(no run id)"} ${state} (completion: ${completion}).`);
+      lastAutoDrainRun = runId ? { runId, state, completion, workspaceId: workspace?.id } : null;
+      await fetchAndRenderAutoDrain();
+    } catch (error) {
+      feedback("auto-drain-operation-feedback", "error", `Auto-delivery window failed to start: ${error.message}`);
+    } finally {
+      pendingOperations.delete(key);
+      if (lastAutoDrain) renderAutoDrain(lastAutoDrain);
+    }
+  });
+  return button;
+}
+
+function renderAutoDrain(payload) {
+  lastAutoDrain = payload;
+  const body = $("auto-drain-body");
+  if (!body) return;
+  body.textContent = "";
+  const reasons = autoDrainReasons(payload);
+  const workspace = selectedWorkspace();
+  if (reasons.submit) {
+    body.appendChild(el("div", { class: "operations-readonly-note", text: reasons.submit }));
+    $("auto-drain-count").textContent = "read-only";
+    return;
+  }
+  const counts = autoDrainCounts(payload);
+  const capacity = payload.capacity || {};
+  body.append(
+    el("div", { class: "operation-grid" }, [
+      field("Active leaf runs", `${capacity.active_leaf_runs ?? "—"} / ${capacity.max_active_leaf_runs ?? "—"}`),
+      field("Free slots", capacity.free_slots),
+      field("Eligible now", counts.eligible),
+      field("Waiting", counts.waiting),
+    ]),
+  );
+  body.appendChild(el("p", {
+    class: "operation-control-note",
+    text: "Proposed tasks are never drained automatically; promote a task to backlog first. This snapshot can change the instant after it is read.",
+  }));
+
+  const durationSelect = el("select", { class: "operation-cadence", title: "Bounded drain window" });
+  for (const value of AUTO_DRAIN_DURATIONS) {
+    const option = el("option", { text: value });
+    option.value = value;
+    option.selected = value === autoDrainDuration;
+    durationSelect.appendChild(option);
+  }
+  durationSelect.addEventListener("change", () => {
+    autoDrainDuration = durationSelect.value;
+  });
+
+  const concurrencyInput = el("input", { class: "operation-cadence", title: "Leaf-run concurrency (blank = runtime default)" });
+  concurrencyInput.type = "number";
+  concurrencyInput.min = "1";
+  concurrencyInput.placeholder = "Default";
+  concurrencyInput.value = autoDrainConcurrency;
+  concurrencyInput.addEventListener("change", () => {
+    autoDrainConcurrency = concurrencyInput.value.trim();
+  });
+
+  const completeLabel = el("label", { class: "operation-field", title: reasons.complete || AUTO_DRAIN_COMPLETE_WARNING });
+  const completeCheckbox = el("input");
+  completeCheckbox.type = "checkbox";
+  completeCheckbox.checked = autoDrainComplete;
+  completeCheckbox.disabled = Boolean(reasons.complete);
+  completeCheckbox.addEventListener("change", () => {
+    autoDrainComplete = completeCheckbox.checked;
+    renderAutoDrain(payload);
+  });
+  completeLabel.append(completeCheckbox, el("span", { text: " Also mark shipped tasks done (skip review)" }));
+
+  const form = el("div", { class: "operation-clock-actions" }, [durationSelect, concurrencyInput, completeLabel, autoDrainStartButton(payload)]);
+  body.appendChild(form);
+  if (autoDrainComplete) {
+    body.appendChild(el("p", { class: "operation-control-note operation-mint-warning", text: AUTO_DRAIN_COMPLETE_WARNING }));
+  }
+  if (lastAutoDrainRun && lastAutoDrainRun.workspaceId === workspace?.id) {
+    const runLink = el("a", {
+      class: "operation-control-note",
+      text: `Open run ${lastAutoDrainRun.runId} (${lastAutoDrainRun.state}, completion: ${lastAutoDrainRun.completion}) →`,
+      title: "Open the submitted parent run",
+    });
+    runLink.href = "#";
+    runLink.addEventListener("click", (event) => {
+      event.preventDefault();
+      navigateToRun(lastAutoDrainRun.runId, lastAutoDrainRun.workspaceId);
+    });
+    body.appendChild(runLink);
+  }
+
+  $("auto-drain-count").textContent = `${counts.eligible} eligible · ${workspace?.name || workspace?.id}`;
+}
+
+function fetchAndRenderAutoDrain() {
+  const workspace = selectedWorkspace();
+  if (!workspace) {
+    renderAutoDrain({});
+    return Promise.resolve();
+  }
+  const query = autoDrainConcurrency ? `?concurrency=${encodeURIComponent(autoDrainConcurrency)}` : "";
+  return fetchJson(`/api/workflows/auto/readiness${query}`).then(renderAutoDrain);
+}
+
 export function fetchAndRenderOperations() {
   return Promise.all([
     fetchJson("/api/routines").then(renderOperations),
     fetchAndRenderAutoTasks().catch((error) => {
       feedback("auto-task-operation-feedback", "error", `Failed to load auto-tasks: ${error.message}`);
+    }),
+    fetchAndRenderAutoDrain().catch((error) => {
+      feedback("auto-drain-operation-feedback", "error", `Failed to load auto-delivery readiness: ${error.message}`);
     }),
   ]);
 }

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -41,7 +41,7 @@ function markWorkspaceSelectorScope(fleetWide) {
 // being diagnostics-shaped, now routes as `#diagnostics/scoreboard`.
 const TABS = ["tasks", "audit", "diagnostics", "operations", "knowledge", "run-detail"];
 const DIAG_SUBTABS = ["runs", "metrics", "errors", "incidents", "reliability", "scoreboard"];
-const OPERATIONS_SUBTABS = ["routines", "auto-tasks"];
+const OPERATIONS_SUBTABS = ["routines", "auto-tasks", "auto-drain"];
 // ORB-10444/ORB-10588: subtabs that replace the two-column diagnostics layout
 // with their own full-width <main>, keyed by the element they reveal.
 const DIAG_FULL_WIDTH_MAINS = {
@@ -151,8 +151,10 @@ function setOperationsSubtabImpl(ctx, name) {
   }
   const routines = $("operations-routines-main");
   const autoTasks = $("operations-auto-tasks-main");
+  const autoDrain = $("operations-auto-drain-main");
   if (routines) routines.hidden = name !== "routines";
   if (autoTasks) autoTasks.hidden = name !== "auto-tasks";
+  if (autoDrain) autoDrain.hidden = name !== "auto-drain";
 }
 
 function setKnowledgeSubtabImpl(ctx, name) {

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -467,6 +467,8 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
         .route("/job-runs", get(jobs::list_job_runs))
         .route("/job-runs/:id/resume", post(jobs::resume_job_run_action))
         .route("/workflows/ship", post(runs::ship_workflow_action))
+        .route("/workflows/auto", post(runs::auto_drain_workflow_action))
+        .route("/workflows/auto/readiness", get(runs::auto_drain_readiness))
         .route("/runs/:id", get(runs::get_run))
         .route("/runs/:id/cancel", post(runs::cancel_run_action))
         .route("/runs/:id/replay", post(runs::replay_run_action))

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -4,6 +4,7 @@ use crate::state::Ws;
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
+use orbit_common::governance::authorization::DASHBOARD_AUTO_DRAIN_COMPLETE;
 use orbit_common::security::redaction::redact_all;
 use orbit_core::application::job::{
     ActivityInvocationEvidence, job_run_to_json_with_activity_provenance,
@@ -12,6 +13,7 @@ use orbit_core::runtime::run_audit::{RunAuditStep, RunCliInvocationRecord, RunPr
 use orbit_core::{InvocationQuery, JobRun, OrbitRuntime, V2AuditEventFilter};
 use serde_json::{Value, json};
 
+use super::routines::{authorization_denied, authorized_caller};
 use super::{
     HISTORY_DEFAULT_LIMIT, LimitQuery, RunEventsQuery, bad_request, bounded_limit,
     map_runtime_error, validate_id,
@@ -103,6 +105,153 @@ fn workspace_default_ship_mode(runtime: &OrbitRuntime) -> orbit_core::ShipMode {
     runtime
         .workspace_runtime_binding()
         .map_or(orbit_core::ShipMode::Pr, |binding| binding.ship_mode)
+}
+
+#[derive(serde::Deserialize, Default)]
+pub(super) struct AutoDrainBody {
+    /// Bounded drain window, e.g. "30m", "2h". Required: unlike the CLI's
+    /// `--for`, this endpoint always starts a bounded window, never an
+    /// open-ended one left running until something else stops it.
+    #[serde(default)]
+    for_duration: String,
+    /// Leaf-run concurrency ceiling; omitted keeps the runtime's own default.
+    #[serde(default)]
+    concurrency: Option<u32>,
+    /// Opt-in to `CompletionPolicy::Done` for this run's whole window,
+    /// mirroring CLI `--complete`. Default keeps every shipped task at
+    /// `review`, same as an omitted `--complete`.
+    #[serde(default)]
+    complete: bool,
+    /// [ORB-10709] Token for this workspace's exclusive claim, when another
+    /// operator holds one.
+    #[serde(default)]
+    claim_token: Option<String>,
+}
+
+/// Minimum bounded window this endpoint accepts, in seconds. `for_seconds:
+/// 0`/omitted is a CLI-only "one tick" shorthand; the dashboard's whole point
+/// is a *bounded* window, so an empty one is rejected rather than silently
+/// accepted.
+const MIN_AUTO_DRAIN_SECONDS: u64 = 1;
+
+/// Read-only eligible/waiting projection for backlog-discovery auto-drain,
+/// same limit the CLI's `orbit run readiness` defaults to.
+const AUTO_DRAIN_READINESS_LIMIT: usize = 50;
+
+/// Parses a "30m"/"2h"/"1d"-shaped duration the same way the CLI's `--for`
+/// does. `orbit-web` does not depend on `orbit-cli` (the dependency edge runs
+/// the other way), so this ~20-line parser is duplicated here rather than
+/// shared across that boundary.
+fn parse_drain_duration_seconds(raw: &str) -> Result<u64, String> {
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err("for_duration must not be empty".to_string());
+    }
+    let split_at = value
+        .find(|c: char| c.is_alphabetic())
+        .ok_or_else(|| format!("invalid duration: {raw}"))?;
+    let (num_raw, unit_raw) = value.split_at(split_at);
+    let num: u64 = num_raw
+        .parse()
+        .map_err(|_| format!("invalid duration number: {raw}"))?;
+    let seconds = match unit_raw {
+        "s" => Some(num),
+        "m" => num.checked_mul(60),
+        "h" => num.checked_mul(3600),
+        "d" => num.checked_mul(86400),
+        "w" => num.checked_mul(604800),
+        _ => {
+            return Err(format!(
+                "invalid duration unit: {unit_raw} (expected s/m/h/d/w)"
+            ));
+        }
+    }
+    .ok_or_else(|| format!("duration '{raw}' is too large to represent"))?;
+    if seconds < MIN_AUTO_DRAIN_SECONDS {
+        return Err("for_duration must describe a bounded window greater than zero".to_string());
+    }
+    Ok(seconds)
+}
+
+/// Submit a bounded `auto` workflow run
+/// (`POST /workflows/auto?workspace=<id>`).
+///
+/// Dashboard counterpart to `orbit run auto --for <duration> [--concurrency
+/// N] [--complete]`, reusing the same `submit_workspace_auto_run` runtime
+/// path: a concrete workspace only (the `Ws` extractor refuses all-workspace
+/// mode the same way `ship_workflow_action` does, and `submit_workspace_auto_run`
+/// enforces the workspace claim), a required bounded duration, and an
+/// explicit, separately-governed opt-in to `CompletionPolicy::Done` — opting
+/// in authorizes `review -> done` for every task the window ships, not only
+/// the ones visible now, so it is gated the same way `auto_task.mint`'s
+/// unconditional mint is.
+pub(super) async fn auto_drain_workflow_action(
+    Ws(runtime): Ws,
+    body: Option<Json<AutoDrainBody>>,
+) -> Response {
+    let Json(body) = body.unwrap_or_default();
+    let for_seconds = match parse_drain_duration_seconds(&body.for_duration) {
+        Ok(seconds) => seconds,
+        Err(message) => return bad_request(message),
+    };
+    let completion = if body.complete {
+        match authorized_caller(&DASHBOARD_AUTO_DRAIN_COMPLETE) {
+            Ok(_) => orbit_core::CompletionPolicy::Done,
+            Err(denial) => return authorization_denied(denial),
+        }
+    } else {
+        orbit_core::CompletionPolicy::Review
+    };
+    match runtime.submit_workspace_auto_run(
+        Some(for_seconds),
+        body.concurrency,
+        completion,
+        Some("dashboard"),
+        body.claim_token.as_deref(),
+    ) {
+        Ok(invoke) => Json(json!({
+            "workflow": "auto",
+            "job_id": invoke.job_name,
+            "run_id": invoke.run_id,
+            "state": if invoke.queued { "queued" } else { "submitted" },
+            "submitted_at": invoke.submitted_at,
+            "completion": completion.as_input_value(),
+        }))
+        .into_response(),
+        Err(orbit_core::OrbitError::InvalidInput(msg)) => bad_request(msg),
+        Err(e) => map_runtime_error(e),
+    }
+}
+
+#[derive(serde::Deserialize, Default)]
+pub(super) struct AutoDrainReadinessQuery {
+    #[serde(default)]
+    concurrency: Option<u32>,
+}
+
+/// `GET /workflows/auto/readiness?workspace=<id>[&concurrency=N]` — the
+/// read-only eligible/waiting snapshot for backlog-discovery auto-drain,
+/// projected straight from `OrbitRuntime::workspace_auto_readiness` (the same
+/// snapshot `orbit run readiness` prints) rather than a dashboard-local
+/// recomputation of eligibility.
+pub(super) async fn auto_drain_readiness(
+    Ws(runtime): Ws,
+    Query(query): Query<AutoDrainReadinessQuery>,
+) -> Response {
+    match runtime.workspace_auto_readiness(&[], query.concurrency, AUTO_DRAIN_READINESS_LIMIT) {
+        Ok(mut payload) => {
+            // So the form can hide/disable the `complete` opt-in before the
+            // operator ever hits the separately-governed 403 at submission.
+            if let Some(object) = payload.as_object_mut() {
+                object.insert(
+                    "controls_authorized".to_string(),
+                    Value::Bool(authorized_caller(&DASHBOARD_AUTO_DRAIN_COMPLETE).is_ok()),
+                );
+            }
+            Json(payload).into_response()
+        }
+        Err(e) => map_runtime_error(e),
+    }
 }
 
 pub(super) async fn get_run(Ws(runtime): Ws, Path(id): Path<String>) -> Response {

--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -924,3 +924,257 @@ fn a_terminal_run_never_projects_an_unfinished_step_as_still_running() {
     );
     assert_eq!(steps[0]["outcome"], "interrupted");
 }
+
+// ─── bounded auto-drain dashboard action [ORB-11250] ──────────────────────
+
+mod auto_drain {
+    use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
+
+    use super::*;
+
+    async fn request_auto(runtime: OrbitRuntime, body: Option<Value>) -> Response {
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/workflows/auto")
+            .header(header::ORIGIN, "http://localhost:3000");
+        let body = match body {
+            Some(json) => {
+                builder = builder.header(header::CONTENT_TYPE, "application/json");
+                Body::from(json.to_string())
+            }
+            None => Body::empty(),
+        };
+        router()
+            .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+            .oneshot(builder.body(body).expect("request"))
+            .await
+            .expect("response")
+    }
+
+    async fn request_readiness(runtime: OrbitRuntime, query: &str) -> Response {
+        router()
+            .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/workflows/auto/readiness{query}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+    }
+
+    /// Pin the process signals `CallerCapabilities::resolve` reads, for the
+    /// whole request. Mirrors `api::tests::auto_tasks`'s helper of the same
+    /// shape: the guard in `orbit_common::test_env` is process-wide, so every
+    /// case whose expected status depends on caller identity must go through
+    /// it rather than reading/setting the env var directly [ORB-10894].
+    #[allow(clippy::await_holding_lock)]
+    async fn with_caller_env<'a, T>(
+        vars: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+        fut: impl std::future::Future<Output = T>,
+    ) -> T {
+        let _env = orbit_common::test_env::scoped(vars);
+        fut.await
+    }
+
+    async fn as_operator<T>(fut: impl std::future::Future<Output = T>) -> T {
+        with_caller_env([(OPERATOR_OVERRIDE_ENV, Some("1"))], fut).await
+    }
+
+    async fn as_agent<T>(fut: impl std::future::Future<Output = T>) -> T {
+        with_caller_env(
+            [
+                (OPERATOR_OVERRIDE_ENV, None),
+                ("ORBIT_AGENT_NAME", Some("orbit-web-test")),
+                ("ORBIT_AGENT_MODEL", Some("orbit-web-test")),
+            ],
+            fut,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn auto_endpoint_rejects_missing_duration() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        let response = request_auto(runtime, None).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("for_duration"))
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_endpoint_rejects_invalid_duration_format() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        let response = request_auto(runtime, Some(json!({ "for_duration": "soon" }))).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("invalid duration"))
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_endpoint_rejects_zero_length_window() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        let response = request_auto(runtime, Some(json!({ "for_duration": "0s" }))).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("bounded window"))
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_endpoint_rejects_zero_concurrency() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        write_replay_job(&runtime, "workspace_auto_pipeline");
+
+        let response = request_auto(
+            runtime,
+            Some(json!({ "for_duration": "30m", "concurrency": 0 })),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("concurrency must be at least 1"))
+        );
+    }
+
+    /// Default completion (no `complete` opt-in) needs no authorization, the
+    /// same as the ship endpoint's always-review submission.
+    #[tokio::test]
+    async fn auto_endpoint_defaults_to_review_without_authorization() {
+        as_agent(async {
+            let runtime = OrbitRuntime::in_memory().expect("build runtime");
+            write_replay_job(&runtime, "workspace_auto_pipeline");
+
+            let response = request_auto(runtime, Some(json!({ "for_duration": "30m" }))).await;
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let payload = body_json(response).await;
+            assert_eq!(payload["completion"].as_str(), Some("review"));
+            assert!(payload["run_id"].as_str().is_some_and(|id| !id.is_empty()));
+        })
+        .await;
+    }
+
+    /// Opting into `complete` is separately governed: an unauthorized caller
+    /// is refused before any run is submitted.
+    #[tokio::test]
+    async fn auto_endpoint_refuses_complete_opt_in_without_authorization() {
+        as_agent(async {
+            let runtime = OrbitRuntime::in_memory().expect("build runtime");
+            write_replay_job(&runtime, "workspace_auto_pipeline");
+
+            let response = request_auto(
+                runtime.clone(),
+                Some(json!({ "for_duration": "30m", "complete": true })),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+            let payload = body_json(response).await;
+            assert_eq!(payload["code"].as_str(), Some("authorization_denied"));
+
+            let runs = runtime
+                .list_job_runs(JobRunListParams::default())
+                .expect("list runs");
+            assert!(
+                runs.is_empty(),
+                "a denied completion opt-in must not submit a run: {runs:?}"
+            );
+        })
+        .await;
+    }
+
+    /// An authorized operator's `complete` opt-in propagates to the same
+    /// `CompletionPolicy::Done` the CLI's `--complete` sends.
+    #[tokio::test]
+    async fn auto_endpoint_propagates_authorized_complete_opt_in() {
+        as_operator(async {
+            let runtime = OrbitRuntime::in_memory().expect("build runtime");
+            write_replay_job(&runtime, "workspace_auto_pipeline");
+
+            let response = request_auto(
+                runtime.clone(),
+                Some(json!({ "for_duration": "2h", "complete": true })),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let payload = body_json(response).await;
+            assert_eq!(payload["completion"].as_str(), Some("done"));
+            let run_id = payload["run_id"].as_str().expect("run_id").to_string();
+
+            let run = runtime.show_job_run(&run_id).expect("show run");
+            let input = run.input.expect("run input");
+            assert_eq!(input["completion"], "done");
+            assert_eq!(input["for_seconds"], 7200);
+        })
+        .await;
+    }
+
+    /// ORB-10008: an unknown `?workspace=` is a clean 404 JSON rejection from
+    /// the workspace extractor, matching the ship endpoint's behavior — this
+    /// is how the endpoint refuses all-workspace mode too, since aggregate
+    /// state has no default workspace to fall back on.
+    #[tokio::test]
+    async fn auto_endpoint_rejects_unknown_workspace_with_404_json() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let state = crate::state::DashboardState::single(Arc::new(runtime));
+
+        let response = router()
+            .with_state(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/workflows/auto?workspace=ghost")
+                    .header(header::ORIGIN, "http://localhost:7878")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(json!({ "for_duration": "30m" }).to_string()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let payload = body_json(response).await;
+        assert!(
+            payload["error"]
+                .as_str()
+                .is_some_and(|m| m.contains("unknown workspace: ghost"))
+        );
+    }
+
+    #[tokio::test]
+    async fn readiness_endpoint_returns_read_only_snapshot() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+        let response = request_readiness(runtime, "").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = body_json(response).await;
+        assert_eq!(payload["snapshot"]["read_only"], true);
+        assert!(payload["capacity"]["free_slots"].is_number());
+        assert!(payload["controls_authorized"].is_boolean());
+    }
+}

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -431,7 +431,9 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
         !operations.contains("hashchange") && !operations.contains("location.reload"),
         "refresh/back must not replay a toggle or mint POST"
     );
-    assert!(router.contains(r#"const OPERATIONS_SUBTABS = ["routines", "auto-tasks"];"#));
+    assert!(
+        router.contains(r#"const OPERATIONS_SUBTABS = ["routines", "auto-tasks", "auto-drain"];"#)
+    );
     assert!(router.contains(r#"hash = `#operations/${sub}`;"#));
     assert!(css.contains("@media (max-width: 720px)"));
     assert!(css.contains("@media (max-width: 600px)"));
@@ -439,6 +441,78 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(css.contains("body.operations-active"));
     assert!(css.contains(".operation-mint-warning"));
     assert!(router.contains(r#"classList.toggle("operations-active", top === "operations")"#));
+}
+
+/// ORB-11250: the bounded auto-delivery window action. Default completion
+/// (review) needs no operator authorization, the same as the ship endpoint;
+/// only the `--complete`-equivalent opt-in is separately governed. The panel
+/// reuses the mint/clock in-flight idiom — one fixed `pendingOperations` key,
+/// guard released in `finally` — rather than a per-row guard, since this is a
+/// single workspace-scoped action, not one per task.
+#[test]
+fn dashboard_auto_drain_action_is_bounded_governed_and_guarded() {
+    let index = include_str!("../../assets/dashboard/index.html");
+    let operations = include_str!("../../assets/dashboard/operations.js");
+    let router = include_str!("../../assets/dashboard/router.js");
+
+    for id in [
+        "operations-auto-drain-main",
+        "auto-drain-panel",
+        "auto-drain-count",
+        "auto-drain-operation-feedback",
+        "auto-drain-body",
+    ] {
+        assert!(index.contains(&format!(r#"id="{id}""#)), "{id}");
+    }
+    assert!(
+        index.contains(r#"<button class="subtab" data-subtab="auto-drain" type="button">"#),
+        "auto-drain must be offered as an Operations subtab"
+    );
+    assert!(
+        router.contains(r#"const autoDrain = $("operations-auto-drain-main");"#)
+            && router.contains(r#"autoDrain.hidden = name !== "auto-drain";"#),
+        "the router must toggle the auto-drain main like its siblings"
+    );
+
+    assert!(
+        operations.contains(r#"postJson("/api/workflows/auto""#),
+        "starting the window must submit through the dashboard auto-drain endpoint"
+    );
+    assert!(
+        operations.contains(r#"fetchJson(`/api/workflows/auto/readiness"#),
+        "the panel must project the read-only readiness snapshot, not recompute eligibility"
+    );
+    assert!(
+        operations.contains("for_duration: autoDrainDuration"),
+        "the submitted duration must come from the bounded picker, not free text"
+    );
+    assert!(
+        operations.contains("complete: autoDrainComplete"),
+        "the completion opt-in must be explicit, not inferred"
+    );
+
+    // Duplicate-click guard: same fixed-key idiom as the clock/mint buttons.
+    assert!(operations.contains(r#"const key = "auto-drain:start";"#));
+    assert!(
+        operations.contains("if (pendingOperations.has(key)) return;")
+            && operations.contains("pendingOperations.add(key);")
+            && operations.contains("pendingOperations.delete(key);"),
+        "the start action must guard against a duplicate submission while one is pending"
+    );
+
+    // Explicit opt-in requires confirmation and states the run's scope.
+    assert!(operations.contains("window.confirm(confirmText)"));
+    assert!(
+        operations.contains("Currently eligible: ${counts.eligible} · waiting: ${counts.waiting}")
+    );
+    assert!(
+        operations.contains("Proposed tasks are never drained automatically"),
+        "the panel must explain proposed tasks require separate authorization"
+    );
+
+    // Failure recovery: an error must surface, not silently no-op, and must
+    // not leave the guard held.
+    assert!(operations.contains("Auto-delivery window failed to start"));
 }
 
 /// The global `main` rule establishes the visible grid while this narrow


### PR DESCRIPTION
## Task

[ORB-11250](https://orbit-cli.com/tasks/ORB-11250) — Start a bounded auto-delivery window from the Orbit dashboard

### Description

Current dashboard API exposes POST /workflows/ship, and ShipBody in crates/orbit-web/src/api/runs.rs always passes CompletionPolicy::Review; there is no dashboard surface for the bounded orbit run auto --for ... --complete workflow used during this run. Add a concrete workspace-scoped dashboard action to start a bounded backlog drain using the existing runtime submission path. Let the operator choose a validated duration and concurrency, and explicitly opt into automatic completion with that run's scope clearly stated. Default completion off. Show readiness/eligible count using the existing read-only readiness projection where practical, explain proposed tasks require separate authorization, and link directly to the returned parent run. Prevent accidental duplicate click submissions using current in-flight UI patterns. Do not invent a second scheduler, implicit all-workspace mutation, or auto-promotion policy. Coordinate with ORB-11242 run-local crew allowlist when available, without requiring a separate provider configuration UI.

### Acceptance Criteria

- In a concrete workspace, an operator can submit a bounded auto window and immediately open its durable parent run; the UI distinguishes submitted from completed.
- Default completion remains review; explicit opt-in propagates to the same runtime CompletionPolicy as CLI --complete, with duration/concurrency validation and no proposed-task promotion.
- All-workspaces mode requires choosing one workspace before submission; server enforces routing/claim and existing admission boundaries.
- API and rendered UI tests cover missing/invalid input, explicit completion, duplicate-click handling, failure recovery and a narrow viewport; reuse existing runtime tests for drain behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a workspace-scoped dashboard action for the bounded `orbit run auto --for <duration> [--concurrency N] [--complete]` workflow, reusing the existing `OrbitRuntime::submit_workspace_auto_run` runtime path (no second scheduler, no new admission/claim logic).

Backend (`crates/orbit-web/src/api/runs.rs`, wired in `api/mod.rs`):
- `POST /workflows/auto`: new `AutoDrainBody { for_duration (required), concurrency, complete, claim_token }`. `for_duration` is parsed by a local `parse_drain_duration_seconds` (mirrors CLI's `--for` grammar s/m/h/d/w; `orbit-web` cannot depend on `orbit-cli` since the edge runs the other way, so this ~25-line parser is duplicated rather than shared) and must resolve to > 0 seconds — the dashboard always starts a *bounded* window, unlike the CLI's optional `--for`. `complete=false` (default) maps to `CompletionPolicy::Review` with no extra gate, identical to the existing `ship_workflow_action` precedent. `complete=true` maps to `CompletionPolicy::Done` but is separately governed by a new `DASHBOARD_AUTO_DRAIN_COMPLETE` operation (`crates/orbit-common/src/governance/authorization.rs`, id `auto_drain.complete`, Operator-only) — flagged because this is the first dashboard-triggered path capable of authorizing `review -> done`; ship's dashboard endpoint deliberately never exposes `--complete`. Concurrency==0 still rejected by Core (`InvalidInput` -> 400). All-workspace mode is refused by the existing `Ws` extractor the same way `ship_workflow_action` is (400/404, no default workspace).
- `GET /workflows/auto/readiness`: thin proxy over `OrbitRuntime::workspace_auto_readiness(&[], concurrency, 50)` (the same read-only snapshot `orbit run readiness` prints), with `controls_authorized` merged in so the UI can hide/disable the `complete` checkbox before hitting a 403.
- 9 new tests in `api/tests/runs.rs` (`auto_drain` submodule): missing/invalid/zero-length duration, zero concurrency, default-review needs no auth, complete opt-in denied/authorized (asserts persisted run `input.completion == "done"` and `for_seconds == 7200`), unknown-workspace 404, readiness snapshot shape. All pass; full `orbit-web` suite (296 tests) green.

Frontend (`assets/dashboard/{index.html,operations.js,router.js,dashboard.css}`): new "Auto-drain" Operations subtab (`operations-auto-drain-main` / `auto-drain-panel`) showing capacity + eligible/waiting counts from the readiness endpoint, a bounded duration `<select>` (15m/30m/1h/2h/4h/8h — no free-text duration field), a concurrency number input, and a "mark shipped tasks done" checkbox that is disabled with an explanatory reason when the caller isn't authorized. Static copy states proposed tasks are never auto-drained. Submission follows the mint/clock in-flight idiom (`pendingOperations` fixed key, guard released in `finally`, `window.confirm` before submit) rather than tasks.js's per-row Ship guard, since this is one workspace-level action. On success the parent run id/state/completion is shown with a click-through link via the existing `navigateToRun` router export (state persisted in a module var so it survives the readiness re-render, not left in transient DOM). New test `dashboard_auto_drain_action_is_bounded_governed_and_guarded` in `src/tests/dashboard_assets.rs`; updated the one pre-existing exact-string assertion on `OPERATIONS_SUBTABS`.

Scope: touched only the 9 files above (all either in context_files or directly required — `dashboard.css`/`router.js`/`mod.rs` for wiring, `authorization.rs` for the new governed operation). Did not touch `docs/design/auto-tasks/2_design.md`: its §5c documents the auto-*task* CRUD/mint surface specifically and makes no exhaustiveness claim about Operations subtabs, so it isn't stale. No design doc exists yet for the ship/auto-drain dashboard surface generally (pre-existing gap, not introduced here); did not create one since it wasn't requested and the PR is scoped to the one feature.

Validation: `make ci-fast` and `make ci-lint` (workspace clippy, `-D warnings`) both pass. `cargo test -p orbit-web` (296 passed) and `cargo test -p orbit-common governance` (57 passed, including the `<domain>.<action>` id-shape guardrail) both green. Did not run full `make ci` per policy (CI is the merge gate). No UI manual smoke test performed (no browser available in this environment) — recommend a quick manual check of the new Auto-drain subtab before merge.

ORB-11242 (run-local crew allowlist) is not present in this codebase yet (no `ORB-11242` references, no `crew_allowlist` anywhere); per the task's own guidance this was built without that plumbing, using the existing `ShipBody`/request-object JSON shape so a future allowlist field can be added without a breaking dashboard change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11250-6a9ba1a2`
- Behind base: 0
- Ahead of base: 1