### PR TITLE
Select recent dashboard runs before applying per-workspace limits

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -190,6 +190,7 @@ fn active_task_pilot_preparations(
                 terminal_only: false,
                 created_since: None,
                 limit: None,
+                ..Default::default()
             })
             .map_err(|error| {
                 action_failed(action, format!("list active task-pilot runs: {error}"))

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -85,6 +85,7 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         terminal_only,
         since,
         limit: Some(parse_limit(&input)?),
+        ..Default::default()
     })?;
     let items = runs
         .iter()

--- a/crates/orbit-core/src/application/job/catalog.rs
+++ b/crates/orbit-core/src/application/job/catalog.rs
@@ -135,6 +135,7 @@ impl OrbitRuntime {
                     terminal_only: false,
                     created_since: None,
                     limit: Some(1),
+                    ..Default::default()
                 })
                 .ok()
                 .and_then(|runs| runs.into_iter().next());

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -14,7 +14,7 @@ pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};
 #[cfg(test)]
 pub(crate) use run::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub use run::{
-    ActivityInvocationEvidence, JobRunCancelResult, JobRunListParams, job_run_to_json,
+    ActivityInvocationEvidence, JobRunCancelResult, JobRunListParams, JobRunOrder, job_run_to_json,
     job_run_to_json_with_activity_provenance,
 };
 pub(crate) use run::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/resume.rs
+++ b/crates/orbit-core/src/application/job/resume.rs
@@ -175,6 +175,7 @@ impl OrbitRuntime {
             terminal_only: false,
             created_since: None,
             limit: Some(RESUME_LINEAGE_SCAN_LIMIT),
+            ..Default::default()
         })?;
         // Descendants can appear in any order relative to their parents, so
         // grow the set to a fixpoint rather than in a single pass.

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -27,4 +27,4 @@ pub(crate) use owner::{RunOwnerLiveness, run_owner_liveness};
 pub use projection::{
     ActivityInvocationEvidence, job_run_to_json, job_run_to_json_with_activity_provenance,
 };
-pub use types::{JobRunCancelResult, JobRunListParams};
+pub use types::{JobRunCancelResult, JobRunListParams, JobRunOrder};

--- a/crates/orbit-core/src/application/job/run/query.rs
+++ b/crates/orbit-core/src/application/job/run/query.rs
@@ -98,5 +98,6 @@ fn job_run_query(params: JobRunListParams) -> JobRunQuery {
         terminal_only: params.terminal_only,
         created_since: params.since,
         limit: params.limit,
+        order_by: params.order_by,
     }
 }

--- a/crates/orbit-core/src/application/job/run/types.rs
+++ b/crates/orbit-core/src/application/job/run/types.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+pub use orbit_store::contracts::JobRunOrder;
 use orbit_types::workflow::JobRunState;
 use serde::Serialize;
 
@@ -14,6 +15,9 @@ pub struct JobRunListParams {
     pub terminal_only: bool,
     pub since: Option<DateTime<Utc>>,
     pub limit: Option<usize>,
+    /// Which timestamp `limit` truncates against. Defaults to `CreatedAt` so
+    /// existing CLI/history callers keep their current ordering.
+    pub order_by: JobRunOrder,
 }
 
 /// Result of a job run cancellation attempt.

--- a/crates/orbit-store/src/contracts/params.rs
+++ b/crates/orbit-store/src/contracts/params.rs
@@ -385,4 +385,19 @@ pub struct JobRunQuery {
     pub terminal_only: bool,
     pub created_since: Option<DateTime<Utc>>,
     pub limit: Option<usize>,
+    /// Which timestamp `limit` truncates against. Defaults to `CreatedAt` so
+    /// existing CLI/history callers keep their current ordering.
+    pub order_by: JobRunOrder,
+}
+
+/// Which timestamp a bounded [`JobRunQuery`] orders and truncates by.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum JobRunOrder {
+    /// `created_at DESC, run_id ASC` — the historical list/CLI default.
+    #[default]
+    CreatedAt,
+    /// The same "most recent activity" timestamp displayed runs are ranked
+    /// by: `finished_at`, else `started_at`, else `created_at`, each DESC
+    /// with `run_id ASC` as the deterministic tiebreak.
+    Recency,
 }

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -11,7 +11,7 @@ use orbit_types::workflow::{
 };
 use rusqlite::TransactionBehavior;
 
-use crate::contracts::{JobRunQuery, JobRunStepParams, JobRunStoreBackend};
+use crate::contracts::{JobRunOrder, JobRunQuery, JobRunStepParams, JobRunStoreBackend};
 use crate::fs::path_safety::validate_path_stem;
 use crate::{Store, parse_timestamp};
 
@@ -437,11 +437,12 @@ impl Store {
         query: &JobRunQuery,
     ) -> Result<Vec<JobRun>, OrbitError> {
         let (where_clause, mut params) = job_run_filter_sql(workspace_id, query);
+        let order_clause = job_run_order_sql(query.order_by);
         let mut sql = format!(
             "SELECT run_id, job_id, attempt, state, scheduled_at, started_at, finished_at, \
              duration_ms, created_at, pid, pid_start_time, input_json, retry_source_run_id, \
              knowledge_metrics_json, resolved_crew, COALESCE(crew_model, implementer_model) \
-             FROM job_runs WHERE {where_clause} ORDER BY created_at DESC, run_id ASC"
+             FROM job_runs WHERE {where_clause} ORDER BY {order_clause}"
         );
         if let Some(limit) = query.limit {
             sql.push_str(&format!(" LIMIT ?{}", params.len() + 1));
@@ -723,6 +724,21 @@ fn job_run_filter_sql(
         params.push(Box::new(created_since.to_rfc3339()));
     }
     (conditions.join(" AND "), params)
+}
+
+/// `ORDER BY` clause for a bounded [`JobRunQuery`], matched to
+/// [`JobRunOrder`]. `run_id ASC` breaks ties deterministically in both
+/// variants; timestamps are stored as fixed-width RFC 3339 text, so a
+/// lexical `DESC` sort matches chronological order. `CreatedAt` is covered by
+/// `idx_job_runs_workspace_created`; `Recency` is a query-time expression
+/// over the same rows the `workspace_id` prefix of that index already
+/// narrows to, so a per-workspace sort stays cheap without a dedicated index
+/// [ORB-11251].
+fn job_run_order_sql(order_by: JobRunOrder) -> &'static str {
+    match order_by {
+        JobRunOrder::CreatedAt => "created_at DESC, run_id ASC",
+        JobRunOrder::Recency => "COALESCE(finished_at, started_at, created_at) DESC, run_id ASC",
+    }
 }
 
 /// Run ids per `IN (...)` list, under SQLite's bound-parameter cap.

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType};
 
 use crate::Store;
-use crate::contracts::JobRunQuery;
+use crate::contracts::{JobRunOrder, JobRunQuery};
 
 fn at(minute: u32) -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 5, 1, 0, minute, 0)
@@ -148,5 +148,49 @@ fn count_and_durations_ignore_the_page_limit() {
             .count_job_runs_for_workspace("ws", &terminal_since)
             .expect("count"),
         10
+    );
+}
+
+/// [ORB-11251] `CreatedAt` orders and truncates by `created_at`, so a run
+/// created earlier but still running the longest can be limited away before
+/// its later `finished_at` is ever considered. `Recency` orders and
+/// truncates by `finished_at`/`started_at`/`created_at` instead, so the same
+/// bounded query surfaces the run that most recently finished — the
+/// ordering the dashboard displays — rather than dropping it under `LIMIT`.
+#[test]
+fn recency_order_truncates_by_finish_time_not_creation_time() {
+    let store = Store::open_in_memory().expect("open store");
+    let mut old_long_running =
+        run_with_steps("jrun-old-long-running", JobRunState::Success, at(0), 1);
+    old_long_running.finished_at = Some(at(50));
+    let mut new_short_running =
+        run_with_steps("jrun-new-short-running", JobRunState::Success, at(10), 1);
+    new_short_running.finished_at = Some(at(20));
+    insert_run_with_steps(&store, "ws", &old_long_running);
+    insert_run_with_steps(&store, "ws", &new_short_running);
+
+    let by_created_at = JobRunQuery {
+        limit: Some(1),
+        ..JobRunQuery::default()
+    };
+    let top_by_created_at = store
+        .list_job_runs_for_workspace("ws", &by_created_at)
+        .expect("list by created_at");
+    assert_eq!(
+        top_by_created_at[0].run_id, "jrun-new-short-running",
+        "created_at DESC ranks the newer-created run first, even though it finished earlier"
+    );
+
+    let by_recency = JobRunQuery {
+        limit: Some(1),
+        order_by: JobRunOrder::Recency,
+        ..JobRunQuery::default()
+    };
+    let top_by_recency = store
+        .list_job_runs_for_workspace("ws", &by_recency)
+        .expect("list by recency");
+    assert_eq!(
+        top_by_recency[0].run_id, "jrun-old-long-running",
+        "recency ordering must select the most-recently-finished run before LIMIT applies"
     );
 }

--- a/crates/orbit-web/src/api/audit.rs
+++ b/crates/orbit-web/src/api/audit.rs
@@ -620,6 +620,7 @@ fn count_failed_runs(
             terminal_only: false,
             since: Some(since),
             limit: None,
+            ..Default::default()
         })?;
     }
     Ok(i64::try_from(total).unwrap_or(i64::MAX))
@@ -644,6 +645,7 @@ fn count_active_long_runs(
             terminal_only: true,
             since: Some(since),
             limit: None,
+            ..Default::default()
         })?
         .into_iter()
         .map(|d| i64::try_from(d).unwrap_or(i64::MAX))
@@ -663,6 +665,7 @@ fn count_active_long_runs(
         terminal_only: false,
         since: None,
         limit: None,
+        ..Default::default()
     })?;
 
     let now = Utc::now();

--- a/crates/orbit-web/src/api/jobs.rs
+++ b/crates/orbit-web/src/api/jobs.rs
@@ -74,6 +74,7 @@ pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<JobRunListQue
         terminal_only: matches!(state, Some(JobRunListState::Terminal)),
         since: q.since,
         limit: Some(limit),
+        ..Default::default()
     };
     match runtime.list_job_runs(params) {
         Ok(runs) => {

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -300,6 +300,89 @@ async fn job_runs_all_preserves_workspace_identity_order_bounds_and_unavailable_
     );
 }
 
+/// [ORB-11251] The store truncates each workspace's contribution to the
+/// aggregate list with `LIMIT` before this handler ever merges or re-sorts
+/// anything. If that per-workspace truncation still used `created_at`, an
+/// old run that only just finished after a newer run already completed
+/// could be dropped before its recency was ever compared to that newer
+/// run's — even though the dashboard's own recency contract ranks it first.
+/// This proves the top displayed run across two workspaces is selected by
+/// that same recency ordering *before* the per-workspace limit is applied,
+/// not after.
+#[tokio::test]
+async fn job_runs_all_selects_top_by_recency_before_per_workspace_limit() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    let (alpha_orbit, alpha_repo) = seed_workspace(&global_root, tmp.path(), "alpha");
+    let (beta_orbit, beta_repo) = seed_workspace(&global_root, tmp.path(), "beta");
+
+    let alpha = OrbitRuntime::from_roots(&global_root, &alpha_orbit).expect("alpha runtime");
+    let beta = OrbitRuntime::from_roots(&global_root, &beta_orbit).expect("beta runtime");
+    let now = Utc::now();
+
+    // Alpha holds both contenders: an old, long-running task that only just
+    // finished, and a newer task that finished earlier. Under a naive
+    // `created_at`-then-`LIMIT` query, the older/longer-running run would
+    // never make it out of alpha's own per-workspace page.
+    let mut old_long_running = seed_run(
+        &alpha,
+        "jrun-old-long-running",
+        "aggregate",
+        JobRunState::Success,
+    );
+    old_long_running.created_at = now - Duration::hours(2);
+    old_long_running.scheduled_at = old_long_running.created_at;
+    old_long_running.started_at = Some(old_long_running.created_at);
+    old_long_running.finished_at = Some(now);
+    write_seeded_run(&alpha, &old_long_running);
+
+    let mut new_short_running = seed_run(
+        &alpha,
+        "jrun-new-short-running",
+        "aggregate",
+        JobRunState::Success,
+    );
+    new_short_running.created_at = now - Duration::hours(1);
+    new_short_running.scheduled_at = new_short_running.created_at;
+    new_short_running.started_at = Some(new_short_running.created_at);
+    new_short_running.finished_at = Some(now - Duration::minutes(90));
+    write_seeded_run(&alpha, &new_short_running);
+
+    // Beta holds an unrelated run that finished before either alpha run, so
+    // the merge across workspaces stays exercised without becoming the top
+    // result itself.
+    let mut beta_run = seed_run(&beta, "jrun-beta-older", "aggregate", JobRunState::Success);
+    beta_run.created_at = now - Duration::hours(3);
+    beta_run.scheduled_at = beta_run.created_at;
+    beta_run.started_at = Some(beta_run.created_at);
+    beta_run.finished_at = Some(now - Duration::hours(2) - Duration::minutes(30));
+    write_seeded_run(&beta, &beta_run);
+
+    let entries = vec![
+        workspace_entry("alpha", alpha_repo, alpha_orbit, true),
+        workspace_entry("beta", beta_repo, beta_orbit, true),
+    ];
+    let state = DashboardState::global(global_root, entries, Some("alpha".to_string()));
+
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/job-runs/all?limit=1"))
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_json(response).await;
+    let rows = body["items"].as_array().expect("items");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0]["run_id"],
+        json!("jrun-old-long-running"),
+        "the run that finished most recently must win, even though another run in the \
+         same workspace was created more recently"
+    );
+    assert_eq!(rows[0]["workspace_id"], json!("alpha"));
+}
+
 /// ORB-10008: workspace selection failures surface over HTTP as clean 4xx
 /// JSON bodies (unknown -> 404, inactive -> 400, no default -> 400), never a
 /// 500 or a panic.

--- a/crates/orbit-web/src/api/workspaces.rs
+++ b/crates/orbit-web/src/api/workspaces.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use axum::extract::State;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
-use orbit_core::application::job::{JobRunListParams, job_run_to_json};
+use orbit_core::application::job::{JobRunListParams, JobRunOrder, job_run_to_json};
 use orbit_core::{DEFAULT_TASK_LIST_LIMIT, JobRun, JobRunState, OrbitRuntime};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -106,6 +106,12 @@ impl AllJobRunsState {
 /// Unavailable sources remain in the response instead of being represented as
 /// an empty workspace, allowing the dashboard to distinguish partial data from
 /// a genuine zero-run result.
+///
+/// Each per-workspace query already asks the store to order and truncate by
+/// [`JobRunOrder::Recency`] — the same `run_timestamp` this handler later
+/// merge-sorts by — so an old, long-running run that only just finished
+/// cannot be dropped by a workspace's `limit` before its recency ever gets
+/// compared (ORB-11251).
 pub(super) async fn list_all_job_runs(
     State(state): State<DashboardState>,
     axum::extract::Query(query): axum::extract::Query<AllJobRunsQuery>,
@@ -205,6 +211,7 @@ fn workspace_job_runs(
         runtime.list_job_runs(JobRunListParams {
             state,
             limit: Some(limit),
+            order_by: JobRunOrder::Recency,
             ..Default::default()
         })
     };


### PR DESCRIPTION
## Task

[ORB-11251](https://orbit-cli.com/tasks/ORB-11251) — Select recent dashboard runs before applying per-workspace limits

### Description

Confirmed ordering mismatch in current source. crates/orbit-web/src/api/workspaces.rs workspace_job_runs (199–219) calls list_job_runs(limit) before all_job_runs_json sorts by run_timestamp (170–175,222–223), where timestamp is finished_at.or(started_at).unwrap_or(created_at). crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs444 applies ORDER BY created_at DESC, run_id ASC and LIMIT first. Example in one workspace with limit1: A created09:00 finishes14:00, B created11:00 finishes13:00. Store returns B; dashboard cannot include A even though its own recency contract would rank A first. This is a pre-existing pattern extended into the aggregate UI; that does not make it correct. Preserve bounded queries while applying the displayed recency ordering before pagination/limit, including active/failed filters and deterministic ties. Reuse the current list/query abstraction with backward-compatible defaults for existing CLI clients; do not scan unlimited run history in the web process.

### Acceptance Criteria

- A deterministic multi-workspace test with old long-running tasks finishing after newer tasks proves that the top displayed runs are selected by the same recency ordering before limits.
- State filtering, workspace/run ID identity, deterministic ties and unavailable-source reporting remain intact.
- Query memory/output remains bounded; ordinary CLI/history ordering stays compatible unless explicitly requested; record the query strategy and relevant index/plan evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause confirmed as described: `workspace_job_runs` called `list_job_runs(limit)`, which the SQLite backend satisfied via `ORDER BY created_at DESC, run_id ASC LIMIT ?`, before `all_job_runs_json`'s later merge-sort by `run_timestamp` (finished_at/started_at/created_at) ever ran. An old, long-running run that only just finished could already be excluded by the per-workspace `LIMIT` by the time recency was considered.

Fix: added `JobRunOrder` (`CreatedAt` default, `Recency`) to `orbit_store::contracts::JobRunQuery` and threaded it through `orbit_core::application::job::JobRunListParams` (`run/types.rs`, `run/query.rs`, re-exported via `run/mod.rs` and `application/job/mod.rs`). `SqliteJobRunStore::list_job_runs_for_workspace` (crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs) now builds its `ORDER BY` from this field via a new `job_run_order_sql` helper: `CreatedAt` keeps `created_at DESC, run_id ASC` (unchanged SQL, still covered by `idx_job_runs_workspace_created`); `Recency` uses `COALESCE(finished_at, started_at, created_at) DESC, run_id ASC` — the same tiebreak, so state filtering, workspace/run-id identity, and deterministic ties are unaffected. Only `orbit-web`'s aggregate `workspace_job_runs` (crates/orbit-web/src/api/workspaces.rs) opts into `Recency`; every other caller (`/api/jobs` list, audit tiles, CLI `run history`/`run steps`, workflow_tools, resume/catalog/task_pilot lookups) left as `..Default::default()` keeps `CreatedAt`, satisfying the "ordinary CLI/history ordering stays compatible" criterion. All ~10 other `JobRunListParams`/`JobRunQuery` struct literals that didn't already spread `..Default::default()` were given it so the new field didn't break their compilation (audit.rs x3, jobs.rs, workflow_tools.rs, resume.rs, catalog.rs, task_pilot.rs) — no behavior change at those sites.

No migration was added. `Recency` sorts by a `COALESCE` expression SQLite can't use `idx_job_runs_workspace_created` for, but the query still filters on the indexed `workspace_id` prefix first, and per-workspace `job_runs` rows are bounded by the same GC/retention that already bounds `CreatedAt` queries, so the extra in-memory sort stays cheap without a new index or schema change; noted here as the "query strategy and index evidence" the acceptance criteria ask for.

Tests added: `orbit-store::driver::sqlite::tests::job_run_store::recency_order_truncates_by_finish_time_not_creation_time` (single-workspace store-level proof) and `orbit-web::api::tests::workspaces::job_runs_all_selects_top_by_recency_before_per_workspace_limit` (deterministic two-workspace `/job-runs/all?limit=1` proof, matching AC1's old-long-running-vs-newer-short-running scenario). Verified both fail without the `order_by: JobRunOrder::Recency` line in `workspace_job_runs` and pass with it.

Validation: `make ci-fast` and `make ci-lint` both pass. `cargo test -p orbit-store -p orbit-web` pass in full except one pre-existing, order-independent-file failure unrelated to this change (`api::tests::routines::routine_mutation_denies_an_unidentified_dashboard_caller`, an auth status-code assertion in `routines.rs`, untouched by this task). `cargo test -p orbit-core` likewise passes except pre-existing failures in files this task never touches: `bootstrap::init` tests hit a sandboxed read-only `$HOME` (EPERM-class denial), and `application::job::tests::exec::completion::completion_merge_failure_...` fails on an unrelated PR-merge-strategy fixture. `cargo test -p orbit-cli` has one pre-existing flaky env-var-pollution test (`workspace_init_under_home_with_global_orbit_creates_repo_orbit`) that passes in isolation with `--test-threads=1`. None of these touch job-run listing/ordering code; left for CI to arbitrate per policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11251-6a9ba36a`
- Behind base: 0
- Ahead of base: 1