### PR TITLE
Start the dashboard drain timeout only after shutdown is requested

### DIFF
--- a/crates/orbit-cli/tests/web_serve_shutdown.rs
+++ b/crates/orbit-cli/tests/web_serve_shutdown.rs
@@ -38,6 +38,63 @@ const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(20);
 /// How long to wait for the dashboard to start accepting connections.
 const STARTUP_DEADLINE: Duration = Duration::from_secs(10);
 
+/// Must exceed orbit-web's own `SHUTDOWN_GRACE_PERIOD` (10s, see
+/// `crates/orbit-web/src/lib.rs`) so that outliving it is meaningful evidence:
+/// ORB-11255's regression started that grace-period timeout counting down
+/// when serving began rather than when a shutdown signal arrived, so an
+/// unsignaled server was killed at exactly this deadline.
+const LONGER_THAN_SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(13);
+
+/// ORB-11255: a server that never received a shutdown signal must keep
+/// serving indefinitely -- in particular, past orbit-web's own
+/// `SHUTDOWN_GRACE_PERIOD`. PR1328 (ORB-11246) introduced a regression where
+/// `tokio::time::timeout(SHUTDOWN_GRACE_PERIOD, drain)` started counting down
+/// as soon as serving began, so a perfectly healthy, never-signaled server
+/// exited (successfully!) once that timeout elapsed. This test fails against
+/// that placement: it waits longer than the grace period with no signal sent
+/// at all, then confirms the server is still alive and serving `/healthz`,
+/// before confirming SIGTERM still produces a prompt, clean shutdown.
+#[test]
+fn dashboard_outlives_shutdown_grace_period_when_no_signal_is_sent() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let port = free_port();
+    let mut server = spawn_dashboard(&home, port);
+    wait_for_listening(port);
+
+    std::thread::sleep(LONGER_THAN_SHUTDOWN_GRACE_PERIOD);
+
+    assert!(
+        matches!(server.try_wait(), Ok(None)),
+        "orbit web serve exited on its own after {LONGER_THAN_SHUTDOWN_GRACE_PERIOD:?} \
+         with no shutdown signal ever sent -- this is the ORB-11255 regression: \
+         the shutdown grace-period timeout must not start until a signal arrives"
+    );
+
+    let body = http_get(port, "/healthz");
+    assert!(
+        body.contains("ok"),
+        "expected /healthz to still report ok after outliving the shutdown \
+         grace period with no signal sent, got: {body}"
+    );
+
+    let before_sigterm = Instant::now();
+    send_sigterm(&server);
+    let status = wait_with_deadline(&mut server, SHUTDOWN_DEADLINE).unwrap_or_else(|| {
+        panic!(
+            "orbit web serve did not exit within {SHUTDOWN_DEADLINE:?} of SIGTERM \
+             after having outlived the shutdown grace period once already"
+        )
+    });
+    assert!(
+        status.success(),
+        "expected a clean shutdown within {SHUTDOWN_DEADLINE:?}, got {status:?} after {:?}",
+        before_sigterm.elapsed()
+    );
+}
+
 #[test]
 fn dashboard_exits_promptly_on_sigterm_with_open_connections() {
     let temp = tempdir().expect("tempdir");

--- a/crates/orbit-web/src/lib.rs
+++ b/crates/orbit-web/src/lib.rs
@@ -25,6 +25,7 @@ mod tests;
 
 pub use connect::{ConnectArgs, connect};
 
+use std::future::{Future, IntoFuture};
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -38,6 +39,7 @@ use clap::Args;
 use orbit_core::{OrbitError, OrbitRuntime};
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::{WorkspaceRegistry, WorkspaceStatus};
+use tokio::sync::Notify;
 
 const INDEX_HTML: &str = include_str!("../assets/dashboard/index.html");
 const DASHBOARD_CSS: &str = include_str!("../assets/dashboard/dashboard.css");
@@ -277,27 +279,78 @@ fn run_server(args: &ServeArgs, state: state::DashboardState) -> Result<(), Orbi
             open_browser(&url);
         }
 
-        let shutdown = async {
+        // Shared with `drain_with_grace_period` below: the grace-period timer
+        // must not start until shutdown is actually requested, so the signal
+        // handler notifies it rather than the drain deadline starting
+        // unconditionally when serving starts (see ORB-11255). `notify_one`
+        // (not `notify_waiters`) is required here: `drain` (polled as part of
+        // the `select!` in `drain_with_grace_period`) can resolve this signal
+        // and reach this call before `grace_elapsed`'s `notified().await` has
+        // ever been polled for the first time -- `notify_waiters` only wakes
+        // *already-registered* waiters and would silently drop that
+        // notification, leaving the grace timer never started. `notify_one`
+        // stores a permit for exactly this case: a `notified().await` that
+        // starts after the notify already fired consumes it immediately.
+        // There is exactly one waiter (`grace_elapsed`), so `notify_one` is
+        // sufficient.
+        let shutdown_notify = Arc::new(Notify::new());
+        let notify_on_signal = Arc::clone(&shutdown_notify);
+        let shutdown = async move {
             shutdown_signal().await;
             // Ask cooperating long-lived connections (the `/api/log/stream`
             // SSE handler) to close now, before the bounded drain deadline
             // below is reached.
             api::request_shutdown();
+            notify_on_signal.notify_one();
         };
-        let drain = axum::serve(listener, app).with_graceful_shutdown(shutdown);
-        match tokio::time::timeout(SHUTDOWN_GRACE_PERIOD, drain).await {
-            Ok(result) => result.map_err(|e| OrbitError::Execution(format!("serve: {e}")))?,
-            Err(_) => {
-                tracing::warn!(
-                    grace_period_secs = SHUTDOWN_GRACE_PERIOD.as_secs(),
-                    "dashboard shutdown grace period elapsed with connections \
-                     still open; exiting without waiting further"
-                );
-            }
-        }
+        let drain = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .into_future();
 
-        Ok::<(), OrbitError>(())
+        drain_with_grace_period(drain, shutdown_notify, SHUTDOWN_GRACE_PERIOD).await
     })
+}
+
+/// Race a server-drain future against a grace-period timeout that only
+/// starts counting down once `shutdown_notify` fires. Returns `drain`'s
+/// result if it finishes first (normal completion of graceful shutdown, or a
+/// serve error). Otherwise, once `grace_period` elapses after shutdown was
+/// signaled, logs a warning and returns `Ok(())` so the process exits without
+/// waiting further for connections that never close on their own.
+///
+/// Critically, `grace_elapsed` cannot resolve before `shutdown_notify` fires:
+/// this is what stops a healthy, unsignaled server from being torn down after
+/// `grace_period` elapses (ORB-11255 -- the prior `tokio::time::timeout`
+/// wrapped the whole drain and started counting down when serving began, not
+/// when shutdown was requested).
+///
+/// Callers must signal `shutdown_notify` with [`Notify::notify_one`], not
+/// `notify_waiters`: `drain` is polled as part of the `select!` below and may
+/// resolve the signal and notify before `grace_elapsed`'s `notified().await`
+/// is ever polled for the first time. `notify_one` stores a permit for that
+/// case; `notify_waiters` would silently drop the notification and leave the
+/// grace timer never started.
+async fn drain_with_grace_period(
+    drain: impl Future<Output = std::io::Result<()>>,
+    shutdown_notify: Arc<Notify>,
+    grace_period: Duration,
+) -> Result<(), OrbitError> {
+    let grace_elapsed = async {
+        shutdown_notify.notified().await;
+        tokio::time::sleep(grace_period).await;
+    };
+
+    tokio::select! {
+        result = drain => result.map_err(|e| OrbitError::Execution(format!("serve: {e}"))),
+        () = grace_elapsed => {
+            tracing::warn!(
+                grace_period_secs = grace_period.as_secs(),
+                "dashboard shutdown grace period elapsed with connections \
+                 still open; exiting without waiting further"
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Reject binding the dashboard to anything other than a loopback address.

--- a/crates/orbit-web/src/tests/serve.rs
+++ b/crates/orbit-web/src/tests/serve.rs
@@ -1,8 +1,11 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use orbit_core::OrbitError;
+use tokio::sync::Notify;
 
-use super::super::check_bindable_host;
+use super::super::{check_bindable_host, drain_with_grace_period};
 
 #[test]
 fn allows_ipv4_loopback() {
@@ -36,4 +39,120 @@ fn rejects_lan_address() {
     let host = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
     let err = check_bindable_host(host, 7878).expect_err("LAN address must be rejected");
     assert!(matches!(err, OrbitError::InvalidInput(_)));
+}
+
+// ORB-11255: `drain_with_grace_period` is the seam that lets the grace-period
+// regression run in milliseconds instead of the real 10s `SHUTDOWN_GRACE_PERIOD`
+// (see `crates/orbit-cli/tests/web_serve_shutdown.rs` for the real-server
+// smoke test that exercises the same behavior end to end).
+
+/// A never-completing "server" future, standing in for `axum::serve(..)`
+/// while a shutdown signal never arrives.
+fn pending_drain() -> impl std::future::Future<Output = std::io::Result<()>> {
+    std::future::pending()
+}
+
+#[tokio::test]
+async fn grace_period_does_not_start_before_shutdown_is_signaled() {
+    let notify = Arc::new(Notify::new());
+    let grace_period = Duration::from_millis(80);
+
+    // Nobody ever calls `notify.notify_one()`, i.e. no shutdown was
+    // requested. Waiting well past `grace_period` must not resolve the
+    // future -- this is the exact PR1328 regression: a timeout that starts
+    // counting down when serving begins, not when shutdown is requested,
+    // would fire here and tear down a healthy server.
+    let result = tokio::time::timeout(
+        grace_period * 4,
+        drain_with_grace_period(pending_drain(), notify, grace_period),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "drain_with_grace_period resolved without a shutdown signal ever firing"
+    );
+}
+
+#[tokio::test]
+async fn grace_period_starts_only_once_shutdown_is_signaled() {
+    let notify = Arc::new(Notify::new());
+    let grace_period = Duration::from_millis(80);
+    let notify_for_signal = Arc::clone(&notify);
+
+    let start = Instant::now();
+    tokio::spawn(async move {
+        // Simulate the delay between serving starting and a signal arriving:
+        // if the grace-period clock started at process boot (the bug), this
+        // delay would already have exhausted most or all of the deadline.
+        tokio::time::sleep(grace_period * 2).await;
+        notify_for_signal.notify_one();
+    });
+
+    let result = drain_with_grace_period(pending_drain(), notify, grace_period).await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok(), "expected the grace-period backstop to fire");
+    assert!(
+        elapsed >= grace_period * 2,
+        "grace period elapsed before the shutdown signal fired: {elapsed:?}"
+    );
+    assert!(
+        elapsed < grace_period * 4,
+        "grace period took far longer than signal_delay + grace_period: {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn drain_completing_first_wins_even_after_shutdown_is_signaled() {
+    let notify = Arc::new(Notify::new());
+    notify.notify_one();
+
+    let drain = async { Ok(()) };
+    let result = drain_with_grace_period(drain, notify, Duration::from_secs(10)).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn early_signal_before_first_poll_is_not_a_lost_wakeup() {
+    // Regression for a real race the reviewer flagged: in production, `drain`
+    // is polled as part of the `select!` inside `drain_with_grace_period` and
+    // can resolve the shutdown signal (calling the notify) before
+    // `grace_elapsed`'s `notified().await` has ever been polled for the first
+    // time. `Notify::notify_waiters` only wakes *already-registered* waiters
+    // and would silently drop a notification that arrives this early,
+    // leaving the grace timer never started -- an uncooperative drain would
+    // then hang forever, reintroducing the exact ORB-11246 bug this whole
+    // mechanism exists to prevent. `notify_one` stores a permit instead, so
+    // this must resolve (via the grace timeout) rather than hang.
+    let notify = Arc::new(Notify::new());
+    notify.notify_one(); // fires before `drain_with_grace_period` even exists
+
+    let grace_period = Duration::from_millis(80);
+    let start = Instant::now();
+    let result = tokio::time::timeout(
+        grace_period * 4,
+        drain_with_grace_period(pending_drain(), notify, grace_period),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Ok(Ok(()))),
+        "an early notification must not be a lost wakeup: {result:?}"
+    );
+    assert!(
+        start.elapsed() < grace_period * 2,
+        "grace timeout should fire close to immediately since the signal \
+         already arrived before polling began: {:?}",
+        start.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn drain_error_propagates_as_execution_error() {
+    let notify = Arc::new(Notify::new());
+    let drain = async { Err(std::io::Error::other("boom")) };
+    let err = drain_with_grace_period(drain, notify, Duration::from_secs(10))
+        .await
+        .expect_err("serve error must propagate");
+    assert!(matches!(err, OrbitError::Execution(msg) if msg.contains("boom")));
 }


### PR DESCRIPTION
## Task

[ORB-11255](https://orbit-cli.com/tasks/ORB-11255) — Start the dashboard drain timeout only after shutdown is requested

### Description

Confirmed post-merge defect in ORB-11246/PR1328 commit a1ae474a5c9818207e08181155d5b0fa2f070822. crates/orbit-web/src/lib.rs now creates `let drain = axum::serve(listener, app).with_graceful_shutdown(shutdown);` and immediately awaits `tokio::time::timeout(SHUTDOWN_GRACE_PERIOD, drain)`. That timeout starts when serving starts, not when shutdown_signal resolves. The nominal10s shutdown budget therefore terminates a healthy server after10s with no SIGTERM. The existing new subprocess test sends SIGTERM promptly and never keeps the server healthy beyond10s, so it misses this production regression. Do not deploy this revision until repaired. Preserve the cooperative SSE shutdown from11246, but start the drain deadline only after the signal/cancellation transition; avoid process-tree/cgroup kills. Add a regression that proves service continues beyond the configured grace duration before a signal, then exits within the grace duration after a signal. Use controlled time/seams for cheap deterministic coverage plus a faithful real-server smoke test where needed.

### Acceptance Criteria

- A server remains serving /healthz beyond the shutdown grace duration when no shutdown was requested; the regression fails against PR1328's timeout placement.
- After SIGTERM with an active SSE and idle connection, cooperative close and bounded drain still complete promptly and cleanly.
- No unrelated/shared processes are terminated, and normal serve errors remain visible rather than being converted to a successful timeout exit.
- Run relevant web and subprocess regressions plus required checks; provide explicit evidence of both long-lived normal serving and bounded post-signal shutdown.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the post-merge regression from PR1328 (ORB-11246, commit a1ae474a): `tokio::time::timeout(SHUTDOWN_GRACE_PERIOD, drain)` in crates/orbit-web/src/lib.rs::run_server wrapped the entire `axum::serve(..).with_graceful_shutdown(..)` future, so the 10s grace-period timer started when serving began rather than when a shutdown signal arrived -- a healthy, never-signaled server was killed (with a successful exit) after exactly 10s.

Fix: added a shared `Arc<tokio::sync::Notify>`. The `shutdown` future (already calling `shutdown_signal().await` then `api::request_shutdown()`) now also calls `notify_one()`. Extracted a `drain_with_grace_period(drain, shutdown_notify, grace_period)` helper that `tokio::select!`s the drain future against a `grace_elapsed` future which awaits the notify *before* sleeping `grace_period` -- the deadline is structurally incapable of starting before a shutdown signal. Cooperative SSE shutdown (ORB-11246's `api::request_shutdown()`) is unchanged; no process-tree/cgroup kill logic touched.

Reviewer caught a real bug in the first pass of this fix (see task comment at 05:24:39): using `notify_waiters()` instead of `notify_one()` has a lost-wakeup race. `drain` is polled as part of the same `select!` and can resolve the internal shutdown signal (calling the notify) before `grace_elapsed`'s `notified().await` has ever been polled for the first time -- `notify_waiters` only wakes *already-registered* waiters and silently drops a notification that arrives before registration, permanently starving the grace timer (reintroducing the exact ORB-11246 hang under a specific poll-order race). Switched to `notify_one()`, which stores a permit for exactly this case since there is exactly one waiter. Documented the requirement on both the call site and `drain_with_grace_period`'s doc comment so a future edit doesn't silently regress it.

Tests (crates/orbit-web/src/tests/serve.rs, all `#[tokio::test]` against `drain_with_grace_period` directly with a `std::future::pending()` stand-in drain and millisecond-scale grace periods -- no tokio test-util/paused-clock dependency needed):
- grace_period_does_not_start_before_shutdown_is_signaled: never notified, waited well past grace period, must not resolve.
- grace_period_starts_only_once_shutdown_is_signaled: notify fired after a delay, timer starts from notify not from call time.
- drain_completing_first_wins_even_after_shutdown_is_signaled / drain_error_propagates_as_execution_error: drain's own Ok/Err result wins over the grace path.
- early_signal_before_first_poll_is_not_a_lost_wakeup: notify.notify_one() called *before* drain_with_grace_period is ever constructed/polled, uncooperative (pending) drain -- must still resolve via the grace timeout almost immediately, not hang. Verified this test fails (times out) if the call site is reverted to notify_waiters(), confirming it catches the exact race the reviewer flagged.

Real-subprocess regression (crates/orbit-cli/tests/web_serve_shutdown.rs): new `dashboard_outlives_shutdown_grace_period_when_no_signal_is_sent` boots the actual `orbit web serve` binary, sleeps 13s (longer than the real 10s SHUTDOWN_GRACE_PERIOD) with no signal sent, asserts the process is still running and `/healthz` still reports ok, then sends SIGTERM and asserts a clean exit within the existing 20s SHUTDOWN_DEADLINE. Verified this test fails against the pre-fix PR1328 code (temporarily reverted lib.rs in-editor, not via git; test failed with the expected panic; restored the fix and reran green).

Validation: `make ci-fast` and `make ci-lint` (workspace clippy, warnings denied) both pass. `cargo test -p orbit-web` passes except one pre-existing, unrelated failure: `api::tests::routines::routine_mutation_denies_an_unidentified_dashboard_caller` (expects 403, gets 400) -- untouched by this diff, last modified by an unrelated prior refactor commit (ced8bbe6), reproduces in isolation independent of this change; out of scope. `cargo test -p orbit-cli --test web_serve_shutdown` passes 2/2 (~13s). No new dependencies added. Files touched: crates/orbit-web/src/lib.rs, crates/orbit-web/src/tests/serve.rs, crates/orbit-cli/tests/web_serve_shutdown.rs -- all already in context_files or a direct sibling test file. `git status --short` shows only these three files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11255-6a9ba5f1`
- Behind base: 0
- Ahead of base: 1