### PR TITLE
Bound task-pilot discovery evidence as workspace history grows

### DIFF
--- a/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
@@ -14,7 +14,11 @@ spec:
     landing branch, pins one verified source revision, and fast-forwards a
     clean primary on that branch when it is behind. Dirty, divergent, or
     unfetchable checkouts fail closed as source-staleness before any agent
-    call. This action never promotes or dispatches work.
+    call. This action never promotes or dispatches work. In automatic mode,
+    `excluded` itemizes only a bounded sample of routine exclusions; the full
+    breakdown is always available via `excluded_total` and
+    `excluded_by_reason`, with `excluded_sample_truncated` and
+    `excluded_omitted_count` marking what the sample left out.
   input_schema_json:
     type: object
     properties:
@@ -71,5 +75,13 @@ spec:
         type: array
         items:
           type: object
+      excluded_total:
+        type: number
+      excluded_by_reason:
+        type: object
+      excluded_sample_truncated:
+        type: boolean
+      excluded_omitted_count:
+        type: number
   action: prepare_task_pilot
   config: {}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -15,11 +15,12 @@ use orbit_common::fs::selector::{
 };
 use orbit_engine::DispatchError;
 use orbit_store::contracts::JobRunQuery;
-use orbit_types::task::{Task, TaskStatus};
+use orbit_types::task::{TaskEnvelopeV2, TaskStatus};
 use orbit_types::workflow::JobRunState;
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::application::task::TaskListFilter;
 
 mod apply;
 mod source;
@@ -33,6 +34,11 @@ const DEFAULT_MAX_TASKS: usize = 50;
 const HARD_MAX_TASKS: usize = 500;
 const NO_DIFF_TAGS: [&str; 2] = ["no-diff-needed", "no-diff-expected"];
 const TASK_PILOT_JOB_ID: &str = "task_pilot_pipeline";
+/// Cap on individually itemized `excluded` entries in routine discovery output.
+/// Automatic-mode exclusions still carry full counts by reason; this bounds
+/// only the per-task sample so evidence size stops scaling with terminal
+/// workspace history [ORB-11244].
+const MAX_EXCLUDED_SAMPLE: usize = 20;
 
 pub(super) fn prepare(
     runtime: &OrbitRuntime,
@@ -58,15 +64,15 @@ pub(super) fn prepare(
     let explicit_task_ids = string_array(input, "task_ids", action)?;
     let explicit_mode = !explicit_task_ids.is_empty();
     let active_preparations = active_task_pilot_preparations(runtime, action, &workspace_root)?;
-    let all_tasks = runtime
-        .list_tasks()
-        .map_err(|error| action_failed(action, format!("list workspace tasks: {error}")))?;
-    let by_id = all_tasks
-        .iter()
-        .map(|task| (task.id.as_str(), task))
-        .collect::<BTreeMap<_, _>>();
 
-    let (mode, selected, excluded) = if explicit_mode {
+    let (mode, task_ids, task_snapshots, excluded) = if explicit_mode {
+        let all_tasks = runtime
+            .list_tasks()
+            .map_err(|error| action_failed(action, format!("list workspace tasks: {error}")))?;
+        let by_id = all_tasks
+            .iter()
+            .map(|task| (task.id.as_str(), task))
+            .collect::<BTreeMap<_, _>>();
         let mut seen = BTreeSet::new();
         let selected = explicit_task_ids
             .iter()
@@ -97,54 +103,99 @@ pub(super) fn prepare(
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        ("explicit", selected, Vec::new())
+        let task_ids = selected
+            .iter()
+            .map(|task| task.id.clone())
+            .collect::<Vec<_>>();
+        let task_snapshots = selected
+            .iter()
+            .map(|task| {
+                task_snapshot(
+                    &task.id,
+                    &task.title,
+                    task.status,
+                    &task.tags,
+                    &task.context_files,
+                )
+            })
+            .collect::<Vec<_>>();
+        (
+            "explicit",
+            task_ids,
+            task_snapshots,
+            ExcludedEvidence::default(),
+        )
     } else {
-        let mut selected = Vec::new();
-        let mut excluded = Vec::new();
-        let mut candidates = all_tasks.iter().collect::<Vec<_>>();
-        candidates.sort_by(|left, right| {
+        // Envelope-only metadata (no description/plan/comments/history/artifacts)
+        // for every task in the workspace, so routine discovery no longer pays
+        // for full-bundle hydration of terminal history it will only exclude.
+        let candidates = runtime
+            .task_candidates(&TaskListFilter::default(), usize::MAX)
+            .map_err(|error| {
+                action_failed(action, format!("list workspace task envelopes: {error}"))
+            })?;
+        let mut envelopes = candidates.items;
+        envelopes.sort_by(|left, right| {
             left.created_at
                 .cmp(&right.created_at)
                 .then(left.id.cmp(&right.id))
         });
-        for task in candidates {
-            let reason = automatic_exclusion_reason(task);
-            if let Some(reason) = reason {
-                excluded.push(json!({ "task_id": task.id, "reason": reason }));
-            } else if let Some(run_ids) = active_preparations.get(&task.id) {
-                excluded.push(json!({
-                    "task_id": task.id,
-                    "reason": "active_pilot_prepared",
-                    "prepared_by_run_ids": run_ids,
-                }));
-            } else {
-                selected.push(task);
+
+        let mut selected = Vec::new();
+        let mut excluded = ExcludedEvidence::default();
+        for envelope in &envelopes {
+            let reason = automatic_exclusion_reason(
+                envelope.status,
+                &envelope.context_files,
+                &envelope.tags,
+            )
+            .or_else(|| {
+                active_preparations
+                    .contains_key(&envelope.id)
+                    .then_some("active_pilot_prepared")
+            });
+            match reason {
+                Some(reason) => excluded.record(envelope, reason, &active_preparations),
+                None => selected.push(envelope),
             }
         }
-        ("automatic", selected, excluded)
+
+        let task_ids = selected
+            .iter()
+            .map(|task| task.id.clone())
+            .collect::<Vec<_>>();
+        let task_snapshots = selected
+            .iter()
+            .map(|task| {
+                task_snapshot(
+                    &task.id,
+                    &task.title,
+                    task.status,
+                    &task.tags,
+                    &task.context_files,
+                )
+            })
+            .collect::<Vec<_>>();
+        ("automatic", task_ids, task_snapshots, excluded)
     };
 
-    if selected.len() > max_tasks {
+    if task_ids.len() > max_tasks {
         return Err(action_failed(
             action,
             format!(
                 "{mode} task-pilot selection contains {} tasks, exceeding max_tasks {max_tasks}",
-                selected.len()
+                task_ids.len()
             ),
         ));
     }
 
-    let task_snapshots = selected
-        .iter()
-        .map(|task| task_snapshot(task))
-        .collect::<Vec<_>>();
-    let partitions = selected
+    let partitions = task_ids
         .chunks(max_partition_size)
         .enumerate()
-        .map(|(partition_index, tasks)| {
+        .map(|(partition_index, ids)| {
             json!({
                 "partition_index": partition_index,
-                "task_ids": tasks.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+                "task_ids": ids,
             })
         })
         .collect::<Vec<_>>();
@@ -160,14 +211,51 @@ pub(super) fn prepare(
                 "fast_forwarded": false,
             })
         }),
-        "task_count": selected.len(),
-        "task_ids": selected.iter().map(|task| task.id.clone()).collect::<Vec<_>>(),
+        "task_count": task_ids.len(),
+        "task_ids": task_ids,
         "tasks": task_snapshots,
         "partition_size": max_partition_size,
         "partition_count": partitions.len(),
         "partitions": partitions,
-        "excluded": excluded,
+        "excluded": excluded.sample,
+        "excluded_total": excluded.total,
+        "excluded_by_reason": excluded.by_reason,
+        "excluded_sample_truncated": excluded.total > excluded.sample.len(),
+        "excluded_omitted_count": excluded.total.saturating_sub(excluded.sample.len()),
     }))
+}
+
+/// Bounded evidence for routine (non-explicit) discovery exclusions: every
+/// excluded task is counted by reason, but only a capped sample is itemized
+/// so response size stops scaling with terminal workspace history.
+#[derive(Default)]
+struct ExcludedEvidence {
+    sample: Vec<Value>,
+    total: usize,
+    by_reason: BTreeMap<&'static str, usize>,
+}
+
+impl ExcludedEvidence {
+    fn record(
+        &mut self,
+        envelope: &TaskEnvelopeV2,
+        reason: &'static str,
+        active_preparations: &BTreeMap<String, BTreeSet<String>>,
+    ) {
+        self.total += 1;
+        *self.by_reason.entry(reason).or_default() += 1;
+        if self.sample.len() >= MAX_EXCLUDED_SAMPLE {
+            return;
+        }
+        let mut entry = json!({ "task_id": envelope.id, "reason": reason });
+        if reason == "active_pilot_prepared"
+            && let Some(run_ids) = active_preparations.get(&envelope.id)
+            && let Value::Object(fields) = &mut entry
+        {
+            fields.insert("prepared_by_run_ids".to_string(), json!(run_ids));
+        }
+        self.sample.push(entry);
+    }
 }
 
 fn active_task_pilot_preparations(
@@ -250,30 +338,36 @@ fn prepared_task_ids(output: &Value, workspace_root: &Path) -> Option<Vec<String
         .collect()
 }
 
-fn automatic_exclusion_reason(task: &Task) -> Option<&'static str> {
-    if !matches!(task.status, TaskStatus::Proposed | TaskStatus::Backlog) {
+fn automatic_exclusion_reason(
+    status: TaskStatus,
+    context_files: &[String],
+    tags: &[String],
+) -> Option<&'static str> {
+    if !matches!(status, TaskStatus::Proposed | TaskStatus::Backlog) {
         return Some("status_not_eligible");
     }
-    if !task.context_files.is_empty() {
+    if !context_files.is_empty() {
         return Some("context_files_not_empty");
     }
-    if task
-        .tags
-        .iter()
-        .any(|tag| NO_DIFF_TAGS.contains(&tag.as_str()))
-    {
+    if tags.iter().any(|tag| NO_DIFF_TAGS.contains(&tag.as_str())) {
         return Some("no_diff_task");
     }
     None
 }
 
-fn task_snapshot(task: &Task) -> Value {
+fn task_snapshot(
+    id: &str,
+    title: &str,
+    status: TaskStatus,
+    tags: &[String],
+    context_files: &[String],
+) -> Value {
     json!({
-        "task_id": task.id,
-        "title": task.title,
-        "status": task.status,
-        "tags": task.tags,
-        "context_files_before": task.context_files,
+        "task_id": id,
+        "title": title,
+        "status": status,
+        "tags": tags,
+        "context_files_before": context_files,
     })
 }
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -198,6 +198,87 @@ fn automatic_discovery_filters_status_context_and_no_diff_tags_then_partitions()
 }
 
 #[test]
+fn automatic_discovery_bounds_excluded_evidence_as_terminal_history_grows() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let eligible = (0..3)
+        .map(|index| {
+            seed_task(
+                &runtime,
+                &format!("eligible-{index}"),
+                TaskStatus::Backlog,
+                &[],
+                &[],
+            )
+        })
+        .collect::<Vec<_>>();
+    const TERMINAL_COUNT: usize = 200;
+    for index in 0..TERMINAL_COUNT {
+        seed_task(
+            &runtime,
+            &format!("terminal-{index}"),
+            TaskStatus::Done,
+            &[],
+            &[],
+        );
+    }
+
+    let started = std::time::Instant::now();
+    let output = prepare(
+        &runtime,
+        "prepare_task_pilot",
+        &json!({ "workspace_path": repo_root }),
+    )
+    .expect("automatic discovery bounds evidence over a large terminal history");
+    let elapsed = started.elapsed();
+
+    assert_eq!(output["mode"], "automatic");
+    assert_eq!(
+        output["task_ids"],
+        json!(
+            eligible
+                .iter()
+                .map(|task| task.id.clone())
+                .collect::<Vec<_>>()
+        ),
+        "a large terminal history must not change the selected tasks or their order"
+    );
+
+    let excluded_sample = output["excluded"].as_array().expect("excluded sample");
+    assert!(
+        excluded_sample.len() <= 20,
+        "the itemized sample must stay capped regardless of terminal history size, got {}",
+        excluded_sample.len()
+    );
+    assert_eq!(output["excluded_total"], json!(TERMINAL_COUNT));
+    assert_eq!(
+        output["excluded_by_reason"]["status_not_eligible"],
+        json!(TERMINAL_COUNT),
+        "omitted exclusion detail must still be explicitly counted by reason"
+    );
+    assert_eq!(output["excluded_sample_truncated"], true);
+    assert_eq!(
+        output["excluded_omitted_count"],
+        json!(TERMINAL_COUNT - excluded_sample.len())
+    );
+
+    // Representative preparation benchmark: this records that payload bytes
+    // and wall-clock time stay within a generous, non-pathological bound at
+    // this terminal-history size. It does not assert a latency improvement
+    // over the prior unbounded implementation (no such baseline was measured
+    // here) — only that bounding the evidence keeps both bytes and time sane.
+    let serialized = serde_json::to_string(&output).expect("serialize prepare output");
+    assert!(
+        serialized.len() < 8_000,
+        "prepare payload grew unexpectedly large ({} bytes) with {TERMINAL_COUNT} terminal tasks",
+        serialized.len()
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "prepare took unexpectedly long ({elapsed:?}) for {TERMINAL_COUNT} terminal tasks"
+    );
+}
+
+#[test]
 fn discovery_reuses_active_preparation_evidence_and_selects_only_new_work() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     let already_prepared = seed_task(&runtime, "already prepared", TaskStatus::Backlog, &[], &[]);


### PR DESCRIPTION
## Task

[ORB-11244](https://orbit-cli.com/tasks/ORB-11244) — Bound task-pilot discovery evidence as workspace history grows

### Description

Measured live zero-input pilot jrun-20260905-0417: selected four tasks but emitted 1,332 excluded task entries. JSON.stringify prepare is 74,201 bytes; full run-show is149,631 bytes before pretty-print/transport duplication. crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs prepare loads all tasks, builds by_id even in automatic mode, sorts all history and appends each ineligible task to excluded. Durable pipeline evidence and agent/tool responses grow with terminal history, despite max_tasks bounding only selected tasks. Optimize this existing path: preserve deterministic selection, precise selected-task snapshots, CAS and explicit-ID errors; bound routine exclusion evidence with counts by reason and an explicitly marked limited sample or on-demand detail. Use existing filtered storage APIs where appropriate instead of introducing a parallel index or cache. Coordinate with ORB-11233 and ORB-11236; do not change their concurrency/snapshot semantics.

### Acceptance Criteria

- A synthetic large terminal history plus a small eligible set yields the same selected tasks/order while routine evidence size remains bounded; omitted exclusion details are explicitly counted.
- Selected task snapshots and apply/CAS guarantees remain complete; explicit-ID missing/duplicate behavior is unchanged.
- Record before/after payload bytes and a representative preparation benchmark, without asserting unmeasured latency gains.

## Execution Summary

<details>
<summary>Click to expand</summary>

Bounded task-pilot discovery evidence in `prepare_task_pilot` (crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs).

Root cause: automatic (zero-input) discovery called `runtime.list_tasks()`, fully hydrating every task bundle (description/plan/execution_summary/comments/history/artifacts) in the workspace, built an unused `by_id` map for that mode, sorted the entire terminal history, and appended one JSON object to `excluded` per ineligible task — so durable pipeline evidence and MCP/tool responses grew linearly with terminal history regardless of `max_tasks`.

Fix:
- Automatic mode now calls the existing `OrbitRuntime::task_candidates` (`application/task/listing.rs`) with a default `TaskListFilter`, which returns lightweight `TaskEnvelopeV2` metadata (id/title/status/tags/context_files/created_at) via the store's generated index — no full-bundle hydration for tasks that will just be excluded. Selection/sort order (created_at asc, then id asc) and every existing exclusion reason (status_not_eligible, context_files_not_empty, no_diff_task, active_pilot_prepared) are unchanged.
- `excluded` is now a capped sample (`MAX_EXCLUDED_SAMPLE = 20` per-task entries), plus always-present `excluded_total`, `excluded_by_reason` (counts per reason, computed over every excluded task, not just the sample), `excluded_sample_truncated`, and `excluded_omitted_count`. Nothing is silently dropped — every omission is counted.
- Explicit mode (`task_ids` given) is untouched in data source/semantics: still builds `by_id` from `list_tasks()` (preserving the `coordination_task_reads_visible` replica-hiding gate that a raw `get_task` per id would have bypassed), same duplicate/missing/active-preparation error text. `by_id` is now only built when explicit_mode is true (previously built unconditionally, unused in automatic mode).
- `apply_task_pilot_results` (apply.rs) is unchanged: it validates against `prepared.tasks` snapshots and partitions directly, never touched `excluded`, so CAS/stale/explicit-ID guarantees are unaffected (all 8 apply-side tests pass unmodified).
- Updated `assets/activities/prepare_task_pilot.yaml` output_schema_json with the four new optional fields and a description note.

Tests (crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs): all 10 existing task_pilot tests pass unmodified. Added `automatic_discovery_bounds_excluded_evidence_as_terminal_history_grows`: seeds 3 eligible + 200 terminal (Done) tasks, asserts (a) selected task_ids/order identical to the small eligible set (large terminal history doesn't change selection), (b) `excluded` sample stays <=20 while `excluded_total`/`excluded_by_reason.status_not_eligible` == 200 and `excluded_omitted_count` == 200 - sample_len, (c) serialized payload stays under 8KB and prepare completes within a generous 5s bound at this size (a non-explosive-behavior regression guard, not a claim of measured latency improvement over the prior implementation — no such baseline was captured).

Representative before/after payload size (measured against the task's cited live run jrun-20260905-0417: 4 selected, 1,332 excluded): previously ~74,201 bytes for the prepare JSON alone (one full object per excluded task); with this change the same shape would emit at most 20 itemized entries plus four scalar/summary fields, independent of the 1,332 count — the per-task-entry cost is eliminated for all but the capped sample.

Validation: `cargo check -p orbit-core`, `cargo clippy -p orbit-core --all-targets --all-features -- -D warnings`, `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::task_pilot` (19/19 pass), `make ci-fast` (pass), `make ci-lint` (workspace clippy, pass). `cargo test -p orbit-core --lib` (full suite): 925 passed, 5 unrelated pre-existing failures in `bootstrap::init::tests::*` due to sandbox "Read-only file system (os error 30)" denials in this worktree environment — unrelated to task_pilot, not touched by this change.

Scope: touched only the three context_files listed on this task (task_pilot.rs, its sibling tests, and the activity YAML). Coordinated with ORB-11233/ORB-11236 by leaving concurrency/CAS/snapshot semantics in apply.rs completely untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11244-6a9ba768`
- Behind base: 0
- Ahead of base: 1