### PR TITLE
Run failed-task triage with an enforceable Linux filesystem policy

### DIFF
--- a/.orbit/resources/activities/triage_failed_runs.yaml
+++ b/.orbit/resources/activities/triage_failed_runs.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   type: agent_loop
   require_response_envelope: true
+  # Direct Linux invocations inherit the primary checkout, not a managed
+  # worktree. Omitting fsProfile falls back to unrestricted writes, which
+  # Bubblewrap cannot combine with non-subtree dotenv denyModify. Reviewer
+  # is read-only: source edits stay denied while Orbit task tools remain
+  # available through the allowlist.
+  fsProfile: reviewer
   description: >
     Diagnose tasks blocked by terminally-failed job runs. For each candidate
     the agent reads the failure evidence, classifies the cause

--- a/crates/orbit-core/assets/activities/triage_failed_runs.yaml
+++ b/crates/orbit-core/assets/activities/triage_failed_runs.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   type: agent_loop
   require_response_envelope: true
+  # Direct Linux invocations inherit the primary checkout, not a managed
+  # worktree. Omitting fsProfile falls back to unrestricted writes, which
+  # Bubblewrap cannot combine with non-subtree dotenv denyModify. Reviewer
+  # is read-only: source edits stay denied while Orbit task tools remain
+  # available through the allowlist.
+  fsProfile: reviewer
   description: >
     Diagnose tasks blocked by terminally-failed job runs. For each candidate
     the agent reads the failure evidence, classifies the cause

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -550,7 +550,18 @@ backend = "cli"
             .iter()
             .find(|(name, _)| *name == "triage_failed_runs")
             .expect("triage agent activity is seeded");
+        let workspace_yaml =
+            include_str!("../../../../.orbit/resources/activities/triage_failed_runs.yaml");
+        assert_eq!(
+            *yaml, workspace_yaml,
+            "shipped and workspace triage resources must remain byte-identical"
+        );
         let asset = load_activity_asset(yaml).expect("parse triage agent activity");
+        assert_eq!(
+            asset.spec.fs_profile.as_deref(),
+            Some("reviewer"),
+            "direct triage must not inherit unrestricted workspace writes"
+        );
         match asset.spec.spec {
             ActivityV2Spec::AgentLoop(spec) => {
                 assert!(!yaml.contains("\n  role:"));

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -13,11 +13,11 @@ use orbit_common::protocol::yaml::parse_policy_resource;
 use orbit_exec::sandbox_exec_program_for_audit;
 #[cfg(target_os = "linux")]
 use orbit_exec::{
-    LinuxBwrapSpawnRequest, bwrap_program_for_audit, compile_linux_bwrap_argv, probe_bwrap,
-    spawn_under_linux_bwrap,
+    LinuxBwrapPostRunGuard, LinuxBwrapSpawnRequest, bwrap_program_for_audit,
+    compile_linux_bwrap_argv, probe_bwrap, spawn_under_linux_bwrap,
 };
 #[cfg(target_os = "linux")]
-use orbit_types::policy::{FsOperation, PolicyDef};
+use orbit_types::policy::{FsOperation, PolicyDef, UNRESTRICTED_FS_PROFILE};
 #[cfg(target_os = "linux")]
 use orbit_types::resource::ResourceKind;
 #[cfg(target_os = "linux")]
@@ -35,6 +35,9 @@ use crate::activity_job::ResolvedSandbox;
 #[cfg(target_os = "linux")]
 const TASK_PILOT_ACTIVITY: &str =
     include_str!("../../../../../orbit-core/assets/activities/task_pilot.yaml");
+#[cfg(target_os = "linux")]
+const TRIAGE_FAILED_RUNS_ACTIVITY: &str =
+    include_str!("../../../../../orbit-core/assets/activities/triage_failed_runs.yaml");
 #[cfg(target_os = "linux")]
 const DEFAULT_POLICY: &str = include_str!("../../../../../orbit-core/assets/policies/default.yaml");
 
@@ -199,6 +202,186 @@ fn task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies() 
             .wait()
             .expect("wait for task-pilot invocation")
             .success()
+    );
+}
+
+/// [ORB-11257] Triage is launched against the primary checkout. It must select
+/// `reviewer` so default dotenv glob denials compile for a direct Bubblewrap
+/// invocation, while source edits stay denied and write-capable profiles still
+/// fail closed.
+#[cfg(target_os = "linux")]
+#[test]
+fn triage_reviewer_profile_starts_direct_linux_invocation_and_protects_env_paths() {
+    let activity = load_activity_asset(TRIAGE_FAILED_RUNS_ACTIVITY).expect("parse triage activity");
+    let profile_name = activity
+        .spec
+        .fs_profile
+        .as_deref()
+        .expect("triage must select an explicit fsProfile");
+    assert_eq!(profile_name, "reviewer");
+    let ActivityV2Spec::AgentLoop(agent) = &activity.spec.spec else {
+        panic!("triage must remain an agent-loop activity");
+    };
+    assert!(
+        agent
+            .tools
+            .iter()
+            .any(|tool| tool == "orbit.task.update" || tool == "orbit.task.show")
+    );
+    assert!(!agent.tools.iter().any(|tool| {
+        matches!(
+            tool.as_str(),
+            "fs.write" | "fs.patch" | "fs.create" | "orbit.pipeline.invoke"
+        )
+    }));
+
+    let resource =
+        parse_policy_resource(DEFAULT_POLICY, "default triage policy").expect("parse policy");
+    assert_eq!(resource.kind, ResourceKind::Policy);
+    assert_eq!(
+        resource
+            .spec
+            .deny_modify
+            .iter()
+            .filter(|rule| rule.contains(".env"))
+            .count(),
+        4,
+        "default dotenv denyModify globs must remain: {:?}",
+        resource.spec.deny_modify
+    );
+    let now = Utc::now();
+    let policy = PolicyDef {
+        name: resource.metadata.name,
+        description: resource.spec.description,
+        deny_read: resource.spec.deny_read,
+        deny_modify: resource.spec.deny_modify,
+        fs_profiles: resource.spec.fs_profiles,
+        created_at: now,
+        updated_at: now,
+    };
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(workspace.join("src")).expect("create workspace fixture");
+    std::fs::write(workspace.join(".env"), "secret").expect("write existing protected path");
+    std::fs::write(workspace.join("src/lib.rs"), "fn main() {}").expect("write source fixture");
+    let workspace = workspace.canonicalize().expect("canonical workspace");
+    let existing_env = workspace.join(".env");
+    let created_env = workspace.join("new.env");
+    let source_file = workspace.join("src/lib.rs");
+    let workspace_root = workspace.display().to_string();
+    let mut effective = policy
+        .effective_profile(profile_name)
+        .expect("resolve reviewer profile");
+    effective.read = effective
+        .read
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    effective.modify = effective
+        .modify
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    assert!(
+        effective.modify.iter().all(|rule| rule.starts_with('!')),
+        "reviewer profile must not contain a positive workspace modify grant: {:?}",
+        effective.modify
+    );
+
+    let sandbox = ResolvedSandbox {
+        kind: ExecutorSandboxKind::LinuxBwrap,
+        fs_profile: effective.clone(),
+        allow_fallback: false,
+        managed_worktree: false,
+    };
+    let argv = try_audit_argv_for_dispatch("/bin/true", &[], Some(&sandbox), Some(&workspace))
+        .expect("direct triage Bubblewrap plan must compile");
+    assert_eq!(
+        argv.first().map(String::as_str),
+        Some(bwrap_program_for_audit())
+    );
+
+    let mut unrestricted = policy
+        .effective_profile(UNRESTRICTED_FS_PROFILE)
+        .expect("resolve unrestricted profile");
+    unrestricted.read = unrestricted
+        .read
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    unrestricted.modify = unrestricted
+        .modify
+        .iter()
+        .map(|rule| absolutize_test_rule(&workspace_root, rule))
+        .collect();
+    let error = compile_linux_bwrap_argv(&unrestricted, "/bin/true", &[], Some(&workspace), false)
+        .expect_err("direct write-capable sandbox must still fail closed");
+    assert!(
+        error.to_string().contains("non-subtree denyModify"),
+        "unsafe profile guard must remain: {error}"
+    );
+
+    let script = format!(
+        "! printf overwritten > '{existing}'; ! printf created > '{created}'; ! printf mutated > '{source}'; test -r '{existing}'",
+        existing = existing_env.display(),
+        created = created_env.display(),
+        source = source_file.display()
+    );
+    let plan = compile_linux_bwrap_argv(
+        &effective,
+        "/bin/sh",
+        &["-c".to_string(), script],
+        Some(&workspace),
+        false,
+    )
+    .expect("compile triage Bubblewrap invocation");
+    assert!(
+        !plan.args.iter().any(|arg| arg == "--bind"),
+        "triage reviewer profile must not gain a writable bind: {:?}",
+        plan.args
+    );
+
+    let guard = LinuxBwrapPostRunGuard::capture(&effective)
+        .expect("capture")
+        .expect("triage reviewer profile still carries non-subtree dotenv denies");
+    assert_eq!(
+        std::fs::read_to_string(&existing_env).expect("read existing protected path"),
+        "secret"
+    );
+    std::fs::write(&created_env, "secret").expect("host-side new protected path");
+    let error = guard
+        .verify()
+        .expect_err("new matching protected path must remain detectable");
+    assert!(error.to_string().contains("before commit"));
+    std::fs::remove_file(&created_env).expect("remove host-side protected path before spawn");
+
+    let probe = probe_bwrap();
+    if !probe.available {
+        return;
+    }
+
+    let mut child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &[],
+        cwd: Some(&workspace),
+        stdin: Stdio::null(),
+        stdout: Stdio::null(),
+        stderr: Stdio::null(),
+    })
+    .expect("start direct triage Bubblewrap invocation");
+    assert!(child.wait().expect("wait for triage invocation").success());
+    assert_eq!(
+        std::fs::read_to_string(&existing_env).expect("read existing protected path"),
+        "secret"
+    );
+    assert!(
+        !created_env.exists(),
+        "newly created matching protected path must stay absent"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&source_file).expect("read source"),
+        "fn main() {}"
     );
 }
 

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -517,6 +517,76 @@ fn direct_invocation_fails_closed_for_overlapping_non_subtree_deny() {
     assert!(error.to_string().contains("non-subtree denyModify"));
 }
 
+/// [ORB-11257] A read-only direct invocation can compile default dotenv glob
+/// denials. Live Bubblewrap must leave an existing match intact and refuse a
+/// newly created matching path; a write-capable sibling still fails closed.
+#[cfg(target_os = "linux")]
+#[test]
+fn kernel_enforces_existing_and_new_protected_env_paths_for_read_only_direct_invocation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let existing = workspace.join(".env");
+    let created = workspace.join("new.env");
+    std::fs::write(&existing, "secret").expect("write existing protected path");
+    let read_only = profile(vec![
+        format!("!{}/**/.env", workspace.display()),
+        format!("!{}/**/.env.*", workspace.display()),
+        format!("!{}/**/*.env", workspace.display()),
+        format!("!{}/**/*.env.*", workspace.display()),
+    ]);
+    let unsafe_profile = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**/*.env", workspace.display()),
+    ]);
+    let error = compile_linux_bwrap_argv(&unsafe_profile, "/bin/true", &[], None, false)
+        .expect_err("direct invocation must fail closed for unsafe profiles");
+    assert!(error.to_string().contains("non-subtree denyModify"));
+
+    let script = format!(
+        "! printf overwritten > '{existing}'; ! printf created > '{created}'; test -r '{existing}'",
+        existing = existing.display(),
+        created = created.display()
+    );
+    let plan = compile_linux_bwrap_argv(
+        &read_only,
+        "/bin/sh",
+        &["-c".to_string(), script],
+        Some(&workspace),
+        false,
+    )
+    .expect("compile read-only direct invocation");
+    assert!(
+        !plan.args.iter().any(|arg| arg == "--bind"),
+        "a no-modify profile must not gain a writable bind: {:?}",
+        plan.args
+    );
+
+    let probe = probe_bwrap();
+    if !probe.available {
+        println!("skipping real Bubblewrap test: {}", probe.detail);
+        return;
+    }
+    let mut child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+        plan: &plan,
+        env: &[],
+        cwd: Some(&workspace),
+        stdin: Stdio::null(),
+        stdout: Stdio::null(),
+        stderr: Stdio::null(),
+    })
+    .expect("spawn");
+    assert!(child.wait().expect("wait").success());
+    assert_eq!(
+        std::fs::read_to_string(&existing).expect("read existing protected path"),
+        "secret"
+    );
+    assert!(
+        !created.exists(),
+        "newly created matching protected path must stay absent"
+    );
+}
+
 #[test]
 fn managed_worktree_guard_rejects_new_forbidden_match() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Task

[ORB-11257](https://orbit-cli.com/tasks/ORB-11257) — Run failed-task triage with an enforceable Linux filesystem policy

### Description

Observed task_triage_pipeline jrun-20260905-0515 failed in 764ms before agent execution: cli invocation failed (permanent): policy denied: linux-bwrap cannot enforce non-subtree denyModify `~/workspace/constellation/codebases/orbit/**/.env` for a direct invocation; use a managed worktree. list_candidates succeeded and selected blocked ORB-11186 from jrun-20260905-0440-3; no triage dispositions applied. The run resolved Sol with empty input; investigate actual activity policy independently of crew selection. Shipped triage_failed_runs is an agent_loop with read-mostly tool permissions, but is launched directly against the workspace. crates/orbit-exec/src/linux_sandbox.rs compile_linux_bwrap_argv rejects a non-subtree denial overlapping writable roots when managed_worktree is false. Diagnose actual effective profile and invocation routing, then supply a least-privilege enforceable triage environment (read-only source checkout with narrowly scoped necessary write grants, or managed worktree using existing machinery). Preserve protected-file enforcement; do not remove .env denials, falsely set managed_worktree, disable sandboxing, or grant broad writes to make launch pass. Preserve authoritative task routing and deterministic disposition application. Keep shipped/local managed resources synchronized where applicable. This is an operational repair, not a request to broaden triage's code-edit/merge permissions.

### Acceptance Criteria

- A nonempty task_triage_pipeline on Linux with default protected .env glob policy reaches the agent and applies valid bounded dispositions without this launch denial.
- Regression test exercises the actual triage activity/profile/invocation contract under Linux bwrap, including protection of an existing and newly created matching protected path; no weakening of direct-invocation guard for unsafe profiles.
- Triage retains authoritative task tools and narrow existing capabilities; source edits and unintended primary checkout writes remain denied.
- Record effective policy, command routing and live run evidence; empty-candidate no-op and deterministic budget/lifecycle guards remain intact.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Diagnosed `jrun-20260905-0515`: `task_triage_pipeline` launches `activity:triage_failed_runs` as a direct Linux invocation (`managed_worktree=false`) against the primary checkout. The activity omitted `fsProfile`, so sandbox resolution fell back to `unrestricted` (workspace `/**` writes). Default policy then appends non-subtree `denyModify` globs (`**/.env`, `**/.env.*`, `**/*.env`, `**/*.env.*`). `compile_linux_bwrap_argv` rejects that combination — the observed `linux-bwrap cannot enforce non-subtree denyModify` launch denial. Crew selection (Sol vs system) is unrelated.
- Set `fsProfile: reviewer` on shipped `crates/orbit-core/assets/activities/triage_failed_runs.yaml` and the byte-identical workspace copy `.orbit/resources/activities/triage_failed_runs.yaml`. Reviewer has no positive modify grant, so glob denials compile without a managed worktree. `.env` denials, sandboxing, and `managed_worktree` detection are unchanged.
- Kept the existing tool allowlist (`orbit.task.show/list/update`, `orbit.friction.add`, `orbit.search`, `proc.spawn`/`rg`). Source edits and primary-checkout writes stay denied; task updates remain Orbit tools, not filesystem writes.
- Asserted profile + byte-identity in `triage_agent_allowlist_makes_write_surfaces_structurally_impossible`.
- Regression `triage_reviewer_profile_starts_direct_linux_invocation_and_protects_env_paths` loads the actual activity, resolves default policy, compiles a direct bwrap plan, proves existing `.env` protection plus post-run detection of a newly created matching path, and proves `unrestricted` still fails closed.
- Kernel companion `kernel_enforces_existing_and_new_protected_env_paths_for_read_only_direct_invocation` covers the same compile/fail-closed contract at the exec layer.

Strategic decisions:
- Reused the existing `reviewer` profile rather than a custom write-grant set or a fake managed worktree. Same least-privilege pattern as `task_pilot` (ORB-10654). Provider-native deletes of orphaned `.orbit/state/worktrees/` stay denied; worktree GC remains the deterministic `worktree_gc` activity.

Effective policy / routing:
- Activity: `triage_failed_runs`; fsProfile: `reviewer`; invocation: direct (`managed_worktree=false`); pipeline step `triage` still targets `activity:triage_failed_runs` with `crew: system`; apply step and empty-candidate `when:` no-op unchanged.

Assessment: Least-privilege repair at the activity boundary. Empty-candidate no-op and `apply_triage_dispositions` budget/lifecycle guards were not touched.

Validation:
- `make ci-fast` passed
- `make ci-lint` passed
- `cargo test -p orbit-core --lib triage_agent_allowlist` passed
- `cargo test -p orbit-engine --lib triage_reviewer_profile` passed (compile + post-run guard; live bwrap spawn skipped)
- `cargo test -p orbit-engine --lib task_pilot_reviewer_profile` passed
- `cargo test -p orbit-exec --test linux_sandbox` (direct_invocation + new kernel test) passed
- Live Bubblewrap spawn skipped in this runner: `bwrap: No permissions to create new namespace, likely because the kernel does not allow non-privileged user namespaces`. Compile-time fail-closed and post-run glob-match detection still ran. Unrestricted CI with real bwrap should execute the spawn half.

Deviations from original plan: none.
Recommended follow-ups: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11257-6a9ba860`
- Behind base: 0
- Ahead of base: 1