### PR TITLE
Ship orbit-orchestrate skill for continuous task preparation, delivery, and recovery

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/skill_list.json
+++ b/crates/orbit-cli/tests/output_goldens/skill_list.json
@@ -4,5 +4,11 @@
     "id": "orbit",
     "meta": null,
     "path": "<HOME>/.orbit/skills/orbit"
+  },
+  {
+    "content_hash": "<CONTENT_HASH>",
+    "id": "orbit-orchestrate",
+    "meta": null,
+    "path": "<HOME>/.orbit/skills/orbit-orchestrate"
   }
 ]

--- a/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
@@ -1,1 +1,2 @@
 orbit	<CONTENT_HASH>	0	
+orbit-orchestrate	<CONTENT_HASH>	0	

--- a/crates/orbit-cli/tests/table_rendering.rs
+++ b/crates/orbit-cli/tests/table_rendering.rs
@@ -108,7 +108,7 @@ fn skill_list_renders_one_line_per_skill() {
     let json = workspace.run(&["skill", "list", "--json"], "skill list JSON");
     let skills: Value = serde_json::from_slice(&json.stdout).expect("skill list JSON");
     let expected = skills.as_array().expect("skill array").len();
-    // Orbit ships one skill whose references load on demand, so the catalog is
+    // Each shipped skill's references load on demand, so the catalog is
     // deliberately small — the invariant under test is one line per record, not
     // the record count.
     assert!(

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: orbit-orchestrate
+description: Operate as an orchestrator over an Orbit backlog — inspect workspace goals and live evidence, search prior work, author bounded tasks, run task_pilot_pipeline before promotion, supervise an authorized completion window, and route CI/QA/operational findings back into repair tasks. Use `orbit` instead to execute a single already-assigned task; a leaf worker must never become an orchestrator.
+---
+
+# Orbit Orchestrate
+
+The orchestrator's operating loop, on top of the primitives the `orbit` skill
+already teaches. This file is the router; each reference below is loaded on
+demand. It does not restate tool schemas or job mechanics — read
+[concepts.md](../orbit/references/concepts.md),
+[tool-surface.md](../orbit/references/tool-surface.md), and
+[workflows.md](../orbit/references/workflows.md) there first if that
+vocabulary is new.
+
+## Who this is for
+
+An orchestrator prepares and supervises a stream of work; it does not
+implement tasks itself. If you were handed exactly one task ID to execute, use
+[task-execution.md](../orbit/references/task-execution.md) instead. A leaf
+worker running inside a managed activity cannot dispatch or resume a run and
+must never try — see [tool-surface.md](../orbit/references/tool-surface.md).
+
+## The loop
+
+```text
+inspect → search → author → prepare (pilot) → promote → dispatch → supervise
+                                                              ↑ feed back  ↓
+                                        post-merge review, QA, CI, operational repairs
+```
+
+Preparation only: a task an orchestrator files stays `proposed` until the
+run's actual start signal, and task-pilot fills its context before promotion
+— creating work is never itself authorization to run it.
+
+## References
+
+| Reference | Read it for |
+|---|---|
+| [loop.md](references/loop.md) | The full preparation loop: inspecting goals and evidence, searching prior work, authoring bounded tasks, choosing a crew, running task_pilot_pipeline, reading its warnings, and promoting to backlog. |
+| [authorization.md](references/authorization.md) | What an authorized completion window means, base/ship defaults, keeping independent work draining without a blocking pre-merge review phase, resumable handoff, and stopping a run. |
+| [recovery.md](references/recovery.md) | Routing CI findings, QA findings, and operational incidents back into repair tasks through the same preparation loop; evidence-led repair instead of retrying an identical failure. |
+| [walkthroughs.md](references/walkthroughs.md) | Short worked examples for seven recurring situations: missing context, duplicate/already-landed pilot warnings, dependency/lock blockage, an unavailable operator capability, a CI finding after merge, a provider failure, and a window expiring with in-flight work. |
+
+## Start here
+
+- New to orchestration → [loop.md](references/loop.md).
+- Asked to keep a backlog moving, or to run for a bounded window → [authorization.md](references/authorization.md).
+- A CI failure, QA finding, or blocked run needs to become tracked work → [recovery.md](references/recovery.md).
+- Something unexpected happened mid-loop → [walkthroughs.md](references/walkthroughs.md).

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
@@ -1,0 +1,91 @@
+# Completion authorization
+
+This assumes [workflows.md](../orbit/references/workflows.md) and
+[orchestration.md](../orbit/references/orchestration.md)'s "Delivery and
+completion" section — read those for the full `completion` input and
+`review -> done` mechanics. This page covers what an orchestrator does with
+that authority once granted, not the mechanism itself.
+
+## Base and ship defaults, not machine specifics
+
+Dispatch reads `workflow.base_branch` and the workspace's registered ship mode
+(`pr` unless the workspace sets otherwise) rather than a branch or path named
+in conversation. Teach and rely on those configured defaults; do not hardcode
+a specific branch name, worktree path, or crew name into a runbook — a
+different workspace configures different ones; use `--base`/`--mode` only to
+deliberately override.
+
+## What authorization actually grants
+
+Every authorization is scoped to what the user actually said, never inferred
+from a prior similar request:
+
+- Creating a task, or promoting it to `backlog`, authorizes neither dispatch
+  nor completion.
+- `orbit run ship <id> --complete` / `orbit run auto --complete` authorize
+  exactly the submitted run to carry the tasks it ships from `review` to
+  `done` — never a standing default, never something a workspace config file
+  or an unattended routine such as `ship-sweep` can turn on.
+- `run auto --complete` covers the whole window, including work filed after
+  the drain starts — the operator asked for a window, so treat everything the
+  drain admits inside it as covered, but not one moment beyond the window's
+  own bound (see below) and never a different drain the user did not invoke.
+- Never carry a specific session's bounded window (a duration, a task list, a
+  crew restriction) forward into a later request as if it were durable
+  policy. Ask again; a duration or scope is a fact about one request, not a
+  standing grant.
+
+## Keep independent work draining
+
+Once the user has authorized continuous completion for a window, do not add a
+blocking pre-merge review phase in front of it — that silently converts an
+authorized auto-drain into a gated one the user did not ask for. Post-merge
+review, QA, and CI feed findings back into new repair tasks that go through
+the ordinary preparation loop; they are not a checkpoint the drain waits on.
+→ [recovery.md](recovery.md)
+
+`--allow-crew` is the lever for a provider that is unavailable, rate-limited,
+or out of budget mid-window: it excludes named crews from *new* dispatch in
+that run only, and a task whose crew is excluded is skipped, not remapped —
+reassigning it to a permitted crew is a separate operator decision. See
+[orchestration.md](../orbit/references/orchestration.md) for the exact
+semantics before relying on it. → [walkthroughs.md](walkthroughs.md)
+
+## Stopping a bounded run
+
+A run's window bounds only the start of new work; a task already shipping
+when it expires keeps running to completion — do not assume expiry stopped
+it, and do not cancel it merely because the window ended. To stop
+in-flight work deliberately:
+
+```bash
+orbit run show <run_id> --json     # confirm what is actually still running
+orbit run cancel <run_id>          # the owning host's authoritative cancel
+```
+
+If cancellation itself needs process-level verification, follow the
+diagnose-before-kill order in [run-debugging.md](../orbit/references/run-debugging.md)
+rather than sending a signal based on a guess. Never cancel a parent
+gate/auto/epic run without first confirming it owns the task(s) you actually
+mean to stop.
+
+## Reporting handoff
+
+Report from durable state, not from what you remember doing:
+
+- Merged/completed work: tasks at `done`, with their run ID and verified
+  merge evidence.
+- Remaining work: tasks still `backlog`/`in-progress`/`review`, with what
+  each is waiting on.
+- Failures: the task and run ID, and the failure class from
+  [run-debugging.md](../orbit/references/run-debugging.md), not a paraphrase.
+
+Never invent a token-cost or spend figure — Orbit does not hand you one, and a
+plausible-looking number is worse than omitting it.
+
+A resumable handoff names, at minimum: the workspace selector, any run IDs
+still in flight, the authorization that was actually granted (what window,
+what scope, `--complete` or not), and the next preparation-loop step for each
+task that isn't done. A session that ends without recording this in task/run
+state (a task comment, an execution summary) leaves the next orchestrator
+guessing exactly like reading only agent prose would.

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/loop.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/loop.md
@@ -1,0 +1,137 @@
+# The preparation loop
+
+Discover tools and workspace authority before acting — call
+`orbit_workspace_list`/`orbit workspace list` first and use its returned
+selector, exactly as [tool-surface.md](../orbit/references/tool-surface.md)
+describes. Everything below assumes that selector is in hand.
+
+## 1. Inspect workspace goals and live evidence
+
+Read the actual current state before deciding what needs doing. Task and run
+state are the evidence; a prior conversation's summary is not:
+
+```bash
+orbit tool run orbit.task.list --input '{"workspace":"<selector>","status":"backlog,in-progress,review,blocked","model":"<agent-family>"}'
+orbit run readiness --json                 # who is eligible to drain right now, and why not
+orbit run history --json                   # recent runs, terminal and in-flight
+```
+
+`orbit run readiness` never mutates anything — read it as often as needed while
+deciding what to prepare next.
+
+## 2. Search open and closed history
+
+Before authoring anything, check whether the work already exists or was
+already done. → [search.md](../orbit/references/search.md)
+
+```bash
+orbit search "<problem terms from the goal>" --hybrid --kind task
+orbit search "<problem terms>" --kind all --status task:done,doc:active
+```
+
+A brand-new task has no vectors yet, so query the *text*, not an ID. Search
+closed history too — proposing a repair for something already merged is a
+wasted preparation cycle, and a genuinely already-landed case still needs to
+be recognized, not silently re-filed. → [walkthroughs.md](walkthroughs.md)
+
+## 3. Author bounded tasks
+
+Write a task the pilot and an executor can act on without guessing: a crisp
+problem statement, acceptance criteria naming observable success, and
+`complexity`. Full authoring standard: [task-authoring.md](../orbit/references/task-authoring.md).
+
+```bash
+orbit tool run orbit.task.add --input '{
+  "title": "<title>", "description": "<multi-line markdown>",
+  "acceptance_criteria": ["<observable outcome>"],
+  "workspace": "<selector>", "priority": "<low|medium|high|critical>",
+  "complexity": "<low|medium|hard>", "type": "<feature|bug|refactor|chore>",
+  "model": "<agent-family>"
+}'
+```
+
+This is the **proposed creation** example: the task now exists in `proposed`.
+Creating it authorizes nothing — not context preparation, not dispatch, not
+completion.
+
+Do not guess `context_files` here to avoid an empty field; an empty list is
+valid and a wrong entry actively misleads conflict detection. Leave selectors
+to the next step.
+
+## 4. Choose a crew within configured limits
+
+Read what this workspace actually configures and what the user has authorized
+for cost and provider before assigning `crew` — `orbit executor list`, the
+workspace's `[workflow].default_crew`, and any provider mix the user stated for
+this session. Do not invent a crew name, and do not carry a crew choice from
+one session into another as if it were durable policy; it is a per-task or
+per-run field, and asking again costs nothing.
+
+## 5. Run task_pilot_pipeline before promotion
+
+Do not fill `context_files` by inline guessing. The task-pilot job inspects a
+pinned revision read-only and applies only the selectors it validated:
+
+```bash
+orbit run job task_pilot_pipeline                                     # zero-input discovery
+orbit run job task_pilot_pipeline --input 'task_ids=["<task-id>"]'    # audit exactly these
+```
+
+This is the **pilot apply** step. Its durable output — read with
+`orbit run show <run_id> --json` — reports each partition as `applied`,
+`skipped_stale`, or `failed`, plus proposals and duplicate,
+already-landed, dependency, and conflicting-decision warnings. Full mechanics:
+[orchestration.md](../orbit/references/orchestration.md).
+
+## 6. Inspect applied context and warnings before promotion
+
+Read the pilot's applied selectors and warnings on the task itself before
+moving it forward:
+
+```bash
+orbit tool run orbit.task.show --full --input '{"id":"<task-id>","model":"<agent-family>"}'
+```
+
+Only once the applied `context_files` and warnings look right does promotion
+happen — an explicit lifecycle transition, not something the pilot performs
+for you:
+
+```bash
+orbit tool run orbit.task.update --input '{"id":"<task-id>","status":"backlog","model":"<agent-family>"}'
+```
+
+This is the **backlog promotion** example. A duplicate, already-landed, or
+unresolved-dependency warning is a reason to stop here, not to promote and
+hope. → [walkthroughs.md](walkthroughs.md)
+
+## 7. Dispatch under explicit authorization
+
+Promotion to `backlog` still does not authorize a run. Dispatch only when the
+user has authorized it, using the entry points in
+[orchestration.md](../orbit/references/orchestration.md):
+
+```bash
+orbit run ship <task-id> ...          # this is the submission example
+orbit run auto --for <duration>       # or drain the backlog for a bounded window
+```
+
+Submission is asynchronous: the command returns once the run is durable, not
+once anything landed.
+
+## 8. Supervise, then feed back
+
+Poll durable state, not agent prose:
+
+```bash
+orbit run show <run_id> --json
+orbit tool run orbit.task.show --input '{"id":"<task-id>","model":"<agent-family>"}'
+```
+
+A task that reaches `review` with a verified merged PR (**merge**) is distinct
+from one an authorized completion run has also carried to `done`
+(**done**) — confirm both independently rather than inferring one from the
+other. → [authorization.md](authorization.md)
+
+Post-merge review comments, QA findings, and CI failures are new input to this
+same loop, starting again at step 2 — not a special path with different rules.
+→ [recovery.md](recovery.md)

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/recovery.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/recovery.md
@@ -1,0 +1,71 @@
+# Routing findings back into work
+
+Post-merge review comments, QA findings, CI failures, and operational
+incidents are not a separate track — they are new input to the same
+preparation loop in [loop.md](loop.md), starting at "search open and closed
+history" so a repair is never filed twice.
+
+## CI findings file, they do not repair
+
+`ci_failure_sweep_pipeline` files GitHub Actions findings as `proposed` and
+runs task-pilot against each new one, admitting only current,
+warning-free repairs to `backlog` — it never implements a fix itself. A repair
+task produced this way still needs the same promotion review as any other
+task before it ships: read its applied context and pilot warnings, don't
+assume the sweep's own admission is sufficient if something looks off.
+→ [orchestration.md](../orbit/references/orchestration.md),
+[workflows.md](../orbit/references/workflows.md)
+
+A **CI finding surfacing after a task already merged** is not a reason to
+patch the merged branch by hand. Let (or trigger) the sweep file the finding,
+confirm it reaches a promotable state through the ordinary pilot step, then
+dispatch the repair like any other backlog task. →
+[walkthroughs.md](walkthroughs.md)
+
+## Blocked runs: triage first, then decide
+
+`task_triage_pipeline` diagnoses tasks blocked by a failed run and separates
+environmental casualties (a transient lock, a provider timeout, a sandbox
+denial — re-backlogged automatically) from real failures (left `blocked` with
+a diagnosis attached):
+
+```bash
+orbit run triage                    # every blocked task attributable to a failed run
+orbit run triage <task-id> ...      # narrow the scan
+```
+
+Run it on a schedule or before a large dispatch — an un-triaged failed run
+just parks a task in `blocked` forever. For a run that hasn't been triaged
+yet, or whose diagnosis needs deeper reading, use
+[run-debugging.md](../orbit/references/run-debugging.md)'s full flow: run
+bundle, audit trail, logs, failure classification, task and git state.
+
+**Repeated identical failures are evidence for a repair task, not for another
+retry.** If triage or manual debugging shows the same task failing the same
+way more than once, stop retrying it as-is. File a repair task describing the
+actual root cause (with the failing run's evidence attached), let it go
+through pilot and promotion like any other task, and only then dispatch it —
+retrying blindly burns runs without ever fixing what triage already
+identified.
+
+## Prefer an actionable task over a bare friction record
+
+When a CI/QA finding or an operational incident points at something concretely
+wrong in the repository or its pipelines, file (or promote) a task that fixes
+it — that is what actually closes the loop. Reserve
+[friction.md](../orbit/references/friction.md) for recording that the
+*tooling or diagnostics themselves* were misleading or missing something
+(a confusing error, an undocumented failure mode) — a report about the
+experience of doing the work, not a substitute for the fix itself. Often
+both: file the friction for what made diagnosis harder, and a task for the
+actual repair, linked with `relations: [{"type":"resolves","target":"<friction-id>"}]`.
+
+## Never build a shadow store
+
+A missing MCP operation, a denied capability, or a host you cannot currently
+reach is reported, not worked around. Do not fall back to direct file edits
+under `.orbit/`, a second local store, or a different host's CLI to make a
+finding "go somewhere" — see
+[tool-surface.md](../orbit/references/tool-surface.md)'s "Missing operations"
+section and [walkthroughs.md](walkthroughs.md) for the concrete shape of that
+conversation.

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/walkthroughs.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/walkthroughs.md
@@ -1,0 +1,113 @@
+# Walkthroughs
+
+Seven short situations an orchestrator runs into mid-loop. Each names what
+actually happened, the tools that surface it, and the response — not a script
+to follow blindly.
+
+## 1. Missing context
+
+A task reaches promotion time with an empty `context_files` and the
+description alone doesn't tell you what it would touch.
+
+- Do not guess selectors to fill the field — a wrong entry actively misleads
+  conflict detection. → [task-authoring.md](../orbit/references/task-authoring.md)
+- Run (or re-run) `task_pilot_pipeline` against exactly that task ID; it
+  inspects the pinned revision read-only and applies only what it validated.
+- If the pilot itself reports it cannot resolve a target, or the task's
+  problem statement is too vague to inspect, stop and comment on the task
+  asking for the missing detail rather than promoting an unprepared task.
+
+## 2. Duplicate or already-landed pilot warnings
+
+Pilot apply returns with a `duplicate` or `already-landed` warning attached to
+a proposed task.
+
+- Read the warning's cited task/commit before acting on it —
+  `orbit tool run orbit.task.show --full`.
+- If the warning is correct, do not promote. Close or re-author the task
+  (link it to the task it duplicates, or drop it if the work is truly done);
+  promoting anyway just races the same file a second time.
+- If the warning is a false positive — a genuine near-miss, not the same
+  change — say so in a task comment before promoting, so the next reader
+  doesn't re-litigate the same question.
+
+## 3. Dependency or lock blockage
+
+`orbit run readiness` reports a task waiting on an unmet dependency ID, or a
+context-lock holder blocking it.
+
+- An unmet `dependencies` entry: check that prerequisite task's own status;
+  it has to reach a satisfying status before this one is eligible, and
+  reordering the backlog doesn't skip that.
+- A stale lock with no owning run: match the
+  [common-failures.md](../orbit/references/common-failures.md) "Stale Task
+  Lock Reservation" signature exactly before touching anything —
+  `orbit task locks list`, confirm the blocking task is not actually active,
+  then `orbit task locks release <reservation_id>`. Never edit the
+  reservation store directly.
+- A live lock held by a task that is genuinely still running is not a bug;
+  wait for it or reprioritize other work instead.
+
+## 4. Unavailable operator capability
+
+A dispatch or resume call needs operator authority the current session
+doesn't have, or the connected MCP server simply doesn't advertise the
+operation.
+
+- Confirm with the server's own `tools/list` or `orbit tool list` before
+  assuming — a similar-sounding name is not evidence the operation exists.
+  → [tool-surface.md](../orbit/references/tool-surface.md)
+- Report the missing capability and what it blocks. Do not retry through a
+  different host's CLI, a raw store read, or any path that bypasses the
+  authority check — that is the shadow-store failure mode, not a workaround.
+- A managed leaf run cannot dispatch or resume another run under any
+  circumstance; that's a role boundary, not a missing feature to route
+  around.
+
+## 5. A CI finding after merge
+
+A `ci_failure_sweep_pipeline` finding names a task that already reached
+`done`.
+
+- Do not hand-patch the merged branch to make the finding go away. Let the
+  finding file as `proposed` (or file it yourself if the sweep hasn't run
+  yet), and route it through the ordinary loop: search for a duplicate,
+  confirm the pilot's applied context and warnings, promote, then dispatch as
+  its own task. → [recovery.md](recovery.md)
+- If the same finding recurs against a series of merges, that pattern itself
+  is worth a task (fix the root cause, not each instance) — not an
+  ever-growing set of one-off repairs.
+
+## 6. A provider failure mid-window
+
+A crew's provider starts failing, rate-limiting, or running out of budget
+while an authorized `run auto --for <duration>` window is still open.
+
+- Start a fresh `run auto --for <duration> --allow-crew <remaining crews>`
+  window rather than editing the running one — the exclusion only governs
+  what a drain starts, and it is scoped to that run.
+- Tasks on the excluded crew are skipped, not remapped, and stay in
+  `backlog`. Reassigning one of them to a different crew is an explicit
+  operator decision (`orbit.task.update`) — do it only for tasks the user
+  wants to move, not the whole backlog by default.
+- `orbit run readiness --allow-crew <remaining crews>` shows exactly which
+  tasks would be skipped as `crew_not_allowed` before you commit to the new
+  window. → [orchestration.md](../orbit/references/orchestration.md)
+
+## 7. Window expiry with in-flight work
+
+An authorized window (`run auto --for <duration>`) ends while tasks are still
+shipping.
+
+- The window bounded only when new work could *start*; anything already
+  shipping keeps running to completion under its original authorization —
+  confirm with `orbit run show <run_id>` rather than assuming it stopped.
+- Do not cancel in-flight runs just because the window closed; that discards
+  work the user already authorized.
+- Continuing to drain *new* work past the window needs a fresh, explicit
+  authorization for a new window — the expired one does not silently renew,
+  and the new request should not assume the same scope (duration, crews,
+  `--complete`) the previous one had. → [authorization.md](authorization.md)
+- Report the window's outcome from durable state: what finished, what's still
+  running, and what's untouched in `backlog` because the window ended before
+  it started.

--- a/crates/orbit-core/src/application/skill.rs
+++ b/crates/orbit-core/src/application/skill.rs
@@ -14,13 +14,12 @@ use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_as
 /// manifest keys on the relative path ([`ManagedAssetLayout::RelativePath`])
 /// instead of a bare definition name.
 ///
-/// Orbit ships exactly one skill. `SKILL.md` is a router carrying only what
-/// every call needs; each reference is loaded on demand, so the whole surface
-/// stays discoverable through one skill description without a per-topic skill
-/// competing for the same trigger. The ordering below mirrors the router's
-/// own reference tables, so the shipped surface reads the same in both
-/// places.
-pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 22] = [
+/// Each shipped skill's `SKILL.md` is a router carrying only what every call
+/// needs; its own references load on demand, so a skill's whole surface stays
+/// discoverable through one description without a per-topic skill competing
+/// for the same trigger. The ordering below mirrors each router's own
+/// reference table, so the shipped surface reads the same in both places.
+pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 27] = [
     (
         "orbit/SKILL.md",
         include_str!("../../assets/skills/orbit/SKILL.md"),
@@ -110,6 +109,27 @@ pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 22] = [
     (
         "orbit/references/setup/remote-access.md",
         include_str!("../../assets/skills/orbit/references/setup/remote-access.md"),
+    ),
+    // The orchestrator's operating loop, layered on the primitives above.
+    (
+        "orbit-orchestrate/SKILL.md",
+        include_str!("../../assets/skills/orbit-orchestrate/SKILL.md"),
+    ),
+    (
+        "orbit-orchestrate/references/loop.md",
+        include_str!("../../assets/skills/orbit-orchestrate/references/loop.md"),
+    ),
+    (
+        "orbit-orchestrate/references/authorization.md",
+        include_str!("../../assets/skills/orbit-orchestrate/references/authorization.md"),
+    ),
+    (
+        "orbit-orchestrate/references/recovery.md",
+        include_str!("../../assets/skills/orbit-orchestrate/references/recovery.md"),
+    ),
+    (
+        "orbit-orchestrate/references/walkthroughs.md",
+        include_str!("../../assets/skills/orbit-orchestrate/references/walkthroughs.md"),
     ),
 ];
 
@@ -359,37 +379,43 @@ mod tests {
         );
     }
 
-    /// The router must link every shipped reference.
+    /// Each shipped skill's own router must link every one of its own
+    /// shipped references.
     ///
-    /// With one skill, progressive disclosure runs entirely through
-    /// `SKILL.md`'s reference table: a reference the router does not link is
-    /// unreachable, however good it is. This replaces the old per-skill
-    /// enumeration check, which goes vacuous once only one skill ships.
+    /// Per skill, progressive disclosure runs entirely through that skill's
+    /// `SKILL.md` reference table: a reference its own router does not link
+    /// is unreachable, however good it is. A skill may still link into
+    /// another skill's references (e.g. `orbit-orchestrate` reusing `orbit`'s
+    /// canonical docs) — those cross-skill links are not required here since
+    /// they are already covered by the target skill's own check.
     #[test]
     fn router_links_every_shipped_reference() {
-        let router_path = assets_skills_dir().join("orbit/SKILL.md");
-        let contents = std::fs::read_to_string(&router_path)
-            .unwrap_or_else(|e| panic!("read {}: {e}", router_path.display()));
+        let mut missing: Vec<String> = Vec::new();
 
-        let mut missing: Vec<&str> = Vec::new();
-        for (relative, _) in DEFAULT_SKILL_FILES {
-            let Some(reference) = relative.strip_prefix("orbit/") else {
-                continue;
-            };
-            if reference == "SKILL.md" {
-                continue;
-            }
-            // The markdown link target, as written from the skill root.
-            if !contents.contains(&format!("({reference})")) {
-                missing.push(relative);
+        for skill_id in default_skill_ids() {
+            let router_path = assets_skills_dir().join(skill_id).join("SKILL.md");
+            let contents = std::fs::read_to_string(&router_path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", router_path.display()));
+
+            let prefix = format!("{skill_id}/");
+            for (relative, _) in DEFAULT_SKILL_FILES {
+                let Some(reference) = relative.strip_prefix(prefix.as_str()) else {
+                    continue;
+                };
+                if reference == "SKILL.md" {
+                    continue;
+                }
+                // The markdown link target, as written from the skill root.
+                if !contents.contains(&format!("({reference})")) {
+                    missing.push(relative.to_string());
+                }
             }
         }
 
         assert!(
             missing.is_empty(),
-            "router skill at {} does not link these shipped references, so they are \
-             unreachable: {missing:?}\nfix by adding a row to a ## References table.",
-            router_path.display(),
+            "a shipped skill's own router does not link these shipped references, so they are \
+             unreachable: {missing:?}\nfix by adding a row to that skill's ## References table.",
         );
     }
 

--- a/plugin/skills/orbit-orchestrate/SKILL.md
+++ b/plugin/skills/orbit-orchestrate/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: orbit-orchestrate
+description: Operate as an orchestrator over an Orbit backlog — inspect workspace goals and live evidence, search prior work, author bounded tasks, run task_pilot_pipeline before promotion, supervise an authorized completion window, and route CI/QA/operational findings back into repair tasks. Use `orbit` instead to execute a single already-assigned task; a leaf worker must never become an orchestrator.
+---
+
+# Orbit Orchestrate
+
+The orchestrator's operating loop, on top of the primitives the `orbit` skill
+already teaches. This file is the router; each reference below is loaded on
+demand. It does not restate tool schemas or job mechanics — read
+[concepts.md](../orbit/references/concepts.md),
+[tool-surface.md](../orbit/references/tool-surface.md), and
+[workflows.md](../orbit/references/workflows.md) there first if that
+vocabulary is new.
+
+## Who this is for
+
+An orchestrator prepares and supervises a stream of work; it does not
+implement tasks itself. If you were handed exactly one task ID to execute, use
+[task-execution.md](../orbit/references/task-execution.md) instead. A leaf
+worker running inside a managed activity cannot dispatch or resume a run and
+must never try — see [tool-surface.md](../orbit/references/tool-surface.md).
+
+## The loop
+
+```text
+inspect → search → author → prepare (pilot) → promote → dispatch → supervise
+                                                              ↑ feed back  ↓
+                                        post-merge review, QA, CI, operational repairs
+```
+
+Preparation only: a task an orchestrator files stays `proposed` until the
+run's actual start signal, and task-pilot fills its context before promotion
+— creating work is never itself authorization to run it.
+
+## References
+
+| Reference | Read it for |
+|---|---|
+| [loop.md](references/loop.md) | The full preparation loop: inspecting goals and evidence, searching prior work, authoring bounded tasks, choosing a crew, running task_pilot_pipeline, reading its warnings, and promoting to backlog. |
+| [authorization.md](references/authorization.md) | What an authorized completion window means, base/ship defaults, keeping independent work draining without a blocking pre-merge review phase, resumable handoff, and stopping a run. |
+| [recovery.md](references/recovery.md) | Routing CI findings, QA findings, and operational incidents back into repair tasks through the same preparation loop; evidence-led repair instead of retrying an identical failure. |
+| [walkthroughs.md](references/walkthroughs.md) | Short worked examples for seven recurring situations: missing context, duplicate/already-landed pilot warnings, dependency/lock blockage, an unavailable operator capability, a CI finding after merge, a provider failure, and a window expiring with in-flight work. |
+
+## Start here
+
+- New to orchestration → [loop.md](references/loop.md).
+- Asked to keep a backlog moving, or to run for a bounded window → [authorization.md](references/authorization.md).
+- A CI failure, QA finding, or blocked run needs to become tracked work → [recovery.md](references/recovery.md).
+- Something unexpected happened mid-loop → [walkthroughs.md](references/walkthroughs.md).

--- a/plugin/skills/orbit-orchestrate/references/authorization.md
+++ b/plugin/skills/orbit-orchestrate/references/authorization.md
@@ -1,0 +1,91 @@
+# Completion authorization
+
+This assumes [workflows.md](../orbit/references/workflows.md) and
+[orchestration.md](../orbit/references/orchestration.md)'s "Delivery and
+completion" section — read those for the full `completion` input and
+`review -> done` mechanics. This page covers what an orchestrator does with
+that authority once granted, not the mechanism itself.
+
+## Base and ship defaults, not machine specifics
+
+Dispatch reads `workflow.base_branch` and the workspace's registered ship mode
+(`pr` unless the workspace sets otherwise) rather than a branch or path named
+in conversation. Teach and rely on those configured defaults; do not hardcode
+a specific branch name, worktree path, or crew name into a runbook — a
+different workspace configures different ones; use `--base`/`--mode` only to
+deliberately override.
+
+## What authorization actually grants
+
+Every authorization is scoped to what the user actually said, never inferred
+from a prior similar request:
+
+- Creating a task, or promoting it to `backlog`, authorizes neither dispatch
+  nor completion.
+- `orbit run ship <id> --complete` / `orbit run auto --complete` authorize
+  exactly the submitted run to carry the tasks it ships from `review` to
+  `done` — never a standing default, never something a workspace config file
+  or an unattended routine such as `ship-sweep` can turn on.
+- `run auto --complete` covers the whole window, including work filed after
+  the drain starts — the operator asked for a window, so treat everything the
+  drain admits inside it as covered, but not one moment beyond the window's
+  own bound (see below) and never a different drain the user did not invoke.
+- Never carry a specific session's bounded window (a duration, a task list, a
+  crew restriction) forward into a later request as if it were durable
+  policy. Ask again; a duration or scope is a fact about one request, not a
+  standing grant.
+
+## Keep independent work draining
+
+Once the user has authorized continuous completion for a window, do not add a
+blocking pre-merge review phase in front of it — that silently converts an
+authorized auto-drain into a gated one the user did not ask for. Post-merge
+review, QA, and CI feed findings back into new repair tasks that go through
+the ordinary preparation loop; they are not a checkpoint the drain waits on.
+→ [recovery.md](recovery.md)
+
+`--allow-crew` is the lever for a provider that is unavailable, rate-limited,
+or out of budget mid-window: it excludes named crews from *new* dispatch in
+that run only, and a task whose crew is excluded is skipped, not remapped —
+reassigning it to a permitted crew is a separate operator decision. See
+[orchestration.md](../orbit/references/orchestration.md) for the exact
+semantics before relying on it. → [walkthroughs.md](walkthroughs.md)
+
+## Stopping a bounded run
+
+A run's window bounds only the start of new work; a task already shipping
+when it expires keeps running to completion — do not assume expiry stopped
+it, and do not cancel it merely because the window ended. To stop
+in-flight work deliberately:
+
+```bash
+orbit run show <run_id> --json     # confirm what is actually still running
+orbit run cancel <run_id>          # the owning host's authoritative cancel
+```
+
+If cancellation itself needs process-level verification, follow the
+diagnose-before-kill order in [run-debugging.md](../orbit/references/run-debugging.md)
+rather than sending a signal based on a guess. Never cancel a parent
+gate/auto/epic run without first confirming it owns the task(s) you actually
+mean to stop.
+
+## Reporting handoff
+
+Report from durable state, not from what you remember doing:
+
+- Merged/completed work: tasks at `done`, with their run ID and verified
+  merge evidence.
+- Remaining work: tasks still `backlog`/`in-progress`/`review`, with what
+  each is waiting on.
+- Failures: the task and run ID, and the failure class from
+  [run-debugging.md](../orbit/references/run-debugging.md), not a paraphrase.
+
+Never invent a token-cost or spend figure — Orbit does not hand you one, and a
+plausible-looking number is worse than omitting it.
+
+A resumable handoff names, at minimum: the workspace selector, any run IDs
+still in flight, the authorization that was actually granted (what window,
+what scope, `--complete` or not), and the next preparation-loop step for each
+task that isn't done. A session that ends without recording this in task/run
+state (a task comment, an execution summary) leaves the next orchestrator
+guessing exactly like reading only agent prose would.

--- a/plugin/skills/orbit-orchestrate/references/loop.md
+++ b/plugin/skills/orbit-orchestrate/references/loop.md
@@ -1,0 +1,137 @@
+# The preparation loop
+
+Discover tools and workspace authority before acting — call
+`orbit_workspace_list`/`orbit workspace list` first and use its returned
+selector, exactly as [tool-surface.md](../orbit/references/tool-surface.md)
+describes. Everything below assumes that selector is in hand.
+
+## 1. Inspect workspace goals and live evidence
+
+Read the actual current state before deciding what needs doing. Task and run
+state are the evidence; a prior conversation's summary is not:
+
+```bash
+orbit tool run orbit.task.list --input '{"workspace":"<selector>","status":"backlog,in-progress,review,blocked","model":"<agent-family>"}'
+orbit run readiness --json                 # who is eligible to drain right now, and why not
+orbit run history --json                   # recent runs, terminal and in-flight
+```
+
+`orbit run readiness` never mutates anything — read it as often as needed while
+deciding what to prepare next.
+
+## 2. Search open and closed history
+
+Before authoring anything, check whether the work already exists or was
+already done. → [search.md](../orbit/references/search.md)
+
+```bash
+orbit search "<problem terms from the goal>" --hybrid --kind task
+orbit search "<problem terms>" --kind all --status task:done,doc:active
+```
+
+A brand-new task has no vectors yet, so query the *text*, not an ID. Search
+closed history too — proposing a repair for something already merged is a
+wasted preparation cycle, and a genuinely already-landed case still needs to
+be recognized, not silently re-filed. → [walkthroughs.md](walkthroughs.md)
+
+## 3. Author bounded tasks
+
+Write a task the pilot and an executor can act on without guessing: a crisp
+problem statement, acceptance criteria naming observable success, and
+`complexity`. Full authoring standard: [task-authoring.md](../orbit/references/task-authoring.md).
+
+```bash
+orbit tool run orbit.task.add --input '{
+  "title": "<title>", "description": "<multi-line markdown>",
+  "acceptance_criteria": ["<observable outcome>"],
+  "workspace": "<selector>", "priority": "<low|medium|high|critical>",
+  "complexity": "<low|medium|hard>", "type": "<feature|bug|refactor|chore>",
+  "model": "<agent-family>"
+}'
+```
+
+This is the **proposed creation** example: the task now exists in `proposed`.
+Creating it authorizes nothing — not context preparation, not dispatch, not
+completion.
+
+Do not guess `context_files` here to avoid an empty field; an empty list is
+valid and a wrong entry actively misleads conflict detection. Leave selectors
+to the next step.
+
+## 4. Choose a crew within configured limits
+
+Read what this workspace actually configures and what the user has authorized
+for cost and provider before assigning `crew` — `orbit executor list`, the
+workspace's `[workflow].default_crew`, and any provider mix the user stated for
+this session. Do not invent a crew name, and do not carry a crew choice from
+one session into another as if it were durable policy; it is a per-task or
+per-run field, and asking again costs nothing.
+
+## 5. Run task_pilot_pipeline before promotion
+
+Do not fill `context_files` by inline guessing. The task-pilot job inspects a
+pinned revision read-only and applies only the selectors it validated:
+
+```bash
+orbit run job task_pilot_pipeline                                     # zero-input discovery
+orbit run job task_pilot_pipeline --input 'task_ids=["<task-id>"]'    # audit exactly these
+```
+
+This is the **pilot apply** step. Its durable output — read with
+`orbit run show <run_id> --json` — reports each partition as `applied`,
+`skipped_stale`, or `failed`, plus proposals and duplicate,
+already-landed, dependency, and conflicting-decision warnings. Full mechanics:
+[orchestration.md](../orbit/references/orchestration.md).
+
+## 6. Inspect applied context and warnings before promotion
+
+Read the pilot's applied selectors and warnings on the task itself before
+moving it forward:
+
+```bash
+orbit tool run orbit.task.show --full --input '{"id":"<task-id>","model":"<agent-family>"}'
+```
+
+Only once the applied `context_files` and warnings look right does promotion
+happen — an explicit lifecycle transition, not something the pilot performs
+for you:
+
+```bash
+orbit tool run orbit.task.update --input '{"id":"<task-id>","status":"backlog","model":"<agent-family>"}'
+```
+
+This is the **backlog promotion** example. A duplicate, already-landed, or
+unresolved-dependency warning is a reason to stop here, not to promote and
+hope. → [walkthroughs.md](walkthroughs.md)
+
+## 7. Dispatch under explicit authorization
+
+Promotion to `backlog` still does not authorize a run. Dispatch only when the
+user has authorized it, using the entry points in
+[orchestration.md](../orbit/references/orchestration.md):
+
+```bash
+orbit run ship <task-id> ...          # this is the submission example
+orbit run auto --for <duration>       # or drain the backlog for a bounded window
+```
+
+Submission is asynchronous: the command returns once the run is durable, not
+once anything landed.
+
+## 8. Supervise, then feed back
+
+Poll durable state, not agent prose:
+
+```bash
+orbit run show <run_id> --json
+orbit tool run orbit.task.show --input '{"id":"<task-id>","model":"<agent-family>"}'
+```
+
+A task that reaches `review` with a verified merged PR (**merge**) is distinct
+from one an authorized completion run has also carried to `done`
+(**done**) — confirm both independently rather than inferring one from the
+other. → [authorization.md](authorization.md)
+
+Post-merge review comments, QA findings, and CI failures are new input to this
+same loop, starting again at step 2 — not a special path with different rules.
+→ [recovery.md](recovery.md)

--- a/plugin/skills/orbit-orchestrate/references/recovery.md
+++ b/plugin/skills/orbit-orchestrate/references/recovery.md
@@ -1,0 +1,71 @@
+# Routing findings back into work
+
+Post-merge review comments, QA findings, CI failures, and operational
+incidents are not a separate track — they are new input to the same
+preparation loop in [loop.md](loop.md), starting at "search open and closed
+history" so a repair is never filed twice.
+
+## CI findings file, they do not repair
+
+`ci_failure_sweep_pipeline` files GitHub Actions findings as `proposed` and
+runs task-pilot against each new one, admitting only current,
+warning-free repairs to `backlog` — it never implements a fix itself. A repair
+task produced this way still needs the same promotion review as any other
+task before it ships: read its applied context and pilot warnings, don't
+assume the sweep's own admission is sufficient if something looks off.
+→ [orchestration.md](../orbit/references/orchestration.md),
+[workflows.md](../orbit/references/workflows.md)
+
+A **CI finding surfacing after a task already merged** is not a reason to
+patch the merged branch by hand. Let (or trigger) the sweep file the finding,
+confirm it reaches a promotable state through the ordinary pilot step, then
+dispatch the repair like any other backlog task. →
+[walkthroughs.md](walkthroughs.md)
+
+## Blocked runs: triage first, then decide
+
+`task_triage_pipeline` diagnoses tasks blocked by a failed run and separates
+environmental casualties (a transient lock, a provider timeout, a sandbox
+denial — re-backlogged automatically) from real failures (left `blocked` with
+a diagnosis attached):
+
+```bash
+orbit run triage                    # every blocked task attributable to a failed run
+orbit run triage <task-id> ...      # narrow the scan
+```
+
+Run it on a schedule or before a large dispatch — an un-triaged failed run
+just parks a task in `blocked` forever. For a run that hasn't been triaged
+yet, or whose diagnosis needs deeper reading, use
+[run-debugging.md](../orbit/references/run-debugging.md)'s full flow: run
+bundle, audit trail, logs, failure classification, task and git state.
+
+**Repeated identical failures are evidence for a repair task, not for another
+retry.** If triage or manual debugging shows the same task failing the same
+way more than once, stop retrying it as-is. File a repair task describing the
+actual root cause (with the failing run's evidence attached), let it go
+through pilot and promotion like any other task, and only then dispatch it —
+retrying blindly burns runs without ever fixing what triage already
+identified.
+
+## Prefer an actionable task over a bare friction record
+
+When a CI/QA finding or an operational incident points at something concretely
+wrong in the repository or its pipelines, file (or promote) a task that fixes
+it — that is what actually closes the loop. Reserve
+[friction.md](../orbit/references/friction.md) for recording that the
+*tooling or diagnostics themselves* were misleading or missing something
+(a confusing error, an undocumented failure mode) — a report about the
+experience of doing the work, not a substitute for the fix itself. Often
+both: file the friction for what made diagnosis harder, and a task for the
+actual repair, linked with `relations: [{"type":"resolves","target":"<friction-id>"}]`.
+
+## Never build a shadow store
+
+A missing MCP operation, a denied capability, or a host you cannot currently
+reach is reported, not worked around. Do not fall back to direct file edits
+under `.orbit/`, a second local store, or a different host's CLI to make a
+finding "go somewhere" — see
+[tool-surface.md](../orbit/references/tool-surface.md)'s "Missing operations"
+section and [walkthroughs.md](walkthroughs.md) for the concrete shape of that
+conversation.

--- a/plugin/skills/orbit-orchestrate/references/walkthroughs.md
+++ b/plugin/skills/orbit-orchestrate/references/walkthroughs.md
@@ -1,0 +1,113 @@
+# Walkthroughs
+
+Seven short situations an orchestrator runs into mid-loop. Each names what
+actually happened, the tools that surface it, and the response — not a script
+to follow blindly.
+
+## 1. Missing context
+
+A task reaches promotion time with an empty `context_files` and the
+description alone doesn't tell you what it would touch.
+
+- Do not guess selectors to fill the field — a wrong entry actively misleads
+  conflict detection. → [task-authoring.md](../orbit/references/task-authoring.md)
+- Run (or re-run) `task_pilot_pipeline` against exactly that task ID; it
+  inspects the pinned revision read-only and applies only what it validated.
+- If the pilot itself reports it cannot resolve a target, or the task's
+  problem statement is too vague to inspect, stop and comment on the task
+  asking for the missing detail rather than promoting an unprepared task.
+
+## 2. Duplicate or already-landed pilot warnings
+
+Pilot apply returns with a `duplicate` or `already-landed` warning attached to
+a proposed task.
+
+- Read the warning's cited task/commit before acting on it —
+  `orbit tool run orbit.task.show --full`.
+- If the warning is correct, do not promote. Close or re-author the task
+  (link it to the task it duplicates, or drop it if the work is truly done);
+  promoting anyway just races the same file a second time.
+- If the warning is a false positive — a genuine near-miss, not the same
+  change — say so in a task comment before promoting, so the next reader
+  doesn't re-litigate the same question.
+
+## 3. Dependency or lock blockage
+
+`orbit run readiness` reports a task waiting on an unmet dependency ID, or a
+context-lock holder blocking it.
+
+- An unmet `dependencies` entry: check that prerequisite task's own status;
+  it has to reach a satisfying status before this one is eligible, and
+  reordering the backlog doesn't skip that.
+- A stale lock with no owning run: match the
+  [common-failures.md](../orbit/references/common-failures.md) "Stale Task
+  Lock Reservation" signature exactly before touching anything —
+  `orbit task locks list`, confirm the blocking task is not actually active,
+  then `orbit task locks release <reservation_id>`. Never edit the
+  reservation store directly.
+- A live lock held by a task that is genuinely still running is not a bug;
+  wait for it or reprioritize other work instead.
+
+## 4. Unavailable operator capability
+
+A dispatch or resume call needs operator authority the current session
+doesn't have, or the connected MCP server simply doesn't advertise the
+operation.
+
+- Confirm with the server's own `tools/list` or `orbit tool list` before
+  assuming — a similar-sounding name is not evidence the operation exists.
+  → [tool-surface.md](../orbit/references/tool-surface.md)
+- Report the missing capability and what it blocks. Do not retry through a
+  different host's CLI, a raw store read, or any path that bypasses the
+  authority check — that is the shadow-store failure mode, not a workaround.
+- A managed leaf run cannot dispatch or resume another run under any
+  circumstance; that's a role boundary, not a missing feature to route
+  around.
+
+## 5. A CI finding after merge
+
+A `ci_failure_sweep_pipeline` finding names a task that already reached
+`done`.
+
+- Do not hand-patch the merged branch to make the finding go away. Let the
+  finding file as `proposed` (or file it yourself if the sweep hasn't run
+  yet), and route it through the ordinary loop: search for a duplicate,
+  confirm the pilot's applied context and warnings, promote, then dispatch as
+  its own task. → [recovery.md](recovery.md)
+- If the same finding recurs against a series of merges, that pattern itself
+  is worth a task (fix the root cause, not each instance) — not an
+  ever-growing set of one-off repairs.
+
+## 6. A provider failure mid-window
+
+A crew's provider starts failing, rate-limiting, or running out of budget
+while an authorized `run auto --for <duration>` window is still open.
+
+- Start a fresh `run auto --for <duration> --allow-crew <remaining crews>`
+  window rather than editing the running one — the exclusion only governs
+  what a drain starts, and it is scoped to that run.
+- Tasks on the excluded crew are skipped, not remapped, and stay in
+  `backlog`. Reassigning one of them to a different crew is an explicit
+  operator decision (`orbit.task.update`) — do it only for tasks the user
+  wants to move, not the whole backlog by default.
+- `orbit run readiness --allow-crew <remaining crews>` shows exactly which
+  tasks would be skipped as `crew_not_allowed` before you commit to the new
+  window. → [orchestration.md](../orbit/references/orchestration.md)
+
+## 7. Window expiry with in-flight work
+
+An authorized window (`run auto --for <duration>`) ends while tasks are still
+shipping.
+
+- The window bounded only when new work could *start*; anything already
+  shipping keeps running to completion under its original authorization —
+  confirm with `orbit run show <run_id>` rather than assuming it stopped.
+- Do not cancel in-flight runs just because the window closed; that discards
+  work the user already authorized.
+- Continuing to drain *new* work past the window needs a fresh, explicit
+  authorization for a new window — the expired one does not silently renew,
+  and the new request should not assume the same scope (duration, crews,
+  `--complete`) the previous one had. → [authorization.md](authorization.md)
+- Report the window's outcome from durable state: what finished, what's still
+  running, and what's untouched in `backlog` because the window ended before
+  it started.

--- a/scripts/sync-plugin-skills.sh
+++ b/scripts/sync-plugin-skills.sh
@@ -1,13 +1,27 @@
 #!/usr/bin/env bash
 # Materialize the agent plugin skill tree from Orbit's canonical embedded assets.
+# Every directory directly under assets/skills is a shipped skill, except a
+# leading-underscore name (an archived skill excluded from the catalog,
+# mirroring crates/orbit-core/src/application/skill.rs's own filter).
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-source_dir="$repo_root/crates/orbit-core/assets/skills/orbit"
-target_dir="$repo_root/plugin/skills/orbit"
+source_root="$repo_root/crates/orbit-core/assets/skills"
+target_root="$repo_root/plugin/skills"
 
-if [[ ! -f "$source_dir/SKILL.md" ]]; then
-  echo "sync-plugin-skills: canonical skill is missing: $source_dir/SKILL.md" >&2
+skill_dirs=()
+for entry in "$source_root"/*/; do
+  name="$(basename "$entry")"
+  [[ "$name" == _* ]] && continue
+  if [[ ! -f "$entry/SKILL.md" ]]; then
+    echo "sync-plugin-skills: canonical skill is missing: ${entry}SKILL.md" >&2
+    exit 1
+  fi
+  skill_dirs+=("$name")
+done
+
+if [[ "${#skill_dirs[@]}" -eq 0 ]]; then
+  echo "sync-plugin-skills: no skills found under $source_root" >&2
   exit 1
 fi
 
@@ -16,9 +30,15 @@ if [[ "${1:-}" == "--check" ]]; then
     echo "usage: $0 [--check]" >&2
     exit 2
   fi
-  if ! diff -qr "$source_dir" "$target_dir" >/dev/null; then
-    echo "sync-plugin-skills: plugin/skills/orbit drifted from crates/orbit-core/assets/skills/orbit" >&2
-    diff -ru "$source_dir" "$target_dir" || true
+  drifted=0
+  for name in "${skill_dirs[@]}"; do
+    if ! diff -qr "$source_root/$name" "$target_root/$name" >/dev/null 2>&1; then
+      echo "sync-plugin-skills: plugin/skills/$name drifted from crates/orbit-core/assets/skills/$name" >&2
+      diff -ru "$source_root/$name" "$target_root/$name" || true
+      drifted=1
+    fi
+  done
+  if [[ "$drifted" -ne 0 ]]; then
     exit 1
   fi
   echo "sync-plugin-skills: committed plugin skill mirror matches canonical assets"
@@ -29,8 +49,10 @@ if [[ "$#" -ne 0 ]]; then
   exit 2
 fi
 
-mkdir -p "$repo_root/plugin/skills"
-rm -rf "$target_dir"
-cp -R "$source_dir" "$target_dir"
+mkdir -p "$target_root"
+for name in "${skill_dirs[@]}"; do
+  rm -rf "$target_root/$name"
+  cp -R "$source_root/$name" "$target_root/$name"
+done
 
-echo "sync-plugin-skills: materialized plugin/skills/orbit from crates/orbit-core/assets/skills/orbit"
+echo "sync-plugin-skills: materialized plugin/skills/{${skill_dirs[*]}} from crates/orbit-core/assets/skills/"


### PR DESCRIPTION
## Task

[ORB-11216](https://orbit-cli.com/tasks/ORB-11216) — Ship orbit-orchestrate skill for continuous task preparation, delivery, and recovery

### Description

## Problem
Daniel requested a dedicated orbit-orchestrate skill teaching an orchestrator how to operate the Orbit way. The current embedded skill catalog contains only orbit/SKILL.md; orchestration.md covers mechanics but there is no discoverable end-to-end orchestrator operating loop.

## Outcome
Ship orbit-orchestrate as an installed and plugin-distributed skill for preparing and supervising an authorized stream of useful work: inspect workspace goals and live evidence; search open and closed history; author bounded tasks; choose configured crews within the user's provider and cost limits; run task_pilot_pipeline; inspect its applied context and warnings before backlog promotion; monitor asynchronous delivery; and feed post-merge review, QA, CI, and operational repairs back through the same preparation loop.

## Boundaries
Reuse canonical Orbit references instead of copying tool schemas or building another orchestrator service. Discover tools and workspace authority before acting. Teach completion authorization and configured base/ship defaults, not machine-specific branches, paths, crew names, or automatic blanket consent. Once the user authorizes continuous completion, keep independent work draining; do not add a blocking pre-merge review phase. ci_failure_sweep_pipeline files findings, not repairs; repair tasks still need pilot and promotion. task_triage_pipeline handles attributable blocked failures; repeated identical failures require evidence-led repair rather than infinite retries. Prefer actionable tasks over separate friction artifacts for operational problems. Cross-host ownership, limited permissions, missing capabilities, dependency readiness, task vs run state, and genuine no-diff work need explicit handling. A leaf worker must never become an orchestrator.

Use task/run evidence for handoff and report merged/completed work, remaining work, and failures without inventing token-cost metrics. Include a resumable session handoff and bounded run stop procedure. Do not hardcode this session's three-hour window or assume permission to launch a run. Crew sonnet is selected for a medium documentation/integration change under Daniel's allowed provider mix.

Preparation only: leave proposed until the run's start signal; task pilot must fill context before promotion.

### Acceptance Criteria

- orbit-orchestrate is discoverable through supported skill installation and plugin distribution; canonical and mirrored assets, embedded catalog, and affected docs are updated through existing mechanisms.
- A reader without source access can prepare a task through pilot and promotion, supervise an authorized auto-complete window, route CI/QA findings into repair tasks, and diagnose/rescue a blocked run using available authoritative tools.
- Examples distinguish proposed creation, pilot apply, backlog promotion, submission, merge, and done; they preserve explicit user authorization and do not invent missing MCP operations or encourage shadow stores.
- Document short walkthroughs for missing context, duplicate/already-landed pilot warnings, dependency/lock blockage, unavailable operator capability, CI finding after merge, provider failure, and window expiry with in-flight work.
- Validate rendered references/install layout, plugin validation and appropriate existing skill/catalog tests; run make ci-fast and make ci-lint. Avoid tests that assert large prose substrings.

## Execution Summary

<details>
<summary>Click to expand</summary>

Shipped orbit-orchestrate as a new skill under crates/orbit-core/assets/skills/orbit-orchestrate/ (SKILL.md router + references/loop.md, authorization.md, recovery.md, walkthroughs.md), teaching the orchestrator loop: inspect goals/evidence, search open+closed history, author bounded tasks, choose a crew within configured limits, run task_pilot_pipeline, inspect applied context/warnings before backlog promotion, dispatch under explicit authorization, supervise asynchronous delivery, and route post-merge review/QA/CI/operational findings back through the same loop. It reuses orbit's canonical references (concepts/tool-surface/task-authoring/orchestration/workflows/search/friction/run-debugging/common-failures) via relative links instead of restating tool schemas, and explicitly defers to task-execution.md for leaf-worker single-task execution. walkthroughs.md covers the seven required short scenarios (missing context, duplicate/already-landed pilot warnings, dependency/lock blockage, unavailable operator capability, CI finding after merge, provider failure mid-window, window expiry with in-flight work) in that order.

Distribution/registration (context_files scope): registered the 5 new files in crates/orbit-core/src/application/skill.rs DEFAULT_SKILL_FILES (22->27 entries), generalized its 'ships exactly one skill' doc comment and the router_links_every_shipped_reference test to check every shipped skill's own router links its own references (was hardcoded to the 'orbit' skill only). Generalized scripts/sync-plugin-skills.sh to mirror every non-underscore-prefixed directory under assets/skills into plugin/skills (was hardcoded to the single 'orbit' directory) and ran it to materialize plugin/skills/orbit-orchestrate. Updated table_rendering.rs's stale 'Orbit ships one skill' comment. No changes needed to plugin manifests (plugin/plugin.json, .claude-plugin/plugin.json, .codex-plugin/plugin.json's "skills": "./skills/", marketplace.json) or scripts/validate-agent-plugin.sh / smoke-plugin-install.sh / test-validate-agent-plugin.sh, since skills are discovered generically by directory there already.

Golden update (crates/orbit-cli/tests/output_goldens/skill_list.{json,plain.txt}): a fresh workspace's `skill list` now returns two rows. Reconstructed both goldens by hand (real content_hash values are redacted to <CONTENT_HASH> by the test itself, so exact hash isn't needed) after reading SkillCatalog::list()/load_skill_from_dir in crates/orbit-store to confirm id-sorted output, alphabetical JSON key order (serde_json's default BTreeMap Map), the <HOME>/.orbit/skills/<id> path shape, and list.rs's tab-separated plain-row shape — could not run `ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli` to generate/confirm them mechanically (see blocker below). crates/orbit-cli/src/output/tests/table.rs's skill_list() fixture is a synthetic table unrelated to the real catalog (fabricated 'orbit-search'/'orbit-task' rows) and needs no change.

Validation: `make ci-fast` passes in full, including scripts/sync-plugin-skills.sh --check, scripts/test-validate-agent-plugin.sh, scripts/smoke-plugin-install.sh, and scripts/check-embedded-asset-portability.py. `cargo test -p orbit-core --lib application::skill::` passes all 7 tests (asset_dirs_match_default_skill_ids, router_links_every_shipped_reference, both portability checks, doctor_client_skill_links, task_id_scanner). `cargo fmt --all -- --check` is clean. `cargo clippy --workspace --all-targets -- -D warnings` (make ci-lint) and `cargo test -p orbit-cli` both fail workspace-wide, but only because orbit-web fails to compile at this branch's base commit (a9b5dab8): crates/orbit-web/src/api/runs.rs:205,241 call submit_workspace_auto_run/workspace_auto_readiness with the pre-ORB-11242 arity, missing the new allow_crew parameter. This is a pre-existing break unrelated to this task's scope (orbit-web/api/runs.rs is not in context_files, and fixing dashboard wiring is a distinct concern from the skill work) — already tracked as ORB-11260 (proposed, priority critical, filed by codex) with the exact fix identified. Confirmed via `cargo check -p orbit-web`/`cargo clippy --workspace` that orbit-core itself (my only compiled-crate change) builds clean with zero clippy warnings; the failure is solely in orbit-web, reached after orbit-core in the build graph. Once ORB-11260 lands, re-run `cargo test -p orbit-cli --test output_goldens` and `crates/orbit-cli/tests/table_rendering.rs` to mechanically confirm the hand-authored skill_list goldens and the one-line-per-skill invariant (already >= 1 skill, non-count-sensitive) still hold, and run `make ci-lint`.

No new dependency edges; no cross-crate boundary changes beyond the already-generic skill catalog/sync mechanism. No CHANGELOG edit (per repo convention).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11216-6a9ba98e`
- Behind base: 0
- Ahead of base: 1