### PR TITLE
Restore dashboard compilation after auto-drain crew allowlist API change

### DIFF
--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -206,6 +206,7 @@ pub(super) async fn auto_drain_workflow_action(
         Some(for_seconds),
         body.concurrency,
         completion,
+        &[],
         Some("dashboard"),
         body.claim_token.as_deref(),
     ) {
@@ -238,7 +239,8 @@ pub(super) async fn auto_drain_readiness(
     Ws(runtime): Ws,
     Query(query): Query<AutoDrainReadinessQuery>,
 ) -> Response {
-    match runtime.workspace_auto_readiness(&[], query.concurrency, AUTO_DRAIN_READINESS_LIMIT) {
+    match runtime.workspace_auto_readiness(&[], query.concurrency, AUTO_DRAIN_READINESS_LIMIT, &[])
+    {
         Ok(mut payload) => {
             // So the form can hide/disable the `complete` opt-in before the
             // operator ever hits the separately-governed 403 at submission.


### PR DESCRIPTION
## Task

[ORB-11260](https://orbit-cli.com/tasks/ORB-11260) — Restore dashboard compilation after auto-drain crew allowlist API change

### Description

Current merged agent-main 3ca4622de7ae85174a4939f906cd65b0c6a32e2c fails to compile orbit-web after integration of ORB-11250 dashboard auto-drain (PR1333) and ORB-11242 crew allowlist (PR1335/a9b5dab8). Exact macOS Platform run33947508927, job101256176534, Build orbit CLI for nested sandbox regression, cargo build -p orbit-cli --locked --bin orbit: E0061 crates/orbit-web/src/api/runs.rs:205 submit_workspace_auto_run takes6 args but5 supplied (missing arg4 &[String]); runs.rs:241 workspace_auto_readiness takes4 but3 supplied (missing arg4 &[String]). Previous a9b5dab8 macOS run33947493592 also failed; preceding ac8d7bd2 CI+macOS were green. Fix dashboard submit/readiness callers and any associated fixtures to the new runtime contract, preserving current unrestricted default via the explicit empty allowed-crew collection when UI/request provides none. Scope is integration compilation repair, not a redesign or a new crew-picker UX. Production allowlist enforcement must remain unchanged. Verify all runtime callsites compile together on the latest merged source, rather than only pre-rebase feature worktrees. No new gate delaying unrelated work.

### Acceptance Criteria

- cargo build -p orbit-cli --locked --bin orbit and cargo check --workspace pass on current integrated agent-main candidate.
- Dashboard auto-drain submit and readiness tests pass with existing default behavior and matching empty/unrestricted allowlist semantics.
- Keep crew allowlist checks intact and record exact passing candidate tests plus follow-up current-head CI evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated the dashboard auto-drain submit caller to pass the explicit empty allowed-crew slice, preserving unrestricted default behavior while keeping runtime allowlist enforcement authoritative.
- Updated the dashboard readiness caller to pass the same empty allowlist to the expanded runtime contract.
- No tests or unrelated files were changed.
Assessment: Minimal integration repair at the dashboard API boundary; all runtime callsites compile together on current worktree HEAD 4a57ff7c786158843bf1b09f1511e88d6fda239c.
Validation:
- `cargo test -p orbit-web api::tests::runs::auto_drain --lib`: passed, 9 passed, 0 failed.
- `cargo build -p orbit-cli --locked --bin orbit`: passed.
- `cargo check --workspace`: passed.
- `cargo fmt --all -- --check`: passed after formatting.
- `cargo test -p orbit-cli table_form_matches_goldens_at_a_pinned_width`: passed, 1 passed.
- Follow-up `cargo test -p orbit-cli --test output_goldens`: 2 passed, 1 failed. The unrelated pre-existing `skill_list.plain.txt` golden expects two stale empty columns (`orbit <HASH> 0`), while current output is `orbit <HASH>`; per the task comment, this distinct fixture drift is reported for separate corrective work and was not changed here.
- `git diff --check`: passed.
- Final `git status --short`: only `crates/orbit-web/src/api/runs.rs`; generated worktree `target` artifacts were removed.
Follow-up current-head CI evidence: local build/check validation passed on the integrated candidate; remote CI should confirm the same current-head commit in the delivery pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11260-6a9bacdf`
- Behind base: 0
- Ahead of base: 1