### PR TITLE
Make task-pilot advisory field types explicit in its response schema

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -39,8 +39,12 @@ spec:
       crew:
         type: string
   # Agent-returned data is advisory until apply_task_pilot_results validates
-  # the complete fan-in, so keep fields optional at this boundary and let that
-  # validation step — not the schema — reject an incomplete partition.
+  # the complete fan-in, so keep fields optional at this boundary (no
+  # `required` list at any level) and let that validation step — not this
+  # schema — reject an incomplete partition. Field *types* below mirror the
+  # canonical apply parser exactly (e.g. adr_conflicts is an array of plain
+  # strings, never an array of objects) so a producer sees the concrete
+  # contract instead of an avoidable shape failure after full exploration.
   output_schema_json:
     type: object
     properties:
@@ -54,6 +58,55 @@ spec:
         type: array
         items:
           type: object
+          properties:
+            task_id:
+              type: string
+            context_files_before:
+              type: array
+              items:
+                type: string
+            context_files_after:
+              type: array
+              items:
+                type: string
+            disposition:
+              type: string
+              enum: [selectors, verified_no_diff, host_operational]
+            evidence:
+              type: string
+            recommended_crew:
+              type: string
+            recommended_complexity:
+              type: string
+              enum: [low, medium, hard]
+            blocked_by:
+              type: array
+              items:
+                type: string
+            duplicate_of:
+              type: [object, "null"]
+              properties:
+                task_id:
+                  type: string
+                evidence:
+                  type: string
+            already_landed:
+              type: [object, "null"]
+              properties:
+                evidence:
+                  type: string
+            adr_conflicts:
+              type: array
+              items:
+                type: string
+            utility_warnings:
+              type: array
+              items:
+                type: string
+            surface_warnings:
+              type: array
+              items:
+                type: string
       summary:
         type: string
   instruction: |
@@ -103,9 +156,13 @@ spec:
        name kept for consumer compatibility — populate it only with concrete
        current-code or current-contract conflicts and their evidence; a
        historical ADR is not by itself a reason to block or reshape work),
-       `utility_warnings`, and `surface_warnings`. Cite evidence for
-       duplicates, already-landed work, and any reported conflicts. Do not
-       choose an architecture alternative silently.
+       `utility_warnings`, and `surface_warnings`. Each of these four fields is
+       an array of plain strings, one string per finding combining the finding
+       and its citation — for example a non-empty adr_conflicts entry reads
+       ["the module this task would change still exports the type it removes
+       (verified via rg -n 'pub use Bar' at source_revision)"]; never an array
+       of objects. Cite evidence for duplicates, already-landed work, and any
+       reported conflicts. Do not choose an architecture alternative silently.
        A prior done repair is evidence to inspect, not blanket immunity: when
        the failure is from the current integration revision and the defect is
        still present, leave `duplicate_of` and `already_landed` null and return

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -39,8 +39,12 @@ spec:
       crew:
         type: string
   # Agent-returned data is advisory until apply_task_pilot_results validates
-  # the complete fan-in, so keep fields optional at this boundary and let that
-  # validation step — not the schema — reject an incomplete partition.
+  # the complete fan-in, so keep fields optional at this boundary (no
+  # `required` list at any level) and let that validation step — not this
+  # schema — reject an incomplete partition. Field *types* below mirror the
+  # canonical apply parser exactly (e.g. adr_conflicts is an array of plain
+  # strings, never an array of objects) so a producer sees the concrete
+  # contract instead of an avoidable shape failure after full exploration.
   output_schema_json:
     type: object
     properties:
@@ -54,6 +58,55 @@ spec:
         type: array
         items:
           type: object
+          properties:
+            task_id:
+              type: string
+            context_files_before:
+              type: array
+              items:
+                type: string
+            context_files_after:
+              type: array
+              items:
+                type: string
+            disposition:
+              type: string
+              enum: [selectors, verified_no_diff, host_operational]
+            evidence:
+              type: string
+            recommended_crew:
+              type: string
+            recommended_complexity:
+              type: string
+              enum: [low, medium, hard]
+            blocked_by:
+              type: array
+              items:
+                type: string
+            duplicate_of:
+              type: [object, "null"]
+              properties:
+                task_id:
+                  type: string
+                evidence:
+                  type: string
+            already_landed:
+              type: [object, "null"]
+              properties:
+                evidence:
+                  type: string
+            adr_conflicts:
+              type: array
+              items:
+                type: string
+            utility_warnings:
+              type: array
+              items:
+                type: string
+            surface_warnings:
+              type: array
+              items:
+                type: string
       summary:
         type: string
   instruction: |
@@ -103,9 +156,13 @@ spec:
        name kept for consumer compatibility — populate it only with concrete
        current-code or current-contract conflicts and their evidence; a
        historical ADR is not by itself a reason to block or reshape work),
-       `utility_warnings`, and `surface_warnings`. Cite evidence for
-       duplicates, already-landed work, and any reported conflicts. Do not
-       choose an architecture alternative silently.
+       `utility_warnings`, and `surface_warnings`. Each of these four fields is
+       an array of plain strings, one string per finding combining the finding
+       and its citation — for example a non-empty adr_conflicts entry reads
+       ["the module this task would change still exports the type it removes
+       (verified via rg -n 'pub use Bar' at source_revision)"]; never an array
+       of objects. Cite evidence for duplicates, already-landed work, and any
+       reported conflicts. Do not choose an architecture alternative silently.
        A prior done repair is evidence to inspect, not blanket immunity: when
        the failure is from the current integration revision and the defect is
        still present, leave `duplicate_of` and `already_landed` null and return

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -435,6 +435,89 @@ fn apply_validates_all_results_then_mutates_context_files_only() {
     );
 }
 
+/// [ORB-11261] A concrete conflict-plus-evidence recommendation, expressed the
+/// way the instruction now documents it (one string per finding), must
+/// validate and apply normally.
+#[test]
+fn adr_conflicts_accepts_nonempty_string_array_with_conflict_and_evidence() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/alpha.rs");
+    let alpha = seed_task(&runtime, "alpha", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![alpha.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let mut assessment = selector_assessment(&alpha, vec!["file:src/alpha.rs"]);
+    assessment["adr_conflicts"] = json!([
+        "crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs still \
+         exports validate_recommendations with the signature this task would \
+         change (verified via `rg -n \"fn validate_recommendations\"` at \
+         source_revision)"
+    ]);
+    let result = partition_result(0, &task_ids, vec![assessment]);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("apply accepts a nonempty string-array adr_conflicts");
+
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "applied");
+    assert_eq!(output["tasks"][0]["applied"], true);
+}
+
+/// [ORB-11261] Reproduces the ORB-11259 incident directly: an agent that
+/// returns `adr_conflicts` as an array of `{conflict, evidence}` objects
+/// instead of plain strings must fail deterministic apply with a clear,
+/// field-specific error before any task is mutated — never be coerced into a
+/// successful typed response.
+#[test]
+fn adr_conflicts_rejects_object_array_conflict_evidence_shape() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/alpha.rs");
+    let alpha = seed_task(&runtime, "alpha", TaskStatus::Backlog, &[], &[]);
+    let task_ids = vec![alpha.id.clone()];
+    let prepared_snapshot = prepared(&runtime, &repo_root, &task_ids);
+    let mut assessment = selector_assessment(&alpha, vec!["file:src/alpha.rs"]);
+    assessment["adr_conflicts"] = json!([
+        {
+            "conflict": "legacy ADR mandates a different storage layout",
+            "evidence": "docs/design/foo/decisions.md",
+        }
+    ]);
+    let result = partition_result(0, &task_ids, vec![assessment]);
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": prepared_snapshot,
+            "results": [result],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("malformed adr_conflicts is a durable failed decision, not an error");
+
+    assert_eq!(output["status"], "failed");
+    assert_eq!(output["partition_decisions"][0]["outcome"], "failed");
+    let error = output["partition_decisions"][0]["error"]
+        .as_str()
+        .expect("failed partition carries an error message");
+    assert!(error.contains("adr_conflicts"));
+    assert!(error.contains("must contain only strings"));
+    assert!(
+        runtime
+            .get_task(&alpha.id)
+            .unwrap()
+            .context_files
+            .is_empty()
+    );
+}
+
 #[test]
 fn invalid_selector_in_later_assessment_prevents_every_mutation() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -536,6 +536,63 @@ backend = "cli"
         }
     }
 
+    /// [ORB-11261] The task-pilot output schema's per-task field types must
+    /// mirror what `apply_task_pilot_results` actually enforces
+    /// (`string_array_value` in `adapter::engine_host::v2_host::task_pilot`),
+    /// so a producer sees the concrete string-array contract for
+    /// `adr_conflicts` and its siblings instead of an avoidable shape failure
+    /// discovered only after full exploration. Optionality (no `required` at
+    /// any level) must survive alongside the added types.
+    #[test]
+    fn task_pilot_output_schema_declares_advisory_field_types() {
+        let (_, yaml) = DEFAULT_ACTIVITY_FILES
+            .iter()
+            .find(|(name, _)| *name == "task_pilot")
+            .expect("task pilot activity is seeded");
+        let asset = load_activity_asset(yaml).expect("parse task pilot activity");
+        let schema = &asset.spec.output_schema_json;
+        assert!(
+            schema.get("required").is_none(),
+            "top-level output schema must stay optional"
+        );
+
+        let task_item = &schema["properties"]["tasks"]["items"];
+        assert_eq!(task_item["type"], serde_json::json!("object"));
+        assert!(
+            task_item.get("required").is_none(),
+            "per-task output schema must stay optional until apply_task_pilot_results validates"
+        );
+
+        let properties = &task_item["properties"];
+        for field in [
+            "blocked_by",
+            "adr_conflicts",
+            "utility_warnings",
+            "surface_warnings",
+            "context_files_before",
+            "context_files_after",
+        ] {
+            assert_eq!(
+                properties[field]["type"],
+                serde_json::json!("array"),
+                "{field} must declare an array type consistent with the deterministic apply parser"
+            );
+            assert_eq!(
+                properties[field]["items"]["type"],
+                serde_json::json!("string"),
+                "{field} items must declare a string type consistent with `string_array_value`"
+            );
+        }
+        assert_eq!(
+            properties["disposition"]["enum"],
+            serde_json::json!(["selectors", "verified_no_diff", "host_operational"])
+        );
+        assert_eq!(
+            properties["recommended_complexity"]["enum"],
+            serde_json::json!(["low", "medium", "hard"])
+        );
+    }
+
     /// [ORB-10129] The triage agent's hard bounds are structural: its tool
     /// allowlist must exclude every write/dispatch surface (code edits,
     /// commits/pushes/merges, PR approval, pipeline invocation, task


### PR DESCRIPTION
## Task

[ORB-11261](https://orbit-cli.com/tasks/ORB-11261) — Make task-pilot advisory field types explicit in its response schema

### Description

Observed jrun-20260905-0532 for ORB-11259: Luna spent332490ms and returned a valid success envelope, but deterministic apply rejected the entire partition: `adr_conflicts` must contain only strings. Actual tasks[0].adr_conflicts contained an object with conflict/evidence keys. Shipped task_pilot.yaml output_schema_json declares tasks.items only as type:object, while prose requests conflicts plus evidence and the example only shows an empty array. This gives the provider no concrete field type contract and defers an avoidable shape failure until after costly exploration. Strengthen nested optional property types to mirror the canonical apply parser (particularly string-array advisories) and include a nonempty example. Keep optionality, authoritative apply validation, partition isolation and CAS; do not coerce malformed objects into strings or treat invalid recommendations as applied. Add focused contract tests that catch producer/consumer type drift using the observed object-vs-string case. No new pipeline engine, broad retry loop, or ADR authority; adr_conflicts is a legacy wire name only.

### Acceptance Criteria

- The provider-visible task response schema declares supported advisory/context/disposition field types consistent with the deterministic parser while preserving appropriate optionality.
- A nonempty conflicts/evidence example produces accepted string-array data; the observed object-array payload fails schema validation before apply instead of being accepted as a successful typed response.
- Canonical apply remains fail-closed and independently valid partitions retain existing behavior; synchronized managed and shipped activity resources plus focused contract tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Strengthened task_pilot's response schema and instruction to give the producer (Luna) a concrete field-type contract, plus contract tests catching the observed producer/consumer type drift.

Changes (both `.orbit/resources/activities/task_pilot.yaml` and `crates/orbit-core/assets/activities/task_pilot.yaml`, kept byte-identical):
- `output_schema_json.properties.tasks.items` now declares full per-task `properties` with explicit types: `context_files_before/after` (array of string), `disposition`/`recommended_complexity` (string enum matching `validate_after_selectors`/`validate_recommendations`), `blocked_by`/`adr_conflicts`/`utility_warnings`/`surface_warnings` (array of string, matching `string_array_value`), `duplicate_of`/`already_landed` (object|null with `task_id`/`evidence`). No `required` added anywhere (top-level or nested) — fields stay advisory until `apply_task_pilot_results` validates, per the existing comment/test.
- Instruction step 5 now states the four warning-type fields are arrays of plain strings (one string per finding combining the finding and its citation) and gives a concrete non-empty example, replacing the previous all-empty-array example that gave no shape signal.
- Confirmed via code research (two Explore agents) that `output_schema_json` is never enforced at runtime anywhere in the engine/agent path (not injected into the agent prompt, not schema-validated against the returned envelope) — it is purely documentation (`orbit activity list`) plus a producer/consumer-drift-catching contract now exercised by tests. The actual runtime fail-closed gate is `validate_recommendations`/`string_array_value` in `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs`, which already correctly rejects the object-array shape from the ORB-11259 incident — confirmed by a new regression test reproducing that exact payload.

Tests added:
- `crates/orbit-core/src/bootstrap/activity.rs`: `task_pilot_output_schema_declares_advisory_field_types` — structurally asserts the shipped schema's per-task field types mirror the deterministic parser, and that optionality is preserved.
- `crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs`: `adr_conflicts_accepts_nonempty_string_array_with_conflict_and_evidence` (nonempty string-array conflict+evidence applies normally) and `adr_conflicts_rejects_object_array_conflict_evidence_shape` (reproduces the ORB-11259 `{conflict, evidence}` object-array payload; asserts `apply` returns a durable `failed` partition decision citing `adr_conflicts` / "must contain only strings", and that no task is mutated).

Validation:
- `cargo fmt -p orbit-core -- --check`: clean.
- `cargo clippy -p orbit-core --all-targets -- -D warnings`: clean.
- `cargo test -p orbit-core`: 941 passed, 5 pre-existing failures unrelated to this change and to any file in this diff (confirmed via `git diff --stat` showing zero overlap): 4 `bootstrap::init` tests fail with `Io("Read-only file system (os error 30)")` (sandbox/environment write restriction on real `$HOME`, not this change), and `skill_residue_is_reported_and_fix_preserves_unproven_content` fails on an unrelated skill-count assertion. One new failure I did introduce and fixed in-flight: my first draft example text tripped `embedded_assets_are_repository_agnostic` (guards against literal `crates/...` paths leaking into shipped assets) — reworded the example to avoid a literal crate path; now passes.
- `make ci-fast`: passes.
- `make ci-lint` (workspace-wide clippy): fails, but on a pre-existing, already-merged, unrelated break in `crates/orbit-web/src/api/runs.rs` (calls `submit_workspace_auto_run`/`workspace_auto_readiness` with stale arg counts after commit a9b5dab8 changed those signatures for ORB-11242). Zero overlap with this diff; not attempted since it's out of scope for this task.

No context_files were added beyond the four originally scoped; all edits stayed within them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11261-6a9bad95`
- Behind base: 0
- Ahead of base: 1