### PR TITLE
Regenerate the skill-list golden after orbit-orchestrate registration

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/skill_list.plain.txt
@@ -1,2 +1,2 @@
-orbit	<CONTENT_HASH>	0	
-orbit-orchestrate	<CONTENT_HASH>	0	
+orbit	<CONTENT_HASH>
+orbit-orchestrate	<CONTENT_HASH>


### PR DESCRIPTION
## Task

[ORB-11264](https://orbit-cli.com/tasks/ORB-11264) — Regenerate the skill-list golden after orbit-orchestrate registration

### Description

Follow-up verification in ORB-11260 after repairing integrated CLI compilation found cargo test -p orbit-cli --test output_goldens: 2 passed, 1 failed. skill_list.plain.txt expects stale extra tab/empty/count columns (`orbit <HASH> 0`) while current canonical CLI emits `orbit <HASH>` (and the new orbit-orchestrate row). ORB-11216 / PR1339 added the second skill but hand-edited the goldens because the contemporaneous E0061 prevented executable generation. That blocker is now fixed by merged PR1340 /87860a0362b770ccc16742e8acd9df80db4fcf5c. Reproduce using the actual current binary and isolated fixture, regenerate only the mismatched skill-list goldens, and verify both list rows and output contract. Do not alter CLI formatting merely to match the hand-written fixture; retain content-hash normalization and inherited-authority isolation. A targeted golden regeneration is the repair, no new abstraction or broad snapshot refresh.

### Acceptance Criteria

- cargo test -p orbit-cli --test output_goldens passes on current integrated source with both orbit and orbit-orchestrate rows.
- Verify table-rendering skill-list output and content-hash redaction still work; refresh only the actually mismatched skill-list fixtures.
- Record exact generation command, observed before/after mismatch, and passing test results.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Regenerated only `crates/orbit-cli/tests/output_goldens/skill_list.plain.txt` with the canonical command `ORBIT_UPDATE_OUTPUT_GOLDENS=1 cargo test -p orbit-cli --test output_goldens`.
- Before regeneration, the fixture expected `orbit\t<CONTENT_HASH>\t0\t` and `orbit-orchestrate\t<CONTENT_HASH>\t0\t`; the current renderer produced `orbit\t<CONTENT_HASH>\n` and `orbit-orchestrate\t<CONTENT_HASH>\n`. After regeneration, the fixture contains the two current rows with content hashes redacted as `<CONTENT_HASH>` and no stale count columns.
- JSON/table fixtures were not changed; final `git status --short` shows only the intended plain skill-list fixture modified.
Validation:
- `cargo test -p orbit-cli --test output_goldens` passed: 3 passed, 0 failed, including table/plain-vs-JSON golden comparison, inherited managed routing/identity isolation, and no-ANSI checks.
Assessment: Targeted golden refresh matches the integrated CLI output without changing formatting or implementation behavior. Removed the run-created Cargo `target/` build artifacts before handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11264-6a9bb10e`
- Behind base: 0
- Ahead of base: 1