### PR TITLE
Make crew selection on run job discoverable and correct invalid-flag guidance

### DIFF
--- a/crates/orbit-cli/src/command/run/job.rs
+++ b/crates/orbit-cli/src/command/run/job.rs
@@ -16,7 +16,7 @@ const FAILED_WAIT_STATUSES: [&str; 4] = ["failed", "timeout", "cancelled", "inte
 
 #[derive(Args)]
 #[command(
-    after_help = "Examples:\n  orbit run job task_auto_pipeline\n  orbit run job task_auto_pipeline --input mode=local\n  orbit run job crates/orbit-core/assets/jobs/task_pipeline.yaml --input task_id=T123\n  orbit run job task_pilot_pipeline --wait\n\nThe run is submitted to a detached worker and the command returns as soon as it is durable.\nInspect it with `orbit run history -j <JOB_ID>` and `orbit run show <RUN_ID>`."
+    after_help = "Examples:\n  orbit run job task_auto_pipeline\n  orbit run job task_auto_pipeline --input mode=local\n  orbit run job crates/orbit-core/assets/jobs/task_pipeline.yaml --input task_id=T123\n  orbit run job task_pilot_pipeline --wait\n  orbit run job task_pilot_pipeline --input crew=luna --json\n\nThere is no `--crew` flag: crew selection is a run input, `--input crew=<name>`.\nThat picks this run's resolved crew; an activity with an explicit `crew` or\n`system_crew: true` still routes there instead. Check `activity_provenance` in\n`orbit run show <RUN_ID> --json` for what actually dispatched.\n\nThe run is submitted to a detached worker and the command returns as soon as it is durable.\nInspect it with `orbit run history -j <JOB_ID>` and `orbit run show <RUN_ID>`."
 )]
 pub struct JobRunArgs {
     /// Job ID from the catalog, or a direct path to a schemaVersion 2 job YAML.

--- a/crates/orbit-cli/src/main.rs
+++ b/crates/orbit-cli/src/main.rs
@@ -153,10 +153,44 @@ fn legacy_json(matches: &ArgMatches) -> bool {
     }
 }
 
+/// Repoint clap's default "pass it after `--`" tip when the rejected flag is
+/// `--crew` on `orbit run job` / `orbit job run` (matched by the `<JOB_ID>`
+/// usage, unique to [`command::run::JobRunArgs`]).
+///
+/// That default tip is actively wrong here: a job run has no positional slot
+/// a trailing `--crew` could land in, so following it just produces a second,
+/// more confusing error. Crew selection for a job run goes through the
+/// existing `--input` contract (`resolve_crew_for_run_input` reads `crew`
+/// from the run input), so the repair only rewrites the tip text — it does
+/// not change what argv the parser accepts or make `--crew` appear to work.
+fn repair_crew_flag_suggestion(mut err: clap::error::Error) -> clap::error::Error {
+    use clap::error::{ContextKind, ContextValue};
+
+    let is_crew_flag = matches!(
+        err.get(ContextKind::InvalidArg),
+        Some(ContextValue::String(arg)) if arg == "--crew"
+    );
+    let is_job_run = matches!(
+        err.get(ContextKind::Usage),
+        Some(ContextValue::StyledStr(usage)) if usage.to_string().contains("<JOB_ID>")
+    );
+    if is_crew_flag && is_job_run {
+        err.insert(
+            ContextKind::Suggested,
+            ContextValue::StyledStrs(vec![clap::builder::StyledStr::from(
+                "crew selection is `--input crew=<name>`, e.g. `--input crew=luna` (see `orbit run job --help`)",
+            )]),
+        );
+    }
+    err
+}
+
 /// Parse argv into the derived CLI plus the two inputs to mode resolution.
 fn parse_cli() -> (command::Cli, Option<FormatArg>, bool) {
     let args = command::mcp::normalize_ssh_login_shell_args(std::env::args_os());
-    let matches = install_format_arg(command::Cli::command()).get_matches_from(args);
+    let matches = install_format_arg(command::Cli::command())
+        .try_get_matches_from(args)
+        .unwrap_or_else(|err| repair_crew_flag_suggestion(err).exit());
     let requested = requested_format(&matches);
     let legacy = legacy_json(&matches);
     let cli = command::Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());

--- a/crates/orbit-cli/src/tests/crew_flag_suggestion.rs
+++ b/crates/orbit-cli/src/tests/crew_flag_suggestion.rs
@@ -1,0 +1,85 @@
+//! [ORB-11245] `orbit run job` / `orbit job run` have no `--crew` flag; crew
+//! selection is `--input crew=<name>`. Clap's default "pass it after `--`"
+//! tip is wrong for this shape (there is no positional slot for it to land
+//! in), so [`crate::repair_crew_flag_suggestion`] repoints the tip without
+//! changing what argv the parser accepts.
+
+use clap::CommandFactory;
+
+use crate::command::Cli;
+use crate::{install_format_arg, repair_crew_flag_suggestion};
+
+fn rejected(argv: &[&str]) -> clap::error::Error {
+    install_format_arg(Cli::command())
+        .try_get_matches_from(argv)
+        .expect_err("argv should be rejected")
+}
+
+#[test]
+fn run_job_crew_flag_points_at_the_input_contract_instead_of_trailing_dashes() {
+    let err = repair_crew_flag_suggestion(rejected(&[
+        "orbit",
+        "run",
+        "job",
+        "task_pilot_pipeline",
+        "--crew",
+        "luna",
+    ]));
+    let rendered = err.render().to_string();
+
+    assert!(
+        rendered.contains("--input crew=<name>"),
+        "expected the repaired tip, got:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("-- --crew"),
+        "misleading trailing-arg tip should have been replaced:\n{rendered}"
+    );
+}
+
+#[test]
+fn job_run_alias_gets_the_same_repair() {
+    let err = repair_crew_flag_suggestion(rejected(&[
+        "orbit",
+        "job",
+        "run",
+        "task_pilot_pipeline",
+        "--crew",
+        "luna",
+    ]));
+    let rendered = err.render().to_string();
+
+    assert!(
+        rendered.contains("--input crew=<name>"),
+        "expected the repaired tip, got:\n{rendered}"
+    );
+}
+
+#[test]
+fn crew_flag_rejection_still_fails_the_command() {
+    let err = repair_crew_flag_suggestion(rejected(&[
+        "orbit",
+        "run",
+        "job",
+        "task_pilot_pipeline",
+        "--crew",
+        "luna",
+    ]));
+
+    // The repair only rewrites the tip text; `--crew` must still be refused
+    // rather than silently parsed as an activity/input argument.
+    assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+}
+
+#[test]
+fn unrelated_unknown_argument_keeps_the_default_trailing_arg_tip() {
+    // `run ship` has no `--input` escape hatch for `--crew`, so the repair
+    // must not touch it — only the `run job` / `job run` shape qualifies.
+    let err = repair_crew_flag_suggestion(rejected(&["orbit", "run", "ship", "--crew", "luna"]));
+    let rendered = err.render().to_string();
+
+    assert!(
+        rendered.contains("-- --crew"),
+        "unrelated command's default tip should be untouched:\n{rendered}"
+    );
+}

--- a/crates/orbit-cli/src/tests/mod.rs
+++ b/crates/orbit-cli/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod audit_middleware;
 mod cli_format;
+mod crew_flag_suggestion;
 pub(crate) mod env_isolation;

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -116,7 +116,12 @@ bounded partitions, and its apply step persists only selectors it validated.
 orbit job show task_pilot_pipeline
 orbit run job task_pilot_pipeline                                  # zero-input discovery
 orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exactly these
+orbit run job task_pilot_pipeline --input crew=luna                # override the pilot's crew for this run
 ```
+
+Crew selection here is `--input crew=<name>`, not a `--crew` flag — see
+[workflows.md](workflows.md#running-a-job) for the full contract and how it
+differs from an activity-level `system_crew` override.
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
 workspace whose `context_files` is empty, and skips tasks tagged as needing no

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -34,11 +34,19 @@ subprocess, or authentication checks.
 orbit job list                                   # catalog
 orbit job show <job_id>
 orbit run job <job_id> --input key=value --json
+orbit run job <job_id> --input crew=<name> --json # override the run's crew for this run
 orbit run job <job_id> --wait                    # block until terminal; nonzero unless it succeeded
 orbit run history --json
 orbit run history -j <job_id>
 orbit run show <run_id> --json
 ```
+
+There is no `--crew` flag on `run job` — crew selection is always a run input.
+That picks the run's resolved crew (`resolved_run_crew` in `orbit run show
+--json`); an individual activity can still route elsewhere via an explicit
+activity `crew` or `system_crew: true`, which overrides even an explicit
+request. [run-debugging.md](run-debugging.md#verify-model-routing-before-reading-logs)
+covers reading `activity_provenance` for what actually dispatched.
 
 **Runs are asynchronous by default.** `orbit run job` submits to a detached
 worker and returns as soon as the run is durable — it prints the run id and the

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -116,7 +116,12 @@ bounded partitions, and its apply step persists only selectors it validated.
 orbit job show task_pilot_pipeline
 orbit run job task_pilot_pipeline                                  # zero-input discovery
 orbit run job task_pilot_pipeline --input 'task_ids=["<id>","<id>"]' # audit exactly these
+orbit run job task_pilot_pipeline --input crew=luna                # override the pilot's crew for this run
 ```
+
+Crew selection here is `--input crew=<name>`, not a `--crew` flag — see
+[workflows.md](workflows.md#running-a-job) for the full contract and how it
+differs from an activity-level `system_crew` override.
 
 Zero-input mode discovers only `proposed`/`backlog` tasks in the invoking
 workspace whose `context_files` is empty, and skips tasks tagged as needing no

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -34,11 +34,19 @@ subprocess, or authentication checks.
 orbit job list                                   # catalog
 orbit job show <job_id>
 orbit run job <job_id> --input key=value --json
+orbit run job <job_id> --input crew=<name> --json # override the run's crew for this run
 orbit run job <job_id> --wait                    # block until terminal; nonzero unless it succeeded
 orbit run history --json
 orbit run history -j <job_id>
 orbit run show <run_id> --json
 ```
+
+There is no `--crew` flag on `run job` — crew selection is always a run input.
+That picks the run's resolved crew (`resolved_run_crew` in `orbit run show
+--json`); an individual activity can still route elsewhere via an explicit
+activity `crew` or `system_crew: true`, which overrides even an explicit
+request. [run-debugging.md](run-debugging.md#verify-model-routing-before-reading-logs)
+covers reading `activity_provenance` for what actually dispatched.
 
 **Runs are asynchronous by default.** `orbit run job` submits to a detached
 worker and returns as soon as the run is durable — it prints the run id and the


### PR DESCRIPTION
## Task

[ORB-11245](https://orbit-cli.com/tasks/ORB-11245) — Make crew selection on run job discoverable and correct invalid-flag guidance

### Description

Observed operator friction on current installed CLI: `orbit run job task_pilot_pipeline --crew luna --json` fails with `unexpected argument --crew` and Clap suggests passing `-- --crew`, which does not express the intended crew override. Supported invocation is `orbit run job task_pilot_pipeline --input crew=luna --json`, verified jrun-20260905-0427-2 resolved Luna. Make current run-job crew selection discoverable in command help and the Orbit workflow/skill guidance, and correct the misleading unsupported-flag suggestion if the parser seam permits a small repair. Do not introduce a second crew-resolution path or silently ignore the user's crew restriction. Distinguish requested crew from activity-level system overrides introduced by ORB-11227. Deduped run job crew against existing tasks; ORB-11223 repaired different task_ids/activity inspection examples.

### Acceptance Criteria

- run job help includes a runnable crew selection example using the supported input contract.
- Relevant workflow/skill examples explain effective activity overrides and where to inspect them.
- Unsupported --crew input must not appear to succeed or silently become an activity argument; any parser repair uses the existing input/validation path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Made run-job crew selection discoverable and corrected the misleading --crew guidance, without adding a second crew-resolution path.

1. crates/orbit-cli/src/command/run/job.rs: added a runnable crew example to JobRunArgs' after_help (`orbit run job task_pilot_pipeline --input crew=luna --json`), plus a short note that there is no `--crew` flag, that an activity's explicit `crew`/`system_crew: true` can still override the run's resolved crew, and to check `activity_provenance` via `orbit run show --json` for what actually dispatched.

2. crates/orbit-cli/src/main.rs: `--crew` on `orbit run job` / `orbit job run` still fails (still ErrorKind::UnknownArgument, exit 2) -- no new parsing branch was added and --crew never becomes an accepted flag or a silent activity/positional argument. What changed is only the misleading clap tip: added `repair_crew_flag_suggestion`, invoked from `parse_cli` on the existing `try_get_matches_from` error path, which rewrites clap's default "pass it after `--`" tip (wrong here -- JobRunArgs has no positional slot for a trailing `--crew` to land in) to point at the real contract (`--input crew=<name>`), matched narrowly on InvalidArg == "--crew" AND Usage containing "<JOB_ID>" (unique to JobRunArgs) so unrelated commands like `run ship --crew` (which has no --input equivalent) keep clap's default tip. Added crates/orbit-cli/src/tests/crew_flag_suggestion.rs covering: run job repair, job run alias repair, that the rejection still fails (UnknownArgument), and that an unrelated command's tip is untouched.

3. Docs (crates/orbit-core/assets/skills/orbit/references/{workflows,orchestration}.md, mirrored byte-for-byte to plugin/skills/orbit/references/ per scripts/sync-plugin-skills.sh): workflows.md's "Running a job" section now shows `--input crew=<name>` explicitly and explains the run-level vs activity-level (system_crew) override distinction from ORB-11227, linking to run-debugging.md's "Verify model routing" section for activity_provenance inspection. orchestration.md's task-pilot example block now includes `orbit run job task_pilot_pipeline --input crew=luna` (the exact friction scenario) with a pointer back to workflows.md.

Validation: make ci-fast and make ci-lint (workspace clippy, -D warnings) both pass. cargo test -p orbit-cli --bin orbit passes 411/411 single-threaded; the only failure under default parallel threading (command::workspace::tests::init::workspace_init_under_home_with_global_orbit_creates_repo_orbit) is a pre-existing env-var-leak flake unrelated to this change -- confirmed by rerunning the full suite with --test-threads=1 (411 passed, 0 failed) and by the change touching none of that test's code paths.

Scope note: touched crates/orbit-cli/src/tests/mod.rs (added one `mod` line) and added crates/orbit-cli/src/tests/crew_flag_suggestion.rs to cover the new main.rs behavior with a sibling-style test file; both are tightly coupled to the job.rs/main.rs change and were not in the original context_files list.

No blockers, no friction filed (the read-only shared .git in this worktree caused one test job run I submitted during manual CLI verification to fail on a git fetch -- expected sandbox behavior, not a code defect, and the run finished terminal with no lingering process).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11245-6a9bb577`
- Behind base: 0
- Ahead of base: 1