### PR TITLE
[code-review] sync-plugin-skills.sh --check does not detect orphaned plugin/skills directories after a skill is removed or renamed

### DIFF
--- a/scripts/sync-plugin-skills.sh
+++ b/scripts/sync-plugin-skills.sh
@@ -25,6 +25,14 @@ if [[ "${#skill_dirs[@]}" -eq 0 ]]; then
   exit 1
 fi
 
+target_skill_dirs=()
+if [[ -d "$target_root" ]]; then
+  for entry in "$target_root"/*/ "$target_root"/.[!.]*/ "$target_root"/..?*/; do
+    [[ -d "$entry" ]] || continue
+    target_skill_dirs+=("$(basename "$entry")")
+  done
+fi
+
 if [[ "${1:-}" == "--check" ]]; then
   if [[ "$#" -ne 1 ]]; then
     echo "usage: $0 [--check]" >&2
@@ -35,6 +43,19 @@ if [[ "${1:-}" == "--check" ]]; then
     if ! diff -qr "$source_root/$name" "$target_root/$name" >/dev/null 2>&1; then
       echo "sync-plugin-skills: plugin/skills/$name drifted from crates/orbit-core/assets/skills/$name" >&2
       diff -ru "$source_root/$name" "$target_root/$name" || true
+      drifted=1
+    fi
+  done
+  for name in "${target_skill_dirs[@]}"; do
+    is_canonical=0
+    for canonical_name in "${skill_dirs[@]}"; do
+      if [[ "$name" == "$canonical_name" ]]; then
+        is_canonical=1
+        break
+      fi
+    done
+    if [[ "$is_canonical" -eq 0 ]]; then
+      echo "sync-plugin-skills: plugin/skills/$name has no matching canonical skill under crates/orbit-core/assets/skills" >&2
       drifted=1
     fi
   done
@@ -50,6 +71,18 @@ if [[ "$#" -ne 0 ]]; then
 fi
 
 mkdir -p "$target_root"
+for name in "${target_skill_dirs[@]}"; do
+  is_canonical=0
+  for canonical_name in "${skill_dirs[@]}"; do
+    if [[ "$name" == "$canonical_name" ]]; then
+      is_canonical=1
+      break
+    fi
+  done
+  if [[ "$is_canonical" -eq 0 ]]; then
+    rm -rf "$target_root/$name"
+  fi
+done
 for name in "${skill_dirs[@]}"; do
   rm -rf "$target_root/$name"
   cp -R "$source_root/$name" "$target_root/$name"


### PR DESCRIPTION
## Task

[ORB-11267](https://orbit-cli.com/tasks/ORB-11267) — [code-review] sync-plugin-skills.sh --check does not detect orphaned plugin/skills directories after a skill is removed or renamed

### Description

`scripts/sync-plugin-skills.sh` builds its `skill_dirs` list (lines 12-21) by enumerating only `crates/orbit-core/assets/skills/*` (the canonical source). Both the `--check` drift loop (lines 34-40) and the materialize loop (lines 53-56) iterate exclusively over that source-derived list — neither ever enumerates what's actually present under `plugin/skills/` (`target_root`).

Consequence: if a skill directory is ever removed or renamed under `crates/orbit-core/assets/skills/`, the stale directory left behind under `plugin/skills/<old-name>` is:
- never diffed in `--check` mode, so it prints `sync-plugin-skills: committed plugin skill mirror matches canonical assets` and exits 0 even though `plugin/skills/` contains a directory with no canonical counterpart, and
- never deleted by the materialize path either, so a plain re-run doesn't clean it up.

`scripts/sync-plugin-skills.sh --check` is invoked directly from `Makefile:131` under the `ci-fast` target — the gate this repo's agent guide requires to pass before a task moves to `review`. So this is a live false-negative in a real CI gate, not a theoretical script issue.

Reproduced in an isolated `/tmp` copy of the script: with a `plugin/skills/stale-skill/SKILL.md` present but no matching `crates/orbit-core/assets/skills/stale-skill`, `--check` printed the "matches canonical assets" success message and exited 0.

This is currently latent (no skill has been removed/renamed since the script was introduced in this window), but the next skill removal or rename will silently ship a stale, unreferenced skill directory in the plugin distribution tree with no CI signal.

Suggested fix direction: also enumerate `target_root`'s existing directories and flag (in `--check`) or delete (in materialize mode) any not present in the current `skill_dirs` list, e.g. via a `comm -13` between sorted source and target directory listings.

### Acceptance Criteria

- `scripts/sync-plugin-skills.sh --check` exits non-zero and reports the stale directory when `plugin/skills/` contains a directory with no matching canonical skill under `crates/orbit-core/assets/skills/`.
- Running `scripts/sync-plugin-skills.sh` (materialize mode) with no arguments removes any `plugin/skills/<name>` directory that no longer has a canonical counterpart.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated scripts/sync-plugin-skills.sh to enumerate all direct plugin/skills directories, report orphaned directories in --check mode, and remove them during materialization.
- Preserved canonical skill validation and existing mirror drift checks.
Validation:
- bash -n scripts/sync-plugin-skills.sh: passed.
- git diff --check: passed.
- Isolated regression test: --check reported both normal and hidden orphan directories with exit 1; materialize mode removed both.
- scripts/sync-plugin-skills.sh --check: passed.
- make ci-fast reached the plugin sync and validation gates successfully, then stopped at scripts/test-compiler-cache.sh because pre-existing /tmp/orbit-workspace/Cargo.toml prevented its symlink setup; no task-scoped failure was reported.
Assessment: The requested orphan detection and cleanup behavior is implemented with one task-scoped script change. Worktree status contains only scripts/sync-plugin-skills.sh.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11267-6a9c4239`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*