### PR TITLE
[code-review] task_auto_pipeline's list_backlog step does not forward allowed_crews, so crew-excluded tasks pass discovery and only fail at the final gate

### DIFF
--- a/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_auto_pipeline.yaml
@@ -58,6 +58,7 @@ spec:
       default_input:
         max_tasks: "{{ input.max_tasks }}"
         task_ids: "{{ input.task_ids }}"
+        allowed_crews: "{{ input.allowed_crews }}"
 
     - id: validate_bundles
       target: activity:validate_bundles

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -1190,6 +1190,42 @@ fn auto_pipeline_checks_gate_results_after_fan_in() {
     }
 }
 
+/// [ORB-11268] `allowed_crews` reaching the `dispatch` fan-out is not enough:
+/// the generic escape hatch (`orbit run job task_auto_pipeline --input
+/// allowed_crews=<crew>` with `task_ids` left empty) forces the discovery
+/// branch in `list_backlog_tasks`, which reads the allowlist off
+/// `list_backlog`'s own rendered step input. If that step never forwards
+/// `input.allowed_crews`, discovery-mode backlog listing silently ignores the
+/// run's crew restriction even though the later gate still enforces it.
+#[test]
+fn auto_pipeline_list_backlog_step_forwards_allowed_crews() {
+    let yaml = DEFAULT_JOB_FILES
+        .iter()
+        .find_map(|(name, yaml)| (*name == "task_auto_pipeline").then_some(*yaml))
+        .expect("task auto pipeline default exists");
+    let asset = load_job_asset(yaml).expect("parse task auto pipeline");
+
+    let list_backlog = asset
+        .spec
+        .steps
+        .iter()
+        .find(|step| step.id == "list_backlog")
+        .expect("task auto pipeline has a list_backlog step");
+    match &list_backlog.body {
+        JobV2StepBody::TargetRef(target) => {
+            assert_eq!(target.target, "activity:list_backlog_tasks");
+            let input = target.default_input.as_ref().expect("list_backlog input");
+            assert_eq!(
+                input["allowed_crews"],
+                Value::String("{{ input.allowed_crews }}".to_string()),
+                "list_backlog must forward the job's top-level allowed_crews input, \
+                 not just the later dispatch step"
+            );
+        }
+        other => panic!("expected list_backlog target ref, got {other:?}"),
+    }
+}
+
 #[test]
 fn gate_pipeline_default_reservation_ttl_covers_child_wait_budget() {
     let yaml = DEFAULT_JOB_FILES


### PR DESCRIPTION
## Task

[ORB-11268](https://orbit-cli.com/tasks/ORB-11268) — [code-review] task_auto_pipeline's list_backlog step does not forward allowed_crews, so crew-excluded tasks pass discovery and only fail at the final gate

### Description

`crates/orbit-core/assets/jobs/task_auto_pipeline.yaml`'s `list_backlog` step (lines 56-60) only forwards `max_tasks` and `task_ids` into `activity:list_backlog_tasks`:

```yaml
- id: list_backlog
  target: activity:list_backlog_tasks
  default_input:
    max_tasks: "{{ input.max_tasks }}"
    task_ids: "{{ input.task_ids }}"
```

It does not forward `input.allowed_crews`, even though the job's `default_input.allowed_crews` (line 43, added by ORB-11242) is documented as "opt-in, run-scoped crew restriction ... Forwarded unchanged so the leaf/epic jobs this run admits inherit the same window."

`list_backlog_tasks` (`crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs:106-146`) reads the crew allowlist via `allowlist_from_input(runtime, action, input)` off exactly that step's own rendered input, and only applies crew filtering on the discovery branch (`explicit_task_ids.is_empty()`, lines 126-135). Since `list_backlog`'s input never carries `allowed_crews`, that branch always resolves an empty/no-op allowlist, so discovery-mode backlog listing returns every admissible task regardless of the run's crew restriction.

This is a forwarding gap, not a core-logic inversion: `allowed_crews` **is** correctly forwarded later, from the `dispatch` fan_out step to `task_gate_pipeline` (line 85), so an excluded-crew task is still refused at the final gate (`enforce_crew_allowlist` in `crates/orbit-core/src/runtime/engine/crew.rs`, wired via `runtime_host.rs:744-761`). So there is no security bypass — but a crew-excluded task is no longer left cleanly in `backlog` for `readiness`/`explain_workspace_auto_readiness` to report; instead it burns a lock reservation and runs partway through `task_gate_pipeline`/`task_local_pipeline`/`task_pr_pipeline` setup before hard-failing at the gate.

Not reachable through the primary documented path (`orbit run auto --allow-crew`): `workspace_auto_pipeline.yaml` calls `classify_workspace_auto_tasks` with the allowlist already applied (line 87) and dispatches `task_auto_pipeline` per already-selected single task id (line 104), so `list_backlog_tasks` takes the `explicit_task_ids` branch there (filtering already done upstream). It **is** reachable via the generic escape hatch `orbit run job task_auto_pipeline --input allowed_crews=<crew>` with `task_ids` left at its default `[]`, which forces the discovery branch.

Not caught by existing tests: `auto_drain_dispatch_chain_declares_and_forwards_the_crew_allowlist` (`crates/orbit-core/src/application/job/tests/catalog.rs:258-295`) only asserts the string `{{ input.allowed_crews }}` appears somewhere in the serialized job spec for jobs marked `forwards: true`. `task_auto_pipeline` passes that check via the `dispatch` step's forward to `task_gate_pipeline`, so the earlier gap in the `list_backlog` step is not detected.

Fix direction: add `allowed_crews: "{{ input.allowed_crews }}"` to the `list_backlog` step's `default_input` in `task_auto_pipeline.yaml`.

### Acceptance Criteria

- Running `orbit run job task_auto_pipeline --input allowed_crews=<crew>` with no explicit `task_ids` excludes tasks whose crew is not in `allowed_crews` from the discovery-mode backlog snapshot (`list_backlog`'s output `tasks`/`bundles`), matching the exclusion already applied when `workspace_auto_pipeline` calls this job with pre-selected task ids.
- A regression test asserts `list_backlog`'s rendered step input carries `allowed_crews` from the job's top-level input, not just the later `dispatch` step.

## Execution Summary

<details>
<summary>Click to expand</summary>

Fixed the forwarding gap: added `allowed_crews: "{{ input.allowed_crews }}"` to `list_backlog`'s `default_input` in `crates/orbit-core/assets/jobs/task_auto_pipeline.yaml`, so `activity:list_backlog_tasks` now receives the run's crew allowlist on its own rendered step input, matching what `dispatch` already forwards to `task_gate_pipeline`. This closes the discovery-mode gap: `orbit run job task_auto_pipeline --input allowed_crews=<crew>` with no explicit `task_ids` now excludes crew-restricted tasks from `list_backlog`'s discovery branch (`allowlist_from_input` in `backlog_exclusion.rs`) instead of leaving them to burn a lock reservation and fail late at the gate.

Added a new regression test `auto_pipeline_list_backlog_step_forwards_allowed_crews` in `crates/orbit-core/src/application/job/tests/catalog.rs` (next to `auto_pipeline_checks_gate_results_after_fan_in`), asserting `list_backlog`'s own `TargetRef.default_input["allowed_crews"]` equals `"{{ input.allowed_crews }}"` — this specifically distinguishes the `list_backlog` step's input from the `dispatch` step's, which the existing whole-spec-string test (`auto_drain_dispatch_chain_declares_and_forwards_the_crew_allowlist`) could not do (it only checks the string appears somewhere in the serialized job).

Validation: `cargo test -p orbit-core --lib application::job::tests::catalog` — 36/36 pass, including the new test. `cargo fmt --all -- --check` clean. `cargo clippy -p orbit-core --lib --tests -- -D warnings` clean (no crate-wide `make ci-lint` run per repo convention — task-scoped clippy only). `make ci-fast` was attempted but hit an unrelated environment collision: this host had 4 worktrees building concurrently and `scripts/test-compiler-cache.sh`/`scripts/rustc-compiler-cache.sh` share a hardcoded `/tmp/orbit-workspace` path across all of them, causing transient failures (including this worktree's `Cargo.toml` briefly reading as deleted and a transient read-only-filesystem error on the shared `.git/worktrees` lock and main-repo `target/`). Restored `Cargo.toml` via `git show HEAD:Cargo.toml` + write (no git-index lock needed) once the transient state cleared; `git status --short` now shows only the two intended files changed. Filed friction F2026-09-012 with details and a suggested fix (scope the stable cache paths per-worktree). No scope changes beyond the two `context_files` already listed on this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11268-6a9c4238`
- Behind base: 0
- Ahead of base: 1