### PR TITLE
[code-review] task_pilot's align_clean_primary fast-forwards the shared primary checkout without serialization, racing under the job's own concurrency limit

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
@@ -5,10 +5,12 @@
 //! checkout lags origin. The only Git write this module will perform is a
 //! fast-forward of a clean primary that already sits on the landing branch.
 
+use std::io;
 use std::path::Path;
 use std::process::Command;
 
 use orbit_common::fs::git::{CurrentBranchStatus, current_branch, run_git};
+use orbit_common::fs::io::with_exclusive_file_lock;
 use orbit_engine::DispatchError;
 use serde_json::{Value, json};
 
@@ -166,23 +168,36 @@ pub(super) fn resolve_source_snapshot(
 
     let base_branch = requested_base_branch(runtime, input);
     let base_branch = normalize_base_branch(action, &base_branch)?;
-    let (source_ref, fetched_remote) = if has_origin_remote(action, workspace_root)? {
-        fetch_origin_branch(action, workspace_root, &base_branch)?;
-        (format!("origin/{base_branch}"), true)
-    } else {
-        (base_branch.clone(), false)
-    };
-    let source_revision = rev_parse_commit(action, workspace_root, &source_ref)?;
-    let head = rev_parse_commit(action, workspace_root, "HEAD")?;
-    let fast_forwarded = align_clean_primary(
-        action,
-        workspace_root,
-        &base_branch,
-        &source_ref,
-        &source_revision,
-        &head,
-        fetched_remote,
-    )?;
+    let has_origin = has_origin_remote(action, workspace_root)?;
+
+    // Concurrent `prepare_task_pilot` calls against the same shared primary
+    // (permitted up to `max_active_runs` by the job spec) each fetch the same
+    // remote-tracking ref and, when the primary is clean and fast-forwardable,
+    // each fast-forward it with `git merge --ff-only`. Both the ref-update and
+    // the merge are check-then-act git writes that race under git's own
+    // locking (`refs/remotes/origin/<branch>` lock, `.git/index.lock`); the
+    // loser's benign lock contention would otherwise be misreported as
+    // source-staleness. A workspace-scoped advisory lock serializes the whole
+    // fetch-then-align sequence per primary so a blocked caller re-evaluates
+    // against the (possibly already fast-forwarded) HEAD instead of racing
+    // the winner.
+    let lock_target = workspace_root
+        .join(".git")
+        .join("orbit-task-pilot-align-primary");
+    let (source_ref, _fetched_remote, source_revision, fast_forwarded) =
+        with_exclusive_file_lock(&lock_target, "task-pilot align primary", || {
+            resolve_source_snapshot_locked(action, workspace_root, &base_branch, has_origin)
+        })
+        .map_err(|error| match error {
+            AlignLockError::Dispatch(error) => error,
+            AlignLockError::Io(error) => action_failed(
+                action,
+                format!(
+                    "failed to acquire task-pilot align lock in '{}': {error}",
+                    workspace_root.display()
+                ),
+            ),
+        })?;
 
     Ok(Some(SourceSnapshot {
         base_branch,
@@ -190,6 +205,39 @@ pub(super) fn resolve_source_snapshot(
         source_revision,
         fast_forwarded,
     }))
+}
+
+fn resolve_source_snapshot_locked(
+    action: &str,
+    workspace_root: &Path,
+    base_branch: &str,
+    has_origin: bool,
+) -> Result<(String, bool, String, bool), AlignLockError> {
+    let (source_ref, fetched_remote) = if has_origin {
+        fetch_origin_branch(action, workspace_root, base_branch)
+            .map_err(AlignLockError::Dispatch)?;
+        (format!("origin/{base_branch}"), true)
+    } else {
+        (base_branch.to_string(), false)
+    };
+    let source_revision =
+        rev_parse_commit(action, workspace_root, &source_ref).map_err(AlignLockError::Dispatch)?;
+    let head =
+        rev_parse_commit(action, workspace_root, "HEAD").map_err(AlignLockError::Dispatch)?;
+    let fast_forwarded = if head == source_revision {
+        false
+    } else {
+        align_clean_primary_locked(
+            action,
+            workspace_root,
+            base_branch,
+            &source_ref,
+            &source_revision,
+            &head,
+            fetched_remote,
+        )?
+    };
+    Ok((source_ref, fetched_remote, source_revision, fast_forwarded))
 }
 
 pub(super) fn requested_base_branch(runtime: &OrbitRuntime, input: &Value) -> String {
@@ -223,7 +271,27 @@ fn normalize_base_branch(action: &str, base: &str) -> Result<String, DispatchErr
     Ok(branch.to_string())
 }
 
-fn align_clean_primary(
+/// Local-error wrapper so [`with_exclusive_file_lock`] (which requires
+/// `E: From<io::Error>`) can carry either lock-acquisition failures or the
+/// module's own [`DispatchError`] out of the locked closure.
+enum AlignLockError {
+    Io(io::Error),
+    Dispatch(DispatchError),
+}
+
+impl From<io::Error> for AlignLockError {
+    fn from(error: io::Error) -> Self {
+        AlignLockError::Io(error)
+    }
+}
+
+/// Runs the dirty/branch/ancestor checks and, when they pass, the
+/// `git merge --ff-only` write. Called only while
+/// [`resolve_source_snapshot`]'s workspace lock is held, so `head` (read
+/// immediately beforehand, under the same lock) reflects the primary's true
+/// current state rather than a value a concurrent caller may have already
+/// moved past.
+fn align_clean_primary_locked(
     action: &str,
     workspace: &Path,
     base_branch: &str,
@@ -231,26 +299,25 @@ fn align_clean_primary(
     source_revision: &str,
     head: &str,
     fetched_remote: bool,
-) -> Result<bool, DispatchError> {
-    if head == source_revision {
-        return Ok(false);
-    }
-
-    let dirty = working_tree_status(action, workspace)?;
+) -> Result<bool, AlignLockError> {
+    let dirty = working_tree_status(action, workspace).map_err(AlignLockError::Dispatch)?;
     let branch = current_branch(workspace)
-        .map_err(|error| action_failed(action, format!("read current branch: {error}")))?;
+        .map_err(|error| action_failed(action, format!("read current branch: {error}")))
+        .map_err(AlignLockError::Dispatch)?;
     let on_landing_branch =
         matches!(branch, CurrentBranchStatus::Named(ref name) if name == base_branch);
-    let can_fast_forward = is_ancestor(action, workspace, head, source_revision)?;
+    let can_fast_forward =
+        is_ancestor(action, workspace, head, source_revision).map_err(AlignLockError::Dispatch)?;
 
     if dirty.is_empty() && on_landing_branch && can_fast_forward {
         let merge = git(
             action,
             workspace,
             &["merge", "--ff-only", "--no-edit", source_revision],
-        )?;
+        )
+        .map_err(AlignLockError::Dispatch)?;
         if !merge.success {
-            return Err(source_stale(
+            return Err(AlignLockError::Dispatch(source_stale(
                 action,
                 base_branch,
                 source_ref,
@@ -258,11 +325,12 @@ fn align_clean_primary(
                 head,
                 fetched_remote,
                 &format!("clean fast-forward failed: {}", merge.stderr.trim()),
-            ));
+            )));
         }
-        let after = rev_parse_commit(action, workspace, "HEAD")?;
+        let after =
+            rev_parse_commit(action, workspace, "HEAD").map_err(AlignLockError::Dispatch)?;
         if after != source_revision {
-            return Err(source_stale(
+            return Err(AlignLockError::Dispatch(source_stale(
                 action,
                 base_branch,
                 source_ref,
@@ -270,7 +338,7 @@ fn align_clean_primary(
                 &after,
                 fetched_remote,
                 "fast-forward completed but HEAD is not the pinned source revision",
-            ));
+            )));
         }
         return Ok(true);
     }
@@ -295,7 +363,7 @@ fn align_clean_primary(
     } else {
         "primary is not at the verified landing-branch revision".to_string()
     };
-    Err(source_stale(
+    Err(AlignLockError::Dispatch(source_stale(
         action,
         base_branch,
         source_ref,
@@ -303,7 +371,7 @@ fn align_clean_primary(
         head,
         fetched_remote,
         &reason,
-    ))
+    )))
 }
 
 fn source_stale(

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -374,6 +374,61 @@ fn untracked_workspace_file_is_not_admitted_against_the_source_snapshot() {
     );
 }
 
+/// ORB-11269: two concurrent `prepare_task_pilot` calls against the same
+/// shared primary must serialize their fast-forward instead of racing
+/// `git merge --ff-only` and misreporting the loser's index-lock contention
+/// as source staleness.
+#[test]
+fn concurrent_prepare_calls_against_the_same_primary_both_succeed() {
+    let fixture = remote_landing_fixture();
+
+    let results: Vec<Result<Value, String>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let fixture = &fixture;
+                scope.spawn(move || prepare_landing(fixture))
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("prepare thread joined"))
+            .collect()
+    });
+
+    for (index, result) in results.iter().enumerate() {
+        let prepared = result
+            .as_ref()
+            .unwrap_or_else(|error| panic!("concurrent prepare {index} failed: {error}"));
+        assert_eq!(prepared["source"]["base_branch"], LANDING);
+        assert_eq!(
+            prepared["source"]["source_revision"], fixture.current_sha,
+            "prepare {index} must pin the landing-branch tip"
+        );
+    }
+
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", "HEAD"]),
+        fixture.current_sha,
+        "the primary must land exactly on the pinned revision, not a merge byproduct"
+    );
+    assert!(fixture.repo.join("src/merged.rs").exists());
+
+    let fast_forwarded_count = results
+        .iter()
+        .filter(|result| {
+            result
+                .as_ref()
+                .ok()
+                .and_then(|prepared| prepared["source"]["fast_forwarded"].as_bool())
+                .unwrap_or(false)
+        })
+        .count();
+    assert!(
+        fast_forwarded_count >= 1,
+        "at least one serialized caller must have performed the fast-forward"
+    );
+}
+
 #[test]
 fn non_git_workspace_still_uses_filesystem_existence() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();


### PR DESCRIPTION
## Task

[ORB-11269](https://orbit-cli.com/tasks/ORB-11269) — [code-review] task_pilot's align_clean_primary fast-forwards the shared primary checkout without serialization, racing under the job's own concurrency limit

### Description

ORB-11236 (`65a2e658`) gave `prepare_task_pilot` its first git-mutating path: `align_clean_primary` in `crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs:226-276` does a check-then-act sequence — working-tree-clean check, current-branch check, ancestor check, then `git merge --ff-only --no-edit <source_revision>` (line ~247) — against `workspace_root`.

`workspace_root` is resolved by `requested_workspace_root` (`task_pilot.rs:556-596`) from `runtime.paths().repo_root`: the single shared primary checkout for the workspace, not a per-run worktree. Before this commit, `prepare_task_pilot` never wrote to git, so no serialization around this path existed or was needed.

`task_pilot_pipeline.yaml:41` sets `max_active_runs: 3` — a limit that predates this change and was safe when `prepare` was read-only. No workspace-level lock or claim was added around `resolve_source_snapshot`/`align_clean_primary` in this window. `active_task_pilot_preparations` (referenced in `task_pilot.rs:66`) only excludes a specific *task* that already has an active preparation run; it does not serialize two different tasks' `prepare` calls against the same shared primary.

Failure scenario: two `task_pilot_pipeline` runs are active concurrently (permitted up to 3 by the job spec) against the same workspace, primary behind `origin/<base_branch>`. Both fetch the same target revision, both see a clean tree, both are on the landing branch, both pass the ancestor check, and both call `git merge --ff-only --no-edit <source_revision>` at nearly the same time. Git's index lock causes the loser to get a non-zero exit (`Unable to create '.git/index.lock'`), which `align_clean_primary` (`source.rs:252-262`) turns into a hard `source_stale`/`action_failed` error even though the primary was clean and genuinely fast-forwardable — a spurious prepare failure caused purely by concurrent invocation, not real staleness. This contradicts the module's own stated invariant (module doc: "The only Git write this module will perform is a fast-forward of a clean primary…") since the write is not safe under the concurrency the job itself permits.

Not covered by existing tests: `crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs` exercises dirty-tree, stale, remote-failure, and prepare-vs-apply TOCTOU scenarios, but not concurrent `prepare` calls racing the same primary's fast-forward.

Fix direction: serialize `align_clean_primary`'s git mutation across concurrent `prepare` calls against the same primary (e.g. a workspace-scoped lock analogous to `with_task_write_lock`), or treat a `git merge` failure caused by lock contention as retryable rather than as source staleness.

### Acceptance Criteria

- Two concurrent `task_pilot_pipeline` runs against the same workspace, both requiring a clean fast-forward of the primary checkout, do not spuriously fail one run with a source-staleness error caused only by git index-lock contention.
- A test exercises two concurrent `prepare_task_pilot` calls (or an equivalent simulated race) against the same primary and asserts both eventually succeed (serialized) or that lock-contention failures are distinguished from genuine staleness.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `align_clean_primary` (source.rs) did a check-then-act sequence (dirty/branch/ancestor checks then `git merge --ff-only`) with no serialization, so two concurrent `prepare_task_pilot` calls against the same shared primary could race git's own locking and have the loser misreported as `source_stale`. The same race also existed one step earlier at `fetch_origin_branch`, which updates the local `refs/remotes/origin/<branch>` ref and hit `cannot lock ref ... unable to update local ref` under concurrency in testing.

Fix: `resolve_source_snapshot` now acquires a workspace-scoped advisory lock (`orbit_common::fs::io::with_exclusive_file_lock` — the same reentrant, cross-process flock primitive `with_task_write_lock` already uses) keyed on `<workspace>/.git/orbit-task-pilot-align-primary`, and runs the whole fetch -> resolve-revision -> align sequence (new `resolve_source_snapshot_locked` / `align_clean_primary_locked`) inside it. A blocked caller re-reads HEAD once it acquires the lock, so it sees the winner's already-fast-forwarded primary and short-circuits instead of racing the merge. A local `AlignLockError` enum (Io | Dispatch) lets the locked closure carry `io::Error` (required by `with_exclusive_file_lock`'s `E: From<io::Error>` bound) alongside the module's existing `DispatchError`, translated back to `DispatchError` at the lock boundary.

Test: added `concurrent_prepare_calls_against_the_same_primary_both_succeed` in task_pilot_source.rs — 4 threads (`std::thread::scope`) call `prepare_task_pilot` concurrently against one shared primary fixture; asserts every call succeeds and pins the same source_revision, primary HEAD lands exactly on that revision (no merge byproduct), and at least one call reports `fast_forwarded: true`. Ran 5x in isolation with no flakes; full `adapter::engine_host::v2_host` suite (184 tests) and full-workspace `cargo clippy --all-targets -D warnings` both pass.

Scope: only the two context files touched (source.rs, tests/task_pilot_source.rs); no new dependency edges.

Validation: `cargo fmt --all -- --check` passes. `cargo clippy --workspace --all-targets -- -D warnings` (the ci-lint gate) passes clean. `make ci-fast` could not complete: its `scripts/test-compiler-cache.sh` step fails on `ln: failed to create symbolic link '/tmp/orbit-workspace/Cargo.toml': File exists` — a pre-existing, non-namespaced shared `/tmp/orbit-workspace` path colliding with another concurrent worktree/session on this shared host (confirmed unrelated to this change: the file predates this run and every guardrail script before that step in the same `ci-fast` run passed). Recorded here per the runbook's sandbox/runner-denial handling rather than reworked, since fixing the test script's shared-tmp-path design is out of scope for ORB-11269.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11269-6a9c4238`
- Behind base: 0
- Ahead of base: 1