### PR TITLE
Pilot from an immutable source snapshot while preserving a dirty primary checkout

### DIFF
--- a/.orbit/resources/activities/prepare_task_pilot.yaml
+++ b/.orbit/resources/activities/prepare_task_pilot.yaml
@@ -11,10 +11,9 @@ spec:
     task_ids it selects only proposed/backlog tasks whose context_files are
     empty, excluding no-diff-needed/no-diff-expected tasks and every active,
     review, or terminal status. In a Git workspace this step also fetches the
-    landing branch, pins one verified source revision, and fast-forwards a
-    clean primary on that branch when it is behind. Dirty, divergent, or
-    unfetchable checkouts fail closed as source-staleness before any agent
-    call. This action never promotes or dispatches work.
+    landing branch and pins one verified source revision without changing
+    the primary HEAD, index, or working files, including dirty and untracked
+    content. Remote failures stop preparation before any agent call. This action never promotes or dispatches work.
   input_schema_json:
     type: object
     properties:

--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -20,7 +20,7 @@ spec:
     # `crew` is optional here: the pipeline names `system` on the pilot step so
     # the crew is readable in the job definition, while a direct invocation may
     # omit it and inherit the run's resolved crew.
-    required: [task_ids, workspace_path, base_branch, partition_index]
+    required: [task_ids, workspace_path, base_branch, inspection_revision, partition_index]
     properties:
       task_ids:
         type: array
@@ -33,7 +33,9 @@ spec:
       base_branch:
         type: string
       source_revision:
-        type: string
+        type: [string, "null"]
+      inspection_revision:
+        type: [string, "null"]
       partition_index:
         type: number
       crew:
@@ -113,9 +115,14 @@ spec:
     You are Orbit's task-pilot for one explicit, bounded partition.
 
     Input contains `task_ids` (one to five exact IDs), `workspace_path`,
-    `base_branch`, `source_revision` (the prepared landing-branch commit),
+    `base_branch`, `inspection_revision` (null only for a non-Git workspace),
+    `source_revision` (the prepared landing-branch commit),
     and `partition_index`. Work only on those task IDs and treat the
-    workspace as read-only.
+    workspace as read-only. The CLI host materializes `inspection_revision`
+    in an invocation-owned checkout and binds `workspace_path`, `repo_root`,
+    subprocess cwd, and filesystem reads to it. Orbit tool calls retain the
+    owning logical workspace through the managed environment; do not route
+    task tools using the temporary checkout path.
 
     For every task:
 
@@ -124,15 +131,15 @@ spec:
        `context_files`. Use `orbit.search` for the task ID and relevant design
        terms; inspect linked decision docs when a result points to one.
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
-       workspace Git top-level. If `source_revision` is a commit id, inspect
+       workspace Git top-level and confirm HEAD equals `source_revision`
+       when set. Read candidate files only under this supplied checkout.
+       If `source_revision` is a commit id, inspect
        that exact snapshot (`git rev-parse`, `git ls-tree`, `git show
        <source_revision>:<path>`) and treat it as the source of truth for
        whether a modification target exists. `base_branch` names the landing
-       branch that snapshot belongs to. If `source_revision` is empty, inspect
-       `base_branch` as it exists in this checkout. If `base_branch` is also
-       empty, resolve the repository's default remote branch (and cross-check
-       the release branch recorded in CI evidence) instead of treating the
-       empty string as a Git ref.
+       branch that snapshot belongs to; it is provenance, not a ref to resolve
+       again. If `source_revision` is empty or null, this is a non-Git workspace:
+       inspect the supplied filesystem directly.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
@@ -145,8 +152,8 @@ spec:
        evidence. Otherwise use disposition `selectors`. Never use an empty list
        merely because inspection was inconclusive.
        For a `ci-failure-sweep` task, compare the runner-tested commit and
-       original run evidence in the task description with `base_branch` as it
-       exists now. Inspect relevant history and current code. A failure from an
+       original run evidence in the task description with the pinned
+       `source_revision`. Inspect relevant history and code at that commit. A failure from an
        old release whose repair is already present must be `verified_no_diff`
        with `already_landed` set to an object containing concrete `evidence`;
        do not return executable selectors for it.

--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -6,10 +6,10 @@
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. In a Git workspace it
-# fetches the landing branch, pins one source revision, and fast-forwards a
-# clean primary on that branch when it is behind; dirty or unfetchable
-# checkouts fail as source-staleness before any agent call. Each read-only
-# pilot receives at most five tasks and inspects that pinned revision.
+# fetches the landing branch and pins one source revision without changing
+# primary HEAD, index, or working files. An unfetchable remote fails before
+# any agent call. Each read-only pilot receives at most five tasks and runs
+# in an invocation-owned checkout at that pinned revision.
 # Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -71,6 +71,7 @@ spec:
             workspace_path: "{{ steps.prepare.output.workspace_path }}"
             base_branch: "{{ steps.prepare.output.source.base_branch }}"
             source_revision: "{{ steps.prepare.output.source.source_revision }}"
+            inspection_revision: "{{ steps.prepare.output.source.source_revision }}"
             # See the crew-resolution note at the top of this file.
             crew: system
       fan_in:

--- a/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/prepare_task_pilot.yaml
@@ -11,10 +11,9 @@ spec:
     task_ids it selects only proposed/backlog tasks whose context_files are
     empty, excluding no-diff-needed/no-diff-expected tasks and every active,
     review, or terminal status. In a Git workspace this step also fetches the
-    landing branch, pins one verified source revision, and fast-forwards a
-    clean primary on that branch when it is behind. Dirty, divergent, or
-    unfetchable checkouts fail closed as source-staleness before any agent
-    call. This action never promotes or dispatches work. In automatic mode,
+    landing branch and pins one verified source revision without changing
+    the primary HEAD, index, or working files, including dirty and untracked
+    content. Remote failures stop preparation before any agent call. This action never promotes or dispatches work. In automatic mode,
     `excluded` itemizes only a bounded sample of routine exclusions; the full
     breakdown is always available via `excluded_total` and
     `excluded_by_reason`, with `excluded_sample_truncated` and

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -20,7 +20,7 @@ spec:
     # `crew` is optional here: the pipeline names `system` on the pilot step so
     # the crew is readable in the job definition, while a direct invocation may
     # omit it and inherit the run's resolved crew.
-    required: [task_ids, workspace_path, base_branch, partition_index]
+    required: [task_ids, workspace_path, base_branch, inspection_revision, partition_index]
     properties:
       task_ids:
         type: array
@@ -33,7 +33,9 @@ spec:
       base_branch:
         type: string
       source_revision:
-        type: string
+        type: [string, "null"]
+      inspection_revision:
+        type: [string, "null"]
       partition_index:
         type: number
       crew:
@@ -113,9 +115,14 @@ spec:
     You are Orbit's task-pilot for one explicit, bounded partition.
 
     Input contains `task_ids` (one to five exact IDs), `workspace_path`,
-    `base_branch`, `source_revision` (the prepared landing-branch commit),
+    `base_branch`, `inspection_revision` (null only for a non-Git workspace),
+    `source_revision` (the prepared landing-branch commit),
     and `partition_index`. Work only on those task IDs and treat the
-    workspace as read-only.
+    workspace as read-only. The CLI host materializes `inspection_revision`
+    in an invocation-owned checkout and binds `workspace_path`, `repo_root`,
+    subprocess cwd, and filesystem reads to it. Orbit tool calls retain the
+    owning logical workspace through the managed environment; do not route
+    task tools using the temporary checkout path.
 
     For every task:
 
@@ -124,15 +131,15 @@ spec:
        `context_files`. Use `orbit.search` for the task ID and relevant design
        terms; inspect linked decision docs when a result points to one.
     2. With `proc.spawn` run only read-only `git`/`rg` commands. Verify the
-       workspace Git top-level. If `source_revision` is a commit id, inspect
+       workspace Git top-level and confirm HEAD equals `source_revision`
+       when set. Read candidate files only under this supplied checkout.
+       If `source_revision` is a commit id, inspect
        that exact snapshot (`git rev-parse`, `git ls-tree`, `git show
        <source_revision>:<path>`) and treat it as the source of truth for
        whether a modification target exists. `base_branch` names the landing
-       branch that snapshot belongs to. If `source_revision` is empty, inspect
-       `base_branch` as it exists in this checkout. If `base_branch` is also
-       empty, resolve the repository's default remote branch (and cross-check
-       the release branch recorded in CI evidence) instead of treating the
-       empty string as a Git ref.
+       branch that snapshot belongs to; it is provenance, not a ref to resolve
+       again. If `source_revision` is empty or null, this is a non-Git workspace:
+       inspect the supplied filesystem directly.
        Use the provider-native file-read tool to inspect candidate targets. Do not edit repository files.
     3. Propose `context_files_after` as exact canonical selectors using only
        `file:`, `dir:`, or `symbol:`. Every anchor must already exist inside
@@ -145,8 +152,8 @@ spec:
        evidence. Otherwise use disposition `selectors`. Never use an empty list
        merely because inspection was inconclusive.
        For a `ci-failure-sweep` task, compare the runner-tested commit and
-       original run evidence in the task description with `base_branch` as it
-       exists now. Inspect relevant history and current code. A failure from an
+       original run evidence in the task description with the pinned
+       `source_revision`. Inspect relevant history and code at that commit. A failure from an
        old release whose repair is already present must be `verified_no_diff`
        with `already_landed` set to an object containing concrete `evidence`;
        do not return executable selectors for it.

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -6,10 +6,10 @@
 # excluding no-diff tasks. Explicit mode audits exactly the named workspace
 # tasks, including non-empty selectors.
 # Preparation never promotes or dispatches a task. In a Git workspace it
-# fetches the landing branch, pins one source revision, and fast-forwards a
-# clean primary on that branch when it is behind; dirty or unfetchable
-# checkouts fail as source-staleness before any agent call. Each read-only
-# pilot receives at most five tasks and inspects that pinned revision.
+# fetches the landing branch and pins one source revision without changing
+# primary HEAD, index, or working files. An unfetchable remote fails before
+# any agent call. Each read-only pilot receives at most five tasks and runs
+# in an invocation-owned checkout at that pinned revision.
 # Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -71,6 +71,7 @@ spec:
             workspace_path: "{{ steps.prepare.output.workspace_path }}"
             base_branch: "{{ steps.prepare.output.source.base_branch }}"
             source_revision: "{{ steps.prepare.output.source.source_revision }}"
+            inspection_revision: "{{ steps.prepare.output.source.source_revision }}"
             # See the crew-resolution note at the top of this file.
             crew: system
       fan_in:

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -133,12 +133,17 @@ selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
 The prepare step fetches the landing branch (`base_branch`, defaulting to
-`workflow.base_branch`) and pins one `source_revision`. A clean primary that
-already sits on that branch and is behind origin is fast-forwarded so inspection
-sees the landed tree; a dirty, divergent, or unfetchable checkout fails as
-source-staleness *before* any agent call. The pilot inspects that pinned
-revision. Apply validates selector existence against the same snapshot, not a
-later working tree, so a newly merged file is not reported as missing merely
+`workflow.base_branch`) and pins one `source_revision`, preserving primary
+HEAD, index, dirty and untracked files. Remote failure stops before an agent
+call. Each pilot runs in its own detached checkout at that revision, with
+its cwd, input paths, and read-only filesystem profile bound there. Task tools
+retain the owning logical workspace, and apply still checks task snapshots
+with compare-and-set on that authority. Inspection checkouts use at most 16
+exclusive slots in the common Git directory; normal return, error, and timeout
+remove the checkout before releasing its lease. A crash releases the kernel
+lease, and the next holder reclaims the abandoned checkout before reuse. No
+registered worktrees or primary branches are removed or modified. Apply
+validates selector existence against the same snapshot, not a later working tree, so a newly merged file is not reported as missing merely
 because the primary lagged origin, and a later origin advance cannot admit a
 path that did not exist at prepare.
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -36,8 +36,8 @@ pub(crate) fn resolve_executor_sandbox(
             }
             #[cfg(target_os = "macos")]
             {
-                let mut resolved =
-                    resolve_fs_profile_absolute(runtime, fs_profile, None).map_err(|err| {
+                let mut resolved = resolve_fs_profile_absolute(runtime, fs_profile, subprocess_cwd)
+                    .map_err(|err| {
                         DispatchError::CliInvocationFailed(format!(
                             "resolve fsProfile for sandbox: {err}"
                         ))

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use orbit_common::fs::selector::{
-    anchor_path, canonical_selector_in_workspace, exists_in_workspace,
+    anchor_path, canonical_selector, canonical_selector_in_workspace, exists_in_workspace,
 };
 use orbit_engine::DispatchError;
 use orbit_store::contracts::JobRunQuery;
@@ -413,13 +413,20 @@ fn validate_after_selectors(
                 format!("task {task_id} selector {selector:?} must use file:, dir:, or symbol:"),
             ));
         }
-        let canonical =
-            canonical_selector_in_workspace(trimmed, workspace_root).map_err(|error| {
-                action_failed(
-                    action,
-                    format!("task {task_id} selector {selector:?} is invalid: {error}"),
-                )
-            })?;
+        // A dirty primary may replace an anchor with a symlink or a different
+        // kind. Only syntax comes from this parser; pinned Git objects own
+        // containment and target validation when source identity is present.
+        let canonical = if source.is_some() {
+            canonical_selector(trimmed)
+        } else {
+            canonical_selector_in_workspace(trimmed, workspace_root)
+        }
+        .map_err(|error| {
+            action_failed(
+                action,
+                format!("task {task_id} selector {selector:?} is invalid: {error}"),
+            )
+        })?;
         if canonical != trimmed {
             return Err(action_failed(
                 action,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
@@ -2,14 +2,14 @@
 //!
 //! Inspection and deterministic selector validation share one pinned revision
 //! so a newly merged target is not reported as missing when the primary
-//! checkout lags origin. The only Git write this module will perform is a
-//! fast-forward of a clean primary that already sits on the landing branch.
+//! checkout lags origin. Fetch updates only remote refs/objects; the primary
+//! HEAD, index and working files are never aligned or otherwise modified.
 
 use std::io;
 use std::path::Path;
 use std::process::Command;
 
-use orbit_common::fs::git::{CurrentBranchStatus, current_branch, run_git};
+use orbit_common::fs::git::run_git;
 use orbit_common::fs::io::with_exclusive_file_lock;
 use orbit_engine::DispatchError;
 use serde_json::{Value, json};
@@ -23,6 +23,8 @@ pub(super) struct SourceSnapshot {
     pub base_branch: String,
     pub source_ref: String,
     pub source_revision: String,
+    // Retained in prepared checkpoints for compatibility with earlier runs.
+    // New preparations never move the primary and always emit false.
     pub fast_forwarded: bool,
 }
 
@@ -143,14 +145,27 @@ impl SourceSnapshot {
                 ),
             )
         })?;
-        let object = format!("{}:{relative}", self.source_revision);
-        let output = git(action, workspace, &["cat-file", "-t", &object])?;
+        let output = git(
+            action,
+            workspace,
+            &[
+                "ls-tree",
+                "--format=%(objectmode) %(objecttype)",
+                &self.source_revision,
+                "--",
+                &format!(":(literal){relative}"),
+            ],
+        )?;
         if !output.success {
-            return Ok(GitPathKind::Missing);
+            return Err(action_failed(
+                action,
+                format!("read pinned source tree: {}", output.stderr.trim()),
+            ));
         }
         Ok(match output.stdout.trim() {
-            "blob" => GitPathKind::Blob,
-            "tree" => GitPathKind::Tree,
+            "100644 blob" | "100755 blob" => GitPathKind::Blob,
+            "040000 tree" => GitPathKind::Tree,
+            "" => GitPathKind::Missing,
             _ => GitPathKind::Other,
         })
     }
@@ -170,74 +185,46 @@ pub(super) fn resolve_source_snapshot(
     let base_branch = normalize_base_branch(action, &base_branch)?;
     let has_origin = has_origin_remote(action, workspace_root)?;
 
-    // Concurrent `prepare_task_pilot` calls against the same shared primary
-    // (permitted up to `max_active_runs` by the job spec) each fetch the same
-    // remote-tracking ref and, when the primary is clean and fast-forwardable,
-    // each fast-forward it with `git merge --ff-only`. Both the ref-update and
-    // the merge are check-then-act git writes that race under git's own
-    // locking (`refs/remotes/origin/<branch>` lock, `.git/index.lock`); the
-    // loser's benign lock contention would otherwise be misreported as
-    // source-staleness. A workspace-scoped advisory lock serializes the whole
-    // fetch-then-align sequence per primary so a blocked caller re-evaluates
-    // against the (possibly already fast-forwarded) HEAD instead of racing
-    // the winner.
-    let lock_target = workspace_root
-        .join(".git")
-        .join("orbit-task-pilot-align-primary");
-    let (source_ref, _fetched_remote, source_revision, fast_forwarded) =
-        with_exclusive_file_lock(&lock_target, "task-pilot align primary", || {
-            resolve_source_snapshot_locked(action, workspace_root, &base_branch, has_origin)
+    // Serialize fetch + resolution across linked checkouts sharing refs. Git's
+    // common directory works for both a primary .git directory and gitfiles.
+    let common = git(
+        action,
+        workspace_root,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    if !common.success {
+        return Err(action_failed(
+            action,
+            "unable to locate shared Git directory",
+        ));
+    }
+    let lock_target = Path::new(common.stdout.trim()).join("orbit-task-pilot-fetch");
+    let (source_ref, source_revision) =
+        with_exclusive_file_lock(&lock_target, "task-pilot source fetch", || {
+            let source_ref = if has_origin {
+                fetch_origin_branch(action, workspace_root, &base_branch)
+                    .map_err(FetchLockError::Dispatch)?;
+                format!("origin/{base_branch}")
+            } else {
+                format!("refs/heads/{base_branch}")
+            };
+            let revision = rev_parse_commit(action, workspace_root, &source_ref)
+                .map_err(FetchLockError::Dispatch)?;
+            Ok::<_, FetchLockError>((source_ref, revision))
         })
         .map_err(|error| match error {
-            AlignLockError::Dispatch(error) => error,
-            AlignLockError::Io(error) => action_failed(
-                action,
-                format!(
-                    "failed to acquire task-pilot align lock in '{}': {error}",
-                    workspace_root.display()
-                ),
-            ),
+            FetchLockError::Dispatch(error) => error,
+            FetchLockError::Io(error) => {
+                action_failed(action, format!("task-pilot fetch lock: {error}"))
+            }
         })?;
 
     Ok(Some(SourceSnapshot {
         base_branch,
         source_ref,
         source_revision,
-        fast_forwarded,
+        fast_forwarded: false,
     }))
-}
-
-fn resolve_source_snapshot_locked(
-    action: &str,
-    workspace_root: &Path,
-    base_branch: &str,
-    has_origin: bool,
-) -> Result<(String, bool, String, bool), AlignLockError> {
-    let (source_ref, fetched_remote) = if has_origin {
-        fetch_origin_branch(action, workspace_root, base_branch)
-            .map_err(AlignLockError::Dispatch)?;
-        (format!("origin/{base_branch}"), true)
-    } else {
-        (base_branch.to_string(), false)
-    };
-    let source_revision =
-        rev_parse_commit(action, workspace_root, &source_ref).map_err(AlignLockError::Dispatch)?;
-    let head =
-        rev_parse_commit(action, workspace_root, "HEAD").map_err(AlignLockError::Dispatch)?;
-    let fast_forwarded = if head == source_revision {
-        false
-    } else {
-        align_clean_primary_locked(
-            action,
-            workspace_root,
-            base_branch,
-            &source_ref,
-            &source_revision,
-            &head,
-            fetched_remote,
-        )?
-    };
-    Ok((source_ref, fetched_remote, source_revision, fast_forwarded))
 }
 
 pub(super) fn requested_base_branch(runtime: &OrbitRuntime, input: &Value) -> String {
@@ -274,128 +261,15 @@ fn normalize_base_branch(action: &str, base: &str) -> Result<String, DispatchErr
 /// Local-error wrapper so [`with_exclusive_file_lock`] (which requires
 /// `E: From<io::Error>`) can carry either lock-acquisition failures or the
 /// module's own [`DispatchError`] out of the locked closure.
-enum AlignLockError {
+enum FetchLockError {
     Io(io::Error),
     Dispatch(DispatchError),
 }
 
-impl From<io::Error> for AlignLockError {
+impl From<io::Error> for FetchLockError {
     fn from(error: io::Error) -> Self {
-        AlignLockError::Io(error)
+        FetchLockError::Io(error)
     }
-}
-
-/// Runs the dirty/branch/ancestor checks and, when they pass, the
-/// `git merge --ff-only` write. Called only while
-/// [`resolve_source_snapshot`]'s workspace lock is held, so `head` (read
-/// immediately beforehand, under the same lock) reflects the primary's true
-/// current state rather than a value a concurrent caller may have already
-/// moved past.
-fn align_clean_primary_locked(
-    action: &str,
-    workspace: &Path,
-    base_branch: &str,
-    source_ref: &str,
-    source_revision: &str,
-    head: &str,
-    fetched_remote: bool,
-) -> Result<bool, AlignLockError> {
-    let dirty = working_tree_status(action, workspace).map_err(AlignLockError::Dispatch)?;
-    let branch = current_branch(workspace)
-        .map_err(|error| action_failed(action, format!("read current branch: {error}")))
-        .map_err(AlignLockError::Dispatch)?;
-    let on_landing_branch =
-        matches!(branch, CurrentBranchStatus::Named(ref name) if name == base_branch);
-    let can_fast_forward =
-        is_ancestor(action, workspace, head, source_revision).map_err(AlignLockError::Dispatch)?;
-
-    if dirty.is_empty() && on_landing_branch && can_fast_forward {
-        let merge = git(
-            action,
-            workspace,
-            &["merge", "--ff-only", "--no-edit", source_revision],
-        )
-        .map_err(AlignLockError::Dispatch)?;
-        if !merge.success {
-            return Err(AlignLockError::Dispatch(source_stale(
-                action,
-                base_branch,
-                source_ref,
-                source_revision,
-                head,
-                fetched_remote,
-                &format!("clean fast-forward failed: {}", merge.stderr.trim()),
-            )));
-        }
-        let after =
-            rev_parse_commit(action, workspace, "HEAD").map_err(AlignLockError::Dispatch)?;
-        if after != source_revision {
-            return Err(AlignLockError::Dispatch(source_stale(
-                action,
-                base_branch,
-                source_ref,
-                source_revision,
-                &after,
-                fetched_remote,
-                "fast-forward completed but HEAD is not the pinned source revision",
-            )));
-        }
-        return Ok(true);
-    }
-
-    let reason = if !dirty.is_empty() {
-        format!(
-            "primary working tree is dirty or has untracked files ({}); refusing checkout, pull, or reset",
-            dirty.join(", ")
-        )
-    } else if !on_landing_branch {
-        format!(
-            "primary is not on landing branch {base_branch} (current: {}); refusing to switch branches",
-            match branch {
-                CurrentBranchStatus::Named(name) => name,
-                CurrentBranchStatus::DetachedHead => "detached HEAD".to_string(),
-                CurrentBranchStatus::NoCurrentBranch => "no current branch".to_string(),
-            }
-        )
-    } else if !can_fast_forward {
-        "primary HEAD is not an ancestor of the landing-branch revision; refusing a non-fast-forward update"
-            .to_string()
-    } else {
-        "primary is not at the verified landing-branch revision".to_string()
-    };
-    Err(AlignLockError::Dispatch(source_stale(
-        action,
-        base_branch,
-        source_ref,
-        source_revision,
-        head,
-        fetched_remote,
-        &reason,
-    )))
-}
-
-fn source_stale(
-    action: &str,
-    base_branch: &str,
-    source_ref: &str,
-    source_revision: &str,
-    head: &str,
-    fetched_remote: bool,
-    reason: &str,
-) -> DispatchError {
-    let sync_hint = if fetched_remote {
-        format!(
-            "make the primary clean and fast-forward `{base_branch}` to `{source_ref}` ({source_revision}) before piloting"
-        )
-    } else {
-        format!("update the local `{base_branch}` checkout to {source_revision} before piloting")
-    };
-    action_failed(
-        action,
-        format!(
-            "source-staleness: landing branch `{base_branch}` is {source_revision} at `{source_ref}`, primary HEAD is {head}. {reason}. {sync_hint}"
-        ),
-    )
 }
 
 fn is_git_work_tree(action: &str, workspace: &Path) -> Result<bool, DispatchError> {
@@ -464,42 +338,6 @@ fn rev_parse_commit(action: &str, workspace: &Path, rev: &str) -> Result<String,
         ));
     }
     Ok(sha.to_string())
-}
-
-fn is_ancestor(
-    action: &str,
-    workspace: &Path,
-    ancestor: &str,
-    descendant: &str,
-) -> Result<bool, DispatchError> {
-    let output = git(
-        action,
-        workspace,
-        &["merge-base", "--is-ancestor", ancestor, descendant],
-    )?;
-    Ok(output.success)
-}
-
-fn working_tree_status(action: &str, workspace: &Path) -> Result<Vec<String>, DispatchError> {
-    let output = git(action, workspace, &["status", "--porcelain=v1", "-uall"])?;
-    if !output.success {
-        return Err(action_failed(
-            action,
-            format!(
-                "unable to read git status in '{}': {}",
-                workspace.display(),
-                output.stderr.trim()
-            ),
-        ));
-    }
-    Ok(output
-        .stdout
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .take(8)
-        .map(ToOwned::to_owned)
-        .collect())
 }
 
 fn git_tree_path(anchor: &Path) -> Option<String> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -19,6 +19,41 @@ fn resolve_executor_sandbox_returns_none_when_executor_has_no_sandbox() {
     assert!(resolved.is_none());
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn reviewer_read_rules_follow_inspection_cwd_without_primary_write_grants() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let inspection = tempfile::tempdir().unwrap();
+    let inspection_root = inspection.path().canonicalize().unwrap();
+    #[cfg(target_os = "linux")]
+    let kind = orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap;
+    #[cfg(target_os = "macos")]
+    let kind = orbit_types::workflow::ExecutorSandboxKind::MacosSandboxExec;
+    seed_executor(&runtime, "claude", Some(kind));
+    let sandbox = runtime
+        .resolve_executor_sandbox("claude", Some("reviewer"), Some(&inspection_root))
+        .unwrap()
+        .unwrap();
+    assert!(
+        sandbox
+            .fs_profile
+            .read
+            .iter()
+            .any(|rule| rule.starts_with(&inspection_root.display().to_string()))
+    );
+    assert!(
+        !sandbox
+            .fs_profile
+            .read
+            .iter()
+            .any(|rule| rule.starts_with(&repo_root.display().to_string()))
+    );
+    assert!(!sandbox.fs_profile.modify.iter().any(|rule| {
+        rule.starts_with(&inspection_root.display().to_string())
+            || rule.starts_with(&repo_root.display().to_string())
+    }));
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn resolve_executor_sandbox_returns_linux_descriptor_with_absolute_mounts() {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -98,14 +98,6 @@ fn git(current_dir: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
-fn git_allow_fail(current_dir: &Path, args: &[&str]) -> std::process::Output {
-    Command::new("git")
-        .args(args)
-        .current_dir(current_dir)
-        .output()
-        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")))
-}
-
 fn init_repo(path: &Path, branch: &str) {
     fs::create_dir_all(path).expect("create repo dir");
     git(path, &["init"]);
@@ -189,7 +181,7 @@ fn prepare_landing(fixture: &RemoteLandingFixture) -> Result<Value, String> {
 }
 
 #[test]
-fn clean_stale_primary_fast_forwards_and_apply_admits_newly_merged_file() {
+fn clean_stale_primary_is_preserved_and_apply_admits_newly_merged_file() {
     let fixture = remote_landing_fixture();
     let prepared = prepare_landing(&fixture).expect("clean stale primary prepares");
 
@@ -199,12 +191,12 @@ fn clean_stale_primary_fast_forwards_and_apply_admits_newly_merged_file() {
         format!("origin/{LANDING}")
     );
     assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
-    assert_eq!(prepared["source"]["fast_forwarded"], true);
+    assert_eq!(prepared["source"]["fast_forwarded"], false);
     assert_eq!(
         git(&fixture.repo, &["rev-parse", "HEAD"]),
-        fixture.current_sha
+        fixture.stale_sha
     );
-    assert!(fixture.repo.join("src/merged.rs").exists());
+    assert!(!fixture.repo.join("src/merged.rs").exists());
 
     let output = apply_selectors(
         &fixture.runtime,
@@ -225,44 +217,66 @@ fn clean_stale_primary_fast_forwards_and_apply_admits_newly_merged_file() {
 }
 
 #[test]
-fn dirty_primary_reports_source_staleness_without_moving_head() {
+fn dirty_primary_preserves_head_index_tracked_and_untracked_bytes() {
     let fixture = remote_landing_fixture();
-    fs::write(fixture.repo.join("src/existing.rs"), "dirty local edit\n")
-        .expect("dirty tracked file");
-    let before = git(&fixture.repo, &["rev-parse", "HEAD"]);
-
-    let error = prepare_landing(&fixture).expect_err("dirty primary must not spend an agent call");
-    assert!(
-        error.contains("source-staleness"),
-        "expected source-staleness, got {error}"
+    fs::write(fixture.repo.join("src/existing.rs"), "staged edit\n").unwrap();
+    git(&fixture.repo, &["add", "src/existing.rs"]);
+    fs::write(fixture.repo.join("src/existing.rs"), b"dirty edit\0\xff").unwrap();
+    fs::write(
+        fixture.repo.join("src/merged.rs"),
+        b"untracked collision\0\xff",
+    )
+    .unwrap();
+    let index = fs::read(fixture.repo.join(".git/index")).unwrap();
+    let prepared = prepare_landing(&fixture).expect("dirty primary prepares");
+    let output = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec![
+            "file:src/merged.rs",
+            "dir:src",
+            "symbol:src/existing.rs#existing:function",
+        ],
     );
-    assert!(error.contains(&fixture.current_sha));
-    assert!(error.contains(&fixture.stale_sha));
-    assert_eq!(git(&fixture.repo, &["rev-parse", "HEAD"]), before);
-    assert!(!fixture.repo.join("src/merged.rs").exists());
+    assert_eq!(output["status"], "succeeded", "{output}");
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", "HEAD"]),
+        fixture.stale_sha
+    );
+    assert_eq!(fs::read(fixture.repo.join(".git/index")).unwrap(), index);
+    assert_eq!(
+        fs::read(fixture.repo.join("src/existing.rs")).unwrap(),
+        b"dirty edit\0\xff"
+    );
+    assert_eq!(
+        fs::read(fixture.repo.join("src/merged.rs")).unwrap(),
+        b"untracked collision\0\xff"
+    );
 }
 
+#[cfg(unix)]
 #[test]
-fn untracked_file_on_stale_primary_does_not_reset_or_admit_later_paths() {
+fn dirty_primary_symlink_does_not_change_pinned_selector_validation() {
     let fixture = remote_landing_fixture();
-    fs::write(fixture.repo.join("scratch.txt"), "untracked\n").expect("untracked file");
-    let before = git(&fixture.repo, &["rev-parse", "HEAD"]);
-
-    let error = prepare_landing(&fixture).expect_err("untracked files block fast-forward");
-    assert!(error.contains("source-staleness"), "{error}");
-    assert!(
-        error.contains("untracked") || error.contains("dirty"),
-        "{error}"
+    fs::remove_file(fixture.repo.join("src/existing.rs")).unwrap();
+    std::os::unix::fs::symlink(
+        "/missing-outside-target",
+        fixture.repo.join("src/existing.rs"),
+    )
+    .unwrap();
+    let prepared = prepare_landing(&fixture).expect("symlink dirty primary prepares");
+    let output = apply_selectors(
+        &fixture.runtime,
+        &prepared,
+        &fixture.task,
+        vec!["file:src/existing.rs"],
     );
-    assert_eq!(git(&fixture.repo, &["rev-parse", "HEAD"]), before);
-    assert!(
-        git_allow_fail(&fixture.repo, &["status", "--porcelain"])
-            .status
-            .success()
+    assert_eq!(output["status"], "succeeded", "{output}");
+    assert_eq!(
+        fs::read_link(fixture.repo.join("src/existing.rs")).unwrap(),
+        Path::new("/missing-outside-target")
     );
-    let status_output = git_allow_fail(&fixture.repo, &["status", "--porcelain"]);
-    let status = String::from_utf8_lossy(&status_output.stdout);
-    assert!(status.contains("scratch.txt"));
 }
 
 #[test]
@@ -348,7 +362,7 @@ fn apply_uses_pinned_revision_after_concurrent_branch_advancement() {
 #[test]
 fn untracked_workspace_file_is_not_admitted_against_the_source_snapshot() {
     let fixture = remote_landing_fixture();
-    let prepared = prepare_landing(&fixture).expect("fast-forward to landing tip");
+    let prepared = prepare_landing(&fixture).expect("pin landing tip");
     fs::write(fixture.repo.join("src/ghost.rs"), "working tree only\n").expect("untracked ghost");
 
     let output = apply_selectors(
@@ -374,10 +388,7 @@ fn untracked_workspace_file_is_not_admitted_against_the_source_snapshot() {
     );
 }
 
-/// ORB-11269: two concurrent `prepare_task_pilot` calls against the same
-/// shared primary must serialize their fast-forward instead of racing
-/// `git merge --ff-only` and misreporting the loser's index-lock contention
-/// as source staleness.
+/// Concurrent prepares serialize shared ref fetching and leave primary untouched.
 #[test]
 fn concurrent_prepare_calls_against_the_same_primary_both_succeed() {
     let fixture = remote_landing_fixture();
@@ -408,24 +419,13 @@ fn concurrent_prepare_calls_against_the_same_primary_both_succeed() {
 
     assert_eq!(
         git(&fixture.repo, &["rev-parse", "HEAD"]),
-        fixture.current_sha,
-        "the primary must land exactly on the pinned revision, not a merge byproduct"
+        fixture.stale_sha
     );
-    assert!(fixture.repo.join("src/merged.rs").exists());
-
-    let fast_forwarded_count = results
-        .iter()
-        .filter(|result| {
-            result
-                .as_ref()
-                .ok()
-                .and_then(|prepared| prepared["source"]["fast_forwarded"].as_bool())
-                .unwrap_or(false)
-        })
-        .count();
+    assert!(!fixture.repo.join("src/merged.rs").exists());
     assert!(
-        fast_forwarded_count >= 1,
-        "at least one serialized caller must have performed the fast-forward"
+        results
+            .iter()
+            .all(|result| result.as_ref().unwrap()["source"]["fast_forwarded"] == false)
     );
 }
 

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -472,6 +472,10 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     );
     assert_eq!(
         pilot_input["source_revision"],
+        pilot_input["inspection_revision"]
+    );
+    assert_eq!(
+        pilot_input["inspection_revision"],
         "{{ steps.prepare.output.source.source_revision }}"
     );
     assert_eq!(

--- a/crates/orbit-engine/src/activity_job/cli_runner/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/inspection.rs
@@ -1,0 +1,249 @@
+//! Invocation-owned source checkouts for read-only inspection [ORB-11256].
+//!
+//! Slots are private scratch space under the source repository's common Git
+//! directory. A kernel lease lasts through provider exit and RAII cleanup.
+//! After a crash the next holder removes the abandoned checkout before reuse.
+//! The fixed slot count bounds leftovers even when no retry follows a crash.
+//! These are standalone repositories: no shared index, alternates, registered
+//! worktree, branch, or global worktree-prune operation is involved.
+
+use std::fs::{self, File, OpenOptions, TryLockError};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use orbit_common::fs::git::run_git;
+use serde_json::Value;
+
+use super::super::dispatcher::DispatchError;
+
+const SLOT_COUNT: usize = 16;
+const OWNER: &str = "orbit-source-inspection-v1\n";
+
+pub(super) struct SourceInspection {
+    root: PathBuf,
+    revision: String,
+    // Drop removes the checkout before the file is closed and releases its lock.
+    _lease: File,
+}
+
+impl SourceInspection {
+    pub(super) fn from_input(
+        input: &Value,
+        source: Option<&Path>,
+        fs_profile: Option<&str>,
+    ) -> Result<Option<Self>, DispatchError> {
+        let Some(value) = input.get("inspection_revision") else {
+            return Ok(None);
+        };
+        if value.is_null() || value.as_str() == Some("") {
+            if let Some(source) = source {
+                let output = run_git(source, &["rev-parse", "--is-inside-work-tree"])
+                    .map_err(|error| failure(error.to_string()))?;
+                if output.success && output.stdout.trim() == "true" {
+                    return Err(failure(
+                        "a Git workspace requires a pinned inspection_revision",
+                    ));
+                }
+            }
+            return Ok(None);
+        }
+        let revision = value
+            .as_str()
+            .ok_or_else(|| failure("inspection_revision must be a commit id"))?;
+        if !matches!(revision.len(), 40 | 64) || !revision.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(failure("inspection_revision must be a full commit id"));
+        }
+        if let Some(source_revision) = input.get("source_revision").and_then(Value::as_str)
+            && source_revision != revision
+        {
+            return Err(failure(
+                "inspection_revision differs from the prepared source_revision",
+            ));
+        }
+        if fs_profile != Some("reviewer") {
+            return Err(failure(
+                "source inspection requires the reviewer filesystem profile",
+            ));
+        }
+        let source = source.ok_or_else(|| failure("source inspection requires a workspace"))?;
+        Self::create(source, revision).map(Some)
+    }
+
+    fn create(source: &Path, revision: &str) -> Result<Self, DispatchError> {
+        git(
+            source,
+            &["cat-file", "-e", &format!("{revision}^{{commit}}")],
+        )?;
+        let common = git(
+            source,
+            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        )?;
+        let format = git(source, &["rev-parse", "--show-object-format"])?;
+        let pool = Path::new(common.trim()).join("orbit-source-inspections-v1");
+        directory(&pool).map_err(io_failure)?;
+        for index in 0..SLOT_COUNT {
+            let slot = pool.join(index.to_string());
+            directory(&slot).map_err(io_failure)?;
+            let lock_path = slot.join("lease");
+            reject_symlink(&lock_path).map_err(io_failure)?;
+            let lease = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(io_failure)?;
+            match lease.try_lock() {
+                Ok(()) => {}
+                Err(TryLockError::WouldBlock) => continue,
+                Err(TryLockError::Error(error)) => return Err(io_failure(error)),
+            }
+            let root = slot.join("checkout");
+            let marker = slot.join("owner");
+            reject_symlink(&marker).map_err(io_failure)?;
+            if marker.exists() {
+                if fs::read_to_string(&marker).map_err(io_failure)? != OWNER {
+                    return Err(failure("inspection slot has an unrecognized owner"));
+                }
+                remove_checkout(&root).map_err(io_failure)?;
+            } else {
+                if root.symlink_metadata().is_ok() {
+                    return Err(failure("refusing to remove an unowned inspection checkout"));
+                }
+                fs::write(&marker, OWNER).map_err(io_failure)?;
+            }
+            let inspection = Self {
+                root,
+                revision: revision.to_string(),
+                _lease: lease,
+            };
+            directory(&inspection.root).map_err(io_failure)?;
+            git(
+                &inspection.root,
+                &[
+                    "init",
+                    "--quiet",
+                    "--template=",
+                    &format!("--object-format={}", format.trim()),
+                ],
+            )?;
+            // Fetch only this immutable revision and its history into private
+            // objects. Avoid alternates so sandboxed Git never needs the primary.
+            git(
+                &inspection.root,
+                &[
+                    "-c",
+                    "protocol.file.allow=always",
+                    "fetch",
+                    "--quiet",
+                    "--no-tags",
+                    common.trim(),
+                    revision,
+                ],
+            )?;
+            git(
+                &inspection.root,
+                &["checkout", "--quiet", "--detach", revision],
+            )?;
+            inspection.verify()?;
+            return Ok(inspection);
+        }
+        Err(failure(
+            "all source inspection slots are leased; retry after a pilot finishes",
+        ))
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(super) fn bind_input(&self, input: &Value) -> Value {
+        let mut bound = input.clone();
+        bound["workspace_path"] = self.root.display().to_string().into();
+        bound["repo_root"] = self.root.display().to_string().into();
+        bound["source_revision"] = self.revision.clone().into();
+        bound
+    }
+
+    pub(super) fn verify(&self) -> Result<(), DispatchError> {
+        if git(&self.root, &["rev-parse", "HEAD"])?.trim() != self.revision
+            || !git(
+                &self.root,
+                &["status", "--porcelain=v1", "--untracked-files=all"],
+            )?
+            .trim()
+            .is_empty()
+        {
+            return Err(failure(
+                "source inspection checkout changed during read-only execution",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SourceInspection {
+    fn drop(&mut self) {
+        if let Err(error) = remove_checkout(&self.root) {
+            tracing::warn!(path = %self.root.display(), %error, "inspection cleanup deferred to next lease holder");
+        }
+    }
+}
+
+fn remove_checkout(root: &Path) -> io::Result<()> {
+    reject_symlink(root)?;
+    if !root.exists() {
+        return Ok(());
+    }
+    // A gitfile belongs to a registered worktree, which this module never owns.
+    let git_dir = root.join(".git");
+    reject_symlink(&git_dir)?;
+    if git_dir.is_file() {
+        return Err(io::Error::other(
+            "refusing to remove a registered worktree from an inspection slot",
+        ));
+    }
+    fs::remove_dir_all(root)
+}
+
+fn directory(path: &Path) -> io::Result<()> {
+    reject_symlink(path)?;
+    match fs::create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists && path.is_dir() => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn reject_symlink(path: &Path) -> io::Result<()> {
+    match path.symlink_metadata() {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(io::Error::other(
+            "inspection resource must not be a symlink",
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn git(root: &Path, args: &[&str]) -> Result<String, DispatchError> {
+    let mut argv = vec!["-c", "core.hooksPath=/dev/null", "-c", "gc.auto=0"];
+    argv.extend_from_slice(args);
+    let output = run_git(root, &argv).map_err(|error| failure(error.to_string()))?;
+    if !output.success {
+        return Err(failure(format!(
+            "git {}: {}",
+            args.join(" "),
+            output.stderr.trim()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+fn failure(message: impl std::fmt::Display) -> DispatchError {
+    DispatchError::CliInvocationFailed(format!("source inspection: {message}"))
+}
+
+fn io_failure(error: io::Error) -> DispatchError {
+    failure(error)
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/mod.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/mod.rs
@@ -1,5 +1,6 @@
 mod argv;
 mod envelope;
+mod inspection;
 mod orchestrator;
 mod spawn;
 mod supervisor;

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -27,6 +27,7 @@ use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
     task_id_from_input, task_ids_from_input,
 };
+use super::inspection::SourceInspection;
 use super::spawn::{
     linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic, orbit_tool_env,
     prepare_sandbox_for_dispatch, resolve_provider_launcher,
@@ -96,8 +97,19 @@ pub fn run_cli_backend(
     // re-allow the active worktree subpath after the policy deny rules. The
     // sandbox's `denyModify .orbit/**` rule otherwise blocks every non-codex
     // provider from writing inside its own jrun worktree. See T20260508-17.
-    let subprocess_cwd =
+    let source_cwd =
         resolve_subprocess_cwd(input, task_ctx.as_ref(), tool_ctx.workspace_root.as_deref())?;
+    let inspection = SourceInspection::from_input(input, source_cwd.as_deref(), fs_profile)?;
+    let inspection_input = inspection
+        .as_ref()
+        .map(|snapshot| snapshot.bind_input(input));
+    let inspection_task_ctx = inspection
+        .as_ref()
+        .and_then(|snapshot| task_ctx.as_ref().map(|task| snapshot.bind_input(task)));
+    let subprocess_cwd = inspection
+        .as_ref()
+        .map(|snapshot| snapshot.root().to_path_buf())
+        .or_else(|| source_cwd.clone());
     let subprocess_cwd_string = subprocess_cwd
         .as_ref()
         .map(|path| path.display().to_string());
@@ -110,8 +122,8 @@ pub fn run_cli_backend(
     let envelope_json = cli_agent_envelope_json(
         spec,
         run_id,
-        input,
-        task_ctx.as_ref(),
+        inspection_input.as_ref().unwrap_or(input),
+        inspection_task_ctx.as_ref().or(task_ctx.as_ref()),
         &activity_tools.requested_tools,
         &activity_tools.effective_tools,
     )?;
@@ -188,6 +200,8 @@ pub fn run_cli_backend(
     let stdin_blob_ref = audit.write_blob(&invocation.stdin);
 
     // L-0095: Provider cwd is advisory; enforce the linked-worktree postcondition.
+    // Inspection owns its temporary checkout separately; retain the original
+    // source pair here so task-worktree ownership validation stays unchanged.
     // Snapshot both sides of a linked-worktree invocation immediately before
     // provider spawn. `tool_ctx.workspace_root` is the registered primary
     // checkout; `subprocess_cwd` is the canonical assigned worktree. Direct
@@ -197,7 +211,7 @@ pub fn run_cli_backend(
         task_ctx.as_ref(),
         run_id,
         &provider,
-        subprocess_cwd.as_deref(),
+        source_cwd.as_deref(),
         tool_ctx.workspace_root.as_deref(),
         declared_worktree_pair.as_ref(),
     )?;
@@ -354,6 +368,10 @@ pub fn run_cli_backend(
             });
         }
     };
+
+    if let Some(snapshot) = &inspection {
+        snapshot.verify()?;
+    }
 
     if let Some(guard) = linux_post_run_guard {
         guard

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
@@ -1,0 +1,328 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use orbit_common::fs::git::run_git;
+use orbit_types::workflow::activity_job::V2AuditEventKind;
+use serde_json::json;
+use tempfile::{TempDir, tempdir};
+
+use super::super::super::audit_writer::V2AuditWriter;
+use super::super::inspection::SourceInspection;
+use super::super::run_cli_backend;
+use super::test_support::{RecordingSink, TestHost, test_agent_loop_spec, write_executable};
+
+fn git(root: &Path, args: &[&str]) -> String {
+    let output = run_git(root, args).unwrap();
+    assert!(output.success, "{args:?}: {}", output.stderr);
+    output.stdout.trim().to_string()
+}
+
+fn repository() -> (TempDir, String) {
+    let root = tempdir().unwrap();
+    git(root.path(), &["init", "--quiet"]);
+    git(root.path(), &["config", "user.name", "Orbit Test"]);
+    git(root.path(), &["config", "user.email", "test@example.com"]);
+    git(root.path(), &["config", "commit.gpgsign", "false"]);
+    fs::write(root.path().join("target.txt"), "pinned\n").unwrap();
+    git(root.path(), &["add", "target.txt"]);
+    git(root.path(), &["commit", "--quiet", "-m", "initial"]);
+    let revision = git(root.path(), &["rev-parse", "HEAD"]);
+    (root, revision)
+}
+
+fn inspect(root: &Path, revision: &str) -> SourceInspection {
+    SourceInspection::from_input(
+        &json!({"inspection_revision": revision}),
+        Some(root),
+        Some("reviewer"),
+    )
+    .unwrap()
+    .unwrap()
+}
+
+#[test]
+fn snapshot_stays_pinned_and_live_leases_are_never_reclaimed() {
+    let (repo, revision) = repository();
+    let registered = git(repo.path(), &["worktree", "list", "--porcelain"]);
+    let first = inspect(repo.path(), &revision);
+    let first_root = first.root().to_path_buf();
+    fs::write(repo.path().join("target.txt"), "later\n").unwrap();
+    git(repo.path(), &["commit", "-am", "later"]);
+    let second = inspect(repo.path(), &revision);
+    assert_ne!(first.root(), second.root());
+    assert_eq!(
+        fs::read_to_string(first.root().join("target.txt")).unwrap(),
+        "pinned\n"
+    );
+    assert_eq!(git(second.root(), &["rev-parse", "HEAD"]), revision);
+    first.verify().unwrap();
+    let bound = second.bind_input(&json!({"workspace_path": repo.path()}));
+    assert_eq!(bound["workspace_path"], second.root().display().to_string());
+    assert_eq!(bound["repo_root"], bound["workspace_path"]);
+    let second_root = second.root().to_path_buf();
+    drop(second);
+    assert!(!second_root.exists());
+    assert!(first_root.exists());
+    drop(first);
+    assert!(!first_root.exists());
+    // The primary's HEAD changed above, but no worktree registry entry was added.
+    assert_eq!(
+        registered
+            .lines()
+            .filter(|line| line.starts_with("worktree "))
+            .collect::<Vec<_>>(),
+        git(repo.path(), &["worktree", "list", "--porcelain"])
+            .lines()
+            .filter(|line| line.starts_with("worktree "))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn rejects_invalid_revision_and_write_profiles_and_detects_edits() {
+    let (repo, revision) = repository();
+    assert!(
+        SourceInspection::from_input(
+            &json!({"inspection_revision": null}),
+            Some(repo.path()),
+            Some("reviewer")
+        )
+        .is_err()
+    );
+    let non_git = tempdir().unwrap();
+    assert!(
+        SourceInspection::from_input(
+            &json!({"inspection_revision": null}),
+            Some(non_git.path()),
+            Some("reviewer")
+        )
+        .unwrap()
+        .is_none()
+    );
+    for (revision, profile) in [
+        ("HEAD", Some("reviewer")),
+        (revision.as_str(), None),
+        (revision.as_str(), Some("implementer")),
+    ] {
+        assert!(
+            SourceInspection::from_input(
+                &json!({"inspection_revision": revision}),
+                Some(repo.path()),
+                profile
+            )
+            .is_err()
+        );
+    }
+    let snapshot = inspect(repo.path(), &revision);
+    fs::write(snapshot.root().join("target.txt"), "changed").unwrap();
+    assert!(snapshot.verify().is_err());
+    assert!(
+        SourceInspection::from_input(
+            &json!({"inspection_revision": revision, "source_revision": "different"}),
+            Some(repo.path()),
+            Some("reviewer"),
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn inspection_capacity_is_bounded_and_released_slots_can_be_reused() {
+    let (repo, revision) = repository();
+    let mut snapshots: Vec<_> = (0..16).map(|_| inspect(repo.path(), &revision)).collect();
+    assert!(
+        SourceInspection::from_input(
+            &json!({"inspection_revision": revision}),
+            Some(repo.path()),
+            Some("reviewer")
+        )
+        .is_err()
+    );
+    let released = snapshots.pop().unwrap();
+    let released_path = released.root().to_path_buf();
+    drop(released);
+    let next = inspect(repo.path(), &revision);
+    assert_eq!(next.root(), released_path);
+    for snapshot in snapshots {
+        snapshot.verify().unwrap();
+    }
+}
+
+#[test]
+fn crash_child() {
+    let Some(repo) = std::env::var_os("ORBIT_INSPECTION_CRASH_FIXTURE") else {
+        return;
+    };
+    let root = Path::new(&repo);
+    let revision = git(root, &["rev-parse", "HEAD"]);
+    let snapshot = inspect(root, &revision);
+    fs::write(snapshot.root().join("abandoned"), "crashed").unwrap();
+    // Exercise kernel lease release without running any Rust destructors.
+    std::process::exit(0);
+}
+
+#[test]
+fn retry_reclaims_crash_leftovers_and_keeps_another_live_snapshot() {
+    let (repo, revision) = repository();
+    let live = inspect(repo.path(), &revision);
+    let status = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "activity_job::cli_runner::tests::inspection::crash_child",
+            "--nocapture",
+        ])
+        .env("ORBIT_INSPECTION_CRASH_FIXTURE", repo.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let abandoned = live
+        .root()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("1/checkout/abandoned");
+    assert!(abandoned.exists());
+    let retry = inspect(repo.path(), &revision);
+    assert!(!abandoned.exists());
+    assert_ne!(retry.root(), live.root());
+    live.verify().unwrap();
+}
+
+#[test]
+fn cleanup_refuses_a_registered_worktree_in_a_slot() {
+    let (repo, revision) = repository();
+    let snapshot = inspect(repo.path(), &revision);
+    let root = snapshot.root().to_path_buf();
+    drop(snapshot);
+    git(
+        repo.path(),
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            root.to_str().unwrap(),
+            &revision,
+        ],
+    );
+    assert!(
+        SourceInspection::from_input(
+            &json!({"inspection_revision": revision}),
+            Some(repo.path()),
+            Some("reviewer")
+        )
+        .is_err()
+    );
+    assert!(root.join("target.txt").exists());
+    git(repo.path(), &["worktree", "remove", root.to_str().unwrap()]);
+}
+
+#[test]
+fn dispatch_binds_native_reads_envelope_and_cwd_but_retains_task_authority() {
+    let (repo, revision) = repository();
+    fs::write(repo.path().join("target.txt"), "primary dirty\n").unwrap();
+    let index = fs::read(repo.path().join(".git/index")).unwrap();
+    let scripts = tempdir().unwrap();
+    let script = scripts.path().join("codex");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+envelope=$(cat)
+[ "$(cat target.txt)" = pinned ] || exit 11
+[ "$ORBIT_WORKSPACE" = ws_owner ] || exit 12
+[ "$ORBIT_REGISTRY_ROOT" = /authoritative/registry ] || exit 13
+printf '%s' "$envelope" | rg -F "$(pwd)" >/dev/null || exit 14
+printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
+"#,
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(repo.path().to_path_buf());
+    host.task_context = Some(json!({"workspace_path": repo.path(), "repo_root": repo.path()}));
+    host.orbit_workspace_selector = Some("ws_owner".into());
+    host.orbit_registry_root = Some("/authoritative/registry".into());
+    let sink = Arc::new(RecordingSink::default());
+    let audit = Arc::new(V2AuditWriter::new("inspection-test", "codex", sink.clone()));
+    let outcome = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(5)),
+        "inspection-test",
+        audit.clone(),
+        &json!({"workspace_path": repo.path(), "inspection_revision": revision}),
+        Some("reviewer"),
+    )
+    .unwrap();
+    assert!(outcome.success);
+    let events = audit.events_snapshot().unwrap();
+    let cwd = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { cwd, .. } => cwd.as_deref(),
+            _ => None,
+        })
+        .unwrap();
+    assert_ne!(Path::new(cwd), repo.path());
+    let envelope_ref = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { stdin_blob_ref, .. } => {
+                stdin_blob_ref.as_deref()
+            }
+            _ => None,
+        })
+        .unwrap();
+    let stdin = String::from_utf8(sink.blob(envelope_ref).unwrap()).unwrap();
+    let (_, encoded) = stdin.split_once("Execution envelope:\n").unwrap();
+    let envelope: serde_json::Value = serde_json::from_str(encoded).unwrap();
+    for field in ["input", "task"] {
+        assert_eq!(envelope[field]["workspace_path"], cwd);
+        assert_eq!(envelope[field]["repo_root"], cwd);
+        assert_eq!(envelope[field]["source_revision"], revision);
+    }
+    assert!(
+        !Path::new(cwd).exists(),
+        "dispatch must release inspection on return"
+    );
+    assert_eq!(fs::read(repo.path().join(".git/index")).unwrap(), index);
+    assert_eq!(
+        fs::read_to_string(repo.path().join("target.txt")).unwrap(),
+        "primary dirty\n"
+    );
+}
+
+#[test]
+fn dispatch_failure_and_timeout_release_the_inspection_checkout() {
+    let (repo, revision) = repository();
+    let scripts = tempdir().unwrap();
+    for ending in ["exit 7", "sleep 5"] {
+        let script = scripts.path().join("codex");
+        write_executable(&script, &format!("#!/bin/sh\ncat >/dev/null\n{ending}\n"));
+        let mut host = TestHost::with_command(script.display().to_string());
+        host.workspace_root = Some(repo.path().to_path_buf());
+        let audit = Arc::new(V2AuditWriter::new(
+            "inspection-failure",
+            "codex",
+            Arc::new(RecordingSink::default()),
+        ));
+        let result = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(1)),
+            "inspection-failure",
+            audit.clone(),
+            &json!({"workspace_path": repo.path(), "inspection_revision": revision}),
+            Some("reviewer"),
+        );
+        assert!(result.is_err() || !result.unwrap().success);
+        let events = audit.events_snapshot().unwrap();
+        let cwd = events
+            .iter()
+            .find_map(|event| match &event.kind {
+                V2AuditEventKind::CliInvocationStarted { cwd, .. } => cwd.as_deref(),
+                _ => None,
+            })
+            .unwrap();
+        assert!(!Path::new(cwd).exists());
+    }
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod argv;
 mod envelope;
+mod inspection;
 mod orchestrator;
 #[cfg(target_os = "macos")]
 mod orchestrator_macos;

--- a/plugin/agents/orbit-task-pilot.md
+++ b/plugin/agents/orbit-task-pilot.md
@@ -10,7 +10,11 @@ You are Orbit's task-pilot agent.
 
 Accept an explicit target workspace, a target branch, a prepared
 `source_revision` when the pipeline pinned one, and a partition of one to
-five Orbit task IDs. Inspect those tasks and return proposals. Do not apply them.
+five Orbit task IDs. The managed CLI host binds the supplied workspace paths
+and cwd to an invocation-owned checkout when `inspection_revision` is set.
+Confirm HEAD matches `source_revision`; native file reads must stay in that
+checkout. Task tools use the inherited logical workspace authority, not the
+temporary path [ORB-11256]. Inspect those tasks and return proposals. Do not apply them.
 
 For each task:
 

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -133,12 +133,17 @@ selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
 The prepare step fetches the landing branch (`base_branch`, defaulting to
-`workflow.base_branch`) and pins one `source_revision`. A clean primary that
-already sits on that branch and is behind origin is fast-forwarded so inspection
-sees the landed tree; a dirty, divergent, or unfetchable checkout fails as
-source-staleness *before* any agent call. The pilot inspects that pinned
-revision. Apply validates selector existence against the same snapshot, not a
-later working tree, so a newly merged file is not reported as missing merely
+`workflow.base_branch`) and pins one `source_revision`, preserving primary
+HEAD, index, dirty and untracked files. Remote failure stops before an agent
+call. Each pilot runs in its own detached checkout at that revision, with
+its cwd, input paths, and read-only filesystem profile bound there. Task tools
+retain the owning logical workspace, and apply still checks task snapshots
+with compare-and-set on that authority. Inspection checkouts use at most 16
+exclusive slots in the common Git directory; normal return, error, and timeout
+remove the checkout before releasing its lease. A crash releases the kernel
+lease, and the next holder reclaims the abandoned checkout before reuse. No
+registered worktrees or primary branches are removed or modified. Apply
+validates selector existence against the same snapshot, not a later working tree, so a newly merged file is not reported as missing merely
 because the primary lagged origin, and a later origin advance cannot admit a
 path that did not exist at prepare.
 


### PR DESCRIPTION
## Task

[ORB-11256](https://orbit-cli.com/tasks/ORB-11256) — Pilot from an immutable source snapshot while preserving a dirty primary checkout

### Description

ORB-11236 correctly makes source identity explicit and fails closed on dirty or untracked primary checkouts. Its accepted fallback is safe but restricts continuous preparation: this Orbit primary intentionally has operator edits to .orbit/auto_tasks/code-review.yaml (Sonnet selection) and security-review.yaml (Sol selection), so the new prepare precondition would stop pilots after installing that code. Improve the existing snapshot mechanism so read-only pilot inspection and deterministic file/dir/symbol validation can use one pinned landing-branch snapshot without requiring the primary to be clean or advancing it. Prefer a bounded immutable inspection worktree/snapshot using existing Git/worktree ownership/cleanup seams. Preserve dirty and untracked user files byte-for-byte, task authority on the owning workspace, source revision evidence, and task CAS. Remote resolution failure must remain actionable; do not silently inspect stale code, stash/reset user work, or allow selectors for nonexistent targets. This extends11236's explicitly permitted fail-closed fallback; it does not undo snapshot safety.

### Acceptance Criteria

- With a dirty primary and a remote landing branch containing a newly merged target, pilot reads and applies selectors against the same pinned immutable source revision while primary HEAD/index/dirty/untracked bytes remain unchanged.
- Agent inspection is actually bound to the pinned snapshot and cannot accidentally read a newer primary; a concurrent branch advance does not change its source.
- Temporary inspection resources have bounded lifetime and ownership-safe cleanup, with crash/retry handling and no removal of other worktrees.
- Authoritative workspace routing and task CAS remain correct even though source inspection occurs in another checkout; remote failure and genuinely missing selectors remain explicit failures.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Preparation now serializes landing-ref fetch and commit resolution using the shared Git directory, without moving primary HEAD, refreshing its index, or changing tracked/dirty/untracked files. Remote failures remain explicit. Existing prepared-checkpoint fast_forwarded evidence is retained for compatibility; new preparations emit false.
- Pilot dispatch materializes the pinned commit and its history in a standalone temporary Git checkout. The provider cwd, envelope input paths, injected single-task paths, and reviewer filesystem profile use that checkout. Managed ORBIT_WORKSPACE and registry routing retain the authoritative owning workspace. Git inspection requires a full pinned revision, and mismatched source/inspection revisions fail closed.
- Invocation-owned inspection storage has 16 exclusive kernel-leased slots. Normal success, errors, and timeouts remove the checkout before lease release. Crashes release leases and retry holders reclaim abandoned content. Cleanup rejects symlinks, unowned directories, and registered-worktree gitfiles; it never prunes the repository worktree registry.
- Selector syntax and file/dir/symbol anchor kinds are validated against pinned Git objects, so dirty-primary symlinks or working-tree-only files cannot influence admission. Existing authoritative task compare-and-set and partition isolation remain unchanged.
- Updated bundled and live pilot activities/jobs, current orchestration guidance, provider instructions, and regression tests.

Validation:
- cargo test -p orbit-core adapter::engine_host::v2_host::tests --lib: 184 passed.
- cargo test -p orbit-engine activity_job::cli_runner --lib: 123 passed, 2 pre-existing Linux namespace-dependent tests ignored.
- Final focused reruns after follow-up edits: task_pilot 27 passed; inspection 8 passed. Coverage includes byte-for-byte dirty/index/untracked preservation, concurrent branch advance, real provider cwd/envelope/task binding and workspace environment, crash subprocess reclamation, timeout/error cleanup, slot exhaustion, registered-worktree preservation, missing selectors, and source pin validation.
- Final make ci-lint: passed (workspace, all targets, warnings denied).
- make ci-fast: all preceding guardrails passed; its final scripts/test-compiler-cache.sh fixture cannot run in this managed runner. Case 6 tries to create /tmp/orbit-workspace/Cargo.toml, which is already the runner's real bind-mounted checkout: ln reports File exists. /tmp/orbit-build is also a live build mount. Attempted mount isolation with unshare --mount true was denied: Operation not permitted. Those mounts and user files were preserved; unrestricted CI must arbitrate this environment-limited check. Friction F2026-09-015 records the evidence.
- Final formatting, diff whitespace, embedded-asset portability, plugin skill mirror, and orphan-module checks passed.

Strategic decisions:
- Used invocation-local standalone repositories rather than registered worktrees or shared object alternates: this keeps cleanup independent of other runs' worktree ownership and lets sandboxed Git read the pinned history without accessing the primary. The tradeoff is copying reachable Git history per active partition, bounded to 16 slots; crash leftovers remain bounded and are reclaimed on slot reuse.
- Expanded context selectors before edits for the tightly coupled CLI dispatch/inspection module, registration, and sandbox tests needed to bind actual native file reads. No new crate or dependency edge was introduced.

Assessment: Scoped implementation is complete and validated, with the single documented runner limitation above. Removed this run's target/debug, target/tmp, and .rustc_info.json build outputs while preserving the pre-existing target directory. Final git status contains only the 20 intended task-scoped source, test, activity/job, and documentation changes. No commit was made and the task remains in-progress for pipeline handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11256-6a9c44b5`
- Behind base: 0
- Ahead of base: 1