### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1000,6 +1000,44 @@
     "name": "orbit_workflow_run_show"
   },
   {
+    "description": "Adjust how many tasks a running workspace drain keeps in flight, without replacing its run. The run ID, deadline, completion authorization, and already-dispatched children are preserved; a lower ceiling stops new admissions until enough children finish and cancels nothing.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "claim_token": {
+          "description": "Token for this workspace's exclusive claim, required when another operator holds one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`.",
+          "type": "string"
+        },
+        "concurrency": {
+          "description": "New ceiling on tasks in flight, from 1 to the ship job's own active-run limit.",
+          "type": "integer"
+        },
+        "id": {
+          "description": "Job run ID.",
+          "type": "string"
+        },
+        "if_revision": {
+          "description": "Apply only if the run's ceiling is still at this revision, so a concurrent adjustment is reported rather than overwritten.",
+          "type": "integer"
+        },
+        "reason": {
+          "description": "Optional note recorded with the change.",
+          "type": "string"
+        },
+        "workspace": {
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "concurrency"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_workflow_run_workers"
+  },
+  {
     "description": "Submit an explicit set of tasks to the ship workflow and return its durable run ID.",
     "inputSchema": {
       "additionalProperties": true,


### PR DESCRIPTION
## Task

[ORB-11274](https://orbit-cli.com/tasks/ORB-11274) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `d48c43f7045fe98832689283e19ec5e5c2d7063c`
- Normalized error signature (the dedupe identity, not a quote): `failures:`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-05T16:44:58.968880094+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/33978430186 run `33978430186` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `d48c43f7045fe98832689283e19ec5e5c2d7063c`
  - current head of that ref: `unknown`
  - commit actually checked out: `d48c43f7045fe98832689283e19ec5e5c2d7063c`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `d48c43f7045fe98832689283e19ec5e5c2d7063c`
  - failed job `Coverage (informational)` (id `101339147196`): https://github.com/danieljhkim/orbit/actions/runs/33978430186/job/101339147196
  - failing step(s): `Collect workspace coverage`
  - failed job `Check / Clippy / Test` (id `101339147197`): https://github.com/danieljhkim/orbit/actions/runs/33978430186/job/101339147197
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8321331Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8321586Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8321597Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8321670Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8321871Z     mcp_serve_tools_list_matches_production_snapshot
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8322048Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8322326Z test result: FAILED. 46 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 67.89s
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8322606Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8322926Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-cli --test mcp_roundtrip`
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8323895Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-05T16:41:03.8333903Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33978426701 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33978294632 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33978290846 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33978143164 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33978139894 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33977952827 — superseded_by_newer_workflow_run: newer repository-wide run 33978430186 at 2026-09-05T16:37:09Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` with the canonical `orbit_workflow_run_workers` MCP tool definition introduced by the existing production registry.
- The snapshot-only change preserves the MCP schema assertion and does not weaken or disable CI.

Assessment: The failure was repository-owned snapshot drift: the production MCP surface advertised `orbit_workflow_run_workers`, while the checked-in production snapshot did not.

Validation:
- Reproduced the reported failure with the narrow equivalent `cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target --workspace --locked --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot`; it initially failed on `mcp_serve_tools_list_matches_production_snapshot`.
- Regenerated the snapshot using the test's documented `ORBIT_MCP_UPDATE_SNAPSHOT=1` path, then reran that command successfully.
- `make ci-lint` passed.
- `make ci-fast` passed all checks through plugin/compiler-cache setup, but its final compiler-cache check could not complete because the managed runner bind-mount already exposed `/tmp/orbit-workspace/Cargo.toml`, so the script's intentionally fresh symlink creation failed with `ln: failed to create symbolic link ... File exists`; this is runner environment interference, not a repository check failure.
- The full workspace test command also exposed unrelated host-runner test isolation failures; the task's failing MCP test passed independently after the snapshot update.
- `git diff --check` passed, and generated Cargo build artifacts were removed with `cargo clean`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11274-6a9c4e4f`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*