### PR TITLE
[ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -36,12 +36,22 @@ pub(crate) fn resolve_executor_sandbox(
             }
             #[cfg(target_os = "macos")]
             {
-                let mut resolved = resolve_fs_profile_absolute(runtime, fs_profile, subprocess_cwd)
+                // Read-only reviewer activities may run from an invocation-owned
+                // inspection checkout, so their read grants must follow that
+                // checkout. Implementer profiles stay anchored at the registered
+                // workspace; the active worktree is re-allowed separately below
+                // after the workspace's `.orbit` deny rules.
+                let profile_root = if fs_profile == Some("reviewer") {
+                    subprocess_cwd
+                } else {
+                    None
+                };
+                let mut resolved = resolve_fs_profile_absolute(runtime, fs_profile, profile_root)
                     .map_err(|err| {
-                        DispatchError::CliInvocationFailed(format!(
-                            "resolve fsProfile for sandbox: {err}"
-                        ))
-                    })?;
+                    DispatchError::CliInvocationFailed(format!(
+                        "resolve fsProfile for sandbox: {err}"
+                    ))
+                })?;
                 append_codex_side_write_roots(runtime, provider, &mut resolved)?;
                 append_orbit_child_runtime_write_roots(runtime, &mut resolved);
                 append_active_worktree_root(runtime, subprocess_cwd, &mut resolved);


### PR DESCRIPTION
## Task

[ORB-11277](https://orbit-cli.com/tasks/ORB-11277) — [ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `macOS Platform`
- Failing job: `macOS Sandbox`
- Failing step: `Run orbit-core sandbox tests`
- Commit the runner actually checked out: `8b0a760bae17b6f0aeee9eab47840684697fa812`
- Normalized error signature (the dedupe identity, not a quote): `test adapter::engine_host::v2_host::tests::sandbox::resolve_executor_sandbox_reallows_claude_active_worktree_under_orbit ... failed`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-05T17:06:25.370414695+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/33979680672 run `33979680672` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `8b0a760bae17b6f0aeee9eab47840684697fa812`
  - current head of that ref: `unknown`
  - commit actually checked out: `8b0a760bae17b6f0aeee9eab47840684697fa812`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/opt/homebrew/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `8b0a760bae17b6f0aeee9eab47840684697fa812`
  - failed job `macOS Sandbox` (id `101342543227`): https://github.com/danieljhkim/orbit/actions/runs/33979680672/job/101342543227
  - failing step(s): `Run orbit-core sandbox tests`

## Failed-step log excerpt

```
[...]
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8515430Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8517100Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8517130Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8519210Z failures:
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8521100Z     adapter::engine_host::v2_host::tests::sandbox::resolve_executor_sandbox_reallows_claude_active_worktree_under_orbit
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8522220Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8522860Z test result: FAILED. 16 passed; 1 failed; 0 ignored; 0 measured; 938 filtered out; finished in 7.15s
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8526490Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-05T17:04:06.8625410Z ##[error]Process completed with exit code 101.
```

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33979677164 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure
- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33948084938 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure
- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33947785005 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure
- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33947782289 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure
- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33947653867 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure
- `macOS Platform` run https://github.com/danieljhkim/orbit/actions/runs/33947508927 — superseded_by_newer_workflow_run: newer repository-wide run 33979680672 at 2026-09-05T17:01:59Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 1,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `macOS Platform` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Fixed macOS sandbox profile anchoring after ORB-11256: reviewer activities keep their read rules rooted at the invocation-owned inspection checkout, while implementer/unrestricted profiles remain rooted at the registered workspace and use the existing narrow active-worktree re-allow after the workspace `.orbit` deny.
- No workflow, assertion, lint level, or blocking behavior was weakened; only `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs` changed.
Validation:
- `cargo test -p orbit-core --locked sandbox` passed locally twice (23 Linux sandbox-filtered tests; the Darwin-only failing test is compiled out on this Linux host).
- `make ci-lint` passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `make ci-fast` reached the final compiler-cache check, but could not complete because the pre-existing shared `/tmp/orbit-workspace/Cargo.toml` is a regular file; the script's `ln` therefore failed with `File exists`. Earlier ci-fast checks, including formatting and guardrails, passed. This is an external shared-temp collision, not a repository change.
- `git diff --check` passed. A 4.8G `target/` tree created by validation was removed from the worktree; final status contains only the intended source edit.
- A Darwin target/cross-check could not be installed because rustup hit `Read-only file system`; the macOS runner remains the required execution environment for the cfg-gated test.
Assessment: The failing test's root cause is repository-owned and is corrected by separating reviewer inspection-root anchoring from implementer workspace-root anchoring. CI should confirm the Darwin-only regression test on the task PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11277-6a9c4e4f`
- Behind base: 0
- Ahead of base: 1