### PR TITLE
[code-review] Compiler-cache guardrail test uses shared /tmp stable mounts and flakes under concurrent runs

### DIFF
--- a/scripts/rustc-compiler-cache.sh
+++ b/scripts/rustc-compiler-cache.sh
@@ -6,8 +6,10 @@
 # cache degrades to ordinary rustc. [ORB-11259]
 set -euo pipefail
 
-STABLE_SRC="/tmp/orbit-workspace"
-STABLE_TGT="/tmp/orbit-build"
+# Tests may override these aliases to avoid sharing host-global /tmp paths.
+# Managed Linux sandboxes use the defaults below.
+STABLE_SRC="${ORBIT_COMPILER_CACHE_STABLE_SRC:-/tmp/orbit-workspace}"
+STABLE_TGT="${ORBIT_COMPILER_CACHE_STABLE_TGT:-/tmp/orbit-build}"
 
 debug() {
   if [[ "${ORBIT_COMPILER_CACHE_DEBUG:-}" == "1" ]]; then

--- a/scripts/test-compiler-cache.sh
+++ b/scripts/test-compiler-cache.sh
@@ -95,25 +95,22 @@ HOME="$HOME" "$ROOT/scripts/compiler-cache.sh" status >/dev/null
 
 # 6. When the Linux stable mounts alias this checkout, argv paths are rewritten.
 fake_tgt="$TMP/stable-target"
-mkdir -p "$fake_tgt" /tmp/orbit-workspace
-ln -s "$ROOT/Cargo.toml" /tmp/orbit-workspace/Cargo.toml
-ln -sfn "$fake_tgt" /tmp/orbit-build
-cleanup_stable() {
-  rm -f /tmp/orbit-workspace/Cargo.toml
-  rmdir /tmp/orbit-workspace 2>/dev/null || true
-  rm -f /tmp/orbit-build
-}
-trap 'cleanup_stable; rm -rf "$TMP"' EXIT
+stable_src="$TMP/orbit-workspace"
+stable_tgt="$TMP/orbit-build"
+mkdir -p "$fake_tgt" "$stable_src"
+ln -s "$ROOT/Cargo.toml" "$stable_src/Cargo.toml"
+ln -s "$fake_tgt" "$stable_tgt"
+export ORBIT_COMPILER_CACHE_STABLE_SRC="$stable_src"
+export ORBIT_COMPILER_CACHE_STABLE_TGT="$stable_tgt"
 export FAKE_SCCACHE_LOG="$TMP/sccache-rewrite.log"
 export FAKE_SCCACHE_ENV="$TMP/sccache-rewrite.env"
 export FAKE_RUSTC_LOG="$TMP/rustc-rewrite.log"
 export CARGO_TARGET_DIR="$fake_tgt"
 rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_RUSTC_LOG"
 "$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" "$ROOT/crates/orbit-types/src/lib.rs"
-grep -Fq "/tmp/orbit-build/debug" "$FAKE_SCCACHE_LOG" || fail "out-dir should rewrite onto the stable build mount"
-grep -Fq "/tmp/orbit-workspace/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "source path should rewrite onto the stable workspace mount"
-cleanup_stable
-trap 'rm -rf "$TMP"' EXIT
+grep -Fq "$stable_tgt/debug" "$FAKE_SCCACHE_LOG" || fail "out-dir should rewrite onto the stable build mount"
+grep -Fq "$stable_src/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "source path should rewrite onto the stable workspace mount"
 unset CARGO_TARGET_DIR
+unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
 
 printf 'test-compiler-cache: ok\n'


### PR DESCRIPTION
## Task

[ORB-11272](https://orbit-cli.com/tasks/ORB-11272) — [code-review] Compiler-cache guardrail test uses shared /tmp stable mounts and flakes under concurrent runs

### Description

`scripts/test-compiler-cache.sh` creates and removes fixed host paths `/tmp/orbit-workspace` and `/tmp/orbit-build` to simulate the Bubblewrap aliases. At `scripts/test-compiler-cache.sh:98-106`, it unconditionally creates `/tmp/orbit-workspace`, then creates `/tmp/orbit-workspace/Cargo.toml` with `ln -s` and later unconditionally deletes those paths. They are not namespaced by the test temporary directory or protected by a lock.

This is reachable from the standard fast gate because `Makefile:138` invokes this script in `ci-fast`. Two worktrees or sessions running the guardrail concurrently race: the later process fails at line 99 when the first process owns `Cargo.toml`; alternatively either cleanup can remove the other process source or build alias while it is still testing.

Verified against live code: executing `./scripts/test-compiler-cache.sh` in this workspace failed with `ln: failed to create symbolic link '/tmp/orbit-workspace/Cargo.toml': File exists`; the host path was concurrently occupied. `ls -l` confirmed the existing `Cargo.toml` at that fixed location. The failing test was introduced in commit `718eb6a7` in the reviewed range.

Fix direction: isolate the synthetic stable mount names under the per-test temporary directory, or use a unique, safely cleaned namespace and make the wrapper test configurable for those aliases. The test must not touch global fixed `/tmp` paths or remove another run artifacts.

### Acceptance Criteria

- `scripts/test-compiler-cache.sh` can run concurrently in separate worktrees without sharing, deleting, or colliding on any `/tmp` alias paths.
- `make ci-fast` no longer has a concurrency-dependent failure from the compiler-cache wrapper test.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added test-only environment overrides for compiler-cache stable mount aliases while retaining the managed-sandbox defaults.
- Moved the stable-mount rewrite fixture entirely below the script mktemp directory, eliminating shared /tmp aliases and cross-run cleanup races.
- Recorded scripts/rustc-compiler-cache.sh as a scope extension because its configurability is required for isolated alias validation.
Assessment: The guardrail now preserves production stable-path behavior while every test run owns and cleans its aliases.
Validation:
- bash -n scripts/rustc-compiler-cache.sh scripts/test-compiler-cache.sh
- ./scripts/test-compiler-cache.sh
- Two concurrent ./scripts/test-compiler-cache.sh invocations completed successfully.
- make ci-fast
- make ci-lint
- git diff --check
Friction checkpoint: no qualifying friction observed.
Working tree: only intended task-scoped modifications remain in scripts/rustc-compiler-cache.sh and scripts/test-compiler-cache.sh.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11272-6a9c5024`
- Behind base: 0
- Ahead of base: 1