### PR TITLE
[code-review] Readiness ignores string concurrency submitted through run job

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -1249,6 +1249,10 @@ fn crew_allowlist_rejects_a_crew_this_workspace_does_not_configure() {
 
 /// A running drain with checkpoint state, as the engine leaves one behind.
 fn seed_running_drain(runtime: &OrbitRuntime, submitted: u32) -> String {
+    seed_running_drain_input(runtime, json!({ "max_active_leaf_runs": submitted }))
+}
+
+fn seed_running_drain_input(runtime: &OrbitRuntime, input: Value) -> String {
     let run = runtime
         .stores()
         .jobs()
@@ -1256,7 +1260,7 @@ fn seed_running_drain(runtime: &OrbitRuntime, submitted: u32) -> String {
             "workspace_auto_pipeline",
             1,
             Utc::now(),
-            Some(json!({ "max_active_leaf_runs": submitted })),
+            Some(input.clone()),
             None,
         )
         .expect("insert drain run");
@@ -1268,7 +1272,7 @@ fn seed_running_drain(runtime: &OrbitRuntime, submitted: u32) -> String {
     let state = orbit_types::workflow::PipelineState::new(
         run.run_id.clone(),
         "workspace_auto_pipeline".to_string(),
-        json!({ "max_active_leaf_runs": submitted }),
+        input,
     );
     runtime
         .stores()
@@ -1426,4 +1430,34 @@ fn readiness_reports_the_live_ceiling_and_who_moved_it() {
     let previewed = readiness(&runtime, &backlog, Some(2));
     assert_eq!(previewed["capacity"]["max_active_leaf_runs"], 2);
     assert_eq!(previewed["capacity"]["limit_source"], "requested");
+}
+
+/// [ORB-11273] `orbit run job ... --input max_active_leaf_runs=7` persists the
+/// ceiling as a JSON string. Readiness must report that live drain ceiling
+/// (and the same source the classifier uses), not the numeric-only fallback of 5.
+#[test]
+fn readiness_parses_numeric_and_string_run_input_ceilings() {
+    for submitted in [json!(7), json!("7")] {
+        let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+        write_workspace_file(&repo_root, "crates/leaf_0/src/lib.rs");
+        let backlog = seed_backlog_leaves(&runtime, 1);
+        let drain_run_id =
+            seed_running_drain_input(&runtime, json!({ "max_active_leaf_runs": submitted }));
+
+        let output = readiness(&runtime, &backlog, None);
+        assert_eq!(
+            output["capacity"]["max_active_leaf_runs"], 7,
+            "submitted {submitted} must report the live ceiling, not the default 5"
+        );
+        assert_eq!(output["capacity"]["limit_source"], "run_input");
+        assert_eq!(output["capacity"]["drain_run_id"], drain_run_id);
+
+        let classified = classify_with(
+            &runtime,
+            json!({ "run_id": drain_run_id, "max_active_leaf_runs": submitted }),
+        );
+        assert_eq!(classified["max_active_leaf_runs"], 7);
+        assert_eq!(classified["submitted_max_active_leaf_runs"], 7);
+        assert_eq!(classified["worker_limit_source"], "run_input");
+    }
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -470,8 +470,7 @@ fn active_drain(runtime: &OrbitRuntime) -> Result<Option<ActiveDrain>, OrbitErro
         .input
         .as_ref()
         .and_then(|input| input.get("max_active_leaf_runs"))
-        .and_then(Value::as_u64)
-        .and_then(|value| u32::try_from(value).ok())
+        .and_then(json_u32)
         .unwrap_or(DEFAULT_MAX_ACTIVE_LEAF_RUNS as u32);
     let limit = read_drain_worker_limit(runtime, &run.run_id);
     Ok(Some(ActiveDrain {
@@ -489,6 +488,17 @@ fn read_drain_worker_limit(runtime: &OrbitRuntime, run_id: &str) -> Option<Drain
         .ok()
         .flatten()
         .and_then(|state| state.drain_worker_limit)
+}
+
+/// A durable run-input ceiling. The generic job surface persists every
+/// `--input key=value` as a JSON string, so `"7"` must parse the same as `7`
+/// ([ORB-11273]). Matches `job_input_u32` on the worker-limit write path.
+fn json_u32(value: &Value) -> Option<u32> {
+    match value {
+        Value::Number(number) => number.as_u64().and_then(|value| u32::try_from(value).ok()),
+        Value::String(text) => text.trim().parse::<u32>().ok(),
+        _ => None,
+    }
 }
 
 /// A numeric loop input, tolerating the string a template renders. A step's


### PR DESCRIPTION
## Task

[ORB-11273](https://orbit-cli.com/tasks/ORB-11273) — [code-review] Readiness ignores string concurrency submitted through run job

### Description

ORB-11253 made `orbit run readiness` report the active drain effective ceiling, but `active_drain` only parses a JSON number from the durable run input: `crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs:469-475` uses `Value::as_u64()` and falls back to 5.

The supported generic job surface persists every `--input key=value` value as a JSON string (`crates/orbit-cli/src/command/run/job.rs:306-322`), so `orbit run job workspace_auto_pipeline --input max_active_leaf_runs=7` creates a valid live drain whose input contains string `"7"`. The job templates that value into `classify_workspace_auto_tasks` (`crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml:87-93`), and that activity explicitly accepts numeric strings in `templated_u64`; it therefore admits seven leaves. Meanwhile readiness sees no numeric `as_u64` value and reports the fallback 5 as the live run input ceiling. This contradicts the new readiness contract that the snapshot reports the active drain ceiling.

The worker-control write path already has `job_input_u32` in `application/job/run/worker_limit.rs` that accepts both JSON numbers and strings; use equivalent parsing for `ActiveDrain.submitted` and add a direct-job string-input regression test.

Verified against live code and no existing task search result covered this symptom.

### Acceptance Criteria

- For a live `workspace_auto_pipeline` submitted through `orbit run job ... --input max_active_leaf_runs=7`, readiness without an explicit concurrency override reports 7 and `limit_source: run_input`.
- Readiness parses numeric and string submitted ceilings consistently with the classifier and worker-limit control path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `active_drain` now parses `max_active_leaf_runs` as a JSON number or numeric string via a local `json_u32` helper matching `job_input_u32`, so a live `workspace_auto_pipeline` submitted through `orbit run job ... --input max_active_leaf_runs=7` reports 7 with `limit_source: run_input` instead of falling back to 5.
- Added `readiness_parses_numeric_and_string_run_input_ceilings` covering both numeric `7` and string `"7"` against readiness and the classifier.
Assessment: Bounded observation-path fix. Parsing is equivalent to the worker-limit write path without lifting `job_input_u32` across the application/adapter boundary. Unparseable values still fall back to the default 5.
Validation:
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::workspace_auto`: 28 passed, including the new regression.
- `make ci-lint`: passed.
- `make ci-fast`: `cargo fmt --all -- --check` and every guardrail except `scripts/test-compiler-cache.sh` passed. That script failed with `ln: failed to create symbolic link '/tmp/orbit-workspace/Cargo.toml': File exists` because `/tmp/orbit-workspace` is an occupied host checkout, unrelated to this change. Unrestricted CI can arbitrate it.
Friction checkpoint: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11273-6a9c5024`
- Behind base: 0
- Ahead of base: 1