### PR TITLE
Ship Linux sandbox prerequisites in the installed Orbit setup skill

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit/SKILL.md
@@ -96,6 +96,7 @@ is seeded disabled and requires deliberate enablement:
 | Reference | Read it for |
 |---|---|
 | [setup/first-run.md](references/setup/first-run.md) | Zero to a working workspace: install, host identity and task prefix, `workspace init`, MCP client registration, verification. |
+| [setup/linux-sandbox.md](references/setup/linux-sandbox.md) | Linux Bubblewrap/AppArmor prerequisite, capability probe, sandbox guarantees, and supported remediation before dispatch. |
 | [setup/configuration.md](references/setup/configuration.md) | `orbit config` keys, crews and executors, policies and filesystem profiles, environment passthrough. |
 | [setup/automation.md](references/setup/automation.md) | The scheduler: OS clock → `orbit sweep` → routines → jobs. The seven seeded routines and the order to enable them. |
 | [setup/auto-tasks.md](references/setup/auto-tasks.md) | Recurring work as data — definitions that mint tasks on a schedule, instead of new code. |
@@ -107,6 +108,7 @@ is seeded disabled and requires deliberate enablement:
 ## Start here
 
 - New to Orbit, or `.orbit/` is absent → [concepts.md](references/concepts.md), then [setup/first-run.md](references/setup/first-run.md).
+- Preparing Linux for dispatch → [setup/linux-sandbox.md](references/setup/linux-sandbox.md) before starting an agent.
 - Given a task ID → [task-execution.md](references/task-execution.md).
 - Asked to create work → [task-authoring.md](references/task-authoring.md).
 - "Why didn't this fire / run / clean up?" → [setup/automation.md](references/setup/automation.md), then [setup/maintenance.md](references/setup/maintenance.md).

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -41,10 +41,9 @@ installation; ask only for missing choices or required host permissions.
 Before dispatch, verify an authenticated supported agent CLI on the execution
 host. PR mode also needs an authenticated `gh` client. On Linux, `/usr/bin/bwrap`
 must pass its namespace/mount probe; Ubuntu's AppArmor restrictions may require
-the packaged narrow Bubblewrap profile. Follow the
-[Linux host runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/linux-sandbox.md)
-for privileged setup. Do not disable host protection or enable sandbox fallback
-to hide a failed probe.
+the packaged narrow Bubblewrap profile. Complete the [Linux sandbox setup](linux-sandbox.md)
+before dispatch. Do not disable host protection or enable sandbox fallback to hide
+a failed probe.
 
 ## Step 3 — Initialize the machine
 

--- a/crates/orbit-core/assets/skills/orbit/references/setup/linux-sandbox.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/linux-sandbox.md
@@ -1,0 +1,62 @@
+# Prepare a Linux Host for Sandboxed Dispatch
+
+Complete this setup after `orbit init` and before dispatching an agent on Linux.
+Orbit's Linux executor uses Bubblewrap and fails closed when the host cannot
+run its namespace-and-mount capability probe.
+
+## What the Linux sandbox guarantees
+
+The `linux-bwrap` executor resolves `/usr/bin/bwrap` and requires an
+unprivileged user to create user namespaces and mounts. A failed capability
+probe stops dispatch; Orbit does not silently fall back to an in-process-only
+boundary.
+
+The enforced boundary protects writes according to the resolved policy. Host
+filesystem reads and host network access remain available, so this sandbox
+does not provide worktree-only reads or policy-gated network egress.
+
+## Ubuntu 24.04
+
+Ubuntu 24.04 can restrict unprivileged user namespaces with AppArmor. Install
+Bubblewrap and the distro's narrow profile, load the profile, verify that
+AppArmor knows it, then run the same probe shape used by Orbit:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes bubblewrap apparmor-profiles
+test -x /usr/bin/bwrap
+test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+sudo install -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
+test -f /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
+
+/usr/bin/bwrap \
+  --die-with-parent \
+  --new-session \
+  --unshare-all \
+  --share-net \
+  --ro-bind / / \
+  -- /bin/true
+```
+
+The final command must exit successfully. The profile path and probe are
+specific to Ubuntu 24.04; use the corresponding packaged profile and the same
+namespace-and-mount capability requirements on another Linux distribution.
+
+## If the probe fails
+
+Re-check that `/usr/bin/bwrap` is executable, that the packaged profile exists,
+and that `apparmor_parser` loaded it. Read the parser output and rerun the
+probe after correcting the host setup.
+
+Do not disable `kernel.apparmor_restrict_unprivileged_userns` globally and do
+not enable `allow_fallback`. Both changes weaken or bypass Orbit's fail-closed
+boundary. Orbit supports fixing the narrow host prerequisite; it does not
+support an implicit sandbox fallback.
+
+Non-Linux hosts are unaffected by this prerequisite: macOS uses `sandbox-exec`,
+and platforms without a shipped OS-level backend rely on in-process filesystem
+guards only.

--- a/crates/orbit-core/src/application/skill.rs
+++ b/crates/orbit-core/src/application/skill.rs
@@ -19,7 +19,7 @@ use super::{ManagedAssetLayout, ManagedAssetReconciliation, reconcile_managed_as
 /// discoverable through one description without a per-topic skill competing
 /// for the same trigger. The ordering below mirrors each router's own
 /// reference table, so the shipped surface reads the same in both places.
-pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 27] = [
+pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 28] = [
     (
         "orbit/SKILL.md",
         include_str!("../../assets/skills/orbit/SKILL.md"),
@@ -81,6 +81,10 @@ pub(crate) const DEFAULT_SKILL_FILES: [(&str, &str); 27] = [
     (
         "orbit/references/setup/first-run.md",
         include_str!("../../assets/skills/orbit/references/setup/first-run.md"),
+    ),
+    (
+        "orbit/references/setup/linux-sandbox.md",
+        include_str!("../../assets/skills/orbit/references/setup/linux-sandbox.md"),
     ),
     (
         "orbit/references/setup/configuration.md",

--- a/crates/orbit-core/src/application/tests/managed_assets.rs
+++ b/crates/orbit-core/src/application/tests/managed_assets.rs
@@ -470,6 +470,10 @@ mod artifacts {
             keys.contains(&"orbit/references/setup/first-run.md"),
             "references nest, so a manifest key is a full relative path: {keys:?}"
         );
+        assert!(
+            keys.contains(&"orbit/references/setup/linux-sandbox.md"),
+            "Linux sandbox setup is an embedded managed reference: {keys:?}"
+        );
     }
 
     /// A freshly initialized workspace is clean on every artifact kind.
@@ -538,8 +542,8 @@ mod artifacts {
             .expect("inspect artifacts");
         let skill_health = health_of(&report, ArtifactKind::Skill);
         assert_eq!(
-            skill_health.scanned, 3,
-            "one healthy skill plus two residues"
+            skill_health.scanned, 4,
+            "two healthy skills plus two residues"
         );
         for residue in [&untracked_dir, &tracked_dir] {
             let name = residue

--- a/plugin/skills/orbit/SKILL.md
+++ b/plugin/skills/orbit/SKILL.md
@@ -96,6 +96,7 @@ is seeded disabled and requires deliberate enablement:
 | Reference | Read it for |
 |---|---|
 | [setup/first-run.md](references/setup/first-run.md) | Zero to a working workspace: install, host identity and task prefix, `workspace init`, MCP client registration, verification. |
+| [setup/linux-sandbox.md](references/setup/linux-sandbox.md) | Linux Bubblewrap/AppArmor prerequisite, capability probe, sandbox guarantees, and supported remediation before dispatch. |
 | [setup/configuration.md](references/setup/configuration.md) | `orbit config` keys, crews and executors, policies and filesystem profiles, environment passthrough. |
 | [setup/automation.md](references/setup/automation.md) | The scheduler: OS clock → `orbit sweep` → routines → jobs. The seven seeded routines and the order to enable them. |
 | [setup/auto-tasks.md](references/setup/auto-tasks.md) | Recurring work as data — definitions that mint tasks on a schedule, instead of new code. |
@@ -107,6 +108,7 @@ is seeded disabled and requires deliberate enablement:
 ## Start here
 
 - New to Orbit, or `.orbit/` is absent → [concepts.md](references/concepts.md), then [setup/first-run.md](references/setup/first-run.md).
+- Preparing Linux for dispatch → [setup/linux-sandbox.md](references/setup/linux-sandbox.md) before starting an agent.
 - Given a task ID → [task-execution.md](references/task-execution.md).
 - Asked to create work → [task-authoring.md](references/task-authoring.md).
 - "Why didn't this fire / run / clean up?" → [setup/automation.md](references/setup/automation.md), then [setup/maintenance.md](references/setup/maintenance.md).

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -41,10 +41,9 @@ installation; ask only for missing choices or required host permissions.
 Before dispatch, verify an authenticated supported agent CLI on the execution
 host. PR mode also needs an authenticated `gh` client. On Linux, `/usr/bin/bwrap`
 must pass its namespace/mount probe; Ubuntu's AppArmor restrictions may require
-the packaged narrow Bubblewrap profile. Follow the
-[Linux host runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/linux-sandbox.md)
-for privileged setup. Do not disable host protection or enable sandbox fallback
-to hide a failed probe.
+the packaged narrow Bubblewrap profile. Complete the [Linux sandbox setup](linux-sandbox.md)
+before dispatch. Do not disable host protection or enable sandbox fallback to hide
+a failed probe.
 
 ## Step 3 — Initialize the machine
 

--- a/plugin/skills/orbit/references/setup/linux-sandbox.md
+++ b/plugin/skills/orbit/references/setup/linux-sandbox.md
@@ -1,0 +1,62 @@
+# Prepare a Linux Host for Sandboxed Dispatch
+
+Complete this setup after `orbit init` and before dispatching an agent on Linux.
+Orbit's Linux executor uses Bubblewrap and fails closed when the host cannot
+run its namespace-and-mount capability probe.
+
+## What the Linux sandbox guarantees
+
+The `linux-bwrap` executor resolves `/usr/bin/bwrap` and requires an
+unprivileged user to create user namespaces and mounts. A failed capability
+probe stops dispatch; Orbit does not silently fall back to an in-process-only
+boundary.
+
+The enforced boundary protects writes according to the resolved policy. Host
+filesystem reads and host network access remain available, so this sandbox
+does not provide worktree-only reads or policy-gated network egress.
+
+## Ubuntu 24.04
+
+Ubuntu 24.04 can restrict unprivileged user namespaces with AppArmor. Install
+Bubblewrap and the distro's narrow profile, load the profile, verify that
+AppArmor knows it, then run the same probe shape used by Orbit:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes bubblewrap apparmor-profiles
+test -x /usr/bin/bwrap
+test -f /usr/share/apparmor/extra-profiles/bwrap-userns-restrict
+sudo install -m 0644 \
+  /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+  /etc/apparmor.d/bwrap-userns-restrict
+test -f /etc/apparmor.d/bwrap-userns-restrict
+sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
+grep -Fq 'bwrap-userns-restrict' /sys/kernel/security/apparmor/profiles
+
+/usr/bin/bwrap \
+  --die-with-parent \
+  --new-session \
+  --unshare-all \
+  --share-net \
+  --ro-bind / / \
+  -- /bin/true
+```
+
+The final command must exit successfully. The profile path and probe are
+specific to Ubuntu 24.04; use the corresponding packaged profile and the same
+namespace-and-mount capability requirements on another Linux distribution.
+
+## If the probe fails
+
+Re-check that `/usr/bin/bwrap` is executable, that the packaged profile exists,
+and that `apparmor_parser` loaded it. Read the parser output and rerun the
+probe after correcting the host setup.
+
+Do not disable `kernel.apparmor_restrict_unprivileged_userns` globally and do
+not enable `allow_fallback`. Both changes weaken or bypass Orbit's fail-closed
+boundary. Orbit supports fixing the narrow host prerequisite; it does not
+support an implicit sandbox fallback.
+
+Non-Linux hosts are unaffected by this prerequisite: macOS uses `sandbox-exec`,
+and platforms without a shipped OS-level backend rely on in-process filesystem
+guards only.


### PR DESCRIPTION
## Task

[ORB-11282](https://orbit-cli.com/tasks/ORB-11282) — Ship Linux sandbox prerequisites in the installed Orbit setup skill

### Description

## Request and chosen option
Daniel permits either shipping docs/runbooks/linux-sandbox.md in crates/orbit-core/assets/skills/orbit/references/setup or disabling unsupported Linux sandbox defaults. Choose the bounded documentation option: make the verified Linux setup/runbook available in the installed Orbit skill and discoverable before first dispatch.

## Evidence
The current runbook documents Ubuntu 24.04 Bubblewrap/AppArmor setup and UID-map troubleshooting, but lives only in repository docs. Installed users need those instructions. Preserve documented Linux sandbox security posture and avoid globally weakening host AppArmor. Keep one canonical documentation owner where practical; ensure references resolve in a standalone installed skill without repository-only relative links.

Crew: low complexity maps to Luna.

## Session authorization and delivery
Daniel explicitly authorizes implementation, promotion, and automatic completion/merge for this session. Use the managed dedicated task worktree and target agent-main. Run make ci-fast, make ci-lint, and focused deterministic behavior tests as appropriate. Do not modify CHANGELOG.md. Judge current code and tests; historical ADRs are not authority.

### Acceptance Criteria

- Installed Orbit skill includes Linux Bubblewrap/AppArmor prerequisite and capability-probe instructions derived from the current runbook.
- Skill router and first-run/setup references make Linux preparation discoverable before dispatch; all links resolve without a source checkout.
- Documentation states the actual sandbox guarantees and supported remediation; no implicit fallback or global security setting changes are introduced.
- Managed asset embedding/installation includes the setup reference; relevant doc checks and required repository gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added the standalone installed reference `references/setup/linux-sandbox.md` with Ubuntu 24.04 Bubblewrap/AppArmor installation, the exact namespace-and-mount capability probe, fail-closed guarantees, and supported remediation that avoids global AppArmor changes and sandbox fallback.
- Updated the canonical Orbit skill router and first-run setup reference with portable relative links, registered the new embedded managed asset, synchronized the plugin mirror, and updated the directly affected managed-assets test.
Assessment: The Linux prerequisite is discoverable before dispatch and the installed/plugin skill trees remain self-contained and in sync. No sandbox defaults or global host security settings were changed.
Validation:
- `make ci-fast` passed, including embedded asset portability, plugin mirror, and plugin installation checks.
- `make ci-lint` passed with workspace clippy and warnings denied.
- `cargo test -p orbit-core managed_assets --lib` passed: 16 tests.
- `scripts/sync-plugin-skills.sh --check`, `git diff --check`, and portable-link/file checks passed.
- Removed the run-created Cargo target artifacts with `cargo clean`; final status contains only the intended task-scoped documentation, embedding, mirror, and test changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11282-6a9c5209`
- Behind base: 0
- Ahead of base: 1