### PR TITLE
Refresh CLI tool-list goldens for the live worker-control tool surface

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -1080,6 +1080,46 @@
   {
     "active": true,
     "builtin": true,
+    "description": "Adjust how many tasks a running workspace drain keeps in flight, without replacing its run. The run ID, deadline, completion authorization, and already-dispatched children are preserved; a lower ceiling stops new admissions until enough children finish and cancels nothing.",
+    "enabled": true,
+    "name": "orbit.workflow.run.workers",
+    "parameters": [
+      {
+        "description": "Job run ID.",
+        "name": "id",
+        "param_type": "string",
+        "required": true
+      },
+      {
+        "description": "New ceiling on tasks in flight, from 1 to the ship job's own active-run limit.",
+        "name": "concurrency",
+        "param_type": "integer",
+        "required": true
+      },
+      {
+        "description": "Optional note recorded with the change.",
+        "name": "reason",
+        "param_type": "string",
+        "required": false
+      },
+      {
+        "description": "Apply only if the run's ceiling is still at this revision, so a concurrent adjustment is reported rather than overwritten.",
+        "name": "if_revision",
+        "param_type": "integer",
+        "required": false
+      },
+      {
+        "description": "Token for this workspace's exclusive claim, required when another operator holds one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`.",
+        "name": "claim_token",
+        "param_type": "string",
+        "required": false
+      }
+    ],
+    "status": "active"
+  },
+  {
+    "active": true,
+    "builtin": true,
     "description": "Submit an explicit set of tasks to the ship workflow and return its durable run ID.",
     "enabled": true,
     "name": "orbit.workflow.ship",

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -22,5 +22,6 @@ orbit.task.update	id:string	Update an Orbit task and return the fresh task JSON
 orbit.workflow.run.list	-	List durable workflow runs newest-first with optional bounded filters.
 orbit.workflow.run.resume	id:string	Resume a terminal resumable workflow run as a new linked run.
 orbit.workflow.run.show	id:string	Fetch one durable workflow run by ID.
+orbit.workflow.run.workers	id:string, concurrency:integer	Adjust how many tasks a running workspace drain keeps in flight, without replacing its run. The run ID, deadline, completion authorization, and already-dispatched children are preserved; a lower ceiling stops new admissions until enough children finish and cancels nothing.
 orbit.workflow.ship	task_ids:string|string[]	Submit an explicit set of tasks to the ship workflow and return its durable run ID.
 proc.spawn	program:string	Spawn a process with timeout and capture output


### PR DESCRIPTION
## Task

[ORB-11285](https://orbit-cli.com/tasks/ORB-11285) — Refresh CLI tool-list goldens for the live worker-control tool surface

### Description

## Failure evidence
GitHub CI run https://github.com/danieljhkim/orbit/actions/runs/33980986126 on agent-main commit e7735204c03445ce624cb1824be0a3521408ed5b failed. Coverage job 101346040619 fails plain_and_json_forms_match_their_goldens at crates/orbit-cli/tests/output_goldens.rs:327; tool_list.plain.txt drifted. Exact runner command: cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target --workspace --locked. Narrow reproducer: cargo test -p orbit-cli --test output_goldens plain_and_json_forms_match_their_goldens. At discovery successor 33981141673 was still running.

## Scope
Compare rendered tool list to current authoritative registry, including orbit.workflow.run.workers introduced by ORB-11253. Regenerate only obsolete plain/JSON tool-list golden outputs through documented ORBIT_UPDATE_OUTPUT_GOLDENS=1 path, review diff, preserve assertions. ORB-11274 fixed the separate MCP snapshot in PR #1352; ORB-11237 earlier fixed github.run.logs descriptions, not this worker-control surface. Search found no existing owner for this new CLI golden failure. Verify current landing head before changing anything; report no-diff with exact delivered-fix evidence if another repair lands first. If rendering itself is wrong, correct root cause rather than approving an incorrect golden.

Daniel authorizes this repair, pilot/promotion and --complete delivery during this session. Low complexity maps to Luna. Use managed worktree, agent-main, required gates; no CHANGELOG edits.

### Acceptance Criteria

- The exact output_goldens test reproduces the drift, then passes without update mode against reviewed current registry output.
- Plain and JSON tool-list snapshots consistently include the correct live worker-control surface; no assertions or checks are weakened.
- Diff is limited to verified stale expected outputs or an evidence-backed rendering fix; make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated only `crates/orbit-cli/tests/output_goldens/tool_list.plain.txt` and `tool_list.json` with the live `orbit.workflow.run.workers` registry entry, including its current description and parameter schema.
- Verified the authoritative builtin registration and governed MCP placement already expose the worker-control tool; no rendering or assertion changes were needed.
Assessment: The diff is limited to the two stale expected outputs and preserves all golden-test assertions. Validation passed: the narrow test reproduced the pre-update drift, update mode completed successfully, the narrow test passed without update mode, the full `cargo test -p orbit-cli --test output_goldens` passed (3/3), `make ci-fast` passed, `make ci-lint` passed, and `git diff --check` passed. Final tracked changes are limited to the two intended golden files; pre-existing ignored `.orbit/config.yaml` and `target/` were left untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11285-6a9c53b7`
- Behind base: 0
- Ahead of base: 1