### PR TITLE
Detect actionable CI failures while newer workflows or sibling checks are still running

### DIFF
--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -15,14 +15,23 @@ spec:
     less. Checkout identity is extracted while the full runner-log stream is
     drained, before the human excerpt is truncated; extraction scans at most
     8 MiB per log and records incomplete evidence rather than guessing.
-    Workflow runs are listed repository-wide in one query and exactly
-    the latest run of each workflow is authoritative, ordered by creation time
-    then run ID. Discovery or investigation failures are bounded, redacted,
-    and emitted in `retryable_errors`; the filing step rejects such a snapshot
-    so it cannot be mistaken for a clean result. When no GitHub client is
-    available or authenticated the snapshot carries `collected: false` and
-    gathers nothing further, so a caller can never mistake it for a clean CI
-    result.
+    Workflow runs are listed repository-wide in one query. `latest_runs`
+    records the newest run of each workflow for audit, ordered by creation
+    time then run ID. Current failures are selected by relevant identity
+    (workflow, ref, and observed failed jobs): a queued or in-progress
+    successor is not evidence that an observed failure is resolved, an
+    unrelated pull-request run cannot erase a landing-branch failure, and a
+    genuinely newer completed non-unsuccessful check of the same identity
+    (or a landing-branch success, for non-landing noise) does suppress it.
+    Already-failed jobs inside an in-flight workflow become current once
+    their evidence is complete; a pending check alone is never a repair
+    task. Incomplete mixed-state logs stay in `retryable_errors` until a
+    later sweep can finish them. Discovery or investigation failures are
+    bounded, redacted, and emitted in `retryable_errors`; the filing step
+    rejects such a snapshot so it cannot be mistaken for a clean result.
+    When no GitHub client is available or authenticated the snapshot carries
+    `collected: false` and gathers nothing further, so a caller can never
+    mistake it for a clean CI result.
   input_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -10,7 +10,9 @@ spec:
     (workflow, failing job, failing step, normalized error signature, and the
     commit the runner actually tested) so one regression repeated across a push
     run and a pull-request run of the same commit becomes one task rather than
-    several. Each surviving cluster is filed at `status: proposed` with the
+    several. Current failures may include already-failed jobs from an
+    in-flight workflow when that evidence is complete; a pending check is
+    never present in the snapshot as a current failure and must not be filed. Each surviving cluster is filed at `status: proposed` with the
     collected evidence rendered inline in the description, so the implementing
     agent never needs a GitHub credential; no `required_tools` are attached and
     the task can later ship through the ordinary pull-request route only after

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -41,6 +41,12 @@
 #   excerpt is formed. The extractor scans no more than 8 MiB per log and
 #   marks the identity incomplete if that hard limit is reached; it never
 #   substitutes an event or PR head SHA as checkout evidence.
+# - Ongoing checks: a queued or in-progress successor does not suppress an
+#   observed failure. Failed jobs inside an in-flight workflow are current
+#   once evidence is complete; a pending check alone is never filed. Freshness
+#   is scoped to workflow/ref/check identity so unrelated pull-request activity
+#   cannot erase a landing-branch failure, while a genuinely newer successful
+#   relevant check still suppresses the resolved case.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -363,6 +363,37 @@ fn live_run_fixture_files_once_with_complete_actionable_evidence() {
 }
 
 #[test]
+fn mixed_state_in_progress_failure_files_once_and_repeat_names_the_owner() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut mixed = failure(
+        33_979_680_684,
+        "CI",
+        "Linux tests",
+        "Run tests",
+        "CI\tLinux tests\tassertion failed in collect.rs\n",
+        "8b0a760bae17b6f0aeee9eab47840684697fa812",
+    );
+    mixed["status"] = json!("in_progress");
+    mixed["conclusion"] = Value::Null;
+    mixed["url"] = json!("https://github.com/danieljhkim/orbit/actions/runs/33979680684");
+    let evidence = snapshot(vec![mixed]);
+
+    let first = file(&runtime, json!({"ci_evidence": evidence.clone()}));
+    assert_eq!(first["outcome"], json!("current_failures"));
+    assert_eq!(first["filed_count"], json!(1));
+    let task_id = filed_task_ids(&first).remove(0);
+    let task = runtime.get_task(&task_id).expect("read filed task");
+    assert!(task.description.contains("Linux tests"));
+    assert!(task.description.contains("33979680684"));
+
+    let second = file(&runtime, json!({"ci_evidence": evidence}));
+    assert_eq!(second["outcome"], json!("current_failures"));
+    assert_eq!(second["filed_count"], json!(0));
+    assert_eq!(second["skipped_existing"][0]["task_id"], json!(task_id));
+    assert_eq!(second["audit"]["existing_task_owners"], json!([task_id]));
+}
+
+#[test]
 fn task_add_failure_is_retryable_and_cannot_persist_a_handled_state() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let evidence = snapshot(vec![failure(

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -6,9 +6,12 @@
 //! the commit the runner actually checked out as separate fields, and the
 //! stale/superseding evidence that says which failures are still real.
 //!
-//! "Still real" is decided per workflow. Runs are listed repository-wide and
-//! exactly the newest run of each workflow is authoritative, regardless of
-//! which branch or SHA an older run used.
+//! "Still real" is decided per relevant identity: workflow, ref, and observed
+//! failed jobs. Runs are listed repository-wide so a newer *relevant* success
+//! can suppress an older failure, but a queued or in-progress successor is
+//! not that evidence, and an unrelated pull-request run cannot erase a
+//! landing-branch failure. Already-failed jobs inside an in-flight workflow
+//! are current when their evidence is complete; a pending check is not.
 //!
 //! Losing the agent's ability to ask a follow-up question mid-diagnosis is the
 //! accepted cost of that boundary. The compensation is that the snapshot is
@@ -168,10 +171,12 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     let mut current: Vec<Value> = Vec::new();
     let mut stale: Vec<Value> = Vec::new();
     let mut in_flight: Vec<Value> = Vec::new();
+    let mut mixed_candidates: Vec<Value> = Vec::new();
     // One repository-wide query rather than one per ref: a single list is what
-    // lets a newer run of a workflow supersede an older one without asking the
-    // ref it ran on whether it has advanced. Selection is repository-wide too:
-    // exactly one latest run per workflow is authoritative.
+    // lets a newer *relevant* success supersede an older failure without
+    // asking the ref it ran on whether it has advanced. Selection itself is
+    // scoped to workflow/ref/check identity so an unrelated pull request or
+    // an in-flight successor cannot hide a landing-branch failure.
     let runs = match queries.repository_runs(bounds.max_runs) {
         Ok(runs) => runs,
         Err(error) => {
@@ -200,18 +205,32 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         &mut current,
         &mut stale,
         &mut in_flight,
+        &mut mixed_candidates,
     );
 
-    sort_current_failures(&mut current);
-    let discovered = current.len();
-    let attempted = discovered.min(bounds.max_investigated_runs);
-    if discovered > attempted {
+    let mut inspect = Vec::new();
+    let mut seen_run_ids = std::collections::BTreeSet::new();
+    for failure in current.iter().chain(mixed_candidates.iter()) {
+        let Some(run_id) = failure.get("run_id").and_then(Value::as_u64) else {
+            continue;
+        };
+        if seen_run_ids.insert(run_id) {
+            inspect.push(failure.clone());
+        }
+    }
+    sort_current_failures(&mut inspect);
+    let investigation_candidates = inspect.len();
+    let attempted = investigation_candidates.min(bounds.max_investigated_runs);
+    if investigation_candidates > attempted {
         notes.push(format!(
-            "{} of {discovered} current failures were listed but not investigated \
-             (max_investigated_runs={attempted}); their run URLs are still present",
-            discovered - attempted
+            "{} of {investigation_candidates} current or mixed-state runs were listed but not \
+             investigated (max_investigated_runs={attempted}); their run URLs are still present",
+            investigation_candidates - attempted
         ));
-        for failure in current.iter().skip(attempted) {
+        for failure in inspect.iter().skip(attempted) {
+            if !run_is_completed(failure) {
+                continue;
+            }
             push_retryable_error(
                 &mut retryable_errors,
                 "investigation",
@@ -222,7 +241,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         }
     }
     let mut checkout_log_reads = 0usize;
-    for (index, failure) in current.iter_mut().enumerate() {
+    for (index, failure) in inspect.iter_mut().enumerate() {
         if index >= attempted {
             failure["investigated"] = json!(false);
             continue;
@@ -235,6 +254,12 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             &mut retryable_errors,
         );
     }
+    current = inspect
+        .into_iter()
+        .filter(is_actionable_current_failure)
+        .collect();
+    sort_current_failures(&mut current);
+    let discovered = current.len();
     let investigated_ids = current
         .iter()
         .filter(|failure| failure.get("investigated").and_then(Value::as_bool) == Some(true))
@@ -425,12 +450,19 @@ fn head_json(scanned: &ScannedRef) -> Value {
     })
 }
 
-/// Evaluate exactly the latest repository-wide run for each workflow.
+/// Classify repository-wide runs by relevant workflow/ref identity.
 ///
-/// Older unsuccessful runs remain useful evidence, but can never become
-/// current merely because the ref they ran on has not advanced. The latest run
-/// supersedes them regardless of branch, SHA, status, or conclusion. This is
-/// the repository-wide workflow invariant established by ORB-11147.
+/// `latest_runs` still records the newest run of each workflow for audit.
+/// Current failures are the newest unsuccessful completed run per
+/// `(workflow, head_branch)` that a *relevant* newer success has not
+/// suppressed. A queued or in-progress successor is listed in `in_flight`
+/// and, when it is the newest run of that identity, also becomes a mixed-state
+/// candidate so already-failed jobs can be observed. Landing-branch
+/// (integration/release) failures are only suppressed by a newer completed
+/// non-unsuccessful run of the same workflow on the same ref. Non-landing
+/// failures may also be suppressed by a landing-branch success of that
+/// workflow, so an abandoned Dependabot run does not revive after the
+/// integration head has gone green.
 fn partition_runs(
     refs: &[ScannedRef],
     runs: &[Value],
@@ -438,7 +470,9 @@ fn partition_runs(
     current: &mut Vec<Value>,
     stale: &mut Vec<Value>,
     in_flight: &mut Vec<Value>,
+    mixed_candidates: &mut Vec<Value>,
 ) {
+    let landing_branches = landing_branch_names(refs);
     let mut workflows = std::collections::BTreeMap::<String, Vec<&Value>>::new();
     for run in runs {
         let workflow = run
@@ -456,50 +490,144 @@ fn partition_runs(
         };
         latest_runs.push(run_summary(ref_for_run(refs, latest), latest));
 
-        for older in workflow_runs.iter().skip(1).copied() {
-            let completed = older.get("status").and_then(Value::as_str) == Some("completed");
-            let conclusion = older.get("conclusion").and_then(Value::as_str);
-            if completed && unsuccessful_conclusion(conclusion) {
-                let mut entry = run_summary(ref_for_run(refs, older), older);
-                entry["reason"] = json!("superseded_by_newer_workflow_run");
-                entry["evidence"] = json!(format!(
-                    "newer repository-wide run {} at {} is {} with conclusion {}",
-                    latest
-                        .get("run_id")
-                        .and_then(Value::as_u64)
-                        .map_or_else(|| "unknown".to_string(), |id| id.to_string()),
-                    latest
-                        .get("created_at")
-                        .and_then(Value::as_str)
-                        .unwrap_or("an unknown time"),
-                    latest
-                        .get("status")
-                        .and_then(Value::as_str)
-                        .unwrap_or("in an unknown state"),
-                    latest
-                        .get("conclusion")
-                        .and_then(Value::as_str)
-                        .unwrap_or("not yet completed"),
-                ));
-                entry["superseded_by"] = json!({
-                    "run_id": latest.get("run_id"),
-                    "url": latest.get("url"),
-                    "created_at": latest.get("created_at"),
-                    "status": latest.get("status"),
-                    "conclusion": latest.get("conclusion"),
-                });
-                stale.push(entry);
-            }
+        let landing_success = workflow_runs.iter().copied().find(|run| {
+            run_is_completed(run)
+                && !run_is_unsuccessful(run)
+                && landing_branches.contains(run_branch(run))
+        });
+
+        let mut by_ref = std::collections::BTreeMap::<String, Vec<&Value>>::new();
+        for run in workflow_runs.iter().copied() {
+            by_ref
+                .entry(run_branch(run).to_string())
+                .or_default()
+                .push(run);
         }
 
-        let completed = latest.get("status").and_then(Value::as_str) == Some("completed");
-        let summary = run_summary(ref_for_run(refs, latest), latest);
-        if !completed {
-            in_flight.push(summary);
-        } else if unsuccessful_conclusion(latest.get("conclusion").and_then(Value::as_str)) {
-            current.push(summary);
+        for ref_runs in by_ref.values_mut() {
+            ref_runs.sort_by_key(|run| std::cmp::Reverse(run_order(run)));
+            let same_ref_success = ref_runs
+                .iter()
+                .copied()
+                .find(|run| run_is_completed(run) && !run_is_unsuccessful(run));
+            let landing = ref_runs
+                .first()
+                .copied()
+                .is_some_and(|run| landing_branches.contains(run_branch(run)));
+            let suppressor = same_ref_success.or(if landing { None } else { landing_success });
+
+            let mut seen_current = false;
+            let mut seen_in_flight = false;
+            for run in ref_runs.iter().copied() {
+                if !run_is_completed(run) {
+                    in_flight.push(run_summary(ref_for_run(refs, run), run));
+                    if !seen_in_flight
+                        && suppressor.is_none_or(|success| run_order(run) > run_order(success))
+                    {
+                        mixed_candidates.push(run_summary(ref_for_run(refs, run), run));
+                    }
+                    seen_in_flight = true;
+                    continue;
+                }
+                if !run_is_unsuccessful(run) {
+                    continue;
+                }
+                if let Some(success) =
+                    suppressor.filter(|success| run_order(success) > run_order(run))
+                {
+                    stale.push(stale_entry(
+                        refs,
+                        run,
+                        success,
+                        "superseded_by_newer_workflow_run",
+                    ));
+                    continue;
+                }
+                if seen_current {
+                    if let Some(newer) = ref_runs.iter().copied().find(|candidate| {
+                        run_is_completed(candidate)
+                            && run_is_unsuccessful(candidate)
+                            && run_order(candidate) > run_order(run)
+                    }) {
+                        stale.push(stale_entry(
+                            refs,
+                            run,
+                            newer,
+                            "superseded_by_newer_workflow_run",
+                        ));
+                    }
+                    continue;
+                }
+                current.push(run_summary(ref_for_run(refs, run), run));
+                seen_current = true;
+            }
         }
     }
+}
+
+fn landing_branch_names(refs: &[ScannedRef]) -> std::collections::BTreeSet<&str> {
+    refs.iter()
+        .filter(|scanned| matches!(scanned.kind, RefKind::Integration | RefKind::Release))
+        .map(|scanned| scanned.branch.as_str())
+        .collect()
+}
+
+fn run_branch(run: &Value) -> &str {
+    run.get("head_branch").and_then(Value::as_str).unwrap_or("")
+}
+
+fn run_is_completed(run: &Value) -> bool {
+    run.get("status").and_then(Value::as_str) == Some("completed")
+}
+
+fn run_is_unsuccessful(run: &Value) -> bool {
+    unsuccessful_conclusion(run.get("conclusion").and_then(Value::as_str))
+}
+
+fn has_failed_jobs(failure: &Value) -> bool {
+    failure
+        .get("failed_jobs")
+        .and_then(Value::as_array)
+        .is_some_and(|jobs| !jobs.is_empty())
+}
+
+fn is_actionable_current_failure(failure: &Value) -> bool {
+    if run_is_completed(failure) {
+        return run_is_unsuccessful(failure);
+    }
+    has_failed_jobs(failure) && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+}
+
+fn stale_entry(refs: &[ScannedRef], older: &Value, newer: &Value, reason: &str) -> Value {
+    let mut entry = run_summary(ref_for_run(refs, older), older);
+    entry["reason"] = json!(reason);
+    entry["evidence"] = json!(format!(
+        "newer relevant run {} at {} is {} with conclusion {}",
+        newer
+            .get("run_id")
+            .and_then(Value::as_u64)
+            .map_or_else(|| "unknown".to_string(), |id| id.to_string()),
+        newer
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or("an unknown time"),
+        newer
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("in an unknown state"),
+        newer
+            .get("conclusion")
+            .and_then(Value::as_str)
+            .unwrap_or("not yet completed"),
+    ));
+    entry["superseded_by"] = json!({
+        "run_id": newer.get("run_id"),
+        "url": newer.get("url"),
+        "created_at": newer.get("created_at"),
+        "status": newer.get("status"),
+        "conclusion": newer.get("conclusion"),
+    });
+    entry
 }
 
 /// Sortable position of a run: creation time first, run id as the tiebreak.
@@ -586,7 +714,8 @@ fn investigate<Q: CiQueries + ?Sized>(
     match queries.run_view(&run_id) {
         Ok(view) => {
             let failed_jobs = view.get("failed_jobs").cloned().unwrap_or(json!([]));
-            if failed_jobs.as_array().is_none_or(Vec::is_empty) {
+            let empty = failed_jobs.as_array().is_none_or(Vec::is_empty);
+            if empty && run_is_completed(failure) {
                 push_retryable_error(
                     retryable_errors,
                     "registration",
@@ -596,6 +725,12 @@ fn investigate<Q: CiQueries + ?Sized>(
                 );
             }
             failure["failed_jobs"] = failed_jobs;
+            // A pending in-flight check is not a repair task. Do not fetch
+            // logs or consume checkout budget until a job has actually failed.
+            if empty && !run_is_completed(failure) {
+                failure["investigated"] = json!(true);
+                return;
+            }
         }
         Err(error) => {
             push_retryable_error(
@@ -605,6 +740,10 @@ fn investigate<Q: CiQueries + ?Sized>(
                 failure.get("run_id"),
                 &error.to_string(),
             );
+            if !run_is_completed(failure) {
+                failure["investigated"] = json!(false);
+                return;
+            }
         }
     }
 

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1,7 +1,25 @@
 use serde_json::{Value, json};
 
 use super::super::collect::collect;
-use super::support::{FakeQueries, run, run_on_branch};
+use super::support::{FakeQueries, failed_job, run, run_on_branch};
+
+fn current_ids(evidence: &Value) -> Vec<u64> {
+    evidence["current_failures"]
+        .as_array()
+        .expect("current failures")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect()
+}
+
+fn in_flight_ids(evidence: &Value) -> Vec<u64> {
+    evidence["in_flight"]
+        .as_array()
+        .expect("in flight")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect()
+}
 
 const HEAD: &str = "1111111111111111111111111111111111111111";
 const OLD: &str = "2222222222222222222222222222222222222222";
@@ -275,11 +293,11 @@ fn latest_non_failing_run_supersedes_older_failures_on_the_same_head() {
         .iter()
         .filter_map(|entry| entry["superseded_by"]["run_id"].as_u64())
         .collect();
-    assert_eq!(superseding_ids, [30, 40]);
+    assert_eq!(superseding_ids, [25, 40]);
 }
 
 #[test]
-fn newer_repository_wide_success_suppresses_an_older_integration_failure() {
+fn unrelated_pull_request_success_does_not_suppress_an_integration_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -290,8 +308,8 @@ fn newer_repository_wide_success_suppresses_an_older_integration_failure() {
             "reported_head_sha": OLD,
         }))
         .with_runs(vec![vec![
-            // The pull-request run of `ci` is the latest repository-wide run
-            // of this workflow, so it supersedes every older failure.
+            // Newest repository-wide `ci` run is an unrelated pull request.
+            // That cannot erase the landing-branch failure on `topic`.
             run_on_branch(
                 40,
                 "ci",
@@ -302,15 +320,6 @@ fn newer_repository_wide_success_suppresses_an_older_integration_failure() {
                 "2026-08-30T04:00:00Z",
             ),
             run_on_branch(
-                30,
-                "ci",
-                "main",
-                OLD,
-                "completed",
-                Some("success"),
-                "2026-08-30T03:00:00Z",
-            ),
-            run_on_branch(
                 20,
                 "ci",
                 "topic",
@@ -319,28 +328,31 @@ fn newer_repository_wide_success_suppresses_an_older_integration_failure() {
                 Some("failure"),
                 "2026-08-30T02:00:00Z",
             ),
-        ]]);
+        ]])
+        .with_run_view("20", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log("20", false, "ci\tbuild\tassertion failed\n")
+        .with_log(
+            "20",
+            true,
+            "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n",
+        );
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    assert_eq!(evidence["current_failures"], json!([]));
-    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(current_ids(&evidence), [20]);
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
     assert_eq!(evidence["latest_runs"][0]["run_id"], json!(40));
-    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(20));
-    assert_eq!(
-        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
-        json!(40)
-    );
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
 }
 
 #[test]
-fn latest_repository_wide_failure_is_current_even_when_its_ref_is_not_scanned() {
+fn distinct_workflow_refs_keep_independent_failures() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
         .with_runs(vec![vec![
-            // Eligibility is workflow-wide, not branch-by-branch. Ref
-            // metadata can be absent without reviving the older run.
+            // A newer unsuccessful run on an unscanned ref must not hide the
+            // landing-branch failure. Distinct refs stay independently current.
             run_on_branch(
                 50,
                 "ci",
@@ -363,24 +375,22 @@ fn latest_repository_wide_failure_is_current_even_when_its_ref_is_not_scanned() 
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    let current_ids: Vec<u64> = evidence["current_failures"]
-        .as_array()
-        .expect("current failures")
-        .iter()
-        .filter_map(|run| run["run_id"].as_u64())
-        .collect();
     assert_eq!(
-        current_ids,
-        [50],
-        "exactly the repository-wide latest workflow run must be current: {evidence}"
+        current_ids(&evidence),
+        [20, 50],
+        "landing and unrelated-ref failures stay independently current: {evidence}"
     );
-    assert_eq!(evidence["current_failures"][0]["ref_kind"], json!("other"));
-    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(20));
+    assert_eq!(
+        evidence["current_failures"][0]["ref_kind"],
+        json!("integration")
+    );
+    assert_eq!(evidence["current_failures"][1]["ref_kind"], json!("other"));
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
     assert_eq!(evidence["in_flight"], json!([]));
 }
 
 #[test]
-fn latest_in_flight_run_does_not_resurrect_an_older_failure() {
+fn queued_or_running_successor_does_not_suppress_an_observed_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -403,29 +413,32 @@ fn latest_in_flight_run_does_not_resurrect_an_older_failure() {
                 Some("failure"),
                 "2026-08-30T04:30:00Z",
             ),
-        ]]);
+        ]])
+        .with_run_view("30", json!({"failed_jobs": [failed_job(7, "build")]}))
+        .with_log("30", false, "ci\tbuild\tassertion failed\n")
+        .with_log(
+            "30",
+            true,
+            "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n",
+        )
+        .with_run_view("45", json!({"failed_jobs": [failed_job(8, "lint")]}))
+        .with_log("45", false, "lint\tlint\tlint failed\n")
+        .with_log(
+            "45",
+            true,
+            "lint\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n",
+        );
 
-    let evidence = collect(&queries, &input()).expect("collect");
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "topic", "max_checkout_log_reads": 2}),
+    )
+    .expect("collect");
 
-    assert_eq!(evidence["current_failures"], json!([]));
-    let in_flight_ids: Vec<u64> = evidence["in_flight"]
-        .as_array()
-        .expect("in flight")
-        .iter()
-        .filter_map(|run| run["run_id"].as_u64())
-        .collect();
-    assert_eq!(in_flight_ids, [40, 50]);
-    let stale_ids: Vec<u64> = evidence["stale_or_superseded"]
-        .as_array()
-        .expect("stale")
-        .iter()
-        .filter_map(|run| run["run_id"].as_u64())
-        .collect();
-    assert_eq!(stale_ids, [30, 45]);
-    assert_eq!(
-        evidence["stale_or_superseded"][0]["superseded_by"]["status"],
-        json!("in_progress")
-    );
+    assert_eq!(current_ids(&evidence), [45, 30]);
+    assert_eq!(in_flight_ids(&evidence), [40, 50]);
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
 }
 
 #[test]
@@ -983,4 +996,201 @@ fn live_failure_fixture_is_latest_current_and_evidence_complete() {
         json!([33_358_160_088_u64])
     );
     assert_eq!(evidence["summary"]["retryable_errors"], json!(0));
+}
+
+/// ORB-11278: a failed job inside an in-progress workflow is current once
+/// evidence is complete. A still-running sibling check is not a repair task.
+#[test]
+fn failed_job_with_running_siblings_is_current_and_pending_sibling_is_not() {
+    const EVENT_SHA: &str = "8b0a760bae17b6f0aeee9eab47840684697fa812";
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", EVENT_SHA)
+        .with_head("main", OLD)
+        .with_runs(vec![vec![run_on_branch(
+            33_979_680_684,
+            "CI",
+            "agent-main",
+            EVENT_SHA,
+            "in_progress",
+            None,
+            "2026-09-05T16:00:00Z",
+        )]])
+        .with_run_view(
+            "33979680684",
+            json!({"failed_jobs": [{
+                "job_id": 11,
+                "name": "Linux tests",
+                "conclusion": "failure",
+                "url": "https://github.com/danieljhkim/orbit/actions/runs/33979680684/job/11",
+                "failed_steps": [{"name": "Run tests", "conclusion": "failure"}],
+            }]}),
+        )
+        .with_log(
+            "33979680684",
+            false,
+            "CI\tLinux tests\tRun tests assertion failed in collect.rs\n",
+        )
+        .with_log(
+            "33979680684",
+            true,
+            "CI\tCheckout\tHEAD is now at 8b0a760bae17b6f0aeee9eab47840684697fa812\n",
+        );
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(current_ids(&evidence), [33_979_680_684_u64]);
+    assert_eq!(failure["status"], json!("in_progress"));
+    assert_eq!(failure["failed_jobs"].as_array().map(Vec::len), Some(1));
+    assert_eq!(failure["failed_jobs"][0]["name"], json!("Linux tests"));
+    assert_eq!(failure["investigated"], json!(true));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(in_flight_ids(&evidence), [33_979_680_684_u64]);
+    assert_eq!(evidence["retryable_errors"], json!([]));
+}
+
+#[test]
+fn pending_in_flight_check_alone_is_not_a_repair_task() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            40,
+            "ci",
+            HEAD,
+            "in_progress",
+            None,
+            "2026-08-30T04:00:00Z",
+        )]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(in_flight_ids(&evidence), [40]);
+    assert_eq!(evidence["retryable_errors"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+}
+
+#[test]
+fn incomplete_mixed_state_evidence_stays_retryable_until_logs_are_available() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![run(
+            40,
+            "ci",
+            HEAD,
+            "in_progress",
+            None,
+            "2026-08-30T04:00:00Z",
+        )]])
+        .with_run_view("40", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log_error("40", false, "logs are not available until the job finishes");
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(
+        current_ids(&evidence),
+        Vec::<u64>::new(),
+        "incomplete mixed-state evidence must not become a repair task: {evidence}"
+    );
+    assert_eq!(in_flight_ids(&evidence), [40]);
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+    let errors = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
+    assert!(
+        errors.iter().any(|error| {
+            error["operation"] == json!("run_logs")
+                && error["retryable"] == json!(true)
+                && error["run_id"] == json!(40)
+        }),
+        "missing in-flight logs must stay retryable: {errors:?}"
+    );
+}
+
+#[test]
+fn unrelated_pull_request_in_flight_does_not_suppress_an_integration_failure() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_pull_request(json!({
+            "number": 12,
+            "url": "https://github.com/acme/orbit/pull/12",
+            "head_branch": "feature-x",
+            "reported_head_sha": OLD,
+        }))
+        .with_runs(vec![vec![
+            run_on_branch(
+                40,
+                "ci",
+                "feature-x",
+                OLD,
+                "in_progress",
+                None,
+                "2026-08-30T04:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T02:00:00Z",
+            ),
+        ]])
+        .with_run_view("20", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log("20", false, "ci\tbuild\tassertion failed\n")
+        .with_log(
+            "20",
+            true,
+            "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n",
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(current_ids(&evidence), [20]);
+    assert_eq!(in_flight_ids(&evidence), [40]);
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+}
+
+#[test]
+fn same_ref_rerun_success_suppresses_the_resolved_failure() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![
+            run(
+                40,
+                "ci",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-08-30T04:00:00Z",
+            ),
+            run(
+                30,
+                "ci",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T03:00:00Z",
+            ),
+        ]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["current_failures"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(30));
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
+        json!(40)
+    );
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
@@ -207,3 +207,13 @@ pub(super) fn run_on_branch(
     value["head_branch"] = json!(branch);
     value
 }
+
+pub(super) fn failed_job(job_id: u64, name: &str) -> Value {
+    json!({
+        "job_id": job_id,
+        "name": name,
+        "conclusion": "failure",
+        "url": format!("https://github.com/acme/orbit/actions/runs/1/job/{job_id}"),
+        "failed_steps": [{"name": name, "conclusion": "failure"}],
+    })
+}


### PR DESCRIPTION
## Task

[ORB-11278](https://orbit-cli.com/tasks/ORB-11278) — Detect actionable CI failures while newer workflows or sibling checks are still running

### Description

## Problem
Daniel reports ci-failure-sweep-orbit misses failing checks especially during ongoing CI. ORB-11158 explicitly implemented repository-wide latest-run suppression, including queued/in-progress runs suppressing older failures. ORB-11248 fixed display caps, not this selection behavior. Reassess current selection/investigation and fix this reliability gap without reviving proven resolved failures.

## Scope
Observe failed jobs/checks within in-flight workflows when evidence is available; queued/running successors are not evidence that an observed failure is resolved. Scope freshness to relevant workflow/ref/check identity so unrelated PR activity does not erase landing-branch failures. Keep failure evidence honest when logs are unavailable until completion, retry later, and keep failures independently investigable. Preserve bounded collection, exact tested SHA provenance, existing-task dedupe, host-owned GitHub access and actionable retry diagnostics. A pending check alone must not become a repair task. Record live reproduction or deterministic fixture if the active window has ended.

## Current evidence
Linux ws_orbit; ORB-11158 done explicitly documents in-flight suppression; ORB-11248 done only separates display truncation from incomplete identity scans. On 2026-09-05 latest CI run 33979680684 at 8b0a760bae17b6f0aeee9eab47840684697fa812 is failed; macOS run 33979680672 is independently covered by ORB-11277. Do not duplicate those underlying test repairs.

Crew: medium-high policy maps to Grok.

## Session authorization and delivery
Daniel explicitly authorizes implementation, promotion, and automatic completion/merge for this session. Use the managed dedicated task worktree and target agent-main. Run make ci-fast, make ci-lint, and focused deterministic behavior tests as appropriate. Do not modify CHANGELOG.md. Judge current code and tests; historical ADRs are not authority.

### Acceptance Criteria

- Deterministic mixed-state fixtures cover failed job plus running siblings, queued/running successor, unrelated PR run, rerun success, and distinct workflow/ref failures.
- An actionable failure produces one evidence-backed task or names its existing owner; pending/incomplete evidence stays explicitly retryable and is discovered once complete.
- A genuinely newer successful relevant check suppresses resolved failures; repeated sweeps do not duplicate tasks.
- Current docs/contracts describe the revised ongoing-check semantics and focused tests plus required gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced repository-wide latest-run-wins selection with relevant-identity freshness (workflow, ref, observed failed jobs).
- Queued/in-progress successors no longer suppress an observed failure. Failed jobs inside an in-flight workflow become current_failures once evidence is complete; a pending check alone stays in_flight and is never filed.
- Unrelated pull-request success or in-flight activity cannot erase a landing-branch failure. A genuinely newer same-ref success, or a landing-branch success for non-landing noise (Dependabot/abandoned PRs), still suppresses resolved failures.
- Incomplete mixed-state logs remain retryable and are not filed until a later sweep can finish them. Existing-task dedupe is unchanged; a mixed-state filing fixture files once and names the owner on repeat.
- Updated collect_ci_evidence, file_ci_failure_tasks, and ci_failure_sweep_pipeline contracts to describe the ongoing-check semantics.
- Added mixed-state fixtures for failed job plus running siblings (run 33979680684), queued/running successor, unrelated PR run, rerun success, distinct workflow/ref failures, pending-only in-flight, and incomplete mixed-state logs.

Strategic decisions:
- latest_runs remains the newest run per workflow for audit only; current_failures is now identity-scoped.
- Non-landing failures remain suppressible by landing-branch success so ORB-11146 Dependabot noise does not revive.

Unlisted files added to context_files:
- file:crates/orbit-engine/src/executor/automation/ci/tests/support.rs — mixed-state job fixture helper.
- file:crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs — mixed-state filing/dedupe fixture required by the actionable-task criterion.

Validation:
- cargo test -p orbit-engine executor::automation::ci::tests --no-fail-fast — passed (27 tests).
- cargo test -p orbit-core ci_failure --no-fail-fast — passed (25 tests, including mixed-state filing/dedupe).
- make ci-fast — passed.
- make ci-lint — passed.
- git diff --check — passed. Remaining worktree entries are the seven intended source/test/contract files. Removed the 6.0 GiB Cargo target directory created by this run.

Assessment: Host-owned collection still never grants GitHub access to agent sandboxes. Pending checks cannot become repair tasks, and a newer successful relevant check still suppresses resolved failures without duplicate filing.

Friction checkpoint: considered; no qualifying recurring or over-10-minute workflow friction was found.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11278-6a9c5209`
- Behind base: 0
- Ahead of base: 1