### PR TITLE
Honor crew effort for supported Claude and Grok executors

### DIFF
--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -63,17 +63,16 @@ impl AgentConfig {
         self
     }
 
-    /// Attach the effort resolved from a crew after verifying the selected
-    /// provider owns the corresponding CLI contract.
+    /// Attach effort resolved from a crew after verifying the provider-model
+    /// CLI contract that will receive it.
     pub fn with_reasoning_effort(
         mut self,
         reasoning_effort: Option<ReasoningEffort>,
     ) -> Result<Self, OrbitError> {
-        if reasoning_effort.is_some() && self.provider_key != "codex" {
-            return Err(OrbitError::InvalidInput(format!(
-                "provider '{}' does not support configured reasoning effort",
-                self.provider_key
-            )));
+        if let Some(effort) = reasoning_effort {
+            effort
+                .validate_for_provider_model(self.provider_key, self.model.as_deref())
+                .map_err(OrbitError::InvalidInput)?;
         }
         self.reasoning_effort = reasoning_effort;
         Ok(self)

--- a/crates/orbit-agent/src/providers/claude/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/claude_cli.rs
@@ -1,5 +1,6 @@
 use crate::providers::common::render_prompt_with_embedded_envelope;
 use crate::types::response_envelope_json_schema_arg;
+use orbit_types::identity::ReasoningEffort;
 
 fn claude_cli_model_arg(model: &str) -> String {
     let trimmed = model.trim();
@@ -17,11 +18,15 @@ fn claude_cli_model_arg(model: &str) -> String {
 
 pub(crate) struct ClaudeCliTransport {
     model: Option<String>,
+    reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl ClaudeCliTransport {
-    pub(crate) fn new(model: Option<String>) -> Self {
-        Self { model }
+    pub(crate) fn new(model: Option<String>, reasoning_effort: Option<ReasoningEffort>) -> Self {
+        Self {
+            model,
+            reasoning_effort,
+        }
     }
 
     // Static Claude CLI flags live in the executor definition; this transport
@@ -50,6 +55,10 @@ impl ClaudeCliTransport {
         if let Some(model) = &self.model {
             args.push("--model".to_string());
             args.push(claude_cli_model_arg(model));
+        }
+        if let Some(effort) = self.reasoning_effort {
+            args.push("--effort".to_string());
+            args.push(effort.to_string());
         }
         args
     }

--- a/crates/orbit-agent/src/providers/claude/claude_runtime.rs
+++ b/crates/orbit-agent/src/providers/claude/claude_runtime.rs
@@ -24,12 +24,13 @@ impl ClaudeRuntime {
     pub(crate) fn new(
         command: String,
         model: Option<String>,
+        reasoning_effort: Option<orbit_types::identity::ReasoningEffort>,
         runtime_key: &'static str,
         required_env_vars: &'static [&'static str],
     ) -> Self {
         Self {
             command,
-            cli: ClaudeCliTransport::new(model),
+            cli: ClaudeCliTransport::new(model, reasoning_effort),
             runtime_key,
             required_env_vars,
         }
@@ -57,6 +58,7 @@ impl AgentRuntimeFactory for ClaudeFactory {
             ProviderOptions::Claude => Ok(Box::new(ClaudeRuntime::new(
                 cfg.command.clone(),
                 cfg.model.clone(),
+                cfg.reasoning_effort,
                 self.key(),
                 self.required_env_vars(),
             ))),

--- a/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
+++ b/crates/orbit-agent/src/providers/claude/tests/claude_cli.rs
@@ -35,7 +35,7 @@ fn static_args(executor_yaml: &str) -> Vec<String> {
 /// the envelope frame has to reach the CLI as a machine constraint.
 #[test]
 fn transport_constrains_every_invocation_with_the_protocol_schema() {
-    let args = ClaudeCliTransport::new(Some("sonnet".to_string())).args(false);
+    let args = ClaudeCliTransport::new(Some("sonnet".to_string()), None).args(false);
     let schema = schema_arg(&args);
 
     assert_eq!(schema["properties"]["schemaVersion"]["const"], 1);
@@ -62,7 +62,7 @@ fn transport_constrains_every_invocation_with_the_protocol_schema() {
 /// API — the most expensive place to learn about a schema mistake.
 #[test]
 fn protocol_schema_avoids_the_conditional_subschema_keywords_the_provider_rejects() {
-    let args = ClaudeCliTransport::new(None).args(false);
+    let args = ClaudeCliTransport::new(None, None).args(false);
     let schema = schema_arg(&args);
     let object = schema.as_object().expect("schema is an object");
 
@@ -79,7 +79,7 @@ fn protocol_schema_avoids_the_conditional_subschema_keywords_the_provider_reject
 /// reader from "fixing" the omission and reintroducing the 400.
 #[test]
 fn protocol_schema_leaves_the_status_error_correlation_to_the_rust_parser() {
-    let args = ClaudeCliTransport::new(None).args(false);
+    let args = ClaudeCliTransport::new(None, None).args(false);
     let schema = schema_arg(&args);
 
     assert_eq!(
@@ -123,7 +123,7 @@ fn neither_packaged_executor_copy_declares_the_flag_the_transport_owns() {
 
 #[test]
 fn per_request_toggles_still_compose_with_the_schema_flag() {
-    let args = ClaudeCliTransport::new(Some("opus-5".to_string())).args(true);
+    let args = ClaudeCliTransport::new(Some("opus-5".to_string()), None).args(true);
 
     assert!(args.iter().any(|arg| arg == "--json-schema"));
     assert!(args.iter().any(|arg| arg == "--verbose"));
@@ -146,11 +146,27 @@ fn short_model_forms_expand_to_claude_cli_ids_for_every_tier() {
         ("fable", "fable"),
         ("claude-fable-5-1", "claude-fable-5-1"),
     ] {
-        let args = ClaudeCliTransport::new(Some(short.to_string())).args(false);
+        let args = ClaudeCliTransport::new(Some(short.to_string()), None).args(false);
         let model_index = args
             .iter()
             .position(|arg| arg == "--model")
             .expect("model flag");
         assert_eq!(args[model_index + 1], expanded, "{short}");
+    }
+}
+
+#[test]
+fn effort_reaches_claude_cli_for_every_supported_crew_value() {
+    use orbit_types::identity::ReasoningEffort;
+
+    for (effort, expected) in [
+        (ReasoningEffort::Low, "low"),
+        (ReasoningEffort::Medium, "medium"),
+        (ReasoningEffort::High, "high"),
+        (ReasoningEffort::Xhigh, "xhigh"),
+        (ReasoningEffort::Max, "max"),
+    ] {
+        let args = ClaudeCliTransport::new(Some("opus".to_string()), Some(effort)).args(false);
+        assert_eq!(args[args.len() - 2..], ["--effort", expected], "{expected}");
     }
 }

--- a/crates/orbit-agent/src/providers/grok/grok_cli.rs
+++ b/crates/orbit-agent/src/providers/grok/grok_cli.rs
@@ -1,12 +1,17 @@
 use crate::providers::common::render_prompt_with_embedded_envelope;
+use orbit_types::identity::ReasoningEffort;
 
 pub(crate) struct GrokCliTransport {
     model: Option<String>,
+    reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl GrokCliTransport {
-    pub(crate) fn new(model: Option<String>) -> Self {
-        Self { model }
+    pub(crate) fn new(model: Option<String>, reasoning_effort: Option<ReasoningEffort>) -> Self {
+        Self {
+            model,
+            reasoning_effort,
+        }
     }
 
     // Static Grok CLI flags live in the executor definition; this transport
@@ -17,6 +22,10 @@ impl GrokCliTransport {
         if let Some(model) = &self.model {
             args.push("--model".to_string());
             args.push(model.clone());
+        }
+        if let Some(effort) = self.reasoning_effort {
+            args.push("--reasoning-effort".to_string());
+            args.push(effort.to_string());
         }
 
         args

--- a/crates/orbit-agent/src/providers/grok/grok_runtime.rs
+++ b/crates/orbit-agent/src/providers/grok/grok_runtime.rs
@@ -24,12 +24,13 @@ impl GrokRuntime {
     pub(crate) fn new(
         command: String,
         model: Option<String>,
+        reasoning_effort: Option<orbit_types::identity::ReasoningEffort>,
         runtime_key: &'static str,
         required_env_vars: &'static [&'static str],
     ) -> Self {
         Self {
             command,
-            cli: GrokCliTransport::new(model),
+            cli: GrokCliTransport::new(model, reasoning_effort),
             runtime_key,
             required_env_vars,
         }
@@ -57,6 +58,7 @@ impl AgentRuntimeFactory for GrokFactory {
             ProviderOptions::Grok => Ok(Box::new(GrokRuntime::new(
                 cfg.command.clone(),
                 cfg.model.clone(),
+                cfg.reasoning_effort,
                 self.key(),
                 self.required_env_vars(),
             ))),

--- a/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/grok_cli.rs
@@ -4,11 +4,23 @@ mod args {
     #![allow(missing_docs)]
 
     use super::super::super::grok_cli::*;
+    use orbit_types::identity::ReasoningEffort;
 
     #[test]
     fn grok_args_pass_model_with_long_flag() {
-        let transport = GrokCliTransport::new(Some("grok-4.6".to_string()));
+        let transport = GrokCliTransport::new(Some("grok-4.6".to_string()), None);
 
         assert_eq!(transport.args(), vec!["--model", "grok-4.6"]);
+    }
+
+    #[test]
+    fn grok_args_pass_supported_effort_with_reasoning_effort_flag() {
+        let transport =
+            GrokCliTransport::new(Some("grok-4.6".to_string()), Some(ReasoningEffort::Xhigh));
+
+        assert_eq!(
+            transport.args(),
+            vec!["--model", "grok-4.6", "--reasoning-effort", "xhigh"]
+        );
     }
 }

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -394,20 +394,21 @@ fn crew_assignment_from_raw(crew: &str, raw: &RawCrewEntry) -> Result<CrewAssign
     Ok(CrewAssignment {
         model: required_crew_field(crew, "model", raw.model.as_deref())?,
         provider: required_crew_field(crew, "provider", raw.provider.as_deref())?,
-        effort: crew_effort_from_raw(crew, raw.effort.as_deref(), raw.provider.as_deref())?,
+        effort: crew_effort_from_raw(
+            crew,
+            raw.effort.as_deref(),
+            raw.provider.as_deref(),
+            raw.model.as_deref(),
+        )?,
     })
 }
 
-/// Validate the one provider-specific crew setting at config admission.
-///
-/// Codex maps these values directly to its documented
-/// `model_reasoning_effort` config key. Other Orbit CLI providers do not share
-/// that argument contract, so accepting the key for them would silently
-/// downgrade a configured request.
+/// Validate the provider-model-specific crew setting at config admission.
 fn crew_effort_from_raw(
     crew: &str,
     raw_effort: Option<&str>,
     raw_provider: Option<&str>,
+    raw_model: Option<&str>,
 ) -> Result<Option<ReasoningEffort>, OrbitError> {
     let Some(raw_effort) = raw_effort else {
         return Ok(None);
@@ -418,15 +419,12 @@ fn crew_effort_from_raw(
     let provider = required_crew_field(crew, "provider", raw_provider)?;
     let provider = Provider::resolve_name(&provider).map_err(|_| {
         OrbitError::InvalidInput(format!(
-            "[crews.{crew}].effort requires provider = \"codex\"; provider '{provider}' is unsupported"
+            "[crews.{crew}].effort requires a supported effort provider; provider '{provider}' is unsupported"
         ))
     })?;
-    if provider.provider != Provider::Codex {
-        return Err(OrbitError::InvalidInput(format!(
-            "[crews.{crew}].effort is supported only for provider = \"codex\"; '{}' cannot receive effort '{effort}'",
-            provider.provider
-        )));
-    }
+    effort
+        .validate_for_provider_model(provider.provider.as_str(), raw_model)
+        .map_err(|error| OrbitError::InvalidInput(format!("[crews.{crew}].effort {error}")))?;
     Ok(Some(effort))
 }
 

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -291,14 +291,46 @@ fn crew_effort_fails_closed_for_invalid_values_and_unsupported_providers() {
     );
 
     let unsupported = load_config(
-        "[crews.sonnet]\nmodel = \"sonnet\"\nprovider = \"claude\"\neffort = \"high\"\n\n[workflow]\ndefault_crew = \"sonnet\"\n",
+        "[crews.gemini]\nmodel = \"gemini\"\nprovider = \"gemini\"\neffort = \"high\"\n\n[workflow]\ndefault_crew = \"gemini\"\n",
     )
     .expect_err("unsupported provider must not silently ignore effort");
     assert!(
         unsupported
             .to_string()
-            .contains("supported only for provider = \"codex\"")
+            .contains("does not support configured reasoning effort")
     );
+}
+
+#[test]
+fn claude_crew_effort_accepts_every_supported_value() {
+    for raw in ["low", "medium", "high", "xhigh", "max"] {
+        load_config(&format!(
+            "[crews.opus]\nmodel = \"opus\"\nprovider = \"claude\"\neffort = \"{raw}\"\n\n[workflow]\ndefault_crew = \"opus\"\n"
+        ))
+        .unwrap_or_else(|error| panic!("Claude effort {raw} should load: {error}"));
+    }
+}
+
+#[test]
+fn grok_crew_effort_enforces_the_verified_model_contract() {
+    for raw in ["low", "medium", "high", "xhigh"] {
+        load_config(&format!(
+            "[crews.grok]\nmodel = \"grok-4.6\"\nprovider = \"grok\"\neffort = \"{raw}\"\n\n[workflow]\ndefault_crew = \"grok\"\n"
+        ))
+        .unwrap_or_else(|error| panic!("Grok 4.6 effort {raw} should load: {error}"));
+    }
+
+    for (model, effort, expected) in [
+        ("grok-4.6", "max", "low, medium, high, xhigh"),
+        ("grok-4.5", "xhigh", "low, medium, high"),
+        ("grok-unknown", "high", "verified only"),
+    ] {
+        let error = load_config(&format!(
+            "[crews.grok]\nmodel = \"{model}\"\nprovider = \"grok\"\neffort = \"{effort}\"\n\n[workflow]\ndefault_crew = \"grok\"\n"
+        ))
+        .expect_err("unsupported Grok model-effort pair must fail config admission");
+        assert!(error.to_string().contains(expected), "{error}");
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -212,9 +212,9 @@ fn system_crew_marker_routes_to_the_configured_system_crew() {
         (
             "system",
             CrewConfig {
-                provider: Some(Provider::Codex),
+                provider: Some(Provider::Claude),
                 model: Some("system-model".to_string()),
-                reasoning_effort: Some(ReasoningEffort::Max),
+                reasoning_effort: Some(ReasoningEffort::Xhigh),
             },
         ),
     ])
@@ -225,9 +225,9 @@ fn system_crew_marker_routes_to_the_configured_system_crew() {
     let overridden = crew_overridden_spec(&target, &ctx, &json!({ "system_crew": true }))
         .expect("resolve injected system crew")
         .expect("configured host returns an override");
-    assert_eq!(overridden.provider, Provider::Codex);
+    assert_eq!(overridden.provider, Provider::Claude);
     assert_eq!(overridden.model.as_deref(), Some("system-model"));
-    assert_eq!(overridden.reasoning_effort, Some(ReasoningEffort::Max));
+    assert_eq!(overridden.reasoning_effort, Some(ReasoningEffort::Xhigh));
     assert_eq!(host.observed(), vec!["system"]);
 }
 

--- a/crates/orbit-types/src/identity/agent_pair.rs
+++ b/crates/orbit-types/src/identity/agent_pair.rs
@@ -42,12 +42,12 @@ impl AgentModelPair {
 pub struct CrewAssignment {
     pub model: String,
     pub provider: String,
-    /// Optional Codex reasoning effort selected for this crew.
+    /// Optional provider-specific reasoning effort selected for this crew.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
 }
 
-/// The reasoning effort values accepted by the Codex CLI.
+/// The shared crew effort vocabulary accepted by supported provider CLIs.
 ///
 /// This closed set is shared by config admission and CLI argument rendering so
 /// an unsupported value cannot make it past config loading and then be
@@ -64,6 +64,46 @@ pub enum ReasoningEffort {
 
 impl ReasoningEffort {
     pub const VALUES: &'static str = "low, medium, high, xhigh, max";
+
+    /// Validates the provider-model contract before an effort reaches argv.
+    ///
+    /// Claude and Codex expose the complete crew vocabulary. Grok's published
+    /// contract is model-specific, so unknown models fail closed instead of
+    /// accepting a setting the CLI might silently reinterpret.
+    pub fn validate_for_provider_model(
+        self,
+        provider: &str,
+        model: Option<&str>,
+    ) -> Result<(), String> {
+        match provider {
+            "claude" | "codex" => Ok(()),
+            "grok" => Self::validate_grok_model_effort(self, model),
+            other => Err(format!(
+                "provider '{other}' does not support configured reasoning effort"
+            )),
+        }
+    }
+
+    fn validate_grok_model_effort(self, model: Option<&str>) -> Result<(), String> {
+        let model = model.map(str::trim).filter(|model| !model.is_empty());
+        match (model, self) {
+            (Some("grok-4.6"), Self::Low | Self::Medium | Self::High | Self::Xhigh) => Ok(()),
+            (Some("grok-4.5"), Self::Low | Self::Medium | Self::High) => Ok(()),
+            (Some("grok-4.6"), effort) => Err(format!(
+                "Grok model 'grok-4.6' supports effort values low, medium, high, xhigh; '{effort}' is unsupported"
+            )),
+            (Some("grok-4.5"), effort) => Err(format!(
+                "Grok model 'grok-4.5' supports effort values low, medium, high; '{effort}' is unsupported"
+            )),
+            (Some(model), _) => Err(format!(
+                "Grok effort support is verified only for models 'grok-4.5' and 'grok-4.6'; model '{model}' is unsupported"
+            )),
+            (None, _) => Err(
+                "Grok effort requires an explicit model; supported models are 'grok-4.5' and 'grok-4.6'"
+                    .to_string(),
+            ),
+        }
+    }
 }
 
 impl fmt::Display for ReasoningEffort {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -67,7 +67,7 @@ A **crew** is one provider-model assignment. Activities do not carry a model-sel
 |---|---|---|
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-6-astra`, `gemini-3.8-flash`, `grok-4.6`) |
 | `provider` | Agent family | `claude`, `codex`, `gemini`, `grok`, `copilot`, `cursor` (the CLI-executable crew families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
-| `effort` | Optional Codex reasoning effort | `low`, `medium`, `high`, `xhigh`, or `max` (Codex crews only) |
+| `effort` | Optional provider reasoning effort | Claude/Codex: `low`, `medium`, `high`, `xhigh`, or `max`; Grok: verified per model below |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
@@ -84,16 +84,24 @@ tags = ["implementation", "review"]
 
 `effort` is omitted by default, which leaves the provider's existing model
 default unchanged. When set, Orbit validates it while loading `config.toml`
-and passes the selected Codex crew's value to the executor as
-`model_reasoning_effort`. Only Codex documents this exact argument contract;
-configuring `effort` on Claude, Gemini, Grok, Copilot, Cursor, or another
-provider fails clearly instead of being ignored or translated to a different
-setting. A selected activity crew (including `workflow.system_crew`) supplies
-its effort together with its provider and model, so it takes precedence over
-an activity's inline baseline in the same way as the rest of that assignment.
-For the standard Codex tiers, use the model-specific crew to choose capability
-first: Terra (`gpt-5.6-terra`) is the medium-low crew; `effort` adjusts the
-reasoning budget inside the chosen Codex model.
+and passes it through the provider's documented argv: Codex receives
+`model_reasoning_effort`, Claude receives `--effort`, and Grok receives
+`--reasoning-effort`. The installed Claude CLI (2.1.261, checked September
+2026) advertises all five values, so Orbit forwards `low`, `medium`, `high`,
+`xhigh`, and `max` exactly; [Claude's effort documentation](https://code.claude.com/docs/en/model-config)
+notes that availability can still depend on the selected model. Grok Build
+1.0.13 advertises `--reasoning-effort` (with `--effort` as an alias), and
+`grok models` currently lists `grok-4.6` and `grok-4.5`. Orbit accepts `low`,
+`medium`, `high`, and `xhigh` for `grok-4.6`, and `low`, `medium`, and `high`
+for `grok-4.5`, matching [xAI's reasoning contract](https://docs.x.ai/developers/model-capabilities/text/reasoning).
+It rejects `max`, unsupported Grok model/effort pairs, and effort on other
+providers clearly rather than silently downgrading or ignoring a request. A
+selected activity crew (including `workflow.system_crew`) supplies its effort
+together with its provider and model, so it takes precedence over an activity's
+inline baseline in the same way as the rest of that assignment. For the
+standard Codex tiers, use the model-specific crew to choose capability first:
+Terra (`gpt-5.6-terra`) is the medium-low crew; `effort` adjusts the reasoning
+budget inside the chosen Codex model.
 
 Example — the standard Grok crew:
 


### PR DESCRIPTION
## Task

[ORB-11286](https://orbit-cli.com/tasks/ORB-11286) — Honor crew effort for supported Claude and Grok executors

### Description

## Delivery gap
ORB-11279 / PR #1358 added the five-value crew effort type and Codex mapping, but rejects every non-Codex crew. docs/CONFIG.md says only Codex documents an effort argument. Live installed CLI help contradicts this:
- ~/.local/bin/claude resolves to ~/.local/share/claude/versions/2.1.261; --help advertises --effort <level> with exactly low, medium, high, xhigh, max.
- ~/.local/bin/grok resolves to ~/.grok/downloads/grok-1.0.13-linux-x86_64; --help advertises --reasoning-effort <EFFORT> (alias --effort). Verify accepted values/model capabilities from the installed CLI or official provider contract before mapping.

Daniel requested effort for crew specifications and explicitly uses Claude Opus and Grok in this session; rejecting their supported effort settings leaves the request incomplete.

## Scope
Extend the existing authoritative effort validation/translation path to supported Claude and Grok configurations and real executor argv. All five Claude values are explicitly advertised. Establish Grok supported values honestly; pass supported exact values, reject unsupported combinations with clear errors, never silently downgrade or ignore. Preserve omitted defaults, selected task/system crew precedence, and Codex coverage. Inspect inline baseline/provider changes so effort cannot leak across providers. Correct CONFIG documentation; no parallel effort framework or guessed flags.

Daniel authorizes repair, pilot/promotion and --complete delivery in this session. Medium-low uses Terra. Dedicated managed worktree and agent-main; focused argv/config/precedence tests plus make ci-fast and make ci-lint.

### Acceptance Criteria

- Configured Claude crew effort reaches --effort with each of the five supported values, including system activity dispatch.
- Verified supported Grok effort values reach --reasoning-effort; unsupported values/model combinations fail clearly and documentation cites the observed/official contract.
- Omitted effort and Codex mapping remain unchanged; mismatched inline/provider effort cannot bypass validation.
- Focused deterministic tests and required gates pass; docs no longer falsely claim only Codex exposes effort.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extended the shared crew-effort contract to allow Claude and verified Grok provider/model pairs while retaining Codex behavior and omitted-effort defaults.
- Claude now forwards all five crew values through --effort; Grok forwards verified values through --reasoning-effort. Grok 4.6 allows low/medium/high/xhigh, Grok 4.5 allows low/medium/high; unknown models and invalid pairs fail closed.
- Preserved crew precedence through the system-crew dispatch test, and added focused config and argv coverage.
- Corrected CONFIG.md with the observed installed CLI contracts and official Claude/xAI references.

Strategic decisions:
- The installed CLIs were checked directly: Claude 2.1.261 advertises five --effort values; Grok Build 1.0.13 advertises --reasoning-effort/--effort and lists grok-4.6 plus grok-4.5. xAI's official contract supplies the model-specific Grok value sets, so Orbit rejects unverified Grok model/effort pairs rather than silently downgrading them.

Assessment: Scoped implementation with one authoritative provider-model validation path and direct argv tests.
Validation:
- cargo test -p orbit-types -p orbit-config -p orbit-agent -p orbit-engine --lib --no-fail-fast (passed: 812 tests total, 2 ignored)
- make ci-fast (passed)
- make ci-lint (passed)
- cargo fmt --check and git diff --check (passed)

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11286-6a9c56eb`
- Behind base: 0
- Ahead of base: 1