### PR TITLE
Make the source-inspection dispatch regression independent of ripgrep installation

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
@@ -231,10 +231,22 @@ fn dispatch_binds_native_reads_envelope_and_cwd_but_retains_task_authority() {
         &script,
         r#"#!/bin/sh
 envelope=$(cat)
-[ "$(cat target.txt)" = pinned ] || exit 11
-[ "$ORBIT_WORKSPACE" = ws_owner ] || exit 12
-[ "$ORBIT_REGISTRY_ROOT" = /authoritative/registry ] || exit 13
-printf '%s' "$envelope" | rg -F "$(pwd)" >/dev/null || exit 14
+if [ "$(cat target.txt)" != pinned ]; then
+  echo "native source read did not use the pinned checkout" >&2
+  exit 11
+fi
+if [ "$ORBIT_WORKSPACE" != ws_owner ]; then
+  echo "managed workspace identity was not retained" >&2
+  exit 12
+fi
+if [ "$ORBIT_REGISTRY_ROOT" != /authoritative/registry ]; then
+  echo "managed registry identity was not retained" >&2
+  exit 13
+fi
+if ! printf '%s' "$envelope" | grep -F "$(pwd)" >/dev/null; then
+  echo "envelope did not retain the dispatched cwd" >&2
+  exit 14
+fi
 printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
 "#,
     );
@@ -254,7 +266,17 @@ printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
         Some("reviewer"),
     )
     .unwrap();
-    assert!(outcome.success);
+    let stderr = outcome
+        .output
+        .get("stderr_blob_ref")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|reference| sink.blob(reference))
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned());
+    assert!(
+        outcome.success,
+        "dispatch failed: message={:?}, stderr={stderr:?}",
+        outcome.message
+    );
     let events = audit.events_snapshot().unwrap();
     let cwd = events
         .iter()


### PR DESCRIPTION
## Task

[ORB-11288](https://orbit-cli.com/tasks/ORB-11288) — Make the source-inspection dispatch regression independent of ripgrep installation

### Description

## Current repeated CI blocker
Coverage fails in run 33982115977 at e62e2bb9941a35ff8f6b19229408bf801b151979 (job logs 17:55:42Z), and run 33981908581 at 6d1ce72db5fc138d568da07a71f9826d4122ad3c. Test activity_job::cli_runner::tests::inspection::dispatch_binds_native_reads_envelope_and_cwd_but_retains_task_authority panics at crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs:257: assertion failed: outcome.success. 458 passed, 1 failed in orbit-engine. Coverage command is cargo test --tests --manifest-path Cargo.toml --target-dir target/llvm-cov-target --workspace --locked under cargo-llvm-cov.

## Evidence and scope
The test's fake Codex /bin/sh script pipes its envelope to rg -F. Current ci.yml installs ripgrep only in the main ci job; coverage has no such prerequisite. This is the leading hypothesis, not a proven diagnosis. Reproduce under a controlled PATH with standard shell tools and no rg; inspect the outcome's stderr/exit evidence. Prefer making this fixture portable (standard fixed-string grep or Rust-owned check) over installing a tool solely for a synthetic test. Preserve assertions that native reads/cwd use pinned checkout while ORBIT_WORKSPACE and ORBIT_REGISTRY_ROOT keep authoritative identity. If hypothesis is false, diagnose actual cause from captured outcome and fix narrowly. Improve assertion diagnostics so future failures expose their reason.

No open task covers this test in authoritative search. ORB-11256 introduced immutable source inspection; don't undo that behavior. Daniel explicitly prioritizes restoring green CI; critical, low complexity Luna. Dedicated managed worktree, agent-main, --complete authorized.

### Acceptance Criteria

- Reproduce and explain actual non-success evidence from the fake dispatch; test passes with no ripgrep installed and all original authority/cwd/content checks remain.
- All source-inspection tests and relevant cli_runner tests pass; no environment-global mutation or new external prerequisite.
- make ci-fast and make ci-lint pass; coverage rerun on the merged head must execute the formerly failing test successfully.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the synthetic Codex fixture's ripgrep-only `rg -F` check with POSIX `grep -F`, eliminating the coverage job's undeclared ripgrep prerequisite while preserving the pinned-source, authoritative workspace/registry, and dispatched-cwd assertions.
- Added explicit stderr diagnostics for each fixture guard and included captured stderr in the Rust assertion failure message so future non-success dispatches expose the failed authority/content check.
- Scope remained limited to `crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs`.
Validation:
- Controlled `env -i PATH=~/.cargo/bin:/usr/bin:/bin HOME=~` focused dispatch test passed with no `rg` on PATH.
- All `orbit-engine` cli_runner unit tests: 123 passed, 2 ignored.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed; final status contains only the intended inspection test change.
- `cargo-llvm-cov` is not installed in this environment, so the full coverage rerun remains for the merged-head CI gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11288-6a9c590d`
- Behind base: 0
- Ahead of base: 1