### PR TITLE
Fix CI capability-map expectations for the worker-control MCP tool

### DIFF
--- a/crates/orbit-mcp/src/federated/capability.rs
+++ b/crates/orbit-mcp/src/federated/capability.rs
@@ -59,7 +59,8 @@ pub fn mcp_tool_class(tool_name: &str) -> McpToolClass {
         "orbit_command_exec"
         | "orbit_workflow_run_list"
         | "orbit_workflow_run_show"
-        | "orbit_workflow_run_resume" => McpToolClass::Execute,
+        | "orbit_workflow_run_resume"
+        | "orbit_workflow_run_workers" => McpToolClass::Execute,
         _ => McpToolClass::Unclassified,
     }
 }

--- a/crates/orbit-mcp/src/federated/tests/capability.rs
+++ b/crates/orbit-mcp/src/federated/tests/capability.rs
@@ -31,6 +31,7 @@ const ADVERTISED_TOOL_CLASSES: &[(&str, McpToolClass)] = &[
     ("orbit.workflow.run.list", McpToolClass::Execute),
     ("orbit.workflow.run.resume", McpToolClass::Execute),
     ("orbit.workflow.run.show", McpToolClass::Execute),
+    ("orbit.workflow.run.workers", McpToolClass::Execute),
     ("orbit.workflow.ship", McpToolClass::ControlPlane),
     ("orbit.workspace.list", McpToolClass::Unclassified),
 ];
@@ -58,7 +59,7 @@ fn the_locked_mapping_covers_exactly_the_advertised_surface() {
         .collect::<std::collections::BTreeSet<_>>();
 
     assert_eq!(advertised, locked);
-    assert_eq!(advertised.len(), 20);
+    assert_eq!(advertised.len(), 21);
 }
 
 #[test]
@@ -66,6 +67,10 @@ fn classification_accepts_the_advertised_spelling() {
     assert_eq!(mcp_tool_class("orbit_task_add"), McpToolClass::ControlPlane);
     assert_eq!(
         mcp_tool_class("orbit_workflow_run_show"),
+        McpToolClass::Execute
+    );
+    assert_eq!(
+        mcp_tool_class("orbit_workflow_run_workers"),
         McpToolClass::Execute
     );
 }
@@ -84,7 +89,11 @@ fn a_replica_refuses_control_plane_and_runs_execute_class_tools() {
         "{refused}"
     );
 
-    for allowed in ["orbit.workflow.run.show", "orbit.command.exec"] {
+    for allowed in [
+        "orbit.workflow.run.show",
+        "orbit.workflow.run.workers",
+        "orbit.command.exec",
+    ] {
         ensure_tool_class_held(allowed, held).expect(allowed);
     }
 }
@@ -134,8 +143,8 @@ fn an_absent_checkout_role_is_treated_as_owner() {
 fn a_control_plane_that_does_not_run_work_refuses_execute_class_tools() {
     let held = CapabilityClasses::new(true, false);
 
-    let refused =
-        ensure_tool_class_held("orbit.workflow.run.resume", held).expect_err("execute is not held");
+    let refused = ensure_tool_class_held("orbit.workflow.run.workers", held)
+        .expect_err("execute is not held");
     assert!(
         matches!(&refused, OrbitError::CapabilityRefused(message) if message.contains("execute")),
         "{refused}"

--- a/crates/orbit-mcp/src/federated/tests/host.rs
+++ b/crates/orbit-mcp/src/federated/tests/host.rs
@@ -105,7 +105,7 @@ fn the_mux_advertises_the_canonical_surface() {
         names,
         canonical.iter().map(String::as_str).collect::<Vec<_>>()
     );
-    assert_eq!(names.len(), 20, "the frozen production surface changed");
+    assert_eq!(names.len(), 21, "the frozen production surface changed");
     let listing = definitions
         .iter()
         .find(|definition| definition.schema.name == FEDERATED_WORKSPACE_LIST_TOOL)

--- a/crates/orbit-mcp/src/remote/tests/discovery.rs
+++ b/crates/orbit-mcp/src/remote/tests/discovery.rs
@@ -57,7 +57,7 @@ fn mcp_owns_the_exact_global_discovery_definitions() {
     assert_eq!(crew.schema.parameters[0].name, "workspace");
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 20, "the frozen production surface changed");
+    assert_eq!(canonical.len(), 21, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()


### PR DESCRIPTION
## Task

[ORB-11287](https://orbit-cli.com/tasks/ORB-11287) — Fix CI capability-map expectations for the worker-control MCP tool

### Description

## Current CI blocker
At current agent-main 8df7a4f3de9b882a0d188a28c018167f814861e6, CI run 33982151723 main job 101349166611 failed at 2026-09-05T17:53:41Z: orbit-mcp federated::tests::capability::the_locked_mapping_covers_exactly_the_advertised_surface, crates/orbit-mcp/src/federated/tests/capability.rs:60. Advertised set includes orbit.workflow.run.workers; expected set omits it and still asserts len 20. 1082 tests passed, 1 failed, 2719 skipped due to nextest fail-fast. Exact job log: https://github.com/danieljhkim/orbit/actions/runs/33982151723/job/101349166611 .

## Scope
Verify the current canonical worker-control tool capability classification and add it to the locked expected mapping with the correct Execute/control ownership. Update the expected count and directly related classification/refusal tests, preserving enforcement. This is separate from ORB-11274 MCP snapshot and ORB-11285 CLI goldens; both are done but did not cover this map. Search found no existing open repair. Reproduce the narrow failure, run all orbit-mcp tests so another omitted surface expectation is not hidden, then required gates. Follow current-head CI after merge; report any additional distinct failures without weakening tests.

Daniel explicitly asked to make red CI green now; critical repair preempts waiting feature work. Low complexity uses Luna; managed worktree, agent-main, --complete authorized.

### Acceptance Criteria

- The reported capability-map test fails before and passes after the scoped fix; every advertised tool has the correct locked capability class.
- All orbit-mcp tests pass without fail-fast, including worker-control destination capability and public spelling coverage.
- make ci-fast and make ci-lint pass; no weakened assertion, permissions, or skipped failure.
- For Daniel's red-CI investigation, perform one workspace-wide diagnostic pass without fail-fast (cargo nextest run --workspace --lib --bins --tests --no-fail-fast, or cargo test equivalent), and record every additional failure with exact test/output evidence. This diagnostic must not weaken tests or expand the implementation scope; separately owned failures can be reported without invalidating this scoped repair.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Classified `orbit.workflow.run.workers` as `McpToolClass::Execute` in the production federated classifier.
- Added the worker-control tool to the locked capability mapping, canonical spelling coverage, and replica/control-plane refusal coverage.
- Updated the two directly affected frozen production-surface counts from 20 to 21.
Validation:
- Focused pre-fix reproduction failed exactly because the live surface contained `orbit.workflow.run.workers` while the locked set did not.
- `cargo nextest run -p orbit-mcp --all-targets --no-fail-fast`: 166 passed, 0 skipped.
- `make ci-fast`: passed.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- Requested diagnostic `cargo nextest run --workspace --lib --bins --tests --no-fail-fast`: 3,806 run; 3,777 passed, 9 skipped, 29 unrelated failures documented in the task comment. No scoped orbit-mcp failure remained.
- `git diff --check`: passed; final worktree contains only the four intended task-scoped source/test files; generated `target/` was removed.
Assessment: Small, behavior-aligned repair preserves capability enforcement and locks the complete 21-tool advertised surface.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11287-6a9c590d`
- Behind base: 0
- Ahead of base: 1