### PR TITLE
Remove model_pair_override from shipped executors while preserving legacy compatibility

### DIFF
--- a/.orbit/resources/executors/claude.yaml
+++ b/.orbit/resources/executors/claude.yaml
@@ -14,9 +14,6 @@ spec:
   - --tools
   - default
   stdout_format: envelope
-  model_pair_override:
-    strong: opus
-    weak: sonnet
   model_flag: --model
   env: {}
   sandbox: linux-bwrap

--- a/.orbit/resources/executors/codex.yaml
+++ b/.orbit/resources/executors/codex.yaml
@@ -9,9 +9,6 @@ spec:
   - exec
   - --json
   stdout_format: envelope
-  model_pair_override:
-    strong: gpt-5.5
-    weak: gpt-5.4-mini
   model_flag: --model
   env: {}
   sandbox: linux-bwrap

--- a/.orbit/resources/executors/gemini.yaml
+++ b/.orbit/resources/executors/gemini.yaml
@@ -13,9 +13,6 @@ spec:
   - -o
   - json
   stdout_format: envelope
-  model_pair_override:
-    strong: gemini-3.1-pro
-    weak: gemini-3-flash
   model_flag: -m
   env: {}
   sandbox: linux-bwrap

--- a/.orbit/resources/executors/grok.yaml
+++ b/.orbit/resources/executors/grok.yaml
@@ -14,9 +14,6 @@ spec:
   - --prompt-file
   - /dev/stdin
   stdout_format: envelope
-  model_pair_override:
-    strong: grok-build
-    weak: grok-build
   model_flag: -m
   env: {}
   sandbox: linux-bwrap

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -9,12 +9,12 @@
 //!
 //! ## Asset ↔ const seam
 //!
-//! YAML/TOML assets (executor definitions under `assets/executors/*.yaml`,
-//! seeded `config.toml`) cannot reference a Rust const. For those, "single
-//! source of truth" means using the provider alias directly in the asset and
-//! keeping this module authoritative for production Rust paths. The executor
-//! asset ↔ const agreement is guarded by a test in orbit-core's executor
-//! command module.
+//! YAML/TOML assets (including seeded `config.toml`) cannot reference a Rust
+//! const. For those, "single source of truth" means using the provider alias
+//! directly in the asset and keeping this module authoritative for production
+//! Rust paths. Shipped executor assets select models through crews and
+//! `model_flag`; the legacy executor model-pair override is retained only for
+//! compatibility with older/user-authored definitions.
 //!
 //! ## Aliases vs. version pins
 //!
@@ -56,7 +56,7 @@ pub const CODEX_ASTRA_MODEL: &str = "gpt-6-astra";
 /// Default codex model (Astra is the provider default).
 pub const CODEX_DEFAULT_MODEL: &str = CODEX_ASTRA_MODEL;
 
-/// Default codex "weak" model used by the executor model pair.
+/// Legacy codex "weak" model retained for compatibility with executor pairs.
 pub const CODEX_DEFAULT_WEAK: &str = "gpt-5.4-mini";
 
 /// Default gemini model for the provider-default map.
@@ -65,10 +65,10 @@ pub const GEMINI_DEFAULT_MODEL: &str = "gemini-3.8-flash";
 /// Default gemini model seeded into crew roles.
 pub const GEMINI_CREW_MODEL: &str = "gemini-3.8-flash";
 
-/// Default gemini "strong" model used by the executor model pair.
+/// Legacy gemini "strong" model retained for compatibility with executor pairs.
 pub const GEMINI_PAIR_STRONG: &str = "gemini-3.1-pro";
 
-/// Default gemini "weak" model used by the executor model pair.
+/// Legacy gemini "weak" model retained for compatibility with executor pairs.
 pub const GEMINI_PAIR_WEAK: &str = "gemini-3.8-flash";
 
 /// Default Grok Build model (the canonical model listed by `grok models`).

--- a/crates/orbit-core/assets/executors/claude.yaml
+++ b/crates/orbit-core/assets/executors/claude.yaml
@@ -15,8 +15,5 @@ spec:
     - default
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: opus
-    weak: sonnet
   model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/codex.yaml
+++ b/crates/orbit-core/assets/executors/codex.yaml
@@ -10,8 +10,5 @@ spec:
     - --json
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: gpt-5.5
-    weak: gpt-5.4-mini
   model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/copilot.yaml
+++ b/crates/orbit-core/assets/executors/copilot.yaml
@@ -30,8 +30,5 @@ spec:
     - --no-remote-export
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: claude-sonnet-4.5
-    weak: claude-haiku-4.5
   model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/cursor.yaml
+++ b/crates/orbit-core/assets/executors/cursor.yaml
@@ -18,8 +18,5 @@ spec:
     - json
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: gpt-5
-    weak: gpt-5
   model_flag: "--model"
   env: {}

--- a/crates/orbit-core/assets/executors/gemini.yaml
+++ b/crates/orbit-core/assets/executors/gemini.yaml
@@ -14,8 +14,5 @@ spec:
     - json
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: gemini-3.1-pro
-    weak: gemini-3.8-flash
   model_flag: "-m"
   env: {}

--- a/crates/orbit-core/assets/executors/grok.yaml
+++ b/crates/orbit-core/assets/executors/grok.yaml
@@ -15,8 +15,5 @@ spec:
     - /dev/stdin
   stdout_format: envelope
   sandbox: macos-sandbox-exec
-  model_pair_override:
-    strong: grok-4.6
-    weak: grok-4.6
   model_flag: "-m"
   env: {}

--- a/crates/orbit-core/src/application/tests/executor.rs
+++ b/crates/orbit-core/src/application/tests/executor.rs
@@ -308,40 +308,44 @@ fn custom_executor_sandbox_choice_is_not_rewritten_by_seed_migration() {
     );
 }
 
-/// The asset↔const seam: the shipped `claude.yaml` cannot reference the
-/// Rust constants, so this test pins the executor asset's model pair to the
-/// authoritative `orbit-common::model_defaults` values. A drift on either side
-/// (bumping the const without the asset, or vice versa) fails here.
+/// Shipped direct-agent defaults use crew-selected models at runtime. Their
+/// legacy model-pair field remains readable for older/user-authored files but
+/// must not be emitted by fresh assets.
 #[test]
-fn shipped_claude_executor_pair_matches_model_defaults() {
-    use orbit_common::model_defaults::{CLAUDE_DEFAULT_STRONG, CLAUDE_DEFAULT_WEAK};
-
-    let (_name, yaml) = DEFAULT_EXECUTOR_FILES
-        .iter()
-        .find(|(name, _)| *name == "claude")
-        .expect("claude executor asset present");
-    let def = parse_default_executor("claude", yaml).expect("parse claude executor");
-    let pair = def
-        .model_pair_override()
-        .expect("claude executor declares a model pair");
-    assert_eq!(pair.strong, CLAUDE_DEFAULT_STRONG);
-    assert_eq!(pair.weak, CLAUDE_DEFAULT_WEAK);
+fn shipped_direct_agent_defaults_omit_legacy_model_pair_override() {
+    for name in SANDBOXED_SHIPPED {
+        let def = parse_default_executor_for_platform(name, yaml_for(name), LINUX)
+            .unwrap_or_else(|err| panic!("parse {name}: {err}"));
+        assert_eq!(
+            def.model_pair_override(),
+            None,
+            "fresh {name} default must omit the legacy model pair override"
+        );
+        assert!(
+            def.model_flag.is_some(),
+            "fresh {name} default must retain crew-selected model flag behavior"
+        );
+    }
 }
 
-/// The Gemini executor asset carries the Flash/default lane while the strong
-/// pin remains independently controlled by the centralized defaults.
 #[test]
-fn shipped_gemini_executor_pair_matches_model_defaults() {
-    use orbit_common::model_defaults::{GEMINI_PAIR_STRONG, GEMINI_PAIR_WEAK};
+fn seeding_preserves_customized_legacy_model_pair_override() {
+    let store = InMemoryExecutorStore::default();
+    let mut custom = base_def("claude", ExecutorType::DirectAgent);
+    custom.model_pair_override = Some(orbit_types::workflow::ModelPairOverride {
+        strong: "custom-strong".to_string(),
+        weak: "custom-weak".to_string(),
+    });
+    custom.model_flag = Some("--model".to_string());
+    custom.sandbox = Some(ExecutorSandboxKind::LinuxBwrap);
+    store.upsert_executor_def(&custom).expect("seed custom def");
 
-    let (_name, yaml) = DEFAULT_EXECUTOR_FILES
-        .iter()
-        .find(|(name, _)| *name == "gemini")
-        .expect("gemini executor asset present");
-    let def = parse_default_executor("gemini", yaml).expect("parse gemini executor");
-    let pair = def
-        .model_pair_override()
-        .expect("gemini executor declares a model pair");
-    assert_eq!(pair.strong, GEMINI_PAIR_STRONG);
-    assert_eq!(pair.weak, GEMINI_PAIR_WEAK);
+    seed_default_executors_for_platform(&store, false, LINUX).expect("seed defaults");
+
+    let persisted = store
+        .get_executor_def("claude")
+        .expect("get")
+        .expect("claude present");
+    assert_eq!(persisted.model_pair_override, custom.model_pair_override);
+    assert_eq!(persisted.model_flag, custom.model_flag);
 }

--- a/crates/orbit-store/src/driver/file/executor_def_store/tests/executor_def_store.rs
+++ b/crates/orbit-store/src/driver/file/executor_def_store/tests/executor_def_store.rs
@@ -1,8 +1,7 @@
 // Migrated from file/executor_def_store.rs per ORB-00231
 use super::super::*;
 use chrono::Utc;
-use orbit_types::workflow::ExecutorSandboxKind;
-use orbit_types::workflow::ExecutorType;
+use orbit_types::workflow::{ExecutorSandboxKind, ExecutorType, ModelPairOverride};
 use std::collections::HashMap;
 use tempfile::tempdir;
 
@@ -87,6 +86,31 @@ fn roundtrips_model_flag_field() {
     assert!(
         on_disk.contains("model_flag: -m"),
         "model_flag should be persisted: {on_disk}"
+    );
+}
+
+#[test]
+fn roundtrips_legacy_model_pair_override_field() {
+    let dir = tempdir().expect("tempdir");
+    let store = ExecutorDefFileStore::new(dir.path().to_path_buf());
+
+    let mut def = baseline_def("claude");
+    def.model_pair_override = Some(ModelPairOverride {
+        strong: "custom-strong".to_string(),
+        weak: "custom-weak".to_string(),
+    });
+    store.upsert_executor_def(&def).expect("upsert");
+
+    let loaded = store
+        .get_executor_def("claude")
+        .expect("get")
+        .expect("present");
+    assert_eq!(loaded.model_pair_override, def.model_pair_override);
+
+    let on_disk = std::fs::read_to_string(dir.path().join("claude.yaml")).expect("read");
+    assert!(
+        on_disk.contains("model_pair_override:"),
+        "legacy override should remain persisted for customized executors: {on_disk}"
     );
 }
 

--- a/crates/orbit-types/src/workflow/executor_def.rs
+++ b/crates/orbit-types/src/workflow/executor_def.rs
@@ -122,8 +122,10 @@ pub struct ExecutorDef {
     /// Expected stdout format, serialized as "envelope", "json", or "text".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stdout_format: Option<StdoutFormat>,
-    /// Overrides the agent family's default `AgentModelPair` resolution for audit
-    /// canonicalization, envelope rendering, and review attribution.
+    /// Legacy override for the agent family's `AgentModelPair` resolution used
+    /// by older/user-authored definitions for audit canonicalization, envelope
+    /// rendering, and review attribution. Fresh shipped defaults use
+    /// crew-selected models instead.
     ///
     /// Does NOT control which model the subprocess actually runs; operators
     /// should encode runtime model selection in `args`.
@@ -159,14 +161,15 @@ pub struct ExecutorDef {
     pub updated_at: DateTime<Utc>,
 }
 
-/// Override for an agent family's strong/weak `AgentModelPair`.
+/// Legacy override for an agent family's strong/weak `AgentModelPair`.
 ///
 /// Controls how Orbit canonicalizes the agent's model for audit trail,
 /// envelope rendering, and review automation attribution.
 ///
-/// Does NOT control which model the subprocess actually runs. Operators must
-/// encode the runtime model in `args`, and may set `ORBIT_AGENT_MODEL` via
-/// `env:` for explicit audit attribution.
+/// Does NOT control which model the subprocess actually runs. Older or
+/// customized definitions may retain this field; new definitions should use
+/// crew-selected models and `model_flag`. Operators can also set
+/// `ORBIT_AGENT_MODEL` via `env:` for explicit audit attribution.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(deny_unknown_fields)]
 pub struct ModelPairOverride {

--- a/docs/design/agent-families/references/glossary.md
+++ b/docs/design/agent-families/references/glossary.md
@@ -2,14 +2,14 @@
 type: design
 summary: "Agent Families — Glossary"
 tags: ["agent-families"]
-last_validated: 2026-08-29
+last_validated: 2026-09-05
 ---
 
 # Agent Families — Glossary
 
 **agent family** — A stable identifier (`claude`, `codex`, `gemini`, `grok`) representing a coherent set of models, CLIs, and integration requirements that Orbit treats uniformly for attribution, execution, and analytics.
 
-**model pair** — The `(orchestrator, helper)` model duo represented by `AgentModelPair`, loaded from an executor's `model_pair_override` via `configured_agent_model_pair()`.
+**model pair** — The legacy `(orchestrator, helper)` model duo represented by `AgentModelPair`. User-authored executor definitions may retain `model_pair_override` for compatibility; shipped defaults use crew-selected models and `model_flag` instead.
 
 **all_agent_families()** — The single source of truth function in `orbit-common` that returns the fixed-size array of supported families. Changing its size is intentionally high-friction.
 


### PR DESCRIPTION
## Task

[ORB-11290](https://orbit-cli.com/tasks/ORB-11290) — Remove model_pair_override from shipped executors while preserving legacy compatibility

### Description

## Explicit request
Daniel asks to remove the no-longer-used model_pair_override field from codebases/orbit/crates/orbit-core/assets/executors definitions while keeping compatibility support.

## Live inventory
All six bundled direct-agent executor YAMLs (claude, codex, copilot, cursor, gemini, grok) currently seed model_pair_override strong/weak values, some stale (Codex gpt-5.5/gpt-5.4-mini). local-shell does not contain it. Compatibility code remains in orbit-types ExecutorDef/ResourceData, file executor store conversions, and orbit-core runtime/engine/identity.rs plus roundtrip/identity tests.

## Scope
Remove model_pair_override blocks from the six shipped defaults and any derived default-generation expectations or mirrored managed-default resources that must match. Keep legacy deserialization, persistence/roundtrip, and explicit legacy override resolution working for user-authored/older executor definitions. Fresh seeded definitions should omit the key rather than emit null or invent replacement strong/weak fields; normal modern crew-selected model behavior must continue. Update tests that assert bundled defaults have overrides while retaining dedicated legacy compatibility fixtures and identity-resolution tests. Managed-asset sync must update untouched shipped defaults through normal provenance without clobbering customized legacy definitions. Do not remove the compatibility types/readers or unrelated executor flags, sandbox defaults, or model_flag support. Document legacy-only status where current docs otherwise recommend new use; do not expand into wholesale model resolution refactoring.

Daniel authorizes implementation and automatic completion in the current session; Luna is appropriate for this bounded defaults cleanup. Managed dedicated worktree, agent-main; make ci-fast, make ci-lint and focused parsing/seeding/compatibility tests. CI restoration remains critical priority ahead of this high-priority cleanup.

### Acceptance Criteria

- None of the six bundled direct-agent executor definitions contains model_pair_override; fresh generated/seeded defaults omit the key.
- An older/user-customized executor containing strong/weak overrides still loads, persists/roundtrips and resolves its explicit overrides compatibly.
- Normal crew-selected execution and model_flag behavior remains intact; omitted legacy override follows the existing modern/default resolution path.
- Managed sync updates untouched bundled defaults but preserves customized legacy files; focused regression tests and required gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed model_pair_override from all six bundled direct-agent executor assets and the four mirrored managed executor resources; retained model_flag and all other defaults.
- Marked model-pair constants, executor compatibility fields, and glossary guidance as legacy-only for older or user-customized definitions.
- Added regression coverage that fresh shipped defaults omit the legacy override, retain model_flag behavior, preserve customized legacy overrides during normal seeding, and file-store round-trip/persist explicit overrides.
Assessment: Compatibility readers, persistence, and runtime legacy resolution were left intact; managed/default files now represent crew-selected model resolution.
Validation:
- Focused orbit-core executor tests: 14 passed.
- Focused orbit-types executor compatibility tests: 8 passed.
- Focused orbit-store executor file-store tests: 8 passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check and shipped-resource absence check: passed.
- No friction report filed; no contradicted assumption or recurring failure exceeded the checkpoint threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11290-6a9c5e84`
- Behind base: 0
- Ahead of base: 1