### PR TITLE
Prevent integration tests from inheriting live managed workspace authority

### DIFF
--- a/crates/orbit-cli/tests/ambient_authority_isolation.rs
+++ b/crates/orbit-cli/tests/ambient_authority_isolation.rs
@@ -1,0 +1,355 @@
+//! ORB-11300: an integration fixture must never inherit live workspace
+//! authority.
+//!
+//! `ORBIT_REGISTRY_ROOT` selects the host-global registry and `ORBIT_WORKSPACE`
+//! selects a workspace inside it, both outranking `HOME`. A suite launched from
+//! inside a managed Orbit run inherits that pair, so fixtures that reset only
+//! `HOME`/`ORBIT_ROOT` routed their `task add` writes into the *live*
+//! workspace — three real task records were created that way before it was
+//! caught.
+//!
+//! Every assertion here targets a disposable **sentinel**: a registry and
+//! workspace built in a `TempDir` for this test alone. The reproducer names
+//! that sentinel explicitly on the child command, so even the deliberately
+//! unisolated case cannot reach production authority no matter what the
+//! ambient environment holds.
+
+#![allow(missing_docs)]
+// Tests use unwrap/expect to keep fixture setup readable.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::Arc;
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use serde_json::Value;
+use tempfile::{TempDir, tempdir};
+
+/// A disposable registry plus one registered workspace, standing in for the
+/// live managed authority a leaking fixture would otherwise reach.
+struct Sentinel {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+    workspace_id: String,
+}
+
+impl Sentinel {
+    fn new() -> Self {
+        let temp = tempdir().expect("sentinel tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        std::fs::create_dir_all(&home).expect("create sentinel home");
+        std::fs::create_dir_all(&work).expect("create sentinel work");
+
+        let mut command = isolated_orbit(&work, &home);
+        run_ok(
+            &mut command,
+            &["workspace", "init", "--name", "orb-11300-sentinel"],
+            "initialize sentinel workspace",
+        );
+
+        let registry: Value = serde_json::from_slice(
+            &std::fs::read(home.join(".orbit/workspaces.json")).expect("read sentinel registry"),
+        )
+        .expect("parse sentinel registry");
+        let workspace_id = registry["workspaces"][0]["id"]
+            .as_str()
+            .expect("sentinel workspace id")
+            .to_string();
+
+        Self {
+            _temp: temp,
+            home,
+            work,
+            workspace_id,
+        }
+    }
+
+    fn registry_root(&self) -> PathBuf {
+        self.home.join(".orbit")
+    }
+
+    /// Every byte the sentinel owns: its global registry and its workspace's
+    /// task store.
+    fn snapshot(&self) -> BTreeMap<PathBuf, Vec<u8>> {
+        let mut files = BTreeMap::new();
+        // Label each half: the registry and the task store both contain a
+        // `.orbit/config.yaml`, and a colliding key would hide a change.
+        collect_files(Path::new("registry"), &self.home, &self.home, &mut files);
+        collect_files(Path::new("workspace"), &self.work, &self.work, &mut files);
+        assert!(
+            !files.is_empty(),
+            "a sentinel with no files would make every assertion vacuous"
+        );
+        files
+    }
+
+    fn assert_unchanged(&self, before: &BTreeMap<PathBuf, Vec<u8>>) {
+        let after = self.snapshot();
+        let changed = before
+            .iter()
+            .filter(|(path, bytes)| after.get(*path).map(Vec::as_slice) != Some(bytes.as_slice()))
+            .map(|(path, _)| path.display().to_string())
+            .chain(
+                after
+                    .keys()
+                    .filter(|path| !before.contains_key(*path))
+                    .map(|path| format!("{} (created)", path.display())),
+            )
+            .collect::<Vec<_>>();
+        assert!(
+            changed.is_empty(),
+            "fixture work reached the sentinel authority: {changed:?}"
+        );
+    }
+
+    /// Present the sentinel to a child exactly the way a managed Orbit run
+    /// presents the live authority to the suite it launches.
+    fn export_authority(&self, command: &mut Command) {
+        command
+            .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
+            .env("ORBIT_RUN_ID", "jrun-orb-11300-regression")
+            .env("ORBIT_REGISTRY_ROOT", self.registry_root())
+            .env("ORBIT_WORKSPACE", &self.workspace_id);
+    }
+}
+
+/// A temp workspace built the way every `orbit-cli` fixture builds one.
+struct Fixture {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+}
+
+impl Fixture {
+    /// Initialize under an ambient sentinel authority. The shared scrub inside
+    /// [`isolated_orbit`] is the only thing keeping this off the sentinel.
+    fn new(sentinel: &Sentinel) -> Self {
+        let temp = tempdir().expect("fixture tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        std::fs::create_dir_all(&home).expect("create fixture home");
+        std::fs::create_dir_all(&work).expect("create fixture work");
+
+        let fixture = Self {
+            _temp: temp,
+            home,
+            work,
+        };
+        let mut command = fixture.orbit(sentinel);
+        run_ok(
+            &mut command,
+            &["workspace", "init", "--name", "orb-11300-fixture"],
+            "initialize fixture workspace",
+        );
+        fixture
+    }
+
+    fn orbit(&self, sentinel: &Sentinel) -> Command {
+        let mut command = cargo_bin_cmd!("orbit");
+        sentinel.export_authority(&mut command);
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        command
+            .current_dir(&self.work)
+            .env("HOME", &self.home)
+            .env("USERPROFILE", &self.home);
+        command
+    }
+
+    fn add_task(&self, sentinel: &Sentinel, title: &str) -> Value {
+        let mut command = self.orbit(sentinel);
+        let output = run_ok(
+            &mut command,
+            &[
+                "task",
+                "add",
+                "--title",
+                title,
+                "--description",
+                "ORB-11300 isolation regression.",
+                "--complexity",
+                "low",
+                "--json",
+            ],
+            "add fixture task",
+        );
+        serde_json::from_slice(&output.stdout).expect("task add JSON")
+    }
+
+    fn task_dir(&self) -> PathBuf {
+        self.work.join(".orbit/tasks")
+    }
+}
+
+/// A leaking fixture is one that never clears the inherited pair. Point it at
+/// the sentinel and it writes there — that is the defect this file guards, and
+/// running it proves the sentinel is a real, reachable authority rather than an
+/// inert directory that would make the isolated assertions vacuous.
+#[test]
+fn an_unscrubbed_child_routes_its_write_into_the_ambient_authority() {
+    let sentinel = Sentinel::new();
+    let before = sentinel.snapshot();
+
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&home).expect("create home");
+    std::fs::create_dir_all(&work).expect("create work");
+
+    // The pre-ORB-11300 fixture shape: pin `HOME`, drop `ORBIT_ROOT`, and
+    // leave everything else inherited.
+    let mut command = cargo_bin_cmd!("orbit");
+    sentinel.export_authority(&mut command);
+    let output = run_ok(
+        command
+            .current_dir(&work)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env_remove("ORBIT_ROOT"),
+        &[
+            "task",
+            "add",
+            "--title",
+            "Unscrubbed probe",
+            "--description",
+            "ORB-11300 leak reproducer.",
+            "--complexity",
+            "low",
+            "--json",
+        ],
+        "add task without the shared scrub",
+    );
+
+    let created: Value = serde_json::from_slice(&output.stdout).expect("task add JSON");
+    let task_id = created["id"].as_str().expect("task id");
+    assert!(
+        sentinel.work.join(".orbit/tasks").join(task_id).exists(),
+        "the reproducer must land in the sentinel, or the isolated cases below \
+         prove nothing"
+    );
+    assert!(
+        !home.join(".orbit").exists(),
+        "resetting HOME did not redirect the write: {task_id}"
+    );
+    assert_ne!(
+        sentinel.snapshot(),
+        before,
+        "the sentinel must be observably mutable"
+    );
+}
+
+/// Initialization, creation, and mutation all route to the fixture's own
+/// authority and leave the ambient sentinel byte-for-byte unchanged.
+#[test]
+fn fixture_lifecycle_leaves_the_ambient_authority_byte_for_byte_unchanged() {
+    let sentinel = Sentinel::new();
+    // Taken after `Sentinel::new`, so workspace initialization is the first
+    // thing measured against it.
+    let before = sentinel.snapshot();
+
+    let fixture = Fixture::new(&sentinel);
+    sentinel.assert_unchanged(&before);
+
+    let created = fixture.add_task(&sentinel, "Isolated task");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+    sentinel.assert_unchanged(&before);
+
+    let mut command = fixture.orbit(&sentinel);
+    let updated = run_ok(
+        &mut command,
+        &["task", "update", &task_id, "--tag", "docs", "--json"],
+        "update fixture task",
+    );
+    let updated: Value = serde_json::from_slice(&updated.stdout).expect("task update JSON");
+    assert_eq!(updated["tags"], serde_json::json!(["docs"]));
+    sentinel.assert_unchanged(&before);
+
+    assert!(
+        fixture.task_dir().join(&task_id).exists(),
+        "the write must land in the fixture's own workspace"
+    );
+}
+
+/// The scrub is per-command and holds no shared state, so repeated fixtures
+/// running concurrently under the same ambient authority must all stay off it.
+#[test]
+fn parallel_repeated_fixtures_all_stay_off_the_ambient_authority() {
+    const THREADS: usize = 4;
+    const ROUNDS: usize = 2;
+
+    let sentinel = Arc::new(Sentinel::new());
+    let before = sentinel.snapshot();
+
+    let workers = (0..THREADS)
+        .map(|thread| {
+            let sentinel = Arc::clone(&sentinel);
+            std::thread::spawn(move || {
+                for round in 0..ROUNDS {
+                    let fixture = Fixture::new(&sentinel);
+                    let created =
+                        fixture.add_task(&sentinel, &format!("Parallel {thread}-{round}"));
+                    let task_id = created["id"].as_str().expect("task id");
+                    assert!(
+                        fixture.task_dir().join(task_id).exists(),
+                        "thread {thread} round {round} wrote outside its own workspace"
+                    );
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for worker in workers {
+        worker.join().expect("fixture thread panicked");
+    }
+
+    sentinel.assert_unchanged(&before);
+}
+
+/// An `orbit` command with no inherited authority and no ambient sentinel —
+/// used to build the sentinel itself.
+fn isolated_orbit(cwd: &Path, home: &Path) -> Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
+fn run_ok(command: &mut Command, args: &[&str], label: &str) -> Output {
+    let output = command.args(args).output().expect("run orbit");
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn collect_files(label: &Path, root: &Path, dir: &Path, files: &mut BTreeMap<PathBuf, Vec<u8>>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries {
+        let entry = entry.expect("read sentinel entry");
+        let path = entry.path();
+        let kind = entry.file_type().expect("sentinel entry type");
+        if kind.is_dir() {
+            collect_files(label, root, &path, files);
+        } else if kind.is_file() {
+            let relative = label.join(path.strip_prefix(root).expect("relative path"));
+            files.insert(relative, std::fs::read(&path).expect("read sentinel file"));
+        }
+    }
+}

--- a/crates/orbit-cli/tests/docs.rs
+++ b/crates/orbit-cli/tests/docs.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
-use orbit_common::test_env::harden_dir;
+use orbit_common::test_env::{self, harden_dir};
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -551,14 +551,18 @@ fn run_orbit_with_companion(
     companion: Option<&std::path::Path>,
 ) -> Output {
     let mut cmd = cargo_bin_cmd!("orbit");
+    // ORB-11300: `HOME`/`ORBIT_HOME` do not outrank the inherited
+    // `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair, so clear the whole
+    // ambient-authority set before pinning this fixture's own paths.
+    test_env::clear_inherited_authority(|name| {
+        cmd.env_remove(name);
+    });
     cmd.current_dir(work)
         .env("HOME", home)
+        .env("USERPROFILE", home)
         .env("ORBIT_HOME", home.join(".orbit-global"))
-        .env_remove("ORBIT_ROOT")
         .env_remove("ORBIT_SEARCH_COMPANION")
         .env_remove("ORBIT_SEARCH_COMPANION_ALLOW_UNSAFE")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
         .args(args);
     if let Some(path) = companion {
         cmd.env("ORBIT_SEARCH_COMPANION", path)

--- a/crates/orbit-cli/tests/github_capability_preflight.rs
+++ b/crates/orbit-cli/tests/github_capability_preflight.rs
@@ -13,6 +13,7 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::{TempDir, tempdir};
 
@@ -52,12 +53,17 @@ impl Lane {
     }
 
     fn preflight(&self) -> Value {
-        let output = cargo_bin_cmd!("orbit")
+        let mut command = cargo_bin_cmd!("orbit");
+        // ORB-11300: `tool run` resolves its runtime from ambient routing
+        // before it ever reaches the stub `gh` on PATH.
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
+        let output = command
             .current_dir(&self.work)
             .env("HOME", &self.home)
             .env("USERPROFILE", &self.home)
             .env("PATH", &self.path)
-            .env_remove("ORBIT_ROOT")
             .env_remove("GH_TOKEN")
             .env_remove("GITHUB_TOKEN")
             .args(["tool", "run", "github.auth.status"])

--- a/crates/orbit-cli/tests/host_administration.rs
+++ b/crates/orbit-cli/tests/host_administration.rs
@@ -2,9 +2,32 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use predicates::prelude::*;
 use serde_json::Value;
 use tempfile::tempdir;
+
+/// An `orbit` invocation with no inherited authority.
+///
+/// ORB-11300: every fixture here writes durable host identity and workspace
+/// registry state. Clearing `ORBIT_ROOT` alone left the inherited
+/// `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair in place, which outranks
+/// `HOME` and routes writes at the live registry.
+fn orbit(cwd: &std::path::Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command.current_dir(cwd);
+    command
+}
+
+/// The same isolation, with `HOME` pinned at the fixture's own global root.
+fn orbit_at_home(cwd: &std::path::Path, home: &std::path::Path) -> assert_cmd::Command {
+    let mut command = orbit(cwd);
+    command.env("HOME", home).env("USERPROFILE", home);
+    command
+}
 
 fn initialized_workspace() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
     let temp = tempdir().expect("tempdir");
@@ -13,11 +36,7 @@ fn initialized_workspace() -> (tempfile::TempDir, std::path::PathBuf, std::path:
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args([
             "init",
             "--non-interactive",
@@ -28,11 +47,7 @@ fn initialized_workspace() -> (tempfile::TempDir, std::path::PathBuf, std::path:
         ])
         .assert()
         .success();
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["workspace", "init", "--name", "local-workspace"])
         .assert()
         .success();
@@ -44,32 +59,20 @@ fn fleet_administration_and_inventory_are_absent_from_cli_and_tool_registry() {
     let (_temp, home, work) = initialized_workspace();
 
     for subcommand in ["register", "list", "retire"] {
-        cargo_bin_cmd!("orbit")
-            .current_dir(&work)
-            .env("HOME", &home)
-            .env("USERPROFILE", &home)
-            .env_remove("ORBIT_ROOT")
+        orbit_at_home(&work, &home)
             .args(["host", subcommand])
             .assert()
             .failure()
             .stderr(predicate::str::contains("unrecognized subcommand"));
     }
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["workspace", "link"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unrecognized subcommand"));
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["tool", "list", "--json"])
         .assert()
         .success()
@@ -91,11 +94,7 @@ fn rename_updates_host_and_local_owner_names_without_changing_stable_identity() 
         .to_string();
     assert_eq!(before["task_prefix"].as_str(), Some("DE"));
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["host", "rename", "local", "renamed"])
         .assert()
         .success()
@@ -118,11 +117,7 @@ fn rename_updates_host_and_local_owner_names_without_changing_stable_identity() 
         "rename must not change stable owner binding"
     );
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["host", "rename", "local", "again"])
         .assert()
         .failure()
@@ -154,8 +149,7 @@ fn show_reports_the_persisted_identity_outside_a_workspace_without_writing() {
         .as_str()
         .expect("machine id")
         .to_string();
-    let human = cargo_bin_cmd!("orbit")
-        .current_dir(&outside)
+    let human = orbit(&outside)
         .args(["--root", root_arg, "host", "show"])
         .assert()
         .success()
@@ -167,8 +161,7 @@ fn show_reports_the_persisted_identity_outside_a_workspace_without_writing() {
         format!("machine_id: {machine_id}\nhost_id: operator-host\ntask_prefix: DE\n")
     );
 
-    let json_output = cargo_bin_cmd!("orbit")
-        .current_dir(&outside)
+    let json_output = orbit(&outside)
         .args(["--root", root_arg, "host", "show", "--json"])
         .assert()
         .success()
@@ -220,8 +213,7 @@ fn show_rejects_invalid_host_identities_without_replacing_them() {
         }
         let before = std::fs::read(&identity_path).ok();
 
-        cargo_bin_cmd!("orbit")
-            .current_dir(temp.path())
+        orbit(temp.path())
             .args(["--root", root.to_str().expect("utf8 root"), "host", "show"])
             .assert()
             .failure()
@@ -233,12 +225,12 @@ fn show_rejects_invalid_host_identities_without_replacing_them() {
 
 #[test]
 fn host_show_is_listed_in_help() {
-    cargo_bin_cmd!("orbit")
+    orbit(std::path::Path::new("."))
         .args(["host", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("show"));
-    cargo_bin_cmd!("orbit")
+    orbit(std::path::Path::new("."))
         .args(["host", "show", "--help"])
         .assert()
         .success()

--- a/crates/orbit-cli/tests/json_output_stability.rs
+++ b/crates/orbit-cli/tests/json_output_stability.rs
@@ -19,6 +19,7 @@
 use std::path::Path;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use tempfile::{TempDir, tempdir};
 
 /// Commands with a `--json` flag whose output must not shift. Each is a list
@@ -46,11 +47,16 @@ fn fixture() -> Fixture {
 
 fn run(home: &Path, work: &Path, args: &[&str], env: &[(&str, &str)]) -> Vec<u8> {
     let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: `task list` reads whatever workspace the ambient
+    // `ORBIT_WORKSPACE`/`ORBIT_REGISTRY_ROOT` pair selects, which is the live
+    // one when the suite runs inside a managed Orbit run.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(work)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
         .env_remove("ORBIT_FORMAT")
         .env_remove("NO_COLOR")
         .env_remove("CLICOLOR_FORCE")

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -20,6 +20,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{Receiver, channel};
 use std::time::{Duration, Instant};
 
+use orbit_common::test_env;
 use rusqlite::Connection;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
@@ -153,24 +154,15 @@ impl McpWorkspace {
 
     fn orbit_program_command(program: &Path, work: &Path, home: &Path) -> Command {
         let mut command = Command::new(program);
+        // ORB-11300: one shared list for every fixture that spawns `orbit`.
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
         command
             .current_dir(work)
             .env("PATH", stub_first_path(&Self::stub_bin_dir(home)))
             .env("HOME", home)
-            .env("USERPROFILE", home)
-            .env_remove("ORBIT_ROOT")
-            .env_remove("ORBIT_SESSION_ID")
-            .env_remove("ORBIT_TASK_ID")
-            .env_remove("ORBIT_RUN_ID")
-            .env_remove("ORBIT_ACTIVITY_ID")
-            .env_remove("ORBIT_STEP_INDEX")
-            .env_remove("ORBIT_AGENT_NAME")
-            .env_remove("ORBIT_AGENT_MODEL")
-            .env_remove("ORBIT_OPERATOR")
-            .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-            .env_remove("ORBIT_TASK_ACTOR_KIND")
-            .env_remove("ORBIT_REGISTRY_ROOT")
-            .env_remove("ORBIT_WORKSPACE");
+            .env("USERPROFILE", home);
         command
     }
 

--- a/crates/orbit-cli/tests/output_goldens.rs
+++ b/crates/orbit-cli/tests/output_goldens.rs
@@ -142,6 +142,12 @@ impl Fixture {
     /// color-configuration sweep.
     fn run(&self, args: &[&str], extra_env: &[(&str, &str)]) -> std::process::Output {
         let mut command = cargo_bin_cmd!("orbit");
+        // ORB-11300: one shared list, so this fixture and its siblings cannot
+        // drift apart on which ambient variable still routes a write. The
+        // pinned identity below is deliberate and applies after the scrub.
+        test_env::clear_inherited_authority(|name| {
+            command.env_remove(name);
+        });
         command
             .current_dir(&self.work)
             .env("HOME", &self.home)
@@ -149,18 +155,6 @@ impl Fixture {
             .env("COLUMNS", "100")
             .env("ORBIT_AGENT_NAME", "claude")
             .env("ORBIT_AGENT_MODEL", "claude")
-            .env_remove("ORBIT_ROOT")
-            .env_remove("ORBIT_SESSION_ID")
-            .env_remove("ORBIT_TASK_ID")
-            .env_remove("ORBIT_ACTIVE_TASK_ID")
-            .env_remove("ORBIT_RUN_ID")
-            .env_remove("ORBIT_ACTIVITY_ID")
-            .env_remove("ORBIT_STEP_INDEX")
-            .env_remove("ORBIT_OPERATOR")
-            .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-            .env_remove("ORBIT_TASK_ACTOR_KIND")
-            .env_remove("ORBIT_REGISTRY_ROOT")
-            .env_remove("ORBIT_WORKSPACE")
             .env_remove("ORBIT_FORMAT")
             .env_remove("NO_COLOR")
             .env_remove("CLICOLOR_FORCE")

--- a/crates/orbit-cli/tests/proc_spawn_managed.rs
+++ b/crates/orbit-cli/tests/proc_spawn_managed.rs
@@ -8,6 +8,7 @@ use std::process::{Command as StdCommand, Output};
 
 use assert_cmd::Command as AssertCommand;
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
@@ -154,17 +155,17 @@ fn run_managed_proc_spawn(
 
 fn orbit_command(workspace: &Path, home: &Path) -> AssertCommand {
     let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: `run_managed_proc_spawn` synthesizes its *own* managed run
+    // context on top of this. Without clearing the inherited
+    // `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair first, that synthetic
+    // context would have pointed the sandboxed tool at the live workspace.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(workspace)
         .env("HOME", home)
-        .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_ACTIVE_TASK_ID")
-        .env_remove("ORBIT_SESSION_ID");
+        .env("USERPROFILE", home);
     command
 }
 

--- a/crates/orbit-cli/tests/routine_root.rs
+++ b/crates/orbit-cli/tests/routine_root.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::{TempDir, tempdir};
 
@@ -177,14 +178,13 @@ fn routine_commands_honor_orbit_root_and_mutate_only_the_selected_root() {
 
 fn run_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
-        .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_REGISTRY_ROOT");
+        .env("USERPROFILE", home);
     if let Some(root) = orbit_root {
         command.env("ORBIT_ROOT", root);
     }
@@ -199,14 +199,13 @@ fn run_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>
 
 fn run_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Path>) -> Value {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
-        .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_REGISTRY_ROOT");
+        .env("USERPROFILE", home);
     if let Some(root) = orbit_root {
         command.env("ORBIT_ROOT", root);
     }

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
-use orbit_common::test_env::harden_dir;
+use orbit_common::test_env::{self, harden_dir};
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -250,11 +250,15 @@ exit 7
 
 fn run_orbit(cwd: &Path, home: &Path, args: &[&str], companion: Option<&Path>) -> Output {
     let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: drop inherited registry/workspace authority before the
+    // companion-specific overrides below.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
         .env_remove("ORBIT_SEARCH_COMPANION")
         .env_remove("ORBIT_SEARCH_COMPANION_ALLOW_UNSAFE")
         .args(args);

--- a/crates/orbit-cli/tests/sweep_root.rs
+++ b/crates/orbit-cli/tests/sweep_root.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::{TempDir, tempdir};
 
@@ -147,14 +148,13 @@ fn command(
     orbit_root: Option<&Path>,
 ) -> assert_cmd::Command {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
-        .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_REGISTRY_ROOT");
+        .env("USERPROFILE", home);
     if let Some(root) = orbit_root {
         command.env("ORBIT_ROOT", root);
     }

--- a/crates/orbit-cli/tests/table_rendering.rs
+++ b/crates/orbit-cli/tests/table_rendering.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::{TempDir, tempdir};
 
@@ -233,27 +234,18 @@ impl TestWorkspace {
 }
 
 fn run_orbit(work: &Path, home: &Path, args: &[&str]) -> Output {
-    cargo_bin_cmd!("orbit")
+    let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: shared with every other fixture that spawns `orbit`.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
         .current_dir(work)
         .env("HOME", home)
         .env("USERPROFILE", home)
         // Pin the geometry: width resolution is only consulted for a terminal
         // sink, and these assertions must not depend on the runner's terminal.
         .env("COLUMNS", "120")
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_SESSION_ID")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_ACTIVE_TASK_ID")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_ACTIVITY_ID")
-        .env_remove("ORBIT_STEP_INDEX")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_OPERATOR")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_TASK_ACTOR_KIND")
-        .env_remove("ORBIT_REGISTRY_ROOT")
-        .env_remove("ORBIT_WORKSPACE")
         .args(args)
         .output()
         .expect("run orbit")

--- a/crates/orbit-cli/tests/task_publication.rs
+++ b/crates/orbit-cli/tests/task_publication.rs
@@ -9,6 +9,7 @@ use std::process::Command as StdCommand;
 use std::os::unix::fs::PermissionsExt;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -742,6 +743,11 @@ fn orbit_command(cwd: &Path, home: &Path, publication_bare: &Path) -> assert_cmd
         .parent()
         .expect("publication parent")
         .join("publication-test-ssh");
+    // ORB-11300: clear inherited authority first; the deliberate
+    // `ORBIT_OPERATOR` grant below is this fixture's own, not the host run's.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
@@ -749,12 +755,7 @@ fn orbit_command(cwd: &Path, home: &Path, publication_bare: &Path) -> assert_cmd
         .env("ORBIT_OPERATOR", "1")
         .env("GIT_SSH", fake_ssh)
         .env("GIT_SSH_VARIANT", "ssh")
-        .env("PUBLICATION_TEST_REPO", publication_bare)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID");
+        .env("PUBLICATION_TEST_REPO", publication_bare);
     command
 }
 

--- a/crates/orbit-cli/tests/task_tags.rs
+++ b/crates/orbit-cli/tests/task_tags.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::process::Output;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -203,11 +204,16 @@ impl TestWorkspace {
 
 fn run_orbit(cwd: &Path, home: &Path, args: &[&str], stdin: Option<&str>) -> Output {
     let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: resetting HOME is not isolation. `ORBIT_REGISTRY_ROOT` and
+    // `ORBIT_WORKSPACE` outrank it, so a suite launched from inside a managed
+    // Orbit run used to add these fixture tasks to the live workspace.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
         .args(args);
     if let Some(input) = stdin {
         command.write_stdin(input);

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -490,46 +490,27 @@ impl TestWorkspace {
 
 fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> Output {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_SESSION_ID")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_ACTIVITY_ID")
-        .env_remove("ORBIT_STEP_INDEX")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_OPERATOR")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_TASK_ACTOR_KIND")
-        .env_remove("ORBIT_REGISTRY_ROOT")
-        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit")
 }
 
 fn run_orbit_as_operator(cwd: &Path, home: &Path, args: &[&str]) -> Output {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
         .env("ORBIT_OPERATOR", "1")
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_SESSION_ID")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_ACTIVITY_ID")
-        .env_remove("ORBIT_STEP_INDEX")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_TASK_ACTOR_KIND")
-        .env_remove("ORBIT_REGISTRY_ROOT")
-        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit as operator")
 }
@@ -542,24 +523,19 @@ fn run_orbit_with_identity(
     model: &str,
 ) -> Output {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_SESSION_ID")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_ACTIVITY_ID")
-        .env_remove("ORBIT_STEP_INDEX")
+        // A managed identity this fixture synthesizes itself, on top of a
+        // cleared environment — never the host run's (ORB-11300).
         .env("ORBIT_AGENT_NAME", agent)
         .env("ORBIT_AGENT_MODEL", model)
         .env("ORBIT_MANAGED_RUN_CONTEXT", "1")
         .env("ORBIT_RUN_ID", "task-trimmed-surface-managed")
-        .env_remove("ORBIT_OPERATOR")
-        .env_remove("ORBIT_TASK_ACTOR_KIND")
-        .env_remove("ORBIT_REGISTRY_ROOT")
-        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.output().expect("run orbit with managed identity")
 }

--- a/crates/orbit-cli/tests/tool_list.rs
+++ b/crates/orbit-cli/tests/tool_list.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeSet;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use predicates::prelude::*;
 use tempfile::tempdir;
 
@@ -30,6 +31,25 @@ const INACTIVE_TOOL_NAMES: &[&str] = &[
     "orbit.friction.stats",
 ];
 
+/// An `orbit` invocation pinned to the fixture's own home, with no inherited
+/// authority.
+///
+/// ORB-11300: clearing `ORBIT_ROOT` alone left the inherited
+/// `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair in place, and that pair
+/// outranks `HOME` — a suite launched from inside a managed Orbit run listed
+/// and initialized against the live workspace instead of this temp one.
+fn orbit_at_home(work: &std::path::Path, home: &std::path::Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(work)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
 #[test]
 fn tool_list_all_shows_inactive_lock_reservation_with_required_input_shape() {
     let temp = tempdir().expect("tempdir");
@@ -38,11 +58,7 @@ fn tool_list_all_shows_inactive_lock_reservation_with_required_input_shape() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         // `--format table` because `assert_cmd` captures through a pipe, where
         // `auto` resolves to the plain form and suppresses the header
         // (`specs/output-modes.md` §2). The STATUS *column* is what this test
@@ -66,11 +82,7 @@ fn tool_list_json_hides_inactive_tools_by_default() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    let output = cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    let output = orbit_at_home(&work, &home)
         .args(["tool", "list", "--json"])
         .assert()
         .success()
@@ -100,11 +112,7 @@ fn tool_list_json_all_includes_inactive_tools_with_status() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    let output = cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    let output = orbit_at_home(&work, &home)
         .args(["tool", "list", "--json", "--all"])
         .assert()
         .success()
@@ -132,11 +140,7 @@ fn tool_list_json_all_includes_parameter_schema_for_inactive_tools() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    let output = cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    let output = orbit_at_home(&work, &home)
         .args(["tool", "list", "--json", "--all"])
         .assert()
         .success()
@@ -175,11 +179,7 @@ fn tool_list_json_includes_task_show_context_parameters() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    let output = cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    let output = orbit_at_home(&work, &home)
         .args(["tool", "list", "--json"])
         .assert()
         .success()
@@ -223,11 +223,7 @@ fn tool_show_displays_lock_reservation_shapes() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args(["tool", "show", "orbit.task.locks.reserve"])
         .assert()
         .success()
@@ -249,11 +245,7 @@ fn tool_run_rejects_inactive_tools() {
     std::fs::create_dir_all(&home).expect("create home");
     std::fs::create_dir_all(&work).expect("create work");
 
-    cargo_bin_cmd!("orbit")
-        .current_dir(&work)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .env_remove("ORBIT_ROOT")
+    orbit_at_home(&work, &home)
         .args([
             "tool",
             "run",

--- a/crates/orbit-cli/tests/web_serve_shutdown.rs
+++ b/crates/orbit-cli/tests/web_serve_shutdown.rs
@@ -26,6 +26,7 @@ use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use orbit_common::test_env;
 use tempfile::tempdir;
 
 /// Upper bound this test allows between SIGTERM and process exit. Generous
@@ -177,10 +178,16 @@ fn free_port() -> u16 {
 }
 
 fn spawn_dashboard(home: &std::path::Path, port: u16) -> Child {
-    Command::new(env!("CARGO_BIN_EXE_orbit"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_orbit"));
+    // ORB-11300: the dashboard serves whichever workspace it resolves. Without
+    // this the inherited `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE` pair pointed
+    // it at the live one instead of this fixture's empty home.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
         .args(["web", "serve", "--port", &port.to_string(), "--no-open"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::Command as StdCommand;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -401,16 +402,16 @@ fn task_ids(value: &Value) -> Vec<String> {
 
 fn run_orbit(cwd: &Path, home: &Path, args: &[&str]) -> assert_cmd::assert::Assert {
     let mut command = cargo_bin_cmd!("orbit");
+    // ORB-11300: this fixture exercises selector resolution, so the inherited
+    // `ORBIT_WORKSPACE`/`ORBIT_REGISTRY_ROOT` pair is exactly the input under
+    // test. Take the whole shared list rather than a local subset.
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
         .env("USERPROFILE", home)
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_WORKSPACE")
         .args(args);
     command.assert()
 }

--- a/crates/orbit-cli/tests/workspace_sync.rs
+++ b/crates/orbit-cli/tests/workspace_sync.rs
@@ -7,18 +7,20 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::tempdir;
 
 fn orbit(cwd: &Path, home: &Path) -> assert_cmd::Command {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
-        .env_remove("ORBIT_HOME")
-        .env_remove("ORBIT_ROOT")
-        .env_remove("ORBIT_REGISTRY_ROOT")
-        .env_remove("ORBIT_WORKSPACE");
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_HOME");
     command
 }
 

--- a/crates/orbit-cli/tests/worktree_resolution.rs
+++ b/crates/orbit-cli/tests/worktree_resolution.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use assert_cmd::Command as AssertCommand;
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -344,6 +345,7 @@ fn run_orbit_success(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<
         .env("HOME", home)
         .env("USERPROFILE", home)
         .args(args);
+    clear_inherited_authority_env(&mut command);
     set_orbit_root_env(&mut command, orbit_root);
     command.assert().success();
 }
@@ -359,25 +361,23 @@ fn run_orbit_json(cwd: &Path, home: &Path, args: &[&str], orbit_root: Option<&Pa
         .env("HOME", home)
         .env("USERPROFILE", home)
         .args(args);
-    clear_agent_identity_env(&mut command);
+    clear_inherited_authority_env(&mut command);
     set_orbit_root_env(&mut command, orbit_root);
     let assert = command.assert().success();
     serde_json::from_slice(&assert.get_output().stdout).expect("orbit json output")
 }
 
-/// Prevent ambient managed-run identity from changing child command behavior.
-fn clear_agent_identity_env(command: &mut AssertCommand) {
-    command
-        .env_remove("ORBIT_AGENT_NAME")
-        .env_remove("ORBIT_AGENT_MODEL")
-        .env_remove("ORBIT_MANAGED_RUN_CONTEXT")
-        .env_remove("ORBIT_RUN_ID")
-        .env_remove("ORBIT_WORKSPACE")
-        .env_remove("ORBIT_TASK_ID")
-        .env_remove("ORBIT_ACTIVE_TASK_ID")
-        .env_remove("ORBIT_SESSION_ID")
-        .env_remove("ORBIT_BIN")
-        .env_remove("LLVM_PROFILE_FILE");
+/// Prevent ambient managed-run authority from changing child command
+/// behavior — or, worse, routing its writes (ORB-11300). Both runners below
+/// apply this before `set_orbit_root_env`, so an explicit fixture root still
+/// wins.
+fn clear_inherited_authority_env(command: &mut AssertCommand) {
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    // Not Orbit authority: a coverage build hands every child the same profile
+    // path, which the child would then clobber.
+    command.env_remove("LLVM_PROFILE_FILE");
 }
 
 fn set_orbit_root_env(command: &mut AssertCommand, orbit_root: Option<&Path>) {

--- a/crates/orbit-common/src/test_env.rs
+++ b/crates/orbit-common/src/test_env.rs
@@ -18,6 +18,11 @@
 //! test (ORB-10350). [`unset`] makes the expectation explicit instead of
 //! ambient.
 //!
+//! Integration tests that *spawn* the `orbit` binary need the same defense
+//! one process out, where the stakes include durable routing rather than just
+//! attribution. [`INHERITED_AUTHORITY_ENV`] is the canonical list for that
+//! case and [`clear_inherited_authority`] applies it.
+//!
 //! Exposed behind the `test-util` feature so integration tests and sibling
 //! crates share one implementation rather than re-deriving the guard.
 
@@ -41,6 +46,79 @@ pub const MANAGED_RUN_ENV: &[&str] = &[
     "ORBIT_MANAGED_RUN_CONTEXT",
     "ORBIT_WORKSPACE",
 ];
+
+/// Every ambient variable a test-spawned `orbit` child process must not
+/// inherit from the process that launched the suite.
+///
+/// [`unset`] and [`MANAGED_RUN_ENV`] defend *in-process* tests. A test that
+/// spawns the `orbit` binary needs the same defense one level out, and the
+/// stakes are higher: the child re-reads the environment from scratch, and
+/// two of these variables are durable routing authority.
+/// `ORBIT_REGISTRY_ROOT` selects the host-global registry regardless of
+/// `HOME`, and `ORBIT_WORKSPACE` selects a registered workspace inside it
+/// (see `orbit-core/src/runtime/resolve.rs` and
+/// `orbit-cmd/src/registry_runtime.rs`). Both are honored only behind the
+/// managed-run trust boundary — but an agent running the suite from inside a
+/// managed Orbit run supplies exactly that boundary, so a fixture that resets
+/// only `HOME`/`ORBIT_ROOT` still routes its writes into the *live* workspace.
+/// That is not hypothetical: it created three real task records before it was
+/// caught (ORB-11300).
+///
+/// Clearing the whole set — routing, managed-run trust, actor identity, and
+/// inherited sandbox grants — makes a fixture's authority a property of the
+/// fixture rather than of how the suite was launched. Apply it with
+/// [`clear_inherited_authority`] *before* any variable a test sets on
+/// purpose, so the deliberate value wins.
+pub const INHERITED_AUTHORITY_ENV: &[&str] = &[
+    // Durable routing: which registry, workspace, and data root the child
+    // writes to. `ORBIT_REGISTRY_ROOT` and `ORBIT_WORKSPACE` outrank `HOME`.
+    "ORBIT_ROOT",
+    "ORBIT_REGISTRY_ROOT",
+    "ORBIT_WORKSPACE",
+    "ORBIT_WORKSPACE_CLAIM_TOKEN",
+    "ORBIT_WORKTREE_ROOT",
+    "ORBIT_JOB_DIR",
+    "ORBIT_ACTIVITY_DIR",
+    // Managed-run trust boundary and run identity. Clearing the marker alone
+    // would be enough to disarm routing today; clearing the whole envelope
+    // keeps the fixture correct if that coupling ever changes.
+    "ORBIT_MANAGED_RUN_CONTEXT",
+    "ORBIT_RUN_ID",
+    "ORBIT_TASK_ID",
+    "ORBIT_ACTIVE_TASK_ID",
+    "ORBIT_SESSION_ID",
+    "ORBIT_ACTIVITY_ID",
+    "ORBIT_STEP_INDEX",
+    // Actor identity and audit role attributed to the child's writes.
+    "ORBIT_AGENT_NAME",
+    "ORBIT_AGENT_MODEL",
+    "ORBIT_OPERATOR",
+    "ORBIT_TASK_ACTOR_KIND",
+    // Sandbox and tool grants leased to the host activity, not to a fixture.
+    "ORBIT_ACTIVITY_TOOLS",
+    "ORBIT_ACTIVITY_FS_PROFILE",
+    "ORBIT_PROC_ALLOWED_PROGRAMS",
+    "ORBIT_BIN",
+];
+
+/// Clear every [`INHERITED_AUTHORITY_ENV`] variable from a child command.
+///
+/// `clear` is the command builder's `env_remove`. Passing it as a closure
+/// keeps this crate free of a test-harness dependency while still giving every
+/// fixture one shared list to drift against:
+///
+/// ```ignore
+/// let mut command = cargo_bin_cmd!("orbit");
+/// test_env::clear_inherited_authority(|name| {
+///     command.env_remove(name);
+/// });
+/// command.current_dir(work).env("HOME", home);
+/// ```
+pub fn clear_inherited_authority(mut clear: impl FnMut(&str)) {
+    for name in INHERITED_AUTHORITY_ENV {
+        clear(name);
+    }
+}
 
 /// Restores the variables captured by [`unset`] when dropped.
 ///

--- a/crates/orbit-common/src/tests/test_env.rs
+++ b/crates/orbit-common/src/tests/test_env.rs
@@ -54,3 +54,39 @@ fn scoped_guard_recovers_after_a_sibling_assertion_panics_while_holding_it() {
 
     assert_eq!(std::env::var(VAR).ok(), baseline);
 }
+
+/// The in-process managed-run envelope and the subprocess scrub must not
+/// drift apart: anything worth hiding from a same-process test is worth
+/// hiding from a spawned `orbit` child, which re-reads the environment from
+/// scratch and can route durable writes with it (ORB-11300).
+#[test]
+fn inherited_authority_covers_the_managed_run_envelope_without_duplicates() {
+    for name in super::MANAGED_RUN_ENV {
+        assert!(
+            super::INHERITED_AUTHORITY_ENV.contains(name),
+            "{name} is scrubbed in-process but would still reach a spawned child"
+        );
+    }
+
+    let mut seen = super::INHERITED_AUTHORITY_ENV.to_vec();
+    seen.sort_unstable();
+    let deduped = {
+        let mut deduped = seen.clone();
+        deduped.dedup();
+        deduped
+    };
+    assert_eq!(seen, deduped, "duplicate names hide an editing mistake");
+}
+
+/// `clear_inherited_authority` must hand the caller every name exactly once —
+/// a fixture wires it straight into `Command::env_remove`.
+#[test]
+fn clear_inherited_authority_visits_every_name_once() {
+    let mut cleared = Vec::new();
+    super::clear_inherited_authority(|name| cleared.push(name.to_string()));
+
+    assert_eq!(cleared.len(), super::INHERITED_AUTHORITY_ENV.len());
+    for name in super::INHERITED_AUTHORITY_ENV {
+        assert!(cleared.iter().any(|seen| seen == name), "missing {name}");
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11300](https://orbit-cli.com/tasks/ORB-11300) — Prevent integration tests from inheriting live managed workspace authority

### Description

Observed during Daniel's authorized red-CI diagnostic in ORB-11287: cargo nextest run --workspace --lib --bins --tests --no-fail-fast produced 29 failures, many temp workspace registration/global-state collisions, AND created real ws_orbit fixture tasks ORB-11291/11292/11293 at 2026-09-05T18:09:53Z. Their exact titles Perf task / Bench task / Perf bench task and Shared tag-search marker description match crates/orbit-cli/tests/task_tags.rs lines 14-18,172-180. run_orbit at204-211 only resets HOME/USERPROFILE and removes ORBIT_ROOT, leaving managed registry/workspace identity inherited. These three records have been rejected as fixtures. Prior fixes ORB-11243 isolated output_goldens/table_rendering; ORB-11085 isolated workspace-init EnvGuard. Audit current test subprocess construction and apply that established test-only isolation across directly affected fixtures rather than weakening production authority precedence. Review ORB-11287 comment with all29 names. Do not rerun known leaking tests against live authority. Reproduce under disposable sentinel authority.

### Acceptance Criteria

- Reproduce inherited authority leakage safely using only disposable registry/workspace sentinels; ensure the reproducer cannot route to production even before the fix.
- Fix task_tags and other directly evidenced integration fixture families using a small shared test-only isolation helper where justified. Audit durable routing and managed identity env, not just HOME/ORBIT_ROOT. Preserve production capability checks.
- Regression proves fixture initialization/task creation/mutations leave an ambient sentinel registry/tasks byte-for-byte unchanged and route to the fixture's isolated authority. Cover parallel repeated tests.
- Run the affected diagnostic families under controlled inherited managed environment; classify residual permission/policy failures with exact evidence instead of weakening them. Record complete outcomes.
- No live fixture records are created by validation. Run focused tests plus ci-fast/ci-lint. Do not modify or delete unrelated live records; report any additional pollution for authoritative orchestration.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause. `orbit-cli` fixtures reset only `HOME`/`USERPROFILE` and removed `ORBIT_ROOT`, but neither outranks the managed routing pair. `orbit_core::runtime::resolve::resolve_global_root` prefers `ORBIT_REGISTRY_ROOT` over `HOME`, and `orbit_cmd::registry_runtime::initialize_with_overrides_mode` falls back to `managed_workspace_selector_from_env` (`ORBIT_WORKSPACE`) when no `--workspace` is passed. Both are gated on the managed-run trust boundary (`ORBIT_MANAGED_RUN_CONTEXT` + non-empty `ORBIT_RUN_ID`) — which an agent running the suite from inside a managed Orbit run supplies. `crates/orbit-cli/tests/task_tags.rs` therefore wrote its `Perf task` / `Bench task` / `Perf bench task` fixtures into the live `ws_orbit` workspace as ORB-11291/11292/11293. Production precedence was NOT weakened; only the fixtures changed.

Fix. `orbit-common::test_env` (feature `test-util`) gains one canonical list, `INHERITED_AUTHORITY_ENV`, plus `clear_inherited_authority(|name| ...)`, a closure-based applier that keeps `orbit-common` free of an `assert_cmd` dependency edge. The list is an evidence-based audit of every ORBIT_* name read by production code, grouped by concern: durable routing (`ORBIT_ROOT`, `ORBIT_REGISTRY_ROOT`, `ORBIT_WORKSPACE`, `ORBIT_WORKSPACE_CLAIM_TOKEN`, `ORBIT_WORKTREE_ROOT`, `ORBIT_JOB_DIR`, `ORBIT_ACTIVITY_DIR`), managed-run trust/identity (`ORBIT_MANAGED_RUN_CONTEXT`, `ORBIT_RUN_ID`, `ORBIT_TASK_ID`, `ORBIT_ACTIVE_TASK_ID`, `ORBIT_SESSION_ID`, `ORBIT_ACTIVITY_ID`, `ORBIT_STEP_INDEX`), actor identity (`ORBIT_AGENT_NAME`, `ORBIT_AGENT_MODEL`, `ORBIT_OPERATOR`, `ORBIT_TASK_ACTOR_KIND`), and inherited sandbox grants (`ORBIT_ACTIVITY_TOOLS`, `ORBIT_ACTIVITY_FS_PROFILE`, `ORBIT_PROC_ALLOWED_PROGRAMS`, `ORBIT_BIN`).

All 19 `orbit-cli` fixture files that spawn the `orbit` binary now apply that one list; the crate no longer contains a single bespoke authority env list. Six were actively leaking (nothing disarmed the trust boundary): task_tags, docs, host_administration, semantic_companion, tool_list, github_capability_preflight, json_output_stability, web_serve_shutdown. The rest held divergent partial copies (output_goldens and table_rendering from ORB-11243, plus mcp_roundtrip, task_trimmed_surface, worktree_resolution, workspace_selector, task_publication, proc_spawn_managed, routine_root, sweep_root, workspace_sync) and were converted so the lists cannot drift again. `proc_spawn_managed` and `task_trimmed_surface` synthesize their own managed context on top of the cleared environment — previously that synthetic context inherited the live `ORBIT_REGISTRY_ROOT`/`ORBIT_WORKSPACE`, pointing a sandboxed `proc.spawn` at the live workspace. `worktree_resolution::run_orbit_success` never called its local scrub at all; it does now. host_administration and tool_list had 8 and 7 duplicated inline call sites collapsed into one local isolated-command helper each.

Regression (`crates/orbit-cli/tests/ambient_authority_isolation.rs`, 3 tests, all passing). A disposable sentinel registry + registered workspace is built in a TempDir; the child commands name that sentinel explicitly via `.env()`, so no case can route to production regardless of ambient state. (1) `an_unscrubbed_child_routes_its_write_into_the_ambient_authority` reproduces the leak — a pre-fix-shaped command (`HOME` pinned, `ORBIT_ROOT` dropped, everything else inherited) creates its task inside the sentinel workspace while the fixture's own `HOME/.orbit` is never created, proving the sentinel is a reachable authority and the isolated assertions are not vacuous. (2) `fixture_lifecycle_leaves_the_ambient_authority_byte_for_byte_unchanged` runs workspace init, task add, and task update under the same ambient authority and asserts a byte-for-byte snapshot (registry half and workspace half keyed separately so a colliding `.orbit/config.yaml` cannot hide a change) is unchanged after each step, and that the record lands in the fixture's own tree. (3) `parallel_repeated_fixtures_all_stay_off_the_ambient_authority` runs 4 threads x 2 rounds of init+add concurrently and re-asserts the snapshot.

Also added two drift guards in `orbit-common/src/tests/test_env.rs`: `MANAGED_RUN_ENV` must be a subset of `INHERITED_AUTHORITY_ENV` (anything hidden from an in-process test must be hidden from a spawned child, which re-reads the env and can route durable writes with it), and the list must be duplicate-free; plus a test that the applier visits every name exactly once.

Validation, and how live records were kept safe. Every suite run redirected the ambient managed environment at a throwaway sentinel registry (`ORBIT_REGISTRY_ROOT=<temp>/.orbit ORBIT_WORKSPACE=ws_validate-sentinel`), so even a residual leak would land there rather than on `ws_orbit`. Ran all 20 affected `orbit-cli` test binaries with `--no-fail-fast`: 148 passed, 1 failed. A sha256 snapshot of all 107 sentinel files taken before the run was identical after it — zero changed, zero created. The live `ws_orbit` task directory was 1400 entries before and after with identical tail entries; no live fixture record was created by this task's validation. `cargo test -p orbit-common --lib test_env` passes (4/4). `make ci-fast` and `make ci-lint` both pass clean.

Residual failure, classified not weakened. `mcp_roundtrip::process_metadata_does_not_supply_a_replayable_key_bound_identity` fails at mcp_roundtrip.rs:1218 with `the Linux security regression requires an unrestricted runner where setgid is enabled and a mapped supplementary group is available`. This is a runner restriction, not a code failure and not caused by this change: its gate `install_test_ssh_launcher` returns None when `/proc/self/status` reports `NoNewPrivs: 1`, and this executor process reports exactly that (`grep NoNewPrivs /proc/self/status` -> `NoNewPrivs:	1`; `id -G` -> `1000 65534`). The gate reads process credentials only and is independent of child environment. The test was left exactly as it is — unrestricted CI should arbitrate it. Note it `.expect()`s an Option the helper deliberately returns None for under a restricted runner, so it hard-fails rather than skipping; converting that to a skip is a separate judgement call and was deliberately not made here.

Scope note (unlisted files changed). Beyond the 9 listed selectors, 13 more were touched and appended to context_files: `crates/orbit-cli/tests/ambient_authority_isolation.rs` (new regression, criterion 3) and `crates/orbit-common/src/tests/test_env.rs` (drift guards for the new const); `tool_list.rs`, `json_output_stability.rs`, `github_capability_preflight.rs`, `web_serve_shutdown.rs` (four additional actively-leaking fixtures found by the criterion-2 audit — leaving them would have left the hole open); and `mcp_roundtrip.rs`, `output_goldens.rs`, `table_rendering.rs`, `task_trimmed_surface.rs`, `routine_root.rs`, `sweep_root.rs`, `workspace_sync.rs` (the divergent partial copies the shared list replaces; converting them is what makes the single-list invariant real rather than aspirational). No production code, ADR, doc, or fixture was deleted, and no new dependency edge was introduced.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11300-6a9c5e47`
- Behind base: 0
- Ahead of base: 1