### PR TITLE
Add a workspace-scoped command to stop auto admissions cleanly

### DIFF
--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -54,6 +54,12 @@ spec:
     # next admission pass — same run id, same deadline, same completion
     # authorization, same children. Lowering it stops new admissions until
     # enough children finish; it cancels nothing.
+    #
+    # ORB-11283: `orbit run auto --stop` records `drain_admissions_stop` on
+    # this same state. Classify then offers nothing, `drain_window` expires
+    # for the stop rather than the deadline, and `invoke_detached` skips a
+    # child that was offered before the stop landed. Children already
+    # submitted keep running; this is not `orbit run cancel`.
     max_active_leaf_runs: 5
     # Waited when the backlog has work but no slot is free: the latency a
     # freed slot sits idle before it is refilled.

--- a/crates/orbit-cli/src/command/run/auto.rs
+++ b/crates/orbit-cli/src/command/run/auto.rs
@@ -1,9 +1,10 @@
 //! `orbit run auto` workspace logistics entrypoint.
 
 use clap::Args;
-use orbit_core::{CompletionPolicy, OrbitRuntime};
+use orbit_core::{CompletionPolicy, DrainAdmissionsStopRequest, OrbitRuntime};
+use serde_json::json;
 
-use crate::command::{CommandOut, CommandOutput, Execute};
+use crate::command::{CommandOut, CommandOutput, Execute, Payload};
 use crate::parse::parse_duration_seconds;
 
 use super::support::{WorkflowDispatchResult, print_workflow_dispatch_results};
@@ -14,7 +15,7 @@ pub(super) const AUTO_WORKFLOW: &str = "auto";
 #[command(
     about = "Drain the workspace backlog for a window (loose leaves, plus one epic)",
     override_usage = "orbit run auto [OPTIONS]",
-    after_help = "Examples:\n  orbit run auto\n  orbit run auto --for 4h\n  orbit run auto --for 4h --concurrency 8\n  orbit run auto --for 4h --complete\n\n\
+    after_help = "Examples:\n  orbit run auto\n  orbit run auto --for 4h\n  orbit run auto --for 4h --concurrency 8\n  orbit run auto --for 4h --complete\n  orbit run auto --stop\n\n\
                   The drain re-lists the whole backlog every pass and keeps `--concurrency`\n\
                   tasks in flight, starting a replacement as each one finishes rather than\n\
                   waiting for the batch. An epic root runs alongside the leaves, one at a time.\n\n\
@@ -27,6 +28,11 @@ pub(super) const AUTO_WORKFLOW: &str = "auto";
                   crew is excluded is simply not started, and `orbit run readiness --allow-crew`\n\
                   names it. To actually move that work, reassign its crew yourself. Tasks a\n\
                   different invocation already has in flight keep running.\n\n\
+                  `--stop` ends new admissions for this workspace's active auto coordinator.\n\
+                  You do not need a run ID. Already admitted workers keep running under the\n\
+                  completion authority they were started with; this is not cancellation.\n\
+                  To cancel those workers, `orbit run cancel <RUN_ID> --confirm` each child.\n\
+                  A second `--stop`, or `--stop` with no active coordinator, is a no-op.\n\n\
                   Inspect submitted runs with `orbit run history -j workspace_auto_pipeline` and\n\
                   `orbit run show <RUN_ID>`."
 )]
@@ -64,10 +70,21 @@ pub struct AutoCommand {
     /// one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`.
     #[arg(long)]
     pub claim_token: Option<String>,
+    /// Stop new admissions for this workspace's active auto coordinator.
+    /// Already admitted workers keep running. Conflicts with the flags that
+    /// start a drain.
+    #[arg(
+        long,
+        conflicts_with_all = ["for_duration", "concurrency", "complete", "allow_crew"]
+    )]
+    pub stop: bool,
 }
 
 impl Execute for AutoCommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        if self.stop {
+            return execute_stop(runtime, self.json, self.claim_token.as_deref());
+        }
         let for_seconds = self
             .for_duration
             .as_deref()
@@ -102,4 +119,67 @@ impl Execute for AutoCommand {
         print_workflow_dispatch_results(AUTO_WORKFLOW, &[run], self.json)?;
         Ok(CommandOutput::Silent)
     }
+}
+
+fn execute_stop(runtime: &OrbitRuntime, json: bool, claim_token: Option<&str>) -> CommandOut {
+    let result = runtime.stop_workspace_auto_admissions(DrainAdmissionsStopRequest {
+        actor: "cli",
+        source: "run_auto_stop",
+        reason: None,
+        claim_token,
+    })?;
+    if json {
+        return Ok(Payload::document(json!({
+            "outcome": result.outcome,
+            "coordinators": result.coordinators.iter().map(|change| json!({
+                "run_id": change.run_id,
+                "job_id": change.job_id,
+                "outcome": change.outcome,
+                "remaining_children": change.remaining_children.iter().map(|child| json!({
+                    "run_id": child.run_id,
+                    "job_name": child.job_name,
+                    "phase": child.phase,
+                    "child_status": child.child_status,
+                })).collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+        }))
+        .into());
+    }
+    if result.coordinators.is_empty() {
+        println!("No active auto coordinator in this workspace.");
+        return Ok(CommandOutput::Silent);
+    }
+    for change in &result.coordinators {
+        match change.outcome {
+            "cancelled_queued" => println!(
+                "Cancelled queued auto run {} before it started; it had not admitted any work.",
+                change.run_id
+            ),
+            "unchanged" => println!("job run {} already has admissions stopped.", change.run_id),
+            _ => println!(
+                "Stopped admissions for job run {} ({}).",
+                change.run_id, change.job_id
+            ),
+        }
+        if change.remaining_children.is_empty() {
+            if change.outcome != "cancelled_queued" {
+                println!("No remaining children.");
+            }
+        } else {
+            println!(
+                "Remaining children (still running under their existing completion authority):"
+            );
+            for child in &change.remaining_children {
+                let status = child.child_status.as_deref().unwrap_or("-");
+                println!(
+                    "  {} job={} phase={} status={}",
+                    child.run_id, child.job_name, child.phase, status
+                );
+            }
+            println!(
+                "To cancel already-running workers, use `orbit run cancel <run_id> --confirm` on each child."
+            );
+        }
+    }
+    Ok(CommandOutput::Silent)
 }

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -20,6 +20,7 @@ use super::triage;
 const RUN_AFTER_HELP: &str = "\
 Workflow entrypoints:
   orbit run auto [--for 30m]
+  orbit run auto --stop
   orbit run ship [task_id ...]
   orbit run ship-sweep [--dry-run] [--json]
   orbit run triage [task_id ...]
@@ -51,7 +52,7 @@ Maintenance:
 {usage-heading} {usage}
 
 Workflows:
-  auto        Drain the workspace backlog for a window (loose leaves, plus one epic)
+  auto        Drain the workspace backlog for a window (loose leaves, plus one epic); --stop ends new admissions
   ship        Ship backlog or explicitly selected tasks through the gated task pipeline
   ship-sweep  Dispatch ship runs in every registered workspace with ready backlog tasks
   triage      Triage tasks blocked by failed runs; re-backlog environmental failures

--- a/crates/orbit-cli/src/command/run/format.rs
+++ b/crates/orbit-cli/src/command/run/format.rs
@@ -62,6 +62,7 @@ pub(crate) fn format_waiting_line(
 /// the whole point of the dispatch checkpoint is that an operator staring at a
 /// stalled — or cancelled — parent can name its child immediately, so the
 /// lineage is printed for terminal runs too.
+///
 /// [ORB-11253] The worker ceiling in force on a drain, and who last moved it.
 ///
 /// Printed only when an operator has retuned the run: an untouched drain is
@@ -77,6 +78,24 @@ pub(crate) fn format_worker_limit_line(state: Option<&PipelineState>) -> Option<
         limit.actor,
     );
     if let Some(reason) = &limit.reason {
+        line.push_str(&format!(" reason={reason}"));
+    }
+    Some(line)
+}
+
+/// [ORB-11283] Whether this drain was told to stop new admissions.
+///
+/// Printed whenever the control is present, including on a finished run: that
+/// is how an operator distinguishes a drain that wound down after `--stop`
+/// from one that was cancelled.
+pub(crate) fn format_admissions_stop_line(state: Option<&PipelineState>) -> Option<String> {
+    let stop = state?.drain_admissions_stop.as_ref()?;
+    let mut line = format!(
+        "Admissions: stopped by {} at {}",
+        stop.actor,
+        stop.stopped_at.format("%Y-%m-%dT%H:%M:%SZ"),
+    );
+    if let Some(reason) = &stop.reason {
         line.push_str(&format!(" reason={reason}"));
     }
     Some(line)

--- a/crates/orbit-cli/src/command/run/steps.rs
+++ b/crates/orbit-cli/src/command/run/steps.rs
@@ -8,8 +8,8 @@ use crate::command::{CommandOut, Payload};
 use crate::output::color::Domain;
 
 use super::format::{
-    format_child_dispatch_lines, format_duration, format_timestamp, format_waiting_line,
-    format_worker_limit_line, summarize_error_message,
+    format_admissions_stop_line, format_child_dispatch_lines, format_duration, format_timestamp,
+    format_waiting_line, format_worker_limit_line, summarize_error_message,
 };
 
 pub(crate) fn resolve_run(
@@ -203,6 +203,9 @@ pub(crate) fn run_header_text_with_state(run: &JobRun, state: Option<&PipelineSt
         lines.push(line);
     }
     if let Some(line) = format_worker_limit_line(state) {
+        lines.push(line);
+    }
+    if let Some(line) = format_admissions_stop_line(state) {
         lines.push(line);
     }
     lines.extend(format_child_dispatch_lines(state));

--- a/crates/orbit-cli/src/command/run/tests/format.rs
+++ b/crates/orbit-cli/src/command/run/tests/format.rs
@@ -135,3 +135,19 @@ fn worker_limit_line_reports_the_change_and_its_author() {
     assert!(line.contains("set by operator"), "{line}");
     assert!(line.contains("reason=more headroom"), "{line}");
 }
+
+/// [ORB-11283] A stopped drain says so in `orbit run show`.
+#[test]
+fn admissions_stop_line_names_the_actor_and_is_absent_when_unset() {
+    let mut state = PipelineState::new(
+        "jrun-drain".to_string(),
+        "workspace_auto_pipeline".to_string(),
+        json!({}),
+    );
+    assert_eq!(format_admissions_stop_line(Some(&state)), None);
+
+    state.set_drain_admissions_stop("operator".to_string(), Some("done for the day".to_string()));
+    let line = format_admissions_stop_line(Some(&state)).expect("stop line");
+    assert!(line.contains("Admissions: stopped by operator"), "{line}");
+    assert!(line.contains("reason=done for the day"), "{line}");
+}

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -133,9 +133,51 @@ fn parses_workspace_auto_defaults() {
             assert_eq!(args.for_duration, None);
             // No crew restriction is the pre-ORB-11242 behavior: every crew.
             assert!(args.allow_crew.is_empty());
+            assert!(!args.stop);
         }
         _ => panic!("expected auto"),
     }
+}
+
+#[test]
+fn parses_workspace_auto_stop() {
+    let command = parse_run(&["orbit", "run", "auto", "--stop"]);
+    match command.command {
+        RunSubcommand::Auto(args) => {
+            assert!(args.stop);
+            assert_eq!(args.for_duration, None);
+            assert!(!args.complete);
+        }
+        _ => panic!("expected auto"),
+    }
+}
+
+#[test]
+fn workspace_auto_stop_conflicts_with_start_flags() {
+    for args in [
+        ["orbit", "run", "auto", "--stop", "--for", "30m"].as_slice(),
+        ["orbit", "run", "auto", "--stop", "--concurrency", "3"].as_slice(),
+        ["orbit", "run", "auto", "--stop", "--complete"].as_slice(),
+        ["orbit", "run", "auto", "--stop", "--allow-crew", "luna"].as_slice(),
+    ] {
+        assert_cli_rejects(args, ErrorKind::ArgumentConflict, "--stop");
+    }
+}
+
+#[test]
+fn auto_stop_with_no_coordinator_is_idle() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    super::auto::AutoCommand {
+        for_duration: None,
+        concurrency: None,
+        complete: false,
+        allow_crew: Vec::new(),
+        json: true,
+        claim_token: None,
+        stop: true,
+    }
+    .execute(&runtime)
+    .expect("idle stop succeeds");
 }
 
 #[test]

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -54,6 +54,12 @@ spec:
     # next admission pass — same run id, same deadline, same completion
     # authorization, same children. Lowering it stops new admissions until
     # enough children finish; it cancels nothing.
+    #
+    # ORB-11283: `orbit run auto --stop` records `drain_admissions_stop` on
+    # this same state. Classify then offers nothing, `drain_window` expires
+    # for the stop rather than the deadline, and `invoke_detached` skips a
+    # child that was offered before the stop landed. Children already
+    # submitted keep running; this is not `orbit run cancel`.
     max_active_leaf_runs: 5
     # Waited when the backlog has work but no slot is free: the latency a
     # freed slot sits idle before it is refilled.

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -24,6 +24,7 @@ orbit run ship --mode local         # implement in a worktree, merge to the base
 orbit run auto --for 2h             # drain the backlog for a window
 orbit run auto --for 2h --concurrency 8   # ... with 8 tasks in flight at a time
 orbit run auto --for 2h --allow-crew opus,sonnet  # ... using only these crews
+orbit run auto --stop                      # stop new admissions; children keep running
 orbit run concurrency <run-id> --set 7     # retune a live drain, without replacing it
 orbit run readiness                        # explain current auto-drain eligibility, read-only
 orbit run readiness TASK-123 --json        # explain selected task IDs as JSON
@@ -60,6 +61,13 @@ authorization. The retune keeps all of them:
   one you read, so two operators cannot silently overwrite each other. The
   current value and who last moved it are on `orbit run show <run-id>`
   (`drain_worker_limit`) and `orbit run readiness`.
+
+`orbit run auto --stop` ends new admissions for this workspace's active
+coordinator. It does not need a run id, does not cancel children, and is
+idempotent when nothing is running. `orbit run show` reports
+`Admissions: stopped by ...` and lists remaining children. To cancel workers
+already in flight, `orbit run cancel <child-run-id> --confirm` each one —
+do not cancel the coordinator for this.
 
 `--allow-crew` restricts one drain to the crews you name — the lever for a
 provider that is unavailable, rate-limited, or out of budget. It is opt-in and

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -233,7 +233,9 @@ pub(crate) fn run_deterministic(
         // Stamp a drain deadline, or answer whether a stamped one has passed
         // [ORB-10819]. Gates the start of the next iteration only; nothing
         // here cancels or shortens an in-flight child run.
-        CoreDeterministicAction::DrainWindow => workspace_auto::drain_window(action, input),
+        CoreDeterministicAction::DrainWindow => {
+            workspace_auto::drain_window(runtime, action, input)
+        }
         // ADR-0223: scheduled shipment resolves only the active runtime's
         // canonical ship input; cross-workspace enumeration stays in the
         // legacy CLI sweep and `workflow.auto_ship` is deliberately ignored.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -354,6 +354,21 @@ pub(super) fn invoke_detached(
     let parent_run_id = child_dispatch::parent_run_id(input);
     let parent_step_id = child_dispatch::parent_step_id(input);
 
+    // [ORB-11283] Re-check at the submit boundary, not only in classify: a
+    // stop can land after the drain offered work and before this child is
+    // durable. Skipping here admits nothing; failing would take down the
+    // coordinator and is not an admissions stop.
+    if parent_run_id
+        .as_deref()
+        .is_some_and(|run_id| runtime.drain_admissions_stopped(run_id))
+    {
+        return Ok(serde_json::json!({
+            "skipped": true,
+            "reason": "admissions_stopped",
+            "job_name": job_name,
+        }));
+    }
+
     let invoke_output = runtime
         .run_tool_with_context_and_role(
             "orbit.pipeline.invoke",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -550,3 +550,37 @@ fn a_detached_child_is_recorded_as_non_blocking() {
         "a detached child was dispatched to outlive its parent's step"
     );
 }
+
+#[test]
+fn invoke_detached_skips_when_the_parent_has_stopped_admissions() {
+    let (runtime, parent) = parent_runtime();
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&parent, chrono::Utc::now(), std::process::id())
+        .expect("start parent");
+    runtime
+        .stop_workspace_auto_admissions(crate::application::job::DrainAdmissionsStopRequest {
+            actor: "tester",
+            source: "unit",
+            reason: None,
+            claim_token: None,
+        })
+        .expect("stop parent");
+
+    let output = invoke_detached(
+        &runtime,
+        "invoke_detached",
+        &ship_leaves_input(&parent),
+        orbit_tools::ToolContext::default(),
+    )
+    .expect("stopped parent skips rather than failing");
+
+    assert_eq!(output["skipped"], true);
+    assert_eq!(output["reason"], "admissions_stopped");
+    assert!(output.get("run_id").is_none());
+    assert!(
+        recorded_dispatches(&runtime, &parent).is_empty(),
+        "a skipped invoke must not create a child"
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -914,6 +914,28 @@ fn a_stamped_window_answers_expiry_against_its_own_deadline() {
 }
 
 #[test]
+fn a_stopped_drain_expires_the_window_without_waiting_for_the_deadline() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let drain_run_id = seed_running_drain(&runtime, 5);
+    runtime
+        .stop_workspace_auto_admissions(crate::application::job::DrainAdmissionsStopRequest {
+            actor: "tester",
+            source: "unit",
+            reason: None,
+            claim_token: None,
+        })
+        .expect("stop drain");
+
+    let stamped = drain_window(
+        &runtime,
+        json!({ "run_id": drain_run_id, "for_seconds": 600 }),
+    );
+    assert_eq!(stamped["expired"], true);
+    assert_eq!(stamped["expired_reason"], "admissions_stopped");
+    assert_eq!(stamped["remaining_seconds"], 0.0);
+}
+
+#[test]
 fn a_drain_window_rejects_an_unparseable_deadline_or_an_oversize_request() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
 
@@ -1311,6 +1333,66 @@ fn seed_backlog_leaves(runtime: &OrbitRuntime, count: usize) -> Vec<String> {
             .id
         })
         .collect()
+}
+
+#[test]
+fn a_stopped_drain_admits_no_leaves_or_epics_and_leaves_live_children() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "crates/leaf_0/src/lib.rs");
+    seed_backlog_leaves(&runtime, 1);
+    let epic = runtime
+        .add_task(crate::application::task::TaskAddParams {
+            title: "Epic root".to_string(),
+            description: "fixture".to_string(),
+            acceptance_criteria: vec!["fixture".to_string()],
+            plan: "fixture".to_string(),
+            tags: vec!["epic".to_string()],
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("seed epic");
+    let drain_run_id = seed_running_drain(&runtime, 5);
+    let live = seed_live_leaf_run(&runtime, &["CARRIED"]);
+
+    runtime
+        .stop_workspace_auto_admissions(crate::application::job::DrainAdmissionsStopRequest {
+            actor: "tester",
+            source: "unit",
+            reason: None,
+            claim_token: None,
+        })
+        .expect("stop drain");
+
+    let output = classify_with(
+        &runtime,
+        json!({ "run_id": drain_run_id, "max_active_leaf_runs": 5 }),
+    );
+    assert_eq!(output["admissions_stopped"], true);
+    assert_eq!(output["free_slots"], 0);
+    assert!(
+        output["loose_task_ids"]
+            .as_array()
+            .expect("admitted")
+            .is_empty(),
+        "a stopped drain admits no leaves: {output}"
+    );
+    assert_eq!(output["epic_task_id"], Value::Null);
+    assert_eq!(output["has_epic"], false);
+    assert_eq!(output["has_leaves"], false);
+    let child = runtime.show_job_run(&live).expect("show child");
+    assert!(
+        !child.state.is_terminal(),
+        "stop must not cancel an already admitted child"
+    );
+    assert_ne!(
+        output["epic_task_id"],
+        json!(epic.id),
+        "a stopped drain must not start an admissible epic"
+    );
+
+    let readiness = readiness(&runtime, &[], None);
+    assert_eq!(readiness["capacity"]["admissions_stopped"], true);
+    assert_eq!(readiness["capacity"]["free_slots"], 0);
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, SecondsFormat, TimeDelta, Utc};
 use orbit_common::OrbitError;
 use orbit_engine::DispatchError;
 use orbit_types::task::{Task, TaskStatus, task_dependencies_ready, unmet_task_dependencies};
-use orbit_types::workflow::DrainWorkerLimit;
+use orbit_types::workflow::{DrainAdmissionsStop, DrainWorkerLimit};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -112,9 +112,15 @@ pub(super) fn classify_workspace_auto_tasks(
         .iter()
         .flat_map(|run| run.task_ids.iter().cloned())
         .collect();
-    let free_slots = usize::try_from(max_active_leaf_runs)
-        .unwrap_or(usize::MAX)
-        .saturating_sub(live_leaves.len());
+    let admissions_stop = live_admissions_stop(runtime, input);
+    let admissions_stopped = admissions_stop.is_some();
+    let free_slots = if admissions_stopped {
+        0
+    } else {
+        usize::try_from(max_active_leaf_runs)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(live_leaves.len())
+    };
 
     let backlog = list_backlog_tasks(runtime, action, input)?;
     // Priority/age order is `list_backlog_tasks`'s, and the truncation to the
@@ -137,19 +143,21 @@ pub(super) fn classify_workspace_auto_tasks(
         .collect();
 
     let active_epic = active_epic_run(runtime, action)?;
-    let epic_task_id = match &active_epic {
-        // One epic at a time. `epic_pipeline` declares `max_active_runs: 1`,
-        // so offering a second root would not run it — it would queue a
-        // `pending` run behind the live one, and the drain loop would mint a
-        // fresh one every iteration. Keying on the run rather than on the
-        // root's status also closes the window between a detached submit and
-        // the child's `worktree_setup` moving that root to `in-progress`.
-        Some(_) => None,
-        None => next_admissible_epic_root(
+    // One epic at a time. `epic_pipeline` declares `max_active_runs: 1`,
+    // so offering a second root would not run it — it would queue a
+    // `pending` run behind the live one, and the drain loop would mint a
+    // fresh one every iteration. Keying on the run rather than on the
+    // root's status also closes the window between a detached submit and
+    // the child's `worktree_setup` moving that root to `in-progress`.
+    // [ORB-11283] A stopped drain offers no new epic either.
+    let epic_task_id = if admissions_stopped || active_epic.is_some() {
+        None
+    } else {
+        next_admissible_epic_root(
             runtime,
             action,
             allowlist_from_input(runtime, action, input)?.as_ref(),
-        )?,
+        )?
     };
 
     let has_leaves = !loose_task_dispatches.is_empty();
@@ -180,6 +188,8 @@ pub(super) fn classify_workspace_auto_tasks(
         "submitted_max_active_leaf_runs": submitted_max_active_leaf_runs,
         "worker_limit_source": if worker_limit.is_some() { "run_control" } else { "run_input" },
         "worker_limit": worker_limit,
+        "admissions_stopped": admissions_stopped,
+        "admissions_stop": admissions_stop,
         "active_epic_run_id": active_epic.as_ref().map(|epic| epic.run_id.clone()),
         "active_epic_task_id": active_epic.and_then(|epic| epic.task_id),
     }))
@@ -247,9 +257,16 @@ pub fn explain_workspace_auto_readiness(
                 }
                 claims
             });
-    let free_slots = usize::try_from(max_active_leaf_runs)
-        .unwrap_or(usize::MAX)
-        .saturating_sub(live_leaves.len());
+    let admissions_stopped = active_drain
+        .as_ref()
+        .is_some_and(|drain| drain.admissions_stopped());
+    let free_slots = if admissions_stopped {
+        0
+    } else {
+        usize::try_from(max_active_leaf_runs)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(live_leaves.len())
+    };
     let pending = snapshot
         .admissible_leaves
         .iter()
@@ -266,7 +283,7 @@ pub fn explain_workspace_auto_readiness(
         .iter()
         .map(|excluded| (excluded.id.as_str(), excluded))
         .collect::<BTreeMap<_, _>>();
-    let next_epic = if active_epic.is_none() {
+    let next_epic = if active_epic.is_none() && !admissions_stopped {
         next_admissible_epic_root(
             runtime,
             "explain_workspace_auto_readiness",
@@ -346,7 +363,12 @@ pub fn explain_workspace_auto_readiness(
                         object.insert("reason".to_string(), Value::String("epic_managed".to_string()));
                     }
                     BacklogTaskExclusionReason::EpicRoot => {
-                        if active_epic.is_some() {
+                        if admissions_stopped {
+                            object.insert(
+                                "reason".to_string(),
+                                Value::String("admissions_stopped".to_string()),
+                            );
+                        } else if active_epic.is_some() {
                             object.insert("reason".to_string(), Value::String("epic_run_active".to_string()));
                             object.insert("epic_run_id".to_string(), json!(active_epic.as_ref().map(|run| &run.run_id)));
                         } else if next_epic.as_deref() == Some(task.id.as_str()) {
@@ -381,6 +403,11 @@ pub fn explain_workspace_auto_readiness(
             if let Some(run_ids) = claimed_by_task.get(&task.id) {
                 object.insert("reason".to_string(), Value::String("claimed_by_live_child".to_string()));
                 object.insert("run_ids".to_string(), json!(run_ids));
+            } else if admissions_stopped {
+                object.insert(
+                    "reason".to_string(),
+                    Value::String("admissions_stopped".to_string()),
+                );
             } else if admitted.contains(&task.id) {
                 object.insert("eligible".to_string(), Value::Bool(true));
                 object.insert("reason".to_string(), Value::String("ready".to_string()));
@@ -404,6 +431,10 @@ pub fn explain_workspace_auto_readiness(
             "limit_source": limit_source,
             "drain_run_id": active_drain.as_ref().map(|drain| &drain.run_id),
             "worker_limit": active_drain.as_ref().and_then(|drain| drain.limit.clone()),
+            "admissions_stopped": admissions_stopped,
+            "admissions_stop": active_drain
+                .as_ref()
+                .and_then(|drain| drain.stop.clone()),
         },
         "tasks": tasks,
     }))
@@ -438,15 +469,33 @@ fn live_worker_limit(runtime: &OrbitRuntime, input: &Value) -> Option<DrainWorke
     read_drain_worker_limit(runtime, run_id)
 }
 
+fn live_admissions_stop(runtime: &OrbitRuntime, input: &Value) -> Option<DrainAdmissionsStop> {
+    let run_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    runtime
+        .read_run_state(run_id)
+        .ok()
+        .flatten()
+        .and_then(|state| state.drain_admissions_stop)
+}
+
 /// The live drain run, with both the ceiling it was submitted with and the one
 /// an operator has since set.
 struct ActiveDrain {
     run_id: String,
     submitted: u32,
     limit: Option<DrainWorkerLimit>,
+    stop: Option<DrainAdmissionsStop>,
 }
 
 impl ActiveDrain {
+    fn admissions_stopped(&self) -> bool {
+        self.stop.is_some()
+    }
+
     fn effective_max_active_leaf_runs(&self) -> u32 {
         self.limit
             .as_ref()
@@ -472,11 +521,21 @@ fn active_drain(runtime: &OrbitRuntime) -> Result<Option<ActiveDrain>, OrbitErro
         .and_then(|input| input.get("max_active_leaf_runs"))
         .and_then(json_u32)
         .unwrap_or(DEFAULT_MAX_ACTIVE_LEAF_RUNS as u32);
-    let limit = read_drain_worker_limit(runtime, &run.run_id);
+    let state = runtime
+        .stores()
+        .jobs()
+        .read_run_state(&run.run_id)
+        .ok()
+        .flatten();
+    let limit = state
+        .as_ref()
+        .and_then(|state| state.drain_worker_limit.clone());
+    let stop = state.and_then(|state| state.drain_admissions_stop);
     Ok(Some(ActiveDrain {
         run_id: run.run_id,
         submitted,
         limit,
+        stop,
     }))
 }
 
@@ -691,7 +750,11 @@ fn next_admissible_epic_root(
 /// what makes "the window does not affect tasks already in progress" true by
 /// construction: an in-flight child is held by `invoke_and_wait`, not by the
 /// window.
-pub(super) fn drain_window(action: &str, input: &Value) -> Result<Value, DispatchError> {
+pub(super) fn drain_window(
+    runtime: &OrbitRuntime,
+    action: &str,
+    input: &Value,
+) -> Result<Value, DispatchError> {
     let now = Utc::now();
     let deadline = match optional_deadline(action, input)? {
         Some(deadline) => deadline,
@@ -708,10 +771,20 @@ pub(super) fn drain_window(action: &str, input: &Value) -> Result<Value, Dispatc
     };
 
     let remaining_seconds = (deadline - now).num_milliseconds() as f64 / 1000.0;
+    let window_expired = remaining_seconds <= 0.0;
+    let admissions_stopped = live_admissions_stop(runtime, input).is_some();
+    let expired = window_expired || admissions_stopped;
     Ok(json!({
         "deadline": deadline.to_rfc3339_opts(SecondsFormat::Secs, true),
-        "expired": remaining_seconds <= 0.0,
-        "remaining_seconds": remaining_seconds.max(0.0),
+        "expired": expired,
+        "remaining_seconds": if admissions_stopped { 0.0 } else { remaining_seconds.max(0.0) },
+        "expired_reason": if admissions_stopped {
+            "admissions_stopped"
+        } else if window_expired {
+            "window"
+        } else {
+            "open"
+        },
     }))
 }
 

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -222,5 +222,11 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
             .and_then(|state| state.drain_worker_limit.as_ref()),
     )
     .map_err(serialize_error("serialize drain worker limit"))?;
+    value["drain_admissions_stop"] = serde_json::to_value(
+        state
+            .as_ref()
+            .and_then(|state| state.drain_admissions_stop.as_ref()),
+    )
+    .map_err(serialize_error("serialize drain admissions stop"))?;
     Ok(value)
 }

--- a/crates/orbit-core/src/application/job/exec.rs
+++ b/crates/orbit-core/src/application/job/exec.rs
@@ -319,10 +319,24 @@ impl OrbitRuntime {
         input: &Value,
         resume: Option<&ResumePlan>,
     ) -> Result<(), OrbitError> {
-        let initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
+        let mut initial_state = match resume.and_then(|plan| plan.resume_state.as_ref()) {
             Some(source_state) => seeded_resume_state(source_state, run),
             None => PipelineState::new(run.run_id.clone(), run.job_id.clone(), input.clone()),
         };
+        // [ORB-11283] A queued drain can carry an operator stop (or worker
+        // ceiling) written before the worker seeded this document. Replacing
+        // the whole state would silently resume admissions.
+        if let Some(existing) = self.read_run_state(&run.run_id)? {
+            if initial_state.drain_worker_limit.is_none() {
+                initial_state.drain_worker_limit = existing.drain_worker_limit;
+            }
+            if initial_state.drain_admissions_stop.is_none() {
+                initial_state.drain_admissions_stop = existing.drain_admissions_stop;
+            }
+            if initial_state.child_dispatches.is_empty() {
+                initial_state.child_dispatches = existing.child_dispatches;
+            }
+        }
         self.stores()
             .jobs()
             .write_run_state(&run.run_id, &initial_state)?;

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -14,8 +14,9 @@ pub use pipeline::{PipelineInvokeResult, PipelineWaitEntry, PipelineWaitResult};
 #[cfg(test)]
 pub(crate) use run::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub use run::{
-    ActivityInvocationEvidence, DrainWorkerLimitChange, DrainWorkerLimitRequest,
-    JobRunCancelResult, JobRunListParams, JobRunOrder, job_run_to_json,
+    ActivityInvocationEvidence, DrainAdmissionsStopChange, DrainAdmissionsStopRequest,
+    DrainAdmissionsStopResult, DrainWorkerLimitChange, DrainWorkerLimitRequest, JobRunCancelResult,
+    JobRunListParams, JobRunOrder, RemainingDrainChild, job_run_to_json,
     job_run_to_json_with_activity_provenance,
 };
 pub(crate) use run::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/run/admissions_stop.rs
+++ b/crates/orbit-core/src/application/job/run/admissions_stop.rs
@@ -1,0 +1,322 @@
+//! Stop new admissions on this workspace's live auto drain [ORB-11283].
+//!
+//! Cancellation of the coordinator cannot implement this: auto children are
+//! detached so they outlive the parent step, but cancelling a parent still
+//! terminalizes *that* run, and a blocking dispatch would cascade. This
+//! control writes a flag the admission path reads. The coordinator keeps its
+//! run id, deadline, completion authorization, and already-dispatched
+//! children. Those children keep running under the authority they were
+//! admitted with.
+//!
+//! Stopping already-running workers is a separate, explicit
+//! `orbit run cancel <child-run-id> --confirm` of each child.
+
+use orbit_common::OrbitError;
+use orbit_common::observability::audit_id::audit_execution_id;
+use orbit_types::telemetry::AuditEventStatus;
+use orbit_types::workflow::{JobRun, JobRunState, PipelineState, RunStateUpdate};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::application::workflow::{AUTO_WORKFLOW_ALIAS, find_workflow};
+
+const STOP_REQUEST_AUDIT: &str = "pipeline.run.admissions_stop.requested";
+const STOP_COMPLETION_AUDIT: &str = "pipeline.run.admissions_stop.completed";
+const STOP_OPERATION: &str = "orbit.workflow.auto";
+
+/// One operator request to stop this workspace's auto admissions.
+#[derive(Debug, Clone, Copy)]
+pub struct DrainAdmissionsStopRequest<'a> {
+    pub actor: &'a str,
+    pub source: &'a str,
+    pub reason: Option<&'a str>,
+    pub claim_token: Option<&'a str>,
+}
+
+/// A child this coordinator still has in flight after admissions stopped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemainingDrainChild {
+    pub run_id: String,
+    pub job_name: String,
+    pub phase: String,
+    pub child_status: Option<String>,
+}
+
+/// Outcome for one auto coordinator this workspace owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrainAdmissionsStopChange {
+    pub run_id: String,
+    pub job_id: String,
+    /// `stopped` when the flag was newly written, `unchanged` when it was
+    /// already set, `cancelled_queued` when a never-started coordinator was
+    /// cancelled so it cannot admit later.
+    pub outcome: &'static str,
+    pub remaining_children: Vec<RemainingDrainChild>,
+}
+
+/// Workspace-scoped result of `orbit run auto --stop`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrainAdmissionsStopResult {
+    /// `idle` when this workspace has no auto coordinator, `stopped` when at
+    /// least one running coordinator was acknowledged, `cancelled_queued`
+    /// when only queued never-started coordinators were removed.
+    pub outcome: &'static str,
+    pub coordinators: Vec<DrainAdmissionsStopChange>,
+}
+
+impl OrbitRuntime {
+    /// Stop new admissions for every live auto coordinator in this workspace.
+    ///
+    /// The selected workspace is the runtime's own: other workspaces and other
+    /// jobs are not inspected. A missing coordinator is success (`idle`). A
+    /// repeated stop is success (`unchanged` per coordinator).
+    pub fn stop_workspace_auto_admissions(
+        &self,
+        request: DrainAdmissionsStopRequest<'_>,
+    ) -> Result<DrainAdmissionsStopResult, OrbitError> {
+        self.require_workspace_claim(STOP_OPERATION, request.claim_token)?;
+        let request_id = audit_execution_id("admissions_stop");
+        let drain_job_id = workflow_job_id(AUTO_WORKFLOW_ALIAS)?;
+        let coordinators = self
+            .stores()
+            .jobs()
+            .list_pending_or_running_job_runs(drain_job_id)?;
+
+        self.record_stop_request(&request_id, request, drain_job_id, coordinators.len())?;
+
+        if coordinators.is_empty() {
+            self.record_stop_completion(
+                None,
+                &request_id,
+                "idle",
+                json!({ "coordinator_count": 0 }),
+                None,
+            )?;
+            return Ok(DrainAdmissionsStopResult {
+                outcome: "idle",
+                coordinators: Vec::new(),
+            });
+        }
+
+        let mut changes = Vec::with_capacity(coordinators.len());
+        for run in coordinators {
+            match self.apply_stop_to_coordinator(&run, request) {
+                Ok(change) => {
+                    self.record_stop_completion(
+                        Some(&change.run_id),
+                        &request_id,
+                        change.outcome,
+                        json!({
+                            "job_id": change.job_id,
+                            "remaining_children": change
+                                .remaining_children
+                                .iter()
+                                .map(|child| json!({
+                                    "run_id": child.run_id,
+                                    "job_name": child.job_name,
+                                    "phase": child.phase,
+                                    "child_status": child.child_status,
+                                }))
+                                .collect::<Vec<_>>(),
+                        }),
+                        None,
+                    )?;
+                    changes.push(change);
+                }
+                Err(error) => {
+                    self.record_stop_completion(
+                        Some(&run.run_id),
+                        &request_id,
+                        "rejected",
+                        json!({ "job_id": run.job_id }),
+                        Some(error.to_string()),
+                    )?;
+                    return Err(error);
+                }
+            }
+        }
+
+        let outcome = if changes.iter().any(|change| change.outcome == "stopped") {
+            "stopped"
+        } else if changes
+            .iter()
+            .any(|change| change.outcome == "cancelled_queued")
+        {
+            "cancelled_queued"
+        } else {
+            "unchanged"
+        };
+        Ok(DrainAdmissionsStopResult {
+            outcome,
+            coordinators: changes,
+        })
+    }
+
+    /// Whether this run's persisted control forbids further auto admissions.
+    pub(crate) fn drain_admissions_stopped(&self, run_id: &str) -> bool {
+        self.read_run_state(run_id)
+            .ok()
+            .flatten()
+            .is_some_and(|state| state.admissions_stopped())
+    }
+
+    fn apply_stop_to_coordinator(
+        &self,
+        run: &JobRun,
+        request: DrainAdmissionsStopRequest<'_>,
+    ) -> Result<DrainAdmissionsStopChange, OrbitError> {
+        if run.state == JobRunState::Pending && self.read_run_state(&run.run_id)?.is_none() {
+            self.cancel_job_run_with_context(&run.run_id, request.actor, request.source)?;
+            return Ok(DrainAdmissionsStopChange {
+                run_id: run.run_id.clone(),
+                job_id: run.job_id.clone(),
+                outcome: "cancelled_queued",
+                remaining_children: Vec::new(),
+            });
+        }
+        if run.state.is_terminal() {
+            return Err(OrbitError::JobValidation(format!(
+                "job run '{}' is {}; a terminal run admits no further work",
+                run.run_id, run.state
+            )));
+        }
+
+        let mut unchanged = false;
+        let update = self.stores().jobs().update_run_state(
+            &run.run_id,
+            &mut |run_state: JobRunState, state: &mut PipelineState| {
+                if run_state.is_terminal() {
+                    return Err(OrbitError::JobValidation(format!(
+                        "job run '{}' is {run_state}; a terminal run admits no further work",
+                        run.run_id
+                    )));
+                }
+                if state.admissions_stopped() {
+                    unchanged = true;
+                    return Ok(());
+                }
+                state.set_drain_admissions_stop(
+                    request.actor.to_string(),
+                    request.reason.map(str::to_string),
+                );
+                Ok(())
+            },
+        )?;
+
+        match update {
+            RunStateUpdate::Updated => {}
+            RunStateUpdate::NotFound => {
+                return Err(orbit_common::OrbitError::not_found(
+                    orbit_common::NotFoundKind::JobRun,
+                    run.run_id.clone(),
+                ));
+            }
+            RunStateUpdate::NoState => {
+                let mut state = PipelineState::new(
+                    run.run_id.clone(),
+                    run.job_id.clone(),
+                    run.input.clone().unwrap_or_else(|| json!({})),
+                );
+                state.set_drain_admissions_stop(
+                    request.actor.to_string(),
+                    request.reason.map(str::to_string),
+                );
+                self.stores().jobs().write_run_state(&run.run_id, &state)?;
+            }
+        }
+
+        let remaining_children = self.remaining_children(&run.run_id)?;
+        Ok(DrainAdmissionsStopChange {
+            run_id: run.run_id.clone(),
+            job_id: run.job_id.clone(),
+            outcome: if unchanged { "unchanged" } else { "stopped" },
+            remaining_children,
+        })
+    }
+
+    fn remaining_children(&self, run_id: &str) -> Result<Vec<RemainingDrainChild>, OrbitError> {
+        let Some(state) = self.read_run_state(run_id)? else {
+            return Ok(Vec::new());
+        };
+        let mut remaining = Vec::new();
+        for dispatch in state.open_child_dispatches() {
+            let Some(child) = self.get_job_run_backend(&dispatch.child_run_id)? else {
+                continue;
+            };
+            if child.state.is_terminal() {
+                continue;
+            }
+            remaining.push(RemainingDrainChild {
+                run_id: dispatch.child_run_id.clone(),
+                job_name: dispatch.job_name.clone(),
+                phase: dispatch.phase.as_str().to_string(),
+                child_status: Some(child.state.to_string()),
+            });
+        }
+        Ok(remaining)
+    }
+
+    fn record_stop_request(
+        &self,
+        request_id: &str,
+        request: DrainAdmissionsStopRequest<'_>,
+        drain_job_id: &str,
+        coordinator_count: usize,
+    ) -> Result<(), OrbitError> {
+        self.record_pipeline_audit(
+            STOP_REQUEST_AUDIT,
+            None,
+            Some(request.actor),
+            AuditEventStatus::Success,
+            json!({
+                "request_id": request_id,
+                "job_id": drain_job_id,
+                "coordinator_count": coordinator_count,
+                "reason": request.reason,
+                "actor": request.actor,
+                "source": request.source,
+                "requested_at": chrono::Utc::now().to_rfc3339(),
+            }),
+            None,
+        )
+    }
+
+    fn record_stop_completion(
+        &self,
+        run_id: Option<&str>,
+        request_id: &str,
+        outcome: &str,
+        detail: Value,
+        error: Option<String>,
+    ) -> Result<(), OrbitError> {
+        let mut arguments = json!({
+            "request_id": request_id,
+            "run_id": run_id,
+            "outcome": outcome,
+            "completed_at": chrono::Utc::now().to_rfc3339(),
+        });
+        if let (Some(target), Some(detail)) = (arguments.as_object_mut(), detail.as_object()) {
+            for (key, value) in detail {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        self.record_pipeline_audit(
+            STOP_COMPLETION_AUDIT,
+            run_id,
+            None,
+            if outcome == "rejected" {
+                AuditEventStatus::Failure
+            } else {
+                AuditEventStatus::Success
+            },
+            arguments,
+            error,
+        )
+    }
+}
+
+fn workflow_job_id(alias: &str) -> Result<&'static str, OrbitError> {
+    find_workflow(alias)
+        .map(|workflow| workflow.job_id)
+        .ok_or_else(|| OrbitError::InvalidInput(format!("unknown workflow '{alias}'")))
+}

--- a/crates/orbit-core/src/application/job/run/mod.rs
+++ b/crates/orbit-core/src/application/job/run/mod.rs
@@ -7,9 +7,11 @@
 //! - `owner` — process signalling, owner identity classification, liveness probes (Unix + shims).
 //! - `conflict` — recording a terminal outcome that contradicts the one already persisted.
 //! - `worker_limit` — adjusting a live auto drain's worker ceiling.
+//! - `admissions_stop` — stopping new admissions on a live auto drain.
 //! - `tests/*` — helpers and regression tests split by concern (actions, reconcile, owner, conflict).
 
 mod actions;
+mod admissions_stop;
 mod conflict;
 mod owner;
 mod projection;
@@ -23,6 +25,10 @@ mod tests;
 
 #[cfg(unix)]
 pub(crate) use actions::CANCELLATION_WORKER_EXIT_AUDIT;
+pub use admissions_stop::{
+    DrainAdmissionsStopChange, DrainAdmissionsStopRequest, DrainAdmissionsStopResult,
+    RemainingDrainChild,
+};
 #[cfg(test)]
 pub(crate) use conflict::TERMINAL_OUTCOME_CONFLICT_CODE;
 pub(crate) use owner::{RunOwnerLiveness, run_owner_liveness};

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -18,11 +18,11 @@ pub struct ActivityInvocationEvidence {
 /// Project a job run and its optional persisted state for operator-facing APIs.
 ///
 /// Child-dispatch lineage is historical and remains visible after a run reaches
-/// a terminal state, and so is an operator-set worker ceiling [ORB-11253]: it
-/// is the evidence of what the run was admitting under, which a reader needs
-/// exactly when explaining a finished drain. Waiting reasons are momentary, so
-/// terminal runs omit them. Presentation adapters may add intentionally
-/// surface-specific fields.
+/// a terminal state, and so are an operator-set worker ceiling [ORB-11253] and
+/// admissions stop [ORB-11283]: they are the evidence of what the run was
+/// actually admitting under, which a reader needs exactly when explaining a
+/// finished drain. Waiting reasons are momentary, so terminal runs omit them.
+/// Presentation adapters may add intentionally surface-specific fields.
 pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let last = run.steps.last();
     let child_dispatches = serde_json::to_value(
@@ -34,6 +34,10 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
     let drain_worker_limit = state
         .and_then(|state| state.drain_worker_limit.as_ref())
         .and_then(|limit| serde_json::to_value(limit).ok())
+        .unwrap_or(Value::Null);
+    let drain_admissions_stop = state
+        .and_then(|state| state.drain_admissions_stop.as_ref())
+        .and_then(|stop| serde_json::to_value(stop).ok())
         .unwrap_or(Value::Null);
     let state = (!run.state.is_terminal()).then_some(state).flatten();
     let waiting_on_deps = state
@@ -51,6 +55,7 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
     json!({
         "child_dispatches": child_dispatches,
         "drain_worker_limit": drain_worker_limit,
+        "drain_admissions_stop": drain_admissions_stop,
         "run_id": run.run_id,
         "job_id": run.job_id,
         "attempt": run.attempt,

--- a/crates/orbit-core/src/application/job/run/tests/admissions_stop.rs
+++ b/crates/orbit-core/src/application/job/run/tests/admissions_stop.rs
@@ -1,0 +1,211 @@
+//! [ORB-11283] Stop new auto admissions without cancelling children.
+
+use chrono::Utc;
+use orbit_types::workflow::{
+    ChildDispatch, ChildDispatchPhase, JobRun, JobRunState, PipelineState,
+};
+use serde_json::json;
+
+use super::*;
+use crate::application::job::DrainAdmissionsStopRequest;
+
+const DRAIN_JOB: &str = "workspace_auto_pipeline";
+
+fn running_drain(runtime: &OrbitRuntime) -> JobRun {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(DRAIN_JOB, 1, Utc::now(), Some(json!({})), None)
+        .expect("insert drain run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("start drain run");
+    let state = PipelineState::new(
+        run.run_id.clone(),
+        DRAIN_JOB.to_string(),
+        run.input.clone().unwrap_or_else(|| json!({})),
+    );
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(&run.run_id, &state)
+        .expect("write drain state");
+    runtime.show_job_run(&run.run_id).expect("reload drain run")
+}
+
+fn request<'a>() -> DrainAdmissionsStopRequest<'a> {
+    DrainAdmissionsStopRequest {
+        actor: "tester",
+        source: "unit",
+        reason: Some("window closed early"),
+        claim_token: None,
+    }
+}
+
+#[test]
+fn stopping_a_running_drain_writes_the_control_and_leaves_children_running() {
+    let (_root, runtime) = test_runtime();
+    let run = running_drain(&runtime);
+    let child = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            "task_auto_pipeline",
+            1,
+            Utc::now(),
+            Some(json!({ "task_ids": ["ORB-1"] })),
+            None,
+        )
+        .expect("insert child");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&child.run_id, Utc::now(), std::process::id())
+        .expect("start child");
+    let mut state = runtime
+        .read_run_state(&run.run_id)
+        .expect("read state")
+        .expect("state exists");
+    state.record_child_dispatch(ChildDispatch::submitted(
+        child.run_id.clone(),
+        "task_auto_pipeline".to_string(),
+        "invoke_detached".to_string(),
+        false,
+        false,
+        Utc::now(),
+    ));
+    runtime
+        .write_run_state(&run.run_id, &state)
+        .expect("link child");
+
+    let result = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("stop drain");
+
+    assert_eq!(result.outcome, "stopped");
+    assert_eq!(result.coordinators.len(), 1);
+    assert_eq!(result.coordinators[0].run_id, run.run_id);
+    assert_eq!(result.coordinators[0].outcome, "stopped");
+    assert_eq!(result.coordinators[0].remaining_children.len(), 1);
+    assert_eq!(
+        result.coordinators[0].remaining_children[0].run_id,
+        child.run_id
+    );
+
+    let reloaded = runtime.show_job_run(&run.run_id).expect("reload parent");
+    assert_eq!(reloaded.state, JobRunState::Running);
+    let stored = runtime
+        .read_run_state(&run.run_id)
+        .expect("read state")
+        .expect("state exists");
+    assert!(stored.admissions_stopped());
+    assert_eq!(
+        stored.drain_admissions_stop.as_ref().expect("stop").actor,
+        "tester"
+    );
+    let child = runtime.show_job_run(&child.run_id).expect("reload child");
+    assert_eq!(child.state, JobRunState::Running);
+    assert_eq!(
+        stored.child_dispatches[0].phase,
+        ChildDispatchPhase::Submitted
+    );
+}
+
+#[test]
+fn repeated_stop_and_no_active_run_are_idempotent() {
+    let (_root, runtime) = test_runtime();
+
+    let idle = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("idle stop");
+    assert_eq!(idle.outcome, "idle");
+    assert!(idle.coordinators.is_empty());
+
+    let run = running_drain(&runtime);
+    runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("first stop");
+    let repeated = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("second stop");
+    assert_eq!(repeated.outcome, "unchanged");
+    assert_eq!(repeated.coordinators[0].run_id, run.run_id);
+    assert_eq!(repeated.coordinators[0].outcome, "unchanged");
+}
+
+#[test]
+fn a_queued_drain_is_cancelled_before_it_can_admit() {
+    let (_root, runtime) = test_runtime();
+    let pending = insert_pending_run(&runtime, DRAIN_JOB);
+
+    let result = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("stop queued drain");
+
+    assert_eq!(result.outcome, "cancelled_queued");
+    assert_eq!(result.coordinators[0].run_id, pending.run_id);
+    let stored = runtime.show_job_run(&pending.run_id).expect("reload");
+    assert_eq!(stored.state, JobRunState::Cancelled);
+}
+
+#[test]
+fn a_leaf_run_in_the_same_workspace_is_not_stopped() {
+    let (_root, runtime) = test_runtime();
+    let leaf = insert_pending_run(&runtime, "task_auto_pipeline");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&leaf.run_id, Utc::now(), std::process::id())
+        .expect("start leaf");
+
+    let result = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("stop with no drain");
+
+    assert_eq!(result.outcome, "idle");
+    let stored = runtime.show_job_run(&leaf.run_id).expect("reload leaf");
+    assert_eq!(stored.state, JobRunState::Running);
+}
+
+#[test]
+fn a_finished_child_is_not_listed_as_remaining() {
+    let (_root, runtime) = test_runtime();
+    let run = running_drain(&runtime);
+    let child = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert child");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&child.run_id, Utc::now(), std::process::id())
+        .expect("start child");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&child.run_id, JobRunState::Success, Utc::now(), Some(1))
+        .expect("finish child");
+    let mut state = runtime
+        .read_run_state(&run.run_id)
+        .expect("read state")
+        .expect("state exists");
+    state.record_child_dispatch(ChildDispatch::submitted(
+        child.run_id.clone(),
+        "task_auto_pipeline".to_string(),
+        "invoke_detached".to_string(),
+        false,
+        false,
+        Utc::now(),
+    ));
+    runtime
+        .write_run_state(&run.run_id, &state)
+        .expect("link child");
+
+    let result = runtime
+        .stop_workspace_auto_admissions(request())
+        .expect("stop drain");
+    assert!(result.coordinators[0].remaining_children.is_empty());
+}

--- a/crates/orbit-core/src/application/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/run/tests/mod.rs
@@ -3,6 +3,7 @@
 use crate::OrbitRuntime;
 
 mod actions;
+mod admissions_stop;
 mod cancellation_race;
 mod conflict;
 mod owner;

--- a/crates/orbit-core/src/application/job/run/tests/projection.rs
+++ b/crates/orbit-core/src/application/job/run/tests/projection.rs
@@ -68,6 +68,7 @@ fn active_run_projects_waiting_reasons_and_child_dispatches() {
         value["child_dispatches"][0]["child_run_id"],
         json!("jrun-child")
     );
+    assert_eq!(value["drain_admissions_stop"], Value::Null);
 }
 
 #[test]

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -65,7 +65,9 @@ pub use orbit_tools::prepare_remote_task_artifact_put;
 // Command-layer types the CLI names in its clap surfaces.
 pub use application::docs::{DocType, TaskRelatedDoc};
 pub use application::job::{
+    DrainAdmissionsStopChange, DrainAdmissionsStopRequest, DrainAdmissionsStopResult,
     DrainWorkerLimitChange, DrainWorkerLimitRequest, PipelineInvokeResult, PipelineWaitEntry,
+    RemainingDrainChild,
 };
 pub use application::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, HitWorkspace, WorkspaceSearchReport,

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -51,6 +51,6 @@ pub use routine::{
     MissedRunPolicy, OverlapPolicy, ROUTINE_SCHEMA_VERSION, RoutineDefinition, RoutinePolicy,
     RoutineRetries, RoutineTarget, RoutineTrigger,
 };
-pub use run_state::{DrainWorkerLimit, PipelineState};
+pub use run_state::{DrainAdmissionsStop, DrainWorkerLimit, PipelineState};
 pub use ship::{CompletionPolicy, ShipMode, resolved_ship_mode};
 pub use skill::Skill;

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -9,6 +9,20 @@ use crate::workflow::child_dispatch::{
     ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase,
 };
 
+/// A live operator request to stop a bounded drain's new admissions [ORB-11283].
+///
+/// This is not cancellation. The coordinator stays the same run, already
+/// admitted children keep their completion authority, and the admission path
+/// treats the flag as "offer nothing" on the next pass. Cancellation of those
+/// children is a separate, explicit `orbit run cancel` of each child run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DrainAdmissionsStop {
+    pub actor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    pub stopped_at: DateTime<Utc>,
+}
+
 /// A live operator adjustment to a bounded drain's worker ceiling [ORB-11253].
 ///
 /// The ceiling a drain was submitted with lives in its immutable
@@ -91,6 +105,12 @@ pub struct PipelineState {
     /// the evidence of what the run was actually admitting under.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub drain_worker_limit: Option<DrainWorkerLimit>,
+    /// Operator stop of *new* admissions on a bounded auto drain [ORB-11283].
+    /// Absent means the drain is still admitting under its window and ceiling.
+    /// Like `drain_worker_limit` this survives terminalization: it is how a
+    /// finished coordinator is distinguished from cancellation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drain_admissions_stop: Option<DrainAdmissionsStop>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -112,6 +132,7 @@ impl PipelineState {
             waiting_on_locks: None,
             child_dispatches: Vec::new(),
             drain_worker_limit: None,
+            drain_admissions_stop: None,
             updated_at: Utc::now(),
         }
     }
@@ -159,6 +180,26 @@ impl PipelineState {
             actor,
             reason,
             updated_at: Utc::now(),
+        });
+        self.updated_at = Utc::now();
+        true
+    }
+
+    /// Whether this drain has been told to stop offering new work.
+    pub fn admissions_stopped(&self) -> bool {
+        self.drain_admissions_stop.is_some()
+    }
+
+    /// Record an admissions stop. Idempotent: a drain that is already stopped
+    /// keeps the original actor and timestamp and returns `false`.
+    pub fn set_drain_admissions_stop(&mut self, actor: String, reason: Option<String>) -> bool {
+        if self.drain_admissions_stop.is_some() {
+            return false;
+        }
+        self.drain_admissions_stop = Some(DrainAdmissionsStop {
+            actor,
+            reason,
+            stopped_at: Utc::now(),
         });
         self.updated_at = Utc::now();
         true

--- a/crates/orbit-types/src/workflow/tests/run_state.rs
+++ b/crates/orbit-types/src/workflow/tests/run_state.rs
@@ -200,5 +200,54 @@ fn state_written_before_the_control_existed_still_loads() {
     });
     let decoded: PipelineState = serde_json::from_value(legacy).expect("deserialize legacy state");
     assert!(decoded.drain_worker_limit.is_none());
+    assert!(decoded.drain_admissions_stop.is_none());
+    assert!(!decoded.admissions_stopped());
     assert_eq!(decoded.effective_max_active_leaf_runs(5), 5);
+}
+
+// [ORB-11283] Stop new admissions without cancelling the coordinator.
+
+#[test]
+fn an_absent_stop_means_the_drain_is_still_admitting() {
+    let state = state();
+    assert!(!state.admissions_stopped());
+    assert!(state.drain_admissions_stop.is_none());
+}
+
+#[test]
+fn setting_the_stop_records_the_actor_and_is_idempotent() {
+    let mut state = state();
+    assert!(state.set_drain_admissions_stop(
+        "operator".to_string(),
+        Some("window closed early".to_string()),
+    ));
+    let first = state.drain_admissions_stop.clone().expect("stop recorded");
+    assert_eq!(first.actor, "operator");
+    assert_eq!(first.reason.as_deref(), Some("window closed early"));
+    assert!(state.admissions_stopped());
+
+    assert!(!state.set_drain_admissions_stop("second".to_string(), None));
+    let second = state
+        .drain_admissions_stop
+        .clone()
+        .expect("original stop kept");
+    assert_eq!(second.actor, "operator");
+    assert_eq!(second.stopped_at, first.stopped_at);
+}
+
+#[test]
+fn the_stop_survives_a_state_round_trip_and_is_omitted_when_absent() {
+    let encoded = serde_json::to_value(state()).expect("encode");
+    assert!(
+        !encoded
+            .as_object()
+            .expect("object")
+            .contains_key("drain_admissions_stop")
+    );
+
+    let mut state = state();
+    state.set_drain_admissions_stop("cli".to_string(), None);
+    let encoded = serde_json::to_string(&state).expect("serialize state");
+    let decoded: PipelineState = serde_json::from_str(&encoded).expect("deserialize state");
+    assert_eq!(decoded.drain_admissions_stop, state.drain_admissions_stop);
 }

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Resident Orchestrator — Design
 owner: codex, grok, claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-05
+last_validated: 2026-09-05
 status: Draft
 feature: resident-orchestrator
 doc_role: design
@@ -190,6 +190,16 @@ next admission pass.
   compare-and-set. The engine's own state writes — step checkpoints and child-dispatch records —
   go through the same transactional path, so a checkpoint cannot discard a control written between
   its read and its write.
+
+**Stopping admissions is a live control, not cancellation** ([ORB-11283]). `orbit run auto --stop`
+resolves this workspace's live `workspace_auto_pipeline` coordinator without a run id and writes
+`drain_admissions_stop` onto the same `PipelineState`. Classify then offers no leaves and no epic;
+`drain_window` expires for the stop rather than the deadline so the loop winds down; `invoke_detached`
+re-checks at submit time and skips a child that classify offered before the stop landed. Already
+admitted children stay detached and keep their completion authority. A queued coordinator that has
+not started is cancelled so it cannot admit later; that is reported as `cancelled_queued`, not as a
+stopped drain. Repeated `--stop` and `--stop` with no coordinator are idle successes. Cancellation
+of already-running workers remains `orbit run cancel <child-run-id> --confirm`.
 
 **Conflict admission replaces `hold`.** An `epic`-tagged root holds one reservation covering the
 union of its descendants' `context_files`. That union is live since [ORB-10816]:

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -24,6 +24,7 @@ orbit run ship --mode local         # implement in a worktree, merge to the base
 orbit run auto --for 2h             # drain the backlog for a window
 orbit run auto --for 2h --concurrency 8   # ... with 8 tasks in flight at a time
 orbit run auto --for 2h --allow-crew opus,sonnet  # ... using only these crews
+orbit run auto --stop                      # stop new admissions; children keep running
 orbit run concurrency <run-id> --set 7     # retune a live drain, without replacing it
 orbit run readiness                        # explain current auto-drain eligibility, read-only
 orbit run readiness TASK-123 --json        # explain selected task IDs as JSON
@@ -60,6 +61,13 @@ authorization. The retune keeps all of them:
   one you read, so two operators cannot silently overwrite each other. The
   current value and who last moved it are on `orbit run show <run-id>`
   (`drain_worker_limit`) and `orbit run readiness`.
+
+`orbit run auto --stop` ends new admissions for this workspace's active
+coordinator. It does not need a run id, does not cancel children, and is
+idempotent when nothing is running. `orbit run show` reports
+`Admissions: stopped by ...` and lists remaining children. To cancel workers
+already in flight, `orbit run cancel <child-run-id> --confirm` each one —
+do not cancel the coordinator for this.
 
 `--allow-crew` restricts one drain to the crews you name — the lever for a
 provider that is unavailable, rate-limited, or out of budget. It is opt-in and

--- a/website/src/content/docs/getting-started/workflows.md
+++ b/website/src/content/docs/getting-started/workflows.md
@@ -86,6 +86,34 @@ Retuning keeps all of them, and keeps the children the drain already started.
   you read, so two operators cannot silently overwrite each other.
   `orbit run readiness` and `orbit run show` both report the value in force.
 
+## Stopping a running drain
+
+`orbit run auto --stop` ends **new admissions** for this workspace's active auto
+coordinator. You do not look up a run ID. Children the drain already started
+keep running under the completion authority they were admitted with, and the
+coordinator is not cancelled.
+
+```bash
+orbit run auto --stop
+orbit run auto --stop --json
+orbit run show "$RUN_ID"                 # Admissions: stopped by ...
+```
+
+A second `--stop`, or `--stop` with no active coordinator, is a no-op. Other
+workspaces and other jobs are untouched. `--stop` cannot be combined with the
+flags that start a drain (`--for`, `--concurrency`, `--complete`, `--allow-crew`).
+
+This is not cancellation. To stop workers that are already running, cancel each
+child explicitly:
+
+```bash
+orbit run cancel "$CHILD_RUN_ID" --confirm
+```
+
+Parent cancellation of the coordinator is the wrong tool for this job: auto
+children are detached so they outlive the parent step, and cancelling a parent
+that *was* blocking would cascade.
+
 ## Completing work with `--complete`
 
 By default a successful task ends in `review`, and a separate operator action

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -23,6 +23,7 @@ sidebar:
 | `orbit run ship [task_id ...]` | Submit backlog or explicitly selected tasks through the gated shipment pipeline and return a run ID immediately. |
 | `orbit run ship --mode local [task_id ...]` | Run the local-only task path for backlog or explicitly selected tasks. |
 | `orbit run auto [--for <duration>]` | Drain the workspace backlog for a window (loose leaves, plus one epic) and return a run ID immediately. |
+| `orbit run auto --stop` | Stop new admissions for this workspace's active auto coordinator. Already admitted workers keep running; this is not cancellation. |
 | `orbit run ship --complete` / `orbit run auto --complete` | Additionally authorize the submitted run to finish delivery and move the tasks it ships from `review` to `done`. Off by default. |
 | `orbit task` | Create, update, and manage tasks. |
 | `orbit task artifact put <task_id> <source_path>` | Store a UTF-8 file under a task's artifacts directory. |


### PR DESCRIPTION
## Task

[ORB-11283](https://orbit-cli.com/tasks/ORB-11283) — Add a workspace-scoped command to stop auto admissions cleanly

### Description

## Request
Add orbit run auto --stop or an equally discoverable equivalent to stop the selected workspace's active auto coordinator without looking up run IDs.

## Semantics
Default stop should stop new admissions and let already admitted workers finish under their existing completion authority. Reuse the canonical run cancellation/drain lifecycle controls where appropriate but do not accidentally cancel children if parent cancellation cascades. Resolve only selected workspace and owning host; report which coordinator(s) stopped and which children remain. Idempotent no-active-run behavior and explicit ambiguity handling are required. Do not disable unrelated routines or mutate other workspaces. Document a separate explicit mechanism for cancellation of already-running workers if supported; don't add a framework. Inspect concurrent admission races, persistence/restart semantics and CLI flag conflicts.

Crew: medium-low maps to Terra.

## Session authorization and delivery
Daniel explicitly authorizes implementation, promotion, and automatic completion/merge for this session. Use the managed dedicated task worktree and target agent-main. Run make ci-fast, make ci-lint, and focused deterministic behavior tests as appropriate. Do not modify CHANGELOG.md. Judge current code and tests; historical ADRs are not authority.

### Acceptance Criteria

- The help surface exposes a simple workspace-scoped auto stop command; users need no run ID for the normal case.
- After acknowledged stop, no new tasks are admitted, including a concurrent claim race; existing workers continue and retain completion authority.
- No-active-run/repeated-stop is idempotent; unrelated workspaces and jobs are untouched; ambiguous ownership is reported safely.
- Persisted coordinator state and CLI output distinguish stopped admissions from cancellation and list remaining children.
- Deterministic lifecycle/CLI tests and required gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `orbit run auto --stop` as a workspace-scoped admissions stop. Users do not need a run ID. It writes `drain_admissions_stop` on the live `workspace_auto_pipeline` coordinator rather than cancelling it.
- Classify offers no new leaves or epics after stop; drain_window expires for the stop so the loop winds down; invoke_detached re-checks at submit time and skips a child offered before the stop landed (concurrent admission race).
- Already admitted children stay detached with their completion authority. CLI output and `orbit run show` distinguish stopped admissions from cancellation and list remaining non-terminal children. Queued never-started coordinators are cancelled_queued. Idle and repeated stop are no-ops. Other jobs and workspaces are untouched.
- Documented explicit `orbit run cancel <child-run-id> --confirm` as the separate mechanism for already-running workers. `--stop` conflicts with `--for`/`--concurrency`/`--complete`/`--allow-crew`.
Assessment: Acceptance criteria are covered by lifecycle, classify/window/invoke, and CLI parse/conflict tests. make ci-fast and make ci-lint passed. Did not add an MCP tool; the discoverable surface is the CLI flag.
Strategic decisions: Did not cancel the running coordinator because auto children are detached and parent cancellation is a different lifecycle. Queued never-started drains are cancelled so they cannot admit after the current coordinator winds down.
Unlisted files changed because they were required: `.orbit/resources/jobs/workspace_auto_pipeline.yaml` (byte-identical twin of the shipped job asset), `exec.rs` (preserve operator controls across seed), `pipeline_actions.rs`/`dispatch.rs` (submit-time skip and drain_window runtime), job/mod.rs and crate re-exports, skill/docs copies.
Validation: `make ci-fast` pass; `make ci-lint` pass; focused orbit-types/orbit-core/orbit-cli tests for stop, classify, invoke skip, CLI parse/conflicts.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11283-6a9c5e67`
- Behind base: 0
- Ahead of base: 1