### PR TITLE
Remove retired website sync commands from CI workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   website:
-    name: Sync, check, and build
+    name: Check and build
     runs-on: ubuntu-latest
     env:
       ASTRO_TELEMETRY_DISABLED: "1"
@@ -31,13 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sync repository content
-        run: |
-          npm run sync:design
-          npm run sync:scoreboard
-
-      - name: Type-check website
-        run: npm exec -- astro check
+      - name: Check website
+        run: npm run check
 
       - name: Build website
-        run: npm exec -- astro build
+        run: npm run build


### PR DESCRIPTION
## Task

[ORB-11307](https://orbit-cli.com/tasks/ORB-11307) — Remove retired website sync commands from CI workflow

### Description

Website revamp ORB-11304 / PR1370 removed sync:design and sync:scoreboard scripts as requested, but .github/workflows/website.yml still invokes both in Sync repository content. Website run33986582084 job101361144093 on PR1370 merge checkout7dcd45b8a214e861ad533c6d03257cd3948514f4 fails npm error Missing script: sync:design. Current main source at22037486 retains the broken workflow. Remove obsolete generation step/references from active website CI, preserve npm install/check/build and validation of authored content. Do not recreate metrics/architecture pages or restore the retired scripts. Evidence https://github.com/danieljhkim/orbit/actions/runs/33986582084/job/101361144093

### Acceptance Criteria

- Website CI runs current npm scripts only; no sync:design/sync:scoreboard calls remain in active workflow definitions.
- npm ci, npm run check and npm run build succeed; removed metrics/architecture sections remain absent. Verify exact repair PR Website workflow succeeds. Preserve existing trigger/security/dependency setup.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the obsolete `Sync repository content` step and its `sync:design`/`sync:scoreboard` calls from `.github/workflows/website.yml`.
- Updated the workflow to invoke the existing `npm run check` and `npm run build` scripts; triggers, read-only permissions, checkout, Node setup, npm cache configuration, and `npm ci` remain unchanged.
Validation:
- `npm ci` succeeded with Node 24/npm using a task-scoped temporary npm cache after the runner's default npm cache returned EROFS.
- `npm run check` passed with 0 errors, 0 warnings, and 0 hints.
- `npm run build` passed and built 29 pages.
- Confirmed no retired sync commands remain in `.github/workflows`; confirmed no metrics, architecture, or scoreboard page filenames remain under `website/src/content/docs`; `git diff --check` passed.
- Removed run-created `website/node_modules`, `.astro`, and `dist` artifacts; the only tracked change is the intended workflow.
Assessment: Small, compatible CI repair that uses the website's current package scripts without restoring retired generation or content sections.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11307-6a9c703f`
- Behind base: 0
- Ahead of base: 1