### PR TITLE
Fix macOS sandbox test initializers after Pi environment support

### DIFF
--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -353,6 +353,7 @@ fn compiled_profile_allows_writes_to_provider_state_dirs() {
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,
+            pi_coding_agent_dir: None,
             claude_config_dir: None,
             grok_home: None,
             copilot_home: None,
@@ -424,6 +425,7 @@ fn compiled_profile_allows_writes_to_grok_json_lock_and_tmp_files() {
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,
+            pi_coding_agent_dir: None,
             claude_config_dir: None,
             grok_home: None,
             copilot_home: None,
@@ -509,6 +511,7 @@ fn compiled_profile_allows_writes_to_claude_home_json_siblings() {
         SandboxCompileEnv {
             home: Some(synthetic_home.path().as_os_str()),
             codex_home: None,
+            pi_coding_agent_dir: None,
             claude_config_dir: None,
             grok_home: None,
             copilot_home: None,


### PR DESCRIPTION
## Task

[ORB-11306](https://orbit-cli.com/tasks/ORB-11306) — Fix macOS sandbox test initializers after Pi environment support

### Description

Current macOS Platform run 33986585197 on agent-main SHA 22037486d2ca03e86a276af009016fb1f22ebb08 fails job 101361153216 at Run orbit-exec sandbox tests (real sandbox-exec). Rust E0063: missing pi_coding_agent_dir in SandboxCompileEnv literals at crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs:353,424,509. Same failure occurred on Pi PR run33986085270/job101359706660. Verified exact source at Pi merge8dfad3ac: those three macOS-only literals lack the field, so Linux gates missed compilation. Narrow repair to complete neutral environment initialization and inspect other cfg(macOS) literals for this same omission. Preserve real sandbox security assertions; no disabling tests. Origin ORB-11296 / PR1369. Evidence https://github.com/danieljhkim/orbit/actions/runs/33986585197/job/101361153216

### Acceptance Criteria

- All SandboxCompileEnv test initializers compile on macOS with pi_coding_agent_dir set appropriately; neutral-provider fixtures do not accidentally grant Pi paths.
- Run focused available tests and ci-fast/ci-lint; report Linux validation separately from actual macOS validation. Exact repair PR/macOS Platform CI must verify compilation and real sandbox assertions before claiming fully green.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `pi_coding_agent_dir: None` to the three macOS-only neutral-provider `SandboxCompileEnv` fixtures in `crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs`.
- Re-scanned every `SandboxCompileEnv` initializer under `crates/orbit-exec/src/macos_sandbox`; all now initialize `pi_coding_agent_dir`, and neutral fixtures do not grant a Pi path.
Validation:
- `cargo test -p orbit-exec --locked` passed on Linux: 49 unit tests and 18 integration tests.
- `make ci-fast` passed.
- `make ci-lint` passed.
- `git diff --check` passed; final `git status --short` contains only the intended provider_dirs.rs change.
Assessment: Narrow fixture-only repair preserves the real sandbox assertions. The macOS target and `sandbox-exec` are unavailable in this Linux environment (`rustup target list --installed` contains only x86_64-unknown-linux-gnu); macOS compilation and real sandbox assertions remain for the exact repair PR/macOS Platform CI.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11306-6a9c76f8`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*