### PR TITLE
Document a reproducible runbook for onboarding a new executor

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
@@ -6,6 +6,11 @@ checkout. This reference covers operating choices; for additional prose see
 the [published configuration reference](https://github.com/danieljhkim/orbit/blob/main/docs/CONFIG.md),
 checking its release against `orbit --version`.
 
+Contributors adding an executor should use the source checkout's
+[executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+It covers the v2 integration and test seams; this reference is for configuring
+an existing lane.
+
 ## Where config lives
 
 | Path | Scope | Created by |

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -45,6 +45,11 @@ the packaged narrow Bubblewrap profile. Complete the [Linux sandbox setup](linux
 before dispatch. Do not disable host protection or enable sandbox fallback to hide
 a failed probe.
 
+To add a provider or deterministic executor to Orbit itself, work in a source
+checkout and follow the [executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+Do not change a production login or workspace configuration merely to test a
+new executor.
+
 ## Step 3 — Initialize the machine
 
 ```bash

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -10,6 +10,11 @@ Reference for Orbit's runtime config — the `config.toml` consumed by `orbit ru
 
 This doc focuses on the user-facing knobs: `[workflow]` and `[crews.*]`. Other sections are summarized at the end.
 
+Contributors adding a new execution lane or deterministic command executor should
+use the [executor onboarding runbook](runbooks/executor-onboarding.md). It
+documents the v2 seams and validation obligations; this reference remains the
+operator contract for configuring an already shipped lane.
+
 ## Where config lives
 
 Two paths are consulted, in order:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,7 @@ CLI behavior, state layout, or recovery semantics change.
 | [Inspect the Audit Trail](./runbooks/audit-trail.md) | Query and interpret Orbit invocation, run, step, and activity audit history. |
 | [Share Rust dependency compilation across worker worktrees](./runbooks/compiler-cache.md) | Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees. |
 | [Recover a Corrupted Database](./runbooks/database-recovery.md) | Recover a corrupted Orbit SQLite database from backup, salvage, or regeneration. |
+| [Onboard an Executor](./runbooks/executor-onboarding.md) | Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state. |
 | [Check Orbit Health](./runbooks/health-checks.md) | Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health. |
 | [Prepare a Linux Host for Sandboxed Dispatch](./runbooks/linux-sandbox.md) | Install and verify the Bubblewrap host prerequisite that Orbit's Linux sandbox fails closed without. |
 | [Inspect and Retain Logs](./runbooks/logging.md) | Locate, filter, rotate, and retain Orbit process and routine-sweep logs. |

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -1,0 +1,156 @@
+---
+type: runbook
+summary: Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state.
+tags: [contributors, executors, providers, testing]
+paths: ["crates/orbit-agent/**", "crates/orbit-core/assets/executors/**", "crates/orbit-core/src/application/executor.rs", "crates/orbit-core/src/adapter/engine_host/v2_host/cli_executor.rs", "crates/orbit-engine/src/activity_job/**"]
+related_features: [activity-job, policy-sandbox]
+related_artifacts: [ORB-11294, ORB-11296, ORB-11299]
+---
+
+# Onboard an Executor
+
+Use this runbook when adding a supported execution lane to Orbit, or when adding a deterministic local command executor. It is a contributor procedure: configuring an already shipped provider is covered by [CONFIG.md](../CONFIG.md).
+
+## Before changing anything
+
+Start from a disposable checkout and registry. Do not point fixtures at a developer's `~/.orbit`, a live workspace, a logged-in provider directory, a production task store, or a real routing configuration. Fixture tests should construct an in-memory `OrbitRuntime`, use a temporary worktree and audit directory, and substitute a fake CLI through the executor definition (as the Pi and Antigravity integration tests do). A fake must record argv, stdin, cwd, and any edit so the contract is observable without credentials or network access.
+
+First establish the installed and source contracts separately:
+
+```bash
+orbit --version
+orbit executor list --json
+orbit executor show <existing-executor> --json
+<provider-cli> --help
+<provider-cli> --version
+```
+
+Use the provider's published CLI help and a pinned observed version to establish flags, stdin format, terminal output, authentication behavior, and supported model/effort values. Do not copy flags from another provider and do not claim a universal `--json`, sandbox, login, or MCP flag. `docs/CONFIG.md` records the currently verified contracts for shipped lanes; the Pi and Antigravity entries are representative, not templates with interchangeable flags.
+
+An authenticated smoke test is optional and needs explicit operator consent. Run it only against an isolated test workspace and test account or disposable credentials. State exactly what it did not prove (for example, no authenticated account, no vendor model access, or no OS sandbox available); passing fixture contract tests remains sufficient for a normal source change when they exercise Orbit's real dispatch seam.
+
+## Choose the execution family
+
+This choice determines the whole integration. Do not revive the deleted v1 executor registry or make a YAML definition alone and call it an implementation.
+
+| Need | Use | It carries | It must not carry |
+| --- | --- | --- | --- |
+| An interactive-capable coding-agent CLI that receives an Orbit task envelope | `direct_agent` / `agent_cli` through the v2 CLI-agent path | provider identity, model and effort where supported, prompt bytes on stdin, tool authority, response envelope, provider state grant | shell command data from task input |
+| A deterministic program or script step | `local_shell` deterministic action | static `command` + `args` or explicit `shell` + `script`, fixed env, cwd, timeout, exit/output report | model, prompt, agent tool authority, registry/workspace identity variables |
+
+`local_shell` is the supported v2 successor to the old `cli_command` spelling. Its parser accepts that legacy spelling for existing definitions, but new assets use `local_shell`. It shares process supervision and optional sandbox selection with the agent runner; it is not an agent adapter. See [the local-shell reference](../design/executors/specs/local-shell.md) for the activity shape.
+
+## Source and symbol map
+
+Verify the seams against the current checkout before editing. These are the authoritative extension points, not historical design records.
+
+| Concern | Current source / symbol | Required change or check |
+| --- | --- | --- |
+| Canonical provider identity and capabilities | `crates/orbit-types/src/workflow/activity_job/mod.rs` — `Provider`, `ProviderEntryPoint` | Add a canonical identity and capability only for a new agent lane; keep the lane identity separate from the model vendor. |
+| Crew configuration, detection, and migration | `crates/orbit-config/src/` and `crates/orbit-cli/src/command/init/` | Add detection and config validation/migration only where current code routes provider identities. Preserve existing explicit crew model pins and custom definitions. |
+| Shipped executor catalog and safe seed migration | `crates/orbit-core/assets/executors/<name>.yaml`; `crates/orbit-core/src/application/executor.rs` — `DEFAULT_EXECUTOR_FILES`, `seed_default_executors_for_platform`, `migrated_default_executor_for_platform` | Register the embedded asset and make seeded-default migration narrow: never overwrite a customized command, credentials, or asset merely because a new default exists. |
+| Executor lookup and the family boundary | `crates/orbit-core/src/adapter/engine_host/v2_host/cli_executor.rs` — `resolve_cli_executor`, `resolve_local_shell_executor` | Preserve the hard split: agent resolution accepts only `direct_agent` / `agent_cli`; shell resolution accepts only `local_shell`. |
+| Provider argv, prompt bytes, and model/effort adapter | `crates/orbit-agent/src/providers/<provider>/`; Pi: `PiCliTransport::args`, `PiCliTransport::stdin`; Antigravity: `AntigravityCliTransport::args`, `AntigravityCliTransport::stdin` | Add a provider-specific adapter. Render only documented flags; send prompt/envelope bytes on stdin, never argv. |
+| Provider terminal-output reduction | `crates/orbit-agent/src/providers/<provider>/<provider>_output.rs` | Reduce the provider protocol to trustworthy terminal response bytes before the common completion-envelope parser. Reject stale, partial, malformed, or failed frames. |
+| Child lifecycle, cancellation, and cleanup | `crates/orbit-engine/src/activity_job/cli_runner/`; `crates/orbit-exec/src/supervision/` | Reuse the v2 runner and supervisor. Do not add provider-owned process spawning or cleanup. |
+| Deterministic shell input and output | `crates/orbit-engine/src/executor/automation/shell.rs` — `local_shell`, `parse_shell_config`, `compose_argv` | Keep argv in static activity config. Run an actual shell only when `shell` and `script` are declared explicitly. |
+| OS sandbox / provider home grant | `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs`; `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs` | Give only the active provider's required state directory a write grant. Keep the activity `fsProfile` authoritative for the worktree. |
+| End-to-end fixtures | `crates/orbit-core/tests/pi_fake_agent.rs`, `crates/orbit-core/tests/antigravity_fake_agent.rs`, `crates/orbit-engine/tests/v2_local_shell.rs` | Exercise the real v2 dispatch seam with fakes; add output/error/timeout/cancellation cases. |
+
+## Add a CLI-agent executor
+
+1. Confirm that the provider's local CLI is an agent capable of completing one non-interactive turn. Record its actual version, official help/output contract, login-state directory, prompt transport, terminal response shape, and supported model/effort vocabulary in `docs/CONFIG.md`.
+2. Add the canonical provider identity at the shared identity boundary if it does not already exist. A model such as `openai/gpt-4o` routed through Pi remains a `pi` execution lane: its login, state directory, sandbox grant, audit attribution, and unsupported-capability error stay Pi's. Never infer the Orbit provider from a model string.
+3. Implement the provider runtime under `crates/orbit-agent/src/providers/<provider>/`. Follow the Pi or Antigravity split: a small argv/stdin transport, a runtime factory with only non-secret required environment, and an output normalizer. Pass optional model/effort only when the provider contract supports them; reject unsupported combinations during configuration resolution rather than silently dropping or remapping them.
+4. Add the bundled executor asset in `crates/orbit-core/assets/executors/<provider>.yaml` and register it in `DEFAULT_EXECUTOR_FILES`. Use static headless flags only. Keep the execution envelope and prompt off argv so process listings, audit argv, and spawn errors cannot expose task content or secrets.
+5. Wire provider discovery and init seeding through the current configuration/init seams. `orbit init` must add a crew only when the local CLI is detected; it must not replace a user-authored crew, credential, command override, or model pin. Check both a fresh seed and a legacy/customized asset through the migration path.
+6. Choose the sandbox posture deliberately. Shipped CLI agent assets opt in to the OS sandbox marker that becomes macOS `sandbox-exec` or Linux Bubblewrap when supported. The provider's own approval flag cannot grant filesystem access the enclosing sandbox denies. Do not use a provider's native sandbox flag as a substitute for Orbit's boundary.
+7. State MCP and shell-tool reach precisely. If the provider has no MCP client, do not add one by implication: the execution envelope must direct the agent to the `orbit` binary supplied on its `PATH`, and tests must retain whatever provider shell capability this route needs. Tool grants and caller-role gates remain enforced by `orbit tool run`.
+
+### Worked configuration: Pi
+
+This existing lane demonstrates the separation between executor identity and inference model. It is a configuration example, not an instruction to install or log into Pi during development.
+
+```toml
+[crews.pi]
+provider = "pi"
+model = "openai/gpt-4o"
+effort = "high"
+description = "Pi through its local CLI"
+tags = ["implementation"]
+```
+
+The crew chooses the `pi` executor. Orbit renders Pi's documented `--model openai/gpt-4o` and `--thinking high`, but the run remains `pi` for its agent directory, authentication, audit and sandbox policy. The shipped asset provides Pi's static non-interactive flags; `PiCliTransport` supplies only per-run argv and stdin. Before changing this or adapting it to another CLI, inspect the effective installed definition rather than assuming a release's asset matches the checkout:
+
+```bash
+orbit config show
+orbit executor show pi --json
+pi --version
+pi --list-models
+```
+
+Do not put an API key in the executor asset or argv. An operator who deliberately uses an API key adds its variable name to `[execution.env].pass`; an interactive provider login is a separate, unsandboxed setup action and is never performed by an Orbit workflow turn.
+
+## Add a deterministic local-shell executor
+
+Use a `local_shell` activity only for a bounded, reproducible command. Its `config` is the authority for `command`/`args` or for `shell`/`script`; rendered job input must never become child argv. The shared `local-shell` definition may supply a static command prefix, environment, and fallback timeout, but a shell action gets no agent prompt, model, tool allowlist, or workspace/registry identity variables.
+
+For a new deterministic default, add a `kind: Executor` resource with `executor_type: local_shell`, then test the actual activity through `local_shell`. Preserve the existing behavior that a bare definition runs under the shared supervisor and cwd containment checks; adding an OS sandbox requires both an explicit sandbox declaration and an activity `fsProfile`. Report the effective sandbox in output. Use explicit `/bin/sh` plus `script` only when shell semantics are really required; otherwise use literal argv.
+
+## Output, errors, and lifecycle contract
+
+An agent exit status and its response envelope are independent evidence; both must be valid. The v2 path fails closed when the CLI exits non-zero even if stdout contains success-looking JSON. It also fails closed on missing terminal output, malformed protocol records, an error/aborted terminal event, missing response/completion envelope, and stale prompt echo. Provider normalization must retain only the documented terminal answer before the common envelope reader scans it. Pi's `message_end` reducer exists specifically to avoid accepting the later conversation replay in `agent_end`; Antigravity accepts only a terminal `result` whose status is `SUCCESS`.
+
+Set a wall-clock deadline through the agent activity or `local_shell` config and reuse the supervisor. Verify timeout cancellation and child-process cleanup rather than implementing a provider-specific timer. A normal local-shell non-zero exit is an activity failure unless `allow_nonzero_exit` is explicitly true; when true, its structured output still reports `success`, `exit_code`, `stderr`, `timed_out`, `timeout_ms`, `argv`, `cwd`, and `sandbox`.
+
+## Validation matrix
+
+| Case | Fixture assertion |
+| --- | --- |
+| Discovery and seeding | Detected CLI creates the intended crew/executor; missing CLI produces the stable unavailable error; an existing custom definition and model pin survive seeding/sync. |
+| Identity and configuration | Canonical provider is retained when the model names another vendor; aliases/migrations are explicit; invalid or unsupported model/effort fails instead of falling back. |
+| argv, stdin, and cwd | Exact static and per-run argv; prompt/envelope bytes appear only on stdin; cwd is the intended temporary workspace; secrets are absent from argv, result, and diagnostics. |
+| Normal output and usage | Only the documented terminal frame reaches the completion parser; a successful envelope projects its result; usage is propagated only when the provider's retained terminal payload supports it. |
+| Error evidence | Non-zero exit, zero-exit provider error, malformed JSON/JSONL, incomplete/stale terminal data, no terminal frame, and absent response/completion envelope each fail closed. |
+| Time and process lifecycle | Deadline returns a timeout failure, cancellation terminates the child process group, and no child remains after a test. |
+| Sandbox and state isolation | Fixture needs no live provider state; only the active provider state root is writable; activity profile restricts the disposable worktree; a shell executor has no agent-only authority. |
+| MCP / CLI envelope | Native-MCP lanes receive only their supported configuration; non-MCP lanes reach granted Orbit tools through the injected `orbit` binary and fail predictably when their required shell tool is unavailable. |
+| Local-shell injection resistance | Runtime input cannot modify argv; both literal argv and explicit shell forms behave as declared; non-zero and timeout output is audited. |
+
+Run focused tests during development, replacing `<provider>` only with a real crate/package/test target:
+
+```bash
+cargo test -p orbit-agent <provider>
+cargo test -p orbit-core --test <provider>_fake_agent
+cargo test -p orbit-engine --test v2_local_shell
+./scripts/generate-doc-indexes.sh --check
+./scripts/sync-plugin-skills.sh --check
+make ci-fast
+make ci-lint
+```
+
+The first two commands are examples of target selection, not provider CLI flags. If no provider-specific test target exists yet, run the package's relevant test module and add the integration fixture before calling the lane supported. `make ci-fast` and `make ci-lint` are the repository handoff gates; do not substitute a live authenticated smoke for fixture coverage.
+
+## Package and hand off managed assets
+
+`crates/orbit-core/assets/` is the canonical source for embedded executors and skills. A new executor asset needs the catalog registration in `DEFAULT_EXECUTOR_FILES`; a changed skill reference needs the matching `include_str!` registration in `crates/orbit-core/src/application/skill.rs::DEFAULT_SKILL_FILES` only when it adds a new file. Then materialize the committed plugin mirror from canonical assets:
+
+```bash
+./scripts/sync-plugin-skills.sh
+./scripts/sync-plugin-skills.sh --check
+./scripts/generate-doc-indexes.sh
+./scripts/generate-doc-indexes.sh --check
+```
+
+Do not edit `plugin/skills/` as an independent source. The sync script copies each canonical skill tree, and `make ci-fast` rejects drift. Do not create or edit the runtime `.orbit-managed-assets.json` manifest: reconciliation owns its digests and records the new catalog after `orbit workspace sync`. Run the managed-asset migration/sync tests when changing executor seeding; use `orbit workspace sync --check` to inspect an installed workspace before asking an operator to reconcile it. Customized managed assets must be preserved with a warning or migration path, never overwritten silently.
+
+## Escalate instead of guessing
+
+Stop and seek a scoped design/task decision when the provider requires a new cross-crate dependency, a new execution mode, a network service, a credential transport outside the cleared environment policy, an unsupported platform boundary, or a generic protocol abstraction without a second concrete use. Record a follow-up rather than smuggling a broader runtime into an executor patch.
+
+## Related references
+
+- [Orbit Configuration](../CONFIG.md) — current crews, provider identity, configuration inheritance, and shipped provider contracts.
+- [Local-shell executor reference](../design/executors/specs/local-shell.md) — deterministic activity schema and output shape.
+- [Linux sandbox runbook](linux-sandbox.md) — host prerequisite for Linux CLI-agent dispatch.
+- [Runbook conventions](CONVENTIONS.md) — maintenance and index generation rules.

--- a/plugin/skills/orbit/references/setup/configuration.md
+++ b/plugin/skills/orbit/references/setup/configuration.md
@@ -6,6 +6,11 @@ checkout. This reference covers operating choices; for additional prose see
 the [published configuration reference](https://github.com/danieljhkim/orbit/blob/main/docs/CONFIG.md),
 checking its release against `orbit --version`.
 
+Contributors adding an executor should use the source checkout's
+[executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+It covers the v2 integration and test seams; this reference is for configuring
+an existing lane.
+
 ## Where config lives
 
 | Path | Scope | Created by |

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -45,6 +45,11 @@ the packaged narrow Bubblewrap profile. Complete the [Linux sandbox setup](linux
 before dispatch. Do not disable host protection or enable sandbox fallback to hide
 a failed probe.
 
+To add a provider or deterministic executor to Orbit itself, work in a source
+checkout and follow the [executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+Do not change a production login or workspace configuration merely to test a
+new executor.
+
 ## Step 3 — Initialize the machine
 
 ```bash


### PR DESCRIPTION
## Task

[ORB-11303](https://orbit-cli.com/tasks/ORB-11303) — Document a reproducible runbook for onboarding a new executor

### Description

Daniel requests a runbook explaining how to onboard a new executor. Add docs/runbooks/executor-onboarding.md following docs/runbooks/CONVENTIONS.md, with discoverable links from the current docs/configuration/executor/setup routing as appropriate. This should be a practical contributor guide grounded in current v2 code and tested commands, not a provider-specific announcement or historical architecture rationale. Use existing integrations plus the newly landed representative Pi, local-shell and Antigravity work to show the true extension points, how executor identity differs from inference model vendor, and how to preserve existing user configuration. The dependencies ensure novel runtime/migration seams exist before finalizing the guide. Do not change any existing task's crew assignments. Historical ADR/decision files are not authority.

### Acceptance Criteria

- Provide a start-to-finish checklist with prerequisites, exact source/symbol map verified against current code, official CLI contract/version verification, discovery/identity/config integration, v2 argv/prompt/output adapter, usage/error semantics, sandbox/state/MCP or CLI-envelope integration, and managed seeding/sync.
- Clearly distinguish onboarding an agent CLI from local-shell deterministic execution. Show how to choose/reuse current seams; do not recommend resurrecting deleted v1 execution code or adding a YAML file alone.
- Include a worked configuration/example and validation matrix covering prompt bytes/cwd/model/effort, unsupported capabilities, zero-exit agent errors, malformed/stale/missing output or usage, timeout/cancellation/process cleanup, credential/state isolation and legacy/customized-asset migration.
- Explain safe test environments: disposable registry/workspace authority, no inherited live routing or identity, no production login/config changes. Explain when fixture contract tests suffice and how to report optional authenticated smoke-test limits.
- Document normal managed-asset packaging/router/manifest updates and required verification commands without inventing universal provider flags. All referenced paths/symbols/commands exist and examples are checked against actual finalized implementations.
- Add discoverability in docs indexes and relevant setup/contributor routing without duplicating the entire runbook into competing copies. Follow documentation gates and required repository checks, with no implementation changes beyond justified documentation plumbing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added docs/runbooks/executor-onboarding.md, a current-v2 contributor runbook covering provider CLI and deterministic local_shell selection, source/symbol map, contract verification, identity/configuration, prompt/output adapters, lifecycle/sandbox/tool authority, managed seeding/sync, migration preservation, and a fixture-first validation matrix.
- Linked it from docs/CONFIG.md, the generated docs index, and the canonical setup skill references; materialized the plugin skill mirror with scripts/sync-plugin-skills.sh.
Assessment: Documentation-only change grounded in the current Pi, Antigravity, and local-shell implementations. It explicitly keeps executor identity distinct from underlying model vendors and avoids resurrecting v1 execution code.
Validation:
- Passed: git diff --check; scripts/sync-plugin-skills.sh --check; make ci-lint.
- Documentation index row was generated to the exact current frontmatter/H1 output. scripts/generate-doc-indexes.sh --check and make ci-fast report docs/INDEX.md stale only because this managed runner makes the shared Git index read-only, so the new untracked runbook cannot be staged for the generator versioned-file filter (git add -N and a temporary index both failed with read-only filesystem errors). In a normal checkout after the new file is tracked, the committed index row matches the generator output.
- Removed the 1.4 GiB target/ build artifacts created by make ci-lint with cargo clean.
Risks: No authenticated provider smoke test was run; the runbook documents that such testing is optional, consent-gated, isolated, and must report its limits.
Friction checkpoint: no report; the index limitation was a runner filesystem denial, not a recurring product gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11303-6a9c76ef`
- Behind base: 0
- Ahead of base: 1