### PR TITLE
Isolate global-init unit tests from inherited managed-run authority

### DIFF
--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -813,6 +813,19 @@ mod tests {
 
     use super::*;
 
+    /// Make global-init routing entirely fixture-owned even when the test
+    /// binary was launched by a managed Orbit run. This is one scoped guard so
+    /// its process-wide lock also restores the parent environment on drop.
+    fn global_init_env(home: &Path) -> orbit_common::test_env::ScopedEnv {
+        orbit_common::test_env::scoped(
+            orbit_common::test_env::INHERITED_AUTHORITY_ENV
+                .iter()
+                .copied()
+                .map(|name| (name, None))
+                .chain(std::iter::once(("HOME", home.to_str()))),
+        )
+    }
+
     #[test]
     fn fresh_workspace_init_seeds_disabled_worktree_gc_routine() {
         let temp = tempdir().expect("tempdir");
@@ -1035,9 +1048,7 @@ mod tests {
     #[test]
     fn global_init_seeds_skills_and_home_level_links() {
         let home = tempdir().expect("home tempdir");
-        // The shared guard serializes every HOME mutation in this test binary,
-        // including the runtime resolve tests; a module-local lock did not.
-        let _env = orbit_common::test_env::scoped([("HOME", home.path().to_str())]);
+        let _env = global_init_env(home.path());
 
         let result = init_global(
             None,
@@ -1208,9 +1219,7 @@ mod tests {
     #[test]
     fn global_init_writes_crew_settings_as_custom_crew_to_config_toml() {
         let home = tempdir().expect("home tempdir");
-        // The shared guard serializes every HOME mutation in this test binary,
-        // including the runtime resolve tests; a module-local lock did not.
-        let _env = orbit_common::test_env::scoped([("HOME", home.path().to_str())]);
+        let _env = global_init_env(home.path());
 
         let settings = BTreeMap::from([(
             "custom".to_string(),
@@ -1264,9 +1273,7 @@ mod tests {
     #[test]
     fn global_init_with_existing_config_does_not_overwrite_crew_settings() {
         let home = tempdir().expect("home tempdir");
-        // The shared guard serializes every HOME mutation in this test binary,
-        // including the runtime resolve tests; a module-local lock did not.
-        let _env = orbit_common::test_env::scoped([("HOME", home.path().to_str())]);
+        let _env = global_init_env(home.path());
 
         // Pre-seed config.toml with user content.
         let orbit_root = home.path().join(".orbit");
@@ -1301,9 +1308,7 @@ mod tests {
     #[test]
     fn global_init_without_crew_settings_writes_clean_template() {
         let home = tempdir().expect("home tempdir");
-        // The shared guard serializes every HOME mutation in this test binary,
-        // including the runtime resolve tests; a module-local lock did not.
-        let _env = orbit_common::test_env::scoped([("HOME", home.path().to_str())]);
+        let _env = global_init_env(home.path());
 
         let result = init_global(
             None,


### PR DESCRIPTION
## Task

[ORB-11309](https://orbit-cli.com/tasks/ORB-11309) — Isolate global-init unit tests from inherited managed-run authority

### Description

ORB-11294 run jrun-20260905-1911 reported4 failures in global_init_* unit tests because they attempted writes under the live ~/.orbit mounted read-only by its sandbox. Source at8dfad3ac (already includes ORB-11300) confirms four tests in crates/orbit-core/src/bootstrap/init.rs:1036,1209,1265,1302 use only test_env::scoped HOME=temp, then init_global(None). init_global:141-144 resolves_global_root(), which honors managed ORBIT_REGISTRY_ROOT above HOME. orbit_common::test_env documents the same leak in INHERITED_AUTHORITY_ENV. ORB-11300 repaired subprocess fixtures but these in-process init tests still retain ambient authority. Narrow test-only repair: use existing shared guard/list in one scope to clear inherited managed authority while preserving intentional HOME values and test assertions. Do not change production root routing, relax sandbox, skip tests, or run unsafe reproductions against real host configuration. Existing crew config must remain untouched. Search global_init found only historical unrelated repairs and11294 report.

### Acceptance Criteria

- All four global_init tests pass inside an Orbit-managed environment with their HOME and registry confined to disposable fixtures; inherit routing/trust sentinels safely and prove no writes outside intended temp home.
- Regression uses a throwaway sentinel registry/config, never real ~/.orbit. Before/after bytes remain unchanged, and generated config/skill assertions still validate the intended test home. Avoid nested shared env guards or races; preserve parent env restoration.
- Use existing common authority list/guard rather than copy an incomplete list. Inspect immediately related init unit fixtures for the same exact pattern; keep repair bounded to test isolation.
- Run affected init tests with inherited-authority fixture plus required ci-fast/ci-lint. Report actual managed-run results; four previous failures must no longer be dismissed as unavoidable sandbox limitations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a test-only `global_init_env` fixture helper in `crates/orbit-core/src/bootstrap/init.rs`.
- The helper uses the shared `INHERITED_AUTHORITY_ENV` authority list and the single restoring `test_env::scoped` guard to clear inherited managed routing/trust state before setting the test's disposable HOME.
- Switched all four `global_init_*` tests to that helper; production routing is unchanged.

Assessment: bounded one-file isolation repair. The existing process-wide guard serializes mutations and restores the parent managed environment on drop.

Validation:
- Managed sentinel run: `ORBIT_MANAGED_RUN_CONTEXT=1 ORBIT_REGISTRY_ROOT=<throwaway> ... cargo test -p orbit-core --lib bootstrap::init::tests::global_init -- --nocapture` — 4 passed, 0 failed. The throwaway registry's config SHA-256 was unchanged before/after and no registry state directory was created.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `cargo clean` removed 3.5 GiB / 7,199 generated build artifacts from this worktree after validation.

Scope: only `file:crates/orbit-core/src/bootstrap/init.rs` changed; no context expansion needed.
Friction checkpoint: no report filed; no qualifying contradicted assumption, recurring failure, or non-obvious gotcha occurred.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11309-6a9c7a0d`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*