### PR TITLE
Revalidate task eligibility after gate waits to prevent archived work from starting

### DIFF
--- a/.orbit/resources/activities/invoke_and_wait.yaml
+++ b/.orbit/resources/activities/invoke_and_wait.yaml
@@ -8,7 +8,16 @@ spec:
     Submit a named v2 Job and block until its Run reaches a terminal
     state, then return the wait entry as data. Internally chains
     `orbit.pipeline.invoke` (to submit the child Run) and
-    `orbit.pipeline.wait` (to block on completion). Workflows that require
+    `orbit.pipeline.wait` (to block on completion). Submission and waiting
+    are separate observable phases: the child's exact run ID is persisted
+    into the parent Run's state, and audited, before the wait begins, so
+    CLI, MCP, API, and dashboard readers can name the child for the whole
+    duration of the block. A submission that cannot produce a durable
+    child Run fails this activity immediately with the invocation error
+    rather than idling until `timeout_seconds`. Cancelling the parent
+    while it waits keeps the child link, marks the wait terminal, and
+    cancels the child (an `invoke_detached` child is left running instead).
+    Workflows that require
     a successful child Run should follow this activity with
     `pipeline_success_guard` after any cleanup that depends on the raw
     child status. The returned `status` mirrors the child Run's terminal state:
@@ -18,9 +27,14 @@ spec:
     Run itself may still be running — callers that care must inspect
     `run_id` to decide follow-up. Gate workflows may pass
     `admission_task_ids` and `admission_workflow` to re-check workflow
-    admission immediately before dispatch; stale `review` / `done` tasks
-    return a succeeded no-op output with `skipped: true` and do not submit a
-    child Run.
+    admission immediately before dispatch, so an admission granted before a
+    long gate wait cannot dispatch work whose status has since changed.
+    Neither case submits a child Run: stale `review` / `done`
+    tasks return a succeeded no-op output with `skipped: true`, while a task
+    withdrawn during the wait returns `skipped: true` with a non-succeeded
+    `status` and an `error` naming the task and its status, so a following
+    release step still runs and `pipeline_success_guard` then fails the
+    parent. A task id that resolves to no task at all fails the activity.
   input_schema_json:
     type: object
     required: [job_name, run_input]

--- a/.orbit/resources/jobs/task_gate_pipeline.yaml
+++ b/.orbit/resources/jobs/task_gate_pipeline.yaml
@@ -30,12 +30,18 @@
 # - The dispatched child pipeline runs while the reservation is still valid;
 #   a fresh `orbit.task.locks.reserve` call from another bundle will either
 #   wait or surface `task.locks.reserve.denied`. `invoke_and_wait` re-checks
-#   worktree workflow admission immediately before child dispatch; stale
+#   worktree workflow admission immediately before child dispatch, because a
+#   gate can sit in `wait_for_window` for its whole budget and the admission
+#   that queued it is a snapshot, not standing approval (ORB-11305). Stale
 #   `review` / `done` tasks return a succeeded no-op output so the reservation
-#   can be released without launching a child run. After `invoke_and_wait`
-#   returns a terminal child-run status, `release_reservation` frees the
-#   reservation immediately before `require_child_success` fails the gate on
-#   a non-succeeded child. TTL remains the fallback for abandoned/crashed runs.
+#   can be released without launching a child run; a task a human withdrew
+#   during the wait (`proposed`, `someday`, `archived`, `rejected`, `blocked`)
+#   returns a non-succeeded output instead, so the reservation is still
+#   released and the gate then fails naming the task and its status. After
+#   `invoke_and_wait` returns a terminal child-run status,
+#   `release_reservation` frees the reservation immediately before
+#   `require_child_success` fails the gate on a non-succeeded child. TTL
+#   remains the fallback for abandoned/crashed runs.
 
 schemaVersion: 2
 kind: Job

--- a/crates/orbit-core/assets/activities/invoke_and_wait.yaml
+++ b/crates/orbit-core/assets/activities/invoke_and_wait.yaml
@@ -27,9 +27,14 @@ spec:
     Run itself may still be running — callers that care must inspect
     `run_id` to decide follow-up. Gate workflows may pass
     `admission_task_ids` and `admission_workflow` to re-check workflow
-    admission immediately before dispatch; stale `review` / `done` tasks
-    return a succeeded no-op output with `skipped: true` and do not submit a
-    child Run.
+    admission immediately before dispatch, so an admission granted before a
+    long gate wait cannot dispatch work whose status has since changed.
+    Neither case submits a child Run: stale `review` / `done`
+    tasks return a succeeded no-op output with `skipped: true`, while a task
+    withdrawn during the wait returns `skipped: true` with a non-succeeded
+    `status` and an `error` naming the task and its status, so a following
+    release step still runs and `pipeline_success_guard` then fails the
+    parent. A task id that resolves to no task at all fails the activity.
   input_schema_json:
     type: object
     required: [job_name, run_input]

--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -30,12 +30,18 @@
 # - The dispatched child pipeline runs while the reservation is still valid;
 #   a fresh `orbit.task.locks.reserve` call from another bundle will either
 #   wait or surface `task.locks.reserve.denied`. `invoke_and_wait` re-checks
-#   worktree workflow admission immediately before child dispatch; stale
+#   worktree workflow admission immediately before child dispatch, because a
+#   gate can sit in `wait_for_window` for its whole budget and the admission
+#   that queued it is a snapshot, not standing approval (ORB-11305). Stale
 #   `review` / `done` tasks return a succeeded no-op output so the reservation
-#   can be released without launching a child run. After `invoke_and_wait`
-#   returns a terminal child-run status, `release_reservation` frees the
-#   reservation immediately before `require_child_success` fails the gate on
-#   a non-succeeded child. TTL remains the fallback for abandoned/crashed runs.
+#   can be released without launching a child run; a task a human withdrew
+#   during the wait (`proposed`, `someday`, `archived`, `rejected`, `blocked`)
+#   returns a non-succeeded output instead, so the reservation is still
+#   released and the gate then fails naming the task and its status. After
+#   `invoke_and_wait` returns a terminal child-run status,
+#   `release_reservation` frees the reservation immediately before
+#   `require_child_success` fails the gate on a non-succeeded child. TTL
+#   remains the fallback for abandoned/crashed runs.
 
 schemaVersion: 2
 kind: Job

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -141,6 +141,14 @@ fn git(current_dir: &Path, args: &[&str]) {
 }
 
 fn run_worktree_setup(runtime: &OrbitRuntime, task_ids: &[String], run_id: &str) -> Value {
+    try_worktree_setup(runtime, task_ids, run_id).expect("run worktree setup")
+}
+
+fn try_worktree_setup(
+    runtime: &OrbitRuntime,
+    task_ids: &[String],
+    run_id: &str,
+) -> Result<Value, orbit_common::OrbitError> {
     orbit_engine::execute_deterministic_action(
         runtime,
         "worktree_setup",
@@ -156,7 +164,6 @@ fn run_worktree_setup(runtime: &OrbitRuntime, task_ids: &[String], run_id: &str)
         &HashMap::new(),
         None,
     )
-    .expect("run worktree setup")
 }
 
 /// ORB-10602: worktree setup no longer materializes sandbox mount anchors.
@@ -343,19 +350,18 @@ fn automation_can_restamp_in_progress_task_without_plan() {
     assert_eq!(updated.job_run_id.as_deref(), Some("jrun-test"));
 }
 
+/// [ORB-11305] Workflow admission accepts `backlog` (fresh authorized work)
+/// and `in-progress` (idempotent retry) and nothing else.
+///
+/// The statuses it refuses are all somebody's decision that the task should not
+/// be running. A bundle containing one refuses as a whole, before the worktree
+/// exists, so nothing is half-started.
 #[test]
-fn worktree_setup_admits_unplanned_workflow_statuses() {
+fn worktree_setup_admits_backlog_and_refuses_withdrawn_statuses() {
     let (root, runtime) = test_runtime();
     let repo = root.path().join("repo");
     init_git_repo(&repo);
-    let proposed = runtime
-        .add_task(TaskAddParams {
-            title: "Proposed workflow task".to_string(),
-            description: "Starts from proposed without a plan.".to_string(),
-            workspace_path: Some(".".to_string()),
-            ..Default::default()
-        })
-        .expect("create proposed task");
+
     let backlog = approve_for_execution(
         &runtime,
         &runtime
@@ -367,53 +373,95 @@ fn worktree_setup_admits_unplanned_workflow_statuses() {
             })
             .expect("create backlog candidate"),
     );
-    let rejected = runtime
-        .add_task(TaskAddParams {
-            title: "Rejected workflow task".to_string(),
-            description: "Starts from rejected without a plan.".to_string(),
-            workspace_path: Some(".".to_string()),
-            ..Default::default()
-        })
-        .expect("create rejected candidate");
-    let rejected = runtime
+
+    // A plan is still not a prerequisite for a workflow start: backlog alone is
+    // the authorization.
+    let output = run_worktree_setup(&runtime, std::slice::from_ref(&backlog.id), "jrun-admit");
+    assert!(
+        !output["workspace_path"]
+            .as_str()
+            .expect("workspace path output")
+            .is_empty()
+    );
+    let admitted = runtime.get_task(&backlog.id).expect("reload admitted task");
+    assert_eq!(admitted.status, TaskStatus::InProgress);
+    assert_eq!(admitted.job_run_id.as_deref(), Some("jrun-admit"));
+
+    // Re-running the same setup over an already-admitted task is the retry
+    // path and must stay a no-op rather than a second start.
+    let admitted_again = runtime
+        .admit_task_for_workflow_as_system(&backlog.id, "worktree_setup")
+        .expect("idempotent workflow admission");
+    assert_eq!(admitted_again.status, TaskStatus::InProgress);
+
+    for (label, task_id) in withdrawn_task_fixtures(&runtime) {
+        let error = try_worktree_setup(
+            &runtime,
+            std::slice::from_ref(&task_id),
+            &format!("jrun-{label}"),
+        )
+        .expect_err(&format!("{label} must not be admitted into a workflow"));
+        let message = error.to_string();
+        assert!(
+            message.contains(&task_id) && message.contains("workflow admission"),
+            "{label}: unexpected refusal message: {message}"
+        );
+
+        let after = runtime.get_task(&task_id).expect("reload refused task");
+        assert_ne!(
+            after.status,
+            TaskStatus::InProgress,
+            "{label} must keep its pre-run status"
+        );
+        assert_eq!(
+            after.job_run_id, None,
+            "{label} must not be coupled to the refused run"
+        );
+    }
+}
+
+/// Every status a human parks work in, each built through the same public
+/// transition a human would use.
+fn withdrawn_task_fixtures(runtime: &OrbitRuntime) -> Vec<(&'static str, String)> {
+    let create = |title: &str| {
+        runtime
+            .add_task(TaskAddParams {
+                title: title.to_string(),
+                description: "Exercises a status workflow admission must refuse.".to_string(),
+                workspace_path: Some(".".to_string()),
+                ..Default::default()
+            })
+            .expect("create admission fixture")
+    };
+
+    let proposed = create("Proposed workflow task");
+    let rejected = create("Rejected workflow task");
+    runtime
         .reject_task(
             &rejected.id,
             "exercise workflow admission".to_string(),
             None,
         )
         .expect("reject task");
-    let archived = runtime
-        .add_task(TaskAddParams {
-            title: "Archived workflow task".to_string(),
-            description: "Starts from archived without a plan.".to_string(),
-            workspace_path: Some(".".to_string()),
-            ..Default::default()
-        })
-        .expect("create archived candidate");
+    let archived = create("Archived workflow task");
     runtime.archive_task(&archived.id).expect("archive task");
-    let task_ids = vec![
-        proposed.id.clone(),
-        backlog.id.clone(),
-        rejected.id.clone(),
-        archived.id.clone(),
-    ];
-    let output = run_worktree_setup(&runtime, &task_ids, "jrun-admit");
-    let workspace_path = output["workspace_path"]
-        .as_str()
-        .expect("workspace path output")
-        .to_string();
-    assert!(!workspace_path.is_empty());
+    let someday = approve_for_execution(runtime, &create("Someday workflow task"));
+    runtime
+        .update_task(
+            &someday.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Someday),
+                ..Default::default()
+            },
+        )
+        .expect("park task in someday");
 
-    for task_id in &task_ids {
-        let task = runtime.get_task(task_id).expect("reload admitted task");
-        assert_eq!(task.status, TaskStatus::InProgress, "{task_id}");
-        assert_eq!(task.job_run_id.as_deref(), Some("jrun-admit"));
-    }
-
-    let admitted_again = runtime
-        .admit_task_for_workflow_as_system(&proposed.id, "worktree_setup")
-        .expect("idempotent workflow admission");
-    assert_eq!(admitted_again.status, TaskStatus::InProgress);
+    vec![
+        ("proposed", proposed.id),
+        ("rejected", rejected.id),
+        ("archived", archived.id),
+        ("someday", someday.id),
+    ]
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -141,8 +141,12 @@ where
     Invoke: FnOnce(Value) -> Result<Value, OrbitError>,
     Wait: FnOnce(Value) -> Result<Value, OrbitError>,
 {
-    if let Some(noop) = stale_gate_admission_noop(runtime, action, input)? {
-        return Ok(noop);
+    // [ORB-11305] Re-ask the eligibility question here, not just wherever this
+    // dispatch was decided. A gate can sit in `wait_for_window` for its whole
+    // budget, so the admission snapshot that queued this child may be an hour
+    // stale by now.
+    if let Some(stop) = gate_admission_stop(runtime, action, input)? {
+        return Ok(stop);
     }
 
     let job_name = required_job_name(action, input)?;
@@ -415,7 +419,23 @@ pub(super) fn invoke_detached(
     }))
 }
 
-fn stale_gate_admission_noop(
+/// Re-check live workflow admission for `admission_task_ids` immediately before
+/// child dispatch, and return the synthetic child result when the bundle must
+/// not launch.
+///
+/// `Ok(None)` means every task is still admissible and dispatch proceeds. Two
+/// stops are distinguished because they mean opposite things to the gate:
+///
+/// - **stale no-op** (`review` / `done`) — the work already landed, so the
+///   bundle succeeds having launched nothing.
+/// - **withdrawn** ([ORB-11305]) — a human moved the task somewhere automation
+///   may not start from between admission and now. The gate reports a
+///   non-success child so `release_reservation` frees the reservation and
+///   `require_child_success` then fails the run with the reason attached.
+///
+/// A task that cannot be read at all stays a hard activity failure: that is a
+/// malformed bundle, not a lifecycle decision.
+fn gate_admission_stop(
     runtime: &OrbitRuntime,
     action: &str,
     input: &Value,
@@ -443,6 +463,7 @@ fn stale_gate_admission_noop(
 
     let mut task_statuses = Vec::with_capacity(task_ids.len());
     let mut stale_statuses = Vec::new();
+    let mut withdrawn_statuses = Vec::new();
     let mut admission_errors = Vec::new();
 
     for task_id in &task_ids {
@@ -465,7 +486,12 @@ fn stale_gate_admission_noop(
                     if matches!(status, TaskStatus::Review | TaskStatus::Done) {
                         stale_statuses.push((task_id.clone(), status.to_string()));
                     } else {
-                        admission_errors.push(error.to_string());
+                        // [ORB-11305] The task still exists, a human just moved
+                        // it somewhere automation may not start from. That is a
+                        // terminal answer, not a malfunction: return it as the
+                        // child result so the gate's `release_reservation` step
+                        // still runs before `require_child_success` fails.
+                        withdrawn_statuses.push((task_id.clone(), status.to_string()));
                     }
                 }
                 Err(_) => admission_errors.push(error.to_string()),
@@ -483,42 +509,116 @@ fn stale_gate_admission_noop(
         ));
     }
 
+    // Withdrawal is the stronger signal: a bundle that mixes an already-shipped
+    // task with a withdrawn one must not report success.
+    if !withdrawn_statuses.is_empty() {
+        let reason = format!(
+            "task_gate_pipeline ineligible: workflow admission for '{workflow}' refused child dispatch because {} \
+             is no longer admissible (admission was granted before the status changed). \
+             Return it to the backlog if this work should still run.",
+            summarize_statuses(&withdrawn_statuses)
+        );
+        record_gate_admission_stop(
+            runtime,
+            action,
+            input,
+            &task_ids,
+            &task_statuses,
+            &reason,
+            "withdrawn",
+        )?;
+        return Ok(Some(gate_admission_stop_output(
+            input,
+            "failed",
+            "withdrawn",
+            &reason,
+            &task_statuses,
+        )));
+    }
+
     if stale_statuses.is_empty() {
         return Ok(None);
     }
 
-    let status_summary = stale_statuses
+    let reason = format!(
+        "task_gate_pipeline stale/no-op: workflow admission for '{workflow}' skipped child dispatch because {}",
+        summarize_statuses(&stale_statuses)
+    );
+    record_gate_admission_stop(
+        runtime,
+        action,
+        input,
+        &task_ids,
+        &task_statuses,
+        &reason,
+        "stale_noop",
+    )?;
+    Ok(Some(gate_admission_stop_output(
+        input,
+        "succeeded",
+        "stale_noop",
+        &reason,
+        &task_statuses,
+    )))
+}
+
+fn summarize_statuses(statuses: &[(String, String)]) -> String {
+    statuses
         .iter()
         .map(|(task_id, status)| format!("{task_id}={status}"))
         .collect::<Vec<_>>()
-        .join(", ");
-    let reason = format!(
-        "task_gate_pipeline stale/no-op: workflow admission for '{workflow}' skipped child dispatch because {status_summary}"
-    );
-    record_gate_stale_noop(runtime, action, input, &task_ids, &task_statuses, &reason)?;
-    let parent_run_id = input
+        .join(", ")
+}
+
+/// Build the synthetic child-run result an admission stop reports in place of a
+/// real dispatch. `status` drives the gate: `succeeded` lets
+/// `pipeline_success_guard` pass, anything else fails the gate *after*
+/// `release_reservation` has run, and `error` is what the guard quotes.
+fn gate_admission_stop_output(
+    input: &Value,
+    status: &str,
+    outcome: &str,
+    reason: &str,
+    task_statuses: &[Value],
+) -> Value {
+    let parent_run_id = parent_run_id_or_unknown(input);
+    // Synthetic: this id never resolves to a real run, it only names the stop
+    // for readers. Keep the established `stale-noop-` spelling.
+    let run_id_prefix = outcome.replace('_', "-");
+    let mut output = serde_json::json!({
+        "status": status,
+        "run_id": format!("{run_id_prefix}-{parent_run_id}"),
+        "skipped": true,
+        "reason": reason,
+        "task_statuses": task_statuses,
+    });
+    if status != "succeeded" {
+        output["error"] = Value::String(reason.to_string());
+    }
+    output
+}
+
+fn parent_run_id_or_unknown(input: &Value) -> &str {
+    input
         .get("run_id")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or("unknown");
-
-    Ok(Some(serde_json::json!({
-        "status": "succeeded",
-        "run_id": format!("stale-noop-{parent_run_id}"),
-        "skipped": true,
-        "reason": reason,
-        "task_statuses": task_statuses,
-    })))
+        .unwrap_or("unknown")
 }
 
-fn record_gate_stale_noop(
+/// Audit an admission stop before the gate acts on it. `outcome` is
+/// `stale_noop` (already-shipped work) or `withdrawn` (a human moved the task
+/// out of automation's reach [ORB-11305]); both are recorded so a run that
+/// launched nothing is still explainable from the audit log alone.
+fn record_gate_admission_stop(
     runtime: &OrbitRuntime,
     action: &str,
     input: &Value,
     task_ids: &[String],
     task_statuses: &[Value],
     reason: &str,
+    outcome: &str,
 ) -> Result<(), DispatchError> {
     let parent_run_id = input
         .get("run_id")
@@ -530,18 +630,18 @@ fn record_gate_stale_noop(
         "task_ids": task_ids,
         "task_statuses": task_statuses,
         "reason": reason,
+        "outcome": outcome,
         "parent_run_id": parent_run_id,
     });
-    let arguments_json = serde_json::to_string(&payload).map_err(|err| {
-        action_failed(action, format!("serialize gate.stale_noop payload: {err}"))
-    })?;
-    let execution_id = audit_execution_id("audit-gate-stale-noop");
+    let arguments_json = serde_json::to_string(&payload)
+        .map_err(|err| action_failed(action, format!("serialize gate.{outcome} payload: {err}")))?;
+    let execution_id = audit_execution_id("audit-gate-admission-stop");
     let working_directory = runtime.paths().repo_root.to_string_lossy().into_owned();
 
     runtime
         .record_audit_event(&AuditEventInsertParams {
             execution_id,
-            command: "gate.stale_noop".to_string(),
+            command: format!("gate.{outcome}"),
             subcommand: None,
             tool_name: None,
             target_type: Some("task_bundle".to_string()),
@@ -573,7 +673,7 @@ fn record_gate_stale_noop(
             activity_id: None,
             step_index: None,
         })
-        .map_err(|err| action_failed(action, format!("record gate.stale_noop audit: {err}")))
+        .map_err(|err| action_failed(action, format!("record gate.{outcome} audit: {err}")))
 }
 
 pub(super) fn pipeline_success_guard(action: &str, input: &Value) -> Result<Value, DispatchError> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -584,3 +584,330 @@ fn invoke_detached_skips_when_the_parent_has_stopped_admissions() {
         "a skipped invoke must not create a child"
     );
 }
+
+// ---------------------------------------------------------------------------
+// [ORB-11305] Live eligibility re-check at the child-dispatch boundary.
+//
+// The incident this pins: a bundle was admitted while its task was `backlog`,
+// its gate then sat in `wait_for_window` waiting on locks held by another run,
+// a human withdrew the task (backlog -> proposed) and archived it, and when the
+// locks freed the gate dispatched anyway on its hour-old admission snapshot.
+// `worktree_setup` moved the archived task to `in-progress` and launched a
+// provider against work its owner had explicitly withdrawn.
+// ---------------------------------------------------------------------------
+
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+use orbit_types::task::TaskStatus;
+
+const GATE_ADMISSION_STOP_AUDIT: &str = "gate.withdrawn";
+const GATE_STALE_NOOP_AUDIT: &str = "gate.stale_noop";
+
+/// A gate `dispatch_child` input carrying the admission re-check contract that
+/// `task_gate_pipeline` passes.
+fn gate_dispatch_input(parent_run_id: &str, task_ids: &[&str]) -> Value {
+    json!({
+        "run_id": parent_run_id,
+        "step_id": "dispatch_child",
+        "job_name": "task_pr_pipeline",
+        "run_input": { "task_ids": task_ids },
+        "admission_task_ids": task_ids,
+        "admission_workflow": "worktree_setup",
+    })
+}
+
+fn backlog_task(runtime: &OrbitRuntime, title: &str) -> String {
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: "Admitted while backlog.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create task");
+    runtime
+        .approve_task(&task.id, None, None)
+        .expect("approve into backlog");
+    task.id
+}
+
+/// Park a task the way a human would, through whichever public transition owns
+/// that status — the domain refuses several of them as bare status writes.
+fn park_task(runtime: &OrbitRuntime, task_id: &str, status: TaskStatus) {
+    match status {
+        TaskStatus::Archived => {
+            runtime.archive_task(task_id).expect("archive task");
+        }
+        TaskStatus::Rejected => {
+            runtime
+                .reject_task(task_id, "withdrawn by its owner".to_string(), None)
+                .expect("reject task");
+        }
+        other => {
+            runtime
+                .update_task(
+                    task_id,
+                    TaskUpdateParams {
+                        status: Some(other),
+                        ..Default::default()
+                    },
+                )
+                .expect("apply status change");
+        }
+    }
+}
+
+/// Walk a task to `review` the way its pipeline would, execution summary and
+/// all, so the "already shipped" branch is reached through a real transition.
+fn ship_to_review(runtime: &OrbitRuntime, task_id: &str) {
+    park_task(runtime, task_id, TaskStatus::InProgress);
+    runtime
+        .update_task(
+            task_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Review),
+                execution_summary: Some("shipped while the gate waited".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("move task to review");
+}
+
+/// Drive `invoke_and_wait` with an invoke that panics if it is ever reached, so
+/// "no child was dispatched" is proven rather than inferred from state.
+fn dispatch_expecting_no_child(runtime: &OrbitRuntime, input: &Value) -> Value {
+    invoke_and_wait_with(
+        runtime,
+        "invoke_and_wait",
+        input,
+        |_| panic!("an ineligible bundle must not submit a child run"),
+        |_| panic!("an ineligible bundle must not wait on a child run"),
+    )
+    .expect("an admission stop is a result, not an activity failure")
+}
+
+/// The whole incident, at the seam that decides it.
+#[test]
+fn a_withdrawn_task_is_refused_at_dispatch_after_the_gate_waited() {
+    let (runtime, parent) = parent_runtime();
+    let task_id = backlog_task(&runtime, "Hermes work the owner withdrew");
+
+    // The gate is admitted here: the task is backlog, so this bundle would have
+    // dispatched had it not had to wait.
+    assert!(
+        runtime
+            .ensure_task_can_enter_workflow_as_system(&task_id, "worktree_setup")
+            .is_ok(),
+        "the bundle must be genuinely admissible at admission time"
+    );
+
+    // ... the gate waits on locks, and during that wait the human withdraws the
+    // task from the backlog and then archives it.
+    park_task(&runtime, &task_id, TaskStatus::Proposed);
+    park_task(&runtime, &task_id, TaskStatus::Archived);
+
+    // ... the locks free and the gate wakes up with its stale snapshot.
+    let output = dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
+
+    assert_eq!(output["skipped"], json!(true));
+    assert_eq!(
+        output["status"], "failed",
+        "a withdrawal must not be reported as a successful bundle"
+    );
+    let reason = output["reason"].as_str().expect("reason");
+    assert!(reason.contains(&task_id), "reason must name the task");
+    assert!(reason.contains("archived"), "reason must name the status");
+    assert!(
+        reason.contains("backlog"),
+        "reason must name the remedy: {reason}"
+    );
+    // `pipeline_success_guard` quotes `error`, so the operator sees the reason
+    // on the failing gate step and not only in the audit log.
+    assert_eq!(output["error"], output["reason"]);
+    assert_eq!(output["task_statuses"][0]["task_id"], json!(task_id));
+    assert_eq!(output["task_statuses"][0]["status"], json!("archived"));
+    assert_eq!(output["task_statuses"][0]["admissible"], json!(false));
+
+    // The task is untouched: no archived -> in-progress mutation, no coupling.
+    let after = runtime.get_task(&task_id).expect("reload task");
+    assert_eq!(after.status, TaskStatus::Archived);
+    assert_eq!(after.job_run_id, None);
+    assert!(
+        recorded_dispatches(&runtime, &parent).is_empty(),
+        "no child run may be linked to the parent"
+    );
+
+    let audits = audit_payloads(&runtime, GATE_ADMISSION_STOP_AUDIT);
+    assert_eq!(audits.len(), 1, "the stop must be explainable from audit");
+    assert_eq!(audits[0].1["outcome"], json!("withdrawn"));
+    assert_eq!(audits[0].1["task_ids"], json!([task_id]));
+}
+
+/// The synthetic result must flow through the gate's own YAML the way a real
+/// child result does: non-success, so `release_reservation` runs first and
+/// `require_child_success` then fails the run with the reason attached.
+#[test]
+fn a_withdrawn_dispatch_result_releases_the_reservation_then_fails_the_gate() {
+    let (runtime, parent) = parent_runtime();
+    let task_id = backlog_task(&runtime, "Withdrawn mid-wait");
+    park_task(&runtime, &task_id, TaskStatus::Archived);
+
+    let output = dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
+
+    // `release_reservation` guards on `status` being none of these.
+    let status = output["status"].as_str().expect("status");
+    assert!(
+        !matches!(status, "timeout" | "pending" | "running"),
+        "the gate must consider the wait terminal so the reservation is released"
+    );
+
+    let err = pipeline_success_guard(
+        "pipeline_success_guard",
+        &json!({
+            "context": "task_gate_pipeline child run",
+            "result": output,
+        }),
+    )
+    .expect_err("an ineligible bundle must fail the gate");
+    let message = action_failure_message(err, "pipeline_success_guard");
+    assert!(message.contains("task_gate_pipeline child run did not succeed"));
+    assert!(message.contains(&task_id));
+    assert!(message.contains("no longer admissible"));
+}
+
+/// Every status a human parks work in is refused, not just `archived`.
+#[test]
+fn each_withdrawn_status_is_refused_at_the_dispatch_boundary() {
+    let (runtime, parent) = parent_runtime();
+
+    for status in [
+        TaskStatus::Proposed,
+        TaskStatus::Someday,
+        TaskStatus::Archived,
+        TaskStatus::Rejected,
+        TaskStatus::Blocked,
+    ] {
+        let task_id = backlog_task(&runtime, &format!("Parked in {status}"));
+        park_task(&runtime, &task_id, status);
+
+        let output =
+            dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
+        assert_eq!(output["status"], "failed", "{status} must refuse dispatch");
+        assert_eq!(
+            runtime.get_task(&task_id).expect("reload").status,
+            status,
+            "{status} must survive the refusal unchanged"
+        );
+    }
+}
+
+/// A bundle that mixes already-shipped work with a withdrawal must not report
+/// the whole bundle as a successful no-op — the withdrawal is the stronger
+/// signal and has to reach the operator.
+#[test]
+fn a_withdrawal_outranks_a_stale_noop_in_the_same_bundle() {
+    let (runtime, parent) = parent_runtime();
+    let shipped = backlog_task(&runtime, "Already in review");
+    ship_to_review(&runtime, &shipped);
+    let withdrawn = backlog_task(&runtime, "Withdrawn by its owner");
+    park_task(&runtime, &withdrawn, TaskStatus::Archived);
+
+    let output = dispatch_expecting_no_child(
+        &runtime,
+        &gate_dispatch_input(&parent, &[&shipped, &withdrawn]),
+    );
+
+    assert_eq!(output["status"], "failed");
+    let reason = output["reason"].as_str().expect("reason");
+    assert!(reason.contains(&withdrawn));
+    assert!(
+        !reason.contains(&shipped),
+        "the shipped task is not why this bundle stopped: {reason}"
+    );
+}
+
+/// Positive control: an eligible bundle still dispatches normally after the
+/// gate waited. The re-check must not cost a healthy run its dispatch.
+#[test]
+fn an_eligible_bundle_still_dispatches_after_the_gate_waited() {
+    let (runtime, parent) = parent_runtime();
+    let backlog = backlog_task(&runtime, "Still wanted after the wait");
+    let retried = backlog_task(&runtime, "This run's own retry");
+    park_task(&runtime, &retried, TaskStatus::InProgress);
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &gate_dispatch_input(&parent, &[&backlog, &retried]),
+        |_| Ok(json!({ "run_id": CHILD_RUN, "job_name": "task_pr_pipeline", "queued": false })),
+        |_| Ok(json!({ "results": [{ "run_id": CHILD_RUN, "status": "succeeded" }] })),
+    )
+    .expect("an eligible bundle dispatches");
+
+    assert_eq!(output["status"], "succeeded");
+    assert!(
+        output.get("skipped").is_none(),
+        "a real dispatch is not a skip"
+    );
+    assert_eq!(recorded_dispatches(&runtime, &parent).len(), 1);
+}
+
+/// Positive control: already-shipped work keeps its succeeded no-op. Making
+/// withdrawal fail the gate must not turn "this already landed" into a failure.
+#[test]
+fn already_shipped_work_still_reports_a_succeeded_noop() {
+    let (runtime, parent) = parent_runtime();
+    let task_id = backlog_task(&runtime, "Landed while the gate waited");
+    ship_to_review(&runtime, &task_id);
+
+    let output = dispatch_expecting_no_child(&runtime, &gate_dispatch_input(&parent, &[&task_id]));
+
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["skipped"], json!(true));
+    assert!(
+        pipeline_success_guard(
+            "pipeline_success_guard",
+            &json!({ "result": output.clone() })
+        )
+        .is_ok(),
+        "a stale no-op must still pass the gate's success guard"
+    );
+    assert_eq!(audit_payloads(&runtime, GATE_STALE_NOOP_AUDIT).len(), 1);
+}
+
+/// A task id that resolves to no task at all stays a hard activity failure:
+/// that is a malformed bundle, not a lifecycle decision, and silently
+/// succeeding a gate over it would hide the misconfiguration.
+#[test]
+fn an_unresolvable_admission_task_still_fails_the_activity() {
+    let (runtime, parent) = parent_runtime();
+
+    let err = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &gate_dispatch_input(&parent, &["ORB-99999"]),
+        |_| panic!("must not dispatch on an unresolvable bundle"),
+        |_| panic!("must not wait on an unresolvable bundle"),
+    )
+    .expect_err("an unknown task id is a hard failure");
+    let message = action_failure_message(err, "invoke_and_wait");
+    assert!(message.contains("workflow admission check before child dispatch failed"));
+}
+
+/// Without the admission contract the activity is unchanged: callers that pass
+/// no `admission_task_ids` (every non-gate parent) get no re-check.
+#[test]
+fn a_dispatch_without_admission_task_ids_is_not_rechecked() {
+    let (runtime, parent) = parent_runtime();
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| Ok(healthy_invoke_output()),
+        |_| Ok(json!({ "results": [{ "run_id": CHILD_RUN, "status": "succeeded" }] })),
+    )
+    .expect("no admission contract, no re-check");
+
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(recorded_dispatches(&runtime, &parent).len(), 1);
+}

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -630,6 +630,9 @@ impl HubCoordinationExecutor {
                     status_note: None,
                     append_history: Vec::new(),
                     append_comments,
+                    // A human/agent update is authoritative by itself; it has no
+                    // earlier read to guard against [ORB-11305].
+                    expected_status: None,
                 },
             )?;
         }

--- a/crates/orbit-core/src/application/task/params.rs
+++ b/crates/orbit-core/src/application/task/params.rs
@@ -34,6 +34,10 @@ pub(crate) struct TaskRecordUpdateParams {
     pub(crate) append_history: Vec<TaskHistoryEntry>,
     pub(crate) append_comments: Vec<TaskComment>,
     pub(crate) upsert_artifacts: Vec<TaskArtifact>,
+    /// [ORB-11305] Forwarded to the store as a compare-and-set on the task's
+    /// persisted status. Setting it does not itself constitute a history
+    /// change — it only constrains one.
+    pub(crate) expected_status: Option<Vec<TaskStatus>>,
 }
 
 impl TaskRecordUpdateParams {

--- a/crates/orbit-core/src/application/task/records.rs
+++ b/crates/orbit-core/src/application/task/records.rs
@@ -88,6 +88,7 @@ impl TaskRecordService<'_> {
                     status_note: params.status_note.clone(),
                     append_history: params.append_history.clone(),
                     append_comments: params.append_comments.clone(),
+                    expected_status: params.expected_status.clone(),
                 },
             )?;
         }

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -403,27 +403,44 @@ impl OrbitRuntime {
     /// and is answered there before the worktree is created (ORB-10464,
     /// `orbit-engine`'s `vcs::worktree::dependency_delivery`). Both halves
     /// must hold for a task to be genuinely ready.
+    ///
+    /// [ORB-11305] The set is exactly `backlog` (fresh authorized work) and
+    /// `in-progress` (this run's own idempotent retry, or work a human
+    /// explicitly restarted through `orbit.task.start`). Every other status is
+    /// somebody's decision that this task should not be running right now, and
+    /// automation must not overturn it:
+    ///
+    /// - `proposed` / `someday` — not approved, or withdrawn from the backlog.
+    /// - `archived` / `rejected` — a human closed it.
+    /// - `review` / `done` — the work already landed.
+    /// - `blocked` — a run failed on it and a human has not looked yet.
+    ///
+    /// This matters most for queued work: a gate that was admitted while the
+    /// task was `backlog` can sit in `wait_for_window` for the better part of
+    /// an hour, and the dispatch decision it made back then is a snapshot, not
+    /// standing approval. Callers re-ask this question at the dispatch and
+    /// start boundaries so a withdrawal that lands during the wait wins.
     pub(crate) fn ensure_task_can_enter_workflow_as_system(
         &self,
         id: &str,
         workflow: &str,
     ) -> Result<Task, OrbitError> {
         let task = self.get_task(id)?;
-        if matches!(
-            task.status,
-            TaskStatus::Proposed
-                | TaskStatus::Backlog
-                | TaskStatus::Rejected
-                | TaskStatus::Archived
-                | TaskStatus::InProgress
-        ) {
+        if Self::workflow_admissible_statuses().contains(&task.status) {
             return Ok(task);
         }
 
         Err(OrbitError::InvalidInput(format!(
-            "task '{id}' is in status '{}'; workflow admission for '{workflow}' requires 'proposed', 'backlog', 'rejected', 'archived', or 'in-progress'",
+            "task '{id}' is in status '{}'; workflow admission for '{workflow}' requires 'backlog' or 'in-progress'. \
+             Move it back to the backlog (or start it explicitly) before automation may run it.",
             task.status
         )))
+    }
+
+    /// The single spelling of the admissible set, shared by the read-only gate
+    /// and the compare-and-set the mutating admission writes with.
+    fn workflow_admissible_statuses() -> [TaskStatus; 2] {
+        [TaskStatus::Backlog, TaskStatus::InProgress]
     }
 
     pub(crate) fn admit_task_for_workflow_as_system(
@@ -445,20 +462,10 @@ impl OrbitRuntime {
         }
 
         let note = Some(format!("workflow admission: {workflow}"));
-        let append_history = if task.status == TaskStatus::Proposed {
-            vec![TaskHistoryEntry {
-                at: chrono::Utc::now(),
-                by: SYSTEM_ACTOR_LABEL.to_string(),
-                event: "proposal_approved".to_string(),
-                note: note.clone(),
-                from_status: Some(task.status),
-                to_status: Some(TaskStatus::Backlog),
-            }]
-        } else {
-            Vec::new()
-        };
-
-        let approved_from_proposed = task.status == TaskStatus::Proposed;
+        // [ORB-11305] The predicate above read the status; this write re-checks
+        // it under the store's per-task lock. Without the compare-and-set a
+        // withdrawal landing in that gap would be overwritten by a `backlog`
+        // snapshot taken before it — exactly how an archived task was restarted.
         let updated = self.with_mutation(|| {
             let task = self.stores().task_records().update(
                 id,
@@ -466,7 +473,7 @@ impl OrbitRuntime {
                     actor: SYSTEM_ACTOR_LABEL.to_string(),
                     status_event: Some("started".to_string()),
                     status_note: note.clone(),
-                    append_history: append_history.clone(),
+                    expected_status: Some(Self::workflow_admissible_statuses().to_vec()),
                     ..StoreTaskUpdateParams::from(TaskUpdateParams {
                         status: Some(TaskStatus::InProgress),
                         ..Default::default()
@@ -478,7 +485,7 @@ impl OrbitRuntime {
                 OrbitEvent::TaskStarted {
                     id: id.to_string(),
                     started_by: SYSTEM_ACTOR_LABEL.to_string(),
-                    approved_from_proposed,
+                    approved_from_proposed: false,
                 },
             ))
         })?;

--- a/crates/orbit-core/src/runtime/task/block_on_run_failure.rs
+++ b/crates/orbit-core/src/runtime/task/block_on_run_failure.rs
@@ -12,7 +12,8 @@
 //! `blocked` is a deliberate dead end for automation: `Blocked` is not in the
 //! workflow-admission allowlist, so the ship
 //! sweep skips these tasks. The only way out is a human/orchestrator decision
-//! (the `orbit.task.start` tool, which accepts `Blocked`, or moving it back
+//! (the `orbit.task.start` tool, which accepts `Blocked` and leaves the task
+//! `in-progress` — a status workflow admission does accept — or moving it back
 //! to backlog with `orbit task update <id> --status backlog`).
 
 use orbit_common::OrbitError;
@@ -37,6 +38,14 @@ pub(crate) fn is_workflow_failure_state(state: JobRunState) -> bool {
 /// failure: `Done`/`Archived`/`Rejected` are terminal or human decisions,
 /// `Review` was already shipped (don't clobber it), and `Blocked` is already
 /// where we want it (keeps the transition idempotent).
+///
+/// [ORB-11305] `Proposed` and `Someday` join them. Both are withdrawals — the
+/// way a human takes work back out of the backlog — and a withdrawal is
+/// routinely what *causes* the run to be cancelled. Cleanup that ran after it
+/// would replace the human's decision with `blocked`, so the withdrawal would
+/// have to be re-applied by hand once the run finished unwinding. Only a task
+/// that is still `in-progress` (or already `backlog`) under the failed run is
+/// this transition's business.
 fn task_is_blockable_on_run_failure(status: TaskStatus) -> bool {
     !matches!(
         status,
@@ -45,6 +54,8 @@ fn task_is_blockable_on_run_failure(status: TaskStatus) -> bool {
             | TaskStatus::Blocked
             | TaskStatus::Rejected
             | TaskStatus::Archived
+            | TaskStatus::Proposed
+            | TaskStatus::Someday
     )
 }
 

--- a/crates/orbit-core/src/runtime/task/tests/block_on_run_failure.rs
+++ b/crates/orbit-core/src/runtime/task/tests/block_on_run_failure.rs
@@ -418,3 +418,99 @@ fn blocked_task_is_rejected_by_workflow_admission() {
         "blocked task must not appear in backlog discovery"
     );
 }
+
+/// [ORB-11305] A withdrawal that lands while the run is being torn down must
+/// survive the teardown.
+///
+/// The ordering this pins comes straight from the incident: the human withdrew
+/// the task, the orchestrator then cancelled the run that had started it
+/// anyway, and cleanup ran *after* the withdrawal. Blocking the task there
+/// would replace the owner's newer decision with `blocked`, so the withdrawal
+/// has to be re-applied by hand once the run finishes unwinding.
+#[test]
+fn failure_cleanup_leaves_a_newer_human_withdrawal_alone() {
+    for withdrawn_to in [
+        TaskStatus::Proposed,
+        TaskStatus::Someday,
+        TaskStatus::Archived,
+        TaskStatus::Rejected,
+    ] {
+        let (_root, runtime, repo_root) = test_runtime();
+        let task_id = create_backlog_task(&runtime, &repo_root, "withdrawn");
+        let run = insert_running_pipeline_run(&runtime);
+        couple_task(&runtime, &task_id, &run.run_id, TaskStatus::InProgress);
+
+        // The human withdraws while the run is still live.
+        couple_task(&runtime, &task_id, &run.run_id, withdrawn_to);
+
+        // Only then does the cancelled run's cleanup arrive.
+        record_failing_step(&runtime, &run.run_id);
+        finalize_failed(&runtime, &run.run_id);
+
+        assert_eq!(
+            runtime.get_task(&task_id).expect("task").status,
+            withdrawn_to,
+            "{withdrawn_to} is newer than the run's failure and must win"
+        );
+        assert!(
+            failure_history_entries(&runtime, &task_id).is_empty(),
+            "{withdrawn_to} must not be annotated as a workflow failure"
+        );
+    }
+}
+
+/// The counterpart: a task still executing under the failed run is exactly what
+/// this cleanup is for, and must still be blocked. Narrowing the transition
+/// must not turn it off.
+#[test]
+fn failure_cleanup_still_blocks_a_task_left_in_progress() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task_id = create_backlog_task(&runtime, &repo_root, "stranded");
+    let run = insert_running_pipeline_run(&runtime);
+    couple_task(&runtime, &task_id, &run.run_id, TaskStatus::InProgress);
+    record_failing_step(&runtime, &run.run_id);
+    finalize_failed(&runtime, &run.run_id);
+
+    assert_eq!(
+        runtime.get_task(&task_id).expect("task").status,
+        TaskStatus::Blocked
+    );
+    assert_eq!(failure_history_entries(&runtime, &task_id).len(), 1);
+}
+
+/// [ORB-11305] The documented way out of `blocked` still works, and lands the
+/// task somewhere workflow admission accepts — otherwise narrowing admission
+/// would have made every blocked task unrecoverable.
+#[test]
+fn an_explicitly_restarted_blocked_task_is_admissible_again() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let task_id = create_backlog_task(&runtime, &repo_root, "recovered");
+    let run = insert_running_pipeline_run(&runtime);
+    couple_task(&runtime, &task_id, &run.run_id, TaskStatus::InProgress);
+    record_failing_step(&runtime, &run.run_id);
+    finalize_failed(&runtime, &run.run_id);
+    assert_eq!(
+        runtime.get_task(&task_id).expect("task").status,
+        TaskStatus::Blocked
+    );
+
+    // `start_task` keeps its own plan prerequisite; that gate is unrelated to
+    // admission and stays exactly where it was.
+    runtime
+        .update_task(
+            &task_id,
+            crate::application::task::TaskUpdateParams {
+                plan: Some("1. Retry the failed step.".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("author a plan");
+    let restarted = runtime
+        .start_task(&task_id, None, None)
+        .expect("a human may restart a blocked task");
+    assert_eq!(restarted.status, TaskStatus::InProgress);
+    let admitted = runtime
+        .ensure_task_can_enter_workflow_as_system(&task_id, "worktree_setup")
+        .expect("an explicitly restarted task is admissible");
+    assert_eq!(admitted.status, TaskStatus::InProgress);
+}

--- a/crates/orbit-store/src/contracts/params.rs
+++ b/crates/orbit-store/src/contracts/params.rs
@@ -90,6 +90,14 @@ pub struct TaskHistoryUpdateParams {
     pub status_note: Option<String>,
     pub append_history: Vec<TaskHistoryEntry>,
     pub append_comments: Vec<TaskComment>,
+    /// [ORB-11305] Compare-and-set guard: when `Some`, the write is applied
+    /// only if the task's *persisted* status at write time is one of these.
+    ///
+    /// The check runs inside the per-task exclusive file lock, after the
+    /// bundle is re-read, so a status a caller observed before calling cannot
+    /// go stale in the gap. `None` keeps the unconditional last-writer-wins
+    /// behavior every other caller relies on.
+    pub expected_status: Option<Vec<TaskStatus>>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/orbit-store/src/repository/task/v2/tests/update.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/update.rs
@@ -312,3 +312,130 @@ fn document_update_on_readonly_bundle_dir_names_lock_path_and_hints_sandbox() {
         .expect_err("update must fail on a read-only bundle dir");
     assert_sandbox_write_io(&err, &lock_path.display().to_string());
 }
+
+/// [ORB-11305] `expected_status` is a compare-and-set: the write is applied
+/// against the status persisted at write time, not the one its caller read.
+///
+/// The caller this exists for is workflow admission, which decides "this task
+/// is `backlog`, start it" and can then be overtaken by a human withdrawal
+/// before the write lands. Without the guard the withdrawal is overwritten and
+/// automation starts work its owner already took back.
+#[test]
+fn history_update_refuses_a_status_write_whose_expectation_no_longer_holds() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params(
+            "Withdrawn under a stale read",
+            TaskStatus::Backlog,
+        ))
+        .expect("create task");
+
+    // The human withdrawal lands first.
+    store
+        .update_task_history(
+            "ORB-00000",
+            &TaskHistoryUpdateParams {
+                actor: "daniel".to_string(),
+                status: Some(TaskStatus::Archived),
+                ..Default::default()
+            },
+        )
+        .expect("archive task");
+
+    let events_before = store
+        .get_task_history("ORB-00000")
+        .expect("read history")
+        .expect("history exists")
+        .len();
+
+    // The admission write, still holding its `backlog` snapshot, loses.
+    let error = store
+        .update_task_history(
+            "ORB-00000",
+            &TaskHistoryUpdateParams {
+                actor: "system".to_string(),
+                status: Some(TaskStatus::InProgress),
+                status_event: Some("started".to_string()),
+                expected_status: Some(vec![TaskStatus::Backlog, TaskStatus::InProgress]),
+                ..Default::default()
+            },
+        )
+        .expect_err("a stale expectation must not overwrite the newer status");
+    let message = error.to_string();
+    assert!(
+        message.contains("archived"),
+        "names what it found: {message}"
+    );
+    assert!(
+        message.contains("backlog"),
+        "names what it expected: {message}"
+    );
+
+    let task = store
+        .get_task("ORB-00000")
+        .expect("get task")
+        .expect("task exists");
+    assert_eq!(task.status, TaskStatus::Archived);
+    assert_eq!(
+        store
+            .get_task_history("ORB-00000")
+            .expect("read history")
+            .expect("history exists")
+            .len(),
+        events_before,
+        "a refused write must not leave a partial history entry behind"
+    );
+}
+
+/// The same guard applied to a status that still holds is transparent, and a
+/// write with no expectation keeps the unconditional behavior every other
+/// caller relies on.
+#[test]
+fn history_update_applies_when_the_expectation_holds_or_is_absent() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    store
+        .create_task(create_params("Still wanted", TaskStatus::Backlog))
+        .expect("create task");
+
+    store
+        .update_task_history(
+            "ORB-00000",
+            &TaskHistoryUpdateParams {
+                actor: "system".to_string(),
+                status: Some(TaskStatus::InProgress),
+                status_event: Some("started".to_string()),
+                expected_status: Some(vec![TaskStatus::Backlog, TaskStatus::InProgress]),
+                ..Default::default()
+            },
+        )
+        .expect("a satisfied expectation applies");
+    assert_eq!(
+        store
+            .get_task("ORB-00000")
+            .expect("get task")
+            .expect("task exists")
+            .status,
+        TaskStatus::InProgress
+    );
+
+    store
+        .update_task_history(
+            "ORB-00000",
+            &TaskHistoryUpdateParams {
+                actor: "daniel".to_string(),
+                status: Some(TaskStatus::Archived),
+                ..Default::default()
+            },
+        )
+        .expect("an unguarded write is still unconditional");
+    assert_eq!(
+        store
+            .get_task("ORB-00000")
+            .expect("get task")
+            .expect("task exists")
+            .status,
+        TaskStatus::Archived
+    );
+}

--- a/crates/orbit-store/src/repository/task/v2/updates.rs
+++ b/crates/orbit-store/src/repository/task/v2/updates.rs
@@ -192,6 +192,23 @@ impl TaskV2Store {
             let mut bundle = self.read_existing_bundle(id)?;
             let now = Utc::now();
             let current_status = bundle.envelope.status;
+            // [ORB-11305] Compare-and-set, evaluated against the bundle we just
+            // re-read under the exclusive lock. A caller that decided this write
+            // was allowed from an earlier read loses here rather than silently
+            // overwriting whatever landed in between.
+            if let Some(expected) = &fields.expected_status
+                && !expected.contains(&current_status)
+            {
+                return Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' status changed to '{current_status}' before this write; \
+                     expected one of [{}]",
+                    expected
+                        .iter()
+                        .map(TaskStatus::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            }
             let target_status = fields.status.unwrap_or(current_status);
             let status_transition =
                 (target_status != current_status).then_some((current_status, target_status));

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -625,7 +625,17 @@ The remote-mode refusal remains part of `git_merge`: a caller that requests remo
 
 ### 8.10 Workflow task admission
 
-After [T20260428-8], task-starting workflows own explicit admission instead of relying on generic task updates. `worktree_setup` accepts `proposed`, `backlog`, `rejected`, and `archived` tasks into `in-progress`; existing `in-progress` tasks are idempotent retry inputs.
+After [T20260428-8], task-starting workflows own explicit admission instead of relying on generic task updates. After [ORB-11305] the admissible set is exactly `backlog` and `in-progress`: `backlog` is fresh authorized work, and `in-progress` is either this run's own idempotent retry or work a human explicitly restarted through `orbit.task.start`. `worktree_setup` moves the former into `in-progress` and leaves the latter alone.
+
+Everything else is refused, because every other status is somebody's decision that the task should not be running: `proposed` and `someday` are unapproved or withdrawn, `archived` and `rejected` are closed, `review` and `done` already landed, and `blocked` is a failed run nobody has looked at yet. The set previously included `proposed`, `rejected`, and `archived`, which let admission silently overturn a withdrawal — the production incident [ORB-11305] investigated, where a bundle admitted while its task was `backlog` waited an hour on locks, the owner withdrew and then archived the task during that wait, and the gate dispatched anyway on its stale snapshot: `worktree_setup` moved the archived task to `in-progress` and launched a provider against withdrawn work.
+
+The repair is that eligibility is re-asked at the boundaries where it is consequential, not just where dispatch was first decided, and that the answer cannot go stale between the check and the write:
+
+- `invoke_and_wait` re-checks live admission for `admission_task_ids` immediately before submitting the child run. Already-shipped tasks (`review`/`done`) return the pre-existing succeeded no-op; a withdrawn task returns a non-success synthetic child result carrying the reason, so the gate's `release_reservation` step still frees the reservation before `require_child_success` fails the run. Both are audited (`gate.stale_noop`, `gate.withdrawn`). A task id that resolves to no task at all remains a hard activity failure — that is a malformed bundle, not a lifecycle decision.
+- `admit_task_for_workflow_as_system` writes its `in-progress` transition under a store-level compare-and-set (`TaskHistoryUpdateParams::expected_status`), evaluated inside the per-task exclusive file lock after the bundle is re-read. A withdrawal landing between the predicate and the write loses the write rather than being overwritten.
+- Symmetrically, the failure/cancellation cleanup in `block_on_run_failure` no longer blocks a task that is `proposed` or `someday`, joining `done`/`review`/`blocked`/`rejected`/`archived`. A withdrawal is routinely what *causes* the cancellation, and cleanup that ran after it would replace the owner's newer decision with `blocked`.
+
+Recovery paths are unchanged: `orbit.task.start` still accepts `blocked` and leaves the task `in-progress`, which admission accepts, and a resumed run's `reclaim_task_for_resumed_run` restoration is a separate lineage-proven path that does not go through this predicate.
 
 This path stays separate from `orbit.task.update` and generic deterministic metadata stamping. Direct task updates keep the non-empty-plan guard, and workflow admission records system-actor lifecycle history.
 


### PR DESCRIPTION
## Task

[ORB-11305](https://orbit-cli.com/tasks/ORB-11305) — Revalidate task eligibility after gate waits to prevent archived work from starting

### Description

Observed authoritative production incident on 2026-09-05: Daniel withdrew Hermes ORB-11297 backlog→proposed at 18:47:58 and archived it at 18:50:48. Previously admitted auto wrapper jrun-20260905-1834-2 / gate jrun-20260905-1834-4 waited on locks. After Pi released its reservations, the gate dispatched task_pr_pipeline jrun-20260905-1906 at 19:06:18; worktree_setup changed archived→in_progress at 19:06:19 and launched Grok. Orchestrator cancelled that leaf at 19:10:43, verified provider exited and wrapper failed, and restored archive at 19:11:16. User's withdrawal must take precedence over stale admission. Investigate current gate wait/recheck, child dispatch, atomic task start and cancellation cleanup seams. Add a narrow authoritative eligibility check that cannot resurrect human-withdrawn work. Preserve valid resumed runs and completion authority of already executing tasks, without treating an old dispatch snapshot as fresh approval. Do not run Hermes or OpenClaw, and do not change their crew assignments. Existing explicit crew assignments elsewhere must remain unchanged.

### Acceptance Criteria

- Regression reproduces admission while backlog, gate waiting for locks/dependencies, human withdrawal/archive, then gate wakeup; no implementation child/provider launch or archived→in-progress mutation occurs.
- Recheck live eligibility at consequential dispatch/start boundaries, with race-safe status transition; proposed, someday, archived, rejected, done and explicitly blocked states cannot be silently revived by stale queued work. Define and test valid retry/resume behavior rather than broadly breaking recovery.
- Waiting wrapper terminates with an actionable withdrawn/ineligible outcome and releases reservations; cancellation/failure cleanup does not overwrite newer human status changes.
- Positive tests retain normal backlog execution, lock/dependency wait completion, authorized recovery and completion after admission-window expiry. Run focused tests plus ci-fast/ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `ensure_task_can_enter_workflow_as_system` (orbit-core `application/task/transitions.rs`) admitted `proposed | backlog | rejected | archived | in-progress`. `rejected`/`archived`/`proposed` are human decisions, so `worktree_setup` -> `admit_task_for_workflow` was authorized to move an archived task to `in-progress` and launch a provider. That is exactly the 2026-09-05 incident: gate jrun-20260905-1834-4 was admitted while ORB-11297 was `backlog`, waited on Pi's locks for ~30min, the owner withdrew (backlog->proposed 18:47:58) and archived (18:50:48) during the wait, and when locks freed the gate dispatched jrun-20260905-1906 on its stale snapshot. Notably, system admission was strictly WIDER than what a human `start_task` allows (`proposed|backlog|someday|blocked`), which is the tell.

Fix, three seams, all narrow:

1. Admissible set narrowed to exactly `backlog | in-progress`, spelled once in `OrbitRuntime::workflow_admissible_statuses()` and shared by the read-only gate and the mutating admission. Refusal message names the remedy. The now-dead `proposed -> proposal_approved` auto-approval history branch in `admit_task_for_workflow_as_system` was deleted (`approved_from_proposed` is now always false there).

2. Race-safe transition: new `TaskHistoryUpdateParams::expected_status: Option<Vec<TaskStatus>>` compare-and-set, evaluated in `update_task_history` INSIDE the existing per-task `with_task_lock` after the bundle is re-read. `admit_task_for_workflow_as_system` passes the admissible set, so a withdrawal landing between the predicate and the write loses the write instead of being overwritten. `None` keeps unconditional last-writer-wins for every other caller (tool_host update is authoritative by itself and passes `None`).

3. Gate wrapper terminates actionably and releases reservations: `invoke_and_wait`'s admission recheck (renamed `stale_gate_admission_noop` -> `gate_admission_stop`) now classifies three ways instead of two. `review`/`done` keep the existing succeeded no-op; a task withdrawn during the wait (`proposed`/`someday`/`archived`/`rejected`/`blocked`) previously became a hard `DispatchError`, which failed the step and LEAKED the reservation until TTL — it now returns a synthetic non-success child result with `skipped: true` + `error`, so `release_reservation` (guarded on status not in timeout/pending/running) still runs and `require_child_success` then fails the gate quoting the task and status. Withdrawal outranks stale-noop in a mixed bundle. An unresolvable task id stays a hard failure (malformed bundle, not a lifecycle decision). Audit split into `gate.stale_noop` / `gate.withdrawn` with an `outcome` field.

4. Cleanup no longer overwrites newer human status: `task_is_blockable_on_run_failure` adds `Proposed` and `Someday` to the existing skip set. A withdrawal is routinely what causes the cancellation, so cleanup arriving after it would replace the owner's decision with `blocked` (the incident needed a manual re-archive at 19:11:16).

Recovery preserved deliberately: `orbit.task.start` still accepts `blocked` and lands `in-progress`, which admission accepts; `reclaim_task_for_resumed_run` (ORB-10470) is a separate lineage-proven restoration that does not go through this predicate; `in-progress` remains idempotent for this run's own retry. `start_task`'s plan prerequisite is untouched.

Files changed beyond the declared context_files, all appended to context_files, each minimal and required: orbit-store `contracts/params.rs` + `repository/task/v2/updates.rs` (+ sibling test) — AC2's race-safe transition can only be enforced at the store's per-task lock, there is no other place it is race-free; orbit-core `application/task/params.rs` + `records.rs` — plumbing the CAS field through `TaskRecordUpdateParams`; `adapter/tool_host/host.rs` — one `expected_status: None` needed to compile after the struct field was added. No new cross-crate dependency edge (orbit-core already depends on orbit-store), so ARCHITECTURE.md is unaffected.

Tests (all new ones fail against the pre-fix code):
- `pipeline_actions.rs`: `a_withdrawn_task_is_refused_at_dispatch_after_the_gate_waited` replays the incident ordering end-to-end (admitted while backlog -> withdrawn -> archived -> gate wakes) with invoke/wait closures that panic if reached, proving no child dispatch, no archived->in_progress, no coupling; `a_withdrawn_dispatch_result_releases_the_reservation_then_fails_the_gate` asserts the release-then-fail ordering through the real `pipeline_success_guard`; `each_withdrawn_status_is_refused_at_the_dispatch_boundary`; `a_withdrawal_outranks_a_stale_noop_in_the_same_bundle`; positives `an_eligible_bundle_still_dispatches_after_the_gate_waited`, `already_shipped_work_still_reports_a_succeeded_noop`, `a_dispatch_without_admission_task_ids_is_not_rechecked`; negative `an_unresolvable_admission_task_still_fails_the_activity`.
- `runtime_host.rs`: replaced `worktree_setup_admits_unplanned_workflow_statuses` (encoded the bug) with `worktree_setup_admits_backlog_and_refuses_withdrawn_statuses`, asserting refused tasks keep their status and stay uncoupled.
- store `update.rs`: `history_update_refuses_a_status_write_whose_expectation_no_longer_holds` (incl. no partial history entry) and `history_update_applies_when_the_expectation_holds_or_is_absent`.
- `block_on_run_failure.rs`: `failure_cleanup_leaves_a_newer_human_withdrawal_alone`, `failure_cleanup_still_blocks_a_task_left_in_progress`, `an_explicitly_restarted_blocked_task_is_admissible_again`.

Docs/assets updated in the same change: design doc 2_design.md 8.10 rewritten; `task_gate_pipeline.yaml` behavioral contract and `invoke_and_wait.yaml` description updated in both `crates/orbit-core/assets/` and the `.orbit/resources/` mirror (the mirror's activity description was already stale, so it was resynced to the shipped asset). Per the Rust-practices rule, the task ID was kept out of `invoke_and_wait.yaml` since that description is advertised tool text — `check-embedded-asset-portability.py` enforces this.

Validation: `make ci-fast` PASS, `make ci-lint` PASS (workspace clippy, warnings denied), `cargo test -p orbit-core -p orbit-store -p orbit-engine --no-fail-fast` — orbit-store 400/400, orbit-engine 482/482 + all integration binaries, orbit-core 991 passed / 4 failed. The 4 failures are `bootstrap::init::tests::global_init_*`, all `Io("Read-only file system (os error 30)")` writing the global `~/.orbit` root; confirmed environmental (`touch $HOME/...` fails with the same error in this sandbox) and untouched by this change — unrestricted CI should arbitrate them.

Constraint honored: no Hermes/OpenClaw run, no crew-assignment changes anywhere.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11305-6a9c76f9`
- Behind base: 0
- Ahead of base: 1