### PR TITLE
Make CI sweep file complete findings despite bounded investigation gaps

### DIFF
--- a/.orbit/resources/activities/collect_ci_evidence.yaml
+++ b/.orbit/resources/activities/collect_ci_evidence.yaml
@@ -15,14 +15,32 @@ spec:
     less. Checkout identity is extracted while the full runner-log stream is
     drained, before the human excerpt is truncated; extraction scans at most
     8 MiB per log and records incomplete evidence rather than guessing.
-    Workflow runs are listed repository-wide in one query and exactly
-    the latest run of each workflow is authoritative, ordered by creation time
-    then run ID. Discovery or investigation failures are bounded, redacted,
-    and emitted in `retryable_errors`; the filing step rejects such a snapshot
-    so it cannot be mistaken for a clean result. When no GitHub client is
-    available or authenticated the snapshot carries `collected: false` and
-    gathers nothing further, so a caller can never mistake it for a clean CI
-    result.
+    Workflow runs are listed repository-wide in one query. `latest_runs`
+    records the newest run of each workflow for audit, ordered by creation
+    time then run ID. Current failures are selected by relevant identity
+    (workflow, ref, and observed failed jobs): a queued or in-progress
+    successor is not evidence that an observed failure is resolved, an
+    unrelated pull-request run cannot erase a landing-branch failure, and a
+    genuinely newer completed non-unsuccessful check of the same identity
+    (or a landing-branch success, for non-landing noise) does suppress it.
+    Already-failed jobs inside an in-flight workflow become current once
+    their evidence is complete; a pending check alone is never a repair
+    task. Incomplete mixed-state logs stay in `retryable_errors` until a
+    later sweep can finish them. A red run on a branch that is neither a
+    scanned head nor present on origin is reported as
+    `ref_no_longer_exists` rather than current: its pull request merged or
+    its branch was deleted, so the landing branch's own runs are the live
+    evidence. That probe is authoritative and bounded — one origin query per
+    distinct branch carrying a red run — and a probe that fails leaves the
+    failure current. When candidates outnumber `max_investigated_runs` the
+    ranked prefix keeps all but one slot and the last slot rotates through
+    the overflow by `investigation_cursor`, so a candidate below the cap is
+    investigated within one rotation instead of never. Discovery or investigation failures are
+    bounded, redacted, and emitted in `retryable_errors`; the filing step
+    rejects such a snapshot so it cannot be mistaken for a clean result.
+    When no GitHub client is available or authenticated the snapshot carries
+    `collected: false` and gathers nothing further, so a caller can never
+    mistake it for a clean CI result.
   input_schema_json:
     type: object
     properties:
@@ -46,6 +64,18 @@ spec:
         type: number
       max_investigated_runs:
         type: number
+      max_retired_ref_probes:
+        type: number
+        description: >
+          Cap on origin probes for branches no scanned head covers. Defaults to
+          20, maximum 100. Branches past the cap keep their failures listed as
+          current rather than being assumed merged.
+      investigation_cursor:
+        type: number
+        description: >
+          Which overflow candidate the rotating investigation slot lands on.
+          Defaults to the collection hour, which advances once per hourly
+          sweep; pin it to make a sweep's selection reproducible.
       log_max_bytes:
         type: number
       max_checkout_log_reads:

--- a/.orbit/resources/activities/file_ci_failure_tasks.yaml
+++ b/.orbit/resources/activities/file_ci_failure_tasks.yaml
@@ -10,26 +10,41 @@ spec:
     (workflow, failing job, failing step, normalized error signature, and the
     commit the runner actually tested) so one regression repeated across a push
     run and a pull-request run of the same commit becomes one task rather than
-    several. Each surviving cluster is filed at `status: proposed` with the
+    several. Current failures may include already-failed jobs from an
+    in-flight workflow when that evidence is complete; a pending check is
+    never present in the snapshot as a current failure and must not be filed. Each surviving cluster is filed at `status: proposed` with the
     collected evidence rendered inline in the description, so the implementing
     agent never needs a GitHub credential; no `required_tools` are attached and
     the task can later ship through the ordinary pull-request route only after
     task-pilot validation and explicit CI-sweep admission. Filing itself never
     promotes or dispatches implementation. It is deduped
-    against still-open tasks by a commit-independent failure key carried as a
-    `ci-failure:<key>` tag, so a repeated sweep over a run that is still red
-    does not file the same root cause twice. The three endings stay distinct
+    against still-open tasks first by a commit-independent failure key carried
+    as a `ci-failure:<key>` tag, then by a shared high-confidence material
+    coverage assessment over untagged tasks. A repeated sweep over a run that
+    is still red, or a root cause already owned by a manual task, therefore
+    does not file the same work twice. Skips name the covering task and bounded
+    match evidence; closed historical tasks and superficial similarities do
+    not suppress a current failure. The three endings stay distinct
     and none of them is a CI pass: a snapshot with `collected: false` reports
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
-    reports `current_failures` with what it filed, skipped as already open, or
-    left unfiled at the `max_tasks` cap. Discovery, investigation,
-    registration, dedupe lookup, or task-creation failures fail the activity
-    with a bounded `retryable_error` payload; a current failure is never
-    converted to `no_current_failure` merely because its handoff failed. Every
+    reports `current_failures` with what it filed, skipped as already open,
+    left unfiled at the `max_tasks` cap, or deferred for incomplete evidence.
+    Retryable failures are separated by blast radius. One that names a run —
+    an exhausted investigation budget, an unreadable log, incomplete checkout
+    identity — defers only that finding: it appears in `deferred` with its
+    reasons, is excluded from clustering, and is left for a later sweep, while
+    every complete finding in the same snapshot still files and dedupes. One
+    that names no run — a repository, run-listing, or pull-request-listing
+    read, a registration, dedupe-lookup, or task-creation failure — leaves the
+    whole snapshot in doubt and fails the activity with a bounded
+    `retryable_error` payload, as does a snapshot in which nothing was complete
+    enough to file. A current failure is never converted to
+    `no_current_failure` merely because its handoff failed. Every
     successful output includes an `audit` object with counts and identities for
-    latest runs, current and investigated failures, created tasks, and existing
-    dedupe owners. The filing entries retain workflow, job, step, runner-tested
+    latest runs, current and investigated failures, created tasks, existing
+    dedupe owners, and the findings deferred for incomplete evidence, so
+    partial registration is legible to an operator rather than inferred. The filing entries retain workflow, job, step, runner-tested
     commit, and source run URLs for the later pilot/admission audit.
   input_schema_json:
     type: object
@@ -49,7 +64,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
     properties:
       outcome:
         type: string
@@ -103,7 +118,7 @@ spec:
         type: array
         items:
           type: object
-          required: [failure_key, task_id]
+          required: [failure_key, task_id, match_kind, match_evidence]
           properties:
             failure_key:
               type: string
@@ -113,6 +128,11 @@ spec:
               type: string
             workflow:
               type: string
+            match_kind:
+              type: string
+              enum: [exact_key, material_coverage]
+            match_evidence:
+              type: object
       skipped_over_cap:
         type: array
         items:
@@ -129,6 +149,38 @@ spec:
               type: array
               items:
                 type: string
+      deferred:
+        type: array
+        description: >
+          Current failures left unfiled because their own evidence is
+          incomplete. Each entry carries the run it is about and the bounded
+          retryable reasons, so the gap stays visible and a later sweep can
+          finish it.
+        items:
+          type: object
+          required: [run_id, reasons]
+          properties:
+            run_id:
+              oneOf:
+                - type: number
+                - type: string
+                - type: "null"
+            url:
+              type: string
+            workflow:
+              type: string
+            head_branch:
+              type: string
+            ref_kind:
+              type: string
+            investigated:
+              type: boolean
+            retryable:
+              type: boolean
+            reasons:
+              type: array
+              items:
+                type: object
       audit:
         type: object
   action: file_ci_failure_tasks

--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -34,13 +34,28 @@
 # - No GitHub client or no credentials on this host: `collect` reports
 #   `capability_unavailable` and `file` passes that through unchanged. That is
 #   never reported as a no-current-failure and is never a CI pass.
-# - A discovery, investigation, registration, dedupe, or task-creation error
-#   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
-#   retries the handoff; no current failure is consumed as a clean result.
+# - Errors are separated by blast radius. One that names a run defers only that
+#   finding: it is reported in `file`'s `deferred` list with its reasons and
+#   left for a later sweep, while every complete finding in the same snapshot
+#   still files, dedupes, and pilots. One that names no run — a repository or
+#   listing read, a registration, dedupe, or task-creation failure — or a
+#   snapshot in which nothing was complete enough to file, fails `file` with a
+#   bounded `retryable_error` payload. The job retry wrapper retries the
+#   handoff; no current failure is consumed as a clean result.
+# - Bounded investigation makes progress across sweeps rather than re-spending
+#   its budget on the same refs: red runs on branches origin no longer has are
+#   reported as `ref_no_longer_exists` instead of current, and the last
+#   investigation slot rotates through whatever the cap left over.
 # - Checkout identity is read from the runner-log stream before the bounded
 #   excerpt is formed. The extractor scans no more than 8 MiB per log and
 #   marks the identity incomplete if that hard limit is reached; it never
 #   substitutes an event or PR head SHA as checkout evidence.
+# - Ongoing checks: a queued or in-progress successor does not suppress an
+#   observed failure. Failed jobs inside an in-flight workflow are current
+#   once evidence is complete; a pending check alone is never filed. Freshness
+#   is scoped to workflow/ref/check identity so unrelated pull-request activity
+#   cannot erase a landing-branch failure, while a genuinely newer successful
+#   relevant check still suppresses the resolved case.
 #
 # Overlap safety
 # - `max_active_runs: 1` makes the sweep single-flight, and the seeded routine

--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -26,7 +26,16 @@ spec:
     Already-failed jobs inside an in-flight workflow become current once
     their evidence is complete; a pending check alone is never a repair
     task. Incomplete mixed-state logs stay in `retryable_errors` until a
-    later sweep can finish them. Discovery or investigation failures are
+    later sweep can finish them. A red run on a branch that is neither a
+    scanned head nor present on origin is reported as
+    `ref_no_longer_exists` rather than current: its pull request merged or
+    its branch was deleted, so the landing branch's own runs are the live
+    evidence. That probe is authoritative and bounded — one origin query per
+    distinct branch carrying a red run — and a probe that fails leaves the
+    failure current. When candidates outnumber `max_investigated_runs` the
+    ranked prefix keeps all but one slot and the last slot rotates through
+    the overflow by `investigation_cursor`, so a candidate below the cap is
+    investigated within one rotation instead of never. Discovery or investigation failures are
     bounded, redacted, and emitted in `retryable_errors`; the filing step
     rejects such a snapshot so it cannot be mistaken for a clean result.
     When no GitHub client is available or authenticated the snapshot carries
@@ -55,6 +64,18 @@ spec:
         type: number
       max_investigated_runs:
         type: number
+      max_retired_ref_probes:
+        type: number
+        description: >
+          Cap on origin probes for branches no scanned head covers. Defaults to
+          20, maximum 100. Branches past the cap keep their failures listed as
+          current rather than being assumed merged.
+      investigation_cursor:
+        type: number
+        description: >
+          Which overflow candidate the rotating investigation slot lands on.
+          Defaults to the collection hour, which advances once per hourly
+          sweep; pin it to make a sweep's selection reproducible.
       log_max_bytes:
         type: number
       max_checkout_log_reads:

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -28,14 +28,23 @@ spec:
     and none of them is a CI pass: a snapshot with `collected: false` reports
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
-    reports `current_failures` with what it filed, skipped as already open, or
-    left unfiled at the `max_tasks` cap. Discovery, investigation,
-    registration, dedupe lookup, or task-creation failures fail the activity
-    with a bounded `retryable_error` payload; a current failure is never
-    converted to `no_current_failure` merely because its handoff failed. Every
+    reports `current_failures` with what it filed, skipped as already open,
+    left unfiled at the `max_tasks` cap, or deferred for incomplete evidence.
+    Retryable failures are separated by blast radius. One that names a run —
+    an exhausted investigation budget, an unreadable log, incomplete checkout
+    identity — defers only that finding: it appears in `deferred` with its
+    reasons, is excluded from clustering, and is left for a later sweep, while
+    every complete finding in the same snapshot still files and dedupes. One
+    that names no run — a repository, run-listing, or pull-request-listing
+    read, a registration, dedupe-lookup, or task-creation failure — leaves the
+    whole snapshot in doubt and fails the activity with a bounded
+    `retryable_error` payload, as does a snapshot in which nothing was complete
+    enough to file. A current failure is never converted to
+    `no_current_failure` merely because its handoff failed. Every
     successful output includes an `audit` object with counts and identities for
-    latest runs, current and investigated failures, created tasks, and existing
-    dedupe owners. The filing entries retain workflow, job, step, runner-tested
+    latest runs, current and investigated failures, created tasks, existing
+    dedupe owners, and the findings deferred for incomplete evidence, so
+    partial registration is legible to an operator rather than inferred. The filing entries retain workflow, job, step, runner-tested
     commit, and source run URLs for the later pilot/admission audit.
   input_schema_json:
     type: object
@@ -55,7 +64,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
     properties:
       outcome:
         type: string
@@ -140,6 +149,38 @@ spec:
               type: array
               items:
                 type: string
+      deferred:
+        type: array
+        description: >
+          Current failures left unfiled because their own evidence is
+          incomplete. Each entry carries the run it is about and the bounded
+          retryable reasons, so the gap stays visible and a later sweep can
+          finish it.
+        items:
+          type: object
+          required: [run_id, reasons]
+          properties:
+            run_id:
+              oneOf:
+                - type: number
+                - type: string
+                - type: "null"
+            url:
+              type: string
+            workflow:
+              type: string
+            head_branch:
+              type: string
+            ref_kind:
+              type: string
+            investigated:
+              type: boolean
+            retryable:
+              type: boolean
+            reasons:
+              type: array
+              items:
+                type: object
       audit:
         type: object
   action: file_ci_failure_tasks

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -34,9 +34,18 @@
 # - No GitHub client or no credentials on this host: `collect` reports
 #   `capability_unavailable` and `file` passes that through unchanged. That is
 #   never reported as a no-current-failure and is never a CI pass.
-# - A discovery, investigation, registration, dedupe, or task-creation error
-#   fails `file` with a bounded `retryable_error` payload. The job retry wrapper
-#   retries the handoff; no current failure is consumed as a clean result.
+# - Errors are separated by blast radius. One that names a run defers only that
+#   finding: it is reported in `file`'s `deferred` list with its reasons and
+#   left for a later sweep, while every complete finding in the same snapshot
+#   still files, dedupes, and pilots. One that names no run — a repository or
+#   listing read, a registration, dedupe, or task-creation failure — or a
+#   snapshot in which nothing was complete enough to file, fails `file` with a
+#   bounded `retryable_error` payload. The job retry wrapper retries the
+#   handoff; no current failure is consumed as a clean result.
+# - Bounded investigation makes progress across sweeps rather than re-spending
+#   its budget on the same refs: red runs on branches origin no longer has are
+#   reported as `ref_no_longer_exists` instead of current, and the last
+#   investigation slot rotates through whatever the cap left over.
 # - Checkout identity is read from the runner-log stream before the bounded
 #   excerpt is formed. The extractor scans no more than 8 MiB per log and
 #   marks the identity incomplete if that hard limit is reached; it never

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -163,6 +163,7 @@ where
             "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
+            "deferred": [],
             "audit": audit,
             "detail": "no CI evidence was gathered, so no task was filed; this is not a CI pass",
         }));
@@ -193,27 +194,56 @@ where
         .into_iter()
         .map(normalize_retryable_error)
         .collect();
+    // A gap in one run's evidence is a fact about that run. Letting it also
+    // withhold every complete finding in the same snapshot is how a sweep that
+    // had three fully evidenced regressions in hand filed nothing at all.
+    let (mut snapshot_wide, mut run_errors) = partition_retryable_errors(&retryable_errors);
+    // An uninvestigated failure collection said nothing else about still needs
+    // its own reason; one that already has a recorded cause keeps that cause
+    // rather than being restated generically.
     for failure in &failures {
-        if failure.get("investigated").and_then(Value::as_bool) != Some(true) {
-            retryable_errors.push(json!({
-                "stage": "registration",
-                "operation": "current_failure_not_investigated",
-                "run_id": failure.get("run_id"),
-                "retryable": true,
-                "message": "a current CI failure has no complete investigation and cannot be filed safely",
-            }));
+        if failure.get("investigated").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let run_id = run_id_key(failure);
+        if run_id
+            .as_ref()
+            .is_some_and(|run_id| run_errors.contains_key(run_id))
+        {
+            continue;
+        }
+        let error = json!({
+            "stage": "registration",
+            "operation": "current_failure_not_investigated",
+            "run_id": failure.get("run_id"),
+            "retryable": true,
+            "message": "a current CI failure has no complete investigation and cannot be filed safely",
+        });
+        retryable_errors.push(error.clone());
+        match run_id {
+            Some(run_id) => run_errors.entry(run_id).or_default().push(error),
+            // Without a run ID there is nothing to defer *to*: the finding
+            // cannot be told apart from any other, so the snapshot is unsafe
+            // to file from at all.
+            None => snapshot_wide += 1,
         }
     }
-    if !retryable_errors.is_empty() {
+    if snapshot_wide > 0 {
+        // A snapshot this incomplete cannot be filed from at all: the listing
+        // that failed may be exactly the one holding the newer run that would
+        // have superseded a finding. Report every error, not just the
+        // snapshot-wide ones, so one payload explains the whole sweep.
         return Err(retryable_pipeline_error(
             "collection_or_investigation",
             &audit,
             retryable_errors,
         ));
     }
-    let clusters = cluster_failures(&failures);
+    let (complete, deferred) = split_deferred_failures(&failures, &run_errors);
+    let audit = deferral_audit(audit, &deferred);
+    let clusters = cluster_failures(&complete);
 
-    if !failures.is_empty() && clusters.is_empty() {
+    if !complete.is_empty() && clusters.is_empty() {
         return Err(retryable_pipeline_error(
             "registration",
             &audit,
@@ -227,6 +257,15 @@ where
     }
 
     if clusters.is_empty() {
+        // Nothing was complete enough to file. The gaps are the whole result,
+        // so this stays a retryable error rather than a clean sweep.
+        if !deferred.is_empty() {
+            return Err(retryable_pipeline_error(
+                "collection_or_investigation",
+                &audit,
+                deferred_errors(&deferred),
+            ));
+        }
         return Ok(json!({
             "outcome": OUTCOME_NO_CURRENT_FAILURE,
             "capability": capability,
@@ -236,6 +275,7 @@ where
             "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
+            "deferred": [],
             "audit": audit,
             "detail": "the queries ran and found no current, non-superseded failure",
         }));
@@ -417,9 +457,111 @@ where
         "pilot_candidates": pilot_candidates,
         "skipped_existing": skipped_existing,
         "skipped_over_cap": skipped_over_cap,
+        "deferred": deferred,
         "max_tasks": max_tasks,
         "audit": final_audit,
     }))
+}
+
+/// The run a snapshot entry — a retryable error or a current failure — is
+/// about, as a comparable key. Collection emits a numeric `run_id`; the
+/// version-1 `query_errors` shape used a string.
+fn run_id_key(entry: &Value) -> Option<String> {
+    match entry.get("run_id") {
+        Some(Value::Number(number)) => Some(number.to_string()),
+        Some(Value::String(text)) if !text.trim().is_empty() => Some(text.trim().to_string()),
+        _ => None,
+    }
+}
+
+/// Split retryable errors by blast radius.
+///
+/// An error that names a run spoils that run's finding and nothing else. An
+/// error that names none — a repository read, a run listing, a pull-request
+/// listing — leaves the whole snapshot in doubt: any finding it did produce
+/// could be missing the newer run that would have superseded it, so filing
+/// from that snapshot is not safe.
+fn partition_retryable_errors(errors: &[Value]) -> (usize, BTreeMap<String, Vec<Value>>) {
+    let mut snapshot_wide = 0usize;
+    let mut by_run: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    for error in errors {
+        match run_id_key(error) {
+            Some(run_id) => by_run.entry(run_id).or_default().push(error.clone()),
+            None => snapshot_wide += 1,
+        }
+    }
+    (snapshot_wide, by_run)
+}
+
+/// Separate the failures that can be filed from the ones whose evidence is
+/// incomplete.
+///
+/// Per-finding evidence requirements are unchanged: a failure is filed only
+/// when collection investigated it fully and no error is recorded against its
+/// run. What changes is that a deferred failure now says so in its own entry
+/// instead of silently withholding its neighbours.
+fn split_deferred_failures(
+    failures: &[Value],
+    run_errors: &BTreeMap<String, Vec<Value>>,
+) -> (Vec<Value>, Vec<Value>) {
+    let mut complete = Vec::new();
+    let mut deferred = Vec::new();
+    for failure in failures {
+        let reasons = run_id_key(failure)
+            .and_then(|run_id| run_errors.get(&run_id).cloned())
+            .unwrap_or_default();
+        let investigated = failure.get("investigated").and_then(Value::as_bool) == Some(true);
+        if reasons.is_empty() && investigated {
+            complete.push(failure.clone());
+            continue;
+        }
+        deferred.push(json!({
+            "run_id": failure.get("run_id"),
+            "url": failure.get("url"),
+            "workflow": failure.get("workflow"),
+            "head_branch": failure.get("head_branch"),
+            "ref_kind": failure.get("ref_kind"),
+            "investigated": investigated,
+            "retryable": true,
+            "reasons": if reasons.is_empty() {
+                vec![json!({
+                    "stage": "registration",
+                    "operation": "current_failure_not_investigated",
+                    "run_id": failure.get("run_id"),
+                    "retryable": true,
+                    "message": "a current CI failure has no complete investigation and cannot be filed safely",
+                })]
+            } else {
+                reasons
+            },
+        }));
+    }
+    (complete, deferred)
+}
+
+/// The deferred entries flattened back into the error list shape, for the
+/// ending where nothing could be filed at all.
+fn deferred_errors(deferred: &[Value]) -> Vec<Value> {
+    deferred
+        .iter()
+        .filter_map(|entry| entry.get("reasons").and_then(Value::as_array))
+        .flat_map(|reasons| reasons.iter().cloned())
+        .collect()
+}
+
+/// Make partial registration legible: an operator reading the audit must be
+/// able to tell "three findings, three filed" from "three findings filed and
+/// eleven still owed".
+fn deferral_audit(mut audit: Value, deferred: &[Value]) -> Value {
+    audit["deferred_failures"] = json!(deferred.len());
+    audit["deferred_failure_run_ids"] = json!(
+        deferred
+            .iter()
+            .filter_map(|entry| entry.get("run_id").cloned())
+            .collect::<Vec<_>>()
+    );
+    audit["retryable_errors"] = json!(deferred_errors(deferred).len());
+    audit
 }
 
 fn audit_summary(evidence: &Value, failures: &[Value]) -> Value {
@@ -452,6 +594,8 @@ fn audit_summary(evidence: &Value, failures: &[Value]) -> Value {
         "created_task_ids": [],
         "existing_task_skips": 0,
         "existing_task_owners": [],
+        "deferred_failures": 0,
+        "deferred_failure_run_ids": [],
         "retryable_errors": 0,
     })
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -983,3 +983,209 @@ fn query_error_prevents_filing_and_remains_retryable() {
             .is_empty()
     );
 }
+
+/// One uninvestigated run, shaped as collection leaves it when the budget runs
+/// out: a URL and a verdict, no job, step, or log.
+fn deferred_failure(run_id: u64, workflow: &str, branch: &str) -> Value {
+    let mut failure = failure(run_id, workflow, "", "", "", "");
+    failure["investigated"] = json!(false);
+    failure["failed_jobs"] = json!([]);
+    failure["log_excerpt"] = json!("");
+    failure["actual_checkout_shas"] = json!([]);
+    failure["checkout_evidence"] = json!([]);
+    failure["head_branch"] = json!(branch);
+    failure["ref_kind"] = json!("pull_request");
+    failure
+}
+
+fn budget_error(run_id: u64) -> Value {
+    json!({
+        "stage": "investigation",
+        "operation": "investigation_budget",
+        "run_id": run_id,
+        "retryable": true,
+        "message": "current failure was not investigated because max_investigated_runs was exhausted",
+    })
+}
+
+/// The jrun-20260905-1932 regression: fourteen candidates, three of them fully
+/// evidenced, and the other eleven starved of investigation budget. The three
+/// complete findings are real, filable defects and must not be withheld
+/// because their neighbours are incomplete.
+#[test]
+fn complete_findings_file_while_incomplete_ones_stay_deferred() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut current = vec![
+        failure(
+            33_986_585_197,
+            "Platform",
+            "macOS",
+            "cargo test",
+            "ci\tmacOS\t2026-09-05T19:20:00Z ##[error]linker command failed\n",
+            CHECKOUT,
+        ),
+        failure(
+            33_986_582_084,
+            "Website",
+            "build",
+            "sync website",
+            "ci\tbuild\t2026-09-05T19:19:00Z ##[error]sync command not found\n",
+            CHECKOUT,
+        ),
+        failure(
+            33_986_085_270,
+            "Pi",
+            "macOS",
+            "cargo build",
+            "ci\tmacOS\t2026-09-05T19:10:00Z ##[error]could not compile orbit-pi\n",
+            CHECKOUT,
+        ),
+    ];
+    let deferred_ids = (0..11_u64)
+        .map(|index| 33_900_000_000 + index)
+        .collect::<Vec<_>>();
+    for run_id in &deferred_ids {
+        current.push(deferred_failure(
+            *run_id,
+            "Platform",
+            "orbit/ORB-11200-older",
+        ));
+    }
+    let mut evidence = snapshot(current);
+    evidence["retryable_errors"] = json!(
+        deferred_ids
+            .iter()
+            .map(|run_id| budget_error(*run_id))
+            .collect::<Vec<_>>()
+    );
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["outcome"], json!("current_failures"));
+    assert_eq!(output["filed_count"], json!(3), "{output}");
+    assert_eq!(filed_task_ids(&output).len(), 3);
+    // The durable outcome is the tasks themselves, not the report.
+    assert_eq!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .len(),
+        3
+    );
+
+    let deferred = output["deferred"].as_array().expect("deferred array");
+    assert_eq!(deferred.len(), 11);
+    assert_eq!(deferred[0]["run_id"], json!(33_900_000_000_u64));
+    assert_eq!(deferred[0]["investigated"], json!(false));
+    assert_eq!(deferred[0]["retryable"], json!(true));
+    assert_eq!(
+        deferred[0]["reasons"][0]["operation"],
+        json!("investigation_budget")
+    );
+
+    let audit = &output["audit"];
+    assert_eq!(audit["current_failures"], json!(14));
+    assert_eq!(audit["investigated_failures"], json!(3));
+    assert_eq!(audit["tasks_created"], json!(3));
+    assert_eq!(audit["deferred_failures"], json!(11));
+    assert_eq!(audit["retryable_errors"], json!(11));
+    assert_eq!(
+        audit["deferred_failure_run_ids"]
+            .as_array()
+            .expect("deferred ids")
+            .len(),
+        11
+    );
+}
+
+/// The boundary the partial path must not cross. A listing that failed may be
+/// the one holding the newer run that would have superseded a finding, so a
+/// snapshot-wide error still withholds everything — including findings that
+/// look complete.
+#[test]
+fn a_snapshot_wide_discovery_error_still_withholds_a_complete_finding() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut evidence = snapshot(vec![failure(
+        10,
+        "ci",
+        "build",
+        "cargo build",
+        "ci\tbuild\t2026-08-30T01:00:00Z ##[error]expected 3 arguments\n",
+        CHECKOUT,
+    )]);
+    evidence["retryable_errors"] = json!([
+        {
+            "stage": "discovery",
+            "operation": "run_list",
+            "run_id": Value::Null,
+            "retryable": true,
+            "message": "HTTP 502: Bad Gateway",
+        },
+        budget_error(11),
+    ]);
+
+    let error = file_error(&runtime, json!({"ci_evidence": evidence}));
+
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("run_list"));
+    // The run-scoped error travels with it, so one payload explains the sweep.
+    assert!(error.contains("investigation_budget"));
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
+    );
+}
+
+/// A finding whose own run carries an error is not filed from partial
+/// evidence: per-finding requirements are unchanged, and the gap is stated
+/// rather than papered over.
+#[test]
+fn a_finding_whose_own_run_failed_a_query_is_deferred_not_filed_from_partial_evidence() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut evidence = snapshot(vec![
+        failure(
+            10,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\t2026-08-30T01:00:00Z ##[error]expected 3 arguments\n",
+            CHECKOUT,
+        ),
+        failure(
+            11,
+            "Website",
+            "deploy",
+            "sync website",
+            "ci\tdeploy\t2026-08-30T01:00:00Z ##[error]sync command not found\n",
+            CHECKOUT,
+        ),
+    ]);
+    evidence["retryable_errors"] = json!([
+        {
+            "stage": "registration",
+            "operation": "checkout_evidence",
+            "run_id": 11,
+            "retryable": true,
+            "message": "checkout evidence scan reached its hard limit; actual checkout identity is incomplete",
+        }
+    ]);
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(output["filed"][0]["workflow"], json!("ci"));
+    let deferred = output["deferred"].as_array().expect("deferred array");
+    assert_eq!(deferred.len(), 1);
+    assert_eq!(deferred[0]["run_id"], json!(11));
+    assert_eq!(
+        deferred[0]["investigated"],
+        json!(true),
+        "the run was investigated; its evidence is what is incomplete"
+    );
+    assert_eq!(
+        deferred[0]["reasons"][0]["operation"],
+        json!("checkout_evidence")
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
@@ -389,3 +389,76 @@ fn later_security_lookup_failure_is_redacted_retryable_and_writes_nothing() {
         "the first candidate must remain pending until all lookups succeed"
     );
 }
+
+/// The jrun-20260905-1932 aftermath: manual repairs (ORB-11306 for the macOS
+/// regression, ORB-11307 for the Website one) already own both complete
+/// findings while older candidates are still starved of investigation budget.
+/// Dedupe has to run against the complete findings — not be withheld by the
+/// incomplete ones — and the sweep still has to say what it owes.
+#[test]
+fn manual_repairs_dedupe_complete_findings_while_gaps_stay_visible() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let macos_owner = seed_manual_task(
+        &runtime,
+        "Fix red CI: Platform / macOS / cargo test",
+        "Workflow: Platform\nFailing job: macOS\nFailing step: cargo test\n\
+         Normalized error signature: ##[error]linker command failed",
+        TaskStatus::Backlog,
+    );
+    let website_owner = seed_manual_task(
+        &runtime,
+        "Fix red CI: Website / build / sync website",
+        "Workflow: Website\nFailing job: build\nFailing step: sync website\n\
+         Normalized error signature: ##[error]sync command not found",
+        TaskStatus::Backlog,
+    );
+
+    let mut uninvestigated = failure(33_900_000_001, "Platform", "", "", "", "");
+    uninvestigated["investigated"] = json!(false);
+    uninvestigated["failed_jobs"] = json!([]);
+    uninvestigated["log_excerpt"] = json!("");
+    let mut evidence = ci_snapshot(vec![
+        failure(
+            33_986_585_197,
+            "Platform",
+            "macOS",
+            "cargo test",
+            "ci\tmacOS\t2026-09-05T19:20:00Z ##[error]linker command failed\n",
+            CHECKOUT,
+        ),
+        failure(
+            33_986_582_084,
+            "Website",
+            "build",
+            "sync website",
+            "ci\tbuild\t2026-09-05T19:19:00Z ##[error]sync command not found\n",
+            CHECKOUT,
+        ),
+        uninvestigated,
+    ]);
+    evidence["retryable_errors"] = json!([{
+        "stage": "investigation",
+        "operation": "investigation_budget",
+        "run_id": 33_900_000_001_u64,
+        "retryable": true,
+        "message": "current failure was not investigated because max_investigated_runs was exhausted",
+    }]);
+
+    let output = file_ci(&runtime, evidence);
+
+    assert_eq!(output["filed_count"], json!(0), "{output}");
+    let owners = output["skipped_existing"]
+        .as_array()
+        .expect("skipped existing")
+        .iter()
+        .map(|entry| entry["task_id"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(owners, vec![macos_owner, website_owner]);
+    assert_eq!(output["audit"]["existing_task_skips"], json!(2));
+    assert_eq!(output["audit"]["deferred_failures"], json!(1));
+    assert_eq!(
+        output["deferred"][0]["run_id"],
+        json!(33_900_000_001_u64),
+        "the starved candidate is still owed: {output}"
+    );
+}

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -49,6 +49,10 @@ const MAX_LOG_MAX_BYTES: u64 = 262_144;
 /// Cap on full-log reads taken purely to evidence a checkout commit. The
 /// failed-step log usually lacks it, and a full log can be tens of megabytes.
 const DEFAULT_MAX_CHECKOUT_LOG_READS: u64 = 3;
+/// Cap on origin probes for branches no scanned head covers. One probe per
+/// distinct branch, and only for branches that actually carry a red run.
+const DEFAULT_MAX_RETIRED_REF_PROBES: u64 = 20;
+const MAX_RETIRED_REF_PROBES: u64 = 100;
 const MAX_RETRYABLE_ERROR_CHARS: usize = 500;
 
 /// Which of the workspace's heads a run belongs to.
@@ -84,6 +88,10 @@ struct Bounds {
     max_investigated_runs: usize,
     log_max_bytes: usize,
     max_checkout_log_reads: usize,
+    max_retired_ref_probes: usize,
+    /// Which overflow candidate this sweep spends its rotating investigation
+    /// slot on. Taken from the collection hour unless the caller pins it.
+    investigation_cursor: u64,
 }
 
 fn bounds_from_input(input: &Value) -> Result<Bounds, OrbitError> {
@@ -113,7 +121,25 @@ fn bounds_from_input(input: &Value) -> Result<Bounds, OrbitError> {
             DEFAULT_MAX_CHECKOUT_LOG_READS,
             MAX_INVESTIGATED_RUNS,
         )? as usize,
+        max_retired_ref_probes: bounded_u64(
+            input,
+            "max_retired_ref_probes",
+            DEFAULT_MAX_RETIRED_REF_PROBES,
+            MAX_RETIRED_REF_PROBES,
+        )? as usize,
+        investigation_cursor: bounded_u64(
+            input,
+            "investigation_cursor",
+            default_investigation_cursor(),
+            u64::MAX,
+        )?,
     })
+}
+
+/// The sweep runs hourly, so the hour advances the rotating investigation slot
+/// exactly once per sweep without any state to persist.
+fn default_investigation_cursor() -> u64 {
+    chrono::Utc::now().timestamp().max(0) as u64 / 3_600
 }
 
 /// Collect one CI evidence snapshot.
@@ -167,11 +193,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         &mut retryable_errors,
     )?;
 
-    let mut latest: Vec<Value> = Vec::new();
-    let mut current: Vec<Value> = Vec::new();
-    let mut stale: Vec<Value> = Vec::new();
-    let mut in_flight: Vec<Value> = Vec::new();
-    let mut mixed_candidates: Vec<Value> = Vec::new();
+    let mut partition = RunPartition::default();
     // One repository-wide query rather than one per ref: a single list is what
     // lets a newer *relevant* success supersede an older failure without
     // asking the ref it ran on whether it has advanced. Selection itself is
@@ -198,15 +220,15 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             bounds.max_runs, bounds.max_runs
         ));
     }
-    partition_runs(
-        &refs,
-        &runs,
-        &mut latest,
-        &mut current,
-        &mut stale,
-        &mut in_flight,
-        &mut mixed_candidates,
-    );
+    let retired = retired_branches(queries, &refs, &runs, &bounds, &mut notes);
+    partition_runs(&refs, &runs, &retired, &mut partition);
+    let RunPartition {
+        latest,
+        mut current,
+        stale,
+        in_flight,
+        mixed_candidates,
+    } = partition;
 
     let mut inspect = Vec::new();
     let mut seen_run_ids = std::collections::BTreeSet::new();
@@ -220,15 +242,21 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     }
     sort_current_failures(&mut inspect);
     let investigation_candidates = inspect.len();
-    let attempted = investigation_candidates.min(bounds.max_investigated_runs);
+    let selected = investigation_slots(
+        investigation_candidates,
+        bounds.max_investigated_runs,
+        bounds.investigation_cursor,
+    );
+    let attempted = selected.len();
     if investigation_candidates > attempted {
         notes.push(format!(
             "{} of {investigation_candidates} current or mixed-state runs were listed but not \
-             investigated (max_investigated_runs={attempted}); their run URLs are still present",
+             investigated (max_investigated_runs={attempted}); their run URLs are still present, \
+             and the rotating slot reaches a different overflow candidate on the next sweep",
             investigation_candidates - attempted
         ));
-        for failure in inspect.iter().skip(attempted) {
-            if !run_is_completed(failure) {
+        for (index, failure) in inspect.iter().enumerate() {
+            if selected.contains(&index) || !run_is_completed(failure) {
                 continue;
             }
             push_retryable_error(
@@ -242,7 +270,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     }
     let mut checkout_log_reads = 0usize;
     for (index, failure) in inspect.iter_mut().enumerate() {
-        if index >= attempted {
+        if !selected.contains(&index) {
             failure["investigated"] = json!(false);
             continue;
         }
@@ -318,6 +346,9 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "log_max_bytes": bounds.log_max_bytes,
             "checkout_log_reads": checkout_log_reads,
             "max_checkout_log_reads": bounds.max_checkout_log_reads,
+            "retired_refs": retired.iter().collect::<Vec<_>>(),
+            "max_retired_ref_probes": bounds.max_retired_ref_probes,
+            "investigation_cursor": bounds.investigation_cursor,
             "notes": notes,
         }),
         "collected_at": chrono::Utc::now().to_rfc3339(),
@@ -440,6 +471,91 @@ fn derive_refs<Q: CiQueries + ?Sized>(
     Ok(refs)
 }
 
+/// Branches that carry a red run but no longer exist on origin.
+///
+/// A task branch is deleted when its pull request merges, so its old red runs
+/// describe code that either landed — where the landing branch's own runs are
+/// the current evidence — or was abandoned. Either way there is no ref left to
+/// fix, and treating those runs as current is what let a backlog of merged
+/// historical pull requests consume every sweep's investigation budget.
+///
+/// The probe is authoritative (origin, not a naming convention) and bounded:
+/// one query per distinct branch that actually carries a red run, and none at
+/// all for a branch already scanned as a landing head or an open pull request.
+/// A probe that fails leaves its branch alone — a failure to reach origin is
+/// never evidence that a failure is resolved.
+fn retired_branches<Q: CiQueries + ?Sized>(
+    queries: &Q,
+    refs: &[ScannedRef],
+    runs: &[Value],
+    bounds: &Bounds,
+    notes: &mut Vec<String>,
+) -> std::collections::BTreeSet<String> {
+    let mut candidates: Vec<&str> = Vec::new();
+    for run in runs {
+        let branch = run_branch(run);
+        if branch.is_empty() || !run_is_completed(run) || !run_is_unsuccessful(run) {
+            continue;
+        }
+        if refs.iter().any(|scanned| scanned.branch == branch) || candidates.contains(&branch) {
+            continue;
+        }
+        candidates.push(branch);
+    }
+
+    let mut retired = std::collections::BTreeSet::new();
+    for (probes, branch) in candidates.iter().enumerate() {
+        if probes >= bounds.max_retired_ref_probes {
+            notes.push(format!(
+                "{} branch(es) carrying red runs were not probed against origin \
+                 (max_retired_ref_probes={}); their failures stay listed as current rather than \
+                 being assumed merged",
+                candidates.len() - probes,
+                bounds.max_retired_ref_probes
+            ));
+            break;
+        }
+        match queries.remote_branch_head(branch) {
+            Ok(None) => {
+                retired.insert((*branch).to_string());
+            }
+            Ok(Some(_)) => {}
+            Err(error) => notes.push(format!(
+                "branch '{branch}' could not be checked against origin ({error}); its failures \
+                 stay listed as current"
+            )),
+        }
+    }
+    retired
+}
+
+/// Which candidates this sweep spends its investigation budget on.
+///
+/// The budget is smaller than the candidate list often enough that a fixed
+/// prefix would mean the same runs are investigated every hour and everything
+/// below the cap is never investigated at all — a permanent starvation that no
+/// number of sweeps resolves. So the ranked prefix keeps all but one slot, and
+/// the last slot rotates through the remainder: the landing-branch failures
+/// that gate delivery still go first, and every other candidate is reached
+/// within one rotation instead of never. With a budget of one there is nothing
+/// to rotate and the highest-ranked candidate keeps the slot.
+fn investigation_slots(
+    candidates: usize,
+    budget: usize,
+    cursor: u64,
+) -> std::collections::BTreeSet<usize> {
+    let attempted = candidates.min(budget);
+    let mut slots: std::collections::BTreeSet<usize> = (0..attempted).collect();
+    if candidates <= attempted || attempted < 2 {
+        return slots;
+    }
+    let rotating = attempted - 1;
+    slots.remove(&rotating);
+    let overflow = candidates - rotating;
+    slots.insert(rotating + (cursor % overflow as u64) as usize);
+    slots
+}
+
 fn head_json(scanned: &ScannedRef) -> Value {
     json!({
         "kind": scanned.kind.as_str(),
@@ -448,6 +564,16 @@ fn head_json(scanned: &ScannedRef) -> Value {
         "pr_number": scanned.pr_number,
         "pr_url": scanned.pr_url,
     })
+}
+
+/// Where each run lands once it has been classified.
+#[derive(Default)]
+struct RunPartition {
+    latest: Vec<Value>,
+    current: Vec<Value>,
+    stale: Vec<Value>,
+    in_flight: Vec<Value>,
+    mixed_candidates: Vec<Value>,
 }
 
 /// Classify repository-wide runs by relevant workflow/ref identity.
@@ -466,11 +592,8 @@ fn head_json(scanned: &ScannedRef) -> Value {
 fn partition_runs(
     refs: &[ScannedRef],
     runs: &[Value],
-    latest_runs: &mut Vec<Value>,
-    current: &mut Vec<Value>,
-    stale: &mut Vec<Value>,
-    in_flight: &mut Vec<Value>,
-    mixed_candidates: &mut Vec<Value>,
+    retired: &std::collections::BTreeSet<String>,
+    out: &mut RunPartition,
 ) {
     let landing_branches = landing_branch_names(refs);
     let mut workflows = std::collections::BTreeMap::<String, Vec<&Value>>::new();
@@ -488,7 +611,8 @@ fn partition_runs(
         let Some(latest) = workflow_runs.first().copied() else {
             continue;
         };
-        latest_runs.push(run_summary(ref_for_run(refs, latest), latest));
+        out.latest
+            .push(run_summary(ref_for_run(refs, latest), latest));
 
         let landing_success = workflow_runs.iter().copied().find(|run| {
             run_is_completed(run)
@@ -520,11 +644,12 @@ fn partition_runs(
             let mut seen_in_flight = false;
             for run in ref_runs.iter().copied() {
                 if !run_is_completed(run) {
-                    in_flight.push(run_summary(ref_for_run(refs, run), run));
+                    out.in_flight.push(run_summary(ref_for_run(refs, run), run));
                     if !seen_in_flight
                         && suppressor.is_none_or(|success| run_order(run) > run_order(success))
                     {
-                        mixed_candidates.push(run_summary(ref_for_run(refs, run), run));
+                        out.mixed_candidates
+                            .push(run_summary(ref_for_run(refs, run), run));
                     }
                     seen_in_flight = true;
                     continue;
@@ -532,10 +657,14 @@ fn partition_runs(
                 if !run_is_unsuccessful(run) {
                     continue;
                 }
+                if retired.contains(run_branch(run)) {
+                    out.stale.push(retired_ref_entry(refs, run));
+                    continue;
+                }
                 if let Some(success) =
                     suppressor.filter(|success| run_order(success) > run_order(run))
                 {
-                    stale.push(stale_entry(
+                    out.stale.push(stale_entry(
                         refs,
                         run,
                         success,
@@ -549,7 +678,7 @@ fn partition_runs(
                             && run_is_unsuccessful(candidate)
                             && run_order(candidate) > run_order(run)
                     }) {
-                        stale.push(stale_entry(
+                        out.stale.push(stale_entry(
                             refs,
                             run,
                             newer,
@@ -558,7 +687,7 @@ fn partition_runs(
                     }
                     continue;
                 }
-                current.push(run_summary(ref_for_run(refs, run), run));
+                out.current.push(run_summary(ref_for_run(refs, run), run));
                 seen_current = true;
             }
         }
@@ -596,6 +725,20 @@ fn is_actionable_current_failure(failure: &Value) -> bool {
         return run_is_unsuccessful(failure);
     }
     has_failed_jobs(failure) && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+}
+
+/// A red run on a branch origin no longer has. Not superseded by a newer run —
+/// there is simply no ref left for the failure to be current on.
+fn retired_ref_entry(refs: &[ScannedRef], run: &Value) -> Value {
+    let mut entry = run_summary(ref_for_run(refs, run), run);
+    entry["reason"] = json!("ref_no_longer_exists");
+    entry["evidence"] = json!(format!(
+        "branch '{}' has no head on origin: its pull request was merged or the branch was \
+         deleted, so this run describes code that is either already landed — where the landing \
+         branch's own runs are the current evidence — or abandoned",
+        run_branch(run)
+    ));
+    entry
 }
 
 fn stale_entry(refs: &[ScannedRef], older: &Value, newer: &Value, reason: &str) -> Value {

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -350,13 +350,16 @@ fn distinct_workflow_refs_keep_independent_failures() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
+        // The ref is unscanned — no open pull request carries it — but it is
+        // still live on origin, so its failure is still somebody's to fix.
+        .with_head("side/feature", OLD)
         .with_runs(vec![vec![
             // A newer unsuccessful run on an unscanned ref must not hide the
             // landing-branch failure. Distinct refs stay independently current.
             run_on_branch(
                 50,
                 "ci",
-                "abandoned/feature",
+                "side/feature",
                 OLD,
                 "completed",
                 Some("failure"),
@@ -1193,4 +1196,240 @@ fn same_ref_rerun_success_suppresses_the_resolved_failure() {
         evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
         json!(40)
     );
+}
+
+/// The jrun-20260905-1932 shape: this workspace lands on `agent-main` while
+/// GitHub still reports `main` as the repository default, and most of the red
+/// runs in the listing belong to task pull requests that merged hours or days
+/// earlier and took their branches with them.
+#[test]
+fn merged_pull_request_branches_are_retired_while_live_refs_stay_current() {
+    let checkout = "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n";
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", HEAD)
+        .with_head("main", OLD)
+        // The open pull request's branch is live on origin; the merged task
+        // branches are gone.
+        .with_head("orbit/ORB-11299-open", OLD)
+        .with_pull_request(json!({
+            "number": 1373,
+            "url": "https://github.com/acme/orbit/pull/1373",
+            "head_branch": "orbit/ORB-11299-open",
+            "reported_head_sha": OLD,
+        }))
+        .with_runs(vec![vec![
+            run_on_branch(
+                33986585197,
+                "Platform",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T19:20:00Z",
+            ),
+            run_on_branch(
+                33986582084,
+                "Website",
+                "orbit/ORB-11299-open",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T19:19:00Z",
+            ),
+            run_on_branch(
+                33900000001,
+                "Platform",
+                "orbit/ORB-11201-merged",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-04T10:00:00Z",
+            ),
+            run_on_branch(
+                33900000002,
+                "Website",
+                "orbit/ORB-11150-merged",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-03T10:00:00Z",
+            ),
+        ]])
+        .with_run_view(
+            "33986585197",
+            json!({"failed_jobs": [failed_job(5, "macOS")]}),
+        )
+        .with_log("33986585197", false, checkout)
+        .with_run_view(
+            "33986582084",
+            json!({"failed_jobs": [failed_job(6, "build")]}),
+        )
+        .with_log("33986582084", false, checkout);
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect");
+
+    assert_eq!(
+        current_ids(&evidence),
+        [33_986_585_197, 33_986_582_084],
+        "the landing-branch red and the open pull request's red are what is left: {evidence}"
+    );
+    let retired = evidence["stale_or_superseded"]
+        .as_array()
+        .expect("stale array")
+        .iter()
+        .map(|entry| (entry["run_id"].clone(), entry["reason"].clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        retired,
+        vec![
+            (json!(33_900_000_001_u64), json!("ref_no_longer_exists")),
+            (json!(33_900_000_002_u64), json!("ref_no_longer_exists")),
+        ],
+        "merged task branches are retired, not current: {evidence}"
+    );
+    assert_eq!(
+        evidence["truncation"]["retired_refs"],
+        json!(["orbit/ORB-11150-merged", "orbit/ORB-11201-merged"])
+    );
+}
+
+/// `Website` runs on its own trigger and has no push-workflow counterpart on
+/// the landing branch. Nothing else going green may stand in for it.
+#[test]
+fn a_landing_branch_website_failure_survives_without_a_push_counterpart() {
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", HEAD)
+        .with_head("main", OLD)
+        .with_runs(vec![vec![
+            run_on_branch(
+                70,
+                "CI",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-09-05T19:30:00Z",
+            ),
+            run_on_branch(
+                71,
+                "Website",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T19:20:00Z",
+            ),
+        ]])
+        .with_run_view("71", json!({"failed_jobs": [failed_job(9, "deploy")]}))
+        .with_log(
+            "71",
+            false,
+            "website\tdeploy\tHEAD is now at 3333333333333333333333333333333333333333\n\
+             website\tdeploy\t##[error]sync command not found\n",
+        );
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect");
+
+    assert_eq!(
+        current_ids(&evidence),
+        [71],
+        "a green CI run is not evidence about the Website workflow: {evidence}"
+    );
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+}
+
+/// A branch origin cannot be reached about is left alone. Failing to look is
+/// never evidence that a failure is resolved.
+#[test]
+fn an_unprobeable_branch_keeps_its_failure_current() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_branch_head_error("gone/feature", "fatal: unable to access origin")
+        .with_runs(vec![vec![run_on_branch(
+            60,
+            "ci",
+            "gone/feature",
+            OLD,
+            "completed",
+            Some("failure"),
+            "2026-08-30T05:00:00Z",
+        )]]);
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(current_ids(&evidence), [60]);
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert!(
+        evidence["truncation"]["notes"]
+            .as_array()
+            .expect("notes")
+            .iter()
+            .any(|note| note
+                .as_str()
+                .is_some_and(|note| note.contains("could not be checked against origin"))),
+        "the unprobed branch is reported: {evidence}"
+    );
+}
+
+/// A fixed prefix would investigate the same runs every hour and never reach
+/// anything below the cap. The ranked prefix keeps its slots; the last one
+/// rotates.
+#[test]
+fn the_investigation_budget_rotates_through_overflow_candidates() {
+    let checkout = "ci\tbuild\tHEAD is now at 3333333333333333333333333333333333333333\n";
+    let mut queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD);
+    let runs = (0..5_u64)
+        .map(|index| {
+            run(
+                10 + index,
+                &format!("workflow-{index}"),
+                HEAD,
+                "completed",
+                Some("failure"),
+                &format!("2026-08-30T0{index}:00:00Z"),
+            )
+        })
+        .collect::<Vec<_>>();
+    for index in 0..5_u64 {
+        queries = queries
+            .with_run_view(
+                &(10 + index).to_string(),
+                json!({"failed_jobs": [failed_job(5, "build")]}),
+            )
+            .with_log(&(10 + index).to_string(), false, checkout);
+    }
+    let queries = queries.with_runs(vec![runs]);
+
+    let investigated = |cursor: u64| {
+        collect(
+            &queries,
+            &json!({
+                "integration_branch": "topic",
+                "max_investigated_runs": 3,
+                "max_checkout_log_reads": 1,
+                "investigation_cursor": cursor,
+            }),
+        )
+        .expect("collect")["summary"]["investigated_failure_run_ids"]
+            .clone()
+    };
+
+    // Newest first inside the integration tier: 14, 13, 12, 11, 10.
+    assert_eq!(investigated(0), json!([14, 13, 12]));
+    assert_eq!(investigated(1), json!([14, 13, 11]));
+    assert_eq!(investigated(2), json!([14, 13, 10]));
+    // One rotation later the cycle repeats, so nothing is starved and the two
+    // highest-ranked candidates never lose their slots.
+    assert_eq!(investigated(3), json!([14, 13, 12]));
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
@@ -26,6 +26,7 @@ pub(super) struct FakeQueries {
     pub(super) logs: HashMap<(String, bool), String>,
     pub(super) repository_runs_error: Option<String>,
     pub(super) run_view_errors: HashMap<String, String>,
+    pub(super) branch_head_errors: HashMap<String, String>,
     pub(super) log_errors: HashMap<(String, bool), String>,
 }
 
@@ -80,6 +81,12 @@ impl FakeQueries {
 
     pub(super) fn with_repository_runs_error(mut self, message: &str) -> Self {
         self.repository_runs_error = Some(message.to_string());
+        self
+    }
+
+    pub(super) fn with_branch_head_error(mut self, branch: &str, message: &str) -> Self {
+        self.branch_head_errors
+            .insert(branch.to_string(), message.to_string());
         self
     }
 
@@ -168,6 +175,9 @@ impl CiQueries for FakeQueries {
     }
 
     fn remote_branch_head(&self, branch: &str) -> Result<Option<String>, OrbitError> {
+        if let Some(message) = self.branch_head_errors.get(branch) {
+            return Err(OrbitError::Execution(message.clone()));
+        }
         Ok(self.branch_heads.get(branch).cloned())
     }
 }

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -329,6 +329,9 @@ const MAX_CHECKOUT_EVIDENCE_LINE_BYTES: usize = 16 * 1024;
 /// tested, so the two travel as separate fields and are never merged into one
 /// `sha`.
 pub struct CheckoutEvidence {
+    /// The distinct commits the log named as checked out, with an
+    /// abbreviation collapsed into the full SHA it prefixes. More than one
+    /// entry means the log genuinely disagreed with itself.
     pub commits: Vec<String>,
     pub lines: Vec<String>,
     /// False only when identity itself may have been missed: the source byte
@@ -431,6 +434,10 @@ struct CheckoutEvidenceCollector {
     dropping_line: bool,
     commits: Vec<String>,
     seen_commits: HashSet<String>,
+    /// Of the observed tokens, the ones a line actually named as the commit
+    /// that was checked out — as opposed to a merge parent or a fetched ref
+    /// that happened to share the line.
+    named_commits: HashSet<String>,
     lines: Vec<String>,
     complete: bool,
     display_truncated: bool,
@@ -447,6 +454,7 @@ impl CheckoutEvidenceCollector {
             dropping_line: false,
             commits: Vec::new(),
             seen_commits: HashSet::new(),
+            named_commits: HashSet::new(),
             lines: Vec::new(),
             complete: true,
             display_truncated: false,
@@ -491,7 +499,7 @@ impl CheckoutEvidenceCollector {
             self.observe_pending_line();
         }
         CheckoutEvidence {
-            commits: self.commits,
+            commits: canonical_checkout_commits(&self.commits, &self.named_commits),
             lines: self.lines,
             complete: self.complete,
             scanned_bytes: self.scanned_bytes,
@@ -516,7 +524,11 @@ impl CheckoutEvidenceCollector {
         } else {
             self.display_truncated = true;
         }
+        let named = named_checkout_commit(payload, &lowered, in_checkout_step);
         for token in commit_sha_tokens(payload) {
+            if named == Some(token) {
+                self.named_commits.insert(token.to_string());
+            }
             if self.seen_commits.contains(token) {
                 continue;
             }
@@ -588,6 +600,82 @@ fn is_hex(byte: u8) -> bool {
 fn is_bare_commit_sha(payload: &str) -> bool {
     let trimmed = payload.trim();
     trimmed.len() == MAX_SHA_LEN && trimmed.bytes().all(is_hex)
+}
+
+/// The prose `actions/checkout` prints in front of the commit it landed on.
+const HEAD_IS_NOW_AT: &str = "head is now at";
+
+/// The commit this line *names* as checked out, if it names one.
+///
+/// `HEAD is now at 7dcd45b Merge 4968f13 into abc1234` reports one checked-out
+/// commit and then quotes the merge's two parents inside the commit subject.
+/// Only the token directly after the marker is identity; the rest is prose
+/// that happens to be hex. Everything else — a fetched ref, a merge summary —
+/// names no commit and stays incidental evidence.
+fn named_checkout_commit<'a>(
+    payload: &'a str,
+    lowered: &str,
+    in_checkout_step: bool,
+) -> Option<&'a str> {
+    if let Some(marker) = lowered.find(HEAD_IS_NOW_AT) {
+        // `to_ascii_lowercase` rewrites ASCII bytes in place and leaves every
+        // multi-byte sequence alone, so offsets into `lowered` index `payload`.
+        return commit_sha_tokens(&payload[marker + HEAD_IS_NOW_AT.len()..])
+            .into_iter()
+            .next();
+    }
+    (in_checkout_step && is_bare_commit_sha(payload)).then(|| payload.trim())
+}
+
+/// Reduce the observed SHA tokens to the distinct commits actually checked out.
+///
+/// Two reductions, neither of which relaxes identity. A line that *names* the
+/// checked-out commit outranks one that merely quotes a merge parent or a
+/// fetched ref. An abbreviation and the full SHA it prefixes are one commit,
+/// not two — the same runner routinely prints both forms. A real disagreement
+/// between two checkout steps survives both reductions and is still reported
+/// as two commits, and an abbreviation with more than one distinct expansion
+/// is left abbreviated rather than resolved to a guess.
+fn canonical_checkout_commits(observed: &[String], named: &HashSet<String>) -> Vec<String> {
+    let identity: Vec<&String> = if observed.iter().any(|commit| named.contains(commit)) {
+        observed
+            .iter()
+            .filter(|commit| named.contains(*commit))
+            .collect()
+    } else {
+        observed.iter().collect()
+    };
+
+    let mut canonical: Vec<String> = Vec::new();
+    for commit in identity {
+        // `observed` holds distinct tokens, so two expansions of the same
+        // length are two different commits and the abbreviation cannot be
+        // resolved to either of them.
+        let mut longest: Option<&String> = None;
+        let mut contested = false;
+        for candidate in observed
+            .iter()
+            .filter(|candidate| candidate.len() > commit.len() && candidate.starts_with(&**commit))
+        {
+            match longest {
+                Some(current) if current.len() > candidate.len() => {}
+                Some(current) if current.len() == candidate.len() => contested = true,
+                _ => {
+                    longest = Some(candidate);
+                    contested = false;
+                }
+            }
+        }
+        let resolved = if contested {
+            commit
+        } else {
+            longest.unwrap_or(commit)
+        };
+        if !canonical.contains(resolved) {
+            canonical.push(resolved.clone());
+        }
+    }
+    canonical
 }
 
 /// Collect every lowercase-hex token of commit-SHA length in `payload`.

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -263,3 +263,81 @@ fn streaming_log_marks_identity_incomplete_after_the_hard_scan_limit() {
     assert!(!log.checkout_evidence.complete);
     assert!(log.checkout_evidence.commits.is_empty());
 }
+
+/// jrun-20260905-1932, run 33986085270: one commit printed in full on the
+/// checkout command line and abbreviated on the `HEAD is now at` line. Two
+/// spellings of one commit are not a contradiction, and reporting them as two
+/// made an otherwise complete investigation look ambiguous.
+#[test]
+fn an_abbreviated_and_a_full_spelling_are_one_commit() {
+    let tested = "4968f137ab9969c35634496414fdc1637d22fe37";
+    let log = format!(
+        "macOS\tRun actions/checkout@v5\t2026-09-05T19:20:00.0000000Z [command]/usr/bin/git checkout --progress --force {tested}\n\
+         macOS\tRun actions/checkout@v5\t2026-09-05T19:20:01.0000000Z HEAD is now at 4968f13 feat: add Pi\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits, vec![tested.to_string()]);
+    assert!(evidence.complete);
+}
+
+/// jrun-20260905-1932, run 33986582084: a pull-request merge checkout whose
+/// subject quotes both parents. The merge commit is what the runner tested;
+/// the parents are prose that happens to be hex.
+#[test]
+fn merge_parents_quoted_in_a_checkout_subject_are_not_checkout_identity() {
+    let merge = "7dcd45b8a214e861ad533c6d03257cd3948514f4";
+    let head = "d5b3f2a1c7e94806b1ad3ee0f1c2a9b8d7e6f504";
+    let base = "22037486aa1bb2cc3dd4ee5ff60718293a4b5c6d";
+    let log = format!(
+        "website\tRun actions/checkout@v5\t2026-09-05T19:20:00.0000000Z  * branch {head} -> FETCH_HEAD\n\
+         website\tRun actions/checkout@v5\t2026-09-05T19:20:01.0000000Z HEAD is now at {merge} Merge {head} into {base}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits, vec![merge.to_string()]);
+    assert!(
+        evidence.lines.iter().any(|line| line.contains(head)),
+        "the fetched head stays visible as evidence: {:?}",
+        evidence.lines
+    );
+}
+
+/// The reductions above must not become a way to launder a real disagreement
+/// into a confident answer.
+#[test]
+fn two_checkout_steps_naming_different_commits_stay_two_commits() {
+    let first = "3333333333333333333333333333333333333333";
+    let second = "4444444444444444444444444444444444444444";
+    let log = format!(
+        "ci\tCheckout\t2026-09-05T19:20:00.0000000Z HEAD is now at {first} first\n\
+         ci\tCheckout\t2026-09-05T19:20:01.0000000Z HEAD is now at {second} second\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(
+        evidence.commits,
+        vec![first.to_string(), second.to_string()]
+    );
+}
+
+/// An abbreviation with two candidate expansions is left abbreviated: picking
+/// one would be a guess presented as evidence.
+#[test]
+fn an_abbreviation_with_rival_expansions_is_not_resolved_to_a_guess() {
+    let short = "abc1234";
+    let first = "abc1234000000000000000000000000000000000";
+    let second = "abc1234111111111111111111111111111111111";
+    let log = format!(
+        "ci\tCheckout\t2026-09-05T19:20:00.0000000Z  * branch {first} -> FETCH_HEAD\n\
+         ci\tCheckout\t2026-09-05T19:20:01.0000000Z  * branch {second} -> FETCH_HEAD\n\
+         ci\tCheckout\t2026-09-05T19:20:02.0000000Z HEAD is now at {short} ambiguous\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits, vec![short.to_string()]);
+}


### PR DESCRIPTION
## Task

[ORB-11308](https://orbit-cli.com/tasks/ORB-11308) — Make CI sweep file complete findings despite bounded investigation gaps

### Description

Live post-upgrade validation of ORB-11278 shows a remaining reliability defect. Installed binary at8dfad3ac ran ci_failure_sweep_pipeline jrun-20260905-1932 at19:32UTC. It detected14 failures and fully investigated3 (33986585197 macOS Platform oncurrent agent-main22037486;33986582084 Website PR1370;33986085270 Pi macOS PR). It then failed file_ci_failure_tasks with25 retryable errors and created0 tasks because older failures exceeded max_investigated_runs and checkout-log budget. Many backlog failures belong to already-merged historical task PRs, now classed current after correcting repository-wide suppression. Current ready-to-file real defects were thus suppressed by unrelated incomplete records. Manual repairs ORB-11306 and ORB-11307 own the observed macOS/Website regressions; dedupe them. Improve bounded investigation and filing so complete actionable findings are committed independently, partial gaps remain visible and retryable, and subsequent runs make progress instead of repeatedly spending their budget on the same old refs. Inspect how active/open PR refs, configured landing/default branch, merged/deleted refs and workflow-specific success affect staleness; do not undo ORB-11278 by allowing unrelated refs or pending runs to suppress failures. Keep evidence quality per individual finding, authority, dedupe and bounded costs. Opus selected because collection/ref freshness/budgeting/registration cross multiple seams.

### Acceptance Criteria

- Regression replay modeled on jrun1932: 14 candidate failures, 3 complete investigations and remaining budget/log gaps. Complete findings file/dedupe successfully; incomplete candidates alone remain deferred/retryable, with precise audit counts and durable outcomes even if run reports partial failure.
- Repeated bounded runs do not starve later actionable failures or repeatedly investigate already-owned identical failures without progress. Preserve appropriate same-ref/job success supersession and never suppress on pending/in-progress or unrelated ref success.
- Classify historical merged/deleted PR runs using current authoritative ref/PR evidence and retain legitimate unresolved integration/workflow failures. Tests cover current landing branch agent-main distinct from GitHub default main, open PRs, merged PR historical reds, and a latest failed Website workflow with no push workflow counterpart.
- Keep per-finding complete checkout/log evidence requirements; unavailable evidence remains explicit, never fabricate task details. Verify dedupe of ORB-11306/11307 evidence and expose partial registration audit for operators.
- Run focused collector/filer tests plus ci-fast/ci-lint; after installation replay the live sweep or an isolated representative fixture using the built binary and confirm correct partial progress.

## Execution Summary

<details>
<summary>Click to expand</summary>

Four seams, in the order the sweep hits them.

1. Partial registration (`crates/orbit-core/.../ci_failure_tasks.rs`). The regression's
   direct cause was `if !retryable_errors.is_empty() { return Err(...) }`: any gap
   anywhere withheld every finding, which is how jrun-20260905-1932 (25 errors) and
   jrun-20260905-2024-3 (14 errors) each created 0 tasks while holding fully evidenced
   regressions. Errors are now split by blast radius. One naming a run defers only that
   finding: excluded from clustering, reported in a new `deferred` output entry with its
   bounded reasons, left for a later sweep. One naming no run — repo/run/PR listing reads,
   cluster registration, dedupe lookup, task creation — still fails the step, because the
   listing that failed may be the one holding the newer run that would have superseded a
   finding; that payload now carries the run-scoped errors too, so one report explains the
   sweep. When nothing was complete enough to file, the step stays a retryable error, so
   `a_listed_but_uninvestigated_failure_is_not_filed_as_an_evidence_free_task` and
   `query_error_prevents_filing_and_remains_retryable` hold unchanged. Per-finding evidence
   requirements are untouched: a run with any recorded error is deferred, never filed from
   partial evidence.

2. Retired refs (`crates/orbit-engine/.../ci/collect.rs`). A red run on a branch that is
   neither a scanned head nor present on origin is now `stale_or_superseded` with reason
   `ref_no_longer_exists` — its PR merged or its branch was deleted, so the landing branch's
   own runs are the live evidence. The probe reuses the existing `remote_branch_head` query
   (no new capability, no `query.rs` change), runs once per distinct branch carrying a red
   run, is bounded by `max_retired_ref_probes` (default 20), and fails open with a truncation
   note — failing to reach origin is never evidence that a failure is resolved. ORB-11278 is
   intact: same-ref/landing supersession, pending/in-progress non-suppression, and
   unrelated-ref independence all still hold and are still covered.

3. Anti-starvation (same file). A fixed ranked prefix meant the same runs were investigated
   every hour and anything below the cap never was. The prefix now keeps all but one slot and
   the last slot rotates over the overflow by `investigation_cursor` (defaults to the
   collection hour, so it advances once per hourly sweep; pinnable for reproducibility).
   Landing-branch failures keep their slots; every other candidate is reached within one
   rotation. `partition_runs`' five out-params became a `RunPartition` struct (clippy
   arity, and it reads better).

4. Checkout identity (`crates/orbit-tools/.../builtin/github/mod.rs`, the owner of SHA
   extraction). Per the task's jrun-1932 evidence: only the token directly after
   `HEAD is now at` (or a bare SHA in a checkout step) is identity — the rest of that line is
   the commit subject, which is where `Merge <head> into <base>` puts two parents — and an
   abbreviation collapses into the full SHA it prefixes. Run 33986085270's false `ambiguous`
   (one commit spelled two ways) becomes `observed`. Identity is not relaxed: two checkout
   steps naming different commits stay two commits, and an abbreviation with rival expansions
   stays abbreviated rather than resolved to a guess.

Assets updated in both `crates/orbit-core/assets/` and the workspace `.orbit/resources/`
copies (the installed sweep reads the latter; their local `integration_branch: agent-main`
is preserved): new `deferred` output schema, the `max_retired_ref_probes` /
`investigation_cursor` inputs, and prose for the deferral, retired-ref and rotation rules.

Validation. New tests: 4 collector (merged-branch retirement with a live open-PR ref and
agent-main distinct from GitHub default `main`; a landing-branch Website red with no push
counterpart and a green CI run that must not stand in for it; unprobeable branch stays
current; budget rotation across cursors), 4 orbit-tools (abbreviation/full spelling,
merge-parent subject, preserved disagreement, rival expansions), 3 filer (14-candidate
jrun-1932 replay -> 3 filed + 11 deferred + audit counts; snapshot-wide error still withholds
a complete finding; a run whose own query failed is deferred not filed), 1 dedupe
(ORB-11306/11307-shaped manual repairs own both complete findings while a starved candidate
stays visible). `cargo test -p orbit-tools -p orbit-engine --lib`: 564 pass, 0 fail.
`cargo test -p orbit-core --lib`: 985 pass, 4 fail — all `bootstrap::init::tests::global_init_*`
with `Io("Read-only file system (os error 30)")`, a runner denial on the real `~/.orbit`
(`touch ~/.orbit/.probe` reproduces it) unrelated to this change; overriding HOME breaks
rustup, so unrestricted CI should arbitrate. Filed as F2026-09-021. `make ci-fast` and
`make ci-lint` both pass.

Built-binary replay (criterion 5; installation is a post-merge step, so this used the binary
built from this worktree). Live `collect_ci_evidence` against this repository via
`orbit job run`: 100 runs listed, 7 merged task branches classified `ref_no_longer_exists`,
0 current failures, 0 retryable errors — the same code path that produced 25 errors an hour
earlier. Then the jrun-1932 shape (14 candidates, 3 complete, 11 budget-starved) through
`file_ci_failure_tasks` in an isolated temp workspace: run succeeded, 3 proposed bug tasks
durably created with correct inline evidence and the canonicalized merge checkout SHA,
11 deferred, audit `{current_failures: 14, investigated_failures: 3, tasks_created: 3,
deferred_failures: 11, retryable_errors: 11}`. Because the step now succeeds, the pipeline's
`pilots` fan-out proceeds for the filed findings instead of being skipped. Replay scratch
directory removed; `git status --short` shows only the 14 task-scoped files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11308-6a9c7704`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*