### PR TITLE
Invalidate Pi completion when a later assistant terminal frame fails

### DIFF
--- a/crates/orbit-agent/src/providers/pi/pi_output.rs
+++ b/crates/orbit-agent/src/providers/pi/pi_output.rs
@@ -57,30 +57,35 @@ pub(crate) fn normalize_pi_stdout(stdout: &[u8]) -> Vec<u8> {
         if value.get("type").and_then(Value::as_str) != Some("message_end") {
             continue;
         }
-        if let Some(rendered) = assistant_text(value.get("message")) {
-            latest = Some(rendered);
+        if let Some(outcome) = assistant_terminal_outcome(value.get("message")) {
+            latest = Some(outcome);
         }
     }
-    latest.map_or_else(Vec::new, String::into_bytes)
+    latest.flatten().map_or_else(Vec::new, String::into_bytes)
 }
 
-/// Concatenate the `text` content blocks of one completed assistant message.
+/// Record the completion evidence from one terminal assistant message.
 ///
-/// Returns `None` unless the frame is a genuine assistant message that stopped
-/// cleanly. `thinking` and `toolCall` blocks are deliberately skipped: they are
-/// not the model's answer, and reasoning text in particular may quote the
-/// prompt's example envelope verbatim.
-fn assistant_text(message: Option<&Value>) -> Option<String> {
+/// `None` means this is not an assistant message and must not affect the
+/// current outcome. `Some(None)` means it is the latest assistant terminal
+/// frame but cannot provide completion evidence. That distinction prevents an
+/// earlier response envelope from surviving a later failed or malformed turn.
+fn assistant_terminal_outcome(message: Option<&Value>) -> Option<Option<String>> {
     let message = message?.as_object()?;
     if message.get("role").and_then(Value::as_str) != Some("assistant") {
         return None;
     }
-    let stop_reason = message.get("stopReason").and_then(Value::as_str)?;
+    let Some(stop_reason) = message.get("stopReason").and_then(Value::as_str) else {
+        return Some(None);
+    };
     if FAILED_STOP_REASONS.contains(&stop_reason) {
-        return None;
+        return Some(None);
     }
     let mut rendered = String::new();
-    for block in message.get("content")?.as_array()? {
+    let Some(content) = message.get("content").and_then(Value::as_array) else {
+        return Some(None);
+    };
+    for block in content {
         if block.get("type").and_then(Value::as_str) != Some("text") {
             continue;
         }
@@ -88,9 +93,9 @@ fn assistant_text(message: Option<&Value>) -> Option<String> {
             // A `text` block whose `text` is absent or not a string is a
             // malformed frame, not an empty answer. Refuse the whole message
             // rather than silently returning the blocks that did parse.
-            return None;
+            return Some(None);
         };
         rendered.push_str(text);
     }
-    (!rendered.is_empty()).then_some(rendered)
+    Some((!rendered.is_empty()).then_some(rendered))
 }

--- a/crates/orbit-agent/src/providers/pi/tests/pi_output.rs
+++ b/crates/orbit-agent/src/providers/pi/tests/pi_output.rs
@@ -144,6 +144,53 @@ fn failed_stop_reasons_never_normalize_to_success() {
 }
 
 #[test]
+fn a_later_failed_or_malformed_assistant_terminal_frame_invalidates_prior_text() {
+    let successful = json!({
+        "type":"message_end",
+        "message":assistant_message(json!([text_block(ORBIT_SUCCESS)]), "stop"),
+    });
+    let failed = |stop_reason| {
+        json!({
+            "type":"message_end",
+            "message":assistant_message(json!([text_block("later text")]), stop_reason),
+        })
+    };
+
+    for terminal in [
+        failed("error"),
+        failed("aborted"),
+        json!({
+            "type":"message_end",
+            "message":{"role":"assistant","content":[text_block("later text")]},
+        }),
+        json!({
+            "type":"message_end",
+            "message":assistant_message(json!([]), "stop"),
+        }),
+    ] {
+        let stdout = format!("{successful}\n{terminal}");
+        assert!(
+            normalize_cli_stdout("pi", stdout.as_bytes()).is_empty(),
+            "later assistant terminal outcome must invalidate prior evidence: {terminal}",
+        );
+    }
+}
+
+#[test]
+fn later_non_assistant_and_control_frames_do_not_replace_an_assistant_outcome() {
+    let stdout = format!(
+        "{}\n{}\n{}\n{}",
+        json!({"type":"message_end","message":assistant_message(json!([text_block(ORBIT_SUCCESS)]), "stop")}),
+        json!({"type":"message_end","message":{"role":"user","content":[text_block("prompt echo")],"stopReason":"stop"}}),
+        json!({"type":"message_end","message":{"role":"tool","content":[text_block("tool output")],"stopReason":"stop"}}),
+        json!({"type":"agent_end","messages":[]}),
+    );
+
+    let normalized = normalize_cli_stdout("pi", stdout.as_bytes());
+    assert_eq!(String::from_utf8_lossy(&normalized), ORBIT_SUCCESS);
+}
+
+#[test]
 fn malformed_or_incomplete_frames_yield_no_completion_evidence() {
     for stdout in [
         String::new(),

--- a/crates/orbit-core/tests/pi_fake_agent.rs
+++ b/crates/orbit-core/tests/pi_fake_agent.rs
@@ -257,6 +257,19 @@ fn non_zero_exit_fails_even_with_a_success_frame() {
 }
 
 #[test]
+fn later_failed_assistant_terminal_frame_cannot_report_success() {
+    let body = format!(
+        "{}\nprintf '%s\\n' '{{\"type\":\"message_end\",\"message\":{{\"role\":\"assistant\",\"content\":[{{\"type\":\"text\",\"text\":\"{SUCCESS_ENVELOPE}\"}}],\"stopReason\":\"aborted\"}}}}'\nexit 0",
+        success_body().replace("exit 0", ""),
+    );
+    let outcome = dispatch(&Harness::new(&body), spec(60));
+    assert!(
+        !outcome.success,
+        "a later aborted assistant terminal frame must invalidate prior completion evidence",
+    );
+}
+
+#[test]
 fn malformed_or_incomplete_output_never_succeeds() {
     for body in [
         // Not JSONL at all.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -522,9 +522,11 @@ The shipped direct-agent executor uses
 The Orbit prompt travels on standard input, never as a positional argument: Pi
 merges piped stdin into the initial prompt in every non-interactive mode.
 
-Orbit reads only the terminal `message_end` frame — the event Pi documents as
-"the final authoritative message" — and takes the `text` content blocks of that
-assistant message. Everything else is dropped before any protocol read. That
+Orbit reads only terminal assistant `message_end` frames — the event Pi documents
+as the final authoritative message. The latest such frame controls completion:
+Orbit takes its `text` content blocks only when it is a clean answer, while a
+later failed, empty, or malformed assistant terminal frame invalidates earlier
+completion evidence. Everything else is dropped before any protocol read. That
 reduction is a correctness requirement, not tidying: Pi's `agent_end` frame
 replays the entire conversation including the user turn, and every Orbit prompt
 embeds a literal example response envelope, so a reverse envelope scan over the


### PR DESCRIPTION
## Task

[ORB-11311](https://orbit-cli.com/tasks/ORB-11311) — Invalidate Pi completion when a later assistant terminal frame fails

### Description

Daniel reproduced against the actual Rust normalize_pi_stdout in an isolated harness: valid assistant message_end followed by an error or aborted assistant message_end leaves the prior completion text. pi_output.rs:60 only updates latest when assistant_text returns Some, so failed later terminal frames do not invalidate earlier completion evidence. Linux origin/agent-main source confirms this. Fix the reducer to represent the latest authoritative assistant terminal outcome, including failure/empty/malformed terminal evidence where appropriate, while ignoring user/tool/control frames. This regresses from ORB-11296. Terra selected for bounded state-machine normalization plus fixtures. Use dedicated worktree and authorized --complete delivery.

### Acceptance Criteria

- Regression tests through the actual Rust normalizer cover valid answer followed by error and by aborted assistant terminal frames; both yield no usable earlier completion evidence and fail on pre-fix code.
- Latest authoritative assistant terminal outcome governs completion: valid later answer replaces earlier text; failed/invalid assistant terminal outcome cannot expose a prior envelope. Preserve ignoring user/tool/thinking/control traffic and prompt-envelope echo protection.
- Exercise the provider/v2 fake execution path for earlier valid envelope followed by later failure so it cannot report successful completion. No authenticated Pi invocation required.
- Run focused provider and relevant integration tests plus make ci-fast/ci-lint; document the bounded behavior change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed the Pi JSONL reducer to retain the latest assistant terminal outcome, including an explicit no-evidence outcome for failed, empty, and malformed assistant terminals so an earlier response envelope cannot survive.
- Added normalizer regressions for later error, aborted, empty, and malformed terminal frames while preserving ignored user, tool, and control traffic.
- Added provider/v2 fake-executor coverage for a successful frame followed by an aborted assistant terminal frame, and documented the bounded latest-terminal behavior.
Assessment: The reducer now fails closed against stale completion evidence without widening the accepted Pi output surface.
Validation:
- cargo test -p orbit-agent pi_output
- cargo test -p orbit-core --test pi_fake_agent
- make ci-fast
- make ci-lint
All passed.
Friction checkpoint: no report; this was a bounded regression with no recurring or non-obvious operational blocker.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11311-6a9c7ea5`
- Behind base: 0
- Ahead of base: 1