### PR TITLE
Keep compiler-cache environment rewriting compatible with macOS Bash 3.2

### DIFF
--- a/scripts/rustc-compiler-cache.sh
+++ b/scripts/rustc-compiler-cache.sh
@@ -79,11 +79,11 @@ fi
 # paths so sccache keys do not include the jrun worktree prefix.
 rewrite_value() {
   local s="$1"
-  if [[ -n "$target_real" && "$s" == "$target_real"* ]]; then
+  if [[ -n "$target_real" && ( "$s" == "$target_real" || "$s" == "$target_real/"* ) ]]; then
     printf '%s%s' "$STABLE_TGT" "${s#"$target_real"}"
     return
   fi
-  if [[ "$s" == "$repo_root"* ]]; then
+  if [[ "$s" == "$repo_root" || "$s" == "$repo_root/"* ]]; then
     printf '%s%s' "$STABLE_SRC" "${s#"$repo_root"}"
     return
   fi
@@ -112,17 +112,17 @@ if same_inode "$STABLE_SRC/Cargo.toml" "$repo_root/Cargo.toml" && same_inode "$S
     rewritten+=("$(rewrite_value "$arg")")
   done
   set -- "${rewritten[@]}"
-  local_env=()
-  mapfile -d '' -t local_env < <(env -0)
-  for entry in "${local_env[@]}"; do
-    name="${entry%%=*}"
-    value="${entry#*=}"
+  # Bash 3.2 has no mapfile, and macOS env does not provide GNU env -0.
+  # compgen emits exported names without touching their values, so indirect
+  # expansion keeps spaces, equals signs, newlines, and empty values intact.
+  while IFS= read -r name; do
+    value="${!name}"
     [[ -n "$name" ]] || continue
     new="$(rewrite_value "$value")"
     if [[ "$new" != "$value" ]]; then
       export "${name}=${new}"
     fi
-  done
+  done < <(compgen -e)
 fi
 
 export SCCACHE_DIR="$cache_dir"

--- a/scripts/test-compiler-cache.sh
+++ b/scripts/test-compiler-cache.sh
@@ -23,7 +23,7 @@ mkdir -p "$TMP/bin"
 cat > "$TMP/bin/rustc" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "${FAKE_RUSTC_LOG}"
-exit 0
+exit "${FAKE_RUSTC_EXIT_STATUS:-0}"
 EOF
 chmod +x "$TMP/bin/rustc"
 
@@ -36,6 +36,12 @@ printf '%s\n' "$@" > "${FAKE_SCCACHE_LOG}"
   printf 'SCCACHE_BASEDIRS=%s\n' "${SCCACHE_BASEDIRS-}"
   printf 'SCCACHE_CLIENT_SIDE=%s\n' "${SCCACHE_CLIENT_SIDE-}"
 } > "${FAKE_SCCACHE_ENV:-/dev/null}"
+printf '%s' "${CACHE_ENV_SPACES-}" > "${FAKE_SCCACHE_SPACES:-/dev/null}"
+printf '%s' "${CACHE_ENV_EQUALS-}" > "${FAKE_SCCACHE_EQUALS:-/dev/null}"
+printf '%s' "${CACHE_ENV_MULTILINE-}" > "${FAKE_SCCACHE_MULTILINE:-/dev/null}"
+printf '%s' "${CACHE_ENV_EMPTY-}" > "${FAKE_SCCACHE_EMPTY:-/dev/null}"
+printf '%s' "${CACHE_ENV_BOUNDARY-}" > "${FAKE_SCCACHE_BOUNDARY:-/dev/null}"
+printf '%s' "${CACHE_ENV_SOURCE_BOUNDARY-}" > "${FAKE_SCCACHE_SOURCE_BOUNDARY:-/dev/null}"
 exec "$@"
 EOF
 chmod +x "$TMP/sccache"
@@ -110,6 +116,46 @@ rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_RUSTC_LOG"
 "$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" "$ROOT/crates/orbit-types/src/lib.rs"
 grep -Fq "$stable_tgt/debug" "$FAKE_SCCACHE_LOG" || fail "out-dir should rewrite onto the stable build mount"
 grep -Fq "$stable_src/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "source path should rewrite onto the stable workspace mount"
+
+# Environment values are read without splitting, and only paths rooted at the
+# checkout or target directory are rewritten. Keep expected files in TMP so
+# this remains fully disposable under Bash 3.2 and current Linux Bash.
+export CACHE_ENV_SPACES='value with spaces = preserved'
+export CACHE_ENV_EQUALS='left=middle=right'
+export CACHE_ENV_MULTILINE="$fake_tgt/debug
+last line"
+export CACHE_ENV_EMPTY=''
+export CACHE_ENV_BOUNDARY="$fake_tgt-sibling"
+export CACHE_ENV_SOURCE_BOUNDARY="$ROOT-sibling"
+export FAKE_SCCACHE_SPACES="$TMP/env-spaces.actual"
+export FAKE_SCCACHE_EQUALS="$TMP/env-equals.actual"
+export FAKE_SCCACHE_MULTILINE="$TMP/env-multiline.actual"
+export FAKE_SCCACHE_EMPTY="$TMP/env-empty.actual"
+export FAKE_SCCACHE_BOUNDARY="$TMP/env-boundary.actual"
+export FAKE_SCCACHE_SOURCE_BOUNDARY="$TMP/env-source-boundary.actual"
+printf '%s' "$CACHE_ENV_SPACES" > "$TMP/env-spaces.expected"
+printf '%s' "$CACHE_ENV_EQUALS" > "$TMP/env-equals.expected"
+printf '%s\nlast line' "$stable_tgt/debug" > "$TMP/env-multiline.expected"
+: > "$TMP/env-empty.expected"
+printf '%s' "$CACHE_ENV_BOUNDARY" > "$TMP/env-boundary.expected"
+printf '%s' "$CACHE_ENV_SOURCE_BOUNDARY" > "$TMP/env-source-boundary.expected"
+"$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" "$ROOT/crates/orbit-types/src/lib.rs" "$fake_tgt-sibling" "$ROOT-sibling"
+grep -Fq "$fake_tgt-sibling" "$FAKE_SCCACHE_LOG" || fail "target path-prefix boundary should remain unchanged in argv"
+grep -Fq "$ROOT-sibling" "$FAKE_SCCACHE_LOG" || fail "source path-prefix boundary should remain unchanged in argv"
+cmp "$TMP/env-spaces.expected" "$FAKE_SCCACHE_SPACES" || fail "spaces in environment value were not preserved"
+cmp "$TMP/env-equals.expected" "$FAKE_SCCACHE_EQUALS" || fail "equals signs in environment value were not preserved"
+cmp "$TMP/env-multiline.expected" "$FAKE_SCCACHE_MULTILINE" || fail "multiline environment value was not rewritten exactly"
+cmp "$TMP/env-empty.expected" "$FAKE_SCCACHE_EMPTY" || fail "empty environment value was not preserved"
+cmp "$TMP/env-boundary.expected" "$FAKE_SCCACHE_BOUNDARY" || fail "target path-prefix boundary was rewritten unexpectedly"
+cmp "$TMP/env-source-boundary.expected" "$FAKE_SCCACHE_SOURCE_BOUNDARY" || fail "source path-prefix boundary was rewritten unexpectedly"
+
+# sccache must return the compiler's status unchanged.
+export FAKE_RUSTC_EXIT_STATUS=23
+set +e
+"$WRAPPER" "$TMP/bin/rustc" --crate-name status-check
+status=$?
+set -e
+assert_eq "$status" "23" "compiler exit status"
 unset CARGO_TARGET_DIR
 unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
 


### PR DESCRIPTION
## Task

[ORB-11312](https://orbit-cli.com/tasks/ORB-11312) — Keep compiler-cache environment rewriting compatible with macOS Bash 3.2

### Description

Daniel reproduced make ci-fast failure on macOS default /bin/bash 3.2 at scripts/rustc-compiler-cache.sh:116: mapfile is unavailable. Line introduced by ORB-11259. Current Linux source contains mapfile -d '' -t local_env < <(env -0). Prefer portable environment iteration compatible with supported macOS and Linux rather than adding an unplanned Bash upgrade requirement. Preserve NUL-safe handling of environment values, path rewriting, argv, compiler exit status and fail-open cache behavior. Related ORB-11272 fixed fixture isolation, not this portability bug. Luna selected for small shell/test repair. Dedicated worktree, agent-main, authorized --complete.

### Acceptance Criteria

- The compiler-cache test and make ci-fast compiler-cache step work with real Bash 3.2 on macOS as well as current Linux Bash; Linux-only modern Bash success is insufficient portability evidence. Record any unavailable platform verification explicitly.
- Preserve exact environment values including spaces, equals signs, multiline text and empty strings, correctly rewrite only intended path prefixes, and preserve compiler argv and exit status. Avoid assuming GNU-only env behavior on macOS.
- Add focused portable regression coverage and retain ORB-11272's fully disposable fixtures. Run scripts/test-compiler-cache.sh and make ci-fast/ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced Bash 4-only mapfile plus GNU env -0 environment enumeration with Bash 3.2-compatible compgen/read iteration that preserves spaces, equals signs, multiline values, empty values, and path rewriting.
- Restricted path rewriting to the target/repository root or descendants, preventing false rewrites for similarly prefixed paths.
- Extended the disposable compiler-cache fixture to cover exact environment values, prefix boundaries, argv preservation, and compiler exit-status propagation.
Validation:
- /bin/bash -n scripts/rustc-compiler-cache.sh scripts/test-compiler-cache.sh — passed.
- /bin/bash scripts/test-compiler-cache.sh — passed.
- make ci-fast — passed.
- make ci-lint — passed.
- Real macOS /bin/bash 3.2 verification was unavailable in this Linux worktree; the task's existing macOS reproduction documents Bash 3.2 mapfile failure for follow-up verification after delivery.
Handoff:
- Only scripts/rustc-compiler-cache.sh and scripts/test-compiler-cache.sh remain modified.
- Removed the run-created target/ build artifacts; repository .cargo configuration was pre-existing and retained.
Assessment: Small, focused shell portability repair with regression coverage; no dependency or API changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11312-6a9c7eac`
- Behind base: 0
- Ahead of base: 1