### PR TITLE
Make auto stop acknowledgement atomic with child admission

### DIFF
--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -56,10 +56,11 @@ spec:
     # enough children finish; it cancels nothing.
     #
     # ORB-11283: `orbit run auto --stop` records `drain_admissions_stop` on
-    # this same state. Classify then offers nothing, `drain_window` expires
-    # for the stop rather than the deadline, and `invoke_detached` skips a
-    # child that was offered before the stop landed. Children already
-    # submitted keep running; this is not `orbit run cancel`.
+    # this same state. Classify then offers nothing and `drain_window` expires
+    # for the stop rather than the deadline. ORB-11310 makes the final check,
+    # child insert, and parent link one cross-process SQLite transaction, so a
+    # child offered before stop is either already linked or is skipped.
+    # Children already submitted keep running; this is not `orbit run cancel`.
     max_active_leaf_runs: 5
     # Waited when the backlog has work but no slot is free: the latency a
     # freed slot sits idle before it is refilled.

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -56,10 +56,11 @@ spec:
     # enough children finish; it cancels nothing.
     #
     # ORB-11283: `orbit run auto --stop` records `drain_admissions_stop` on
-    # this same state. Classify then offers nothing, `drain_window` expires
-    # for the stop rather than the deadline, and `invoke_detached` skips a
-    # child that was offered before the stop landed. Children already
-    # submitted keep running; this is not `orbit run cancel`.
+    # this same state. Classify then offers nothing and `drain_window` expires
+    # for the stop rather than the deadline. ORB-11310 makes the final check,
+    # child insert, and parent link one cross-process SQLite transaction, so a
+    # child offered before stop is either already linked or is skipped.
+    # Children already submitted keep running; this is not `orbit run cancel`.
     max_active_leaf_runs: 5
     # Waited when the backlog has work but no slot is free: the latency a
     # freed slot sits idle before it is refilled.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/child_dispatch.rs
@@ -9,13 +9,12 @@
 //! operator could not tell a healthy long wait apart from a dispatch path
 //! wedged before persistence, and no reader could name the child.
 //!
-//! This module makes the dispatch boundary fail-observable. Submission and
-//! waiting are separate persisted phases even though they remain one
-//! activity: either a durable child run exists and is linked immediately, or
-//! the parent fails promptly carrying the exact pre-dispatch error. Evidence
-//! lands in two independent stores — the parent's `PipelineState` (which CLI,
-//! MCP, API, and dashboard readers project) and the audit log — so losing one
-//! does not hide the child.
+//! This module makes the dispatch boundary fail-observable. [ORB-11310] moved
+//! the first parent link into the same SQLite transaction that creates an
+//! auto child, before `orbit.pipeline.invoke` returns. This checkpoint then
+//! records the independent audit evidence and refreshes derived fields such as
+//! `queued`. Either a durable child is already linked, or the parent fails
+//! promptly carrying the exact pre-dispatch error.
 
 use chrono::Utc;
 use orbit_common::observability::audit_id::audit_execution_id;
@@ -54,9 +53,10 @@ pub(super) fn parent_run_id(input: &Value) -> Option<String> {
 
 /// Persist a freshly submitted child into the parent's run state.
 ///
-/// Ordering is the whole point: the audit event goes first, then the run
-/// state. The two stores fail independently, and the child run id must
-/// survive in at least one of them before the parent blocks on anything.
+/// The auto-admission path already wrote the first link atomically with the
+/// child row [ORB-11310]. Re-recording is an idempotent refresh and preserves
+/// the original submission timestamp. Direct callers without trusted parent
+/// context retain this checkpoint as their first parent-state link.
 ///
 /// A run state that cannot be written is a hard failure of the dispatch step,
 /// not a warning. The alternative — blocking for an hour on a child nobody can
@@ -137,27 +137,17 @@ pub(super) fn advance_child_phase(
     let Some(parent_run_id) = parent_run_id else {
         return;
     };
-    let state = match runtime.read_run_state(parent_run_id) {
-        Ok(Some(state)) => Some(state),
-        Ok(None) => None,
-        Err(error) => {
-            tracing::warn!(
-                parent_run_id,
-                child_run_id,
-                phase = phase.as_str(),
-                %error,
-                "could not read parent run state to advance child dispatch phase"
-            );
-            None
-        }
-    };
-    let Some(mut state) = state else {
-        return;
-    };
-    if !state.advance_child_dispatch(child_run_id, phase, child_status, error) {
-        return;
-    }
-    if let Err(error) = runtime.write_run_state(parent_run_id, &state) {
+    // Keep phase bookkeeping on the same transactional update path as stop
+    // and admission. A read followed by a plain write here could otherwise
+    // restore a stale pre-stop document after the operator was acknowledged.
+    let update = runtime
+        .stores()
+        .jobs()
+        .update_run_state(parent_run_id, &mut |_, state| {
+            state.advance_child_dispatch(child_run_id, phase, child_status.clone(), error.clone());
+            Ok(())
+        });
+    if let Err(error) = update {
         tracing::warn!(
             parent_run_id,
             child_run_id,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/pipeline_actions.rs
@@ -87,12 +87,11 @@ pub(super) fn validate_bundles(action: &str, input: &Value) -> Result<Value, Dis
 /// Submit a child v2 Job, link it durably, then block on its terminal state.
 ///
 /// [ORB-10971] Submission and waiting are two observable phases of one
-/// activity. The child's exact run id — the one `orbit.pipeline.invoke`
-/// returned, never one inferred from task status or timestamps — is persisted
-/// into the parent's run state and the audit log *before* the wait begins, so
-/// the dispatch boundary is fail-observable: either a durable child exists and
-/// every reader can name it, or the step fails promptly carrying the concrete
-/// invocation error instead of idling to the wait timeout.
+/// activity. [ORB-11310] Child creation and the first parent link now share the
+/// store transaction that checks the parent's admissions stop; the checkpoint
+/// below adds independent audit evidence before the wait begins. The exact run
+/// id always comes from that durable admission, never from task status or
+/// timestamps.
 ///
 /// [ORB-10819]'s blocking leaf contract is unchanged past that checkpoint: the
 /// activity still returns the child's terminal wait entry, so a following
@@ -103,7 +102,16 @@ pub(super) fn invoke_and_wait(
     input: &Value,
     tool_context: ToolContext,
 ) -> Result<Value, DispatchError> {
-    let wait_context = tool_context.clone();
+    let parent_step_id = child_dispatch::parent_step_id(input);
+    let parent_run_id = child_dispatch::parent_run_id(input);
+    let invoke_context = child_invoke_context(
+        tool_context.clone(),
+        action,
+        parent_run_id,
+        parent_step_id,
+        true,
+    )?;
+    let wait_context = tool_context;
     invoke_and_wait_with(
         runtime,
         action,
@@ -113,7 +121,7 @@ pub(super) fn invoke_and_wait(
                 "orbit.pipeline.invoke",
                 args,
                 Role::Admin,
-                tool_context,
+                invoke_context,
             )
         },
         |args| {
@@ -167,6 +175,14 @@ where
         );
         action_failed(action, message)
     })?;
+    if invoke_output_admissions_stopped(&invoke_output) {
+        return Ok(serde_json::json!({
+            "skipped": true,
+            "status": "succeeded",
+            "reason": "admissions_stopped",
+            "job_name": job_name,
+        }));
+    }
 
     // Phase 2 — link, durably, before blocking on anything.
     let dispatch = child_dispatch::dispatch_from_invoke_output(
@@ -358,10 +374,9 @@ pub(super) fn invoke_detached(
     let parent_run_id = child_dispatch::parent_run_id(input);
     let parent_step_id = child_dispatch::parent_step_id(input);
 
-    // [ORB-11283] Re-check at the submit boundary, not only in classify: a
-    // stop can land after the drain offered work and before this child is
-    // durable. Skipping here admits nothing; failing would take down the
-    // coordinator and is not an admissions stop.
+    // [ORB-11283] This read is a fast path, not the authority: a stop can land
+    // after it. [ORB-11310] The pipeline submission below re-reads the same
+    // state inside the SQLite transaction that creates and links the child.
     if parent_run_id
         .as_deref()
         .is_some_and(|run_id| runtime.drain_admissions_stopped(run_id))
@@ -373,12 +388,19 @@ pub(super) fn invoke_detached(
         }));
     }
 
+    let invoke_context = child_invoke_context(
+        tool_context,
+        action,
+        parent_run_id.clone(),
+        parent_step_id.clone(),
+        false,
+    )?;
     let invoke_output = runtime
         .run_tool_with_context_and_role(
             "orbit.pipeline.invoke",
             invoke_args(&job_name, input),
             Role::Admin,
-            tool_context,
+            invoke_context,
         )
         .map_err(|err| {
             let message = format!("pipeline.invoke failed: {err}");
@@ -392,6 +414,9 @@ pub(super) fn invoke_detached(
             );
             action_failed(action, message)
         })?;
+    if invoke_output_admissions_stopped(&invoke_output) {
+        return Ok(invoke_output);
+    }
 
     // [ORB-10971] A detached child is linked on the same durable checkpoint as
     // a blocked-on one. The caller re-observes it later, so the linkage is the
@@ -417,6 +442,56 @@ pub(super) fn invoke_detached(
         "queued": dispatch.queued,
         "submitted_at": invoke_output.get("submitted_at").cloned(),
     }))
+}
+
+/// Attach trusted dispatch metadata to the engine-owned parent-run context.
+/// Tool input cannot select the parent whose stop governs this admission.
+fn child_invoke_context(
+    mut tool_context: ToolContext,
+    action: &str,
+    parent_run_id: Option<String>,
+    parent_step_id: Option<String>,
+    blocking: bool,
+) -> Result<ToolContext, DispatchError> {
+    if let (Some(owner), Some(parent_run_id)) = (
+        tool_context.reservation_owner.as_ref(),
+        parent_run_id.as_ref(),
+    ) && owner.owner_run_id != *parent_run_id
+    {
+        return Err(action_failed(
+            action,
+            format!(
+                "activity parent run '{}' does not match trusted run owner '{}'",
+                parent_run_id, owner.owner_run_id
+            ),
+        ));
+    }
+    let Some(owner) = tool_context.reservation_owner.as_mut() else {
+        return Ok(tool_context);
+    };
+    let mut metadata = match owner.owner_metadata_json.as_deref() {
+        Some(raw) => serde_json::from_str::<Value>(raw)
+            .map_err(|error| action_failed(action, format!("invalid run metadata: {error}")))?,
+        None => serde_json::json!({}),
+    };
+    let object = metadata
+        .as_object_mut()
+        .ok_or_else(|| action_failed(action, "run metadata must be a JSON object".to_string()))?;
+    object.insert(
+        "pipeline_child_admission".to_string(),
+        serde_json::json!({
+            "action": action,
+            "parent_step_id": parent_step_id,
+            "blocking": blocking,
+        }),
+    );
+    owner.owner_metadata_json = Some(metadata.to_string());
+    Ok(tool_context)
+}
+
+fn invoke_output_admissions_stopped(output: &Value) -> bool {
+    output.get("skipped").and_then(Value::as_bool) == Some(true)
+        && output.get("reason").and_then(Value::as_str) == Some("admissions_stopped")
 }
 
 /// Re-check live workflow admission for `admission_task_ids` immediately before

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/pipeline_actions.rs
@@ -203,6 +203,7 @@ use crate::adapter::engine_host::v2_host::child_dispatch::{
     CHILD_DISPATCH_AUDIT, CHILD_WAIT_AUDIT,
 };
 use orbit_common::OrbitError;
+use orbit_store::contracts::{ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams};
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
     ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase, PipelineState,
@@ -258,6 +259,135 @@ fn healthy_invoke_output() -> Value {
         "queued": false,
         "submitted_at": "2026-08-22T19:55:00Z",
     })
+}
+
+fn atomic_child_admission(parent_run_id: &str, blocking: bool) -> ChildJobRunAdmissionParams {
+    ChildJobRunAdmissionParams {
+        parent_run_id: parent_run_id.to_string(),
+        parent_step_id: Some("ship_leaves".to_string()),
+        job_id: "task_auto_pipeline".to_string(),
+        action: if blocking {
+            "invoke_and_wait".to_string()
+        } else {
+            "invoke_detached".to_string()
+        },
+        blocking,
+        attempt: 1,
+        scheduled_at: chrono::Utc::now(),
+        input: Some(json!({ "task_ids": ["ORB-1", "ORB-2"] })),
+    }
+}
+
+fn admitted_output(outcome: ChildJobRunAdmissionOutcome) -> Value {
+    match outcome {
+        ChildJobRunAdmissionOutcome::Admitted(run) => json!({
+            "run_id": run.run_id,
+            "job_name": run.job_id,
+            "queued": false,
+            "submitted_at": run.scheduled_at.to_rfc3339(),
+        }),
+        ChildJobRunAdmissionOutcome::AdmissionsStopped => json!({
+            "skipped": true,
+            "reason": "admissions_stopped",
+            "job_name": "task_auto_pipeline",
+        }),
+    }
+}
+
+/// The exact TOCTOU sequence from ORB-11310: the action observes eligibility,
+/// stop acknowledges, and only then does the stale action attempt its durable
+/// admission. The store boundary, rather than another read in the action,
+/// refuses the child.
+#[test]
+fn stop_between_eligibility_observation_and_admission_creates_no_child() {
+    let (runtime, parent) = parent_runtime();
+    assert!(!runtime.drain_admissions_stopped(&parent));
+
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| {
+            runtime
+                .stop_workspace_auto_admissions(
+                    crate::application::job::DrainAdmissionsStopRequest {
+                        actor: "tester",
+                        source: "unit",
+                        reason: None,
+                        claim_token: None,
+                    },
+                )
+                .expect("stop acknowledges between observation and admission");
+            runtime
+                .stores()
+                .jobs()
+                .admit_child_job_run(&atomic_child_admission(&parent, true))
+                .map(admitted_output)
+        },
+        |_| panic!("a stopped admission must not wait on a child"),
+    )
+    .expect("admissions stop is an idempotent skip");
+
+    assert_eq!(output["skipped"], true);
+    assert_eq!(output["status"], "succeeded");
+    assert_eq!(output["reason"], "admissions_stopped");
+    assert!(
+        runtime
+            .stores()
+            .jobs()
+            .list_job_runs("task_auto_pipeline")
+            .expect("list children")
+            .is_empty()
+    );
+}
+
+/// Admission's SQLite transaction ends before the action waits. A stop issued
+/// from inside the wait callback therefore completes immediately, while the
+/// already-admitted child remains linked and reaches its ordinary result.
+#[test]
+fn blocking_child_wait_holds_no_admission_lock_and_stop_does_not_cancel_child() {
+    let (runtime, parent) = parent_runtime();
+    let output = invoke_and_wait_with(
+        &runtime,
+        "invoke_and_wait",
+        &ship_leaves_input(&parent),
+        |_| {
+            runtime
+                .stores()
+                .jobs()
+                .admit_child_job_run(&atomic_child_admission(&parent, true))
+                .map(admitted_output)
+        },
+        |args| {
+            runtime
+                .stop_workspace_auto_admissions(
+                    crate::application::job::DrainAdmissionsStopRequest {
+                        actor: "tester",
+                        source: "unit",
+                        reason: None,
+                        claim_token: None,
+                    },
+                )
+                .expect("stop must not deadlock behind child wait");
+            let child_run_id = args["run_ids"][0].as_str().expect("child run id");
+            Ok(json!({
+                "results": [{ "run_id": child_run_id, "status": "succeeded" }]
+            }))
+        },
+    )
+    .expect("already-admitted child completes normally");
+
+    assert_eq!(output["status"], "succeeded");
+    let parent_state = runtime
+        .read_run_state(&parent)
+        .expect("read parent")
+        .expect("parent state");
+    assert!(parent_state.admissions_stopped());
+    assert_eq!(parent_state.child_dispatches.len(), 1);
+    let child = runtime
+        .show_job_run(&parent_state.child_dispatches[0].child_run_id)
+        .expect("read child");
+    assert_eq!(child.state, orbit_types::workflow::JobRunState::Pending);
 }
 
 fn recorded_dispatches(runtime: &OrbitRuntime, parent_run_id: &str) -> Vec<ChildDispatch> {

--- a/crates/orbit-core/src/adapter/tool_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/tool_host/dispatch.rs
@@ -43,7 +43,7 @@ pub(super) fn execute(
             super::friction_tools::dispatch(runtime, verb, input, model)
         }
         OrbitBuiltinAction::PipelineInvoke => {
-            super::pipeline_tools::invoke(runtime, input, agent, model)
+            super::pipeline_tools::invoke(runtime, input, agent, model, reservation_owner)
         }
         OrbitBuiltinAction::PipelineWait => {
             super::pipeline_tools::wait(runtime, input, agent, model)

--- a/crates/orbit-core/src/adapter/tool_host/pipeline_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/pipeline_tools.rs
@@ -1,9 +1,11 @@
 use orbit_common::OrbitError;
 use orbit_common::protocol::tool_input::{optional_string, required_string};
+use orbit_tools::ReservationOwnerContext;
 use orbit_types::identity::normalize_optional_attribution_label;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::application::job::pipeline::ChildPipelineAdmission;
 
 use super::input::{
     parse_optional_poll_interval_seconds, parse_optional_timeout_seconds, parse_string_array_field,
@@ -16,6 +18,7 @@ pub(super) fn invoke(
     input: Value,
     agent: Option<String>,
     model: Option<String>,
+    reservation_owner: Option<ReservationOwnerContext>,
 ) -> Result<Value, OrbitError> {
     let job_name = required_string(&input, &["job_name"], "job_name")?;
     let payload = require_object_field(&input, "input")?.clone();
@@ -31,13 +34,66 @@ pub(super) fn invoke(
         .unwrap_or_else(|| runtime.actor_label().to_string()),
     )
     .filter(|value| !value.trim().is_empty());
-    serde_json::to_value(runtime.submit_pipeline_run(
-        &job_name,
-        payload,
-        priority.as_deref(),
-        actor.as_deref(),
-    )?)
-    .map_err(serialize_error("serialize pipeline invoke"))
+    let result = match child_admission(reservation_owner)? {
+        Some(admission) => runtime.submit_child_pipeline_run(
+            &job_name,
+            payload,
+            priority.as_deref(),
+            actor.as_deref(),
+            &admission,
+        )?,
+        None => Some(runtime.submit_pipeline_run(
+            &job_name,
+            payload,
+            priority.as_deref(),
+            actor.as_deref(),
+        )?),
+    };
+    match result {
+        Some(result) => {
+            serde_json::to_value(result).map_err(serialize_error("serialize pipeline invoke"))
+        }
+        None => Ok(serde_json::json!({
+            "skipped": true,
+            "reason": "admissions_stopped",
+            "job_name": job_name,
+        })),
+    }
+}
+
+fn child_admission(
+    reservation_owner: Option<ReservationOwnerContext>,
+) -> Result<Option<ChildPipelineAdmission>, OrbitError> {
+    let Some(owner) = reservation_owner else {
+        return Ok(None);
+    };
+    let Some(metadata) = owner.owner_metadata_json else {
+        return Ok(None);
+    };
+    let metadata: Value = serde_json::from_str(&metadata).map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "invalid trusted reservation owner metadata: {error}"
+        ))
+    })?;
+    let Some(admission) = metadata.get("pipeline_child_admission") else {
+        return Ok(None);
+    };
+    let action = required_string(admission, &["action"], "action")?;
+    let blocking = admission
+        .get("blocking")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            OrbitError::InvalidInput(
+                "trusted pipeline child admission is missing boolean `blocking`".to_string(),
+            )
+        })?;
+    let parent_step_id = optional_string(admission, "parent_step_id")?;
+    Ok(Some(ChildPipelineAdmission {
+        parent_run_id: owner.owner_run_id,
+        parent_step_id,
+        action,
+        blocking,
+    }))
 }
 
 pub(super) fn wait(

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -11,7 +11,8 @@ use chrono::Utc;
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_store::contracts::{
-    AuditEventInsertParams, JobRunStepParams, TaskReservationReleaseReason,
+    AuditEventInsertParams, ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams,
+    JobRunStepParams, TaskReservationReleaseReason,
 };
 use orbit_types::record::OrbitEvent;
 use orbit_types::telemetry::AuditEventStatus;
@@ -57,6 +58,19 @@ struct PipelineSubmission<'a> {
     input: Value,
     resume: Option<&'a ResumePlan>,
     actor: Option<&'a str>,
+}
+
+/// Trusted context for a pipeline child submitted by a running v2 activity.
+///
+/// The parent run id comes from the engine-owned [`orbit_tools::ToolContext`],
+/// never from tool input. The remaining fields make the parent link complete
+/// at the same atomic boundary that creates the child.
+#[derive(Debug, Clone)]
+pub(crate) struct ChildPipelineAdmission {
+    pub parent_run_id: String,
+    pub parent_step_id: Option<String>,
+    pub action: String,
+    pub blocking: bool,
 }
 
 /// How a submitted run's definition reaches its worker.
@@ -400,6 +414,62 @@ impl OrbitRuntime {
         result
     }
 
+    /// Submit a v2 activity's child through the parent's durable admission
+    /// boundary [ORB-11310].
+    ///
+    /// `Ok(None)` is the benign, idempotent result when the parent auto drain
+    /// has already acknowledged an admissions stop. Direct/non-child callers
+    /// continue to use [`Self::submit_pipeline_run`] and are unchanged.
+    pub(crate) fn submit_child_pipeline_run(
+        &self,
+        job_name: &str,
+        input: Value,
+        priority: Option<&str>,
+        actor: Option<&str>,
+        admission: &ChildPipelineAdmission,
+    ) -> Result<Option<PipelineInvokeResult>, OrbitError> {
+        let result = self.submit_persisted_pipeline_run_with_admission(
+            PipelineSubmission {
+                job_name,
+                definition: SubmittedDefinition::Catalog,
+                input: input.clone(),
+                resume: None,
+                actor,
+            },
+            Some(admission),
+        );
+
+        self.record_pipeline_audit(
+            "pipeline.invoke",
+            result
+                .as_ref()
+                .ok()
+                .and_then(|value| value.as_ref())
+                .map(|value| value.run_id.as_str()),
+            actor,
+            match &result {
+                Ok(_) => AuditEventStatus::Success,
+                Err(_) => AuditEventStatus::Failure,
+            },
+            json!({
+                "actor": actor,
+                "job_name": job_name,
+                "priority": priority,
+                "parent_run_id": admission.parent_run_id,
+                "outcome": if matches!(&result, Ok(None)) { "admissions_stopped" } else { "submitted" },
+                "run_id": result
+                    .as_ref()
+                    .ok()
+                    .and_then(|value| value.as_ref())
+                    .map(|value| value.run_id.clone()),
+                "input_hash": input_hash(&input),
+            }),
+            result.as_ref().err().map(|error| error.to_string()),
+        )?;
+
+        result
+    }
+
     /// Record the `pipeline.invoke` audit for a direct-path submission, which
     /// does not route through [`Self::submit_pipeline_run`].
     fn record_submission_audit(
@@ -438,6 +508,19 @@ impl OrbitRuntime {
         &self,
         submission: PipelineSubmission<'_>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
+        self.submit_persisted_pipeline_run_with_admission(submission, None)?
+            .ok_or_else(|| {
+                OrbitError::Execution(
+                    "unconditional pipeline submission was refused as stopped".to_string(),
+                )
+            })
+    }
+
+    fn submit_persisted_pipeline_run_with_admission(
+        &self,
+        submission: PipelineSubmission<'_>,
+        admission: Option<&ChildPipelineAdmission>,
+    ) -> Result<Option<PipelineInvokeResult>, OrbitError> {
         let PipelineSubmission {
             job_name,
             definition,
@@ -457,14 +540,34 @@ impl OrbitRuntime {
             }
 
             let submitted_at = Utc::now();
-            let run = self.stores().jobs().insert_job_run(
-                job_name,
-                resume.map_or(1, |plan| plan.attempt),
-                submitted_at,
-                Some(input.clone()),
-                resume.map(|plan| plan.source.run_id.clone()),
-            )?;
-            self.seed_v2_pipeline_run(&run, &input, resume)?;
+            let run = if let Some(admission) = admission {
+                match self
+                    .stores()
+                    .jobs()
+                    .admit_child_job_run(&ChildJobRunAdmissionParams {
+                        parent_run_id: admission.parent_run_id.clone(),
+                        parent_step_id: admission.parent_step_id.clone(),
+                        job_id: job_name.to_string(),
+                        action: admission.action.clone(),
+                        blocking: admission.blocking,
+                        attempt: 1,
+                        scheduled_at: submitted_at,
+                        input: Some(input.clone()),
+                    })? {
+                    ChildJobRunAdmissionOutcome::Admitted(run) => *run,
+                    ChildJobRunAdmissionOutcome::AdmissionsStopped => return Ok(None),
+                }
+            } else {
+                let run = self.stores().jobs().insert_job_run(
+                    job_name,
+                    resume.map_or(1, |plan| plan.attempt),
+                    submitted_at,
+                    Some(input.clone()),
+                    resume.map(|plan| plan.source.run_id.clone()),
+                )?;
+                self.seed_v2_pipeline_run(&run, &input, resume)?;
+                run
+            };
 
             // Pin the definition before the worker can exist. A direct-path
             // submission must not depend on the source file surviving
@@ -497,18 +600,22 @@ impl OrbitRuntime {
                 return Err(error);
             }
 
-            Ok(PipelineInvokeResult {
+            Ok(Some(PipelineInvokeResult {
                 run_id: run.run_id,
                 job_name: job_name.to_string(),
                 submitted_at: submitted_at.to_rfc3339(),
                 queued,
-            })
+            }))
         })();
 
         if let Some(plan) = resume {
             self.record_pipeline_audit(
                 "pipeline.resume",
-                result.as_ref().ok().map(|value| value.run_id.as_str()),
+                result
+                    .as_ref()
+                    .ok()
+                    .and_then(|value| value.as_ref())
+                    .map(|value| value.run_id.as_str()),
                 actor,
                 match &result {
                     Ok(_) => AuditEventStatus::Success,
@@ -521,7 +628,11 @@ impl OrbitRuntime {
                     "attempt": plan.attempt,
                     "resumed_from_checkpoints": plan.resume_state.is_some(),
                     "checkpoint_batch_id": plan.checkpoint_batch_id,
-                    "run_id": result.as_ref().ok().map(|value| value.run_id.clone()),
+                    "run_id": result
+                        .as_ref()
+                        .ok()
+                        .and_then(|value| value.as_ref())
+                        .map(|value| value.run_id.clone()),
                 }),
                 result.as_ref().err().map(|error| error.to_string()),
             )?;

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -374,6 +374,19 @@ pub trait JobRunStoreBackend: Send + Sync {
         input: Option<serde_json::Value>,
         retry_source_run_id: Option<String>,
     ) -> Result<JobRun, OrbitError>;
+    /// Atomically admit and link a child run unless its parent has stopped
+    /// admissions.
+    ///
+    /// The parent-state read, child insert, and parent dispatch checkpoint are
+    /// committed in one backend transaction. That commit is the
+    /// cross-process linearization point shared with an admissions-stop
+    /// update: a stop that commits first makes this return
+    /// [`ChildJobRunAdmissionOutcome::AdmissionsStopped`], while a child that
+    /// commits first is already linked when stop acknowledges.
+    fn admit_child_job_run(
+        &self,
+        params: &ChildJobRunAdmissionParams,
+    ) -> Result<ChildJobRunAdmissionOutcome, OrbitError>;
     /// [ORB-10965] Apply a `Start` event to a run, atomically and idempotently.
     ///
     /// Scheduling is at-least-once, so this is the single point that decides
@@ -446,6 +459,25 @@ pub trait JobRunStoreBackend: Send + Sync {
         run_id: &str,
         update: &mut dyn FnMut(JobRunState, &mut PipelineState) -> Result<(), OrbitError>,
     ) -> Result<RunStateUpdate, OrbitError>;
+}
+
+/// Durable inputs for one parent-authorized child admission.
+#[derive(Debug, Clone)]
+pub struct ChildJobRunAdmissionParams {
+    pub parent_run_id: String,
+    pub parent_step_id: Option<String>,
+    pub job_id: String,
+    pub action: String,
+    pub blocking: bool,
+    pub attempt: u32,
+    pub scheduled_at: DateTime<Utc>,
+    pub input: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChildJobRunAdmissionOutcome {
+    Admitted(Box<JobRun>),
+    AdmissionsStopped,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -6,12 +6,15 @@ use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::identity::Crew;
 use orbit_types::workflow::{
-    JobRun, JobRunStartOutcome, JobRunState, JobRunStep, JobTargetType, KnowledgeRunMetrics,
-    PipelineState, RunEvent, RunStateUpdate,
+    ChildDispatch, JobRun, JobRunStartOutcome, JobRunState, JobRunStep, JobTargetType,
+    KnowledgeRunMetrics, PipelineState, RunEvent, RunStateUpdate,
 };
-use rusqlite::TransactionBehavior;
+use rusqlite::{OptionalExtension, TransactionBehavior};
 
-use crate::contracts::{JobRunOrder, JobRunQuery, JobRunStepParams, JobRunStoreBackend};
+use crate::contracts::{
+    ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams, JobRunOrder, JobRunQuery,
+    JobRunStepParams, JobRunStoreBackend,
+};
 use crate::fs::path_safety::validate_path_stem;
 use crate::{Store, parse_timestamp};
 
@@ -145,6 +148,122 @@ impl JobRunStoreBackend for SqliteJobRunStore {
         self.store
             .upsert_job_run_for_workspace(&self.workspace_id, &run, None)?;
         Ok(run)
+    }
+
+    /// [ORB-11310] The admissions-stop flag and durable child creation share
+    /// this SQLite `IMMEDIATE` transaction. SQLite's database writer lock is
+    /// process-wide, unlike a Rust mutex: whichever transaction commits first
+    /// defines the order seen by every process. The child row, its initial
+    /// state, and the parent link commit together, so stop can never
+    /// acknowledge between admission and linkage.
+    fn admit_child_job_run(
+        &self,
+        params: &ChildJobRunAdmissionParams,
+    ) -> Result<ChildJobRunAdmissionOutcome, OrbitError> {
+        validate_path_stem(&params.job_id, "job")?;
+        self.store
+            .with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+                let parent_row = tx
+                    .tx
+                    .query_row(
+                        "SELECT state, pipeline_state_json FROM job_runs \
+                         WHERE workspace_id = ?1 AND run_id = ?2",
+                        rusqlite::params![self.workspace_id, params.parent_run_id],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+                    )
+                    .map_err(|error| match error {
+                        rusqlite::Error::QueryReturnedNoRows => OrbitError::not_found(
+                            NotFoundKind::JobRun,
+                            params.parent_run_id.clone(),
+                        ),
+                        other => OrbitError::Store(other.to_string()),
+                    })?;
+                let parent_run_state = JobRunState::from_str(&parent_row.0).map_err(|error| {
+                    OrbitError::Store(format!("invalid job run state: {error}"))
+                })?;
+                if parent_run_state.is_terminal() {
+                    return Err(OrbitError::JobValidation(format!(
+                        "parent job run '{}' is {parent_run_state}; a terminal run admits no further work",
+                        params.parent_run_id
+                    )));
+                }
+                let raw_parent_state = parent_row.1.ok_or_else(|| {
+                    OrbitError::JobValidation(format!(
+                        "parent job run '{}' has no pipeline state; child admission cannot be guarded",
+                        params.parent_run_id
+                    ))
+                })?;
+                let mut parent_state: PipelineState = serde_json::from_str(&raw_parent_state)
+                    .map_err(|error| {
+                        OrbitError::Store(format!("invalid pipeline_state_json: {error}"))
+                    })?;
+                if parent_state.admissions_stopped() {
+                    return Ok(ChildJobRunAdmissionOutcome::AdmissionsStopped);
+                }
+
+                let run_id = next_run_id_conn(
+                    &tx.tx,
+                    &self.workspace_id,
+                    &params.job_id,
+                    params.scheduled_at,
+                )?;
+                let run = JobRun {
+                    run_id: run_id.clone(),
+                    job_id: params.job_id.clone(),
+                    attempt: params.attempt,
+                    state: JobRunState::Pending,
+                    scheduled_at: params.scheduled_at,
+                    started_at: None,
+                    finished_at: None,
+                    duration_ms: None,
+                    created_at: Utc::now(),
+                    pid: None,
+                    pid_start_time: None,
+                    input: params.input.clone(),
+                    retry_source_run_id: None,
+                    knowledge_metrics: None,
+                    resolved_crew: None,
+                    crew_model: None,
+                    steps: Vec::new(),
+                };
+                let child_state = PipelineState::new(
+                    run_id.clone(),
+                    params.job_id.clone(),
+                    params.input.clone().unwrap_or_else(|| serde_json::json!({})),
+                );
+                parent_state.record_child_dispatch(
+                    ChildDispatch::submitted(
+                        run_id,
+                        params.job_id.clone(),
+                        params.action.clone(),
+                        params.blocking,
+                        false,
+                        params.scheduled_at,
+                    )
+                    .with_parent_step_id(params.parent_step_id.clone()),
+                );
+
+                upsert_job_run_for_workspace_conn(
+                    &tx.tx,
+                    &self.workspace_id,
+                    &run,
+                    Some(&child_state),
+                )?;
+                let parent_state_json = serde_json::to_string_pretty(&parent_state)
+                    .map_err(|error| OrbitError::Store(format!("serialize pipeline state: {error}")))?;
+                tx.tx
+                    .execute(
+                        "UPDATE job_runs SET pipeline_state_json = ?3 \
+                         WHERE workspace_id = ?1 AND run_id = ?2",
+                        rusqlite::params![
+                            self.workspace_id,
+                            params.parent_run_id,
+                            parent_state_json
+                        ],
+                    )
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                Ok(ChildJobRunAdmissionOutcome::Admitted(Box::new(run)))
+            })
     }
 
     /// [ORB-10965] The single arbiter of job-run start authority.
@@ -704,6 +823,35 @@ fn upsert_job_run_for_workspace_conn(
     )
     .map_err(|e| OrbitError::Store(e.to_string()))?;
     Ok(())
+}
+
+fn next_run_id_conn(
+    conn: &rusqlite::Connection,
+    workspace_id: &str,
+    job_id: &str,
+    submitted_at: DateTime<Utc>,
+) -> Result<String, OrbitError> {
+    let base = format!("jrun-{}", submitted_at.format("%Y%m%d-%H%M"));
+    for suffix in 1..1024_u32 {
+        let candidate = if suffix == 1 {
+            base.clone()
+        } else {
+            format!("{base}-{suffix}")
+        };
+        let exists = conn
+            .query_row(
+                "SELECT 1 FROM job_runs WHERE workspace_id = ?1 AND run_id = ?2",
+                rusqlite::params![workspace_id, candidate],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(|error| OrbitError::Store(error.to_string()))?
+            .is_some();
+        if !exists {
+            return Ok(candidate);
+        }
+    }
+    Ok(format!("{base}-{job_id}"))
 }
 
 fn get_job_run_for_workspace_conn(

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -199,16 +199,18 @@ fn recency_order_truncates_by_finish_time_not_creation_time() {
 /// mutation, and the write are one operation, so a caller can refuse a run that
 /// has terminalized and can never half-apply a change it aborts.
 mod run_state_update {
-    use std::sync::{Arc, Barrier};
+    use std::sync::{Arc, Barrier, mpsc};
     use std::thread;
     use std::time::Duration;
 
     use chrono::Utc;
     use orbit_common::OrbitError;
-    use orbit_types::workflow::{JobRunState, PipelineState, RunStateUpdate};
+    use orbit_types::workflow::{ChildDispatchPhase, JobRunState, PipelineState, RunStateUpdate};
 
     use crate::Store;
-    use crate::contracts::JobRunStoreBackend;
+    use crate::contracts::{
+        ChildJobRunAdmissionOutcome, ChildJobRunAdmissionParams, JobRunStoreBackend,
+    };
     use crate::driver::sqlite::job_run_store::SqliteJobRunStore;
 
     fn started_run_with_state(backend: &SqliteJobRunStore, job_id: &str) -> String {
@@ -227,6 +229,19 @@ mod run_state_update {
             .write_run_state(&run.run_id, &state)
             .expect("write state");
         run.run_id
+    }
+
+    fn child_admission(parent_run_id: &str) -> ChildJobRunAdmissionParams {
+        ChildJobRunAdmissionParams {
+            parent_run_id: parent_run_id.to_string(),
+            parent_step_id: Some("leaf_invoke".to_string()),
+            job_id: "task_auto_pipeline".to_string(),
+            action: "invoke_detached".to_string(),
+            blocking: false,
+            attempt: 1,
+            scheduled_at: Utc::now(),
+            input: Some(serde_json::json!({ "task_ids": ["ORB-1"] })),
+        }
     }
 
     #[test]
@@ -382,5 +397,155 @@ mod run_state_update {
             .expect("read state")
             .expect("state exists");
         assert_eq!(stored.drain_worker_limit_revision(), 1);
+    }
+
+    /// [ORB-11310] Reproduce the stale-observation interleaving without a
+    /// timing sleep: admission first observes the parent as eligible, then a
+    /// stop transaction takes the SQLite writer lock and pauses before commit,
+    /// and an independent connection attempts child admission while that lock
+    /// is held. Stop commits first, so the serialized admission must observe
+    /// the flag and create nothing.
+    #[test]
+    fn stop_acknowledgement_wins_over_a_stale_child_admission_observation() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = temp.path().join("orbit.db");
+        let seed = SqliteJobRunStore::new(Store::open(&db_path).expect("seed store"), "ws_a");
+        let parent_run_id = started_run_with_state(&seed, "workspace_auto_pipeline");
+        assert!(
+            !seed
+                .read_run_state(&parent_run_id)
+                .expect("initial eligibility read")
+                .expect("parent state")
+                .admissions_stopped(),
+            "the admission path must first observe an eligible parent"
+        );
+        drop(seed);
+
+        let (stop_holds_lock_tx, stop_holds_lock_rx) = mpsc::channel();
+        let (release_stop_tx, release_stop_rx) = mpsc::channel();
+        let stop_path = db_path.clone();
+        let stop_parent = parent_run_id.clone();
+        let stop = thread::spawn(move || {
+            let backend =
+                SqliteJobRunStore::new(Store::open(&stop_path).expect("stop store"), "ws_a");
+            backend.update_run_state(&stop_parent, &mut |_, state| {
+                state.set_drain_admissions_stop("operator".to_string(), None);
+                stop_holds_lock_tx.send(()).expect("signal stop lock");
+                release_stop_rx.recv().expect("release stop commit");
+                Ok(())
+            })
+        });
+        stop_holds_lock_rx.recv().expect("stop holds writer lock");
+
+        let (admission_attempted_tx, admission_attempted_rx) = mpsc::channel();
+        let admission_path = db_path.clone();
+        let admission_parent = parent_run_id.clone();
+        let admission = thread::spawn(move || {
+            let backend = SqliteJobRunStore::new(
+                Store::open(&admission_path).expect("admission store"),
+                "ws_a",
+            );
+            admission_attempted_tx
+                .send(())
+                .expect("signal admission attempt");
+            backend.admit_child_job_run(&child_admission(&admission_parent))
+        });
+        admission_attempted_rx
+            .recv()
+            .expect("admission attempted after stale read");
+
+        release_stop_tx.send(()).expect("let stop acknowledge");
+        assert_eq!(
+            stop.join().expect("stop thread").expect("stop update"),
+            RunStateUpdate::Updated
+        );
+        assert_eq!(
+            admission
+                .join()
+                .expect("admission thread")
+                .expect("admission result"),
+            ChildJobRunAdmissionOutcome::AdmissionsStopped
+        );
+
+        let stored = SqliteJobRunStore::new(Store::open(&db_path).expect("verify store"), "ws_a");
+        assert!(
+            stored
+                .list_job_runs("task_auto_pipeline")
+                .expect("list children")
+                .is_empty(),
+            "no child may become durable after stop acknowledges"
+        );
+        let parent = stored
+            .read_run_state(&parent_run_id)
+            .expect("read parent")
+            .expect("parent state");
+        assert!(parent.admissions_stopped());
+        assert!(parent.child_dispatches.is_empty());
+    }
+
+    #[test]
+    fn a_child_admitted_before_stop_is_linked_and_left_running() {
+        let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+        let parent_run_id = started_run_with_state(&backend, "workspace_auto_pipeline");
+
+        let child = match backend
+            .admit_child_job_run(&child_admission(&parent_run_id))
+            .expect("admit child")
+        {
+            ChildJobRunAdmissionOutcome::Admitted(child) => child,
+            ChildJobRunAdmissionOutcome::AdmissionsStopped => panic!("parent was admitting"),
+        };
+        backend
+            .update_run_state(&parent_run_id, &mut |_, state| {
+                state.set_drain_admissions_stop("operator".to_string(), None);
+                Ok(())
+            })
+            .expect("stop after admission");
+
+        let parent = backend
+            .read_run_state(&parent_run_id)
+            .expect("read parent")
+            .expect("parent state");
+        assert!(parent.admissions_stopped());
+        assert_eq!(parent.child_dispatches.len(), 1);
+        assert_eq!(parent.child_dispatches[0].child_run_id, child.run_id);
+        assert_eq!(
+            parent.child_dispatches[0].phase,
+            ChildDispatchPhase::Submitted
+        );
+        assert_eq!(
+            backend
+                .get_job_run(&child.run_id)
+                .expect("read child")
+                .expect("child run")
+                .state,
+            JobRunState::Pending,
+            "stop is not cancellation"
+        );
+    }
+
+    #[test]
+    fn a_refused_terminal_parent_rolls_back_and_releases_the_writer_lock() {
+        let backend = SqliteJobRunStore::new(Store::open_in_memory().expect("store"), "ws_a");
+        let parent_run_id = started_run_with_state(&backend, "workspace_auto_pipeline");
+        backend
+            .finalize_job_run(&parent_run_id, JobRunState::Success, Utc::now(), Some(1))
+            .expect("finish parent");
+
+        let error = backend
+            .admit_child_job_run(&child_admission(&parent_run_id))
+            .expect_err("terminal parent refuses admission");
+        assert!(matches!(error, OrbitError::JobValidation(_)), "{error:?}");
+        assert!(
+            backend
+                .list_job_runs("task_auto_pipeline")
+                .expect("list children")
+                .is_empty(),
+            "the failed transaction must not leave a child"
+        );
+
+        backend
+            .insert_job_run("unrelated_pipeline", 1, Utc::now(), None, None)
+            .expect("a later writer proves the admission lock was released");
     }
 }

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -91,12 +91,12 @@ pub struct PipelineState {
     pub waiting_on_locks: Option<Vec<String>>,
     /// Child Runs this run dispatched, in submission order.
     ///
-    /// Written the moment `orbit.pipeline.invoke` returns a durable child run
-    /// id — before a blocking parent enters its wait — so parent/child lineage
-    /// is observable for the whole life of the dispatch rather than only after
-    /// the step's output is finally persisted. Unlike the waiting reasons
-    /// above, this survives terminalization: a cancelled parent must still
-    /// name the child it left behind.
+    /// For auto children, written in the same durable admission transaction
+    /// that creates the child run [ORB-11310]. Other child callers checkpoint
+    /// it the moment `orbit.pipeline.invoke` returns. Parent/child lineage is
+    /// therefore observable before a blocking wait and survives
+    /// terminalization: a cancelled parent must still name the child it left
+    /// behind.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub child_dispatches: Vec<ChildDispatch>,
     /// Live worker ceiling for a bounded auto drain, when an operator has

--- a/docs/design/resident-orchestrator/2_design.md
+++ b/docs/design/resident-orchestrator/2_design.md
@@ -139,7 +139,7 @@ open_window(input.for_seconds)          # stamps a deadline; absent/zero = one t
 loop
     admissible = backlog leaves whose context_files do not overlap a live holder
                + one backlog epic root, when no epic_pipeline run is live
-    ship leaves      -> invoke_and_wait task_auto_pipeline
+    ship leaves      -> invoke_detached task_auto_pipeline
     start epic root  -> invoke_detached epic_pipeline
     re-read the window
     sleep when nothing was admissible and the window is still open
@@ -153,9 +153,9 @@ artifact, and re-reading the window is a pure function of a value the run alread
 `break_when` is evaluated after the loop body, a zero window still yields exactly one iteration,
 which is why `orbit run auto` with no `--for` behaves exactly as it did before the window existed.
 
-- The deadline gates **starting** new work. In-flight children finish because `invoke_and_wait`
-  blocks on them — that is what makes "the window does not affect tasks already in progress" true
-  by construction rather than by special-casing.
+- The deadline gates **starting** new work. Leaf and epic children are detached and durably linked;
+  the coordinator re-observes their run rows to refill capacity but does not cancel them when its
+  window closes.
 - Each iteration **re-lists** the backlog, so a task created after the run started still ships.
 - Epic dispatch is **detached** (`invoke_detached`). Waiting on a multi-hour epic would consume the
   rest of the window and starve conflict-free leaves behind it, which is the v1 failure mode with a
@@ -166,8 +166,8 @@ which is why `orbit run auto` with no `--for` behaves exactly as it did before t
   window between a detached submit and the child's `worktree_setup` moving that root to
   `in-progress`.
 - An expired window with nothing left is a plain success. Fail-closed lives at the epic gate (§3),
-  not here. A failed **leaf** ship still fails the drain: `pipeline_success_guard` follows the wait,
-  as it did in v1, and the resulting `blocked` task is the triage pipeline's input.
+  not here. Detached leaf results belong to their own runs; the drain records their durable links
+  and keeps filling available slots.
 
 **The worker ceiling is a live control, not a submission-time constant** ([ORB-11253]). The
 `max_active_leaf_runs` a drain is submitted with lands in the run's immutable `initial_input`, so
@@ -191,13 +191,19 @@ next admission pass.
   go through the same transactional path, so a checkpoint cannot discard a control written between
   its read and its write.
 
-**Stopping admissions is a live control, not cancellation** ([ORB-11283]). `orbit run auto --stop`
-resolves this workspace's live `workspace_auto_pipeline` coordinator without a run id and writes
-`drain_admissions_stop` onto the same `PipelineState`. Classify then offers no leaves and no epic;
-`drain_window` expires for the stop rather than the deadline so the loop winds down; `invoke_detached`
-re-checks at submit time and skips a child that classify offered before the stop landed. Already
-admitted children stay detached and keep their completion authority. A queued coordinator that has
-not started is cancelled so it cannot admit later; that is reported as `cancelled_queued`, not as a
+**Stopping admissions is a live control, not cancellation** ([ORB-11283], [ORB-11310]). `orbit run
+auto --stop` resolves this workspace's live `workspace_auto_pipeline` coordinator without a run id
+and writes `drain_admissions_stop` onto the same `PipelineState`. Classify then offers no leaves and
+no epic, and `drain_window` expires for the stop rather than the deadline so the loop winds down.
+
+The authoritative admission check is the SQLite `IMMEDIATE` transaction that also inserts and seeds
+the child run and writes its first parent `child_dispatches` link. The transaction commit is the
+cross-process linearization point shared with stop: if stop commits first, both blocking and detached
+child submissions return an idempotent `admissions_stopped` skip; if admission commits first, stop
+waits and then acknowledges with that child already linked. The lock is released before worker spawn
+or any child wait, so child completion cannot deadlock the control path. Already admitted children
+keep their original completion authority and are not cancelled. A queued coordinator that has not
+started is cancelled so it cannot admit later; that is reported as `cancelled_queued`, not as a
 stopped drain. Repeated `--stop` and `--stop` with no coordinator are idle successes. Cancellation
 of already-running workers remains `orbit run cancel <child-run-id> --confirm`.
 
@@ -369,5 +375,6 @@ child. The banner table at the top says which rows below are already true of the
 - **[ORB-10818]** — §3 completion gate and delivery.
 - **[ORB-10819]** — §4 drain window and detached dispatch.
 - **[ORB-11253]** — §4 live worker ceiling for a running drain.
+- **[ORB-11310]** — Atomic admissions-stop and child creation boundary.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.


### PR DESCRIPTION
## Task

[ORB-11310](https://orbit-cli.com/tasks/ORB-11310) — Make auto stop acknowledgement atomic with child admission

### Description

Daniel's P1 source-level review of ORB-11283 identifies a TOCTOU race: invoke_detached reads drain_admissions_stopped at pipeline_actions.rs:361, then separately calls orbit.pipeline.invoke at372. Stop can acknowledge in between and a child is still submitted afterwards. Source inspected on Linux origin/agent-main confirms the separated operations. This is a source-level finding, not a reproduced live race; existing stop-before-check coverage does not exercise the interleaving. Fix at the actual admission/stop shared atomic boundary, including the blocking leaf and detached epic paths as applicable. Preserve already-admitted workers and their completion authority; --stop must not become cancellation. Coordinate with landed ORB-11305 task-withdrawal guards and preserve user crew/status decisions. Opus selected for cross-process admission/store coordination. Dedicated worktree, agent-main, authorized --complete delivery.

### Acceptance Criteria

- Deterministic concurrency regression places stop between initial eligibility observation and attempted durable child admission; after stop acknowledges, no new child may be admitted. Test fails on the old implementation, without timing sleeps as proof.
- Stop and all auto child-admission paths share a cross-process atomic boundary with a documented linearization point. Check-then-call rechecks alone and process-local-only locks do not satisfy this.
- A child admitted before stop remains linked, runs under original completion authority, and is not cancelled. Repeated stop/no active coordinator remain safe and idempotent; unrelated non-auto workflows remain functional.
- Verify failure/rollback/lock release paths and no deadlock while awaiting child completion. Run focused race/lifecycle tests and make ci-fast/ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added JobRunStoreBackend::admit_child_job_run. Its SQLite IMMEDIATE transaction re-reads the parent stop/terminal state, inserts and seeds the child, and writes the parent dispatch link as one commit. That commit is the documented cross-process linearization point shared with stop.
- Routed blocking and detached v2 child invocation through trusted activity ownership metadata. A stop-first ordering returns an idempotent admissions_stopped skip; an admission-first ordering leaves the child linked and preserves its original completion authority.
- Moved child phase changes onto transactional run-state updates so waiting/terminal bookkeeping cannot restore a stale pre-stop document. The admission lock ends before worker spawn or child wait.
- Added deterministic no-sleep regressions using independent SQLite connections and channel barriers, plus coverage for stop between eligibility and admission, admission-before-stop linkage/non-cancellation, rollback/lock release, and no deadlock while waiting.
- Updated the resident-orchestrator design and both managed workspace-auto assets; also corrected the design's stale blocking-leaf description to match the shipped detached-leaf workflow.
- Added file:crates/orbit-store/src/contracts/traits.rs and file:crates/orbit-core/src/adapter/tool_host/dispatch.rs to context because the store contract and trusted tool-host routing are required boundaries for the atomic operation.
Assessment: Acceptance criteria are met. Stop and child admission serialize through SQLite across processes; no process-local lock or check-then-call recheck is relied on for authority. Repeated/idle stop behavior and unrelated submission behavior remain covered and passing. No known design weakness remains in scope.
Validation:
- cargo test -p orbit-store driver::sqlite::tests::job_run_store::run_state_update (8 passed)
- cargo test -p orbit-core adapter::engine_host::v2_host::tests::pipeline_actions (25 passed)
- cargo test -p orbit-core application::job::run::tests::admissions_stop (5 passed)
- cargo test -p orbit-core application::tests::job_submission (8 passed)
- cargo test -p orbit-core adapter::tool_host::tests::workflow_tools (7 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed); managed workspace-auto assets match
- Removed the generated target/ directory created by this run.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11310-6a9c7e9d`
- Behind base: 0
- Ahead of base: 1