### PR TITLE
Add OpenCode as a first-class headless Orbit executor

### DIFF
--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -22,6 +22,7 @@ pub enum ProviderOptions {
     Cursor,
     Ollama,
     Pi,
+    Opencode,
     Mock,
 }
 

--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -11,7 +11,8 @@
 //! Agent provider abstraction for Orbit. Two transport families coexist:
 //!
 //! - **CLI transports** — drive `claude`, `codex`, `gemini`, `grok`, `copilot`,
-//!   `cursor-agent`, `ollama`, `pi`, or `mock` as subprocesses through
+//!   `cursor-agent`, `ollama`, `opencode`, `pi`, or `mock` as subprocesses
+//!   through
 //!   [`AgentRuntime`]. Each runtime builds an
 //!   [`AgentInvocationSpec`] (program, args, stdin envelope) that the engine
 //!   executes through `orbit-exec`; responses are parsed via

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -3,7 +3,7 @@
 //! Two families live here:
 //!
 //! - **CLI transports** (`claude`, `codex`, `copilot`, `cursor-agent`, `gemini`,
-//!   `agy`, `grok`, `ollama`, `pi`, `mock_agent`):
+//!   `agy`, `grok`, `ollama`, `opencode`, `pi`, `mock_agent`):
 //!   translate an [`AgentRequest`] into a CLI command invocation and stdin
 //!   envelope that the engine runs via `orbit-exec`.
 //! - **HTTP transports** (`anthropic`, `openai_compat`, `gemini_http`): implement the sibling
@@ -27,6 +27,7 @@ pub(crate) mod grok;
 pub(crate) mod mock_agent;
 pub(crate) mod ollama;
 pub mod openai_compat;
+pub(crate) mod opencode;
 pub(crate) mod pi;
 
 use std::borrow::Cow;
@@ -62,7 +63,10 @@ pub(crate) fn build_invocation_spec(
 /// module docs for why that reduction is a correctness requirement rather
 /// than tidying. `cursor` wraps the assistant response in a terminal JSON
 /// result object; its adapter validates that wrapper and exposes only the
-/// model-authored `result` string. [ORB-10946] [ORB-10945]
+/// model-authored `result` string. `opencode` emits NDJSON events whose
+/// `tool_use` and `reasoning` frames can replay Orbit's own prompt, so its
+/// adapter keeps only the assistant `text` parts.
+/// [ORB-10946] [ORB-10945] [ORB-11295]
 ///
 /// `provider` is the resolved canonical provider id. An unrecognized id is
 /// not an error here: normalization is a per-provider accommodation, and the
@@ -73,6 +77,7 @@ pub fn normalize_cli_stdout<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8
         "cursor" => Cow::Owned(cursor::normalize_cursor_stdout(stdout)),
         "pi" => Cow::Owned(pi::normalize_pi_stdout(stdout)),
         "antigravity" | "agy" => Cow::Owned(antigravity::normalize_antigravity_stdout(stdout)),
+        "opencode" => Cow::Owned(opencode::normalize_opencode_stdout(stdout)),
         _ => Cow::Borrowed(stdout),
     }
 }

--- a/crates/orbit-agent/src/providers/opencode/mod.rs
+++ b/crates/orbit-agent/src/providers/opencode/mod.rs
@@ -1,0 +1,9 @@
+mod opencode_cli;
+mod opencode_output;
+mod opencode_runtime;
+
+pub(crate) use opencode_output::normalize_opencode_stdout;
+pub(crate) use opencode_runtime::OpencodeFactory;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-agent/src/providers/opencode/opencode_cli.rs
+++ b/crates/orbit-agent/src/providers/opencode/opencode_cli.rs
@@ -1,0 +1,53 @@
+use orbit_types::identity::ReasoningEffort;
+
+use crate::providers::common::render_prompt_with_embedded_envelope;
+
+/// Per-request command construction for the OpenCode CLI. [ORB-11295]
+///
+/// The shipped executor owns the static headless flags (`run`, `--format json`,
+/// `--auto`); this transport adds only what Orbit's crew resolution decides per
+/// invocation.
+pub(crate) struct OpencodeCliTransport {
+    model: Option<String>,
+    reasoning_effort: Option<ReasoningEffort>,
+}
+
+impl OpencodeCliTransport {
+    pub(crate) fn new(model: Option<String>, reasoning_effort: Option<ReasoningEffort>) -> Self {
+        Self {
+            model,
+            reasoning_effort,
+        }
+    }
+
+    /// `--model` takes OpenCode's `provider/model` coordinate, which names the
+    /// *model vendor* inside the OpenCode lane and never changes the Orbit
+    /// executor identity. `--variant` carries the crew effort; the agent
+    /// configuration boundary has already rejected any effort outside
+    /// OpenCode's documented variant vocabulary, so nothing is remapped or
+    /// silently dropped here.
+    pub(crate) fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(model) = &self.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        if let Some(effort) = self.reasoning_effort {
+            args.push("--variant".to_string());
+            args.push(effort.to_string());
+        }
+        args
+    }
+
+    /// OpenCode reads piped stdin whenever stdin is not a TTY and uses it as
+    /// the whole message when no positional `[message..]` is supplied, so the
+    /// execution envelope never reaches argv — and therefore never reaches
+    /// process listings, audit argv, or spawn diagnostics.
+    pub(crate) fn stdin(&self, envelope_json: &[u8]) -> Vec<u8> {
+        render_prompt_with_embedded_envelope(envelope_json)
+    }
+
+    pub(crate) fn model_name(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+}

--- a/crates/orbit-agent/src/providers/opencode/opencode_output.rs
+++ b/crates/orbit-agent/src/providers/opencode/opencode_output.rs
@@ -1,0 +1,90 @@
+//! Reducing OpenCode's `--format json` NDJSON event stream to the bytes
+//! Orbit's response/envelope contract is allowed to read. [ORB-11295]
+//!
+//! With `--format json`, OpenCode writes one JSON object per line, each shaped
+//! `{"type":…,"timestamp":…,"sessionID":…,…}`:
+//!
+//! ```text
+//! {"type":"step_start","timestamp":1,"sessionID":"ses_1","part":{…}}
+//! {"type":"tool_use","timestamp":2,"sessionID":"ses_1","part":{…}}
+//! {"type":"text","timestamp":3,"sessionID":"ses_1","part":{"type":"text","text":"…"}}
+//! {"type":"error","timestamp":4,"sessionID":"ses_1","error":{…}}
+//! ```
+//!
+//! Orbit's envelope finder searches a provider's stdout in reverse for a
+//! recognizable envelope, descending through wrapper objects and JSON-encoded
+//! strings. Handing it the raw stream is unsafe here for two reasons.
+//!
+//! First, `tool_use` frames carry the full tool call and result. An Orbit run
+//! whose agent reads its own task record, or echoes the prompt into a shell
+//! command, replays Orbit's own execution envelope — including the literal
+//! example envelope in the response contract — back inside a tool payload. That
+//! is not model-authored completion evidence and must not be readable as one.
+//!
+//! Second, `reasoning` frames are the model thinking aloud. A draft envelope
+//! written while reasoning is not the answer, and OpenCode emits reasoning and
+//! answer text as separate part types precisely so they stay distinguishable.
+//!
+//! So this module keeps only `text` frames — the assistant's answer parts,
+//! which OpenCode emits only once a part has completed (`part.time.end` is
+//! set) — and concatenates them in stream order. Everything else is dropped:
+//! the session control plane, tool traffic, reasoning, and step boundaries.
+//!
+//! A terminal `error` frame invalidates the whole turn. OpenCode also sets exit
+//! code 1 in that case, and the v2 runner fails closed on a non-zero exit, but
+//! normalization must not depend on the caller checking status: an `error`
+//! frame anywhere in the stream clears the accumulated text so a partially
+//! written envelope from before the failure cannot be projected as success.
+//!
+//! When nothing survives, the result is empty, and empty stdout carries no
+//! envelope — which is exactly how a missing completion is meant to be
+//! reported.
+
+use serde_json::Value;
+
+/// Return the model-authored answer text from an OpenCode `--format json`
+/// stream.
+///
+/// Any malformed, failed, or absent shape normalizes to empty bytes and
+/// therefore cannot satisfy Orbit's completion contract.
+pub(crate) fn normalize_opencode_stdout(stdout: &[u8]) -> Vec<u8> {
+    let stream = String::from_utf8_lossy(stdout);
+    let mut answer = String::new();
+    for line in stream.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // A line that is not JSON is not an OpenCode event. `--print-logs`
+        // sends logs to stderr and never interleaves here, so the tolerant
+        // choice — skip it — keeps a stray banner from discarding a valid
+        // answer without ever letting non-event text reach the envelope
+        // reader.
+        let Ok(event) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        match event.get("type").and_then(Value::as_str) {
+            Some("error") => return Vec::new(),
+            Some("text") => match text_part_content(event.get("part")) {
+                // A `text` event whose `part.text` is absent or not a string is
+                // a malformed frame, not an empty answer. Refuse the whole
+                // stream rather than returning the frames that did parse.
+                None => return Vec::new(),
+                Some(text) => answer.push_str(text),
+            },
+            _ => {}
+        }
+    }
+    answer.into_bytes()
+}
+
+/// Extract the answer text carried by one `text` event's `part`.
+///
+/// `None` means the frame is malformed and the stream cannot be trusted.
+fn text_part_content(part: Option<&Value>) -> Option<&str> {
+    let part = part?.as_object()?;
+    if part.get("type").and_then(Value::as_str) != Some("text") {
+        return None;
+    }
+    part.get("text").and_then(Value::as_str)
+}

--- a/crates/orbit-agent/src/providers/opencode/opencode_runtime.rs
+++ b/crates/orbit-agent/src/providers/opencode/opencode_runtime.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+
+use orbit_common::OrbitError;
+use orbit_types::identity::ReasoningEffort;
+use orbit_types::telemetry::InvocationTrace;
+
+use crate::agent::{AgentConfig, ProviderOptions};
+use crate::providers::opencode::opencode_cli::OpencodeCliTransport;
+use crate::runtime::{AgentRuntime, AgentRuntimeFactory};
+use crate::types::{AgentInvocationSpec, AgentRequest};
+
+const RUNTIME_KEY: &str = "opencode";
+
+/// Non-secret process context required by the local OpenCode CLI.
+///
+/// No `*_API_KEY` appears here. OpenCode resolves credentials from
+/// `opencode auth login` state under its XDG data directory
+/// (`$XDG_DATA_HOME/opencode`, default `$HOME/.local/share/opencode`).
+/// An operator who deliberately uses an API key instead names its variable in
+/// `[execution.env].pass`; Orbit never renders a credential onto argv.
+/// [ORB-11295]
+const REQUIRED_ENV_VARS: &[&str] = &["HOME", "PATH"];
+
+pub(crate) struct OpencodeRuntime {
+    command: String,
+    cli: OpencodeCliTransport,
+    runtime_key: &'static str,
+    required_env_vars: &'static [&'static str],
+}
+
+pub(crate) struct OpencodeFactory;
+
+impl OpencodeRuntime {
+    pub(crate) fn new(
+        command: String,
+        model: Option<String>,
+        reasoning_effort: Option<ReasoningEffort>,
+        runtime_key: &'static str,
+        required_env_vars: &'static [&'static str],
+    ) -> Self {
+        Self {
+            command,
+            cli: OpencodeCliTransport::new(model, reasoning_effort),
+            runtime_key,
+            required_env_vars,
+        }
+    }
+}
+
+impl AgentRuntimeFactory for OpencodeFactory {
+    fn key(&self) -> &'static str {
+        RUNTIME_KEY
+    }
+
+    fn required_env_vars(&self) -> &'static [&'static str] {
+        REQUIRED_ENV_VARS
+    }
+
+    fn options_from_config(
+        &self,
+        _config: &HashMap<String, String>,
+    ) -> Result<ProviderOptions, OrbitError> {
+        Ok(ProviderOptions::Opencode)
+    }
+
+    fn build(&self, cfg: &AgentConfig) -> Result<Box<dyn AgentRuntime>, OrbitError> {
+        match &cfg.provider_options {
+            ProviderOptions::Opencode => Ok(Box::new(OpencodeRuntime::new(
+                cfg.command.clone(),
+                cfg.model.clone(),
+                cfg.reasoning_effort,
+                self.key(),
+                self.required_env_vars(),
+            ))),
+            _ => Err(OrbitError::InvalidInput(format!(
+                "provider options '{}' cannot build opencode runtime",
+                cfg.provider_key
+            ))),
+        }
+    }
+}
+
+impl AgentRuntime for OpencodeRuntime {
+    fn invoke(
+        &self,
+        req: AgentRequest,
+    ) -> Result<(AgentInvocationSpec, InvocationTrace), OrbitError> {
+        Ok((
+            crate::providers::build_invocation_spec(
+                self.runtime_key,
+                self.required_env_vars,
+                self.command.clone(),
+                self.cli.args(),
+                self.cli.stdin(&req.envelope_json),
+            ),
+            // OpenCode reports token usage on `step_finish` parts, which
+            // normalization drops before any Orbit read: those frames are the
+            // provider's own accounting, not the model-authored answer, and
+            // keeping them would put tool traffic back in front of the envelope
+            // reader. Orbit therefore claims no usage here rather than
+            // inventing one; the invocation trace stays whatever the Orbit
+            // response envelope itself declares.
+            InvocationTrace::default(),
+        ))
+    }
+
+    fn model_name(&self) -> Option<&str> {
+        self.cli.model_name()
+    }
+}

--- a/crates/orbit-agent/src/providers/opencode/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/opencode/tests/mod.rs
@@ -1,0 +1,2 @@
+mod opencode_cli;
+mod opencode_output;

--- a/crates/orbit-agent/src/providers/opencode/tests/opencode_cli.rs
+++ b/crates/orbit-agent/src/providers/opencode/tests/opencode_cli.rs
@@ -1,0 +1,129 @@
+#![allow(missing_docs)]
+
+use orbit_types::identity::ReasoningEffort;
+
+use super::super::opencode_cli::OpencodeCliTransport;
+use super::super::opencode_runtime::OpencodeRuntime;
+use crate::runtime::AgentRuntime;
+use crate::types::{AgentOperation, AgentRequest};
+
+#[test]
+fn args_pass_explicit_model_and_variant() {
+    let transport = OpencodeCliTransport::new(
+        Some("anthropic/claude-sonnet-4-5".to_string()),
+        Some(ReasoningEffort::High),
+    );
+
+    assert_eq!(
+        transport.args(),
+        vec![
+            "--model",
+            "anthropic/claude-sonnet-4-5",
+            "--variant",
+            "high"
+        ]
+    );
+}
+
+#[test]
+fn args_are_empty_without_a_model_or_effort() {
+    assert!(OpencodeCliTransport::new(None, None).args().is_empty());
+}
+
+#[test]
+fn model_coordinate_names_the_vendor_inside_the_opencode_lane() {
+    // `--model provider/model` selects the *model vendor*, never the Orbit
+    // executor. No separate provider flag is rendered, and the vendor half of
+    // the coordinate must not leak into a second argument. [ORB-11295]
+    let transport = OpencodeCliTransport::new(Some("openai/gpt-5".to_string()), None);
+
+    assert_eq!(transport.args(), vec!["--model", "openai/gpt-5"]);
+    assert!(!transport.args().iter().any(|arg| arg == "--provider"));
+}
+
+#[test]
+fn only_the_documented_variant_vocabulary_is_admitted_for_opencode() {
+    // OpenCode forwards `--variant` verbatim to the selected model provider and
+    // publishes no provider-independent vocabulary, so admission is restricted
+    // to the spellings its own help text names. An unsupported effort must fail
+    // at configuration time rather than be dropped or remapped at spawn.
+    // [ORB-11295]
+    for effort in [ReasoningEffort::High, ReasoningEffort::Max] {
+        let args = OpencodeCliTransport::new(None, Some(effort)).args();
+        assert_eq!(args, vec!["--variant".to_string(), effort.to_string()]);
+        assert!(
+            effort.validate_for_provider_model("opencode", None).is_ok(),
+            "crew effort '{effort}' must be admitted for opencode",
+        );
+    }
+
+    for effort in [
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::Xhigh,
+    ] {
+        let error = effort
+            .validate_for_provider_model("opencode", Some("anthropic/claude-sonnet-4-5"))
+            .expect_err("unsupported effort must be refused");
+        assert!(
+            error.contains("not remapped"),
+            "rejection must state that values are not remapped: {error}",
+        );
+    }
+}
+
+#[test]
+fn prompt_travels_on_stdin_and_never_through_argv() {
+    let envelope = br#"{"schemaVersion":1,"input":{"secret_path":"/srv/tenant-42"}}"#;
+    let transport = OpencodeCliTransport::new(
+        Some("anthropic/claude-sonnet-4-5".to_string()),
+        Some(ReasoningEffort::Max),
+    );
+
+    let stdin = String::from_utf8(transport.stdin(envelope)).expect("utf8 stdin");
+    assert!(stdin.contains("/srv/tenant-42"));
+    assert!(stdin.contains("Execution envelope:"));
+
+    let argv = transport.args().join(" ");
+    assert!(!argv.contains("/srv/tenant-42"));
+    assert!(!argv.contains("schemaVersion"));
+}
+
+#[test]
+fn model_name_reports_the_selected_model() {
+    assert_eq!(
+        OpencodeCliTransport::new(Some("openai/gpt-5".to_string()), None).model_name(),
+        Some("openai/gpt-5")
+    );
+    assert_eq!(OpencodeCliTransport::new(None, None).model_name(), None);
+}
+
+#[test]
+fn runtime_requires_state_context_but_never_implicitly_forwards_an_api_key() {
+    let runtime = OpencodeRuntime::new(
+        "opencode".to_string(),
+        Some("anthropic/claude-sonnet-4-5".to_string()),
+        Some(ReasoningEffort::High),
+        "opencode",
+        &["HOME", "PATH"],
+    );
+    let (invocation, trace) = runtime
+        .invoke(AgentRequest {
+            operation: AgentOperation::Activity {
+                activity_id: "opencode-auth-env".to_string(),
+            },
+            envelope_json: br#"{"schemaVersion":1,"input":{}}"#.to_vec(),
+            verbose: false,
+        })
+        .expect("render invocation");
+
+    assert_eq!(invocation.required_env_vars, &["HOME", "PATH"]);
+    assert!(
+        !invocation
+            .required_env_vars
+            .iter()
+            .any(|var| var.ends_with("API_KEY"))
+    );
+    // Usage is not fabricated from a stream Orbit reduces away.
+    assert_eq!(trace, orbit_types::telemetry::InvocationTrace::default());
+}

--- a/crates/orbit-agent/src/providers/opencode/tests/opencode_output.rs
+++ b/crates/orbit-agent/src/providers/opencode/tests/opencode_output.rs
@@ -1,0 +1,226 @@
+#![allow(missing_docs)]
+
+use orbit_types::tool::ExecutionResult;
+use serde_json::json;
+
+use crate::providers::normalize_cli_stdout;
+use crate::types::{AgentResponseStatus, parse_and_validate_response};
+
+const ORBIT_SUCCESS: &str =
+    r#"{"schemaVersion":1,"status":"success","result":{"edited":true},"error":null}"#;
+
+/// The literal example envelope every Orbit prompt embeds in its response
+/// contract. An OpenCode agent that reads its own task record or echoes the
+/// prompt through a shell tool replays this inside a `tool_use` frame, so a
+/// normalizer that read the whole stream could mistake Orbit's own instructions
+/// for the agent's completion evidence. [ORB-11295]
+const PROMPT_ECHO_ENVELOPE: &str =
+    r#"{"schemaVersion":1,"status":"success|failed|timeout","result":{},"error":null}"#;
+
+const SESSION_ID: &str = "ses_7f3a";
+
+fn event(kind: &str, data: serde_json::Value) -> serde_json::Value {
+    let mut event = json!({
+        "type": kind,
+        "timestamp": 1_762_000_000_000i64,
+        "sessionID": SESSION_ID,
+    });
+    let object = event.as_object_mut().expect("event object");
+    for (key, value) in data.as_object().expect("data object") {
+        object.insert(key.clone(), value.clone());
+    }
+    event
+}
+
+fn text_event(text: &str) -> serde_json::Value {
+    event(
+        "text",
+        json!({"part": {
+            "id": "prt_text",
+            "type": "text",
+            "sessionID": SESSION_ID,
+            "text": text,
+            "time": {"start": 1_762_000_000_000i64, "end": 1_762_000_000_500i64},
+        }}),
+    )
+}
+
+/// A full OpenCode `--format json` stream for one successful turn, in the
+/// documented event order.
+fn opencode_stream(final_text: &str) -> String {
+    [
+        event(
+            "step_start",
+            json!({"part": {"id": "prt_step", "type": "step-start", "sessionID": SESSION_ID}}),
+        ),
+        event(
+            "reasoning",
+            json!({"part": {
+                "id": "prt_reason",
+                "type": "reasoning",
+                "sessionID": SESSION_ID,
+                // A draft envelope written while thinking aloud is not the
+                // answer and must not be readable as one.
+                "text": PROMPT_ECHO_ENVELOPE,
+                "time": {"start": 1i64, "end": 2i64},
+            }}),
+        ),
+        event(
+            "tool_use",
+            json!({"part": {
+                "id": "prt_tool",
+                "type": "tool",
+                "tool": "bash",
+                "sessionID": SESSION_ID,
+                "state": {
+                    "status": "completed",
+                    "input": {"command": "orbit task show ORB-1"},
+                    "output": PROMPT_ECHO_ENVELOPE,
+                },
+            }}),
+        ),
+        text_event(final_text),
+        event(
+            "step_finish",
+            json!({"part": {
+                "id": "prt_stepend",
+                "type": "step-finish",
+                "sessionID": SESSION_ID,
+                "tokens": {"input": 120, "output": 40},
+            }}),
+        ),
+    ]
+    .iter()
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
+    ExecutionResult {
+        success: exit_code == 0,
+        stdout: String::from_utf8(normalize_cli_stdout("opencode", stdout.as_bytes()).into_owned())
+            .expect("utf8 normalized stdout"),
+        stderr: stderr.to_string(),
+        exit_code: Some(exit_code),
+        duration_ms: 1_200,
+        output: None,
+    }
+}
+
+#[test]
+fn documented_stream_yields_the_assistant_answer_text() {
+    let stdout = opencode_stream(ORBIT_SUCCESS);
+
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec_result(&stdout, "", 0)).expect("parse success envelope");
+
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(envelope.status, "success");
+}
+
+#[test]
+fn tool_and_reasoning_frames_are_never_read_as_completion_evidence() {
+    // Same stream with the assistant's answer removed: the run produced tool
+    // traffic and thinking that both echo Orbit's own prompt, but no answer.
+    let stdout = opencode_stream(ORBIT_SUCCESS)
+        .lines()
+        .filter(|line| !line.contains(r#""type":"text""#))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let normalized = normalize_cli_stdout("opencode", stdout.as_bytes());
+    assert!(normalized.is_empty());
+    assert!(!String::from_utf8_lossy(&normalized).contains("schemaVersion"));
+}
+
+#[test]
+fn successive_answer_parts_concatenate_in_stream_order() {
+    let stdout = format!(
+        "{}\n{}",
+        text_event(r#"{"schemaVersion":1,"status":"success","#),
+        text_event(r#""result":{"edited":true},"error":null}"#),
+    );
+
+    let normalized = normalize_cli_stdout("opencode", stdout.as_bytes());
+    assert_eq!(String::from_utf8_lossy(&normalized), ORBIT_SUCCESS);
+}
+
+#[test]
+fn a_terminal_error_frame_invalidates_prior_answer_text() {
+    // OpenCode also exits 1 here, and the v2 runner fails closed on a non-zero
+    // exit, but normalization must not depend on the caller checking status.
+    let stdout = format!(
+        "{}\n{}",
+        text_event(ORBIT_SUCCESS),
+        event(
+            "error",
+            json!({"error": {
+                "name": "ProviderAuthError",
+                "data": {"message": "no credentials for provider anthropic"},
+            }}),
+        ),
+    );
+
+    assert!(
+        normalize_cli_stdout("opencode", stdout.as_bytes()).is_empty(),
+        "a terminal error frame must carry no completion evidence",
+    );
+}
+
+#[test]
+fn a_malformed_text_frame_refuses_the_whole_stream() {
+    for malformed in [
+        // `part.text` absent.
+        event(
+            "text",
+            json!({"part": {"id": "p", "type": "text", "sessionID": SESSION_ID}}),
+        ),
+        // `part.text` is not a string.
+        event(
+            "text",
+            json!({"part": {"id": "p", "type": "text", "sessionID": SESSION_ID, "text": 42}}),
+        ),
+        // `part` is not a text part.
+        event(
+            "text",
+            json!({"part": {"id": "p", "type": "reasoning", "sessionID": SESSION_ID, "text": "x"}}),
+        ),
+        // `part` absent entirely.
+        event("text", json!({})),
+    ] {
+        let stdout = format!("{}\n{malformed}", text_event(ORBIT_SUCCESS));
+        assert!(
+            normalize_cli_stdout("opencode", stdout.as_bytes()).is_empty(),
+            "malformed text frame must invalidate the stream: {malformed}",
+        );
+    }
+}
+
+#[test]
+fn absent_or_unparseable_output_yields_no_completion_evidence() {
+    for stdout in [
+        String::new(),
+        "not json".to_string(),
+        "{\"type\":\"text\"".to_string(),
+        // Only control-plane frames: no answer was ever produced.
+        event("step_start", json!({"part": {"type": "step-start"}})).to_string(),
+    ] {
+        let normalized = normalize_cli_stdout("opencode", stdout.as_bytes());
+        assert!(
+            normalized.is_empty(),
+            "stdout '{stdout}' must carry no completion evidence",
+        );
+        assert!(parse_and_validate_response(&exec_result(&stdout, "", 0)).is_err());
+    }
+}
+
+#[test]
+fn a_nonzero_exit_fails_even_when_the_stream_carried_an_answer() {
+    let stdout = opencode_stream(ORBIT_SUCCESS);
+
+    assert!(
+        parse_and_validate_response(&exec_result(&stdout, "session error", 1)).is_err(),
+        "exit status and envelope are independent evidence; both must be valid",
+    );
+}

--- a/crates/orbit-agent/src/runtime/backend.rs
+++ b/crates/orbit-agent/src/runtime/backend.rs
@@ -60,6 +60,7 @@ impl Default for ProviderRegistry {
         let _ = registry.register(Arc::new(crate::providers::cursor::CursorFactory));
         let _ = registry.register(Arc::new(crate::providers::ollama::OllamaFactory));
         let _ = registry.register(Arc::new(crate::providers::pi::PiFactory));
+        let _ = registry.register(Arc::new(crate::providers::opencode::OpencodeFactory));
         registry
     }
 }

--- a/crates/orbit-cli/src/command/init/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/agent_detect.rs
@@ -93,6 +93,11 @@ pub struct DetectedAgents {
     /// run, so a detected `pi` is evidence of the Pi execution lane only, never
     /// of an Anthropic/OpenAI/Google lane. [ORB-11296]
     pub pi_cli: bool,
+    /// The OpenCode CLI, whose binary is `opencode`. OpenCode's own
+    /// `--model provider/model` names the model vendor behind a run, so a
+    /// detected `opencode` is evidence of the OpenCode execution lane only,
+    /// never of an Anthropic/OpenAI/Google lane. [ORB-11295]
+    pub opencode_cli: bool,
     pub ollama_cli: bool,
 }
 
@@ -108,6 +113,7 @@ pub fn detect(probe: &dyn AgentEnvProbe) -> DetectedAgents {
         copilot_cli: probe.binary_on_path("copilot"),
         cursor_cli: probe.binary_on_path("cursor-agent"),
         pi_cli: probe.binary_on_path("pi"),
+        opencode_cli: probe.binary_on_path("opencode"),
         ollama_cli: probe.binary_on_path("ollama"),
     }
 }
@@ -143,6 +149,9 @@ pub fn available_crew_families(detected: &DetectedAgents) -> Vec<&'static str> {
     if detected.pi_cli {
         families.push("pi");
     }
+    if detected.opencode_cli {
+        families.push("opencode");
+    }
     families
 }
 
@@ -159,10 +168,12 @@ pub fn default_model_for(provider: &str) -> Option<&'static str> {
 /// Pick a default provider for the role given a detection snapshot.
 ///
 /// Preference order: first detected CLI in [claude, codex, antigravity,
-/// gemini, grok, copilot, cursor, pi, ollama], else `claude` as a last
-/// resort. Antigravity (`agy`) occupies Gemini CLI's previous slot so a host
-/// with both prefers the current Google terminal CLI. [ORB-10946] [ORB-10945]
-/// [ORB-11296] [ORB-11299]
+/// gemini, grok, copilot, cursor, pi, opencode, ollama], else `claude` as a
+/// last resort. Antigravity (`agy`) occupies Gemini CLI's previous slot so a
+/// host with both prefers the current Google terminal CLI. OpenCode is
+/// appended after the existing lanes so adding it cannot change what an
+/// already-provisioned host would pick. [ORB-10946] [ORB-10945] [ORB-11296]
+/// [ORB-11299] [ORB-11295]
 pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     if detected.claude_cli {
         return "claude";
@@ -187,6 +198,9 @@ pub fn default_provider(detected: &DetectedAgents) -> &'static str {
     }
     if detected.pi_cli {
         return "pi";
+    }
+    if detected.opencode_cli {
+        return "opencode";
     }
     if detected.ollama_cli {
         return "ollama";

--- a/crates/orbit-cli/src/command/init/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/agent_prompt.rs
@@ -115,11 +115,12 @@ pub(crate) fn collect_system_crew_setting(
 
 /// Cheap-tier system options in the same preference order as
 /// `orbit-config::default_system_crew`: Codex Luna, Claude Sonnet, Grok,
-/// Antigravity Flash, Gemini Flash, Copilot Haiku, Cursor, Pi.
+/// Antigravity Flash, Gemini Flash, Copilot Haiku, Cursor, Pi, OpenCode.
 fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
     use orbit_common::model_defaults::{
         ANTIGRAVITY_CREW_MODEL, CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL,
-        CURSOR_CREW_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, PI_CREW_MODEL,
+        CURSOR_CREW_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, OPENCODE_CREW_MODEL,
+        PI_CREW_MODEL,
     };
     let mut options = Vec::new();
     for (enabled, provider, model) in [
@@ -135,6 +136,7 @@ fn system_crew_options(detected: &DetectedAgents) -> Vec<CrewSeed> {
         (detected.copilot_cli, "copilot", COPILOT_CREW_MODEL),
         (detected.cursor_cli, "cursor", CURSOR_CREW_MODEL),
         (detected.pi_cli, "pi", PI_CREW_MODEL),
+        (detected.opencode_cli, "opencode", OPENCODE_CREW_MODEL),
     ] {
         if enabled {
             options.push(CrewSeed {
@@ -172,6 +174,7 @@ fn system_crew_label(option: &CrewSeed) -> &'static str {
         Some("copilot") => "Copilot",
         Some("cursor") => "Cursor",
         Some("pi") => "Pi",
+        Some("opencode") => "OpenCode",
         _ => "Agent",
     }
 }
@@ -246,7 +249,7 @@ struct AgentFamily {
     provider: &'static str,
 }
 
-const AGENT_FAMILIES: [AgentFamily; 9] = [
+const AGENT_FAMILIES: [AgentFamily; 10] = [
     AgentFamily {
         label: "Claude CLI",
         provider: "claude",
@@ -280,6 +283,10 @@ const AGENT_FAMILIES: [AgentFamily; 9] = [
         provider: "pi",
     },
     AgentFamily {
+        label: "OpenCode CLI",
+        provider: "opencode",
+    },
+    AgentFamily {
         label: "Ollama CLI",
         provider: "ollama",
     },
@@ -295,6 +302,7 @@ fn agent_families(detected: &DetectedAgents) -> impl Iterator<Item = (AgentFamil
         detected.copilot_cli,
         detected.cursor_cli,
         detected.pi_cli,
+        detected.opencode_cli,
         detected.ollama_cli,
     ])
 }

--- a/crates/orbit-cli/src/command/init/tests/agent_detect.rs
+++ b/crates/orbit-cli/src/command/init/tests/agent_detect.rs
@@ -65,6 +65,7 @@ fn default_provider_prefers_cli_in_documented_order() {
         copilot_cli: true,
         cursor_cli: true,
         pi_cli: true,
+        opencode_cli: true,
         ollama_cli: true,
     };
     assert_eq!(default_provider(&detected), "claude");
@@ -140,6 +141,23 @@ fn default_provider_prefers_cli_in_documented_order() {
         ..DetectedAgents::default()
     };
     assert_eq!(default_provider(&detected), "pi");
+
+    // opencode wins over ollama when the earlier agent families are absent, and
+    // an installed opencode does not displace pi. [ORB-11295]
+    let detected = DetectedAgents {
+        pi_cli: true,
+        opencode_cli: true,
+        ollama_cli: true,
+        ..DetectedAgents::default()
+    };
+    assert_eq!(default_provider(&detected), "pi");
+
+    let detected = DetectedAgents {
+        opencode_cli: true,
+        ollama_cli: true,
+        ..DetectedAgents::default()
+    };
+    assert_eq!(default_provider(&detected), "opencode");
 
     // ollama wins when nothing else
     let detected = DetectedAgents {

--- a/crates/orbit-cli/src/command/init/tests/agent_prompt.rs
+++ b/crates/orbit-cli/src/command/init/tests/agent_prompt.rs
@@ -79,7 +79,7 @@ fn detected_agents_lists_every_family_when_only_copilot_is_present() {
 
     assert_eq!(result.provider.as_deref(), Some("copilot"));
     assert!(prompter.transcript().contains(
-        "Detected agents:\n  Claude CLI         not found\n  Codex CLI          not found\n  Antigravity CLI    not found\n  Gemini CLI         not found\n  Grok CLI           not found\n  Copilot CLI        found\n  Cursor Agent CLI   not found\n  Pi CLI             not found\n  Ollama CLI         not found"
+        "Detected agents:\n  Claude CLI         not found\n  Codex CLI          not found\n  Antigravity CLI    not found\n  Gemini CLI         not found\n  Grok CLI           not found\n  Copilot CLI        found\n  Cursor Agent CLI   not found\n  Pi CLI             not found\n  OpenCode CLI       not found\n  Ollama CLI         not found"
     ));
 }
 

--- a/crates/orbit-common/src/model_defaults.rs
+++ b/crates/orbit-common/src/model_defaults.rs
@@ -122,6 +122,22 @@ pub const PI_DEFAULT_MODEL: &str = "sonnet";
 /// wants a cheaper tier names one explicitly in `[crews.system]`.
 pub const PI_CREW_MODEL: &str = PI_DEFAULT_MODEL;
 
+/// Default model for the OpenCode execution lane.
+///
+/// OpenCode addresses models as a `provider/model` coordinate, where the
+/// leading segment names the *model vendor* inside the OpenCode lane — never
+/// the Orbit executor, which stays `opencode` whichever vendor is selected.
+/// The coordinate must be fully qualified: OpenCode splits on the first `/`
+/// and looks the vendor up in its provider catalog, so a bare model id does
+/// not resolve. [ORB-11295]
+pub const OPENCODE_DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-5";
+
+/// Model used for OpenCode's bounded system crew. OpenCode publishes no
+/// vendor-independent cheap tier, so this names the cheap tier of the same
+/// vendor as [`OPENCODE_DEFAULT_MODEL`]; an operator who prefers another
+/// vendor names one explicitly in `[crews.system]`.
+pub const OPENCODE_CREW_MODEL: &str = "anthropic/claude-haiku-4-5";
+
 /// Cheap Claude model used by the orbit-agent HTTP examples.
 ///
 /// Version pinned like [`ANTHROPIC_HTTP_DEFAULT_MODEL`] because the examples

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -16,7 +16,8 @@ use orbit_common::OrbitError;
 use orbit_common::model_defaults::{
     ANTIGRAVITY_DEFAULT_MODEL, CLAUDE_DEFAULT_STRONG, CLAUDE_DEFAULT_WEAK, CLAUDE_FABLE_MODEL,
     CODEX_ASTRA_MODEL, CODEX_LUNA_MODEL, CODEX_SOL_MODEL, CODEX_TERRA_MODEL, COPILOT_DEFAULT_MODEL,
-    CURSOR_DEFAULT_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, PI_DEFAULT_MODEL,
+    CURSOR_DEFAULT_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, OPENCODE_DEFAULT_MODEL,
+    PI_DEFAULT_MODEL,
 };
 use orbit_common::security::child_env::{allowlisted_child_env, inherited_child_env};
 use orbit_common::security::redaction::redact_home_dir;
@@ -216,6 +217,7 @@ pub(crate) fn default_crews() -> BTreeMap<String, Crew> {
         ("copilot", COPILOT_DEFAULT_MODEL, "copilot"),
         ("cursor", CURSOR_DEFAULT_MODEL, "cursor"),
         ("pi", PI_DEFAULT_MODEL, "pi"),
+        ("opencode", OPENCODE_DEFAULT_MODEL, "opencode"),
         // [ORB-10877] Shipped job steps name `system` directly, so the
         // built-in set used by a config with no `[crews]` table must define it
         // or those pipelines fail validation. `orbit init` overwrites this with

--- a/crates/orbit-config/src/seed.rs
+++ b/crates/orbit-config/src/seed.rs
@@ -23,8 +23,9 @@ pub(crate) const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../assets/default
 /// Antigravity occupies Gemini's previous default-provider slot so a host
 /// with `agy` prefers the current Google terminal CLI. Legacy `gemini` stays
 /// later so enterprise Gemini CLI-only hosts still seed. Copilot, Cursor, and
-/// Pi remain appended after the original families. [ORB-10946] [ORB-10945]
-/// [ORB-11296] [ORB-11299]
+/// Pi remain appended after the original families, and OpenCode after those,
+/// so adding a lane never reorders an existing host's preference.
+/// [ORB-10946] [ORB-10945] [ORB-11296] [ORB-11299] [ORB-11295]
 const CREW_FAMILY_PREFERENCE: &[&str] = &[
     "claude",
     "codex",
@@ -34,6 +35,7 @@ const CREW_FAMILY_PREFERENCE: &[&str] = &[
     "copilot",
     "cursor",
     "pi",
+    "opencode",
 ];
 
 /// Explicit, host-independent inputs for rendering a fresh `config.toml`.
@@ -172,6 +174,7 @@ fn default_crew_name(seed: &ConfigSeed) -> Option<&'static str> {
             "copilot" => "copilot",
             "cursor" => "cursor",
             "pi" => "pi",
+            "opencode" => "opencode",
             _ => unreachable!("available crew families are fixed"),
         })
 }
@@ -260,7 +263,8 @@ fn render_crews(seed: &ConfigSeed) -> Result<String, OrbitError> {
 fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
     use orbit_common::model_defaults::{
         ANTIGRAVITY_CREW_MODEL, CLAUDE_DEFAULT_WEAK, CODEX_LUNA_MODEL, COPILOT_CREW_MODEL,
-        CURSOR_CREW_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, PI_CREW_MODEL,
+        CURSOR_CREW_MODEL, GEMINI_CREW_MODEL, GROK_DEFAULT_MODEL, OPENCODE_CREW_MODEL,
+        PI_CREW_MODEL,
     };
     let (provider, model) = if seed.has_family("codex") {
         ("codex", CODEX_LUNA_MODEL)
@@ -278,6 +282,8 @@ fn default_system_crew(seed: &ConfigSeed) -> Option<CrewSeed> {
         ("cursor", CURSOR_CREW_MODEL)
     } else if seed.has_family("pi") {
         ("pi", PI_CREW_MODEL)
+    } else if seed.has_family("opencode") {
+        ("opencode", OPENCODE_CREW_MODEL)
     } else {
         return None;
     };

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -31,10 +31,10 @@ fn built_in_crews_use_standard_model_specific_names() {
     // lane. [ORB-10877] It is built in because shipped job steps name it
     // directly, so a config with no `[crews]` table must still resolve it.
     //
-    // `copilot`, `cursor`, `pi`, and `antigravity` are provider-lane
-    // exceptions: each can route to models supplied by several vendors, so the
-    // crew names retain the execution provider identity. [ORB-10946]
-    // [ORB-10945] [ORB-11296] [ORB-11299]
+    // `copilot`, `cursor`, `pi`, `antigravity`, and `opencode` are
+    // provider-lane exceptions: each can route to models supplied by several
+    // vendors, so the crew names retain the execution provider identity.
+    // [ORB-10946] [ORB-10945] [ORB-11296] [ORB-11299] [ORB-11295]
     assert_eq!(
         crews.keys().map(String::as_str).collect::<Vec<_>>(),
         vec![
@@ -46,6 +46,7 @@ fn built_in_crews_use_standard_model_specific_names() {
             "gemini",
             "grok",
             "luna",
+            "opencode",
             "opus",
             "pi",
             "sol",
@@ -68,6 +69,7 @@ fn built_in_crews_use_standard_model_specific_names() {
         ("copilot", "copilot", "claude-sonnet-4.5"),
         ("cursor", "cursor", "gpt-5"),
         ("pi", "pi", "sonnet"),
+        ("opencode", "opencode", "anthropic/claude-sonnet-4-5"),
         ("system", "claude", "sonnet"),
     ] {
         let assignment = &crews.get(name).expect("built-in crew").assignment;

--- a/crates/orbit-config/src/tests/seed.rs
+++ b/crates/orbit-config/src/tests/seed.rs
@@ -164,6 +164,38 @@ fn adding_pi_never_displaces_an_earlier_family() {
     assert_crew(&parsed, "pi", "pi", "sonnet");
 }
 
+#[test]
+fn opencode_only_seeds_opencode_and_a_system_crew() {
+    let contents = seed_contents(&seed_for(&["opencode"]));
+    let parsed = parsed_config(&contents);
+
+    assert_eq!(crew_names(&parsed), vec!["opencode", "system"]);
+    assert_crew(
+        &parsed,
+        "opencode",
+        "opencode",
+        "anthropic/claude-sonnet-4-5",
+    );
+    assert_crew(&parsed, "system", "opencode", "anthropic/claude-haiku-4-5");
+    assert_default_crew(&parsed, Some("opencode"));
+}
+
+/// [ORB-11295] OpenCode is appended last in the preference order, so installing
+/// it beside an earlier family never moves that host's default or system crew.
+#[test]
+fn adding_opencode_never_displaces_an_earlier_family() {
+    let parsed = parsed_config(&seed_contents(&seed_for(&["claude", "pi", "opencode"])));
+
+    assert_default_crew(&parsed, Some("opus"));
+    assert_crew(&parsed, "system", "claude", "sonnet");
+    assert_crew(
+        &parsed,
+        "opencode",
+        "opencode",
+        "anthropic/claude-sonnet-4-5",
+    );
+}
+
 /// Orbit ships no `ollama` crew, so a host whose only agent CLI is ollama
 /// seeds an explicitly empty registry rather than a dangling default.
 #[test]

--- a/crates/orbit-core/assets/executors/opencode.yaml
+++ b/crates/orbit-core/assets/executors/opencode.yaml
@@ -1,0 +1,32 @@
+schemaVersion: 2
+kind: Executor
+metadata:
+  name: opencode
+spec:
+  executor_type: direct_agent
+  command: opencode
+  # OpenCode headless contract (opencode 1.18.29). Static flags only. The
+  # prompt is NOT passed here: `opencode run` reads piped stdin whenever stdin
+  # is not a TTY and uses it as the whole message when no positional
+  # `[message..]` is given, which keeps the Orbit execution envelope out of
+  # argv and therefore out of process listings and audit records. [ORB-11295]
+  args:
+    # Non-interactive subcommand. Without it the CLI starts its TUI.
+    - run
+    # Raw JSON event stream, one object per line, shaped
+    # `{type, timestamp, sessionID, ...}`. Orbit reads only the assistant
+    # `text` parts; see the `opencode` stdout adapter for why `tool_use` and
+    # `reasoning` frames are dropped rather than searched.
+    - --format
+    - json
+    # Required for unattended runs. Without it OpenCode *auto-rejects* every
+    # permission request and the turn cannot touch the worktree. This is the
+    # documented non-interactive analog of an interactive approval, not a
+    # security boundary: Orbit's OS sandbox remains the filesystem/network
+    # boundary and the activity `fsProfile` stays authoritative for the
+    # worktree.
+    - --auto
+  stdout_format: envelope
+  sandbox: macos-sandbox-exec
+  model_flag: "--model"
+  env: {}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -358,6 +358,7 @@ fn append_linux_provider_state_roots(
     directories.extend(linux_copilot_state_roots(provider, home.as_deref()));
     directories.extend(linux_cursor_state_roots_with(provider, home.as_deref()));
     directories.extend(linux_pi_state_roots(provider, home.as_deref()));
+    directories.extend(linux_opencode_state_roots(provider, home.as_deref()));
     for directory in directories {
         ensure_owned_directory(&directory)?;
         let canonical = directory.canonicalize().map_err(|error| {
@@ -418,6 +419,76 @@ pub(super) fn linux_pi_state_roots_with(
         Some(path) => vec![path.to_path_buf()],
         None => home.map(|home| vec![home.join(".pi")]).unwrap_or_default(),
     }
+}
+
+/// Process-env wrapper around [`linux_opencode_state_roots_with`].
+#[cfg(target_os = "linux")]
+fn linux_opencode_state_roots(provider: &str, home: Option<&Path>) -> Vec<PathBuf> {
+    let env_path = |name: &str| std::env::var_os(name).map(PathBuf::from);
+    linux_opencode_state_roots_with(
+        provider,
+        home,
+        OpencodeStateEnv {
+            xdg_data_home: env_path("XDG_DATA_HOME"),
+            xdg_config_home: env_path("XDG_CONFIG_HOME"),
+            xdg_state_home: env_path("XDG_STATE_HOME"),
+            xdg_cache_home: env_path("XDG_CACHE_HOME"),
+            opencode_config_dir: env_path("OPENCODE_CONFIG_DIR"),
+        },
+    )
+}
+
+/// XDG roots that locate OpenCode's writable state on Linux.
+#[cfg(target_os = "linux")]
+#[derive(Default, Clone)]
+pub(super) struct OpencodeStateEnv {
+    pub(super) xdg_data_home: Option<PathBuf>,
+    pub(super) xdg_config_home: Option<PathBuf>,
+    pub(super) xdg_state_home: Option<PathBuf>,
+    pub(super) xdg_cache_home: Option<PathBuf>,
+    pub(super) opencode_config_dir: Option<PathBuf>,
+}
+
+/// Writable state roots for an active OpenCode executor on Linux.
+///
+/// OpenCode resolves every root through `xdg-basedir` and creates its data,
+/// config, and state directories at startup, before it reads Orbit's envelope.
+/// The data root holds `auth.json` from `opencode auth login`, the session and
+/// message stores, and logs. No other provider receives this grant — every
+/// entry in the caller's list is *created* by `ensure_owned_directory`, so an
+/// unconditional entry would mkdir an `~/.local/share/opencode` on hosts that
+/// never installed OpenCode. [ORB-11295]
+#[cfg(target_os = "linux")]
+pub(super) fn linux_opencode_state_roots_with(
+    provider: &str,
+    home: Option<&Path>,
+    env: OpencodeStateEnv,
+) -> Vec<PathBuf> {
+    if orbit_types::workflow::Provider::parse(provider).ok()
+        != Some(orbit_types::workflow::Provider::Opencode)
+    {
+        return Vec::new();
+    }
+    let scoped = |xdg_base: Option<PathBuf>, home_relative_default: &[&str]| -> Option<PathBuf> {
+        let base = xdg_base.or_else(|| {
+            home.map(|home| {
+                home_relative_default
+                    .iter()
+                    .fold(home.to_path_buf(), |path, segment| path.join(segment))
+            })
+        })?;
+        Some(base.join("opencode"))
+    };
+    [
+        scoped(env.xdg_data_home, &[".local", "share"]),
+        env.opencode_config_dir
+            .or_else(|| scoped(env.xdg_config_home, &[".config"])),
+        scoped(env.xdg_state_home, &[".local", "state"]),
+        scoped(env.xdg_cache_home, &[".cache"]),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 /// Process-env wrapper around [`linux_copilot_state_roots_with`].

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -907,6 +907,97 @@ mod cursor_state_roots {
 }
 
 #[cfg(target_os = "linux")]
+mod opencode_state_roots {
+    use std::path::{Path, PathBuf};
+
+    use crate::adapter::engine_host::v2_host::sandbox::{
+        OpencodeStateEnv, linux_opencode_state_roots_with,
+    };
+
+    #[test]
+    fn active_opencode_gets_its_four_xdg_roots_from_home_defaults() {
+        assert_eq!(
+            linux_opencode_state_roots_with(
+                "opencode",
+                Some(Path::new("/home/test")),
+                OpencodeStateEnv::default(),
+            ),
+            vec![
+                PathBuf::from("/home/test/.local/share/opencode"),
+                PathBuf::from("/home/test/.config/opencode"),
+                PathBuf::from("/home/test/.local/state/opencode"),
+                PathBuf::from("/home/test/.cache/opencode"),
+            ]
+        );
+        assert!(
+            linux_opencode_state_roots_with("opencode", None, OpencodeStateEnv::default())
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn xdg_variables_and_the_config_override_replace_the_home_defaults() {
+        assert_eq!(
+            linux_opencode_state_roots_with(
+                "opencode",
+                Some(Path::new("/home/test")),
+                OpencodeStateEnv {
+                    xdg_data_home: Some(PathBuf::from("/srv/data")),
+                    xdg_config_home: Some(PathBuf::from("/srv/config")),
+                    xdg_state_home: Some(PathBuf::from("/srv/state")),
+                    xdg_cache_home: Some(PathBuf::from("/srv/cache")),
+                    opencode_config_dir: None,
+                },
+            ),
+            vec![
+                PathBuf::from("/srv/data/opencode"),
+                PathBuf::from("/srv/config/opencode"),
+                PathBuf::from("/srv/state/opencode"),
+                PathBuf::from("/srv/cache/opencode"),
+            ]
+        );
+
+        // `OPENCODE_CONFIG_DIR` is the config root itself, not an XDG base, so
+        // it is used verbatim and outranks `XDG_CONFIG_HOME`.
+        let roots = linux_opencode_state_roots_with(
+            "opencode",
+            Some(Path::new("/home/test")),
+            OpencodeStateEnv {
+                xdg_config_home: Some(PathBuf::from("/srv/config")),
+                opencode_config_dir: Some(PathBuf::from("/srv/opencode-config")),
+                ..OpencodeStateEnv::default()
+            },
+        );
+        assert_eq!(roots[1], PathBuf::from("/srv/opencode-config"));
+    }
+
+    #[test]
+    fn other_and_unknown_providers_get_nothing() {
+        for provider in [
+            "claude",
+            "codex",
+            "gemini",
+            "grok",
+            "copilot",
+            "cursor",
+            "pi",
+            "ollama",
+            "not-a-provider",
+        ] {
+            assert!(
+                linux_opencode_state_roots_with(
+                    provider,
+                    Some(Path::new("/home/test")),
+                    OpencodeStateEnv::default(),
+                )
+                .is_empty(),
+                "{provider} must not inherit OpenCode state roots",
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
 mod pi_state_roots {
     use std::path::{Path, PathBuf};
 

--- a/crates/orbit-core/src/application/executor.rs
+++ b/crates/orbit-core/src/application/executor.rs
@@ -19,6 +19,10 @@ pub(crate) const DEFAULT_EXECUTOR_FILES: &[(&str, &str)] = &[
     ("cursor", include_str!("../../assets/executors/cursor.yaml")),
     ("pi", include_str!("../../assets/executors/pi.yaml")),
     (
+        "opencode",
+        include_str!("../../assets/executors/opencode.yaml"),
+    ),
+    (
         "local-shell",
         include_str!("../../assets/executors/local-shell.yaml"),
     ),

--- a/crates/orbit-core/src/application/tests/executor.rs
+++ b/crates/orbit-core/src/application/tests/executor.rs
@@ -25,6 +25,7 @@ const SANDBOXED_SHIPPED: &[&str] = &[
     "copilot",
     "cursor",
     "pi",
+    "opencode",
 ];
 
 fn base_def(name: &str, executor_type: ExecutorType) -> ExecutorDef {

--- a/crates/orbit-core/tests/opencode_fake_agent.rs
+++ b/crates/orbit-core/tests/opencode_fake_agent.rs
@@ -1,0 +1,408 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used)]
+// [ORB-11295] Deterministic end-to-end coverage for the OpenCode executor. The
+// fake binary exercises Orbit's real runtime, runner, NDJSON adapter, and
+// shipped executor asset without network access or credentials.
+//
+// Contract verified against opencode 1.18.29 (`packages/opencode`): the
+// published CLI reference at https://opencode.ai/docs/cli/ for the flag
+// spellings, `src/cli/cmd/run.ts` for stdin prompt handling
+// (`process.stdin.isTTY ? undefined : await Bun.stdin.text()` fed through
+// `resolveRunInput`), the `--format json` event emitter, and the exit-code
+// paths this fake reproduces.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use orbit_core::OrbitRuntime;
+use orbit_engine::{DispatchOutcome, V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+use orbit_types::identity::ReasoningEffort;
+use orbit_types::resource::{EXECUTOR_RESOURCE_SCHEMA_VERSION, ExecutorResource};
+use orbit_types::workflow::ExecutorDef;
+use orbit_types::workflow::activity_job::{ActivityV2Spec, AgentLoopSpec, OnDenial, Provider};
+
+const PROMPT_SECRET: &str = "opencode-tenant-42-authorization-bearer-zzz";
+const SUCCESS_ENVELOPE: &str =
+    r#"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"edited\":true},\"error\":null}"#;
+const MODEL: &str = "anthropic/claude-sonnet-4-5";
+
+fn fake_opencode(
+    dir: &Path,
+    body: &str,
+    argv_path: &Path,
+    stdin_path: &Path,
+    cwd_path: &Path,
+) -> PathBuf {
+    let program = dir.join("opencode");
+    let script = format!(
+        r#"#!/bin/sh
+: > '{argv}'
+for arg in "$@"; do printf '%s\n' "$arg" >> '{argv}'; done
+pwd > '{cwd}'
+cat > '{stdin}'
+{body}
+"#,
+        argv = argv_path.display(),
+        stdin = stdin_path.display(),
+        cwd = cwd_path.display(),
+    );
+    std::fs::write(&program, script).expect("write fake opencode");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake opencode");
+    }
+    program
+}
+
+struct Harness {
+    _dir: tempfile::TempDir,
+    argv_path: PathBuf,
+    stdin_path: PathBuf,
+    cwd_path: PathBuf,
+    edit_path: PathBuf,
+    runtime: OrbitRuntime,
+}
+
+impl Harness {
+    fn new(body: &str) -> Self {
+        let dir = tempfile::tempdir().expect("harness tempdir");
+        let argv_path = dir.path().join("argv.txt");
+        let stdin_path = dir.path().join("stdin.txt");
+        let cwd_path = dir.path().join("cwd.txt");
+        let edit_path = dir.path().join("workspace/edited.txt");
+        std::fs::create_dir_all(edit_path.parent().expect("workspace parent"))
+            .expect("create fake workspace");
+        let body = body.replace("{EDIT_PATH}", &edit_path.display().to_string());
+        let program = fake_opencode(dir.path(), &body, &argv_path, &stdin_path, &cwd_path);
+
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        seed_opencode_executor(&runtime, &program, false);
+        Self {
+            _dir: dir,
+            argv_path,
+            stdin_path,
+            cwd_path,
+            edit_path,
+            runtime,
+        }
+    }
+
+    fn argv(&self) -> Vec<String> {
+        std::fs::read_to_string(&self.argv_path)
+            .expect("fake agent recorded argv")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn stdin(&self) -> String {
+        std::fs::read_to_string(&self.stdin_path).expect("fake agent recorded stdin")
+    }
+
+    fn cwd(&self) -> String {
+        std::fs::read_to_string(&self.cwd_path)
+            .expect("fake agent recorded cwd")
+            .trim()
+            .to_string()
+    }
+}
+
+fn opencode_resource() -> ExecutorResource {
+    serde_yaml::from_str(include_str!("../assets/executors/opencode.yaml"))
+        .expect("parse embedded OpenCode executor")
+}
+
+fn seed_opencode_executor(runtime: &OrbitRuntime, program: &Path, keep_sandbox: bool) {
+    let resource = opencode_resource();
+    assert_eq!(resource.schema_version, EXECUTOR_RESOURCE_SCHEMA_VERSION);
+    assert_eq!(resource.metadata.name, "opencode");
+    let mut def = ExecutorDef::from_resource_spec(
+        resource.metadata.name.clone(),
+        resource.spec.clone(),
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    );
+    def.command = Some(program.to_string_lossy().into_owned());
+    if !keep_sandbox {
+        // Sandbox compilation has deterministic focused coverage. Keeping the
+        // wrapper here would make transport cases depend on host bwrap/SBPL.
+        def.sandbox = None;
+    }
+    runtime
+        .upsert_executor_def(&def)
+        .expect("seed OpenCode executor");
+}
+
+fn spec(timeout_seconds: u64) -> AgentLoopSpec {
+    AgentLoopSpec {
+        instruction: "Return the requested Orbit response envelope.".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: Some(MODEL.to_string()),
+        reasoning_effort: Some(ReasoningEffort::High),
+        max_iterations: 1,
+        backend: None,
+        provider: Provider::Opencode,
+        wall_clock_timeout_seconds: timeout_seconds,
+        require_response_envelope: true,
+        require_completion_envelope: true,
+        proc_allowed_programs: None,
+    }
+}
+
+fn try_dispatch(harness: &Harness, spec: AgentLoopSpec) -> Result<DispatchOutcome, String> {
+    let audit_dir = tempfile::tempdir().expect("audit tempdir");
+    let audit = V2AuditWriter::with_disk_sinks(
+        audit_dir.path(),
+        Arc::new(orbit_store::Store::open_in_memory().expect("audit store")),
+        "ws_test",
+        "opencode-fake",
+        format!("opencode:{MODEL}"),
+        None,
+    )
+    .expect("build audit writer");
+
+    dispatch_v2_activity(V2DispatchInput {
+        activity_name: "opencode_fake_agent",
+        spec: &ActivityV2Spec::AgentLoop(spec),
+        fs_profile: None,
+        input: serde_json::json!({
+            "prompt": format!("Edit the checkout. Credential: {PROMPT_SECRET}"),
+        }),
+        audit,
+        run_id: "opencode-fake",
+        host: Some(&harness.runtime),
+    })
+    .map_err(|error| error.to_string())
+}
+
+fn dispatch(harness: &Harness, spec: AgentLoopSpec) -> DispatchOutcome {
+    try_dispatch(harness, spec).expect("dispatch OpenCode CLI backend")
+}
+
+/// The documented `--format json` stream: step boundaries, a reasoning part and
+/// a completed tool call that both replay Orbit's own prompt, then the
+/// assistant's answer text.
+fn success_body() -> String {
+    format!(
+        r#"printf '%s\n' '{{"type":"step_start","timestamp":1,"sessionID":"ses_7f3a","part":{{"id":"prt_a","type":"step-start","sessionID":"ses_7f3a"}}}}'
+printf '%s\n' '{{"type":"reasoning","timestamp":2,"sessionID":"ses_7f3a","part":{{"id":"prt_b","type":"reasoning","sessionID":"ses_7f3a","text":"drafting {SUCCESS_ENVELOPE}","time":{{"start":1,"end":2}}}}}}'
+printf '%s\n' '{{"type":"tool_use","timestamp":3,"sessionID":"ses_7f3a","part":{{"id":"prt_c","type":"tool","tool":"bash","sessionID":"ses_7f3a","state":{{"status":"completed","input":{{"command":"cat prompt"}},"output":"{SUCCESS_ENVELOPE}"}}}}}}'
+printf '%s\n' '{{"type":"text","timestamp":4,"sessionID":"ses_7f3a","part":{{"id":"prt_d","type":"text","sessionID":"ses_7f3a","text":"{SUCCESS_ENVELOPE}","time":{{"start":3,"end":4}}}}}}'
+printf '%s\n' '{{"type":"step_finish","timestamp":5,"sessionID":"ses_7f3a","part":{{"id":"prt_e","type":"step-finish","sessionID":"ses_7f3a","tokens":{{"input":120,"output":40}}}}}}'
+exit 0"#
+    )
+}
+
+#[test]
+fn command_construction_matches_the_shipped_headless_contract() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+
+    let argv = harness.argv();
+    assert_eq!(argv.first().map(String::as_str), Some("run"));
+    assert!(argv.windows(2).any(|args| args == ["--format", "json"]));
+    assert!(argv.iter().any(|arg| arg == "--auto"));
+    assert!(argv.windows(2).any(|args| args == ["--model", MODEL]));
+    assert!(argv.windows(2).any(|args| args == ["--variant", "high"]));
+    // OpenCode's `--model provider/model` names the underlying model vendor;
+    // Orbit never renders a separate provider flag, so the executor lane
+    // identity cannot be re-pointed by a crew.
+    assert!(!argv.iter().any(|arg| arg == "--provider"));
+    // The prompt must never be a positional `[message..]` argument.
+    assert!(
+        !argv.iter().any(|arg| arg.contains(PROMPT_SECRET)),
+        "prompt must not enter argv",
+    );
+    assert!(!argv.iter().any(|arg| arg.contains("schemaVersion")));
+    // Session continuation and sharing would leak one run's context into
+    // another, or publish it; neither is part of the headless contract.
+    assert!(!argv.iter().any(|arg| arg == "--share"));
+    assert!(!argv.iter().any(|arg| arg == "--continue" || arg == "-c"));
+    assert!(!argv.iter().any(|arg| arg == "--session"));
+}
+
+#[test]
+fn prompt_is_delivered_on_stdin_in_the_workspace_cwd() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(&harness, spec(60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    assert!(harness.stdin().contains(PROMPT_SECRET));
+    assert!(harness.stdin().contains("Execution envelope:"));
+
+    // The child runs in the dispatch cwd rather than needing `--dir`, which
+    // would put the workspace path on argv.
+    let cwd = harness.cwd();
+    assert!(!cwd.is_empty(), "fake agent recorded a working directory");
+    assert!(!harness.argv().iter().any(|arg| arg == "--dir"));
+
+    let invocation = outcome.invocation.expect("invocation trace");
+    assert_eq!(invocation.provider, "opencode");
+    assert_eq!(invocation.model.as_deref(), Some(MODEL));
+    let rendered = serde_json::to_string(&outcome.output).expect("serialize output");
+    assert!(!rendered.contains(PROMPT_SECRET));
+}
+
+#[test]
+fn successful_run_persists_worktree_edit_and_projects_result() {
+    let body = format!(
+        "printf 'edited by opencode\\n' > '{{EDIT_PATH}}'\n{}",
+        success_body()
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(60));
+
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    assert_eq!(outcome.output["edited"], serde_json::Value::Bool(true));
+    assert_eq!(
+        std::fs::read_to_string(&harness.edit_path).expect("agent edit persists"),
+        "edited by opencode\n"
+    );
+}
+
+#[test]
+fn crew_effort_is_optional_and_omitted_when_unset() {
+    let harness = Harness::new(&success_body());
+    let outcome = dispatch(
+        &harness,
+        AgentLoopSpec {
+            reasoning_effort: None,
+            ..spec(60)
+        },
+    );
+
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    assert!(!harness.argv().iter().any(|arg| arg == "--variant"));
+}
+
+#[test]
+fn an_unsupported_effort_fails_instead_of_being_silently_dropped() {
+    // OpenCode forwards `--variant` verbatim to the selected model provider and
+    // documents only `high`/`max`/`minimal`. An Orbit effort outside the
+    // supported set must be refused rather than remapped or omitted.
+    let harness = Harness::new(&success_body());
+    for effort in [
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::Xhigh,
+    ] {
+        let error = try_dispatch(
+            &harness,
+            AgentLoopSpec {
+                reasoning_effort: Some(effort),
+                ..spec(60)
+            },
+        )
+        .err()
+        .unwrap_or_else(|| panic!("effort '{effort}' must be refused before spawn"));
+        assert!(
+            error.contains("unsupported"),
+            "diagnostic must name the unsupported effort: {error}",
+        );
+    }
+}
+
+#[test]
+fn non_zero_exit_fails_even_with_a_success_frame() {
+    let body = success_body().replace("exit 0", "exit 9");
+    let outcome = dispatch(&Harness::new(&body), spec(60));
+    assert!(!outcome.success);
+    assert!(
+        outcome.message.unwrap_or_default().contains('9'),
+        "the terminal exit code reaches the operator diagnostic",
+    );
+}
+
+#[test]
+fn a_terminal_error_event_cannot_report_success() {
+    // OpenCode emits `{"type":"error",...}` and sets exit code 1 when the
+    // session fails. Normalization must invalidate the answer text that was
+    // already streamed, independently of the exit status.
+    let body = format!(
+        r#"{}
+printf '%s\n' '{{"type":"error","timestamp":6,"sessionID":"ses_7f3a","error":{{"name":"ProviderAuthError","data":{{"message":"no credentials"}}}}}}'
+exit 0"#,
+        success_body().replace("exit 0", ""),
+    );
+    let outcome = dispatch(&Harness::new(&body), spec(60));
+    assert!(
+        !outcome.success,
+        "a terminal error event must invalidate prior completion evidence",
+    );
+}
+
+#[test]
+fn malformed_or_incomplete_output_never_succeeds() {
+    for body in [
+        // Not NDJSON at all.
+        "printf '%s\\n' 'not json'\nexit 0".to_string(),
+        // Truncated frame.
+        "printf '%s\\n' '{\"type\":\"text\",\"part\":'\nexit 0".to_string(),
+        // A `text` event whose part carries no text: a malformed frame, not an
+        // empty answer.
+        r#"printf '%s\n' '{"type":"text","timestamp":1,"sessionID":"s","part":{"id":"p","type":"text","sessionID":"s"}}'
+exit 0"#
+            .to_string(),
+        // Only tool traffic replaying Orbit's own prompt: that is not the
+        // agent's completion evidence.
+        format!(
+            r#"printf '%s\n' '{{"type":"tool_use","timestamp":1,"sessionID":"s","part":{{"id":"p","type":"tool","tool":"bash","sessionID":"s","state":{{"status":"completed","output":"{SUCCESS_ENVELOPE}"}}}}}}'
+exit 0"#
+        ),
+        // Only reasoning: a draft envelope written while thinking aloud.
+        format!(
+            r#"printf '%s\n' '{{"type":"reasoning","timestamp":1,"sessionID":"s","part":{{"id":"p","type":"reasoning","sessionID":"s","text":"{SUCCESS_ENVELOPE}","time":{{"start":1,"end":2}}}}}}'
+exit 0"#
+        ),
+        // Step boundaries without any answer: the agent stopped mid-turn.
+        r#"printf '%s\n' '{"type":"step_start","timestamp":1,"sessionID":"s","part":{"id":"p","type":"step-start"}}'
+exit 0"#
+            .to_string(),
+    ] {
+        let outcome = dispatch(&Harness::new(&body), spec(60));
+        assert!(!outcome.success, "invalid OpenCode output must fail: {body}");
+    }
+}
+
+#[test]
+fn wall_clock_timeout_cancels_the_agent_and_fails_the_step() {
+    let outcome = dispatch(&Harness::new("sleep 30\nexit 0"), spec(1));
+    assert!(!outcome.success);
+    let message = outcome.message.unwrap_or_default();
+    assert!(message.contains("timeout") || message.contains("wall-clock"));
+}
+
+#[test]
+fn shipped_executor_is_sandboxed_and_missing_binary_is_stable() {
+    let resource = opencode_resource();
+    assert!(
+        resource.spec.sandbox.is_some(),
+        "OpenCode asset must opt into the OS sandbox"
+    );
+    assert_eq!(resource.spec.command.as_deref(), Some("opencode"));
+
+    let dir = tempfile::tempdir().expect("missing-binary tempdir");
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let missing = dir.path().join("missing/opencode");
+    seed_opencode_executor(&runtime, &missing, false);
+    let harness = Harness {
+        argv_path: dir.path().join("argv.txt"),
+        stdin_path: dir.path().join("stdin.txt"),
+        cwd_path: dir.path().join("cwd.txt"),
+        _dir: dir,
+        edit_path: PathBuf::new(),
+        runtime,
+    };
+    let error = try_dispatch(&harness, spec(60)).expect_err("missing binary must fail");
+    assert!(
+        error.contains("opencode"),
+        "stable diagnostic names binary: {error}"
+    );
+    assert!(
+        error.contains("failed to spawn"),
+        "stable diagnostic names spawn failure: {error}"
+    );
+}

--- a/crates/orbit-exec/src/macos_sandbox/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/compile.rs
@@ -47,6 +47,10 @@ pub fn compile_macos_sandbox_profile(
     let copilot_home = std::env::var_os("COPILOT_HOME");
     let xdg_cache_home = std::env::var_os("XDG_CACHE_HOME");
     let pi_coding_agent_dir = std::env::var_os("PI_CODING_AGENT_DIR");
+    let xdg_data_home = std::env::var_os("XDG_DATA_HOME");
+    let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+    let xdg_state_home = std::env::var_os("XDG_STATE_HOME");
+    let opencode_config_dir = std::env::var_os("OPENCODE_CONFIG_DIR");
     compile_macos_sandbox_profile_with_env(
         rules,
         provider,
@@ -58,6 +62,10 @@ pub fn compile_macos_sandbox_profile(
             copilot_home: copilot_home.as_deref(),
             xdg_cache_home: xdg_cache_home.as_deref(),
             pi_coding_agent_dir: pi_coding_agent_dir.as_deref(),
+            xdg_data_home: xdg_data_home.as_deref(),
+            xdg_config_home: xdg_config_home.as_deref(),
+            xdg_state_home: xdg_state_home.as_deref(),
+            opencode_config_dir: opencode_config_dir.as_deref(),
         },
     )
 }
@@ -74,6 +82,10 @@ pub(super) struct SandboxCompileEnv<'a> {
     pub(super) copilot_home: Option<&'a OsStr>,
     pub(super) xdg_cache_home: Option<&'a OsStr>,
     pub(super) pi_coding_agent_dir: Option<&'a OsStr>,
+    pub(super) xdg_data_home: Option<&'a OsStr>,
+    pub(super) xdg_config_home: Option<&'a OsStr>,
+    pub(super) xdg_state_home: Option<&'a OsStr>,
+    pub(super) opencode_config_dir: Option<&'a OsStr>,
 }
 
 pub(super) fn compile_macos_sandbox_profile_with_env(
@@ -89,6 +101,10 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
         copilot_home,
         xdg_cache_home,
         pi_coding_agent_dir,
+        xdg_data_home,
+        xdg_config_home,
+        xdg_state_home,
+        opencode_config_dir,
     } = env;
     let mut out = String::new();
     out.push_str("(version 1)\n");
@@ -187,6 +203,27 @@ pub(super) fn compile_macos_sandbox_profile_with_env(
             "(allow file-write* (subpath \"{}\"))\n",
             super::sbpl_filter::sbpl_escape(&state_dir.display().to_string())
         ));
+    }
+    // OpenCode creates its XDG data/config/state roots during startup, before
+    // it reads Orbit's envelope, so they are granted only to the active
+    // OpenCode executor. `auth.json` lives in the data root; API-key auth is an
+    // explicit environment opt-in and needs no additional path. [ORB-11295]
+    if Provider::parse(provider).ok() == Some(Provider::Opencode) {
+        for state_dir in
+            super::provider_dirs::opencode_state_dirs(super::provider_dirs::OpencodeDirEnv {
+                home,
+                xdg_data_home,
+                xdg_config_home,
+                xdg_state_home,
+                xdg_cache_home,
+                opencode_config_dir,
+            })
+        {
+            out.push_str(&format!(
+                "(allow file-write* (subpath \"{}\"))\n",
+                super::sbpl_filter::sbpl_escape(&state_dir.display().to_string())
+            ));
+        }
     }
     super::provider_dirs::emit_claude_home_json_allows(home, claude_config_dir, &mut out);
     super::provider_dirs::emit_grok_state_file_allows(home, grok_home, &mut out);

--- a/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/provider_dirs.rs
@@ -149,6 +149,78 @@ pub(crate) fn pi_state_dir(
         .or_else(|| non_empty_env_path(home).map(|path| path.join(".pi")))
 }
 
+/// Writable directories an **active** OpenCode executor needs. [ORB-11295]
+///
+/// OpenCode resolves every root through `xdg-basedir` and creates `data`,
+/// `config`, and `state` at startup — before it ever reads Orbit's envelope —
+/// so all of them must be writable or the CLI aborts during initialization.
+/// `cache` is included because the same startup path takes a lock under it.
+///
+/// 1. `$XDG_DATA_HOME/opencode`, else `$HOME/.local/share/opencode` —
+///    `auth.json` from `opencode auth login`, session/message stores, `log/`,
+///    and `repos/`.
+/// 2. `$OPENCODE_CONFIG_DIR`, else `$XDG_CONFIG_HOME/opencode`, else
+///    `$HOME/.config/opencode` — `opencode.json` plus the `agents/`,
+///    `commands/`, `plugins/`, `skills/`, `tools/`, and `themes/` trees.
+/// 3. `$XDG_STATE_HOME/opencode`, else `$HOME/.local/state/opencode`.
+/// 4. `$XDG_CACHE_HOME/opencode`, else `$HOME/.cache/opencode`.
+///
+/// Like Copilot's, Cursor's, and Pi's entries, this is gated on the active
+/// provider by its caller so an unrelated lane is not handed OpenCode's
+/// credential store.
+pub(crate) fn opencode_state_dirs(env: OpencodeDirEnv<'_>) -> Vec<PathBuf> {
+    let OpencodeDirEnv {
+        home,
+        xdg_data_home,
+        xdg_config_home,
+        xdg_state_home,
+        xdg_cache_home,
+        opencode_config_dir,
+    } = env;
+    let mut dirs = Vec::with_capacity(4);
+    let mut push = |dir: Option<PathBuf>| {
+        if let Some(dir) = dir {
+            dirs.push(dir);
+        }
+    };
+    push(xdg_scoped_dir(home, xdg_data_home, &[".local", "share"]));
+    push(
+        non_empty_env_path(opencode_config_dir)
+            .or_else(|| xdg_scoped_dir(home, xdg_config_home, &[".config"])),
+    );
+    push(xdg_scoped_dir(home, xdg_state_home, &[".local", "state"]));
+    push(xdg_scoped_dir(home, xdg_cache_home, &[".cache"]));
+    dirs
+}
+
+/// Env inputs that locate OpenCode's XDG roots.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct OpencodeDirEnv<'a> {
+    pub(crate) home: Option<&'a OsStr>,
+    pub(crate) xdg_data_home: Option<&'a OsStr>,
+    pub(crate) xdg_config_home: Option<&'a OsStr>,
+    pub(crate) xdg_state_home: Option<&'a OsStr>,
+    pub(crate) xdg_cache_home: Option<&'a OsStr>,
+    pub(crate) opencode_config_dir: Option<&'a OsStr>,
+}
+
+/// Resolve one `<xdg base>/opencode` root: the explicit XDG variable when set,
+/// otherwise its specified default relative to `$HOME`.
+fn xdg_scoped_dir(
+    home: Option<&OsStr>,
+    xdg_base: Option<&OsStr>,
+    home_relative_default: &[&str],
+) -> Option<PathBuf> {
+    let base = non_empty_env_path(xdg_base).or_else(|| {
+        non_empty_env_path(home).map(|home| {
+            home_relative_default
+                .iter()
+                .fold(home, |path, segment| path.join(segment))
+        })
+    })?;
+    Some(base.join("opencode"))
+}
+
 pub(super) fn non_empty_env_path(value: Option<&OsStr>) -> Option<PathBuf> {
     let value = value?;
     if value.to_string_lossy().is_empty() {

--- a/crates/orbit-exec/src/macos_sandbox/test_support.rs
+++ b/crates/orbit-exec/src/macos_sandbox/test_support.rs
@@ -23,6 +23,10 @@ pub(super) struct EnvOverrides<'a> {
     pub(super) copilot_home: Option<&'a str>,
     pub(super) xdg_cache_home: Option<&'a str>,
     pub(super) pi_coding_agent_dir: Option<&'a str>,
+    pub(super) xdg_data_home: Option<&'a str>,
+    pub(super) xdg_config_home: Option<&'a str>,
+    pub(super) xdg_state_home: Option<&'a str>,
+    pub(super) opencode_config_dir: Option<&'a str>,
 }
 
 /// Provider used by profile tests that are not about the per-provider
@@ -46,6 +50,10 @@ pub(super) fn compile_with_env(
             copilot_home: env.copilot_home.map(OsStr::new),
             xdg_cache_home: env.xdg_cache_home.map(OsStr::new),
             pi_coding_agent_dir: env.pi_coding_agent_dir.map(OsStr::new),
+            xdg_data_home: env.xdg_data_home.map(OsStr::new),
+            xdg_config_home: env.xdg_config_home.map(OsStr::new),
+            xdg_state_home: env.xdg_state_home.map(OsStr::new),
+            opencode_config_dir: env.opencode_config_dir.map(OsStr::new),
         },
     )
     .expect("compile")

--- a/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/provider_dirs.rs
@@ -358,6 +358,7 @@ fn compiled_profile_allows_writes_to_provider_state_dirs() {
             grok_home: None,
             copilot_home: None,
             xdg_cache_home: None,
+            ..SandboxCompileEnv::default()
         },
     )
     .expect("compile sbpl");
@@ -430,6 +431,7 @@ fn compiled_profile_allows_writes_to_grok_json_lock_and_tmp_files() {
             grok_home: None,
             copilot_home: None,
             xdg_cache_home: None,
+            ..SandboxCompileEnv::default()
         },
     )
     .expect("compile sbpl");
@@ -516,6 +518,7 @@ fn compiled_profile_allows_writes_to_claude_home_json_siblings() {
             grok_home: None,
             copilot_home: None,
             xdg_cache_home: None,
+            ..SandboxCompileEnv::default()
         },
     )
     .expect("compile sbpl");
@@ -808,4 +811,113 @@ fn copilot_does_not_receive_the_macos_keychain_carve_out() {
     assert!(!text.contains("(allow file-read* (subpath \"/Users/test/Library/Keychains\"))"));
     assert!(text.contains("(deny file-read* (subpath \"/Users/test/Library/Keychains\"))"));
     assert!(text.contains("(deny file-read* (subpath \"/Users/test/.config/gh\"))"));
+}
+
+#[test]
+fn opencode_state_dirs_default_to_the_xdg_home_locations() {
+    // [ORB-11295] OpenCode resolves every root through `xdg-basedir` and
+    // creates data/config/state during startup, before it reads Orbit's
+    // envelope, so all four roots must be present.
+    assert_eq!(
+        opencode_state_dirs(OpencodeDirEnv {
+            home: Some(OsStr::new("/Users/test")),
+            ..Default::default()
+        }),
+        vec![
+            PathBuf::from("/Users/test/.local/share/opencode"),
+            PathBuf::from("/Users/test/.config/opencode"),
+            PathBuf::from("/Users/test/.local/state/opencode"),
+            PathBuf::from("/Users/test/.cache/opencode"),
+        ]
+    );
+    assert!(opencode_state_dirs(OpencodeDirEnv::default()).is_empty());
+}
+
+#[test]
+fn opencode_state_dirs_honor_xdg_variables_and_the_config_override() {
+    assert_eq!(
+        opencode_state_dirs(OpencodeDirEnv {
+            home: Some(OsStr::new("/Users/test")),
+            xdg_data_home: Some(OsStr::new("/srv/data")),
+            xdg_config_home: Some(OsStr::new("/srv/config")),
+            xdg_state_home: Some(OsStr::new("/srv/state")),
+            xdg_cache_home: Some(OsStr::new("/srv/cache")),
+            opencode_config_dir: None,
+        }),
+        vec![
+            PathBuf::from("/srv/data/opencode"),
+            PathBuf::from("/srv/config/opencode"),
+            PathBuf::from("/srv/state/opencode"),
+            PathBuf::from("/srv/cache/opencode"),
+        ]
+    );
+
+    // `OPENCODE_CONFIG_DIR` is the config root itself, not an XDG base, so it
+    // is used verbatim and outranks `XDG_CONFIG_HOME`.
+    let dirs = opencode_state_dirs(OpencodeDirEnv {
+        home: Some(OsStr::new("/Users/test")),
+        xdg_config_home: Some(OsStr::new("/srv/config")),
+        opencode_config_dir: Some(OsStr::new("/srv/opencode-config")),
+        ..Default::default()
+    });
+    assert_eq!(dirs[1], PathBuf::from("/srv/opencode-config"));
+}
+
+#[test]
+fn opencode_state_dirs_ignore_empty_overrides() {
+    assert_eq!(
+        opencode_state_dirs(OpencodeDirEnv {
+            home: Some(OsStr::new("/Users/test")),
+            xdg_data_home: Some(OsStr::new("")),
+            opencode_config_dir: Some(OsStr::new("")),
+            ..Default::default()
+        }),
+        vec![
+            PathBuf::from("/Users/test/.local/share/opencode"),
+            PathBuf::from("/Users/test/.config/opencode"),
+            PathBuf::from("/Users/test/.local/state/opencode"),
+            PathBuf::from("/Users/test/.cache/opencode"),
+        ]
+    );
+}
+
+#[test]
+fn compile_grants_opencode_state_only_to_an_active_opencode_executor() {
+    let resolved = profile("default", &["/Users/test/repo"], &["/Users/test/repo/src"]);
+    let opencode_profile = compile_with_env(
+        &resolved,
+        "opencode",
+        EnvOverrides {
+            home: Some("/Users/test"),
+            ..Default::default()
+        },
+    );
+    for root in [
+        "/Users/test/.local/share/opencode",
+        "/Users/test/.config/opencode",
+        "/Users/test/.local/state/opencode",
+        "/Users/test/.cache/opencode",
+    ] {
+        assert!(
+            opencode_profile.contains(&format!("(allow file-write* (subpath \"{root}\"))")),
+            "active OpenCode must be granted {root}",
+        );
+    }
+
+    for provider in [
+        "claude", "codex", "gemini", "grok", "copilot", "cursor", "pi",
+    ] {
+        let other = compile_with_env(
+            &resolved,
+            provider,
+            EnvOverrides {
+                home: Some("/Users/test"),
+                ..Default::default()
+            },
+        );
+        assert!(
+            !other.contains("/opencode"),
+            "{provider} must not inherit OpenCode state write access",
+        );
+    }
 }

--- a/crates/orbit-types/src/identity/agent_pair.rs
+++ b/crates/orbit-types/src/identity/agent_pair.rs
@@ -75,7 +75,8 @@ impl ReasoningEffort {
     ///
     /// Grok's published contract is model-specific, so unknown models fail
     /// closed instead of accepting a setting the CLI might silently
-    /// reinterpret.
+    /// reinterpret. OpenCode is narrower still: see
+    /// [`Self::validate_opencode_effort`]. [ORB-11295]
     pub fn validate_for_provider_model(
         self,
         provider: &str,
@@ -85,8 +86,27 @@ impl ReasoningEffort {
             "claude" | "codex" | "pi" => Ok(()),
             "grok" => Self::validate_grok_model_effort(self, model),
             "antigravity" => Self::validate_antigravity_effort(self, model),
+            "opencode" => Self::validate_opencode_effort(self),
             other => Err(format!(
                 "provider '{other}' does not support configured reasoning effort"
+            )),
+        }
+    }
+
+    /// OpenCode renders effort as `--variant`, documented as "model variant
+    /// (provider-specific reasoning effort, e.g., high, max, minimal)". The
+    /// value is forwarded verbatim to whichever model provider `--model`
+    /// selected, and OpenCode publishes no provider-independent vocabulary, so
+    /// only the two spellings its own help text names *and* that exist in
+    /// Orbit's crew vocabulary are accepted. `low`, `medium`, and `xhigh` fail
+    /// closed rather than being remapped onto `minimal`/`high`: a variant the
+    /// underlying provider does not define is a configuration error, not
+    /// something Orbit should guess at. [ORB-11295]
+    fn validate_opencode_effort(self) -> Result<(), String> {
+        match self {
+            Self::High | Self::Max => Ok(()),
+            other => Err(format!(
+                "OpenCode CLI supports effort values high, max (`opencode run --variant`); '{other}' is unsupported. Values are not remapped; choose a supported effort or set a model whose provider defines the variant."
             )),
         }
     }

--- a/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
@@ -195,6 +195,7 @@ pub enum Provider {
     Cursor,
     Pi,
     Antigravity,
+    Opencode,
 }
 
 /// One accepted non-canonical spelling for a [`Provider`]. Alias normalization
@@ -235,7 +236,7 @@ impl std::error::Error for ProviderParseError {}
 impl Provider {
     /// Every canonical provider, in declaration order. Adding a variant here is
     /// a compile-time forcing function for the match arms below.
-    pub const ALL: [Provider; 10] = [
+    pub const ALL: [Provider; 11] = [
         Provider::Claude,
         Provider::Codex,
         Provider::Gemini,
@@ -246,6 +247,7 @@ impl Provider {
         Provider::Cursor,
         Provider::Pi,
         Provider::Antigravity,
+        Provider::Opencode,
     ];
 
     /// Accepted non-canonical spellings, normalized by [`Provider::parse`] /
@@ -257,14 +259,16 @@ impl Provider {
     /// This table is **closed** — an unlisted string is `provider.unknown`,
     /// never guessed. New aliases require a contract bump.
     ///
-    /// `copilot`, `cursor`, `pi`, and `antigravity` deliberately have **no**
-    /// alias rows.
+    /// `copilot`, `cursor`, `pi`, `antigravity`, and `opencode` deliberately
+    /// have **no** alias rows.
     /// Neither the platform name nor a selected underlying model vendor may
     /// resolve to a different execution lane. This matters most for `pi`,
     /// whose own `--provider` flag names the model vendor (`anthropic`,
     /// `openai`, ...) *inside* the Pi lane: those vendor spellings already
-    /// resolve to other Orbit executors and must keep doing so.
-    /// [ORB-10946] [ORB-10945] [ORB-11296] [ORB-11299]
+    /// resolve to other Orbit executors and must keep doing so. The same holds
+    /// for `opencode`, whose `--model provider/model` argument names the model
+    /// vendor *inside* the OpenCode lane. [ORB-10946] [ORB-10945] [ORB-11296]
+    /// [ORB-11299] [ORB-11295]
     pub const ALIASES: &'static [ProviderAlias] = &[
         ProviderAlias {
             alias: "anthropic",
@@ -299,8 +303,7 @@ impl Provider {
     ];
 
     /// Human-readable canonical id list used in diagnostics.
-    pub const CANONICAL_LIST: &'static str =
-        "claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor, pi, antigravity";
+    pub const CANONICAL_LIST: &'static str = "claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor, pi, antigravity, opencode";
 
     pub fn as_str(self) -> &'static str {
         match self {
@@ -314,6 +317,7 @@ impl Provider {
             Provider::Cursor => "cursor",
             Provider::Pi => "pi",
             Provider::Antigravity => "antigravity",
+            Provider::Opencode => "opencode",
         }
     }
 
@@ -374,8 +378,8 @@ impl Provider {
 
     /// Whether the model-neutral Worker leaf executor can execute this
     /// provider. Worker only wires the four shared CLI agent families;
-    /// `copilot`, `cursor`, `pi`, `antigravity`, `ollama`, and `openai_compat`
-    /// are Orbit-canonical capabilities Worker does not run.
+    /// `copilot`, `cursor`, `pi`, `antigravity`, `opencode`, `ollama`, and
+    /// `openai_compat` are Orbit-canonical capabilities Worker does not run.
     /// Preserving this distinction is an explicit ORB-10091 constraint — Orbit
     /// keeps the wider set even though Worker cannot execute all of it.
     ///

--- a/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/activity_v2.rs
@@ -80,13 +80,13 @@ fn provider_capability_predicates_match_contract() {
     // the only variants allowed to exist without a row are the ones named here.
     // An accidental new variant still fails this test.
     //
-    // Copilot, Cursor, Pi, and Antigravity are such identities. Adding any of
-    // them upstream is a cross-system change (Worker and Bridge resolve
-    // against the same rows); until that lands, Orbit can dispatch them while
-    // Worker correctly refuses them — which is what
+    // Copilot, Cursor, Pi, Antigravity, and OpenCode are such identities.
+    // Adding any of them upstream is a cross-system change (Worker and Bridge
+    // resolve against the same rows); until that lands, Orbit can dispatch them
+    // while Worker correctly refuses them — which is what
     // `is_worker_executable() == false` encodes.
-    // [ORB-10946] [ORB-10945] [ORB-11296] [ORB-11299]
-    const ORBIT_ONLY_PROVIDERS: &[&str] = &["copilot", "cursor", "pi", "antigravity"];
+    // [ORB-10946] [ORB-10945] [ORB-11296] [ORB-11299] [ORB-11295]
+    const ORBIT_ONLY_PROVIDERS: &[&str] = &["copilot", "cursor", "pi", "antigravity", "opencode"];
 
     for name in &known {
         assert!(

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -71,8 +71,8 @@ A **crew** is one provider-model assignment. Activities do not carry a model-sel
 | Field | Purpose | Values |
 |---|---|---|
 | `model` | Model identifier passed to the provider CLI | Provider-specific (e.g. `opus`, `sonnet`, `gpt-6-astra`, `gemini-3.8-flash-high`, `grok-4.6`) |
-| `provider` | Agent family or execution lane | `claude`, `codex`, `antigravity`, `gemini`, `grok`, `copilot`, `cursor`, `pi` (the CLI-executable crew families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
-| `effort` | Optional provider reasoning effort | Claude/Codex: `low`, `medium`, `high`, `xhigh`, or `max`; Antigravity: `low`, `medium`, `high`; Grok: verified per model below |
+| `provider` | Agent family or execution lane | `claude`, `codex`, `antigravity`, `gemini`, `grok`, `copilot`, `cursor`, `pi`, `opencode` (the CLI-executable crew families; see [Provider identity and resolution](#provider-identity-and-resolution) for the full canonical set) |
+| `effort` | Optional provider reasoning effort | Claude/Codex: `low`, `medium`, `high`, `xhigh`, or `max`; Antigravity: `low`, `medium`, `high`; OpenCode: `high` or `max`; Grok: verified per model below |
 | `description` | Optional human-facing crew summary | Any non-empty string after trimming |
 | `tags` | Optional discovery labels | Array of strings; normalized, sorted, and deduplicated |
 
@@ -101,6 +101,7 @@ notes that availability can still depend on the selected model. Grok Build
 `medium`, `high`, and `xhigh` for `grok-4.6`, and `low`, `medium`, and `high`
 for `grok-4.5`, matching [xAI's reasoning contract](https://docs.x.ai/developers/model-capabilities/text/reasoning).
 It rejects `max`, unsupported Grok model/effort pairs, Antigravity `xhigh`/`max`,
+OpenCode `low`/`medium`/`xhigh`,
 legacy Gemini CLI model ids on the Antigravity lane, and effort on other
 providers clearly rather than silently downgrading or ignoring a request. A
 selected activity crew (including `workflow.system_crew`) supplies its effort
@@ -169,6 +170,7 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
 | `cursor` | — | yes (`cursor-agent`) | no | **no** |
 | `pi` | — | yes (`pi`) | no | **no** |
 | `antigravity` | — | yes (`agy`) | no | **no** |
+| `opencode` | — | yes (`opencode`) | no | **no** |
 
 - **Parsing is case- and whitespace-insensitive.** `Claude`, `  claude `, and `CLAUDE` all resolve to `claude`. `openai-compat` normalizes to `openai_compat`.
 - **Deprecated aliases resolve *and* warn.** The legacy vendor names normalize to their canonical id and log an `orbit.config.crew` deprecation warning (`{alias, canonical}`) — they never fail, but update the config:
@@ -180,16 +182,16 @@ Every `provider` string Orbit reads — in `[crews.<name>]`, in an activity's in
   | `google` | `gemini` |
   | `xai` | `grok` |
 
-  `copilot`, `cursor`, `pi`, and `antigravity` have **no** aliases. `github`,
-  `cursor-agent`, `anysphere`, `pi-coding-agent`, `earendil`, and `agy` are not
-  provider spellings, and the vendor that supplies a session's underlying model
-  never changes its execution-lane identity. `google` still aliases to `gemini`
-  (the model family / legacy Gemini CLI), not Antigravity. See
-  [GitHub Copilot CLI](#github-copilot-cli),
-  [Cursor Agent CLI](#cursor-agent-cli), [Pi CLI](#pi-cli), and
-  [Antigravity CLI](#antigravity-cli).
+  `copilot`, `cursor`, `pi`, `antigravity`, and `opencode` have **no** aliases.
+  `github`, `cursor-agent`, `anysphere`, `pi-coding-agent`, `earendil`, `agy`,
+  and `sst` are not provider spellings, and the vendor that supplies a session's
+  underlying model never changes its execution-lane identity. `google` still
+  aliases to `gemini` (the model family / legacy Gemini CLI), not Antigravity.
+  See [GitHub Copilot CLI](#github-copilot-cli),
+  [Cursor Agent CLI](#cursor-agent-cli), [Pi CLI](#pi-cli),
+  [Antigravity CLI](#antigravity-cli), and [OpenCode CLI](#opencode-cli).
 
-- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `copilot`, `cursor`, `pi`, `antigravity`, `ollama`, and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset. For `copilot`, `cursor`, `pi`, and `antigravity` this is a *stable diagnostic*, not a fallback: a Worker-routed step naming one of those lanes is refused by identity rather than silently re-pointed at another family.
+- **Canonical ≠ Worker-executable.** Orbit's canonical set is deliberately wider than what the model-neutral Worker leaf executor can run: `copilot`, `cursor`, `pi`, `antigravity`, `opencode`, `ollama`, and `openai_compat` are first-class Orbit providers but Worker does not execute them. This distinction is preserved on purpose — do not narrow the canonical set to Worker's subset. For `copilot`, `cursor`, `pi`, `antigravity`, and `opencode` this is a *stable diagnostic*, not a fallback: a Worker-routed step naming one of those lanes is refused by identity rather than silently re-pointed at another family.
 - **Known ≠ executable at this entry point.** The shared contract recognizes `ollama`, but the Orbit CLI capability set is the canonical cross-repo four; explicitly selecting `ollama` fails as `provider.unsupported` rather than falling back.
 - **`openai_compat` has no CLI runtime.** Every crew dispatches through the CLI agent path, so selecting it fails structurally (see below) rather than falling back.
 
@@ -221,7 +223,7 @@ Explicit selections that are unsupported or unavailable **fail with a stable dia
 
 - `provider openai_compat is unsupported by the Orbit CLI entry point (HTTP-only)` — a CLI-executable dispatch selected an HTTP-only provider.
 - `provider ollama is unsupported by the Orbit CLI entry point` — a known provider is outside this entry point's capability set.
-- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor, pi, antigravity — no CLI runtime registered` — the provider string did not resolve to a canonical id.
+- `unknown provider '<x>'; expected one of claude, codex, gemini, grok, copilot, ollama, openai_compat, cursor, pi, antigravity, opencode — no CLI runtime registered` — the provider string did not resolve to a canonical id.
 
 An **unrecognized `[crews.<name>].provider` value** is the one non-fatal case: it is logged (`orbit.config.crew` warn) and that field falls back to the activity's inline `provider`, because a config typo should not coerce dispatch onto a wrong runtime — the inline value is the known-good identity, not a default guess.
 
@@ -656,6 +658,160 @@ MCP for Antigravity is configured at `~/.gemini/config/mcp_config.json`
 
 `$HOME/.gemini` is already a sandbox write grant (shared with the legacy
 Gemini CLI). Other providers do not receive extra Antigravity-only roots.
+
+---
+
+## OpenCode CLI
+
+The `opencode` provider launches the local `opencode` binary as an
+Orbit-supervised worker. Everything below was verified against **opencode
+1.18.29**: the published [CLI reference](https://opencode.ai/docs/cli/) and the
+upstream `packages/opencode/src/cli/cmd/run.ts` and
+`packages/core/src/global.ts` sources. OpenCode's hosted/served modes
+(`opencode serve`, `--attach`, `opencode web`) are not used.
+
+### Installation and detection
+
+```sh
+opencode --version   # this change was verified against 1.18.29
+opencode models
+```
+
+Fresh init detects `opencode`, adds a `[crews.opencode]` assignment, and can
+choose it only after every previously supported family in the preference order,
+so adding this lane cannot change what an already-provisioned host picks.
+Selecting `opencode` when its binary is unavailable fails with a permanent
+diagnostic naming `opencode`; Orbit never substitutes another provider.
+
+### Authentication and credential handling
+
+OpenCode supports two local authentication paths, and Orbit changes neither:
+
+1. Run `opencode auth login` once. The resulting credentials live in
+   `auth.json` under OpenCode's XDG **data** directory — `$XDG_DATA_HOME/opencode`,
+   default `$HOME/.local/share/opencode`.
+2. Export a vendor API key and explicitly pass it to the agent subprocess:
+
+   ```toml
+   [execution.env]
+   pass = ["ANTHROPIC_API_KEY"]
+   ```
+
+Orbit adds no `*_API_KEY` to the provider's required environment and never puts
+a credential on argv. An interactive `opencode auth login` is a separate,
+unsandboxed setup action that no Orbit workflow turn performs.
+
+### Model and variant selection
+
+Every OpenCode invocation receives `--model <provider>/<model>` from its crew
+assignment. The coordinate must be **fully qualified**: OpenCode splits on the
+first `/` and looks the leading segment up in its own provider catalog, so a
+bare model id does not resolve.
+
+```toml
+[crews.opencode]
+model = "anthropic/claude-sonnet-4-5"
+provider = "opencode"
+effort = "high"
+description = "OpenCode through its local CLI"
+tags = ["implementation"]
+```
+
+The crew chooses the `opencode` executor. The `anthropic/` prefix names the
+**model vendor inside the OpenCode lane** and **never changes the provider
+identity**: the run remains an `opencode` run for its authentication, state
+directories, audit attribution, and sandbox policy. Orbit renders no separate
+provider flag, and `anthropic`, `openai`, and `google` continue to resolve to
+their own executors rather than to `opencode`. Run `opencode models` to inspect
+the coordinates available to the authenticated account.
+
+A crew `effort` is rendered as OpenCode's `--variant <value>`, documented as
+"model variant (provider-specific reasoning effort, e.g., high, max, minimal)".
+Because OpenCode forwards that value verbatim to whichever model provider
+`--model` selected and publishes no provider-independent vocabulary, Orbit
+admits only `high` and `max`. `low`, `medium`, and `xhigh` are **rejected at
+configuration load** with a diagnostic — they are not remapped onto `minimal` or
+`high`, and they are never silently dropped at spawn. Omitting `effort` omits
+the flag and leaves OpenCode's own default in place.
+
+### Headless execution, output, and permissions
+
+The shipped executor supplies only static non-interactive flags:
+
+- `run` is the non-interactive subcommand; without it the CLI starts its TUI.
+- `--format json` is OpenCode's raw event stream: one JSON object per line,
+  shaped `{type, timestamp, sessionID, ...}`.
+- `--auto` auto-approves permission requests that are not explicitly denied.
+  This is **required** for unattended runs: without it OpenCode *auto-rejects*
+  every request and the turn cannot touch the worktree. It is the documented
+  non-interactive analog of an interactive approval, **not** a security
+  boundary — see [Sandbox](#sandbox-1) below.
+
+`--continue`, `--session`, and `--share` are deliberately absent: the first two
+would let one run's context resurface inside another, and `--share` publishes
+the session. Every Orbit invocation is a fresh session.
+
+The Orbit prompt travels on standard input, never as a positional argument.
+OpenCode reads piped stdin whenever stdin is not a TTY and uses it as the whole
+message when no positional `[message..]` is supplied, which keeps the execution
+envelope out of process listings, audit argv, and spawn diagnostics.
+
+Orbit reads only the assistant `text` parts of the event stream, concatenated in
+order. Dropping the rest is a correctness requirement, not tidying: `tool_use`
+frames carry full tool input and output, so an agent that reads its own task
+record or echoes the prompt through a shell tool replays Orbit's own execution
+envelope — including the literal example envelope in the response contract —
+inside a tool payload, and `reasoning` frames are the model thinking aloud,
+where a draft envelope is not an answer. A terminal `error` event clears any
+answer text already accumulated, so a partially written envelope from before a
+failure cannot be projected as success. OpenCode also exits non-zero on session
+failure, and the v2 runner fails closed on a non-zero exit even when stdout
+contains success-looking JSON; exit status and envelope are independent
+evidence and both must be valid.
+
+Because the reduction drops OpenCode's `step_finish` frames, Orbit does **not**
+claim provider-reported token usage for an OpenCode run; the invocation trace
+carries whatever the Orbit response envelope itself declares. Full stdout and
+stderr are still captured in the run's audit record, so OpenCode's own
+diagnostics remain available for debugging. `--print-logs` is not passed;
+OpenCode writes logs to its data directory's `log/` tree.
+
+### Tool integration: MCP is not auto-configured
+
+OpenCode has a native MCP client configured through its own `opencode.json`.
+**Orbit does not write, merge, or manage that file**, and `orbit mcp setup` does
+not offer an OpenCode target. An operator who wants OpenCode's MCP client
+pointed at an Orbit server configures it themselves.
+
+This costs nothing for Orbit's own tools. An OpenCode run reaches them the same
+way every non-MCP lane does: the execution envelope directs the agent to call
+`orbit tool run <tool.name> --input '<json>'` through OpenCode's shell tool,
+using the `orbit` binary supplied on its `PATH`. Tool grants and caller-role
+gates are still enforced by `orbit tool run`, so the activity's scoped authority
+is unchanged. Two consequences follow:
+
+- OpenCode cannot receive an MCP-native tool schema for Orbit's tools, so tool
+  discovery is what the envelope states rather than a negotiated list.
+- The route depends on OpenCode's shell tool being available. An operator who
+  has disabled it on a custom executor or in `opencode.json` breaks Orbit tool
+  access for that lane.
+
+### Sandbox
+
+Only an active OpenCode executor receives write access to OpenCode's XDG roots:
+`$XDG_DATA_HOME/opencode` (default `$HOME/.local/share/opencode`, holding
+`auth.json`, the session and message stores, and logs), the config root
+(`$OPENCODE_CONFIG_DIR`, else `$XDG_CONFIG_HOME/opencode`, else
+`$HOME/.config/opencode`), `$XDG_STATE_HOME/opencode`, and
+`$XDG_CACHE_HOME/opencode`. All four are granted because OpenCode creates the
+data, config, and state roots during startup — before it ever reads Orbit's
+envelope. Other providers do not inherit that grant, and OpenCode does not
+inherit theirs.
+
+The worktree and all other paths remain governed by the activity filesystem
+profile. `--auto` cannot grant filesystem access the enclosing sandbox denies:
+the Orbit macOS/Linux sandbox is the only filesystem boundary and remains
+authoritative.
 
 ---
 

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -4,7 +4,7 @@ summary: Add and validate a CLI-agent or deterministic local-shell executor with
 tags: [contributors, executors, providers, testing]
 paths: ["crates/orbit-agent/**", "crates/orbit-core/assets/executors/**", "crates/orbit-core/src/application/executor.rs", "crates/orbit-core/src/adapter/engine_host/v2_host/cli_executor.rs", "crates/orbit-engine/src/activity_job/**"]
 related_features: [activity-job, policy-sandbox]
-related_artifacts: [ORB-11294, ORB-11296, ORB-11299]
+related_artifacts: [ORB-11294, ORB-11295, ORB-11296, ORB-11299]
 ---
 
 # Onboard an Executor
@@ -25,7 +25,9 @@ orbit executor show <existing-executor> --json
 <provider-cli> --version
 ```
 
-Use the provider's published CLI help and a pinned observed version to establish flags, stdin format, terminal output, authentication behavior, and supported model/effort values. Do not copy flags from another provider and do not claim a universal `--json`, sandbox, login, or MCP flag. `docs/CONFIG.md` records the currently verified contracts for shipped lanes; the Pi and Antigravity entries are representative, not templates with interchangeable flags.
+Use the provider's published CLI help and a pinned observed version to establish flags, stdin format, terminal output, authentication behavior, and supported model/effort values. Do not copy flags from another provider and do not claim a universal `--json`, sandbox, login, or MCP flag. `docs/CONFIG.md` records the currently verified contracts for shipped lanes; the Pi, Antigravity, and OpenCode entries are representative, not templates with interchangeable flags.
+
+Verify the prompt transport specifically, and do not assume a CLI that documents a positional prompt cannot accept stdin. OpenCode documents `opencode run [message..]`, but upstream reads piped stdin when stdin is not a TTY and uses it as the whole message when the positional is empty — which is what let that lane keep the envelope off argv. If the published help is silent, read the upstream argument handling before choosing a transport. [ORB-11295]
 
 An authenticated smoke test is optional and needs explicit operator consent. Run it only against an isolated test workspace and test account or disposable credentials. State exactly what it did not prove (for example, no authenticated account, no vendor model access, or no OS sandbox available); passing fixture contract tests remains sufficient for a normal source change when they exercise Orbit's real dispatch seam.
 
@@ -55,7 +57,7 @@ Verify the seams against the current checkout before editing. These are the auth
 | Child lifecycle, cancellation, and cleanup | `crates/orbit-engine/src/activity_job/cli_runner/`; `crates/orbit-exec/src/supervision/` | Reuse the v2 runner and supervisor. Do not add provider-owned process spawning or cleanup. |
 | Deterministic shell input and output | `crates/orbit-engine/src/executor/automation/shell.rs` — `local_shell`, `parse_shell_config`, `compose_argv` | Keep argv in static activity config. Run an actual shell only when `shell` and `script` are declared explicitly. |
 | OS sandbox / provider home grant | `crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs`; `crates/orbit-exec/src/macos_sandbox/provider_dirs.rs` | Give only the active provider's required state directory a write grant. Keep the activity `fsProfile` authoritative for the worktree. |
-| End-to-end fixtures | `crates/orbit-core/tests/pi_fake_agent.rs`, `crates/orbit-core/tests/antigravity_fake_agent.rs`, `crates/orbit-engine/tests/v2_local_shell.rs` | Exercise the real v2 dispatch seam with fakes; add output/error/timeout/cancellation cases. |
+| End-to-end fixtures | `crates/orbit-core/tests/pi_fake_agent.rs`, `crates/orbit-core/tests/antigravity_fake_agent.rs`, `crates/orbit-core/tests/opencode_fake_agent.rs`, `crates/orbit-engine/tests/v2_local_shell.rs` | Exercise the real v2 dispatch seam with fakes; add output/error/timeout/cancellation cases. |
 
 ## Add a CLI-agent executor
 
@@ -99,7 +101,7 @@ For a new deterministic default, add a `kind: Executor` resource with `executor_
 
 ## Output, errors, and lifecycle contract
 
-An agent exit status and its response envelope are independent evidence; both must be valid. The v2 path fails closed when the CLI exits non-zero even if stdout contains success-looking JSON. It also fails closed on missing terminal output, malformed protocol records, an error/aborted terminal event, missing response/completion envelope, and stale prompt echo. Provider normalization must retain only the documented terminal answer before the common envelope reader scans it. Pi's `message_end` reducer exists specifically to avoid accepting the later conversation replay in `agent_end`; Antigravity accepts only a terminal `result` whose status is `SUCCESS`.
+An agent exit status and its response envelope are independent evidence; both must be valid. The v2 path fails closed when the CLI exits non-zero even if stdout contains success-looking JSON. It also fails closed on missing terminal output, malformed protocol records, an error/aborted terminal event, missing response/completion envelope, and stale prompt echo. Provider normalization must retain only the documented terminal answer before the common envelope reader scans it. Pi's `message_end` reducer exists specifically to avoid accepting the later conversation replay in `agent_end`; Antigravity accepts only a terminal `result` whose status is `SUCCESS`; OpenCode keeps only assistant `text` parts, because its `tool_use` frames carry tool output that can replay Orbit's own prompt and its `reasoning` frames can carry a draft envelope.
 
 Set a wall-clock deadline through the agent activity or `local_shell` config and reuse the supervisor. Verify timeout cancellation and child-process cleanup rather than implementing a provider-specific timer. A normal local-shell non-zero exit is an activity failure unless `allow_nonzero_exit` is explicitly true; when true, its structured output still reports `success`, `exit_code`, `stderr`, `timed_out`, `timeout_ms`, `argv`, `cwd`, and `sandbox`.
 


### PR DESCRIPTION
## Task

[ORB-11295](https://orbit-cli.com/tasks/ORB-11295) — Add OpenCode as a first-class headless Orbit executor

### Description

Daniel requests executor support for OpenCode. Implement a first-class executor through the current v2 dispatch/provider/config/identity surfaces and normal bundled/managed asset installation. Keep executor identity separate from the underlying model vendor, preserve existing executors, and do not reintroduce model_pair_override defaults. Use existing process lifecycle and activity authority mechanisms. Verify CLI flags against current official documentation and upstream source/help; record supported version assumptions. Do not invent structured output fields or require a messaging gateway.

Official contract: https://opencode.ai/docs/cli/
Use noninteractive opencode run with --format json and --model provider/model; verify prompt stdin support against upstream or choose an explicit safe prompt transport. Handle terminal errors and event output; map effort only through verified --variant capabilities.

### Acceptance Criteria

- OpenCode is selectable in executor and crew configuration, is discoverable/seeded through normal managed assets, and successfully dispatches through the real v2 activity seam using a fake CLI contract test.
- Prompt bytes, cwd, explicit model and supported effort are passed correctly; unsupported effort/flags fail clearly rather than being silently ignored. No legacy model_pair_override default is introduced.
- Tests cover response extraction, missing binary, nonzero/terminal errors, malformed supported structured output, timeout and cancellation via shared lifecycle; preserve logs and honest usage availability.
- Retain scoped activity authority, sandbox and credential/environment behavior. Document provider-specific tool integration limitations and a working configuration/example, with no automatic external messages or authentication changes.
- Run focused tests and required ci-fast/ci-lint gates; cite the exact official CLI contract/version verified. Actual authenticated live-provider testing is optional and must be reported separately from fixture validation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added `opencode` as a first-class v2 CLI-agent executor, following `docs/runbooks/executor-onboarding.md`.

## CLI contract verified — opencode 1.18.29

The CLI is **not installed on this host**, so the contract was established from the
official reference plus upstream source, and **all validation below is fixture-based**.
No authenticated live-provider run was performed and none is claimed.

- https://opencode.ai/docs/cli/ (published flag reference)
- upstream `packages/opencode/src/cli/cmd/run.ts` (argument table, event emitter, exit paths)
- upstream `packages/core/src/global.ts` (XDG state roots)
- version pinned from `packages/opencode/package.json` → **1.18.29**

Findings that shaped the implementation:

- **Prompt transport.** The published docs show `opencode run [message..]`, which would
  have forced the envelope onto argv and violated the repo rule. Upstream disproves
  that: `const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()` fed
  through `resolveRunInput`, which returns `piped` when the positional is empty. So the
  envelope travels entirely on stdin and never reaches argv.
- **`--auto` is mandatory** for unattended runs: without it OpenCode *auto-rejects* every
  permission request and the turn cannot touch the worktree.
- **`--format json`** emits NDJSON `{type, timestamp, sessionID, ...}` with types
  `text`, `reasoning`, `tool_use`, `step_start`, `step_finish`, `error`.
- **`--variant`** = "model variant (provider-specific reasoning effort, e.g. high, max,
  minimal)", forwarded verbatim to the selected model provider.
- **State roots are XDG**: data `~/.local/share/opencode` (`auth.json`), config
  `~/.config/opencode` (override `OPENCODE_CONFIG_DIR`), state `~/.local/state/opencode`,
  cache `~/.cache/opencode`. data/config/state are mkdir'd at startup.

## What changed

- **Identity** (`orbit-types`): `Provider::Opencode`, no alias rows — `opencode`'s own
  `--model provider/model` names the model vendor *inside* the lane, so vendor spellings
  keep resolving to their own executors. `is_worker_executable() == false`.
- **Effort** (`agent_pair.rs`): `opencode` admits only `high`/`max`. `low`/`medium`/`xhigh`
  fail closed at config load with a diagnostic; they are **not** remapped onto
  `minimal`/`high` and never silently dropped.
- **Provider** (`orbit-agent`): `providers/opencode/` — argv/stdin transport, runtime
  factory (`HOME`, `PATH` only; no `*_API_KEY`), and an NDJSON normalizer that keeps only
  assistant `text` parts. Dropping `tool_use`/`reasoning` is a correctness requirement:
  tool frames carry tool output that can replay Orbit's own envelope, and reasoning frames
  can carry a draft. A terminal `error` frame clears accumulated text.
- **Asset**: `assets/executors/opencode.yaml` (`run --format json --auto`,
  `stdout_format: envelope`, `sandbox: macos-sandbox-exec`, `model_flag: --model`),
  registered in `DEFAULT_EXECUTOR_FILES`. No `model_pair_override`.
- **Config/init**: `OPENCODE_DEFAULT_MODEL`/`OPENCODE_CREW_MODEL`, `default_crews()` entry,
  seed preference + system-crew fallback, `opencode` binary detection, and init prompt
  entries. OpenCode is appended **last** everywhere, so no already-provisioned host's
  default or system crew moves.
- **Sandbox**: the four XDG roots are granted only when opencode is the active provider —
  macOS via `opencode_state_dirs`/`OpencodeDirEnv` in `compile.rs`, Linux via
  `linux_opencode_state_roots_with`. No other provider inherits them.
- **Docs**: new `## OpenCode CLI` section in `docs/CONFIG.md` (install, auth, worked crew
  config, model/variant, headless contract, sandbox) plus provider tables/diagnostics;
  `executor-onboarding.md` gains the new fixture, OpenCode's reduction rule, and a
  "verify prompt transport against upstream, not just published help" note.

**Tool integration limitation, documented explicitly:** OpenCode has a native MCP client,
but Orbit does **not** write or manage `opencode.json` and `orbit mcp setup` offers no
OpenCode target. The lane reaches granted tools like every non-MCP lane — the envelope
directs it to `orbit tool run` via the injected `orbit` binary on `PATH`, so tool grants
and caller-role gates still enforce scoped activity authority. Consequences noted: no
MCP-native tool schema, and the route depends on OpenCode's shell tool being enabled.
No automatic external messages and no authentication changes (`--share`, `--continue`,
`--session` are all deliberately absent).

## Validation

- `cargo test -p orbit-agent opencode` → **14 passed** (argv/variant/stdin, response
  extraction, tool+reasoning echo rejection, terminal error, malformed frames, nonzero exit).
- `cargo test -p orbit-core --test opencode_fake_agent` → **10 passed** through the real
  v2 dispatch seam with a fake CLI: argv/stdin/cwd contract, worktree edit + result
  projection, unsupported effort refused before spawn, nonzero exit, terminal `error`
  event, malformed NDJSON, wall-clock timeout/cancellation, missing binary.
- `make ci-fast` → **PASS**; `make ci-lint` → **PASS**.
- `cargo test --workspace --no-fail-fast` → **4024 passed, 3 failed**.

All 3 failures are environmental/pre-existing, none from this change:

1. `mcp_roundtrip::process_metadata_does_not_supply_a_replayable_key_bound_identity` —
   explicit runner denial: "requires an unrestricted runner where setgid is enabled and a
   mapped supplementary group is available". Sandbox capability gap; CI should arbitrate.
2. `orbit-tools policy_deny_tracing::policy_denials_emit_redacted_jsonl_tracing_events` —
   deterministic 2s log-flush deadline miss in this sandbox. Fails in isolation;
   `orbit-tools` is untouched and references nothing this change modified.
3. `orbit-cli workspace_init_under_home_with_global_orbit_creates_repo_orbit` —
   pre-existing parallel-test env race. Passes in isolation and single-threaded
   (419/419); the test captures and asserts `ORBIT_REGISTRY_ROOT` *outside* the
   `EnvGuard` lock that serializes env mutation. Filed as friction **F2026-09-022**;
   adding any detected agent family perturbs scheduling and re-surfaces it, so it will
   mislead future executor onboarding until fixed.

One real gap this change introduced was caught by the repo's own forcing function and
fixed: `provider_capability_predicates_match_contract` requires every `Provider` variant
to have a shared-contract row or be a declared Orbit-only identity, so `opencode` was
added to `ORBIT_ONLY_PROVIDERS`. The vendored `provider_contract.json` was deliberately
**not** edited — it is a byte-for-byte copy of a cross-system contract Orbit does not own,
and its hash pin exists to force a reviewed upstream bump.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11295-6a9c8338`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*