### PR TITLE
Default task orchestrator attribution from MCP session configuration

### DIFF
--- a/crates/orbit-cli/src/command/mcp/command.rs
+++ b/crates/orbit-cli/src/command/mcp/command.rs
@@ -302,6 +302,25 @@ pub struct ServeArgs {
     /// never from the server process cwd.
     #[arg(long, value_name = "SELECTOR", conflicts_with = "mode")]
     pub workspace: Option<String>,
+    /// Attribute tasks this session creates to a named orchestrator crew,
+    /// unless the call names one itself.
+    ///
+    /// Attribution only. Unlike `--operator` it grants nothing: a session
+    /// still holds exactly the capabilities it was served with, and the crew
+    /// named here neither selects the crew a task executes under nor the
+    /// model recorded for that execution. The name is resolved against the
+    /// crews of whichever workspace the call lands in, so an unconfigured
+    /// crew fails that call rather than quietly selecting another one.
+    ///
+    /// It applies only when a task is created, and only to that task: an
+    /// existing task's orchestrator is never rewritten from this default.
+    ///
+    /// Treat it as configuration, not as evidence of who is calling. A
+    /// long-lived MCP connection outlives a model switch in the client, so
+    /// pass `orchestrator` on the individual call, or restart the connection
+    /// with a new value, when the orchestrating crew actually changes.
+    #[arg(long, value_name = "CREW")]
+    pub orchestrator: Option<String>,
 }
 
 impl ServeArgs {
@@ -324,7 +343,10 @@ impl ServeArgs {
                             .to_string(),
                     )
                 })?;
-                orbit_mcp::serve_mcp_remote_proxy(RemoteProxyArgs { ssh_host })?
+                orbit_mcp::serve_mcp_remote_proxy(RemoteProxyArgs {
+                    ssh_host,
+                    orchestrator: self.orchestrator,
+                })?
             }
             Some(ServeMode::Federated) => {
                 if let Some(ssh_host) = self.ssh_host {
@@ -334,7 +356,7 @@ impl ServeArgs {
                          `~/.orbit/mcp-destinations.toml`"
                     )));
                 }
-                super::server::serve_mcp_federated_stdio()?
+                super::server::serve_mcp_federated_stdio(self.orchestrator)?
             }
             None => super::server::serve_mcp_stdio(
                 self.remote_caller_machine_id,
@@ -356,8 +378,13 @@ impl ServeArgs {
                 } else {
                     SshAcceptance::Environment
                 },
+                self.orchestrator,
             )?,
         }
         Ok(CommandOutput::Silent)
     }
 }
+
+#[cfg(test)]
+#[path = "tests/command.rs"]
+mod tests;

--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -41,6 +41,7 @@ pub(super) fn serve_mcp_stdio(
     authority: McpSessionAuthority,
     bound_workspace: Option<String>,
     acceptance: SshAcceptance,
+    bound_orchestrator: Option<String>,
 ) -> Result<(), OrbitError> {
     let global_root = resolve_global_root()?;
     let policy = orbit_mcp::mcp_serve_session_policy(
@@ -54,6 +55,7 @@ pub(super) fn serve_mcp_stdio(
         remote_caller_machine_id,
         policy,
         bound_workspace,
+        bound_orchestrator,
     )?;
     block_on_server(orbit_mcp::serve_stdio_with_context(host, session_context))
 }
@@ -66,7 +68,9 @@ pub(super) fn serve_mcp_stdio(
 /// machine-global destinations file, whose duplicate-`machine_id` check runs
 /// here, before any tool is advertised. A missing or empty file is a valid
 /// local-only configuration.
-pub(super) fn serve_mcp_federated_stdio() -> Result<(), OrbitError> {
+pub(super) fn serve_mcp_federated_stdio(
+    bound_orchestrator: Option<String>,
+) -> Result<(), OrbitError> {
     let global_root = resolve_global_root()?;
     let remotes = federated::load_destinations(&federated::destinations_path(&global_root))?;
     // The mux is a client to each remote, and identifies itself with the same
@@ -75,11 +79,17 @@ pub(super) fn serve_mcp_federated_stdio() -> Result<(), OrbitError> {
     // why it composes a local policy: each destination caps the mux
     // independently with its own callers file, and the mux is not a
     // destination for its own request [ORB-11052].
-    let identity = orbit_mcp::mcp_server_identity(
+    let mut identity = orbit_mcp::mcp_server_identity(
         &global_root,
         None,
         &SessionCapabilityPolicy::local(McpSessionAuthority::Agent),
     )?;
+    // The mux binds no workspace, but it does carry one attribution default.
+    // Local destinations read it from this context; remote ones are told in
+    // their own argv, because a routed SSH session forwards no context
+    // [ORB-11313].
+    let bound_orchestrator = normalized_selector(bound_orchestrator);
+    identity.session_context.orchestrator = bound_orchestrator.clone();
     let destinations = federated::federated_membership(
         identity.process_machine_id.clone(),
         identity.process_host_id.clone(),
@@ -104,6 +114,7 @@ pub(super) fn serve_mcp_federated_stdio() -> Result<(), OrbitError> {
             identity.process_machine_id.clone(),
             federated::DEFAULT_PROBE_TIMEOUT,
             federated::DEFAULT_ROUTED_DELIVERY_TIMEOUT,
+            bound_orchestrator,
         )),
     );
     let host: Arc<dyn McpHost> = Arc::new(federated::FederatedMcpHost::new(
@@ -146,6 +157,7 @@ pub(super) fn serve_mcp_listener(
         None,
         SessionCapabilityPolicy::local(McpSessionAuthority::Agent),
         None,
+        None,
     )?;
     block_on_server(async move {
         let listener = McpListener::bind(addr, exposure, host, session_context).await?;
@@ -172,14 +184,12 @@ fn compose_server(
     remote_caller_machine_id: Option<String>,
     policy: SessionCapabilityPolicy,
     bound_workspace: Option<String>,
+    bound_orchestrator: Option<String>,
 ) -> Result<(Arc<dyn McpHost>, ToolSessionContext), OrbitError> {
     let mut identity =
         orbit_mcp::mcp_server_identity(&global_root, remote_caller_machine_id, &policy)?;
-    identity.session_context.workspace = bound_workspace
-        .as_deref()
-        .map(str::trim)
-        .filter(|selector| !selector.is_empty())
-        .map(ToOwned::to_owned);
+    identity.session_context.workspace = normalized_selector(bound_workspace);
+    identity.session_context.orchestrator = normalized_selector(bound_orchestrator);
     let host = Arc::new(ServerMcpHost::new(
         global_root,
         identity.process_machine_id,
@@ -187,6 +197,16 @@ fn compose_server(
         policy,
     ));
     Ok((host, identity.session_context))
+}
+
+/// Reduce a launch-time selector to the value a session should carry, so an
+/// omitted flag and a whitespace-only one are the same absent default.
+fn normalized_selector(value: Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn block_on_server<F>(server: F) -> Result<(), OrbitError>

--- a/crates/orbit-cli/src/command/mcp/tests/command.rs
+++ b/crates/orbit-cli/src/command/mcp/tests/command.rs
@@ -1,0 +1,63 @@
+//! Argument surface for `orbit mcp serve` [ORB-11313].
+
+use clap::Parser;
+
+use super::*;
+
+/// Minimal parser so the subcommand's own arguments can be exercised without
+/// the whole CLI tree.
+#[derive(Parser)]
+struct ServeCli {
+    #[command(flatten)]
+    args: ServeArgs,
+}
+
+fn parse(argv: &[&str]) -> ServeArgs {
+    ServeCli::parse_from(argv).args
+}
+
+#[test]
+fn serve_binds_no_orchestrator_by_default() {
+    let args = parse(&["serve"]);
+    assert_eq!(args.orchestrator, None);
+}
+
+#[test]
+fn the_orchestrator_default_is_independent_of_operator_authority() {
+    // Attribution and authority are separate switches: naming an orchestrator
+    // must not raise a session above the agent capability, and asking for
+    // operator authority must not attribute anything.
+    let attribution_only = parse(&["serve", "--orchestrator", "hub"]);
+    assert_eq!(attribution_only.orchestrator.as_deref(), Some("hub"));
+    assert!(!attribution_only.operator);
+
+    let authority_only = parse(&["serve", "--operator"]);
+    assert!(authority_only.operator);
+    assert_eq!(authority_only.orchestrator, None);
+
+    let both = parse(&["serve", "--operator", "--orchestrator", "hub"]);
+    assert!(both.operator);
+    assert_eq!(both.orchestrator.as_deref(), Some("hub"));
+}
+
+#[test]
+fn the_orchestrator_default_is_forwarded_by_the_client_modes() {
+    // Unlike `--operator` and `--workspace`, which describe the server this
+    // process is, attribution travels to whichever server actually creates the
+    // task — so it is accepted alongside every mode.
+    let remote = parse(&["serve", "--mode", "remote", "box", "--orchestrator", "hub"]);
+    assert_eq!(remote.mode, Some(ServeMode::Remote));
+    assert_eq!(remote.orchestrator.as_deref(), Some("hub"));
+
+    let federated = parse(&["serve", "--mode", "federated", "--orchestrator", "hub"]);
+    assert_eq!(federated.mode, Some(ServeMode::Federated));
+    assert_eq!(federated.orchestrator.as_deref(), Some("hub"));
+}
+
+#[test]
+fn the_orchestrator_default_takes_a_crew_name() {
+    assert!(
+        ServeCli::try_parse_from(["serve", "--orchestrator"]).is_err(),
+        "`--orchestrator` must require a crew name rather than acting as a flag"
+    );
+}

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -414,7 +414,7 @@
           "type": "string"
         },
         "orchestrator": {
-          "description": "Optional named crew responsible for orchestration attribution; does not select execution",
+          "description": "Optional named crew responsible for orchestration attribution; does not select execution. Defaults to the MCP session's `orbit mcp serve --orchestrator` crew when omitted",
           "type": "string"
         },
         "priority": {

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/SKILL.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/SKILL.md
@@ -29,6 +29,13 @@ Inspect evidence → search open and closed work → author a bounded task → p
 - Under an authorized continuous-completion policy, post-merge review, QA, and
   CI produce repair tasks; do not insert an unrequested pre-merge review gate.
   Repository protections still apply.
+- Attribute the work you orchestrate. `orchestrator` records the crew that
+  prepared and supervised a task; it is not the execution crew and grants no
+  authority. Set it while the task is `proposed` or `backlog`, either per call
+  or once for the session with `orbit mcp serve --orchestrator <crew>`. That
+  flag is configuration, not proof of who is calling: a connection outlives a
+  model switch, so override it per call or restart the session when the
+  orchestrating crew changes.
 - Agent reports are advisory. Verify persisted task changes, run outcomes,
   merges, tests, and deployed behavior independently. Do not make activity
   success depend on enforcing the shape of an agent's reported output.
@@ -40,7 +47,7 @@ Inspect evidence → search open and closed work → author a bounded task → p
 
 | Reference | Read it for |
 |---|---|
-| [loop.md](references/loop.md) | Discovery, task quality, crew selection, zero-input pilot, immediate promotion, and observation. |
+| [loop.md](references/loop.md) | Discovery, task quality, crew selection, orchestrator attribution, zero-input pilot, immediate promotion, and observation. |
 | [authorization.md](references/authorization.md) | Executable `--complete` examples, concurrency and crew limits, window boundaries, and handoff metrics. |
 | [recovery.md](references/recovery.md) | CI deduplication, triage, failed completion, operational repair tasks, and deployment verification. |
 | [walkthroughs.md](references/walkthroughs.md) | Decisions for missing context, duplicates, locks, unavailable authority, provider limits, and window expiry. |

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/loop.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/loop.md
@@ -58,6 +58,40 @@ per-run crew input: passing `--input crew=...` does not override that step.
 Inspect `[crews.system]` and any compatibility fallback in the active config;
 change persistent configuration only within the user's authorization.
 
+## Record who orchestrated the work
+
+Orchestrator attribution is a separate field from the execution crew. It names
+the crew that prepared and supervised the task; it selects nothing, grants no
+authority, and never changes which crew or model executes the task. Set it on
+creation, when the task is `proposed` or `backlog` — after that it is fixed.
+
+A session can carry the value so every task it creates is attributed without
+each call remembering to pass it. Start the server with the crew you orchestrate
+as:
+
+```bash
+orbit mcp serve --workspace <selector> --orchestrator <your-crew>
+```
+
+Precedence is explicit-then-session: a call that passes `orchestrator` uses that
+value, a call that omits it inherits the session's, and a session started
+without the flag attributes nothing at all. The name is resolved against the
+crews of whichever workspace the call lands in, so an unconfigured crew fails
+that call rather than being replaced by another one. The default applies only to
+tasks the session creates: existing tasks are never rewritten.
+
+```bash
+orbit tool run orbit.task.add --input '{"workspace":"<selector>","title":"<title>","description":"<description>","complexity":"medium","orchestrator":"<crew>","model":"<agent-family>"}'
+```
+
+Treat the flag as configuration, not as evidence of who is calling. An MCP
+connection outlives a model switch in the client, so a session started under one
+crew keeps stamping that crew after the client moves to another. When the
+orchestrating crew actually changes, pass `orchestrator` on the individual call
+or restart the connection with the new value. `--operator` is unrelated and
+unchanged: it decides what a session may do, this decides only what gets
+recorded.
+
 ## Prepare context with task-pilot
 
 ```bash

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -94,6 +94,16 @@ This is the deliberate bootstrap path for a human-facing orchestrator; bare
 workspace-scoped tools route without an explicit selector on every call —
 most MCP clients cannot announce one at initialize.
 
+`orbit mcp serve --orchestrator <crew>` binds a second session default, this
+one purely descriptive: tasks the session creates are attributed to that crew
+unless the call passes its own `orchestrator`. It is independent of
+`--operator` and grants nothing, does not select the crew or model a task
+executes under, and never rewrites an existing task. The crew is resolved
+against the workspace the call lands in, so an unconfigured name fails that
+call instead of silently selecting another crew. Because a connection outlives
+a model switch in the client, pass `orchestrator` per call or restart the
+session when the orchestrating crew changes.
+
 Choose the real integration branch; do not assume the product default `main`
 is the repository's landing branch. `--ship-mode local` selects worktree-based
 local merge delivery instead of opening PRs. For another host's workspace, use

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -975,6 +975,180 @@ fn task_update_tool_persists_complexity_without_adding_history() {
     assert_eq!(omitted.get("complexity"), Some(&json!("medium")));
 }
 
+/// An MCP session started with `orbit mcp serve --orchestrator <crew>` and
+/// bound to this test workspace.
+fn session_with_orchestrator(workspace: &str, orchestrator: &str) -> ToolSessionContext {
+    ToolSessionContext {
+        orchestrator: Some(orchestrator.to_string()),
+        ..ToolSessionContext::with_workspace(workspace.to_string())
+    }
+}
+
+fn add_with_session(
+    runtime: &crate::OrbitRuntime,
+    input: Value,
+    session: ToolSessionContext,
+) -> Result<Value, orbit_common::OrbitError> {
+    runtime
+        .execute_tool_command_dispatch_with_session_context(
+            "orbit.task.add",
+            input,
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            ToolEntryPoint::Mcp,
+            session,
+        )
+        .map(|outcome| outcome.value)
+}
+
+#[test]
+fn session_orchestrator_default_is_resolved_against_the_target_workspace_crews() {
+    // The default is a crew name, not a persisted decision: the workspace the
+    // call lands in resolves it, so an unconfigured name fails that call
+    // rather than quietly attributing the task to some other crew.
+    let (_root, runtime, repo_root) = test_runtime();
+    let workspace = repo_root.to_string_lossy().into_owned();
+
+    let added = add_with_session(
+        &runtime,
+        json!({
+            "title": "Session-attributed task",
+            "description": "The MCP session supplies orchestrator attribution.",
+            "complexity": "low",
+        }),
+        session_with_orchestrator(&workspace, "sol"),
+    )
+    .expect("a configured session orchestrator is accepted");
+    assert_eq!(added.get("orchestrator"), Some(&json!("sol")));
+    assert_eq!(
+        added.get("crew"),
+        Some(&json!(null)),
+        "attribution must not select an execution crew"
+    );
+
+    let rejected = add_with_session(
+        &runtime,
+        json!({
+            "title": "Unconfigured session orchestrator",
+            "description": "An unknown session default must fail loudly.",
+            "complexity": "low",
+        }),
+        session_with_orchestrator(&workspace, "does-not-exist"),
+    );
+    let message = match rejected {
+        Err(error) => format!("{error:?}"),
+        Ok(value) => panic!("expected an unknown session orchestrator to be rejected, got {value}"),
+    };
+    assert!(
+        message.contains("crew 'does-not-exist' is not defined"),
+        "error should name the unresolvable crew: {message}"
+    );
+}
+
+#[test]
+fn an_explicit_orchestrator_beats_the_session_default_end_to_end() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let workspace = repo_root.to_string_lossy().into_owned();
+
+    let added = add_with_session(
+        &runtime,
+        json!({
+            "title": "Explicit attribution",
+            "description": "The call names its own orchestrator.",
+            "complexity": "low",
+            "orchestrator": "terra",
+        }),
+        session_with_orchestrator(&workspace, "sol"),
+    )
+    .expect("explicit orchestrator is accepted");
+    assert_eq!(added.get("orchestrator"), Some(&json!("terra")));
+}
+
+#[test]
+fn the_session_orchestrator_never_backfills_an_existing_task() {
+    // The default applies at creation only. A task created before the session
+    // was configured keeps its own attribution, and an ordinary update through
+    // that session must not acquire one.
+    let (_root, runtime, repo_root) = test_runtime();
+    let workspace = repo_root.to_string_lossy().into_owned();
+
+    let created = add_with_session(
+        &runtime,
+        json!({
+            "title": "Unattributed task",
+            "description": "Created before any session default existed.",
+            "complexity": "low",
+        }),
+        ToolSessionContext::with_workspace(workspace.clone()),
+    )
+    .expect("task add succeeds");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+    assert_eq!(created.get("orchestrator"), Some(&json!(null)));
+
+    let updated = runtime
+        .execute_tool_command_dispatch_with_session_context(
+            "orbit.task.update",
+            json!({ "id": task_id, "title": "Still unattributed" }),
+            Some("codex".to_string()),
+            Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+            ToolEntryPoint::Mcp,
+            session_with_orchestrator(&workspace, "sol"),
+        )
+        .expect("task update succeeds")
+        .value;
+    assert_eq!(
+        updated.get("orchestrator"),
+        Some(&json!(null)),
+        "a configured session must not backfill attribution on an existing task"
+    );
+}
+
+#[test]
+fn the_session_orchestrator_respects_the_lifecycle_restriction() {
+    // Attribution stays changeable only while proposed or backlog, whether it
+    // came from the call or from the session.
+    let (_root, runtime, repo_root) = test_runtime();
+    let workspace = repo_root.to_string_lossy().into_owned();
+
+    let created = add_with_session(
+        &runtime,
+        json!({
+            "title": "Lifecycle-restricted attribution",
+            "description": "Attribution changes stay gated by status.",
+            "complexity": "low",
+        }),
+        session_with_orchestrator(&workspace, "sol"),
+    )
+    .expect("task add succeeds");
+    let task_id = created["id"].as_str().expect("task id").to_string();
+
+    for status in ["backlog", "in-progress"] {
+        run_tool_as_operator(
+            &runtime,
+            "orbit.task.update",
+            json!({ "id": task_id, "status": status, "model": "codex" }),
+        )
+        .unwrap_or_else(|error| panic!("advance to {status}: {error}"));
+    }
+
+    let message = invalid_input_message(
+        runtime
+            .execute_tool_command_dispatch_with_session_context(
+                "orbit.task.update",
+                json!({ "id": task_id, "orchestrator": "terra" }),
+                Some("codex".to_string()),
+                Some(orbit_common::test_fixtures::TEST_CODEX_MODEL.to_string()),
+                ToolEntryPoint::Mcp,
+                session_with_orchestrator(&workspace, "sol"),
+            )
+            .map(|outcome| outcome.value),
+    );
+    assert!(
+        message.contains("only be changed while proposed or backlog"),
+        "error should name the lifecycle restriction: {message}"
+    );
+}
+
 #[test]
 fn task_add_tool_rejects_unknown_crew() {
     // Un-retiring crew also means it is validated: an unknown crew is now

--- a/crates/orbit-mcp/src/federated/probe.rs
+++ b/crates/orbit-mcp/src/federated/probe.rs
@@ -103,6 +103,11 @@ pub struct SshDestinationProbe {
     caller_machine_id: String,
     probe_timeout: Duration,
     delivery_timeout: Duration,
+    /// The mux's orchestrator attribution default, carried into each
+    /// destination's own argv [ORB-11313]. A routed session forwards no
+    /// session context of its own, so this travels the same way the caller
+    /// machine identity does.
+    orchestrator: Option<String>,
 }
 
 impl SshDestinationProbe {
@@ -113,11 +118,13 @@ impl SshDestinationProbe {
         caller_machine_id: String,
         probe_timeout: Duration,
         delivery_timeout: Duration,
+        orchestrator: Option<String>,
     ) -> Self {
         Self {
             caller_machine_id,
             probe_timeout,
             delivery_timeout,
+            orchestrator,
         }
     }
 }
@@ -240,7 +247,11 @@ impl DestinationProbe for CompositeDestinationProbe {
 
 impl SshDestinationProbe {
     fn start_session(&self, destination: &Destination) -> Result<DestinationSession, OrbitError> {
-        let child = spawn_destination_session(destination, &self.caller_machine_id)?;
+        let child = spawn_destination_session(
+            destination,
+            &self.caller_machine_id,
+            self.orchestrator.as_deref(),
+        )?;
         // The session is one process; the guard ends it on every path,
         // including the timeout path where the child is still mid-answer.
         let mut session =
@@ -313,6 +324,7 @@ impl RoutedSession for SshRoutedSession {
 fn spawn_destination_session(
     destination: &Destination,
     caller_machine_id: &str,
+    orchestrator: Option<&str>,
 ) -> Result<Child, OrbitError> {
     let ssh = destination.ssh_target().ok_or_else(|| {
         OrbitError::InvalidInput(format!(
@@ -324,7 +336,10 @@ fn spawn_destination_session(
         .arg("-T")
         .arg("--")
         .arg(ssh)
-        .arg(crate::remote::remote_serve_command(caller_machine_id))
+        .arg(crate::remote::remote_serve_command(
+            caller_machine_id,
+            orchestrator,
+        ))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         // The destination's logs are its own; folding them into this process's

--- a/crates/orbit-mcp/src/remote/proxy.rs
+++ b/crates/orbit-mcp/src/remote/proxy.rs
@@ -21,12 +21,17 @@ pub struct RemoteProxyArgs {
     /// SSH destination accepted by `ssh`, such as a host, `user@host`, or a
     /// configured alias.
     pub ssh_host: String,
+    /// Orchestrator attribution default to configure on the remote server
+    /// [ORB-11313]. Forwarded in the remote argv because the proxy is
+    /// byte-faithful and never edits the JSON-RPC stream.
+    pub orchestrator: Option<String>,
 }
 
 /// Relay this process's MCP stdio directly through one non-PTY SSH child.
 pub fn serve_mcp_remote_proxy(args: RemoteProxyArgs) -> Result<(), OrbitError> {
     let caller_machine_id = local_caller_machine_id();
     let mut command = ssh_command(&args, &caller_machine_id);
+
     tracing::info!(
         ssh_host = %args.ssh_host,
         caller_machine_id = %caller_machine_id,
@@ -60,7 +65,10 @@ pub(super) fn ssh_command(args: &RemoteProxyArgs, caller_machine_id: &str) -> Co
         .arg("-T")
         .arg("--")
         .arg(&args.ssh_host)
-        .arg(remote_serve_command(caller_machine_id))
+        .arg(remote_serve_command(
+            caller_machine_id,
+            args.orchestrator.as_deref(),
+        ))
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -68,11 +76,24 @@ pub(super) fn ssh_command(args: &RemoteProxyArgs, caller_machine_id: &str) -> Co
 }
 
 /// Remote command whose hidden argument marks an SSH-originated MCP session.
-pub(crate) fn remote_serve_command(caller_machine_id: &str) -> String {
-    format!(
+///
+/// `orchestrator` is the caller's attribution default for the session it is
+/// opening [ORB-11313]. Like the requested authority in `--operator`, it is a
+/// request the destination may replace: a destination whose `authorized_keys`
+/// pins a forced command composes its own argv, and its configuration wins.
+pub(crate) fn remote_serve_command(caller_machine_id: &str, orchestrator: Option<&str>) -> String {
+    let mut command = format!(
         "orbit mcp serve --remote-caller-machine-id {}",
         quote_posix_arg(caller_machine_id)
-    )
+    );
+    if let Some(orchestrator) = orchestrator
+        .map(str::trim)
+        .filter(|orchestrator| !orchestrator.is_empty())
+    {
+        command.push_str(" --orchestrator ");
+        command.push_str(&quote_posix_arg(orchestrator));
+    }
+    command
 }
 
 /// Resolve the caller's persisted machine identity, or the audit-only fallback.

--- a/crates/orbit-mcp/src/remote/tests/proxy.rs
+++ b/crates/orbit-mcp/src/remote/tests/proxy.rs
@@ -8,20 +8,31 @@ use super::super::proxy::{
 fn args(ssh_host: &str) -> RemoteProxyArgs {
     RemoteProxyArgs {
         ssh_host: ssh_host.to_string(),
+        orchestrator: None,
     }
+}
+
+fn args_with_orchestrator(ssh_host: &str, orchestrator: &str) -> RemoteProxyArgs {
+    RemoteProxyArgs {
+        ssh_host: ssh_host.to_string(),
+        orchestrator: Some(orchestrator.to_string()),
+    }
+}
+
+fn argv(command: &std::process::Command) -> Vec<String> {
+    command
+        .get_args()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect()
 }
 
 #[test]
 fn ssh_invocation_is_one_non_pty_remote_stdio_server() {
     let command = ssh_command(&args("orbit-box"), "hm_client");
-    let argv = command
-        .get_args()
-        .map(|value| value.to_string_lossy().into_owned())
-        .collect::<Vec<_>>();
 
     assert_eq!(command.get_program(), "ssh");
     assert_eq!(
-        argv,
+        argv(&command),
         vec![
             "-T",
             "--",
@@ -34,27 +45,55 @@ fn ssh_invocation_is_one_non_pty_remote_stdio_server() {
 #[test]
 fn ssh_invocation_has_no_tunnel_listener_or_capability_policy() {
     let command = ssh_command(&args("orbit-box"), "hm_client");
-    let argv = command
-        .get_args()
-        .map(|value| value.to_string_lossy().into_owned())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let joined = argv(&command).join(" ");
 
     for forbidden in ["-L", "-tt", "--listen", "--capabilities"] {
-        assert!(!argv.contains(forbidden), "unexpected {forbidden}: {argv}");
+        assert!(
+            !joined.contains(forbidden),
+            "unexpected {forbidden}: {joined}"
+        );
     }
 }
 
 #[test]
 fn remote_command_quotes_the_audit_identity_for_the_remote_shell() {
     assert_eq!(
-        remote_serve_command("host/local"),
+        remote_serve_command("host/local", None),
         "orbit mcp serve --remote-caller-machine-id 'host/local'"
     );
     assert_eq!(
-        remote_serve_command("hm_machine"),
+        remote_serve_command("hm_machine", None),
         "orbit mcp serve --remote-caller-machine-id 'hm_machine'"
     );
+}
+
+#[test]
+fn orchestrator_attribution_default_is_forwarded_and_quoted() {
+    assert_eq!(
+        remote_serve_command("hm_machine", Some("hub crew")),
+        "orbit mcp serve --remote-caller-machine-id 'hm_machine' --orchestrator 'hub crew'"
+    );
+    assert_eq!(
+        *argv(&ssh_command(
+            &args_with_orchestrator("orbit-box", "hub"),
+            "hm_client"
+        ))
+        .last()
+        .expect("remote argv"),
+        "orbit mcp serve --remote-caller-machine-id 'hm_client' --orchestrator 'hub'"
+    );
+}
+
+#[test]
+fn a_blank_orchestrator_default_forwards_nothing() {
+    // An omitted flag and a whitespace-only one are the same absent default,
+    // so neither can reach a destination as an unresolvable empty crew name.
+    for blank in [None, Some(""), Some("   ")] {
+        assert_eq!(
+            remote_serve_command("hm_machine", blank),
+            "orbit mcp serve --remote-caller-machine-id 'hm_machine'"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -302,6 +302,43 @@ pub(super) fn resolve_workspace_argument(
     }
 }
 
+/// Apply the MCP session's configured orchestrator crew to a task-creation
+/// call that did not name one [ORB-11313].
+///
+/// Creation only. Attribution on an existing task is never rewritten from
+/// ambient session configuration, so `orbit.task.update` deliberately does
+/// not call this and existing records are never backfilled.
+///
+/// An explicit `orchestrator` on the call always wins; JSON `null` counts as
+/// absent, matching how every other optional field reads. The resolved name
+/// is written into the input rather than checked here: only the target
+/// workspace's crew registry knows which crews exist, and it rejects an
+/// unknown name instead of falling back to another crew.
+pub(super) fn apply_session_orchestrator_default(ctx: &ToolContext, input: &mut Value) {
+    if input
+        .get("orchestrator")
+        .is_some_and(|value| !value.is_null())
+    {
+        return;
+    }
+    let Some(session_orchestrator) = ctx
+        .session_context
+        .orchestrator
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let Some(object) = input.as_object_mut() else {
+        return;
+    };
+    object.insert(
+        "orchestrator".to_string(),
+        Value::String(session_orchestrator.to_string()),
+    );
+}
+
 fn set_input_workspace(input: &mut Value, workspace: &str) -> Result<(), OrbitError> {
     let Some(object) = input.as_object_mut() else {
         return Err(OrbitError::InvalidInput(

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -97,7 +97,7 @@ impl Tool for OrbitTaskAddTool {
             },
             ToolParam {
                 name: "orchestrator".to_string(),
-                description: "Optional named crew responsible for orchestration attribution; does not select execution".to_string(),
+                description: "Optional named crew responsible for orchestration attribution; does not select execution. Defaults to the MCP session's `orbit mcp serve --orchestrator` crew when omitted".to_string(),
                 param_type: "string".to_string(),
                 required: false,
             },
@@ -118,6 +118,7 @@ impl Tool for OrbitTaskAddTool {
         required_string(&input, &["description"], "description")?;
         required_string(&input, &["complexity"], "complexity")?;
         super::super::resolve_workspace_argument(ctx, &mut input, "orbit.task.add")?;
+        super::super::apply_session_orchestrator_default(ctx, &mut input);
 
         let ignored_fields = strip_retired_task_add_input_fields(&mut input);
         if !ignored_fields.is_empty() {

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -491,3 +491,142 @@ fn schema_workspace_param_documents_the_shared_selector_grammar() {
         workspace.description
     );
 }
+
+/// A session configured with `orbit mcp serve --orchestrator <crew>` and,
+/// like every MCP session, a bound workspace.
+fn session_with_orchestrator(workspace: &str, orchestrator: &str) -> ToolSessionContext {
+    ToolSessionContext {
+        orchestrator: Some(orchestrator.to_string()),
+        ..ToolSessionContext::with_workspace(workspace)
+    }
+}
+
+fn add_input(title: &str) -> Value {
+    json!({
+        "title": title,
+        "description": "orchestrator attribution default",
+        "complexity": "low",
+        "model": "codex"
+    })
+}
+
+fn recorded_add(host: &RecordingHost) -> Value {
+    host.call
+        .lock()
+        .expect("lock")
+        .take()
+        .expect("host was called")
+        .input
+}
+
+#[test]
+fn add_call_uses_session_orchestrator_when_input_omits_one() {
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = session_with_orchestrator("/tmp/canonical-ws", "hub");
+
+    OrbitTaskAddTool
+        .execute(&ctx, add_input("Session orchestrator default"))
+        .expect("session orchestrator should apply");
+
+    assert_eq!(recorded_add(&host)["orchestrator"], "hub");
+}
+
+#[test]
+fn explicit_orchestrator_takes_precedence_over_the_session_default() {
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = session_with_orchestrator("/tmp/canonical-ws", "hub");
+
+    let mut input = add_input("Explicit orchestrator wins");
+    input["orchestrator"] = json!("relay");
+    OrbitTaskAddTool
+        .execute(&ctx, input)
+        .expect("explicit orchestrator should win");
+
+    assert_eq!(recorded_add(&host)["orchestrator"], "relay");
+}
+
+#[test]
+fn add_call_without_a_session_orchestrator_sends_no_attribution() {
+    // The absent-default path must be byte-identical to the behavior that
+    // shipped before the session default existed, so a server started without
+    // the flag cannot start attributing tasks to anyone.
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = ToolSessionContext::with_workspace("/tmp/canonical-ws");
+
+    OrbitTaskAddTool
+        .execute(&ctx, add_input("No attribution"))
+        .expect("absent default should preserve existing behavior");
+
+    assert!(
+        recorded_add(&host).get("orchestrator").is_none(),
+        "an unconfigured session must not invent an orchestrator"
+    );
+}
+
+#[test]
+fn a_blank_session_orchestrator_is_the_same_as_none() {
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = session_with_orchestrator("/tmp/canonical-ws", "   ");
+
+    OrbitTaskAddTool
+        .execute(&ctx, add_input("Blank default"))
+        .expect("blank default should be ignored");
+
+    assert!(recorded_add(&host).get("orchestrator").is_none());
+}
+
+#[test]
+fn the_session_orchestrator_is_isolated_between_sessions() {
+    // Two clients against the same tool must not see each other's configured
+    // default: it lives on the per-session context, never in process state.
+    let host = RecordingHost::default();
+    let mut hub = mk_ctx(host.clone());
+    hub.session_context = session_with_orchestrator("/tmp/canonical-ws", "hub");
+    let mut relay = mk_ctx(host.clone());
+    relay.session_context = session_with_orchestrator("/tmp/canonical-ws", "relay");
+    let mut unconfigured = mk_ctx(host.clone());
+    unconfigured.session_context = ToolSessionContext::with_workspace("/tmp/canonical-ws");
+
+    for (ctx, expected) in [
+        (&hub, Some("hub")),
+        (&relay, Some("relay")),
+        (&unconfigured, None),
+        (&hub, Some("hub")),
+    ] {
+        OrbitTaskAddTool
+            .execute(ctx, add_input("Session isolation"))
+            .expect("add succeeds");
+        assert_eq!(
+            recorded_add(&host)
+                .get("orchestrator")
+                .and_then(Value::as_str),
+            expected
+        );
+    }
+}
+
+#[test]
+fn the_session_orchestrator_grants_no_capability_and_selects_no_execution_crew() {
+    // Attribution is independent of authority and of execution provenance:
+    // the default must not appear as a capability, a `crew`, or a `model`.
+    let host = RecordingHost::default();
+    let mut ctx = mk_ctx(host.clone());
+    ctx.session_context = session_with_orchestrator("/tmp/canonical-ws", "hub");
+
+    OrbitTaskAddTool
+        .execute(&ctx, add_input("Independent provenance"))
+        .expect("add succeeds");
+
+    let recorded = recorded_add(&host);
+    assert_eq!(recorded["orchestrator"], "hub");
+    assert!(recorded.get("crew").is_none());
+    assert_eq!(recorded["model"], "codex");
+    assert!(
+        ctx.session_context.effective_capabilities.is_empty(),
+        "attribution must not add a session capability"
+    );
+}

--- a/crates/orbit-types/src/tool/definition.rs
+++ b/crates/orbit-types/src/tool/definition.rs
@@ -65,6 +65,22 @@ pub struct ToolSessionContext {
     /// one that never asked.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_caller_grant: Option<RemoteCallerGrant>,
+    /// Orchestrator crew this session attributes newly created tasks to,
+    /// configured by `orbit mcp serve --orchestrator` [ORB-11313].
+    ///
+    /// Session-scoped like [`Self::workspace`] and, like it, purely a
+    /// default: an explicit per-call `orchestrator` wins, and the value is
+    /// resolved against the target workspace's crews on every call rather
+    /// than trusted as written. It is attribution only — it grants no
+    /// capability, never contributes to [`Self::effective_capabilities`] or
+    /// any authorization decision, and never selects the execution crew or
+    /// the model a task runs under.
+    ///
+    /// It is a configured default, not authenticated evidence of the model
+    /// answering a given call: a persistent MCP connection outlives a model
+    /// switch on the client side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestrator: Option<String>,
 }
 
 impl ToolSessionContext {
@@ -98,6 +114,9 @@ impl ToolSessionContext {
             // ever arrives from the client, at initialize.
             self_reported_actor: None,
             remote_caller_grant: None,
+            // The standalone adapter is launched per call, not configured as
+            // a session, so it carries no attribution default.
+            orchestrator: None,
         }
     }
 

--- a/docs/design/mcp-session-context/2_design.md
+++ b/docs/design/mcp-session-context/2_design.md
@@ -28,10 +28,13 @@ related_artifacts: []
 | transport | Accepting server | local or ssh-mcp |
 | caller_ip | Accepting SSH environment | Best-effort first field of SSH_CONNECTION |
 | trace_id | MCP adapter | Fresh correlation ID for one tools/call |
+| orchestrator | The server's launch binding | Crew name attributed to tasks the session creates; never an authorization or execution input |
 
 Clients cannot populate trusted fields through initialize metadata or tool JSON. Initialize accepts only the workspace selector under _meta.orbit.workspace, plus the compatibility spelling _meta["orbit.workspace"].
 
 A session may also be bound at launch: `orbit mcp serve --workspace <selector>` seeds the trusted envelope's workspace before any client connects. That binding is decided by whoever wrote the launch configuration, not by the connecting client, but it is still only a selector — it is resolved against the registry on every call and overridden by an explicit per-call workspace.
+
+`orbit mcp serve --orchestrator <crew>` binds a second launch value the same way, and is deliberately the weaker of the two: it is attribution, so it contributes nothing to effective_capabilities, to any authorization decision, or to the crew and model a task executes under. It applies at task creation only — orbit.task.add fills an omitted `orchestrator` from it, an explicit one on the call wins, and orbit.task.update never reads it, so no existing record is backfilled. Like the workspace binding it is only a name: the workspace the call lands in resolves it against its own crews and rejects an unconfigured one rather than substituting another. Both client modes forward it into the destination's argv, since a routed session carries no context of its own; a destination running a forced command composes its own argv and its configuration wins there. It is configuration, not authenticated evidence of the model answering a call — a connection outlives a client-side model switch, so a changed orchestrator needs a per-call value or a restarted session.
 
 ## 2. Local and SSH sessions
 

--- a/plugin/skills/orbit-orchestrate/SKILL.md
+++ b/plugin/skills/orbit-orchestrate/SKILL.md
@@ -29,6 +29,13 @@ Inspect evidence → search open and closed work → author a bounded task → p
 - Under an authorized continuous-completion policy, post-merge review, QA, and
   CI produce repair tasks; do not insert an unrequested pre-merge review gate.
   Repository protections still apply.
+- Attribute the work you orchestrate. `orchestrator` records the crew that
+  prepared and supervised a task; it is not the execution crew and grants no
+  authority. Set it while the task is `proposed` or `backlog`, either per call
+  or once for the session with `orbit mcp serve --orchestrator <crew>`. That
+  flag is configuration, not proof of who is calling: a connection outlives a
+  model switch, so override it per call or restart the session when the
+  orchestrating crew changes.
 - Agent reports are advisory. Verify persisted task changes, run outcomes,
   merges, tests, and deployed behavior independently. Do not make activity
   success depend on enforcing the shape of an agent's reported output.
@@ -40,7 +47,7 @@ Inspect evidence → search open and closed work → author a bounded task → p
 
 | Reference | Read it for |
 |---|---|
-| [loop.md](references/loop.md) | Discovery, task quality, crew selection, zero-input pilot, immediate promotion, and observation. |
+| [loop.md](references/loop.md) | Discovery, task quality, crew selection, orchestrator attribution, zero-input pilot, immediate promotion, and observation. |
 | [authorization.md](references/authorization.md) | Executable `--complete` examples, concurrency and crew limits, window boundaries, and handoff metrics. |
 | [recovery.md](references/recovery.md) | CI deduplication, triage, failed completion, operational repair tasks, and deployment verification. |
 | [walkthroughs.md](references/walkthroughs.md) | Decisions for missing context, duplicates, locks, unavailable authority, provider limits, and window expiry. |

--- a/plugin/skills/orbit-orchestrate/references/loop.md
+++ b/plugin/skills/orbit-orchestrate/references/loop.md
@@ -58,6 +58,40 @@ per-run crew input: passing `--input crew=...` does not override that step.
 Inspect `[crews.system]` and any compatibility fallback in the active config;
 change persistent configuration only within the user's authorization.
 
+## Record who orchestrated the work
+
+Orchestrator attribution is a separate field from the execution crew. It names
+the crew that prepared and supervised the task; it selects nothing, grants no
+authority, and never changes which crew or model executes the task. Set it on
+creation, when the task is `proposed` or `backlog` — after that it is fixed.
+
+A session can carry the value so every task it creates is attributed without
+each call remembering to pass it. Start the server with the crew you orchestrate
+as:
+
+```bash
+orbit mcp serve --workspace <selector> --orchestrator <your-crew>
+```
+
+Precedence is explicit-then-session: a call that passes `orchestrator` uses that
+value, a call that omits it inherits the session's, and a session started
+without the flag attributes nothing at all. The name is resolved against the
+crews of whichever workspace the call lands in, so an unconfigured crew fails
+that call rather than being replaced by another one. The default applies only to
+tasks the session creates: existing tasks are never rewritten.
+
+```bash
+orbit tool run orbit.task.add --input '{"workspace":"<selector>","title":"<title>","description":"<description>","complexity":"medium","orchestrator":"<crew>","model":"<agent-family>"}'
+```
+
+Treat the flag as configuration, not as evidence of who is calling. An MCP
+connection outlives a model switch in the client, so a session started under one
+crew keeps stamping that crew after the client moves to another. When the
+orchestrating crew actually changes, pass `orchestrator` on the individual call
+or restart the connection with the new value. `--operator` is unrelated and
+unchanged: it decides what a session may do, this decides only what gets
+recorded.
+
 ## Prepare context with task-pilot
 
 ```bash

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -94,6 +94,16 @@ This is the deliberate bootstrap path for a human-facing orchestrator; bare
 workspace-scoped tools route without an explicit selector on every call —
 most MCP clients cannot announce one at initialize.
 
+`orbit mcp serve --orchestrator <crew>` binds a second session default, this
+one purely descriptive: tasks the session creates are attributed to that crew
+unless the call passes its own `orchestrator`. It is independent of
+`--operator` and grants nothing, does not select the crew or model a task
+executes under, and never rewrites an existing task. The crew is resolved
+against the workspace the call lands in, so an unconfigured name fails that
+call instead of silently selecting another crew. Because a connection outlives
+a model switch in the client, pass `orchestrator` per call or restart the
+session when the orchestrating crew changes.
+
 Choose the real integration branch; do not assume the product default `main`
 is the repository's landing branch. `--ship-mode local` selects worktree-based
 local merge delivery instead of opening PRs. For another host's workspace, use

--- a/website/src/content/docs/how-to/mcp-integration.md
+++ b/website/src/content/docs/how-to/mcp-integration.md
@@ -90,6 +90,41 @@ Use `orbit tool list` to inspect the current local registry. MCP exposure is a
 capability-filtered subset of that registry. The retired graph tools are not
 exposed.
 
+### Attribute the tasks a session creates
+
+A server can carry the orchestrator crew that its tasks are attributed to, so
+each call does not have to remember it:
+
+```bash
+orbit mcp serve --workspace <selector> --orchestrator <crew>
+```
+
+The value is attribution only. Unlike `--operator` it grants no authority, and
+it neither selects the crew a task executes under nor the model recorded for
+that execution. A call that passes its own `orchestrator` wins; a call that
+omits it inherits the session's; a server started without the flag attributes
+nothing, exactly as before. The crew is resolved against the workspace the call
+lands in, so an unconfigured name fails that call rather than falling back to
+another crew, and only newly created tasks are affected — existing ones are
+never rewritten.
+
+Both client modes forward the value to the server that actually creates the
+task:
+
+```bash
+orbit mcp serve --mode remote <ssh-host> --orchestrator <crew>
+orbit mcp serve --mode federated --orchestrator <crew>
+```
+
+A destination whose `authorized_keys` pins a forced command composes its own
+argv, so its configuration wins there — the same rule that already applies to
+the authority a remote session asks for.
+
+Treat the flag as configuration, not as evidence of which model is answering a
+given call: an MCP connection commonly outlives a model switch on the client
+side. Pass `orchestrator` on the individual call, or restart the connection
+with a new value, when the orchestrating crew genuinely changes.
+
 ## Listen on a socket
 
 Deployments that need the server on a port — a server-side Orbit reached through

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -123,7 +123,7 @@ See [Schedule Recurring Work](../../how-to/recurring-work/).
 | Command | Purpose |
 |---|---|
 | `orbit mcp init` / `orbit mcp remove` | Register or unregister MCP client integration. Clients: `claude`, `codex`, `gemini`, `grok`, `cursor`, `vscode`, `windsurf`. `--federated` manages the mux entry separately. |
-| `orbit mcp serve` | Serve the MCP tool surface over stdio. |
+| `orbit mcp serve` | Serve the MCP tool surface over stdio. `--operator` serves operator authority; `--orchestrator <crew>` sets the orchestrator attribution recorded on tasks the session creates, and grants nothing. |
 | `orbit mcp listen [ADDR]` | Serve the same surface on a TCP socket. Binds `127.0.0.1:7879` unless `--allow-non-loopback` is passed. |
 | `orbit mcp callers` | Inspect and seed which callers this machine serves, and as what. |
 | `orbit web serve` | Serve the Orbit dashboard. |


### PR DESCRIPTION
## Task

[ORB-11313](https://orbit-cli.com/tasks/ORB-11313) — Default task orchestrator attribution from MCP session configuration

### Description

Add an optional --orchestrator <crew> argument to orbit mcp serve so task creation can obtain orchestrator attribution deterministically from the configured MCP session instead of relying solely on agents remembering to supply it. Keep --operator unchanged and independent: it controls authority, while --orchestrator supplies attribution and grants no permissions.

On task creation, an explicit task orchestrator takes precedence over the session default. If neither is supplied, preserve existing behavior. Apply this default only at creation; never backfill or overwrite existing tasks implicitly, and preserve lifecycle restrictions on subsequent attribution changes. Keep execution crew and model provenance independent. Forward the attribution default through remote and federated MCP paths and validate the resolved crew in the target workspace, reporting invalid configuration clearly instead of silently substituting another crew. Session attribution must remain isolated between clients and must not alter capability checks.

Treat --orchestrator as a configured default, not authenticated evidence of the model handling each call. Persistent MCP connections can outlive a model switch: document explicit per-task overrides or restarting/reconfiguring the connection when the orchestrator changes. Update orbit-orchestrate guidance and portable task-creation examples accordingly, without hardcoding astra; sync the committed plugin skill mirror using the supported generator.

This expands the original skill-only request to include runtime support and focused tests. The request is to update the task only; leave it undispatched.

### Acceptance Criteria

- orbit mcp serve accepts optional --orchestrator <crew>; --operator retains its current boolean authority semantics and attribution grants no capability.
- Task creation uses explicit orchestrator first, then the session default; omitting both preserves existing behavior. Existing records are not implicitly overwritten or backfilled, and lifecycle restrictions remain intact.
- Local, remote, and federated MCP paths preserve the default with session isolation. The effective crew is validated against the selected target workspace; invalid values produce a clear error without silent fallback.
- Execution crew and model provenance remain independent from orchestration attribution; focused tests cover precedence, absent defaults, invalid crews, forwarding, session isolation, and unchanged authorization behavior.
- Canonical orbit-orchestrate guidance and relevant CLI/setup documentation explain session defaults, explicit overrides, and persistent connections during model switches, using portable examples.
- Committed plugin skill mirror matches canonical source. Run focused tests, sync-plugin-skills.sh --check, and make ci-fast; report unrelated validation failures separately.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added `orbit mcp serve --orchestrator <crew>` as a session-scoped attribution default. `--operator` is untouched and independent.

Design
- New `ToolSessionContext.orchestrator` (orbit-types), stamped from launch argv exactly like the existing `workspace` binding. It is attribution only: it never enters `effective_capabilities`, any authorization decision, or execution crew/model resolution.
- Injection happens at the one canonical choke point, `OrbitTaskAddTool::execute`, via a new `apply_session_orchestrator_default` beside `resolve_workspace_argument`. Precedence: explicit call value (JSON null counts as absent) > session default > nothing. `orbit.task.update` deliberately does not call it, so no existing task is backfilled and the existing proposed/backlog lifecycle gate is untouched.
- Validation is unchanged and already lives at the right boundary: the injected name flows into `add_task_with_identity` -> `canonical_crew_name`, which resolves it against the crews of whichever workspace the call landed in and errors with `crew '<name>' is not defined in [crews.*]` plus suggestions. No silent fallback was added.
- Forwarding: `--orchestrator` is accepted alongside `--mode` (unlike `--operator`/`--workspace`, which describe the local server). `--mode remote` and the federated mux append it to the destination argv through the shared `remote_serve_command`, because a routed SSH session forwards no session context. The federated mux also stamps its own context so in-process local destinations see it. Blank/whitespace values normalize to absent everywhere. The TCP listener stays unbound, matching its existing no-workspace rule for a socket shared by many clients.
- Known, documented boundary: a destination whose authorized_keys pins a forced command composes its own argv, so its configuration wins there — the same rule that already governs a remote session's requested authority. Documented in the how-to and the design doc; the forced-command generator was not touched.

Tests (all passing)
- orbit-tools: session default applied, explicit override wins, absent default byte-identical to prior behavior, blank default ignored, session isolation across three interleaved contexts, and attribution granting no capability / no crew / no model change.
- orbit-core (real runtime): valid default persisted and resolved against the target workspace's crews, unknown default rejected by name, explicit beats session end to end, update never backfills, lifecycle restriction still enforced through a configured session.
- orbit-mcp: remote argv forwards and posix-quotes the crew; blank/None forwards nothing.
- orbit-cli (new `tests/command.rs`): default absent, `--operator` and `--orchestrator` independent in both directions, accepted with both client modes, requires a value.

Docs
- orbit-orchestrate SKILL.md + references/loop.md: new "Record who orchestrated the work" section covering session defaults, explicit-then-session precedence, target-workspace validation, creation-only scope, and the persistent-connection/model-switch caveat. Portable `<crew>` placeholders; no crew name hardcoded.
- orbit skill setup/first-run.md, website how-to/mcp-integration.md, website reference/cli.md, and docs/design/mcp-session-context/2_design.md (field table row + launch-binding paragraph).
- Plugin mirror regenerated with `scripts/sync-plugin-skills.sh`; `--check` reports it matches canonical.

Context expansion: the task listed only the four skill files. Runtime support, focused tests, and the CLI/setup documentation required by the acceptance criteria are all outside that list, so the touched runtime, test, snapshot, and doc files were appended as canonical `file:` selectors.

RELEASE NOTE — the `orbit.task.add` `orchestrator` parameter description now states that it defaults to the session's crew, so `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` was regenerated. The drift is that one description string only: no parameter was added, removed, or made required. Per the snapshot guard's wording in RELEASING.md, tools/list drift should be classified at release time.

Validation
- `make ci-fast`: pass (includes `sync-plugin-skills.sh --check`).
- `make ci-lint` (workspace clippy, all targets, warnings denied): pass.
- Focused suites: orbit-tools lib 84/84, orbit-mcp lib 165/165, orbit-cli bins command::mcp 68/68, orbit-core adapter::tool_host 120/120, orbit-tools public_tool_surface 17/17, orbit-cli mcp_roundtrip 46/47.
- Two unrelated pre-existing failures, neither caused by this change:
  1. `orbit-tools --test policy_deny_tracing::policy_denials_emit_redacted_jsonl_tracing_events` — times out waiting for the JSONL appender under a temp HOME. Confirmed by re-running the same test with this change's orbit-types/orbit-tools files reverted to HEAD: it fails identically.
  2. `orbit-cli --test mcp_roundtrip::process_metadata_does_not_supply_a_replayable_key_bound_identity` — the test's own message: "requires an unrestricted runner where setgid is enabled and a mapped supplementary group is available". A runner capability denial, not a code failure.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11313-6a9c963c`
- Behind base: 0
- Ahead of base: 1