### PR TITLE
[code-review] Use the canonical Antigravity identity when validating crew effort

### DIFF
--- a/crates/orbit-agent/src/agent/agent.rs
+++ b/crates/orbit-agent/src/agent/agent.rs
@@ -26,6 +26,30 @@ pub enum ProviderOptions {
     Mock,
 }
 
+impl ProviderOptions {
+    /// The canonical provider identity used for cross-provider validation
+    /// (e.g. [`ReasoningEffort::validate_for_provider_model`]), independent
+    /// of `AgentConfig::provider_key` — the registry dispatch key, which is
+    /// derived from the CLI executable name and can diverge from it (the
+    /// Antigravity executable is `agy`, but its canonical identity is
+    /// `antigravity`).
+    fn canonical_provider_name(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex { .. } => "codex",
+            Self::Gemini => "gemini",
+            Self::Antigravity => "antigravity",
+            Self::Grok => "grok",
+            Self::Copilot => "copilot",
+            Self::Cursor => "cursor",
+            Self::Ollama => "ollama",
+            Self::Pi => "pi",
+            Self::Opencode => "opencode",
+            Self::Mock => "mock",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentConfig {
     pub command: String,
@@ -74,7 +98,10 @@ impl AgentConfig {
     ) -> Result<Self, OrbitError> {
         if let Some(effort) = reasoning_effort {
             effort
-                .validate_for_provider_model(self.provider_key, self.model.as_deref())
+                .validate_for_provider_model(
+                    self.provider_options.canonical_provider_name(),
+                    self.model.as_deref(),
+                )
                 .map_err(OrbitError::InvalidInput)?;
         }
         self.reasoning_effort = reasoning_effort;

--- a/crates/orbit-agent/src/agent/mod.rs
+++ b/crates/orbit-agent/src/agent/mod.rs
@@ -1,4 +1,7 @@
 #[allow(clippy::module_inception)]
 mod agent;
 
+#[cfg(test)]
+mod tests;
+
 pub use agent::{Agent, AgentConfig, ProviderOptions};

--- a/crates/orbit-agent/src/agent/tests/agent.rs
+++ b/crates/orbit-agent/src/agent/tests/agent.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use orbit_common::OrbitError;
+use orbit_types::identity::ReasoningEffort;
+
+use crate::agent::{Agent, AgentConfig};
+use crate::types::{AgentOperation, AgentRequest};
+
+/// Builds the config the same way real dispatch does: resolve the `agy`
+/// factory from the CLI name, then attach crew-resolved effort. [ORB-11320]
+fn antigravity_config(model: &str, effort: ReasoningEffort) -> Result<AgentConfig, OrbitError> {
+    AgentConfig::from_cli_config("agy", Some(model), &HashMap::new())?
+        .with_reasoning_effort(Some(effort))
+}
+
+#[test]
+fn supported_antigravity_effort_reaches_the_agy_invocation() {
+    let cfg = antigravity_config("gemini-3.8-flash-high", ReasoningEffort::High)
+        .expect("low/medium/high must be admitted for a *-high model slug");
+
+    let agent = Agent::new(&cfg).expect("agy runtime should build from the admitted config");
+    let (invocation, _) = agent
+        .invoke(AgentRequest {
+            operation: AgentOperation::Activity {
+                activity_id: "agy-effort-regression".to_string(),
+            },
+            envelope_json: br#"{"schemaVersion":1,"input":{}}"#.to_vec(),
+            verbose: false,
+        })
+        .expect("invoke should render an invocation spec");
+
+    assert!(
+        invocation
+            .args
+            .windows(2)
+            .any(|pair| pair == ["--effort", "high"]),
+        "expected --effort high in {:?}",
+        invocation.args
+    );
+}
+
+#[test]
+fn unsupported_antigravity_effort_is_rejected_at_config_admission() {
+    let err = antigravity_config("gemini-3.8-flash-high", ReasoningEffort::Xhigh)
+        .expect_err("xhigh is outside the antigravity crew vocabulary");
+
+    assert!(
+        matches!(err, OrbitError::InvalidInput(ref message) if message.contains("xhigh")),
+        "{err}"
+    );
+}
+
+#[test]
+fn legacy_gemini_cli_model_id_is_rejected_at_config_admission() {
+    let err = antigravity_config("gemini-3.8-flash", ReasoningEffort::Low)
+        .expect_err("bare gemini CLI model ids are not agy model slugs");
+
+    assert!(
+        matches!(err, OrbitError::InvalidInput(ref message) if message.contains("gemini-3.8-flash")),
+        "{err}"
+    );
+}

--- a/crates/orbit-agent/src/agent/tests/mod.rs
+++ b/crates/orbit-agent/src/agent/tests/mod.rs
@@ -1,0 +1,1 @@
+mod agent;


### PR DESCRIPTION
## Task

[ORB-11320](https://orbit-cli.com/tasks/ORB-11320) — [code-review] Use the canonical Antigravity identity when validating crew effort

### Description

Antigravity crew configuration admits `effort = "low|medium|high"` against the canonical provider name `antigravity` (`crates/orbit-types/src/identity/agent_pair.rs:80-92`). At dispatch, however, `AgentConfig::with_reasoning_effort` validates against `self.provider_key` (`crates/orbit-agent/src/agent/agent.rs:69-80`), and the Antigravity factory sets that key to the executable name `agy` (`crates/orbit-agent/src/providers/antigravity/antigravity_runtime.rs:12` and `:46-49`). Since `validate_for_provider_model` has no `agy` branch, every otherwise-valid Antigravity effort is rejected as `provider agy does not support configured reasoning effort` before the CLI starts. Keep executable/runtime naming separate from the canonical provider identity, or explicitly normalize `agy` at this boundary, and cover the real `AgentConfig::from_cli_config(agy, ...).with_reasoning_effort(...)` dispatch path.

### Acceptance Criteria

- An Antigravity crew with a supported effort reaches the `agy` invocation with the corresponding `--effort` argument.
- Unsupported Antigravity efforts and legacy Gemini model IDs remain rejected at configuration admission.
- Regression coverage exercises the full AgentConfig/runtime construction path rather than only the transport argument helper.

## Execution Summary

<details>
<summary>Click to expand</summary>

Root cause: `AgentConfig::with_reasoning_effort` (crates/orbit-agent/src/agent/agent.rs) validated against `self.provider_key`, which is the CLI-dispatch/registry key returned by `AgentRuntimeFactory::key()` — for Antigravity that's the executable name `agy` (crates/orbit-agent/src/providers/antigravity/antigravity_runtime.rs), not the canonical provider identity `antigravity` that `ReasoningEffort::validate_for_provider_model` (crates/orbit-types/src/identity/agent_pair.rs) matches on. Every Antigravity effort therefore fell into the `other => Err(...)` branch and was rejected before the `agy` CLI ever ran.

Fix: added `ProviderOptions::canonical_provider_name()` in crates/orbit-agent/src/agent/agent.rs, a private mapping from the `ProviderOptions` enum (the real per-provider discriminant already produced by each factory's `options_from_config`) to its canonical identity string (`"claude"`, `"codex"`, `"gemini"`, `"antigravity"`, `"grok"`, `"copilot"`, `"cursor"`, `"ollama"`, `"pi"`, `"opencode"`, `"mock"`). `with_reasoning_effort` now validates against `self.provider_options.canonical_provider_name()` instead of `self.provider_key`. `provider_key` itself is untouched and still used only for runtime/registry dispatch (crates/orbit-agent/src/runtime/factory.rs), keeping executable naming separate from canonical provider identity as the task asked, with no change to any other provider's behavior (Cursor's `cursor-agent` key already fell into the same `other` error branch as `cursor` would, so it's a no-op there; all others already had provider_key == canonical name).

Regression coverage: new sibling test module crates/orbit-agent/src/agent/tests/{mod.rs,agent.rs} (declared via `#[cfg(test)] mod tests;` in agent/mod.rs), exercising the full `AgentConfig::from_cli_config("agy", ...).with_reasoning_effort(...)` -> `Agent::new` -> `Agent::invoke` path per the task's third acceptance criterion, not just the transport arg helper (which already had coverage in providers/antigravity/tests/antigravity_cli.rs):
- supported_antigravity_effort_reaches_the_agy_invocation: builds AgentConfig from CLI name "agy" with model gemini-3.8-flash-high and effort High, builds the Agent, invokes it, and asserts the rendered invocation args contain `--effort high`.
- unsupported_antigravity_effort_is_rejected_at_config_admission: Xhigh is still rejected at config admission (not remapped/ignored).
- legacy_gemini_cli_model_id_is_rejected_at_config_admission: bare `gemini-3.8-flash` (no -low/-medium/-high suffix) is still rejected at config admission.

Validation: `cargo test -p orbit-agent` (135 passed, including the 3 new tests), `cargo clippy -p orbit-agent --all-targets` (clean), `make ci-fast` (passed). Kicked off `make ci-lint` (workspace-wide clippy, denies warnings) in the background to confirm no fallout elsewhere; will report if it turns up anything.

Scope: touched only the two files listed in context_files (crates/orbit-agent/src/agent/agent.rs, crates/orbit-agent/src/agent/mod.rs) plus the new sibling tests/ directory required by the repo's test-layout convention for a module that previously had no tests — no context_files update needed since the new files are additive test scaffolding for agent.rs, not a change to an unlisted existing file. No cross-crate dependency edges added.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11320-6a9ca0b6`
- Behind base: 0
- Ahead of base: 1