### PR TITLE
[code-review] Fix prerelease ordering so orbit update cannot bypass downgrade safety

### DIFF
--- a/crates/orbit-cmd/src/update/tests/flow.rs
+++ b/crates/orbit-cmd/src/update/tests/flow.rs
@@ -140,6 +140,21 @@ fn a_downgrade_is_refused_until_it_is_asked_for_explicitly() {
 }
 
 #[test]
+fn an_explicit_prerelease_downgrade_is_refused_until_it_is_asked_for() {
+    let fixture = Fixture::new("0.19.0-rc.10");
+    fixture.publish("0.19.0-rc.2", FakeBinary::Healthy);
+
+    let mut requested = request();
+    requested.target_version = Some("0.19.0-rc.2".to_string());
+    let error = run_update(&fixture.environment(), &requested).expect_err("downgrade is refused");
+
+    assert!(error.to_string().contains("--allow-downgrade"), "{error}");
+    assert!(error.to_string().contains("0.19.0-rc.2"), "{error}");
+    assert_eq!(fixture.installed_reports(), "orbit 0.19.0-rc.10");
+    assert!(fixture.invocations().is_empty());
+}
+
+#[test]
 fn an_incompatible_downgrade_is_caught_before_the_binary_is_replaced() {
     let fixture = Fixture::new("0.19.0");
     // The older release cannot open state the newer one already migrated, so
@@ -166,6 +181,31 @@ fn an_incompatible_downgrade_is_caught_before_the_binary_is_replaced() {
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn an_incompatible_prerelease_downgrade_runs_the_compatibility_preflight() {
+    let fixture = Fixture::new("0.19.0-rc.10");
+    fixture.publish("0.19.0-rc.2", FakeBinary::MigrationFails);
+
+    let mut requested = request();
+    requested.target_version = Some("0.19.0-rc.2".to_string());
+    requested.allow_downgrade = true;
+    let error = run_update(&fixture.environment(), &requested).expect_err("incompatible downgrade");
+
+    assert!(
+        error.to_string().contains("cannot open this workspace"),
+        "{error}"
+    );
+    assert!(
+        error.to_string().contains("nothing was replaced"),
+        "{error}"
+    );
+    assert_eq!(fixture.installed_reports(), "orbit 0.19.0-rc.10");
+    assert_eq!(
+        fixture.invocations(),
+        vec!["0.19.0-rc.2: migrate --dry-run".to_string()]
     );
 }
 

--- a/crates/orbit-cmd/src/update/tests/version.rs
+++ b/crates/orbit-cmd/src/update/tests/version.rs
@@ -27,8 +27,35 @@ fn a_prerelease_sorts_below_the_release_it_leads_to() {
 }
 
 #[test]
+fn prerelease_numbers_compare_numerically_not_lexically() {
+    assert!(parse("0.19.0-rc.2") < parse("0.19.0-rc.10"));
+    assert!(parse("0.19.0-rc.10") < parse("0.19.0"));
+    assert!(parse("0.19.0-rc.10") > parse("0.18.9"));
+    assert_eq!(parse("0.19.0-rc.10").to_string(), "0.19.0-rc.10");
+}
+
+#[test]
 fn rejects_input_that_is_not_a_release_version() {
     for value in ["", "latest", "0.18", "0.18.0.1", "0.18.x", "v"] {
+        let error = ReleaseVersion::parse(value).expect_err("should reject");
+        assert!(
+            error.to_string().contains("MAJOR.MINOR.PATCH"),
+            "{value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn rejects_malformed_or_unsupported_prerelease_identifiers() {
+    for value in [
+        "0.19.0-",
+        "0.19.0-rc.",
+        "0.19.0-rc..1",
+        "0.19.0-rc.01",
+        "0.19.0-rc.1+build",
+        "0.19.0-rc_1",
+        "0.19.0-rc.1_2",
+    ] {
         let error = ReleaseVersion::parse(value).expect_err("should reject");
         assert!(
             error.to_string().contains("MAJOR.MINOR.PATCH"),

--- a/crates/orbit-cmd/src/update/version.rs
+++ b/crates/orbit-cmd/src/update/version.rs
@@ -10,14 +10,33 @@ use std::fmt::{Display, Formatter};
 
 use orbit_common::OrbitError;
 
+/// One prerelease identifier. Numbers compare numerically (`rc.10` > `rc.2`);
+/// everything else compares lexically. `Numeric` is declared first so a number
+/// sorts below a non-numeric identifier. Unsupported syntax is rejected at
+/// parse time so `orbit update` never assigns an unsafe order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum PreReleaseIdent {
+    Numeric(u64),
+    Alpha(String),
+}
+
+impl Display for PreReleaseIdent {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Numeric(value) => write!(formatter, "{value}"),
+            Self::Alpha(value) => write!(formatter, "{value}"),
+        }
+    }
+}
+
 /// A published Orbit release version.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseVersion {
     major: u64,
     minor: u64,
     patch: u64,
-    /// Pre-release identifier without the leading `-`, e.g. `rc.1`.
-    pre: Option<String>,
+    /// Parsed identifiers without the leading `-`, e.g. `rc` + `1` for `rc.1`.
+    pre: Option<Vec<PreReleaseIdent>>,
 }
 
 impl ReleaseVersion {
@@ -26,8 +45,8 @@ impl ReleaseVersion {
         let trimmed = value.trim();
         let body = trimmed.strip_prefix('v').unwrap_or(trimmed);
         let (core, pre) = match body.split_once('-') {
-            Some((core, pre)) if !pre.is_empty() => (core, Some(pre.to_string())),
-            Some(_) | None => (body, None),
+            Some((core, pre)) => (core, Some(parse_prerelease(pre, value)?)),
+            None => (body, None),
         };
         let mut fields = core.split('.');
         let mut next = |label: &str| -> Result<u64, OrbitError> {
@@ -67,7 +86,16 @@ impl Display for ReleaseVersion {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         write!(formatter, "{}.{}.{}", self.major, self.minor, self.patch)?;
         match &self.pre {
-            Some(pre) => write!(formatter, "-{pre}"),
+            Some(pre) => {
+                write!(formatter, "-")?;
+                for (index, ident) in pre.iter().enumerate() {
+                    if index > 0 {
+                        write!(formatter, ".")?;
+                    }
+                    write!(formatter, "{ident}")?;
+                }
+                Ok(())
+            }
             None => Ok(()),
         }
     }
@@ -77,8 +105,9 @@ impl Ord for ReleaseVersion {
     fn cmp(&self, other: &Self) -> Ordering {
         (self.major, self.minor, self.patch)
             .cmp(&(other.major, other.minor, other.patch))
-            // A pre-release sorts before the release it leads to, and two
-            // pre-releases of the same core version compare lexically.
+            // A pre-release sorts before the release it leads to. Two
+            // pre-releases of the same core version compare identifier by
+            // identifier, with numeric parts compared as numbers.
             .then_with(|| match (&self.pre, &other.pre) {
                 (None, None) => Ordering::Equal,
                 (None, Some(_)) => Ordering::Greater,
@@ -92,4 +121,49 @@ impl PartialOrd for ReleaseVersion {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
+}
+
+fn parse_prerelease(pre: &str, value: &str) -> Result<Vec<PreReleaseIdent>, OrbitError> {
+    if pre.is_empty() {
+        return Err(ReleaseVersion::invalid(value, "empty prerelease"));
+    }
+    if pre.contains('+') {
+        return Err(ReleaseVersion::invalid(value, "build metadata"));
+    }
+    let mut idents = Vec::with_capacity(pre.bytes().filter(|byte| *byte == b'.').count() + 1);
+    for ident in pre.split('.') {
+        idents.push(parse_prerelease_ident(ident, value)?);
+    }
+    Ok(idents)
+}
+
+fn parse_prerelease_ident(ident: &str, value: &str) -> Result<PreReleaseIdent, OrbitError> {
+    if ident.is_empty() {
+        return Err(ReleaseVersion::invalid(
+            value,
+            "empty prerelease identifier",
+        ));
+    }
+    if ident.bytes().all(|byte| byte.is_ascii_digit()) {
+        if ident.len() > 1 && ident.starts_with('0') {
+            return Err(ReleaseVersion::invalid(
+                value,
+                "leading zero in prerelease identifier",
+            ));
+        }
+        let number = ident
+            .parse::<u64>()
+            .map_err(|_| ReleaseVersion::invalid(value, "prerelease identifier"))?;
+        return Ok(PreReleaseIdent::Numeric(number));
+    }
+    if ident
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Ok(PreReleaseIdent::Alpha(ident.to_string()));
+    }
+    Err(ReleaseVersion::invalid(
+        value,
+        "unsupported prerelease identifier",
+    ))
 }


### PR DESCRIPTION
## Task

[ORB-11319](https://orbit-cli.com/tasks/ORB-11319) — [code-review] Fix prerelease ordering so orbit update cannot bypass downgrade safety

### Description

`ReleaseVersion::cmp` compares prerelease suffixes as plain strings (`crates/orbit-cmd/src/update/version.rs:76-87`). This makes `0.19.0-rc.10` sort below `0.19.0-rc.2`, even though rc.10 is newer. `run_update` uses that ordering for both the explicit downgrade refusal and the staged-binary compatibility probe (`crates/orbit-cmd/src/update/mod.rs:228-234` and `:262-264`). Consequently, running `orbit update --version 0.19.0-rc.2` from rc.10 is misclassified as an upgrade: it neither requires `--allow-downgrade` nor runs `migrate --dry-run`, and can replace the executable with an older binary after workspace state has been migrated by rc.10. Parse and compare supported prerelease identifiers with numeric components numerically, or reject unsupported prerelease syntax, so every older target takes the downgrade-safety path. Add regression coverage for rc.10 versus rc.2 through both version ordering and the update flow.

### Acceptance Criteria

- `0.19.0-rc.10` compares newer than `0.19.0-rc.2`, while prereleases still compare below their final release.
- An explicit update from rc.10 to rc.2 is refused without `--allow-downgrade` and runs the compatibility preflight when downgrade authorization is present.
- Malformed or unsupported prerelease identifiers fail closed instead of receiving an unsafe ordering.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Parse prerelease suffixes as dot-separated identifiers so numeric parts (`rc.10` vs `rc.2`) compare numerically, while a prerelease still sorts below its final release.
- Reject empty identifiers, leading zeros, build metadata, and unsupported characters at parse time instead of assigning an unsafe lexical order.
- Add version-order and `run_update` flow coverage for an explicit rc.10 → rc.2 downgrade (refused without `--allow-downgrade`; `migrate --dry-run` preflight when authorized).
Assessment: Scoped to `ReleaseVersion` and its sibling tests. `run_update` already keys downgrade safety on `target < current`, so correcting Ord is sufficient. No new crate edges.
Validation: `cargo test -p orbit-cmd --lib -- update::tests::version update::tests::flow` (28 passed); `make ci-fast`; `make ci-lint`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11319-6a9ca0b6`
- Behind base: 0
- Ahead of base: 1