### PR TITLE
[friction-curation] Stop the task-authoring skill from recommending source_task_id on task.add

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-authoring.md
@@ -88,8 +88,12 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   but inert. Only `produces`/`resolves` accept non-task targets; the rest
   require a task ID. A dangling target (unknown in every workspace this host
   can see) succeeds but emits a `TaskRelationDangling` audit event.
-- `parent_id`, `source_task_id` (the bug-introducing task; creation-time only —
-  `update` silently drops it), `tags` (reuse existing before inventing new).
+- `parent_id` is a retired `orbit.task.add` input and is stripped with the
+  other entries in `RETIRED_TASK_ADD_INPUT_FIELDS`; use a `child_of` relation
+  in `relations` when creating a subtask. `source_task_id` is also retired
+  from `orbit.task.add`; for bug tasks, set it after creation with
+  `orbit.task.update` (which accepts the field), and use an empty string there
+  to clear it. `tags` (reuse existing before inventing new).
 - `required_tools: ["<exact.canonical.tool>", ...]` — tools the task must add to
   any agent activity's baseline. Use only exact, active, agent-facing registered
   names; wildcards and prefixes are rejected at dispatch. The list is normalized,

--- a/plugin/skills/orbit/references/task-authoring.md
+++ b/plugin/skills/orbit/references/task-authoring.md
@@ -88,8 +88,12 @@ job fills them from real inspection. → [orchestration.md](orchestration.md)
   but inert. Only `produces`/`resolves` accept non-task targets; the rest
   require a task ID. A dangling target (unknown in every workspace this host
   can see) succeeds but emits a `TaskRelationDangling` audit event.
-- `parent_id`, `source_task_id` (the bug-introducing task; creation-time only —
-  `update` silently drops it), `tags` (reuse existing before inventing new).
+- `parent_id` is a retired `orbit.task.add` input and is stripped with the
+  other entries in `RETIRED_TASK_ADD_INPUT_FIELDS`; use a `child_of` relation
+  in `relations` when creating a subtask. `source_task_id` is also retired
+  from `orbit.task.add`; for bug tasks, set it after creation with
+  `orbit.task.update` (which accepts the field), and use an empty string there
+  to clear it. `tags` (reuse existing before inventing new).
 - `required_tools: ["<exact.canonical.tool>", ...]` — tools the task must add to
   any agent activity's baseline. Use only exact, active, agent-facing registered
   names; wildcards and prefixes are rejected at dispatch. The list is normalized,


### PR DESCRIPTION
## Task

[ORB-11323](https://orbit-cli.com/tasks/ORB-11323) — [friction-curation] Stop the task-authoring skill from recommending source_task_id on task.add

### Description

## Problem

The shipped task-authoring skill tells authors to pass `source_task_id` at creation time, but `orbit.task.add` strips it as a retired field and warns. Provenance the author believes they recorded is silently discarded.

- Guidance: `crates/orbit-core/assets/skills/orbit/references/task-authoring.md:91-92` — "`parent_id`, `source_task_id` (the bug-introducing task; creation-time only — `update` silently drops it)". This is exactly backwards.
- Behavior: `crates/orbit-tools/src/builtin/orbit/task/add.rs:122` calls `strip_retired_task_add_input_fields` (`crates/orbit-common/src/protocol/tool_input.rs:16`) and logs `ignored retired orbit.task.add fields` at line 127.
- `source_task_id` is *not* retired generally — `orbit.task.update` exposes it (`crates/orbit-tools/src/builtin/orbit/task/update.rs:83`) and it is a live field on the model and in `task show`. Only the `add` path drops it.

## Reproduction (verified 2026-09-05, ORB-11318)

Originally recorded during ORB-11177 (run jrun-20260904-0208-9), where filing with `source_task_id: ORB-11162` succeeded but emitted the ignore warning. Independently re-confirmed in this pass: an `orbit tool run orbit.task.add` call in this run emitted `WARN orbit.tools.task.add: ignored retired orbit.task.add fields ignored_fields=["status"]`, which is the same strip path, and `RETIRED_TASK_ADD_INPUT_FIELDS` still contains `source_task_id`.

## Suggested direction

Correct the guidance to match the tool: `source_task_id` is set through `orbit.task.update` after creation, not on `orbit.task.add`. Keep the description of what the field means. While editing, check the neighbouring claim about `parent_id` against the same retired-field list rather than assuming it is right.

The skill is mirrored: `plugin/skills/orbit/references/task-authoring.md` is byte-checked against the crate asset by `./scripts/sync-plugin-skills.sh --check` in `make ci-fast`, so both copies must change in the same commit.

Out of scope: whether `orbit.task.add` *should* accept the field. That is a separate product decision; this task only stops the shipped guidance from recommending a discarded parameter.

### Acceptance Criteria

- `crates/orbit-core/assets/skills/orbit/references/task-authoring.md` no longer presents `source_task_id` as an `orbit.task.add` creation-time field, and states the surface that actually persists it (`orbit.task.update`).
- The stated behavior for every field the edit touches matches `RETIRED_TASK_ADD_INPUT_FIELDS` in `crates/orbit-common/src/protocol/tool_input.rs` and the `orbit.task.update` parameter list; `parent_id` is checked against the same list rather than left unverified.
- `plugin/skills/orbit/references/task-authoring.md` is updated in the same change and `./scripts/sync-plugin-skills.sh --check` passes.
- An `orbit tool run orbit.task.add` call built by following the corrected guidance produces no `ignored retired orbit.task.add fields` warning, and setting `source_task_id` the corrected way is confirmed persisted via `orbit task show <id> --json`.
- `make ci-fast` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Corrected the canonical task-authoring skill to document `parent_id` as a retired `orbit.task.add` input, recommend `relations`/`child_of` for subtasks, and direct `source_task_id` provenance through `orbit.task.update`.
- Regenerated the mirrored plugin skill; both files remain identical.
Validation:
- `./scripts/sync-plugin-skills.sh --check` passed.
- Created validation task ORB-11336 with the corrected `orbit.task.add` fields (no retired-field warning), set `source_task_id` via `orbit.task.update`, and confirmed it with `orbit.task.show`; the validation-only task was then rejected.
- `make ci-fast` passed.
- `git diff --check` passed and final status contains only the two intended skill files.
Assessment: Documentation now matches `RETIRED_TASK_ADD_INPUT_FIELDS` and the live `orbit.task.update` parameter surface.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11323-6a9ca308`
- Behind base: 0
- Ahead of base: 1