### PR TITLE
[friction-curation] Surface orchestrator task comments in the executor's injected task context

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -58,6 +58,17 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
+    1a. Read the injected `comments` array (chronological, each with `by` and
+        `at`) before trusting the description. A description is written once
+        at filing time and is never rewritten when an orchestrator later posts
+        a refinement; a comment that postdates the description always takes
+        precedence over a "Suggested direction"/"Suggested fix" section still
+        sitting in that description. For example, if the description proposes
+        one approach and a later comment says not to adopt it, implement the
+        comment's direction, not the description's. If `comments_truncated` is
+        `true`, the visible comments are still authoritative — truncation
+        drops the oldest entries first, so the newest, most relevant
+        refinements are always present.
     2. Resolve every canonical `context_files` selector: read each `file:`
        target with the provider-native file-read tool. For each `dir:` selector,
        do not call the file-read tool on the directory; after verifying it

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -58,6 +58,17 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
+    1a. Read the injected `comments` array (chronological, each with `by` and
+        `at`) before trusting the description. A description is written once
+        at filing time and is never rewritten when an orchestrator later posts
+        a refinement; a comment that postdates the description always takes
+        precedence over a "Suggested direction"/"Suggested fix" section still
+        sitting in that description. For example, if the description proposes
+        one approach and a later comment says not to adopt it, implement the
+        comment's direction, not the description's. If `comments_truncated` is
+        `true`, the visible comments are still authoritative — truncation
+        drops the oldest entries first, so the newest, most relevant
+        refinements are always present.
     2. Resolve every canonical `context_files` selector: read each `file:`
        target with the provider-native file-read tool. For each `dir:` selector,
        do not call the file-read tool on the directory; after verifying it

--- a/crates/orbit-core/assets/skills/orbit/references/task-execution.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-execution.md
@@ -14,6 +14,13 @@ then use
 required outcome), `plan` (author one if blank or placeholder), `context_files`,
 and `status`.
 
+Also read `comments` (chronological, each with `by` and `at`) before trusting
+the description. A description is written once at filing time and is never
+rewritten when an orchestrator later posts a refinement, so a comment that
+postdates the description always takes precedence over a "Suggested
+direction"/"Suggested fix" section still sitting in that description —
+implement the comment's direction, not the description's.
+
 Read each `file:` target with the provider-native file-read tool. For a `dir:`
 selector, do not call the file-read tool on the directory: after verifying it
 resolves beneath the workspace root, use `rg --files <directory>` to list it,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs
@@ -2,12 +2,28 @@ use std::path::Path;
 
 use orbit_common::fs::task_io::prune_missing_context_files;
 use orbit_engine::{DispatchError, WORKFLOW_RUN_FAILED_EVENT};
-use orbit_types::task::{Task, TaskHistoryEntry, TaskStatus};
+use orbit_types::task::{Task, TaskComment, TaskHistoryEntry, TaskStatus};
 use serde_json::Value;
 
 use crate::OrbitRuntime;
 use crate::application::task::{canonicalize_context_files_for_read, context_workspace_root};
 use crate::runtime::run_input::singular_task_id_from_input;
+
+/// Ceiling on the number of comments surfaced to an implementing agent.
+///
+/// Comments are unbounded in principle (an orchestrator can post any number of
+/// refinements), but the envelope is a single JSON payload handed to an agent
+/// invocation. The newest comments are the ones that can supersede the
+/// description (see [ORB-11327]), so truncation must drop the oldest entries
+/// first and say so rather than silently dropping the entries that matter.
+const MAX_TASK_COMMENTS: usize = 20;
+
+/// Ceiling on the total size, in bytes, of the retained comment bodies.
+///
+/// Applied after [`MAX_TASK_COMMENTS`] as a second, size-based cut: a handful
+/// of very long comments could still blow out the envelope even under the
+/// count cap.
+const MAX_TASK_COMMENTS_BYTES: usize = 16 * 1024;
 
 pub(crate) fn associated_task_ids(input: &Value) -> Vec<String> {
     let mut task_ids = Vec::new();
@@ -56,9 +72,15 @@ pub(crate) fn task_context_for_agent_input(
             "load task `{task_id}` history for agent envelope: {err}"
         ))
     })?;
+    let comments = runtime.get_task_comments(task_id).map_err(|err| {
+        DispatchError::CliInvocationFailed(format!(
+            "load task `{task_id}` comments for agent envelope: {err}"
+        ))
+    })?;
     Ok(Some(agent_task_context_json(
         &task,
         &task_history,
+        &comments,
         input,
         &runtime.paths().repo_root,
     )))
@@ -67,6 +89,7 @@ pub(crate) fn task_context_for_agent_input(
 fn agent_task_context_json(
     task: &Task,
     task_history: &[TaskHistoryEntry],
+    comments: &[TaskComment],
     input: &Value,
     fallback_repo_root: &Path,
 ) -> Value {
@@ -119,7 +142,40 @@ fn agent_task_context_json(
         );
     }
 
+    let (kept_comments, omitted_count) = bounded_task_comments(comments);
+    context.insert(
+        "comments".to_string(),
+        serde_json::to_value(kept_comments).unwrap_or_else(|_| Value::Array(Vec::new())),
+    );
+    if omitted_count > 0 {
+        context.insert("comments_truncated".to_string(), Value::Bool(true));
+        context.insert(
+            "comments_omitted_count".to_string(),
+            Value::Number(omitted_count.into()),
+        );
+    }
+
     Value::Object(context)
+}
+
+/// Keep the newest comments within [`MAX_TASK_COMMENTS`] and
+/// [`MAX_TASK_COMMENTS_BYTES`], dropping the oldest entries first so a
+/// superseding refinement never falls off the envelope. Returns the retained
+/// comments (still in chronological order) and how many oldest entries were
+/// dropped.
+fn bounded_task_comments(comments: &[TaskComment]) -> (&[TaskComment], usize) {
+    let count_start = comments.len().saturating_sub(MAX_TASK_COMMENTS);
+    let mut kept = &comments[count_start..];
+
+    while kept.len() > 1 {
+        let total_bytes: usize = kept.iter().map(|comment| comment.message.len()).sum();
+        if total_bytes <= MAX_TASK_COMMENTS_BYTES {
+            break;
+        }
+        kept = &kept[1..];
+    }
+
+    (kept, comments.len() - kept.len())
 }
 
 fn workflow_failure_status_note(task_history: &[TaskHistoryEntry]) -> Option<&str> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_context.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_context.rs
@@ -126,3 +126,152 @@ fn task_context_for_agent_input_marks_write_gated_statuses_terminal() {
     assert_eq!(context["status"], "done");
     assert_eq!(context["terminal"], true);
 }
+
+/// [ORB-11327]: a task with no comments must still project a `comments` array
+/// rather than a null/absent field, so downstream consumers never special-case
+/// the empty case.
+#[test]
+fn task_context_for_agent_input_has_empty_comments_when_none_posted() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "No comments yet".to_string(),
+            description: "Task description for agent context.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+
+    let context = runtime
+        .task_context_for_agent_input(&json!({ "task_id": task.id.clone() }))
+        .expect("build task context")
+        .expect("task context present");
+
+    assert_eq!(context["comments"], json!([]));
+    assert!(context.get("comments_truncated").is_none());
+    assert!(context.get("comments_omitted_count").is_none());
+}
+
+/// [ORB-11327]: comments are the mechanism an orchestrator uses to supersede a
+/// stale "suggested direction" left in the description (the ORB-11248
+/// incident). The envelope must carry them, in order, with author and
+/// timestamp so the executor can see a later refinement without an extra call.
+#[test]
+fn task_context_for_agent_input_includes_ordered_comments_with_author_and_timestamp() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Suggested direction gets superseded".to_string(),
+            description: "## Suggested direction\n\nDo the naive thing.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+
+    runtime
+        .update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                comment: Some("First pass looks reasonable.".to_string()),
+                ..Default::default()
+            },
+            Some("codex".to_string()),
+            None,
+        )
+        .expect("post first comment");
+    runtime
+        .update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                comment: Some(
+                    "Orchestrator refinement before implementation: do not adopt the \
+                     suggested direction as-is."
+                        .to_string(),
+                ),
+                ..Default::default()
+            },
+            Some("codex".to_string()),
+            None,
+        )
+        .expect("post superseding comment");
+
+    let context = runtime
+        .task_context_for_agent_input(&json!({ "task_id": task.id.clone() }))
+        .expect("build task context")
+        .expect("task context present");
+
+    let comments = context["comments"]
+        .as_array()
+        .expect("comments is an array");
+    assert_eq!(comments.len(), 2);
+    assert_eq!(comments[0]["message"], "First pass looks reasonable.");
+    assert_eq!(comments[0]["by"], "codex");
+    assert!(comments[0]["at"].is_string());
+    assert_eq!(
+        comments[1]["message"],
+        "Orchestrator refinement before implementation: do not adopt the suggested \
+         direction as-is."
+    );
+    assert_eq!(comments[1]["by"], "codex");
+    // Chronological order: the superseding comment is last, not first.
+    assert!(comments[0]["at"].as_str() <= comments[1]["at"].as_str());
+    assert!(context.get("comments_truncated").is_none());
+}
+
+/// [ORB-11327]: comment history is unbounded in principle, so the envelope
+/// caps it. Truncation must drop the *oldest* entries first — the newest
+/// comments are the ones that can supersede the description — and must signal
+/// that truncation happened rather than silently dropping entries.
+#[test]
+fn task_context_for_agent_input_truncates_oldest_comments_over_the_count_cap() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Long comment history".to_string(),
+            description: "Task description for agent context.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+
+    const POSTED: usize = 25;
+    const MAX_KEPT: usize = 20;
+    for index in 0..POSTED {
+        runtime
+            .update_task_with_identity(
+                &task.id,
+                TaskUpdateParams {
+                    comment: Some(format!("comment {index}")),
+                    ..Default::default()
+                },
+                Some("codex".to_string()),
+                None,
+            )
+            .expect("post comment");
+    }
+
+    let context = runtime
+        .task_context_for_agent_input(&json!({ "task_id": task.id.clone() }))
+        .expect("build task context")
+        .expect("task context present");
+
+    let comments = context["comments"]
+        .as_array()
+        .expect("comments is an array");
+    assert_eq!(comments.len(), MAX_KEPT);
+    // Oldest-first truncation: the surviving window is the newest MAX_KEPT
+    // comments, still in chronological order, ending on the very last post.
+    assert_eq!(
+        comments[0]["message"],
+        format!("comment {}", POSTED - MAX_KEPT)
+    );
+    assert_eq!(
+        comments[MAX_KEPT - 1]["message"],
+        format!("comment {}", POSTED - 1)
+    );
+    assert_eq!(context["comments_truncated"], true);
+    assert_eq!(
+        context["comments_omitted_count"],
+        (POSTED - MAX_KEPT) as u64
+    );
+}

--- a/plugin/skills/orbit/references/task-execution.md
+++ b/plugin/skills/orbit/references/task-execution.md
@@ -14,6 +14,13 @@ then use
 required outcome), `plan` (author one if blank or placeholder), `context_files`,
 and `status`.
 
+Also read `comments` (chronological, each with `by` and `at`) before trusting
+the description. A description is written once at filing time and is never
+rewritten when an orchestrator later posts a refinement, so a comment that
+postdates the description always takes precedence over a "Suggested
+direction"/"Suggested fix" section still sitting in that description —
+implement the comment's direction, not the description's.
+
 Read each `file:` target with the provider-native file-read tool. For a `dir:`
 selector, do not call the file-read tool on the directory: after verifying it
 resolves beneath the workspace root, use `rg --files <directory>` to list it,


### PR DESCRIPTION
## Task

[ORB-11327](https://orbit-cli.com/tasks/ORB-11327) — [friction-curation] Surface orchestrator task comments in the executor's injected task context

### Description

## Problem

The execution envelope handed to an implementing agent contains `description`, `acceptance_criteria`, `plan` and `context_files`, but not the task's comment history. When an orchestrator posts a refinement that contradicts a suggestion still sitting in the description, the executor has no way to see it and implements the superseded direction.

`crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs:95-98` builds that JSON with exactly those four fields.

## Concrete incident (ORB-11248)

ORB-11248's description ended with a "Suggested direction" proposing that `collect.rs:681` only raise a retryable error when the scan is incomplete *and* `actual_checkout_shas` is empty. A comment already on the task (2026-09-05T04:37:19Z, by `codex`, "Orchestrator refinement before implementation") explicitly rejected it: "Do not adopt suggested `incomplete && shas.empty()` as the sole safety gate. Separate display-only truncation from incomplete identity extraction; preserve fail-closed current-identity/admission semantics for genuine partial scans..."

The executor implemented the description's version, wrote tests for it, ran `make ci-fast` / `make ci-lint`, and only discovered the conflict when it happened to see the comment history in an unrelated `orbit.task.update` response. It then had to revert the branching and rewrite two tests.

## Root cause

A description is written once at filing time and is never rewritten when an orchestrator later posts a comment that changes the required behavior. Descriptions sourced from code review are the highest-risk case, because they are authored before any orchestration review exists.

Verified 2026-09-05 (ORB-11318): still current. `task_context.rs` has no `comments` key, and neither `crates/orbit-core/assets/activities/agent_implement.yaml` nor `crates/orbit-core/assets/skills/orbit/references/task-execution.md` tells an executor to read comments before trusting the description.

## Suggested direction

Include the task's comment history in the injected task context so the contradiction is visible as data rather than depending on the agent making an extra call. Keep it bounded — comments are unbounded in principle, so cap the number and/or size and make the truncation explicit in the payload rather than silently dropping the newest entries, which are the ones that supersede.

Also state in the executor instructions that a comment postdating the description wins over a description's suggested-fix section, so the precedence is unambiguous when both are present.

The alternative considered in the original report — requiring orchestrators to fold refinements back into `plan`/`description` — is weaker: it depends on every future orchestrator remembering, and it silently loses the refinement when they do not. Prefer surfacing the data. Record the rejected alternative in the change.

No fail-closed guard is widened; this adds read-only context to an existing payload.

### Acceptance Criteria

- The task context injected by `crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs` includes the task's comments with their author and timestamp, in chronological order.
- The comment payload is bounded by an explicit cap on count and/or total size, truncation drops oldest-first so the newest superseding comments always survive, and any truncation is signalled in the payload rather than silent.
- A test in the sibling `tests/` directory for `task_context.rs` pins that comments appear, that ordering and author/timestamp are preserved, and that an over-cap history truncates as specified while retaining the newest entries.
- Executor-facing instructions state that a comment postdating the description takes precedence over a suggested-fix section in the description; the ORB-11248 case is reproducible from the instruction text alone.
- A task with no comments produces an unchanged-in-spirit payload (no null/`"comments": null` surprises for consumers) and existing task-context tests still pass.
- `cargo test -p orbit-core` passes, and `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added `comments` (chronological, `at`/`by`/`message`) to the agent_implement task-context payload built in `task_context.rs`, sourced from `runtime.get_task_comments`. Truncation caps at 20 comments and 16KiB of combined message bytes, dropping oldest-first so superseding comments always survive; when truncated the payload adds `comments_truncated: true` and `comments_omitted_count`. No comments -> `"comments": []` (never null/omitted). Pinned with 3 new tests in the sibling `tests/task_context.rs`: empty case, ordered comments with author/timestamp, and count-cap truncation (25 posted -> newest 20 kept, oldest 5 signalled as omitted). Existing task-context tests pass unchanged.

Updated `agent_implement.yaml` instructions (step 1a) and the `orbit` skill's `task-execution.md` Step 1 to state that a comment postdating the description takes precedence over a "Suggested direction"/"Suggested fix" section in the description — this reproduces the ORB-11248 pattern from instruction text alone: read `comments` before trusting the description, and a later comment overrides an earlier suggested-fix section.

Rejected alternative (per the task's suggested direction): requiring orchestrators to fold refinements back into `plan`/`description` instead of surfacing raw comments. Rejected because it depends on every future orchestrator remembering to do so and silently loses the refinement when they don't; surfacing the comment data as read-only context is strictly safer.

Scope note: appended two files to context_files beyond the original two via `orbit.task.update` (recorded in that call's comment): `tests/task_context.rs` (new tests, required to pin the behavior per acceptance criteria) and `assets/skills/orbit/references/task-execution.md` (the task's own problem statement named this file as a second location lacking the precedence guidance; kept in sync with the agent_implement.yaml wording). Editing `task-execution.md` also required regenerating its mirrors: `.orbit/resources/activities/agent_implement.yaml` (byte-identical-mirror test `agent_implement_guidance_allows_bounded_scope_expansion`) and `plugin/skills/orbit/references/task-execution.md` (via `./scripts/sync-plugin-skills.sh`, enforced by `make ci-fast`).

Validation: `cargo test -p orbit-core` (1012 passed, 0 failed, plus all integration suites green), `make ci-fast` (all guardrails including the plugin-skill sync and activity-mirror checks), and `make ci-lint` (workspace clippy, warnings denied) all pass locally.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11327-6a9ca0b6`
- Behind base: 0
- Ahead of base: 1