### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -595,7 +595,7 @@
         "required": false
       },
       {
-        "description": "Optional named crew responsible for orchestration attribution; does not select execution",
+        "description": "Optional named crew responsible for orchestration attribution; does not select execution. Defaults to the MCP session's `orbit mcp serve --orchestrator` crew when omitted",
         "name": "orchestrator",
         "param_type": "string",
         "required": false


### PR DESCRIPTION
## Task

[ORB-11335](https://orbit-cli.com/tasks/ORB-11335) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `19f74dab12e8c2288192e99775fab33b8c56efe5`
- Normalized error signature (the dedupe identity, not a quote): `failures:`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-05T23:06:44.278494754+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/33997431229 run `33997431229` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `19f74dab12e8c2288192e99775fab33b8c56efe5`
  - current head of that ref: `unknown`
  - commit actually checked out: `19f74dab12e8c2288192e99775fab33b8c56efe5`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `19f74dab12e8c2288192e99775fab33b8c56efe5`
  - failed job `Coverage (informational)` (id `101390296224`): https://github.com/danieljhkim/orbit/actions/runs/33997431229/job/101390296224
  - failing step(s): `Collect workspace coverage`
  - failed job `Check / Clippy / Test` (id `101390296321`): https://github.com/danieljhkim/orbit/actions/runs/33997431229/job/101390296321
  - failing step(s): `Run CI guardrails`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4003863Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004146Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004150Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004217Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004400Z     plain_and_json_forms_match_their_goldens
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004560Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4004771Z test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.14s
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4005047Z 
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4005418Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-cli --test output_goldens`
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4006389Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-05T23:04:21.4018890Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33997159945 — superseded_by_newer_workflow_run: newer relevant run 33997431229 at 2026-09-05T22:59:30Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33996698428 — superseded_by_newer_workflow_run: newer relevant run 33997431229 at 2026-09-05T22:59:30Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33996649018 — ref_no_longer_exists: branch 'orbit/ORB-11313-6a9c963c' has no head on origin: its pull request was merged or the branch was deleted, so this run describes code that is either already landed — where the landing branch's own runs are the current evidence — or abandoned

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 4,
  "investigation_cursor": 496847,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11294-6a9c6955",
    "orbit/ORB-11299-6a9c6f23",
    "orbit/ORB-11313-6a9c963c"
  ],
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated crates/orbit-cli/tests/output_goldens/tool_list.json to match the current orbit.task.add schema description, including the MCP-session orchestrator default.
- The source definition and existing MCP schema snapshot already contained this wording; no workflow, assertion, lint level, or runtime behavior was weakened.

Assessment: The CI failure was a stale checked-in tool-list golden introduced when the task orchestrator description changed in ORB-11313. The focused reproduction failed before the update and passed after it; the final diff is one intended line.

Validation:
- Before fix: cargo test -p orbit-cli --test output_goldens plain_and_json_forms_match_their_goldens -- --exact --nocapture reproduced the reported plain_and_json_forms_match_their_goldens failure at tool_list.json.
- After fix: cargo test -p orbit-cli --test output_goldens passed 3/3.
- Coverage-target equivalent: with managed-only ORBIT_* variables removed to match the GitHub runner environment, cargo test --tests --manifest-path <worktree>/Cargo.toml --target-dir <worktree>/target/llvm-cov-target --workspace --locked passed the full CLI unit suite (423/423) and all reached integration tests; execution stopped only at process_metadata_does_not_supply_a_replayable_key_bound_identity, whose test explicitly requires an unrestricted Linux runner with setgid enabled and a mapped supplementary group. This environment denial is unrelated to the golden change. cargo llvm-cov was unavailable locally, so the underlying runner cargo-test command was used as the narrow faithful equivalent.
- make ci-fast passed.
- make ci-lint passed with -D warnings.
- Generated Cargo target directories were removed before handoff.
- Final git status contains only crates/orbit-cli/tests/output_goldens/tool_list.json.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11335-6a9ca0b6`
- Behind base: 0
- Ahead of base: 1