### PR TITLE
[friction-curation] Correct the compiler-cache runbook's SCCACHE_BASEDIRS claim and the wrapper's dead export

### DIFF
--- a/docs/runbooks/compiler-cache.md
+++ b/docs/runbooks/compiler-cache.md
@@ -94,7 +94,7 @@ them on the Orbit process):
 | `SCCACHE_CACHE_SIZE` | `5G` (sccache LRU) |
 | `ORBIT_COMPILER_CACHE_BIN` | `$HOME/.orbit/cache/bin/sccache`, else `sccache` on `PATH` |
 | `ORBIT_COMPILER_CACHE=0` | Force ordinary rustc |
-| `SCCACHE_BASEDIRS` | Set by the wrapper to the worktree root and `CARGO_TARGET_DIR` so absolute paths strip before hashing |
+| `SCCACHE_BASEDIRS` | For the pinned sccache `v0.17.0`, inert for rustc; Rust path normalization comes from the wrapper's `STABLE_SRC`/`STABLE_TGT` argv and environment rewrite when Linux Bubblewrap stable mounts alias the checkout and target |
 | `CARGO_INCREMENTAL=0` | Recommended for workers; sccache cannot cache rustc incremental invocations |
 
 After upgrading the Orbit binary that contains the Linux cache grant, new

--- a/scripts/rustc-compiler-cache.sh
+++ b/scripts/rustc-compiler-cache.sh
@@ -127,6 +127,9 @@ fi
 
 export SCCACHE_DIR="$cache_dir"
 export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-5G}"
+# sccache v0.17.0 does not use SCCACHE_BASEDIRS for rustc; retain this export
+# for sccache's non-Rust compatibility. Rust path normalization is performed by
+# the STABLE_SRC/STABLE_TGT rewrite above when the stable mounts are available.
 export SCCACHE_BASEDIRS="${SCCACHE_BASEDIRS:-$STABLE_SRC:$STABLE_TGT:$repo_root:$target_real}"
 debug "enabled bin=$cache_bin dir=$cache_dir"
 exec "$cache_bin" "$@"

--- a/scripts/test-compiler-cache.sh
+++ b/scripts/test-compiler-cache.sh
@@ -84,7 +84,7 @@ rm -f "$FAKE_SCCACHE_LOG" "$FAKE_RUSTC_LOG"
 [[ ! -f "$FAKE_SCCACHE_LOG" ]] || fail "unwritable cache must not exec sccache"
 chmod u+w "$HOME/.orbit/cache/compiler"
 
-# 4. Writable cache + sccache -> sccache then rustc, with path-stripping basedirs.
+# 4. Writable cache + sccache -> sccache then rustc.
 export FAKE_SCCACHE_LOG="$TMP/sccache-hit.log"
 export FAKE_SCCACHE_ENV="$TMP/sccache-hit.env"
 export FAKE_RUSTC_LOG="$TMP/rustc-hit.log"


### PR DESCRIPTION
## Task

[ORB-11328](https://orbit-cli.com/tasks/ORB-11328) — [friction-curation] Correct the compiler-cache runbook's SCCACHE_BASEDIRS claim and the wrapper's dead export

### Description

## Problem

`docs/runbooks/compiler-cache.md:97` documents `SCCACHE_BASEDIRS` as "Set by the wrapper to the worktree root and `CARGO_TARGET_DIR` so absolute paths strip before hashing". That is not what happens for Rust. sccache 0.17.0's `rust.rs` has no basedirs support at all — basedirs applies to the C/C++ preprocessor path only. Nothing strips worktree prefixes from rustc invocations.

The repository already knows this. ORB-11259's own execution summary records: "sccache's `SCCACHE_BASEDIRS` does not apply to rustc; cross-worktree hits require the stable mounts plus wrapper rewrite." The runbook table shipped in that same change contradicts it.

The actual normalization is the argv/env rewrite in `scripts/rustc-compiler-cache.sh`: `STABLE_SRC`/`STABLE_TGT` (lines 11-12), the rewrite helpers at lines 83-87, and the inode-equality gate at line 108 that only rewrites when the stable mounts really alias this checkout. The `export SCCACHE_BASEDIRS=...` at line 130 is a no-op for rustc.

## Evidence (F2026-09-010, measured during ORB-11259)

A two-worktree `cargo check -p orbit-types --offline` with private target dirs recorded 0 hits on the second tree, and 92 hits / 92 misses (50%) only when the same absolute target path was reused. `SCCACHE_BASEDIRS` alone produced no cross-worktree sharing.

## Why it matters

An operator reading the runbook will conclude that path normalization is handled by an environment variable and is therefore portable. It is not: it depends on the Linux Bubblewrap stable `/tmp` mounts plus the wrapper rewrite, which the runbook itself notes are Linux-only. The wrong mental model leads to expecting cross-worktree hits on macOS or outside a managed run, and to "fixing" a cache miss by adjusting basedirs.

Verified 2026-09-05 (ORB-11318): the runbook line and the wrapper export are both still present and unchanged.

## Suggested direction

Correct the runbook entry to say what `SCCACHE_BASEDIRS` actually does (nothing for rustc in the pinned sccache version) and point at the stable-mount rewrite as the mechanism that produces path-stable cache keys, naming the Linux-only precondition. Then either delete the dead `SCCACHE_BASEDIRS` export from the wrapper or keep it with a comment stating it is inert for rustc and why it is retained — do not leave it undocumented. Pin the sccache version the claim is scoped to, so a future upgrade that adds rustc basedirs support does not silently make the corrected doc wrong in the other direction.

No behavior change to the cache path is intended; no fail-closed guard is affected.

### Acceptance Criteria

- `docs/runbooks/compiler-cache.md` no longer claims `SCCACHE_BASEDIRS` strips absolute paths for Rust compilation, and names the `STABLE_SRC`/`STABLE_TGT` argv rewrite in `scripts/rustc-compiler-cache.sh` as the actual mechanism, with its Linux Bubblewrap-only precondition stated.
- The corrected claim is scoped to the pinned sccache version the repository installs (v0.17.0) so a later upgrade is not silently misdescribed.
- The `SCCACHE_BASEDIRS` export in `scripts/rustc-compiler-cache.sh` is either removed or retained with a comment stating it is inert for rustc and why it is kept; no undocumented dead export remains.
- `./scripts/test-compiler-cache.sh` passes, including its stable-mount rewrite cases, and `make ci-fast` passes.
- If the export is removed, a `cargo check -p orbit-types --offline` under the stable mounts still shows the same rewrite behavior in the wrapper's debug output as before the change.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Corrected the compiler-cache runbook to scope SCCACHE_BASEDIRS behavior to pinned sccache v0.17.0 and identify the STABLE_SRC/STABLE_TGT argv/environment rewrite, gated by Linux Bubblewrap stable mounts, as Rust path normalization.
- Retained the SCCACHE_BASEDIRS export with an explicit comment that it is inert for rustc in sccache v0.17.0 and kept for non-Rust compatibility.
- Removed the stale path-stripping-basedirs wording from the directly affected compiler-cache test comment; test assertions and behavior are unchanged.
Validation:
- ./scripts/test-compiler-cache.sh — passed, including stable-mount rewrite cases.
- make ci-fast — passed.
- git diff --check — passed.
Assessment: Small documentation/comment-only correction with no cache-path or fail-closed behavior change. Worktree contains only the three intended task-scoped files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11328-6a9ca3e3`
- Behind base: 0
- Ahead of base: 1