### PR TITLE
[friction-curation] Serialize the workspace-init env capture and restore assertions under EnvGuard

### DIFF
--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -1068,12 +1068,13 @@ fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
     std::fs::write(&managed_registry_path, "managed registry sentinel\n")
         .expect("seed managed registry");
 
-    let previous_registry_root = std::env::var_os("ORBIT_REGISTRY_ROOT");
-    let previous_managed_context = std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT");
-    let previous_run_id = std::env::var_os("ORBIT_RUN_ID");
-
     {
-        let env = EnvGuard::acquire().managed_registry_root(managed_registry.path());
+        let mut env = EnvGuard::acquire();
+        let previous_registry_root = std::env::var_os("ORBIT_REGISTRY_ROOT");
+        let previous_managed_context = std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT");
+        let previous_run_id = std::env::var_os("ORBIT_RUN_ID");
+
+        env = env.managed_registry_root(managed_registry.path());
 
         assert_eq!(
             orbit_core::runtime::resolve_global_root().expect("resolve managed registry root"),
@@ -1081,7 +1082,7 @@ fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
             "a trusted managed child must retain registry-root precedence"
         );
 
-        let _env = env.home(home.path()).cwd(&workspace);
+        env = env.home(home.path()).cwd(&workspace);
 
         assert_eq!(
             orbit_core::runtime::resolve_global_root().expect("resolve fixture registry root"),
@@ -1120,17 +1121,18 @@ fn workspace_init_under_home_with_global_orbit_creates_repo_orbit() {
             orbit_gitignore_block()
         );
         assert!(!orbit_gitignore_block().contains(".orbit/adrs"));
-    }
 
-    assert_eq!(
-        std::env::var_os("ORBIT_REGISTRY_ROOT"),
-        previous_registry_root
-    );
-    assert_eq!(
-        std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT"),
-        previous_managed_context
-    );
-    assert_eq!(std::env::var_os("ORBIT_RUN_ID"), previous_run_id);
+        env.restore_now();
+        assert_eq!(
+            std::env::var_os("ORBIT_REGISTRY_ROOT"),
+            previous_registry_root
+        );
+        assert_eq!(
+            std::env::var_os("ORBIT_MANAGED_RUN_CONTEXT"),
+            previous_managed_context
+        );
+        assert_eq!(std::env::var_os("ORBIT_RUN_ID"), previous_run_id);
+    }
 }
 
 #[test]

--- a/crates/orbit-cli/src/tests/env_isolation.rs
+++ b/crates/orbit-cli/src/tests/env_isolation.rs
@@ -180,12 +180,27 @@ impl EnvGuard {
         let _scope = HomeScope::set(home);
         f()
     }
+
+    /// Restore all captured state while retaining the crate-wide lock.
+    ///
+    /// This lets tests verify restoration before another env-mutating test can
+    /// acquire the lock. `Drop` calls the same implementation for panic-safe
+    /// cleanup.
+    pub(crate) fn restore_now(&mut self) {
+        self.restore();
+    }
 }
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
-        // Restore cwd before HOME so nothing observes a mismatched pair, then
-        // let `_lock` release the crate-wide lock via its own drop.
+        self.restore();
+    }
+}
+
+impl EnvGuard {
+    fn restore(&mut self) {
+        // Restore cwd before HOME so nothing observes a mismatched pair. The
+        // `_lock` field remains held until EnvGuard itself drops.
         if let Some(previous) = self.cwd.take() {
             let _ = std::env::set_current_dir(previous);
         }


### PR DESCRIPTION
## Task

[ORB-11322](https://orbit-cli.com/tasks/ORB-11322) — [friction-curation] Serialize the workspace-init env capture and restore assertions under EnvGuard

### Description

## Problem

`command::workspace::tests::init::workspace_init_under_home_with_global_orbit_creates_repo_orbit` fails intermittently under the default parallel in-process test harness, on its own teardown assertion rather than on anything about `workspace init`.

The test captures the ambient env *before* taking the process-wide lock and asserts the restore *after* the lock has been released:

- `crates/orbit-cli/src/command/workspace/tests/init.rs:1071-1073` — `previous_registry_root` / `previous_managed_context` / `previous_run_id` are read from `std::env::var_os` before `EnvGuard::acquire()`.
- `crates/orbit-cli/src/command/workspace/tests/init.rs:1076` — `EnvGuard::acquire().managed_registry_root(...)` takes the lock.
- `crates/orbit-cli/src/command/workspace/tests/init.rs:1124-1133` — the matching `assert_eq!` calls run after the guard's block has dropped.

`crates/orbit-cli/src/tests/env_isolation.rs` is the other writer of these variables (it sets `ORBIT_REGISTRY_ROOT` at line 102 and removes it at line 137), and it does so under the same guard. Any sibling holding the lock concurrently can therefore be mid-mutation while this test performs its unlocked capture or its unlocked assertion, and the two legitimately disagree.

## Reproduction (verified 2026-09-05, ORB-11318)

```
cargo test -p orbit-cli --bin orbit
...
thread 'command::workspace::tests::init::workspace_init_under_home_with_global_orbit_creates_repo_orbit'
panicked at crates/orbit-cli/src/command/workspace/tests/init.rs:1125:5:
assertion `left == right` failed
  left: Some("~/.orbit")
 right: None
test result: FAILED. 418 passed; 1 failed
```

The captured `previous_registry_root` was `None` (a sibling had removed the variable at capture time) while the post-block read observed the ambient `~/.orbit` — the two reads straddle the lock.

It passes in isolation and with `--test-threads=1`, and it passes under nextest's process-per-test model, which is what CI uses. So this only bites agents and contributors running bare `cargo test`, which is exactly when it looks like a regression in the change under development.

## Why it recurs

This has now cost time on at least two unrelated changes (ORB-11187 and ORB-11295) because any change that perturbs test scheduling in `orbit-cli` — for example onboarding another executor family and its tests — re-surfaces it and misattributes it to that change.

## Suggested direction

Move the capture and the restore assertions inside the `EnvGuard` scope, or have `EnvGuard` itself own and assert the restore invariant on drop, so the whole capture/mutate/assert cycle is covered by the single lock that serializes process env mutation. Prefer the second if other tests in the crate hand-roll the same capture/assert pair. Do not paper over it by removing the restore assertion — the invariant it checks is worth keeping.

This does not widen any fail-closed guard; it narrows a test-only race.

### Acceptance Criteria

- `cargo test -p orbit-cli --bin orbit` passes with the default parallel harness, repeated at least 3 consecutive times, with no failure at the env-restore assertions of `workspace_init_under_home_with_global_orbit_creates_repo_orbit`.
- The capture of `ORBIT_REGISTRY_ROOT` / `ORBIT_MANAGED_RUN_CONTEXT` / `ORBIT_RUN_ID` and the matching restore assertions are both inside the region serialized by `EnvGuard`'s process-wide lock, or the equivalent invariant is owned and asserted by `EnvGuard` itself; no unlocked `std::env::var_os` capture/assert pair for these variables remains in `crates/orbit-cli/src/command/workspace/tests/init.rs`.
- The restore invariant is still actually asserted after the change (it is not deleted or weakened to an unconditional pass); a deliberate temporary mutation that skips restoration makes the test fail.
- `cargo test -p orbit-cli --bin orbit -- --test-threads=1` and `cargo nextest run -p orbit-cli` both still pass.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Moved ORBIT_REGISTRY_ROOT / ORBIT_MANAGED_RUN_CONTEXT / ORBIT_RUN_ID capture inside the EnvGuard lock scope in the workspace-init test.
- Added EnvGuard::restore_now() backed by the same idempotent restoration path used by Drop, allowing restoration assertions to run while the process-wide lock remains held.
- Kept the existing explicit equality assertions intact; a skipped restoration would still fail them.
Assessment: The environment capture, restoration, and verification are serialized under EnvGuard without widening production behavior. Only the two task-scoped files changed.
Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-cli --bin orbit: passed 3 consecutive times with the default parallel harness (423 passed each run).
- cargo test -p orbit-cli --bin orbit -- --test-threads=1: passed (423 passed).
- cargo nextest run -p orbit-cli: runner-limited; 60 tests passed before the Linux security regression process_metadata_does_not_supply_a_replayable_key_bound_identity required an unrestricted runner with setgid and a mapped supplementary group, then failed at its explicit capability assertion.
- make ci-fast: passed.
- make ci-lint: passed.
- Final git diff --check: passed; generated target/ artifacts removed with cargo clean; remaining changes are the two intended source files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11322-6a9ca2a1`
- Behind base: 0
- Ahead of base: 1