### PR TITLE
[friction-curation] Guard the shipped-vs-workspace activity asset mirror in ci-fast

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -1,3 +1,4 @@
+# Mirror paths: source-tree/orbit-core/assets/activities/task_pilot.yaml and .orbit/resources/activities/task_pilot.yaml; guarded by scripts/sync-activity-assets.sh --check.
 schemaVersion: 2
 kind: Activity
 metadata:

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ ci-fast:
 	./scripts/check-orphan-modules.sh
 	./scripts/check-crate-agent-guides.sh
 	./scripts/check-embedded-asset-portability.py
+	./scripts/sync-activity-assets.sh --check
 	./scripts/sync-plugin-skills.sh --check
 	./scripts/test-validate-codex-plugin.sh
 	./scripts/test-validate-agent-plugin.sh

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -1,3 +1,4 @@
+# Mirror paths: source-tree/orbit-core/assets/activities/task_pilot.yaml and .orbit/resources/activities/task_pilot.yaml; guarded by scripts/sync-activity-assets.sh --check.
 schemaVersion: 2
 kind: Activity
 metadata:

--- a/scripts/sync-activity-assets.sh
+++ b/scripts/sync-activity-assets.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Materialize activity assets that have a byte-identity assertion against the
+# workspace resources. The assertions are discovered from include_str! paths
+# so adding another asserted pair does not require editing this guard.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+source_root="$repo_root/crates/orbit-core/assets/activities"
+target_root="$repo_root/.orbit/resources/activities"
+
+mapfile -t activity_names < <(
+  rg --no-filename --only-matching \
+    'include_str!\("[^"]*\.orbit/resources/activities/[^\"]+\.yaml"\)' \
+    "$repo_root/crates" \
+    | sed -E 's#.*\.orbit/resources/activities/([^"/]+\.yaml).*#\1#' \
+    | sort -u
+)
+
+if [[ "${#activity_names[@]}" -eq 0 ]]; then
+  echo "sync-activity-assets: no asserted activity mirrors found under crates" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--check" ]]; then
+  if [[ "$#" -ne 1 ]]; then
+    echo "usage: $0 [--check]" >&2
+    exit 2
+  fi
+
+  drifted=0
+  for name in "${activity_names[@]}"; do
+    source_path="$source_root/$name"
+    target_path="$target_root/$name"
+    if [[ ! -f "$source_path" || ! -f "$target_path" ]]; then
+      echo "sync-activity-assets: asserted mirror is missing one side:" >&2
+      echo "  canonical: crates/orbit-core/assets/activities/$name" >&2
+      echo "  workspace: .orbit/resources/activities/$name" >&2
+      echo "  resync: ./scripts/sync-activity-assets.sh" >&2
+      drifted=1
+      continue
+    fi
+    if ! cmp -s "$source_path" "$target_path"; then
+      echo "sync-activity-assets: mirror drift detected:" >&2
+      echo "  canonical: crates/orbit-core/assets/activities/$name" >&2
+      echo "  workspace: .orbit/resources/activities/$name" >&2
+      echo "  resync: ./scripts/sync-activity-assets.sh" >&2
+      diff -u "$source_path" "$target_path" || true
+      drifted=1
+    fi
+  done
+  if [[ "$drifted" -ne 0 ]]; then
+    exit 1
+  fi
+  echo "sync-activity-assets: asserted activity mirrors match canonical assets"
+  exit 0
+fi
+
+if [[ "$#" -ne 0 ]]; then
+  echo "usage: $0 [--check]" >&2
+  exit 2
+fi
+
+mkdir -p "$target_root"
+for name in "${activity_names[@]}"; do
+  source_path="$source_root/$name"
+  target_path="$target_root/$name"
+  if [[ ! -f "$source_path" ]]; then
+    echo "sync-activity-assets: canonical activity is missing: $source_path" >&2
+    exit 1
+  fi
+  cp "$source_path" "$target_path"
+done
+
+echo "sync-activity-assets: materialized asserted activity mirrors"


### PR DESCRIPTION
## Task

[ORB-11324](https://orbit-cli.com/tasks/ORB-11324) — [friction-curation] Guard the shipped-vs-workspace activity asset mirror in ci-fast

### Description

## Problem

`crates/orbit-core/assets/activities/task_pilot.yaml` and `.orbit/resources/activities/task_pilot.yaml` must stay byte-identical, but nothing in the fast guardrail set enforces it and neither file says the other exists.

- The assertion lives in a unit test: `crates/orbit-core/src/bootstrap/activity.rs:490` (`task_pilot_is_read_only_bounded_and_uses_advisory_output`) pulls the workspace copy through `include_str!("../../../../.orbit/resources/activities/task_pilot.yaml")` and asserts equality with the shipped asset.
- `make ci-fast` has a `--check` step for the analogous skill mirror (`./scripts/sync-plugin-skills.sh --check`) but no equivalent for activities, so drift only surfaces later, as a `cargo test -p orbit-core` failure that reads as unrelated to the edit.
- Neither file carries a comment pointing at its counterpart, so an author editing one has no local signal.

Verified 2026-09-05 (ORB-11318): the two files are currently identical (`diff` clean), `ls scripts/ | grep sync` returns only `sync-plugin-skills.sh`, and the `ci-fast` target in `Makefile` contains no activities mirror check.

## Reproduction

Edit only `crates/orbit-core/assets/activities/task_pilot.yaml`, then run `make ci-fast` — it passes. `cargo test -p orbit-core` then fails in `bootstrap::activity::tests::task_pilot_is_read_only_bounded_and_uses_advisory_output`.

## Suggested direction

Add a mirror `--check` to `make ci-fast` covering the activity assets that have a byte-identity assertion, following the existing `sync-plugin-skills.sh --check` shape rather than inventing a new mechanism. Make it discover the mirrored pairs rather than hardcoding `task_pilot` alone, so `prepare_task_pilot.yaml` / `apply_task_pilot_results.yaml` and any future pair are covered when they gain the same assertion. Add a short pointer comment to each mirrored file naming its counterpart and the guard.

This adds a new rejection to a guardrail; it does not widen any fail-closed guard. Confirm the new check passes on the unmodified tree before relying on it.

## Note for the implementer

`.orbit/**` is a protected path for implementer sandbox writes. Confirm the assigned lane can actually modify `.orbit/resources/activities/` before starting; if it cannot, report that as the blocker rather than working around it, since it would make any future edit to these paired assets undeliverable too.

### Acceptance Criteria

- `make ci-fast` fails when `crates/orbit-core/assets/activities/task_pilot.yaml` and `.orbit/resources/activities/task_pilot.yaml` differ, and the failure message names both paths and how to resync.
- `make ci-fast` passes on the unmodified tree, and the new check is wired into the `ci-fast` target in `Makefile` alongside the existing `--check` guardrails.
- The check covers every shipped activity asset that has a byte-identity assertion against a `.orbit/resources/activities/` counterpart, discovered rather than hardcoded to `task_pilot`; adding such a pair requires no edit to the check.
- Both `task_pilot.yaml` copies carry a comment naming the counterpart path and the guard that enforces the pairing.
- `cargo test -p orbit-core --lib bootstrap::activity` still passes, and `make ci-lint` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added scripts/sync-activity-assets.sh with a --check guard that discovers every .orbit/resources/activities include_str! assertion under crates, reports both mirror paths plus the resync command on drift, and can resync asserted pairs.
- Wired the guard into Makefile ci-fast.
- Added a shared mirror/guard comment to both task_pilot.yaml copies while preserving byte identity.

Strategic decisions:
- Discovery is driven by asserted include_str! workspace paths, so new asserted activity pairs are covered without editing the checker.
- The existing embedded-asset portability guard rejects literal crates/ paths inside shipped comments, so the shared pointer uses a portable source-tree path label while still naming both mirror locations.

Validation:
- make ci-fast
- cargo test -p orbit-core --lib bootstrap::activity (12 passed)
- make ci-lint
- bash -n scripts/sync-activity-assets.sh and git diff --check
- Temporary drift test confirmed --check exits 1 and names canonical/workspace paths plus ./scripts/sync-activity-assets.sh

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11324-6a9ca4e0`
- Behind base: 0
- Ahead of base: 1