### PR TITLE
[friction-curation] Add a runbook for validating website changes inside a job-run sandbox

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ CLI behavior, state layout, or recovery semantics change.
 | [Recover Stuck Job Runs](./runbooks/stuck-job-runs.md) | Diagnose, cancel, resume, or replay pending and running Orbit job runs. |
 | [Publish Orbit Tasks to a Dedicated Repository](./runbooks/task-publication.md) | Bind, authenticate, publish, verify, inspect, and recover an Orbit task-publication repository. |
 | [Upgrade Orbit Safely](./runbooks/upgrades.md) | Install a new Orbit release with `orbit update`, then review, apply, and verify workspace-layout and store-schema migrations safely. |
+| [Validate Website Changes in a Job-Run Sandbox](./runbooks/website-validation.md) | Build, preview, and validate Orbit website changes with Playwright inside a job-run sandbox. |
 
 Authoring rules live in [runbook conventions](./runbooks/CONVENTIONS.md).
 

--- a/docs/runbooks/website-validation.md
+++ b/docs/runbooks/website-validation.md
@@ -1,0 +1,226 @@
+---
+type: runbook
+summary: Build, preview, and validate Orbit website changes with Playwright inside a job-run sandbox.
+tags: [operations, website, sandbox, playwright, validation]
+paths: ["website/**"]
+related_features: [orbit-docs]
+related_artifacts: ["ORB-11329"]
+last_validated: 2026-09-05
+---
+
+# Validate Website Changes in a Job-Run Sandbox
+
+Use this runbook when a website task needs rendered-page evidence from an Orbit job-run
+sandbox, including a working `astro preview` and a Chromium launch.
+
+## Prerequisites and safety
+
+This procedure assumes a Debian- or Ubuntu-like host with `node`, `git`, `apt-get`,
+`dpkg-deb`, and `ldd`. It does not require root. Replace `<task>` with a short unique
+identifier, and set the repository path from the checkout in which the run is executing:
+
+```bash
+export REPO="$(git rev-parse --show-toplevel)"
+export SANDBOX_ROOT="$(mktemp -d /tmp/orbit-website-<task>.XXXXXX)"
+export npm_config_cache="$SANDBOX_ROOT/npm-cache"
+mkdir -p "$npm_config_cache"
+trap 'rm -rf "$SANDBOX_ROOT"' EXIT
+```
+
+Keep the Playwright package and browser, npm cache, downloaded `.deb` files, extracted
+libraries, and logs under `SANDBOX_ROOT` or another `/tmp` directory. `npm ci` necessarily
+populates `website/node_modules`; record whether that directory existed before the run and
+remove it at handoff only when this run created it. The Playwright package and its browsers
+must remain outside the worktree, so Playwright-specific handoff cleanup has nothing to undo.
+
+## Establish the Node and npm environment
+
+Do not assume the Node version from another host. Discover the binaries available to this
+run and use the npm installation from the same Node toolchain when possible:
+
+```bash
+NODE_BIN="$(command -v node)"
+NODE_DIR="$(dirname "$(readlink -f "$NODE_BIN")")"
+if [ -x "$NODE_DIR/npm" ]; then
+  NPM_BIN="$NODE_DIR/npm"
+else
+  NPM_BIN="$(find "$HOME/.nvm/versions/node" -maxdepth 4 -path '*/bin/npm' -print -quit 2>/dev/null || true)"
+fi
+test -n "$NPM_BIN" && test -x "$NPM_BIN"
+export PATH="$(dirname "$NPM_BIN"):$PATH"
+command -v node
+command -v npm
+node --version
+npm --version
+```
+
+The dispatched shell can start in the repository root even when a previous command changed
+directories. Use `--prefix` on every npm command so the target is unambiguous. The writable
+cache is also required because the sandbox may not permit npm's default `~/.npm/_logs` path:
+
+```bash
+npm --prefix "$REPO/website" ci
+```
+
+Check the output, not only the runner status. A background command can report exit code 0
+while its output contains `npm: command not found` (for example, the shell may have launched
+the background wrapper successfully). A safe background form records and checks both:
+
+```bash
+LOG="$SANDBOX_ROOT/npm-ci.log"
+npm --prefix "$REPO/website" ci >"$LOG" 2>&1 &
+NPM_PID=$!
+wait "$NPM_PID"
+NPM_STATUS=$?
+if [ "$NPM_STATUS" -ne 0 ] || grep -Eq 'npm: command not found|command not found: npm' "$LOG"; then
+  sed -n '1,160p' "$LOG" >&2
+  exit 1
+fi
+```
+
+## Stage Playwright and Chromium without root
+
+Install Playwright and its browser outside the worktree. `playwright install-deps` is not a
+solution in a job-run sandbox: it installs operating-system packages and therefore needs
+root. `sudo` cannot elevate when the sandbox has Linux `no-new-privs` enabled; it fails with
+`The 'no new privileges' flag is set, which prevents sudo from running as root.`
+
+```bash
+export PLAYWRIGHT_ROOT="$SANDBOX_ROOT/playwright"
+export PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_ROOT/browsers"
+mkdir -p "$PLAYWRIGHT_ROOT" "$PLAYWRIGHT_BROWSERS_PATH"
+npm --prefix "$PLAYWRIGHT_ROOT" install --no-save playwright
+PLAYWRIGHT="$PLAYWRIGHT_ROOT/node_modules/.bin/playwright"
+test -x "$PLAYWRIGHT"
+"$PLAYWRIGHT" install chromium
+```
+
+The browser download can succeed while Chromium still cannot start if shared libraries are
+missing. Find the downloaded `chrome-headless-shell` and inspect all unresolved libraries:
+
+```bash
+CHROME="$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -name chrome-headless-shell -perm -u+x -print -quit)"
+test -n "$CHROME"
+ldd "$CHROME" | grep 'not found' || true
+```
+
+On the affected Ubuntu host, the existing image provided `libnss3`, `libcups`, `libgbm`, and
+`libpango`, while five runtime libraries (including GTK, ATK, X11, and audio libraries) were
+absent. Package names have release-specific
+suffixes (`-t64` on newer Ubuntu), so resolve candidates on the actual host rather than
+copying a fixed package list:
+
+```bash
+apt-cache policy \
+  libatk1.0-0 libatk1.0-0t64 \
+  libatk-bridge2.0-0 libatk-bridge2.0-0t64 \
+  libatspi2.0-0 libatspi2.0-0t64 \
+  libgtk-3-0 libgtk-3-0t64 libxcomposite1
+```
+
+Select the available package for each library reported by `ldd`, download the packages as an
+unprivileged user, and unpack them into a temporary prefix. `apt-get download` writes files
+where it is run and does not install them system-wide:
+
+```bash
+export DEB_ROOT="$SANDBOX_ROOT/debs"
+export LIB_ROOT="$SANDBOX_ROOT/libs"
+mkdir -p "$DEB_ROOT" "$LIB_ROOT"
+cd "$DEB_ROOT"
+apt-get download <package-for-libatk> <package-for-libatk-bridge> <package-for-libatspi> <package-for-libgtk> <package-for-libxcomposite>
+for deb in ./*.deb; do
+  dpkg-deb -x "$deb" "$LIB_ROOT"
+done
+export LD_LIBRARY_PATH="$LIB_ROOT/usr/lib/x86_64-linux-gnu:$LIB_ROOT/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+```
+
+Run `ldd "$CHROME" | grep 'not found'` again after every package batch. Repeat the download,
+unpack, and `LD_LIBRARY_PATH` update until it prints nothing; the initial launch error often
+names only the first missing library. If the host uses a different architecture, replace the
+library directory with the directory shown by `find "$LIB_ROOT" -type d -name '*linux-gnu*'`.
+
+## Build, preview, and collect evidence
+
+Build before previewing, then bind the preview to loopback on a known port. Keep the preview
+PID so it can be stopped before handoff:
+
+```bash
+npm --prefix "$REPO/website" run build
+export PREVIEW_PORT=4321
+npm --prefix "$REPO/website" run preview -- --host 127.0.0.1 --port "$PREVIEW_PORT" \
+  >"$SANDBOX_ROOT/astro-preview.log" 2>&1 &
+PREVIEW_PID=$!
+export PREVIEW_URL="http://127.0.0.1:$PREVIEW_PORT"
+curl --fail --silent --show-error "$PREVIEW_URL/" >/dev/null
+```
+
+Launch Chromium through the staged Playwright package at both representative desktop and
+mobile sizes. The following smoke check records HTTP status, heading, rendered text length,
+console/page errors, and horizontal overflow; extend `PAGES` with the routes changed by the
+task:
+
+```bash
+PAGES=(/ /getting-started/install/ /how-to/task-lifecycle/ /reference/cli/)
+node --input-type=module - "$PLAYWRIGHT_ROOT/node_modules/playwright/index.mjs" "$PREVIEW_URL" "${PAGES[@]}" <<'NODE'
+const [playwrightEntry, baseUrl, ...pages] = process.argv.slice(2);
+const { chromium } = await import(`file://${playwrightEntry}`);
+const browser = await chromium.launch({ headless: true });
+const failures = [];
+for (const viewport of [{ width: 1440, height: 900 }, { width: 390, height: 844 }]) {
+  const page = await browser.newPage({ viewport });
+  page.on('console', message => console.log(JSON.stringify({ type: 'console', viewport, level: message.type(), text: message.text() })));
+  page.on('pageerror', error => failures.push({ type: 'pageerror', viewport, text: error.message }));
+  for (const route of pages) {
+    const response = await page.goto(`${baseUrl}${route}`, { waitUntil: 'networkidle' });
+    const result = await page.evaluate(() => ({
+      h1: document.querySelector('h1')?.textContent?.trim() ?? null,
+      textLength: document.body.innerText.length,
+      scrollWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+    console.log(JSON.stringify({ viewport, route, status: response?.status() ?? null, ...result }));
+    if (!response || response.status() >= 400 || result.scrollWidth > result.viewportWidth) failures.push({ type: 'page-check', viewport, route, status: response?.status(), ...result });
+  }
+  await page.close();
+}
+await browser.close();
+if (failures.length) { console.error(JSON.stringify({ failures }, null, 2)); process.exit(1); }
+NODE
+```
+
+For changes involving search or navigation, add checks for the live Pagefind UI and the
+documentation journeys affected by the change. For example, enter a query in the search
+control and assert that a result is visible, then click the links for the relevant
+getting-started or how-to journey and assert each destination response is below 400. Save the
+command output and the preview log with the job evidence; do not copy either into the
+worktree.
+
+Stop the server after validation:
+
+```bash
+kill "$PREVIEW_PID" 2>/dev/null || true
+wait "$PREVIEW_PID" 2>/dev/null || true
+```
+
+## Preferred long-term fix
+
+Pre-stage the missing GTK/ATK/X11 libraries in the job-run host image. That is more reliable
+and faster than downloading and unpacking `.deb` files for every run. Host provisioning is
+out of repository scope for this runbook; coordinate it with the sandbox image owner rather
+than adding privileged installation commands here.
+
+## Handoff and escalation
+
+Playwright, Chromium, npm's cache, downloaded packages, extracted libraries, logs, and any
+temporary validation scripts all live outside the worktree under `SANDBOX_ROOT` and are
+removed by the trap. Therefore handoff cleanup has nothing to undo in the repository. Before
+handoff, confirm the worktree contains only the intended website changes and report the
+preview URL, routes, viewport results, browser launch result, and any console/page errors in
+the task execution summary. If Chromium still fails, retain the exact `ldd ... | grep 'not
+found'` output and the host package candidates for escalation.
+
+## Related references
+
+- [Runbook conventions](./CONVENTIONS.md)
+- [Prepare a Linux host for sandboxed dispatch](./linux-sandbox.md)
+- [Orbit website README](../../website/README.md)


### PR DESCRIPTION
## Task

[ORB-11329](https://orbit-cli.com/tasks/ORB-11329) — [friction-curation] Add a runbook for validating website changes inside a job-run sandbox

### Description

## Problem

Any task whose acceptance criteria demand rendered-page evidence for `website/` has to rediscover two non-obvious sandbox setup steps. Both cost real time on ORB-11304 and neither is written down anywhere. `docs/runbooks/` has no website entry, and nothing in `website/README.md` covers sandbox execution.

### 1. `npm` is not on the sandbox PATH, and a background run hides the failure

`node` resolves to `~/.local/bin/node`, but `npm` lives only under nvm and is not on the dispatched shell's PATH. The trap: running `npm install` as a background task reported `completed (exit code 0)` while its output file contained only `/bin/bash: line 1: npm: command not found`. Work proceeded on the belief that dependencies were installed and failed several steps later when `astro` was missing.

The working form prepends nvm's bin, redirects the cache (`~/.npm/_logs` is not writable), and uses `--prefix` because the shell cwd resets to the worktree root between calls:

```sh
export PATH="$HOME/.nvm/versions/node/<version>/bin:$PATH"
export npm_config_cache=/tmp/npm-cache-<task>
npm --prefix "$REPO/website" ci
```

### 2. Playwright Chromium cannot launch, and `install-deps` cannot help

`playwright install chromium` succeeds but launching fails with `error while loading shared libraries: libatk-1.0.so.0`. `playwright install-deps` needs root and the sandbox sets no-new-privs, so `sudo` refuses: "The 'no new privileges' flag is set, which prevents sudo from running as root."

The host already provides libnss3, libcups, libgbm and libpango; five libraries are missing. They can be staged without root by unpacking the debs into a temp prefix and extending `LD_LIBRARY_PATH`. `ldd <chrome-headless-shell> | grep 'not found'` must be iterated, because the launch error names only one missing library at a time.

Playwright and its browsers must be installed **outside** the worktree (`--prefix /tmp/...`, `PLAYWRIGHT_BROWSERS_PATH=/tmp/...`) so the handoff cleanup step has nothing to undo.

With that in place, `astro preview` plus Playwright yields genuine evidence: per-page HTTP status, `<h1>`, rendered text length, console/pageerror capture, horizontal-overflow measurement at 1440x900 and 390x844, live Pagefind queries, and click-through of documentation journeys.

## Suggested direction

Add a `docs/runbooks/` entry following the existing runbook conventions (see `docs/runbooks/CONVENTIONS.md` and a current example such as `linux-sandbox.md`). Record both setup steps, the background-exit-code trap explicitly, and the outside-the-worktree install rule. Resolve the node version from the host rather than hardcoding the one observed on a single machine, or state how to discover it.

Pre-staging the five libraries on the host would remove step 2 entirely, but that is host provisioning rather than a repository change; note it in the runbook as the better long-term fix instead of doing it here.

Verified 2026-09-05 (ORB-11318): no runbook or other repository document mentions this setup.

### Acceptance Criteria

- A runbook exists under `docs/runbooks/` covering website validation inside a job-run sandbox, follows `docs/runbooks/CONVENTIONS.md`, and is reachable from the docs index (`./scripts/generate-doc-indexes.sh --check` passes).
- It documents the npm/PATH setup including the writable `npm_config_cache` and the `--prefix` requirement, and calls out explicitly that a background command can report exit code 0 while its output contains `npm: command not found`.
- It documents the Playwright Chromium library staging without root, including why `playwright install-deps` and `sudo` cannot work under no-new-privs, and the `ldd ... | grep 'not found'` iteration.
- It states that Playwright and its browsers install outside the worktree so handoff cleanup has nothing to undo.
- The node version is discovered rather than hardcoded, or the runbook states how to determine the correct one on the host.
- The runbook records host pre-staging of the missing libraries as the preferred long-term fix and marks it as out of repository scope.
- A reader following the runbook end to end reaches a running `astro preview` with Playwright able to launch Chromium; the validating run's evidence is cited in the task's execution summary.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `docs/runbooks/website-validation.md` with locked runbook frontmatter and command-first procedures for discovering the host Node/npm toolchain, setting writable `npm_config_cache`, using npm `--prefix`, detecting the background-command `npm: command not found` trap, staging Playwright/Chromium and missing libraries without root, iterating `ldd ... | grep 'not found'`, running `astro preview`, collecting Playwright evidence, and cleaning up outside-worktree assets.
- Regenerated `docs/INDEX.md` so the runbook is reachable from the generated Runbooks index.
- Added friction record F2026-09-025 for the managed worktree's read-only Git index, which prevents staging the new file during this run.
Assessment: The runbook is scoped to the sandbox website-validation workflow, explains host pre-staging as the preferred long-term fix and out of repository scope, and keeps Playwright plus its browsers outside the worktree.
Validation:
- Discovered Node v24.18.0 and npm 11.16.0 at runtime; no version is hardcoded in the runbook.
- `npm --prefix website ci` completed successfully (427 packages, 0 vulnerabilities); `npm --prefix website run build` completed successfully with Astro v7.1.3, 29 pages, and Pagefind output.
- Playwright Chromium was installed under `/tmp`; initial `ldd` reported five missing libraries (`libatk-1.0.so.0`, `libatk-bridge-2.0.so.0`, `libXdamage.so.1`, `libasound.so.2`, `libatspi.so.0`). Unprivileged `apt-get download` plus `dpkg-deb -x` staging cleared all `not found` entries.
- `astro preview` served `http://127.0.0.1:4321`; Playwright launched Chromium and checked four routes at 1440x900 and 390x844. All 8 responses were HTTP 200, headings/text were present, scroll width matched viewport width, and no console/page errors were reported.
- The generated-index check passed with a temporary index containing the new tracked-path entry. The ordinary `./scripts/generate-doc-indexes.sh --check` was attempted after generation but reports `docs/INDEX.md is stale` while the new runbook is untracked; `git add` cannot create the worktree index lock (`Read-only file system`). This runner denial is deferred to the pipeline, which must stage the new file before its normal check.
- Run-created `website/node_modules`, `website/dist`, and `website/.astro` were removed; final `git status --short` contains only the intended `docs/INDEX.md` and new runbook.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11329-6a9ca4e0`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*