### PR TITLE
[friction-curation] Isolate the orbit-tools policy-deny tracing fixture from inherited managed-run authority

### DIFF
--- a/crates/orbit-tools/tests/policy_deny_tracing.rs
+++ b/crates/orbit-tools/tests/policy_deny_tracing.rs
@@ -7,12 +7,14 @@ use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
 use orbit_common::observability::logging::init_default_subscriber;
+use orbit_common::test_env::{INHERITED_AUTHORITY_ENV, unset};
 use orbit_tools::{ToolContext, ToolRegistry};
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
 #[test]
 fn policy_denials_emit_redacted_jsonl_tracing_events() {
+    let _env_guard = unset(INHERITED_AUTHORITY_ENV.iter().copied());
     let home = tempdir().expect("create temp home");
     let log_path = home.path().join(".orbit/state/logs/orbit.jsonl");
 


### PR DESCRIPTION
## Task

[ORB-11326](https://orbit-cli.com/tasks/ORB-11326) — [friction-curation] Isolate the orbit-tools policy-deny tracing fixture from inherited managed-run authority

### Description

## Problem

`crates/orbit-tools/tests/policy_deny_tracing.rs` fails inside any managed Orbit run and passes everywhere else. The denial itself works — the `orbit.policy.deny` WARN is emitted — but it is never written to the fixture's own JSONL log, because the log sink is routed by ambient managed-run environment variables that outrank the `HOME` the fixture sets.

The fixture sets only `HOME` and `RUST_LOG` before calling `init_default_subscriber` (lines 20-25). It never clears the inherited authority set, so `ORBIT_REGISTRY_ROOT` / `ORBIT_MANAGED_RUN_CONTEXT` / `ORBIT_RUN_ID` from the dispatching run win and the events land outside `<temp>/.orbit/state/logs/orbit.jsonl`. `wait_for_policy_events` then times out at line 66.

This is the in-process counterpart of the class ORB-11300 fixed for spawned children. That task introduced `orbit_common::test_env::INHERITED_AUTHORITY_ENV` as the one canonical list, and `crates/orbit-common/src/test_env.rs:53` documents `unset` plus that list as the in-process defense. This fixture predates it and was never converted.

## Reproduction (verified 2026-09-05, ORB-11318)

Inside a managed run worktree, with the executor's 13 ambient `ORBIT_*` variables present:

```
$ cargo nextest run -p orbit-tools --test policy_deny_tracing
FAIL [2.048s] orbit-tools::policy_deny_tracing policy_denials_emit_redacted_jsonl_tracing_events
  WARN orbit.policy.deny: tool="proc.spawn" path="sh" profile="proc.allowed_programs" matched_rule="echo"
  panicked at crates/orbit-tools/tests/policy_deny_tracing.rs:66:5:
  timed out waiting for 1 policy deny events at "/tmp/.tmphtepjU/.orbit/state/logs/orbit.jsonl"

$ env $(env | grep -E '^ORBIT_' | cut -d= -f1 | sed 's/^/-u /' | tr '\n' ' ') \
    cargo nextest run -p orbit-tools --test policy_deny_tracing
PASS [0.059s] orbit-tools::policy_deny_tracing policy_denials_emit_redacted_jsonl_tracing_events
```

This is the only remaining environment-caused failure in a full `cargo nextest run --workspace --lib --bins --tests --no-fail-fast` from a managed worktree: 4024 tests, 4022 passed, 2 failed. The other failure, `orbit-cli::mcp_roundtrip process_metadata_does_not_supply_a_replayable_key_bound_identity`, self-reports as needing an unrestricted runner with setgid and a mapped supplementary group, and is a genuine runner-capability gap rather than a defect.

## Suggested direction

Hold `orbit_common::test_env::unset(INHERITED_AUTHORITY_ENV)` for the body of the test, applied *before* the fixture sets `HOME` and before `init_default_subscriber`, so the deliberate value wins. `orbit-tools` already has `orbit-common` with the `test-util` feature in `[dev-dependencies]`, so this needs no new dependency edge. Do not hand-write a partial `env_remove` list — that drift is exactly what ORB-11300 consolidated.

This is a test-isolation fix only; no production behavior and no fail-closed guard changes.

### Acceptance Criteria

- `cargo nextest run -p orbit-tools --test policy_deny_tracing` passes with the managed-run ambient `ORBIT_*` variables present (`ORBIT_REGISTRY_ROOT`, `ORBIT_MANAGED_RUN_CONTEXT`, `ORBIT_RUN_ID`, `ORBIT_WORKSPACE` at minimum) and still passes with them absent.
- The fixture obtains its isolation from the shared `orbit_common::test_env` canonical list rather than a locally hand-written variable list.
- The test still fails if the policy-deny event is not emitted or not redacted as asserted — the isolation change does not weaken the assertions (verified by a deliberate temporary break).
- `cargo nextest run --workspace --lib --bins --tests --no-fail-fast` from a managed worktree reports no failure other than the known setgid runner-capability test `orbit-cli::mcp_roundtrip process_metadata_does_not_supply_a_replayable_key_bound_identity`.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-tools/tests/policy_deny_tracing.rs` to hold `orbit_common::test_env::unset(INHERITED_AUTHORITY_ENV.iter().copied())` for the fixture body before setting `HOME` or installing the subscriber.
- Reused the shared canonical inherited-authority list; no production code or dependencies changed.

Assessment: The fixture now owns its log routing even inside a managed Orbit run, while all existing policy-denial and redaction assertions remain unchanged.

Validation:
- Focused `cargo nextest run -p orbit-tools --test policy_deny_tracing`: passed with managed-run `ORBIT_*` variables present and with them removed.
- Deliberately changed an existing path assertion: the focused test failed as expected; restored the assertion and reran successfully.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- Full `cargo nextest run --workspace --lib --bins --tests --no-fail-fast` completed with the known setgid capability failure `orbit-cli::mcp_roundtrip process_metadata_does_not_supply_a_replayable_key_bound_identity` plus an unrelated pre-existing `orbit-cli::output_goldens::plain_and_json_forms_match_their_goldens` golden drift failure. The latter is outside this test-isolation change and was left untouched.

Diff: one test file, two added lines.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11326-6a9ca3a5`
- Behind base: 0
- Ahead of base: 1