### PR TITLE
[code-review] Enforce the task-comment byte budget in executor envelopes

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs
@@ -22,8 +22,16 @@ const MAX_TASK_COMMENTS: usize = 20;
 ///
 /// Applied after [`MAX_TASK_COMMENTS`] as a second, size-based cut: a handful
 /// of very long comments could still blow out the envelope even under the
-/// count cap.
+/// count cap. Comment creation accepts any non-empty message, so the last
+/// retained comment can exceed this on its own; the projection then cuts the
+/// body itself rather than shipping it whole (see [ORB-11338]).
 const MAX_TASK_COMMENTS_BYTES: usize = 16 * 1024;
+
+/// Marker appended to a comment body cut down to fit
+/// [`MAX_TASK_COMMENTS_BYTES`]. Its own bytes count against the budget, and it
+/// carries no variable-length detail so the cut point is computable in one
+/// pass.
+const COMMENT_TRUNCATION_MARKER: &str = "\n\n[comment truncated to fit the envelope byte budget]";
 
 pub(crate) fn associated_task_ids(input: &Value) -> Vec<String> {
     let mut task_ids = Vec::new();
@@ -142,28 +150,45 @@ fn agent_task_context_json(
         );
     }
 
-    let (kept_comments, omitted_count) = bounded_task_comments(comments);
+    let bounded_comments = bounded_task_comments(comments);
     context.insert(
         "comments".to_string(),
-        serde_json::to_value(kept_comments).unwrap_or_else(|_| Value::Array(Vec::new())),
+        serde_json::to_value(&bounded_comments.comments)
+            .unwrap_or_else(|_| Value::Array(Vec::new())),
     );
-    if omitted_count > 0 {
+    if bounded_comments.omitted_count > 0 || bounded_comments.body_truncated {
         context.insert("comments_truncated".to_string(), Value::Bool(true));
+    }
+    if bounded_comments.omitted_count > 0 {
         context.insert(
             "comments_omitted_count".to_string(),
-            Value::Number(omitted_count.into()),
+            Value::Number(bounded_comments.omitted_count.into()),
         );
     }
 
     Value::Object(context)
 }
 
+/// The comment projection for one envelope: the retained comments plus what
+/// had to be cut to hold them to [`MAX_TASK_COMMENTS_BYTES`].
+struct BoundedTaskComments {
+    /// Retained comments, still in chronological order. The last body may have
+    /// been cut down; every other body is verbatim.
+    comments: Vec<TaskComment>,
+    /// How many oldest entries were dropped entirely.
+    omitted_count: usize,
+    /// Whether the last retained body was cut down to fit the budget.
+    body_truncated: bool,
+}
+
 /// Keep the newest comments within [`MAX_TASK_COMMENTS`] and
 /// [`MAX_TASK_COMMENTS_BYTES`], dropping the oldest entries first so a
-/// superseding refinement never falls off the envelope. Returns the retained
-/// comments (still in chronological order) and how many oldest entries were
-/// dropped.
-fn bounded_task_comments(comments: &[TaskComment]) -> (&[TaskComment], usize) {
+/// superseding refinement never falls off the envelope.
+///
+/// Dropping entries cannot get under the byte budget once a single comment is
+/// left, and that comment is the newest — the one that can supersede the
+/// description — so it is kept and its body is cut instead ([ORB-11338]).
+fn bounded_task_comments(comments: &[TaskComment]) -> BoundedTaskComments {
     let count_start = comments.len().saturating_sub(MAX_TASK_COMMENTS);
     let mut kept = &comments[count_start..];
 
@@ -175,7 +200,35 @@ fn bounded_task_comments(comments: &[TaskComment]) -> (&[TaskComment], usize) {
         kept = &kept[1..];
     }
 
-    (kept, comments.len() - kept.len())
+    let omitted_count = comments.len() - kept.len();
+    let mut kept = kept.to_vec();
+    // Only reachable with one comment left: the loop above exits early once the
+    // retained window fits, so a longer window is already under budget.
+    let body_truncated = match kept.as_mut_slice() {
+        [only] if only.message.len() > MAX_TASK_COMMENTS_BYTES => {
+            only.message = truncate_comment_body(&only.message);
+            true
+        }
+        _ => false,
+    };
+
+    BoundedTaskComments {
+        comments: kept,
+        omitted_count,
+        body_truncated,
+    }
+}
+
+/// Cut `message` so the result, marker included, fits
+/// [`MAX_TASK_COMMENTS_BYTES`]. The cut lands on a UTF-8 character boundary at
+/// or below the budget, so a multi-byte character is dropped rather than split.
+fn truncate_comment_body(message: &str) -> String {
+    let budget = MAX_TASK_COMMENTS_BYTES.saturating_sub(COMMENT_TRUNCATION_MARKER.len());
+    let mut cut = budget.min(message.len());
+    while cut > 0 && !message.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}{COMMENT_TRUNCATION_MARKER}", &message[..cut])
 }
 
 fn workflow_failure_status_note(task_history: &[TaskHistoryEntry]) -> Option<&str> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_context.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_context.rs
@@ -275,3 +275,58 @@ fn task_context_for_agent_input_truncates_oldest_comments_over_the_count_cap() {
         (POSTED - MAX_KEPT) as u64
     );
 }
+
+/// [ORB-11338]: comment creation imposes no size limit, so the newest retained
+/// comment can exceed the envelope's byte budget on its own. Dropping older
+/// entries cannot help there — the projection has to cut the body itself
+/// rather than hand the agent an unbounded prompt.
+#[test]
+fn task_context_for_agent_input_truncates_a_single_oversized_comment_body() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "One enormous comment".to_string(),
+            description: "Task description for agent context.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+
+    const MAX_BYTES: usize = 16 * 1024;
+    let oversized = format!("HEAD MARKER {}", "x".repeat(MAX_BYTES * 2));
+    runtime
+        .update_task_with_identity(
+            &task.id,
+            TaskUpdateParams {
+                comment: Some(oversized),
+                ..Default::default()
+            },
+            Some("codex".to_string()),
+            None,
+        )
+        .expect("post oversized comment");
+
+    let context = runtime
+        .task_context_for_agent_input(&json!({ "task_id": task.id.clone() }))
+        .expect("build task context")
+        .expect("task context present");
+
+    let comments = context["comments"]
+        .as_array()
+        .expect("comments is an array");
+    // The comment is retained, not dropped: it is the newest one.
+    assert_eq!(comments.len(), 1);
+    let message = comments[0]["message"]
+        .as_str()
+        .expect("comment message is a string");
+    assert!(
+        message.len() <= MAX_BYTES,
+        "projected comment body is {} bytes, over the {MAX_BYTES}-byte budget",
+        message.len()
+    );
+    assert!(message.starts_with("HEAD MARKER "));
+    assert!(message.ends_with("[comment truncated to fit the envelope byte budget]"));
+    // Truncation is reported, and no whole entry was omitted.
+    assert_eq!(context["comments_truncated"], true);
+    assert!(context.get("comments_omitted_count").is_none());
+}


### PR DESCRIPTION
## Task

[ORB-11338](https://orbit-cli.com/tasks/ORB-11338) — [code-review] Enforce the task-comment byte budget in executor envelopes

### Description

## Problem

The comment projection added in ORB-11327 does not enforce its advertised 16 KiB total byte ceiling when the newest retained comment alone exceeds that budget. `bounded_task_comments` only removes entries while more than one comment remains, then returns the final oversized comment unchanged. Task comment creation accepts any non-empty message and has no separate size validation.

## Evidence

- `crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs:169-176`: the loop condition is `kept.len() > 1`, so a single 16 KiB-plus comment always reaches the agent envelope.
- `crates/orbit-core/src/application/task/helpers.rs:72-95`: comment validation trims and rejects blank text, but imposes no maximum size.

## Impact

A task commenter can make a managed executor inject an arbitrarily large comment into every implementing-agent prompt. This bypasses the new envelope budget, can exhaust model context or dispatch limits, and can prevent otherwise valid task execution.

## Constraints / Notes

Preserve newest-first retention semantics, but ensure the serialized comment projection never exceeds the documented budget. Add a regression test for one oversized newest comment.

### Acceptance Criteria

- An executor envelope built from a task with one comment larger than the configured comment-byte budget does not include that oversized body in full.
- The projected comment bodies stay within the configured byte budget and report truncation/omission accurately.
- A focused task-context test covers the single-oversized-comment case.

## Execution Summary

<details>
<summary>Click to expand</summary>

Enforced the 16 KiB comment-byte budget in the executor task-context envelope.

Problem: `bounded_task_comments` only dropped oldest entries while `kept.len() > 1`, so a single comment larger than MAX_TASK_COMMENTS_BYTES (16 KiB) reached the agent envelope verbatim. Comment creation has no size validation, so any commenter could inflate every implementing-agent prompt.

Change (crates/orbit-core/src/adapter/engine_host/v2_host/task_context.rs):
- `bounded_task_comments` now returns an owned `BoundedTaskComments { comments, omitted_count, body_truncated }` instead of a borrowed slice + count. Count cap and oldest-first byte-cap retention are unchanged.
- When the retention loop bottoms out at one comment that is still over budget, the newest comment is kept (newest-first semantics preserved) and its body is cut by `truncate_comment_body` to a UTF-8 character boundary, with the fixed `COMMENT_TRUNCATION_MARKER` ("\n\n[comment truncated to fit the envelope byte budget]") appended. The marker's own bytes are charged against the budget, so the projected body is <= 16 KiB. The marker is fixed-length precisely so the cut point is computable in one pass.
- Reporting: `comments_truncated` is now set when entries were dropped OR a body was cut; `comments_omitted_count` still reports only whole entries dropped, so the two signals stay distinguishable.

Test (tests/task_context.rs): `task_context_for_agent_input_truncates_a_single_oversized_comment_body` posts one 32 KiB comment and asserts the projected body is <= 16 KiB, retains its head, ends with the marker, sets `comments_truncated`, and does not set `comments_omitted_count`.

Scope note: the description's second evidence line (crates/orbit-core/src/application/task/helpers.rs — no size cap on comment creation) was deliberately left alone. The acceptance criteria and the Constraints note both target the projection, and a hard creation-side cap would reject legitimate long comments and change a persisted-write contract outside the listed context_files. The projection is now safe regardless of what is stored. A creation-side cap remains available as a separate task if wanted.

Validation: `cargo test -p orbit-core --lib task_context` (7 passed), `make ci-fast` (pass), `make ci-lint` (pass). `git status --short` shows only the two task-scoped files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11338-6a9cab02`
- Behind base: 0
- Ahead of base: 1