### PR TITLE
[friction-curation] Document that a step output read by a job condition must belong to an always-run step

### DIFF
--- a/.orbit/resources/jobs/task_gate_pipeline.yaml
+++ b/.orbit/resources/jobs/task_gate_pipeline.yaml
@@ -42,6 +42,13 @@
 #   `release_reservation` frees the reservation immediately before
 #   `require_child_success` fails the gate on a non-succeeded child. TTL
 #   remains the fallback for abandoned/crashed runs.
+# - `dispatch_child` and `require_child_success` carry no `when:` of their
+#   own: `starvation_check`'s `when: reserved == false` is the exact
+#   complement, and `gate_starvation_fail` always errors, which halts the run
+#   before these steps would otherwise be reached on that branch (ORB-11325).
+#   That makes `dispatch_child` a step `release_reservation` may safely read
+#   `steps.dispatch_child.output` from — see design doc §8.2 on why a
+#   condition may only read the output of a step that always runs.
 
 schemaVersion: 2
 kind: Job
@@ -97,7 +104,6 @@ spec:
         max_wait_seconds: "{{ input.max_wait_seconds }}"
 
     - id: dispatch_child
-      when: "{{ steps.reserve.output.reserved }} == true"
       target: activity:invoke_and_wait
       default_input:
         job_name: "task_{{ input.mode }}_pipeline"
@@ -120,7 +126,6 @@ spec:
         reservation_id: "{{ steps.reserve.output.reservation_id }}"
 
     - id: require_child_success
-      when: "{{ steps.reserve.output.reserved }} == true"
       target: activity:pipeline_success_guard
       default_input:
         context: task_gate_pipeline child run

--- a/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_gate_pipeline.yaml
@@ -42,6 +42,13 @@
 #   `release_reservation` frees the reservation immediately before
 #   `require_child_success` fails the gate on a non-succeeded child. TTL
 #   remains the fallback for abandoned/crashed runs.
+# - `dispatch_child` and `require_child_success` carry no `when:` of their
+#   own: `starvation_check`'s `when: reserved == false` is the exact
+#   complement, and `gate_starvation_fail` always errors, which halts the run
+#   before these steps would otherwise be reached on that branch (ORB-11325).
+#   That makes `dispatch_child` a step `release_reservation` may safely read
+#   `steps.dispatch_child.output` from — see design doc §8.2 on why a
+#   condition may only read the output of a step that always runs.
 
 schemaVersion: 2
 kind: Job
@@ -97,7 +104,6 @@ spec:
         max_wait_seconds: "{{ input.max_wait_seconds }}"
 
     - id: dispatch_child
-      when: "{{ steps.reserve.output.reserved }} == true"
       target: activity:invoke_and_wait
       default_input:
         job_name: "task_{{ input.mode }}_pipeline"
@@ -120,7 +126,6 @@ spec:
         reservation_id: "{{ steps.reserve.output.reservation_id }}"
 
     - id: require_child_success
-      when: "{{ steps.reserve.output.reserved }} == true"
       target: activity:pipeline_success_guard
       default_input:
         context: task_gate_pipeline child run

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -815,6 +815,30 @@ fn default_jobs_only_reference_registered_deterministic_actions() {
     }
 }
 
+/// [ORB-11325] No shipped job's `when:` / `break_when:` may read
+/// `steps.<id>.output` for a step that itself carries a `when:` — that step
+/// can be skipped, and `condition::evaluate_bool_expr` renders the whole
+/// expression before parsing it, so the reference fails with
+/// `template.rs`'s "no data recorded for step" error on exactly the branch
+/// where the referenced step would have been skipped. `validate_job` is the
+/// catalog-load gate; no shipped job is exempted from it.
+#[test]
+fn default_jobs_only_read_step_output_from_always_run_steps() {
+    let catalog = default_activity_catalog();
+
+    for (job_name, yaml) in DEFAULT_JOB_FILES {
+        let mut asset = load_job_asset(yaml)
+            .unwrap_or_else(|err| panic!("default job {job_name} should parse: {err}"));
+        resolve_job_target_refs(&mut asset.spec, &catalog)
+            .unwrap_or_else(|err| panic!("default job {job_name} refs resolve: {err}"));
+        orbit_engine::validate_job(&asset.spec).unwrap_or_else(|err| {
+            panic!(
+                "default job {job_name} reads a conditional step's output from a when/break_when: {err}"
+            )
+        });
+    }
+}
+
 /// Companion to the job sweep above: a seeded deterministic activity that
 /// no shipped job targets yet must still be dispatchable, or the first job
 /// to bind it inherits the same skew.
@@ -1094,6 +1118,11 @@ fn gate_pipeline_releases_reservation_before_child_success_guard() {
     );
 
     let dispatch = &asset.spec.steps[dispatch_index];
+    // No `when:` of its own (ORB-11325): `starvation_check`'s complementary
+    // `when: reserved == false` always fails and halts the run before this
+    // step would otherwise be reached on that branch, which is what lets
+    // `release_reservation` safely read `steps.dispatch_child.output`.
+    assert_eq!(dispatch.when.as_deref(), None);
     match &dispatch.body {
         JobV2StepBody::TargetRef(target) => {
             assert_eq!(target.target, "activity:invoke_and_wait");
@@ -1134,10 +1163,11 @@ fn gate_pipeline_releases_reservation_before_child_success_guard() {
     }
 
     let guard = &asset.spec.steps[guard_index];
-    assert_eq!(
-        guard.when.as_deref(),
-        Some("{{ steps.reserve.output.reserved }} == true")
-    );
+    // No `when:` of its own: reaching this step already implies
+    // `reserve.output.reserved == true`, since `starvation_check`'s
+    // complementary `when: reserved == false` always fails and halts the run
+    // on the other branch (ORB-11325).
+    assert_eq!(guard.when.as_deref(), None);
     match &guard.body {
         JobV2StepBody::TargetRef(target) => {
             assert_eq!(target.target, "activity:pipeline_success_guard");

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/validate.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/validate.rs
@@ -332,3 +332,89 @@ fn failure_activity_unavailable_after_admission_preserves_original_step_error() 
         "the terminal hook is still attempted once"
     );
 }
+
+// --------------------------------------------------------------------------
+// [ORB-11325] A `when:` / `break_when:` condition may only read the output
+// of a step that always runs — see design doc §8.2.
+// --------------------------------------------------------------------------
+
+fn step_with_when(id: &str, when: &str, action: &str) -> JobV2Step {
+    JobV2Step {
+        id: id.to_string(),
+        when: Some(when.to_string()),
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(deterministic_target(action)),
+    }
+}
+
+#[test]
+fn validate_job_rejects_when_reading_output_of_a_conditionally_run_step() {
+    let conditional = step_with_when("maybe_run", "{{ input.flag }} == true", "maybe_run_action");
+    let reader = step_with_when(
+        "reader",
+        "{{ steps.maybe_run.output.done }} == true",
+        "reader_action",
+    );
+
+    let err = validate_job(&job_with_steps(vec![conditional, reader]))
+        .expect_err("reading a conditional step's output must be rejected");
+
+    match &err {
+        DispatchError::JobValidation(message) => {
+            assert!(
+                message.contains("reader"),
+                "message must name the reading step: {message}"
+            );
+            assert!(
+                message.contains("maybe_run"),
+                "message must name the conditional step: {message}"
+            );
+        }
+        other => panic!("expected JobValidation, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_job_accepts_when_reading_output_of_an_always_run_step() {
+    let always = target_step("always_run", "always_run_action");
+    let reader = step_with_when(
+        "reader",
+        "{{ steps.always_run.output.done }} == true",
+        "reader_action",
+    );
+
+    assert!(
+        validate_job(&job_with_steps(vec![always, reader])).is_ok(),
+        "reading an always-run step's output must be accepted"
+    );
+}
+
+#[test]
+fn validate_job_rejects_break_when_reading_output_of_a_conditionally_run_step_in_a_loop() {
+    let conditional = step_with_when("maybe_run", "{{ input.flag }} == true", "maybe_run_action");
+    let loop_step = JobV2Step {
+        id: "loop_step".to_string(),
+        when: None,
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Loop {
+            loop_: LoopBlock {
+                items: None,
+                max_iterations: 3,
+                break_when: Some("{{ steps.maybe_run.output.done }} == true".to_string()),
+                steps: vec![conditional],
+            },
+        },
+    };
+
+    let err = validate_job(&job_with_steps(vec![loop_step]))
+        .expect_err("break_when reading a conditional step's output must be rejected");
+
+    assert!(
+        matches!(err, DispatchError::JobValidation(ref message) if message.contains("maybe_run")),
+        "got {err:?}"
+    );
+}

--- a/crates/orbit-engine/src/activity_job/job_executor/validate.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/validate.rs
@@ -20,7 +20,117 @@ pub fn validate_job(job: &JobV2) -> Result<(), DispatchError> {
     for step in &job.steps {
         validate_step(step)?;
     }
+    validate_step_output_readiness(job)?;
     Ok(())
+}
+
+/// [ORB-11325] Reject a job whose `when:` / `break_when:` reads
+/// `steps.<id>.output` for a step that itself carries a `when:`.
+///
+/// `condition::evaluate_bool_expr` renders the whole expression before it
+/// parses it, so both sides of `&&` / `||` render unconditionally; a step
+/// skipped by `when:` records no output at all, so a reference to it fails
+/// with `template.rs`'s "no data recorded for step" error — and fails on
+/// exactly the branch where the referenced step would have been skipped,
+/// which is the branch an author is least likely to exercise first. See
+/// design doc §8.2 for the working alternative and the workarounds that do
+/// not help.
+fn validate_step_output_readiness(job: &JobV2) -> Result<(), DispatchError> {
+    let mut carries_when = HashMap::new();
+    for step in &job.steps {
+        record_step_when(step, &mut carries_when);
+    }
+    for step in &job.steps {
+        check_step_output_refs(step, &carries_when)?;
+    }
+    Ok(())
+}
+
+fn record_step_when(step: &JobV2Step, carries_when: &mut HashMap<String, bool>) {
+    carries_when.insert(step.id.clone(), step.when.is_some());
+    match &step.body {
+        JobV2StepBody::Parallel { parallel } => {
+            for branch in &parallel.branches {
+                record_step_when(branch, carries_when);
+            }
+        }
+        JobV2StepBody::FanOut { fan_out, .. } => record_step_when(&fan_out.worker, carries_when),
+        JobV2StepBody::Loop { loop_ } => {
+            for body in &loop_.steps {
+                record_step_when(body, carries_when);
+            }
+        }
+        JobV2StepBody::Target(_) | JobV2StepBody::TargetRef(_) => {}
+    }
+}
+
+fn check_step_output_refs(
+    step: &JobV2Step,
+    carries_when: &HashMap<String, bool>,
+) -> Result<(), DispatchError> {
+    if let Some(expr) = &step.when {
+        check_expr_output_refs(&step.id, expr, carries_when)?;
+    }
+    match &step.body {
+        JobV2StepBody::Parallel { parallel } => {
+            for branch in &parallel.branches {
+                check_step_output_refs(branch, carries_when)?;
+            }
+        }
+        JobV2StepBody::FanOut { fan_out, .. } => {
+            check_step_output_refs(&fan_out.worker, carries_when)?;
+        }
+        JobV2StepBody::Loop { loop_ } => {
+            if let Some(expr) = &loop_.break_when {
+                check_expr_output_refs(&step.id, expr, carries_when)?;
+            }
+            for body in &loop_.steps {
+                check_step_output_refs(body, carries_when)?;
+            }
+        }
+        JobV2StepBody::Target(_) | JobV2StepBody::TargetRef(_) => {}
+    }
+    Ok(())
+}
+
+fn check_expr_output_refs(
+    referencing_step: &str,
+    expr: &str,
+    carries_when: &HashMap<String, bool>,
+) -> Result<(), DispatchError> {
+    for referenced_step in output_step_refs(expr) {
+        if carries_when.get(&referenced_step).copied().unwrap_or(false) {
+            return Err(DispatchError::JobValidation(format!(
+                "step `{referencing_step}` reads `steps.{referenced_step}.output`, but step \
+                 `{referenced_step}` carries its own `when:` and may be skipped — a `when:` or \
+                 `break_when:` condition may only read the output of a step that always runs"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Extract every `steps.<id>.output...` reference from the `{{ }}` template
+/// tokens in a `when:` / `break_when:` expression, mirroring the token shape
+/// `template::resolve_token` parses at render time.
+fn output_step_refs(expr: &str) -> Vec<String> {
+    let mut refs = Vec::new();
+    let mut remaining = expr;
+    while let Some(start) = remaining.find("{{") {
+        let after_start = &remaining[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            break;
+        };
+        let token = after_start[..end].trim();
+        let mut parts = token.split('.');
+        if parts.next() == Some("steps")
+            && let (Some(step_id), Some("output")) = (parts.next(), parts.next())
+        {
+            refs.push(step_id.to_string());
+        }
+        remaining = &after_start[end + 2..];
+    }
+    refs
 }
 
 /// [ORB-10385] Reject a job whose resolved activities name deterministic

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -528,6 +528,16 @@ Direct agent responses are advisory audit/diagnostic data. Workflows gate on dur
 
 After [T20260509-11], the shipped condition grammar remains equality-only (`==` / `!=`, combined with `&&` / `||`); skip-on-empty guards express emptiness as `!= 0` or `!= []` rather than numeric comparisons, preserving the `orbit run ship` auto-mode empty-backlog no-op behavior.
 
+**A step output read by any `when:` / `break_when:` condition must belong to a step that always runs** (ORB-11325). Two facts combine to make this a hard requirement rather than a style preference: `condition::evaluate_bool_expr` (`crates/orbit-engine/src/condition.rs`) renders the *whole* expression through the template engine before it parses it, so there is no short-circuit — both sides of `&&` / `||` render even when the left side alone would decide the result — and a step skipped by `when:` records no output at all, so any reference to it resolves to `template.rs`'s `no data recorded for step '{step_id}'` error. Together, a condition that reads `steps.<id>.output` for a step that itself carries a `when:` fails at runtime on exactly the branch where the referenced step would have been skipped — the branch an author is least likely to exercise first, since the happy path usually runs it.
+
+The working alternative is to end the run on the stranding branch instead of skipping past the reader: give the branch that would leave the reference unresolved its own unconditional failure (as `task_gate_pipeline`'s `starvation_check` does — its `when:` is the exact complement of the gated step's, and its activity always errors, so the run never reaches a downstream reader on that branch). Three plausible-looking workarounds do not help, and are not worth retrying:
+
+- `A == x && B != true` — no short-circuit, so `B` still renders even when `A == x` is already false.
+- Gating the reading step with the same `when:` as the referenced step — the reading step's own `when:` is still evaluated (and rendered) for every run, so the reference inside it still renders and still fails when the referenced step was skipped.
+- A single-iteration `loop:` wrapping just the referenced step as a grouping construct — this only renames which id is skippable. If the loop step itself carries the `when:` that used to guard the body step, then when that condition is false the *loop* is skipped, the body step never runs, and a reader outside the loop still finds no data recorded for the body step's id. Wrapping the referenced step *and every reader of its output* together in the same guarded block does work (nothing outside the block needs the skipped id), but wrapping only the referenced step does not.
+
+Catalog load enforces this: `validate_job` (`crates/orbit-engine/src/activity_job/job_executor/validate.rs`) walks every step's `when:` and every loop's `break_when:` for `steps.<id>.output` references and rejects the job, naming both the reading and the referenced step, when the referenced step itself carries a `when:`.
+
 The retry wrapper re-runs the whole step body up to `max_attempts`, with exponential or linear backoff. Some errors bypass retry:
 
 - tool denial


### PR DESCRIPTION
## Task

[ORB-11325](https://orbit-cli.com/tasks/ORB-11325) — [friction-curation] Document that a step output read by a job condition must belong to an always-run step

### Description

## Problem

A v2 job step's `when:` / `break_when:` expression is rendered in full before it is parsed, and a step skipped by `when:` records no output at all. Together these mean **any step whose output a condition reads must run unconditionally** — otherwise the run fails with `no data recorded for step '<id>'`, and it fails on the branch where the condition would have been false, which is the branch an author is least likely to exercise first.

The constraint is real in the current tree but is written down only as a local aside:

- `crates/orbit-engine/src/condition.rs:22-23` — `evaluate_bool_expr` calls `template::render(expr, ctx)` on the whole expression and only then parses it. There is no short-circuit, so both sides of an `&&` or `||` render.
- `crates/orbit-engine/src/template.rs:100` — an unrecorded step reference produces `no data recorded for step '{step_id}'`.
- `crates/orbit-core/assets/jobs/task_gate_pipeline.yaml:17` states the rule as a comment about one specific reserve step, not as a general authoring constraint.
- `docs/design/activity-job/2_design.md` documents the `when:` / `break_when:` contract but does not state it.

The shipped `task_pr_pipeline.yaml` already depends on the rule: its `commit` step runs unconditionally precisely so that `steps.commit.output.skipped_no_diff_expected` can be read by six downstream conditions (lines 86, 97, 117, 132, 149, 165, 176, 188).

## Cost

Originally recorded during ORB-11101 at roughly an hour of design rework. Three plausible-looking workarounds do not help and are worth naming in the doc so the next author does not retry them: `A == x && B != true` (no short-circuit, `B` still renders); gating the reading step with the same condition as the referenced step (the `when:` is still evaluated for every step, so it still renders); and a single-iteration `loop:` as a grouping construct (works, but the outputs are still unreachable after the loop).

Note that ORB-11101 itself was rejected as an over-complicated solution and `task_ci_remediation_pipeline.yaml` never landed, so the constraint is currently recorded nowhere except the `task_gate_pipeline.yaml` aside.

## Suggested direction

State the rule once in `docs/design/activity-job/2_design.md` alongside the existing `when:` / `break_when:` contract: *a step output read by any condition must belong to a step that always runs*, with the working alternative (make the branch that would strand a reader end the run rather than skip past it) and the three failed workarounds.

Then add a load-time check in `crates/orbit-engine/src/activity_job/job_executor/validate.rs` that walks each `when:` / `break_when:` for `steps.<id>.output` references and rejects one naming a step that carries its own `when:`, turning a runtime failure on an unexercised branch into a catalog-load error.

This *adds* a rejection to a load-time validator rather than widening a fail-closed guard, so no existing rejection guarantee is relaxed. Every shipped job in `crates/orbit-core/assets/jobs/` must still load unchanged; if any legitimately violates the new rule, report it rather than silently exempting it.

### Acceptance Criteria

- `docs/design/activity-job/2_design.md` states, next to the `when:` / `break_when:` contract, that a step output read by any condition must belong to a step that always runs, citing the render-before-parse behavior in `crates/orbit-engine/src/condition.rs` and the `no data recorded for step` error in `crates/orbit-engine/src/template.rs`.
- The doc records the working alternative (end the run on the stranding branch instead of skipping past the reader) and names the three non-working workarounds (`&&` without short-circuit, gating the reader with the same condition, single-iteration `loop:`).
- Catalog load rejects a job whose `when:` or `break_when:` reads `steps.<id>.output` for a step that itself carries a `when:`, with an error naming both step ids; a unit test in the sibling `tests/` directory for `validate.rs` pins both the rejection and an accepted always-run reference.
- Every job asset under `crates/orbit-core/assets/jobs/` still loads successfully under the new validation, verified by test; no shipped job is exempted by a special case.
- `cargo test -p orbit-engine` passes, and `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Documented the when:/break_when: output-readiness rule and enforced it at catalog load.

docs/design/activity-job/2_design.md §8.2: added a paragraph stating that a step output read by any when:/break_when: condition must belong to a step that always runs, citing the render-before-parse behavior in condition::evaluate_bool_expr and the "no data recorded for step" error in template.rs. Recorded the working alternative (end the run on the stranding branch instead of skipping past the reader, as task_gate_pipeline's starvation_check already does) and the three non-working workarounds (no-short-circuit &&, gating the reader with the same condition, and a single-iteration loop: that only relocates which id is skippable).

crates/orbit-engine/src/activity_job/job_executor/validate.rs: added validate_step_output_readiness, called from validate_job. It builds a map of every step id (including nested parallel/fan_out/loop bodies) to whether it carries a when:, then walks every when: and loop break_when: for `steps.<id>.output` references and rejects the job with DispatchError::JobValidation naming both the reading and referenced step ids when the referenced step carries its own when:. Reference extraction mirrors template::resolve_token's {{ }}-token parsing rather than adding a regex dependency.

crates/orbit-engine/src/activity_job/job_executor/tests/validate.rs: added three unit tests — rejects a when: reading a conditional step's output (names both steps), accepts a when: reading an always-run step's output, and rejects a loop's break_when: reading a conditional step's output.

Running the new check against every crates/orbit-core/assets/jobs/*.yaml found one real violation: task_gate_pipeline.yaml's release_reservation reads steps.dispatch_child.output.status, and dispatch_child carried when: reserved == true. Fixed rather than exempted (see friction F2026-09-027 for the investigation): removed the redundant when: reserved == true from dispatch_child and require_child_success, since starvation_check's complementary when: reserved == false always fails (gate_starvation_fail unconditionally errors) and halts the run before those steps would otherwise be reached on that branch — the guard was dead code, so this is behavior-preserving. Updated crates/orbit-core/assets/jobs/task_gate_pipeline.yaml and its byte-identical .orbit/resources/jobs/task_gate_pipeline.yaml mirror, and updated the one pinned test assertion in crates/orbit-core/src/application/job/tests/catalog.rs (gate_pipeline_releases_reservation_before_child_success_guard) plus added dispatch.when/guard.when None assertions. Added a new sweep test default_jobs_only_read_step_output_from_always_run_steps that runs validate_job over every DEFAULT_JOB_FILES entry.

Validation: cargo test -p orbit-engine (489 passed), cargo test -p orbit-core --lib application::job (145 passed), make ci-fast and make ci-lint (cargo clippy --workspace --all-targets -D warnings) all pass. git status --short shows only the six intended files changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11325-6a9caac5`
- Behind base: 0
- Ahead of base: 1