### PR TITLE
Align Antigravity print timeout with Orbit activity budget and surface terminal errors

### DIFF
--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -64,7 +64,9 @@ mod types;
 
 pub use agent::{Agent, AgentConfig, ProviderOptions};
 pub use orbit_types::telemetry::{InvocationTrace, TokenUsage, ToolCallTrace};
-pub use providers::normalize_cli_stdout;
+pub use providers::{
+    antigravity_terminal_error_diagnostic, apply_antigravity_print_timeout, normalize_cli_stdout,
+};
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};
 pub use types::{

--- a/crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs
+++ b/crates/orbit-agent/src/providers/antigravity/antigravity_cli.rs
@@ -1,12 +1,24 @@
+use std::time::Duration;
+
 use crate::providers::common::render_prompt_with_embedded_envelope;
 use crate::types::response_envelope_json_schema_arg;
 use orbit_types::identity::ReasoningEffort;
+
+/// Leave this much of the remaining Orbit spawn deadline for outer process
+/// supervision after `agy --print-timeout` fires, so a terminal `result` can
+/// be written before process-group kill. [ORB-11337]
+pub(crate) const PRINT_TIMEOUT_SHUTDOWN_MARGIN: Duration = Duration::from_secs(30);
+const PRINT_TIMEOUT_FLAG: &str = "--print-timeout";
+const PRINT_TIMEOUT_EQUALS_PREFIX: &str = "--print-timeout=";
+const MIN_PRINT_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Per-request command construction for Antigravity CLI (`agy`).
 ///
 /// Static headless flags live on the shipped executor. This transport adds
 /// only the model, effort, and generated envelope schema for one turn.
-/// [ORB-11299]
+/// `--print-timeout` is merged later from the remaining spawn deadline so a
+/// custom executor can keep a shorter explicit value without duplicating the
+/// flag. [ORB-11299] [ORB-11337]
 pub(crate) struct AntigravityCliTransport {
     model: Option<String>,
     reasoning_effort: Option<ReasoningEffort>,
@@ -55,4 +67,190 @@ impl AntigravityCliTransport {
     pub(crate) fn model_name(&self) -> Option<&str> {
         self.model.as_deref()
     }
+}
+
+/// Derive documented `agy --print-timeout` from the remaining Orbit spawn
+/// deadline. A 30s shutdown margin keeps outer supervision authoritative.
+/// Budgets that do not fit the margin still get an explicit value so the
+/// documented 5m default cannot apply.
+pub(crate) fn derived_antigravity_print_timeout(remaining_deadline: Duration) -> Duration {
+    let remaining = remaining_deadline.max(MIN_PRINT_TIMEOUT);
+    if remaining > PRINT_TIMEOUT_SHUTDOWN_MARGIN {
+        remaining - PRINT_TIMEOUT_SHUTDOWN_MARGIN
+    } else {
+        remaining
+    }
+}
+
+/// Format a duration as the Go `time.ParseDuration` spelling `agy` documents
+/// (`2h59m30s`, `15m`, `30s`).
+pub(crate) fn format_antigravity_print_timeout(duration: Duration) -> String {
+    let total_secs = duration.as_secs();
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+    if hours > 0 {
+        format!("{hours}h{minutes}m{seconds}s")
+    } else if minutes > 0 {
+        if seconds == 0 {
+            format!("{minutes}m")
+        } else {
+            format!("{minutes}m{seconds}s")
+        }
+    } else if total_secs > 0 {
+        format!("{seconds}s")
+    } else {
+        format!("{}ms", duration.as_millis().max(1))
+    }
+}
+
+/// Merge `--print-timeout` into combined executor + invocation argv.
+///
+/// No-ops for other providers. A shorter explicit executor value is kept; a
+/// longer one is capped to the derived budget; the flag is never duplicated.
+pub fn apply_antigravity_print_timeout(
+    provider: &str,
+    args: &mut Vec<String>,
+    remaining_deadline: Duration,
+) {
+    if provider != "antigravity" && provider != "agy" {
+        return;
+    }
+    let derived = derived_antigravity_print_timeout(remaining_deadline);
+    let chosen = existing_print_timeout(args)
+        .map(|existing| existing.min(derived))
+        .unwrap_or(derived);
+    set_print_timeout(args, chosen);
+}
+
+fn existing_print_timeout(args: &[String]) -> Option<Duration> {
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        if let Some(value) = arg.strip_prefix(PRINT_TIMEOUT_EQUALS_PREFIX) {
+            return parse_go_duration(value);
+        }
+        if arg == PRINT_TIMEOUT_FLAG {
+            let value = args.get(idx + 1).filter(|next| !next.starts_with('-'))?;
+            return parse_go_duration(value);
+        }
+        idx += 1;
+    }
+    None
+}
+
+fn set_print_timeout(args: &mut Vec<String>, timeout: Duration) {
+    let formatted = format_antigravity_print_timeout(timeout);
+    let mut idx = 0;
+    let mut seen = false;
+    while idx < args.len() {
+        if args[idx].starts_with(PRINT_TIMEOUT_EQUALS_PREFIX) {
+            if seen {
+                args.remove(idx);
+                continue;
+            }
+            args[idx] = format!("{PRINT_TIMEOUT_EQUALS_PREFIX}{formatted}");
+            seen = true;
+            idx += 1;
+            continue;
+        }
+        if args[idx] == PRINT_TIMEOUT_FLAG {
+            if seen {
+                if idx + 1 < args.len() && !args[idx + 1].starts_with('-') {
+                    args.remove(idx + 1);
+                }
+                args.remove(idx);
+                continue;
+            }
+            if idx + 1 < args.len() && !args[idx + 1].starts_with('-') {
+                args[idx + 1] = formatted.clone();
+                seen = true;
+                idx += 2;
+            } else {
+                args.insert(idx + 1, formatted.clone());
+                seen = true;
+                idx += 2;
+            }
+            continue;
+        }
+        idx += 1;
+    }
+    if !seen {
+        args.push(PRINT_TIMEOUT_FLAG.to_string());
+        args.push(formatted);
+    }
+}
+
+fn parse_go_duration(raw: &str) -> Option<Duration> {
+    let mut rest = raw.trim();
+    if rest.is_empty() {
+        return None;
+    }
+    if let Some(stripped) = rest.strip_prefix('+') {
+        rest = stripped;
+    }
+    if rest.starts_with('-') {
+        return None;
+    }
+    let mut total = Duration::ZERO;
+    let mut parsed_any = false;
+    while !rest.is_empty() {
+        let (number, after_number) = parse_leading_number(rest)?;
+        let (unit, after_unit) = parse_leading_unit(after_number)?;
+        let contrib = duration_from_unit(number, unit)?;
+        total = total.checked_add(contrib)?;
+        rest = after_unit;
+        parsed_any = true;
+    }
+    parsed_any.then_some(total)
+}
+
+fn parse_leading_number(raw: &str) -> Option<(f64, &str)> {
+    let mut end = 0;
+    let bytes = raw.as_bytes();
+    let mut seen_digit = false;
+    let mut seen_dot = false;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' => {
+                seen_digit = true;
+                end += 1;
+            }
+            b'.' if !seen_dot => {
+                seen_dot = true;
+                end += 1;
+            }
+            _ => break,
+        }
+    }
+    if !seen_digit {
+        return None;
+    }
+    let number: f64 = raw[..end].parse().ok()?;
+    Some((number, &raw[end..]))
+}
+
+fn parse_leading_unit(raw: &str) -> Option<(&'static str, &str)> {
+    for unit in ["ms", "us", "µs", "μs", "ns", "h", "m", "s"] {
+        if let Some(rest) = raw.strip_prefix(unit) {
+            return Some((unit, rest));
+        }
+    }
+    None
+}
+
+fn duration_from_unit(number: f64, unit: &str) -> Option<Duration> {
+    if !number.is_finite() || number < 0.0 {
+        return None;
+    }
+    let seconds = match unit {
+        "h" => number * 3600.0,
+        "m" => number * 60.0,
+        "s" => number,
+        "ms" => number / 1000.0,
+        "us" | "µs" | "μs" => number / 1_000_000.0,
+        "ns" => number / 1_000_000_000.0,
+        _ => return None,
+    };
+    Duration::try_from_secs_f64(seconds).ok()
 }

--- a/crates/orbit-agent/src/providers/antigravity/antigravity_output.rs
+++ b/crates/orbit-agent/src/providers/antigravity/antigravity_output.rs
@@ -9,6 +9,11 @@
 
 use serde_json::Value;
 
+/// Upper bound on a provider `error` string copied into a diagnostic. The CLI
+/// runner bounds and redacts again; this keeps the extracted text from ever
+/// carrying a prompt or response transcript. [ORB-11337]
+const TERMINAL_ERROR_LIMIT_CHARS: usize = 400;
+
 /// Return the terminal `result` payload when `agy` completed successfully.
 ///
 /// The returned JSON keeps `response` (and `structured_output` when present)
@@ -53,4 +58,55 @@ fn terminal_result(stdout: &[u8]) -> Option<Value> {
 fn is_json_envelope(value: &Value) -> bool {
     value.get("status").and_then(Value::as_str).is_some()
         && (value.get("response").is_some() || value.get("error").is_some())
+}
+
+/// Extract a bounded Antigravity terminal `error` for a failed run.
+///
+/// Reads only `status` and `error`. The `response` field is never copied, so a
+/// failed terminal cannot leak prompt or completion transcripts into
+/// diagnostics. SUCCESS terminals yield `None`.
+pub(crate) fn antigravity_terminal_error(stdout: &[u8]) -> Option<String> {
+    let result = terminal_result(stdout)?;
+    let status = result.get("status").and_then(Value::as_str)?;
+    if status == "SUCCESS" {
+        return None;
+    }
+    let error_text = terminal_error_text(result.get("error"));
+    let text = if error_text.is_empty() {
+        format!("Antigravity terminal status {status}")
+    } else {
+        error_text
+    };
+    Some(bound_terminal_error(&text))
+}
+
+/// Provider-gated diagnostic for a nonzero CLI exit whose stderr is empty.
+pub fn antigravity_terminal_error_diagnostic(provider: &str, stdout: &[u8]) -> Option<String> {
+    if provider != "antigravity" && provider != "agy" {
+        return None;
+    }
+    let error = antigravity_terminal_error(stdout)?;
+    Some(format!("Antigravity terminal error: {error}"))
+}
+
+fn terminal_error_text(error: Option<&Value>) -> String {
+    match error {
+        Some(Value::String(text)) => text.trim().to_string(),
+        Some(Value::Object(object)) => object
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+fn bound_terminal_error(text: &str) -> String {
+    let bounded: String = text.chars().take(TERMINAL_ERROR_LIMIT_CHARS).collect();
+    if bounded.chars().count() < text.chars().count() {
+        format!("{bounded}…")
+    } else {
+        bounded
+    }
 }

--- a/crates/orbit-agent/src/providers/antigravity/mod.rs
+++ b/crates/orbit-agent/src/providers/antigravity/mod.rs
@@ -2,6 +2,8 @@ mod antigravity_cli;
 mod antigravity_output;
 mod antigravity_runtime;
 
+pub use antigravity_cli::apply_antigravity_print_timeout;
+pub use antigravity_output::antigravity_terminal_error_diagnostic;
 pub(crate) use antigravity_output::normalize_antigravity_stdout;
 pub(crate) use antigravity_runtime::AntigravityFactory;
 

--- a/crates/orbit-agent/src/providers/antigravity/tests/antigravity_cli.rs
+++ b/crates/orbit-agent/src/providers/antigravity/tests/antigravity_cli.rs
@@ -1,11 +1,37 @@
 #![allow(missing_docs)]
 
+use std::time::Duration;
+
 use orbit_types::identity::ReasoningEffort;
 
-use super::super::antigravity_cli::AntigravityCliTransport;
+use super::super::antigravity_cli::{
+    AntigravityCliTransport, PRINT_TIMEOUT_SHUTDOWN_MARGIN, apply_antigravity_print_timeout,
+    derived_antigravity_print_timeout, format_antigravity_print_timeout,
+};
 use super::super::antigravity_runtime::AntigravityRuntime;
 use crate::runtime::AgentRuntime;
 use crate::types::{AgentOperation, AgentRequest};
+
+fn print_timeout_values(args: &[String]) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut idx = 0;
+    while idx < args.len() {
+        if let Some(value) = args[idx].strip_prefix("--print-timeout=") {
+            values.push(value.to_string());
+            idx += 1;
+            continue;
+        }
+        if args[idx] == "--print-timeout"
+            && let Some(value) = args.get(idx + 1)
+        {
+            values.push(value.clone());
+            idx += 2;
+            continue;
+        }
+        idx += 1;
+    }
+    values
+}
 
 #[test]
 fn args_pass_model_effort_and_generated_schema() {
@@ -61,4 +87,99 @@ fn runtime_requires_state_context_but_never_implicitly_forwards_credentials() {
     assert_eq!(invocation.required_env_vars, &["HOME", "PATH"]);
     assert!(!invocation.args.iter().any(|arg| arg == "--login"));
     assert!(!invocation.program.contains("gemini"));
+}
+
+#[test]
+fn long_budget_print_timeout_exceeds_the_documented_five_minute_default() {
+    let remaining = Duration::from_secs(3 * 60 * 60);
+    let derived = derived_antigravity_print_timeout(remaining);
+    assert_eq!(derived, remaining - PRINT_TIMEOUT_SHUTDOWN_MARGIN);
+    assert!(derived > Duration::from_secs(5 * 60));
+    assert_eq!(format_antigravity_print_timeout(derived), "2h59m30s");
+
+    let mut args = vec![
+        "--input-format".to_string(),
+        "stream-json".to_string(),
+        "--json-schema".to_string(),
+        "{}".to_string(),
+    ];
+    apply_antigravity_print_timeout("antigravity", &mut args, remaining);
+    assert_eq!(print_timeout_values(&args), vec!["2h59m30s".to_string()]);
+}
+
+#[test]
+fn short_budget_uses_the_remaining_deadline_when_the_margin_does_not_fit() {
+    let remaining = Duration::from_secs(10);
+    let derived = derived_antigravity_print_timeout(remaining);
+    assert_eq!(derived, remaining);
+    assert_eq!(format_antigravity_print_timeout(derived), "10s");
+
+    let mut args = Vec::new();
+    apply_antigravity_print_timeout("antigravity", &mut args, remaining);
+    assert_eq!(print_timeout_values(&args), vec!["10s".to_string()]);
+}
+
+#[test]
+fn minute_scale_budget_subtracts_the_shutdown_margin() {
+    let remaining = Duration::from_secs(60);
+    let derived = derived_antigravity_print_timeout(remaining);
+    assert_eq!(derived, Duration::from_secs(30));
+    let mut args = Vec::new();
+    apply_antigravity_print_timeout("agy", &mut args, remaining);
+    assert_eq!(print_timeout_values(&args), vec!["30s".to_string()]);
+}
+
+#[test]
+fn shorter_executor_print_timeout_is_preserved_without_a_duplicate_flag() {
+    let mut args = vec![
+        "--print-timeout".to_string(),
+        "2m".to_string(),
+        "--model".to_string(),
+        "gemini-3.8-flash-high".to_string(),
+    ];
+    apply_antigravity_print_timeout("antigravity", &mut args, Duration::from_secs(3 * 60 * 60));
+    assert_eq!(print_timeout_values(&args), vec!["2m".to_string()]);
+    assert_eq!(
+        args,
+        vec![
+            "--print-timeout".to_string(),
+            "2m".to_string(),
+            "--model".to_string(),
+            "gemini-3.8-flash-high".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn longer_executor_print_timeout_is_capped_to_the_derived_budget() {
+    let mut args = vec![
+        "--print-timeout=4h".to_string(),
+        "--effort".to_string(),
+        "high".to_string(),
+    ];
+    apply_antigravity_print_timeout("antigravity", &mut args, Duration::from_secs(3 * 60 * 60));
+    assert_eq!(args[0], "--print-timeout=2h59m30s");
+    assert_eq!(print_timeout_values(&args), vec!["2h59m30s".to_string()]);
+}
+
+#[test]
+fn duplicate_print_timeout_flags_are_collapsed() {
+    let mut args = vec![
+        "--print-timeout".to_string(),
+        "4h".to_string(),
+        "--print-timeout=15m".to_string(),
+    ];
+    apply_antigravity_print_timeout("antigravity", &mut args, Duration::from_secs(3 * 60 * 60));
+    assert_eq!(
+        args,
+        vec!["--print-timeout".to_string(), "2h59m30s".to_string()]
+    );
+}
+
+#[test]
+fn other_providers_are_not_given_a_print_timeout() {
+    let mut args = vec!["--json".to_string()];
+    apply_antigravity_print_timeout("claude", &mut args, Duration::from_secs(3600));
+    apply_antigravity_print_timeout("gemini", &mut args, Duration::from_secs(3600));
+    assert_eq!(args, vec!["--json".to_string()]);
 }

--- a/crates/orbit-agent/src/providers/antigravity/tests/antigravity_output.rs
+++ b/crates/orbit-agent/src/providers/antigravity/tests/antigravity_output.rs
@@ -2,6 +2,9 @@
 
 use orbit_types::tool::ExecutionResult;
 
+use super::super::antigravity_output::{
+    antigravity_terminal_error, antigravity_terminal_error_diagnostic,
+};
 use crate::providers::normalize_cli_stdout;
 use crate::types::{AgentResponseStatus, parse_and_validate_response};
 
@@ -106,6 +109,58 @@ fn malformed_or_missing_result_yields_no_completion_evidence() {
     ] {
         assert!(normalize_cli_stdout("antigravity", stdout.as_bytes()).is_empty());
     }
+}
+
+#[test]
+fn timeout_terminal_error_is_bounded_and_omits_response_transcript() {
+    let response = format!(
+        r#"{{"schemaVersion":1,"status":"success","result":{{"prompt":"do not leak"}},"error":null}} credential {secret}"#,
+        secret = "agy-tenant-42-authorization-bearer-zzz"
+    );
+    let stdout = serde_json::json!({
+        "event": "result",
+        "result": {
+            "status": "ERROR",
+            "response": response,
+            "error": "timeout waiting for response"
+        }
+    })
+    .to_string();
+
+    let error = antigravity_terminal_error(stdout.as_bytes()).expect("terminal error");
+    assert_eq!(error, "timeout waiting for response");
+    assert!(!error.contains("do not leak"));
+    assert!(!error.contains("agy-tenant-42"));
+
+    let diagnostic = antigravity_terminal_error_diagnostic("antigravity", stdout.as_bytes())
+        .expect("diagnostic");
+    assert!(diagnostic.contains("timeout waiting for response"));
+    assert!(!diagnostic.contains(&response));
+    assert!(antigravity_terminal_error_diagnostic("claude", stdout.as_bytes()).is_none());
+}
+
+#[test]
+fn success_terminal_does_not_yield_an_error_diagnostic() {
+    let stdout = stream_success(ORBIT_SUCCESS);
+    assert!(antigravity_terminal_error(stdout.as_bytes()).is_none());
+}
+
+#[test]
+fn long_terminal_error_is_truncated_without_copying_response() {
+    let error = "x".repeat(500);
+    let stdout = serde_json::json!({
+        "event": "result",
+        "result": {
+            "status": "ERROR",
+            "response": ORBIT_SUCCESS,
+            "error": error
+        }
+    })
+    .to_string();
+    let extracted = antigravity_terminal_error(stdout.as_bytes()).expect("bounded error");
+    assert_eq!(extracted.chars().count(), 401);
+    assert!(extracted.ends_with('…'));
+    assert!(!extracted.contains("edited"));
 }
 
 #[test]

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -30,6 +30,8 @@ pub mod openai_compat;
 pub(crate) mod opencode;
 pub(crate) mod pi;
 
+pub use antigravity::{antigravity_terminal_error_diagnostic, apply_antigravity_print_timeout};
+
 use std::borrow::Cow;
 
 use crate::types::AgentInvocationSpec;

--- a/crates/orbit-core/assets/executors/antigravity.yaml
+++ b/crates/orbit-core/assets/executors/antigravity.yaml
@@ -11,6 +11,10 @@ spec:
   # unattended analog of interactive Ask; Orbit's OS sandbox remains the
   # filesystem/network boundary. Do not pass Gemini CLI flags
   # (`--approval-mode`, `-o json`, `--allowed-mcp-server-names`) or `agy --sandbox`.
+  # `--print-timeout` is injected per invocation from the remaining activity
+  # deadline minus a 30s shutdown margin; do not hard-code the documented 5m
+  # default here. Custom executor values are merged (shorter wins, longer is
+  # capped) without duplicating the flag.
   args:
     - --input-format
     - stream-json

--- a/crates/orbit-core/tests/antigravity_fake_agent.rs
+++ b/crates/orbit-core/tests/antigravity_fake_agent.rs
@@ -191,6 +191,17 @@ fn command_construction_matches_the_shipped_headless_contract() {
     assert!(!argv.iter().any(|arg| arg == "--sandbox"));
     assert!(!argv.iter().any(|arg| arg == "-p" || arg == "--print"));
     assert!(
+        argv.windows(2)
+            .any(|args| args == ["--print-timeout", "30s"]),
+        "60s remaining deadline minus 30s margin must be explicit: {argv:?}"
+    );
+    assert_eq!(
+        argv.iter()
+            .filter(|arg| arg.as_str() == "--print-timeout" || arg.starts_with("--print-timeout="))
+            .count(),
+        1
+    );
+    assert!(
         !argv.iter().any(|arg| arg.contains(PROMPT_SECRET)),
         "prompt must not enter argv",
     );
@@ -251,6 +262,61 @@ fn malformed_or_incomplete_output_never_succeeds() {
             "invalid Antigravity output must fail: {body}"
         );
     }
+}
+
+#[test]
+fn long_budget_is_not_capped_by_the_default_five_minute_print_timeout() {
+    let body = format!(
+        r#"print_timeout=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--print-timeout" ]; then print_timeout="$arg"; fi
+  case "$arg" in --print-timeout=*) print_timeout="${{arg#--print-timeout=}}" ;; esac
+  prev="$arg"
+done
+case "$print_timeout" in
+  ""|5m|5m0s|300s)
+    printf '%s\n' '{{"event":"result","result":{{"status":"ERROR","response":"","error":"timeout waiting for response"}}}}'
+    exit 1
+    ;;
+esac
+{success}"#,
+        success = success_body()
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(3 * 60 * 60));
+    assert!(outcome.success, "dispatch failed: {:?}", outcome.message);
+    let argv = harness.argv();
+    assert!(
+        argv.windows(2)
+            .any(|args| args == ["--print-timeout", "2h59m30s"]),
+        "3h remaining deadline must raise --print-timeout above 5m: {argv:?}"
+    );
+}
+
+#[test]
+fn timeout_terminal_error_with_empty_stderr_fails_without_exposing_transcript() {
+    let body = format!(
+        r#"printf '%s\n' '{{"event":"result","result":{{"status":"ERROR","response":"{SUCCESS_ENVELOPE}","error":"timeout waiting for response"}}}}'
+exit 1"#
+    );
+    let harness = Harness::new(&body);
+    let outcome = dispatch(&harness, spec(60));
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["timed_out"], serde_json::Value::Bool(false));
+    assert_eq!(outcome.output["exit_code"], serde_json::json!(1));
+    let message = outcome.message.unwrap_or_default();
+    assert!(
+        message.contains("timeout waiting for response"),
+        "empty stderr must still surface the terminal error: {message}"
+    );
+    assert!(!message.contains(PROMPT_SECRET));
+    assert!(!message.contains("edited"));
+    let rendered = serde_json::to_string(&outcome.output).expect("serialize output");
+    assert!(
+        !rendered.contains(PROMPT_SECRET),
+        "prompt must not appear in durable diagnostics"
+    );
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/argv.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::time::Duration;
 
 use orbit_exec::{
     bwrap_program_for_audit, claude_state_dir_from_env, compile_linux_bwrap_argv,
@@ -99,6 +100,18 @@ pub(super) fn apply_provider_static_arg_fixups(provider: &str, static_args: &mut
     if provider == "claude" {
         rewrite_claude_debug_file_path(static_args);
     }
+}
+
+/// Per-invocation argv fixups that depend on the remaining spawn deadline.
+///
+/// Today this only merges Antigravity `--print-timeout` so `agy`'s documented
+/// 5m default cannot cut off a longer Orbit activity budget. [ORB-11337]
+pub(super) fn apply_provider_runtime_arg_fixups(
+    provider: &str,
+    args: &mut Vec<String>,
+    remaining_deadline: Duration,
+) {
+    orbit_agent::apply_antigravity_print_timeout(provider, args, remaining_deadline);
 }
 
 /// Replace the value following any `--debug-file` token in `static_args`

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use orbit_agent::{
-    Agent, AgentConfig, AgentOperation, AgentRequest, normalize_cli_stdout, peek_response_status,
-    provider_invocation_diagnostic, response_envelope_protocol_check,
+    Agent, AgentConfig, AgentOperation, AgentRequest, antigravity_terminal_error_diagnostic,
+    normalize_cli_stdout, peek_response_status, provider_invocation_diagnostic,
+    response_envelope_protocol_check,
 };
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
@@ -21,7 +22,8 @@ use super::super::workspace::{
     WorktreeBoundaryGuard, resolve_subprocess_cwd, validate_declared_worktree_pair,
 };
 use super::argv::{
-    apply_provider_static_arg_fixups, neutralize_inner_sandbox, try_audit_argv_for_dispatch,
+    apply_provider_runtime_arg_fixups, apply_provider_static_arg_fixups, neutralize_inner_sandbox,
+    try_audit_argv_for_dispatch,
 };
 use super::envelope::{
     cli_agent_envelope_json, parse_cli_invocation_trace, parse_cli_response_result,
@@ -183,6 +185,10 @@ pub fn run_cli_backend(
     let mut subprocess_args = Vec::with_capacity(cli_executor.args.len() + invocation.args.len());
     subprocess_args.extend(cli_executor.args.iter().cloned());
     subprocess_args.extend(invocation.args.iter().cloned());
+    // Combined executor + transport argv is the only place that can honor a
+    // custom `--print-timeout` without duplicating it, and the remaining
+    // spawn deadline is known here. [ORB-11337]
+    apply_provider_runtime_arg_fixups(&provider, &mut subprocess_args, wall_clock_timeout);
 
     // The audit argv reflects what actually runs. Under sandbox-exec the
     // parent is `<trusted sandbox-exec> -f <profile.sb> <program> <args...>`;
@@ -528,6 +534,21 @@ pub fn run_cli_backend(
                 .or_else(|| {
                     provider_invocation_diagnostic(stdout_text.as_ref(), stderr_text.as_ref())
                         .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
+                })
+                // Antigravity writes terminal `ERROR` on stdout and often
+                // leaves stderr empty. Read the raw capture: normalization
+                // drops failed terminals so they cannot satisfy completion.
+                // [ORB-11337]
+                .or_else(|| {
+                    antigravity_terminal_error_diagnostic(&provider, stdout.protocol_bytes()).map(
+                        |diagnostic| {
+                            format!(
+                                "{} {}",
+                                exit_message(),
+                                bounded_diagnostic(&diagnostic, &redaction)
+                            )
+                        },
+                    )
                 })
                 .unwrap_or_else(exit_message),
         )

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
+use std::time::Duration;
 
 #[cfg(target_os = "linux")]
 use crate::activity_job::load_activity_asset;
@@ -26,7 +27,8 @@ use orbit_types::workflow::{ActivityV2Spec, ExecutorSandboxKind};
 #[cfg(target_os = "linux")]
 use super::super::argv::try_audit_argv_for_dispatch;
 use super::super::argv::{
-    audit_argv_for_dispatch, neutralize_inner_sandbox, rewrite_debug_file_value,
+    apply_provider_runtime_arg_fixups, audit_argv_for_dispatch, neutralize_inner_sandbox,
+    rewrite_debug_file_value,
 };
 use super::test_support::sandbox_for_test;
 #[cfg(target_os = "linux")]
@@ -554,6 +556,42 @@ fn rewrite_debug_file_value_ignores_dangling_flag() {
         args, original,
         "trailing --debug-file with no value must not panic or rewrite"
     );
+}
+
+#[test]
+fn apply_provider_runtime_arg_fixups_sets_antigravity_print_timeout() {
+    let mut args = vec![
+        "--input-format".to_string(),
+        "stream-json".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+    ];
+    apply_provider_runtime_arg_fixups("antigravity", &mut args, Duration::from_secs(3 * 60 * 60));
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == ["--print-timeout", "2h59m30s"]),
+        "long budgets must raise --print-timeout above the 5m default: {args:?}"
+    );
+    assert_eq!(
+        args.iter()
+            .filter(|arg| arg.as_str() == "--print-timeout" || arg.starts_with("--print-timeout="))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn apply_provider_runtime_arg_fixups_keeps_a_shorter_executor_print_timeout() {
+    let mut args = vec!["--print-timeout".to_string(), "45s".to_string()];
+    apply_provider_runtime_arg_fixups("antigravity", &mut args, Duration::from_secs(3 * 60 * 60));
+    assert_eq!(args, vec!["--print-timeout".to_string(), "45s".to_string()]);
+}
+
+#[test]
+fn apply_provider_runtime_arg_fixups_ignores_other_providers() {
+    let mut args = vec!["--json".to_string()];
+    apply_provider_runtime_arg_fixups("codex", &mut args, Duration::from_secs(3600));
+    assert_eq!(args, vec!["--json".to_string()]);
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -3775,6 +3775,113 @@ fn run_cli_backend_redacts_token_shaped_argv_in_audit() {
     );
 }
 
+#[test]
+fn run_cli_backend_passes_derived_antigravity_print_timeout() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("agy");
+    write_executable(&script, "#!/bin/sh\ncat > /dev/null\nexit 0\n");
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-agy-print-timeout",
+        "antigravity:gemini-3.8-flash-high",
+        sink_for_writer,
+    ));
+    let audit_for_assert = Arc::clone(&audit);
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("antigravity", Duration::from_secs(3 * 60 * 60));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-agy-print-timeout",
+        audit,
+        &serde_json::json!({"prompt": "do it"}),
+        None,
+    )
+    .expect("run cli backend");
+    assert!(!outcome.success);
+
+    let events = audit_for_assert.events_snapshot().expect("audit snapshot");
+    let argv = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted { argv_redacted, .. } => {
+                Some(argv_redacted.clone())
+            }
+            _ => None,
+        })
+        .expect("started event");
+    assert!(
+        argv.windows(2)
+            .any(|pair| pair == ["--print-timeout", "2h59m30s"]),
+        "long budgets must raise --print-timeout above the 5m default: {argv:?}"
+    );
+    assert_eq!(
+        argv.iter()
+            .filter(|arg| arg.as_str() == "--print-timeout" || arg.starts_with("--print-timeout="))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn run_cli_backend_surfaces_antigravity_timeout_terminal_error_when_stderr_empty() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("agy");
+    let stdout = serde_json::json!({
+        "event": "result",
+        "result": {
+            "status": "ERROR",
+            "response": "secret-transcript should not appear in diagnostics",
+            "error": "timeout waiting for response"
+        }
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{stdout}'\nexit 1\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-agy-timeout-error",
+        "antigravity:gemini-3.8-flash-high",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec_for("antigravity", Duration::from_secs(60));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-agy-timeout-error",
+        audit,
+        &serde_json::json!({"prompt": "do it"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["timed_out"], false);
+    assert_eq!(outcome.output["exit_code"], 1);
+    let message = outcome.message.expect("provider diagnostic");
+    assert!(
+        message.contains("timeout waiting for response"),
+        "{message}"
+    );
+    assert!(
+        message.contains("cli subprocess exited with code Some(1)"),
+        "{message}"
+    );
+    assert!(
+        !message.contains("secret-transcript"),
+        "response transcript leaked into diagnostics: {message}"
+    );
+}
+
 /// [ORB-10746] The `error_max_turns` ending: exit 0, `is_error: true`, no
 /// envelope in either `result` or `structured_output`. Structured output stops
 /// a model from *answering in prose*; it cannot stop a run from hitting its

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -394,6 +394,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         "codex" => Provider::Codex,
         "gemini" => Provider::Gemini,
         "grok" => Provider::Grok,
+        "antigravity" => Provider::Antigravity,
         other => panic!("unsupported provider for test: {other}"),
     };
     AgentLoopSpec {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -649,9 +649,21 @@ Do not copy Gemini CLI flags (`--approval-mode yolo`, `-o json`,
 `--allowed-mcp-server-names`). Do not pass `agy --sandbox`; the outer Orbit
 sandbox is authoritative.
 
+`agy --print-timeout` defaults to five minutes. Orbit always passes an
+explicit `--print-timeout` derived from the remaining activity wall-clock
+deadline minus a 30-second shutdown margin, so a three-hour activity is not
+cut off at five minutes. A custom executor that already sets the flag keeps a
+shorter value and is capped if it exceeds the derived budget; the flag is
+never duplicated. Orbit's outer process timeout and cleanup remain
+authoritative if the CLI ignores the flag.
+
 On success `agy` emits a terminal `result` with `status: "SUCCESS"`, the
 assistant text in `response`, and token counts in `usage`. Orbit rejects
 `ERROR` / malformed / missing terminal objects as missing completion evidence.
+When `agy` exits non-zero with empty stderr and a terminal `ERROR` (for
+example `timeout waiting for response`), Orbit surfaces that bounded, redacted
+`error` string in run/task diagnostics and does not copy `response` or prompt
+text into the message.
 MCP for Antigravity is configured at `~/.gemini/config/mcp_config.json`
 (home) or `.agents/mcp_config.json` (workspace), not the legacy Gemini
 `.gemini/settings.json` `mcpServers` map.


### PR DESCRIPTION
## Task

[ORB-11337](https://orbit-cli.com/tasks/ORB-11337) — Align Antigravity print timeout with Orbit activity budget and surface terminal errors

### Description

## Problem
ORB-11325 failed in task_pr_pipeline run jrun-20260905-2322-3 at implement_one on 2026-09-05 23:27 UTC. Crew gemini-flash actually used Antigravity ~/.local/bin/agy 1.1.27 with model gemini-3.8-flash-high. Its terminal stream-json result was status ERROR, response empty, error "timeout waiting for response"; stderr was empty. Orbit reported only cli subprocess exited with code Some(1).

## Verified evidence
Invocation audit event v2evt-jrun-20260905-2322-3-0000000b records wall_clock_timeout_ms=10800000 (3 hours). Actual duration 304368 ms, exit1, timed_out=false. agy --help documents --print-timeout default5m0s. Actual argv and shipped executor omit it; AntigravityCliTransport adds schema/model/effort only. Terminal error stdout blob: 1da121e142128162c1bd9c010f96da482c47f8efef7e66d083e10111ab987148. Strong live timing/config evidence of internal five-minute cutoff; no controlled replay and no evidence of a Gemini-model-family-only defect.

## Intended outcome
Honor Orbit's resolved activity execution budget through the appropriate invocation boundary, with explicit shutdown margin and defined handling of shorter user overrides. Preserve bounded Orbit process supervision. Surface bounded redacted provider terminal errors when stderr is empty.

## Constraints
No arbitrary globally oversized timeout, disabled supervision, ERROR-as-completion, automatic retry, or crew change. Preserve custom executors. ORB-11320 fixes effort identity, not timeout; hybrid and exact-error searches found no duplicate. Related incident ORB-11325. File-only authorization: proposed/undispatched. Source inspected at29efec8a99ec1b5e06df3b340398ccdc26dd482d; failed worktree base f60f0f9eb06a6d534b6de604eb5e16f61e1c8a1b.

### Acceptance Criteria

- Deterministic invocation tests prove Antigravity receives documented --print-timeout derived from resolved Orbit activity budget/remaining deadline with defined shutdown margin; cover short/long budgets and explicit executor values without duplicate flags.
- A fake Antigravity executable verifies long-budget activity is not implicitly capped by default five minutes, without a real five-minute wait or authenticated provider.
- ERROR terminal result with timeout waiting for response, empty stderr, exit1 fails activity with bounded redacted provider error in durable run/task diagnostics; no prompt/response transcript is exposed.
- Failed/malformed terminal results never satisfy completion; outer timeout and process cleanup remain authoritative and tested.
- Update relevant provider/executor docs and managed mirrors if changed; focused provider/runner tests and required fast/lint gates pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Inject `agy --print-timeout` at the combined executor+invocation argv boundary from the remaining CLI spawn deadline minus a 30s shutdown margin (Go duration, e.g. 3h → `2h59m30s`, 60s → `30s`). Short remaining deadlines still get an explicit value so the documented 5m default cannot apply. Shorter custom executor values are kept; longer ones are capped; the flag is never duplicated. Shipped executor YAML is unchanged except a comment; timeout is not a static arg.
- Surface bounded, redacted Antigravity terminal `error` text on nonzero exit with empty stderr (the live `timeout waiting for response` shape). Failed/malformed terminals still normalize to empty bytes and cannot satisfy completion. Outer `spawn_with_timeout` process-group kill remains authoritative.
- Docs: `docs/CONFIG.md` Antigravity headless section records print-timeout derivation and terminal-error diagnostics.
- Tests: unit coverage for short/long budgets and executor overrides; fake `agy` proves a 3h budget is not 5m-capped without waiting; ERROR+exit1+empty stderr fails with the provider error and no prompt/response leak; existing wall-clock kill tests still pass.
Assessment: Scoped to the Antigravity invocation/diagnostic boundary. Validation: `cargo test` orbit-agent antigravity (18), orbit-engine print-timeout/diagnostic/kill tests, orbit-core `antigravity_fake_agent` (9); `make ci-fast`; `make ci-lint`.
Strategic decisions: Derive timeout in orbit-agent and apply after combining argv so custom executors can keep a shorter `--print-timeout` without a second flag. Read terminal errors from the raw capture because normalization drops failed terminals on purpose.
Deviations from original plan: none.
Recommended follow-ups: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11337-6a9caa88`
- Behind base: 0
- Ahead of base: 1