### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### DIFF
--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -26,6 +26,8 @@ use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+#[cfg(target_os = "linux")]
+const EXEC_BUSY_RETRY_WINDOW: Duration = Duration::from_secs(2);
 
 /// Path of the checked-in `tools/list` snapshot, relative to the crate root.
 const SNAPSHOT_RELATIVE_PATH: &str = "tests/snapshots/mcp_tools_list.json";
@@ -212,8 +214,7 @@ impl McpWorkspace {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let child = command
-            .spawn()
+        let child = retry_executable_busy(|| command.spawn())
             .expect("spawn generated orbit mcp serve command");
         let mut client = McpClient::new(child);
         self.initialize(&mut client);
@@ -994,6 +995,59 @@ struct GeneratedForcedCommand {
     acceptance_token: String,
 }
 
+/// Retry a freshly copied test launcher while another parallel test's child
+/// still has its writable descriptor inherited across `fork`.
+///
+/// The descriptor is close-on-exec, but Linux can reject a concurrent exec
+/// with `ETXTBSY` during that short pre-exec window. This is the same bounded
+/// transient the production updater handles when it launches a newly written
+/// binary; all other errors remain immediate test failures.
+#[cfg(target_os = "linux")]
+fn retry_executable_busy<T>(
+    mut operation: impl FnMut() -> std::io::Result<T>,
+) -> std::io::Result<T> {
+    let deadline = Instant::now() + EXEC_BUSY_RETRY_WINDOW;
+    loop {
+        match operation() {
+            Err(error)
+                if error.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && Instant::now() < deadline =>
+            {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            result => return result,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_fresh_test_launcher_waits_for_a_writer_to_close() {
+    let temp = tempdir().expect("tempdir");
+    let launcher = temp.path().join("launcher");
+    std::fs::copy("/bin/true", &launcher).expect("copy executable fixture");
+    let writer = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&launcher)
+        .expect("hold launcher open for writing");
+    let error = Command::new(&launcher)
+        .spawn()
+        .expect_err("Linux must reject an executable that is open for writing");
+    assert_eq!(error.kind(), std::io::ErrorKind::ExecutableFileBusy);
+    let release_writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(75));
+        drop(writer);
+    });
+
+    let mut command = Command::new(&launcher);
+    let mut child = retry_executable_busy(|| command.spawn())
+        .expect("spawn launcher after transient executable-file-busy errors");
+    let status = child.wait().expect("wait for launcher");
+    release_writer.join().expect("release launcher writer");
+
+    assert!(status.success(), "copied launcher must eventually execute");
+}
+
 /// Install a metadata-valid copy of the tested binary whose setgid exec will
 /// change this account's effective group. Sandboxes that set `NoNewPrivs` or
 /// expose no mapped supplementary group cannot exercise the kernel boundary;
@@ -1269,18 +1323,19 @@ printf 'clear:%s:public=%s\n' "$sweeps" "$saw_public_caller"
     let mut repeated_launches = Vec::new();
     for _ in 0..48 {
         let argv = &generated.argv;
-        let child = McpWorkspace::orbit_program_command(
+        let mut command = McpWorkspace::orbit_program_command(
             Path::new(&argv[0]),
             &workspace.work,
             &workspace.home,
-        )
-        .args(["-c", generated.forced_command.as_str()])
-        .env(orbit_mcp::SSH_ACCEPTANCE_ENV, &generated.acceptance_token)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("start repeated legitimate protected destination");
+        );
+        command
+            .args(["-c", generated.forced_command.as_str()])
+            .env(orbit_mcp::SSH_ACCEPTANCE_ENV, &generated.acceptance_token)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = retry_executable_busy(|| command.spawn())
+            .expect("start repeated legitimate protected destination");
         repeated_launches.push(child);
     }
     std::fs::write(&stop, "stop\n").expect("stop proc scanner");
@@ -1413,7 +1468,8 @@ capabilities = ["agent", "operator"]
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let child = command.spawn().expect("spawn destination-issued command");
+    let child =
+        retry_executable_busy(|| command.spawn()).expect("spawn destination-issued command");
     let mut client = McpClient::new(child);
     workspace.initialize(&mut client);
     let listed = client.call_tool_ok("orbit_workflow_run_list", json!({}));
@@ -1497,13 +1553,13 @@ ssh_key_fingerprint = "{OTHER_KEY_FINGERPRINT}"
         return;
     };
     let argv = &generated.argv;
-    let output =
-        McpWorkspace::orbit_program_command(Path::new(&argv[0]), &workspace.work, &workspace.home)
-            .args(["-c", generated.forced_command.as_str()])
-            .env(orbit_mcp::SSH_ACCEPTANCE_ENV, &generated.acceptance_token)
-            .stdin(Stdio::null())
-            .output()
-            .expect("run orbit mcp serve");
+    let mut command =
+        McpWorkspace::orbit_program_command(Path::new(&argv[0]), &workspace.work, &workspace.home);
+    command
+        .args(["-c", generated.forced_command.as_str()])
+        .env(orbit_mcp::SSH_ACCEPTANCE_ENV, &generated.acceptance_token)
+        .stdin(Stdio::null());
+    let output = retry_executable_busy(|| command.output()).expect("run orbit mcp serve");
 
     assert!(!output.status.success(), "a key mismatch must fail closed");
     let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Task

[ORB-11340](https://orbit-cli.com/tasks/ORB-11340) — [ci-failure-sweep] Fix red CI: CI / Coverage (informational) / Collect workspace coverage

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Coverage (informational)`
- Failing step: `Collect workspace coverage`
- Commit the runner actually checked out: `5530555cc4d75935465b7c4cdc533dca86951dbf`
- Normalized error signature (the dedupe identity, not a quote): `test mcp_serve_error_paths_return_tool_errors_and_keep_serving ... ok`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-06T00:19:01.008156239+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/34000381226 run `34000381226` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `5530555cc4d75935465b7c4cdc533dca86951dbf`
  - current head of that ref: `unknown`
  - commit actually checked out: `5530555cc4d75935465b7c4cdc533dca86951dbf`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `5530555cc4d75935465b7c4cdc533dca86951dbf`
  - failed job `Coverage (informational)` (id `101398056828`): https://github.com/danieljhkim/orbit/actions/runs/34000381226/job/101398056828
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
Coverage (informational)	Collect workspace coverage	﻿2026-09-06T00:08:20.1812272Z ##[group]Run cargo llvm-cov --workspace --locked --no-report
Coverage (informational)	Collect workspace coverage	2026-09-06T00:11:12.5688638Z test unmanaged_orbit_workspace_env_does_not_bind_mcp ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:11:13.0794585Z test task_show_is_global_by_default_across_tool_run_and_mcp ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:11:13.0846149Z test the_generated_forced_command_obeys_the_matched_rows_operator_ceiling ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:11:13.8274016Z test workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:11:14.7148611Z test worktree_backed_activity_routes_task_and_search_by_advertised_workspace_argument ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:07.1585438Z test process_metadata_does_not_supply_a_replayable_key_bound_identity has been running for over 60 seconds
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7226670Z test process_metadata_does_not_supply_a_replayable_key_bound_identity ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7227487Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7227713Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7227920Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7228289Z ---- a_forced_command_ignores_the_command_the_caller_asked_for stdout ----
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7228844Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7229635Z thread 'a_forced_command_ignores_the_command_the_caller_asked_for' (10411) panicked at crates/orbit-cli/tests/mcp_roundtrip.rs:1416:33:
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7231094Z spawn destination-issued command: Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" }
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7232171Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7232744Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7232751Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7232889Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7233309Z     a_forced_command_ignores_the_command_the_caller_asked_for
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7234017Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7234438Z test result: FAILED. 46 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 81.42s
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7235107Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7235943Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-cli --test mcp_roundtrip`
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7319437Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-06T00:12:19.7339056Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33998464516 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33998432381 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33998378321 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33998255665 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33998177461 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/33997737182 — superseded_by_newer_workflow_run: newer relevant run 33999937143 at 2026-09-05T23:55:34Z is completed with conclusion success

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 2,
  "investigation_cursor": 496848,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11313-6a9c963c",
    "orbit/ORB-11319-6a9ca0b6",
    "orbit/ORB-11320-6a9ca0b6",
    "orbit/ORB-11321-6a9ca0b6",
    "orbit/ORB-11323-6a9ca308",
    "orbit/ORB-11327-6a9ca0b6"
  ],
  "runs_listed": 100
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a Linux-only, two-second bounded retry for `ExecutableFileBusy` around every launch of the freshly copied setgid MCP test launcher. Only ETXTBSY is retried; all other spawn/output failures remain immediate.
- Added a deterministic regression that holds a copied executable open for writing, proves the raw launch returns OS error 26, then proves the bounded retry launches it after the writer closes.
Assessment: The CI failure was a fixture concurrency race: parallel test-process forks can briefly inherit a writable launcher descriptor before close-on-exec, so Linux rejects a concurrent exec with ETXTBSY. The fix mirrors the repository's existing production updater behavior and does not weaken the security assertions, Linux capability skips, coverage workflow, or lint levels.
Validation:
- `cargo llvm-cov -p orbit-cli --test mcp_roundtrip --locked --no-report`: unavailable locally because the cargo-llvm-cov subcommand is not installed.
- `cargo test -p orbit-cli --test mcp_roundtrip --locked a_fresh_test_launcher_waits_for_a_writer_to_close -- --exact`: passed; the regression first reproduced `ExecutableFileBusy` and then exercised the retry.
- `cargo test -p orbit-cli --test mcp_roundtrip --locked a_forced_command_ignores_the_command_the_caller_asked_for -- --exact`: passed.
- `cargo test -p orbit-cli --test mcp_roundtrip --locked -- --skip process_metadata_does_not_supply_a_replayable_key_bound_identity`: passed (47 passed). The omitted existing security test requires a mapped supplementary group; the local runner lacks that capability, while unrestricted CI is the documented owner of that check.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed; final status contains only `crates/orbit-cli/tests/mcp_roundtrip.rs`. The run-created Cargo target directory was removed with `cargo clean`.
Friction checkpoint: filed F2026-09-028 with the diagnosed parallel-fork/ETXTBSY evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11340-6a9cb26f`
- Behind base: 0
- Ahead of base: 1