### PR TITLE
Restore failed Orbit updates with atomic executable replacement

### DIFF
--- a/crates/orbit-cmd/src/update/stage.rs
+++ b/crates/orbit-cmd/src/update/stage.rs
@@ -84,15 +84,64 @@ impl Drop for StagedRelease {
 /// state; once migrations have been attempted the caller must resume forward
 /// instead.
 pub fn restore_backup(destination: &Path, backup: &Path) -> Result<(), OrbitError> {
-    std::fs::copy(backup, destination)
-        .map(|_| ())
-        .map_err(|error| {
-            OrbitError::Io(format!(
-                "failed to restore '{}' from '{}': {error}; the backup is still on disk",
-                destination.display(),
-                backup.display()
-            ))
-        })
+    restore_backup_with_rename(destination, backup, |from, to| std::fs::rename(from, to))
+}
+
+/// Stage a complete copy of `backup`, then atomically replace `destination`.
+///
+/// Keeping the replace operation injectable lets the sibling tests exercise
+/// the recovery evidence and cleanup path without depending on filesystem
+/// permission behavior.
+pub(super) fn restore_backup_with_rename(
+    destination: &Path,
+    backup: &Path,
+    replace: impl FnOnce(&Path, &Path) -> std::io::Result<()>,
+) -> Result<(), OrbitError> {
+    let staging = sibling_staging_path(destination, ".orbit-update-restore")?;
+    if let Err(error) = std::fs::copy(backup, &staging) {
+        return Err(restore_failure(
+            destination,
+            backup,
+            &staging,
+            "stage the previous executable",
+            error,
+        ));
+    }
+    if let Err(error) = replace(&staging, destination) {
+        return Err(restore_failure(
+            destination,
+            backup,
+            &staging,
+            "atomically replace the installed executable",
+            error,
+        ));
+    }
+    Ok(())
+}
+
+fn restore_failure(
+    destination: &Path,
+    backup: &Path,
+    staging: &Path,
+    action: &str,
+    error: std::io::Error,
+) -> OrbitError {
+    let cleanup = match std::fs::remove_file(staging) {
+        Ok(()) => "the incomplete restore staging file was removed".to_string(),
+        Err(cleanup_error) if cleanup_error.kind() == std::io::ErrorKind::NotFound => {
+            "no restore staging file was left behind".to_string()
+        }
+        Err(cleanup_error) => format!(
+            "cleanup also failed for restore staging file '{}': {cleanup_error}; remove it before retrying",
+            staging.display()
+        ),
+    };
+    OrbitError::Io(format!(
+        "failed to {action} at '{}': {error}; the installed executable at '{}' was left intact, the backup remains at '{}', and {cleanup}",
+        staging.display(),
+        destination.display(),
+        backup.display()
+    ))
 }
 
 /// Download `asset` for `version`, authenticate it, and stage the executable
@@ -196,13 +245,7 @@ fn extract_release_executable(archive: &[u8], asset: &str) -> Result<Vec<u8>, Or
 /// Write the staged executable beside `destination` so the swap is a
 /// same-directory rename.
 fn write_staging_file(destination: &Path, executable: &[u8]) -> Result<PathBuf, OrbitError> {
-    let directory = destination.parent().ok_or_else(|| {
-        OrbitError::InvalidInput(format!(
-            "'{}' has no parent directory to stage into",
-            destination.display()
-        ))
-    })?;
-    let path = directory.join(format!(".orbit-update-staged.{}", std::process::id()));
+    let path = sibling_staging_path(destination, ".orbit-update-staged")?;
     std::fs::write(&path, executable).map_err(|error| {
         OrbitError::Io(format!(
             "failed to stage the replacement executable at '{}': {error}",
@@ -211,6 +254,16 @@ fn write_staging_file(destination: &Path, executable: &[u8]) -> Result<PathBuf, 
     })?;
     set_executable_mode(&path)?;
     Ok(path)
+}
+
+fn sibling_staging_path(destination: &Path, prefix: &str) -> Result<PathBuf, OrbitError> {
+    let directory = destination.parent().ok_or_else(|| {
+        OrbitError::InvalidInput(format!(
+            "'{}' has no parent directory to stage into",
+            destination.display()
+        ))
+    })?;
+    Ok(directory.join(format!("{prefix}.{}", std::process::id())))
 }
 
 #[cfg(unix)]

--- a/crates/orbit-cmd/src/update/tests/mod.rs
+++ b/crates/orbit-cmd/src/update/tests/mod.rs
@@ -3,4 +3,5 @@
 mod channel;
 mod fixture;
 mod flow;
+mod stage;
 mod version;

--- a/crates/orbit-cmd/src/update/tests/stage.rs
+++ b/crates/orbit-cmd/src/update/tests/stage.rs
@@ -1,0 +1,161 @@
+use std::io;
+
+use crate::update::stage::{restore_backup, restore_backup_with_rename};
+
+#[test]
+fn a_failed_atomic_restore_keeps_both_complete_files_and_cleans_staging() {
+    let root = tempfile::tempdir().expect("fixture root");
+    let destination = root.path().join("orbit");
+    let backup = root.path().join("orbit.previous");
+    let replacement = b"#!/bin/sh\nprintf 'orbit replacement-complete\\n'\n";
+    let previous = b"#!/bin/sh\nprintf 'orbit previous-complete\\n'\n";
+    std::fs::write(&destination, replacement).expect("write replacement");
+    std::fs::write(&backup, previous).expect("write backup");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        for path in [&destination, &backup] {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+                .expect("make fixture executable runnable");
+        }
+    }
+
+    let error = restore_backup_with_rename(&destination, &backup, |_, _| {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "injected rename failure",
+        ))
+    })
+    .expect_err("restore should fail");
+
+    assert_eq!(
+        std::fs::read(&destination).expect("read destination"),
+        replacement
+    );
+    assert_eq!(std::fs::read(&backup).expect("read backup"), previous);
+    #[cfg(unix)]
+    {
+        let installed = std::process::Command::new(&destination)
+            .output()
+            .expect("launch intact replacement");
+        let retained = std::process::Command::new(&backup)
+            .output()
+            .expect("launch retained backup");
+        assert!(installed.status.success());
+        assert!(retained.status.success());
+        assert_eq!(installed.stdout, b"orbit replacement-complete\n");
+        assert_eq!(retained.stdout, b"orbit previous-complete\n");
+    }
+    assert!(!restore_staging_file_remains(root.path()));
+    let message = error.to_string();
+    assert!(message.contains("atomically replace"), "{message}");
+    assert!(message.contains("was left intact"), "{message}");
+    assert!(message.contains(&backup.display().to_string()), "{message}");
+    assert!(message.contains("staging file was removed"), "{message}");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn rollback_replaces_a_running_executable_atomically() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    let root = tempfile::tempdir().expect("fixture root");
+    let destination = root.path().join("orbit");
+    let backup = root.path().join("orbit.previous");
+    let ready = root.path().join("replacement.ready");
+    let release = root.path().join("replacement.release");
+    std::fs::copy(
+        std::env::current_exe().expect("current test executable"),
+        &destination,
+    )
+    .expect("install replacement test executable");
+    let previous = b"#!/bin/sh\nprintf 'orbit previous-complete\\n'\n";
+    std::fs::write(&backup, previous).expect("write previous executable");
+    std::fs::set_permissions(&backup, std::fs::Permissions::from_mode(0o751))
+        .expect("make previous executable runnable");
+
+    let mut running = Command::new(&destination)
+        .args([
+            "--ignored",
+            "--exact",
+            "update::tests::stage::running_replacement_process_fixture",
+        ])
+        .env("ORBIT_TEST_REPLACEMENT_READY", &ready)
+        .env("ORBIT_TEST_REPLACEMENT_RELEASE", &release)
+        .spawn()
+        .expect("launch installed replacement");
+    wait_for_path(&ready, Duration::from_secs(5));
+
+    restore_backup(&destination, &backup).expect("atomically restore previous executable");
+    std::fs::write(&release, b"release").expect("release running replacement");
+    assert!(running.wait().expect("wait for replacement").success());
+
+    assert_eq!(
+        std::fs::read(&destination).expect("read restored executable"),
+        previous
+    );
+    assert_eq!(
+        std::fs::read(&backup).expect("read retained backup"),
+        previous
+    );
+    assert_eq!(
+        std::fs::metadata(&destination)
+            .expect("restored metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o751
+    );
+    assert!(!restore_staging_file_remains(root.path()));
+    let output = Command::new(&destination)
+        .output()
+        .expect("launch restored executable");
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"orbit previous-complete\n");
+
+    fn wait_for_path(path: &std::path::Path, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "subprocess fixture for rollback_replaces_a_running_executable_atomically"]
+fn running_replacement_process_fixture() {
+    use std::time::{Duration, Instant};
+
+    let Some(ready) = std::env::var_os("ORBIT_TEST_REPLACEMENT_READY") else {
+        return;
+    };
+    let release =
+        std::env::var_os("ORBIT_TEST_REPLACEMENT_RELEASE").expect("replacement release path");
+    std::fs::write(&ready, b"ready").expect("signal replacement is running");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !std::path::Path::new(&release).exists() {
+        assert!(Instant::now() < deadline, "timed out waiting for release");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn restore_staging_file_remains(directory: &std::path::Path) -> bool {
+    std::fs::read_dir(directory)
+        .expect("read fixture directory")
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".orbit-update-restore")
+        })
+}

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -35,8 +35,10 @@ orbit update --json               # machine-readable report
    into a staging file beside the installed one.
 5. Copy the current executable to `<orbit>.previous`, then swap the staged file in with one
    atomic same-directory rename, and confirm the installed binary reports the requested
-   version. If it does not, the previous executable is restored and no workspace state is
-   touched.
+   version. If it does not, the previous executable is copied into a complete sibling staging
+   file and atomically renamed over the replacement, so concurrent launches see either the
+   complete replacement or the complete previous executable; the retained backup is not consumed
+   and no workspace state is touched.
 6. Run `orbit migrate --confirm`, then `orbit workspace sync` — **using the newly installed
    binary**, in the current workspace. Only the new binary carries the migrations and managed
    asset definitions for the version being installed.


### PR DESCRIPTION
## Task

[ORB-11345](https://orbit-cli.com/tasks/ORB-11345) — Restore failed Orbit updates with atomic executable replacement

### Description

Source-level finding at 5530555cc4d75935465b7c4cdc533dca86951dbf, independently verified after Astra audit. Normal installation uses same-directory rename at crates/orbit-cmd/src/update/stage.rs:62, but restore_backup at :86-95 calls fs::copy directly onto the live executable. Version verification failures call it from update/mod.rs:278 and :285. A concurrent process can launch the installed replacement before rollback: on Linux writing that running executable can fail ETXTBSY; otherwise readers or crashes can encounter a partially overwritten executable. No destructive live installation experiment was performed.

Restore through a complete sibling staging file and atomic rename while retaining the backup. Reuse existing staging and cleanup patterns; preserve modes and clearly report restoration failure. Test using isolated executable fixtures, including a running replacement, before any workspace migration. Preserve the existing no-rollback-after-migrations rule. ORB-11340's fixture ETXTBSY is a separate test defect; this task owns production rollback. Done ORB-11280 and ORB-11319 do not cover atomic restoration. Authorized for normal pilot/completion in the current session.

### Acceptance Criteria

- Regression holds a replacement executable running during restoration and proves rollback succeeds and new launches read the complete previous executable.
- Backup remains intact, staging files are cleaned appropriately, and failure injection leaves a complete executable plus actionable recovery evidence.
- Focused update tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rollback now copies the retained `.previous` executable into a complete same-directory `.orbit-update-restore.<pid>` file and atomically renames it over the live replacement, preserving the backup and its executable mode.
- Restore copy/rename failures clean partial staging when possible and report the intact live destination, retained backup path, staging cleanup state, and retry cleanup action when needed.
- Added isolated regressions that hold the installed replacement test executable running during restoration, launch and verify the complete previous executable afterward, retain the backup, preserve mode bits, clean staging, and inject rename failure to prove both executables remain runnable with actionable diagnostics.
- Updated the upgrade runbook to document atomic rollback semantics.
Validation:
- `cargo test -p orbit-cmd update::tests -- --nocapture` (35 passed, 1 intentionally ignored subprocess fixture; the fixture ran and passed inside its parent regression)
- `make ci-fast`
- `make ci-lint`
- `git diff --check`
Assessment: The rollback path now has the same complete-file-before-swap invariant as installation, retains the no-rollback-after-migrations boundary, and is covered at the filesystem/process and injected-failure boundaries. No new dependency edge or out-of-scope file was required. Generated Cargo build artifacts from this run were removed with `cargo clean`; final status contains only the four intended task-scoped files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11345-6a9cb41a`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*