### PR TITLE
Revalidate installed version under the update lock before replacement

### DIFF
--- a/crates/orbit-cmd/src/update/converge.rs
+++ b/crates/orbit-cmd/src/update/converge.rs
@@ -6,7 +6,7 @@
 //! so asking the outgoing process to converge state would apply the version
 //! the operator is leaving.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{Duration, Instant};
 
@@ -88,6 +88,36 @@ pub fn run_step(executable: &Path, cwd: &Path, args: &[&str]) -> ConvergenceStep
             detail: Some(format!("failed to run '{}': {error}", executable.display())),
         },
     }
+}
+
+/// Path of the installed executable that version checks and replacement use.
+///
+/// Linux exposes a process whose executable inode was unlinked as
+/// `/installed/path (deleted)`. That names the still-running image, not the
+/// file now sitting at the install location. After another `orbit update`
+/// has replaced the binary, mutation decisions must follow the live path.
+/// A real file whose name ends in ` (deleted)` is left alone.
+pub fn resolve_installed_executable(executable: &Path) -> PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let current_path_is_missing = matches!(
+            std::fs::metadata(executable),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        );
+        if current_path_is_missing
+            && let Some(installed_path) = executable
+                .as_os_str()
+                .as_bytes()
+                .strip_suffix(b" (deleted)")
+        {
+            return PathBuf::from(OsString::from_vec(installed_path.to_vec()));
+        }
+    }
+
+    executable.to_path_buf()
 }
 
 /// Ask `executable` what version it is.

--- a/crates/orbit-cmd/src/update/mod.rs
+++ b/crates/orbit-cmd/src/update/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! The command is one linear pipeline with an explicit, idempotent order:
 //! decide the target version, refuse a channel Orbit does not own, take the
-//! update lock, stage and authenticate the archive, swap it in atomically,
-//! confirm the new executable reports the version that was asked for, then let
-//! *that* executable migrate `.orbit/` state and reconcile managed assets.
+//! update lock, re-read the installed version (resolving a replaced Linux
+//! inode back to the live path), then stage and authenticate the archive,
+//! swap it in atomically, confirm the new executable reports the version
+//! that was asked for, then let *that* executable migrate `.orbit/` state
+//! and reconcile managed assets.
 //!
 //! Migration runs before managed-asset sync because a layout migration can
 //! move the directories those assets live in; converging assets first would
@@ -64,7 +66,9 @@ pub struct UpdateRequest {
 pub struct UpdateEnvironment {
     /// The executable to replace.
     pub executable: PathBuf,
-    /// The version that executable reports today.
+    /// Process snapshot of the running binary's version (`CARGO_PKG_VERSION`
+    /// in production). `--check` uses this; mutation uses the on-disk
+    /// version re-read under the install lock.
     pub current_version: String,
     /// Release target triple for this platform.
     pub target_triple: String,
@@ -83,8 +87,10 @@ pub struct UpdateEnvironment {
 impl UpdateEnvironment {
     /// Read this process's own installation, platform, and workspace.
     pub fn from_process(root_override: Option<&Path>) -> Result<Self, OrbitError> {
-        let executable = std::env::current_exe()
-            .map_err(|error| OrbitError::Io(format!("cannot locate the running orbit: {error}")))?;
+        let executable =
+            converge::resolve_installed_executable(&std::env::current_exe().map_err(|error| {
+                OrbitError::Io(format!("cannot locate the running orbit: {error}"))
+            })?);
         let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
         let workspace_cwd =
             RegisteredRuntimeFactory::try_resolve_initialized_roots(&cwd, root_override)?
@@ -177,7 +183,7 @@ pub fn run_update(
     environment: &UpdateEnvironment,
     request: &UpdateRequest,
 ) -> Result<UpdateReport, OrbitError> {
-    let current = ReleaseVersion::parse(&environment.current_version)?;
+    let snapshot = ReleaseVersion::parse(&environment.current_version)?;
     let target = match &request.target_version {
         Some(requested) => ReleaseVersion::parse(requested)?,
         None => ReleaseVersion::parse(&environment.source.latest_version()?)?,
@@ -195,7 +201,7 @@ pub fn run_update(
         release_source: environment.source.describe(),
         target: environment.target_triple.clone(),
         asset: asset.clone(),
-        current_version: current.to_string(),
+        current_version: snapshot.to_string(),
         target_version: target.to_string(),
         outcome: UpdateOutcome::AlreadyCurrent,
         replaced: false,
@@ -210,7 +216,7 @@ pub fn run_update(
         // Read-only: report what an update would do, including for a channel
         // Orbit does not own. Refusing here would make "is there an update?"
         // fail for a reason that has nothing to do with the answer.
-        report.outcome = if target == current {
+        report.outcome = if target == snapshot {
             UpdateOutcome::AlreadyCurrent
         } else {
             UpdateOutcome::UpdateAvailable
@@ -225,14 +231,6 @@ pub fn run_update(
     {
         return Err(error);
     }
-    if target < current && !request.allow_downgrade {
-        return Err(OrbitError::InvalidInput(format!(
-            "refusing to replace orbit {current} with the older release {target}; \
-             an older binary cannot open workspace state a newer one has already migrated. \
-             Pass --allow-downgrade to attempt it anyway (it is checked against this \
-             workspace before anything is replaced)"
-        )));
-    }
 
     let install_dir = environment.executable.parent().ok_or_else(|| {
         OrbitError::InvalidInput(format!(
@@ -242,17 +240,47 @@ pub fn run_update(
     })?;
     let _lock = UpdateLock::acquire(install_dir)?;
 
+    // Another update may have finished between the process snapshot and this
+    // lock. Version decisions follow the live installed path, not the running
+    // inode or the compile-time snapshot.
+    let executable = converge::resolve_installed_executable(&environment.executable);
+    let current = locked_installed_version(&executable)?;
+    report.executable = executable.clone();
+    report.current_version = current.to_string();
+    if current != snapshot {
+        tracing::info!(
+            snapshot = %snapshot,
+            installed = %current,
+            executable = %executable.display(),
+            "installed orbit version changed before the update lock was acquired"
+        );
+    }
+
+    if target < current && !request.allow_downgrade {
+        return Err(OrbitError::InvalidInput(format!(
+            "refusing to replace orbit {current} with the older release {target}; \
+             an older binary cannot open workspace state a newer one has already migrated. \
+             Pass --allow-downgrade to attempt it anyway (it is checked against this \
+             workspace before anything is replaced)"
+        )));
+    }
+
     if target == current {
         // Not a no-op: re-running `orbit update` at the installed version is
         // the documented way to finish a run whose convergence failed.
-        return Ok(finish(environment, report, UpdateOutcome::AlreadyCurrent));
+        return Ok(finish(
+            environment,
+            &executable,
+            report,
+            UpdateOutcome::AlreadyCurrent,
+        ));
     }
 
     let staged = stage_release(
         environment.source.as_ref(),
         &target.to_string(),
         &asset,
-        &environment.executable,
+        &executable,
         environment.trusted_keys,
         environment.today,
     )?;
@@ -263,26 +291,26 @@ pub fn run_update(
         assert_downgrade_is_compatible(environment, staged.path(), &current, &target)?;
     }
 
-    let backup = backup_path(&environment.executable);
-    staged.commit(&environment.executable, &backup)?;
+    let backup = backup_path(&executable);
+    staged.commit(&executable, &backup)?;
     report.replaced = true;
     report.backup_path = Some(backup.clone());
 
     // Nothing has touched `.orbit/` yet, so a binary that does not identify
     // itself as the requested version is still safely reversible.
-    let installed = converge::probe_version(&environment.executable)
-        .and_then(|reported| ReleaseVersion::parse(&reported));
+    let installed =
+        converge::probe_version(&executable).and_then(|reported| ReleaseVersion::parse(&reported));
     match installed {
         Ok(installed) if installed == target => {}
         Ok(installed) => {
-            restore_backup(&environment.executable, &backup)?;
+            restore_backup(&executable, &backup)?;
             return Err(OrbitError::Execution(format!(
                 "the release published as {target} reports itself as {installed}; \
                  restored the previous executable and changed no workspace state"
             )));
         }
         Err(error) => {
-            restore_backup(&environment.executable, &backup)?;
+            restore_backup(&executable, &backup)?;
             return Err(OrbitError::Execution(format!(
                 "the installed release could not be verified ({error}); \
                  restored the previous executable and changed no workspace state"
@@ -290,16 +318,28 @@ pub fn run_update(
         }
     }
 
-    Ok(finish(environment, report, UpdateOutcome::Updated))
+    Ok(finish(
+        environment,
+        &executable,
+        report,
+        UpdateOutcome::Updated,
+    ))
+}
+
+/// Probe the on-disk executable after the install lock is held.
+fn locked_installed_version(executable: &Path) -> Result<ReleaseVersion, OrbitError> {
+    let reported = converge::probe_version(executable)?;
+    ReleaseVersion::parse(&reported)
 }
 
 /// Run the convergence steps and settle the outcome.
 fn finish(
     environment: &UpdateEnvironment,
+    executable: &Path,
     mut report: UpdateReport,
     success_outcome: UpdateOutcome,
 ) -> UpdateReport {
-    report.steps = converge_workspace(environment);
+    report.steps = converge_workspace(environment, executable);
     let failed: Vec<&str> = report
         .steps
         .iter()
@@ -316,7 +356,7 @@ fn finish(
 }
 
 /// Migrate `.orbit/` state, then reconcile managed assets — in that order.
-fn converge_workspace(environment: &UpdateEnvironment) -> Vec<ConvergenceStep> {
+fn converge_workspace(environment: &UpdateEnvironment, executable: &Path) -> Vec<ConvergenceStep> {
     const STEPS: [&[&str]; 2] = [&["migrate", "--confirm"], &["workspace", "sync"]];
     let Some(cwd) = environment.workspace_cwd.as_deref() else {
         return STEPS
@@ -332,7 +372,7 @@ fn converge_workspace(environment: &UpdateEnvironment) -> Vec<ConvergenceStep> {
     };
     let mut steps = Vec::new();
     for args in STEPS {
-        let step = run_step(&environment.executable, cwd, args);
+        let step = run_step(executable, cwd, args);
         let stop = step.failed();
         steps.push(step);
         if stop {

--- a/crates/orbit-cmd/src/update/tests/converge.rs
+++ b/crates/orbit-cmd/src/update/tests/converge.rs
@@ -1,0 +1,25 @@
+use crate::update::converge::resolve_installed_executable;
+
+#[test]
+fn a_real_file_named_deleted_is_left_alone() {
+    let dir = tempfile::tempdir().expect("fixture root");
+    let executable = dir.path().join("orbit (deleted)");
+    std::fs::write(&executable, "keep").expect("write real deleted-named file");
+
+    assert_eq!(resolve_installed_executable(&executable), executable);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn a_missing_deleted_inode_path_resolves_to_the_live_install() {
+    let dir = tempfile::tempdir().expect("fixture root");
+    let installed = dir.path().join("orbit");
+    std::fs::write(&installed, "replacement").expect("write live install");
+    let deleted = installed.with_file_name("orbit (deleted)");
+
+    assert!(
+        !deleted.exists(),
+        "the kernel-style deleted-inode pseudo-path must be absent"
+    );
+    assert_eq!(resolve_installed_executable(&deleted), installed);
+}

--- a/crates/orbit-cmd/src/update/tests/fixture.rs
+++ b/crates/orbit-cmd/src/update/tests/fixture.rs
@@ -6,10 +6,13 @@
 //! testable at all — the flow runs the installed binary, so the installed
 //! binary has to be something a test can write and observe.
 
+use std::fmt::{self, Debug};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
 
 use chrono::NaiveDate;
+use orbit_common::OrbitError;
 use orbit_common::security::release::{
     RELEASE_CHECKSUMS_FILENAME, RELEASE_CHECKSUMS_SIGNATURE_FILENAME, TrustedReleaseKey,
 };
@@ -21,7 +24,7 @@ use rsa::signature::{SignatureEncoding, Signer};
 use tempfile::TempDir;
 
 use crate::update::channel::InstallChannel;
-use crate::update::source::{DirectoryReleaseSource, MIRROR_LATEST_FILE};
+use crate::update::source::{DirectoryReleaseSource, MIRROR_LATEST_FILE, ReleaseSource};
 use crate::update::{UpdateEnvironment, UpdateRequest};
 
 /// A throwaway keypair generated for these tests. It is not the release
@@ -204,11 +207,10 @@ impl Fixture {
 
     /// What the installed executable reports for `--version`.
     pub fn installed_reports(&self) -> String {
-        let output = std::process::Command::new(&self.executable)
-            .arg("--version")
-            .output()
-            .expect("run installed binary");
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
+        format!(
+            "orbit {}",
+            crate::update::converge::probe_version(&self.executable).expect("run installed binary")
+        )
     }
 
     /// Every argv the fake binaries have been invoked with, in order.
@@ -242,6 +244,58 @@ impl Fixture {
 /// A default request: latest version, apply, no downgrade.
 pub fn request() -> UpdateRequest {
     UpdateRequest::default()
+}
+
+/// Parks `latest_version` on `paused` until `resume`, then returns a frozen
+/// version. Lets another update finish between snapshot and lock without
+/// timing sleeps.
+pub struct PausingLatestSource {
+    inner: Box<dyn ReleaseSource>,
+    latest: String,
+    paused: Arc<Barrier>,
+    resume: Arc<Barrier>,
+}
+
+impl PausingLatestSource {
+    pub fn wrap(
+        inner: Box<dyn ReleaseSource>,
+        latest: impl Into<String>,
+        paused: Arc<Barrier>,
+        resume: Arc<Barrier>,
+    ) -> Self {
+        Self {
+            inner,
+            latest: latest.into(),
+            paused,
+            resume,
+        }
+    }
+}
+
+impl Debug for PausingLatestSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PausingLatestSource")
+            .field("inner", &self.inner)
+            .field("latest", &self.latest)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReleaseSource for PausingLatestSource {
+    fn describe(&self) -> String {
+        self.inner.describe()
+    }
+
+    fn latest_version(&self) -> Result<String, OrbitError> {
+        self.paused.wait();
+        self.resume.wait();
+        Ok(self.latest.clone())
+    }
+
+    fn fetch(&self, version: &str, asset: &str) -> Result<Vec<u8>, OrbitError> {
+        self.inner.fetch(version, asset)
+    }
 }
 
 fn sign(message: &[u8]) -> Vec<u8> {

--- a/crates/orbit-cmd/src/update/tests/flow.rs
+++ b/crates/orbit-cmd/src/update/tests/flow.rs
@@ -1,8 +1,13 @@
 use std::path::Path;
+use std::sync::{Arc, Barrier};
 
 use crate::update::channel::InstallChannel;
-use crate::update::tests::fixture::{FakeBinary, Fixture, request, tar_gz, tar_gz_named};
-use crate::update::{EXIT_NEEDS_RECOVERY, EXIT_UPDATE_AVAILABLE, UpdateOutcome, run_update};
+use crate::update::tests::fixture::{
+    FakeBinary, Fixture, PausingLatestSource, request, tar_gz, tar_gz_named,
+};
+use crate::update::{
+    EXIT_NEEDS_RECOVERY, EXIT_UPDATE_AVAILABLE, UpdateEnvironment, UpdateOutcome, run_update,
+};
 
 #[test]
 fn updating_to_latest_replaces_the_binary_then_migrates_before_syncing_assets() {
@@ -395,6 +400,183 @@ fn a_second_concurrent_update_is_refused_rather_than_queued() {
     assert_eq!(fixture.installed_reports(), "orbit 0.18.0");
     drop(held);
     run_update(&fixture.environment(), &request()).expect("update after the lock is released");
+}
+
+#[test]
+fn a_stale_writer_refuses_to_replace_a_newer_install() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+    fixture.publish("0.20.0", FakeBinary::Healthy);
+
+    let error = with_stale_discovery(
+        &fixture,
+        "0.19.0",
+        |environment| run_update(environment, &request()).expect_err("stale writer must refuse"),
+        || {
+            let mut newer = request();
+            newer.target_version = Some("0.20.0".to_string());
+            let report =
+                run_update(&fixture.environment(), &newer).expect("interloper installs 0.20");
+            assert_eq!(report.outcome, UpdateOutcome::Updated);
+            assert_eq!(fixture.installed_reports(), "orbit 0.20.0");
+        },
+    );
+
+    assert!(error.to_string().contains("--allow-downgrade"), "{error}");
+    assert!(error.to_string().contains("0.20"), "{error}");
+    assert!(error.to_string().contains("0.19"), "{error}");
+    assert_eq!(fixture.installed_reports(), "orbit 0.20.0");
+    assert!(
+        !fixture
+            .invocations()
+            .iter()
+            .any(|line| line.starts_with("0.19.0:")),
+        "stale 0.19 writer must not run against the 0.20 install: {:?}",
+        fixture.invocations()
+    );
+}
+
+#[test]
+fn a_stale_writer_reconverges_when_the_lock_already_holds_the_target() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+
+    let report = with_stale_discovery(
+        &fixture,
+        "0.19.0",
+        |environment| run_update(environment, &request()).expect("stale writer reconverges"),
+        || {
+            let mut newer = request();
+            newer.target_version = Some("0.19.0".to_string());
+            run_update(&fixture.environment(), &newer).expect("interloper installs 0.19");
+        },
+    );
+
+    assert_eq!(report.outcome, UpdateOutcome::AlreadyCurrent);
+    assert!(!report.replaced);
+    assert_eq!(report.current_version, "0.19.0");
+    assert_eq!(fixture.installed_reports(), "orbit 0.19.0");
+    let migrate = fixture
+        .invocations()
+        .iter()
+        .filter(|line| line.as_str() == "0.19.0: migrate --confirm")
+        .count();
+    assert_eq!(migrate, 2, "{:?}", fixture.invocations());
+}
+
+#[test]
+fn a_stale_writer_upgrades_from_the_locked_installed_version() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+    fixture.publish("0.20.0", FakeBinary::Healthy);
+
+    let report = with_stale_discovery(
+        &fixture,
+        "0.20.0",
+        |environment| run_update(environment, &request()).expect("stale writer upgrades"),
+        || {
+            let mut middle = request();
+            middle.target_version = Some("0.19.0".to_string());
+            run_update(&fixture.environment(), &middle).expect("interloper installs 0.19");
+        },
+    );
+
+    assert_eq!(report.outcome, UpdateOutcome::Updated);
+    assert!(report.replaced);
+    assert_eq!(report.current_version, "0.19.0");
+    assert_eq!(report.target_version, "0.20.0");
+    assert_eq!(fixture.installed_reports(), "orbit 0.20.0");
+}
+
+#[test]
+fn a_stale_permitted_downgrade_still_preflights_the_workspace() {
+    let fixture = Fixture::new("0.19.0");
+    fixture.publish("0.18.0", FakeBinary::MigrationFails);
+    fixture.publish("0.20.0", FakeBinary::Healthy);
+
+    let mut stale_request = request();
+    stale_request.allow_downgrade = true;
+
+    let error = with_stale_discovery(
+        &fixture,
+        "0.18.0",
+        |environment| run_update(environment, &stale_request).expect_err("incompatible downgrade"),
+        || {
+            let mut newer = request();
+            newer.target_version = Some("0.20.0".to_string());
+            run_update(&fixture.environment(), &newer).expect("interloper installs 0.20");
+        },
+    );
+
+    assert!(
+        error.to_string().contains("cannot open this workspace"),
+        "{error}"
+    );
+    assert!(
+        error.to_string().contains("nothing was replaced"),
+        "{error}"
+    );
+    assert!(error.to_string().contains("0.20"), "{error}");
+    assert_eq!(fixture.installed_reports(), "orbit 0.20.0");
+    assert!(
+        fixture
+            .invocations()
+            .iter()
+            .any(|line| line.as_str() == "0.18.0: migrate --dry-run"),
+        "{:?}",
+        fixture.invocations()
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn replacement_uses_the_live_path_when_current_exe_is_a_deleted_inode() {
+    let fixture = Fixture::new("0.18.0");
+    fixture.publish("0.19.0", FakeBinary::Healthy);
+    let mut environment = fixture.environment();
+    environment.executable = environment.executable.with_file_name("orbit (deleted)");
+
+    let report = run_update(&environment, &request()).expect("resolves live path");
+
+    assert_eq!(report.outcome, UpdateOutcome::Updated);
+    assert_eq!(report.executable, fixture.executable);
+    assert_eq!(fixture.installed_reports(), "orbit 0.19.0");
+}
+
+/// Run `stale` parked in `latest_version` while `interloper` installs under
+/// the same lock, then resume. `stale` must call `latest_version`.
+fn with_stale_discovery<R, S, I>(
+    fixture: &Fixture,
+    frozen_latest: &str,
+    stale: S,
+    interloper: I,
+) -> R
+where
+    R: Send,
+    S: FnOnce(&UpdateEnvironment) -> R + Send,
+    I: FnOnce(),
+{
+    let paused = Arc::new(Barrier::new(2));
+    let resume = Arc::new(Barrier::new(2));
+    let mut environment = fixture.environment();
+    let inner = environment.source;
+    environment.source = Box::new(PausingLatestSource::wrap(
+        inner,
+        frozen_latest,
+        Arc::clone(&paused),
+        Arc::clone(&resume),
+    ));
+    std::thread::scope(|scope| {
+        let handle = scope.spawn(|| stale(&environment));
+        paused.wait();
+        let interloper_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(interloper));
+        resume.wait();
+        let stale_result = handle.join().expect("stale writer thread");
+        if let Err(payload) = interloper_result {
+            std::panic::resume_unwind(payload);
+        }
+        stale_result
+    })
 }
 
 #[test]

--- a/crates/orbit-cmd/src/update/tests/mod.rs
+++ b/crates/orbit-cmd/src/update/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Sibling unit tests for the `orbit update` pipeline.
 
 mod channel;
+mod converge;
 mod fixture;
 mod flow;
 mod stage;

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -4,8 +4,8 @@ summary: Install a new Orbit release with `orbit update`, then review, apply, an
 tags: [operations, upgrades, migrations, recovery]
 paths: ["crates/orbit-cmd/src/update/**", "crates/orbit-store/src/workflow/layout/**", "crates/orbit-store/src/driver/sqlite/migration/**"]
 related_features: [orbit-core]
-related_artifacts: [ORB-10014, ORB-11280]
-last_validated: 2026-09-05
+related_artifacts: [ORB-10014, ORB-11280, ORB-11344]
+last_validated: 2026-09-06
 ---
 
 # Upgrade Orbit Safely
@@ -30,16 +30,21 @@ orbit update --json               # machine-readable report
    install`, or checkout build is reported with the command that *does* upgrade it, before
    anything is downloaded.
 3. Take an exclusive lock in the install directory, so two updates cannot interleave.
-4. Download the release archive, authenticate the checksum manifest against the trusted
+4. Re-read the installed binary's version under that lock, and on Linux resolve a replaced
+   running inode (`/path/to/orbit (deleted)`) back to the live install path. Equal, newer,
+   and older installed versions are decided from that evidence — a writer that started on
+   an older snapshot cannot overwrite a newer install that finished while it was discovering
+   a release. `--check` stays read-only and does not take the lock.
+5. Download the release archive, authenticate the checksum manifest against the trusted
    release signing keys, compare the archive's SHA-256, and extract its single `orbit` member
    into a staging file beside the installed one.
-5. Copy the current executable to `<orbit>.previous`, then swap the staged file in with one
+6. Copy the current executable to `<orbit>.previous`, then swap the staged file in with one
    atomic same-directory rename, and confirm the installed binary reports the requested
    version. If it does not, the previous executable is copied into a complete sibling staging
    file and atomically renamed over the replacement, so concurrent launches see either the
    complete replacement or the complete previous executable; the retained backup is not consumed
    and no workspace state is touched.
-6. Run `orbit migrate --confirm`, then `orbit workspace sync` — **using the newly installed
+7. Run `orbit migrate --confirm`, then `orbit workspace sync` — **using the newly installed
    binary**, in the current workspace. Only the new binary carries the migrations and managed
    asset definitions for the version being installed.
 
@@ -68,9 +73,10 @@ replacement build.
 
 ### Downgrades
 
-A release older than the running one is refused unless `--allow-downgrade` is passed. Even
-then, the staged older binary must be able to open this workspace's state — `orbit update` runs
-its `migrate --dry-run` *before* replacing anything and aborts, with that binary's own
+A release older than the **currently installed** binary — re-read under the update lock, not
+the version the running process started with — is refused unless `--allow-downgrade` is passed.
+Even then, the staged older binary must be able to open this workspace's state — `orbit update`
+runs its `migrate --dry-run` *before* replacing anything and aborts, with that binary's own
 diagnostic, when it cannot.
 
 ### Release mirrors


### PR DESCRIPTION
## Task

[ORB-11344](https://orbit-cli.com/tasks/ORB-11344) — Revalidate installed version under the update lock before replacement

### Description

Source-level concurrency finding at 5530555cc4d75935465b7c4cdc533dca86951dbf, independently verified after Astra audit. UpdateEnvironment captures compile-time current_version at crates/orbit-cmd/src/update/mod.rs:98. run_update :180 reads that snapshot before potentially slow release discovery, checks downgrade at :228, acquires install lock at :243, and selects compatibility probe at :262 from the original snapshot. There is no installed-version revalidation under the lock.

Concrete source-derived interleaving (not a live reproduced race): A starts as 0.18 and pauses during discovery; B installs/converges 0.20 and releases the lock; A resumes targeting 0.19 and overwrites 0.20 without --allow-downgrade or compatibility validation. The try-lock prevents simultaneous writes but does not prevent this sequential stale-writer interleaving.

Establish current installed identity/version under the existing install lock before all mutation-dependent version decisions. Handle a replaced running inode/current_exe identity explicitly on supported platforms. Preserve check-only semantics, signed artifact validation, package ownership, existing recovery and proper downgrade preflight. No second lock framework or generic transaction abstraction. Done ORB-11280 and ORB-11319 do not cover this interleaving. Update relevant docs and use deterministic barriers/fixtures rather than timing sleeps. Authorized for normal pilot and completion in this session.

### Acceptance Criteria

- A deterministic barrier-controlled regression lets B install a newer version between A's initial snapshot and lock acquisition; A refuses or safely restarts/delegates without unauthorized replacement.
- Equal/newer/older installed versions are handled from locked current evidence; explicit permitted downgrades still run compatibility checks against the selected workspace before replacement.
- Existing update tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- After the existing install lock is held, `run_update` resolves the live installed path (Linux deleted-inode `current_exe` → install path) and probes its version. Equal/newer/older decisions, unauthorized-downgrade refusal, already-current reconverge, and `--allow-downgrade` workspace preflight all use that locked evidence. `--check`, channel ownership, signed staging, and recovery are unchanged.
- Barrier-controlled flow tests: B can install 0.20 while A is parked in `latest_version`; A then refuses to overwrite with 0.19. Equal target reconverges without replace; a middle install is upgraded from the locked version; a permitted stale downgrade still runs `migrate --dry-run` against the selected workspace.
- `docs/runbooks/upgrades.md` documents lock-held revalidation.
Assessment: Scoped to the update pipeline. No second lock. Existing update tests, `make ci-fast`, and `make ci-lint` pass.
Strategic decisions: Mutation-dependent version checks moved under the lock rather than duplicated before it, so a stale snapshot cannot authorize replacement. `--check` still uses the process snapshot and does not take the lock.
Validation: `cargo test -p orbit-cmd --lib -- update::tests` (42 passed, 1 ignored fixture); `make ci-fast`; `make ci-lint`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11344-6a9cb5c3`
- Behind base: 0
- Ahead of base: 1