### PR TITLE
Restrict Codex and Copilot answer projection to assistant answer content

### DIFF
--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -66,6 +66,7 @@ pub use agent::{Agent, AgentConfig, ProviderOptions};
 pub use orbit_types::telemetry::{InvocationTrace, TokenUsage, ToolCallTrace};
 pub use providers::{
     antigravity_terminal_error_diagnostic, apply_antigravity_print_timeout, normalize_cli_stdout,
+    project_cli_response,
 };
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};

--- a/crates/orbit-agent/src/providers/codex/codex_output.rs
+++ b/crates/orbit-agent/src/providers/codex/codex_output.rs
@@ -1,0 +1,56 @@
+//! Projects Codex CLI JSONL onto completed assistant answer text.
+//!
+//! `codex exec --json` interleaves assistant messages with reasoning, command
+//! executions, and usage events. Only completed `agent_message` item text is
+//! an assistant answer; every other event remains raw invocation telemetry but
+//! must not become Orbit response/status evidence. [ORB-11348]
+
+/// Return answer-only bytes when `stdout` is a recognized Codex JSONL stream.
+///
+/// `None` means the capture is not Codex event JSONL and lets legacy direct
+/// envelope output retain the provider-agnostic fallback behavior.
+pub(crate) fn project_codex_response(stdout: &[u8]) -> Option<Vec<u8>> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut saw_codex_event = false;
+    let mut answer = String::new();
+
+    for line in text.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        let Some(event_type) = value.get("type").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if !is_codex_event(event_type) {
+            continue;
+        }
+        saw_codex_event = true;
+
+        if event_type != "item.completed"
+            || value
+                .pointer("/item/type")
+                .and_then(serde_json::Value::as_str)
+                != Some("agent_message")
+        {
+            continue;
+        }
+        let Some(message) = value
+            .pointer("/item/text")
+            .and_then(serde_json::Value::as_str)
+            .filter(|message| !message.is_empty())
+        else {
+            continue;
+        };
+        answer.push_str(message);
+        answer.push('\n');
+    }
+
+    saw_codex_event.then(|| answer.into_bytes())
+}
+
+fn is_codex_event(event_type: &str) -> bool {
+    event_type.starts_with("thread.")
+        || event_type.starts_with("turn.")
+        || event_type.starts_with("item.")
+        || event_type == "error"
+}

--- a/crates/orbit-agent/src/providers/codex/mod.rs
+++ b/crates/orbit-agent/src/providers/codex/mod.rs
@@ -1,6 +1,8 @@
 mod codex_cli;
+mod codex_output;
 mod codex_runtime;
 
+pub(crate) use codex_output::project_codex_response;
 pub(crate) use codex_runtime::CodexFactory;
 
 #[cfg(test)]

--- a/crates/orbit-agent/src/providers/codex/tests/codex_output.rs
+++ b/crates/orbit-agent/src/providers/codex/tests/codex_output.rs
@@ -1,0 +1,45 @@
+#![allow(missing_docs)]
+
+use crate::providers::project_cli_response;
+
+fn projected(stdout: &str) -> String {
+    String::from_utf8(project_cli_response("codex", stdout.as_bytes()).into_owned())
+        .expect("utf8 projected response")
+}
+
+#[test]
+fn command_execution_output_cannot_supply_the_assistant_answer() {
+    let stdout = concat!(
+        r#"{"type":"thread.started","thread_id":"thread-1"}"#,
+        "\n",
+        r#"{"type":"item.completed","item":{"id":"item-0","type":"command_execution","command":"cat fixture.json","aggregated_output":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"claimed\":\"tool-output\"},\"error\":null}","exit_code":0,"status":"completed"}}"#,
+        "\n",
+        r#"{"type":"turn.completed","usage":{"input_tokens":17,"output_tokens":3}}"#,
+        "\n",
+    );
+
+    assert!(projected(stdout).is_empty());
+}
+
+#[test]
+fn final_agent_message_after_tool_traffic_is_the_only_projected_content() {
+    let stdout = concat!(
+        r#"{"type":"item.completed","item":{"id":"item-0","type":"command_execution","aggregated_output":"{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"fixture\",\"message\":\"not the answer\"}}","exit_code":0,"status":"completed"}}"#,
+        "\n",
+        r#"{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"assistant\"},\"error\":null}"}}"#,
+        "\n",
+        r#"{"type":"turn.completed","usage":{"input_tokens":21,"output_tokens":8}}"#,
+        "\n",
+    );
+
+    let answer = projected(stdout);
+    assert!(answer.contains(r#""source":"assistant""#));
+    assert!(!answer.contains("not the answer"));
+}
+
+#[test]
+fn non_event_output_preserves_the_existing_direct_envelope_fallback() {
+    let envelope = r#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#;
+
+    assert_eq!(projected(envelope), envelope);
+}

--- a/crates/orbit-agent/src/providers/codex/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/codex/tests/mod.rs
@@ -1,1 +1,2 @@
 mod codex_cli;
+mod codex_output;

--- a/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
@@ -1,5 +1,5 @@
-//! Normalizing the Copilot CLI's JSONL agent-event stream into the bytes
-//! Orbit's response/envelope contract is allowed to read. [ORB-10946]
+//! Normalizing and projecting the Copilot CLI's JSONL agent-event stream.
+//! [ORB-10946] [ORB-11348]
 //!
 //! `copilot --output-format json` documents its stdout as "JSONL, one JSON
 //! object per line". Every line is an agent-event frame:
@@ -19,12 +19,12 @@
 //! could read Orbit's own instructions back as if they were the agent's
 //! completion evidence.
 //!
-//! So this module reduces the stream to model-authored frames before any
-//! protocol read. What survives is what Copilot itself produced; what is
-//! dropped is Orbit's own prompt coming back and the session control plane.
-//! When nothing survives — the auth-failure and cancellation shapes — the
-//! result is empty, and an empty stdout carries no envelope, which is exactly
-//! how a missing completion is meant to be reported.
+//! So this module exposes two deliberately different views: normalization
+//! retains model-authored frames for invocation telemetry and diagnostics,
+//! while response projection retains only assistant message content. Both
+//! drop Orbit's echoed prompt and session control plane. When no assistant
+//! answer survives — including auth-failure and cancellation shapes — the
+//! response projection is empty and carries no completion evidence.
 
 /// Event-type prefixes whose frames are model output.
 ///
@@ -44,8 +44,8 @@ const MODEL_OUTPUT_EVENT_PREFIXES: &[&str] = &["assistant.", "error."];
 ///
 /// Returns the retained frames as JSONL. Lines that are not valid JSON, frames
 /// with no `type` string, and frames outside [`MODEL_OUTPUT_EVENT_PREFIXES`]
-/// are dropped: a malformed or truncated stream degrades toward "no completion
-/// evidence", never toward a false one.
+/// are dropped: a malformed or truncated stream degrades toward less trace
+/// data, never toward attributing Orbit's own input to the provider.
 pub(crate) fn normalize_copilot_stdout(stdout: &[u8]) -> Vec<u8> {
     let text = String::from_utf8_lossy(stdout);
     let mut out = String::new();
@@ -64,6 +64,34 @@ pub(crate) fn normalize_copilot_stdout(stdout: &[u8]) -> Vec<u8> {
         out.push('\n');
     }
     out.into_bytes()
+}
+
+/// Project a Copilot event stream onto completed assistant message content.
+///
+/// Reasoning, usage, errors, and tool request arguments remain available in
+/// the normalized invocation trace, but only `assistant.message.data.content`
+/// can supply Orbit response/status fields. [ORB-11348]
+pub(crate) fn project_copilot_response(stdout: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut answer = String::new();
+    for line in text.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        if value.get("type").and_then(serde_json::Value::as_str) != Some("assistant.message") {
+            continue;
+        }
+        let Some(content) = value
+            .pointer("/data/content")
+            .and_then(serde_json::Value::as_str)
+            .filter(|content| !content.is_empty())
+        else {
+            continue;
+        };
+        answer.push_str(content);
+        answer.push('\n');
+    }
+    answer.into_bytes()
 }
 
 fn is_model_output_frame(value: &serde_json::Value) -> bool {

--- a/crates/orbit-agent/src/providers/copilot/mod.rs
+++ b/crates/orbit-agent/src/providers/copilot/mod.rs
@@ -3,7 +3,7 @@ mod copilot_runtime;
 mod copilot_stream;
 
 pub(crate) use copilot_runtime::CopilotFactory;
-pub(crate) use copilot_stream::normalize_copilot_stdout;
+pub(crate) use copilot_stream::{normalize_copilot_stdout, project_copilot_response};
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
@@ -7,7 +7,7 @@
 
 use orbit_types::tool::ExecutionResult;
 
-use crate::providers::normalize_cli_stdout;
+use crate::providers::{normalize_cli_stdout, project_cli_response};
 use crate::types::{AgentResponseStatus, parse_and_validate_response};
 
 /// Verbatim stdout from a real Copilot 1.0.80 run whose token lacked Copilot
@@ -37,6 +37,11 @@ fn envelope_line(content: &str) -> String {
 fn normalized(stdout: &str) -> String {
     String::from_utf8(normalize_cli_stdout("copilot", stdout.as_bytes()).into_owned())
         .expect("utf8 normalized stdout")
+}
+
+fn projected(stdout: &str) -> String {
+    String::from_utf8(project_cli_response("copilot", stdout.as_bytes()).into_owned())
+        .expect("utf8 projected response")
 }
 
 fn exec_result(stdout: &str, stderr: &str, exit_code: i32) -> ExecutionResult {
@@ -85,6 +90,46 @@ fn assistant_usage_survives_normalization_for_the_invocation_trace() {
 
     assert!(kept.contains("assistant.usage"));
     assert!(kept.contains("assistant.message"));
+}
+
+#[test]
+fn reasoning_cannot_supply_the_assistant_answer() {
+    let stdout = concat!(
+        r#"{"type":"assistant.reasoning","data":{"content":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"claimed\":\"reasoning\"},\"error\":null}"},"id":"reason-1"}"#,
+        "\n",
+        r#"{"type":"assistant.usage","data":{"inputTokens":120,"outputTokens":34}}"#,
+        "\n",
+    );
+
+    assert!(projected(stdout).is_empty());
+    assert!(normalized(stdout).contains("assistant.usage"));
+}
+
+#[test]
+fn empty_message_tool_arguments_cannot_supply_the_assistant_answer() {
+    let stdout = concat!(
+        r#"{"type":"assistant.message","data":{"content":"","toolRequests":[{"toolCallId":"call-1","name":"shell","arguments":{"command":"printf '%s' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"claimed\":\"tool-arguments\"},\"error\":null}'"}}]},"id":"msg-1"}"#,
+        "\n",
+        r#"{"type":"session.abort","data":{"reason":"cancelled"},"ephemeral":true}"#,
+        "\n",
+    );
+
+    assert!(projected(stdout).is_empty());
+    assert!(normalized(stdout).contains("toolRequests"));
+}
+
+#[test]
+fn final_message_after_tool_traffic_is_the_only_projected_content() {
+    let stdout = concat!(
+        r#"{"type":"assistant.message","data":{"content":"","toolRequests":[{"toolCallId":"call-1","name":"shell","arguments":{"command":"echo {\"schemaVersion\":1,\"status\":\"failed\"}"}}]},"id":"msg-1"}"#,
+        "\n",
+        r#"{"type":"assistant.message","data":{"content":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"assistant\"},\"error\":null}"},"id":"msg-2"}"#,
+        "\n",
+    );
+
+    let answer = projected(stdout);
+    assert!(answer.contains(r#""source":"assistant""#));
+    assert!(!answer.contains("toolCallId"));
 }
 
 #[test]

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -55,19 +55,13 @@ pub(crate) fn build_invocation_spec(
     }
 }
 
-/// Reduce a provider's raw stdout to the bytes Orbit's response/envelope
-/// contract may read.
+/// Normalize a provider's raw stdout for invocation tracing and diagnostics.
 ///
 /// Most providers emit their Orbit envelope directly and are returned
-/// borrowed and unchanged. `copilot` streams JSONL agent events that replay
-/// Orbit's own prompt back as a `user.message` frame, so its stream is
-/// reduced to model-authored frames first — see the `copilot::copilot_stream`
-/// module docs for why that reduction is a correctness requirement rather
-/// than tidying. `cursor` wraps the assistant response in a terminal JSON
-/// result object; its adapter validates that wrapper and exposes only the
-/// model-authored `result` string. `opencode` emits NDJSON events whose
-/// `tool_use` and `reasoning` frames can replay Orbit's own prompt, so its
-/// adapter keeps only the assistant `text` parts.
+/// borrowed and unchanged. Provider adapters remove input echoes and
+/// unsupported control-plane frames while retaining the provider-authored
+/// material needed for telemetry. Response/status projection applies the
+/// stricter [`project_cli_response`] boundary afterward.
 /// [ORB-10946] [ORB-10945] [ORB-11295]
 ///
 /// `provider` is the resolved canonical provider id. An unrecognized id is
@@ -81,5 +75,24 @@ pub fn normalize_cli_stdout<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8
         "antigravity" | "agy" => Cow::Owned(antigravity::normalize_antigravity_stdout(stdout)),
         "opencode" => Cow::Owned(opencode::normalize_opencode_stdout(stdout)),
         _ => Cow::Borrowed(stdout),
+    }
+}
+
+/// Expose only provider-attributed assistant answer content to Orbit's
+/// response-envelope projection.
+///
+/// Invocation traces and diagnostics continue to use [`normalize_cli_stdout`]
+/// so usage, tool traffic, and provider failures remain observable. Codex and
+/// Copilot need a narrower view because their JSONL streams also contain
+/// reasoning and tool payloads that may quote an unrelated Orbit envelope.
+/// Other providers retain their existing normalized response boundary.
+/// [ORB-11348]
+pub fn project_cli_response<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8]> {
+    match provider {
+        "codex" => {
+            codex::project_codex_response(stdout).map_or_else(|| Cow::Borrowed(stdout), Cow::Owned)
+        }
+        "copilot" => Cow::Owned(copilot::project_copilot_response(stdout)),
+        _ => normalize_cli_stdout(provider, stdout),
     }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use orbit_agent::{
     Agent, AgentConfig, AgentOperation, AgentRequest, antigravity_terminal_error_diagnostic,
-    normalize_cli_stdout, peek_response_status, provider_invocation_diagnostic,
-    response_envelope_protocol_check,
+    normalize_cli_stdout, peek_response_status, project_cli_response,
+    provider_invocation_diagnostic, response_envelope_protocol_check,
 };
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
@@ -436,16 +436,16 @@ pub fn run_cli_backend(
     // from its diagnostic prefix. Protocol parsing must use that tail so a
     // verbose provider's final Orbit envelope remains authoritative.
     //
-    // [ORB-10946] Reduce the capture to the bytes this provider's protocol
-    // contract may be read from, once, so every check below agrees on what the
-    // agent actually emitted. For all providers but `copilot` this borrows the
-    // capture unchanged; `copilot` streams JSONL agent events that replay
-    // Orbit's own prompt — example envelope included — back as a `user.message`
-    // frame, which the reverse envelope scan would otherwise be free to read as
-    // completion evidence.
-    let protocol_stdout = normalize_cli_stdout(&provider, stdout.protocol_bytes());
-    let stdout_text = String::from_utf8_lossy(protocol_stdout.as_ref());
-    let envelope_status = peek_response_status(stdout_text.as_ref());
+    // Keep invocation telemetry distinct from answer projection. Provider
+    // JSONL carries usage, tool traffic, failures, reasoning, and command
+    // output; those frames belong in the trace and diagnostics, but only
+    // provider-attributed assistant answer content may supply Orbit response
+    // fields or completion status. [ORB-10946] [ORB-11348]
+    let trace_stdout = normalize_cli_stdout(&provider, stdout.protocol_bytes());
+    let answer_stdout = project_cli_response(&provider, stdout.protocol_bytes());
+    let answer_text = String::from_utf8_lossy(answer_stdout.as_ref());
+    let trace_stdout_text = String::from_utf8_lossy(trace_stdout.as_ref());
+    let envelope_status = peek_response_status(answer_text.as_ref());
     // The operator-facing preview stays on the *raw* capture: normalization
     // drops the session control plane, and that is where a provider puts the
     // policy and authentication failures an operator needs to see.
@@ -454,7 +454,7 @@ pub fn run_cli_backend(
         stdout_text_preview(raw_stdout_text.as_ref(), &redaction, stdout.truncated());
     let parsed_result = exit_success.then(|| {
         parse_cli_response_result(
-            protocol_stdout.as_ref(),
+            answer_stdout.as_ref(),
             stderr.protocol_bytes(),
             exit_code,
             duration.as_millis() as u64,
@@ -476,7 +476,7 @@ pub fn run_cli_backend(
     // Only meaningful on an otherwise-clean exit: a timeout or nonzero exit
     // already fails the step with a more specific message.
     let completion_envelope_error = exit_success
-        .then(|| response_envelope_protocol_check(stdout_text.as_ref()))
+        .then(|| response_envelope_protocol_check(answer_text.as_ref()))
         .and_then(Result::err)
         .map(|error| completion_diagnostic(&error.to_string(), &redaction));
     let completion_protocol_violation =
@@ -497,7 +497,7 @@ pub fn run_cli_backend(
         && !completion_status_failure
         && (!spec.require_response_envelope || response_envelope_valid);
     let trace = parse_cli_invocation_trace(
-        protocol_stdout.as_ref(),
+        trace_stdout.as_ref(),
         stderr.protocol_bytes(),
         exit_code,
         duration.as_millis() as u64,
@@ -523,7 +523,7 @@ pub fn run_cli_backend(
                     macos_keychain_auth_diagnostic(
                         &provider,
                         sandbox,
-                        &format!("{stdout_text}\n{stderr_text}"),
+                        &format!("{trace_stdout_text}\n{stderr_text}"),
                     )
                     .map(|diagnostic| format!("{} {diagnostic}", exit_message()))
                 })
@@ -532,7 +532,7 @@ pub fn run_cli_backend(
                 // schema" from any other nonzero exit, and the first two are
                 // configuration faults an operator can act on immediately.
                 .or_else(|| {
-                    provider_invocation_diagnostic(stdout_text.as_ref(), stderr_text.as_ref())
+                    provider_invocation_diagnostic(trace_stdout_text.as_ref(), stderr_text.as_ref())
                         .map(|diagnostic| bounded_diagnostic(&diagnostic, &redaction))
                 })
                 // Antigravity writes terminal `ERROR` on stdout and often

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -105,6 +105,201 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
 }
 
 #[test]
+fn run_cli_backend_does_not_project_codex_command_output_as_response() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-0\",\"type\":\"command_execution\",\"command\":\"read fixture\",\"aggregated_output\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"claimed\\\":\\\"tool-output\\\"},\\\"error\\\":null}\",\"exit_code\":0,\"status\":\"completed\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":17,\"output_tokens\":3}}'\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-codex-command-only",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-codex-command-only",
+        audit,
+        &serde_json::json!({"prompt": "read the fixture"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert!(outcome.output["response_envelope_status"].is_null());
+    assert_eq!(outcome.output["response_envelope_valid"], false);
+    assert!(outcome.output.get("claimed").is_none());
+    assert!(
+        outcome.output["stdout_text"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("tool-output")),
+        "raw stdout remains available for diagnostics"
+    );
+}
+
+#[test]
+fn run_cli_backend_projects_codex_final_answer_and_keeps_raw_trace() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-0\",\"type\":\"command_execution\",\"command\":\"read fixture\",\"aggregated_output\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"failed\\\",\\\"result\\\":{},\\\"error\\\":{\\\"code\\\":\\\"fixture\\\",\\\"message\\\":\\\"tool-output\\\"}}\",\"exit_code\":0,\"status\":\"completed\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"source\\\":\\\"assistant\\\"},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":101,\"cached_input_tokens\":11,\"output_tokens\":9}}'\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-codex-final-answer",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-codex-final-answer",
+        audit,
+        &serde_json::json!({"prompt": "read then answer"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(outcome.output["source"], "assistant");
+    assert_eq!(outcome.output["response_envelope_status"], "success");
+    let trace = &outcome
+        .invocation
+        .as_ref()
+        .expect("raw invocation trace")
+        .trace;
+    assert_eq!(trace.usage.input, 101);
+    assert_eq!(trace.usage.cache_read, 11);
+    assert_eq!(trace.usage.output, 9);
+    assert_eq!(trace.tool_calls.len(), 1);
+    assert!(
+        outcome.output["stdout_text"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("tool-output")),
+        "raw stdout remains available for diagnostics"
+    );
+}
+
+#[test]
+fn run_cli_backend_copilot_cancellation_cannot_project_tool_arguments() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("copilot");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"assistant.reasoning\",\"data\":{\"content\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"claimed\\\":\\\"reasoning\\\"},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"assistant.message\",\"data\":{\"content\":\"\",\"toolRequests\":[{\"toolCallId\":\"call-1\",\"name\":\"shell\",\"arguments\":{\"command\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"claimed\\\":\\\"tool-arguments\\\"},\\\"error\\\":null}\"}}]}}'\n",
+            "printf '%s\\n' '{\"type\":\"session.abort\",\"data\":{\"reason\":\"cancelled\"},\"ephemeral\":true}'\n",
+            "exit 130\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-copilot-cancelled",
+        "copilot:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-copilot-cancelled",
+        audit,
+        &serde_json::json!({"prompt": "cancel after tool request"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert!(outcome.output["response_envelope_status"].is_null());
+    assert!(outcome.output.get("claimed").is_none());
+    assert!(
+        outcome.output["stdout_text"]
+            .as_str()
+            .is_some_and(|stdout| stdout.contains("tool-arguments")),
+        "raw stdout remains available for diagnostics"
+    );
+}
+
+#[test]
+fn run_cli_backend_projects_copilot_final_answer_and_keeps_usage() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("copilot");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"assistant.message\",\"data\":{\"content\":\"\",\"toolRequests\":[{\"toolCallId\":\"call-1\",\"name\":\"shell\",\"arguments\":{\"command\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"failed\\\"}\"}}]}}'\n",
+            "printf '%s\\n' '{\"type\":\"assistant.message\",\"data\":{\"content\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"source\\\":\\\"assistant\\\"},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"assistant.usage\",\"data\":{\"inputTokens\":73,\"outputTokens\":12}}'\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-copilot-final-answer",
+        "copilot:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-copilot-final-answer",
+        audit,
+        &serde_json::json!({"prompt": "use a tool then answer"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(outcome.output["source"], "assistant");
+    assert_eq!(outcome.output["response_envelope_status"], "success");
+    let usage = &outcome
+        .invocation
+        .as_ref()
+        .expect("normalized invocation trace")
+        .trace
+        .usage;
+    assert_eq!(usage.input, 73);
+    assert_eq!(usage.output, 12);
+}
+
+#[test]
 fn run_cli_backend_projects_prose_prefixed_claude_envelope_result() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("claude");
@@ -609,7 +804,7 @@ while [ "$i" -lt 18000 ]; do
   i=$((i + 1))
 done
 printf '%s\n' '"}}'
-printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"workflow":"usable"},"error":null}'
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"workflow\":\"usable\"},\"error\":null}"}}'
 "#,
     );
 
@@ -662,9 +857,11 @@ printf '%s\n' '{"schemaVersion":1,"status":"success","result":{"workflow":"usabl
     assert_eq!(
         documents
             .last()
-            .and_then(|value| value.get("status"))
+            .and_then(|value| value.pointer("/item/text"))
             .and_then(serde_json::Value::as_str),
-        Some("success")
+        Some(
+            r#"{"schemaVersion":1,"status":"success","result":{"workflow":"usable"},"error":null}"#
+        )
     );
 
     let stdout_blob_ref = outcome.output["stdout_blob_ref"]


### PR DESCRIPTION
## Task

[ORB-11348](https://orbit-cli.com/tasks/ORB-11348) — Restrict Codex and Copilot answer projection to assistant answer content

### Description

## Verified provider-attribution defect
Astra audit at source 5530555cc4d75935465b7c4cdc533dca86951dbf reproduced the existing normalization/finder behavior with an isolated harness using current Copilot normalization and byte-copied current Rust envelope-finder functions plus minimal DTO stubs. No live delivery incident was reproduced. Sol independently inspected the source.

Codex exec --json is passed unchanged by normalize_cli_stdout (crates/orbit-agent/src/providers/mod.rs:76-84). Copilot normalization keeps entire assistant.* and error.* frames (providers/copilot/copilot_stream.rs:41,63-64), including reasoning and tool arguments. The existing response envelope finder recursively searches arbitrary objects and strings (types/response/envelope.rs:329-377). Engine response/status projection receives that stream at crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:446-458.

Three provider-shaped fixtures returned Some(success) with NO assistant answer: a Codex item.completed command_execution frame whose aggregated_output contains an envelope; Copilot assistant.reasoning with the envelope in data.content; and Copilot assistant.message with empty data.content and the envelope only in data.toolRequests[].arguments.command. The embedded object was {"schemaVersion":1,"status":"success","result":{"claimed":"tool-output"},"error":null}. Thus reading a test fixture/task record/tool output can incorrectly supply workflow-result fields.

## Scope
At provider normalization/projection boundaries, expose only genuine assistant answer content to downstream response/status projection. Confirm event vocabulary against supported CLI versions and captured authentic fixtures. Keep raw diagnostic capture and usage accounting intact. Preserve genuine final answers after tool traffic and terminal failure semantics. Reuse existing provider modules and tests.

Do NOT add generic workflow schema gates, require envelopes for every activity, or make missing prose override persisted task/Git evidence. Artifact-backed agent output remains advisory. This task is about attributing provider answer content correctly, not making model reports authoritative. Existing Codex/Copilot onboarding and completed normalization tasks were searched; no duplicate owner found. Use isolated fake-provider/projection tests, never run this against live durable state. Authorized for pilot and normal completion under Daniel's continuous quality goal.

### Acceptance Criteria

- Realistic Codex command-output-only and Copilot reasoning-only/empty-message-with-tool-arguments fixtures cannot supply assistant answer or workflow-result fields.
- Authentic final-answer fixtures following tool traffic still project correctly; provider failures/cancellations cannot resurrect unrelated tool payloads.
- Raw diagnostics and token accounting are preserved, artifact-backed activities retain advisory semantics, and focused provider/engine projection tests plus make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added answer-only provider projection: Codex accepts only completed `agent_message` item text from recognized JSONL streams, and Copilot accepts only non-empty `assistant.message.data.content`. Command output, reasoning, usage/error frames, and tool arguments cannot supply response or status fields.
- Separated engine answer projection from normalized invocation-trace input. Raw stdout previews/blobs and provider diagnostics remain intact, while Codex tool/usage telemetry and Copilot usage telemetry remain available to invocation accounting. Artifact-backed advisory behavior and nonzero-exit semantics are unchanged.
- Added realistic provider and engine fixtures for command-output-only, reasoning-only, empty-message tool arguments, cancellation, authentic final answers after tool traffic, trace usage/tool preservation, and truncated Codex JSONL capture.
Assessment: Scoped provider-boundary fix with no new dependency edge or persisted format. Existing direct-envelope compatibility remains for non-event Codex fixtures.
Validation:
- `cargo test -p orbit-agent` (151 passed)
- `cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator` (69 passed, 2 platform-sandbox tests ignored)
- Focused Codex/Copilot provider and engine projection tests passed, including the added Copilot final-answer/usage case
- `make ci-fast` passed
- `make ci-lint` passed
- `git diff --check` passed
Deviations from original plan:
- Added `file:crates/orbit-agent/src/lib.rs` to context because the existing cross-crate export surface had to expose the projection boundary; no dependency direction changed.
Cleanup: Removed run-created Cargo build artifacts with `cargo clean`; final `git status --short` contains only the 11 intended task-scoped source/test changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11348-6a9cb76b`
- Behind base: 0
- Ahead of base: 1