### PR TITLE
Preserve explicit Orbit root through update migration and synchronization

### DIFF
--- a/crates/orbit-cli/src/command/migrate.rs
+++ b/crates/orbit-cli/src/command/migrate.rs
@@ -42,7 +42,9 @@ impl MigrateCommand {
                     .to_string(),
             ));
         };
-        let global_root = orbit_registry::workspace_registry::global_orbit_dir()?;
+        let global_root =
+            RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&cwd, root_override)?
+                .global_root;
         let status = migrate_dry_run_at(&global_root, &resolved.shared_root)?;
 
         // `--dry-run` exits nonzero when there is anything pending, and a

--- a/crates/orbit-cli/tests/update.rs
+++ b/crates/orbit-cli/tests/update.rs
@@ -11,17 +11,24 @@
 //! rewrite a binary a package manager owns — which is exactly the shape this
 //! test binary itself has, since it lives in `target/`.
 
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
 
 use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
 use serde_json::Value;
 use tempfile::tempdir;
 
 fn orbit(cwd: &Path, home: &Path, mirror: &Path) -> assert_cmd::Command {
     let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
     command
         .current_dir(cwd)
         .env("HOME", home)
+        .env("USERPROFILE", home)
         .env("ORBIT_UPDATE_RELEASE_DIR", mirror)
         .env_remove("ORBIT_HOME")
         .env_remove("ORBIT_ROOT")
@@ -36,6 +43,243 @@ fn mirror_publishing(version: &str) -> tempfile::TempDir {
     let mirror = tempdir().expect("mirror tempdir");
     std::fs::write(mirror.path().join("latest-version.txt"), version).expect("write latest");
     mirror
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {output:?}",
+        args.join(" ")
+    );
+}
+
+fn init_git_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repository");
+    run_git(repo, &["init", "--quiet"]);
+    run_git(repo, &["config", "user.name", "Orbit Test"]);
+    run_git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    run_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "# update root test\n").expect("write readme");
+    run_git(repo, &["add", "README.md"]);
+    run_git(repo, &["commit", "--quiet", "-m", "initial"]);
+}
+
+fn initialize_root(repo: &Path, home: &Path, mirror: &Path, root: &Path, suffix: &str) {
+    let root = root.to_string_lossy();
+    let host_name = format!("update-{suffix}");
+    orbit(repo, home, mirror)
+        .args([
+            "--root",
+            root.as_ref(),
+            "init",
+            "--non-interactive",
+            "--host-name",
+            &host_name,
+            "--task-prefix",
+            "UP",
+        ])
+        .assert()
+        .success();
+    let workspace_name = format!("update-{suffix}");
+    orbit(repo, home, mirror)
+        .args([
+            "--root",
+            root.as_ref(),
+            "workspace",
+            "init",
+            "--name",
+            &workspace_name,
+        ])
+        .assert()
+        .success();
+}
+
+fn installed_orbit(
+    executable: &Path,
+    cwd: &Path,
+    home: &Path,
+    mirror: &Path,
+) -> assert_cmd::Command {
+    let mut command = assert_cmd::Command::new(executable);
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("ORBIT_UPDATE_RELEASE_DIR", mirror)
+        .env(
+            "ORBIT_INSTALL_DIR",
+            executable.parent().expect("managed install directory"),
+        )
+        .env_remove("ORBIT_HOME")
+        .env_remove("ORBIT_INSTALL_REPO");
+    command
+}
+
+fn install_test_binary(directory: &Path) -> PathBuf {
+    fs::create_dir_all(directory).expect("create managed install directory");
+    let executable = directory.join("orbit");
+    fs::copy(env!("CARGO_BIN_EXE_orbit"), &executable).expect("copy tested Orbit binary");
+    executable
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn update_preserves_explicit_and_environment_roots_from_another_checkout() {
+    let temp = tempdir().expect("fixture tempdir");
+    let home = temp.path().join("home");
+    let checkout_b = temp.path().join("checkout-b");
+    let root_a = temp.path().join("root-a");
+    let root_b = temp.path().join("root-b");
+    fs::create_dir_all(&home).expect("create home");
+    init_git_repo(&checkout_b);
+    let mirror = mirror_publishing(env!("CARGO_PKG_VERSION"));
+    initialize_root(&checkout_b, &home, mirror.path(), &root_a, "a");
+    initialize_root(&checkout_b, &home, mirror.path(), &root_b, "b");
+
+    let marker_a = root_a.join("state/layout.version");
+    let marker_b = root_b.join("state/layout.version");
+    fs::write(&marker_a, "1\n").expect("make root A migration pending");
+    fs::write(&marker_b, "99\n").expect("make root B incompatible");
+    let managed_a = root_a.join("auto_tasks/code-review.yaml");
+    let managed_b = root_b.join("auto_tasks/code-review.yaml");
+    fs::remove_file(&managed_a).expect("remove root A managed asset");
+    fs::remove_file(&managed_b).expect("remove root B managed asset");
+
+    let executable = install_test_binary(&temp.path().join("managed-bin"));
+    let root_a_arg = root_a.to_string_lossy();
+    let output = installed_orbit(&executable, &checkout_b, &home, mirror.path())
+        .env("ORBIT_ROOT", &root_b)
+        .args(["update", "--root", root_a_arg.as_ref(), "--json"])
+        .output()
+        .expect("run update with explicit root A");
+    assert!(
+        output.status.success(),
+        "explicit-root update failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("parse update report");
+    assert_eq!(report["workspace_root"], root_a.to_string_lossy().as_ref());
+    assert_eq!(report["steps"][0]["command"], "migrate --confirm");
+    assert_eq!(report["steps"][0]["status"], "succeeded");
+    assert_eq!(report["steps"][1]["command"], "workspace sync");
+    assert_eq!(report["steps"][1]["status"], "succeeded");
+    assert_ne!(
+        fs::read_to_string(&marker_a).expect("read migrated root A marker"),
+        "1\n"
+    );
+    assert_eq!(
+        fs::read_to_string(&marker_b).expect("read untouched root B marker"),
+        "99\n"
+    );
+    assert!(managed_a.exists(), "sync did not restore root A asset");
+    assert!(!managed_b.exists(), "sync unexpectedly touched root B");
+
+    let compatibility = installed_orbit(&executable, &checkout_b, &home, mirror.path())
+        .env("ORBIT_ROOT", &root_b)
+        .args([
+            "migrate",
+            "--dry-run",
+            "--root",
+            root_a_arg.as_ref(),
+            "--json",
+        ])
+        .output()
+        .expect("run downgrade compatibility inspection against root A");
+    assert!(
+        compatibility.status.success(),
+        "root A compatibility inspection failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compatibility.stdout),
+        String::from_utf8_lossy(&compatibility.stderr)
+    );
+    let compatibility: Value =
+        serde_json::from_slice(&compatibility.stdout).expect("parse compatibility report");
+    assert_eq!(
+        compatibility["orbit_dir"],
+        root_a.to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        fs::read_to_string(&marker_b).expect("reread untouched root B marker"),
+        "99\n"
+    );
+
+    fs::remove_file(&managed_a).expect("remove root A asset for environment-only retry");
+    let retry = installed_orbit(&executable, &checkout_b, &home, mirror.path())
+        .env("ORBIT_ROOT", &root_a)
+        .args(["update", "--json"])
+        .output()
+        .expect("run update with environment root A");
+    assert!(
+        retry.status.success(),
+        "environment-root update failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&retry.stdout),
+        String::from_utf8_lossy(&retry.stderr)
+    );
+    assert!(managed_a.exists(), "environment-only root did not reach A");
+    assert!(!managed_b.exists(), "environment-only update touched B");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn update_without_a_root_override_retains_default_workspace_routing() {
+    let temp = tempdir().expect("fixture tempdir");
+    let home = temp.path().join("home");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    init_git_repo(&repo);
+    let mirror = mirror_publishing(env!("CARGO_PKG_VERSION"));
+    orbit(&repo, &home, mirror.path())
+        .args([
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "update-default",
+            "--task-prefix",
+            "UD",
+        ])
+        .assert()
+        .success();
+    orbit(&repo, &home, mirror.path())
+        .args(["workspace", "init", "--name", "update-default"])
+        .assert()
+        .success();
+
+    let workspace_root = repo.join(".orbit");
+    let managed = workspace_root.join("auto_tasks/code-review.yaml");
+    fs::remove_file(&managed).expect("remove default-root managed asset");
+    let executable = install_test_binary(&temp.path().join("managed-bin"));
+    let output = installed_orbit(&executable, &repo, &home, mirror.path())
+        .args(["update", "--json"])
+        .output()
+        .expect("run default-root update");
+    assert!(
+        output.status.success(),
+        "default-root update failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("parse update report");
+    assert_eq!(
+        report["workspace_root"],
+        workspace_root
+            .canonicalize()
+            .expect("canonical workspace root")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert!(
+        managed.exists(),
+        "default routing did not sync the workspace"
+    );
 }
 
 #[test]

--- a/crates/orbit-cmd/src/update/converge.rs
+++ b/crates/orbit-cmd/src/update/converge.rs
@@ -64,10 +64,19 @@ impl ConvergenceStep {
     }
 }
 
-/// Run `orbit <args>` with `executable`, in `cwd`, and record the outcome.
-pub fn run_step(executable: &Path, cwd: &Path, args: &[&str]) -> ConvergenceStep {
+/// Run an Orbit convergence command in `cwd`, retaining an explicit root when selected.
+pub fn run_step(
+    executable: &Path,
+    cwd: &Path,
+    root_argument: Option<&Path>,
+    args: &[&str],
+) -> ConvergenceStep {
     let command = args.join(" ");
-    let output = run_process(Command::new(executable).args(args).current_dir(cwd));
+    let mut process = Command::new(executable);
+    if let Some(root) = root_argument {
+        process.arg("--root").arg(root);
+    }
+    let output = run_process(process.args(args).current_dir(cwd));
     match output {
         Ok(output) if output.status.success() => ConvergenceStep {
             command,

--- a/crates/orbit-cmd/src/update/mod.rs
+++ b/crates/orbit-cmd/src/update/mod.rs
@@ -80,8 +80,18 @@ pub struct UpdateEnvironment {
     pub trusted_keys: &'static [TrustedReleaseKey],
     /// Today's date, for signing-key expiry.
     pub today: NaiveDate,
-    /// An initialized Orbit workspace to converge, when the caller is in one.
-    pub workspace_cwd: Option<PathBuf>,
+    /// The initialized Orbit workspace selected for convergence, if any.
+    pub workspace: Option<UpdateWorkspace>,
+}
+
+/// The process location and resolved root that update subprocesses must retain.
+pub struct UpdateWorkspace {
+    /// Working directory inherited by the replacement executable.
+    pub cwd: PathBuf,
+    /// Authoritative `.orbit` root selected by `--root`, `ORBIT_ROOT`, or cwd discovery.
+    pub root: PathBuf,
+    /// Root argument to forward when selection was explicit rather than cwd-based.
+    pub root_argument: Option<PathBuf>,
 }
 
 impl UpdateEnvironment {
@@ -92,9 +102,16 @@ impl UpdateEnvironment {
                 OrbitError::Io(format!("cannot locate the running orbit: {error}"))
             })?);
         let cwd = std::env::current_dir().map_err(|error| OrbitError::Io(error.to_string()))?;
-        let workspace_cwd =
-            RegisteredRuntimeFactory::try_resolve_initialized_roots(&cwd, root_override)?
-                .map(|_| cwd);
+        let root_was_explicit = root_override.is_some()
+            || std::env::var("ORBIT_ROOT").is_ok_and(|root| !root.trim().is_empty());
+        let workspace =
+            RegisteredRuntimeFactory::try_resolve_initialized_roots(&cwd, root_override)?.map(
+                |roots| UpdateWorkspace {
+                    cwd,
+                    root_argument: root_was_explicit.then(|| roots.shared_root.clone()),
+                    root: roots.shared_root,
+                },
+            );
         Ok(Self {
             install_channel: InstallChannel::detect(
                 &executable,
@@ -106,7 +123,7 @@ impl UpdateEnvironment {
             source: release_source_from_env(),
             trusted_keys: TRUSTED_RELEASE_KEYS,
             today: chrono::Utc::now().date_naive(),
-            workspace_cwd,
+            workspace,
         })
     }
 }
@@ -162,6 +179,9 @@ pub struct UpdateReport {
     pub backup_path: Option<PathBuf>,
     /// Post-replacement convergence steps, in the order they ran.
     pub steps: Vec<ConvergenceStep>,
+    /// Workspace root selected for convergence, when one was found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<PathBuf>,
     /// What the operator must do to finish, when the run did not.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery: Option<String>,
@@ -209,6 +229,10 @@ pub fn run_update(
         signing_key_id: None,
         backup_path: None,
         steps: Vec::new(),
+        workspace_root: environment
+            .workspace
+            .as_ref()
+            .map(|workspace| workspace.root.clone()),
         recovery: None,
     };
 
@@ -351,14 +375,21 @@ fn finish(
         return report;
     }
     report.outcome = UpdateOutcome::NeedsRecovery;
-    report.recovery = Some(recovery_text(&report, &failed));
+    report.recovery = Some(recovery_text(
+        &report,
+        &failed,
+        environment
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.root_argument.as_deref()),
+    ));
     report
 }
 
 /// Migrate `.orbit/` state, then reconcile managed assets — in that order.
 fn converge_workspace(environment: &UpdateEnvironment, executable: &Path) -> Vec<ConvergenceStep> {
     const STEPS: [&[&str]; 2] = [&["migrate", "--confirm"], &["workspace", "sync"]];
-    let Some(cwd) = environment.workspace_cwd.as_deref() else {
+    let Some(workspace) = environment.workspace.as_ref() else {
         return STEPS
             .iter()
             .map(|args| {
@@ -372,7 +403,12 @@ fn converge_workspace(environment: &UpdateEnvironment, executable: &Path) -> Vec
     };
     let mut steps = Vec::new();
     for args in STEPS {
-        let step = run_step(executable, cwd, args);
+        let step = run_step(
+            executable,
+            &workspace.cwd,
+            workspace.root_argument.as_deref(),
+            args,
+        );
         let stop = step.failed();
         steps.push(step);
         if stop {
@@ -385,14 +421,24 @@ fn converge_workspace(environment: &UpdateEnvironment, executable: &Path) -> Vec
     steps
 }
 
-fn recovery_text(report: &UpdateReport, failed: &[&str]) -> String {
+fn recovery_text(report: &UpdateReport, failed: &[&str], root_argument: Option<&Path>) -> String {
+    let command = |args: &str| {
+        root_argument.map_or_else(
+            || format!("`orbit {args}`"),
+            |root| format!("`orbit --root {} {args}`", root.display()),
+        )
+    };
+    let retry = command("update");
+    let direct = failed
+        .iter()
+        .map(|args| command(args))
+        .collect::<Vec<_>>()
+        .join(" and ");
     let mut text = format!(
-        "orbit {} is installed, but `orbit {}` did not finish. \
-         Re-run `orbit update` from this workspace to retry — every step is idempotent — \
-         or run `orbit {}` directly and read its diagnostics.",
+        "orbit {} is installed, but {direct} did not finish. \
+         Re-run {retry} from this workspace to retry — every step is idempotent — \
+         or run {direct} directly and read its diagnostics.",
         report.target_version,
-        failed.join("` and `orbit "),
-        failed.join("` and `orbit "),
     );
     if let Some(backup) = &report.backup_path {
         text.push_str(&format!(
@@ -417,10 +463,15 @@ fn assert_downgrade_is_compatible(
     current: &ReleaseVersion,
     target: &ReleaseVersion,
 ) -> Result<(), OrbitError> {
-    let Some(cwd) = environment.workspace_cwd.as_deref() else {
+    let Some(workspace) = environment.workspace.as_ref() else {
         return Ok(());
     };
-    let probe = run_step(staged, cwd, &["migrate", "--dry-run"]);
+    let probe = run_step(
+        staged,
+        &workspace.cwd,
+        workspace.root_argument.as_deref(),
+        &["migrate", "--dry-run"],
+    );
     if !probe.failed() {
         return Ok(());
     }

--- a/crates/orbit-cmd/src/update/tests/fixture.rs
+++ b/crates/orbit-cmd/src/update/tests/fixture.rs
@@ -25,7 +25,7 @@ use tempfile::TempDir;
 
 use crate::update::channel::InstallChannel;
 use crate::update::source::{DirectoryReleaseSource, MIRROR_LATEST_FILE, ReleaseSource};
-use crate::update::{UpdateEnvironment, UpdateRequest};
+use crate::update::{UpdateEnvironment, UpdateRequest, UpdateWorkspace};
 
 /// A throwaway keypair generated for these tests. It is not the release
 /// signing key and no published artifact will ever verify against it.
@@ -190,6 +190,17 @@ impl Fixture {
         self.environment_with_workspace(None)
     }
 
+    /// Build an environment with independently selected cwd and Orbit root.
+    pub fn environment_for_workspace(&self, cwd: PathBuf, root: PathBuf) -> UpdateEnvironment {
+        let mut environment = self.environment_without_workspace();
+        environment.workspace = Some(UpdateWorkspace {
+            cwd,
+            root_argument: Some(root.clone()),
+            root,
+        });
+        environment
+    }
+
     fn environment_with_workspace(&self, workspace_cwd: Option<PathBuf>) -> UpdateEnvironment {
         UpdateEnvironment {
             install_channel: InstallChannel::Managed {
@@ -201,7 +212,11 @@ impl Fixture {
             source: Box::new(DirectoryReleaseSource::new(self.mirror.clone())),
             trusted_keys: test_trusted_keys(),
             today: NaiveDate::from_ymd_opt(2026, 9, 5).expect("valid date"),
-            workspace_cwd,
+            workspace: workspace_cwd.map(|cwd| UpdateWorkspace {
+                root_argument: Some(cwd.join(".orbit")),
+                root: cwd.join(".orbit"),
+                cwd,
+            }),
         }
     }
 
@@ -220,6 +235,19 @@ impl Fixture {
             .lines()
             .map(str::to_string)
             .collect()
+    }
+
+    /// Expected invocation log entry for a convergence command.
+    pub fn invocation(&self, version: &str, command: &str) -> String {
+        format!(
+            "{version}: --root {} {command}",
+            self.workspace.join(".orbit").display()
+        )
+    }
+
+    /// Root selected for fixture convergence.
+    pub fn workspace_root(&self) -> PathBuf {
+        self.workspace.join(".orbit")
     }
 
     /// Path the outgoing executable is preserved at.
@@ -318,7 +346,9 @@ fn script(version: &str, log: &Path, behavior: FakeBinary) -> Vec<u8> {
     format!(
         "#!/bin/sh\n\
          if [ \"$1\" = --version ]; then echo 'orbit {version}'; exit 0; fi\n\
-         echo \"{version}: $*\" >> '{log}'\n\
+         all_args=\"$*\"\n\
+         if [ \"$1\" = --root ]; then shift 2; fi\n\
+         echo \"{version}: $all_args\" >> '{log}'\n\
          {failure}exit 0\n",
         log = log.display()
     )

--- a/crates/orbit-cmd/src/update/tests/flow.rs
+++ b/crates/orbit-cmd/src/update/tests/flow.rs
@@ -29,10 +29,11 @@ fn updating_to_latest_replaces_the_binary_then_migrates_before_syncing_assets() 
     assert_eq!(
         fixture.invocations(),
         vec![
-            "0.19.0: migrate --confirm".to_string(),
-            "0.19.0: workspace sync".to_string(),
+            fixture.invocation("0.19.0", "migrate --confirm"),
+            fixture.invocation("0.19.0", "workspace sync"),
         ]
     );
+    assert_eq!(report.workspace_root, Some(fixture.workspace_root()));
     assert!(report.steps.iter().all(|step| !step.failed()));
 }
 
@@ -126,8 +127,8 @@ fn rerunning_at_the_installed_version_reconverges_without_replacing_anything() {
     assert_eq!(
         fixture.invocations(),
         vec![
-            "0.19.0: migrate --confirm".to_string(),
-            "0.19.0: workspace sync".to_string(),
+            fixture.invocation("0.19.0", "migrate --confirm"),
+            fixture.invocation("0.19.0", "workspace sync"),
         ]
     );
 }
@@ -168,7 +169,11 @@ fn an_incompatible_downgrade_is_caught_before_the_binary_is_replaced() {
 
     let mut requested = request();
     requested.allow_downgrade = true;
-    let error = run_update(&fixture.environment(), &requested).expect_err("incompatible downgrade");
+    let cwd_b = fixture.workspace.join("checkout-b");
+    let root_a = fixture.workspace.join("root-a");
+    std::fs::create_dir_all(&cwd_b).expect("create alternate cwd");
+    let environment = fixture.environment_for_workspace(cwd_b.clone(), root_a.clone());
+    let error = run_update(&environment, &requested).expect_err("incompatible downgrade");
 
     assert!(
         error.to_string().contains("cannot open this workspace"),
@@ -179,6 +184,21 @@ fn an_incompatible_downgrade_is_caught_before_the_binary_is_replaced() {
         "{error}"
     );
     assert_eq!(fixture.installed_reports(), "orbit 0.19.0");
+    assert_eq!(
+        fixture.invocations(),
+        vec![format!(
+            "0.18.0: --root {} migrate --dry-run",
+            root_a.display()
+        )]
+    );
+    assert!(
+        fixture
+            .invocations()
+            .iter()
+            .all(|invocation| !invocation.contains(&cwd_b.display().to_string())),
+        "downgrade probe leaked the caller cwd into root selection: {:?}",
+        fixture.invocations()
+    );
     assert_eq!(
         fixture.install_dir_entries(),
         vec!["orbit".to_string(), ".orbit-update.lock".to_string()]
@@ -210,7 +230,7 @@ fn an_incompatible_prerelease_downgrade_runs_the_compatibility_preflight() {
     assert_eq!(fixture.installed_reports(), "orbit 0.19.0-rc.10");
     assert_eq!(
         fixture.invocations(),
-        vec!["0.19.0-rc.2: migrate --dry-run".to_string()]
+        vec![fixture.invocation("0.19.0-rc.2", "migrate --dry-run")]
     );
 }
 
@@ -330,8 +350,12 @@ fn a_failed_migration_is_reported_as_needing_recovery_not_as_success() {
         report.steps[0].detail
     );
     let recovery = report.recovery.expect("recovery guidance");
-    assert!(recovery.contains("Re-run `orbit update`"), "{recovery}");
+    assert!(recovery.contains("Re-run `orbit --root"), "{recovery}");
     assert!(recovery.contains("migrate --confirm"), "{recovery}");
+    assert!(
+        recovery.contains(&fixture.workspace_root().display().to_string()),
+        "{recovery}"
+    );
     assert!(
         recovery.contains(&fixture.backup_path().display().to_string()),
         "{recovery}"
@@ -459,7 +483,7 @@ fn a_stale_writer_reconverges_when_the_lock_already_holds_the_target() {
     let migrate = fixture
         .invocations()
         .iter()
-        .filter(|line| line.as_str() == "0.19.0: migrate --confirm")
+        .filter(|line| *line == &fixture.invocation("0.19.0", "migrate --confirm"))
         .count();
     assert_eq!(migrate, 2, "{:?}", fixture.invocations());
 }
@@ -522,7 +546,7 @@ fn a_stale_permitted_downgrade_still_preflights_the_workspace() {
         fixture
             .invocations()
             .iter()
-            .any(|line| line.as_str() == "0.18.0: migrate --dry-run"),
+            .any(|line| line == &fixture.invocation("0.18.0", "migrate --dry-run")),
         "{:?}",
         fixture.invocations()
     );

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -45,8 +45,10 @@ orbit update --json               # machine-readable report
    complete replacement or the complete previous executable; the retained backup is not consumed
    and no workspace state is touched.
 7. Run `orbit migrate --confirm`, then `orbit workspace sync` — **using the newly installed
-   binary**, in the current workspace. Only the new binary carries the migrations and managed
-   asset definitions for the version being installed.
+   binary**, in the selected workspace. Orbit passes the resolved root to both subprocesses;
+   an explicit `--root` remains authoritative even when `ORBIT_ROOT` names another workspace.
+   Only the new binary carries the migrations and managed asset definitions for the version
+   being installed.
 
 Migration runs before managed-asset sync because a layout migration can move the directories
 those assets live in.
@@ -60,16 +62,19 @@ names the step that failed.
 Re-running `orbit update` is the resume. At the installed version it skips the replacement and
 re-runs the same idempotent convergence steps, so a run that failed at `migrate --confirm` or
 `workspace sync` is finished by running it again — or by running that one command directly and
-reading its diagnostics.
+reading its diagnostics. When `--root` or `ORBIT_ROOT` selected the workspace, recovery output
+includes that root explicitly, so retrying from a different checkout does not silently switch the
+workspace being repaired.
 
 The outgoing executable stays at `<orbit>.previous`. Restore it only if `.orbit/` state was not
 migrated: once a migration has been applied, an older binary refuses to open the workspace by
 design. See [Respect the downgrade guard](#respect-the-downgrade-guard).
 
-`orbit update` converges **the workspace you run it from**. Run it (or `orbit migrate --confirm`
-and `orbit workspace sync`) from each other registered workspace after upgrading, and restart
-long-lived Orbit services and pipeline workers so newly dispatched agents inherit the
-replacement build.
+Without a root override, `orbit update` converges **the workspace you run it from**. `ORBIT_ROOT`
+selects an environment-only override, while an explicit `--root` takes precedence over it. Run
+the update (or `orbit migrate --confirm` and `orbit workspace sync`) for each other registered
+workspace after upgrading, and restart long-lived Orbit services and pipeline workers so newly
+dispatched agents inherit the replacement build.
 
 ### Downgrades
 


### PR DESCRIPTION
## Task

[ORB-11343](https://orbit-cli.com/tasks/ORB-11343) — Preserve explicit Orbit root through update migration and synchronization

### Description

Source-level finding at 5530555cc4d75935465b7c4cdc533dca86951dbf, independently verified after Astra audit. UpdateEnvironment::from_process in crates/orbit-cmd/src/update/mod.rs:89-91 resolves root_override then discards resolved roots using .map(|_| cwd). converge_workspace at :335 and assert_downgrade_is_compatible at :383 call run_step with original cwd and no explicit root; converge.rs:70 forwards only args. Running from workspace B with --root A therefore detects A but can migrate/sync or downgrade-probe B/default state. No live migration experiment was performed.

Preserve authoritative selected root through every newly installed/staged subprocess, with explicit CLI root precedence over conflicting ORBIT_ROOT. Reuse existing root resolution and update execution seams. Cover default and environment-only invocation, migration before sync, recovery retries and downgrade probe. Do not alter unrelated workspace state. Existing done ORB-11280 implements update and ORB-11319 fixes prerelease ordering; neither covers lost root propagation. Update current upgrade docs. Authorized for normal pilot and completion under Daniel's continuous session.

### Acceptance Criteria

- Isolated CLI regression with distinct roots A and B invokes update from B with --root A and proves migration, sync and downgrade compatibility inspect only A.
- Explicit --root wins over conflicting ORBIT_ROOT; default and environment-only routing remain correct and recovery reports preserve selected scope.
- Focused update tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- UpdateEnvironment now retains the resolved workspace root and whether selection came from --root/ORBIT_ROOT; replacement-binary migration, managed-asset sync, recovery retries, and staged downgrade probes forward that authoritative root while default cwd discovery remains unchanged.
- Migrate dry-run now resolves its global database root through the same root-aware bootstrap path, so explicit --root wins over a conflicting ORBIT_ROOT for compatibility inspection.
- Update reports expose workspace_root and recovery commands include the selected explicit/environment root. The upgrade runbook documents precedence and scoped recovery.
- Added isolated binary regression coverage with roots A/B, execution from checkout B, a conflicting ORBIT_ROOT, pending migration and missing managed asset in A, incompatible sentinel state in B, direct downgrade-compatible dry-run inspection, environment-only routing, and default routing. Added focused fake-binary assertions for staged downgrade argv and recovery scope.
Scope expansion:
- Added file:crates/orbit-cli/tests/update.rs because the acceptance criterion explicitly requires an isolated CLI regression.
- Added file:crates/orbit-cli/src/command/migrate.rs because staged downgrade inspection reaches this adapter and its prior global-root lookup ignored --root.
Validation:
- cargo test -p orbit-cmd update::tests (42 passed, 1 ignored subprocess fixture; its spawned case passed)
- cargo test -p orbit-cli --test update (7 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed)
Assessment: The selected-root invariant is carried at the update boundary and applied to every child execution seam. Explicit/environment roots are pinned; default routing deliberately remains cwd-based so host-global and workspace roots do not collapse. No qualifying friction record was identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11343-6a9cb974`
- Behind base: 0
- Ahead of base: 1