### PR TITLE
Keep nested repository workspace initialization from inheriting the parent registration

### DIFF
--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -1319,6 +1319,137 @@ fn workspace_init_from_git_subdir_gitignores_repo_orbit_dir() {
 }
 
 #[test]
+fn workspace_init_in_independent_nested_git_repo_preserves_parent_binding() {
+    let parent = tempdir().expect("parent workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_nested_init\"\nhost_id = \"nested-init\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+    let parent_git = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .arg(parent.path())
+        .status()
+        .expect("run git init for parent");
+    assert!(parent_git.success(), "initialize parent git repository");
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(parent.path());
+    let init = |name: &str| WorkspaceInitArgs {
+        name: Some(name.to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: Some("local".to_string()),
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: false,
+    };
+    init("registered-parent")
+        .execute_without_runtime(None)
+        .expect("initialize registered parent");
+
+    let registry_path = global.join("workspaces.json");
+    let parent_identity_path = parent.path().join(".orbit/config.yaml");
+    let parent_identity_before =
+        std::fs::read(&parent_identity_path).expect("read parent identity before child init");
+    let parent_gitignore_before =
+        std::fs::read(parent.path().join(".gitignore")).expect("read parent gitignore");
+    let registry_before =
+        workspace_registry::load_registry_from(&registry_path).expect("load parent registry");
+    let parent_id = canonical_workspace_id("registered-parent");
+    let parent_workspace_before = serde_json::to_vec(
+        registry_before
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == parent_id)
+            .expect("parent workspace registration"),
+    )
+    .expect("serialize parent workspace registration");
+    let parent_checkout_before = serde_json::to_vec(
+        workspace_registry::find_checkout(&registry_before, &parent_id)
+            .expect("parent checkout registration"),
+    )
+    .expect("serialize parent checkout registration");
+
+    let child = parent.path().join("codebases/independent-child");
+    let child_git = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .arg(&child)
+        .status()
+        .expect("run git init for child");
+    assert!(child_git.success(), "initialize independent child git repo");
+    std::env::set_current_dir(&child).expect("switch to independent child repo");
+    init("independent-child")
+        .execute_without_runtime(None)
+        .expect("initialize independent child workspace");
+
+    let child_id = canonical_workspace_id("independent-child");
+    let child_orbit = child.join(".orbit");
+    let child_identity =
+        std::fs::read_to_string(child_orbit.join("config.yaml")).expect("read child identity");
+    assert!(
+        child_identity.contains(&format!("workspace_id: {child_id}")),
+        "child repository must own its workspace identity: {child_identity}"
+    );
+    for state_dir in ["resources", "tasks", "state"] {
+        assert!(
+            child_orbit.join(state_dir).is_dir(),
+            "child workspace must own its {state_dir} state"
+        );
+    }
+    assert!(
+        !parent.path().join("codebases/.orbit").exists(),
+        "bootstrap must not create an intermediate shadow store"
+    );
+
+    let registry_after =
+        workspace_registry::load_registry_from(&registry_path).expect("load child registry");
+    let child_workspace = registry_after
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.id == child_id)
+        .expect("child workspace registration");
+    let child_checkout = workspace_registry::find_checkout(&registry_after, &child_id)
+        .expect("child checkout registration");
+    assert_eq!(child_workspace.name, "independent-child");
+    assert_eq!(
+        std::fs::canonicalize(&child_checkout.repo_root).expect("canonical child checkout"),
+        std::fs::canonicalize(&child).expect("canonical child repo")
+    );
+    assert_eq!(child_checkout.orbit_dir, child_orbit);
+
+    let parent_workspace_after = serde_json::to_vec(
+        registry_after
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.id == parent_id)
+            .expect("preserved parent workspace registration"),
+    )
+    .expect("serialize preserved parent workspace registration");
+    let parent_checkout_after = serde_json::to_vec(
+        workspace_registry::find_checkout(&registry_after, &parent_id)
+            .expect("preserved parent checkout registration"),
+    )
+    .expect("serialize preserved parent checkout registration");
+    assert_eq!(parent_workspace_after, parent_workspace_before);
+    assert_eq!(parent_checkout_after, parent_checkout_before);
+    assert_eq!(
+        std::fs::read(&parent_identity_path).expect("read parent identity after child init"),
+        parent_identity_before
+    );
+    assert_eq!(
+        std::fs::read(parent.path().join(".gitignore"))
+            .expect("read parent gitignore after child init"),
+        parent_gitignore_before
+    );
+}
+
+#[test]
 fn workspace_init_with_root_override_uses_custom_registry() {
     let workspace = tempdir().expect("workspace tempdir");
     let home = tempdir().expect("home tempdir");

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -75,7 +75,7 @@ impl RegisteredRuntimeFactory {
         cwd: &Path,
         root_override: Option<&Path>,
     ) -> Result<OrbitRuntimeRoots, OrbitError> {
-        let hint = workspace_root_hint(cwd);
+        let hint = bootstrap_workspace_root_hint(cwd);
         OrbitRuntime::resolve_bootstrap_roots_for_cwd_with_hint(cwd, root_override, hint.as_ref())
     }
 
@@ -565,6 +565,41 @@ fn workspace_root_hint(cwd: &Path) -> Option<WorkspaceRootHint> {
     Some(WorkspaceRootHint {
         orbit_dir: checkout.orbit_dir.clone(),
     })
+}
+
+/// Resolve a catalog hint for a bootstrap command without crossing into a
+/// nested, independently rooted Git repository.
+///
+/// Ordinary runtime lookup keeps longest-prefix registry semantics. Bootstrap
+/// is different because it is allowed to create a workspace: an ancestor
+/// checkout must not capture a new child repository before Core's Git-bounded
+/// walk-up gets a chance to select `<child>/.orbit`. An explicit path override
+/// rooted inside the child repository remains authoritative.
+fn bootstrap_workspace_root_hint(cwd: &Path) -> Option<WorkspaceRootHint> {
+    let registry = workspace_registry::load_registry().ok()?;
+    let checkout = workspace_registry::find_checkout_by_path(&registry, cwd)?;
+    if checkout_crosses_nested_git_boundary(checkout, cwd) {
+        return None;
+    }
+    Some(WorkspaceRootHint {
+        orbit_dir: checkout.orbit_dir.clone(),
+    })
+}
+
+fn checkout_crosses_nested_git_boundary(checkout: &WorkspaceCheckout, cwd: &Path) -> bool {
+    let cwd = canonical_or_original(cwd);
+    let Some(git_root) = cwd.ancestors().find(|ancestor| {
+        let git_marker = ancestor.join(".git");
+        git_marker.is_dir() || git_marker.is_file()
+    }) else {
+        return false;
+    };
+    let git_root = canonical_or_original(git_root);
+
+    !std::iter::once(&checkout.repo_root)
+        .chain(&checkout.path_overrides)
+        .map(|root| canonical_or_original(root))
+        .any(|root| cwd.starts_with(&root) && root.starts_with(&git_root))
 }
 
 fn binding_for_roots(

--- a/crates/orbit-cmd/src/tests/registry_runtime.rs
+++ b/crates/orbit-cmd/src/tests/registry_runtime.rs
@@ -372,6 +372,56 @@ fn registered_workspace(
     (workspace, checkout)
 }
 
+#[test]
+fn bootstrap_hint_stays_within_its_registered_git_repository() {
+    let root = tempfile::tempdir().expect("root");
+    let home = root.path().join("home");
+    let global = home.join(".orbit");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_nested_hint\"\nhost_id = \"nested-hint\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+
+    let (parent, checkout) =
+        registered_workspace(root.path(), "ws_parent", "parent", "hm_nested_hint");
+    std::fs::create_dir_all(checkout.repo_root.join(".git")).expect("parent git directory");
+    save_registry_to(
+        &WorkspaceRegistry {
+            workspaces: vec![parent],
+            checkouts: vec![checkout.clone()],
+            ..Default::default()
+        },
+        &registry_path_for(&global),
+    )
+    .expect("workspace registry");
+
+    let same_repo_subdir = checkout.repo_root.join("packages/demo");
+    let independent_child = checkout.repo_root.join("codebases/child");
+    std::fs::create_dir_all(&same_repo_subdir).expect("same-repo subdirectory");
+    std::fs::create_dir_all(independent_child.join(".git")).expect("child git directory");
+    let home_var = home.to_string_lossy().into_owned();
+    let _env = orbit_common::test_env::scoped([
+        ("HOME", Some(home_var.as_str())),
+        ("ORBIT_ROOT", None),
+        ("ORBIT_REGISTRY_ROOT", None),
+        ("ORBIT_MANAGED_RUN_CONTEXT", None),
+        ("ORBIT_WORKSPACE", None),
+    ]);
+
+    let same_repo =
+        RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&same_repo_subdir, None)
+            .expect("resolve registered subdirectory");
+    assert_eq!(same_repo.shared_root, checkout.orbit_dir);
+
+    let child = RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&independent_child, None)
+        .expect("resolve independent child repository");
+    assert_eq!(child.shared_root, independent_child.join(".orbit"));
+    assert_eq!(child.local_root, independent_child.join(".orbit"));
+    assert_eq!(child.global_root, global);
+}
+
 fn unsupported_workspace_message(error: OrbitError, selector: &str) -> String {
     match error {
         OrbitError::InvalidInput(message) => {
@@ -762,6 +812,10 @@ fn managed_registry_locator_routes_linked_worktree_to_authoritative_store() {
     let roots = RegisteredRuntimeFactory::resolve_roots_for_cwd(&fixture.worktree_root, None)
         .expect("resolve production-shaped managed roots");
     assert_eq!(roots, fixture.unpinned_roots());
+    let bootstrap_roots =
+        RegisteredRuntimeFactory::resolve_bootstrap_roots_for_cwd(&fixture.worktree_root, None)
+            .expect("resolve linked-worktree bootstrap roots");
+    assert_eq!(bootstrap_roots, fixture.unpinned_roots());
     let runtime = RegisteredRuntimeFactory::open_resolved_roots(roots)
         .expect("open registered linked-worktree runtime");
 


### PR DESCRIPTION
## Task

[ORB-11360](https://orbit-cli.com/tasks/ORB-11360) — Keep nested repository workspace initialization from inheriting the parent registration

### Description

Encountered while executing Daniel-approved orbit-research/Parallax onboarding; he explicitly requests Orbit operational fix tasks. Required outcome is a validated PR candidate, not an unapproved merge, deployment or new shadow registry. Sol is permitted for hard implementation work and fits this workspace-identity boundary. Work in a dedicated Orbit worktree off agent-main.

Observed on authoritative Linux machine hm_9ca6004473492f06, /usr/local/bin/orbit 0.18.0, Orbit checkout HEAD 5530555cc4d75935465b7c4cdc533dca86951dbf. Via mcp__orbit_linux__orbit_command_exec with workspace ws_constellation and working_directory ~/workspace/constellation/codebases/orbit-research, argv ['orbit','workspace','init','--name','orbit-research','--base-branch','agent-main','--ship-mode','local'] fails: "workspace identity 'ws_orbit' at '~/workspace/constellation/.orbit/config.yaml' conflicts with requested workspace 'ws_orbit-research'; rerun with --force to reconcile it". The same command from independent existing codebases/parallax fails for ws_parallax. Exact cwd was verified with Python. ORBIT_ROOT, ORBIT_WORKSPACE, ORBIT_WORKSPACE_ROOT, ORBIT_CONFIG and ORBIT_CONFIG_PATH were all unset. New orbit-research is a distinct Git repository with root commit 9b2d6ac, remote https://github.com/danieljhkim/orbit-research.git, branch agent-main; Parallax is its own clean repository on agent-main with origin ~/git/parallax.git. Neither is listed by authoritative workspace_list. No --force was attempted, no identities or registry files were edited.

Code inspection candidate: crates/orbit-cmd/src/registry_runtime.rs::workspace_root_hint calls find_checkout_by_path and feeds a parent registered-checkout hint into resolve_bootstrap_roots_for_cwd. crates/orbit-core/src/runtime/resolve.rs gives that hint precedence over its new Git-bounded bootstrap walk-up, so the nested-repo protection may be defeated before that boundary executes. Verify on current owning source instead of assuming this is the cause. Prior ORB-10577 handles an unregistered preseeded identity, not a new independent repository captured by an ancestor's registered checkout. Search found no exact duplicate for workspace_root_hint/bootstrap parent.

Add an isolated reproduction with a registered parent, a separate nested Git repository and no child .orbit; fix bootstrap selection at the narrow owning boundary. Preserve legitimate subdirectories and linked worktrees, global registry authority, and fail-closed existing identity checks. Do not use --root to create a replacement global store or --force to rewrite a parent identity. Document a supported safe operational route if one already exists; otherwise report exactly what release/deployment is needed to unblock onboarding. Root .orbit's ws_orbit vs ws_constellation mismatch may be separate stale metadata: do not rewrite it as part of this child-init repair.

### Acceptance Criteria

- A deterministic isolated regression reproduces nested independent Git repository capture and passes after the fix; workspace init creates the child's own registration/state and leaves parent identity/registration bytes unchanged.
- Normal subdirectory resolution within one Git repository and linked-worktree shared identity still work; invalid or conflicting existing bindings remain refused, with no new global/shadow store.
- Targeted resolver/workspace-init tests and required Orbit checks pass, dedicated worktree diff is scoped, and a PR candidate describes exact reproduction and safe unblock/deployment prerequisites. Do not merge or deploy.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Restricted registry-derived workspace hints only for bootstrap resolution: if cwd is inside an independently rooted nested Git repository, an ancestor checkout no longer outranks Core's Git-bounded bootstrap walk. Explicit path overrides rooted in the child remain authoritative; ordinary runtime resolution is unchanged.
- Added resolver coverage proving a registered same-repository subdirectory still shares the parent root, a nested independent repository selects its own .orbit, and linked-worktree bootstrap still resolves shared/local roots correctly.
- Added an isolated real-Git workspace-init regression: initialize a registered parent, git-init a nested child, then initialize the child. It asserts child-owned identity/resources/tasks/state and registration, no intermediate shadow store, and byte-for-byte preservation of the parent's identity, checkout/workspace records, and managed .gitignore.
Assessment: Narrow bootstrap-only adapter fix; no new dependency edge, global/shadow registry, compatibility layer, or change to existing conflict/force validation.
Exact reproduction covered: with HOME-scoped global registration for a parent checkout and no child .orbit, run workspace init from an independently git-initialized child using a different name. Before the fix the parent hint selected parent/.orbit and raised the conflicting identity error; after the fix child/.orbit is selected and registered.
Validation:
- cargo test -p orbit-cmd tests::registry_runtime -- --nocapture (16 passed)
- cargo test -p orbit-cli command::workspace::tests::init:: -- --nocapture (26 passed)
- cargo test -p orbit-core runtime::tests::resolve -- --nocapture (20 passed)
- make ci-fast (passed)
- make ci-lint (passed)
- git diff --check (passed); scoped diff is 3 intended files, 221 insertions/1 deletion from baseline abdbe02a97f86618497c6642d9faa34de9ada338.
Safe unblock / deployment prerequisites: there is no safe current-version route that meets the constraints without forcing/repointing state. After human review, merge the PR candidate to agent-main, cut and promote an Orbit release containing this fix under the normal release process, install that release on authoritative host hm_9ca6004473492f06, and rerun each child repository's original workspace init command without --force or --root. No commit, merge, release, installation, onboarding retry, or production deployment was performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11360-6a9cbcad`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*