### PR TITLE
[code-review] Reject a parent guard that reads its own nested output

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/tests/validate.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/validate.rs
@@ -592,9 +592,10 @@ fn validate_job_accepts_when_reading_a_step_under_an_always_run_ancestor_chain()
 
 #[test]
 fn validate_job_accepts_a_reader_that_shares_every_guard_with_the_step_it_reads() {
-    // `break_when` is only evaluated while the loop is running, and the body
-    // reader only runs when the same guard passed: a guard both sides sit
-    // under skips them together and can never strand the reader.
+    // [ORB-11346] / [ORB-11361] `break_when` is evaluated after the body, so
+    // it may read an earlier body step; a later sibling `when:` only runs
+    // when the same enclosing guard passed. A guard both sides sit under
+    // skips them together and can never strand the reader.
     let mut gate = loop_step(
         "gate",
         None,
@@ -615,4 +616,110 @@ fn validate_job_accepts_a_reader_that_shares_every_guard_with_the_step_it_reads(
         validate_job(&job_with_steps(vec![gate])).is_ok(),
         "a guard shared by reader and referenced step must stay valid"
     );
+}
+
+// --------------------------------------------------------------------------
+// [ORB-11361] A step's `when:` runs before its body, so it cannot read an
+// output that only that body produces — including a nested child or the
+// step's own output. `break_when` stays after-body (covered above).
+// --------------------------------------------------------------------------
+
+fn container_when_reading_nested(parent: JobV2Step) -> JobV2Step {
+    JobV2Step {
+        when: Some("{{ steps.produce.output.done }} == true".to_string()),
+        ..parent
+    }
+}
+
+#[test]
+fn validate_job_rejects_container_when_reading_a_nested_parallel_output() {
+    let gate = container_when_reading_nested(parallel_step(
+        "gate",
+        JoinMode::All,
+        vec![target_step("produce", "produce_action")],
+    ));
+
+    let err = validate_job(&job_with_steps(vec![gate]))
+        .expect_err("a container when: must not read a nested output");
+
+    match &err {
+        DispatchError::JobValidation(message) => {
+            assert!(
+                message.contains("gate"),
+                "message must name the reading step: {message}"
+            );
+            assert!(
+                message.contains("produce"),
+                "message must name the referenced step: {message}"
+            );
+        }
+        other => panic!("expected JobValidation, got {other:?}"),
+    }
+}
+
+#[test]
+fn validate_job_rejects_container_when_reading_a_nested_loop_output() {
+    let gate = container_when_reading_nested(loop_step(
+        "gate",
+        None,
+        3,
+        None,
+        vec![target_step("produce", "produce_action")],
+    ));
+
+    let err = validate_job(&job_with_steps(vec![gate]))
+        .expect_err("a loop when: must not read a nested output");
+
+    assert!(
+        matches!(&err, DispatchError::JobValidation(message)
+            if message.contains("gate") && message.contains("produce")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn validate_job_rejects_container_when_reading_a_nested_fan_out_worker_output() {
+    let gate = container_when_reading_nested(fanout_step(
+        "gate",
+        "{{ input.items }}",
+        2,
+        target_step("produce", "produce_action"),
+        JoinMode::All,
+        None,
+    ));
+
+    let err = validate_job(&job_with_steps(vec![gate]))
+        .expect_err("a fan-out when: must not read a worker output");
+
+    assert!(
+        matches!(&err, DispatchError::JobValidation(message)
+            if message.contains("gate") && message.contains("produce")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn validate_job_rejects_when_reading_the_same_step_own_output() {
+    let self_reader = step_with_when(
+        "reader",
+        "{{ steps.reader.output.done }} == true",
+        "reader_action",
+    );
+
+    let err = validate_job(&job_with_steps(vec![self_reader]))
+        .expect_err("a step when: must not read its own output");
+
+    match &err {
+        DispatchError::JobValidation(message) => {
+            assert!(
+                message.contains("reader"),
+                "message must name the reading step: {message}"
+            );
+            assert!(
+                message.contains("steps.reader.output"),
+                "message must name the referenced output: {message}"
+            );
+        }
+        other => panic!("expected JobValidation, got {other:?}"),
+    }
 }

--- a/crates/orbit-engine/src/activity_job/job_executor/validate.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/validate.rs
@@ -41,6 +41,13 @@ pub fn validate_job(job: &JobV2) -> Result<(), DispatchError> {
 /// nested in a `parallel:`, `fan_out:`, or `loop:` block under a
 /// `when:`-carrying ancestor is skipped with it and records nothing, however
 /// unguarded the nested step looks on its own.
+///
+/// [ORB-11361] Shared-guard membership is not enough: `when:` is evaluated
+/// before the body, so a step does not yet sit under its own id. A container
+/// `when:` that reads a nested output, or a step `when:` that reads its own
+/// output, is therefore unsafe even though `record_step_guards` stored the
+/// reader id on the referenced step. `break_when` is the opposite — it runs
+/// after the loop body — so the loop's own guard *is* covering there.
 fn validate_step_output_readiness(job: &JobV2) -> Result<(), DispatchError> {
     let mut guards = HashMap::new();
     for step in &job.steps {
@@ -94,7 +101,11 @@ fn check_step_output_refs(
 ) -> Result<(), DispatchError> {
     let chain = guard_chain(step, inherited);
     if let Some(expr) = &step.when {
-        check_expr_output_refs(&step.id, expr, &chain, guards)?;
+        // `when:` is evaluated before the body (`step.rs`), so this step's
+        // own id is not yet a covering guard: nested outputs have not run,
+        // and the step cannot read its own output. Only enclosing guards
+        // skip the reader together with the referenced step.
+        check_expr_output_refs(&step.id, expr, inherited, guards)?;
     }
     match &step.body {
         JobV2StepBody::Parallel { parallel } => {
@@ -107,9 +118,10 @@ fn check_step_output_refs(
         }
         JobV2StepBody::Loop { loop_ } => {
             if let Some(expr) = &loop_.break_when {
-                // `break_when` is evaluated between iterations of the loop
-                // body, so it reads under the loop's own guards — the same
-                // ones its body steps inherit.
+                // `break_when` is evaluated after the loop body
+                // (`loop_block.rs`), so nested body outputs exist whenever
+                // the loop itself ran. The loop's own `when:` is a covering
+                // guard here — unlike the pre-body `when:` check above.
                 check_expr_output_refs(&step.id, expr, &chain, guards)?;
             }
             for body in &loop_.steps {

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,8 +3,8 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-09-05
-last_validated: 2026-09-05
+last_updated: 2026-09-06
+last_validated: 2026-09-06
 status: Draft
 feature: activity-job
 doc_role: design
@@ -537,6 +537,8 @@ The working alternative is to end the run on the stranding branch instead of ski
 - A single-iteration `loop:` wrapping just the referenced step as a grouping construct — this only renames which id is skippable. If the loop step itself carries the `when:` that used to guard the body step, then when that condition is false the *loop* is skipped, the body step never runs, and a reader outside the loop still finds no data recorded for the body step's id. Wrapping the referenced step *and every reader of its output* together in the same guarded block does work (nothing outside the block needs the skipped id), but wrapping only the referenced step does not.
 
 Catalog load enforces this: `validate_job` (`crates/orbit-engine/src/activity_job/job_executor/validate.rs`) walks every step's `when:` and every loop's `break_when:` for `steps.<id>.output` references and rejects the job, naming both the reading and the referenced step, when the referenced step may be skipped. Skippability is inherited (ORB-11346): `run_step` returns before running any body when a guard is false, so a step nested in a `parallel:`, `fan_out:`, or `loop:` block under a `when:`-carrying ancestor is skipped with that ancestor and records nothing, however unguarded the nested step looks on its own. The validator therefore compares guard *chains* rather than a per-step flag: a guard the reading step itself sits under skips both steps together and can never strand the reader, which is exactly what keeps the admissible shapes above valid — wrapping the referenced step and every reader of its output in the same guarded block, and a guarded loop's `break_when:` reading its own body step.
+
+That shared-guard exemption is relative to execution order, not mere set membership (ORB-11361). `when:` is evaluated before the step body, so a step does not sit under its own guard when its condition is rendered: a container `when:` that reads a nested body or worker output, and a step `when:` that reads that same step's output, are rejected even though the referenced step's recorded chain includes the reader id. `break_when` is the opposite — it is evaluated after the loop body — so a guarded loop may still read an earlier body step. A later sibling `when:` that shares an enclosing guard with the referenced step remains valid.
 
 The retry wrapper re-runs the whole step body up to `max_attempts`, with exponential or linear backoff. Some errors bypass retry:
 


### PR DESCRIPTION
## Task

[ORB-11361](https://orbit-cli.com/tasks/ORB-11361) — [code-review] Reject a parent guard that reads its own nested output

### Description

## Problem

The guard-chain repair in ORB-11346 still admits a condition that runs before the output it reads can exist. In `crates/orbit-engine/src/activity_job/job_executor/validate.rs:95-98`, a step checks its own `when:` using a chain that already includes that same step id. `check_expr_output_refs` at `validate.rs:134-142` then treats every guard shared by reader and referenced step as safe.

For a guarded container `gate` whose `when:` reads `{{ steps.produce.output.done }}` and whose nested body contains `produce`, `record_step_guards` records `produce` under guard `gate`, while the reader chain for the `gate` condition also contains `gate`. The subtraction therefore finds no unsafe guard and `validate_job` accepts the job.

Live execution has the opposite ordering: `crates/orbit-engine/src/activity_job/job_executor/step.rs:3-8` evaluates `gate.when` before `run_step_body`, so the nested `produce` step cannot have recorded output. Rendering the accepted condition fails with `no data recorded for step 'produce'`. The same representation also admits a step whose own `when:` reads its own output.

## Why It Matters

A malformed user job passes the preventive catalog-load gate and fails only at runtime. This is a distinct ordering hole in the completed ancestor-guard fix, not the downstream-reader case ORB-11346 repaired.

## Constraints / Notes

- Preserve the valid guarded-loop `break_when:` case because it is evaluated after the loop body.
- Preserve sibling readers that run after the referenced step under the same enclosing guard.
- Validate relative execution order, not only set membership of guard ids.

### Acceptance Criteria

- `validate_job` rejects a container `when:` that reads an output produced only inside that container, with a diagnostic naming the reader and referenced step.
- `validate_job` rejects a step `when:` that reads that same step own output.
- Regression tests preserve a loop `break_when:` reading an earlier body step and a later sibling reader sharing an enclosing guard.
- `cargo test -p orbit-engine`, `make ci-fast`, and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `check_step_output_refs` now checks a step's `when:` against enclosing (`inherited`) guards only, because `run_step` evaluates `when:` before the body. Nested outputs and the step's own output are no longer treated as already covered by the reader's id.
- Loop `break_when:` still uses the full guard chain (after-body), so a guarded loop may read an earlier body step.
- Tests reject container `when:` (parallel/loop/fan-out) reading nested `produce` and a target `when:` reading its own output; the shared-guard loop `break_when:` + later sibling reader case remains accepted.
- Design doc §8.2 records the before-body vs after-body distinction (ORB-11361).
Assessment: Small validator-seam fix matching ORB-11346 style. Diagnostics still name reader and referenced step via the existing JobValidation message. No unlisted files were changed.
Validation: `cargo test -p orbit-engine` ok; `make ci-fast` ok; `make ci-lint` ok.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11361-6a9cbf8e`
- Behind base: 0
- Ahead of base: 1