### PR TITLE
Clarify local ship review side effects and authoritative completion routing

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -1120,7 +1120,7 @@
   {
     "active": true,
     "builtin": true,
-    "description": "Submit an explicit set of tasks to the ship workflow and return its durable run ID.",
+    "description": "Submit explicit tasks to the review-only ship workflow and return its durable run ID. This MCP tool does not accept completion authorization; an authorized operator on the owning host can use `orbit run ship <task-id> --complete`.",
     "enabled": true,
     "name": "orbit.workflow.ship",
     "parameters": [

--- a/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.plain.txt
@@ -23,5 +23,5 @@ orbit.workflow.run.list	-	List durable workflow runs newest-first with optional 
 orbit.workflow.run.resume	id:string	Resume a terminal resumable workflow run as a new linked run.
 orbit.workflow.run.show	id:string	Fetch one durable workflow run by ID.
 orbit.workflow.run.workers	id:string, concurrency:integer	Adjust how many tasks a running workspace drain keeps in flight, without replacing its run. The run ID, deadline, completion authorization, and already-dispatched children are preserved; a lower ceiling stops new admissions until enough children finish and cancels nothing.
-orbit.workflow.ship	task_ids:string|string[]	Submit an explicit set of tasks to the ship workflow and return its durable run ID.
+orbit.workflow.ship	task_ids:string|string[]	Submit explicit tasks to the review-only ship workflow and return its durable run ID. This MCP tool does not accept completion authorization; an authorized operator on the owning host can use `orbit run ship <task-id> --complete`.
 proc.spawn	program:string	Spawn a process with timeout and capture output

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1038,7 +1038,7 @@
     "name": "orbit_workflow_run_workers"
   },
   {
-    "description": "Submit an explicit set of tasks to the ship workflow and return its durable run ID.",
+    "description": "Submit explicit tasks to the review-only ship workflow and return its durable run ID. This MCP tool does not accept completion authorization; an authorized operator on the owning host can use `orbit run ship <task-id> --complete`.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
@@ -2,8 +2,10 @@
 
 ## Choose the requested delivery behavior
 
-Default shipping ends in `review`. It prepares a PR in PR mode; submission or
-PR creation does not prove a merge. Use `--complete` only when the user has
+Default shipping ends in `review`. In PR mode it prepares a PR and stops with it
+unmerged; submission or PR creation does not prove a merge. In local mode it
+may commit and merge to the configured base before the task reaches `review`,
+so review is not a pre-merge stop. Use `--complete` only when the user has
 authorized delivery through `done`:
 
 ```bash
@@ -18,9 +20,11 @@ authorization, omit `--complete`. If the user will start the drain themselves,
 prepare work without launching a second coordinator.
 
 Prefer the connected MCP submission tool when it supports the requested
-options. If its schema lacks completion, use an available authorized admin
-command surface on the same host; do not invent a `complete` argument or
-silently submit a review-only run. See
+options. `orbit_workflow_ship` intentionally has no completion input and always
+submits review-only work. If completion is authorized, use `orbit run ship
+<task-id> --complete` through an available authorized operator command surface
+on the owning host; do not invent a `completion` argument, silently submit a
+review-only run, or use a local shadow store. See
 [tool-surface.md](../../orbit/references/tool-surface.md).
 
 `--complete` is default-off and applies to that submitted run:

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -241,11 +241,13 @@ prose. An orchestrator that reads a summary paragraph instead of
 ## Delivery and completion
 
 By default the task pipelines end in `review`. PR mode prepares a source branch
-and opens a PR; that is not evidence it merged. Local mode implements in an
-isolated worktree and fast-forwards the configured local base branch; the leaf
-job's `auto_push` input controls its optional push. Inspect the effective wrapper
-and child job inputs rather than assuming local mode means the current checkout
-was edited or a remote branch was updated.
+and opens a PR, then stops with that PR unmerged unless `--complete` was
+authorized. Local mode implements in an isolated worktree and fast-forwards the
+configured local base branch before the task reaches `review`; the leaf job's
+`auto_push` input controls its optional push. Review is not a pre-merge stop in
+local mode. Inspect the effective wrapper and child job inputs rather than
+assuming local mode means the current checkout was edited or a remote branch was
+updated.
 
 Record validation, commit, branch/PR, and run evidence, then follow the user's
 approval policy for completion. Task snapshot publication is independent of

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -35,7 +35,7 @@ records in a second store merely to get past a connection error.
 | Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host |
 | Retrieval | `orbit_search` | `orbit search`; semantic install/index is separate |
 | Friction | `orbit_friction_add/list/update` | Additional show/stats/tags/resolve commands |
-| Submit explicit tasks | `orbit_workflow_ship` | `orbit run ship`, `run auto` |
+| Submit explicit tasks | `orbit_workflow_ship` (review-only; no completion input) | `orbit run ship`, `run auto` |
 | Observe/resume workflows | `orbit_workflow_run_show/list/resume` | `orbit run show/history/events/trace/logs/cancel`; job replay/resume |
 | Auto-tasks | `orbit_auto_task_list/mint` | Definition add/show/update/toggle are CLI operations; do not assume they are advertised over MCP |
 | Host commands | `orbit_command_exec` when advertised and authorized | Explicit argv and working directory, never a shell string |
@@ -80,6 +80,12 @@ evidence; inspect status and the recorded implementation/validation outcome.
 
 Use with `orbit_workflow_ship` only when execution is authorized. At least one
 explicit ID is required; MCP does not offer the CLI's no-ID discovery mode.
+It also intentionally accepts no completion authorization, so it always
+submits review-only work. When an authorized operator has access to the owning
+host, use `orbit run ship <task-id> --complete` there for a one-run completion
+authorization; do not use a local shadow store as a substitute. Otherwise
+report the MCP completion capability gap rather than inventing a `completion`
+argument.
 Read the returned run with `orbit_workflow_run_show` using `id` and `workspace`.
 List bounded history with `limit`, `job_id`, `state` (including `terminal`), and
 RFC3339 `since`. Submission success means a durable run exists, not that the

--- a/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
@@ -78,7 +78,7 @@ impl Tool for OrbitWorkflowShipTool {
         parameters.extend(super::model_identity_params());
         ToolSchema {
             name: "orbit.workflow.ship".to_string(),
-            description: "Submit an explicit set of tasks to the ship workflow and return its durable run ID."
+            description: "Submit explicit tasks to the review-only ship workflow and return its durable run ID. This MCP tool does not accept completion authorization; an authorized operator on the owning host can use `orbit run ship <task-id> --complete`."
                 .to_string(),
             parameters,
             builtin: true,

--- a/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
@@ -50,7 +50,7 @@ fn managed_run_rejects_dispatch_before_host_resolution() {
 }
 
 #[test]
-fn ship_schema_has_no_retired_review_controls() {
+fn ship_schema_is_review_only_and_has_no_retired_review_controls() {
     let schema = OrbitWorkflowShipTool.schema();
     let names = schema
         .parameters
@@ -60,6 +60,14 @@ fn ship_schema_has_no_retired_review_controls() {
 
     assert!(!names.contains(&"review"));
     assert!(!names.contains(&"review_crew"));
+    assert!(!names.contains(&"completion"));
+    assert!(schema.description.contains("review-only"));
+    assert!(schema.description.contains("does not accept completion"));
+    assert!(
+        schema
+            .description
+            .contains("orbit run ship <task-id> --complete")
+    );
 }
 
 #[test]

--- a/plugin/skills/orbit-orchestrate/references/authorization.md
+++ b/plugin/skills/orbit-orchestrate/references/authorization.md
@@ -2,8 +2,10 @@
 
 ## Choose the requested delivery behavior
 
-Default shipping ends in `review`. It prepares a PR in PR mode; submission or
-PR creation does not prove a merge. Use `--complete` only when the user has
+Default shipping ends in `review`. In PR mode it prepares a PR and stops with it
+unmerged; submission or PR creation does not prove a merge. In local mode it
+may commit and merge to the configured base before the task reaches `review`,
+so review is not a pre-merge stop. Use `--complete` only when the user has
 authorized delivery through `done`:
 
 ```bash
@@ -18,9 +20,11 @@ authorization, omit `--complete`. If the user will start the drain themselves,
 prepare work without launching a second coordinator.
 
 Prefer the connected MCP submission tool when it supports the requested
-options. If its schema lacks completion, use an available authorized admin
-command surface on the same host; do not invent a `complete` argument or
-silently submit a review-only run. See
+options. `orbit_workflow_ship` intentionally has no completion input and always
+submits review-only work. If completion is authorized, use `orbit run ship
+<task-id> --complete` through an available authorized operator command surface
+on the owning host; do not invent a `completion` argument, silently submit a
+review-only run, or use a local shadow store. See
 [tool-surface.md](../../orbit/references/tool-surface.md).
 
 `--complete` is default-off and applies to that submitted run:

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -241,11 +241,13 @@ prose. An orchestrator that reads a summary paragraph instead of
 ## Delivery and completion
 
 By default the task pipelines end in `review`. PR mode prepares a source branch
-and opens a PR; that is not evidence it merged. Local mode implements in an
-isolated worktree and fast-forwards the configured local base branch; the leaf
-job's `auto_push` input controls its optional push. Inspect the effective wrapper
-and child job inputs rather than assuming local mode means the current checkout
-was edited or a remote branch was updated.
+and opens a PR, then stops with that PR unmerged unless `--complete` was
+authorized. Local mode implements in an isolated worktree and fast-forwards the
+configured local base branch before the task reaches `review`; the leaf job's
+`auto_push` input controls its optional push. Review is not a pre-merge stop in
+local mode. Inspect the effective wrapper and child job inputs rather than
+assuming local mode means the current checkout was edited or a remote branch was
+updated.
 
 Record validation, commit, branch/PR, and run evidence, then follow the user's
 approval policy for completion. Task snapshot publication is independent of

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -35,7 +35,7 @@ records in a second store merely to get past a connection error.
 | Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host |
 | Retrieval | `orbit_search` | `orbit search`; semantic install/index is separate |
 | Friction | `orbit_friction_add/list/update` | Additional show/stats/tags/resolve commands |
-| Submit explicit tasks | `orbit_workflow_ship` | `orbit run ship`, `run auto` |
+| Submit explicit tasks | `orbit_workflow_ship` (review-only; no completion input) | `orbit run ship`, `run auto` |
 | Observe/resume workflows | `orbit_workflow_run_show/list/resume` | `orbit run show/history/events/trace/logs/cancel`; job replay/resume |
 | Auto-tasks | `orbit_auto_task_list/mint` | Definition add/show/update/toggle are CLI operations; do not assume they are advertised over MCP |
 | Host commands | `orbit_command_exec` when advertised and authorized | Explicit argv and working directory, never a shell string |
@@ -80,6 +80,12 @@ evidence; inspect status and the recorded implementation/validation outcome.
 
 Use with `orbit_workflow_ship` only when execution is authorized. At least one
 explicit ID is required; MCP does not offer the CLI's no-ID discovery mode.
+It also intentionally accepts no completion authorization, so it always
+submits review-only work. When an authorized operator has access to the owning
+host, use `orbit run ship <task-id> --complete` there for a one-run completion
+authorization; do not use a local shadow store as a substitute. Otherwise
+report the MCP completion capability gap rather than inventing a `completion`
+argument.
 Read the returned run with `orbit_workflow_run_show` using `id` and `workspace`.
 List bounded history with `limit`, `job_id`, `state` (including `terminal`), and
 RFC3339 `since`. Submission success means a durable run exists, not that the

--- a/website/src/content/docs/getting-started/workflows.md
+++ b/website/src/content/docs/getting-started/workflows.md
@@ -36,9 +36,13 @@ orbit run ship "$TASK_ID" "$SECOND_TASK_ID" --mode local
 orbit run ship "$TASK_ID" --base main
 ```
 
-`--mode pr` (the default) opens or updates a pull request. `--mode local`
-delivers in place. When you omit `--mode`, the mode comes from the workspace's
-registry entry, falling back to `pr`.
+`--mode pr` (the default) opens or updates a pull request, then stops with the
+task in `review` and the PR unmerged unless you authorize `--complete`.
+`--mode local` delivers in place: it commits and merges to the configured base
+before the task reaches `review`, and may push that base as part of the same
+delivery. `review` is therefore not a pre-merge stop in local mode. When you
+omit `--mode`, the mode comes from the workspace's registry entry, falling back
+to `pr`.
 
 Underlying job: `task_auto_pipeline`, which fans into `task_gate_pipeline` and
 then routes to `task_pr_pipeline` or `task_local_pipeline`.
@@ -117,9 +121,11 @@ unattended routine — including `orbit run ship-sweep` — turns it on.
 
 What the run then does depends on the mode:
 
-- **`--mode local`** — the task reaches `done` only after the bundle has
-  committed, merged, and pushed. A failed merge or push fails the run with the
-  task still in `review`.
+- **`--mode local`** — without `--complete`, the bundle can commit and merge
+  before it reaches `review`; its optional push is still part of delivery, not
+  a review gate. With `--complete`, the task reaches `done` only after the
+  bundle has committed, merged, and pushed. A failed merge or push fails the
+  run with the task still in `review`.
 - **`--mode pr`** — the run opens or reuses the PR as usual, then merges it
   through GitHub. Branch protections and required checks are respected; Orbit
   never uses an administrative bypass. If required checks are still running it


### PR DESCRIPTION
## Task

[ORB-11362](https://orbit-cli.com/tasks/ORB-11362) — Clarify local ship review side effects and authoritative completion routing

### Description

Operational issue encountered while orchestrating Daniel's scientific work. The orchestrator incorrectly treated completion=review as a pre-merge stop. Actual task_local_pipeline.yaml commits, merges and optionally pushes before mark_review/push completion finishes; completion=done only adds task_complete after delivery. ORB-11352 run jrun-20260906-0104-3 landed 13866b2848fbcce9a1f1ef2d4b97051a65f7e626 and ORB-11350 run jrun-20260906-0051-3 landed f95ec6a6a5b0e0aceddcd67bbbf895c2858e3c0c while task status remained review. Both runs had auto_push=true and completion=review. This was a caller misunderstanding of current semantics, not evidence of a pipeline bypassing its implementation. Daniel subsequently explicitly authorized --complete / automatic merge and completion, and both delivered tasks were independently verified and approved to done.

A related current routing gap: OrbitWorkflowShipTool advertises task_ids/mode/base/claim_token, but no completion input. adapter/tool_host/workflow_tools.rs::ship explicitly hardcodes CompletionPolicy::Review with a comment that completion belongs to CLI. The skill says default shipping ends in review without making local Git side effects equally prominent, making --complete easy to mistake for the merge-authorization boundary. Do not silently change local delivery behavior or add unapproved automatic completion. Make help, tool descriptions and canonical orbit/orbit-orchestrate references accurately distinguish local delivery, PR review, task review status and task done status; explain a verified authoritative on-host CLI route for operator-authorized --complete where MCP lacks the field, or explicitly report that capability gap. Preserve user approval boundaries and avoid suggesting a Mac-local shadow CLI.

Orchestrator correction: verify effective job/mode/side effects before dispatch; agent prose requesting no merge cannot override deterministic pipeline steps. Worker .git read-only commit failures were expected isolation; successful deterministic commit/merge/push was verified independently. Attempted running-run cancellation was rejected by the app's automatic approval review and no cancellation occurred; no workaround followed. Record these as distinct layers, not generic failed execution.

### Acceptance Criteria

- Current user-facing ship guidance explicitly says local mode may merge/push before review, PR mode stops at an unmerged PR absent completion authorization, and --complete adds authorized delivery/completion behavior as actually implemented.
- MCP schema/capability documentation accurately reflects whether completion is accepted, and provides a tested authoritative operator route or explicit gap without local-shadow-store fallback.
- Update canonical skills and plugin mirrors together where touched; verify examples against installed/current help and actual workflow definitions. Do not change approval policy or pipeline defaults as a documentation fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Clarified that local shipment merges before review while PR shipment remains unmerged without --complete, and documented --complete delivery semantics.
- Marked MCP ship as review-only with no completion input; documented the authorized owning-host CLI route and no-shadow-store rule.
- Synchronized canonical skill assets with plugin mirrors and regenerated tool-list/MCP schema fixtures.
Assessment: Focused schema coverage and generated contracts confirm the documented capability boundary. No approval policy, pipeline default, or delivery behavior changed.
Validation:
- cargo test -p orbit-tools workflow::tests::ship_schema_is_review_only_and_has_no_retired_review_controls
- cargo test -p orbit-cli --test output_goldens
- cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot
- make ci-fast
- make ci-lint
Friction checkpoint: no qualifying friction observed.
Cleanup: cargo clean removed 6.5 GiB of target artifacts created during this run.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11362-6a9cc137`
- Behind base: 0
- Ahead of base: 1