### PR TITLE
Select the terminal Codex answer without concatenating progress messages

### DIFF
--- a/crates/orbit-agent/src/providers/codex/codex_output.rs
+++ b/crates/orbit-agent/src/providers/codex/codex_output.rs
@@ -1,9 +1,9 @@
 //! Projects Codex CLI JSONL onto completed assistant answer text.
 //!
 //! `codex exec --json` interleaves assistant messages with reasoning, command
-//! executions, and usage events. Only completed `agent_message` item text is
-//! an assistant answer; every other event remains raw invocation telemetry but
-//! must not become Orbit response/status evidence. [ORB-11348]
+//! executions, and usage events. The terminal completed `agent_message` item
+//! text is the assistant answer; every other event remains raw invocation
+//! telemetry but must not become Orbit response/status evidence. [ORB-11348]
 
 /// Return answer-only bytes when `stdout` is a recognized Codex JSONL stream.
 ///
@@ -12,7 +12,7 @@
 pub(crate) fn project_codex_response(stdout: &[u8]) -> Option<Vec<u8>> {
     let text = String::from_utf8_lossy(stdout);
     let mut saw_codex_event = false;
-    let mut answer = String::new();
+    let mut terminal_answer = None;
 
     for line in text.lines() {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
@@ -34,18 +34,16 @@ pub(crate) fn project_codex_response(stdout: &[u8]) -> Option<Vec<u8>> {
         {
             continue;
         }
-        let Some(message) = value
+        let message = value
             .pointer("/item/text")
             .and_then(serde_json::Value::as_str)
-            .filter(|message| !message.is_empty())
-        else {
-            continue;
-        };
-        answer.push_str(message);
-        answer.push('\n');
+            .unwrap_or_default();
+        // A later empty or malformed answer must not let an earlier envelope
+        // become authoritative. The response parser owns validation.
+        terminal_answer = Some(message.as_bytes().to_vec());
     }
 
-    saw_codex_event.then(|| answer.into_bytes())
+    saw_codex_event.then(|| terminal_answer.unwrap_or_default())
 }
 
 fn is_codex_event(event_type: &str) -> bool {

--- a/crates/orbit-agent/src/providers/codex/tests/codex_output.rs
+++ b/crates/orbit-agent/src/providers/codex/tests/codex_output.rs
@@ -38,6 +38,37 @@ fn final_agent_message_after_tool_traffic_is_the_only_projected_content() {
 }
 
 #[test]
+fn terminal_agent_message_replaces_earlier_commentary() {
+    let stdout = concat!(
+        r#"{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"Commentary: I inspected the task."}}"#,
+        "\n",
+        r#"{"type":"item.completed","item":{"id":"item-8","type":"agent_message","text":"Commentary: I updated the files."}}"#,
+        "\n",
+        r#"{"type":"item.completed","item":{"id":"item-12","type":"agent_message","text":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"terminal\"},\"error\":null}"}}"#,
+        "\n",
+        r#"{"type":"turn.completed","usage":{"input_tokens":21,"output_tokens":8}}"#,
+        "\n",
+    );
+
+    assert_eq!(
+        projected(stdout),
+        r#"{"schemaVersion":1,"status":"success","result":{"source":"terminal"},"error":null}"#
+    );
+}
+
+#[test]
+fn malformed_terminal_agent_message_does_not_retain_an_earlier_envelope() {
+    let stdout = concat!(
+        r#"{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"earlier\"},\"error\":null}"}}"#,
+        "\n",
+        r#"{"type":"item.completed","item":{"id":"item-2","type":"agent_message","text":"not valid JSON"}}"#,
+        "\n",
+    );
+
+    assert_eq!(projected(stdout), "not valid JSON");
+}
+
+#[test]
 fn non_event_output_preserves_the_existing_direct_envelope_fallback() {
     let envelope = r#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#;
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -159,7 +159,9 @@ fn run_cli_backend_projects_codex_final_answer_and_keeps_raw_trace() {
         concat!(
             "#!/bin/sh\ncat > /dev/null\n",
             "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-0\",\"type\":\"command_execution\",\"command\":\"read fixture\",\"aggregated_output\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"failed\\\",\\\"result\\\":{},\\\"error\\\":{\\\"code\\\":\\\"fixture\\\",\\\"message\\\":\\\"tool-output\\\"}}\",\"exit_code\":0,\"status\":\"completed\"}}'\n",
-            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"source\\\":\\\"assistant\\\"},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"Commentary: I inspected the task.\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-8\",\"type\":\"agent_message\",\"text\":\"Commentary: I updated the files.\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-12\",\"type\":\"agent_message\",\"text\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"source\\\":\\\"assistant\\\"},\\\"error\\\":null}\"}}'\n",
             "printf '%s\\n' '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":101,\"cached_input_tokens\":11,\"output_tokens\":9}}'\n",
         ),
     );
@@ -202,6 +204,45 @@ fn run_cli_backend_projects_codex_final_answer_and_keeps_raw_trace() {
             .is_some_and(|stdout| stdout.contains("tool-output")),
         "raw stdout remains available for diagnostics"
     );
+}
+
+#[test]
+fn run_cli_backend_rejects_an_invalid_terminal_codex_answer() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{\\\"source\\\":\\\"earlier\\\"},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"id\":\"item-2\",\"type\":\"agent_message\",\"text\":\"not valid JSON\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":21,\"output_tokens\":8}}'\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-codex-invalid-terminal-answer",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let spec = test_agent_loop_spec(Duration::from_secs(5));
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-codex-invalid-terminal-answer",
+        audit,
+        &serde_json::json!({"prompt": "read then answer"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["response_envelope_valid"], false);
+    assert!(outcome.output.get("source").is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11363](https://orbit-cli.com/tasks/ORB-11363) — Select the terminal Codex answer without concatenating progress messages

### Description

Mac ws_kvdb task_pilot_pipeline jrun-20260906-0112 exited 0 but event v2evt-jrun-20260906-0112-00000010 failed response parsing: stdout is not valid JSON expected value at line 1 column 1. Recorded completed agent_message items item_1 and item_8 are prose progress; terminal item_12 is independently valid schemaVersion:1,status:success JSON for DANI-10244. Replaying their concatenation reproduces Unexpected token I. Current source 737564f5 (ORB-11348) providers/codex/codex_output.rs:44-45 appends every completed agent_message. cli_runner/orchestrator.rs:445 passes that to strict envelope.rs parsing. Mac binary /Users/daniel/.cargo/bin/orbit reports0.18.0; exact installed build SHA is unproven. Complete final item and turn.completed were captured; no evidence of truncation. Fix terminal assistant answer selection at provider projection seam, preserving raw telemetry. Do not scan backward for any valid JSON to mask an invalid final response. Separate dsearch same-numbered run actually emitted malformed final JSON and is not evidence for this bug. Targeted retry0117 succeeded but defect remains. All-status recent dedupe found predecessor ORB-11348 done, no open matching repair.

### Acceptance Criteria

- Two commentary agent_message items followed by valid terminal envelope parse as the final envelope through the real provider/response seam.
- Earlier valid-looking envelope followed by malformed final answer remains a failure; tool output never supplies an answer.
- Preserve raw telemetry and supported direct-envelope fallback; focused regression tests and required Orbit checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Codex JSONL projection now retains only the terminal completed agent_message, so commentary cannot corrupt the response envelope.
- A terminal empty, missing, or malformed assistant answer replaces any earlier envelope and is left for the response parser to reject.
- Added provider and real CLI-runner regressions for commentary before a valid terminal envelope and for an invalid terminal answer after an earlier valid envelope.
Assessment: The projection boundary now selects one authoritative terminal response while raw stdout telemetry and direct-envelope fallback remain unchanged.
Validation:
- cargo test -p orbit-agent codex_output --lib
- cargo test -p orbit-engine run_cli_backend_projects_codex_final_answer_and_keeps_raw_trace --lib
- cargo test -p orbit-engine run_cli_backend_rejects_an_invalid_terminal_codex_answer --lib
- make ci-fast
- make ci-lint
Cleanup note: build output under target/ was created during validation. Recoverable cleanup via gio trash was denied because the trash directory is read-only; it remains ignored and outside the task diff.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11363-6a9cc486`
- Behind base: 0
- Ahead of base: 1