### PR TITLE
Add an interactive executor and crew setup explorer to the website

### DIFF
--- a/website/src/content/docs/concepts/agents.md
+++ b/website/src/content/docs/concepts/agents.md
@@ -1,8 +1,174 @@
 ---
 title: Agents
-description: "How Orbit invokes coding agents through CLI and HTTP runtimes."
+description: "How Orbit invokes coding agents through provider CLIs, which executors ship today, and how to write a crew for one."
 sidebar:
   order: 6
+head:
+  - tag: style
+    content: |
+      .orbit-setup-explorer {
+        --ose-line: var(--sl-color-hairline-light);
+        max-width: 100%;
+        margin: 1.5rem 0 2rem;
+        padding: 1.1rem;
+        border: 1px solid var(--ose-line);
+        border-radius: 10px;
+        background: var(--sl-color-bg);
+      }
+      .orbit-setup-explorer * { min-width: 0; }
+      .ose-field { margin: 0 0 1.1rem; padding: 0; border: 0; }
+      .ose-field > legend {
+        margin-bottom: 0.5rem;
+        padding: 0;
+        font-size: var(--sl-text-sm);
+        font-weight: 600;
+        color: var(--sl-color-white);
+      }
+      .ose-lede {
+        margin: 0 0 1rem;
+        font-size: var(--sl-text-sm);
+        line-height: 1.6;
+        color: var(--sl-color-gray-3);
+      }
+      .ose-choices { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+      .ose-choice { position: relative; display: inline-flex; }
+      .ose-choice input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: 0;
+        opacity: 0;
+        pointer-events: none;
+      }
+      .ose-choice label {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 0.4rem;
+        padding: 0.35rem 0.75rem;
+        border: 1px solid var(--ose-line);
+        border-radius: 999px;
+        background: var(--sl-color-bg-inline-code);
+        color: var(--sl-color-gray-2);
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-text-xs);
+        line-height: 1.5;
+        cursor: pointer;
+      }
+      .ose-choice label:hover { border-color: var(--sl-color-gray-4); }
+      .ose-choice input:checked + label {
+        border-color: var(--sl-color-text-accent);
+        background: var(--sl-color-accent-low);
+        color: var(--sl-color-white);
+      }
+      .ose-choice input:focus-visible + label {
+        outline: 2px solid var(--sl-color-text-accent);
+        outline-offset: 2px;
+      }
+      .ose-choice-note {
+        font-family: var(--sl-font);
+        font-size: 0.7rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--sl-color-gray-3);
+      }
+      .ose-panel {
+        display: none;
+        padding-top: 1.1rem;
+        border-top: 1px solid var(--ose-line);
+      }
+      .orbit-setup-explorer:has(#ose-p-claude:checked) #ose-panel-claude,
+      .orbit-setup-explorer:has(#ose-p-codex:checked) #ose-panel-codex,
+      .orbit-setup-explorer:has(#ose-p-antigravity:checked) #ose-panel-antigravity,
+      .orbit-setup-explorer:has(#ose-p-gemini:checked) #ose-panel-gemini,
+      .orbit-setup-explorer:has(#ose-p-grok:checked) #ose-panel-grok,
+      .orbit-setup-explorer:has(#ose-p-copilot:checked) #ose-panel-copilot,
+      .orbit-setup-explorer:has(#ose-p-cursor:checked) #ose-panel-cursor,
+      .orbit-setup-explorer:has(#ose-p-pi:checked) #ose-panel-pi,
+      .orbit-setup-explorer:has(#ose-p-opencode:checked) #ose-panel-opencode { display: block; }
+      .ose-facts {
+        display: grid;
+        grid-template-columns: max-content minmax(0, 1fr);
+        gap: 0.35rem 1.1rem;
+        margin: 0 0 1.1rem;
+        font-size: var(--sl-text-sm);
+      }
+      .ose-facts dt { color: var(--sl-color-gray-3); }
+      .ose-facts dd {
+        margin: 0;
+        color: var(--sl-color-white);
+        overflow-wrap: anywhere;
+      }
+      .ose-facts code, .ose-note code, .ose-lede code {
+        padding: 0.1rem 0.3rem;
+        border-radius: 4px;
+        background: var(--sl-color-bg-inline-code);
+        font-family: var(--sl-font-mono);
+        font-size: 0.9em;
+      }
+      .ose-code {
+        margin: 0;
+        padding: 0.85rem 1rem;
+        overflow-x: auto;
+        border: 1px solid var(--ose-line);
+        border-radius: 8px;
+        background: var(--sl-color-bg-inline-code);
+        color: var(--sl-color-white);
+        font-family: var(--sl-font-mono);
+        font-size: var(--sl-text-xs);
+        line-height: 1.6;
+      }
+      .ose-code code {
+        padding: 0;
+        border: 0;
+        background: none;
+        font: inherit;
+        color: inherit;
+      }
+      .ose-eff { display: none; }
+      .ose-panel:has(.ose-eff-radio[value="low"]:checked) .ose-eff[data-effort="low"],
+      .ose-panel:has(.ose-eff-radio[value="medium"]:checked) .ose-eff[data-effort="medium"],
+      .ose-panel:has(.ose-eff-radio[value="high"]:checked) .ose-eff[data-effort="high"],
+      .ose-panel:has(.ose-eff-radio[value="xhigh"]:checked) .ose-eff[data-effort="xhigh"],
+      .ose-panel:has(.ose-eff-radio[value="max"]:checked) .ose-eff[data-effort="max"] { display: inline; }
+      .ose-actions {
+        display: none;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+        margin-top: 0.7rem;
+      }
+      .ose-js .ose-actions { display: flex; }
+      .ose-copy {
+        padding: 0.35rem 0.85rem;
+        border: 1px solid var(--ose-line);
+        border-radius: 6px;
+        background: var(--sl-color-bg);
+        color: var(--sl-color-gray-2);
+        font-family: var(--sl-font);
+        font-size: var(--sl-text-xs);
+        cursor: pointer;
+      }
+      .ose-copy:hover { border-color: var(--sl-color-text-accent); color: var(--sl-color-white); }
+      .ose-copy:focus-visible { outline: 2px solid var(--sl-color-text-accent); outline-offset: 2px; }
+      .ose-status { font-size: var(--sl-text-xs); color: var(--sl-color-gray-3); }
+      .ose-status[data-state="error"] { color: var(--sl-color-text-accent); }
+      .ose-note {
+        margin: 1rem 0 0;
+        padding: 0.6rem 0.85rem;
+        border-left: 3px solid var(--sl-color-hairline);
+        border-radius: 0 6px 6px 0;
+        background: var(--sl-color-bg-inline-code);
+        font-size: var(--sl-text-sm);
+        line-height: 1.6;
+        color: var(--sl-color-gray-2);
+      }
+      .ose-note p { margin: 0 0 0.5rem; }
+      .ose-note p:last-child { margin-bottom: 0; }
+      @media (max-width: 30rem) {
+        .orbit-setup-explorer { padding: 0.85rem; }
+        .ose-facts { grid-template-columns: minmax(0, 1fr); gap: 0.1rem; }
+        .ose-facts dt { margin-top: 0.55rem; }
+      }
 ---
 
 ## Runtime Paths
@@ -19,18 +185,409 @@ agent.
 
 ## Providers
 
-Canonical provider values are:
+A **provider** is a canonical agent family id. An **executor** is the shipped
+spawn recipe — command, static flags, output format, sandbox backend — that
+Orbit uses to run that family. The two are separate: a provider id can be
+recognized by Orbit without a CLI executor existing for it, and one executor
+(`local-shell`) runs no agent at all.
 
-- `claude`
-- `codex`
-- `gemini`
-- `grok`
-- `ollama`
-- `openai_compat`
+Every canonical provider id, and what it can actually execute today:
 
-CLI execution is available for `claude`, `codex`, `gemini`, and `grok`.
-Transport support is provider-specific; selecting an unsupported
-provider fails instead of silently switching providers.
+| Provider | Executor command | Reasoning `effort` | Status |
+|---|---|---|---|
+| `claude` | `claude` | `low`–`max`, via `--effort` | Active |
+| `codex` | `codex exec` | `low`–`max`, via `--config model_reasoning_effort` | Active |
+| `antigravity` | `agy` | `low`, `medium`, `high`, via `--effort` | Active |
+| `grok` | `grok` | Model-specific, via `--reasoning-effort` | Active |
+| `copilot` | `copilot` | Not supported | Active |
+| `cursor` | `cursor-agent` | Not supported | Active |
+| `pi` | `pi` | `low`–`max`, via `--thinking` | Active |
+| `opencode` | `opencode run` | `high`, `max`, via `--variant` | Active |
+| `gemini` | `gemini` | Not supported | Legacy |
+| `ollama` | — | Not supported | No shipped crew or executor |
+| `openai_compat` | — | Not supported | No CLI runtime; dispatch fails |
+
+`openai_compat` has no CLI runtime, so dispatching to it fails structurally
+instead of falling back to another family. `ollama` is a recognized provider
+id, but Orbit ships no `ollama` executor definition and no `ollama` crew, and
+`orbit init` never seeds one — nothing gives it a headless agent contract.
+Neither id is rewritten: a crew naming one loads, and the refusal comes at
+dispatch rather than the run being quietly re-pointed at a family that does
+have an executor.
+
+Orbit ships one more executor, **`local-shell`**, which is not a provider. It
+runs deterministic local commands for `local_shell` steps and carries no model,
+prompt, or agent tool authority, so it is never named by a crew. Unlike the
+agent executors it declares no sandbox by default; see
+[Platform Support](#platform-support).
+
+### Deprecated aliases
+
+Five legacy vendor spellings still resolve, and keep resolving so persisted
+identities are never broken — but they are deprecated and emit a warning:
+
+| Alias | Resolves to |
+|---|---|
+| `anthropic` | `claude` |
+| `openai`, `chatgpt` | `codex` |
+| `google` | `gemini` |
+| `xai` | `grok` |
+
+`openai-compat` is an accepted, non-deprecated spelling of `openai_compat`. The
+alias table is closed: any other string is an unknown provider and is rejected
+rather than guessed at. In particular, the model vendor named *inside* a Pi or
+OpenCode run (`pi --provider anthropic`, `opencode --model anthropic/...`) is
+not an Orbit provider id and never re-points the run at another execution lane.
+
+## Set up an executor
+
+Pick an executor to see what it needs and a starter crew you can paste into
+`config.toml`. Every snippet below is a complete example file and is selectable
+whether or not JavaScript is enabled; the Copy button is an enhancement.
+
+<div class="orbit-setup-explorer not-content">
+<p class="ose-lede">These are <strong>examples</strong>, not availability guarantees. Orbit passes the <code>model</code> string to the provider CLI verbatim — whether your account can actually run it is between you and that provider. Orbit does not read, store, or send credentials; authenticate each CLI with its own vendor instructions first.</p>
+<fieldset class="ose-field">
+<legend>1. Executor</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-claude" value="claude" checked><label for="ose-p-claude">claude</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-codex" value="codex"><label for="ose-p-codex">codex</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-antigravity" value="antigravity"><label for="ose-p-antigravity">antigravity</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-grok" value="grok"><label for="ose-p-grok">grok</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-copilot" value="copilot"><label for="ose-p-copilot">copilot</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-cursor" value="cursor"><label for="ose-p-cursor">cursor</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-pi" value="pi"><label for="ose-p-pi">pi</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-opencode" value="opencode"><label for="ose-p-opencode">opencode</label></span>
+<span class="ose-choice"><input type="radio" name="ose-provider" id="ose-p-gemini" value="gemini"><label for="ose-p-gemini">gemini <span class="ose-choice-note">legacy</span></label></span>
+</div>
+</fieldset>
+<div class="ose-panel" id="ose-panel-claude">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>claude</code></dd>
+<dt>Example model</dt><dd><code>opus</code></dd>
+<dt>Reasoning effort</dt><dd>Supported — the full crew vocabulary, rendered as <code>claude --effort &lt;value&gt;</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-none" value="none" checked><label for="ose-e-claude-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-low" value="low"><label for="ose-e-claude-low">low</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-medium" value="medium"><label for="ose-e-claude-medium">medium</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-high" value="high"><label for="ose-e-claude-high">high</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-xhigh" value="xhigh"><label for="ose-e-claude-xhigh">xhigh</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-claude" id="ose-e-claude-max" value="max"><label for="ose-e-claude-max">max</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "opus"
+
+[crews.opus]
+provider = "claude"
+model = "opus"
+<span class="ose-eff" data-effort="low">effort = "low"
+</span><span class="ose-eff" data-effort="medium">effort = "medium"
+</span><span class="ose-eff" data-effort="high">effort = "high"
+</span><span class="ose-eff" data-effort="xhigh">effort = "xhigh"
+</span><span class="ose-eff" data-effort="max">effort = "max"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>Omitting <code>effort</code> leaves the model's own default alone — Orbit passes no effort argument at all.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-codex">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>codex</code></dd>
+<dt>Example model</dt><dd><code>gpt-5.6-sol</code></dd>
+<dt>Reasoning effort</dt><dd>Supported — the full crew vocabulary, rendered as <code>codex exec --config model_reasoning_effort="&lt;value&gt;"</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-none" value="none" checked><label for="ose-e-codex-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-low" value="low"><label for="ose-e-codex-low">low</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-medium" value="medium"><label for="ose-e-codex-medium">medium</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-high" value="high"><label for="ose-e-codex-high">high</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-xhigh" value="xhigh"><label for="ose-e-codex-xhigh">xhigh</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-codex" id="ose-e-codex-max" value="max"><label for="ose-e-codex-max">max</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "sol"
+
+[crews.sol]
+provider = "codex"
+model = "gpt-5.6-sol"
+<span class="ose-eff" data-effort="low">effort = "low"
+</span><span class="ose-eff" data-effort="medium">effort = "medium"
+</span><span class="ose-eff" data-effort="high">effort = "high"
+</span><span class="ose-eff" data-effort="xhigh">effort = "xhigh"
+</span><span class="ose-eff" data-effort="max">effort = "max"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>Codex sandbox mode and approval policy are separate settings — see <a href="../../reference/config/#settable-keys"><code>execution.codex.*</code></a>.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-antigravity">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>agy</code></dd>
+<dt>Example model</dt><dd><code>gemini-3.8-flash-high</code></dd>
+<dt>Reasoning effort</dt><dd>Supported for <code>low</code>, <code>medium</code>, <code>high</code> only, rendered as <code>agy --effort &lt;value&gt;</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-antigravity" id="ose-e-antigravity-none" value="none" checked><label for="ose-e-antigravity-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-antigravity" id="ose-e-antigravity-low" value="low"><label for="ose-e-antigravity-low">low</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-antigravity" id="ose-e-antigravity-medium" value="medium"><label for="ose-e-antigravity-medium">medium</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-antigravity" id="ose-e-antigravity-high" value="high"><label for="ose-e-antigravity-high">high</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "antigravity"
+
+[crews.antigravity]
+provider = "antigravity"
+model = "gemini-3.8-flash-high"
+<span class="ose-eff" data-effort="low">effort = "low"
+</span><span class="ose-eff" data-effort="medium">effort = "medium"
+</span><span class="ose-eff" data-effort="high">effort = "high"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p><code>xhigh</code> and <code>max</code> are deliberately absent: <code>agy --effort</code> does not define them, and Orbit rejects the config rather than quietly downgrading to <code>high</code>.</p><p>Antigravity model ids carry their own effort suffix and must come from <code>agy models</code>. A bare Gemini CLI id such as <code>gemini-3.8-flash</code> is rejected at config load — it is not rewritten into a suffixed slug.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-grok">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>grok</code></dd>
+<dt>Example model</dt><dd><code>grok-4.6</code></dd>
+<dt>Reasoning effort</dt><dd>Supported per model, rendered as <code>grok --reasoning-effort &lt;value&gt;</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort for <code>grok-4.6</code> (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-grok" id="ose-e-grok-none" value="none" checked><label for="ose-e-grok-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-grok" id="ose-e-grok-low" value="low"><label for="ose-e-grok-low">low</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-grok" id="ose-e-grok-medium" value="medium"><label for="ose-e-grok-medium">medium</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-grok" id="ose-e-grok-high" value="high"><label for="ose-e-grok-high">high</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-grok" id="ose-e-grok-xhigh" value="xhigh"><label for="ose-e-grok-xhigh">xhigh</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "grok"
+
+[crews.grok]
+provider = "grok"
+model = "grok-4.6"
+<span class="ose-eff" data-effort="low">effort = "low"
+</span><span class="ose-eff" data-effort="medium">effort = "medium"
+</span><span class="ose-eff" data-effort="high">effort = "high"
+</span><span class="ose-eff" data-effort="xhigh">effort = "xhigh"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>Grok effort is the one model-specific case. This picker shows the <code>grok-4.6</code> set; <code>grok-4.5</code> accepts <code>low</code>, <code>medium</code>, <code>high</code> and rejects <code>xhigh</code>.</p><p>Effort is verified only for those two models. Setting <code>effort</code> alongside any other Grok model — or alongside no model at all — fails config load instead of being sent to a CLI that might reinterpret it.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-copilot">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>copilot</code> (npm <code>@github/copilot</code>)</dd>
+<dt>Example model</dt><dd><code>claude-sonnet-4.5</code></dd>
+<dt>Reasoning effort</dt><dd>Not supported.</dd>
+</dl>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "copilot"
+
+[crews.copilot]
+provider = "copilot"
+model = "claude-sonnet-4.5"
+</code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>No effort picker is shown because Orbit has no verified Copilot effort contract. Adding <code>effort</code> to this crew fails config load with <em>provider 'copilot' does not support configured reasoning effort</em> — the key is never silently dropped.</p><p>The retired <code>gh-copilot</code> gh extension is a different tool and is not an Orbit executor.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-cursor">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>cursor-agent</code></dd>
+<dt>Example model</dt><dd><code>gpt-5</code></dd>
+<dt>Reasoning effort</dt><dd>Not supported.</dd>
+</dl>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "cursor"
+
+[crews.cursor]
+provider = "cursor"
+model = "gpt-5"
+</code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>Adding <code>effort</code> to this crew fails config load rather than being ignored.</p><p>Orbit dispatches to the standalone headless <code>cursor-agent</code> binary. Having the Cursor editor installed is not evidence that this executable is on <code>PATH</code>.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-pi">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>pi</code> (npm <code>@earendil-works/pi-coding-agent</code>)</dd>
+<dt>Example model</dt><dd><code>sonnet</code></dd>
+<dt>Reasoning effort</dt><dd>Supported — the full crew vocabulary, rendered as <code>pi --thinking &lt;value&gt;</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-none" value="none" checked><label for="ose-e-pi-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-low" value="low"><label for="ose-e-pi-low">low</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-medium" value="medium"><label for="ose-e-pi-medium">medium</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-high" value="high"><label for="ose-e-pi-high">high</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-xhigh" value="xhigh"><label for="ose-e-pi-xhigh">xhigh</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-pi" id="ose-e-pi-max" value="max"><label for="ose-e-pi-max">max</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "pi"
+
+[crews.pi]
+provider = "pi"
+model = "sonnet"
+<span class="ose-eff" data-effort="low">effort = "low"
+</span><span class="ose-eff" data-effort="medium">effort = "medium"
+</span><span class="ose-eff" data-effort="high">effort = "high"
+</span><span class="ose-eff" data-effort="xhigh">effort = "xhigh"
+</span><span class="ose-eff" data-effort="max">effort = "max"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p>Pi's <code>--thinking</code> vocabulary is model-independent and a strict superset of Orbit's, so the whole crew set is accepted here.</p><p>Pi's own <code>--provider</code> flag names the model vendor <em>inside</em> a Pi run. It is not an Orbit provider: <code>provider = "pi"</code> is what selects this lane.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-opencode">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>opencode</code></dd>
+<dt>Example model</dt><dd><code>anthropic/claude-sonnet-4-5</code></dd>
+<dt>Reasoning effort</dt><dd>Supported for <code>high</code> and <code>max</code> only, rendered as <code>opencode run --variant &lt;value&gt;</code>.</dd>
+</dl>
+<fieldset class="ose-field">
+<legend>2. Reasoning effort (optional)</legend>
+<div class="ose-choices">
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-opencode" id="ose-e-opencode-none" value="none" checked><label for="ose-e-opencode-none">omit</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-opencode" id="ose-e-opencode-high" value="high"><label for="ose-e-opencode-high">high</label></span>
+<span class="ose-choice"><input class="ose-eff-radio" type="radio" name="ose-effort-opencode" id="ose-e-opencode-max" value="max"><label for="ose-e-opencode-max">max</label></span>
+</div>
+</fieldset>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "opencode"
+
+[crews.opencode]
+provider = "opencode"
+model = "anthropic/claude-sonnet-4-5"
+<span class="ose-eff" data-effort="high">effort = "high"
+</span><span class="ose-eff" data-effort="max">effort = "max"
+</span></code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p><code>low</code>, <code>medium</code>, and <code>xhigh</code> are missing because <code>opencode run --variant</code> forwards the value straight to whichever model provider <code>--model</code> selected, and OpenCode publishes no provider-independent vocabulary. Only the two spellings its own help text names are accepted; the rest are rejected rather than remapped onto <code>minimal</code> or <code>high</code>.</p><p>The vendor prefix in <code>anthropic/claude-sonnet-4-5</code> is OpenCode's own model addressing. It does not make this an Anthropic lane — <code>provider = "opencode"</code> is what Orbit dispatches through.</p></div>
+</div>
+<div class="ose-panel" id="ose-panel-gemini">
+<dl class="ose-facts">
+<dt>Binary on <code>PATH</code></dt><dd><code>gemini</code></dd>
+<dt>Example model</dt><dd><code>gemini-3.8-flash</code></dd>
+<dt>Reasoning effort</dt><dd>Not supported.</dd>
+</dl>
+<div class="ose-snippet">
+
+<pre class="ose-code"><code>[workflow]
+default_crew = "gemini"
+
+[crews.gemini]
+provider = "gemini"
+model = "gemini-3.8-flash"
+</code></pre>
+
+<div class="ose-actions"><button class="ose-copy" type="button">Copy config</button><span class="ose-status" role="status" aria-live="polite"></span></div>
+</div>
+<div class="ose-note"><p><strong>This is the legacy Google lane.</strong> Individual Gemini CLI accounts stopped on 2026-06-18; enterprise Gemini Code Assist and API-key authentication remain available on it. New setups should prefer the <code>antigravity</code> executor, which is what <code>orbit init</code> now picks when <code>agy</code> is installed.</p><p>Adding <code>effort</code> to this crew fails config load rather than being ignored.</p></div>
+</div>
+</div>
+
+<script is:inline>
+  (function () {
+    var root = document.querySelector(".orbit-setup-explorer");
+    if (!root) return;
+    // Progressive enhancement: selection is CSS-only, so the Copy control is
+    // revealed only once this handler is attached.
+    root.classList.add("ose-js");
+
+    function snippetText(pre) {
+      var text = "";
+      pre.querySelector("code").childNodes.forEach(function (node) {
+        if (node.nodeType === 3) {
+          text += node.textContent;
+        } else if (node.nodeType === 1 && window.getComputedStyle(node).display !== "none") {
+          text += node.textContent;
+        }
+      });
+      return text;
+    }
+
+    function setStatus(status, message, state) {
+      status.textContent = message;
+      if (state) {
+        status.setAttribute("data-state", state);
+      } else {
+        status.removeAttribute("data-state");
+      }
+    }
+
+    root.addEventListener("click", function (event) {
+      var button = event.target.closest && event.target.closest(".ose-copy");
+      if (!button) return;
+      var panel = button.closest(".ose-panel");
+      var status = panel.querySelector(".ose-status");
+      var text = snippetText(panel.querySelector(".ose-code"));
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        setStatus(status, "Clipboard unavailable here. Select the snippet and copy it manually.", "error");
+        return;
+      }
+      navigator.clipboard.writeText(text).then(
+        function () {
+          setStatus(status, "Copied the crew config to the clipboard.", "ok");
+        },
+        function () {
+          setStatus(status, "Copy failed. Select the snippet and copy it manually.", "error");
+        }
+      );
+    });
+
+    // Never leave a copy result standing next to a snippet it no longer describes.
+    root.addEventListener("change", function () {
+      root.querySelectorAll(".ose-status").forEach(function (status) {
+        setStatus(status, "", null);
+      });
+    });
+  })();
+</script>
+
+Before a first dispatch you also need an authenticated provider CLI and, on
+Linux, a working sandbox. Both are covered in
+[Install Orbit](../../getting-started/install/#prerequisites).
 
 ## Tool Allowlists
 
@@ -63,10 +620,15 @@ effort = "high"
 ```
 
 `effort` is an optional reasoning-budget request, forwarded through each
-provider's own argument and validated against the provider and model at config
-load. Claude and Codex accept `low` through `max`; Grok's accepted set depends
-on the model; other providers reject it. See
+provider's own argument and validated against the provider **and** model at
+config load. An unsupported combination is rejected outright — Orbit never
+downgrades a value to the nearest supported one, and never accepts a key it
+would then ignore. The per-provider sets are in
 [Configuration](../../reference/config/#reasoning-effort).
+
+`[workflow] system_crew` is a separate assignment used for system activities
+synthesized at runtime, such as step-failure recovery. It never inherits a
+failed task's crew or the workspace default.
 
 Reassigning work between providers is always explicit — `orbit task update <id>
 --crew <name>`. Nothing in Orbit silently moves a task to a different provider.

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -100,9 +100,13 @@ lets an agent dispatch workflows and run governed operations. Plain
 
 ## Prerequisites
 
-You need an authenticated provider CLI — `claude`, `codex`, `gemini`, or `grok`
-— because agent activities dispatch through it. PR mode additionally needs the
-GitHub CLI (`gh`) authenticated in the environment where Orbit runs.
+You need at least one authenticated provider CLI, because agent activities
+dispatch through it. `orbit init` probes `PATH` for `claude`, `codex`, `agy`
+(Antigravity), `gemini`, `grok`, `copilot`, `cursor-agent`, `pi`, and
+`opencode`, and seeds crews for the ones it finds. The
+[setup explorer](../../concepts/agents/#set-up-an-executor) shows each
+executor's binary and a starter crew. PR mode additionally needs the GitHub CLI
+(`gh`) authenticated in the environment where Orbit runs.
 
 Orbit itself installs without Rust. You only need a Rust toolchain to build from
 source or contribute to the workspace.

--- a/website/src/content/docs/reference/config.md
+++ b/website/src/content/docs/reference/config.md
@@ -50,33 +50,55 @@ default_crew = "sol"
 
 | Field | Purpose |
 |---|---|
-| `provider` | Agent family. CLI-executable families are `claude`, `codex`, `gemini`, `grok`, `copilot`, and `cursor`. |
+| `provider` | Agent family. CLI-executable families are `claude`, `codex`, `antigravity`, `gemini`, `grok`, `copilot`, `cursor`, `pi`, and `opencode`. |
 | `model` | Model identifier passed to the provider CLI. |
 | `effort` | Optional reasoning effort. See below. |
 | `description` | Optional human-facing summary. |
 | `tags` | Optional discovery labels. |
 
+`ollama` and `openai_compat` are recognized provider ids that no shipped crew
+uses: `openai_compat` has no CLI runtime, and Orbit ships no `ollama` executor
+definition or crew. Config load accepts a crew naming either one — the failure
+comes later, at dispatch, rather than the run being remapped onto another
+family. `gemini` is the legacy Google lane —
+`orbit init` prefers `antigravity` when `agy` is installed. For the full
+catalog, the deprecated vendor aliases, and a starter crew per executor, see
+[Agents](../../concepts/agents/#set-up-an-executor).
+
 Crew precedence at dispatch is: an explicit crew on the activity input, then the
 task's `crew` field, then `[workflow] default_crew`.
+
+`[workflow] default_crew` is required as soon as you define any `[crews.*]`
+table, so a crew snippet is only loadable together with the crew it defaults to.
 
 ### Reasoning effort
 
 `effort` is omitted by default, which leaves the provider's own model default
 alone. When set, Orbit validates it while loading `config.toml` and passes it
-through the provider's documented argument — Codex receives
-`model_reasoning_effort`, Claude receives `--effort`, and Grok receives
-`--reasoning-effort`.
+through the provider's documented argument.
 
-| Provider | Accepted values |
-|---|---|
-| `claude`, `codex` | `low`, `medium`, `high`, `xhigh`, `max` |
-| `grok` with `grok-4.6` | `low`, `medium`, `high`, `xhigh` |
-| `grok` with `grok-4.5` | `low`, `medium`, `high` |
-| others | Not supported — configuring `effort` is rejected. |
+| Provider | Accepted values | Rendered as |
+|---|---|---|
+| `claude` | `low`, `medium`, `high`, `xhigh`, `max` | `--effort` |
+| `codex` | `low`, `medium`, `high`, `xhigh`, `max` | `--config model_reasoning_effort` |
+| `pi` | `low`, `medium`, `high`, `xhigh`, `max` | `--thinking` |
+| `antigravity` | `low`, `medium`, `high` | `--effort` |
+| `opencode` | `high`, `max` | `--variant` |
+| `grok` with `grok-4.6` | `low`, `medium`, `high`, `xhigh` | `--reasoning-effort` |
+| `grok` with `grok-4.5` | `low`, `medium`, `high` | `--reasoning-effort` |
+| others | Not supported — configuring `effort` is rejected. | — |
+
+The narrower sets are narrow on purpose. `antigravity` omits `xhigh`/`max`
+because `agy --effort` does not define them; `opencode` omits everything but
+`high`/`max` because `--variant` is forwarded verbatim to whichever model
+provider `--model` selected and OpenCode publishes no provider-independent
+vocabulary. Grok is the only model-specific case, and effort is verified only
+for `grok-4.5` and `grok-4.6` — any other Grok model with `effort` set is
+rejected.
 
 Orbit rejects an unsupported provider/model/effort combination outright rather
-than silently downgrading or ignoring it. Availability can still depend on the
-selected model on the provider's side.
+than silently downgrading, remapping, or ignoring it. Availability can still
+depend on the selected model on the provider's side.
 
 Choose capability with the model first, then use `effort` to adjust the
 reasoning budget inside it.


### PR DESCRIPTION
## Task

[ORB-11370](https://orbit-cli.com/tasks/ORB-11370) — Add an interactive executor and crew setup explorer to the website

### Description

Daniel requests additional website UI work while core/orbit-web are occupied. Build a focused setup explorer in the existing Agents/Configuration documentation, using page-local components/styles so it can run alongside the homepage refresh. Current inspected pages are static: Agents still lists only claude/codex/gemini/grok/ollama/openai_compat and claims four CLI executors, while config shows six providers. This no longer matches the expanded executor work. The page description also still says CLI and HTTP runtimes although its body says CLI is the only agent path. ORB-11279 added effort support; no open website setup-explorer duplicate was found.

Provide a clear accessible provider/executor selector with concise prerequisites and a copyable starter crew TOML example, plus an optional effort choice only where supported by current Orbit validation. Keep model identifiers and provider-side availability honest; explain omitted effort and unsupported combinations instead of silently substituting. Ground the supported catalog and examples in current shipped executors/config validation and existing onboarding runbook, not marketing guesses. Cover active Antigravity, local-shell and newly supported executors as appropriate to actual landed code; identify deprecated aliases and do not revive archived Hermes/OpenClaw work. Preserve crew versus executor/system-crew distinctions and link to existing install/sandbox guidance.

This is a static website interaction, no hosted backend, secret inputs, live provider calls, telemetry or writes to user configuration. Keep useful reference tables/examples available without JS. Avoid duplicating runtime policy engines or adding dependencies solely for a few UI controls; reuse existing Astro patterns. Do not edit shared homepage CSS, homepage content, ORB-11362's workflow guide, or orbit-web/core. New page-local components are fine; task-pilot should scope only necessary existing modification paths. Preserve routes/deep links. UI routing overrides ordinary medium-low crew selection: use Opus, orchestrator Sol, normal authorized pipeline delivery.

### Acceptance Criteria

- Agents/config documentation accurately reflects the active shipped executor catalog and CLI execution model, with explicit legacy/unsupported distinctions and links to prerequisites.
- Keyboard-operable explorer presents the selected provider, a valid starter crew snippet and supported optional effort choices; changing selection cannot retain an incompatible effort. Copy feedback handles success/failure accessibly.
- Starter examples are validated through current Orbit config parsing in isolated fixtures or a comparable real supported path; they are explicitly examples, do not require credentials, and make no unsupported provider/model availability claims.
- Static content remains useful without JS. Mobile/tablet/desktop and both themes have no horizontal page overflow, focus traps or stale selection/copy output; record actual browser validation and screenshots.
- npm check/build and relevant validation pass; source changes remain website-scoped and independent of the homepage/ongoing workflow-guide work.

## Execution Summary

<details>
<summary>Click to expand</summary>

Added a keyboard-operable executor/crew setup explorer to the Agents page and corrected the stale executor claims across Agents, Configuration, and Install. Website-scoped: 3 files, +616/-29. No shared homepage CSS, homepage content, workflow guide, orbit-web, or core touched; no dependency added; all routes and existing headings/anchors preserved.

## Files

- `website/src/content/docs/concepts/agents.md` — rewrote the page description (it still claimed "CLI and HTTP runtimes" while the body said CLI is the only path); replaced the 6-id provider list with an 11-id catalog table carrying executor command, effort support, and status; added a `### Deprecated aliases` section; added the `## Set up an executor` explorer; clarified crew vs. executor vs. `system_crew`.
- `website/src/content/docs/reference/config.md` — corrected the CLI-executable family list (was 6, now the 9 that ship crews), rebuilt the reasoning-effort table with `antigravity`/`pi`/`opencode` and a "Rendered as" column, documented the `default_crew`-required-with-`[crews.*]` rule, linked to the explorer.
- `website/src/content/docs/getting-started/install.md` — Prerequisites named only 4 CLIs; now names the 9 `orbit init` actually probes and links to the explorer. Added to `context_files` with rationale in a task comment.

## Design

Page-local, no new dependency and no MDX: CSS via Starlight's per-page frontmatter `head:` style tag, markup as raw HTML, one small `<script is:inline>` matching the existing `index.md` idiom.

Selection is **CSS-only** (`:has()` over radio inputs), so the explorer is fully functional without JavaScript — provider switching and effort choice both work. JS adds only the Copy button, which is revealed by an `ose-js` class the script adds, so it is never offered inert.

Two structural decisions make an incompatible effort unrepresentable rather than merely prevented:
- Each provider panel owns its **own** effort radio group, so switching provider selects a different group entirely; a value can never carry across.
- Each provider offers exactly its supported values; `model` is fixed per provider (the shipped default-crew model), so there is no second interactive dimension that could drift out of sync.

Withheld efforts are explained, never silently substituted — e.g. Antigravity states that `xhigh`/`max` are absent because `agy --effort` does not define them and that Orbit rejects rather than downgrading to `high`.

## Grounding

Every claim traced to this worktree, not to marketing: `Provider::ALL`/`ALIASES`/`has_cli_runtime` (`orbit-types/.../activity_v2.rs`), the 10 executor assets (`orbit-core/assets/executors/`), `ReasoningEffort::validate_for_provider_model` (`orbit-types/src/identity/agent_pair.rs`), each provider's `*_cli.rs` for the actual flag rendered, `default_crews()` + `model_defaults.rs` for crew names/models, and `agent_detect.rs` for probed binary names. Snippets carry no credentials and state up front that they are examples, not availability guarantees.

## Validation

**Config parsing (isolated `--root` fixtures, real `orbit config get`).** Extracted each snippet from the *built HTML* and ran the full cross-product: all 9 starter snippets load, and all 45 provider×effort combinations match — every effort the page offers is accepted, every effort it withholds is rejected. Also asserted 7 documented edge claims (grok-4.5 xhigh rejected, unverified Grok model rejected, bare `gemini-3.8-flash` on Antigravity rejected, `anthropic` alias resolves, `[crews.*]` without `default_crew` rejected).

**Browser (Playwright chromium, served build): 42/42.** 3 viewports (390/820/1440) × 2 themes with zero horizontal page overflow and no element escaping the viewport; arrow-key provider and effort operation; hidden panels expose 0 focusable controls (no focus trap); **216 provider transitions** with no unsupported effort surfaced and no picker/snippet disagreement; copy writes exactly the visible snippet, announces success via `role="status" aria-live="polite"`, clears on any selection change, and reports failure with a manual-copy fallback under a rejected clipboard; no-JS pass confirms panel switching, effort switching, hidden copy button, and static tables.

**`npm run check`** 0 errors/warnings/hints; **`npm run build`** 29 pages.

Artifacts under `validation/` on this task: both reports, the reproducible harnesses, and 9 screenshots (dark/light × mobile/tablet/desktop, antigravity-high in both themes, no-JS).

## Corrected during work

The initial draft said an `openai_compat` crew is rejected at config load. Fixture testing showed it **loads**; the refusal is at dispatch. Both pages were reworded to say so precisely.

## Notes

`website/node_modules`, `dist`, and `.astro` were created for validation and removed; `package-lock.json` is unmodified; `git status` shows only the 3 intended files. Filed F2026-09-030: rendered browser validation needed ~25 min of environment bootstrap (npm off `PATH`, unwritable npm cache, and Playwright chromium missing 5 system `.so` files with no root available), with the root-free workaround recorded.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11370-6a9cc5b6`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*