### PR TITLE
Upgrade the website homepage for current Orbit workflows

### DIFF
--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -28,7 +28,9 @@ The Orbit website is a **documentation site**, not a marketing site. It exists t
 1. **Reference-heavy, search-first.** Users land via `⌘K` or Google. Every page must be findable and self-contained.
 2. **Minimalism as a feature.** Restraint is the aesthetic. One accent color, one type family per role, no decorative motion in docs content.
 3. **Legibility over personality.** The orbit metaphor shows up structurally (logo, section glyphs) — never at the cost of reading comfort.
-4. **Static and fast.** Zero JS by default. Hundreds of pages should feel identical in performance to ten.
+4. **Static and fast.** Zero JS by default; the homepage's copy controls are the one
+   scripted exception, and every other interaction is CSS. Hundreds of pages should
+   feel identical in performance to ten.
 5. **Dark-default, light-available.** Theme toggle persists per user; neither mode is an afterthought.
 
 ---
@@ -90,15 +92,38 @@ Three-column, fixed:
 
 The homepage uses an in-content hero in place of Starlight's auto-rendered title (which is hidden via a scoped CSS rule on the homepage only):
 
-- **Eyebrow** — mono uppercase tag (`v0.9.2 · early access`).
+- **Eyebrow** — mono uppercase tag (`early access`).
 - **Headline** — 2.75rem display heading. The only heading on the site that exceeds the body type scale.
 - **Lede + install bar + primary/secondary CTAs.** Install bar carries a `$` prompt and a Copy action.
-- **Orbit diagram** — single rotating ring in the hero column. Respects `prefers-reduced-motion`.
+- **Provider strip** — mono uppercase list of the shipped CLI executors, with the
+  legacy Gemini executor named in a footnote rather than implied current.
+- **Transcript** — a `figure` of the task → ship → inspect → commit loop, with a
+  `figcaption` naming it illustrative. Real commands, placeholder identifiers.
 
-Below the hero: a **Start here** 5-card grid (each card carries a mono numbered
-tag `01`–`05` and a thin SVG glyph — the only place glyphs appear in content)
-and a **Why Orbit** 2-column value-prop strip whose columns align to the card
-grid above. Mono uppercase keys, plain prose values.
+Below the hero, in order:
+
+1. **Start here** — a 3-card grid, each card carrying a mono numbered tag
+   `01`–`03` and the command it runs.
+2. **Choose a delivery mode** — a four-mode explorer over `orbit run ship`,
+   `--mode local`, `orbit run auto` and `orbit run ship-sweep`. Each panel
+   states the command, where the run stops, and that `--complete` is a separate
+   explicit authorization. Built as a native radio group switched by CSS
+   `:has()`, so pointer, keyboard and screen-reader support are the platform's
+   and the selected panel still renders without JavaScript.
+3. **Why Orbit** — a 4-card value-prop strip. Each card carries a thin SVG glyph;
+   these and the Start here tags are the only glyphs in content.
+4. **Go further** — a 4-card grid routing to continuous delivery, recurring work,
+   publication and recovery, and the CLI reference.
+5. **Explore the docs** — a flat index of the sidebar groups.
+
+Commands shown on this page must match current CLI behaviour, and illustrative
+output must say that it is illustrative. The page advertises no unlanded feature
+and publishes no live metric.
+
+The only script on the site is a small inline handler for the copy controls.
+Those buttons are served `hidden` and unhidden by that script, so a page without
+JavaScript shows the command text and no dead control; a clipboard that is
+unavailable or refuses the write reports failure rather than a false success.
 
 Other pages keep Starlight's default chrome (auto title, sidebar, TOC) unchanged.
 

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: What Orbit Is
-description: "Orbit is a durable, intent-tracked, auditable task layer for developers driving AI coding agents at high volume — local-first by design."
+description: "Orbit runs your coding agents as tracked, reviewable tasks — isolated worktrees, declared file scope, a gated delivery pipeline, and joined audit records. Local-first, bring your own provider CLI."
 template: splash
 prev: false
 next: false
@@ -11,28 +11,36 @@ next: false
 <section class="orbit-hero">
   <div class="orbit-hero-copy">
     <div class="orbit-hero-eyebrow">early access</div>
-    <h1 class="orbit-hero-headline">The audit log for your AI coding agents.</h1>
-    <p class="orbit-hero-lede">Durable task lifecycle, task-attributed workflow commits, and structured audit records for agent workflows. Local-first, bring your own model provider.</p>
+    <h1 class="orbit-hero-headline">Run coding agents as tracked, reviewable tasks.</h1>
+    <p class="orbit-hero-lede">Write a task with acceptance criteria. Orbit reserves its file scope, runs an agent in an isolated worktree, and takes it through a gated pipeline to a pull request you review — with every mutation in a joined audit record. Local-first, driving the provider CLI you already have.</p>
     <div class="orbit-hero-install">
-      <span class="orbit-hero-install-prompt">$</span>
+      <span class="orbit-hero-install-prompt" aria-hidden="true">$</span>
       <code>npm install -g @orbit-tools/cli</code>
-      <button class="orbit-hero-install-copy" type="button" data-copy="npm install -g @orbit-tools/cli">Copy</button>
+      <button class="orbit-copy" type="button" data-copy="npm install -g @orbit-tools/cli" hidden>
+        <span class="orbit-copy-label">Copy</span><span class="orbit-sr-only"> the install command</span>
+      </button>
+      <span class="orbit-copy-status" role="status"></span>
     </div>
     <div class="orbit-hero-actions">
       <a class="orbit-button primary" href="/getting-started/install/">Install Orbit →</a>
-      <a class="orbit-button" href="/reference/cli/">Read the CLI reference</a>
+      <a class="orbit-button" href="/getting-started/first-task/">Write your first task</a>
     </div>
     <div class="orbit-hero-providers">
-      <span>Runs your provider CLI</span>
+      <span>Drives your provider CLI</span>
       <span class="orbit-hero-providers-rule" aria-hidden="true"></span>
       <span>Claude Code</span>
       <span>Codex</span>
-      <span>Gemini</span>
-      <span>Grok Build</span>
+      <span>Antigravity</span>
+      <span>Grok</span>
+      <span>Copilot</span>
+      <span>Cursor</span>
+      <span>OpenCode</span>
+      <span>Pi</span>
     </div>
+    <p class="orbit-hero-providers-note">Gemini CLI ships as a legacy executor for enterprise Gemini Code Assist and API-key accounts. <a href="/concepts/agents/">How agents are invoked →</a></p>
   </div>
 
-  <div class="orbit-terminal">
+  <figure class="orbit-terminal">
     <div class="orbit-terminal-bar">
       <span>~/repo</span>
       <span>one task, end to end</span>
@@ -55,7 +63,8 @@ next: false
       <div><span class="orbit-terminal-prompt">$ </span><span class="orbit-terminal-cmd">git log -1 --grep "$TASK_ID" --oneline</span></div>
       <div><span class="orbit-terminal-id">[SHA]</span> docs: document fsProfile resolution</div>
     </div>
-  </div>
+    <figcaption class="orbit-terminal-caption">Illustrative transcript. The commands are real; identifiers, step rows and durations are placeholders, not measured results.</figcaption>
+  </figure>
 </section>
 
 <div class="orbit-section-title">Start here</div>
@@ -63,19 +72,163 @@ next: false
 <div class="orbit-card-grid orbit-card-grid-3">
   <a class="orbit-card" data-tag="01" href="/getting-started/install/">
     <h3>Install</h3>
-    <p>One binary, no Rust toolchain. Then <code>orbit init</code> sets up your root and skills.</p>
+    <p>One binary, no Rust toolchain. Then <code>orbit init</code> sets up your global root, and <code>orbit workspace init</code> registers the repository.</p>
     <div class="orbit-card-cmd">orbit init</div>
   </a>
   <a class="orbit-card" data-tag="02" href="/getting-started/first-task/">
     <h3>Write a task</h3>
-    <p>Acceptance criteria are required — agents self-evaluate against them.</p>
+    <p>Acceptance criteria are required — agents self-evaluate against them. Context selectors declare the file scope the run may touch.</p>
     <div class="orbit-card-cmd">orbit task add --title "…"</div>
   </a>
   <a class="orbit-card" data-tag="03" href="/how-to/task-lifecycle/">
     <h3>Ship it</h3>
-    <p>The gated pipeline opens a PR, or stays local with <code>--mode local</code>.</p>
+    <p>The gated pipeline runs the agent, then opens a pull request. The task stops in <code>review</code> for you.</p>
     <div class="orbit-card-cmd">orbit run ship "$TASK_ID"</div>
   </a>
+</div>
+
+<div class="orbit-section-title">Choose a delivery mode</div>
+
+<p class="orbit-section-lede">Every <code>orbit run</code> command is asynchronous: it prints a durable run ID and returns without knowing the outcome. Follow up with <code>orbit run show</code>. Pick the shape of delivery you want — the differences are where the run stops and who authorizes the last step.</p>
+
+<div class="orbit-flow">
+  <div class="orbit-flow-tabs" role="radiogroup" aria-label="Delivery mode">
+    <label class="orbit-flow-tab">
+      <input type="radio" name="orbit-flow" id="orbit-flow-pr" value="pr" checked />
+      <span class="orbit-flow-tab-name">One task, one PR</span>
+      <span class="orbit-flow-tab-cmd">run ship</span>
+    </label>
+    <label class="orbit-flow-tab">
+      <input type="radio" name="orbit-flow" id="orbit-flow-local" value="local" />
+      <span class="orbit-flow-tab-name">One task, merged locally</span>
+      <span class="orbit-flow-tab-cmd">--mode local</span>
+    </label>
+    <label class="orbit-flow-tab">
+      <input type="radio" name="orbit-flow" id="orbit-flow-auto" value="auto" />
+      <span class="orbit-flow-tab-name">A bounded window</span>
+      <span class="orbit-flow-tab-cmd">run auto</span>
+    </label>
+    <label class="orbit-flow-tab">
+      <input type="radio" name="orbit-flow" id="orbit-flow-sweep" value="sweep" />
+      <span class="orbit-flow-tab-name">Unattended sweep</span>
+      <span class="orbit-flow-tab-cmd">run ship-sweep</span>
+    </label>
+  </div>
+
+  <div class="orbit-flow-panels">
+    <section class="orbit-flow-panel" data-flow="pr" aria-label="One task, one PR">
+      <div class="orbit-flow-main">
+        <div class="orbit-flow-cmd">
+          <span class="orbit-flow-cmd-prompt" aria-hidden="true">$</span>
+          <code>orbit run ship "$TASK_ID"</code>
+          <button class="orbit-copy" type="button" data-copy="orbit run ship &quot;$TASK_ID&quot;" hidden>
+            <span class="orbit-copy-label">Copy</span><span class="orbit-sr-only"> the ship command</span>
+          </button>
+          <span class="orbit-copy-status" role="status"></span>
+        </div>
+        <p>The default. The gated pipeline reserves the task's declared file scope, runs the agent in an isolated worktree, then opens or updates a pull request.</p>
+      </div>
+      <dl class="orbit-flow-facts">
+        <div>
+          <dt>Stops at</dt>
+          <dd><code>review</code>, with the pull request open and unmerged.</dd>
+        </div>
+        <div>
+          <dt>Base branch</dt>
+          <dd><code>[workflow] base_branch</code> from <code>config.toml</code>, or <code>main</code> when unset. Override with <code>--base</code>.</dd>
+        </div>
+        <div>
+          <dt>Authorized completion</dt>
+          <dd>Separate and explicit. <code>orbit run ship "$TASK_ID" --complete</code> lets that one run move the task to <code>done</code>, once the PR is verified merged and branch protections and required checks are respected.</dd>
+        </div>
+      </dl>
+      <a class="orbit-flow-link" href="/how-to/task-lifecycle/">Run a task lifecycle →</a>
+    </section>
+    <section class="orbit-flow-panel" data-flow="local" aria-label="One task, merged locally">
+      <div class="orbit-flow-main">
+        <div class="orbit-flow-cmd">
+          <span class="orbit-flow-cmd-prompt" aria-hidden="true">$</span>
+          <code>orbit run ship "$TASK_ID" --mode local</code>
+          <button class="orbit-copy" type="button" data-copy="orbit run ship &quot;$TASK_ID&quot; --mode local" hidden>
+            <span class="orbit-copy-label">Copy</span><span class="orbit-sr-only"> the local ship command</span>
+          </button>
+          <span class="orbit-copy-status" role="status"></span>
+        </div>
+        <p>Delivers in place, with no pull request. The run commits and merges to the configured base <em>before</em> the task reaches <code>review</code>, and may push that base as part of the same delivery.</p>
+      </div>
+      <dl class="orbit-flow-facts">
+        <div>
+          <dt>Stops at</dt>
+          <dd><code>review</code> — but the merge has already happened, so this is not a pre-merge stop.</dd>
+        </div>
+        <div>
+          <dt>When you omit <code>--mode</code></dt>
+          <dd>The mode comes from the workspace's registry entry, falling back to <code>pr</code>.</dd>
+        </div>
+        <div>
+          <dt>Authorized completion</dt>
+          <dd>Still separate. <code>--complete</code> moves the task to <code>done</code> once the work is merged and pushed.</dd>
+        </div>
+      </dl>
+      <a class="orbit-flow-link" href="/getting-started/workflows/">Compare the run surface →</a>
+    </section>
+    <section class="orbit-flow-panel" data-flow="auto" aria-label="A bounded window">
+      <div class="orbit-flow-main">
+        <div class="orbit-flow-cmd">
+          <span class="orbit-flow-cmd-prompt" aria-hidden="true">$</span>
+          <code>orbit run auto --for 4h --concurrency 8</code>
+          <button class="orbit-copy" type="button" data-copy="orbit run auto --for 4h --concurrency 8" hidden>
+            <span class="orbit-copy-label">Copy</span><span class="orbit-sr-only"> the auto drain command</span>
+          </button>
+          <span class="orbit-copy-status" role="status"></span>
+        </div>
+        <p>Drains the workspace backlog for a time-bounded window. The drain re-lists the backlog every pass and keeps <code>--concurrency</code> tasks in flight, starting a replacement as each one finishes rather than waiting for a batch.</p>
+      </div>
+      <dl class="orbit-flow-facts">
+        <div>
+          <dt>The window</dt>
+          <dd><code>--for</code> bounds only the <em>start</em> of new work. A task already being shipped when it expires still finishes. Without <code>--for</code>, the run takes one tick and stops.</dd>
+        </div>
+        <div>
+          <dt>Parallelism</dt>
+          <dd>Defaults to 5. An epic root runs alongside the leaves, one at a time. Check first with <code>orbit run readiness</code>, which reserves and submits nothing.</dd>
+        </div>
+        <div>
+          <dt>Authorized completion</dt>
+          <dd><code>--complete</code> here is blanket authorization for every task the drain admits during the whole window — not just the backlog visible when you started it.</dd>
+        </div>
+      </dl>
+      <a class="orbit-flow-link" href="/how-to/continuous-delivery/">Run a continuous delivery window →</a>
+    </section>
+    <section class="orbit-flow-panel" data-flow="sweep" aria-label="Unattended sweep">
+      <div class="orbit-flow-main">
+        <div class="orbit-flow-cmd">
+          <span class="orbit-flow-cmd-prompt" aria-hidden="true">$</span>
+          <code>orbit run ship-sweep --dry-run</code>
+          <button class="orbit-copy" type="button" data-copy="orbit run ship-sweep --dry-run" hidden>
+            <span class="orbit-copy-label">Copy</span><span class="orbit-sr-only"> the ship sweep command</span>
+          </button>
+          <span class="orbit-copy-status" role="status"></span>
+        </div>
+        <p>Dispatches a ship run in every registered workspace that has ready backlog tasks. Only workspaces with <code>[workflow] auto_ship = true</code> are swept; everything else is reported as skipped.</p>
+      </div>
+      <dl class="orbit-flow-facts">
+        <div>
+          <dt>Intended for</dt>
+          <dd>A scheduler. Routines fire it on the <code>orbit sweep</code> clock, which is also what mints recurring auto-tasks.</dd>
+        </div>
+        <div>
+          <dt>Start read-only</dt>
+          <dd><code>--dry-run</code> reports what would be swept. Drop it once the selection looks right.</dd>
+        </div>
+        <div>
+          <dt>Authorized completion</dt>
+          <dd>Never available here. <code>--complete</code> is off unless you pass it on an invocation, and no workspace setting, environment variable, or unattended routine turns it on.</dd>
+        </div>
+      </dl>
+      <a class="orbit-flow-link" href="/how-to/recurring-work/">Schedule recurring work →</a>
+    </section>
+  </div>
 </div>
 
 <div class="orbit-section-title">Why Orbit</div>
@@ -99,8 +252,33 @@ next: false
   <div class="orbit-card">
     <div class="orbit-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="7" height="16" rx="2"/><rect x="14" y="4" width="7" height="16" rx="2"/></svg></div>
     <h3>Safe parallel</h3>
-    <p>Worktree isolation and filesystem policies (<code>sandbox-exec</code>, <code>bwrap</code>) keep parallel agents from colliding.</p>
+    <p>Worktree isolation, file-scope locks, and OS sandboxes (<code>sandbox-exec</code>, <code>bwrap</code>) keep parallel agents from colliding.</p>
   </div>
+</div>
+
+<div class="orbit-section-title">Go further</div>
+
+<div class="orbit-card-grid orbit-card-grid-4">
+  <a class="orbit-card" href="/how-to/continuous-delivery/">
+    <h3>Continuous delivery</h3>
+    <p>Prepare work, approve it, check readiness, then authorize a bounded drain — and recover it safely.</p>
+    <div class="orbit-card-cmd">orbit run readiness</div>
+  </a>
+  <a class="orbit-card" href="/how-to/recurring-work/">
+    <h3>Recurring work</h3>
+    <p>Routines fire jobs on a cadence and auto-tasks mint recurring chores. Both run on the sweep clock.</p>
+    <div class="orbit-card-cmd">orbit sweep --dry-run</div>
+  </a>
+  <a class="orbit-card" href="/how-to/task-publication/">
+    <h3>Publication and recovery</h3>
+    <p>Push a validated snapshot of one workspace's tasks to a Git repository you control, then verify and restore it.</p>
+    <div class="orbit-card-cmd">orbit task publication status</div>
+  </a>
+  <a class="orbit-card" href="/reference/cli/">
+    <h3>CLI reference</h3>
+    <p>Every command surface, with the flags, defaults, and JSON output shapes each one accepts.</p>
+    <div class="orbit-card-cmd">orbit --help</div>
+  </a>
 </div>
 
 <div class="orbit-section-title">Explore the docs</div>
@@ -148,15 +326,86 @@ next: false
 </div>
 
 <script is:inline>
-  document.addEventListener("click", (e) => {
-    const btn = e.target.closest(".orbit-hero-install-copy");
-    if (!btn) return;
-    const text = btn.dataset.copy || "";
-    if (!text || !navigator.clipboard) return;
-    navigator.clipboard.writeText(text).then(() => {
-      const prev = btn.textContent;
-      btn.textContent = "Copied";
-      setTimeout(() => { btn.textContent = prev; }, 1400);
+  (() => {
+    const RESET_MS = 2400;
+    const timers = new WeakMap();
+    /** The `role="status"` span that pairs with a copy button. */
+    const statusFor = (btn) => {
+      const next = btn.nextElementSibling;
+      return next && next.classList.contains("orbit-copy-status") ? next : null;
+    };
+    /* Feedback goes to two places: the button's own visible label, which is
+       kept short so the control never reflows the row it sits in, and an
+       adjacent `role="status"` region that carries the full sentence for
+       assistive technology. */
+    const report = (btn, state, message) => {
+      const label = btn.querySelector(".orbit-copy-label");
+      btn.dataset.state = state;
+      if (label) label.textContent = state === "ok" ? "Copied" : "Failed";
+      if (state === "error") btn.title = message; else btn.removeAttribute("title");
+      const status = statusFor(btn);
+      // Clearing first makes a repeated identical message announce again.
+      if (status) {
+        status.textContent = "";
+        window.setTimeout(() => { status.textContent = message; }, 30);
+      }
+      window.clearTimeout(timers.get(btn));
+      timers.set(btn, window.setTimeout(() => {
+        delete btn.dataset.state;
+        btn.removeAttribute("title");
+        if (label) label.textContent = "Copy";
+        if (status) status.textContent = "";
+      }, RESET_MS));
+    };
+    /* Last-resort path for browsers without an async clipboard, or on an
+       insecure origin where `navigator.clipboard` is undefined. Returns the
+       browser's own verdict so a failure is never reported as a success. */
+    const legacyCopy = (text) => {
+      const field = document.createElement("textarea");
+      field.value = text;
+      field.setAttribute("readonly", "");
+      field.setAttribute("aria-hidden", "true");
+      field.style.cssText = "position:fixed;top:0;left:-9999px;opacity:0;";
+      document.body.appendChild(field);
+      const selection = document.getSelection();
+      const previous = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+      field.select();
+      let copied = false;
+      try {
+        copied = document.execCommand("copy");
+      } catch {
+        copied = false;
+      }
+      field.remove();
+      if (previous && selection) { selection.removeAllRanges(); selection.addRange(previous); }
+      return copied;
+    };
+    const copy = async (btn) => {
+      const text = btn.dataset.copy || "";
+      if (!text) return;
+      try {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          report(btn, "ok", "Copied to clipboard.");
+          return;
+        }
+      } catch {
+        // A rejected permission or a hidden document falls through to the
+        // legacy path rather than surfacing an unhandled rejection.
+      }
+      if (legacyCopy(text)) {
+        report(btn, "ok", "Copied to clipboard.");
+      } else {
+        report(btn, "error", "Copy failed — select the command and copy it manually.");
+      }
+    };
+    // The buttons ship hidden so a JavaScript-free page has no dead control.
+    for (const btn of document.querySelectorAll(".orbit-copy")) {
+      btn.hidden = false;
+    }
+    document.addEventListener("click", (event) => {
+      const btn = event.target.closest(".orbit-copy");
+      if (btn) copy(btn);
     });
-  });
+  })();
 </script>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -29,6 +29,10 @@
   --sl-color-hairline-light: #26262b;
   --sl-color-hairline: #26262b;
   --sl-color-hairline-shade: #17171a;
+
+  /* Failure state for the copy controls. Not a Starlight role, so it carries
+     the project prefix; tuned for AA contrast on the surface colour above. */
+  --orbit-color-danger: #ff9d9d;
 }
 
 :root[data-theme='light'] {
@@ -52,6 +56,8 @@
   --sl-color-hairline-light: #d8dbe2;
   --sl-color-hairline: #eceef3;
   --sl-color-hairline-shade: #f4f5f8;
+
+  --orbit-color-danger: #b3261e;
 }
 
 html {
@@ -275,21 +281,59 @@ body {
   white-space: nowrap;
 }
 
-.orbit-hero-install-copy {
+/* Copy-to-clipboard control, shared by the hero install bar and the delivery
+   mode commands. It is delivered `hidden` and unhidden by the inline script,
+   so a page without JavaScript shows the command text and no dead button. */
+.orbit-copy {
   background: transparent;
-  border: 0;
-  color: var(--sl-color-gray-4);
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--sl-color-gray-3);
   cursor: pointer;
+  flex: 0 0 auto;
   font: inherit;
   font-size: 0.75rem;
-  margin-left: 1rem;
-  padding: 0;
-  flex: 0 0 auto;
-  transition: color 120ms ease;
+  margin-left: 0.75rem;
+  padding: 0.15rem 0.4rem;
+  transition: color 120ms ease, border-color 120ms ease;
+  /* The label swaps between "Copy", "Copied" and "Failed"; reserving the
+     width keeps the surrounding row from reflowing on feedback. */
+  min-width: 3.75rem;
+  text-align: center;
 }
 
-.orbit-hero-install-copy:hover {
+.orbit-copy:hover {
   color: var(--sl-color-text-accent);
+}
+
+.orbit-copy:focus-visible {
+  border-color: var(--sl-color-accent);
+  color: var(--sl-color-text-accent);
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: 2px;
+}
+
+.orbit-copy[data-state='ok'] {
+  color: var(--sl-color-text-accent);
+}
+
+.orbit-copy[data-state='error'] {
+  color: var(--orbit-color-danger);
+}
+
+/* The full success/failure sentence, announced rather than shown: the visible
+   channel is the button label, which cannot carry a sentence without
+   reflowing its row. */
+.orbit-copy-status,
+.orbit-sr-only {
+  border: 0;
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .orbit-hero-actions {
@@ -350,11 +394,31 @@ body {
   width: 1px;
 }
 
+/* Gemini is still shipped but is no longer the current Google terminal agent,
+   so it is named apart from the strip rather than dropped or implied current. */
+.orbit-landing .orbit-hero-providers-note {
+  color: var(--sl-color-gray-3);
+  font-size: 0.8rem;
+  line-height: 1.55;
+  margin: 0.6rem 0 0;
+  max-width: 32rem;
+}
+
+.orbit-hero-providers-note a {
+  color: var(--sl-color-text-accent);
+}
+
+.orbit-hero-providers-note a:hover,
+.orbit-hero-providers-note a:focus-visible {
+  text-decoration: underline;
+}
+
 /* Hero terminal: a transcript of the task -> ship -> inspect -> commit loop. */
 .orbit-terminal {
   background: var(--sl-color-bg-inline-code);
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 8px;
+  margin: 0;
   min-width: 0;
   overflow: hidden;
 }
@@ -407,6 +471,17 @@ body {
   height: 1.85em;
 }
 
+/* Names the transcript as illustrative. The commands above are real; the
+   identifiers and durations are placeholders, and saying so is the point. */
+.orbit-terminal-caption {
+  border-top: 1px solid var(--sl-color-hairline-light);
+  color: var(--sl-color-gray-3);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0.75rem 1.25rem;
+}
+
 .orbit-section-title {
   align-items: center;
   color: var(--sl-color-gray-4);
@@ -424,6 +499,217 @@ body {
   content: "";
   flex: 1;
   height: 1px;
+}
+
+.orbit-landing .orbit-section-lede {
+  color: var(--sl-color-gray-3);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+  max-width: 46rem;
+}
+
+/* ------------------------------------------------------------------------
+   Delivery mode explorer
+   ------------------------------------------------------------------------
+   A radio group over four panels, switched entirely in CSS. Native radios do
+   the work: pointer users click the label, keyboard users arrow through the
+   group, and assistive technology reads the checked state without a script.
+   Nothing here depends on JavaScript, so the panel for the checked mode is
+   readable on a static page.
+   ------------------------------------------------------------------------ */
+.orbit-flow {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* Same reason as `.orbit-card-grid > *`: Starlight's adjacent-sibling margin
+   would otherwise open gaps between grid and flex children. */
+.orbit-flow-tabs > *,
+.orbit-flow-panels > *,
+.orbit-flow-panel > *,
+.orbit-flow-facts > * {
+  margin-top: 0;
+}
+
+.orbit-flow-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.orbit-flow-tab {
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+  border-right: 1px solid var(--sl-color-hairline-light);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.9rem 1rem;
+  position: relative;
+  transition: background-color 150ms ease;
+}
+
+.orbit-flow-tab:last-child {
+  border-right: 0;
+}
+
+/* Visually hidden, but still focusable and still the accessible control:
+   removing it from the layout would take the keyboard and the screen reader
+   with it. */
+.orbit-flow-tab input {
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.orbit-flow-tab-name {
+  color: var(--sl-color-gray-3);
+  font-size: 0.92rem;
+  font-weight: 600;
+  transition: color 120ms ease;
+}
+
+.orbit-flow-tab-cmd {
+  color: var(--sl-color-gray-3);
+  font-family: var(--sl-font-mono);
+  font-size: 0.72rem;
+}
+
+.orbit-flow-tab:hover {
+  background: var(--sl-color-hairline-shade);
+}
+
+.orbit-flow-tab:hover .orbit-flow-tab-name {
+  color: var(--sl-color-text-accent);
+}
+
+.orbit-flow-tab:has(input:checked) {
+  background: var(--sl-color-accent-low);
+}
+
+.orbit-flow-tab:has(input:checked) .orbit-flow-tab-name {
+  color: var(--sl-color-accent-high);
+}
+
+/* The selected-state marker is a 2px rule, not colour alone, so the choice
+   survives a monochrome or high-contrast rendering. */
+.orbit-flow-tab:has(input:checked)::after {
+  background: var(--sl-color-accent);
+  bottom: -1px;
+  content: "";
+  height: 2px;
+  left: 0;
+  position: absolute;
+  right: 0;
+}
+
+.orbit-flow-tab:has(input:focus-visible) {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: -3px;
+}
+
+.orbit-flow-panel {
+  display: none;
+  gap: 2rem 3rem;
+  padding: 1.5rem;
+}
+
+/* Only the checked mode's panel is laid out. `display: none` also takes the
+   other three out of the accessibility tree, so the group reads as one
+   answer rather than four. */
+.orbit-flow:has(#orbit-flow-pr:checked) .orbit-flow-panel[data-flow='pr'],
+.orbit-flow:has(#orbit-flow-local:checked) .orbit-flow-panel[data-flow='local'],
+.orbit-flow:has(#orbit-flow-auto:checked) .orbit-flow-panel[data-flow='auto'],
+.orbit-flow:has(#orbit-flow-sweep:checked) .orbit-flow-panel[data-flow='sweep'] {
+  display: grid;
+  grid-template-areas:
+    "main facts"
+    "link facts";
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-rows: 1fr auto;
+}
+
+.orbit-flow-main {
+  grid-area: main;
+}
+
+.orbit-flow-main p {
+  color: var(--sl-color-gray-3);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.orbit-flow-cmd {
+  align-items: center;
+  background: var(--sl-color-bg-inline-code);
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 6px;
+  display: flex;
+  font-family: var(--sl-font-mono);
+  font-size: 0.82rem;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.orbit-flow-cmd-prompt {
+  color: var(--sl-color-gray-4);
+  flex: 0 0 auto;
+}
+
+.orbit-flow-cmd code {
+  background: transparent;
+  border: 0;
+  color: var(--sl-color-text);
+  flex: 1 1 auto;
+  font-family: var(--sl-font-mono);
+  min-width: 0;
+  overflow-x: auto;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.orbit-flow-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  grid-area: facts;
+  margin: 0;
+}
+
+.orbit-flow-facts dt {
+  color: var(--sl-color-gray-3);
+  font-family: var(--sl-font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
+.orbit-flow-facts dd {
+  color: var(--sl-color-gray-2);
+  font-size: 0.9rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.orbit-flow-link {
+  align-self: end;
+  color: var(--sl-color-text-accent);
+  font-size: 0.9rem;
+  font-weight: 600;
+  grid-area: link;
+  justify-self: start;
+  margin-top: 1.5rem;
+}
+
+.orbit-flow-link:hover,
+.orbit-flow-link:focus-visible {
+  text-decoration: underline;
 }
 
 .orbit-card-grid {
@@ -471,8 +757,14 @@ body {
 .orbit-card:focus-visible {
   background: var(--sl-color-accent-low);
   border-color: var(--sl-color-accent);
-  outline: none;
   transform: translateY(-1px);
+}
+
+/* The hover treatment alone is not a focus indicator — keyboard users get a
+   real ring on top of it. */
+.orbit-card:focus-visible {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: 2px;
 }
 
 .orbit-card:hover h3,
@@ -618,6 +910,16 @@ body {
     gap: 1.25rem 2rem;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .orbit-flow-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  /* With two per row, the right-hand border of every second tab is the
+     container edge. */
+  .orbit-flow-tab:nth-child(2n) {
+    border-right: 0;
+  }
 }
 
 @media (max-width: 54rem) {
@@ -641,13 +943,69 @@ body {
     margin-top: 3.25rem;
   }
 
+  /* The hero has already stacked by here, but a tablet still has room for two
+     cards per row; one column this early wastes half the viewport. */
   .orbit-card-grid,
   .orbit-card-grid-3,
-  .orbit-card-grid-4 {
+  .orbit-card-grid-4,
+  .orbit-docs-index {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .orbit-flow-panel,
+  .orbit-flow:has(input:checked) .orbit-flow-panel {
+    padding: 1.25rem;
+  }
+
+  /* One column: the facts follow the command they qualify instead of sitting
+     beside it, and the guide link stays last. */
+  .orbit-flow:has(#orbit-flow-pr:checked) .orbit-flow-panel[data-flow='pr'],
+  .orbit-flow:has(#orbit-flow-local:checked) .orbit-flow-panel[data-flow='local'],
+  .orbit-flow:has(#orbit-flow-auto:checked) .orbit-flow-panel[data-flow='auto'],
+  .orbit-flow:has(#orbit-flow-sweep:checked) .orbit-flow-panel[data-flow='sweep'] {
+    gap: 1.5rem;
+    grid-template-areas:
+      "main"
+      "facts"
+      "link";
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
+  }
+
+  .orbit-flow-link {
+    margin-top: 0;
+  }
+}
+
+/* Phone widths: everything becomes one column, including the pairs the tablet
+   step above kept side by side. */
+@media (max-width: 34rem) {
+  .orbit-card-grid,
+  .orbit-card-grid-3,
+  .orbit-card-grid-4,
+  .orbit-docs-index,
+  .orbit-flow-tabs {
     grid-template-columns: 1fr;
   }
 
-  .orbit-docs-index {
-    grid-template-columns: 1fr;
+  .orbit-flow-tab {
+    border-right: 0;
+  }
+}
+
+/* Restraint over motion: the only transitions here are hover affordances, and
+   they are dropped entirely when the reader asks for reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .orbit-card,
+  .orbit-card h3,
+  .orbit-copy,
+  .orbit-flow-tab,
+  .orbit-flow-tab-name {
+    transition: none;
+  }
+
+  .orbit-card:hover,
+  .orbit-card:focus-visible {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Task

[ORB-11369](https://orbit-cli.com/tasks/ORB-11369) — Upgrade the website homepage for current Orbit workflows

### Description

Daniel explicitly requests website UI upgrades to keep useful work moving while ORB-11330 holds core/orbit-web locks. Website only; do not modify orbit-web or core. Current homepage was inspected: it leads with 'The audit log for your AI coding agents', shows one old fixed terminal transcript, lists only Claude/Codex/Gemini/Grok, and relegates continuous delivery, recurring work and publication to a flat link index. ORB-11304 refreshed documentation, and ORB-11347 validated those routes; this is a separate product-entry UX upgrade, not a redo of their corpus work. Bounded duplicate search found no open homepage owner.

Design and implement a polished, responsive homepage that makes Orbit's current task orchestration workflow understandable quickly: clear positioning, installation/first-task paths, and visible routes into continuous delivery, recurring work, publication/recovery and the reference. Add an accessible compact workflow explorer or equivalent useful interaction that explains single-task PR delivery versus a bounded auto window with accurate commands and opt-in completion semantics. Commands/transcripts must match current CLI/job behavior; label illustrative output honestly and do not promise still-unlanded operation-mode features. Refresh provider mentions against the actual shipped executor catalog, retaining legacy compatibility distinctions and excluding archived Hermes/OpenClaw proposals.

Keep the existing restrained visual language, both themes, Starlight navigation/search and direct route links. Improve the current install-copy control with keyboard/screen-reader feedback and clipboard failure handling. Use purposeful hierarchy and spacing, not ornamental motion. Isolate homepage styles/markup from the parallel crew setup explorer and ORB-11362's workflows documentation/schema repair. Opus owns UI implementation under Daniel's routing; regular high complexity (not Astra ultra-high). Dedicated worktree, task-scoped PR, normal authorized --complete delivery.

### Acceptance Criteria

- Homepage gives clear working entry paths to install/first task, continuous delivery, recurring work and publication; current capabilities and provider support are accurate at the tested revision.
- Workflow interaction works with keyboard and pointer, exposes selection/accessibility state, and preserves usable static links/content without JavaScript. Displayed commands distinguish explicit PR review from authorized completion and match current help.
- Install/command copy controls have accessible success/error feedback, including unavailable/rejected clipboard; no false success or unhandled rejection.
- Render and exercise 390px mobile, tablet and 1440px desktop in light/dark themes; no page overflow, clipped controls, contrast/focus regressions or broken routes. Record before/after screenshots and actual browser interactions as task evidence.
- Website npm check/build and relevant repository checks pass. No orbit-web/core behavior changes, fabricated live metrics, resurrected metrics/architecture sections, or advertised unlanded automation features.

## Execution Summary

<details>
<summary>Click to expand</summary>

Website-only homepage upgrade. Three files changed: `website/src/content/docs/index.md`, `website/src/styles/custom.css`, `website/DESIGN.md`. No orbit-web or core change; `git status` at handoff shows exactly these three.

## What changed

**Positioning and hero.** Headline moved from "The audit log for your AI coding agents" to "Run coding agents as tracked, reviewable tasks", with a lede that names the actual pipeline (declared file scope -> isolated worktree -> gated pipeline -> PR -> joined audit record). CTAs are now Install / Write your first task.

**Provider strip refreshed against the shipped executor catalog** (`crates/orbit-core/src/application/executor.rs` + `assets/executors/*.yaml`), not the old four: Claude Code, Codex, Antigravity, Grok, Copilot, Cursor, OpenCode, Pi. The legacy distinction is kept rather than dropped — Gemini is named in a footnote as a legacy executor for enterprise Gemini Code Assist and API-key accounts, matching the `[ORB-11299]` note in `gemini.yaml`. No archived Hermes/OpenClaw proposal is mentioned (neither appears anywhere in the tree outside one unrelated test).

**New "Choose a delivery mode" explorer** — the interaction the task asked for. Four modes over `orbit run ship`, `orbit run ship --mode local`, `orbit run auto` and `orbit run ship-sweep`. Each panel gives the command, what runs, where it stops, and a dedicated "Authorized completion" row. That row is what distinguishes explicit PR review from authorized completion: `--complete` is described as separate, per-invocation, off by default, moving the task to `done` only once the PR is verified merged (pr) or the work is merged and pushed (local), blanket for the whole window (auto), and never available under ship-sweep because no setting, environment variable, or unattended routine turns it on.

Built as a native radio group switched by CSS `:has()`. There is no JavaScript in it at all, so pointer, keyboard and screen-reader support are the platform's rather than reimplemented.

**New "Go further" card row** giving visible routes into continuous delivery, recurring work, publication/recovery, and the CLI reference — these were previously only flat links in the docs index, which the docs index still keeps.

**Honesty fixes.** The hero transcript is now a `figure` with a `figcaption` reading "Illustrative transcript. The commands are real; identifiers, step rows and durations are placeholders, not measured results." No live metric, no metrics/architecture section resurrected, no unlanded feature advertised.

**Copy controls.** The single `.orbit-hero-install-copy` became a shared `.orbit-copy` used by the install bar and all four mode commands. Feedback goes to two channels: a short visible button label (Copy / Copied / Failed, width-reserved so the row never reflows) and an adjacent `role="status"` region carrying the full sentence for assistive technology. Failure also sets `title`. The clipboard path tries `navigator.clipboard` in a secure context, falls back to `execCommand`, and reports success only on the browser's own verdict, so an unavailable or rejected clipboard reports failure rather than a false success and never leaves an unhandled rejection. The buttons ship `hidden` and are unhidden by the script, so a page without JavaScript shows the command text and no dead control.

## Command accuracy

Every command was checked against current source, not against the docs alone: `run/ship.rs` (`--mode`, `--base`, `--complete`, registry fallback to `pr`), `run/auto.rs` (`--for`, `--concurrency` default 5, `--allow-crew`, `--complete` blanket wording), `run/command.rs`, `task/add.rs`, and `task/publication.rs` (`status` subcommand). Base-branch and ship-sweep wording matches `getting-started/workflows.md`.

## Validation

- `npm run check`: 0 errors, 0 warnings, 0 hints. `npm run build`: 29 pages.
- `make ci-fast`: pass. `make ci-lint`: pass (exit 0) — no Rust changed, run because the repo gate requires it.
- Rendered in headless Chromium at 390x844, 834x1112 and 1440x900, light and dark (12 full-page captures, before and after). No horizontal page overflow at any size (`scrollWidth == clientWidth` in all six after-cases), no console or page errors. The only elements extending past the viewport are inside the hero terminal's own `overflow-x: auto` scroller, which is pre-existing and identical in the before capture.
- 26/26 scripted browser checks pass (`interaction-checks.txt`): pointer click on each of the four modes; ArrowRight/ArrowLeft through the radio group; a visible 2px focus ring on the focused tab; `role="radiogroup"` with label and exactly one checked radio; an ARIA snapshot showing four radios with one `[checked]` and the three unselected panels absent from the accessibility tree; clipboard success writing the real string and resetting; clipboard rejection and clipboard-unavailable both reporting failure with guidance and zero unhandled errors; and with JavaScript disabled, all four panels present, the default panel rendered, the CSS radio switch still changing panels, the copy button still hidden, and all 36 links present. Every internal homepage link returns 200.
- WCAG AA contrast audited on 14 text surfaces per viewport/theme (`contrast-report.txt`). The first pass found six genuine failures in new markup, all fixed: tab command, fact key, terminal caption and copy button moved from `gray-4` to `gray-3`; the selected tab name moved from `text-accent` to `accent-high` (4.2:1 in light); and `.orbit-section-lede` / `.orbit-hero-providers-note` needed a `.orbit-landing` prefix because `.sl-markdown-content :is(p, li)` outranks a lone class selector. Final: 14/14 AA in all six combinations.
- Focus improvement beyond the new components: `.orbit-card:focus-visible` previously set `outline: none` and relied on the hover treatment alone; it now draws a real ring.
- Added a `prefers-reduced-motion` guard covering the card, copy and tab transitions and the card lift.
- Tablet density: the 3- and 4-card grids collapsed straight from multi-column to one column at 54rem, wasting half an 834px viewport. Added an intermediate two-column step and a new 34rem phone breakpoint for the final collapse.

## Scope notes

`website/DESIGN.md` was not in `context_files`; I appended it and recorded it here. Its section 3.5 described a landing page that does not exist (a rotating orbit diagram, a five-card `01`-`05` grid, a two-column Why Orbit strip, a `v0.9.2` eyebrow) and would have been stale in a different way after this change; the repository treats a stale description of live behavior as a review blocker. It now describes the shipped page, and principle 4's "Zero JS by default" notes the copy handler as the one scripted exception.

Homepage markup and styles stay isolated: everything new is under the `orbit-flow-*`, `orbit-copy*`, `orbit-section-lede`, `orbit-terminal-caption` and `orbit-hero-providers-note` names, all reached only from `index.md`. No shared component, no `astro.config.mjs` change, nothing touching a crew setup explorer or the workflows documentation/schema.

Two frictions filed: F2026-09-031 (blank lines before four-space-indented raw HTML in a Starlight `.md` page silently become expressive-code blocks — this shipped a visible broken block past a clean `astro check`) and F2026-09-032 (Playwright Chromium needs five system libraries this host lacks, plus the npm PATH and read-only npm cache workarounds, all of which any future rendered-validation task will hit).

`website/node_modules`, `website/dist`, `website/.astro` and the 1.4 GB `target/` produced by this run were removed at handoff; the npm and Playwright caches were kept outside the worktree in `/tmp` throughout. 24 evidence artifacts attached (12 before/after full pages, 6 explorer details, 4 interaction captures including the no-JS render and both clipboard failure states, and the two validation logs).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11369-6a9cc5b7`
- Behind base: 0
- Ahead of base: 1