### PR TITLE
Resolve task-pilot base branch from the owning workspace instead of agent-main

### DIFF
--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -10,6 +10,9 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
+# The base branch is deliberately omitted from the job defaults: an absent or
+# empty input resolves through the owning workspace's `workflow.base_branch`.
+# A non-empty run input remains an explicit override.
 # Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -42,7 +45,6 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
-    base_branch: agent-main
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -10,6 +10,9 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
+# The base branch is deliberately omitted from the job defaults: an absent or
+# empty input resolves through the owning workspace's `workflow.base_branch`.
+# A non-empty run input remains an explicit override.
 # Agent dispatch failures still stop at the
 # all-join. Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -42,7 +45,6 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
-    base_branch: agent-main
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its zero-input source snapshot uses the owning workspace's `[workflow] base_branch`; pass a non-empty `base_branch` run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -10,7 +10,9 @@ use tempfile::TempDir;
 
 use super::super::task_pilot::{apply, prepare};
 use crate::OrbitRuntime;
-use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+use crate::adapter::engine_host::v2_host::test_support::{
+    runtime_with_workspace_config, runtime_with_workspace_layout,
+};
 use crate::application::task::TaskAddParams;
 
 const LANDING: &str = "agent-main";
@@ -118,12 +120,18 @@ fn commit_file(repo: &Path, relative: &str, contents: &str) -> String {
     git(repo, &["rev-parse", "HEAD"])
 }
 
-fn remote_landing_fixture() -> RemoteLandingFixture {
-    let (root, runtime, repo) = runtime_with_workspace_layout();
+fn remote_landing_fixture_with_workspace_config(
+    branch: &str,
+    config_toml: Option<&str>,
+) -> RemoteLandingFixture {
+    let (root, runtime, repo) = match config_toml {
+        Some(config_toml) => runtime_with_workspace_config(Some(config_toml)),
+        None => runtime_with_workspace_layout(),
+    };
     let remote = root.path().join("remote.git");
     let seed = root.path().join("seed");
     git(root.path(), &["init", "--bare", remote.to_str().unwrap()]);
-    init_repo(&repo, LANDING);
+    init_repo(&repo, branch);
     fs::create_dir_all(repo.join("src")).expect("src dir");
     fs::write(repo.join(".gitignore"), ".orbit/\n").expect("ignore orbit store");
     fs::write(repo.join("src/existing.rs"), "existing\n").expect("write existing");
@@ -133,7 +141,7 @@ fn remote_landing_fixture() -> RemoteLandingFixture {
         &repo,
         &["remote", "add", "origin", remote.to_str().unwrap()],
     );
-    git(&repo, &["push", "-u", "origin", LANDING]);
+    git(&repo, &["push", "-u", "origin", branch]);
     let stale_sha = git(&repo, &["rev-parse", "HEAD"]);
 
     git(
@@ -141,7 +149,7 @@ fn remote_landing_fixture() -> RemoteLandingFixture {
         &[
             "clone",
             "--branch",
-            LANDING,
+            branch,
             remote.to_str().unwrap(),
             seed.to_str().unwrap(),
         ],
@@ -150,7 +158,7 @@ fn remote_landing_fixture() -> RemoteLandingFixture {
     git(&seed, &["config", "user.email", "orbit-test@example.com"]);
     git(&seed, &["config", "commit.gpgsign", "false"]);
     let current_sha = commit_file(&seed, "src/merged.rs", "newly merged\n");
-    git(&seed, &["push", "origin", LANDING]);
+    git(&seed, &["push", "origin", branch]);
 
     assert_eq!(git(&repo, &["rev-parse", "HEAD"]), stale_sha);
     assert!(!repo.join("src/merged.rs").exists());
@@ -167,6 +175,14 @@ fn remote_landing_fixture() -> RemoteLandingFixture {
     }
 }
 
+fn remote_landing_fixture_for(branch: &str) -> RemoteLandingFixture {
+    remote_landing_fixture_with_workspace_config(branch, None)
+}
+
+fn remote_landing_fixture() -> RemoteLandingFixture {
+    remote_landing_fixture_for(LANDING)
+}
+
 fn prepare_landing(fixture: &RemoteLandingFixture) -> Result<Value, String> {
     prepare(
         &fixture.runtime,
@@ -178,6 +194,66 @@ fn prepare_landing(fixture: &RemoteLandingFixture) -> Result<Value, String> {
         }),
     )
     .map_err(|error| error.to_string())
+}
+
+fn prepare_with_base_branch(
+    fixture: &RemoteLandingFixture,
+    base_branch: Option<&str>,
+) -> Result<Value, String> {
+    let mut input = json!({
+        "task_ids": [fixture.task.id.clone()],
+        "workspace_path": fixture.repo,
+    });
+    if let Some(base_branch) = base_branch {
+        input["base_branch"] = json!(base_branch);
+    }
+    prepare(&fixture.runtime, "prepare_task_pilot", &input).map_err(|error| error.to_string())
+}
+
+#[test]
+fn zero_input_preparation_uses_the_owning_workspace_main_branch() {
+    let fixture = remote_landing_fixture_for("main");
+
+    let prepared = prepare_with_base_branch(&fixture, None)
+        .expect("zero-input preparation must use the default workspace branch");
+
+    assert_eq!(prepared["source"]["base_branch"], "main");
+    assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
+}
+
+#[test]
+fn zero_input_preparation_uses_a_configured_agent_main_branch() {
+    let fixture = remote_landing_fixture_with_workspace_config(
+        LANDING,
+        Some("[workflow]\nbase_branch = \"agent-main\"\n"),
+    );
+
+    let prepared = prepare_with_base_branch(&fixture, None)
+        .expect("zero-input preparation must use the configured agent-main branch");
+
+    assert_eq!(prepared["source"]["base_branch"], LANDING);
+    assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
+}
+
+#[test]
+fn explicit_base_branch_overrides_the_owning_workspace_default() {
+    let fixture = remote_landing_fixture();
+
+    let prepared = prepare_with_base_branch(&fixture, Some(LANDING))
+        .expect("an explicit task-pilot branch must remain authoritative");
+
+    assert_eq!(prepared["source"]["base_branch"], LANDING);
+    assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
+}
+
+#[test]
+fn explicit_missing_base_branch_fails_before_pilot_dispatch() {
+    let fixture = remote_landing_fixture_for("main");
+
+    let error = prepare_with_base_branch(&fixture, Some("missing-branch"))
+        .expect_err("an unavailable explicit branch must fail closed");
+
+    assert!(error.contains("could not fetch"), "{error}");
 }
 
 #[test]

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -443,6 +443,10 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions() {
     let asset = load_job_asset(yaml).expect("task pilot pipeline parses");
     let defaults = asset.spec.default_input.as_ref().expect("default input");
     assert_eq!(defaults["task_ids"], json!([]));
+    assert!(
+        defaults.get("base_branch").is_none(),
+        "zero-input task-pilot runs must resolve the branch from their owning workspace"
+    );
     assert_eq!(defaults["max_partition_size"], 5);
     assert_eq!(defaults["promotion_authorized"], false);
     assert_eq!(defaults["ci_sweep_filing"], Value::Null);


### PR DESCRIPTION
## Task

[ORB-11351](https://orbit-cli.com/tasks/ORB-11351) — Resolve task-pilot base branch from the owning workspace instead of agent-main

### Description

Mac Orbit 0.18.0 repeatedly fails zero-input task_pilot_pipeline in workspaces registered and configured on main. dsearch ws_dsearch run jrun-20260906-0046 and monodev/local-data-platform jrun-20260905-2346 fail prepare_task_pilot with `could not fetch origin/agent-main ... couldn't find remote ref refs/heads/agent-main`. Authoritative Mac machine hm_ba054a1a8fbfb914 workspace list and effective config both report main. Installed /Users/daniel/.orbit/resources/jobs/task_pilot_pipeline.yaml:45 and canonical crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml:45 hardcode base_branch: agent-main. The job forwards that value into preparation, overriding the correct configured branch. Fix default source selection using existing workspace/config resolution, preserving explicit run overrides and source freshness. Include scheduled zero-input callers and custom resource compatibility. Do not create agent-main branches to accommodate the defect. Dedicated Orbit worktree and focused regression tests required. This is a product fix task filed by Mac orchestration; no change to the separate Linux Orbit drain or automation policy.

### Acceptance Criteria

- Zero-input manual and scheduled pilot in a main-only remote prepares successfully and persists selectors pinned to main.
- Explicit base_branch remains authoritative; agent-main workspaces still use their configured branch.
- An integration test exercises effective shipped job defaults against a main-only remote, and covers a deliberate alternate branch override plus invalid/missing-ref failure.
- Canonical managed assets and documentation reflect the resolution contract; repository validation passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the hard-coded agent-main task-pilot job default from both canonical and managed resources, so empty input defers to the owning workspace workflow base branch.
- Documented zero-input resolution and explicit run overrides in the shipped workflows reference.
- Added source-snapshot coverage for main-only zero-input, configured agent-main zero-input, explicit alternate branch override, and unavailable-ref failure; catalog coverage pins the shipped default contract.
Assessment: focused resource-only behavior change; existing runtime resolution already preserves non-empty explicit inputs.
Validation:
- cargo fmt --check
- cargo test -p orbit-core task_pilot_source --lib (12 passed)
- cargo test -p orbit-core task_pilot_pipeline_resolves_system_crew_and_bounded_all_join_partitions --lib (1 passed)
- make ci-fast
- make ci-lint
- git diff --check
Friction checkpoint: no qualifying friction observed.
Cleanup: removed this run generated target build output; remaining tracked changes are the five task-scoped resources, tests, and documentation files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11351-6a9cca37`
- Behind base: 0
- Ahead of base: 1