### PR TITLE
Recognize checkout SHA command output when CI step labels are unknown

### DIFF
--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1001,6 +1001,55 @@ fn live_failure_fixture_is_latest_current_and_evidence_complete() {
     assert_eq!(evidence["summary"]["retryable_errors"], json!(0));
 }
 
+/// The 2026-09-06 current-main macOS failure logged `git log -1 --format=%H`
+/// under `UNKNOWN STEP`. Its command/output pair is still runner evidence, so
+/// collection must pass the complete failure to the filing sweep instead of
+/// deferring it as missing checkout identity.
+#[test]
+fn unknown_step_git_log_checkout_is_investigated_for_filing() {
+    const CHECKOUT: &str = "9a611e053bb440451cdfb5468749327853b12ff9";
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", CHECKOUT)
+        .with_head("main", OLD)
+        .with_runs(vec![vec![run_on_branch(
+            33_948_877_857,
+            "macOS Platform",
+            "agent-main",
+            CHECKOUT,
+            "completed",
+            Some("failure"),
+            "2026-09-06T06:07:50Z",
+        )]])
+        .with_run_view(
+            "33948877857",
+            json!({"failed_jobs": [{
+                "job_id": 101_260_058_863_u64,
+                "name": "macOS tests",
+                "conclusion": "failure",
+            }]}),
+        )
+        .with_log("33948877857", false, "macOS Platform\tmacOS tests\tassertion failed\n")
+        .with_log(
+            "33948877857",
+            true,
+            "macOS Platform\tUNKNOWN STEP\t2026-09-06T06:07:50.4897836Z [command]/usr/bin/git log -1 --format=%H\n\
+             macOS Platform\tUNKNOWN STEP\t2026-09-06T06:07:50.4927165Z 9a611e053bb440451cdfb5468749327853b12ff9\n",
+        );
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 1}),
+    )
+    .expect("collect");
+    let failure = &evidence["current_failures"][0];
+
+    assert_eq!(failure["actual_checkout_shas"], json!([CHECKOUT]));
+    assert_eq!(failure["checkout_identity"]["state"], json!("observed"));
+    assert_eq!(failure["investigated"], json!(true));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(evidence["retryable_errors"], json!([]));
+}
+
 /// ORB-11278: a failed job inside an in-progress workflow is current once
 /// evidence is complete. A still-running sibling check is not a repair task.
 #[test]

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -438,6 +438,10 @@ struct CheckoutEvidenceCollector {
     /// that was checked out — as opposed to a merge parent or a fetched ref
     /// that happened to share the line.
     named_commits: HashSet<String>,
+    /// A recognized command whose immediately following output line may name
+    /// the checkout. Keep only one bounded line: an unrelated intervening
+    /// line consumes it instead of letting a later SHA inherit its authority.
+    pending_checkout_command: Option<String>,
     lines: Vec<String>,
     complete: bool,
     display_truncated: bool,
@@ -455,6 +459,7 @@ impl CheckoutEvidenceCollector {
             commits: Vec::new(),
             seen_commits: HashSet::new(),
             named_commits: HashSet::new(),
+            pending_checkout_command: None,
             lines: Vec::new(),
             complete: true,
             display_truncated: false,
@@ -480,6 +485,10 @@ impl CheckoutEvidenceCollector {
                 let identity_bearing = overlong_line_is_identity_bearing(&self.pending_line, part);
                 self.pending_line.clear();
                 self.dropping_line = !part.ends_with('\n');
+                // A dropped physical line still consumes a preceding
+                // `git log` command. Otherwise a later unrelated SHA could
+                // inherit authority that belonged only to this line.
+                self.pending_checkout_command = None;
                 if identity_bearing {
                     self.complete = false;
                 } else {
@@ -516,15 +525,25 @@ impl CheckoutEvidenceCollector {
             .iter()
             .any(|marker| lowered.contains(marker));
         let in_checkout_step = step.to_ascii_lowercase().contains("checkout");
-        if !(marked || in_checkout_step && is_bare_commit_sha(payload)) {
+        let command_output = self
+            .pending_checkout_command
+            .take()
+            .filter(|_| is_bare_commit_sha(payload));
+        let command = checkout_identity_command(payload);
+        if !(marked || in_checkout_step && is_bare_commit_sha(payload) || command_output.is_some())
+        {
+            self.pending_checkout_command = command;
             return;
         }
-        if self.lines.len() < self.max_lines {
-            self.lines.push(redact_all(payload.trim()));
-        } else {
-            self.display_truncated = true;
+        if let Some(command) = &command_output {
+            self.record_evidence_line(&command);
         }
-        let named = named_checkout_commit(payload, &lowered, in_checkout_step);
+        self.record_evidence_line(payload);
+        let named = named_checkout_commit(
+            payload,
+            &lowered,
+            in_checkout_step || command_output.is_some(),
+        );
         for token in commit_sha_tokens(payload) {
             if named == Some(token) {
                 self.named_commits.insert(token.to_string());
@@ -539,6 +558,15 @@ impl CheckoutEvidenceCollector {
             let token = token.to_string();
             self.seen_commits.insert(token.clone());
             self.commits.push(token);
+        }
+        self.pending_checkout_command = command;
+    }
+
+    fn record_evidence_line(&mut self, payload: &str) {
+        if self.lines.len() < self.max_lines {
+            self.lines.push(redact_all(payload.trim()));
+        } else {
+            self.display_truncated = true;
         }
     }
 }
@@ -600,6 +628,25 @@ fn is_hex(byte: u8) -> bool {
 fn is_bare_commit_sha(payload: &str) -> bool {
     let trimmed = payload.trim();
     trimmed.len() == MAX_SHA_LEN && trimmed.bytes().all(is_hex)
+}
+
+/// Recognize the runner command that prints the checked-out `HEAD` as its
+/// next line. This intentionally accepts only `git log -1 --format=%H`, not
+/// a generic bare SHA after any command: ordinary test output and arbitrary
+/// repository probes must not become checkout identity.
+fn checkout_identity_command(payload: &str) -> Option<String> {
+    let command = payload.strip_prefix("[command]")?.trim();
+    let mut words = command.split_ascii_whitespace();
+    let program = words.next()?;
+    if program.rsplit('/').next()? != "git"
+        || !matches!(words.next(), Some("log"))
+        || !matches!(words.next(), Some("-1"))
+        || !matches!(words.next(), Some("--format=%H"))
+        || words.next().is_some()
+    {
+        return None;
+    }
+    Some(command.to_string())
 }
 
 /// The prose `actions/checkout` prints in front of the commit it landed on.

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -129,6 +129,65 @@ build\tRun tests\t2026-01-01T00:00:00.0000000Z 5dbb8eff6f1ec88a24da618df1962d2c6
     assert!(evidence.lines.is_empty());
 }
 
+/// A macOS runner emitted the command under `UNKNOWN STEP`, so step names
+/// alone could not distinguish the following SHA from ordinary test output.
+#[test]
+fn git_log_head_command_in_an_unknown_step_names_its_following_sha() {
+    let tested = "9a611e053bb440451cdfb5468749327853b12ff9";
+    let log = format!(
+        "macOS Platform\tUNKNOWN STEP\t2026-09-06T06:07:50.4897836Z [command]/usr/bin/git log -1 --format=%H\n\
+         macOS Platform\tUNKNOWN STEP\t2026-09-06T06:07:50.4927165Z {tested}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits, [tested]);
+    assert!(evidence.complete);
+    assert!(
+        evidence
+            .lines
+            .iter()
+            .any(|line| line.contains("git log -1 --format=%H")),
+        "the command provenance must be retained: {:?}",
+        evidence.lines
+    );
+}
+
+#[test]
+fn only_the_immediate_output_of_the_recognized_command_is_checkout_evidence() {
+    let unrelated = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let delayed = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let log = format!(
+        "ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0000000Z [command]/usr/bin/git rev-parse HEAD\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0010000Z {unrelated}\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0020000Z [command]/usr/bin/git log -1 --format=%H\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0030000Z not a SHA\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0040000Z {delayed}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert!(evidence.commits.is_empty(), "{:?}", evidence.commits);
+    assert!(evidence.lines.is_empty(), "{:?}", evidence.lines);
+}
+
+#[test]
+fn multiple_recognized_command_outputs_remain_ambiguous() {
+    let first = "cccccccccccccccccccccccccccccccccccccccc";
+    let second = "dddddddddddddddddddddddddddddddddddddddd";
+    let log = format!(
+        "ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0000000Z [command]/usr/bin/git log -1 --format=%H\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0010000Z {first}\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0020000Z [command]/usr/bin/git log -1 --format=%H\n\
+         ci\tUNKNOWN STEP\t2026-09-06T06:07:50.0030000Z {second}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert_eq!(evidence.commits, [first, second]);
+    assert!(evidence.complete);
+}
+
 #[test]
 fn checkout_evidence_lines_are_capped_and_redacted() {
     let line = format!(
@@ -230,6 +289,23 @@ fn an_overlong_checkout_line_is_dropped_and_marks_identity_incomplete() {
 }
 
 #[test]
+fn an_overlong_line_consumes_pending_checkout_command_context() {
+    let tested = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    let overlong = "x".repeat(20_000);
+    let log = format!(
+        "ci\tUNKNOWN STEP\t[command]/usr/bin/git log -1 --format=%H\n\
+         ci\tUNKNOWN STEP\t{overlong}\n\
+         ci\tUNKNOWN STEP\t{tested}\n"
+    );
+
+    let evidence = scan_checkout_evidence(&log, 40);
+
+    assert!(evidence.commits.is_empty(), "{:?}", evidence.commits);
+    assert!(evidence.complete);
+    assert!(evidence.display_truncated);
+}
+
+#[test]
 fn streaming_log_finds_middle_checkout_without_retaining_it_in_the_excerpt() {
     let sha = "2d773a649844b168c5cfce4c80feadb8b025bb69";
     let mut collector = StreamedLogCollector::new(96, 40);
@@ -257,6 +333,22 @@ fn streaming_log_marks_identity_incomplete_after_the_hard_scan_limit() {
     let mut collector = StreamedLogCollector::new(64, 40);
     collector.push(&vec![b'x'; MAX_CHECKOUT_LOG_SCAN_BYTES]);
     collector.push(format!("\nsetup\tCheckout\tHEAD is now at {sha}\n").as_bytes());
+    let log = collector.finish();
+
+    assert!(log.checkout_evidence.source_truncated);
+    assert!(!log.checkout_evidence.complete);
+    assert!(log.checkout_evidence.commits.is_empty());
+}
+
+#[test]
+fn command_output_past_the_hard_scan_limit_is_not_verified() {
+    let tested = "2d773a649844b168c5cfce4c80feadb8b025bb69";
+    let command = b"ci\tUNKNOWN STEP\t[command]/usr/bin/git log -1 --format=%H\n";
+    let fill = MAX_CHECKOUT_LOG_SCAN_BYTES - command.len();
+    let mut collector = StreamedLogCollector::new(64, 40);
+    collector.push(command);
+    collector.push(&vec![b'x'; fill]);
+    collector.push(format!("\nci\tUNKNOWN STEP\t{tested}\n").as_bytes());
     let log = collector.finish();
 
     assert!(log.checkout_evidence.source_truncated);


### PR DESCRIPTION
## Task

[ORB-11358](https://orbit-cli.com/tasks/ORB-11358) — Recognize checkout SHA command output when CI step labels are unknown

### Description

Mac CI sweep ws_kvdb jrun-20260906-0056-2 deferred current main run 33948877857 with 'run logs contained no actual checkout SHA'. Authoritative GitHub failed job 101260058863 log contains UNKNOWN STEP 06:07:50.4897836Z [command]/usr/bin/git log -1 --format=%H followed at 06:07:50.4927165Z by 9a611e053bb440451cdfb5468749327853b12ff9. Current ref and run metadata agree. crates/orbit-tools/src/builtin/github/mod.rs:511-520 only admits bare SHA when the step label contains checkout; named_checkout_commit:615-632 has the same condition. Track bounded recognized checkout-command/output context so missing display step names do not hide real identity. This is separate from completed ORB-11248 display truncation handling. Preserve explicit source/ambiguity limits; never substitute event head for tested checkout.

### Acceptance Criteria

- A real UNKNOWN STEP fixture with git log -1 --format=%H and its following SHA yields the actual checkout identity.
- Unrelated bare SHAs, ambiguous/multiple checkouts, partial scans and output from unrelated commands remain unverified; preserve bounded memory and scan limits.
- Collector-to-sweep regression verifies the complete current-main failure is investigated/filed instead of deferred; owning tests and ci-fast pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- The bounded checkout-evidence collector now recognizes a full SHA only as the immediately following output of the exact runner command `git log -1 --format=%H`; it preserves that command as evidence and consumes pending context on any intervening or dropped line.
- Added real UNKNOWN STEP macOS command/output coverage, negative unrelated-command and delayed-output cases, multiple-output ambiguity coverage, and hard-scan/overlong-line bounds coverage.
- Added the current-main collector-to-sweep regression for run 33948877857, proving complete evidence is investigated and emitted as `current_failures` for filing rather than deferred.
Assessment: source provenance remains explicit, SHA identity is never inferred from event metadata or arbitrary output, and pending context stays bounded to one physical log line.
Validation:
- `cargo test -p orbit-tools bounded_logs --no-fail-fast` (23 passed)
- `cargo test -p orbit-engine unknown_step_git_log_checkout_is_investigated_for_filing --no-fail-fast` (passed)
- `make ci-fast` (passed)
Cleanup: removed this run’s generated Cargo target directory with `cargo clean`; final worktree contains only the three intended task-scoped source/test changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11358-6a9cca37`
- Behind base: 0
- Ahead of base: 1