### PR TITLE
Exclude passing test names from CI failure deduplication signatures

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1153,9 +1153,10 @@ const ERROR_MARKERS: &[&str] = &[
 /// again every hour. Prefer an `##[error]`-annotated line over an unanchored
 /// marker substring, except that GitHub's generic runner-completion annotation
 /// yields to a specific unannotated diagnostic immediately before it. Never
-/// sign off runner-bookkeeping (checkout, group headers, `env:`/`with:` dumps).
-/// With no usable line the step name alone is the signature — weaker, but
-/// stable, and still scoped by workflow and job.
+/// sign off runner-bookkeeping (checkout, group headers, `env:`/`with:` dumps)
+/// or libtest success/section lines whose names happen to contain a marker
+/// word. With no usable line the step name alone is the signature — weaker,
+/// but stable, and still scoped by workflow and job.
 fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
     let lines = classify_log_lines(log_excerpt);
     for (kind, line) in &lines {
@@ -1308,7 +1309,7 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
                 LineKind::ErrorAnnotated
             } else if is_runner_bookkeeping(&lowered) || lowered.contains("##[group]") {
                 LineKind::Bookkeeping
-            } else if ERROR_MARKERS.iter().any(|marker| lowered.contains(marker)) {
+            } else if is_error_marker_line(&lowered) {
                 LineKind::Marker
             } else {
                 LineKind::Content
@@ -1345,6 +1346,38 @@ fn is_run_command_payload(payload: &str) -> bool {
 
 fn is_runner_bookkeeping(lowered: &str) -> bool {
     lowered.starts_with("head is now at") || lowered.starts_with("syncing repository")
+}
+
+/// Unanchored marker hit that is an actual diagnostic, not a passing test or
+/// cargo/libtest section header. Those headers are identical across distinct
+/// panics, and success lines often contain `error`/`failure` in the test name.
+fn is_error_marker_line(lowered: &str) -> bool {
+    if is_libtest_non_diagnostic(lowered) {
+        return false;
+    }
+    ERROR_MARKERS.iter().any(|marker| lowered.contains(marker))
+}
+
+fn is_libtest_non_diagnostic(lowered: &str) -> bool {
+    let trimmed = lowered.trim();
+    matches!(trimmed, "failures:" | "errors:" | "successes:")
+        || trimmed.starts_with("test result:")
+        || is_successful_test_result(trimmed)
+}
+
+/// `test <name> ... ok` / `ignored`, with an optional timing suffix.
+fn is_successful_test_result(lowered: &str) -> bool {
+    let Some(rest) = lowered.strip_prefix("test ") else {
+        return false;
+    };
+    let Some((_, status)) = rest.rsplit_once(" ... ") else {
+        return false;
+    };
+    let status = status.trim();
+    status == "ok"
+        || status.starts_with("ok ")
+        || status == "ignored"
+        || status.starts_with("ignored ")
 }
 
 /// Cap `text` at `max_bytes` while keeping `anchor_line`, not the head.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -1027,6 +1027,150 @@ fn same_failure_under_a_different_commit_message_reuses_the_failure_key() {
     );
 }
 
+/// Captured Coverage / Collect workspace coverage shape from ORB-11340:
+/// passing libtest names that contain `error`/`failure`, then `failures:`,
+/// the panic, cargo wrappers, and GitHub's generic exit trailer. Collection
+/// often drops the `test … FAILED` line with the middle of the log.
+fn orb_11340_style_rust_test_log(passing: &[&str], failing: &str) -> String {
+    let prefix = |msg: &str| {
+        format!(
+            "Coverage (informational)\tCollect workspace coverage\t2026-09-06T00:12:19.7226670Z {msg}\n"
+        )
+    };
+    let mut out = String::new();
+    out.push_str(&prefix(
+        "##[group]Run cargo llvm-cov --workspace --locked --no-report",
+    ));
+    for name in passing {
+        out.push_str(&prefix(&format!("test {name} ... ok")));
+    }
+    out.push_str(&prefix(""));
+    out.push_str(&prefix("failures:"));
+    out.push_str(&prefix(""));
+    out.push_str(&prefix(&format!("---- {failing} stdout ----")));
+    out.push_str(&prefix(""));
+    out.push_str(&prefix(&format!(
+        "thread '{failing}' (10411) panicked at crates/orbit-cli/tests/mcp_roundtrip.rs:1416:33:"
+    )));
+    out.push_str(&prefix(
+        "spawn destination-issued command: Os { code: 26, kind: ExecutableFileBusy, message: \"Text file busy\" }",
+    ));
+    out.push_str(&prefix(
+        "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+    ));
+    out.push_str(&prefix(""));
+    out.push_str(&prefix("failures:"));
+    out.push_str(&prefix(&format!("    {failing}")));
+    out.push_str(&prefix(""));
+    out.push_str(&prefix(
+        "test result: FAILED. 46 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 81.42s",
+    ));
+    out.push_str(&prefix(""));
+    out.push_str(&prefix(
+        "error: test failed, to rerun pass `-p orbit-cli --test mcp_roundtrip`",
+    ));
+    out.push_str(&prefix(
+        "error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)",
+    ));
+    out.push_str(&prefix("##[error]Process completed with exit code 101."));
+    out
+}
+
+const ORB_11340_PASSING: &[&str] = &[
+    "unmanaged_orbit_workspace_env_does_not_bind_mcp",
+    "mcp_serve_error_paths_return_tool_errors_and_keep_serving",
+    "task_show_is_global_by_default_across_tool_run_and_mcp",
+];
+
+const ORB_11340_FAILING: &str = "a_forced_command_ignores_the_command_the_caller_asked_for";
+
+#[test]
+fn passing_test_names_with_error_words_are_not_the_signature() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = orb_11340_style_rust_test_log(ORB_11340_PASSING, ORB_11340_FAILING);
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let signature = signature_line(&description).to_ascii_lowercase();
+    assert!(
+        signature.contains(ORB_11340_FAILING) && signature.contains("panicked"),
+        "signature must be the panic diagnostic: {signature}"
+    );
+    assert!(
+        !signature.contains("mcp_serve_error_paths")
+            && !signature.contains("... ok")
+            && !signature.contains("keep_serving"),
+        "a passing test whose name contains error must not be the signature: {signature}"
+    );
+    assert!(
+        !signature.contains("process completed"),
+        "generic runner trailer must not be the signature: {signature}"
+    );
+}
+
+#[test]
+fn distinct_rust_panics_with_the_same_passing_preamble_keep_distinct_keys() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let foo_log = orb_11340_style_rust_test_log(ORB_11340_PASSING, ORB_11340_FAILING);
+    let bar_log = orb_11340_style_rust_test_log(
+        ORB_11340_PASSING,
+        "another_forced_command_ignores_the_command_the_caller_asked_for",
+    );
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![
+            failure(10, "ci", "coverage", "collect coverage", &foo_log, CHECKOUT),
+            failure(11, "ci", "coverage", "collect coverage", &bar_log, CHECKOUT),
+        ])}),
+    );
+
+    assert_eq!(first["filed_count"], json!(2));
+    let filed = first["filed"].as_array().expect("filed");
+    assert_ne!(filed[0]["failure_key"], filed[1]["failure_key"]);
+    for (task_id, needle) in filed_task_ids(&first).iter().zip([
+        ORB_11340_FAILING,
+        "another_forced_command_ignores_the_command_the_caller_asked_for",
+    ]) {
+        let description = runtime
+            .get_task(task_id)
+            .expect("read filed task")
+            .description;
+        let signature = signature_line(&description).to_ascii_lowercase();
+        assert!(
+            signature.contains(needle) && signature.contains("panicked"),
+            "each panic must be its own signature: {signature}"
+        );
+        assert!(
+            !signature.contains("mcp_serve_error_paths"),
+            "shared passing preamble must not become the signature: {signature}"
+        );
+    }
+
+    let renamed_preamble = orb_11340_style_rust_test_log(
+        &[
+            "renamed_mcp_serve_error_paths_return_tool_errors_and_keep_serving",
+            "workspace_init_mcp_config_reaches_a_governed_tool_over_the_real_transport",
+        ],
+        ORB_11340_FAILING,
+    );
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            12,
+            "ci",
+            "coverage",
+            "collect coverage",
+            &renamed_preamble,
+            NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(
+        repeated["skipped_existing"][0]["failure_key"], filed[0]["failure_key"],
+        "the same panic must retain its failure key across passing-test names, run ids, and commits"
+    );
+}
+
 #[test]
 fn query_error_prevents_filing_and_remains_retryable() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();


### PR DESCRIPTION
## Task

[ORB-11341](https://orbit-cli.com/tasks/ORB-11341) — Exclude passing test names from CI failure deduplication signatures

### Description

## Observed defect
At source 5530555cc4d75935465b7c4cdc533dca86951dbf, sweep jrun-20260906-0018 filed ORB-11340 for run https://github.com/danieljhkim/orbit/actions/runs/34000381226, Coverage (informational) / Collect workspace coverage. The persisted normalized signature is `test mcp_serve_error_paths_return_tool_errors_and_keep_serving ... ok`, a passing test. The actual failure is `a_forced_command_ignores_the_command_the_caller_asked_for`, panic at crates/orbit-cli/tests/mcp_roundtrip.rs:1416, `ExecutableFileBusy` / Text file busy (OS 26).

## Cause and impact
crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs:1137 defines bare substring markers, and error_signature at :1159 selects the first Marker after specific annotations. A successful test name containing `error`/`failure` therefore becomes the commit-independent dedupe identity. Distinct real failures with the same successful preamble can collapse; a renamed successful test can refile the same failure.

## Scope
Fix classification/signature selection at the existing boundary so successful test result lines cannot become failure anchors merely because of their names. Preserve real compiler/test diagnostics, specific annotations, runner-completion fallback, bookkeeping exclusions, bounded excerpts, and stable cross-run dedupe. Do not invent a new parser framework. ORB-11113 and ORB-11132 are done and address checkout bookkeeping/generic annotation precedence; this live passing-test case remains. ORB-11340 owns the actual ETXTBSY repair, not this signature defect.

Use the captured realistic log shape from ORB-11340 as a regression fixture, including passing test names before a panic and generic GitHub exit trailer. Add regression_from/related relations to prior signature tasks if supported. Daniel authorized normal pilot/delivery/complete in the maximum-throughput session.

### Acceptance Criteria

- A realistic failing Rust test log containing earlier successful test names with error/failed/failure words selects the actual diagnostic, never the passing line.
- Two distinct failures with identical successful preambles produce distinct failure keys; the same failure with changed successful preambles and run/commit metadata reuses its key.
- Existing annotation precedence, runner-bookkeeping exclusion, bounded excerpts and no-diagnostic fallback remain covered by behavioral tests; focused filing tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `classify_log_lines` no longer treats libtest success lines (`test <name> ... ok` / `ignored`) or cargo/libtest section/summary lines (`failures:`, `errors:`, `successes:`, `test result:`) as Marker hits, so a passing test whose name contains error/failed/failure cannot become the commit-independent dedupe signature.
- Added an ORB-11340-shaped filing fixture: passing tests with error/failure in the name, then `failures:`, the panic/`ExecutableFileBusy` diagnostic, cargo wrappers, and GitHub's generic exit trailer. Filing selects the panic; two distinct panics with the same preamble get distinct keys; the same panic with renamed passing tests and different run/commit metadata reuses its key.
- Linked `related_to` ORB-11113, ORB-11132, and ORB-11340. Existing annotation precedence, bookkeeping exclusion, bounded excerpts, and step-name fallback tests remain.
Assessment: The change stays at the existing classification boundary rather than adding a parser. Skipping bare `failures:` is required for the truncated live log shape; otherwise that header would collapse distinct panics after passing tests are ignored.
Validation:
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure_tasks`: 28 passed (including the two new regressions and the prior annotation/bookkeeping/excerpt/fallback cases).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed. Remaining worktree entries are the two scoped files. Run-created `target/` was removed with `cargo clean`.
Friction checkpoint: none filed. No contradicted assumption, recurring failure, incident root cause, or >10-minute gotcha.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11341-6a9cca37`
- Behind base: 0
- Ahead of base: 1