### PR TITLE
[code-review] Copilot answer projection concatenates commentary, dropping a declared failed/timeout status

### DIFF
--- a/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/copilot_stream.rs
@@ -73,7 +73,7 @@ pub(crate) fn normalize_copilot_stdout(stdout: &[u8]) -> Vec<u8> {
 /// can supply Orbit response/status fields. [ORB-11348]
 pub(crate) fn project_copilot_response(stdout: &[u8]) -> Vec<u8> {
     let text = String::from_utf8_lossy(stdout);
-    let mut answer = String::new();
+    let mut terminal_answer = None;
     for line in text.lines() {
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
             continue;
@@ -81,17 +81,28 @@ pub(crate) fn project_copilot_response(stdout: &[u8]) -> Vec<u8> {
         if value.get("type").and_then(serde_json::Value::as_str) != Some("assistant.message") {
             continue;
         }
-        let Some(content) = value
+
+        // Tool-only messages are intermediate turns, not answers. Every
+        // other assistant message is terminal answer evidence, including an
+        // empty or malformed content field: a later invalid answer must not
+        // let an earlier envelope remain authoritative.
+        if has_tool_requests(&value) {
+            continue;
+        }
+        let content = value
             .pointer("/data/content")
             .and_then(serde_json::Value::as_str)
-            .filter(|content| !content.is_empty())
-        else {
-            continue;
-        };
-        answer.push_str(content);
-        answer.push('\n');
+            .unwrap_or_default();
+        terminal_answer = Some(content.as_bytes().to_vec());
     }
-    answer.into_bytes()
+    terminal_answer.unwrap_or_default()
+}
+
+fn has_tool_requests(value: &serde_json::Value) -> bool {
+    value
+        .pointer("/data/toolRequests")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|requests| !requests.is_empty())
 }
 
 fn is_model_output_frame(value: &serde_json::Value) -> bool {

--- a/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
+++ b/crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs
@@ -133,6 +133,46 @@ fn final_message_after_tool_traffic_is_the_only_projected_content() {
 }
 
 #[test]
+fn terminal_assistant_message_replaces_earlier_commentary() {
+    let envelope = r#"{"schemaVersion":1,"status":"failed","result":{},"error":{"code":"fixture","message":"failed"}}"#;
+    let stdout = format!(
+        "{}{}",
+        envelope_line("Commentary: I updated the files."),
+        envelope_line(envelope),
+    );
+
+    assert_eq!(projected(&stdout), envelope);
+}
+
+#[test]
+fn trailing_assistant_message_replaces_an_earlier_envelope() {
+    let stdout = format!(
+        "{}{}",
+        envelope_line(r#"{"schemaVersion":1,"status":"success","result":{},"error":null}"#),
+        envelope_line("Courtesy: the run is complete."),
+    );
+
+    assert_eq!(projected(&stdout), "Courtesy: the run is complete.");
+}
+
+#[test]
+fn empty_or_missing_terminal_content_replaces_an_earlier_envelope() {
+    let envelope = envelope_line(
+        r#"{"schemaVersion":1,"status":"success","result":{"source":"earlier"},"error":null}"#,
+    );
+
+    for terminal_message in [
+        r#"{"type":"assistant.message","data":{"content":""},"id":"msg-2"}"#,
+        r#"{"type":"assistant.message","data":{},"id":"msg-3"}"#,
+    ] {
+        assert!(
+            projected(&(envelope.clone() + terminal_message + "\n")).is_empty(),
+            "terminal message must replace the earlier envelope: {terminal_message}",
+        );
+    }
+}
+
+#[test]
 fn prompt_echo_is_never_read_as_completion_evidence() {
     // The regression this normalization exists for. Orbit's own prompt embeds
     // the response contract, example envelope included, and Copilot echoes the

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -341,6 +341,102 @@ fn run_cli_backend_projects_copilot_final_answer_and_keeps_usage() {
 }
 
 #[test]
+fn run_cli_backend_rejects_copilot_terminal_failed_or_timeout_after_commentary() {
+    let temp = tempdir().expect("tempdir");
+
+    for status in ["failed", "timeout"] {
+        let script = temp.path().join("copilot");
+        let commentary = serde_json::json!({
+            "type": "assistant.message",
+            "data": {"content": "Commentary: I updated the files."},
+        });
+        let envelope = serde_json::json!({
+            "schemaVersion": 1,
+            "status": status,
+            "result": {},
+            "error": {"code": "fixture", "message": status},
+        });
+        let terminal = serde_json::json!({
+            "type": "assistant.message",
+            "data": {"content": envelope.to_string()},
+        });
+        write_executable(
+            &script,
+            &format!(
+                "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{commentary}'\nprintf '%s\\n' '{terminal}'\n"
+            ),
+        );
+
+        let sink = Arc::new(RecordingSink::default());
+        let sink_for_writer: Arc<dyn AuditSink> = sink;
+        let audit = Arc::new(V2AuditWriter::new(
+            format!("job-copilot-{status}-after-commentary"),
+            "copilot:gpt-5.5",
+            sink_for_writer,
+        ));
+        let host = TestHost::with_command(script.display().to_string());
+        let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+        spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+        let outcome = run_cli_backend(
+            &host,
+            &spec,
+            &format!("job-copilot-{status}-after-commentary"),
+            audit,
+            &serde_json::json!({"prompt": "answer after progress"}),
+            None,
+        )
+        .expect("run cli backend");
+
+        assert!(
+            !outcome.success,
+            "{status} terminal envelope must fail the step"
+        );
+        assert_eq!(outcome.output["response_envelope_status"], status);
+        assert_eq!(outcome.output["completion_envelope_satisfied"], true);
+    }
+}
+
+#[test]
+fn run_cli_backend_rejects_copilot_trailing_terminal_prose() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("copilot");
+    write_executable(
+        &script,
+        concat!(
+            "#!/bin/sh\ncat > /dev/null\n",
+            "printf '%s\\n' '{\"type\":\"assistant.message\",\"data\":{\"content\":\"{\\\"schemaVersion\\\":1,\\\"status\\\":\\\"success\\\",\\\"result\\\":{},\\\"error\\\":null}\"}}'\n",
+            "printf '%s\\n' '{\"type\":\"assistant.message\",\"data\":{\"content\":\"Courtesy: the run is complete.\"}}'\n",
+        ),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-copilot-trailing-prose",
+        "copilot:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec(Duration::from_secs(5));
+    spec.provider = orbit_types::workflow::activity_job::Provider::Copilot;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "job-copilot-trailing-prose",
+        audit,
+        &serde_json::json!({"prompt": "answer then add courtesy prose"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert!(outcome.output["response_envelope_status"].is_null());
+    assert_eq!(outcome.output["completion_envelope_satisfied"], false);
+}
+
+#[test]
 fn run_cli_backend_projects_prose_prefixed_claude_envelope_result() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("claude");


### PR DESCRIPTION
## Task

[ORB-11375](https://orbit-cli.com/tasks/ORB-11375) — [code-review] Copilot answer projection concatenates commentary, dropping a declared failed/timeout status

### Description

## Symptom

For the `copilot` provider, a run in which the agent emits **any** non-empty
`assistant.message` besides the terminal envelope one (progress commentary
before the answer, or a courtesy line after it) is reported as a **successful**
step even when the agent's own envelope declares `status: "failed"` or
`"timeout"`.

## Confirmed control flow (live code)

1. `crates/orbit-agent/src/providers/mod.rs:95` routes `copilot` response/status
   projection to `project_copilot_response`.
2. `crates/orbit-agent/src/providers/copilot/copilot_stream.rs:74-95`
   concatenates *every* non-empty `assistant.message` `/data/content` with a
   trailing `\n`. Two messages therefore project as
   `"Commentary: I updated the files.\n{\"schemaVersion\":1,\"status\":\"failed\",…}\n"`.
3. `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:445-448`
   feeds exactly those projected bytes to `peek_response_status`.
4. `crates/orbit-agent/src/types/response/envelope.rs:35-42` —
   `peek_response_status` is `parse_json_documents(stdout).ok()?`, so it returns
   `None` the moment the projection is not a pure JSON stream.
5. `crates/orbit-agent/src/types/response/envelope.rs:115-129` —
   `parse_json_documents` runs `serde_json::Deserializer::from_str` over the
   whole projection. A leading prose line fails at the first token, so the whole
   call is `Err`.
6. `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:488-491` —
   `completion_status_failure` fires only on
   `Some("failed") | Some("timeout")`. With `envelope_status == None` it is
   `false`.
7. `crates/orbit-agent/src/types/response/envelope.rs:69-75` —
   `response_envelope_protocol_check` has a raw-string fallback
   (`find_agent_response_envelope_in_string`) when the stream will not parse, so
   `completion_envelope_error` at `orchestrator.rs:478-482` is `None` and the
   completion gate passes.
8. `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:495-499` —
   `success = exit_success && !completion_protocol_violation &&
   !completion_status_failure && …`, so the step succeeds.

The failure declaration is silently lost: the completion gate accepts the run
(step 7) while the status gate cannot see the token (steps 4-6). Only an
activity that opts into `require_response_envelope` catches it, because that
path uses `parse_cli_response_result`, which fails on the same unparseable
projection.

## Why now

ORB-11363 (`47ccc1767`) fixed exactly this shape for Codex:
`crates/orbit-agent/src/providers/codex/codex_output.rs:37-46` now retains only
the terminal completed `agent_message`, so the Codex projection stays a single
JSON document. Codex and Copilot were introduced as one symmetric boundary by
ORB-11348 — both modules cite it and `project_cli_response` treats them as the
same narrowed view — and Copilot was left on the concatenating behavior that
ORB-11363 established is wrong. `crates/orbit-core/assets/executors/copilot.yaml`
ships the provider, so the lane is live.

The repository's own Copilot fixtures already show multi-frame runs
(`crates/orbit-agent/src/providers/copilot/tests/copilot_stream.rs:111,124,126`);
those particular frames carry empty `content` and are filtered, but nothing
prevents a narrating turn from carrying non-empty `content` alongside its
`toolRequests`.

## Suggested direction

Give Copilot the same terminal-answer selection Codex now has: retain only the
last non-empty `assistant.message` `/data/content` instead of concatenating, and
keep validation in the response parser. Cover the two orderings (commentary
before the envelope, and a trailing message after it) and assert that a declared
`status: "failed"` still fails the step.

### Acceptance Criteria

- A Copilot JSONL stream carrying a non-empty assistant message before the terminal envelope message projects to the terminal answer alone, so `peek_response_status` resolves the declared status.
- A Copilot run whose terminal envelope declares `status: "failed"` (or `"timeout"`) fails the CLI-runner step even when earlier non-empty assistant messages are present.
- A trailing non-empty assistant message after the envelope does not let the earlier envelope remain authoritative, matching the Codex terminal-answer rule.
- Existing Copilot projection behavior is preserved for prompt-echo, tool-argument, auth-failure, and cancellation shapes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Copilot response projection now retains only the final non-tool assistant message, preserving raw normalized telemetry.
- A terminal empty or malformed message clears earlier envelope evidence; tool-request-only frames remain non-answers.
- Added projection and CLI-runner regressions for commentary before failed/timeout envelopes and trailing terminal prose.
Assessment: Scoped provider-boundary repair; all acceptance criteria covered.
Validation:
- cargo fmt --all --check
- cargo test -p orbit-agent providers::copilot::tests::copilot_stream --lib
- cargo test -p orbit-engine activity_job::cli_runner::tests::orchestrator::run_cli_backend_rejects_copilot --lib
- make ci-fast
- make ci-lint
Cleanup: cargo clean removed 3.8 GiB of generated target artifacts.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11375-6a9ccc26`
- Behind base: 0
- Ahead of base: 1