### PR TITLE
Defer CI refs whose current relevance was not established within probe bounds

### DIFF
--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -31,8 +31,12 @@ spec:
     `ref_no_longer_exists` rather than current: its pull request merged or
     its branch was deleted, so the landing branch's own runs are the live
     evidence. That probe is authoritative and bounded — one origin query per
-    distinct branch carrying a red run — and a probe that fails leaves the
-    failure current. When candidates outnumber `max_investigated_runs` the
+    distinct branch carrying a red run, rotating through overflow candidates
+    across bounded sweeps by `investigation_cursor` without starvation. A candidate
+    branch whose origin probe is skipped past the probe budget or fails transiently
+    remains in `deferred` with a run-scoped retryable error rather than being
+    listed as current or assumed merged; verified current failures still progress.
+    When candidates outnumber `max_investigated_runs` the
     ranked prefix keeps all but one slot and the last slot rotates through
     the overflow by `investigation_cursor`, so a candidate below the cap is
     investigated within one rotation instead of never. Discovery or investigation failures are
@@ -68,8 +72,9 @@ spec:
         type: number
         description: >
           Cap on origin probes for branches no scanned head covers. Defaults to
-          20, maximum 100. Branches past the cap keep their failures listed as
-          current rather than being assumed merged.
+          20, maximum 100. Branches past the cap keep their failures deferred
+          with retryable errors until relevance is established rather than
+          being assumed merged or current.
       investigation_cursor:
         type: number
         description: >
@@ -109,6 +114,8 @@ spec:
           stale_or_superseded:
             type: array
           in_flight:
+            type: array
+          deferred:
             type: array
           retryable_errors:
             type: array

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -248,21 +248,30 @@ where
     // of the retryable gap it is: surface it as its own deferred entry so the
     // run ID and reason stay visible for a later sweep.
     let matched_run_ids: BTreeSet<String> = failures.iter().filter_map(run_id_key).collect();
+    let evidence_deferred = evidence
+        .get("deferred")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
     for (run_id, reasons) in &run_errors {
         if matched_run_ids.contains(run_id) {
             continue;
         }
+        let from_evidence = evidence_deferred
+            .iter()
+            .find(|entry| run_id_key(entry).as_deref() == Some(run_id));
         let run_id_value = reasons
             .first()
             .and_then(|reason| reason.get("run_id"))
             .cloned()
+            .or_else(|| from_evidence.and_then(|entry| entry.get("run_id")).cloned())
             .unwrap_or(Value::Null);
         deferred.push(json!({
             "run_id": run_id_value,
-            "url": Value::Null,
-            "workflow": Value::Null,
-            "head_branch": Value::Null,
-            "ref_kind": Value::Null,
+            "url": from_evidence.and_then(|entry| entry.get("url")).cloned().unwrap_or(Value::Null),
+            "workflow": from_evidence.and_then(|entry| entry.get("workflow")).cloned().unwrap_or(Value::Null),
+            "head_branch": from_evidence.and_then(|entry| entry.get("head_branch")).cloned().unwrap_or(Value::Null),
+            "ref_kind": from_evidence.and_then(|entry| entry.get("ref_kind")).cloned().unwrap_or(Value::Null),
             "investigated": false,
             "retryable": true,
             "reasons": reasons,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -269,6 +269,51 @@ fn a_pending_in_flight_run_with_no_failed_jobs_is_still_a_no_op() {
 }
 
 #[test]
+fn explicit_deferred_evidence_retains_metadata_alongside_filed_tasks() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = "ci\ttest\t2026-08-30T01:00:00Z assertion failed: left == right\n";
+    let mut evidence = snapshot(vec![failure(
+        10,
+        "ci",
+        "test (ubuntu)",
+        "cargo test",
+        log,
+        CHECKOUT,
+    )]);
+    evidence["deferred"] = json!([{
+        "run_id": 99,
+        "url": "https://github.com/acme/orbit/actions/runs/99",
+        "workflow": "ci",
+        "head_branch": "feature/unverified",
+        "ref_kind": "other",
+        "investigated": false,
+    }]);
+    evidence["retryable_errors"] = json!([{
+        "stage": "discovery",
+        "operation": "remote_branch_head",
+        "run_id": 99,
+        "retryable": true,
+        "message": "candidate branch 'feature/unverified' could not be checked against origin; its failure remains deferred until verified",
+    }]);
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["filed_count"], json!(1));
+    let deferred = output["deferred"].as_array().expect("deferred entries");
+    assert_eq!(deferred.len(), 1);
+    assert_eq!(deferred[0]["run_id"], json!(99));
+    assert_eq!(
+        deferred[0]["url"],
+        json!("https://github.com/acme/orbit/actions/runs/99")
+    );
+    assert_eq!(deferred[0]["workflow"], json!("ci"));
+    assert_eq!(deferred[0]["head_branch"], json!("feature/unverified"));
+    assert_eq!(deferred[0]["ref_kind"], json!("other"));
+    assert_eq!(deferred[0]["investigated"], json!(false));
+    assert_eq!(deferred[0]["retryable"], json!(true));
+}
+
+#[test]
 fn one_regression_across_push_and_pull_request_runs_becomes_one_task() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let log = "ci\tbuild\t2026-08-30T01:00:00Z error: expected 3 arguments, found 2\n";

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -193,7 +193,6 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         &mut retryable_errors,
     )?;
 
-    let mut partition = RunPartition::default();
     // One repository-wide query rather than one per ref: a single list is what
     // lets a newer *relevant* success supersede an older failure without
     // asking the ref it ran on whether it has advanced. Selection itself is
@@ -220,15 +219,30 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             bounds.max_runs, bounds.max_runs
         ));
     }
-    let retired = retired_branches(queries, &refs, &runs, &bounds, &mut notes);
-    partition_runs(&refs, &runs, &retired, &mut partition);
+    let probes = probe_branches(queries, &refs, &runs, &bounds, &mut notes);
+    let mut partition = RunPartition::default();
+    partition_runs(&refs, &runs, &probes.retired, &probes.unverified, &mut partition);
     let RunPartition {
         latest,
         mut current,
         stale,
         in_flight,
         mixed_candidates,
+        mut deferred,
     } = partition;
+
+    for failure in &mut deferred {
+        failure["investigated"] = json!(false);
+        if let Some((operation, message)) = probes.unverified.get(run_branch(failure)) {
+            push_retryable_error(
+                &mut retryable_errors,
+                "discovery",
+                operation,
+                failure.get("run_id"),
+                message,
+            );
+        }
+    }
 
     let mut inspect = Vec::new();
     let mut seen_run_ids = std::collections::BTreeSet::new();
@@ -301,8 +315,13 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         .iter()
         .filter_map(|run| run.get("run_id").cloned())
         .collect::<Vec<_>>();
+    let deferred_ids = deferred
+        .iter()
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
     let investigated_count = investigated_ids.len();
     let retryable_error_count = retryable_errors.len();
+    let unverified_refs = probes.unverified.keys().cloned().collect::<Vec<_>>();
 
     Ok(json!({
         "schema_version": CI_EVIDENCE_SCHEMA_VERSION,
@@ -321,6 +340,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         "current_failures": current,
         "stale_or_superseded": stale,
         "in_flight": in_flight,
+        "deferred": deferred,
         "retryable_errors": retryable_errors,
         "summary": {
             "latest_runs_discovered": latest_ids.len(),
@@ -329,6 +349,8 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "current_failure_run_ids": current_ids,
             "investigated_failures": investigated_count,
             "investigated_failure_run_ids": investigated_ids,
+            "deferred_failures": deferred_ids.len(),
+            "deferred_failure_run_ids": deferred_ids,
             "retryable_errors": retryable_error_count,
         },
         "truncation": json!({
@@ -346,7 +368,8 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "log_max_bytes": bounds.log_max_bytes,
             "checkout_log_reads": checkout_log_reads,
             "max_checkout_log_reads": bounds.max_checkout_log_reads,
-            "retired_refs": retired.iter().collect::<Vec<_>>(),
+            "retired_refs": probes.retired.iter().collect::<Vec<_>>(),
+            "unverified_refs": unverified_refs,
             "max_retired_ref_probes": bounds.max_retired_ref_probes,
             "investigation_cursor": bounds.investigation_cursor,
             "notes": notes,
@@ -471,7 +494,13 @@ fn derive_refs<Q: CiQueries + ?Sized>(
     Ok(refs)
 }
 
-/// Branches that carry a red run but no longer exist on origin.
+struct CandidateProbeResults {
+    retired: std::collections::BTreeSet<String>,
+    unverified: std::collections::BTreeMap<String, (String, String)>,
+}
+
+/// Branches that carry a red run but no longer exist on origin, or whose
+/// current relevance could not be verified within probe bounds.
 ///
 /// A task branch is deleted when its pull request merges, so its old red runs
 /// describe code that either landed — where the landing branch's own runs are
@@ -482,15 +511,15 @@ fn derive_refs<Q: CiQueries + ?Sized>(
 /// The probe is authoritative (origin, not a naming convention) and bounded:
 /// one query per distinct branch that actually carries a red run, and none at
 /// all for a branch already scanned as a landing head or an open pull request.
-/// A probe that fails leaves its branch alone — a failure to reach origin is
-/// never evidence that a failure is resolved.
-fn retired_branches<Q: CiQueries + ?Sized>(
+/// A probe that fails or is skipped due to probe budget keeps its branch
+/// deferred rather than assuming it is merged or current.
+fn probe_branches<Q: CiQueries + ?Sized>(
     queries: &Q,
     refs: &[ScannedRef],
     runs: &[Value],
     bounds: &Bounds,
     notes: &mut Vec<String>,
-) -> std::collections::BTreeSet<String> {
+) -> CandidateProbeResults {
     let mut candidates: Vec<&str> = Vec::new();
     for run in runs {
         let branch = run_branch(run);
@@ -503,30 +532,92 @@ fn retired_branches<Q: CiQueries + ?Sized>(
         candidates.push(branch);
     }
 
+    let selected = probe_slots(
+        candidates.len(),
+        bounds.max_retired_ref_probes,
+        bounds.investigation_cursor,
+    );
+
+    if candidates.len() > selected.len() {
+        notes.push(format!(
+            "{} branch(es) carrying red runs were not probed against origin \
+             (max_retired_ref_probes={}); their failures remain deferred until verified",
+            candidates.len() - selected.len(),
+            bounds.max_retired_ref_probes
+        ));
+    }
+
     let mut retired = std::collections::BTreeSet::new();
-    for (probes, branch) in candidates.iter().enumerate() {
-        if probes >= bounds.max_retired_ref_probes {
-            notes.push(format!(
-                "{} branch(es) carrying red runs were not probed against origin \
-                 (max_retired_ref_probes={}); their failures stay listed as current rather than \
-                 being assumed merged",
-                candidates.len() - probes,
-                bounds.max_retired_ref_probes
-            ));
-            break;
+    let mut unverified = std::collections::BTreeMap::new();
+
+    for (index, branch) in candidates.iter().enumerate() {
+        if !selected.contains(&index) {
+            unverified.insert(
+                (*branch).to_string(),
+                (
+                    "retired_ref_budget".to_string(),
+                    format!(
+                        "candidate branch '{branch}' was not probed against origin because \
+                         max_retired_ref_probes ({}) was exhausted; its failure remains deferred \
+                         until verified",
+                        bounds.max_retired_ref_probes
+                    ),
+                ),
+            );
+            continue;
         }
+
         match queries.remote_branch_head(branch) {
             Ok(None) => {
                 retired.insert((*branch).to_string());
             }
             Ok(Some(_)) => {}
-            Err(error) => notes.push(format!(
-                "branch '{branch}' could not be checked against origin ({error}); its failures \
-                 stay listed as current"
-            )),
+            Err(error) => {
+                notes.push(format!(
+                    "branch '{branch}' could not be checked against origin ({error}); its \
+                     failure remains deferred until verified"
+                ));
+                unverified.insert(
+                    (*branch).to_string(),
+                    (
+                        "remote_branch_head".to_string(),
+                        format!(
+                            "candidate branch '{branch}' could not be checked against origin \
+                             ({error}); its failure remains deferred until verified"
+                        ),
+                    ),
+                );
+            }
         }
     }
-    retired
+
+    CandidateProbeResults {
+        retired,
+        unverified,
+    }
+}
+
+/// Which candidate branches this sweep probes against origin.
+///
+/// If candidate count exceeds the probe budget, the prefix of slots probes the
+/// newest candidates while the final slot rotates through overflow candidates
+/// with each advancing cursor so all candidates eventually get probed without
+/// starvation.
+fn probe_slots(
+    candidates: usize,
+    budget: usize,
+    cursor: u64,
+) -> std::collections::BTreeSet<usize> {
+    let attempted = candidates.min(budget);
+    let mut slots: std::collections::BTreeSet<usize> = (0..attempted).collect();
+    if candidates <= attempted || attempted == 0 {
+        return slots;
+    }
+    let rotating = attempted - 1;
+    slots.remove(&rotating);
+    let overflow = candidates - rotating;
+    slots.insert(rotating + (cursor % overflow as u64) as usize);
+    slots
 }
 
 /// Which candidates this sweep spends its investigation budget on.
@@ -574,6 +665,7 @@ struct RunPartition {
     stale: Vec<Value>,
     in_flight: Vec<Value>,
     mixed_candidates: Vec<Value>,
+    deferred: Vec<Value>,
 }
 
 /// Classify repository-wide runs by relevant workflow/ref identity.
@@ -593,6 +685,7 @@ fn partition_runs(
     refs: &[ScannedRef],
     runs: &[Value],
     retired: &std::collections::BTreeSet<String>,
+    unverified: &std::collections::BTreeMap<String, (String, String)>,
     out: &mut RunPartition,
 ) {
     let landing_branches = landing_branch_names(refs);
@@ -646,6 +739,7 @@ fn partition_runs(
                 if !run_is_completed(run) {
                     out.in_flight.push(run_summary(ref_for_run(refs, run), run));
                     if !seen_in_flight
+                        && !unverified.contains_key(run_branch(run))
                         && suppressor.is_none_or(|success| run_order(run) > run_order(success))
                     {
                         out.mixed_candidates
@@ -685,6 +779,11 @@ fn partition_runs(
                             "superseded_by_newer_workflow_run",
                         ));
                     }
+                    continue;
+                }
+                if unverified.contains_key(run_branch(run)) {
+                    out.deferred.push(run_summary(ref_for_run(refs, run), run));
+                    seen_current = true;
                     continue;
                 }
                 out.current.push(run_summary(ref_for_run(refs, run), run));
@@ -813,14 +912,16 @@ fn run_summary(scanned: Option<&ScannedRef>, run: &Value) -> Value {
     })
 }
 
-/// Integration first, then release, then pull requests; newest run first
-/// within each. Investigation budget therefore lands on the heads that gate
-/// delivery before it lands on a pull request.
+/// Integration first, then release, then pull requests, then other refs;
+/// newest run first within each. Investigation budget therefore lands on the
+/// heads that gate delivery before pull requests, and on verified pull
+/// requests before any other branch.
 fn sort_current_failures(failures: &mut [Value]) {
     let rank = |value: &Value| match value.get("ref_kind").and_then(Value::as_str) {
         Some("integration") => 0,
         Some("release") => 1,
-        _ => 2,
+        Some("pull_request") => 2,
+        _ => 3,
     };
     failures.sort_by(|left, right| {
         rank(left)

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -21,6 +21,15 @@ fn in_flight_ids(evidence: &Value) -> Vec<u64> {
         .collect()
 }
 
+fn deferred_ids(evidence: &Value) -> Vec<u64> {
+    evidence["deferred"]
+        .as_array()
+        .expect("deferred")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect()
+}
+
 const HEAD: &str = "1111111111111111111111111111111111111111";
 const OLD: &str = "2222222222222222222222222222222222222222";
 
@@ -1395,10 +1404,10 @@ fn a_landing_branch_website_failure_survives_without_a_push_counterpart() {
     assert_eq!(evidence["stale_or_superseded"], json!([]));
 }
 
-/// A branch origin cannot be reached about is left alone. Failing to look is
-/// never evidence that a failure is resolved.
+/// A branch origin cannot be reached about is kept deferred, not current. Failing to look is
+/// never evidence that a failure is resolved or current.
 #[test]
-fn an_unprobeable_branch_keeps_its_failure_current() {
+fn an_unprobeable_branch_keeps_its_failure_deferred() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)
         .with_head("main", HEAD)
@@ -1415,8 +1424,26 @@ fn an_unprobeable_branch_keeps_its_failure_current() {
 
     let evidence = collect(&queries, &input()).expect("collect");
 
-    assert_eq!(current_ids(&evidence), [60]);
+    assert_eq!(current_ids(&evidence), Vec::<u64>::new());
+    let deferred = evidence["deferred"].as_array().expect("deferred array");
+    assert_eq!(deferred.len(), 1);
+    assert_eq!(deferred[0]["run_id"], 60);
+    assert_eq!(deferred[0]["investigated"], false);
+    assert_eq!(evidence["summary"]["deferred_failures"], 1);
+    assert_eq!(evidence["summary"]["deferred_failure_run_ids"], json!([60]));
     assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert!(
+        evidence["retryable_errors"]
+            .as_array()
+            .expect("retryable_errors")
+            .iter()
+            .any(|err| err["operation"] == "remote_branch_head"
+                && err["run_id"] == 60
+                && err["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("fatal: unable to access origin"))),
+        "the unprobeable branch failure carries a remote_branch_head retryable error: {evidence}"
+    );
     assert!(
         evidence["truncation"]["notes"]
             .as_array()
@@ -1481,4 +1508,372 @@ fn the_investigation_budget_rotates_through_overflow_candidates() {
     // One rotation later the cycle repeats, so nothing is starved and the two
     // highest-ranked candidates never lose their slots.
     assert_eq!(investigated(3), json!([14, 13, 12]));
+}
+
+#[test]
+fn unprobed_branches_past_probe_budget_remain_deferred_without_consuming_investigation_slots() {
+    let checkout = "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n";
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![
+            run_on_branch(
+                10,
+                "integration-ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T05:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "feature-ci",
+                "feature/unprobed",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T04:00:00Z",
+            ),
+        ]])
+        .with_run_view("10", json!({"failed_jobs": [failed_job(1, "build")]}))
+        .with_log("10", false, checkout);
+
+    let evidence = collect(
+        &queries,
+        &json!({
+            "integration_branch": "topic",
+            "max_retired_ref_probes": 0,
+            "max_investigated_runs": 1,
+            "max_checkout_log_reads": 1,
+        }),
+    )
+    .expect("collect");
+
+    // The integration failure consumes the 1 investigation slot and is current and investigated
+    assert_eq!(current_ids(&evidence), [10]);
+    assert_eq!(evidence["summary"]["investigated_failures"], 1);
+    assert_eq!(evidence["summary"]["investigated_failure_run_ids"], json!([10]));
+
+    // The candidate branch was past the probe budget (0) so it was deferred without probing
+    assert_eq!(deferred_ids(&evidence), [20]);
+    let deferred = evidence["deferred"].as_array().expect("deferred array");
+    assert_eq!(deferred[0]["investigated"], false);
+    assert_eq!(deferred[0]["ref_kind"], "other");
+    assert_eq!(deferred[0]["head_branch"], "feature/unprobed");
+
+    // It carries a retryable error for retired_ref_budget
+    assert!(
+        evidence["retryable_errors"]
+            .as_array()
+            .expect("retryable errors")
+            .iter()
+            .any(|err| err["operation"] == "retired_ref_budget"
+                && err["run_id"] == 20
+                && err["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("max_retired_ref_probes"))),
+        "unprobed candidate has retired_ref_budget retryable error: {evidence}"
+    );
+}
+
+#[test]
+fn current_heads_and_verified_open_prs_retain_priority_over_other_refs() {
+    let checkout = "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n";
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_head("pr-branch", OLD)
+        .with_head("other-live", OLD)
+        .with_pull_request(json!({
+            "number": 42,
+            "url": "https://github.com/acme/orbit/pull/42",
+            "head_branch": "pr-branch",
+            "reported_head_sha": OLD,
+        }))
+        .with_runs(vec![vec![
+            run_on_branch(
+                10,
+                "ci-int",
+                "topic",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T01:00:00Z",
+            ),
+            run_on_branch(
+                20,
+                "ci-rel",
+                "main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T02:00:00Z",
+            ),
+            run_on_branch(
+                30,
+                "ci-pr",
+                "pr-branch",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T03:00:00Z",
+            ),
+            run_on_branch(
+                40,
+                "ci-other",
+                "other-live",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-30T04:00:00Z",
+            ),
+        ]])
+        .with_run_view("10", json!({"failed_jobs": [failed_job(1, "int")]}))
+        .with_log("10", false, checkout)
+        .with_run_view("20", json!({"failed_jobs": [failed_job(2, "rel")]}))
+        .with_log("20", false, checkout)
+        .with_run_view("30", json!({"failed_jobs": [failed_job(3, "pr")]}))
+        .with_log("30", false, checkout)
+        .with_run_view("40", json!({"failed_jobs": [failed_job(4, "other")]}))
+        .with_log("40", false, checkout);
+
+    // Budget of 3 investigated runs:
+    // Ranked priority is integration (10) -> release (20) -> PR (30) -> other (40).
+    let evidence = collect(
+        &queries,
+        &json!({
+            "integration_branch": "topic",
+            "max_investigated_runs": 3,
+            "max_checkout_log_reads": 3,
+        }),
+    )
+    .expect("collect");
+
+    // All 4 are current failures (other-live was verified on origin)
+    assert_eq!(current_ids(&evidence), [10, 20, 30, 40]);
+    // But only integration, release, and PR were investigated!
+    assert_eq!(
+        evidence["summary"]["investigated_failure_run_ids"],
+        json!([10, 20, 30])
+    );
+    assert_eq!(evidence["summary"]["investigated_failures"], 3);
+
+    let current = evidence["current_failures"].as_array().expect("current array");
+    let other_run = current.iter().find(|r| r["run_id"] == 40).expect("run 40");
+    assert_eq!(other_run["investigated"], false);
+}
+
+#[test]
+fn bounded_repeated_sweeps_rotate_probes_without_starvation() {
+    let mut queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD);
+
+    // 4 candidate branches, none of which exist on origin (all retired)
+    let runs = (0..4_u64)
+        .map(|index| {
+            run_on_branch(
+                100 + index,
+                &format!("wf-{index}"),
+                &format!("candidate-branch-{index}"),
+                OLD,
+                "completed",
+                Some("failure"),
+                &format!("2026-08-30T0{index}:00:00Z"),
+            )
+        })
+        .collect::<Vec<_>>();
+    queries = queries.with_runs(vec![runs]);
+
+    let retired_for_sweep = |cursor: u64| -> Vec<String> {
+        let evidence = collect(
+            &queries,
+            &json!({
+                "integration_branch": "topic",
+                "max_retired_ref_probes": 2,
+                "investigation_cursor": cursor,
+            }),
+        )
+        .expect("collect");
+        let retired = evidence["truncation"]["retired_refs"]
+            .as_array()
+            .expect("retired_refs")
+            .iter()
+            .map(|r| r.as_str().unwrap().to_string())
+            .collect();
+        retired
+    };
+
+    // Candidates in order of appearance in runs (newest run first: candidate-branch-3, 2, 1, 0)
+    // Budget is 2. Slot 0 is fixed on candidate-branch-3. Slot 1 rotates through 2, 1, 0.
+    let sweep0 = retired_for_sweep(0);
+    let sweep1 = retired_for_sweep(1);
+    let sweep2 = retired_for_sweep(2);
+
+    let mut all_probed = std::collections::BTreeSet::new();
+    all_probed.extend(sweep0);
+    all_probed.extend(sweep1);
+    all_probed.extend(sweep2);
+
+    assert_eq!(
+        all_probed,
+        [
+            "candidate-branch-0".to_string(),
+            "candidate-branch-1".to_string(),
+            "candidate-branch-2".to_string(),
+            "candidate-branch-3".to_string(),
+        ]
+        .into_iter()
+        .collect::<std::collections::BTreeSet<_>>()
+    );
+}
+
+#[test]
+fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_probe_failures_and_pending_successors() {
+    let checkout = "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n";
+    let queries = FakeQueries::authenticated()
+        .with_head("agent-main", HEAD)
+        .with_head("main", OLD)
+        // open PR branch
+        .with_head("orbit/ORB-100-open", OLD)
+        .with_pull_request(json!({
+            "number": 100,
+            "url": "https://github.com/acme/orbit/pull/100",
+            "head_branch": "orbit/ORB-100-open",
+            "reported_head_sha": OLD,
+        }))
+        // orbit/ORB-200-merged has no head on origin (returns None) -> retired
+        // orbit/ORB-300-transient has probe error -> deferred
+        .with_branch_head_error("orbit/ORB-300-transient", "network timeout contacting origin")
+        // orbit/ORB-400-overflow is past max_retired_ref_probes -> deferred
+        .with_runs(vec![vec![
+            // 1. Integration failure (agent-main)
+            run_on_branch(
+                1001,
+                "Platform",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T20:00:00Z",
+            ),
+            // 2. Release failure (main)
+            run_on_branch(
+                1002,
+                "Platform",
+                "main",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T19:50:00Z",
+            ),
+            // 3. Open PR failure (orbit/ORB-100-open)
+            run_on_branch(
+                1003,
+                "Website",
+                "orbit/ORB-100-open",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T19:40:00Z",
+            ),
+            // 4. Pending in-flight successor on integration head (run 1004 queued)
+            run_on_branch(
+                1004,
+                "Deploy",
+                "agent-main",
+                HEAD,
+                "in_progress",
+                None,
+                "2026-09-05T20:10:00Z",
+            ),
+            // 5. Merged historical PR (orbit/ORB-200-merged)
+            run_on_branch(
+                1005,
+                "Platform",
+                "orbit/ORB-200-merged",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T18:00:00Z",
+            ),
+            // 6. Transient probe failure (orbit/ORB-300-transient)
+            run_on_branch(
+                1006,
+                "Platform",
+                "orbit/ORB-300-transient",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T17:00:00Z",
+            ),
+            // 7. Unprobed live ref past budget (orbit/ORB-400-overflow)
+            run_on_branch(
+                1007,
+                "Platform",
+                "orbit/ORB-400-overflow",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-09-05T16:00:00Z",
+            ),
+        ]])
+        .with_run_view("1001", json!({"failed_jobs": [failed_job(1, "macOS")]}))
+        .with_log("1001", false, checkout)
+        .with_run_view("1002", json!({"failed_jobs": [failed_job(2, "linux")]}))
+        .with_log("1002", false, checkout)
+        .with_run_view("1003", json!({"failed_jobs": [failed_job(3, "web")]}))
+        .with_log("1003", false, checkout);
+
+    // With max_retired_ref_probes: 2, candidate branches are:
+    // [orbit/ORB-200-merged, orbit/ORB-300-transient, orbit/ORB-400-overflow]
+    // Slot 0 probes ORB-200-merged (Ok(None) -> retired)
+    // Slot 1 probes ORB-300-transient (Err -> unverified / deferred)
+    // ORB-400-overflow is beyond budget -> unverified / deferred
+    let evidence = collect(
+        &queries,
+        &json!({
+            "integration_branch": "agent-main",
+            "max_retired_ref_probes": 2,
+            "max_investigated_runs": 5,
+            "max_checkout_log_reads": 5,
+        }),
+    )
+    .expect("collect");
+
+    // Current failures only contain the genuine current failures: integration, release, open PR
+    assert_eq!(current_ids(&evidence), [1001, 1002, 1003]);
+    assert_eq!(
+        evidence["summary"]["investigated_failure_run_ids"],
+        json!([1001, 1002, 1003])
+    );
+
+    // In-flight successor is captured in in_flight
+    assert_eq!(in_flight_ids(&evidence), [1004]);
+
+    // Merged PR is retired (in stale_or_superseded)
+    let stale = evidence["stale_or_superseded"].as_array().expect("stale");
+    assert!(
+        stale.iter().any(|entry| entry["run_id"] == 1005 && entry["reason"] == "ref_no_longer_exists"),
+        "merged PR is retired: {evidence}"
+    );
+
+    // Transient failure and unprobed overflow are deferred, NOT current
+    assert_eq!(deferred_ids(&evidence), [1006, 1007]);
+    let deferred = evidence["deferred"].as_array().expect("deferred");
+    assert_eq!(deferred.len(), 2);
+    assert_eq!(deferred[0]["investigated"], false);
+    assert_eq!(deferred[1]["investigated"], false);
+
+    // Retryable errors carry the run-scoped discovery errors for deferred runs
+    let retryable = evidence["retryable_errors"].as_array().expect("retryable_errors");
+    assert!(
+        retryable.iter().any(|err| err["operation"] == "remote_branch_head" && err["run_id"] == 1006),
+        "transient probe error is attached to run 1006: {evidence}"
+    );
+    assert!(
+        retryable.iter().any(|err| err["operation"] == "retired_ref_budget" && err["run_id"] == 1007),
+        "budget exhaustion error is attached to run 1007: {evidence}"
+    );
 }


### PR DESCRIPTION
## Task

[ORB-11359](https://orbit-cli.com/tasks/ORB-11359) — Defer CI refs whose current relevance was not established within probe bounds

### Description

Mac ws_kvdb sweep jrun-20260906-0056-2 filed DANI-10237 for run33291695911 on orbit/DANI-10062-6a93a85b with current ref unknown. Live PR52 is MERGED at 2026-08-30T04:10:36Z. Current main run33948877857 was deferred. crates/orbit-engine/src/executor/automation/ci/collect.rs:508-514 explicitly leaves unprobed refs current when max_retired_ref_probes exhausts. This promotes uncertainty to actionable evidence and spends pilot capacity on historical merged work. Related prior ORB-11308 is done; repair this remaining relevance boundary, keeping partial progress for confirmed current failures. Do not silently drop unknown refs or assume they are merged: retain retryable deferrals with progress across bounded passes.

### Acceptance Criteria

- When retirement/ref probe budget is exhausted, unverified refs remain deferred and cannot create or auto-promote repair tasks until relevance is established.
- Current integration/release heads and verified open PRs retain priority; independent complete relevant failures still progress.
- Fixtures include merged/deleted historical PRs, unprobed live refs, transient probe failure, pending successors and distinct integration/release branches; bounded repeated sweeps eventually classify pending refs without starvation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Repaired the relevance boundary in collect_ci_evidence so that when origin probe budget is exhausted or probes fail, candidate refs (branches of failed runs not covered by scanned landing heads or open PRs) remain deferred in evidence.deferred with run-scoped retryable errors (retired_ref_budget or remote_branch_head) and investigated=false rather than being classified current or assumed merged. Implemented probe_slots rotation through overflow candidate branches across sweeps via investigation_cursor to avoid starvation. Updated sort_current_failures so verified open PRs retain priority over other non-landing refs (integration: 0, release: 1, pull_request: 2, other: 3). Updated file_ci_failure_tasks to retain metadata (url, workflow, head_branch, ref_kind) from explicit deferred evidence entries alongside filed tasks. Added comprehensive test coverage in orbit-engine and orbit-core; all 35 CI collect tests and 27 ci_failure_tasks tests pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11359-6a9cca37`
- Behind base: 0
- Ahead of base: 1