### PR TITLE
Read complete task bundles consistently during concurrent lifecycle writes

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -297,7 +297,8 @@ fn claim_lock_path(path: &Path) -> Option<HeldLockPath> {
 /// The lock is re-entrant per thread: a nested call for the same lock path
 /// runs `op` directly under the outermost acquisition instead of deadlocking
 /// on a second descriptor. Cross-thread and cross-process callers still block
-/// on the flock as before.
+/// on the flock as before, including readers holding
+/// [`with_shared_file_lock`] on the same target.
 ///
 /// The closure returns `Result<T, E>` where any filesystem error hit while
 /// acquiring the lock is folded into `E` via `From<std::io::Error>` —
@@ -354,6 +355,70 @@ where
     })?;
 
     op()
+}
+
+/// Run `op` while holding a *shared* advisory flock on the same sibling lock
+/// file [`with_exclusive_file_lock`] uses, so readers exclude writers of that
+/// target while staying concurrent with each other.
+///
+/// This is the read half of a multi-file critical section (ORB-11349): a task
+/// bundle's transition appends to one file and republishes another, so a
+/// reader that assembles both without coordination can pair a new event log
+/// with an old envelope and report that mismatch as corruption.
+///
+/// Three properties keep this usable from read-only surfaces:
+///
+/// - The parent directory is never created. A read of something that does not
+///   exist must not materialize it, and a missing parent also means no writer
+///   can be holding anything inside it, so `op` runs directly.
+/// - Acquisition is best effort. A store on a read-only mount, or any
+///   filesystem that refuses the lock file, still serves the read unlocked
+///   rather than failing it — the same exposure as before this lock existed.
+/// - Re-entrancy is shared with the exclusive variant, so a read nested inside
+///   a writer's own critical section runs directly instead of deadlocking on a
+///   second descriptor.
+///
+/// Do not take the *write* lock for a target inside a read lock on that same
+/// target. A nested request never upgrades the outer acquisition, so the
+/// mutation would run under a shared lock that concurrent readers also hold.
+pub fn with_shared_file_lock<T, E, F>(target_path: &Path, label: &str, op: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
+    let Some(parent) = target_path.parent() else {
+        return op();
+    };
+    if !parent.is_dir() {
+        return op();
+    }
+    let lock_path = resolved_lock_path(target_path)?;
+    let Some(_held) = claim_lock_path(&lock_path) else {
+        return op();
+    };
+    let _lock_file = match acquire_shared_lock(&lock_path) {
+        Ok(file) => Some(file),
+        Err(error) => {
+            crate::tracing::debug!(
+                target: "orbit.common.fs",
+                lock_path = %lock_path.display(),
+                label,
+                error = %error,
+                "shared lock unavailable; reading without writer coordination",
+            );
+            None
+        }
+    };
+
+    op()
+}
+
+fn acquire_shared_lock(lock_path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    let lock_file = open_private_file(lock_path, &mut options)?;
+    lock_file.lock_shared()?;
+    Ok(lock_file)
 }
 
 /// The lock path to open and to key re-entrancy on, resolved through symlinks

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
@@ -549,6 +549,54 @@ fn reserve_locks_publishes_empty_waiting_on_deps_when_dependencies_are_met() {
     assert_eq!(output["reserved"], json!(true));
 }
 
+/// ORB-11349: admission loads every task, so one unrelated task's lifecycle
+/// write used to decide whether this gate ran. A transition is a multi-file
+/// publication held under that task's bundle lock; a gate that read through it
+/// paired the new event log with the not-yet-republished envelope and failed
+/// the whole run as bundle corruption. Hold exactly that critical section on
+/// task A and require B's gate to admit correctly anyway.
+#[test]
+fn reserve_locks_admits_through_an_unrelated_task_mid_transition() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let dependency = seed_task(&runtime, "Dependency", TaskStatus::Done, Vec::new());
+    let blocked = seed_task(
+        &runtime,
+        "Blocked",
+        TaskStatus::Backlog,
+        vec![dependency.clone()],
+    );
+    let unrelated = seed_task(&runtime, "Unrelated", TaskStatus::Backlog, Vec::new());
+
+    let transition_open = std::sync::Barrier::new(2);
+    let transition_closed = std::sync::atomic::AtomicBool::new(false);
+
+    let output = std::thread::scope(|scope| {
+        scope.spawn(|| {
+            runtime
+                .stores()
+                .tasks()
+                .with_task_write_lock(&unrelated, &mut || {
+                    transition_open.wait();
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    transition_closed.store(true, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                })
+                .expect("hold the unrelated task's write lock");
+        });
+
+        transition_open.wait();
+        let (_, result) = reserve_locks_for(&runtime, vec![blocked.clone()]);
+        result.expect("an unrelated task's transition must not fail this gate")
+    });
+
+    assert!(
+        transition_closed.load(std::sync::atomic::Ordering::SeqCst),
+        "the gate must read the unrelated task as settled, not mid-transition"
+    );
+    assert_eq!(output["reserved"], json!(true));
+    assert_eq!(output["waiting_on_deps"], json!([]));
+}
+
 #[test]
 fn waiting_locks_from_reserve_output_extracts_unique_conflict_files() {
     let locks = waiting_locks_from_reserve_output(&json!({

--- a/crates/orbit-store/src/repository/task/v2/index.rs
+++ b/crates/orbit-store/src/repository/task/v2/index.rs
@@ -210,11 +210,15 @@ impl TaskV2Store {
         })
     }
 
+    /// Run `op` under this task's exclusive bundle lock.
+    ///
+    /// The lock target belongs to the bundle store, which hands the same file
+    /// to the shared lock its full-bundle reads take, so a write and a
+    /// concurrent read cannot disagree about what coordinates them.
     pub(crate) fn with_task_lock<T, F>(&self, id: &str, op: F) -> Result<T, OrbitError>
     where
         F: FnOnce() -> Result<T, OrbitError>,
     {
-        let lock_target = self.bundle_store.bundle_path(id)?.join("task.yaml");
-        with_exclusive_file_lock(&lock_target, "task artifact v2", op)
+        self.bundle_store.with_bundle_write_lock(id, op)
     }
 }

--- a/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
@@ -6,7 +6,9 @@
 //! missing or half there. These tests pin both halves of the rule: transient
 //! states are skipped, genuine corruption still fails fast.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
 
 use super::*;
 use crate::driver::file::task_bundle::task_bundle_lock_sentinel_path;
@@ -227,4 +229,247 @@ fn parallel_updates_to_one_task_keep_every_appended_comment() {
         created_comments + WRITERS * COMMENTS_PER_WRITER,
         "no concurrent comment may be lost"
     );
+}
+
+/// ORB-11349: the transition row and the envelope that agrees with it are two
+/// files, so `update_task_history` is only a consistent unit to a reader that
+/// waits for the writer. Build exactly that half-published state — hold the
+/// task's write lock, append the event, and stall before republishing the
+/// envelope — and require a reader that arrives inside the window to observe
+/// the settled transition rather than the mixed pair.
+#[test]
+fn a_reader_never_observes_a_transition_between_its_event_and_its_envelope() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let id = create_tasks(&store, 2).remove(0);
+
+    let event_appended = Barrier::new(2);
+    let envelope_published = AtomicBool::new(false);
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .with_task_lock(&id, || {
+                    let bundle = store.bundle_store.read_bundle(&id).expect("read bundle");
+                    store
+                        .bundle_store
+                        .append_event(&id, &transition_event(&bundle))
+                        .expect("append transition event");
+                    event_appended.wait();
+                    // Wide enough that a reader taking no lock lands inside the
+                    // window every run, not just under load.
+                    std::thread::sleep(Duration::from_millis(300));
+                    let mut envelope = bundle.envelope.clone();
+                    envelope.status = TaskStatus::InProgress;
+                    envelope.updated_at = Utc::now();
+                    store
+                        .bundle_store
+                        .rewrite_envelope(&id, &envelope)
+                        .expect("publish envelope");
+                    envelope_published.store(true, Ordering::SeqCst);
+                    Ok(())
+                })
+                .expect("half-published transition");
+        });
+
+        event_appended.wait();
+        let task = store
+            .get_task(&id)
+            .expect("a half-published transition must not read as corruption")
+            .expect("task exists");
+        assert!(
+            envelope_published.load(Ordering::SeqCst),
+            "the read must have waited for the writer to publish the envelope"
+        );
+        assert_eq!(
+            task.status,
+            TaskStatus::InProgress,
+            "the read must see the settled transition, not the pre-transition envelope"
+        );
+
+        let listed = store
+            .list_tasks()
+            .expect("a half-published transition must not fail the listing");
+        assert_eq!(listed.len(), 2, "no task may drop out of a listing");
+    });
+}
+
+/// The tolerance stays narrow: once no writer holds the bundle, an event log
+/// that disagrees with the envelope is real damage and must still surface.
+#[test]
+fn a_settled_event_and_envelope_mismatch_is_still_corruption() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let id = create_tasks(&store, 2).remove(0);
+
+    let bundle = store.bundle_store.read_bundle(&id).expect("read bundle");
+    store
+        .bundle_store
+        .append_event(&id, &transition_event(&bundle))
+        .expect("append transition event");
+
+    let err = store
+        .get_task(&id)
+        .expect_err("a settled status mismatch must not be silently tolerated");
+    assert!(
+        matches!(err, OrbitError::TaskBundleCorrupt { ref task_id, .. } if *task_id == id),
+        "expected corruption for {id}, got {err}"
+    );
+    let err = store
+        .list_tasks()
+        .expect_err("a settled status mismatch must not be silently skipped");
+    assert!(
+        matches!(err, OrbitError::TaskBundleCorrupt { ref task_id, .. } if *task_id == id),
+        "expected corruption for {id}, got {err}"
+    );
+}
+
+/// Every lifecycle write reads the bundle it is about to modify from inside
+/// its own write lock, and some read every *other* task too. The read lock
+/// must re-enter the write lock it is nested in rather than block on it.
+#[test]
+fn a_full_read_inside_the_write_lock_does_not_deadlock() {
+    let temp = Arc::new(TempDir::new().expect("tempdir"));
+    let store = Arc::new(store(&temp));
+    let ids = create_tasks(&store, 3);
+
+    // Detached, not scoped: a regression here deadlocks, and a scoped thread
+    // would take the whole suite down with it on join.
+    let finished = run_within(Duration::from_secs(20), move || {
+        let _temp = temp;
+        store
+            .with_task_lock(&ids[0], || {
+                store.bundle_store.read_bundle(&ids[0])?;
+                store.get_task(&ids[0])?;
+                store.list_tasks().map(|tasks| tasks.len())
+            })
+            .expect("a nested read must not deadlock against its own write lock")
+    });
+    assert_eq!(
+        finished,
+        Some(3),
+        "a read nested inside this task's own write lock must re-enter it"
+    );
+}
+
+/// The lock is per bundle, so a writer stalled on one task must not stop reads
+/// of any other. This is the property the incident actually broke: one task's
+/// transition failed an unrelated task's admission.
+#[test]
+fn a_stalled_writer_on_one_task_does_not_block_reads_of_another() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, 2);
+
+    let holding = Barrier::new(2);
+    let released = AtomicBool::new(false);
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .with_task_lock(&ids[0], || {
+                    holding.wait();
+                    std::thread::sleep(Duration::from_millis(300));
+                    released.store(true, Ordering::SeqCst);
+                    Ok(())
+                })
+                .expect("hold the write lock");
+        });
+
+        holding.wait();
+        let other = store
+            .get_task(&ids[1])
+            .expect("read of an unrelated task")
+            .expect("task exists");
+        assert_eq!(other.id, ids[1]);
+        assert!(
+            !released.load(Ordering::SeqCst),
+            "an unrelated task's read must not wait for this writer"
+        );
+    });
+}
+
+/// The reported failure shape at status-transition scale: writers flipping
+/// their own task's status while readers assemble whole bundles.
+#[test]
+fn parallel_status_transitions_never_fail_a_concurrent_read() {
+    const TASKS: usize = 6;
+    const ROUNDS: usize = 10;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let ids = create_tasks(&store, TASKS);
+
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let store = &store;
+            scope.spawn(move || {
+                for round in 0..ROUNDS {
+                    let status = if round % 2 == 0 {
+                        TaskStatus::InProgress
+                    } else {
+                        TaskStatus::Backlog
+                    };
+                    store
+                        .update_task_history(
+                            id,
+                            &TaskHistoryUpdateParams {
+                                actor: "codex:gpt-5.5".to_string(),
+                                status: Some(status),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap_or_else(|err| panic!("transition of {id} failed: {err}"));
+                }
+            });
+        }
+        for _ in 0..4 {
+            let store = &store;
+            let ids = &ids;
+            scope.spawn(move || {
+                for _ in 0..(ROUNDS * TASKS) {
+                    let tasks = store
+                        .list_tasks()
+                        .unwrap_or_else(|err| panic!("listing failed under transitions: {err}"));
+                    assert_eq!(tasks.len(), TASKS, "no task may drop out of a listing");
+                    for id in ids {
+                        store
+                            .get_task(id)
+                            .unwrap_or_else(|err| panic!("read of {id} failed: {err}"))
+                            .expect("task exists");
+                    }
+                }
+            });
+        }
+    });
+}
+
+/// A status transition for `bundle`'s task that its envelope does not yet
+/// reflect — the exact row `update_task_history` appends before republishing.
+fn transition_event(bundle: &TaskBundleV2) -> TaskEventRowV2 {
+    TaskEventRowV2 {
+        schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        event_id: format!("EV-{:04}", bundle.events.len() + 1),
+        at: Utc::now(),
+        by: "codex:gpt-5.5".to_string(),
+        event_type: "status_changed".to_string(),
+        note: None,
+        from_status: Some(bundle.envelope.status),
+        to_status: Some(TaskStatus::InProgress),
+    }
+}
+
+/// Run `op` on its own thread, returning `None` if it has not finished within
+/// `budget`. A deadlock regression then fails this one test instead of hanging
+/// the whole suite until CI kills it.
+fn run_within<T, F>(budget: Duration, op: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(op());
+    });
+    receiver.recv_timeout(budget).ok()
 }

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -7,7 +7,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
-use orbit_common::fs::io::{atomic_write_text, sync_parent_dir, with_exclusive_file_lock};
+use orbit_common::fs::io::{
+    atomic_write_text, sync_parent_dir, with_exclusive_file_lock, with_shared_file_lock,
+};
 use orbit_types::task::{
     ArtifactManifestV2, TASK_ARTIFACT_MANIFEST_FILE_NAME, TASK_ARTIFACTS_DIR_NAME,
     TASK_COMMENTS_FILE_NAME, TASK_ENVELOPE_FILE_NAME, TASK_EVENTS_FILE_NAME, TaskCommentRowV2,
@@ -84,6 +86,24 @@ impl TaskBundleStoreV2 {
             .canonical_task_bundle_path(&self.workspace_id, task_id)
     }
 
+    /// Run `op` while holding this task's exclusive bundle lock.
+    ///
+    /// A lifecycle write spans more than one file — a transition appends to
+    /// `events.jsonl` and republishes `task.yaml` — so it is only a consistent
+    /// unit to a reader that observes the same lock. This store owns the lock
+    /// target for both sides ([`bundle_lock_target`]) precisely so a reader and
+    /// a writer cannot drift onto different files (ORB-11349).
+    pub(crate) fn with_bundle_write_lock<T, F>(&self, task_id: &str, op: F) -> Result<T, OrbitError>
+    where
+        F: FnOnce() -> Result<T, OrbitError>,
+    {
+        with_exclusive_file_lock(
+            &bundle_lock_target(&self.bundle_path(task_id)?),
+            "task artifact v2",
+            op,
+        )
+    }
+
     /// The caller has durably reserved this ID for one action and input digest.
     /// Re-enter after a crash under the canonical bundle lock. A readable bundle
     /// wins; unreadable bytes are retained for explicit recovery.
@@ -94,7 +114,11 @@ impl TaskBundleStoreV2 {
         let id = &proposed.envelope.id;
         let path = self.bundle_path(id)?;
         with_exclusive_file_lock(&path, "task action admission", || {
-            if let Ok(existing) = read_bundle_at(&path) {
+            // Under the *creation* lock, which does not exclude a lifecycle
+            // write to an already-recovered bundle — so read this the same
+            // coordinated way, or a replay racing a transition would declare a
+            // perfectly good bundle unreadable.
+            if let Ok(existing) = read_bundle_consistently(&path) {
                 self.registry
                     .register_task_bundle(id, &self.workspace_id, &path)?;
                 if let Some(workspace) = &self.workspace_orbit_dir
@@ -237,7 +261,7 @@ impl TaskBundleStoreV2 {
         self.bundle_reads
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let bundle_dir = self.bundle_path(task_id)?;
-        read_bundle_at(&bundle_dir)
+        read_bundle_consistently(&bundle_dir)
     }
 
     pub(crate) fn delete_bundle(&self, task_id: &str) -> Result<bool, OrbitError> {
@@ -383,8 +407,34 @@ impl TaskBundleStoreV2 {
     }
 }
 
+/// The lock file coordinating one bundle's readers and writers.
+///
+/// Deliberately *not* the create/delete sentinel, which keys on the bundle
+/// directory itself: a reader must not block a task's creation or removal, and
+/// those transient states stay governed by [`skip_if_in_flight`].
+fn bundle_lock_target(bundle_dir: &Path) -> PathBuf {
+    bundle_dir.join(TASK_ENVELOPE_FILE_NAME)
+}
+
+/// Assemble a whole bundle under this task's shared read lock.
+///
+/// A bundle spans several files, so reading it is only atomic with respect to
+/// a lifecycle write that publishes across those same files if the reader
+/// observes the writer's lock (ORB-11349). Without it a reader could pair an
+/// appended transition event with the envelope the writer had not yet
+/// republished, and report that mismatch as bundle corruption.
+///
+/// Envelope-only reads stay lock-free on purpose: `task.yaml` is renamed into
+/// place atomically, so one file is always self-consistent, and the index
+/// validation that reads it on every listing pays nothing here.
+fn read_bundle_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    with_shared_file_lock(&bundle_lock_target(bundle_dir), "task artifact v2", || {
+        read_bundle_at(bundle_dir)
+    })
+}
+
 fn read_bundle_tolerating_in_flight(bundle_dir: &Path) -> Result<Option<TaskBundleV2>, OrbitError> {
-    match read_bundle_at(bundle_dir) {
+    match read_bundle_consistently(bundle_dir) {
         Ok(bundle) => Ok(Some(bundle)),
         Err(err) => skip_if_in_flight(bundle_dir, err),
     }

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -235,7 +235,7 @@ The file bundle does not provide all-or-nothing transactions across Markdown sid
 
 - `task.yaml` remains canonical for structured metadata.
 - JSONL tail corruption is repaired only at the final partial row; corruption before the tail is an error.
-- The last event with `to_status` must match `task.yaml.status`; mismatches are corruption and must fail reads.
+- The last event with `to_status` must match `task.yaml.status`; a mismatch on a *settled* bundle is corruption and must fail reads. A mismatch observed while a writer is mid-publication is not corruption and must not be observable at all — see [Concurrent reads and lifecycle writes](#concurrent-reads-and-lifecycle-writes).
 - Generated indexes are invalid when count or `updated_at` stamps differ from registered bundle envelopes and must be rebuilt from bundles.
 - Artifact manifest entries must reference existing relative files with matching size and SHA-256; unmanifested files are ignored until a future compaction/prune command removes them.
 
@@ -244,6 +244,39 @@ diagnostic containing the task ID, canonical path, and reason. Direct lookup of
 another ID and allocation/publication of a new task must not scan the malformed
 bundle. List and search remain fail-loud and return that diagnostic. None of
 these query paths may delete, move, repair, or quarantine bundle bytes.
+
+### Concurrent reads and lifecycle writes
+
+A lifecycle write publishes across more than one file — a status transition
+appends to `events.jsonl` and then republishes `task.yaml` — so between those
+two steps the bundle on disk has an event log the envelope does not yet agree
+with. That intermediate state is indistinguishable on inspection from the
+settled mismatch the rule above calls corruption.
+
+Readers must therefore observe the writer's coordination rather than infer
+intent from bytes:
+
+- A writer holds that task's exclusive bundle lock (`<bundle>/task.yaml`, via
+  its sibling lock file) for the whole multi-file publication.
+- A reader that assembles a **complete** bundle must hold the same lock in
+  shared mode. It then observes only settled bundles, so a genuine mismatch
+  still fails the read (`task_bundle_corrupt`) with no tolerance widened.
+- The lock is per bundle: one task's transition must never block, fail, or
+  delay a read of any other task.
+- Reads of the **envelope alone** need no lock. `task.yaml` is renamed into
+  place atomically, so a single file is always self-consistent; the index
+  freshness scan every listing performs stays lock-free.
+- The read lock is not the create/delete sentinel, which keys on the bundle
+  directory. Readers never block a task's creation or removal, and those
+  transient states stay governed by the existing skip tolerance
+  (missing directory or sentinel held).
+- Acquisition is re-entrant per thread, so a writer that reads the bundle it
+  is about to modify from inside its own critical section does not deadlock,
+  and it is best effort, so a store on a read-only mount still serves reads.
+
+This is coordination between live processes, not a file-format transaction: it
+adds no on-disk state and changes nothing about post-crash recovery, which
+remains detect-and-repair. [ORB-11349]
 
 ## Artifacts
 
@@ -263,7 +296,9 @@ files:
 
 Artifact paths must be relative, UTF-8, slash-separated, canonical paths and must not contain `.`, `..`, or leading `./` components. Writers that ingest hand-authored manifests should normalize leading `./` before validation. `sha256` must be a 64-character lowercase hex SHA-256 digest; writer code should format digest bytes with lowercase hex (`{:x}`), not uppercase.
 
-The bundle format does not guarantee cross-file transactions. Writers must keep single-file updates atomic and keep partial multi-file states readable; generated repair/indexing commands reconcile cases such as appended events before envelope status rewrite or artifact files written before manifest rewrite.
+The bundle format does not guarantee cross-file transactions *across a crash*. Writers must keep single-file updates atomic and keep post-crash partial multi-file states readable; generated repair/indexing commands reconcile cases such as appended events before envelope status rewrite or artifact files written before manifest rewrite.
+
+A *live* writer is a different case, and readers must not be exposed to its intermediate states. See [Concurrent reads and lifecycle writes](#concurrent-reads-and-lifecycle-writes).
 
 ## Cutover
 


### PR DESCRIPTION
## Task

[ORB-11349](https://orbit-cli.com/tasks/ORB-11349) — Read complete task bundles consistently during concurrent lifecycle writes

### Description

## Live incident and verified source
At 2026-09-06T00:34:20.195965193Z, jrun-20260906-0030-6 (gate for ORB-11343) failed reserve_locks: ORB-11346 event log status in-progress did not match envelope backlog. The legitimate start event was 6.987ms earlier. Two later task_show reads were valid with no repair event. This strongly supports a transient mixed-generation read; require controlled reproduction.

At 5530555cc4d75935465b7c4cdc533dca86951dbf, repository/task/v2/updates.rs:191 holds a writer lock, appends event at :262, then publishes envelope at :274. driver/file/task_bundle/bundle_io/mod.rs:240-254 reads envelope then events without common coordination, then validates. repository/task/v2_bundle.rs:198-203 does not synchronize full reads with writers; creation/deletion tolerance omits normal transitions. Core dispatch.rs:491 loads all tasks, so this fails unrelated admission. Independently verified by Sol after read-only audit.

## Scope
Make complete reads consistent with lifecycle writes at canonical store boundary using existing writer coordination or smallest sound equivalent. Preserve strict settled corruption errors, read-only/observational access, cross-process semantics and per-task concurrency; handle reads inside writer locks without deadlock. No task skipping, disabled validation, broad gate retries or duplicate persistence path. Rejected ORB-10486 covers persistent corruption and done ORB-11100 covers stale writes; neither duplicates this read race.

## Execution
Daniel resolved the earlier assignment hold by replying continue after the explicit Astra confirmation request. Use Astra under his current session routing policy, with Luna task-pilot before verified backlog promotion. Hard complexity reflects canonical cross-process snapshot consistency and nested/read-only paths.

### Acceptance Criteria

- Pause a transition deterministically between event append and envelope publication; concurrent full read/list never returns mixed data or false corruption.
- Gate B survives task A's concurrent transition with correct dependency admission; settled mismatches still report TaskBundleCorrupt.
- Nested same-task paths avoid deadlock, separate tasks remain concurrent, and read-only CLI/MCP reads remain observational.
- Focused store/gate tests, make ci-fast and make ci-lint pass; update current architecture documentation if ownership changes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Root cause (reproduced, not inferred): a lifecycle write publishes across two files under the per-task bundle lock — `append_event` then `rewrite_envelope` — while full-bundle reads took no lock at all. A reader landing in that window paired the new event log with the not-yet-republished envelope, `validate_bundle_consistency` rejected the pair, and `read_bundle_at` mapped it to `TaskBundleCorrupt`. `bundle_read_failure_is_in_flight` only tolerates create/delete, so an ordinary transition surfaced as false corruption and failed the whole listing — exactly the incident, where task A's transition failed gate B's admission.

Write ordering cannot fix this (the invariant is an equality across two files, so either order exposes a mismatched intermediate) and relaxing the check would forfeit settled-corruption detection. The fix gives readers the writer's coordination.

Changes:
- `crates/orbit-common/src/fs/io.rs` — new `with_shared_file_lock`: shared-mode sibling of `with_exclusive_file_lock` over the same resolved lock path and the same per-thread `HELD_LOCK_PATHS` re-entrancy. Never creates the parent directory (a read must not materialize a missing bundle) and degrades to an unlocked read when the lock file cannot be opened or locked, so read-only mounts keep serving reads.
- `crates/orbit-store/src/repository/task/v2_bundle.rs` — `TaskBundleStoreV2` now owns the per-task lock target (`bundle_lock_target` = `<bundle>/task.yaml`) for both sides. Full-bundle reads go through `read_bundle_consistently` under the shared lock: `read_bundle`, `read_bundle_if_settled`, each read in `list_bundles`, and the recovery read in `create_or_recover_action_bundle` (which holds only the creation lock, so a replay racing a transition previously declared a good bundle unreadable).
- `crates/orbit-store/src/repository/task/v2/index.rs` — `with_task_lock` delegates to `with_bundle_write_lock`, so reader and writer provably cannot drift onto different lock files.
- `docs/design/task-artifacts/specs/task-bundle-v2.md` — new "Concurrent reads and lifecycle writes" subsection under Crash Consistency stating the implemented guarantee; the settled-mismatch corruption bullet and the "no cross-file transactions" paragraph now scope themselves to crash recovery instead of legitimizing a live-writer race.

Preserved by construction: envelope-only reads stay lock-free (`task.yaml` is renamed atomically, so the per-listing index freshness scan pays nothing); the read lock is not the create/delete sentinel, so readers never block creation or deletion and the existing skip tolerance still governs those; the lock is per bundle, so separate tasks stay concurrent; flock keeps cross-process semantics; re-entrancy makes reads nested inside a writer's own critical section run directly rather than deadlock.

Tests (all new ones verified to fail with the read lock removed, reproducing the incident's exact message "task event log status 'in-progress' does not match envelope status 'backlog'"):
- `v2/tests/concurrency.rs`: `a_reader_never_observes_a_transition_between_its_event_and_its_envelope` (deterministic — holds the write lock, appends the event, stalls 300ms before republishing; a concurrent `get_task`/`list_tasks` must wait and see the settled transition), `a_settled_event_and_envelope_mismatch_is_still_corruption`, `a_full_read_inside_the_write_lock_does_not_deadlock` (detached with a 20s budget so a regression fails one test instead of hanging the suite), `a_stalled_writer_on_one_task_does_not_block_reads_of_another`, `parallel_status_transitions_never_fail_a_concurrent_read`.
- `v2_host/tests/dispatch.rs`: `reserve_locks_admits_through_an_unrelated_task_mid_transition` — gate B admits correctly through task A's held critical section and is asserted to have waited for it, pinning the coordination end-to-end at the gate.

Validation: `cargo test -p orbit-store` (411 passed), `cargo test -p orbit-core` (995 passed), `cargo test -p orbit-common` (240 passed), `make ci-fast` and `make ci-lint` both pass. No sandbox denials.

Scope note: `file:crates/orbit-common/src/fs/io.rs` was appended to context_files — the shared-lock primitive belongs beside its exclusive counterpart in the module that already owns advisory locking, rather than duplicating flock handling inside orbit-store. No crate dependency edge or crate-level ownership changed, so ARCHITECTURE.md needed no update.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11349-6a9cca37`
- Behind base: 0
- Ahead of base: 1

*authored by: claude*