### PR TITLE
Diagnose empty workspace identity after resumed local delivery and support safe recovery

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use clap::Args;
 use orbit_cmd::agent_rules::{InjectionAction, inject_agent_rules};
 use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
-use orbit_common::fs::io::atomic_write_text;
+use orbit_common::fs::io::{atomic_write_bytes, atomic_write_text};
 use orbit_core::OrbitError;
 use orbit_core::bootstrap::init::{InitOptions, init_workspace_at_root};
 use orbit_registry::workspace_registry;
@@ -63,9 +63,10 @@ pub struct WorkspaceInitArgs {
     /// No-op (kept for backwards compatibility — defaults are always refreshed on init)
     #[arg(long, hide = true)]
     pub refresh_defaults: bool,
-    /// Reconcile an already registered workspace after validating its complete
-    /// logical, checkout, and durable-identity binding, or replace a checkout
-    /// identity that no registration claims.
+    /// Reconcile an already registered workspace after validating its logical
+    /// and checkout binding. A missing or malformed identity is restored only
+    /// for that exact binding; malformed bytes are archived first. Also
+    /// replaces a checkout identity that no registration claims.
     #[arg(long)]
     pub force: bool,
 }
@@ -219,6 +220,7 @@ impl WorkspaceInitArgs {
                     )));
                 }
 
+                let mut identity_recovery = None;
                 if reconciling_existing {
                     validate_existing_registration(
                         existing_workspace,
@@ -228,7 +230,7 @@ impl WorkspaceInitArgs {
                         &id,
                     )?;
                     if !registered_shared_root {
-                        validate_workspace_identity(orbit_dir, &id)?;
+                        identity_recovery = validate_or_recover_workspace_identity(orbit_dir, &id)?;
                     }
                 } else if !registered_shared_root
                     && let Some(identity) = read_workspace_identity(orbit_dir)?
@@ -374,6 +376,10 @@ impl WorkspaceInitArgs {
                     )?;
                 }
                 workspace_registry::save_registry_to(&registry, registry_path)?;
+                if let Some(recovery) = identity_recovery {
+                    preserve_corrupt_workspace_identity(orbit_dir, &recovery)?;
+                    write_workspace_identity(orbit_dir, &id)?;
+                }
                 Ok((reconciling_existing, registered_shared_root))
             })?;
         if !reconciling_existing && !registered_shared_root {
@@ -423,6 +429,11 @@ struct WorkspaceIdentityDocument<'a> {
 struct StoredWorkspaceIdentity {
     schema_version: u32,
     workspace_id: String,
+}
+
+enum WorkspaceIdentityRecovery {
+    Missing,
+    Corrupt(Vec<u8>),
 }
 
 fn validate_existing_registration(
@@ -483,21 +494,57 @@ fn read_workspace_identity(
     Ok(Some(identity))
 }
 
-fn validate_workspace_identity(orbit_dir: &Path, workspace_id: &str) -> Result<(), OrbitError> {
+/// A registered checkout may recover an identity that carries no competing
+/// claim. The registry binding is validated before this function is called;
+/// a parseable different workspace id remains an ownership conflict.
+fn validate_or_recover_workspace_identity(
+    orbit_dir: &Path,
+    workspace_id: &str,
+) -> Result<Option<WorkspaceIdentityRecovery>, OrbitError> {
     let path = orbit_dir.join("config.yaml");
-    let identity = read_workspace_identity(orbit_dir)?.ok_or_else(|| {
-        OrbitError::WorkspaceError(format!(
-            "cannot reconcile workspace '{workspace_id}': checkout identity '{}' is missing",
-            path.display()
-        ))
-    })?;
-    if identity.schema_version != 1 || identity.workspace_id != workspace_id {
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Some(WorkspaceIdentityRecovery::Missing));
+        }
+        Err(error) => return Err(OrbitError::Io(error.to_string())),
+    };
+    let identity: StoredWorkspaceIdentity = match serde_yaml::from_slice(&bytes) {
+        Ok(identity) => identity,
+        Err(_) => return Ok(Some(WorkspaceIdentityRecovery::Corrupt(bytes))),
+    };
+    if identity.workspace_id.trim().is_empty() {
+        return Ok(Some(WorkspaceIdentityRecovery::Corrupt(bytes)));
+    }
+    if identity.workspace_id != workspace_id {
         return Err(OrbitError::WorkspaceError(format!(
             "cannot reconcile workspace '{workspace_id}': checkout identity '{}' does not match",
             path.display()
         )));
     }
-    Ok(())
+    if identity.schema_version != 1 {
+        return Ok(Some(WorkspaceIdentityRecovery::Corrupt(bytes)));
+    }
+    Ok(None)
+}
+
+fn preserve_corrupt_workspace_identity(
+    orbit_dir: &Path,
+    recovery: &WorkspaceIdentityRecovery,
+) -> Result<(), OrbitError> {
+    let WorkspaceIdentityRecovery::Corrupt(bytes) = recovery else {
+        return Ok(());
+    };
+    let timestamp = Utc::now().format("%Y%m%dT%H%M%S%.9fZ");
+    let archive = orbit_dir
+        .join("state/recovery/workspace-identity")
+        .join(format!("config.yaml.{timestamp}.corrupt"));
+    atomic_write_bytes(&archive, bytes).map_err(|error| {
+        OrbitError::Io(format!(
+            "archive corrupt workspace identity '{}' before recovery: {error}",
+            archive.display()
+        ))
+    })
 }
 
 fn validate_shared_root_identity(orbit_dir: &Path) -> Result<(), OrbitError> {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -515,6 +515,110 @@ fn forced_workspace_reconciliation_preserves_registry_and_identity_on_validation
 }
 
 #[test]
+fn force_recovers_empty_or_missing_identity_only_for_the_exact_registration() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_identity_recovery\"\nhost_id = \"identity-recovery\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+    let args = |force| WorkspaceInitArgs {
+        name: Some("identity-recovery".to_string()),
+        base_branch: None,
+        ship_mode: None,
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force,
+    };
+
+    args(false)
+        .execute_without_runtime(None)
+        .expect("initial workspace init");
+    let registry_path = global.join("workspaces.json");
+    let registry_without_refresh_time = || {
+        let mut registry: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(&registry_path).expect("read registry for comparison"),
+        )
+        .expect("parse registry for comparison");
+        for workspace in registry["workspaces"]
+            .as_array_mut()
+            .expect("workspace registry array")
+        {
+            workspace
+                .as_object_mut()
+                .expect("workspace registry object")
+                .remove("updated_at");
+        }
+        registry
+    };
+    let registry_before = registry_without_refresh_time();
+    let identity_path = workspace.path().join(".orbit/config.yaml");
+    let expected_id = canonical_workspace_id("identity-recovery");
+
+    std::fs::write(&identity_path, []).expect("truncate identity to zero bytes");
+    let error = args(false)
+        .execute_without_runtime(None)
+        .expect_err("recovery must require force")
+        .to_string();
+    assert!(error.contains("rerun with --force"), "unexpected: {error}");
+    assert_eq!(
+        std::fs::read(&identity_path).expect("read refused empty identity"),
+        Vec::<u8>::new()
+    );
+
+    args(true)
+        .execute_without_runtime(None)
+        .expect("force must recover an empty identity for the exact registration");
+    let recovered = std::fs::read_to_string(&identity_path).expect("read recovered identity");
+    assert!(recovered.contains(&format!("workspace_id: {expected_id}")));
+    let evidence_dir = workspace
+        .path()
+        .join(".orbit/state/recovery/workspace-identity");
+    let evidence = std::fs::read_dir(&evidence_dir)
+        .expect("read identity recovery evidence")
+        .map(|entry| entry.expect("read evidence entry").path())
+        .collect::<Vec<_>>();
+    assert_eq!(evidence.len(), 1, "unexpected evidence: {evidence:?}");
+    assert_eq!(
+        std::fs::read(&evidence[0]).expect("read archived corrupt identity"),
+        Vec::<u8>::new(),
+        "the exact corrupt bytes must be preserved before recovery"
+    );
+    assert_eq!(
+        registry_without_refresh_time(),
+        registry_before,
+        "identity recovery must preserve the global registration"
+    );
+
+    std::fs::remove_file(&identity_path).expect("remove identity for missing recovery");
+    args(true)
+        .execute_without_runtime(None)
+        .expect("force must recover a missing identity for the exact registration");
+    let recovered = std::fs::read_to_string(&identity_path).expect("read recovered identity");
+    assert!(recovered.contains(&format!("workspace_id: {expected_id}")));
+    assert_eq!(
+        std::fs::read_dir(&evidence_dir)
+            .expect("read evidence after missing recovery")
+            .count(),
+        1,
+        "a missing identity has no corrupt bytes to archive"
+    );
+    assert_eq!(
+        registry_without_refresh_time(),
+        registry_before,
+        "missing-identity recovery must preserve the global registration"
+    );
+}
+
+#[test]
 fn multi_host_workspace_init_persists_an_explicit_local_owner() {
     let workspace = tempdir().expect("workspace tempdir");
     let home = tempdir().expect("home tempdir");
@@ -1395,6 +1499,19 @@ fn workspace_init_in_independent_nested_git_repo_preserves_parent_binding() {
     assert!(
         child_identity.contains(&format!("workspace_id: {child_id}")),
         "child repository must own its workspace identity: {child_identity}"
+    );
+    std::fs::write(child_orbit.join("config.yaml"), [])
+        .expect("truncate child identity for recovery");
+    let mut child_recovery = init("independent-child");
+    child_recovery.force = true;
+    child_recovery
+        .execute_without_runtime(None)
+        .expect("recover exactly registered child identity");
+    assert_eq!(
+        std::fs::read_to_string(child_orbit.join("config.yaml"))
+            .expect("read recovered child identity"),
+        child_identity,
+        "child recovery must restore its own identity"
     );
     for state_dir in ["resources", "tasks", "state"] {
         assert!(

--- a/crates/orbit-core/assets/policies/default.yaml
+++ b/crates/orbit-core/assets/policies/default.yaml
@@ -13,7 +13,6 @@ spec:
     - .orbit/**
     - "!.orbit/auto_tasks/**"
     - "!.orbit/routines/**"
-    - "!.orbit/config.yaml"
     - "!.orbit/config.toml"
     - "!.orbit/resources/**"
     - "**/.env"

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sandbox.rs
@@ -382,7 +382,7 @@ fn managed_worktree_without_an_fs_profile_can_write_under_docs() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny() {
+fn resolved_sandbox_never_materializes_checkout_identity_as_a_write_anchor() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     seed_executor(
         &runtime,
@@ -397,10 +397,8 @@ fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny
         std::fs::create_dir_all(worktree.join(".orbit").join(directory))
             .expect("create worktree Orbit fixture");
     }
-    for file in ["config.yaml", "config.toml"] {
-        std::fs::write(worktree.join(".orbit").join(file), "versioned = true")
-            .expect("create versioned config fixture");
-    }
+    std::fs::write(worktree.join(".orbit/config.toml"), "versioned = true")
+        .expect("create versioned config fixture");
 
     let resolved = runtime
         .resolve_executor_sandbox("claude", None, Some(&worktree))
@@ -418,7 +416,6 @@ fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny
     for allowed in [
         format!("{}/auto_tasks/**", orbit.display()),
         format!("{}/routines/**", orbit.display()),
-        format!("{}/config.yaml", orbit.display()),
         format!("{}/config.toml", orbit.display()),
         format!("{}/resources/**", orbit.display()),
     ] {
@@ -428,6 +425,24 @@ fn resolve_executor_sandbox_orders_versioned_orbit_exceptions_after_default_deny
             .unwrap_or_else(|| panic!("versioned exception `{allowed}` missing from {modify:?}"));
         assert!(deny_pos < allow_pos, "exception must follow default deny");
     }
+    let identity = orbit.join("config.yaml");
+    assert!(
+        linux_bwrap_write_grant_diagnostic(&resolved.fs_profile, &identity)
+            .expect("diagnose runtime identity")
+            .is_some(),
+        "checkout-local runtime identity must remain read-only"
+    );
+    let prepared = prepare_linux_bwrap_write_grants(&resolved.fs_profile, &worktree)
+        .expect("prepare versioned write grants");
+    assert!(
+        !identity.exists(),
+        "an absent runtime identity must never become an empty sandbox anchor"
+    );
+    assert!(
+        prepared.created.iter().all(|path| path != &identity),
+        "runtime identity appeared in prepared anchors: {:?}",
+        prepared.created
+    );
     for protected in [
         format!("{}/state/**", orbit.display()),
         format!("{}/tasks/**", orbit.display()),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/argv.rs
@@ -106,7 +106,6 @@ fn task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies() 
             ".orbit/**",
             "!.orbit/auto_tasks/**",
             "!.orbit/routines/**",
-            "!.orbit/config.yaml",
             "!.orbit/config.toml",
             "!.orbit/resources/**",
             "**/.env",

--- a/docs/design/policy-sandbox/1_overview.md
+++ b/docs/design/policy-sandbox/1_overview.md
@@ -3,8 +3,8 @@ summary: "Policy & Sandboxing — Overview"
 type: design
 title: "Policy & Sandboxing — Overview"
 owner: claude
-last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_updated: 2026-09-06
+last_validated: 2026-09-06
 status: Draft
 feature: policy-sandbox
 doc_role: overview
@@ -45,7 +45,7 @@ When an activity omits `fsProfile:`, the v2 host uses `UNRESTRICTED_FS_PROFILE`.
 
 `PolicyDef::check_path` evaluates normalized workspace-relative paths against positive and negated rules. The last matching rule wins. Empty positive sets deny with `[]`; unmatched positive sets deny with `<no matching rule>`.
 
-The shipped host policy keeps `.orbit/**` protected, then explicitly re-allows only versioned definitions and configuration: `.orbit/auto_tasks/**`, `.orbit/routines/**`, `.orbit/config.yaml`, `.orbit/config.toml`, and `.orbit/resources/**`. Runtime state, Orbit-owned records, databases, locks, and unknown `.orbit` paths stay protected. These exceptions intersect the activity profile; they do not derive authority from task `context_files`.
+The shipped host policy keeps `.orbit/**` protected, then explicitly re-allows only repository-versioned definitions and configuration: `.orbit/auto_tasks/**`, `.orbit/routines/**`, `.orbit/config.toml`, and `.orbit/resources/**`. Checkout-local `.orbit/config.yaml` is runtime identity, is ignored by the initializer, and remains protected from managed agents. Runtime state, Orbit-owned records, databases, locks, and unknown `.orbit` paths stay protected. These exceptions intersect the activity profile; they do not derive authority from task `context_files`. [ORB-11376]
 
 Linux provider launch materializes a missing write-grant anchor before spawning, because Bubblewrap cannot bind-mount a nonexistent child beneath the read-only `.orbit` parent. The set of anchors is read off the effective profile that compiles the same argv — every narrow re-allow nested under an earlier deny — so it cannot drift from what the kernel enforces, and it is re-derived at each spawn rather than snapshotted once. Materialization runs only inside the disposable worktree, never opens an existing target for writing, and rejects symlinks and filesystem-type mismatches. Task `context_files` are not consulted: they are planning selectors, not policy authority. A grant the plan cannot mount is reported against its path and rule, never silently dropped. [ORB-10602]
 
@@ -94,5 +94,6 @@ When the default policy denies workspace `.orbit/**`, the v2 host re-allows only
 - **[ORB-10560]** — Permit only explicit versioned `.orbit` configuration beneath the default protected boundary.
 - **[ORB-10573]** — Prepare only missing, exactly scoped versioned-config anchors that remain permitted by the effective host policy/profile.
 - **[ORB-10602]** — Derive write-grant anchors from the effective profile at each spawn instead of a hardcoded table plus a context-file snapshot, and report every unmountable grant.
+- **[ORB-11376]** — Keep checkout-local runtime identity outside the agent-write and sandbox-anchor surface; add exact-registration recovery for missing or corrupt identity.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,8 +3,8 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-08-30
-last_validated: 2026-08-30
+last_updated: 2026-09-06
+last_validated: 2026-09-06
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -33,7 +33,7 @@ A valid policy declares `name`, optional `description`, global `denyRead` / `den
 
 `PolicyDef::merged(global, workspace)` lets workspace `fsProfiles` overwrite globals by name while global denies accumulate. A workspace may repeat or narrow a host `denyModify` exception, but cannot introduce an exception outside the host exception surface. Workspace denies are appended after host exceptions and therefore can narrow them. The merged policy is revalidated.
 
-The shipped default expresses the versioned Orbit boundary as an ordered `.orbit/**` deny followed by exceptions for `.orbit/auto_tasks/**`, `.orbit/routines/**`, `.orbit/config.yaml`, `.orbit/config.toml`, and `.orbit/resources/**`. The broad deny continues to cover `.orbit/state/**`, task/learning/ADR/friction stores, databases, locks, and any future or misspelled `.orbit` path. Task `context_files` remain planning and conflict selectors; policy resolution does not convert them into filesystem grants ([ORB-10560]), and anchor materialization does not consult them at all ([ORB-10602]).
+The shipped default expresses the versioned Orbit boundary as an ordered `.orbit/**` deny followed by exceptions for `.orbit/auto_tasks/**`, `.orbit/routines/**`, `.orbit/config.toml`, and `.orbit/resources/**`. Checkout-local `.orbit/config.yaml` is ignored runtime identity rather than repository configuration; it stays under the deny and therefore cannot become a managed-worktree sandbox anchor ([ORB-11376]). The broad deny continues to cover `.orbit/state/**`, task/learning/ADR/friction stores, databases, locks, and any future or misspelled `.orbit` path. Task `context_files` remain planning and conflict selectors; policy resolution does not convert them into filesystem grants ([ORB-10560]), and anchor materialization does not consult them at all ([ORB-10602]).
 
 ---
 
@@ -341,5 +341,6 @@ asserts 100 collision-free dense IDs per artifact kind ([ORB-10596]).
 - **[ORB-10573]** — Materialize only exact missing versioned-config anchors gated by both task scope and the effective host policy/profile before Linux provider launch.
 - **[ORB-10602]** — Replace that table-and-selector gate with per-spawn derivation from the effective profile, and surface every unmountable grant against its path and rule.
 - **[ORB-10596]** — Allow executor-authored Proposed ADRs through one narrow managed-worktree mount while preserving global allocation, federated discovery, and separate acceptance.
+- **[ORB-11376]** — Remove checkout-local runtime identity from the managed-agent write exception so absent identities cannot be published as empty anchors.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -3,12 +3,12 @@ summary: "Policy & Sandboxing — Decisions"
 type: design
 title: "Policy & Sandboxing — Decisions"
 owner: claude
-last_updated: 2026-08-15
+last_updated: 2026-09-06
 status: Draft
 feature: policy-sandbox
 doc_role: decisions
 tags: ["policy-sandbox"]
-last_validated: 2026-08-15
+last_validated: 2026-09-06
 ---
 
 # Policy & Sandboxing — Decisions
@@ -368,7 +368,7 @@ Creation is confined to the managed worktree: every component that root owns is 
 - Adding a versioned `.orbit` path is now a one-line policy change; no Rust inventory tracks it.
 - The grant set is recomputed per spawn from the enforced profile, so it cannot drift from the kernel's view.
 - A denial is attributable before the provider starts, against a path and a rule, instead of as an EROFS inside an agent turn.
-- Cost: an exact *file* grant that is absent, untracked, and un-ignored leaves an empty anchor in the worktree that `git add -A` would stage. It is empty and therefore visible in review rather than silent. In this repository `.orbit/config.toml` is tracked and `.orbit/config.yaml` is ignored, so no such anchor arises.
+- Cost: an exact *file* grant that is absent, untracked, and un-ignored leaves an empty anchor in the worktree that `git add -A` would stage. Checkout-local `.orbit/config.yaml` is no longer such a grant after [ORB-11376]; repository-versioned exact grants must still account for this behavior.
 - Cost: anchor shape for an absent exact rule is inferred, not declared. Spelling a directory grant as `<path>/**` remains the way to state it unambiguously.
 - Read-only git metadata for linked worktrees is unchanged and still out of scope.
 
@@ -388,6 +388,33 @@ Derive Linux write-grant candidates at every provider spawn from the same ordere
 - Later workspace denies prevent materialization, while narrower denies below a writable subtree preserve the remaining grant.
 - Cost: policy authors must use exact syntax for file anchors and `<root>/**` syntax for directory anchors; an existing target whose filesystem type contradicts that syntax fails closed.
 - Cost: post-invocation attribution depends on the child including the attempted path in its EROFS stderr; failures that omit the path retain the generic nonzero-exit diagnostic.
+
+## Keep checkout identity outside managed-agent write grants
+
+**Recorded:** 2026-09-06 · [ORB-11376]
+**Paths:** `crates/orbit-core/assets/policies/default.yaml`, `crates/orbit-cli/src/command/workspace/init.rs`, `docs/runbooks/state-and-backup.md`
+
+### Context
+
+The Linux pre-spawn writer derives every narrow re-allow from the effective policy and creates an absent exact file as a zero-byte Bubblewrap mount anchor. The default policy still re-allowed `.orbit/config.yaml` even though workspace initialization ignores that checkout-local identity rather than versioning it. A worker branch created before the initializer's `.gitignore` landed therefore retained the empty anchor, and its delivery commit introduced a tracked zero-byte identity. Resumed local delivery exposed and merged that already-created artifact; no evidence identifies resume as the writer.
+
+### Decision
+
+Keep `.orbit/config.yaml` beneath the default `.orbit/**` agent-write deny. The initializer remains the authoritative writer. `workspace init --force` may restore a missing or malformed identity only after the global registry supplies both the requested logical workspace and the exact checkout path/data-root binding. It archives malformed bytes under `.orbit/state/recovery/workspace-identity/` before atomically restoring the registered ID. A parseable different workspace ID remains an ownership conflict and is never replaced through this recovery.
+
+### Rejected alternatives
+
+**Delete empty anchors just before commit.** Emptiness is not evidence that a repository file is disposable, and commit-time cleanup would duplicate policy semantics after the writer already ran.
+
+**Relax identity mismatch validation.** A parseable different ID is a competing ownership claim, not corruption. Replacing it would turn `--force` into a registry bypass.
+
+**Require operators to hand-create the YAML.** Manual reconstruction loses the supported ownership proof and makes it easier to bind the child to a parent or invented workspace.
+
+### Consequences
+
+- Managed agents cannot create or modify checkout identity, and Linux launch has no identity anchor to leak into delivery.
+- Exact registered checkouts have a bounded recovery command; corrupt bytes remain available as local evidence.
+- Workspace identity changes remain an operator-owned initializer action rather than ordinary repository editing.
 
 ## Task References
 
@@ -427,5 +454,6 @@ Derive Linux write-grant candidates at every provider spawn from the same ordere
 - **[ORB-10602]** — Derive write-grant anchors from the effective profile at each spawn; remove the hardcoded target inventory and the context-file materialization gate. [Derive Linux sandbox write-grant anchors from the effective profile at each spawn](#derive-linux-sandbox-write-grant-anchors-from-the-effective-profile-at-each-spawn-1)
 - **[ORB-10607]** — Enforce final-policy materialization, canonical/symlink containment, rule-derived anchor types, and production failed-write attribution. [Derive Linux sandbox write-grant anchors from the effective profile at each spawn](#derive-linux-sandbox-write-grant-anchors-from-the-effective-profile-at-each-spawn-1)
 - **[ORB-10833]** — Retire the remaining unregistered `fs.*` builtins and their private policy helpers. [Retire the remaining unregistered fs builtins and their policy helpers](#retire-the-remaining-unregistered-fs-builtins-and-their-policy-helpers)
+- **[ORB-11376]** — Protect checkout-local runtime identity from managed-agent writes and add exact-registration recovery. [Keep checkout identity outside managed-agent write grants](#keep-checkout-identity-outside-managed-agent-write-grants)
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -4,8 +4,8 @@ summary: Locate Orbit state and perform WAL-safe backups, explicit task publicat
 tags: [operations, backup, restore, state, sqlite, task-publication]
 paths: ["crates/orbit-common/src/types/workspace.rs", "crates/orbit-config/src/**", "crates/orbit-registry/**", "crates/orbit-store/**", "crates/orbit-web/src/state.rs"]
 related_features: [orbit-core, remote-access, task-publication]
-related_artifacts: [ORB-10014, ORB-10294, ORB-10473, ORB-11077]
-last_validated: 2026-08-30
+related_artifacts: [ORB-10014, ORB-10294, ORB-10473, ORB-11077, ORB-11376]
+last_validated: 2026-09-06
 ---
 
 # Inventory and Protect Orbit State
@@ -118,6 +118,26 @@ owns today:
 
 Any additional operator-authored paths require an explicit repository policy; do not
 assume workspace initialization commits them.
+
+### Recover a missing or corrupt checkout identity
+
+Do not hand-create `.orbit/config.yaml` or edit `workspaces.json`. First preserve any
+incident evidence outside the checkout when an investigation requires an operator-owned
+copy. Then, from the registered checkout root, rerun the original initializer arguments
+with `--force`, including the registered `--name`:
+
+```bash
+orbit workspace init --name <registered-name> --force
+```
+
+Recovery is accepted only when the global registry unambiguously matches both that logical
+workspace and the current checkout's repository/data-root paths. A missing or malformed
+identity is restored atomically from that binding. Malformed bytes (including a zero-byte
+file) are first archived beneath
+`.orbit/state/recovery/workspace-identity/config.yaml.<timestamp>.corrupt`; a missing file
+has no bytes to archive. A parseable identity naming another workspace is still refused,
+even with `--force`. Valid identity, parent-workspace identity, and unrelated registry
+records are not recovery inputs and are not rewritten. [ORB-11376]
 
 ## Back up Orbit
 


### PR DESCRIPTION
## Task

[ORB-11376](https://orbit-cli.com/tasks/ORB-11376) — Diagnose empty workspace identity after resumed local delivery and support safe recovery

### Description

Evidence from approved orbit-research delivery: jrun-20260906-0134-3 completed implementation but failed dirty-base git_merge. Operator committed only init-generated .gitignore/default disabled auto_tasks/routines as 6359bcb and used authoritative workflow_run_resume, creating jrun-20260906-0158. Subsequent workflow_run_show(ws_orbit-research) failed invalid workspace config .orbit/config.yaml missing schema_version. Authoritative command_exec through ws_constellation verified that exact child config.yaml is a regular, zero-byte file; registry remains correctly bound to ws_orbit-research, owner hm_9ca6004473492f06, child repo_root and child orbit_dir. Git agent-main now contains delivery commit 51b117d above 6359bcb, clean. No evidence yet attributes truncation to resume; diagnose timestamps/audit/code and concurrent writers rather than assuming causality. Parent config is still 41 bytes. orbit workspace init --name orbit-research --base-branch agent-main --ship-mode local --force also refuses empty config before recovery. Initial registration was from merged ORB-11360 dev binary and succeeded with parent bytes unchanged. Do not rewrite parent identity, invent a registry or weaken conflict validation. Investigate non-atomic identity writes and supported recovery for an invalid/empty checkout identity when authoritative registration unambiguously identifies it; preserve corruption evidence and require exact ownership. Dedicated worktree, focused repro, relevant checks. Proposed diagnostic/fix record under Daniel's instruction to file operational problems; no blind attribution or generic relaxation.

### Acceptance Criteria

- Identify the actual writer/cause where evidence permits; distinguish confirmed mechanism from temporal correlation with resumed delivery.
- Regression covers interrupted/empty identity handling and preserves existing valid identities, parent workspace and global registration; conflicting ownership remains refused.
- Document or implement a bounded supported recovery for an unambiguously registered child with corrupt identity, preserving evidence; required Orbit checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Confirmed the writer: Linux pre-spawn write-grant preparation created absent exact policy grants as zero-byte files, and the shipped default incorrectly re-allowed checkout-local .orbit/config.yaml. The worker branch predated the later .gitignore commit, so its delivery commit could track the placeholder. Resume exposed and merged the pre-existing worker artifact; it was temporal correlation, not the writer.
- Removed .orbit/config.yaml from the managed-agent policy exception while retaining repository-versioned auto_tasks, routines, config.toml, and resources write grants. Added a regression proving the resolved Linux sandbox keeps identity read-only and never materializes an absent identity anchor.
- Extended workspace init --force to recover a missing or malformed identity only after exact logical-workspace, repo-root, and orbit-dir registration validation. Corrupt bytes are archived under .orbit/state/recovery/workspace-identity before atomic restoration. Parseable different workspace ownership remains refused.
- Added regressions for zero-byte and missing identity recovery, evidence preservation, force requirement, global registration preservation, nested-child recovery, parent identity/registration preservation, existing valid identity behavior, and conflicting ownership refusal.
- Updated current sandbox design and state recovery runbook. Filed root-cause friction F2026-09-033 and linked this task as its resolver.
Assessment: Bounded recovery and prevention at authoritative boundaries; no dependency edge, registry bypass, parent identity rewrite, manual identity synthesis, or commit-time cleanup heuristic.
Validation:
- cargo test -p orbit-cli command::workspace::tests::init:: -- --nocapture (27 passed)
- cargo test -p orbit-cli force_recovers_empty_or_missing_identity_only_for_the_exact_registration -- --nocapture (passed after final recovery semantics)
- cargo test -p orbit-cli workspace_init_in_independent_nested_git_repo_preserves_parent_binding -- --nocapture (passed after child-recovery extension)
- cargo test -p orbit-core resolved_sandbox_never_materializes_checkout_identity_as_a_write_anchor -- --nocapture (passed)
- cargo test -p orbit-engine task_pilot_reviewer_profile_starts_direct_linux_invocation_with_env_denies -- --nocapture (passed)
- make ci-fast (passed on final tree)
- make ci-lint (workspace/all-target clippy passed)
- cargo fmt --all -- --check and git diff --check (passed)
Diff: 9 intended files, 260 insertions and 33 deletions from baseline 932d7000b2e2c99f9d385005ee6c30b2ebc0411c. No commit created, per repository policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11376-6a9ccad7`
- Behind base: 0
- Ahead of base: 1