### PR TITLE
Format the CI relevance repair so the repository guardrail passes

### DIFF
--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -221,7 +221,13 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     }
     let probes = probe_branches(queries, &refs, &runs, &bounds, &mut notes);
     let mut partition = RunPartition::default();
-    partition_runs(&refs, &runs, &probes.retired, &probes.unverified, &mut partition);
+    partition_runs(
+        &refs,
+        &runs,
+        &probes.retired,
+        &probes.unverified,
+        &mut partition,
+    );
     let RunPartition {
         latest,
         mut current,
@@ -603,11 +609,7 @@ fn probe_branches<Q: CiQueries + ?Sized>(
 /// newest candidates while the final slot rotates through overflow candidates
 /// with each advancing cursor so all candidates eventually get probed without
 /// starvation.
-fn probe_slots(
-    candidates: usize,
-    budget: usize,
-    cursor: u64,
-) -> std::collections::BTreeSet<usize> {
+fn probe_slots(candidates: usize, budget: usize, cursor: u64) -> std::collections::BTreeSet<usize> {
     let attempted = candidates.min(budget);
     let mut slots: std::collections::BTreeSet<usize> = (0..attempted).collect();
     if candidates <= attempted || attempted == 0 {

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1553,7 +1553,10 @@ fn unprobed_branches_past_probe_budget_remain_deferred_without_consuming_investi
     // The integration failure consumes the 1 investigation slot and is current and investigated
     assert_eq!(current_ids(&evidence), [10]);
     assert_eq!(evidence["summary"]["investigated_failures"], 1);
-    assert_eq!(evidence["summary"]["investigated_failure_run_ids"], json!([10]));
+    assert_eq!(
+        evidence["summary"]["investigated_failure_run_ids"],
+        json!([10])
+    );
 
     // The candidate branch was past the probe budget (0) so it was deferred without probing
     assert_eq!(deferred_ids(&evidence), [20]);
@@ -1659,7 +1662,9 @@ fn current_heads_and_verified_open_prs_retain_priority_over_other_refs() {
     );
     assert_eq!(evidence["summary"]["investigated_failures"], 3);
 
-    let current = evidence["current_failures"].as_array().expect("current array");
+    let current = evidence["current_failures"]
+        .as_array()
+        .expect("current array");
     let other_run = current.iter().find(|r| r["run_id"] == 40).expect("run 40");
     assert_eq!(other_run["investigated"], false);
 }
@@ -1730,7 +1735,8 @@ fn bounded_repeated_sweeps_rotate_probes_without_starvation() {
 }
 
 #[test]
-fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_probe_failures_and_pending_successors() {
+fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_probe_failures_and_pending_successors()
+ {
     let checkout = "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n";
     let queries = FakeQueries::authenticated()
         .with_head("agent-main", HEAD)
@@ -1745,7 +1751,10 @@ fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_prob
         }))
         // orbit/ORB-200-merged has no head on origin (returns None) -> retired
         // orbit/ORB-300-transient has probe error -> deferred
-        .with_branch_head_error("orbit/ORB-300-transient", "network timeout contacting origin")
+        .with_branch_head_error(
+            "orbit/ORB-300-transient",
+            "network timeout contacting origin",
+        )
         // orbit/ORB-400-overflow is past max_retired_ref_probes -> deferred
         .with_runs(vec![vec![
             // 1. Integration failure (agent-main)
@@ -1855,7 +1864,9 @@ fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_prob
     // Merged PR is retired (in stale_or_superseded)
     let stale = evidence["stale_or_superseded"].as_array().expect("stale");
     assert!(
-        stale.iter().any(|entry| entry["run_id"] == 1005 && entry["reason"] == "ref_no_longer_exists"),
+        stale
+            .iter()
+            .any(|entry| entry["run_id"] == 1005 && entry["reason"] == "ref_no_longer_exists"),
         "merged PR is retired: {evidence}"
     );
 
@@ -1867,13 +1878,19 @@ fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_prob
     assert_eq!(deferred[1]["investigated"], false);
 
     // Retryable errors carry the run-scoped discovery errors for deferred runs
-    let retryable = evidence["retryable_errors"].as_array().expect("retryable_errors");
+    let retryable = evidence["retryable_errors"]
+        .as_array()
+        .expect("retryable_errors");
     assert!(
-        retryable.iter().any(|err| err["operation"] == "remote_branch_head" && err["run_id"] == 1006),
+        retryable
+            .iter()
+            .any(|err| err["operation"] == "remote_branch_head" && err["run_id"] == 1006),
         "transient probe error is attached to run 1006: {evidence}"
     );
     assert!(
-        retryable.iter().any(|err| err["operation"] == "retired_ref_budget" && err["run_id"] == 1007),
+        retryable
+            .iter()
+            .any(|err| err["operation"] == "retired_ref_budget" && err["run_id"] == 1007),
         "budget exhaustion error is attached to run 1007: {evidence}"
     );
 }


### PR DESCRIPTION
## Task

[ORB-11385](https://orbit-cli.com/tasks/ORB-11385) — Format the CI relevance repair so the repository guardrail passes

### Description

PR1418/ORB-11359 merged as914241d0ada9f20881ccf5530f7ac24a48e036f1. Its CI run34006351567, Check/Clippy/Test job101414163188, fails Run CI guardrails at 2026-09-06T02:26:22Z with exit1 after rustfmt differences in exactly crates/orbit-engine/src/executor/automation/ci/collect.rs and tests/collect.rs. Exact job log via gh api repos/danieljhkim/orbit/actions/jobs/101414163188/logs shows formatting of new branch probing and assertions, including tests/collect.rs1855/1867/1876. The worker reported focused35 collector+27 filer tests but no fmt/ci-fast/ci-lint result. This is a newly introduced validation failure distinct from ORB-11381 snapshot drift and ORB-11382 Clippy borrow. Apply repository formatting to the affected files, inspect for formatting-only diff, and run the required fast gate. Do not alter behavior or suppress checks; no new behavior-mirroring test needed.

### Acceptance Criteria

- cargo fmt --all --check passes for the affected revision and the task diff contains formatting only in the intended files.
- make ci-fast passes; distinguish any other known CI blockers by task ID rather than claiming the entire suite is green.
- Record the validated SHA and exact check outcomes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Applied repository rustfmt to `crates/orbit-engine/src/executor/automation/ci/collect.rs` and `crates/orbit-engine/src/executor/automation/ci/tests/collect.rs`.
- The diff from validated baseline SHA `a467b43e4ff7143903527088e9dcda3e57e20a6c` is limited to those two intended files (8 insertions/6 deletions and 25 insertions/8 deletions) and contains formatting-only layout changes; `git diff --check` passes.
Assessment: scoped formatting repair only; no behavior, test logic, dependency, or check suppression changes.
Validation:
- `cargo fmt --all --check`: passed (exit 0).
- `make ci-fast`: exit 2 after the `sync-plugin-skills.sh --check` guard found pre-existing drift between `crates/orbit-core/assets/skills/orbit/references/workflows.md` and `plugin/skills/orbit/references/workflows.md`; this unrelated drift comes from the completed ORB-11351 change and is outside this task's two-file scope. Therefore the full fast gate is not green, and no claim is made that the entire suite passes.
- Final `git status --short`: only the two intended CI collector files are modified.
Friction checkpoint: no qualifying friction observed.
Cleanup: no generated build artifacts or caches were created inside the worktree; final status contains only intended task-scoped changes.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11385-6a9cd420`
- Behind base: 0
- Ahead of base: 1