### PR TITLE
Reconcile the broken runner-local CI task reporter with host-owned failure filing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,87 +276,36 @@ jobs:
         if: always()
         run: df -h /
 
-      - name: Create orbit task on CI failure
-        if: failure() && github.event_name == 'pull_request'
+      # CI runners report bounded provenance only. The host-owned
+      # `ci_failure_sweep_pipeline` queries GitHub and is the sole authority
+      # that may create durable Orbit remediation tasks. [ORB-11383]
+      - name: Report CI failure for host sweep
+        if: failure()
         env:
           WORKFLOW: ${{ format('{0}', github.workflow) }}
-          PR_NUMBER: ${{ format('{0}', github.event.pull_request.number) }}
-          BRANCH: ${{ format('{0}', github.head_ref) }}
-          SHA: ${{ format('{0}', github.event.pull_request.head.sha) }}
+          EVENT: ${{ format('{0}', github.event_name) }}
+          JOB: ${{ format('{0}', github.job) }}
+          REF: ${{ format('{0}', github.ref_name) }}
+          EVENT_SHA: ${{ format('{0}', github.sha) }}
+          PR_HEAD_SHA: ${{ format('{0}', github.event.pull_request.head.sha) }}
           RUN_ID: ${{ format('{0}', github.run_id) }}
+          RUN_ATTEMPT: ${{ format('{0}', github.run_attempt) }}
         run: |
-          # This step must never fail the job. A missing checkout, a merged PR,
-          # or a missing orbit binary are skip conditions, not new reds.
+          # This step must never change the job conclusion. `github.sha` can
+          # be a PR merge SHA, so retain it separately from both the PR head
+          # and the commit the runner actually checked out.
           set +e
-          report() { echo "Create orbit task on CI failure: $*"; }
-
-          if [ ! -f Cargo.toml ]; then
-            report "skipping because no checkout is present"
-            exit 0
-          fi
-
-          if [ -n "${PR_NUMBER:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] && command -v gh >/dev/null 2>&1; then
-            merged="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .merged 2>/dev/null)"
-            if [ "$merged" = "true" ]; then
-              report "skipping because PR #${PR_NUMBER} is already merged"
-              exit 0
+          tested_sha="unavailable"
+          if command -v git >/dev/null 2>&1; then
+            candidate="$(git rev-parse HEAD 2>/dev/null)"
+            if [ -n "$candidate" ]; then
+              tested_sha="$candidate"
             fi
           fi
-
-          orbit_bin=""
-          if command -v orbit >/dev/null 2>&1; then
-            orbit_bin="$(command -v orbit)"
-          elif [ -x "${HOME}/.orbit/bin/orbit" ]; then
-            orbit_bin="${HOME}/.orbit/bin/orbit"
-          elif [ -x target/debug/orbit ]; then
-            orbit_bin="$(pwd)/target/debug/orbit"
-          elif [ -x target/release/orbit ]; then
-            orbit_bin="$(pwd)/target/release/orbit"
-          fi
-          if [ -z "$orbit_bin" ]; then
-            report "skipping because orbit CLI is not available (will not compile from source)"
-            exit 0
-          fi
-
-          workspace="${GITHUB_WORKSPACE:-}"
-          case "$workspace" in
-            /*) ;;
-            *) workspace="$(pwd -P)" ;;
-          esac
-
           run_url="${GITHUB_SERVER_URL:-}/${GITHUB_REPOSITORY:-}/actions/runs/${RUN_ID:-}"
-          description="$(printf '%s\n' \
-            "## Problem" \
-            "CI failed on PR #${PR_NUMBER} (\`${BRANCH}\`)." \
-            "" \
-            "Commit: \`${SHA}\`" \
-            "Run: ${run_url}")"
-
-          payload="$(jq -n \
-            --arg title "CI failure: ${WORKFLOW} on PR #${PR_NUMBER}" \
-            --arg description "$description" \
-            --arg branch "${BRANCH:-}" \
-            --arg workspace "$workspace" \
-            '{
-              title: $title,
-              description: $description,
-              acceptance_criteria: ["CI passes on branch \($branch)"],
-              context_files: ["file:.github/workflows/ci.yml"],
-              workspace: $workspace,
-              priority: "high",
-              type: "bug",
-              model: "github-actions",
-              tags: ["ci"]
-            }'
-          )"
-          if [ -z "$payload" ]; then
-            report "skipping because payload construction failed"
-            exit 0
-          fi
-
-          "$orbit_bin" tool run orbit.task.add --input "$payload"
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            report "orbit.task.add failed with exit ${status}; not failing the job"
-          fi
+          printf '%s\n' \
+            "CI failure reported for host-owned ci_failure_sweep_pipeline; durable filing happens only on the Orbit host." \
+            "workflow=${WORKFLOW:-} event=${EVENT:-} job=${JOB:-} ref=${REF:-}" \
+            "run_id=${RUN_ID:-} run_attempt=${RUN_ATTEMPT:-} run_url=${run_url}" \
+            "event_sha=${EVENT_SHA:-} pr_head_sha=${PR_HEAD_SHA:-} tested_sha=${tested_sha}"
           exit 0

--- a/.orbit/auto_tasks/ci-failure-remediation.yaml
+++ b/.orbit/auto_tasks/ci-failure-remediation.yaml
@@ -20,9 +20,10 @@ template:
        Cover failures for the current heads of `agent-main`, `main`, and every
        open pull request, including informational jobs such as coverage rather
        than looking only at required checks or the main `ci` job.
-    2. The PR-only `Create orbit task on CI failure` step in
-       `.github/workflows/ci.yml` is an input and coverage signal. Search open
-       Orbit tasks for its run URL, PR number, SHA, and failure signature.
+    2. The fail-open CI failure report in `.github/workflows/ci.yml` records
+       runner provenance only; it never creates Orbit tasks. Durable filing is
+       owned by the host-side `ci_failure_sweep_pipeline`. Search open Orbit
+       tasks for the report's run URL, job, SHAs, and failure signature.
        Reference matching tasks in the execution summary; do not create
        another task for the same run or root cause. This remediation task owns
        the repair and must not fan a red-run cluster out into more failure

--- a/docs/design/auto-tasks/1_overview.md
+++ b/docs/design/auto-tasks/1_overview.md
@@ -127,7 +127,8 @@ encode this repository's branches and gates. Re-init preserves them:
   are no longer listed as if they were embedded defaults.
 - ORB-11095 — Added centralized finding-title provenance and established the
   shipped definition's canonical `code-review` name.
-- ORB-11115 — Retired the shipped CI-failure auto-task; CI-failure filing now
-  belongs to the `ci_failure_sweep` routine.
+- ORB-11115 / ORB-11383 — Retired the shipped CI-failure auto-task;
+  runner workflows only emit fail-open run/job/commit provenance, while the
+  host-owned `ci_failure_sweep` routine performs durable CI-failure filing.
 
 > Resolve any task above with `orbit task show <ID>` or `git log --grep=<ID>`.

--- a/scripts/check-ci-failure-reporting.sh
+++ b/scripts/check-ci-failure-reporting.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workflow="$repo_root/.github/workflows/ci.yml"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "check-ci-failure-reporting: ripgrep (rg) is required; install it before running" >&2
+  exit 1
+fi
+
+required_patterns=(
+  'name: Report CI failure for host sweep'
+  'if: failure()'
+  'host-owned ci_failure_sweep_pipeline'
+  'durable filing happens only on the Orbit host'
+  'RUN_ID: ${{ format('\''{0}'\'', github.run_id) }}'
+  'RUN_ATTEMPT: ${{ format('\''{0}'\'', github.run_attempt) }}'
+  'JOB: ${{ format('\''{0}'\'', github.job) }}'
+  'EVENT_SHA: ${{ format('\''{0}'\'', github.sha) }}'
+  'PR_HEAD_SHA: ${{ format('\''{0}'\'', github.event.pull_request.head.sha) }}'
+  'git rev-parse HEAD'
+  'exit 0'
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! rg -F -q -- "$pattern" "$workflow"; then
+    echo "CI failure reporting is missing required provenance or fail-open behavior: $pattern" >&2
+    exit 1
+  fi
+done
+
+if rg -n -- 'Create orbit task on CI failure|orbit\.task\.add|github-actions' "$workflow"; then
+  echo "CI runners must not create Orbit tasks or claim an unsupported filer identity" >&2
+  exit 1
+fi
+
+echo "CI failure reporting guard passed"

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -39,6 +39,7 @@ fi
 "$repo_root/scripts/check-history-note-size.sh"
 "$repo_root/scripts/check-stability.sh"
 "$repo_root/scripts/check-artifact-redaction-guardrail.sh"
+"$repo_root/scripts/check-ci-failure-reporting.sh"
 "$repo_root/scripts/check-public-artifact-ids.py"
 "$repo_root/scripts/check-changelog-style.sh"
 "$repo_root/scripts/check-error-translation.sh"


### PR DESCRIPTION
## Task

[ORB-11383](https://orbit-cli.com/tasks/ORB-11383) — Reconcile the broken runner-local CI task reporter with host-owned failure filing

### Description

CI run34006052963 job101413310913 reports at 2026-09-06T02:18:01Z: invalid input: missing `complexity`, then 'Create orbit task on CI failure: orbit.task.add failed with exit1; not failing the job'. Current merged949b3c0d .github/workflows/ci.yml:279-362 contains this legacy step. Its payload omits required complexity, sets model github-actions rather than a supported canonical family, hardcodes ci.yml as the modification target regardless of the failing source, and selects ephemeral GITHUB_WORKSPACE as durable authority before invoking local orbit.task.add. Merely adding complexity would not establish delivery to authoritative ws_orbit.

Reconcile this obsolete runner-local task-creation path with the existing host-owned collect_ci_evidence/file_ci_failure_tasks architecture. Prefer removing the false automatic-filing claim and emitting an exact bounded GitHub run/job/SHA failure summary for the existing host sweep, unless there is an already-supported explicit authoritative transport to reuse. Do not create a shadow task store, introduce credentials, broaden GitHub permissions, or teach a second failure classifier. Preserve fail-open reporting, existing CI failure conclusions, fork PR behavior, and host-side deduplication. Document the responsibility boundary and ensure a CI error cannot be described as successfully filed merely because a subprocess ran. Search found no open equivalent; prior ORB-11107 establishes host-owned collection.

### Acceptance Criteria

- The CI workflow no longer attempts invalid runner-local task creation or falsely implies authoritative filing.
- Failure reporting preserves exact run/job/commit provenance for the existing host sweep and remains fail-open, including forks/missing tools.
- Focused workflow/script validation covers the chosen reporting path without creating real remote tasks or introducing secrets; current docs describe who files durable failures.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed CI runner-local `orbit.task.add` creation and replaced it with a fail-open host-sweep provenance report carrying workflow/event/job/ref, run ID/attempt/URL, event SHA, PR-head SHA, and actual checked-out SHA.
- Retired the stale PR-hook wording in the workspace CI-remediation template and documented that the host-owned `ci_failure_sweep` routine performs durable filing.
- Added `scripts/check-ci-failure-reporting.sh` to CI guardrails so the reporting step remains fail-open, provenance-bearing, and free of runner-side filing.
Assessment: The runner makes no durable-task or credential-dependent call; the existing host sweep remains the sole classifier, deduper, and filer.
Validation:
- Passed: `./scripts/check-ci-failure-reporting.sh`; `bash -n scripts/ci-guardrails.sh scripts/check-ci-failure-reporting.sh`; PyYAML parsing of the workflow and CI-failure assets; `git diff --check`.
- `make ci-fast` could not complete because untouched baseline files fail `cargo fmt --check` (`crates/orbit-engine/src/executor/automation/ci/collect.rs` and tests).
- `make ci-lint` could not complete because untouched baseline code fails Clippy `needless_borrow` at `crates/orbit-tools/src/builtin/github/mod.rs:539`.
- Actionlint and Ruby were not installed; no remote task creation, credentials, or remote transport was exercised.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11383-6a9cd420`
- Behind base: 0
- Ahead of base: 1