### PR TITLE
Fix Clippy needless borrow in checkout evidence command handling

### DIFF
--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -536,7 +536,7 @@ impl CheckoutEvidenceCollector {
             return;
         }
         if let Some(command) = &command_output {
-            self.record_evidence_line(&command);
+            self.record_evidence_line(command);
         }
         self.record_evidence_line(payload);
         let named = named_checkout_commit(


### PR DESCRIPTION
## Task

[ORB-11382](https://orbit-cli.com/tasks/ORB-11382) — Fix Clippy needless borrow in checkout evidence command handling

### Description

CI run34006052963 job101413310913 on PR1416 head9a7f9f8da6eb64acd81485aec12546632c0a0241 fails Run CI guardrails before tests: clippy::needless_borrow at crates/orbit-tools/src/builtin/github/mod.rs:539, self.record_evidence_line(&command), where command is already a reference from if let Some(command) = &command_output. Introduced by ORB-11358/PR1415, visible in merged949b3c0d. Diagnostic asks to pass command directly; -D warnings makes this blocking. The former task ran ci-fast but did not report ci-lint. Fix only the needless borrow and preserve immediate-next-line SHA attribution and bounded-log behavior; no lint allowance. Raw authoritative job log was retrieved through gh api repos/danieljhkim/orbit/actions/jobs/101413310913/logs because gh run view --log returned empty for this completed job.

### Acceptance Criteria

- The affected code passes the same all-target Clippy gate with warnings denied, without suppressions.
- Existing bounded_logs tests still pass; no new mirrored implementation test is needed for the one-line correction.
- Record a validated source revision and required checks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Corrected crates/orbit-tools/src/builtin/github/mod.rs to pass the existing checkout command reference directly to record_evidence_line, removing only the redundant borrow and preserving immediate-next-line SHA attribution and bounded-log behavior.
- No test changes; existing bounded_logs coverage remains authoritative.
Validation:
- cargo test -p orbit-tools --lib bounded_logs — passed (23 passed, 0 failed).
- cargo clippy -p orbit-tools --all-targets -- -D warnings — passed with no warnings.
- git diff --check — passed.
- make ci-fast — blocked by pre-existing rustfmt differences in crates/orbit-engine/src/executor/automation/ci/collect.rs and its tests; no formatting issue in the scoped file.
- make ci-lint — blocked by pre-existing clippy::let_and_return in crates/orbit-engine/src/executor/automation/ci/tests/collect.rs:1705; the scoped orbit-tools package passes the equivalent all-target gate above.
Source revision: a467b43e4ff7143903527088e9dcda3e57e20a6c plus the single intended working-tree change in crates/orbit-tools/src/builtin/github/mod.rs.
Assessment: Minimal, warning-free one-line correction; working tree contains only the intended task-scoped modification.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11382-6a9cd420`
- Behind base: 0
- Ahead of base: 1