### PR TITLE
Refresh MCP tools snapshots for automation coverage artifact guidance

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -525,7 +525,7 @@
     "name": "orbit_task_approve"
   },
   {
-    "description": "Store a source file under a task's artifacts directory",
+    "description": "Store a source file under a task's artifacts directory. For automation-coverage.json, use the versioned evidence template in the assigned task: exact batch/input/revisions, complete examined commit and delivery lists, examination_complete, concrete checks and findings. Coverage acceptance requires the assigned executor run context; malformed, stale or unauthorized evidence is rejected during evaluation. Attaching ordinary artifacts never advances coverage.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {


### PR DESCRIPTION
## Task

[ORB-11381](https://orbit-cli.com/tasks/ORB-11381) — Refresh MCP tools snapshots for automation coverage artifact guidance

### Description

PR1411/ORB-11330 changed orbit.task.artifact.put's advertised description to explain automation-coverage.json, but crates/orbit-cli/tests/snapshots/mcp_tools_list.json still contains the old one-line description. Independently compared actual left/right arrays from CI run34006052963: tool names identical; first differing bytes are artifact.put description. Current merged949b3c0d source crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs:41 contains expanded intentional guidance. CI34005501977 (PR1411) fails both nextest and coverage at mcp_roundtrip.rs:480, mcp_serve_tools_list_matches_production_snapshot; later CI34006052963 coverage repeats it. Nextest skipped1735 tests after fail-fast. Reconcile the current production snapshot and any affected generated tool goldens through their supported generation commands, inspect the exact diff and account for the contract change in current release documentation as required. Do not weaken snapshot assertions or remove coverage guidance.

### Acceptance Criteria

- Production tools/list snapshot matches current intended artifact guidance, with generated diffs reviewed for unrelated drift.
- Focused mcp_roundtrip snapshot test and any affected output goldens pass; required repository checks pass.
- Record exact validation SHA and CI run evidence; preserve advertised coverage semantics and snapshot enforcement.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Regenerated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` with the repository-supported `ORBIT_MCP_UPDATE_SNAPSHOT=1 cargo test -p orbit-cli --test mcp_roundtrip` command.
- The generated diff is exactly one description update for `orbit.task.artifact.put`, adding the required automation-coverage.json evidence guidance; no tool names, schemas, or unrelated goldens changed.
- Existing `RELEASING.md` documents MCP tool-schema snapshot enforcement and the breaking-change review requirement, so no additional release-document edit was needed.

Assessment: Snapshot contract is reconciled while preserving the production coverage guidance and strict equality assertion.

Validation:
- Validation SHA: `a467b43e4ff7143903527088e9dcda3e57e20a6c`.
- Focused `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot -- --exact`: passed (1/1).
- Snapshot regeneration test run: 47 passed; 1 environment-specific failure in `process_metadata_does_not_supply_a_replayable_key_bound_identity`, which requires unrestricted setgid and a mapped supplementary group. This is the already-filed validation-only ORB-11390 issue; the target snapshot test passed.
- `make ci-fast`: blocked by pre-existing rustfmt drift in `crates/orbit-engine/src/executor/automation/ci/collect.rs` and its tests; the snapshot diff itself passes `git diff --check`.
- `make ci-lint`: blocked by pre-existing `clippy::needless_borrow` at `crates/orbit-tools/src/builtin/github/mod.rs:539`.
- CI evidence from the task: CI runs 34005501977 and 34006052963 reproduced the original snapshot mismatch before this refresh.
- Removed the run-created ignored `target/` build tree; final status contains only the intended snapshot change.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11381-6a9cd420`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*