### PR TITLE
Restore a verifiable publication path for the stale public Orbit website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,16 +4,23 @@ on:
   pull_request:
     paths:
       - "website/**"
-      - "docs/design/**"
       - ".github/workflows/website.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - ".github/workflows/website.yml"
+  workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  website:
+  build:
     name: Check and build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       ASTRO_TELEMETRY_DISABLED: "1"
     defaults:
@@ -36,3 +43,115 @@ jobs:
 
       - name: Build website
         run: npm run build
+
+      - name: Attach publication provenance
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SOURCE_REVISION: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { writeFile } from 'node:fs/promises';
+
+          const metadata = {
+            schemaVersion: 1,
+            sourceRevision: process.env.SOURCE_REVISION,
+            sourceRef: process.env.SOURCE_REF,
+            runUrl: process.env.SOURCE_RUN_URL,
+          };
+          await writeFile('dist/deployment.json', `${JSON.stringify(metadata, null, 2)}\n`);
+          NODE
+
+      - name: Upload static site
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: website-${{ github.sha }}
+          path: website/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish to Cloudflare Pages
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    concurrency:
+      group: website-production
+      cancel-in-progress: false
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download static site
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: website-${{ github.sha }}
+          path: website/dist
+
+      - name: Resolve existing Pages project
+        id: target
+        env:
+          PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$PAGES_PROJECT" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo "Set production environment variable CLOUDFLARE_PAGES_PROJECT to the existing Pages project serving orbit-cli.com" >&2
+            exit 1
+          fi
+          printf 'project=%s\n' "$PAGES_PROJECT" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy static site
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: website
+          wranglerVersion: "4.129.0"
+          command: pages deploy dist --project-name=${{ steps.target.outputs.project }} --branch=main --commit-hash=${{ github.sha }}
+
+      - name: Verify deployment and custom domain
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          EXPECTED_REVISION: ${{ github.sha }}
+          PUBLIC_URL: https://orbit-cli.com
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          verify_site() {
+            local base_url="${1%/}"
+            local homepage
+            local metadata
+
+            for _ in {1..12}; do
+              homepage="$(curl --fail --silent --show-error --max-time 20 "$base_url/")" || true
+              metadata="$(curl --fail --silent --show-error "$base_url/deployment.json")" || true
+              if grep -Fq 'Run coding agents as tracked, reviewable tasks.' <<<"$homepage" \
+                && grep -Fq 'Choose a delivery mode' <<<"$homepage" \
+                && curl --fail --silent --show-error --max-time 20 \
+                  "$base_url/getting-started/install/" >/dev/null \
+                && METADATA="$metadata" node --input-type=module --eval \
+                  "const metadata = JSON.parse(process.env.METADATA ?? '{}'); if (metadata.sourceRevision !== process.env.EXPECTED_REVISION) process.exit(1);"
+              then
+                return 0
+              fi
+              sleep 5
+            done
+
+            echo "expected homepage, setup explorer, install route, and source revision did not reach $base_url" >&2
+            return 1
+          }
+
+          test -n "$DEPLOYMENT_URL"
+          verify_site "$DEPLOYMENT_URL"
+          verify_site "$PUBLIC_URL"

--- a/docs/runbooks/website-validation.md
+++ b/docs/runbooks/website-validation.md
@@ -4,8 +4,8 @@ summary: Build, preview, and validate Orbit website changes with Playwright insi
 tags: [operations, website, sandbox, playwright, validation]
 paths: ["website/**"]
 related_features: [orbit-docs]
-related_artifacts: ["ORB-11329"]
-last_validated: 2026-09-05
+related_artifacts: ["ORB-11329", "ORB-11379"]
+last_validated: 2026-09-06
 ---
 
 # Validate Website Changes in a Job-Run Sandbox
@@ -201,6 +201,83 @@ Stop the server after validation:
 kill "$PREVIEW_PID" 2>/dev/null || true
 wait "$PREVIEW_PID" 2>/dev/null || true
 ```
+
+## Production publication and evidence
+
+The supported production path is the repository's `Website` GitHub Actions
+workflow. Pull requests run only the `Check and build` job. Publication is
+release-gated: a `main` push that changes `website/**` or the workflow launches
+the distinct `Publish to Cloudflare Pages` job. A maintainer may also dispatch
+the workflow against `main` to recover from a failed or missed publication.
+Selecting another ref builds it but cannot enter the production job.
+
+The checked-in and public evidence identifies Cloudflare as the intended
+publication boundary, but does not expose the current origin project. Public
+responses from `orbit-cli.com` and its authoritative nameservers are
+Cloudflare. Repository history previously used Wrangler direct upload, and
+`website/wrangler.toml` configures Pages static output. However, every one of
+the 26 public GitHub Deployment records from that workflow ended in failure.
+The former hard-coded project name is not trustworthy:
+`https://orbit-website.pages.dev` served an unrelated social-video site when
+ORB-11379 was investigated. The repaired workflow therefore obtains the exact
+existing project name from the protected `production` environment instead of
+guessing it. This evidence supports the repository mechanism; it does not prove
+who currently owns the external account, which project owns the custom domain,
+or that repository secrets exist. Do not create a project, rotate or invent
+credentials, or edit DNS as part of website publication.
+
+ORB-11379 recorded the publication gap on 2026-09-06:
+
+- `.github/workflows/website.yml` had only a pull-request build trigger and no
+  upload step.
+- GitHub's newest deployment record was production deployment `4604816061` for
+  `agent-main` revision `ec8545b4de696a5b714fe344c9d2d1bca9d21f01`.
+  Its build step succeeded, its Cloudflare Pages upload step failed, and its
+  workflow/job log is
+  `https://github.com/danieljhkim/orbit/actions/runs/25479096320/job/74759046156`.
+- The separate deploy workflow that created that record was deleted immediately
+  afterward in `fc2ae9d4ef26c92d0e10dc4aff63934d3c007b09`.
+- The live homepage still contained the old `v0.9.2` headline and Architecture
+  navigation. Successful Website checks on newer commits therefore proved
+  buildability, not publication.
+
+The repaired workflow uploads one immutable build artifact and writes
+`deployment.json` into it with the full source revision, source ref, and Actions
+run URL. Wrangler receives the same revision through `--commit-hash`. Production
+deployments are serialized, use only `contents: read` and `deployments: write`,
+and are recorded in both the Actions run and GitHub Deployments. The final step
+checks the unique homepage headline, the delivery-mode setup explorer, the
+install route, and the expected source revision at both the deployment URL and
+`orbit-cli.com`.
+
+### Operate and recover
+
+1. Open the `Website` workflow run for the `main` revision. Confirm `Check and
+   build` completed before interpreting `Publish to Cloudflare Pages`.
+2. Follow the failed step and GitHub Deployment links. A green build with a red
+   or absent publication job is not a deployed site.
+3. Before the first repaired publication, an authorized Cloudflare account
+   owner must identify the existing Pages project whose custom domains include
+   `orbit-cli.com`. Set that exact name as the production environment variable
+   `CLOUDFLARE_PAGES_PROJECT`. If authentication fails, the owner must restore
+   `CLOUDFLARE_ACCOUNT_ID` and a `CLOUDFLARE_API_TOKEN` scoped to Pages edit
+   access for that same project. Record the external action; do not replace the
+   project or DNS.
+4. After correcting an external cause, dispatch `Website` from the `main` ref.
+   This rebuilds tracked sources and uploads them; no manual or untracked source
+   upload is part of recovery.
+5. Require the verification step to pass, then independently open
+   `https://orbit-cli.com/`, its delivery-mode explorer, and
+   `https://orbit-cli.com/getting-started/install/`. Fetch
+   `https://orbit-cli.com/deployment.json` and compare `sourceRevision` with the
+   workflow's `github.sha` before declaring publication successful.
+
+If the workflow has not yet reached `main`, the exact existing project mapping
+has not been confirmed, or the environment credentials are missing or invalid,
+repository-side validation can still succeed but a real publication is
+externally blocked. Report the precise missing promotion, environment
+ownership, project mapping, or credential repair and never claim that the live
+site was updated.
 
 ## Preferred long-term fix
 

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -150,7 +150,11 @@ Each section has an index page that lists its children with one-line description
 - **Search:** Pagefind (built into Starlight, static, offline, no third-party account)
 - **Content:** MDX in `src/content/docs/`
 - **Styling:** Starlight's CSS custom properties, overridden in a single `custom.css`
-- **Hosting:** TBD (Cloudflare Pages, Vercel, or GitHub Pages — all work with Astro's static output)
+- **Hosting:** The public edge and DNS are on Cloudflare. The repository-supported
+  path directly uploads to the existing Pages project identified by the protected
+  production environment, and publishes only from the release/production `main`
+  branch. The `orbit-cli.com` DNS remains externally managed; publication neither
+  provisions hosting nor edits DNS. See ORB-11379.
 - **Repo layout:** new top-level `website/` directory, independent of the Rust workspace
 
 ### 5.1 Why Starlight over Nextra
@@ -177,11 +181,10 @@ Nextra is reserved for a future scenario where interactive React widgets become 
 
 ## 7. Open Questions
 
-1. **Domain name.** `orbit.dev`, `orbitcli.dev`, subdomain of an existing property? orbit-cli.com
-2. **Versioning.** Starlight supports versioned docs via directory structure. Add it when release-specific documentation becomes necessary.
-3. **Architecture detail.** Crate boundaries and dependency direction are contributor material, not published here; they live in the repository's `ARCHITECTURE.md`. Revisit only if a public extension surface makes them user-facing.
-4. **Logo design.** Ring-with-offset-dot concept agreed; actual SVG not yet drawn.
-5. **Analytics.** Plausible (privacy-respecting) or none at all? Default to none unless there's a decision to measure something specific.
+1. **Versioning.** Starlight supports versioned docs via directory structure. Add it when release-specific documentation becomes necessary.
+2. **Architecture detail.** Crate boundaries and dependency direction are contributor material, not published here; they live in the repository's `ARCHITECTURE.md`. Revisit only if a public extension surface makes them user-facing.
+3. **Logo design.** Ring-with-offset-dot concept agreed; actual SVG not yet drawn.
+4. **Analytics.** Plausible (privacy-respecting) or none at all? Default to none unless there's a decision to measure something specific.
 
 ---
 

--- a/website/README.md
+++ b/website/README.md
@@ -10,6 +10,33 @@ npm run build    # static build into dist/
 npm run preview  # serve the built site
 ```
 
+## Production publication
+
+The repository-supported publication path is a direct upload to the existing
+Cloudflare Pages project that serves the externally managed `orbit-cli.com`
+custom domain. The `Website` GitHub Actions workflow builds pull requests, but
+publishes only from `main`, Orbit's release/production branch. A push to `main`
+that changes `website/**` (or the workflow itself) publishes automatically. A
+maintainer can also dispatch the workflow against `main` to recover or repeat
+publication.
+
+Publication requires the existing `production` GitHub environment to provide
+`CLOUDFLARE_PAGES_PROJECT`, `CLOUDFLARE_ACCOUNT_ID`, and a project-scoped
+`CLOUDFLARE_API_TOKEN` with Pages edit access. An account owner must set the
+project variable only after confirming that project already owns the
+`orbit-cli.com` custom domain. The job has only `contents: read` and
+`deployments: write`; it does not create a Pages project or change DNS. It
+uploads the exact artifact built earlier in the run, attributes the upload to
+the source commit, and verifies the deployment URL plus
+`https://orbit-cli.com` before succeeding. The published `/deployment.json`
+records the source revision and Actions run URL.
+
+Build success is not publication success. The `Check and build` job proves only
+that Astro produced static output; the separate `Publish to Cloudflare Pages`
+job and its GitHub Deployment record prove upload and post-deploy verification.
+See the [website validation runbook](../docs/runbooks/website-validation.md) for
+evidence, recovery, and external-blocker handling (ORB-11379).
+
 Every published page is authored by hand under `src/content/docs/`. Nothing on
 this site is generated at build time, so `npm run build` is a pure function of
 the tracked sources. Before website commands run, a cleanup hook removes the

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -1,3 +1,2 @@
-name = "orbit-website"
 compatibility_date = "2026-05-04"
 pages_build_output_dir = "./dist"


### PR DESCRIPTION
## Task

[ORB-11379](https://orbit-cli.com/tasks/ORB-11379) — Restore a verifiable publication path for the stale public Orbit website

### Description

Live browser verification on 2026-09-06 around 02:10 UTC found https://orbit-cli.com still rendering the old 'The audit log for your AI coding agents' homepage, V0.9.2 EARLY ACCESS badge, four-provider strip and Architecture navigation. This contradicts the merged website revamp ORB-11304 and the newly merged ORB-11369/11370 (PR1413 932d7000b2e2c99f9d385005ee6c30b2ebc0411c and PR1412 7a00bf75c11f1721d39c3a264ee57dcd334067e9). Their Website checks pass, but are build-only.

At 932d7000, .github/workflows/website.yml triggers only pull_request and runs npm ci/check/build; no publication step or push/manual trigger exists. website/README.md and package.json document local build/preview but no production deployment path. GitHub Pages API returned404. Latest repository deployment record returned by GitHub is 4604816061, created May7 with sha ec8545b4de696a5b714fe344c9d2d1bca9d21f01/ref agent-main; its status is failure with log https://github.com/danieljhkim/orbit/actions/runs/25479096320/job/74759046156. This is evidence of a publication gap, not proof of the current hosting provider or root cause.

Investigate current intended host, source branch and existing deployment ownership from repository/runtime evidence and supported read-only provider metadata. Restore a minimal reviewable publish path for the existing static site, with source SHA/version attribution, serialized deployments, appropriate existing permissions, explicit failure visibility, documented operator/recovery procedure and post-deploy verification. Do not invent a new hosting service, move DNS, create credentials or expand access. Preserve intentional release boundaries if hosting is deliberately release-gated; make that policy and the deploy trigger explicit. If a required external operator action or missing credential blocks publication, finish the repository-side repair and provide the exact remaining action/evidence rather than claiming the public site updated. No homepage/explorer redesign or revival of retired docs. Sol/hard is a deliberate step up for deployment authority/provenance and uncertain external ownership.

### Acceptance Criteria

- The current hosting/deployment mechanism and reason public content is stale are evidenced; build success is distinguished from publication success.
- The supported publication trigger and intended source branch/release policy are documented and implemented with bounded permissions and source revision attribution; existing custom hosting/DNS/access is preserved.
- A validation run proves the static site build and publication configuration. A real publication, if available within existing authority, is verified in a browser against the expected homepage and setup explorer; otherwise the precise external blocker is recorded without a false deployed claim.
- Future publication failures remain observable with run/deployment links, and the documented recovery procedure does not require manual untracked source uploads.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Established the publication gap from current repository and public runtime evidence: the active Website workflow built pull requests only; all 26 historical GitHub Deployment records from the deleted Wrangler workflow failed; the newest record shows build success followed by upload failure; the live site still renders the old v0.9.2 homepage and has no deployment metadata.
- Added a release-gated publication path to .github/workflows/website.yml. Pull requests remain build-only. Main-branch pushes and main-targeted manual dispatches build once, publish the exact retained artifact to the existing Cloudflare Pages project, serialize production uploads, create GitHub Deployment evidence, attribute the full source SHA in both Wrangler metadata and public deployment.json, and verify the deployment URL plus orbit-cli.com.
- Bounded GitHub permissions to none by default, contents: read for builds, and contents: read plus deployments: write for publication. The workflow does not provision hosting or change DNS.
- Removed the unsafe hard-coded Pages project name from website/wrangler.toml. The protected production environment must provide CLOUDFLARE_PAGES_PROJECT after a Cloudflare owner confirms that the existing project has orbit-cli.com in its custom domains. This extra file was added to context because the former orbit-website target currently serves an unrelated social-video product.
- Documented the main release policy, required protected environment configuration, build-versus-publication distinction, observable run/deployment evidence, post-deploy checks, and tracked-source recovery procedure in website/README.md, website/DESIGN.md, and docs/runbooks/website-validation.md.

Assessment: The repository-side repair is complete and fail-closed around the unverified external project mapping. No live deployment was claimed or attempted because this branch is not main and current authority cannot inspect Cloudflare ownership or protected GitHub environment values.

Validation:
- npm ci: passed (427 packages, zero vulnerabilities before temporary Playwright staging).
- npm run check: passed with 0 errors, warnings, or hints.
- npm run build: passed; 29 static pages and Pagefind index generated.
- actionlint 1.7.12: passed for all workflows.
- Every inline workflow shell script parsed with bash -n.
- Wrangler 4.129.0 pages deploy --help confirmed --project-name, --branch, and --commit-hash.
- Local provenance artifact smoke check passed for sourceRevision, sourceRef, and runUrl.
- Playwright 1.55.0 Chromium checks passed at 1440x900 and 390x844: HTTP 200, expected homepage headline, four-option delivery-mode explorer, explorer interaction, install route, and no horizontal overflow.
- Live Playwright evidence: https://orbit-cli.com returned HTTP 200 with The audit log for your AI coding agents., v0.9.2, Architecture navigation, no new delivery explorer, and /deployment.json returned 404. This confirms publication has not occurred.
- git diff --check and final scoped worktree inspection passed; generated node_modules, dist, .astro, target, and temporary validation caches were removed.
- make ci-fast could not pass on the unchanged baseline: cargo fmt --check reports pre-existing formatting diffs in crates/orbit-engine/src/executor/automation/ci/collect.rs and its sibling test. All subsequent fast guardrails were run separately; they passed except the pre-existing sync-plugin-skills mirror drift in plugin/skills/orbit/references/workflows.md.
- make ci-lint could not pass on the unchanged baseline: clippy reports pre-existing needless_borrow at crates/orbit-tools/src/builtin/github/mod.rs:539.

External blocker:
- A real publication requires this workflow to reach main through the documented agent-main to main release promotion.
- An authorized Cloudflare account owner must identify the existing Pages project whose custom domains include orbit-cli.com.
- An authorized GitHub environment owner must set production variable CLOUDFLARE_PAGES_PROJECT and confirm CLOUDFLARE_ACCOUNT_ID plus project-scoped CLOUDFLARE_API_TOKEN. Read-only GitHub APIs confirm the production environment exists but return 401 for protected variable and secret metadata in this lane.
- After those checks, dispatch Website against main and require both deployment URL and custom-domain verification to pass.

Strategic decisions:
- main, not agent-main, is the production source because current repository policy defines main as the release/production branch.
- The historical orbit-website project name was rejected as unsafe evidence rather than reused.

Deviations from original plan:
- Added file:website/wrangler.toml after runtime evidence showed its target was unsafe; this was the minimum change that prevents accidental upload to an unrelated project.

Friction:
- Filed F2026-09-035 for the misleading hard-coded Pages project name and uniformly failed historical deployments.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11379-6a9cd421`
- Behind base: 0
- Ahead of base: 1