### PR TITLE
Add an operator-only agent invocation job for exploration and debugging

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -327,6 +327,12 @@ impl Commands {
             Commands::Run(command) => {
                 use super::run::RunSubcommand;
                 let (subcommand, target_type, target_id, runtime_need) = match &command.command {
+                    RunSubcommand::Agent(_) => (
+                        "agent",
+                        Some("workflow"),
+                        Some("agent_invoke"),
+                        RuntimeNeed::Required,
+                    ),
                     RunSubcommand::Auto(_) => (
                         "auto",
                         Some("workflow"),

--- a/crates/orbit-cli/src/command/run/agent.rs
+++ b/crates/orbit-cli/src/command/run/agent.rs
@@ -1,0 +1,143 @@
+//! `orbit run agent` — operator-only host exploration invocation [ORB-11354].
+//!
+//! A thin collector. The admission, the workspace/cwd validation, the crew and
+//! timeout rules, and the durable submission all live in
+//! `OrbitRuntime::submit_agent_invoke_run`, which the MCP tool calls too — so
+//! this command cannot drift from the tool's behavior or relax its checks.
+
+use clap::Args;
+use orbit_core::{AgentInvokeRequest, OrbitRuntime};
+use orbit_types::tool::ToolSessionContext;
+use serde_json::json;
+
+use crate::command::{CommandOut, CommandOutput, Execute, Payload};
+
+#[derive(Args)]
+#[command(
+    about = "Invoke an agent on the host for exploration or debugging",
+    override_usage = "orbit run agent <PROMPT> [OPTIONS]",
+    after_help = "\
+The agent runs OUTSIDE Orbit's filesystem sandbox, as the same OS user as Orbit,
+so it can read and write anything that user can. That is the point of the
+command and it is not an isolation boundary — invoke it the way you would run a
+shell command yourself. Each invocation is admitted separately and requires
+operator capability; a managed run cannot invoke one.
+
+The agent investigates and reports. It changes no task, makes no commit, opens
+no pull request, and dispatches no further work.
+
+Submission is asynchronous: this prints the durable run ID and returns. Track
+and read the invocation with the ordinary run surfaces:
+  orbit run show <RUN_ID>      structured state, outcome, and bounded preview
+  orbit run logs <RUN_ID>      the complete captured output
+  orbit run cancel <RUN_ID>    stop it and terminate its process tree
+
+Examples:
+  orbit run agent 'why does the sweep clock keep restarting?'
+  orbit run agent 'explain this failure' --cwd /srv/checkout --crew qa
+  orbit run agent 'long investigation' --timeout 3600 --json
+  orbit run agent 'retryable submit' --idempotency-key incident-4821"
+)]
+pub struct RunAgentArgs {
+    /// What to investigate.
+    #[arg(value_name = "PROMPT")]
+    pub prompt: String,
+
+    /// Absolute directory the agent starts in. Defaults to the current
+    /// directory; must be inside this workspace's checkout.
+    #[arg(long)]
+    pub cwd: Option<String>,
+
+    /// Configured crew selecting provider, model, and reasoning effort.
+    /// Defaults to the workspace's default crew.
+    #[arg(long)]
+    pub crew: Option<String>,
+
+    /// Wall-clock bound in seconds. Defaults to 1800; the maximum is 7200.
+    #[arg(long)]
+    pub timeout: Option<u64>,
+
+    /// Retry handle. Resubmitting with a key a recent submission already used
+    /// resolves that run instead of starting a second agent.
+    #[arg(long)]
+    pub idempotency_key: Option<String>,
+
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Execute for RunAgentArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        // An omitted `--cwd` resolves here, in the operator's own process,
+        // rather than in Core: Core deliberately never reads a caller's cwd,
+        // because its other caller is an MCP server in an unrelated directory.
+        let cwd = match self.cwd {
+            Some(cwd) => cwd,
+            None => std::env::current_dir()
+                .map_err(|error| {
+                    orbit_core::OrbitError::InvalidInput(format!(
+                        "could not read the current directory; pass --cwd explicitly: {error}"
+                    ))
+                })?
+                .to_string_lossy()
+                .into_owned(),
+        };
+        let session_context = ToolSessionContext::default();
+        let submission = runtime.submit_agent_invoke_run(AgentInvokeRequest {
+            prompt: &self.prompt,
+            cwd: &cwd,
+            crew: self.crew.as_deref(),
+            timeout_seconds: self.timeout,
+            idempotency_key: self.idempotency_key.as_deref(),
+            actor: None,
+            session_context: &session_context,
+        })?;
+
+        if self.json {
+            return Ok(Payload::document(json!({
+                "run_id": submission.run_id,
+                "job_id": submission.job_id,
+                "submitted_at": submission.submitted_at,
+                "state": if submission.queued { "queued" } else { "submitted" },
+                "deduplicated": submission.deduplicated,
+                "timeout_seconds": submission.timeout_seconds,
+                "authorized_by": submission.admission.authorized_by,
+                "authorizer_provenance": submission.admission.authorizer_provenance,
+                "workspace_path": submission.admission.workspace_path,
+                "cwd": submission.admission.cwd,
+                "sandboxed": false,
+            }))
+            .into());
+        }
+
+        if submission.deduplicated {
+            println!(
+                "resolved existing agent run {} for idempotency key (no new agent started)",
+                submission.run_id
+            );
+        } else {
+            println!(
+                "submitted agent run {} ({}) in {}",
+                submission.run_id,
+                if submission.queued {
+                    "queued"
+                } else {
+                    "running"
+                },
+                submission.admission.cwd
+            );
+            println!(
+                "running outside the executor sandbox, bounded at {}s, authorized by {} ({})",
+                submission.timeout_seconds,
+                submission.admission.authorized_by,
+                submission.admission.authorizer_provenance
+            );
+        }
+        println!(
+            "track it: orbit run show {run_id}  |  orbit run logs {run_id}  |  orbit run cancel {run_id}",
+            run_id = submission.run_id
+        );
+        Ok(CommandOutput::Silent)
+    }
+}

--- a/crates/orbit-cli/src/command/run/command.rs
+++ b/crates/orbit-cli/src/command/run/command.rs
@@ -3,6 +3,7 @@ use orbit_core::OrbitRuntime;
 
 use crate::command::{CommandOut, Execute};
 
+use super::agent::RunAgentArgs;
 use super::auto;
 use super::cancel::RunCancelArgs;
 use super::concurrency::RunConcurrencyArgs;
@@ -25,6 +26,7 @@ Workflow entrypoints:
   orbit run ship-sweep [--dry-run] [--json]
   orbit run triage [task_id ...]
   orbit run job <job_id> [--input key=value] [--json] [--debug]
+  orbit run agent <prompt> [--cwd DIR] [--crew NAME] [--timeout SECONDS]
 
 Run history:
   orbit run history [--limit 50]
@@ -58,6 +60,7 @@ Workflows:
   triage      Triage tasks blocked by failed runs; re-backlog environmental failures
   readiness   Explain why backlog tasks are waiting in auto-drain
   job         Run an arbitrary job by ID
+  agent       Invoke an agent on the host for exploration or debugging (operator only)
 
 Audits:
   history    Show recent job runs, optionally filtered to one job
@@ -117,6 +120,8 @@ pub enum RunSubcommand {
     Concurrency(RunConcurrencyArgs),
     /// Run an arbitrary job by ID
     Job(JobRunArgs),
+    /// Invoke an agent on the host for exploration or debugging (operator only)
+    Agent(RunAgentArgs),
 }
 
 impl Execute for RunSubcommand {
@@ -138,6 +143,7 @@ impl Execute for RunSubcommand {
             RunSubcommand::Cancel(command) => command.execute(runtime),
             RunSubcommand::Concurrency(command) => command.execute(runtime),
             RunSubcommand::Job(command) => command.execute(runtime),
+            RunSubcommand::Agent(command) => command.execute(runtime),
         }
     }
 }

--- a/crates/orbit-cli/src/command/run/mod.rs
+++ b/crates/orbit-cli/src/command/run/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod auto;
 mod cancel;
 mod command;

--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -85,6 +85,7 @@ pub(crate) fn run_show_payload(
         header.push('\n');
     }
     header.push_str(&live_provider_process_lines(&provider_processes));
+    header.push_str(&agent_invocation_lines(&doc["run"]["agent_invocation"]));
     header.push('\n');
 
     let steps = run.steps.iter().collect::<Vec<_>>();
@@ -96,6 +97,57 @@ pub(crate) fn run_show_payload(
         ],
     )
     .into())
+}
+
+/// The operator-facing result of an agent invocation run [ORB-11354].
+///
+/// Empty for every other job. The outcome comes from the run record, not the
+/// provider's exit code — an agent that exits 0 without terminating its
+/// envelope stopped mid-turn, and the run says `failed`. The preview is
+/// bounded; the blob reference names where the rest is.
+fn agent_invocation_lines(value: &Value) -> String {
+    let Some(result) = value.as_object() else {
+        return String::new();
+    };
+    let text = |key: &str| result.get(key).and_then(Value::as_str);
+    let mut lines = format!(
+        "\n{} outcome={} envelope_completed={} timed_out={} exit_code={}",
+        crate::output::color::bold("Invocation:"),
+        text("outcome").unwrap_or("-"),
+        result
+            .get("completed_envelope")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        result
+            .get("timed_out")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        result
+            .get("exit_code")
+            .and_then(Value::as_i64)
+            .map_or_else(|| "-".to_string(), |code| code.to_string()),
+    );
+    if let Some(reason) = text("failure_reason") {
+        lines.push_str(&format!("\n  reason: {reason}"));
+    }
+    if let Some(summary) = text("summary") {
+        lines.push_str(&format!("\n  summary: {summary}"));
+    }
+    if let Some(blob) = text("stdout_blob_ref") {
+        let truncated = result
+            .get("preview_truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        lines.push_str(&format!(
+            "\n  output: {blob}{} (full text: orbit run logs <RUN_ID>)",
+            if truncated {
+                " — preview truncated"
+            } else {
+                ""
+            }
+        ));
+    }
+    lines
 }
 
 /// One line per provider subprocess that has not reported an exit.

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1,5 +1,53 @@
 [
   {
+    "description": "Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Track it with `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, and dispatches nothing.",
+    "inputSchema": {
+      "additionalProperties": true,
+      "properties": {
+        "crew": {
+          "description": "Configured crew selecting the provider, model, and reasoning effort. Defaults to the workspace's default crew.",
+          "type": "string"
+        },
+        "cwd": {
+          "description": "Absolute working directory the agent starts in. Must exist and be inside this workspace's checkout; it is never inferred from the caller.",
+          "type": "string"
+        },
+        "idempotency_key": {
+          "description": "Retry handle. A resubmission carrying a key a recent submission already used resolves that run instead of starting a second agent.",
+          "type": "string"
+        },
+        "model": {
+          "description": "Preferred provenance field. Pass the canonical agent family (codex, claude, gemini, or grok); full model strings are accepted and auto-normalized.",
+          "enum": [
+            "codex",
+            "claude",
+            "gemini",
+            "grok"
+          ],
+          "type": "string"
+        },
+        "prompt": {
+          "description": "What to investigate. The invoked agent reports back; it makes no Orbit task, lifecycle, commit, or pull-request change.",
+          "type": "string"
+        },
+        "timeout_seconds": {
+          "description": "Wall-clock bound for the invocation. Defaults to 1800 and may not exceed 7200.",
+          "type": "integer"
+        },
+        "workspace": {
+          "description": "Workspace selector for the authoritative server: a registered workspace name, a logical workspace ID (`ws_*`), or an absolute path registered on that server. Optional in this session, which is already bound to a workspace — by `orbit mcp serve --workspace` at launch or `_meta.orbit.workspace` at initialize. Pass it to address a different registered workspace; never inferred from the server process cwd.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "prompt",
+        "cwd"
+      ],
+      "type": "object"
+    },
+    "name": "orbit_agent_invoke"
+  },
+  {
     "description": "List every auto-task definition in this workspace.",
     "inputSchema": {
       "additionalProperties": true,

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -238,6 +238,17 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         rationale: "retuning a live drain's worker ceiling changes how much work the workspace starts",
     },
     GovernedOperation {
+        id: "orbit.agent.invoke",
+        surface: OperationSurface::Tool,
+        // Deliberately not `Runner`. Every other run-reachable operation lists
+        // it so a sanctioned run can perform its own work; this one must not,
+        // because the whole point of the mode is to leave the sandbox a managed
+        // run exists to stay inside. A run that could admit itself would be a
+        // sandbox escape wearing an authorization.
+        allowed: &[McpCapability::Operator],
+        rationale: "an agent invocation runs a provider subprocess on the host outside the executor sandbox, so only a present operator may admit one",
+    },
+    GovernedOperation {
         id: "orbit.command.exec",
         surface: OperationSurface::Tool,
         allowed: &[McpCapability::Operator],

--- a/crates/orbit-core/assets/activities/agent_invoke.yaml
+++ b/crates/orbit-core/assets/activities/agent_invoke.yaml
@@ -1,0 +1,130 @@
+# Operator-only host exploration/debugging invocation.
+#
+# This is the ONLY activity permitted to declare `trustedHostExecution`, and
+# asset load rejects the key anywhere else. Even here the key is inert on its
+# own: the engine also requires a `trusted_host_admission` stamped into the run
+# input by the governed `orbit.agent.invoke` submission, and fails the
+# invocation closed when one is absent.
+#
+# Be clear about what the mode does and does not do:
+#   - It removes Orbit's filesystem sandbox from this one provider subprocess,
+#     which then runs as the same OS user as Orbit and can read and write
+#     anything that user can. It is not an isolation boundary.
+#   - It grants the child no Orbit capability. The subprocess still carries
+#     managed-run provenance, so it resolves as an agent at every capability
+#     chokepoint and cannot perform a governed operation.
+#   - `proc_allowed_programs` below is Orbit's own `proc.spawn` allowlist. The
+#     provider harness owns its native shell tool and Orbit does not enforce
+#     the list against it, so treat the list as documentation of intent rather
+#     than as a control.
+#
+# The activity investigates and reports. It has no task-write, lifecycle,
+# dispatch, commit, or PR grant, and the pipeline performs no task transition
+# on its behalf.
+schemaVersion: 2
+kind: Activity
+metadata:
+  name: agent_invoke
+spec:
+  type: agent_loop
+  trustedHostExecution: true
+  # Completion is enforced, content is advisory: an investigation that exits 0
+  # without terminating its envelope stopped mid-turn and must not checkpoint
+  # as success. What it *concluded* stays advisory — an operator reads the
+  # answer, Orbit does not act on it.
+  require_completion_envelope: true
+  require_response_envelope: false
+  description: >
+    Operator-admitted exploration and debugging invocation. Runs one provider
+    subprocess on the host, outside the executor sandbox, in an explicit
+    working directory, and returns its findings. Read-oriented by contract: it
+    reports to the operator and changes no Orbit record.
+  input_schema_json:
+    type: object
+    required: [prompt, workspace_path, cwd]
+    properties:
+      prompt:
+        type: string
+      # The subprocess cwd. Named `workspace_path` because that is the key the
+      # CLI runner resolves the child's working directory from; the admission
+      # below records the owning checkout separately.
+      workspace_path:
+        type: string
+      cwd:
+        type: string
+      crew:
+        type: string
+      # Shortens the declared `wall_clock_timeout_seconds` below; it can never
+      # raise it, so the asset remains the ceiling.
+      timeout_seconds:
+        type: number
+      trusted_host_admission:
+        type: object
+  output_schema_json:
+    type: object
+    properties:
+      summary:
+        type: string
+      findings:
+        type: array
+        items:
+          type: string
+      next_steps:
+        type: array
+        items:
+          type: string
+  instruction: |
+    You are an operator's exploration and debugging assistant, invoked directly
+    on the host.
+
+    Input contains `prompt` (what the operator wants investigated), `cwd` (the
+    directory you start in, also supplied as `workspace_path`), and the
+    operator's `trusted_host_admission`.
+
+    You are running outside Orbit's filesystem sandbox as the operator's own
+    OS user. Investigate whatever the prompt requires. Prefer read-only
+    inspection; when the prompt asks you to change something, do exactly what
+    was asked and nothing adjacent.
+
+    Hard bounds — these are contract, not preference:
+    - Do not change Orbit task state, promote, dispatch, submit a run, or
+      invoke another agent. You have no lifecycle grant and requesting one is
+      out of scope for this invocation.
+    - Do not commit, push, open, merge, or comment on a pull request.
+    - Do not act on anything outside the operator's prompt because it looked
+      wrong to you. Report it instead.
+
+    Return exactly one Orbit response envelope, whatever the outcome:
+    {"schemaVersion":1,"status":"success","result":{
+      "summary":"one paragraph answering the operator's question",
+      "findings":["concrete finding with its evidence"],
+      "next_steps":["what the operator could do next"]
+    },"error":null}
+
+    If the investigation could not be completed, return the same envelope with
+    `status":"failed"` and a non-empty `error.message` saying what blocked it.
+    Exiting without an envelope is not a valid outcome and is recorded as a
+    failed invocation.
+  tools:
+    - orbit.task.show
+    - orbit.task.list
+    - orbit.search
+    - proc.spawn
+  proc_allowed_programs:
+    - awk
+    - bash
+    - cargo
+    - cat
+    - find
+    - git
+    - grep
+    - jq
+    - ls
+    - make
+    - ps
+    - python3
+    - rg
+    - sed
+    - sh
+  on_denial: terminate
+  wall_clock_timeout_seconds: 1800

--- a/crates/orbit-core/assets/jobs/agent_invoke_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/agent_invoke_pipeline.yaml
@@ -1,0 +1,37 @@
+# Operator-only host exploration/debugging run.
+#
+# Submitted exclusively by the governed `orbit.agent.invoke` operation (MCP,
+# or `orbit run agent` on the CLI), which is the only caller that can stamp the
+# `trusted_host_admission` the activity requires. Submitting this job through
+# `orbit run job` produces a run with no admission, and the invocation fails
+# closed rather than running sandboxed.
+#
+# One step on purpose. This is an investigation, not a delivery pipeline: there
+# is no worktree setup, no lock reservation, no task transition, and no PR
+# behavior to sequence. Status, results and cancellation are the ordinary run
+# surfaces — `orbit run show|logs|cancel <RUN_ID>`.
+#
+# The crew comes from the submission (`crew` in the run input) rather than
+# being pinned here, so an operator picks the model per investigation the way
+# they pick the prompt.
+schemaVersion: 2
+kind: Job
+metadata:
+  name: agent_invoke_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  # Exploration runs are operator-initiated and interactive in spirit; several
+  # concurrent investigations are normal, and each is one subprocess.
+  max_active_runs: 8
+
+  steps:
+    - id: invoke
+      target: activity:agent_invoke
+      default_input:
+        prompt: "{{ input.prompt }}"
+        workspace_path: "{{ input.cwd }}"
+        cwd: "{{ input.cwd }}"
+        crew: "{{ input.crew }}"
+        timeout_seconds: "{{ input.timeout_seconds }}"
+        trusted_host_admission: "{{ input.trusted_host_admission }}"

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -96,6 +96,32 @@ evidence. Treat `checkout_identity.state: incomplete`, `missing`, or
 - **Recovery failure:** the original step failed and `step_failure_recovery` also failed — report both, keep the original step as primary unless recovery caused additional damage.
 - **Parent orchestration failure:** a child run failed and a gate/auto/epic parent is still running or waiting — identify both run ids.
 
+## Operator Agent Invocations
+
+A run of `agent_invoke_pipeline` is not a delivery pipeline. It is one operator
+invocation of an agent for exploration or debugging, submitted with
+`orbit run agent` / `orbit_agent_invoke`, and it changes no task, branch, or
+pull request — so do not look for a worktree, a task lifecycle, or a delivery
+tail when triaging one.
+
+`orbit run show <RUN_ID>` prints an `Invocation:` line for these runs, and
+`--json` carries the same facts under `agent_invocation`:
+
+- `outcome` is the run's own state, never the provider's exit code.
+- `envelope_completed: false` on an otherwise-clean exit means the agent stopped
+  mid-turn: exit zero is not evidence the investigation succeeded.
+- `timed_out: true` means the wall-clock bound killed it — resubmit with a
+  longer `--timeout` (the maximum is 7200s) or a narrower prompt.
+- `summary` and the bounded preview are the answer; `orbit run logs <RUN_ID>`
+  has the complete captured output when the preview is truncated.
+
+These runs execute their provider subprocess outside the executor sandbox by
+explicit per-invocation operator admission, so a sandbox-denial diagnostic is
+never the explanation for one failing. The run trail records the admission as a
+`trusted_host.execution_admitted` audit event naming the authorizing operator
+and the working directory. They are deliberately **not resumable**: the
+admission covered one invocation, so submit a new one rather than resuming.
+
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.
 
 ## Check Task State

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -39,6 +39,7 @@ records in a second store merely to get past a connection error.
 | Observe/resume workflows | `orbit_workflow_run_show/list/resume` | `orbit run show/history/events/trace/logs/cancel`; job replay/resume |
 | Auto-tasks | `orbit_auto_task_list/mint` | Definition add/show/update/toggle are CLI operations; do not assume they are advertised over MCP |
 | Host commands | `orbit_command_exec` when advertised and authorized | Explicit argv and working directory, never a shell string |
+| Host agent invocation | `orbit_agent_invoke` when advertised and authorized | `orbit run agent <prompt>`; asynchronous, returns a run ID |
 | Setup and maintenance | Discover any server extensions; do not guess | config, doctor, semantic, docs, audit, GC, policy, skill, routine, sweep, job/activity catalogs, workspace role/sync/publication |
 
 Provider/gateway prefixes are transport wrappers around these names. A connected
@@ -51,6 +52,42 @@ integration. Governed workflow and command operations need operator authority;
 a managed worker cannot dispatch/resume another workflow or use operator command
 execution. An allowlisted tool still has to pass runtime policy, filesystem,
 subprocess, and external authentication checks.
+
+### Host agent invocation
+
+`orbit_agent_invoke` submits one asynchronous agent run for exploration or
+debugging and returns its run ID. It is the surface for a question that cannot
+be answered from inside a managed run's sandbox — why a host is behaving the
+way it is.
+
+Be clear-eyed about what it does. The invoked agent runs **outside Orbit's
+filesystem sandbox**, as the same operating-system user as Orbit, so it can read
+and write anything that user can. Withholding capabilities from the child is not
+an isolation boundary, and neither is the activity's declared program list: the
+provider harness owns its own shell tool. Treat an invocation the way you would
+treat running a command yourself on that machine.
+
+What it is not:
+
+- It is **not** a task, and it performs no task transition. It does not commit,
+  push, open or merge a pull request, or dispatch further work.
+- It is **not** available to a managed run or to a federated caller. Each
+  invocation is admitted separately by an operator present on the machine that
+  will run it, and the admission covers that invocation only.
+- It is **not** resumable. A resumed run would carry an admission nobody granted
+  now; submit a new invocation instead.
+
+Required arguments are the `prompt` and an absolute `cwd` inside the workspace's
+checkout. `crew` selects the provider/model, `timeout_seconds` bounds the run
+(default 1800, maximum 7200), and `idempotency_key` makes a resubmission resolve
+the run the first attempt created rather than starting a second agent.
+
+Track it with the ordinary run surfaces — `orbit_workflow_run_show`, or
+`orbit run show|logs|cancel <RUN_ID>`. `show` carries the invocation's outcome,
+whether it terminated its response envelope, a bounded preview of the answer,
+and a durable reference to the full captured output. A provider that exits zero
+without terminating its envelope stopped mid-turn: the run records `failed`, and
+the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 See [remote-access.md](setup/remote-access.md). Do not relaunch a server with

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -74,6 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation operator admission, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -22,7 +22,7 @@ use orbit_types::task::{
     push_external_ref_if_missing,
 };
 use orbit_types::telemetry::InvocationTrace;
-use orbit_types::tool::is_exact_canonical_tool_name;
+use orbit_types::tool::{ToolSessionContext, is_exact_canonical_tool_name};
 use orbit_types::workflow::{ActivityV2, JobRun, JobRunStartOutcome, JobRunState};
 use serde_json::Value;
 
@@ -645,6 +645,7 @@ impl RuntimeHost for OrbitRuntime {
                     .map(str::trim)
                     .filter(|value| !value.is_empty())
                     .map(ToOwned::to_owned),
+                ToolSessionContext::default(),
             )),
             ..Default::default()
         }

--- a/crates/orbit-core/src/adapter/tool_execution.rs
+++ b/crates/orbit-core/src/adapter/tool_execution.rs
@@ -48,8 +48,12 @@ impl OrbitRuntime {
     ) -> Result<Value, OrbitError> {
         if tool_context.orbit_host.is_none() {
             let task_id = resolve_task_id_from_context(self, &tool_context)?;
-            tool_context.orbit_host =
-                Some(super::tool_host::build_orbit_tool_host(self, task_id, None));
+            tool_context.orbit_host = Some(super::tool_host::build_orbit_tool_host(
+                self,
+                task_id,
+                None,
+                tool_context.session_context.clone(),
+            ));
         }
         self.execute_registered_tool(name, input, tool_context, capability_enforcement)
     }

--- a/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
@@ -1,0 +1,64 @@
+//! `orbit.agent.invoke` protocol translation [ORB-11354].
+//!
+//! Parses the tool payload and hands it to
+//! [`OrbitRuntime::submit_agent_invoke_run`], which owns the admission and
+//! every validation rule. Nothing here decides anything.
+
+use orbit_common::OrbitError;
+use orbit_common::protocol::tool_input::{optional_string, required_string};
+use orbit_types::tool::ToolSessionContext;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::application::job::AgentInvokeRequest;
+
+pub(super) fn invoke(
+    runtime: &OrbitRuntime,
+    session_context: &ToolSessionContext,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+) -> Result<Value, OrbitError> {
+    let prompt = required_string(&input, &["prompt"], "prompt")?;
+    let cwd = required_string(&input, &["cwd"], "cwd")?;
+    let crew = optional_string(&input, "crew")?;
+    let idempotency_key = optional_string(&input, "idempotency_key")?;
+    let timeout_seconds = parse_timeout(&input)?;
+    let actor = orbit_types::identity::normalize_optional_attribution_label(
+        model.as_deref().or(agent.as_deref()),
+        model.as_deref(),
+    );
+
+    let submission = runtime.submit_agent_invoke_run(AgentInvokeRequest {
+        prompt: &prompt,
+        cwd: &cwd,
+        crew: crew.as_deref(),
+        timeout_seconds,
+        idempotency_key: idempotency_key.as_deref(),
+        actor: actor.as_deref(),
+        session_context,
+    })?;
+
+    Ok(json!({
+        "run_id": submission.run_id,
+        "job_id": submission.job_id,
+        "submitted_at": submission.submitted_at,
+        "state": if submission.queued { "queued" } else { "submitted" },
+        "deduplicated": submission.deduplicated,
+        "timeout_seconds": submission.timeout_seconds,
+        "authorized_by": submission.admission.authorized_by,
+        "authorizer_provenance": submission.admission.authorizer_provenance,
+        "workspace_path": submission.admission.workspace_path,
+        "cwd": submission.admission.cwd,
+        "sandboxed": false,
+    }))
+}
+
+fn parse_timeout(input: &Value) -> Result<Option<u64>, OrbitError> {
+    match input.get("timeout_seconds") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_u64().map(Some).ok_or_else(|| {
+            OrbitError::InvalidInput("`timeout_seconds` must be a non-negative integer".to_string())
+        }),
+    }
+}

--- a/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
+++ b/crates/orbit-core/src/adapter/tool_host/artifact_redaction.rs
@@ -327,7 +327,14 @@ fn policy_for_action(action: OrbitBuiltinAction) -> ActionPolicy {
         | OrbitBuiltinAction::WorkflowShip
         | OrbitBuiltinAction::WorkspaceClaimAcquire
         | OrbitBuiltinAction::WorkspaceClaimRelease
-        | OrbitBuiltinAction::WorkspaceClaimShow => NO_REDACTION,
+        | OrbitBuiltinAction::WorkspaceClaimShow
+        // [ORB-11354] The invocation prompt is free text and *is* persisted on
+        // the run record, but redacting it would change the instruction the
+        // agent receives — an operator debugging an auth failure needs to name
+        // the thing they are debugging. It stays verbatim; the run record is
+        // already operator-only, and the provider argv/stdout paths keep their
+        // own redactors.
+        | OrbitBuiltinAction::AgentInvoke => NO_REDACTION,
     }
 }
 

--- a/crates/orbit-core/src/adapter/tool_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/tool_host/dispatch.rs
@@ -1,18 +1,36 @@
 use orbit_common::OrbitError;
 use orbit_tools::{OrbitBuiltinAction, OrbitTaskScope, ReservationOwnerContext};
+use orbit_types::tool::ToolSessionContext;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
 
+/// Everything the dispatch table knows about *who* is making this call.
+///
+/// Grouped rather than passed as four more parameters because the handlers
+/// consume different subsets of it: attribution for a persisted record, the
+/// reservation owner for a lock write, and the session itself for the one
+/// operation whose decision depends on the caller [ORB-11354].
+pub(super) struct ToolCaller<'a> {
+    pub(super) session_context: &'a ToolSessionContext,
+    pub(super) agent: Option<String>,
+    pub(super) model: Option<String>,
+    pub(super) reservation_owner: Option<ReservationOwnerContext>,
+}
+
 pub(super) fn execute(
     runtime: &OrbitRuntime,
     task_scope: &OrbitTaskScope,
+    caller: ToolCaller<'_>,
     action: OrbitBuiltinAction,
     input: Value,
-    agent: Option<String>,
-    model: Option<String>,
-    reservation_owner: Option<ReservationOwnerContext>,
 ) -> Result<Value, OrbitError> {
+    let ToolCaller {
+        session_context,
+        agent,
+        model,
+        reservation_owner,
+    } = caller;
     let (input, redaction_report) = super::artifact_redaction::sanitize_tool_input(action, input)?;
     let agent_for_audit = agent.clone();
     let model_for_audit = model.clone();
@@ -25,6 +43,9 @@ pub(super) fn execute(
         | OrbitBuiltinAction::AdrSupersede => Err(OrbitError::InvalidInput(
             "ADR lifecycle tools have been retired; edit docs/design/**/4_decisions.md".to_string(),
         )),
+        OrbitBuiltinAction::AgentInvoke => {
+            super::agent_tools::invoke(runtime, session_context, input, agent, model)
+        }
         OrbitBuiltinAction::AutoTaskAdd => super::auto_task_tools::add(runtime, input),
         OrbitBuiltinAction::AutoTaskList => super::auto_task_tools::list(runtime, input),
         OrbitBuiltinAction::AutoTaskMint => super::auto_task_tools::mint(runtime, input),

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -48,6 +48,7 @@ pub(crate) fn build_orbit_tool_host(
     runtime: &OrbitRuntime,
     task_id: Option<String>,
     run_id: Option<String>,
+    session_context: ToolSessionContext,
 ) -> Arc<dyn OrbitToolHost> {
     Arc::new(RuntimeOrbitToolHost {
         runtime: runtime.clone(),
@@ -56,6 +57,7 @@ pub(crate) fn build_orbit_tool_host(
             task_id,
             run_id: run_id.or_else(trusted_env_run_id),
         },
+        session_context,
     })
 }
 
@@ -63,6 +65,15 @@ pub(crate) fn build_orbit_tool_host(
 struct RuntimeOrbitToolHost {
     runtime: OrbitRuntime,
     task_scope: OrbitTaskScope,
+    /// The calling session's asserted grants, carried so a handler whose
+    /// decision depends on *who is calling* can reach them [ORB-11354].
+    ///
+    /// The tool chokepoint resolves capabilities before dispatch, but its
+    /// answer is a yes/no it does not pass on. `orbit.agent.invoke` needs the
+    /// caller itself, because it records the authorizing operator on a durable
+    /// admission and refuses federated callers the ordinary registry would
+    /// allow.
+    session_context: ToolSessionContext,
 }
 
 /// Checkout-independent executor for coordination-authoritative hub tools.
@@ -1080,11 +1091,14 @@ impl OrbitToolHost for RuntimeOrbitToolHost {
         super::dispatch::execute(
             &self.runtime,
             &self.task_scope,
+            super::dispatch::ToolCaller {
+                session_context: &self.session_context,
+                agent,
+                model,
+                reservation_owner,
+            },
             action,
             input,
-            agent,
-            model,
-            reservation_owner,
         )
     }
 

--- a/crates/orbit-core/src/adapter/tool_host/mod.rs
+++ b/crates/orbit-core/src/adapter/tool_host/mod.rs
@@ -1,3 +1,4 @@
+mod agent_tools;
 mod artifact_redaction;
 mod auto_task_tools;
 mod command_tools;

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -132,10 +132,15 @@ fn managed_run_environment_denies_ship_and_resume_end_to_end() {
     // The step the mock skipped: a host built with no explicit run id still
     // reports one, because the environment supplied it.
     assert_eq!(
-        build_orbit_tool_host(&runtime, None, None)
-            .task_scope()
-            .run_id
-            .as_deref(),
+        build_orbit_tool_host(
+            &runtime,
+            None,
+            None,
+            orbit_types::tool::ToolSessionContext::default()
+        )
+        .task_scope()
+        .run_id
+        .as_deref(),
         Some("jrun-test-managed"),
     );
 
@@ -182,9 +187,14 @@ fn unmanaged_environment_admits_operator_ship_and_resume() {
     // The mirror of the denial test's scope assertion: with no envelope there is
     // no run scope, which is what leaves the guard inert.
     assert_eq!(
-        build_orbit_tool_host(&runtime, None, None)
-            .task_scope()
-            .run_id,
+        build_orbit_tool_host(
+            &runtime,
+            None,
+            None,
+            orbit_types::tool::ToolSessionContext::default()
+        )
+        .task_scope()
+        .run_id,
         None,
     );
 

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -228,5 +228,14 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
             .and_then(|state| state.drain_admissions_stop.as_ref()),
     )
     .map_err(serialize_error("serialize drain admissions stop"))?;
+    // [ORB-11354] An operator tracking an agent invocation reads it here, from
+    // the same show/list surface as any other run: its distinguishable outcome,
+    // a bounded preview of the answer, and the durable reference to the full
+    // captured output.
+    value["agent_invocation"] = serde_json::to_value(crate::application::job::agent_invoke_result(
+        run,
+        state.as_ref().map(|state| &state.step_outputs),
+    ))
+    .map_err(serialize_error("serialize agent invocation result"))?;
     Ok(value)
 }

--- a/crates/orbit-core/src/application/automation/tests/consumer.rs
+++ b/crates/orbit-core/src/application/automation/tests/consumer.rs
@@ -105,6 +105,7 @@ fn attach(
                     runtime,
                     Some(id.clone()),
                     owner.map(str::to_owned),
+                    orbit_types::tool::ToolSessionContext::default(),
                 )),
                 reservation_owner: owner.map(|id| ReservationOwnerContext {
                     owner_run_id: id.into(),

--- a/crates/orbit-core/src/application/job/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/agent_invoke.rs
@@ -1,0 +1,340 @@
+//! Operator-only host exploration/debugging invocation [ORB-11354].
+//!
+//! One durable, asynchronous run of one provider subprocess, outside the
+//! executor's filesystem sandbox, in an explicit working directory. It exists
+//! for the question an operator cannot answer from inside a managed run's
+//! sandbox — "why is this host behaving this way" — and it deliberately reuses
+//! the ordinary job machinery rather than adding a second scheduler: the same
+//! run record, the same detached worker, the same supervision, the same
+//! `orbit run show|logs|cancel`.
+//!
+//! # What this module owns
+//!
+//! Exactly the admission and the shape of the submission:
+//!
+//! * the operator check (delegated to
+//!   [`OrbitRuntime::admit_agent_invoke`](crate::OrbitRuntime), the single
+//!   canonical chokepoint),
+//! * validation of the explicit workspace/cwd pair, prompt, crew and timeout,
+//! * stamping the durable [`TrustedHostAdmission`] the engine requires,
+//! * the bounded operator-facing projection of a finished invocation.
+//!
+//! Everything after submission is the existing pipeline: nothing here spawns,
+//! supervises, cancels, or mutates a task.
+//!
+//! # What it is not
+//!
+//! Not a task, and not a delivery pipeline. The run performs no task
+//! transition, opens no PR, and dispatches nothing. The child subprocess
+//! carries managed-run provenance, so it resolves as an *agent* at every
+//! capability chokepoint and cannot admit another invocation of its own.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use orbit_common::OrbitError;
+use orbit_types::tool::ToolSessionContext;
+use orbit_types::workflow::JobRun;
+use orbit_types::workflow::activity_job::{TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+
+/// Catalog job that carries one agent invocation.
+pub const AGENT_INVOKE_JOB_ID: &str = "agent_invoke_pipeline";
+
+/// Wall-clock bound applied when the caller does not name one. The activity
+/// asset's own `wall_clock_timeout_seconds` remains the ceiling; a request may
+/// only shorten it.
+pub const DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS: u64 = 1800;
+
+/// Longest bound a caller may request. Anything above this is refused rather
+/// than silently clamped, so an operator who asked for a day-long unsandboxed
+/// process learns that they did.
+pub const MAX_AGENT_INVOKE_TIMEOUT_SECONDS: u64 = 7200;
+
+/// How much of the provider's captured output the operator-facing projection
+/// inlines. The full capture stays addressable through the durable blob
+/// reference the projection carries alongside it.
+const RESULT_PREVIEW_LIMIT_BYTES: usize = 4096;
+
+/// One operator's request to run an exploration invocation.
+#[derive(Debug, Clone)]
+pub struct AgentInvokeRequest<'a> {
+    /// What the operator wants investigated. Required and non-empty: an
+    /// invocation with nothing to do would still start an unsandboxed process.
+    pub prompt: &'a str,
+    /// Working directory the provider subprocess starts in. Required and
+    /// explicit — never inferred from the caller's cwd, because the caller may
+    /// be an MCP server in an unrelated directory.
+    pub cwd: &'a str,
+    /// Crew selecting provider/model/effort. `None` uses the workspace default.
+    pub crew: Option<&'a str>,
+    /// Requested wall-clock bound, in seconds.
+    pub timeout_seconds: Option<u64>,
+    /// Caller-supplied retry key. Two submissions carrying the same key resolve
+    /// to the same run rather than starting a second subprocess.
+    pub idempotency_key: Option<&'a str>,
+    /// Attribution label for the authorizing operator.
+    pub actor: Option<&'a str>,
+    /// The caller's session, resolved at the admission chokepoint.
+    pub session_context: &'a ToolSessionContext,
+}
+
+/// The durable outcome of a successful submission.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentInvokeSubmission {
+    pub run_id: String,
+    pub job_id: String,
+    pub submitted_at: String,
+    /// Whether the run is waiting on the job's `max_active_runs` ceiling rather
+    /// than already executing.
+    pub queued: bool,
+    /// Whether this submission resolved an existing run through its
+    /// idempotency key instead of creating a new one.
+    pub deduplicated: bool,
+    /// The admission recorded on the run.
+    pub admission: TrustedHostAdmission,
+    /// Effective wall-clock bound for the invocation.
+    pub timeout_seconds: u64,
+}
+
+/// A finished (or running) invocation, rendered for an operator.
+///
+/// Deliberately distinguishes the ways an invocation can end. A provider that
+/// exits 0 without terminating its response envelope did not finish its turn,
+/// and the run records that as a failure — so `outcome` here is never derived
+/// from the exit code alone.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentInvokeResult {
+    /// `running`, `queued`, `succeeded`, `failed`, `timeout`, `cancelled`,
+    /// or `interrupted` — the run's own state, not the subprocess's exit code.
+    pub outcome: String,
+    /// Why a non-success outcome happened, when the run recorded a reason.
+    pub failure_reason: Option<String>,
+    /// The provider's exit code, when the subprocess ran to completion.
+    pub exit_code: Option<i64>,
+    /// Whether the subprocess was killed for exceeding its wall-clock bound.
+    pub timed_out: bool,
+    /// Whether the invocation terminated with a well-formed response envelope.
+    /// `false` on an otherwise-clean exit means the agent stopped mid-turn.
+    pub completed_envelope: bool,
+    /// The agent's own summary, when it returned one.
+    pub summary: Option<String>,
+    /// Bounded preview of the captured output.
+    pub preview: Option<String>,
+    /// Whether `preview` is shorter than what the invocation actually produced.
+    pub preview_truncated: bool,
+    /// Durable reference to the complete captured stdout, readable with
+    /// `orbit run logs <RUN_ID>` after the preview is exhausted.
+    pub stdout_blob_ref: Option<String>,
+}
+
+impl OrbitRuntime {
+    /// Admit and submit one exploration invocation.
+    ///
+    /// Order is the contract: the operator check happens before validation,
+    /// and both happen before anything durable exists. An unauthorized caller
+    /// therefore never creates a run record, a worktree, or a process.
+    pub fn submit_agent_invoke_run(
+        &self,
+        request: AgentInvokeRequest<'_>,
+    ) -> Result<AgentInvokeSubmission, OrbitError> {
+        let provenance = self.admit_agent_invoke(request.session_context)?;
+
+        let prompt = require_non_empty(request.prompt, "prompt")?;
+        let cwd = self.resolve_invocation_cwd(request.cwd)?;
+        let crew = self.canonical_crew_name(request.crew)?;
+        let timeout_seconds = resolve_timeout(request.timeout_seconds)?;
+        let actor = request
+            .actor
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map_or_else(|| self.actor_label().to_string(), ToOwned::to_owned);
+
+        let admission = TrustedHostAdmission {
+            authorized_by: actor.clone(),
+            authorizer_provenance: provenance.to_string(),
+            authorized_at: Utc::now().to_rfc3339(),
+            workspace_path: self.paths().repo_root.display().to_string(),
+            cwd: cwd.display().to_string(),
+        };
+
+        let input = json!({
+            "prompt": prompt,
+            "cwd": cwd.display().to_string(),
+            "crew": crew,
+            "timeout_seconds": timeout_seconds,
+            TRUSTED_HOST_ADMISSION_KEY: serde_json::to_value(&admission)
+                .map_err(|error| OrbitError::Execution(format!("encode admission: {error}")))?,
+        });
+
+        let (invoke, deduplicated) =
+            self.submit_trusted_host_pipeline_run(input, &actor, request.idempotency_key)?;
+
+        tracing::warn!(
+            target: "orbit.trusted_host",
+            run_id = %invoke.run_id,
+            authorized_by = %admission.authorized_by,
+            authorizer_provenance = %admission.authorizer_provenance,
+            cwd = %admission.cwd,
+            deduplicated,
+            "admitted an operator agent invocation outside the executor sandbox"
+        );
+
+        Ok(AgentInvokeSubmission {
+            run_id: invoke.run_id,
+            job_id: invoke.job_name,
+            submitted_at: invoke.submitted_at,
+            queued: invoke.queued,
+            deduplicated,
+            admission,
+            timeout_seconds,
+        })
+    }
+
+    /// Canonicalize and validate the explicit working directory.
+    ///
+    /// The directory must exist and lie inside the runtime's own checkout.
+    /// Containment is what keeps "the owning workspace authorized this" true:
+    /// a caller addressing workspace A must not be able to point an unsandboxed
+    /// subprocess at workspace B's checkout, or anywhere else on the host,
+    /// through the same admission.
+    fn resolve_invocation_cwd(&self, cwd: &str) -> Result<PathBuf, OrbitError> {
+        let requested = require_non_empty(cwd, "cwd")?;
+        let path = Path::new(requested);
+        if !path.is_absolute() {
+            return Err(OrbitError::InvalidInput(format!(
+                "`cwd` must be an absolute path; got '{requested}'"
+            )));
+        }
+        let canonical = path.canonicalize().map_err(|error| {
+            OrbitError::InvalidInput(format!("`cwd` '{requested}' is not readable: {error}"))
+        })?;
+        if !canonical.is_dir() {
+            return Err(OrbitError::InvalidInput(format!(
+                "`cwd` '{requested}' is not a directory"
+            )));
+        }
+        let workspace_root = self.paths().repo_root.canonicalize().map_err(|error| {
+            OrbitError::Execution(format!(
+                "canonicalize workspace root '{}': {error}",
+                self.paths().repo_root.display()
+            ))
+        })?;
+        if !canonical.starts_with(&workspace_root) {
+            return Err(OrbitError::InvalidInput(format!(
+                "`cwd` '{}' is outside this workspace checkout '{}'; an invocation is admitted \
+                 against the workspace that authorizes it, so run it from the owning workspace \
+                 instead",
+                canonical.display(),
+                workspace_root.display()
+            )));
+        }
+        Ok(canonical)
+    }
+}
+
+/// Read a finished or in-flight invocation for an operator [ORB-11354].
+///
+/// Returns `None` for any run that is not an agent invocation, so the ordinary
+/// run projections can call it unconditionally.
+///
+/// Reads the run record and its persisted state rather than the live process:
+/// results survive the submitting client disconnecting, and stay readable long
+/// after the subprocess is gone.
+pub fn agent_invoke_result(
+    run: &JobRun,
+    step_outputs: Option<&std::collections::BTreeMap<u32, Value>>,
+) -> Option<AgentInvokeResult> {
+    if run.job_id != AGENT_INVOKE_JOB_ID {
+        return None;
+    }
+    let output = step_outputs.and_then(|outputs| outputs.values().next_back());
+    let field = |key: &str| output.and_then(|value| value.get(key));
+
+    let timed_out = field("timed_out").and_then(Value::as_bool).unwrap_or(false);
+    let preview = field("stdout_text")
+        .and_then(Value::as_str)
+        .map(bounded_preview);
+    let preview_truncated = field("stdout_text_truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || field("stdout_text")
+            .and_then(Value::as_str)
+            .is_some_and(|text| text.len() > RESULT_PREVIEW_LIMIT_BYTES);
+
+    Some(AgentInvokeResult {
+        outcome: outcome_label(run),
+        failure_reason: run
+            .steps
+            .last()
+            .and_then(|step| step.error_message.clone())
+            .or_else(|| {
+                field("completion_envelope_error")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            }),
+        exit_code: field("exit_code").and_then(Value::as_i64),
+        timed_out,
+        // Absent output means the invocation never reported, which is not the
+        // same as reporting a complete envelope. Default to `false`.
+        completed_envelope: field("completion_envelope_satisfied")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        summary: field("summary")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        preview,
+        preview_truncated,
+        stdout_blob_ref: field("stdout_blob_ref")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+/// The run state, rendered as the outcome vocabulary an operator reads.
+///
+/// Taken from the run record, never from the provider's exit code: a
+/// subprocess that exits 0 without finishing its turn produces a `failed` run,
+/// and that is the answer to "did the investigation succeed".
+fn outcome_label(run: &JobRun) -> String {
+    run.state.to_string()
+}
+
+fn bounded_preview(text: &str) -> String {
+    if text.len() <= RESULT_PREVIEW_LIMIT_BYTES {
+        return text.to_string();
+    }
+    let mut end = RESULT_PREVIEW_LIMIT_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_string()
+}
+
+fn require_non_empty<'a>(value: &'a str, field: &str) -> Result<&'a str, OrbitError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(OrbitError::InvalidInput(format!("`{field}` is required")));
+    }
+    Ok(trimmed)
+}
+
+fn resolve_timeout(requested: Option<u64>) -> Result<u64, OrbitError> {
+    let Some(seconds) = requested else {
+        return Ok(DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS);
+    };
+    if seconds == 0 {
+        return Err(OrbitError::InvalidInput(
+            "`timeout_seconds` must be at least 1".to_string(),
+        ));
+    }
+    if seconds > MAX_AGENT_INVOKE_TIMEOUT_SECONDS {
+        return Err(OrbitError::InvalidInput(format!(
+            "`timeout_seconds` must be at most {MAX_AGENT_INVOKE_TIMEOUT_SECONDS}"
+        )));
+    }
+    Ok(seconds)
+}

--- a/crates/orbit-core/src/application/job/catalog.rs
+++ b/crates/orbit-core/src/application/job/catalog.rs
@@ -23,6 +23,10 @@ use crate::application::{
 /// only.
 pub(crate) const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
     (
+        "agent_invoke_pipeline",
+        include_str!("../../../assets/jobs/agent_invoke_pipeline.yaml"),
+    ),
+    (
         "auto_task_scheduler_pipeline",
         include_str!("../../../assets/jobs/auto_task_scheduler_pipeline.yaml"),
     ),

--- a/crates/orbit-core/src/application/job/exec.rs
+++ b/crates/orbit-core/src/application/job/exec.rs
@@ -15,7 +15,10 @@ use orbit_engine::{
 };
 use orbit_store::contracts::{JobRunStepParams, TaskReservationReleaseReason};
 use orbit_types::record::OrbitEvent;
-use orbit_types::workflow::activity_job::{V2AuditEventKind, validate_job_retired_sessions};
+use orbit_types::workflow::activity_job::{
+    V2AuditEventKind, run_input_declares_trusted_host, strip_trusted_host_admission,
+    validate_job_retired_sessions,
+};
 use orbit_types::workflow::{
     JobRun, JobRunStartOutcome, JobRunState, JobTargetType, PipelineState,
 };
@@ -80,7 +83,13 @@ impl OrbitRuntime {
     /// to continue from the failed step instead.
     pub fn replay_job_run(&self, source_run_id: &str) -> Result<V2JobRunResult, OrbitError> {
         let source = self.show_job_run(source_run_id)?;
-        let input = source.input.clone().unwrap_or_else(|| json!({}));
+        let mut input = source.input.clone().unwrap_or_else(|| json!({}));
+        // [ORB-11354] A replay re-runs a historical input under no new
+        // admission, so the source's trusted-host admission does not travel
+        // with it. Stripping rather than refusing keeps replay usable for the
+        // rest of the run's input; the activity then fails closed on the
+        // missing admission, which is the honest outcome.
+        strip_trusted_host_admission(&mut input);
         let (job_path, _) = self.load_v2_job_asset_by_name(&source.job_id)?;
         self.run_job_v2_from_yaml_with_retry_source(
             &job_path,
@@ -130,6 +139,13 @@ impl OrbitRuntime {
         resume: Option<&ResumePlan>,
     ) -> Result<V2JobRunResult, OrbitError> {
         let job_name = load_job_name(yaml_path)?;
+        // [ORB-11354] The foreground path takes caller-shaped input too, so it
+        // gets the same reserved-key refusal as the detached submission path.
+        // Nothing runs a trusted-host activity in the foreground: an admitted
+        // invocation is always a detached run so it survives disconnect.
+        if run_input_declares_trusted_host(&input) {
+            return Err(super::pipeline::reserved_trusted_host_key_error(&job_name));
+        }
         let scheduled_at = chrono::Utc::now();
         let run = self.stores().jobs().insert_job_run(
             &job_name,

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod agent_invoke;
 pub(crate) mod catalog;
 mod exec;
 pub(crate) mod pipeline;
@@ -7,6 +8,10 @@ mod run;
 #[cfg(test)]
 mod tests;
 
+pub use agent_invoke::{
+    AGENT_INVOKE_JOB_ID, AgentInvokeRequest, AgentInvokeResult, AgentInvokeSubmission,
+    DEFAULT_AGENT_INVOKE_TIMEOUT_SECONDS, MAX_AGENT_INVOKE_TIMEOUT_SECONDS, agent_invoke_result,
+};
 pub(crate) use catalog::{DEFAULT_JOB_FILES, seed_default_jobs};
 pub use catalog::{JobCatalogEntry, JobCatalogFilter};
 pub use exec::V2JobRunResult;

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -26,7 +26,9 @@ use sha2::{Digest, Sha256};
 
 use orbit_engine::activity_job::load_job_asset;
 use orbit_types::workflow::JobV2;
-use orbit_types::workflow::activity_job::validate_job_retired_sessions;
+use orbit_types::workflow::activity_job::{
+    TRUSTED_HOST_ADMISSION_KEY, run_input_declares_trusted_host, validate_job_retired_sessions,
+};
 
 use crate::OrbitRuntime;
 use crate::application::job::exec::V2RunFinalizationOptions;
@@ -45,10 +47,27 @@ const PIPELINE_WAIT_MAX_TIMEOUT_SECONDS: u64 = 7200;
 const PIPELINE_WAIT_DEFAULT_POLL_SECONDS: u64 = 5;
 const PIPELINE_WAIT_MIN_POLL_SECONDS: u64 = 1;
 const PIPELINE_WORKER_LOG_TAIL_BYTES: u64 = 16 * 1024;
+/// Run-input field carrying a caller's agent-invocation retry key [ORB-11354].
+const AGENT_INVOKE_IDEMPOTENCY_KEY_FIELD: &str = "idempotency_key";
+/// Cap on the run history scanned when matching an agent-invocation retry key.
+const AGENT_INVOKE_IDEMPOTENCY_SCAN_LIMIT: usize = 200;
+
 /// [ORB-10544] Cap on the run history scanned by the in-flight ship guard.
 /// Non-terminal runs are always among the newest rows, so a bounded window is
 /// enough to spot a duplicate dispatch without walking the whole history.
 const SHIP_IN_FLIGHT_SCAN_LIMIT: usize = 200;
+
+/// The refusal for a submission that supplied the reserved trusted-host
+/// admission key it is not entitled to write [ORB-11354].
+///
+/// Shared by every entry point that accepts caller-shaped run input so the
+/// refusal reads identically whether it came from `orbit run job`, a direct
+/// YAML path, a resume, or a tool call.
+pub(crate) fn reserved_trusted_host_key_error(job_name: &str) -> OrbitError {
+    OrbitError::InvalidInput(format!(
+        "run input for job '{job_name}' set the reserved `{TRUSTED_HOST_ADMISSION_KEY}` field;          trusted host execution is admitted per invocation by the governed `orbit.agent.invoke`          operation and cannot be requested through ordinary job input"
+    ))
+}
 
 /// One durable pipeline submission: what to run, with what input, and how the
 /// detached worker will find the definition again.
@@ -59,6 +78,26 @@ struct PipelineSubmission<'a> {
     resume: Option<&'a ResumePlan>,
     actor: Option<&'a str>,
     action_key: Option<&'a str>,
+    /// Whether this submission is the canonical trusted-host admission
+    /// [ORB-11354]. Only it may carry [`TRUSTED_HOST_ADMISSION_KEY`] in its
+    /// input; every other submission is refused for supplying it.
+    trusted_host: bool,
+}
+
+impl<'a> PipelineSubmission<'a> {
+    /// An ordinary submission: catalog definition, no resume, no idempotency
+    /// key, and no trusted-host admission.
+    fn catalog(job_name: &'a str, input: Value, actor: Option<&'a str>) -> Self {
+        Self {
+            job_name,
+            definition: SubmittedDefinition::Catalog,
+            input,
+            resume: None,
+            actor,
+            action_key: None,
+            trusted_host: false,
+        }
+    }
 }
 
 /// Trusted context for a pipeline child submitted by a running v2 activity.
@@ -286,6 +325,93 @@ impl OrbitRuntime {
         }))
     }
 
+    /// Persist and dispatch one operator-admitted trusted-host invocation
+    /// [ORB-11354].
+    ///
+    /// The only submission permitted to write [`TRUSTED_HOST_ADMISSION_KEY`],
+    /// which is why it is here — on the module that owns the refusal — rather
+    /// than assembling a `PipelineSubmission` from outside.
+    ///
+    /// `idempotency_key` makes a retried submission resolve the run the first
+    /// attempt created instead of starting a second subprocess. Keys are
+    /// matched over a bounded window of this job's recent runs, the same shape
+    /// the ship guard uses: a key older than that window is not recognized and
+    /// submits again, which is why a key is a retry handle rather than a
+    /// permanent uniqueness constraint.
+    pub(super) fn submit_trusted_host_pipeline_run(
+        &self,
+        input: Value,
+        actor: &str,
+        idempotency_key: Option<&str>,
+    ) -> Result<(PipelineInvokeResult, bool), OrbitError> {
+        let job_name = crate::application::job::AGENT_INVOKE_JOB_ID;
+        let idempotency_key = idempotency_key
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let mut input = input;
+        if let Some(key) = idempotency_key {
+            if let Some(existing) = self.agent_invoke_run_for_key(job_name, key)? {
+                return Ok((
+                    PipelineInvokeResult {
+                        run_id: existing.run_id,
+                        job_name: job_name.to_string(),
+                        submitted_at: existing.scheduled_at.to_rfc3339(),
+                        queued: existing.state == JobRunState::Pending,
+                    },
+                    true,
+                ));
+            }
+            if let Some(object) = input.as_object_mut() {
+                object.insert(
+                    AGENT_INVOKE_IDEMPOTENCY_KEY_FIELD.to_string(),
+                    Value::String(key.to_string()),
+                );
+            }
+        }
+        let result = self.submit_persisted_pipeline_run(PipelineSubmission {
+            trusted_host: true,
+            ..PipelineSubmission::catalog(job_name, input.clone(), Some(actor))
+        });
+        self.record_pipeline_audit(
+            "agent.invoke",
+            result.as_ref().ok().map(|value| value.run_id.as_str()),
+            Some(actor),
+            match &result {
+                Ok(_) => AuditEventStatus::Success,
+                Err(_) => AuditEventStatus::Failure,
+            },
+            json!({
+                "actor": actor,
+                "job_name": job_name,
+                "run_id": result.as_ref().ok().map(|value| value.run_id.clone()),
+                "idempotency_key": idempotency_key,
+                "input_hash": input_hash(&input),
+            }),
+            result.as_ref().err().map(|error| error.to_string()),
+        )?;
+        result.map(|invoke| (invoke, false))
+    }
+
+    /// The newest recent run of `job_name` submitted under `key`, if any.
+    fn agent_invoke_run_for_key(
+        &self,
+        job_name: &str,
+        key: &str,
+    ) -> Result<Option<JobRun>, OrbitError> {
+        let runs = self.list_job_runs(crate::application::job::JobRunListParams {
+            job_id: Some(job_name.to_string()),
+            limit: Some(AGENT_INVOKE_IDEMPOTENCY_SCAN_LIMIT),
+            ..Default::default()
+        })?;
+        Ok(runs.into_iter().find(|run| {
+            run.input
+                .as_ref()
+                .and_then(|input| input.get(AGENT_INVOKE_IDEMPOTENCY_KEY_FIELD))
+                .and_then(Value::as_str)
+                == Some(key)
+        }))
+    }
+
     /// [ORB-10470] Submit a resume of a terminal run as a detached run.
     ///
     /// The non-blocking counterpart to
@@ -312,12 +438,8 @@ impl OrbitRuntime {
         let plan = self.plan_job_run_resume(source_run_id)?;
         let job_id = plan.source.job_id.clone();
         self.submit_persisted_pipeline_run(PipelineSubmission {
-            job_name: &job_id,
-            definition: SubmittedDefinition::Catalog,
-            input: plan.input.clone(),
             resume: Some(&plan),
-            actor,
-            action_key: None,
+            ..PipelineSubmission::catalog(&job_id, plan.input.clone(), actor)
         })
     }
 
@@ -350,15 +472,11 @@ impl OrbitRuntime {
 
         let (job_name, spec, yaml) = self.load_direct_job_definition(direct_path)?;
         let result = self.submit_persisted_pipeline_run(PipelineSubmission {
-            job_name: &job_name,
             definition: SubmittedDefinition::Snapshot {
                 spec: &spec,
                 yaml: &yaml,
             },
-            input: input.clone(),
-            resume: None,
-            actor,
-            action_key: None,
+            ..PipelineSubmission::catalog(&job_name, input.clone(), actor)
         });
         self.record_submission_audit(&job_name, &input, actor, &result)?;
         result
@@ -388,12 +506,8 @@ impl OrbitRuntime {
         key: &str,
     ) -> Result<PipelineInvokeResult, OrbitError> {
         let result = self.submit_persisted_pipeline_run(PipelineSubmission {
-            job_name,
-            definition: SubmittedDefinition::Catalog,
-            input: input.clone(),
-            resume: None,
-            actor: Some("automation"),
             action_key: Some(key),
+            ..PipelineSubmission::catalog(job_name, input.clone(), Some("automation"))
         });
         self.record_submission_audit(job_name, &input, Some("automation"), &result)?;
         result
@@ -406,14 +520,11 @@ impl OrbitRuntime {
         priority: Option<&str>,
         actor: Option<&str>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
-        let result = self.submit_persisted_pipeline_run(PipelineSubmission {
+        let result = self.submit_persisted_pipeline_run(PipelineSubmission::catalog(
             job_name,
-            definition: SubmittedDefinition::Catalog,
-            input: input.clone(),
-            resume: None,
+            input.clone(),
             actor,
-            action_key: None,
-        });
+        ));
 
         self.record_pipeline_audit(
             "pipeline.invoke",
@@ -451,14 +562,7 @@ impl OrbitRuntime {
         admission: &ChildPipelineAdmission,
     ) -> Result<Option<PipelineInvokeResult>, OrbitError> {
         let result = self.submit_persisted_pipeline_run_with_admission(
-            PipelineSubmission {
-                job_name,
-                definition: SubmittedDefinition::Catalog,
-                input: input.clone(),
-                resume: None,
-                actor,
-                action_key: None,
-            },
+            PipelineSubmission::catalog(job_name, input.clone(), actor),
             Some(admission),
         );
 
@@ -551,7 +655,16 @@ impl OrbitRuntime {
             resume,
             actor,
             action_key,
+            trusted_host,
         } = submission;
+        // [ORB-11354] The reserved admission key is writable by exactly one
+        // caller. Refusing it here — on the single path every submission
+        // surface funnels through — is what stops `orbit run job`, a resume,
+        // an automation key, or a child dispatch from manufacturing an
+        // unsandboxed run out of ordinary job input.
+        if !trusted_host && run_input_declares_trusted_host(&input) {
+            return Err(reserved_trusted_host_key_error(job_name));
+        }
         let result = (|| {
             let spec = match &definition {
                 SubmittedDefinition::Catalog => self.load_v2_job_asset_by_name(job_name)?.1,

--- a/crates/orbit-core/src/application/job/resume.rs
+++ b/crates/orbit-core/src/application/job/resume.rs
@@ -29,6 +29,7 @@ use std::path::PathBuf;
 
 use orbit_common::OrbitError;
 use orbit_store::contracts::JobRunQuery;
+use orbit_types::workflow::activity_job::run_input_declares_trusted_host;
 use orbit_types::workflow::{JobRun, JobRunState, PipelineState};
 use serde_json::Value;
 
@@ -77,6 +78,20 @@ impl OrbitRuntime {
         // `show_job_run` reconciles a stale Running owner first, so a run
         // orphaned by SIGKILL flips to Interrupted before the state guard.
         let source = self.show_job_run(source_run_id)?;
+        // [ORB-11354] A resume reuses the source run's persisted input, which
+        // for a trusted-host invocation would carry its admission forward into
+        // a run nobody authorized now. The mode is per-invocation on purpose,
+        // so resume refuses rather than re-admitting; submitting again is the
+        // operator's explicit re-authorization.
+        if source
+            .input
+            .as_ref()
+            .is_some_and(run_input_declares_trusted_host)
+        {
+            return Err(OrbitError::JobValidation(format!(
+                "job run '{source_run_id}' was an operator-admitted trusted host invocation and                  cannot be resumed; its admission covered that invocation only. Submit a new                  `orbit.agent.invoke` to authorize another one"
+            )));
+        }
         if !matches!(
             source.state,
             JobRunState::Interrupted | JobRunState::Failed | JobRunState::Timeout

--- a/crates/orbit-core/src/application/job/run/projection.rs
+++ b/crates/orbit-core/src/application/job/run/projection.rs
@@ -39,6 +39,9 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         .and_then(|state| state.drain_admissions_stop.as_ref())
         .and_then(|stop| serde_json::to_value(stop).ok())
         .unwrap_or(Value::Null);
+    // Read before the terminal filter below: an invocation's result is most
+    // interesting *after* the run finishes.
+    let state_for_agent_result = state;
     let state = (!run.state.is_terminal()).then_some(state).flatten();
     let waiting_on_deps = state
         .and_then(|state| state.waiting_on_deps.as_ref())
@@ -52,7 +55,18 @@ pub fn job_run_to_json(run: &JobRun, state: Option<&PipelineState>) -> Value {
         .and_then(|input| input.get("crew"))
         .and_then(Value::as_str);
 
+    // [ORB-11354] An agent invocation's answer is the reason its run exists,
+    // so the shared projection carries it rather than making each surface dig
+    // it out of the step output. `None` for every other job.
+    let agent_invocation = crate::application::job::agent_invoke_result(
+        run,
+        state_for_agent_result.map(|state| &state.step_outputs),
+    )
+    .and_then(|result| serde_json::to_value(result).ok())
+    .unwrap_or(Value::Null);
+
     json!({
+        "agent_invocation": agent_invocation,
         "child_dispatches": child_dispatches,
         "drain_worker_limit": drain_worker_limit,
         "drain_admissions_stop": drain_admissions_stop,

--- a/crates/orbit-core/src/application/job/tests/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/tests/agent_invoke.rs
@@ -1,0 +1,542 @@
+//! Admission and lifecycle of the operator-only agent invocation [ORB-11354].
+//!
+//! The tests below are grouped by the question they answer:
+//!
+//! 1. Who may admit one (and who is refused before anything durable exists).
+//! 2. What the admission records.
+//! 3. Why no other submission path can manufacture the mode.
+//! 4. How a finished invocation reads back, including the case where the
+//!    provider exits 0 without finishing its turn.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use chrono::Utc;
+use orbit_common::OrbitError;
+use orbit_types::tool::{McpCapability, RemoteCallerGrant, ToolSessionContext};
+use orbit_types::workflow::activity_job::TRUSTED_HOST_ADMISSION_KEY;
+use orbit_types::workflow::{JobRun, JobRunState};
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+use crate::OrbitRuntime;
+use crate::application::job::{
+    AGENT_INVOKE_JOB_ID, AgentInvokeRequest, MAX_AGENT_INVOKE_TIMEOUT_SECONDS, agent_invoke_result,
+};
+
+/// A runtime plus the checkout an invocation is admitted against.
+fn test_runtime() -> (TempDir, OrbitRuntime, PathBuf) {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    (root, runtime, repo_root)
+}
+
+/// A session an MCP operator surface would present.
+fn operator_session() -> ToolSessionContext {
+    ToolSessionContext {
+        effective_capabilities: [McpCapability::Operator].into_iter().collect(),
+        ..ToolSessionContext::default()
+    }
+}
+
+/// A session an ordinary agent MCP surface would present.
+fn agent_session() -> ToolSessionContext {
+    ToolSessionContext {
+        effective_capabilities: [McpCapability::Agent].into_iter().collect(),
+        ..ToolSessionContext::default()
+    }
+}
+
+/// A run's own dispatcher stamp. `Runner` is deliberately absent from the
+/// operation's allowed set, so this must be refused.
+fn runner_session() -> ToolSessionContext {
+    ToolSessionContext {
+        effective_capabilities: [McpCapability::Runner].into_iter().collect(),
+        ..ToolSessionContext::default()
+    }
+}
+
+/// A federated caller the destination granted full operator capability.
+fn federated_operator_session() -> ToolSessionContext {
+    ToolSessionContext {
+        effective_capabilities: [McpCapability::Operator].into_iter().collect(),
+        remote_caller_grant: Some(RemoteCallerGrant {
+            caller_machine_id: "hm_remote".to_string(),
+            granted_capabilities: [McpCapability::Operator].into_iter().collect(),
+            source: "mcp-callers.toml".to_string(),
+            identity: Default::default(),
+        }),
+        ..ToolSessionContext::default()
+    }
+}
+
+fn request<'a>(cwd: &'a str, session: &'a ToolSessionContext) -> AgentInvokeRequest<'a> {
+    AgentInvokeRequest {
+        prompt: "why is the sweep clock restarting",
+        cwd,
+        crew: None,
+        timeout_seconds: None,
+        idempotency_key: None,
+        actor: Some("human"),
+        session_context: session,
+    }
+}
+
+fn assert_denied(error: OrbitError, expectation: &str) {
+    match error {
+        OrbitError::CapabilityDenied(message) => assert!(
+            message.contains("orbit.agent.invoke"),
+            "{expectation}: the refusal must name the operation, got {message}"
+        ),
+        other => panic!("{expectation}: expected a capability denial, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------- admission
+
+#[test]
+fn an_agent_session_cannot_admit_an_invocation() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = agent_session();
+    let error = runtime
+        .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
+        .expect_err("an agent must not start an unsandboxed process");
+    assert_denied(error, "agent session");
+    assert_no_run_created(&runtime);
+}
+
+#[test]
+fn a_runs_own_runner_grant_cannot_admit_an_invocation() {
+    // The mode exists to leave the sandbox a managed run executes inside, so a
+    // run that could admit itself would be a sandbox escape wearing an
+    // authorization. Every other run-reachable governed operation lists
+    // `runner`; this one deliberately does not.
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = runner_session();
+    let error = runtime
+        .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
+        .expect_err("a managed run must not admit an unsandboxed process");
+    assert_denied(error, "runner session");
+    assert_no_run_created(&runtime);
+}
+
+#[test]
+fn a_federated_operator_cannot_admit_an_invocation() {
+    // A destination-side grant may legitimately carry `operator` for ordinary
+    // operator work, but it cannot assert "a person is present on the machine
+    // that would run this process", which is what the mode requires.
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = federated_operator_session();
+    let error = runtime
+        .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
+        .expect_err("a federated caller must not admit an unsandboxed process");
+    match error {
+        OrbitError::CapabilityDenied(message) => {
+            assert!(message.contains("hm_remote"), "{message}");
+            assert!(
+                message.contains("only to an operator on the machine"),
+                "{message}"
+            );
+        }
+        other => panic!("expected a capability denial, got {other:?}"),
+    }
+    assert_no_run_created(&runtime);
+}
+
+#[test]
+fn an_unidentified_caller_cannot_admit_an_invocation() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = ToolSessionContext::default();
+    // The process running these tests is neither an interactive terminal nor
+    // an operator override, so the envelope resolves to nothing at all.
+    let error = runtime
+        .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
+        .expect_err("ambiguity must fail closed");
+    assert_denied(error, "unidentified caller");
+    assert_no_run_created(&runtime);
+}
+
+fn assert_no_run_created(runtime: &OrbitRuntime) {
+    let runs = runtime
+        .list_job_runs(crate::application::job::JobRunListParams::default())
+        .expect("list runs");
+    assert!(
+        runs.is_empty(),
+        "a refused caller must not leave a durable run behind"
+    );
+}
+
+// --------------------------------------------------------------- validation
+//
+// Validation runs *after* admission, so these use an operator session. They
+// assert the invocation's own contract: an explicit, containable cwd and a
+// bounded timeout.
+
+#[test]
+fn a_cwd_outside_the_workspace_checkout_is_refused() {
+    let (root, runtime, _repo_root) = test_runtime();
+    let outside = root.path().join("elsewhere");
+    std::fs::create_dir_all(&outside).expect("create outside dir");
+    let session = operator_session();
+    let error = runtime
+        .submit_agent_invoke_run(request(&outside.display().to_string(), &session))
+        .expect_err("an admission is scoped to the workspace that granted it");
+    match error {
+        OrbitError::InvalidInput(message) => {
+            assert!(
+                message.contains("outside this workspace checkout"),
+                "{message}"
+            )
+        }
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_relative_or_missing_cwd_is_refused() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = operator_session();
+    for (cwd, expected) in [("crates", "must be an absolute path"), ("", "is required")] {
+        match runtime
+            .submit_agent_invoke_run(request(cwd, &session))
+            .expect_err("cwd must be explicit and absolute")
+        {
+            OrbitError::InvalidInput(message) => assert!(message.contains(expected), "{message}"),
+            other => panic!("expected invalid input, got {other:?}"),
+        }
+    }
+    let absent = repo_root.join("does-not-exist");
+    match runtime
+        .submit_agent_invoke_run(request(&absent.display().to_string(), &session))
+        .expect_err("cwd must exist")
+    {
+        OrbitError::InvalidInput(message) => assert!(message.contains("not readable"), "{message}"),
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_empty_prompt_is_refused() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let mut request = request(&cwd, &session);
+    request.prompt = "   ";
+    match runtime
+        .submit_agent_invoke_run(request)
+        .expect_err("an invocation with nothing to do still starts a process")
+    {
+        OrbitError::InvalidInput(message) => assert!(message.contains("`prompt`"), "{message}"),
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_timeout_beyond_the_ceiling_is_refused_rather_than_clamped() {
+    let (_root, runtime, repo_root) = test_runtime();
+    let session = operator_session();
+    let cwd = repo_root.display().to_string();
+    let mut request = request(&cwd, &session);
+    request.timeout_seconds = Some(MAX_AGENT_INVOKE_TIMEOUT_SECONDS + 1);
+    match runtime
+        .submit_agent_invoke_run(request)
+        .expect_err("an operator who asked for too long should learn that they did")
+    {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains("at most"), "{message}")
+        }
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+// -------------------------------------------------------------- forgery
+
+#[test]
+fn ordinary_job_input_cannot_carry_a_trusted_host_admission() {
+    // The reserved key is refused on the single path every submission surface
+    // funnels through, so this covers `orbit run job`, a tool call, and an
+    // automation key alike.
+    let (_root, runtime, _repo_root) = test_runtime();
+    let forged = json!({
+        "prompt": "why",
+        TRUSTED_HOST_ADMISSION_KEY: {
+            "authorized_by": "not-an-operator",
+            "authorizer_provenance": "session",
+            "authorized_at": Utc::now().to_rfc3339(),
+            "workspace_path": "/",
+            "cwd": "/",
+        },
+    });
+    let error = runtime
+        .submit_pipeline_run(AGENT_INVOKE_JOB_ID, forged, None, Some("agent"))
+        .expect_err("run input must not be able to manufacture the mode");
+    match error {
+        OrbitError::InvalidInput(message) => {
+            assert!(message.contains(TRUSTED_HOST_ADMISSION_KEY), "{message}");
+            assert!(message.contains("orbit.agent.invoke"), "{message}");
+        }
+        other => panic!("expected invalid input, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_foreground_job_run_cannot_carry_a_trusted_host_admission() {
+    let (root, runtime, _repo_root) = test_runtime();
+    let job_path = root.path().join("forged.yaml");
+    std::fs::write(
+        &job_path,
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: forged_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  max_active_runs: 1
+  steps:
+    - id: noop
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+"#,
+    )
+    .expect("write job");
+
+    let error = runtime
+        .run_job_v2_from_yaml(
+            &job_path,
+            json!({ TRUSTED_HOST_ADMISSION_KEY: { "authorized_by": "x" } }),
+        )
+        .expect_err("the foreground path takes caller input too");
+    assert!(matches!(error, OrbitError::InvalidInput(_)), "{error:?}");
+}
+
+// ------------------------------------------------------------ result reading
+
+fn finished_run(state: JobRunState, output: Value) -> (JobRun, BTreeMap<u32, Value>) {
+    let run = JobRun {
+        run_id: "jrun-test-1".to_string(),
+        job_id: AGENT_INVOKE_JOB_ID.to_string(),
+        attempt: 1,
+        state,
+        scheduled_at: Utc::now(),
+        started_at: Some(Utc::now()),
+        finished_at: Some(Utc::now()),
+        duration_ms: Some(10),
+        created_at: Utc::now(),
+        pid: None,
+        pid_start_time: None,
+        input: None,
+        retry_source_run_id: None,
+        knowledge_metrics: None,
+        resolved_crew: None,
+        crew_model: None,
+        steps: Vec::new(),
+    };
+    (run, BTreeMap::from([(0, output)]))
+}
+
+#[test]
+fn a_provider_that_exits_zero_without_finishing_is_not_a_successful_investigation() {
+    // The whole point of the projection: the exit code is present and zero, and
+    // the answer to "did this succeed" is still no, because the run recorded a
+    // failure when the envelope never terminated.
+    let (run, outputs) = finished_run(
+        JobRunState::Failed,
+        json!({
+            "exit_code": 0,
+            "timed_out": false,
+            "completion_envelope_satisfied": false,
+            "completion_envelope_error": "no terminating envelope",
+            "stdout_text": "thinking...",
+            "stdout_blob_ref": "blob-7",
+        }),
+    );
+    let result = agent_invoke_result(&run, Some(&outputs)).expect("an agent invocation run");
+    assert_eq!(result.outcome, "failed");
+    assert_eq!(result.exit_code, Some(0));
+    assert!(!result.completed_envelope);
+    assert_eq!(
+        result.failure_reason.as_deref(),
+        Some("no terminating envelope")
+    );
+}
+
+#[test]
+fn a_timeout_and_a_cancellation_read_differently() {
+    let (timed_out, outputs) = finished_run(
+        JobRunState::Timeout,
+        json!({ "timed_out": true, "exit_code": Value::Null }),
+    );
+    let result = agent_invoke_result(&timed_out, Some(&outputs)).expect("result");
+    assert_eq!(result.outcome, "timeout");
+    assert!(result.timed_out);
+
+    let (cancelled, outputs) = finished_run(JobRunState::Cancelled, json!({}));
+    let result = agent_invoke_result(&cancelled, Some(&outputs)).expect("result");
+    assert_eq!(result.outcome, "cancelled");
+    assert!(!result.timed_out);
+    // Nothing reported, so nothing is claimed about the envelope.
+    assert!(!result.completed_envelope);
+}
+
+#[test]
+fn the_preview_is_bounded_and_names_where_the_rest_lives() {
+    let long = "x".repeat(10_000);
+    let (run, outputs) = finished_run(
+        JobRunState::Success,
+        json!({
+            "exit_code": 0,
+            "completion_envelope_satisfied": true,
+            "summary": "the clock restarts on config reload",
+            "stdout_text": long,
+            "stdout_blob_ref": "blob-9",
+        }),
+    );
+    let result = agent_invoke_result(&run, Some(&outputs)).expect("result");
+    assert_eq!(result.outcome, JobRunState::Success.to_string());
+    assert!(result.completed_envelope);
+    assert_eq!(
+        result.summary.as_deref(),
+        Some("the clock restarts on config reload")
+    );
+    let preview = result.preview.expect("a preview");
+    assert!(preview.len() < 10_000, "preview must be bounded");
+    assert!(result.preview_truncated);
+    assert_eq!(result.stdout_blob_ref.as_deref(), Some("blob-9"));
+}
+
+#[test]
+fn an_unrelated_run_has_no_agent_invocation_projection() {
+    let (mut run, outputs) = finished_run(JobRunState::Success, json!({}));
+    run.job_id = "task_auto_pipeline".to_string();
+    assert!(agent_invoke_result(&run, Some(&outputs)).is_none());
+}
+
+// ---------------------------------------------------- restart and retry
+
+/// A run that carries an admission cannot be resumed: the admission covered one
+/// invocation, and a resume would carry it into a run nobody authorized now.
+#[test]
+fn an_admitted_run_cannot_be_resumed() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let admitted_input = json!({
+        "prompt": "why",
+        TRUSTED_HOST_ADMISSION_KEY: {
+            "authorized_by": "human",
+            "authorizer_provenance": "interactive-terminal",
+            "authorized_at": Utc::now().to_rfc3339(),
+            "workspace_path": "/checkout",
+            "cwd": "/checkout",
+        },
+    });
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            AGENT_INVOKE_JOB_ID,
+            1,
+            Utc::now(),
+            Some(admitted_input.clone()),
+            None,
+        )
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("start run");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&run.run_id, JobRunState::Failed, Utc::now(), Some(10))
+        .expect("finalize run as failed");
+
+    let error = runtime
+        .submit_resume_run(&run.run_id, Some("human"), None)
+        .expect_err("an admission covers one invocation only");
+    match error {
+        OrbitError::JobValidation(message) => {
+            assert!(message.contains("cannot be resumed"), "{message}");
+            assert!(message.contains("orbit.agent.invoke"), "{message}");
+        }
+        other => panic!("expected a job validation refusal, got {other:?}"),
+    }
+}
+
+/// A resubmission carrying a key a previous submission used resolves that run
+/// rather than starting a second unsandboxed agent.
+///
+/// Terminal state is deliberately not a factor: retrying after the original
+/// finished should hand back the original result, not re-run the investigation.
+#[test]
+fn a_repeated_idempotency_key_resolves_the_original_run() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let first = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            AGENT_INVOKE_JOB_ID,
+            1,
+            Utc::now(),
+            Some(json!({ "prompt": "why", "idempotency_key": "incident-4821" })),
+            None,
+        )
+        .expect("insert first run");
+
+    let (resolved, deduplicated) = runtime
+        .submit_trusted_host_pipeline_run(
+            json!({ "prompt": "why", "cwd": "/checkout" }),
+            "human",
+            Some("incident-4821"),
+        )
+        .expect("a retry resolves rather than failing");
+
+    assert!(deduplicated, "a repeated key must not start a second agent");
+    assert_eq!(resolved.run_id, first.run_id);
+    assert_eq!(resolved.job_name, AGENT_INVOKE_JOB_ID);
+
+    let runs = runtime
+        .list_job_runs(crate::application::job::JobRunListParams::default())
+        .expect("list runs");
+    assert_eq!(runs.len(), 1, "no second run may be created");
+}
+
+/// A blank key is no key: it must not collide with every other blank one.
+#[test]
+fn a_blank_idempotency_key_is_treated_as_absent() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    runtime
+        .stores()
+        .jobs()
+        .insert_job_run(
+            AGENT_INVOKE_JOB_ID,
+            1,
+            Utc::now(),
+            Some(json!({ "prompt": "why", "idempotency_key": "" })),
+            None,
+        )
+        .expect("insert run");
+
+    // Submission proceeds past the dedupe check and fails later for a reason
+    // that is not "resolved an existing run" — the catalog has no seeded job in
+    // this bare fixture. What matters is that a blank key did not match.
+    let error = runtime
+        .submit_trusted_host_pipeline_run(
+            json!({ "prompt": "why", "cwd": "/checkout" }),
+            "human",
+            Some("   "),
+        )
+        .expect_err("the bare fixture has no seeded job catalog");
+    assert!(
+        matches!(error, OrbitError::NotFound { .. }),
+        "expected the submission to reach catalog resolution, got {error:?}"
+    );
+}

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -18,6 +18,10 @@ use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
 
 const DEFAULT_JOB_FILES: &[(&str, &str)] = &[
     (
+        "agent_invoke_pipeline",
+        include_str!("../../../../assets/jobs/agent_invoke_pipeline.yaml"),
+    ),
+    (
         "auto_task_scheduler_pipeline",
         include_str!("../../../../assets/jobs/auto_task_scheduler_pipeline.yaml"),
     ),

--- a/crates/orbit-core/src/application/job/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/tests/mod.rs
@@ -1,3 +1,4 @@
+mod agent_invoke;
 mod catalog;
 mod exec;
 mod resume;

--- a/crates/orbit-core/src/bootstrap/activity.rs
+++ b/crates/orbit-core/src/bootstrap/activity.rs
@@ -57,6 +57,10 @@ pub(crate) const DEFAULT_ACTIVITY_FILES: &[(&str, &str)] = &[
         include_str!("../../assets/activities/epic_orchestrator.yaml"),
     ),
     (
+        "agent_invoke",
+        include_str!("../../assets/activities/agent_invoke.yaml"),
+    ),
+    (
         "gate_starvation_fail",
         include_str!("../../assets/activities/gate_starvation_fail.yaml"),
     ),
@@ -245,6 +249,10 @@ backend = "cli"
 
         let expected = BTreeMap::from([
             ("agent_implement", ("codex", "gpt-5.6-sol".to_string())),
+            // The exploration invocation names no crew either: an operator
+            // chooses one per submission, and an omitted choice falls through
+            // to the run's crew exactly like every other activity here.
+            ("agent_invoke", ("codex", "gpt-5.6-sol".to_string())),
             ("epic_orchestrator", ("codex", "gpt-5.6-sol".to_string())),
             (
                 "step_failure_recovery",

--- a/crates/orbit-core/src/lib.rs
+++ b/crates/orbit-core/src/lib.rs
@@ -65,9 +65,9 @@ pub use orbit_tools::prepare_remote_task_artifact_put;
 // Command-layer types the CLI names in its clap surfaces.
 pub use application::docs::{DocType, TaskRelatedDoc};
 pub use application::job::{
-    DrainAdmissionsStopChange, DrainAdmissionsStopRequest, DrainAdmissionsStopResult,
-    DrainWorkerLimitChange, DrainWorkerLimitRequest, PipelineInvokeResult, PipelineWaitEntry,
-    RemainingDrainChild,
+    AgentInvokeRequest, AgentInvokeSubmission, DrainAdmissionsStopChange,
+    DrainAdmissionsStopRequest, DrainAdmissionsStopResult, DrainWorkerLimitChange,
+    DrainWorkerLimitRequest, PipelineInvokeResult, PipelineWaitEntry, RemainingDrainChild,
 };
 pub use application::search::{
     GlobalSearchHit, GlobalSearchKind, GlobalSearchParams, HitWorkspace, WorkspaceSearchReport,

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -19,8 +19,8 @@
 
 use orbit_common::OrbitError;
 use orbit_common::governance::authorization::{
-    CallerCapabilities, CallerEnvelope, GovernedOperation, authorize, governed_command,
-    governed_tool,
+    CallerCapabilities, CallerEnvelope, CallerProvenance, GovernedOperation, authorize,
+    governed_command, governed_tool,
 };
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_store::contracts::AuditEventInsertParams;
@@ -29,6 +29,10 @@ use orbit_types::tool::{McpCapability, ToolSessionContext};
 
 use crate::OrbitRuntime;
 use crate::runtime::tool_exec::CapabilityEnforcement;
+
+/// Canonical tool name of the trusted-host agent invocation, named once so the
+/// admission and the governed-operation registry cannot drift apart.
+pub(crate) const AGENT_INVOKE_OPERATION_ID: &str = "orbit.agent.invoke";
 
 impl OrbitRuntime {
     /// Authorize a governed tool call, then require destination-granted remote
@@ -112,6 +116,61 @@ impl OrbitRuntime {
             Some(message.clone()),
         );
         Err(OrbitError::CapabilityDenied(message))
+    }
+
+    /// Admit one trusted-host agent invocation, returning how the authorizing
+    /// operator was identified [ORB-11354].
+    ///
+    /// The single canonical admission for the unsandboxed execution mode. Every
+    /// surface that can submit one — the `orbit.agent.invoke` tool and the
+    /// `orbit run agent` CLI — calls this before anything durable exists, so a
+    /// refusal happens before a run record and long before a process.
+    ///
+    /// Two rules beyond the ordinary governed-operation check:
+    ///
+    /// * **The process envelope counts.** The tool chokepoint resolves an MCP
+    ///   call session-only, which is right for placement but would let a leaf
+    ///   agent shelling out to the CLI look like nothing at all. Resolving the
+    ///   process envelope here means a managed run's `ORBIT_MANAGED_RUN_CONTEXT`
+    ///   resolves as `agent`, and an agent is refused.
+    /// * **Remote callers are refused outright.** A destination-side grant may
+    ///   legitimately carry `operator` for ordinary operator work, but "an
+    ///   operator is present on this machine" is exactly what admitting an
+    ///   unsandboxed local subprocess requires, and a federated grant cannot
+    ///   assert it. This is narrower than [`authorize`] on purpose.
+    pub(crate) fn admit_agent_invoke(
+        &self,
+        session_context: &ToolSessionContext,
+    ) -> Result<CallerProvenance, OrbitError> {
+        let operation = governed_tool(AGENT_INVOKE_OPERATION_ID).ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "'{AGENT_INVOKE_OPERATION_ID}' is missing from the governed operation registry"
+            ))
+        })?;
+        let caller =
+            CallerCapabilities::resolve(&CallerEnvelope::from_process_env(session_context));
+        if let Some(grant) = caller.remote_caller_grant() {
+            let message = format!(
+                "operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process and                  is available only to an operator on the machine that would run it; caller '{}'                  was resolved through {}",
+                grant.caller_machine_id, grant.source,
+            );
+            tracing::warn!(
+                target: "orbit.authorization",
+                operation = AGENT_INVOKE_OPERATION_ID,
+                provenance = %caller.provenance(),
+                caller_machine_id = grant.caller_machine_id,
+                "trusted host admission denied to a federated caller"
+            );
+            self.record_authorization_event(
+                AGENT_INVOKE_OPERATION_ID,
+                &caller,
+                AuditEventStatus::Denied,
+                Some(message.clone()),
+            );
+            return Err(OrbitError::CapabilityDenied(message));
+        }
+        self.decide_with_envelope(operation, CallerEnvelope::from_process_env(session_context))?;
+        Ok(caller.provenance())
     }
 
     /// Authorize a governed CLI command, or pass an ungoverned one through.

--- a/crates/orbit-core/src/runtime/tests/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tests/tool_exec.rs
@@ -55,6 +55,7 @@ fn run_tool_context_allowlist_honors_task_wildcard() {
                     &runtime,
                     Some(task.id.clone()),
                     None,
+                    orbit_types::tool::ToolSessionContext::default(),
                 )),
                 ..Default::default()
             },

--- a/crates/orbit-core/tests/antigravity_fake_agent.rs
+++ b/crates/orbit-core/tests/antigravity_fake_agent.rs
@@ -122,6 +122,7 @@ fn spec(timeout_seconds: u64) -> AgentLoopSpec {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-core/tests/copilot_fake_agent.rs
+++ b/crates/orbit-core/tests/copilot_fake_agent.rs
@@ -133,6 +133,7 @@ fn spec(model: Option<&str>, timeout_seconds: u64) -> AgentLoopSpec {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-core/tests/cursor_fake_agent.rs
+++ b/crates/orbit-core/tests/cursor_fake_agent.rs
@@ -122,6 +122,7 @@ fn spec(timeout_seconds: u64) -> AgentLoopSpec {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-core/tests/grok_cli_backend_smoke.rs
+++ b/crates/orbit-core/tests/grok_cli_backend_smoke.rs
@@ -78,6 +78,7 @@ fn installed_grok_cli_backend_smoke_captures_stdout_artifact() {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     };
 
     let outcome = dispatch_v2_activity(V2DispatchInput {

--- a/crates/orbit-core/tests/opencode_fake_agent.rs
+++ b/crates/orbit-core/tests/opencode_fake_agent.rs
@@ -149,6 +149,7 @@ fn spec(timeout_seconds: u64) -> AgentLoopSpec {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-core/tests/pi_fake_agent.rs
+++ b/crates/orbit-core/tests/pi_fake_agent.rs
@@ -127,6 +127,7 @@ fn spec(timeout_seconds: u64) -> AgentLoopSpec {
         require_response_envelope: true,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/asset_loader.rs
@@ -4,7 +4,9 @@ use orbit_types::resource::ResourceKind;
 
 use orbit_types::workflow::JobV2;
 use orbit_types::workflow::SchemaHeader;
-use orbit_types::workflow::activity_job::ActivityV2;
+use orbit_types::workflow::activity_job::{
+    ActivityV2, ActivityV2Spec, TrustedHostActivityError, validate_trusted_host_activity,
+};
 
 fn parse_schema_header(yaml: &str) -> Result<SchemaHeader, serde_yaml::Error> {
     serde_yaml::from_str(yaml)
@@ -49,6 +51,8 @@ pub enum AssetLoadError {
         activity: String,
         source: ToolAllowlistError,
     },
+    #[error(transparent)]
+    TrustedHostActivity(#[from] TrustedHostActivityError),
 }
 
 /// Two-pass activity-asset loader for schemaVersion 2 assets.
@@ -69,6 +73,13 @@ pub fn load_activity_asset(yaml: &str) -> Result<ActivityAsset, AssetLoadError> 
                     source,
                 }
             })?;
+            // The unsandboxed execution mode is legal on exactly one built-in
+            // activity name, so an edited or hand-written asset cannot claim
+            // it. [ORB-11354]
+            validate_trusted_host_activity(
+                &res.metadata.name,
+                matches!(&res.spec.spec, ActivityV2Spec::AgentLoop(spec) if spec.trusted_host_execution),
+            )?;
             Ok(ActivityAsset {
                 name: res.metadata.name,
                 spec: res.spec,

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -11,7 +11,7 @@ use orbit_agent::{
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
 use orbit_types::policy::UNRESTRICTED_FS_PROFILE;
-use orbit_types::workflow::activity_job::{AgentLoopSpec, V2AuditEventKind};
+use orbit_types::workflow::activity_job::{AgentLoopSpec, TrustedHostAdmission, V2AuditEventKind};
 use serde_json::Value;
 
 use crate::context::{ProvenanceEnv, provenance_env};
@@ -31,8 +31,8 @@ use super::envelope::{
 };
 use super::inspection::SourceInspection;
 use super::spawn::{
-    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic, orbit_tool_env,
-    prepare_sandbox_for_dispatch, resolve_provider_launcher,
+    PreparedSandbox, linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic,
+    orbit_tool_env, prepare_sandbox_for_dispatch, resolve_provider_launcher,
 };
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
@@ -47,17 +47,46 @@ const RESPONSE_DIAGNOSTIC_LIMIT_CHARS: usize = 1024;
 pub fn run_cli_backend(
     host: &dyn RuntimeHost,
     spec: &AgentLoopSpec,
+    activity_name: &str,
     run_id: &str,
     audit: Arc<V2AuditWriter>,
     input: &Value,
     fs_profile: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
     let provider = spec.provider.as_str().to_string();
+    // [ORB-11354] Trusted host execution needs both halves: the built-in
+    // activity declares the mode, and the operator's canonical submission
+    // stamps the admission into the run input. A declaration without an
+    // admission is a broken admission path, not a request for a sandboxed run,
+    // so it fails closed here rather than silently downgrading.
+    let trusted_host = if spec.trusted_host_execution {
+        Some(TrustedHostAdmission::from_run_input(input).ok_or_else(|| {
+            DispatchError::CliInvocationPermanent(format!(
+                "activity `{activity_name}` declares trusted host execution but this run carries                  no operator admission; submit it through the governed `orbit.agent.invoke`                  operation"
+            ))
+        })?)
+    } else {
+        None
+    };
     let mut cli_executor = host.resolve_cli_executor(&provider)?;
-    let timeout_seconds = if spec.wall_clock_timeout_seconds == 0 {
+    let declared_timeout_seconds = if spec.wall_clock_timeout_seconds == 0 {
         DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS
     } else {
         spec.wall_clock_timeout_seconds
+    };
+    // [ORB-11354] An operator submitting an exploration says how long they are
+    // willing to wait. The request can only *shorten* the activity's declared
+    // bound, so the asset stays the ceiling and no run input can extend an
+    // unsandboxed subprocess past it. Only the admitted mode reads the key;
+    // every other activity keeps its declared timeout verbatim.
+    let timeout_seconds = match trusted_host.as_ref().and(
+        input
+            .get("timeout_seconds")
+            .and_then(Value::as_u64)
+            .filter(|seconds| *seconds > 0),
+    ) {
+        Some(requested) => requested.min(declared_timeout_seconds),
+        None => declared_timeout_seconds,
     };
     let wall_clock_timeout = Duration::from_secs(timeout_seconds);
 
@@ -115,10 +144,19 @@ pub fn run_cli_backend(
     let subprocess_cwd_string = subprocess_cwd
         .as_ref()
         .map(|path| path.display().to_string());
-    let resolved_sandbox =
-        host.resolve_executor_sandbox(&provider, fs_profile, subprocess_cwd.as_deref())?;
-    let prepared_sandbox = prepare_sandbox_for_dispatch(resolved_sandbox.as_ref())
-        .map_err(|error| DispatchError::CliInvocationPermanent(error.message))?;
+    // An admitted trusted-host invocation skips sandbox resolution entirely
+    // rather than resolving one and discarding it: there is no profile to
+    // compile, no wrapper to probe, and no inner-sandbox flag to neutralize.
+    // Every other activity, including every managed task job, is unchanged.
+    let resolved_sandbox = match &trusted_host {
+        Some(_) => None,
+        None => host.resolve_executor_sandbox(&provider, fs_profile, subprocess_cwd.as_deref())?,
+    };
+    let prepared_sandbox = match &trusted_host {
+        Some(_) => PreparedSandbox::none_trusted_host(),
+        None => prepare_sandbox_for_dispatch(resolved_sandbox.as_ref())
+            .map_err(|error| DispatchError::CliInvocationPermanent(error.message))?,
+    };
     let sandbox = prepared_sandbox.effective;
 
     let envelope_json = cli_agent_envelope_json(
@@ -222,6 +260,29 @@ pub fn run_cli_backend(
         tool_ctx.workspace_root.as_deref(),
         declared_worktree_pair.as_ref(),
     )?;
+
+    if let Some(admission) = &trusted_host {
+        tracing::warn!(
+            target: "orbit.trusted_host",
+            run_id,
+            activity_name,
+            provider = %provider,
+            authorized_by = %admission.authorized_by,
+            authorizer_provenance = %admission.authorizer_provenance,
+            workspace_path = %admission.workspace_path,
+            cwd = %admission.cwd,
+            "starting an operator-admitted provider subprocess outside the executor sandbox"
+        );
+        audit.emit_lossy(V2AuditEventKind::TrustedHostExecutionAdmitted {
+            provider: provider.clone(),
+            activity_name: activity_name.to_string(),
+            authorized_by: admission.authorized_by.clone(),
+            authorizer_provenance: admission.authorizer_provenance.clone(),
+            authorized_at: admission.authorized_at.clone(),
+            workspace_path: admission.workspace_path.clone(),
+            cwd: admission.cwd.clone(),
+        });
+    }
 
     let model_redacted = agent.model_name().map(|m| redaction.apply_str(m));
     audit.emit_lossy(V2AuditEventKind::CliInvocationStarted {

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -53,6 +53,28 @@ pub(crate) struct PreparedSandbox<'a> {
     pub(crate) metadata: SandboxDispatchMetadata,
 }
 
+impl PreparedSandbox<'_> {
+    /// The deliberate absence of a sandbox for an operator-admitted
+    /// trusted-host invocation [ORB-11354].
+    ///
+    /// Named distinctly from the `None` arm of
+    /// [`prepare_sandbox_for_dispatch`] — which means "this executor declares
+    /// no sandbox" — so a run trail distinguishes an executor that never had
+    /// one from an operator who explicitly removed it.
+    pub(crate) fn none_trusted_host() -> Self {
+        Self {
+            effective: None,
+            metadata: SandboxDispatchMetadata {
+                backend: Some("none-trusted-host".to_string()),
+                trusted_wrapper: None,
+                probe_outcome: None,
+                write_enforcement: "write_unrestricted_trusted_host".to_string(),
+                read_enforcement: "read_unrestricted_trusted_host".to_string(),
+            },
+        }
+    }
+}
+
 /// Resolve availability before provider argv construction. This ordering is
 /// security-sensitive: provider-native flags are neutralized only when the
 /// outer wrapper is actually usable, while an explicitly allowed bare

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
@@ -260,6 +260,7 @@ printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
     let outcome = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "inspection-test",
         audit.clone(),
         &json!({"workspace_path": repo.path(), "inspection_revision": revision}),
@@ -331,6 +332,7 @@ fn dispatch_failure_and_timeout_release_the_inspection_checkout() {
         let result = run_cli_backend(
             &host,
             &test_agent_loop_spec(Duration::from_secs(1)),
+            "test_activity",
             "inspection-failure",
             audit.clone(),
             &json!({"workspace_path": repo.path(), "inspection_revision": revision}),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
@@ -9,3 +9,4 @@ mod orchestrator_macos;
 mod spawn;
 mod supervisor;
 pub(in crate::activity_job::cli_runner) mod test_support;
+mod trusted_host;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -65,8 +65,16 @@ fn run_cli_backend_finished_audit_event_keeps_stdout_stderr_blob_refs() {
         "task_id": "TAUDIT"
     });
 
-    let outcome = run_cli_backend(&host, &spec, "job-audit", audit.clone(), &input, None)
-        .expect("run succeeds");
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "test_activity",
+        "job-audit",
+        audit.clone(),
+        &input,
+        None,
+    )
+    .expect("run succeeds");
 
     assert!(outcome.success);
     let stdout = "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}\n";
@@ -131,6 +139,7 @@ fn run_cli_backend_does_not_project_codex_command_output_as_response() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-codex-command-only",
         audit,
         &serde_json::json!({"prompt": "read the fixture"}),
@@ -179,6 +188,7 @@ fn run_cli_backend_projects_codex_final_answer_and_keeps_raw_trace() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-codex-final-answer",
         audit,
         &serde_json::json!({"prompt": "read then answer"}),
@@ -233,6 +243,7 @@ fn run_cli_backend_rejects_an_invalid_terminal_codex_answer() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-codex-invalid-terminal-answer",
         audit,
         &serde_json::json!({"prompt": "read then answer"}),
@@ -274,6 +285,7 @@ fn run_cli_backend_copilot_cancellation_cannot_project_tool_arguments() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-copilot-cancelled",
         audit,
         &serde_json::json!({"prompt": "cancel after tool request"}),
@@ -320,6 +332,7 @@ fn run_cli_backend_projects_copilot_final_answer_and_keeps_usage() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-copilot-final-answer",
         audit,
         &serde_json::json!({"prompt": "use a tool then answer"}),
@@ -381,6 +394,7 @@ fn run_cli_backend_rejects_copilot_terminal_failed_or_timeout_after_commentary()
         let outcome = run_cli_backend(
             &host,
             &spec,
+            "test_activity",
             &format!("job-copilot-{status}-after-commentary"),
             audit,
             &serde_json::json!({"prompt": "answer after progress"}),
@@ -424,6 +438,7 @@ fn run_cli_backend_rejects_copilot_trailing_terminal_prose() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-copilot-trailing-prose",
         audit,
         &serde_json::json!({"prompt": "answer then add courtesy prose"}),
@@ -492,6 +507,7 @@ fn run_cli_backend_projects_prose_prefixed_claude_envelope_result() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-claude-envelope-result",
         audit,
         &serde_json::json!({"prompt": "triage failed runs"}),
@@ -542,6 +558,7 @@ fn run_cli_backend_rejects_schema_invalid_success_envelope() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-invalid-envelope",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -594,6 +611,7 @@ fn run_cli_backend_fails_artifact_activity_when_exit_zero_carries_no_envelope() 
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-artifact-response",
         audit,
         &serde_json::json!({"task_id": "ORB-10230"}),
@@ -642,6 +660,7 @@ fn run_cli_backend_keeps_advisory_activity_successful_without_an_envelope() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-advisory-response",
         audit,
         &serde_json::json!({"prompt": "group the backlog"}),
@@ -685,6 +704,7 @@ fn run_cli_backend_keeps_opted_out_declared_failure_advisory() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-advisory-declared-failure",
         audit,
         &serde_json::json!({"prompt": "emit decorative status"}),
@@ -725,6 +745,7 @@ fn run_cli_backend_completion_gate_demotes_a_declared_failure_envelope() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-declared-failure",
         audit,
         &serde_json::json!({"task_id": "ORB-10449"}),
@@ -769,6 +790,7 @@ fn run_cli_backend_completion_gate_demotes_a_declared_timeout_envelope() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-declared-timeout",
         audit,
         &serde_json::json!({"task_id": "ORB-10733"}),
@@ -810,6 +832,7 @@ fn run_cli_backend_completion_check_tolerates_interleaved_non_json_stdout() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-interleaved-stdout",
         audit,
         &serde_json::json!({"task_id": "ORB-10449"}),
@@ -868,6 +891,7 @@ fn run_cli_backend_fails_on_the_jrun_20260726_1758_5_stall_shape() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "jrun-20260726-1758-5",
         audit,
         &serde_json::json!({"task_id": "ORB-10436"}),
@@ -908,6 +932,7 @@ fn run_cli_backend_requires_envelope_when_activity_opts_in() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-required-response",
         audit,
         &serde_json::json!({"prompt": "return structured data"}),
@@ -959,6 +984,7 @@ printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{
         run_cli_backend(
             &host,
             &spec,
+            "test_activity",
             "job-verbose-output",
             audit,
             &serde_json::json!({"prompt": "perform verbose work"}),
@@ -1046,6 +1072,7 @@ fn run_cli_backend_bounds_stdout_text_preview_and_keeps_envelope_status_from_ful
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-stdout-preview",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -1107,6 +1134,7 @@ printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-stdout-redaction",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -1165,6 +1193,7 @@ fn run_cli_backend_redacts_live_env_values_in_stored_blobs() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-cli-blob-redaction",
         audit,
         &serde_json::json!({"prompt": format!("provider stdin contains {secret}")}),
@@ -1228,8 +1257,16 @@ fn run_cli_backend_returns_error_when_declared_workspace_path_missing() {
         "task_id": "TMISSING"
     });
 
-    let err = run_cli_backend(&host, &spec, "job-missing-cwd", audit.clone(), &input, None)
-        .expect_err("missing declared workspace should fail");
+    let err = run_cli_backend(
+        &host,
+        &spec,
+        "test_activity",
+        "job-missing-cwd",
+        audit.clone(),
+        &input,
+        None,
+    )
+    .expect_err("missing declared workspace should fail");
     match err {
         DispatchError::CliInvocationFailed(message) => {
             assert!(
@@ -1288,6 +1325,7 @@ fn run_cli_backend_records_resolved_cwd_in_started_event() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-cwd-audit",
         audit.clone(),
         &serde_json::json!({ "prompt": "do it", "task_id": "TCWD" }),
@@ -1359,6 +1397,7 @@ fn linux_bwrap_failed_invocation_names_ungranted_write_path_and_deny() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-linux-write-denial",
         audit,
         &serde_json::json!({"prompt": "attempt the write"}),
@@ -1470,6 +1509,7 @@ fn linux_bwrap_exit_zero_without_an_envelope_still_names_the_denied_write() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-linux-exit-zero-denial",
         audit,
         &serde_json::json!({"prompt": "attempt the write"}),
@@ -1540,6 +1580,7 @@ fn run_cli_backend_emits_provider_pid_between_the_started_and_finished_events() 
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-pid-audit",
         audit.clone(),
         &serde_json::json!({ "prompt": "do it" }),
@@ -1632,6 +1673,7 @@ printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{}},"error":null
             let outcome = run_cli_backend(
                 &host,
                 &spec,
+                "test_activity",
                 &format!("run-{pipeline}-{provider}"),
                 audit,
                 &input,
@@ -1686,6 +1728,7 @@ printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{}},"error":null
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "run-epic-finisher",
         test_audit("run-epic-finisher", "codex"),
         &input,
@@ -1727,6 +1770,7 @@ fn epic_orchestrator_declared_root_mismatch_fails_before_provider_spawn() {
     let error = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "run-epic-finisher-mismatch",
         audit.clone(),
         &input,
@@ -1764,6 +1808,7 @@ fn declared_repo_root_mismatch_fails_typed_before_provider_spawn() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-repo-root-mismatch",
         audit.clone(),
         &input,
@@ -1783,6 +1828,7 @@ fn declared_repo_root_mismatch_fails_typed_before_provider_spawn() {
     let null_error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-null-repo-root",
         audit.clone(),
         &input,
@@ -1824,6 +1870,7 @@ fn declared_non_git_checkout_fails_typed_before_provider_spawn() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-non-git-pair",
         audit.clone(),
         &input,
@@ -1860,6 +1907,7 @@ fn declared_checkout_from_different_repository_fails_before_provider_spawn() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-different-common-dir",
         audit.clone(),
         &worktree_input(&assigned_fixture, "ORB-DIFFERENT-REPO"),
@@ -1900,6 +1948,7 @@ fn declared_checkout_cannot_collapse_to_registered_primary() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-primary-collapse",
         audit.clone(),
         &input,
@@ -1936,6 +1985,7 @@ fn unchanged_pre_dirty_primary_does_not_block_valid_worktree_implementation() {
     let outcome = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-pre-dirty-primary",
         test_audit("run-pre-dirty-primary", "codex"),
         &worktree_input(&fixture, "ORB-PRE-DIRTY"),
@@ -1971,6 +2021,7 @@ fn concurrent_primary_fast_forward_does_not_block_disjoint_worktree_changes() {
     let outcome = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-concurrent-fast-forward",
         test_audit("run-concurrent-fast-forward", "codex"),
         &worktree_input(&fixture, "ORB-CONCURRENT-FF"),
@@ -2219,6 +2270,7 @@ fn failed_auto_task_refresh_preserves_primary_and_audits_definition_and_run() {
     let outcome = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-auto-task-refresh-failed",
         audit.clone(),
         &worktree_input(&fixture, "ORB-AUTO-TASK-REFRESH"),
@@ -2278,6 +2330,7 @@ fn unchanged_pre_dirty_path_is_excluded_from_escape_diagnostic() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-predirty-attribution",
         test_audit("run-predirty-attribution", "codex"),
         &worktree_input(&fixture, "ORB-PREDIRTY-ATTRIBUTION"),
@@ -2322,6 +2375,7 @@ fn staged_only_primary_delta_reports_its_path_and_index_identity() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-staged-only-attribution",
         test_audit("run-staged-only-attribution", "codex"),
         &worktree_input(&fixture, "ORB-STAGED-ONLY"),
@@ -2365,6 +2419,7 @@ fn primary_escape_is_typed_non_retryable_and_preserves_both_checkouts() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec_for("claude", Duration::from_secs(5)),
+        "test_activity",
         "run-deliberate-escape",
         audit.clone(),
         &worktree_input(&fixture, "ORB-ESCAPE"),
@@ -2426,6 +2481,7 @@ fn primary_content_mutation_is_typed_even_when_assigned_content_also_changes() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-ambiguous-integrity",
         test_audit("run-ambiguous-integrity", "codex"),
         &worktree_input(&fixture, "ORB-AMBIGUOUS"),
@@ -2585,6 +2641,7 @@ fn assigned_history_divergence_is_a_typed_worktree_content_conflict() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-assigned-history-change",
         test_audit("run-assigned-history-change", "codex"),
         &worktree_input(&fixture, "ORB-ASSIGNED-HISTORY"),
@@ -2632,6 +2689,7 @@ fn non_fast_forward_primary_move_remains_a_typed_drift_failure() {
     let error = run_cli_backend(
         &host,
         &test_agent_loop_spec(Duration::from_secs(5)),
+        "test_activity",
         "run-primary-reset",
         test_audit("run-primary-reset", "codex"),
         &worktree_input(&fixture, "ORB-PRIMARY-RESET"),
@@ -2923,6 +2981,7 @@ fn primary_escape_is_checked_after_nonzero_exit_and_timeout() {
         let error = run_cli_backend(
             &host,
             &test_agent_loop_spec(timeout),
+            "test_activity",
             &run_id,
             test_audit(&run_id, "codex"),
             &worktree_input(&fixture, &task_id),
@@ -3351,6 +3410,7 @@ fn run_cli_backend_passes_provider_config_to_codex_runtime_args() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-config",
         audit.clone(),
         &serde_json::json!({ "prompt": "do it" }),
@@ -3426,6 +3486,7 @@ fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-model",
         audit.clone(),
         &serde_json::json!({"prompt": "hi"}),
@@ -3504,6 +3565,7 @@ fi
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-identity-env",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -3559,6 +3621,7 @@ fi
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-telemetry",
         audit,
         &serde_json::json!({"prompt": "hi", "task_id": "ORB-10342"}),
@@ -3619,6 +3682,7 @@ fi
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-env-allowlist",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -3676,6 +3740,7 @@ fi
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-orbit-root",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -3778,6 +3843,7 @@ printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"identity":"ok"
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-registry-root",
         audit.clone(),
         &serde_json::json!({"prompt": "hi", "task_id": "ORB-10980"}),
@@ -3923,6 +3989,7 @@ fn run_cli_backend_demotes_success_when_envelope_reports_failed_despite_exit_zer
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-success-demote",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -3967,6 +4034,7 @@ fn run_cli_backend_keeps_success_when_envelope_reports_success() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-success-keep",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -4014,6 +4082,7 @@ fn single_crew_drives_exact_model_to_agent() {
     let _ = run_cli_backend(
         &host_i,
         &spec_i_run,
+        "test_activity",
         "job-crew-impl",
         audit_i.clone(),
         &input_i,
@@ -4080,6 +4149,7 @@ fn run_cli_backend_redacts_token_shaped_argv_in_audit() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-argv-redaction",
         audit,
         &serde_json::json!({"prompt": "hi"}),
@@ -4129,6 +4199,7 @@ fn run_cli_backend_passes_derived_antigravity_print_timeout() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-agy-print-timeout",
         audit,
         &serde_json::json!({"prompt": "do it"}),
@@ -4191,6 +4262,7 @@ fn run_cli_backend_surfaces_antigravity_timeout_terminal_error_when_stderr_empty
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-agy-timeout-error",
         audit,
         &serde_json::json!({"prompt": "do it"}),
@@ -4253,6 +4325,7 @@ fn run_cli_backend_names_the_terminal_reason_on_an_exit_zero_error_ending() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-max-turns",
         audit,
         &serde_json::json!({"task_id": "ORB-10746"}),
@@ -4296,6 +4369,7 @@ fn run_cli_backend_reports_a_missing_json_schema_flag_as_a_capability_failure() 
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-missing-flag",
         audit,
         &serde_json::json!({"task_id": "ORB-10746"}),
@@ -4351,6 +4425,7 @@ fn run_cli_backend_reports_a_rejected_schema_from_the_response_wrapper() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-rejected-schema",
         audit,
         &serde_json::json!({"task_id": "ORB-10746"}),
@@ -4424,6 +4499,7 @@ fn run_cli_backend_accepts_a_structured_output_envelope_from_a_tool_using_run() 
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-structured-output",
         audit,
         &serde_json::json!({"task_id": "ORB-10734"}),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
@@ -53,6 +53,7 @@ fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
         let outcome = run_cli_backend(
             &host,
             &spec,
+            "test_activity",
             "job-sandbox-shape",
             audit.clone(),
             &serde_json::json!({"prompt": "hi"}),
@@ -129,6 +130,7 @@ fn run_cli_backend_pins_codex_sandbox_under_outer_wrapper() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-codex-pin",
         audit.clone(),
         &serde_json::json!({"prompt": "hi"}),
@@ -204,6 +206,7 @@ fn run_cli_backend_drops_gemini_sandbox_flag_under_outer_wrapper() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-gemini-drop",
         audit.clone(),
         &serde_json::json!({"prompt": "hi"}),
@@ -272,6 +275,7 @@ fn run_cli_backend_drops_grok_sandbox_flag_under_outer_wrapper() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-grok-drop",
         audit.clone(),
         &serde_json::json!({"prompt": "hi"}),
@@ -340,6 +344,7 @@ fn run_cli_backend_leaves_claude_argv_suffix_unchanged_under_sandbox() {
     let outcome = run_cli_backend(
         &host,
         &spec,
+        "test_activity",
         "job-claude-passthrough",
         audit.clone(),
         &serde_json::json!({"prompt": "hi"}),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -382,6 +382,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec(
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 
@@ -410,6 +411,7 @@ pub(in crate::activity_job::cli_runner) fn test_agent_loop_spec_for(
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -1,0 +1,307 @@
+//! Trusted-host execution admission at the CLI-runner boundary [ORB-11354].
+//!
+//! The mode has two halves — the activity declares it, the operator's
+//! submission admits it — and these tests pin each combination, because only
+//! one of them may run an unsandboxed process.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use orbit_agent::loop_engine::audit::AuditSink;
+use orbit_types::workflow::activity_job::{
+    TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission, V2AuditEventKind,
+};
+use tempfile::tempdir;
+
+use super::super::super::audit_writer::V2AuditWriter;
+use super::super::super::dispatcher::DispatchError;
+use super::super::run_cli_backend;
+use super::test_support::{RecordingSink, TestHost, test_agent_loop_spec, write_executable};
+
+fn admission() -> TrustedHostAdmission {
+    TrustedHostAdmission {
+        authorized_by: "human".to_string(),
+        authorizer_provenance: "interactive-terminal".to_string(),
+        authorized_at: "2026-09-06T00:00:00Z".to_string(),
+        workspace_path: "/checkout".to_string(),
+        cwd: "/checkout".to_string(),
+    }
+}
+
+fn admitted_input() -> serde_json::Value {
+    serde_json::json!({
+        "prompt": "why is this host slow",
+        TRUSTED_HOST_ADMISSION_KEY: serde_json::to_value(admission()).expect("encode admission"),
+    })
+}
+
+fn writer(run_id: &'static str) -> (Arc<V2AuditWriter>, Arc<RecordingSink>) {
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink.clone();
+    (
+        Arc::new(V2AuditWriter::new(run_id, "codex:gpt-5.5", sink_for_writer)),
+        sink,
+    )
+}
+
+fn echoing_provider(dir: &std::path::Path) -> String {
+    let script = dir.join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' \
+         '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"summary\":\"ok\"},\"error\":null}'\n",
+    );
+    script.display().to_string()
+}
+
+/// The admitted path: flag plus admission runs, and says so in the trail.
+#[test]
+fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(10));
+    spec.trusted_host_execution = true;
+    let (audit, _sink) = writer("job-trusted-ok");
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "agent_invoke",
+        "job-trusted-ok",
+        audit.clone(),
+        &admitted_input(),
+        None,
+    )
+    .expect("an admitted invocation runs");
+
+    assert!(outcome.success, "provider completed its envelope");
+
+    let events = audit.events_snapshot().expect("events snapshot");
+    let admitted = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::TrustedHostExecutionAdmitted {
+                activity_name,
+                authorized_by,
+                authorizer_provenance,
+                cwd,
+                ..
+            } => Some((
+                activity_name.clone(),
+                authorized_by.clone(),
+                authorizer_provenance.clone(),
+                cwd.clone(),
+            )),
+            _ => None,
+        })
+        .expect("an unsandboxed invocation must announce itself in the run trail");
+    assert_eq!(admitted.0, "agent_invoke");
+    assert_eq!(admitted.1, "human");
+    assert_eq!(admitted.2, "interactive-terminal");
+    assert_eq!(admitted.3, "/checkout");
+
+    // The absence of a sandbox is stated, not left to be inferred from a
+    // missing field, so a reader can tell it apart from an executor that never
+    // declared one.
+    let backend = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                sandbox_backend,
+                sandbox_write_enforcement,
+                ..
+            } => Some((sandbox_backend.clone(), sandbox_write_enforcement.clone())),
+            _ => None,
+        })
+        .expect("started event");
+    assert_eq!(backend.0.as_deref(), Some("none-trusted-host"));
+    assert_eq!(
+        backend.1.as_deref(),
+        Some("write_unrestricted_trusted_host")
+    );
+}
+
+/// The dangerous combination: the asset claims the mode, nothing admitted it.
+/// It must fail, not quietly run sandboxed — a silent downgrade would hide a
+/// broken admission path behind a confusing sandbox denial much later.
+#[test]
+fn a_declared_mode_without_an_admission_fails_closed() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(10));
+    spec.trusted_host_execution = true;
+    let (audit, _sink) = writer("job-trusted-unadmitted");
+
+    let error = run_cli_backend(
+        &host,
+        &spec,
+        "agent_invoke",
+        "job-trusted-unadmitted",
+        audit.clone(),
+        &serde_json::json!({ "prompt": "why" }),
+        None,
+    )
+    .expect_err("an unadmitted invocation must not run");
+
+    match error {
+        DispatchError::CliInvocationPermanent(message) => assert!(
+            message.contains("no operator admission"),
+            "the refusal must name the missing admission: {message}"
+        ),
+        other => panic!("expected a permanent refusal, got {other:?}"),
+    }
+    assert!(
+        audit
+            .events_snapshot()
+            .expect("events snapshot")
+            .iter()
+            .all(|event| !matches!(
+                event.kind,
+                V2AuditEventKind::CliInvocationStarted { .. }
+                    | V2AuditEventKind::TrustedHostExecutionAdmitted { .. }
+            )),
+        "nothing may be spawned before the admission check"
+    );
+}
+
+/// A malformed admission is not an admission.
+#[test]
+fn a_forged_admission_value_does_not_admit_the_mode() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(10));
+    spec.trusted_host_execution = true;
+    let (audit, _sink) = writer("job-trusted-forged");
+
+    let error = run_cli_backend(
+        &host,
+        &spec,
+        "agent_invoke",
+        "job-trusted-forged",
+        audit,
+        &serde_json::json!({ TRUSTED_HOST_ADMISSION_KEY: true }),
+        None,
+    )
+    .expect_err("a non-admission value must not admit the mode");
+    assert!(matches!(error, DispatchError::CliInvocationPermanent(_)));
+}
+
+/// The inverse: an admission riding on an activity that never declared the mode
+/// changes nothing. Ordinary managed activities keep their sandbox resolution.
+#[test]
+fn an_admission_alone_does_not_remove_an_ordinary_activitys_sandbox() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let spec = test_agent_loop_spec(Duration::from_secs(10));
+    assert!(!spec.trusted_host_execution);
+    let (audit, _sink) = writer("job-untrusted-with-admission");
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "agent_implement",
+        "job-untrusted-with-admission",
+        audit.clone(),
+        &admitted_input(),
+        None,
+    )
+    .expect("an ordinary activity still runs");
+    assert!(outcome.success);
+
+    let events = audit.events_snapshot().expect("events snapshot");
+    assert!(
+        events.iter().all(|event| !matches!(
+            event.kind,
+            V2AuditEventKind::TrustedHostExecutionAdmitted { .. }
+        )),
+        "an activity that did not declare the mode must not enter it"
+    );
+    // `TestHost` declares no sandbox, so the metadata here is the ordinary
+    // "this executor has none" shape rather than the trusted-host one.
+    let backend = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                sandbox_backend, ..
+            } => Some(sandbox_backend.clone()),
+            _ => None,
+        })
+        .expect("started event");
+    assert_eq!(backend, None);
+}
+
+/// An operator may shorten the activity's bound, never extend it.
+#[test]
+fn a_requested_timeout_can_only_shorten_the_declared_bound() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(60));
+    spec.trusted_host_execution = true;
+
+    for (requested, expected_ms) in [(30_u64, 30_000_u64), (600, 60_000)] {
+        let (audit, _sink) = writer("job-trusted-timeout");
+        let mut input = admitted_input();
+        input["timeout_seconds"] = serde_json::json!(requested);
+        run_cli_backend(
+            &host,
+            &spec,
+            "agent_invoke",
+            "job-trusted-timeout",
+            audit.clone(),
+            &input,
+            None,
+        )
+        .expect("run");
+        let observed = audit
+            .events_snapshot()
+            .expect("events snapshot")
+            .iter()
+            .find_map(|event| match &event.kind {
+                V2AuditEventKind::CliInvocationStarted {
+                    wall_clock_timeout_ms,
+                    ..
+                } => Some(*wall_clock_timeout_ms),
+                _ => None,
+            })
+            .expect("started event");
+        assert_eq!(
+            observed, expected_ms,
+            "requested {requested}s against a 60s declared bound"
+        );
+    }
+}
+
+/// A `timeout_seconds` in ordinary run input is inert: only the admitted mode
+/// reads it, so no activity's declared bound can be moved from run input.
+#[test]
+fn an_ordinary_activity_ignores_a_requested_timeout() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let spec = test_agent_loop_spec(Duration::from_secs(45));
+    let (audit, _sink) = writer("job-untrusted-timeout");
+
+    run_cli_backend(
+        &host,
+        &spec,
+        "agent_implement",
+        "job-untrusted-timeout",
+        audit.clone(),
+        &serde_json::json!({ "prompt": "x", "timeout_seconds": 1 }),
+        None,
+    )
+    .expect("run");
+
+    let observed = audit
+        .events_snapshot()
+        .expect("events snapshot")
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::CliInvocationStarted {
+                wall_clock_timeout_ms,
+                ..
+            } => Some(*wall_clock_timeout_ms),
+            _ => None,
+        })
+        .expect("started event");
+    assert_eq!(observed, 45_000);
+}

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -456,7 +456,7 @@ fn run_agent_loop_activity(
     input: &Value,
     fs_profile: Option<&str>,
 ) -> Result<DispatchOutcome, DispatchError> {
-    run_cli_backend(host, spec, run_id, audit, input, fs_profile)
+    run_cli_backend(host, spec, activity_name, run_id, audit, input, fs_profile)
         .map(|outcome| label_failure_with_step(activity_name, outcome))
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -791,6 +791,7 @@ fn recovery_agent_loop_spec(provider: Provider, model: Option<&str>) -> AgentLoo
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
@@ -293,6 +293,7 @@ fn agent_implement_shaped_step(id: &str, retry: Option<RetrySpec>) -> JobV2Step 
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     };
     JobV2Step {
         id: id.to_string(),

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -109,6 +109,7 @@ fn inline_agent_loop_spec() -> AgentLoopSpec {
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
+++ b/crates/orbit-engine/src/activity_job/tests/asset_loader.rs
@@ -114,3 +114,63 @@ fn load_activity_asset_accepts_explicit_empty_program_allowlist() {
 
     assert_eq!(asset.name, "deny_all_spawn");
 }
+
+/// [ORB-11354] The unsandboxed execution mode is legal on exactly one built-in
+/// activity name. Asset load is where that is enforced, because activity assets
+/// live in a workspace directory an operator can edit — a key in YAML must
+/// never be able to name a second activity into the mode.
+fn trusted_host_activity_yaml(name: &str) -> String {
+    format!(
+        r#"schemaVersion: 2
+kind: Activity
+metadata:
+  name: {name}
+spec:
+  type: agent_loop
+  trustedHostExecution: true
+  description: Test agent loop.
+  instruction: Test.
+  tools:
+    - orbit.task.show
+"#
+    )
+}
+
+#[test]
+fn load_activity_asset_accepts_trusted_host_execution_on_the_builtin_activity() {
+    let asset = load_activity_asset(&trusted_host_activity_yaml("agent_invoke"))
+        .expect("the built-in exploration activity declares the mode");
+
+    let orbit_types::workflow::activity_job::ActivityV2Spec::AgentLoop(spec) = asset.spec.spec
+    else {
+        panic!("expected an agent_loop activity");
+    };
+    assert!(spec.trusted_host_execution);
+}
+
+#[test]
+fn load_activity_asset_rejects_trusted_host_execution_on_any_other_activity() {
+    let error = load_activity_asset(&trusted_host_activity_yaml("agent_implement"))
+        .expect_err("no other activity may claim the mode");
+
+    assert!(
+        matches!(error, AssetLoadError::TrustedHostActivity(_)),
+        "expected a trusted-host refusal, got {error:?}"
+    );
+    assert!(error.to_string().contains("agent_implement"));
+}
+
+#[test]
+fn an_activity_that_omits_the_key_does_not_declare_the_mode() {
+    let asset = load_activity_asset(&agent_loop_activity_yaml(
+        "agent_implement",
+        "    - orbit.task.show\n",
+    ))
+    .expect("activity should load");
+
+    let orbit_types::workflow::activity_job::ActivityV2Spec::AgentLoop(spec) = asset.spec.spec
+    else {
+        panic!("expected an agent_loop activity");
+    };
+    assert!(!spec.trusted_host_execution);
+}

--- a/crates/orbit-engine/src/activity_job/tests/crew.rs
+++ b/crates/orbit-engine/src/activity_job/tests/crew.rs
@@ -22,6 +22,7 @@ fn inline_spec() -> AgentLoopSpec {
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1701,13 +1701,12 @@ fn bounded_repeated_sweeps_rotate_probes_without_starvation() {
             }),
         )
         .expect("collect");
-        let retired = evidence["truncation"]["retired_refs"]
+        evidence["truncation"]["retired_refs"]
             .as_array()
             .expect("retired_refs")
             .iter()
             .map(|r| r.as_str().unwrap().to_string())
-            .collect();
-        retired
+            .collect()
     };
 
     // Candidates in order of appearance in runs (newest run first: candidate-branch-3, 2, 1, 0)

--- a/crates/orbit-engine/tests/v2_cli_agent.rs
+++ b/crates/orbit-engine/tests/v2_cli_agent.rs
@@ -382,6 +382,7 @@ fn cli_agent_loop_spec(provider: Option<Provider>) -> AgentLoopSpec {
         require_response_envelope: false,
         require_completion_envelope: true,
         proc_allowed_programs: None,
+        trusted_host_execution: false,
     }
 }
 
@@ -462,6 +463,7 @@ fn synthetic_loop_session_job() -> JobV2 {
                 require_response_envelope: false,
                 require_completion_envelope: true,
                 proc_allowed_programs: None,
+                trusted_host_execution: false,
             }),
             activity_name: None,
             fs_profile: None,

--- a/crates/orbit-tools/src/builtin/orbit/agent.rs
+++ b/crates/orbit-tools/src/builtin/orbit/agent.rs
@@ -1,0 +1,100 @@
+//! Operator-only host agent invocation [ORB-11354].
+//!
+//! Submits one durable, asynchronous exploration run and returns its run ID.
+//! Everything that decides whether it may run lives below this file: the
+//! governed-operation chokepoint in
+//! `orbit_common::governance::authorization` gates the tool name, and
+//! `OrbitRuntime::admit_agent_invoke` is the canonical admission that also
+//! covers the CLI. This tool collects input and hands it over.
+//!
+//! The self-dispatch guard below mirrors `orbit.command.exec`: a managed run's
+//! leaf agent must not reach a surface whose entire purpose is to start a
+//! process outside the sandbox that run is executing inside. The capability
+//! chokepoint would refuse it anyway — a managed run resolves as an agent —
+//! but refusing by run scope first gives the leaf the reason rather than a
+//! capability message that reads like a misconfiguration.
+
+use orbit_common::OrbitError;
+use orbit_types::tool::{ToolParam, ToolSchema};
+use serde_json::Value;
+
+use crate::{OrbitBuiltinAction, Tool, ToolContext};
+
+pub struct OrbitAgentInvokeTool;
+
+impl Tool for OrbitAgentInvokeTool {
+    fn schema(&self) -> ToolSchema {
+        let mut parameters = vec![
+            ToolParam {
+                name: "prompt".to_string(),
+                description: "What to investigate. The invoked agent reports back; it makes no \
+                     Orbit task, lifecycle, commit, or pull-request change."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "cwd".to_string(),
+                description: "Absolute working directory the agent starts in. Must exist and be \
+                     inside this workspace's checkout; it is never inferred from the caller."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: true,
+            },
+            ToolParam {
+                name: "crew".to_string(),
+                description: "Configured crew selecting the provider, model, and reasoning \
+                     effort. Defaults to the workspace's default crew."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "timeout_seconds".to_string(),
+                description: "Wall-clock bound for the invocation. Defaults to 1800 and may not \
+                     exceed 7200."
+                    .to_string(),
+                param_type: "integer".to_string(),
+                required: false,
+            },
+            ToolParam {
+                name: "idempotency_key".to_string(),
+                description: "Retry handle. A resubmission carrying a key a recent submission \
+                     already used resolves that run instead of starting a second agent."
+                    .to_string(),
+                param_type: "string".to_string(),
+                required: false,
+            },
+        ];
+        parameters.extend(super::model_identity_params());
+        ToolSchema {
+            name: "orbit.agent.invoke".to_string(),
+            description:
+                "Submit an asynchronous agent invocation for exploration or debugging and return \
+                 its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as \
+                 the same OS user as Orbit, so it can reach anything that user can; it is \
+                 admitted per invocation and requires operator capability. Track it with \
+                 `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop \
+                 it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, \
+                 and dispatches nothing."
+                    .to_string(),
+            parameters,
+            builtin: true,
+        }
+    }
+
+    fn execute(&self, ctx: &ToolContext, input: Value) -> Result<Value, OrbitError> {
+        if ctx
+            .orbit_host
+            .as_ref()
+            .is_some_and(|host| host.task_scope().run_id.is_some())
+        {
+            return Err(OrbitError::CapabilityDenied(
+                "managed runs cannot invoke a host agent; a leaf agent admitting an unsandboxed \
+                 subprocess would step outside the sandbox its own run executes inside"
+                    .to_string(),
+            ));
+        }
+        super::execute_host_action(ctx, input, OrbitBuiltinAction::AgentInvoke)
+    }
+}

--- a/crates/orbit-tools/src/builtin/orbit/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod auto_task;
 pub mod command;
 pub mod docs;
@@ -72,6 +73,9 @@ pub fn register(registry: &mut ToolRegistry) {
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimAcquireTool);
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimReleaseTool);
     registry.register_inactive(workspace_claim::OrbitWorkspaceClaimShowTool);
+    // Agent invocation is workspace-scoped: the admission is made against the
+    // checkout that owns it, and Core is where that decision lives.
+    registry.register_mcp(agent::OrbitAgentInvokeTool, McpToolScope::WorkspaceRequired);
     // Command execution is workspace-scoped; Core retains its domain and claim
     // validation.
     registry.register_mcp(

--- a/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
+++ b/crates/orbit-tools/src/builtin/orbit/tests/authorization.rs
@@ -47,6 +47,10 @@ const GOVERNED_TOOL_PLACEMENT: &[(&str, Placement)] = &[
     // The operator MCP surface [ORB-10534, ORB-10711]: advertised so an
     // operator session can drive dispatch over MCP, governed so an agent
     // session holding only `agent` is refused.
+    // [ORB-11354] Advertised so an operator MCP session can start an
+    // exploration; governed to `operator` alone (never `runner`) so a managed
+    // run cannot admit a subprocess outside the sandbox it executes inside.
+    ("orbit.agent.invoke", Placement::Advertised),
     ("orbit.command.exec", Placement::Advertised),
     ("orbit.workflow.run.list", Placement::Advertised),
     ("orbit.workflow.run.resume", Placement::Advertised),

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -92,6 +92,7 @@ pub enum OrbitBuiltinAction {
     AutoTaskShow,
     AutoTaskUpdate,
     AutoTaskToggle,
+    AgentInvoke,
     CommandExec,
     DocsList,
     DocsShow,

--- a/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/activity_v2.rs
@@ -127,6 +127,16 @@ pub struct AgentLoopSpec {
     /// treats `None` as deny-all too. [ORB-10959]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proc_allowed_programs: Option<Vec<String>>,
+    /// Run this activity's provider subprocess directly on the host, outside
+    /// the executor's filesystem sandbox [ORB-11354].
+    ///
+    /// Legal only on the built-in
+    /// [`TRUSTED_HOST_ACTIVITY`](crate::workflow::activity_job::TRUSTED_HOST_ACTIVITY)
+    /// — asset load rejects it anywhere else — and inert without a per-invocation
+    /// operator admission in the run input. The flag names the mode; it never
+    /// grants it. See `crate::workflow::activity_job::trusted_host`.
+    #[serde(rename = "trustedHostExecution", default)]
+    pub trusted_host_execution: bool,
 }
 
 /// Accepted-but-inert value of the retired `backend:` key [ORB-10801].

--- a/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
+++ b/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
@@ -173,6 +173,28 @@ pub enum V2AuditEventKind {
         /// Compatibility projection of `effective_tools`.
         tools: Vec<String>,
     },
+    /// [ORB-11354] An operator-admitted provider subprocess is about to run
+    /// **outside** the executor's filesystem sandbox.
+    ///
+    /// Emitted immediately before the invocation starts, and only for the one
+    /// activity that may run this way, so the run trail names who authorized an
+    /// unsandboxed process and against which checkout — rather than leaving the
+    /// absence of a sandbox to be inferred from a missing field on
+    /// `cli.invocation.started`.
+    TrustedHostExecutionAdmitted {
+        provider: String,
+        activity_name: String,
+        /// Attribution label of the operator recorded in the run's admission.
+        authorized_by: String,
+        /// How the authorization chokepoint resolved that operator.
+        authorizer_provenance: String,
+        /// RFC 3339 timestamp the admission was stamped.
+        authorized_at: String,
+        /// Canonical checkout the invocation was admitted against.
+        workspace_path: String,
+        /// Canonical working directory of the provider subprocess.
+        cwd: String,
+    },
     /// §7.6 — CLI backend subprocess starting. Emitted after redaction has been
     /// applied to `argv`; the stdin blob is already written and hashed by the
     /// time this event fires.
@@ -263,6 +285,9 @@ impl V2AuditEventKind {
             V2AuditEventKind::ToolDenied { .. } => V2_EVENT_TYPE_TOOL_DENIED,
             V2AuditEventKind::ToolAllowlistHarnessDelegated { .. } => {
                 "tool_allowlist.harness_delegated"
+            }
+            V2AuditEventKind::TrustedHostExecutionAdmitted { .. } => {
+                "trusted_host.execution_admitted"
             }
             V2AuditEventKind::CliInvocationStarted { .. } => "cli.invocation.started",
             V2AuditEventKind::CliInvocationProcess { .. } => "cli.invocation.process",

--- a/crates/orbit-types/src/workflow/activity_job/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/mod.rs
@@ -10,6 +10,7 @@ pub mod job_v2;
 pub mod retired;
 pub mod schema_header;
 pub mod tool_allowlist;
+pub mod trusted_host;
 
 /// The single declaration of the deterministic action catalog. The generated
 /// typed actions make the core/engine ownership boundary exhaustive at compile
@@ -152,6 +153,11 @@ pub use tool_allowlist::{
     tool_allowed, validate_activity_tool_allowlist,
     validate_activity_tool_allowlist_against_registered_tools, validate_tool_allowlist,
     validate_tool_allowlist_against_registered_tools,
+};
+pub use trusted_host::{
+    TRUSTED_HOST_ACTIVITY, TRUSTED_HOST_ADMISSION_KEY, TrustedHostActivityError,
+    TrustedHostAdmission, run_input_declares_trusted_host, strip_trusted_host_admission,
+    validate_trusted_host_activity,
 };
 
 #[cfg(test)]

--- a/crates/orbit-types/src/workflow/activity_job/tests/mod.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/mod.rs
@@ -3,3 +3,4 @@ mod activity_v2;
 mod audit_envelope;
 mod job_v2;
 mod tool_allowlist;
+mod trusted_host;

--- a/crates/orbit-types/src/workflow/activity_job/tests/tool_allowlist.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/tool_allowlist.rs
@@ -184,6 +184,7 @@ fn agent_loop_activity(
             require_response_envelope: false,
             require_completion_envelope: true,
             proc_allowed_programs,
+            trusted_host_execution: false,
         }),
     }
 }

--- a/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
@@ -1,0 +1,76 @@
+use serde_json::json;
+
+use crate::workflow::activity_job::{
+    TRUSTED_HOST_ACTIVITY, TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission,
+    run_input_declares_trusted_host, strip_trusted_host_admission, validate_trusted_host_activity,
+};
+
+fn admission() -> TrustedHostAdmission {
+    TrustedHostAdmission {
+        authorized_by: "human".to_string(),
+        authorizer_provenance: "interactive-terminal".to_string(),
+        authorized_at: "2026-09-06T00:00:00Z".to_string(),
+        workspace_path: "/checkout".to_string(),
+        cwd: "/checkout/crates".to_string(),
+    }
+}
+
+#[test]
+fn only_the_builtin_activity_may_declare_trusted_host_execution() {
+    assert!(validate_trusted_host_activity(TRUSTED_HOST_ACTIVITY, true).is_ok());
+    let error = validate_trusted_host_activity("agent_implement", true)
+        .expect_err("a second activity must not be able to claim the mode");
+    assert_eq!(error.activity, "agent_implement");
+    assert!(
+        error.to_string().contains("admitted per invocation"),
+        "the refusal must say where the mode actually comes from: {error}"
+    );
+}
+
+#[test]
+fn an_activity_that_does_not_declare_the_mode_is_always_accepted() {
+    assert!(validate_trusted_host_activity("agent_implement", false).is_ok());
+    assert!(validate_trusted_host_activity(TRUSTED_HOST_ACTIVITY, false).is_ok());
+}
+
+#[test]
+fn an_admission_round_trips_through_run_input() {
+    let input = json!({
+        "prompt": "why",
+        TRUSTED_HOST_ADMISSION_KEY: serde_json::to_value(admission()).expect("encode"),
+    });
+    assert!(run_input_declares_trusted_host(&input));
+    assert_eq!(
+        TrustedHostAdmission::from_run_input(&input).expect("decode"),
+        admission()
+    );
+}
+
+#[test]
+fn a_malformed_admission_still_counts_as_declaring_the_reserved_key() {
+    // The submission guard and the engine ask different questions on purpose:
+    // a caller who supplies garbage under the reserved key is forging one and
+    // must be refused, while the engine must not treat garbage as an admission.
+    let input = json!({ TRUSTED_HOST_ADMISSION_KEY: "not-an-admission" });
+    assert!(run_input_declares_trusted_host(&input));
+    assert!(TrustedHostAdmission::from_run_input(&input).is_none());
+}
+
+#[test]
+fn ordinary_run_input_declares_nothing() {
+    let input = json!({ "task_ids": ["ORB-1"], "mode": "pr" });
+    assert!(!run_input_declares_trusted_host(&input));
+    assert!(TrustedHostAdmission::from_run_input(&input).is_none());
+}
+
+#[test]
+fn stripping_reports_whether_an_admission_was_present() {
+    let mut input = json!({
+        "prompt": "why",
+        TRUSTED_HOST_ADMISSION_KEY: serde_json::to_value(admission()).expect("encode"),
+    });
+    assert!(strip_trusted_host_admission(&mut input));
+    assert!(!run_input_declares_trusted_host(&input));
+    assert_eq!(input.get("prompt").and_then(|v| v.as_str()), Some("why"));
+    assert!(!strip_trusted_host_admission(&mut input));
+}

--- a/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
@@ -1,0 +1,125 @@
+//! The trusted-host execution contract [ORB-11354].
+//!
+//! Ordinary managed activities run their provider subprocess inside the
+//! executor's sandbox. Exactly one activity does not: the operator-only
+//! exploration invocation, which exists precisely to reach the host the way
+//! the operator's own shell would. This module owns the three facts that mode
+//! is made of, in the leaf crate both the engine and the application layer can
+//! read:
+//!
+//! 1. [`TRUSTED_HOST_ACTIVITY`] — the one activity name allowed to declare it.
+//! 2. [`TRUSTED_HOST_ADMISSION_KEY`] — the reserved run-input key that carries
+//!    an operator's admission to the worker.
+//! 3. [`TrustedHostAdmission`] — what that admission records.
+//!
+//! # This is a mode, not a privilege
+//!
+//! Trusted host execution removes Orbit's *filesystem sandbox* from one
+//! provider subprocess. It does not hand the child any Orbit capability: the
+//! child still runs with managed-run provenance, so it resolves as an agent at
+//! every capability chokepoint and cannot perform a governed operation. That is
+//! deliberate, and it is also not an isolation boundary — the subprocess runs
+//! as the same OS user as Orbit and can read and write anything that user can.
+//! The honest summary is in
+//! `crates/orbit-core/assets/skills/orbit/references/tool-surface.md`.
+//!
+//! # Why the flag alone is not enough
+//!
+//! Activity assets live in a workspace directory an operator can edit, so a
+//! YAML key can never be the admission by itself. The engine requires the flag
+//! *and* an admission stamped into the run input by the canonical governed
+//! submission, and the flag is legal only on [`TRUSTED_HOST_ACTIVITY`]. A
+//! definition that declares the flag without an admission fails closed rather
+//! than degrading to a sandboxed run, so a broken admission path is loud.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The one activity name permitted to declare `trustedHostExecution: true`.
+pub const TRUSTED_HOST_ACTIVITY: &str = "agent_invoke";
+
+/// Reserved run-input key carrying an operator's trusted-host admission.
+///
+/// Reserved means reserved: every ordinary submission path refuses input that
+/// contains it, so the key can only ever have been written by the canonical
+/// submission.
+pub const TRUSTED_HOST_ADMISSION_KEY: &str = "trusted_host_admission";
+
+/// One operator's admission of one trusted-host invocation.
+///
+/// Recorded rather than reduced to a boolean because the durable run record is
+/// the only place that can later answer "who authorized an unsandboxed process,
+/// against which checkout, from where".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustedHostAdmission {
+    /// Attribution label of the operator who authorized the invocation.
+    pub authorized_by: String,
+    /// How the authorization chokepoint resolved that operator
+    /// (`interactive-terminal`, `operator-override`, `session`).
+    pub authorizer_provenance: String,
+    /// RFC 3339 timestamp of the admission.
+    pub authorized_at: String,
+    /// Canonical workspace checkout the invocation was admitted against.
+    pub workspace_path: String,
+    /// Canonical working directory the provider subprocess starts in.
+    pub cwd: String,
+}
+
+impl TrustedHostAdmission {
+    /// Read an admission out of a run input, if one is present and well-formed.
+    ///
+    /// A malformed value reads as absent so the engine fails closed on it the
+    /// same way it fails closed on a missing one.
+    pub fn from_run_input(input: &Value) -> Option<Self> {
+        serde_json::from_value(input.get(TRUSTED_HOST_ADMISSION_KEY)?.clone()).ok()
+    }
+}
+
+/// Whether `input` carries the reserved admission key at all, well-formed or not.
+///
+/// Submission guards ask this rather than [`TrustedHostAdmission::from_run_input`]:
+/// a caller who supplies a *malformed* admission is still forging one, and must
+/// be refused rather than quietly stripped.
+pub fn run_input_declares_trusted_host(input: &Value) -> bool {
+    input
+        .as_object()
+        .is_some_and(|object| object.contains_key(TRUSTED_HOST_ADMISSION_KEY))
+}
+
+/// Remove the reserved admission key from a run input, returning whether one
+/// was present.
+///
+/// Used by replay, which re-runs a historical input under no new admission.
+pub fn strip_trusted_host_admission(input: &mut Value) -> bool {
+    input
+        .as_object_mut()
+        .is_some_and(|object| object.remove(TRUSTED_HOST_ADMISSION_KEY).is_some())
+}
+
+/// Refusal to load an asset that claims trusted-host execution it may not have.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "activity `{activity}` declares `trustedHostExecution: true`, which only the built-in \
+     `{TRUSTED_HOST_ACTIVITY}` activity may declare; an unsandboxed provider subprocess is \
+     admitted per invocation by an operator, never by an asset"
+)]
+pub struct TrustedHostActivityError {
+    /// Name of the offending activity asset.
+    pub activity: String,
+}
+
+/// Reject `trustedHostExecution` on any activity but [`TRUSTED_HOST_ACTIVITY`].
+///
+/// Called from asset load, so a hand-written or edited asset is refused before
+/// it can reach a dispatcher.
+pub fn validate_trusted_host_activity(
+    activity: &str,
+    declares_trusted_host: bool,
+) -> Result<(), TrustedHostActivityError> {
+    if declares_trusted_host && activity != TRUSTED_HOST_ACTIVITY {
+        return Err(TrustedHostActivityError {
+            activity: activity.to_string(),
+        });
+    }
+    Ok(())
+}

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -131,6 +131,36 @@ orbit run cancel <run_id>
 This terminalizes the run on demand. Do not cancel solely because a legitimate step has
 been `running` longer than expected.
 
+Cancellation is truthful about the race with completion: a run that reached a terminal
+state before the signal landed reports `already_terminal` and keeps its real outcome
+rather than being overwritten with `cancelled`.
+
+## Operator agent invocations
+
+A run of `agent_invoke_pipeline` is one operator invocation of an agent for exploration
+or debugging (`orbit run agent <prompt>`, or the `orbit.agent.invoke` tool). It is a
+single-step run with no worktree, no task ownership, and no delivery tail, so most of
+this runbook's task-recovery steps do not apply to one.
+
+Three differences matter when triaging one:
+
+- **It is unsandboxed by design.** The provider subprocess runs on the host as the same
+  operating-system user as Orbit, admitted per invocation by an operator. A sandbox
+  denial is never the explanation for one failing, and the admission is recorded as a
+  `trusted_host.execution_admitted` audit event naming the authorizing operator, the
+  workspace, and the working directory.
+- **Cancel it the ordinary way.** `orbit run cancel <run_id>` signals the owner process
+  (TERM then KILL) and terminates the process tree, exactly as for any other run.
+- **It cannot be resumed.** `orbit job resume` and `submit_resume_run` refuse a run that
+  carries an admission, because that admission covered one invocation and a resume would
+  reuse it without a new authorization. Submit a fresh invocation instead. `orbit job
+  replay` is likewise not a workaround: the replayed input carries no admission, so the
+  activity fails closed.
+
+Read the outcome with `orbit run show <run_id>` — its `Invocation:` line distinguishes a
+completed answer from a mid-turn stop, a timeout, and a cancellation — and
+`orbit run logs <run_id>` for the full captured output.
+
 ## Resume from checkpoints
 
 The v2 executor checkpoints every completed top-level step into

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -96,6 +96,32 @@ evidence. Treat `checkout_identity.state: incomplete`, `missing`, or
 - **Recovery failure:** the original step failed and `step_failure_recovery` also failed — report both, keep the original step as primary unless recovery caused additional damage.
 - **Parent orchestration failure:** a child run failed and a gate/auto/epic parent is still running or waiting — identify both run ids.
 
+## Operator Agent Invocations
+
+A run of `agent_invoke_pipeline` is not a delivery pipeline. It is one operator
+invocation of an agent for exploration or debugging, submitted with
+`orbit run agent` / `orbit_agent_invoke`, and it changes no task, branch, or
+pull request — so do not look for a worktree, a task lifecycle, or a delivery
+tail when triaging one.
+
+`orbit run show <RUN_ID>` prints an `Invocation:` line for these runs, and
+`--json` carries the same facts under `agent_invocation`:
+
+- `outcome` is the run's own state, never the provider's exit code.
+- `envelope_completed: false` on an otherwise-clean exit means the agent stopped
+  mid-turn: exit zero is not evidence the investigation succeeded.
+- `timed_out: true` means the wall-clock bound killed it — resubmit with a
+  longer `--timeout` (the maximum is 7200s) or a narrower prompt.
+- `summary` and the bounded preview are the answer; `orbit run logs <RUN_ID>`
+  has the complete captured output when the preview is truncated.
+
+These runs execute their provider subprocess outside the executor sandbox by
+explicit per-invocation operator admission, so a sandbox-denial diagnostic is
+never the explanation for one failing. The run trail records the admission as a
+`trusted_host.execution_admitted` audit event naming the authorizing operator
+and the working directory. They are deliberately **not resumable**: the
+admission covered one invocation, so submit a new one rather than resuming.
+
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.
 
 ## Check Task State

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -39,6 +39,7 @@ records in a second store merely to get past a connection error.
 | Observe/resume workflows | `orbit_workflow_run_show/list/resume` | `orbit run show/history/events/trace/logs/cancel`; job replay/resume |
 | Auto-tasks | `orbit_auto_task_list/mint` | Definition add/show/update/toggle are CLI operations; do not assume they are advertised over MCP |
 | Host commands | `orbit_command_exec` when advertised and authorized | Explicit argv and working directory, never a shell string |
+| Host agent invocation | `orbit_agent_invoke` when advertised and authorized | `orbit run agent <prompt>`; asynchronous, returns a run ID |
 | Setup and maintenance | Discover any server extensions; do not guess | config, doctor, semantic, docs, audit, GC, policy, skill, routine, sweep, job/activity catalogs, workspace role/sync/publication |
 
 Provider/gateway prefixes are transport wrappers around these names. A connected
@@ -51,6 +52,42 @@ integration. Governed workflow and command operations need operator authority;
 a managed worker cannot dispatch/resume another workflow or use operator command
 execution. An allowlisted tool still has to pass runtime policy, filesystem,
 subprocess, and external authentication checks.
+
+### Host agent invocation
+
+`orbit_agent_invoke` submits one asynchronous agent run for exploration or
+debugging and returns its run ID. It is the surface for a question that cannot
+be answered from inside a managed run's sandbox — why a host is behaving the
+way it is.
+
+Be clear-eyed about what it does. The invoked agent runs **outside Orbit's
+filesystem sandbox**, as the same operating-system user as Orbit, so it can read
+and write anything that user can. Withholding capabilities from the child is not
+an isolation boundary, and neither is the activity's declared program list: the
+provider harness owns its own shell tool. Treat an invocation the way you would
+treat running a command yourself on that machine.
+
+What it is not:
+
+- It is **not** a task, and it performs no task transition. It does not commit,
+  push, open or merge a pull request, or dispatch further work.
+- It is **not** available to a managed run or to a federated caller. Each
+  invocation is admitted separately by an operator present on the machine that
+  will run it, and the admission covers that invocation only.
+- It is **not** resumable. A resumed run would carry an admission nobody granted
+  now; submit a new invocation instead.
+
+Required arguments are the `prompt` and an absolute `cwd` inside the workspace's
+checkout. `crew` selects the provider/model, `timeout_seconds` bounds the run
+(default 1800, maximum 7200), and `idempotency_key` makes a resubmission resolve
+the run the first attempt created rather than starting a second agent.
+
+Track it with the ordinary run surfaces — `orbit_workflow_run_show`, or
+`orbit run show|logs|cancel <RUN_ID>`. `show` carries the invocation's outcome,
+whether it terminated its response envelope, a bounded preview of the answer,
+and a durable reference to the full captured output. A provider that exits zero
+without terminating its envelope stopped mid-turn: the run records `failed`, and
+the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 See [remote-access.md](setup/remote-access.md). Do not relaunch a server with

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its zero-input source snapshot uses the owning workspace's `[workflow] base_branch`; pass a non-empty `base_branch` run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |
@@ -74,6 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation operator admission, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.


### PR DESCRIPTION
## Task

[ORB-11354](https://orbit-cli.com/tasks/ORB-11354) — Add an operator-only agent invocation job for exploration and debugging

### Description

Daniel requested an agent_invoke bridge in Orbit for exploration/debugging: a subagent-like capability without managed sandbox restrictions, available only to operator callers. Implement one bounded vertical slice: orbit.agent.invoke (final naming follows registry conventions) submits a durable, asynchronous host-executed exploration job and returns its run ID. Reuse existing crew/model/effort configuration, provider invocation, process supervision, run persistence, output capture and canonical authorization rather than blocking command.exec or a second agent scheduler. Require explicit authoritative workspace and cwd, prompt, selected crew, bounded timeout, and defined submission retry/idempotency semantics. Integrate existing show/list and operator cancellation, with bounded result preview and durable raw output reference.

Read-only Astra audit and independent Linux source verification at 5530555cc4d75935465b7c4cdc533dca86951dbf found current seams: orbit-common governance/authorization.rs governs operator calls; orbit-tools builtin/orbit/command.rs:65-76 denies run-scoped command use; orbit-engine activity_job/cli_runner/orchestrator.rs:118-121 builds sandbox and :244-246 unconditionally marks managed provenance. Core runtime/command_exec.rs uses blocking process output, unsuitable for lifecycle. Existing job cancellation/process-group supervision should be reused. Refresh against latest landing before implementation, especially ORB-11348 projection changes. Search agent_invoke/subagent/exploration found no current duplicate; rejected legacy ORB-10500 concerned cross-workspace routing, not this feature.

Trusted host execution is an explicit server-controlled mode admitted only by a current operator and owning workspace authority. Ordinary activity/job inputs, resume, managed callers and federated routing cannot manufacture it. Preserve authorizing operator and child identity/provenance. Do not automatically mint a blanket operator grant for the child or loosen sandbox behavior for normal task delivery. Be candid in docs that an unsandboxed same-user process can access host resources; a missing child capability flag is not an OS isolation boundary. No implicit task lifecycle changes, PR/commit behavior, or recursive dispatch.

Hard complexity is justified by execution-mode admission, authority propagation, durable async lifecycle and cancellation races. Daniel's current session explicitly routes hard work to Astra and authorizes proactive feature delivery, overriding the older crew table; orchestrator is Sol. Use Luna task-pilot, dedicated worktree, focused deterministic integration tests and repository checks. Current code and explicit requirements govern, not historical ADRs.

### Acceptance Criteria

- Agent-only, run-scoped and unauthorized federated callers are rejected before durable submission or process creation; authorized operator submission records explicit workspace/cwd, authorizer and child provenance.
- Existing managed task jobs keep their sandbox and leaf restrictions. Arbitrary YAML/input/crew settings and resume paths cannot select trusted host mode without canonical operator admission.
- Successful provider completion, provider error, spawn failure, timeout and cancellation are distinguishable; process exit zero is not evidence that an investigation or task succeeded. Results/logs survive disconnect and show provides bounded preview plus durable output reference.
- Operator cancellation terminates the process tree using existing supervision and handles completion races truthfully. Submission retries cannot silently duplicate children; interruption/restart behavior is explicit and tested.
- CLI/MCP help and managed skill/runbook documentation explain usage, trusted host semantics, status/results/cancel, and no automatic task/PR mutation. Focused capability/provider/lifecycle tests, make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Delivered the operator-only agent invocation as one vertical slice on the existing job/run, dispatch, supervision and authorization seams. Refreshed against a467b43e4 (post ORB-11348): the runner's answer/trace separation is untouched — the projection reads `stdout_text`/`stdout_blob_ref` from the existing step output rather than re-parsing provider frames.

TRUSTED-HOST CONTRACT (orbit-types)
- New `workflow::activity_job::trusted_host`: canonical activity name `agent_invoke`, reserved run-input key `trusted_host_admission`, `TrustedHostAdmission {authorized_by, authorizer_provenance, authorized_at, workspace_path, cwd}`, and `validate_trusted_host_activity`.
- `AgentLoopSpec.trusted_host_execution` (`trustedHostExecution:`), default false. New `V2AuditEventKind::TrustedHostExecutionAdmitted`.

ADMISSION (two halves, both required)
- `load_activity_asset` rejects the flag on any activity but `agent_invoke`, so an edited/hand-written asset cannot name itself into the mode.
- `run_cli_backend` requires the flag AND a well-formed admission in the run input. Flag without admission is a permanent dispatch error — it fails closed rather than silently running sandboxed. Admitted invocations skip sandbox resolution entirely (`PreparedSandbox::none_trusted_host`, backend `none-trusted-host`) and emit the admission audit event; managed provenance is retained, so the child still resolves as an agent and gets no operator grant. Every other activity's sandbox path is byte-identical.
- Only the admitted mode reads `timeout_seconds` from run input, and it may only shorten the asset's declared bound.

CANONICAL OPERATOR ADMISSION
- `orbit.agent.invoke` added to `GOVERNED_OPERATIONS`, `Operator` only — deliberately not `Runner`, since a run that could admit itself would be a sandbox escape wearing an authorization.
- `OrbitRuntime::admit_agent_invoke` (runtime/authorization.rs) resolves the process envelope layered with session grants, refuses any caller carrying a destination-side remote grant, and returns the provenance recorded on the admission. It runs before any validation, so a refused caller creates no run record and no process.
- `ToolSessionContext` is now carried on `RuntimeOrbitToolHost` and passed through `dispatch::execute` (grouped into a `ToolCaller` struct to keep the arity within lint budget), because this is the one handler whose decision depends on who is calling.

FORGERY / RESTART CLOSURE
- `submit_persisted_pipeline_run_with_admission` — the single path every detached submission funnels through — refuses caller input containing the reserved key; only `submit_trusted_host_pipeline_run` sets `trusted_host: true`. Foreground `run_job_v2_from_yaml_with_retry_source` gets the same refusal. Replay strips the key (activity then fails closed). Resume is refused outright with a "submit a new invocation" message.

SUBMISSION AND SURFACES
- `application/job/agent_invoke.rs`: validates non-empty prompt, requires an absolute existing `cwd` canonicalized and contained inside the workspace checkout, canonical crew, timeout default 1800 / max 7200 (refused, not clamped). `idempotency_key` resolves a prior run over a bounded recent-run window (same shape as the in-flight ship guard) instead of starting a second agent.
- Assets `agent_invoke.yaml` + `agent_invoke_pipeline.yaml` seeded through the existing default lists. `require_completion_envelope: true`, so exit 0 without a terminating envelope is a failed run.
- `orbit.agent.invoke` tool (MCP, workspace-scoped) with a run-scope self-dispatch guard mirroring `orbit.command.exec`; `orbit run agent <prompt>` CLI. `agent_invoke_result` projection (distinguishable outcome, envelope-completion flag, timed_out, summary, 4 KiB preview, `stdout_blob_ref`) added to the shared run projection and `orbit.workflow.run.show|list`, plus an `Invocation:` line in `orbit run show`. Cancellation/list reuse the existing surfaces unchanged (`orbit run cancel` already reports `already_terminal` on the completion race).

DOCS: tool-surface.md (candid that an unsandboxed same-user process reaches host resources and that a withheld child capability is not an OS boundary; no task/PR mutation), run-debugging.md, workflows.md, docs/runbooks/stuck-job-runs.md. Plugin skill mirror resynced via scripts/sync-plugin-skills.sh.

TESTS: 17 core admission/validation/forgery/idempotency/projection tests, 6 engine trusted-host dispatch tests, 3 asset-load tests, 6 types contract tests, and the governed-tool placement guardrail row.

VALIDATION: `make ci-fast` and `make ci-lint` pass. `cargo test --workspace` passes except `orbit-cli::mcp_roundtrip::process_metadata_does_not_supply_a_replayable_key_bound_identity`, which self-reports "requires an unrestricted runner where setgid is enabled and a mapped supplementary group is available" — a runner-capability denial, pre-existing and unrelated; unrestricted CI can arbitrate it.

FLAGGED, OUT OF THE ORIGINAL SELECTOR SET
- `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` regenerated because a new tool is advertised. Per RELEASING.md this is a BREAKING MCP schema change and the release must be called breaking.
- The local toolchain (1.96.0) is newer than whatever last gated these files, so `make ci-fast`/`ci-lint` failed at HEAD on pre-existing drift unrelated to this task. Fixed minimally so the required gates could run: `cargo fmt --all` reformatted `orbit-engine/src/executor/automation/ci/{collect.rs,tests/collect.rs}`, plus two one-line lint fixes (`needless_borrow` in orbit-tools/src/builtin/github/mod.rs, `let_and_return` in that ci tests file). All behavior-preserving; selectors appended.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11354-6a9ccf69`
- Behind base: 0
- Ahead of base: 1