### PR TITLE
[qa-sweep] mcp_roundtrip Linux security regression hard-fails instead of skipping in restricted sandboxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ env:
   # line-tables-only (deps included) — 50–70% smaller target/.
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_TEST_DEBUG: line-tables-only
+  # [ORB-11390] The protected SSH process-metadata regression may self-skip in
+  # restricted local/agent sandboxes, but ubuntu-latest must exercise it.
+  ORBIT_REQUIRE_PROTECTED_SSH_REGRESSION: "1"
   NEXTEST_VERSION: 0.9.136
   NEXTEST_LINUX_SHA256: a098eed56f2dd88c7fdca1e554a6b99fa1ffbd2a7a1c41b865700112981f6f52
   CARGO_DENY_VERSION: 0.19.9

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -28,6 +28,8 @@ use tempfile::{TempDir, tempdir};
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(target_os = "linux")]
 const EXEC_BUSY_RETRY_WINDOW: Duration = Duration::from_secs(2);
+#[cfg(target_os = "linux")]
+const REQUIRE_PROTECTED_SSH_REGRESSION_ENV: &str = "ORBIT_REQUIRE_PROTECTED_SSH_REGRESSION";
 
 /// Path of the checked-in `tools/list` snapshot, relative to the crate root.
 const SNAPSHOT_RELATIVE_PATH: &str = "tests/snapshots/mcp_tools_list.json";
@@ -1053,27 +1055,73 @@ fn a_fresh_test_launcher_waits_for_a_writer_to_close() {
 /// expose no mapped supplementary group cannot exercise the kernel boundary;
 /// those hosts leave the Linux deployment test to unrestricted CI.
 #[cfg(target_os = "linux")]
-fn install_test_ssh_launcher(workspace: &McpWorkspace) -> Option<PathBuf> {
-    use std::os::unix::fs::PermissionsExt;
+#[derive(Debug)]
+enum ProtectedSshRegressionUnavailable {
+    NoNewPrivileges,
+    NoMappedSupplementaryGroup,
+    GroupOwnershipDenied(std::io::Error),
+}
 
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
-    if status.lines().any(|line| line == "NoNewPrivs:\t1") {
-        return None;
+#[cfg(target_os = "linux")]
+impl std::fmt::Display for ProtectedSshRegressionUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoNewPrivileges => formatter
+                .write_str("NoNewPrivs is enabled, so Linux will ignore the launcher's setgid bit"),
+            Self::NoMappedSupplementaryGroup => formatter
+                .write_str("no mapped supplementary group differs from the process's real group"),
+            Self::GroupOwnershipDenied(error) => write!(
+                formatter,
+                "the runner denied changing the owned launcher to a supplementary group: {error}"
+            ),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_test_ssh_launcher(
+    workspace: &McpWorkspace,
+) -> Result<PathBuf, ProtectedSshRegressionUnavailable> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let status = std::fs::read_to_string("/proc/self/status")
+        .expect("read Linux process status for the setgid capability probe");
+    let no_new_privileges = status
+        .lines()
+        .find_map(|line| line.strip_prefix("NoNewPrivs:"))
+        .and_then(|value| value.trim().parse::<u8>().ok())
+        .expect("Linux process status must report NoNewPrivs as an integer");
+    if no_new_privileges == 1 {
+        return Err(ProtectedSshRegressionUnavailable::NoNewPrivileges);
     }
     // Safety: the first call queries the required length; the second writes
     // exactly that many gid_t entries into the allocated vector.
     let group_count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
-    if group_count <= 0 {
-        return None;
+    assert!(
+        group_count >= 0,
+        "getgroups length query failed: {}",
+        std::io::Error::last_os_error()
+    );
+    if group_count == 0 {
+        return Err(ProtectedSshRegressionUnavailable::NoMappedSupplementaryGroup);
     }
     let mut groups = vec![0 as libc::gid_t; group_count as usize];
     let read = unsafe { libc::getgroups(group_count, groups.as_mut_ptr()) };
-    if read != group_count {
-        return None;
-    }
+    assert!(
+        read >= 0,
+        "getgroups failed: {}",
+        std::io::Error::last_os_error()
+    );
+    assert_eq!(
+        read, group_count,
+        "getgroups returned an unstable group count"
+    );
     // Safety: getgid only reads the process's real group credential.
     let real_group = unsafe { libc::getgid() };
-    let launcher_group = groups.into_iter().find(|group| *group != real_group)?;
+    let launcher_group = groups
+        .into_iter()
+        .find(|group| *group != real_group)
+        .ok_or(ProtectedSshRegressionUnavailable::NoMappedSupplementaryGroup)?;
     let launcher = workspace.home.join("orbit-mcp-ssh-launcher");
     std::fs::copy(env!("CARGO_BIN_EXE_orbit"), &launcher).expect("copy tested Orbit launcher");
     let path = std::ffi::CString::new(launcher.as_os_str().as_encoded_bytes())
@@ -1081,11 +1129,28 @@ fn install_test_ssh_launcher(workspace: &McpWorkspace) -> Option<PathBuf> {
     // Safety: the path is a live NUL-terminated filesystem path; -1 preserves
     // the owner and the selected gid is one of this process's groups.
     if unsafe { libc::chown(path.as_ptr(), !0 as libc::uid_t, launcher_group) } != 0 {
-        return None;
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EPERM) {
+            return Err(ProtectedSshRegressionUnavailable::GroupOwnershipDenied(
+                error,
+            ));
+        }
+        panic!("change test launcher group failed: {error}");
     }
     std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o2555))
         .expect("protect test SSH launcher");
-    Some(launcher)
+    let metadata = std::fs::metadata(&launcher).expect("inspect protected test SSH launcher");
+    assert_eq!(
+        metadata.gid(),
+        launcher_group,
+        "the protected test launcher must retain the selected supplementary group"
+    );
+    assert_eq!(
+        metadata.mode() & 0o7777,
+        0o2555,
+        "the protected test launcher must retain its setgid mode"
+    );
+    Ok(launcher)
 }
 
 /// Use the production Tier 2 issuer and renderer to recover the complete
@@ -1093,7 +1158,9 @@ fn install_test_ssh_launcher(workspace: &McpWorkspace) -> Option<PathBuf> {
 /// additionally verifies `/etc/passwd`, which an unprivileged test cannot
 /// change; the launch and acceptance path below are otherwise the shipped one.
 #[cfg(target_os = "linux")]
-fn generated_forced_command(workspace: &McpWorkspace) -> Option<GeneratedForcedCommand> {
+fn try_generated_forced_command(
+    workspace: &McpWorkspace,
+) -> Result<GeneratedForcedCommand, ProtectedSshRegressionUnavailable> {
     let launcher = install_test_ssh_launcher(workspace)?;
     let key = workspace.home.join("caller.pub");
     std::fs::write(&key, format!("{CALLER_PUBLIC_KEY}\n")).expect("write caller public key");
@@ -1123,7 +1190,7 @@ fn generated_forced_command(workspace: &McpWorkspace) -> Option<GeneratedForcedC
         .split_once("\",command=\"")
         .and_then(|(_, line)| line.split_once("\",").map(|(command, _)| command))
         .expect("a forced command in the authorized_keys line");
-    Some(GeneratedForcedCommand {
+    Ok(GeneratedForcedCommand {
         argv: forced_command
             .split_ascii_whitespace()
             .map(ToOwned::to_owned)
@@ -1131,6 +1198,11 @@ fn generated_forced_command(workspace: &McpWorkspace) -> Option<GeneratedForcedC
         forced_command: forced_command.to_string(),
         acceptance_token,
     })
+}
+
+#[cfg(target_os = "linux")]
+fn generated_forced_command(workspace: &McpWorkspace) -> Option<GeneratedForcedCommand> {
+    try_generated_forced_command(workspace).ok()
 }
 
 /// [ORB-11184] Setup must reject the ordinary binary before it rotates the
@@ -1256,6 +1328,7 @@ ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
 /// copied public argv still cannot reconstruct a key-bound session.
 #[cfg(target_os = "linux")]
 #[test]
+#[allow(clippy::print_stdout)]
 fn process_metadata_does_not_supply_a_replayable_key_bound_identity() {
     let workspace = McpWorkspace::init();
     write_callers(
@@ -1269,10 +1342,21 @@ ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
 "#
         ),
     );
-    let generated = generated_forced_command(&workspace).expect(
-        "the Linux security regression requires an unrestricted runner where setgid is enabled \
-         and a mapped supplementary group is available",
-    );
+    let generated = match try_generated_forced_command(&workspace) {
+        Ok(generated) => generated,
+        Err(reason) => {
+            assert!(
+                std::env::var_os(REQUIRE_PROTECTED_SSH_REGRESSION_ENV).is_none(),
+                "the protected SSH process-metadata regression is required on this runner but \
+                 cannot execute: {reason}"
+            );
+            println!(
+                "skipping protected SSH process-metadata regression: {reason}; \
+                 unrestricted CI requires this test to execute"
+            );
+            return;
+        }
+    };
     let mut legitimate = workspace.serve_with_generated_command(&generated);
 
     let stop = workspace.home.join("stop-proc-scanner");


### PR DESCRIPTION
## Task

[ORB-11390](https://orbit-cli.com/tasks/ORB-11390) — [qa-sweep] mcp_roundtrip Linux security regression hard-fails instead of skipping in restricted sandboxes

### Description

Found by post-merge QA sweep ORB-11377 while running the repository's prescribed validation at integration revision `932d7000b`.

## Failure

```
$ cargo test --workspace
...
---- process_metadata_does_not_supply_a_replayable_key_bound_identity stdout ----
thread 'process_metadata_does_not_supply_a_replayable_key_bound_identity' (58109) panicked at crates/orbit-cli/tests/mcp_roundtrip.rs:1272:58:
the Linux security regression requires an unrestricted runner where setgid is enabled and a mapped supplementary group is available

test result: FAILED. 46 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.33s
error: test failed, to rerun pass `-p orbit-cli --test mcp_roundtrip`
```

Rerun in isolation:

```
$ cargo test -p orbit-cli --test mcp_roundtrip process_metadata_does_not_supply_a_replayable_key_bound_identity
test result: FAILED. 0 passed; 1 failed; ...
```

The panic comes from the `.expect(...)` on `generated_forced_command(&workspace)` at `crates/orbit-cli/tests/mcp_roundtrip.rs:1272`, added by ORB-11184 (`f73739e55`). The message text states the precondition explicitly, so the test already knows it is environment-dependent — but it asserts the precondition with `expect`, which turns an unavailable capability into a test failure rather than a skip.

## Environment evidence

- Host: dk-server-1, Linux 6.8.0-138-generic, x86_64.
- Runner: Orbit agent-executor sandbox (this task's own managed run). `setgid` is not enabled and no mapped supplementary group is available in that sandbox.
- The test is `#[cfg(target_os = "linux")]`, so it is compiled and run here; there is no `ignore` or capability probe guarding it.

## Scope

- **Validation impact: yes.** `cargo test --workspace` — the `test` target of the repository `Makefile` and the suite `make ci` runs via `scripts/ci-guardrails.sh` — cannot complete inside the agent-executor sandbox. This is the only blocker of that suite at this revision aside from the already-filed ORB-11381 snapshot drift; with both present, `cargo test --workspace` exits 101 and every later crate's tests are skipped, so the sandbox cannot be used to validate any change against the full suite.
- **Production impact: none.** This does not demonstrate a product defect. The same test passes on GitHub Actions Linux runners — see ORB-11340's captured CI log, where `process_metadata_does_not_supply_a_replayable_key_bound_identity ... ok` after running for over 60 seconds. The security property under test is unaffected; only its harness precondition is non-portable.

Distinct from ORB-11381 (`mcp_serve_tools_list_matches_production_snapshot` snapshot drift from ORB-11330), which is the other failure in the same test binary at this revision and is a real repository-owned defect.

## Suggested direction

Probe the required capability and skip with a recorded reason instead of panicking, matching the precedent set by ORB-10835 (`Make fd-launch regression portable and require QA to task breaking tests`). A skip must stay visible — the point of ORB-11184's coverage is that it runs on unrestricted CI — so gate on a probe plus an env opt-out that CI does not set, rather than deleting or weakening the assertion.

### Acceptance Criteria

- `cargo test --workspace` completes in a restricted sandbox where setgid and a mapped supplementary group are unavailable, without this test failing.
- The test still executes and asserts the security property on an unrestricted runner such as GitHub Actions Linux.
- The skip is visible in test output with the reason, not silently ignored.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the broad `Option` capability probe with a typed Linux precondition result. Only verified `NoNewPrivs`, missing mapped supplementary group, or EPERM changing an owned launcher to that group are skippable; `/proc`, `getgroups`, launcher copy/mode, authorization rendering, and downstream security failures still fail loudly.
- The process-metadata regression now prints the exact skip reason in captured test output and returns in restricted sandboxes.
- Added `ORBIT_REQUIRE_PROTECTED_SSH_REGRESSION=1` to GitHub Actions so ubuntu-latest refuses the skip and must execute the security assertions. Added `.github/workflows/ci.yml` to context because this CI enforcement was required by the post-filing security refinement.
Validation:
- PASS: focused regression with `--exact --nocapture`; sandbox skip was visible as `NoNewPrivs is enabled...`.
- PASS (expected failure contract): the same focused command with `ORBIT_REQUIRE_PROTECTED_SSH_REGRESSION=1` exited 101 and named the unavailable precondition, proving CI cannot silently skip.
- PASS: `cargo clippy -p orbit-cli --test mcp_roundtrip -- -D warnings`.
- PASS: formatting and `git diff --check`.
- `cargo test --workspace` compiled and ran the changed mcp_roundtrip binary: all 48 tests passed, including this regression; the wider command later exited 101 on pre-existing `output_goldens::plain_and_json_forms_match_their_goldens` drift outside this task.
- `make ci-fast` reached and failed on pre-existing mirrored Orbit skill drift in `plugin/skills/orbit/references/workflows.md`; `make ci-lint` reached and failed on pre-existing `clippy::let_and_return` in `crates/orbit-engine/src/executor/automation/ci/tests/collect.rs:1710`. Neither file is modified here; focused gates pass.
Assessment: The portability fix is narrow and preserves the ORB-11184 security coverage by failing closed on setup/configuration regressions and by requiring actual execution in unrestricted Linux CI. No friction record was warranted; the unrelated baseline failures were direct and already outside the scoped diff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11390-6a9cd830`
- Behind base: 0
- Ahead of base: 1