### PR TITLE
[qa-sweep] Dashboard refuses to start when any one registered workspace is missing .orbit/config.yaml

### DIFF
--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -1301,3 +1301,54 @@ fn malformed_refresh_emits_credential_safe_diagnostic() {
     assert_eq!(state.entries().len(), 1);
     assert_eq!(state.entries()[0].id, "alpha");
 }
+
+/// A broken registered checkout must not prevent the dashboard from starting
+/// for its healthy peers. Its identity is never accepted from the registry:
+/// without a readable config it remains listed but unavailable, and the
+/// operator receives a diagnostic naming the affected checkout.
+#[tokio::test]
+async fn registry_startup_skips_unresolvable_checkout_and_serves_healthy_workspace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    let (_alpha_orbit, alpha_repo) = seed_workspace(&global_root, tmp.path(), "alpha");
+    let (beta_orbit, beta_repo) = seed_workspace(&global_root, tmp.path(), "beta");
+    std::fs::remove_file(beta_orbit.join("config.yaml")).expect("remove beta identity");
+    write_registry(
+        &global_root,
+        &[("alpha", &alpha_repo), ("beta", &beta_repo)],
+    );
+
+    let buf = SharedBuf::default();
+    let subscriber = Registry::default().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(buf.clone()),
+    );
+    let state = tracing::subscriber::with_default(subscriber, || registry_state(&global_root));
+
+    assert_eq!(route_status(&state, "alpha").await, StatusCode::OK);
+    assert_eq!(route_status(&state, "beta").await, StatusCode::BAD_REQUEST);
+
+    let response = router()
+        .with_state(state)
+        .oneshot(get("/workspaces"))
+        .await
+        .expect("response");
+    let listed = body_json(response).await;
+    let beta = listed
+        .as_array()
+        .expect("workspace array")
+        .iter()
+        .find(|workspace| workspace["id"] == json!("beta"))
+        .expect("broken workspace remains visible");
+    assert_eq!(beta["status"], json!("invalid"));
+
+    let logged = String::from_utf8(buf.0.lock().expect("buffer lock").clone()).expect("utf8");
+    assert!(
+        logged.contains("registered workspace is unavailable")
+            && logged.contains("beta/.orbit")
+            && logged.contains("workspace config is missing"),
+        "startup must identify the skipped checkout for operators, got {logged:?}"
+    );
+}

--- a/crates/orbit-web/src/state.rs
+++ b/crates/orbit-web/src/state.rs
@@ -29,7 +29,7 @@
 //! concurrent add/remove/rebind is observed as one coherent old-or-new view —
 //! never old metadata spliced onto a newer runtime.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -64,8 +64,9 @@ pub(crate) type PrePublishHook = Arc<dyn Fn(&str) + Send + Sync>;
 /// `orbit_dir` is the workspace's `.orbit` directory — the value passed to
 /// [`RegisteredRuntimeFactory::open_resolved_checkout`] as the workspace root. Active
 /// entries carry the complete runtime binding resolved from the logical
-/// workspace and local checkout. Inactive (stale-path) entries keep no binding:
-/// they are listed but never built.
+/// workspace and local checkout. Inactive entries — whether their checkout path
+/// is stale or its identity cannot be read — keep no binding: they are listed
+/// but never built.
 #[derive(Clone, Debug)]
 pub(crate) struct WsEntry {
     pub(crate) id: String,
@@ -102,6 +103,29 @@ pub(crate) struct RegistrySource {
     root_override: Option<PathBuf>,
     /// Process cwd captured at startup, for default re-selection.
     cwd: Option<PathBuf>,
+    /// Per-checkout failures already reported to operators. A refresh happens at
+    /// every request boundary, so retaining this set avoids emitting the same
+    /// diagnostic for every request while allowing a repaired-and-broken-again
+    /// checkout to be reported anew.
+    reported_unavailable: Mutex<HashSet<UnavailableCheckout>>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct UnavailableCheckout {
+    workspace: String,
+    checkout: PathBuf,
+    error: String,
+}
+
+impl UnavailableCheckout {
+    fn warn(&self) {
+        tracing::warn!(
+            workspace = %self.workspace,
+            checkout = %self.checkout.display(),
+            error = %self.error,
+            "registered workspace is unavailable; dashboard will continue serving healthy workspaces"
+        );
+    }
 }
 
 impl RegistrySource {
@@ -114,40 +138,73 @@ impl RegistrySource {
             registry_path,
             root_override,
             cwd,
+            reported_unavailable: Mutex::new(HashSet::new()),
         }
     }
 
     /// Reload the authoritative registry into a fresh (generation-less) snapshot
     /// view. Stale-path workspaces are marked inactive (never deleted) via
-    /// `validate_workspaces`. The caller stamps the generation at publication.
+    /// `validate_workspaces`; active checkouts whose identity cannot be resolved
+    /// are likewise excluded after an operator-visible warning. The caller stamps
+    /// the generation at publication.
     fn load(&self) -> Result<SnapshotData, OrbitError> {
         let mut registry = workspace_registry::load_registry_from(&self.registry_path)?;
         workspace_registry::validate_workspaces(&mut registry);
-        let default_workspace = crate::default_workspace_selection(
-            &registry,
-            self.root_override.as_deref(),
-            self.cwd.as_deref(),
-        );
-        let entries = workspace_registry::local_workspaces(&registry)
+        let mut unavailable = HashSet::new();
+        let entries: Vec<WsEntry> = workspace_registry::local_workspaces(&registry)
             .map(|(workspace, checkout)| {
-                let active = workspace.status == WorkspaceStatus::Active;
-                let binding = active
+                let binding = (workspace.status == WorkspaceStatus::Active)
                     .then(|| workspace_runtime_binding(workspace, checkout))
-                    .transpose()?;
-                Ok(WsEntry {
+                    .and_then(|result| match result {
+                        Ok(binding) => Some(binding),
+                        Err(error) => {
+                            unavailable.insert(UnavailableCheckout {
+                                workspace: workspace.id.clone(),
+                                checkout: checkout.orbit_dir.clone(),
+                                error: error.to_string(),
+                            });
+                            None
+                        }
+                    });
+                let active = binding.is_some();
+                WsEntry {
                     id: workspace.id.clone(),
                     name: workspace.name.clone(),
                     repo_root: checkout.repo_root.clone(),
                     orbit_dir: checkout.orbit_dir.clone(),
                     binding,
                     active,
-                })
+                }
             })
-            .collect::<Result<Vec<_>, OrbitError>>()?;
+            .collect();
+        self.report_unavailable(unavailable);
+        let default_workspace = crate::default_workspace_selection(
+            &registry,
+            self.root_override.as_deref(),
+            self.cwd.as_deref(),
+        )
+        .filter(|id| entries.iter().any(|entry| entry.id == *id && entry.active));
         Ok(SnapshotData {
             entries,
             default_workspace,
         })
+    }
+
+    fn report_unavailable(&self, unavailable: HashSet<UnavailableCheckout>) {
+        let new_failures = {
+            let mut reported = self
+                .reported_unavailable
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            reported.retain(|failure| unavailable.contains(failure));
+            unavailable
+                .into_iter()
+                .filter(|failure| reported.insert(failure.clone()))
+                .collect::<Vec<_>>()
+        };
+        for failure in new_failures {
+            failure.warn();
+        }
     }
 }
 
@@ -437,7 +494,9 @@ impl DashboardState {
     /// workspace init/remove` and binding changes become visible without a
     /// restart. The initial load is eager — a malformed registry at startup is
     /// fatal (matching the pre-refresh behavior), whereas a later malformed
-    /// refresh retains the last valid snapshot.
+    /// refresh retains the last valid snapshot. An individual checkout with an
+    /// unreadable identity is instead listed inactive so it cannot take down
+    /// healthy workspaces.
     pub(crate) fn from_registry(
         global_root: PathBuf,
         source: RegistrySource,
@@ -688,7 +747,7 @@ impl WsRejection {
     fn inactive(id: &str) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,
-            message: format!("workspace '{id}' is inactive (its path no longer exists)"),
+            message: format!("workspace '{id}' is unavailable"),
         }
     }
 


### PR DESCRIPTION
## Task

[ORB-11386](https://orbit-cli.com/tasks/ORB-11386) — [qa-sweep] Dashboard refuses to start when any one registered workspace is missing .orbit/config.yaml

### Description

Found by post-merge QA sweep ORB-11377 at integration revision `932d7000b` (covering `abdbe02a9..932d7000b`, including PR1411/ORB-11330). **Not a regression from those commits** — reproduced identically on the ORB-11357 QA baseline `abdbe02a9` and on the installed release binary `orbit 0.18.0` (`~/.orbit/bin/orbit`).

## Defect

`orbit web serve` serves every registered workspace (global mode is the only mode). Startup resolves each registered checkout fail-closed, so a **single** workspace whose checkout is missing `.orbit/config.yaml` aborts the process before it binds a port. The dashboard is then unavailable for **every** healthy workspace, not just the broken one. `orbit workspace list` and ordinary task commands keep working against the same registry, so nothing else signals the outage.

## Observed production window (dk-server-1)

While this sweep ran, `ws_orbit-research` was registered `active` in `~/.orbit/workspaces.json` but its checkout had no `.orbit/config.yaml`. Every dashboard start failed:

```
$ orbit web serve --port 8897 --no-open
error: invalid input: workspace config is missing: ~/workspace/constellation/codebases/orbit-research/.orbit/config.yaml (expected key `workspace_id`)
```

The window closed on its own at `2026-09-06T02:29:13Z` when that checkout's `config.yaml` appeared; a later `orbit web serve` returned `HTTP 200`. So the real-host exposure is transient, but it is a full dashboard outage while it lasts, and any permanently-broken or hand-edited checkout makes it permanent.

## Deterministic reproduction (isolated, no host state touched)

```sh
rm -rf /tmp/wsbug && mkdir -p /tmp/wsbug/home /tmp/wsbug/a /tmp/wsbug/b
run() { env -i HOME=/tmp/wsbug/home PATH="$PATH" USER="$USER" TERM=dumb orbit "$@"; }
run init --non-interactive --host-name wsbug --task-prefix WSB
for d in a b; do (cd /tmp/wsbug/$d && git init -q -b main . \
  && git config user.email q@x.i && git config user.name q \
  && echo x > f && git add -A && git commit -qm init); done
(cd /tmp/wsbug/a && run workspace init)
(cd /tmp/wsbug/b && run workspace init)

# Healthy: dashboard starts.
env -i HOME=/tmp/wsbug/home PATH="$PATH" USER="$USER" TERM=dumb orbit web serve --port 8895 --no-open &
sleep 8; curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8895/   # => 200

# Break exactly one workspace.
rm -f /tmp/wsbug/b/.orbit/config.yaml
env -i HOME=/tmp/wsbug/home PATH="$PATH" USER="$USER" TERM=dumb orbit web serve --port 8894 --no-open &
sleep 8; curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8894/   # => 000
```

Second start exits 1 with:

```
error: invalid input: workspace config is missing: /tmp/wsbug/b/.orbit/config.yaml (expected key `workspace_id`)
```

while `orbit workspace list` still lists both `a` and `b` normally.

## Scope

- **Production impact:** yes. A shared operator surface is taken down by one unrelated workspace, with an error that names only the broken path and gives no remediation or skip option.
- **Validation impact:** none. `make ci-fast`, `make ci-lint` and the workspace test suite are unaffected by this.

## Suggested direction

Degrade per workspace instead of failing the process: skip (or surface as a load error, alongside the existing `load_errors` channel the auto-tasks API already exposes) any registered checkout that cannot be resolved, and keep serving the rest. The error text raised at `crates/orbit-store/src/driver/file/workspace_binding.rs:27` is the fail-closed point; the enumeration that calls it during `orbit web serve` startup is what should tolerate a partial registry.

Related, filed separately from this sweep: `orbit web serve` also ignores an explicit `--root`, which is why this cannot be isolated with `--root` and forces the `HOME` override used above.

### Acceptance Criteria

- `orbit web serve` starts and serves healthy workspaces when a registered checkout is missing or has an unreadable `.orbit/config.yaml`.
- The unresolvable workspace is reported through an operator-visible diagnostic rather than aborting startup.
- A regression test covers a registry containing one healthy and one unresolvable checkout.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Registry-backed dashboard snapshots now isolate per-checkout runtime-binding failures: an unreadable `.orbit/config.yaml` leaves only that logical workspace unavailable, never accepts its unverified identity, and keeps healthy workspaces servable.
- Unavailable-checkout diagnostics identify the logical workspace, checkout path, and binding error; repeated request refreshes are deduplicated until the checkout recovers. Default selection excludes unavailable entries, so it never silently routes to another workspace.
- Added a regression test with one healthy and one config-less registered checkout, asserting startup succeeds, the healthy API routes, the broken entry remains invalid, and the warning is operator-visible.
Assessment: scoped implementation preserves malformed-registry fail-closed/keep-last-valid behavior while degrading only independent checkout-resolution failures.
Validation:
- Passed: `cargo fmt --check`; focused regression `cargo test -p orbit-web registry_startup_skips_unresolvable_checkout_and_serves_healthy_workspace`; `cargo clippy -p orbit-web --all-targets -- -D warnings`; previously ran `cargo test -p orbit-web`.
- Repository-wide gates could not complete due unrelated baseline failures: `make ci-fast` reports pre-existing drift between `crates/orbit-core/assets/skills/orbit/references/workflows.md` and `plugin/skills/orbit/references/workflows.md`; `make ci-lint` fails on pre-existing `clippy::let_and_return` in `crates/orbit-engine/src/executor/automation/ci/tests/collect.rs:1710`.
- Cleanup: generated `target/` could not be moved to trash because `~/.local/share/Trash` is read-only; it remains the only ignored generated artifact.
Friction checkpoint: no record filed; the validation failures were immediately attributable to unrelated baseline files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11386-6a9cd7f4`
- Behind base: 0
- Ahead of base: 1