### PR TITLE
Catch initialized dirty landing checkouts before expensive local implementation

### DIFF
--- a/.orbit/resources/jobs/task_local_pipeline.yaml
+++ b/.orbit/resources/jobs/task_local_pipeline.yaml
@@ -24,6 +24,7 @@ spec:
     base_branch: main
     base_sync: remote
     landing_branch: ""
+    landing_mode: local
     terminal_status: review
     # `review` (default) ends successful tasks at review. `done` is explicit
     # per-invocation operator authorization to finish delivery.
@@ -46,6 +47,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         base: "{{ input.base_branch }}"
         base_sync: "{{ input.base_sync }}"
+        landing_mode: "{{ input.landing_mode }}"
 
     - id: implement_bundle
       loop:

--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -71,6 +71,9 @@ pub struct WorkspaceInitArgs {
     pub force: bool,
 }
 
+pub(crate) const ONBOARDING_FINALIZE_GUIDANCE: &str =
+    "review and commit generated definitions (.gitignore, .orbit/auto_tasks, .orbit/routines) before local workflows (Orbit does not auto-commit or discard operator changes)";
+
 impl WorkspaceInitArgs {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
         let cwd = std::env::current_dir().map_err(|e| OrbitError::Io(e.to_string()))?;
@@ -87,6 +90,7 @@ impl WorkspaceInitArgs {
         println!("  id:        {}", init_result.id);
         println!("  root:      {}", init_result.root.display());
         println!("  orbit_dir: {}", init_result.orbit_dir.display());
+        println!("  onboarding: {ONBOARDING_FINALIZE_GUIDANCE}");
 
         if let Some(start) = task_id_start {
             let outcome =

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -10,7 +10,9 @@ use orbit_types::workspace::{
 
 use crate::tests::env_isolation::EnvGuard;
 
-use super::super::init::{WorkspaceInitArgs, canonical_workspace_id};
+use super::super::init::{
+    ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id,
+};
 use super::super::list::{format_workspace_list, workspace_list_json};
 use super::super::role::CliCheckoutRole;
 use super::super::show::format_workspace_show;
@@ -1786,4 +1788,63 @@ fn nameless_tmp_workspace_registers_only_in_isolated_registry() {
         sentinel,
         "workspace init must never mutate the operator's real registry"
     );
+}
+
+#[test]
+fn workspace_init_guidance_and_generated_onboarding_files_lifecycle() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_guidance\"\nhost_id = \"guidance-host\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+
+    // Initialize git repo
+    let git_init = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .arg(workspace.path())
+        .status()
+        .expect("git init");
+    assert!(git_init.success());
+
+    // Verify guidance explicitly explains generated files and operator remediation
+    assert!(ONBOARDING_FINALIZE_GUIDANCE.contains(".gitignore"));
+    assert!(ONBOARDING_FINALIZE_GUIDANCE.contains(".orbit/auto_tasks"));
+    assert!(ONBOARDING_FINALIZE_GUIDANCE.contains(".orbit/routines"));
+    assert!(ONBOARDING_FINALIZE_GUIDANCE.contains("review and commit"));
+    assert!(ONBOARDING_FINALIZE_GUIDANCE.contains("does not auto-commit or discard"));
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+    WorkspaceInitArgs {
+        name: Some("guidance-test".to_string()),
+        base_branch: Some("agent-main".to_string()),
+        ship_mode: Some("local".to_string()),
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: false,
+    }
+    .execute_without_runtime(None)
+    .expect("workspace init");
+
+    // Verify the generated files exist
+    assert!(workspace.path().join(".gitignore").exists());
+    assert!(workspace.path().join(".orbit/auto_tasks").is_dir());
+    assert!(workspace.path().join(".orbit/routines").is_dir());
+
+    // Git status shows dirt from generated files
+    let status_output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(workspace.path())
+        .output()
+        .expect("git status");
+    let status_str = String::from_utf8_lossy(&status_output.stdout);
+    assert!(status_str.contains(".gitignore"), "git status: {status_str}");
+    assert!(status_str.contains(".orbit/"), "git status: {status_str}");
 }

--- a/crates/orbit-core/assets/activities/worktree_setup.yaml
+++ b/crates/orbit-core/assets/activities/worktree_setup.yaml
@@ -28,6 +28,12 @@ spec:
         enum: [remote, local]
       branch_prefix:
         type: string
+      landing_mode:
+        type: string
+        enum: [local, pr]
+      ship_mode:
+        type: string
+        enum: [local, pr]
   output_schema_json:
     type: object
     properties:

--- a/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_local_pipeline.yaml
@@ -24,6 +24,7 @@ spec:
     base_branch: main
     base_sync: remote
     landing_branch: ""
+    landing_mode: local
     terminal_status: review
     # `review` (default) ends successful tasks at review. `done` is explicit
     # per-invocation operator authorization to finish delivery.
@@ -46,6 +47,7 @@ spec:
         task_ids: "{{ input.task_ids }}"
         base: "{{ input.base_branch }}"
         base_sync: "{{ input.base_sync }}"
+        landing_mode: "{{ input.landing_mode }}"
 
     - id: implement_bundle
       loop:

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -110,7 +110,7 @@ local merge delivery instead of opening PRs. For another host's workspace, use
 `--role replica --owner <owner-machine-id>` rather than creating another owner.
 See [multi-host.md](multi-host.md).
 
-Two things to know about what it seeded:
+Three things to know about what it seeded and how to finalize:
 
 - **Every routine and auto-task ships disabled.** The automation layer is
   installed but dark until someone reviews and opts in. Do not assume a fresh
@@ -118,6 +118,17 @@ Two things to know about what it seeded:
 - **Definitions belong in git; state does not.** `orbit workspace init` seeds a
   `.gitignore` pattern that ignores `.orbit/` and then re-includes the versioned
   definition directories. Keep it.
+- **Finalize generated files before local shipping.** `orbit workspace init`
+  updates `.gitignore` and creates untracked definitions in `.orbit/auto_tasks/`
+  and `.orbit/routines/`. Orbit intentionally does not auto-commit, stash, or
+  discard operator modifications. When using local delivery (`--ship-mode local`),
+  the landing base checkout must be clean before running workflows. Review and
+  commit the generated onboarding files to finalize setup safely:
+
+  ```bash
+  git add .gitignore .orbit/auto_tasks .orbit/routines
+  git commit -m "chore: initialize Orbit workspace definitions"
+  ```
 
 Ordinary `orbit mcp init` installs agent-only authority, unlike the operator
 bootstrap above. Re-registering a client is not a way to preserve or grant

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
@@ -149,7 +149,7 @@ fn merge_with_rebase_retry(
 /// to check the same branch out in the primary checkout, so stacked local
 /// pipelines must merge directly in the owning worktree (the epic worktree in
 /// particular).
-fn checkout_holding_branch(repo_root: &Path, base: &str) -> Result<Option<PathBuf>, OrbitError> {
+pub(super) fn checkout_holding_branch(repo_root: &Path, base: &str) -> Result<Option<PathBuf>, OrbitError> {
     let listing = git_output(repo_root, &["worktree", "list", "--porcelain"])?;
     let expected_branch = format!("refs/heads/{base}");
     let mut current_path = None;
@@ -221,7 +221,7 @@ fn parse_divergence_count(
     })
 }
 
-fn ensure_clean_checkout(path: &Path, label: &str) -> Result<(), OrbitError> {
+pub(super) fn ensure_clean_checkout(path: &Path, label: &str) -> Result<(), OrbitError> {
     let status = git_output(path, &["status", "--porcelain"])?;
     if status.trim().is_empty() {
         return Ok(());

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -15,6 +15,7 @@ use super::dependency_delivery::{
     DependencyDeliveryMode, dependency_delivery_mode_from_input,
     ensure_dependencies_delivered_into_base,
 };
+use super::merge::{checkout_holding_branch, ensure_clean_checkout};
 use super::{WorktreeIdentity, is_registered_worktree};
 
 const DEFAULT_BASE: &str = "main";
@@ -39,6 +40,14 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
         .unwrap_or_else(|| DEFAULT_BASE.to_string());
     let base_sync_mode = base_sync_mode_from_input(input)?;
     let dependency_delivery_mode = dependency_delivery_mode_from_input(input)?;
+    let landing_mode = match (
+        input_string_field(input, "landing_mode"),
+        input_string_field(input, "ship_mode"),
+    ) {
+        (Some(mode), _) => Some(("landing_mode", mode)),
+        (None, Some(mode)) => Some(("ship_mode", mode)),
+        (None, None) => None,
+    };
 
     let repo_root_str = host.repo_root()?;
     let repo_root = Path::new(&repo_root_str);
@@ -69,6 +78,26 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
             &start_point,
             &base_sha,
         )?;
+    }
+
+    // ORB-11373: when delivering into a local checkout, verify that the landing
+    // base checkout is clean before creating the worktree or admitting tasks.
+    // An initialized dirty base (e.g. from `workspace init`) will deterministically
+    // fail the final merge step, so catch it early before expensive agent runs.
+    if let Some((field, mode)) = landing_mode {
+        match mode.as_str() {
+            "local" => {
+                let base_checkout = checkout_holding_branch(repo_root, &base)?
+                    .unwrap_or_else(|| repo_root.to_path_buf());
+                ensure_clean_checkout(&base_checkout, "base branch checkout")?;
+            }
+            "pr" => {}
+            other => {
+                return Err(OrbitError::InvalidInput(format!(
+                    "input.{field} must be 'local' or 'pr', got '{other}'"
+                )));
+            }
+        }
     }
 
     let branch_name = branch_name_for_tasks(&identity.branch_prefix, task_ids);

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -1,14 +1,28 @@
 #![allow(missing_docs)]
 
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 
+use chrono::Utc;
+use orbit_common::{NotFoundKind, OrbitError};
+use orbit_tools::ToolContext;
+use orbit_types::policy::Role;
+use orbit_types::record::OrbitEvent;
+use orbit_types::task::{
+    ExternalRef, Task, TaskArtifact, TaskPriority, TaskStatus, TaskType,
+};
+use orbit_types::workflow::JobRun;
 use tempfile::tempdir;
 
-use serde_json::json;
+use serde_json::{Value, json};
 
-use super::super::setup::{ensure_worktree, worktree_setup_output};
+use crate::context::{RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate};
+
+use super::super::resolve_worktree_path_from_prefix;
+use super::super::setup::{ensure_worktree, setup_worktree, worktree_setup_output};
 
 #[test]
 fn ensure_worktree_reattaches_existing_checkout_without_resetting_its_branch() {
@@ -218,4 +232,270 @@ fn assert_git_fails(current_dir: &Path, args: &[&str]) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn setup_worktree_refuses_dirty_base_checkout_when_landing_mode_is_local() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+
+    // Introduce dirty landing state in the base repository checkout (simulating init generated files)
+    fs::write(repo.join(".gitignore"), ".orbit/*\n").unwrap();
+    fs::create_dir_all(repo.join(".orbit").join("auto_tasks")).unwrap();
+    fs::write(
+        repo.join(".orbit").join("auto_tasks").join("curation.yaml"),
+        "enabled: false\n",
+    )
+    .unwrap();
+
+    let host = FakeHost::new(&repo, &["ORB-11373"]);
+    let run_id = "jrun-dirty-local-test";
+    let input = json!({
+        "task_ids": ["ORB-11373"],
+        "run_id": run_id,
+        "base": "agent-main",
+        "base_sync": "local",
+        "landing_mode": "local",
+        "dependency_delivery": "ignore",
+    });
+
+    let error = setup_worktree(&host, &input).unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("base branch checkout")
+            && message.contains("must be clean before merge_batch_worktree_into_base"),
+        "expected clean base checkout refusal, got: {message}"
+    );
+
+    // Verify refusal prevented worktree creation and task admission
+    let worktree_path = resolve_worktree_path_from_prefix(&repo, "orbit", run_id).unwrap();
+    assert!(
+        !worktree_path.exists(),
+        "refused setup must not leave a worktree behind"
+    );
+    assert!(
+        host.admitted().is_empty(),
+        "refused setup must not admit the task into workflow"
+    );
+}
+
+#[test]
+fn setup_worktree_allows_dirty_base_checkout_when_landing_mode_is_pr_or_omitted() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+
+    // Introduce dirty state in base checkout
+    fs::write(repo.join(".gitignore"), ".orbit/*\n").unwrap();
+
+    let host = FakeHost::new(&repo, &["ORB-11373"]);
+    let run_id = "jrun-dirty-pr-test";
+    let input = json!({
+        "task_ids": ["ORB-11373"],
+        "run_id": run_id,
+        "base": "agent-main",
+        "base_sync": "local",
+        "landing_mode": "pr",
+        "dependency_delivery": "ignore",
+    });
+
+    let output = setup_worktree(&host, &input).expect("PR mode must allow dirty base checkout");
+    assert_eq!(output["job_run_id"], json!(run_id));
+    assert_eq!(host.admitted(), vec!["ORB-11373".to_string()]);
+}
+
+#[test]
+fn setup_worktree_succeeds_when_landing_mode_is_local_and_base_is_clean() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+
+    let host = FakeHost::new(&repo, &["ORB-11373"]);
+    let run_id = "jrun-clean-local-test";
+    let input = json!({
+        "task_ids": ["ORB-11373"],
+        "run_id": run_id,
+        "base": "agent-main",
+        "base_sync": "local",
+        "landing_mode": "local",
+        "dependency_delivery": "ignore",
+    });
+
+    let output =
+        setup_worktree(&host, &input).expect("Clean base checkout must succeed in local mode");
+    assert_eq!(output["job_run_id"], json!(run_id));
+    assert_eq!(host.admitted(), vec!["ORB-11373".to_string()]);
+}
+
+struct FakeHost {
+    tasks: BTreeMap<String, Task>,
+    repo_root: PathBuf,
+    data_root: PathBuf,
+    scoreboard_dir: PathBuf,
+    admitted: Mutex<Vec<String>>,
+}
+
+impl FakeHost {
+    fn new(repo_root: &Path, task_ids: &[&str]) -> Self {
+        let now = Utc::now();
+        let tasks = task_ids
+            .iter()
+            .map(|id| {
+                (
+                    id.to_string(),
+                    Task {
+                        id: id.to_string(),
+                        title: format!("Task {id}"),
+                        description: String::new(),
+                        acceptance_criteria: Vec::new(),
+                        tags: Vec::new(),
+                        required_tools: Vec::new(),
+                        plan: String::new(),
+                        execution_summary: String::new(),
+                        context_files: Vec::new(),
+                        created_by: None,
+                        planned_by: None,
+                        implemented_by: None,
+                        status: TaskStatus::Backlog,
+                        priority: TaskPriority::Medium,
+                        complexity: None,
+                        task_type: TaskType::Chore,
+                        pr_status: None,
+                        external_refs: Vec::new(),
+                        relations: Vec::new(),
+                        job_run_id: None,
+                        crew: None,
+                        orchestrator: None,
+                        created_at: now,
+                        updated_at: now,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            tasks,
+            repo_root: repo_root.to_path_buf(),
+            data_root: repo_root.join(".orbit-test-data"),
+            scoreboard_dir: repo_root.join(".orbit-test-data").join("scoreboard"),
+            admitted: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn admitted(&self) -> Vec<String> {
+        self.admitted.lock().expect("admitted lock").clone()
+    }
+}
+
+impl RuntimeHost for FakeHost {
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.tasks
+            .get(task_id)
+            .cloned()
+            .ok_or_else(|| OrbitError::not_found(NotFoundKind::Task, task_id.to_string()))
+    }
+
+    fn get_task_artifacts(&self, _task_id: &str) -> Result<Vec<TaskArtifact>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn list_tasks_filtered(
+        &self,
+        _status: Option<TaskStatus>,
+        _priority: Option<TaskPriority>,
+        _parent_id: Option<&str>,
+        _job_run_id: Option<&str>,
+        _external_ref: Option<&ExternalRef>,
+        _has_external_ref_system: Option<&str>,
+    ) -> Result<Vec<Task>, OrbitError> {
+        Ok(self.tasks.values().cloned().collect())
+    }
+
+    fn start_task(
+        &self,
+        _task_id: &str,
+        _note: Option<String>,
+        _comment: Option<String>,
+    ) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(
+            "start_task not needed in setup tests".to_string(),
+        ))
+    }
+
+    fn admit_task_for_workflow(&self, task_id: &str, _workflow: &str) -> Result<Task, OrbitError> {
+        self.admitted
+            .lock()
+            .expect("admitted lock")
+            .push(task_id.to_string());
+        self.get_task(task_id)
+    }
+
+    fn update_task_from_activity(
+        &self,
+        _task_id: &str,
+        _update: TaskActivityUpdate,
+    ) -> Result<Task, OrbitError> {
+        Err(OrbitError::Execution(
+            "update_task_from_activity not needed in setup tests".to_string(),
+        ))
+    }
+
+    fn apply_task_automation_update(
+        &self,
+        _task_id: &str,
+        _update: TaskAutomationUpdate,
+    ) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn record_event(&self, _event: OrbitEvent) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn repo_root(&self) -> Result<String, OrbitError> {
+        Ok(self.repo_root.to_string_lossy().to_string())
+    }
+
+    fn data_root(&self) -> &Path {
+        &self.data_root
+    }
+
+    fn list_job_runs_for_gc(&self) -> Result<Vec<JobRun>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn run_tool_with_context_and_role(
+        &self,
+        _name: &str,
+        _input: Value,
+        _role: Role,
+        _tool_context: ToolContext,
+    ) -> Result<Value, OrbitError> {
+        Err(OrbitError::Execution(
+            "run_tool_with_context_and_role not needed in setup tests".to_string(),
+        ))
+    }
+
+    fn maybe_create_failure_task(
+        &self,
+        _job_id: &str,
+        _run_id: &str,
+        _error_code: &str,
+        _error_message: &str,
+        _agent: Option<&str>,
+        _model: Option<&str>,
+    ) -> Result<(), OrbitError> {
+        Ok(())
+    }
+
+    fn scoring_enabled(&self) -> bool {
+        false
+    }
+
+    fn scoreboard_dir(&self) -> &Path {
+        &self.scoreboard_dir
+    }
 }

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -119,6 +119,25 @@ owns today:
 Any additional operator-authored paths require an explicit repository policy; do not
 assume workspace initialization commits them.
 
+#### Finalizing generated onboarding files
+
+`orbit workspace init` updates `.gitignore` and creates untracked definition files under
+`.orbit/auto_tasks/` and `.orbit/routines/`. Orbit intentionally does not auto-commit,
+stash, or discard working-tree modifications.
+
+For local delivery (`--ship-mode local`), the base branch landing checkout must be clean
+to ensure safe fast-forward merges. Operators should review and finalize generated
+onboarding definitions before dispatching local implementation workflows:
+
+```bash
+git add .gitignore .orbit/auto_tasks .orbit/routines
+git commit -m "chore: initialize Orbit workspace definitions"
+```
+
+If local shipping is attempted while the landing checkout remains dirty, the workflow
+fails early before agent implementation runs, reporting the unmerged or dirty landing
+state so operators can safely commit or remediate the files without lost work.
+
 ### Recover a missing or corrupt checkout identity
 
 Do not hand-create `.orbit/config.yaml` or edit `workspaces.json`. First preserve any


### PR DESCRIPTION
## Task

[ORB-11373](https://orbit-cli.com/tasks/ORB-11373) — Catch initialized dirty landing checkouts before expensive local implementation

### Description

Observed while onboarding approved orbit-research. workspace init generated a .gitignore change plus untracked .orbit/auto_tasks and .orbit/routines (all enabled:false). First local ship ORB-11367 ran a successful 20-minute Astra implementation and tests, committed candidate 9b5c891d56cc67dfc9d107f51befc91e89ba9e1f, then failed jrun-20260906-0134-3 at deterministic git_merge: base branch checkout must be clean before merge_batch_worktree_into_base. The same dirt existed at admission and was known to originate from init; no scientific changes caused it. Orchestrator recorded only the exact generated files in onboarding commit 6359bcb, then resumed through workflow_run_resume (jrun-20260906-0158). Diagnose current admission/landing preflight and onboarding guidance; provide an early actionable failure for known incompatible dirty base state before launching costly implementation, while retaining a final merge-time check for races. Do not auto-commit/stash/discard user changes, weaken Git safety, or unconditionally refuse dirt that the delivery mode can legitimately preserve. Explain how operators finalize generated onboarding files. This is distinct from ORB-11360 nested identity resolution. File proposed only under Daniel's operational-issue instruction; dedicated Orbit worktree for future implementation.

### Acceptance Criteria

- A regression with initialized dirty landing state reports the exact blocker before agent implementation runs in the affected local mode.
- Clean local shipping still works and a post-admission dirty race remains rejected at the merge boundary; other supported modes preserve their current semantics.
- Onboarding/CLI guidance explains generated files and safe operator remediation without auto-committing or discarding data; focused tests and required Orbit checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented early preflight cleanliness checks for landing checkouts in local delivery pipelines:
1. Extended worktree_setup activity schema in crates/orbit-core/assets/activities/worktree_setup.yaml to accept landing_mode and ship_mode (enum [local, pr]).
2. Updated task_local_pipeline in both crates/orbit-core/assets/jobs/task_local_pipeline.yaml and .orbit/resources/jobs/task_local_pipeline.yaml to specify landing_mode: local and pass landing_mode to the worktree setup step.
3. Exposed checkout_holding_branch and ensure_clean_checkout as pub(super) in crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs for reuse in setup preflight.
4. Updated setup_worktree in crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs to check base checkout cleanliness when landing_mode is local prior to worktree creation and task admission, reporting exact blocker details while preserving PR mode dirt tolerance and merge boundary race protection.
5. Added unit tests in crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs:
   - setup_worktree_refuses_dirty_base_checkout_when_landing_mode_is_local
   - setup_worktree_allows_dirty_base_checkout_when_landing_mode_is_pr_or_omitted
   - setup_worktree_succeeds_when_landing_mode_is_local_and_base_is_clean
6. Added operator onboarding finalize guidance to orbit workspace init in crates/orbit-cli/src/command/workspace/init.rs and regression test in crates/orbit-cli/src/command/workspace/tests/init.rs.
7. Documented onboarding finalization and operator remediation in crates/orbit-core/assets/skills/orbit/references/setup/first-run.md and docs/runbooks/state-and-backup.md.
8. Verified with cargo test -p orbit-engine -- vcs::worktree::tests (46 passed), cargo test -p orbit-cli -- command::workspace::tests::init (28 passed), cargo test -p orbit-core -- catalog (52 passed), and cargo check --workspace.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11373-6a9cd92d`
- Behind base: 0
- Ahead of base: 1