### PR TITLE
[qa-sweep] Delivery inspection reports not_due while admission is actually halted by definition_changed or open_instance

### DIFF
--- a/crates/orbit-automation/src/delivery/mod.rs
+++ b/crates/orbit-automation/src/delivery/mod.rs
@@ -191,6 +191,9 @@ pub fn evaluate(
             Some(state),
         );
     }
+    if let Some(reason) = host.admission_deferral()? {
+        return diagnostic(store, consumer, &reason, Some(state));
+    }
     if dry_run {
         return diagnostic(
             store,
@@ -202,9 +205,6 @@ pub fn evaluate(
             },
             Some(state),
         );
-    }
-    if let Some(reason) = host.admission_deferral()? {
-        return diagnostic(store, consumer, &reason, Some(state));
     }
     // Freeze an oldest prefix. Unattributed neighbors remain explicit obligations.
     let deliveries = state

--- a/crates/orbit-automation/src/delivery/tests/evidence.rs
+++ b/crates/orbit-automation/src/delivery/tests/evidence.rs
@@ -54,6 +54,7 @@ struct Host {
     evidence: Mutex<Option<CoverageEvidence>>,
     fail_admit: AtomicBool,
     failed: AtomicBool,
+    admission_deferred: AtomicBool,
 }
 impl Host {
     fn new() -> Self {
@@ -71,6 +72,7 @@ impl Host {
             evidence: Mutex::new(None),
             fail_admit: AtomicBool::new(false),
             failed: AtomicBool::new(false),
+            admission_deferred: AtomicBool::new(false),
         }
     }
     fn page(&self, from: usize, to: usize) {
@@ -111,6 +113,13 @@ impl Host {
     }
 }
 impl DeliveryHost for Host {
+    fn admission_deferral(&self) -> Result<Option<String>, AutomationError> {
+        Ok(self
+            .admission_deferred
+            .load(Ordering::SeqCst)
+            .then(|| "open_instance".into()))
+    }
+
     fn head(&self, _: &str) -> Result<(String, SourceRevision), AutomationError> {
         Ok(("owner/repo".into(), revision(0)))
     }
@@ -181,6 +190,32 @@ fn setup() -> (Arc<dyn AutomationStoreBackend>, Host, DeliveryTrigger) {
         "baselined"
     );
     (store, host, trigger)
+}
+
+#[test]
+fn preview_reports_admission_deferral_without_persisting_observation() {
+    let (store, host, trigger) = setup();
+    let before = store.automation_state("ws/qa").unwrap();
+    host.page(0, 2);
+    host.admission_deferred.store(true, Ordering::SeqCst);
+
+    let diagnostic = delivery::evaluate(
+        store.as_ref(),
+        &host,
+        Evaluation {
+            consumer: "ws/qa",
+            epoch: "v1",
+            trigger: &trigger,
+            enabled: true,
+            dry_run: true,
+            now: now(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(diagnostic.reason, "open_instance");
+    assert_eq!(store.automation_state("ws/qa").unwrap(), before);
+    assert!(host.actions.lock().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/auto_task/show.rs
+++ b/crates/orbit-cli/src/command/auto_task/show.rs
@@ -24,17 +24,17 @@ impl Execute for AutoTaskShowArgs {
         })?;
 
         let mut doc = definition_to_json(&definition);
-        if let orbit_core::AutoTaskSchedule::Deliveries { deliveries_landed } = &definition.schedule
-        {
-            doc["automation"] = serde_json::to_value(orbit_core::application::automation::inspect(
-                runtime,
-                "auto-task",
-                &definition.name,
-                deliveries_landed,
-                definition.enabled,
-                chrono::Utc::now(),
-            )?)
-            .map_err(|e| OrbitError::InvalidInput(e.to_string()))?;
+        if matches!(
+            definition.schedule,
+            orbit_core::AutoTaskSchedule::Deliveries { .. }
+        ) {
+            doc["automation"] =
+                serde_json::to_value(orbit_core::application::automation::inspect_auto_task(
+                    runtime,
+                    &definition,
+                    chrono::Utc::now(),
+                )?)
+                .map_err(|e| OrbitError::InvalidInput(e.to_string()))?;
         }
 
         if self.preview

--- a/crates/orbit-core/src/adapter/tool_host/auto_task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/auto_task_tools.rs
@@ -53,7 +53,7 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         .auto_task_show(&name)?
         .ok_or_else(|| OrbitError::InvalidInput(format!("no such auto-task '{name}'")))?;
     let mut value = to_json(&definition)?;
-    if let AutoTaskSchedule::Deliveries { deliveries_landed } = &definition.schedule {
+    if matches!(definition.schedule, AutoTaskSchedule::Deliveries { .. }) {
         let diagnostic = if input
             .get("preview")
             .and_then(Value::as_bool)
@@ -66,12 +66,9 @@ pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
                 chrono::Utc::now(),
             )?
         } else {
-            crate::application::automation::inspect(
+            crate::application::automation::inspect_auto_task(
                 runtime,
-                "auto-task",
-                &definition.name,
-                deliveries_landed,
-                definition.enabled,
+                &definition,
                 chrono::Utc::now(),
             )?
         };

--- a/crates/orbit-core/src/application/automation/inspect.rs
+++ b/crates/orbit-core/src/application/automation/inspect.rs
@@ -1,44 +1,136 @@
 //! Read-only diagnostics share persisted scheduler state; inspection never ticks.
 use crate::OrbitRuntime;
 use chrono::{DateTime, Utc};
+use orbit_automation::delivery;
 use orbit_common::OrbitError;
-use orbit_types::workflow::automation::{AutomationDiagnostic, DeliveryTrigger};
+use orbit_types::workflow::{
+    AutoTaskDefinition, AutoTaskSchedule, DedupePolicy, RoutineDefinition,
+    automation::{AutomationDiagnostic, BatchState, DeliveryTrigger},
+};
 
-pub fn inspect(
+pub fn inspect_auto_task(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+    now: DateTime<Utc>,
+) -> Result<AutomationDiagnostic, OrbitError> {
+    let AutoTaskSchedule::Deliveries { deliveries_landed } = &definition.schedule else {
+        return Err(OrbitError::InvalidInput("not a delivery definition".into()));
+    };
+    let epoch = delivery::definition_epoch(&(
+        &definition.schedule,
+        &definition.template,
+        definition.dedupe,
+    ))
+    .map_err(orbit_automation::automation_error_to_orbit)?;
+    let admission_deferred = matches!(definition.dedupe, DedupePolicy::SkipIfOpen)
+        && super::auto_task_admission_deferral(runtime, definition)?.is_some();
+    inspect(
+        runtime,
+        "auto-task",
+        &definition.name,
+        &epoch,
+        deliveries_landed,
+        definition.enabled,
+        admission_deferred,
+        now,
+    )
+}
+
+pub fn inspect_routine(
+    runtime: &OrbitRuntime,
+    definition: &RoutineDefinition,
+    now: DateTime<Utc>,
+) -> Result<AutomationDiagnostic, OrbitError> {
+    let trigger = definition
+        .trigger
+        .deliveries_landed
+        .as_ref()
+        .ok_or_else(|| OrbitError::InvalidInput("not a delivery routine".into()))?;
+    let mut effective_trigger = trigger.clone();
+    effective_trigger.retries = effective_trigger.retries.min(definition.policy.retries.max);
+    let epoch =
+        delivery::definition_epoch(&(&definition.trigger, &definition.target, &definition.policy))
+            .map_err(orbit_automation::automation_error_to_orbit)?;
+    inspect(
+        runtime,
+        "routine",
+        &definition.name,
+        &epoch,
+        &effective_trigger,
+        definition.enabled,
+        false,
+        now,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect(
     runtime: &OrbitRuntime,
     kind: &str,
     name: &str,
+    epoch: &str,
     trigger: &DeliveryTrigger,
     enabled: bool,
+    admission_deferred: bool,
     now: DateTime<Utc>,
 ) -> Result<AutomationDiagnostic, OrbitError> {
     let consumer = super::consumer_key(runtime, kind, name)?;
     let store = runtime.automation_store()?;
     let state = store.automation_state(&consumer)?;
+    let owner = trigger.owner_machine.as_deref();
+    let owned_here =
+        owner.is_some_and(|owner| Some(owner) == runtime.automation_machine_identity());
+    let owned_elsewhere =
+        owner.is_some_and(|owner| Some(owner) != runtime.automation_machine_identity());
     let reason = match &state {
-        _ if trigger.owner_machine.as_deref() != runtime.automation_machine_identity() => {
-            "owned_elsewhere"
-        }
         None => {
-            if enabled {
-                "awaiting_baseline"
-            } else {
+            if !enabled {
                 "disabled"
+            } else if owned_elsewhere {
+                "owned_elsewhere"
+            } else if !owned_here {
+                "disabled"
+            } else {
+                "awaiting_baseline"
             }
         }
+        Some(state) if state.epoch != epoch || state.branch != trigger.branch => {
+            "definition_changed"
+        }
         Some(_) if !enabled => "disabled",
+        Some(_) if owned_elsewhere => "owned_elsewhere",
+        Some(_) if !owned_here => "disabled",
         Some(state)
-            if state.active.as_ref().is_some_and(|a| {
-                matches!(
-                    a.state,
-                    orbit_types::workflow::automation::BatchState::Exhausted
-                        | orbit_types::workflow::automation::BatchState::Failed
-                )
-            }) =>
+            if state
+                .active
+                .as_ref()
+                .is_some_and(|a| matches!(a.state, BatchState::Exhausted | BatchState::Failed)) =>
         {
             "needs_attention"
         }
+        Some(state)
+            if state.active.as_ref().is_some_and(|active| {
+                active.action_id.is_none()
+                    && active.state == BatchState::Claimed
+                    && active.attempt > 1
+                    && now > active.batch.retry_until
+            }) =>
+        {
+            "retry_deadline_expired"
+        }
+        Some(state)
+            if state.active.as_ref().is_some_and(|active| {
+                active.action_id.is_none()
+                    && active.state == BatchState::Claimed
+                    && active.retry_after.is_some_and(|at| now < at)
+            }) =>
+        {
+            "retry_backoff"
+        }
         Some(state) if state.active.is_some() => "batch_pending",
+        Some(state) if state.pending.len() >= trigger.threshold && admission_deferred => {
+            "open_instance"
+        }
         Some(state) if state.pending.len() >= trigger.threshold => "threshold_reached",
         Some(state)
             if state.pending.first().is_some_and(|d| {
@@ -46,7 +138,11 @@ pub fn inspect(
                     >= i64::from(trigger.max_wait_minutes)
             }) =>
         {
-            "max_wait_reached"
+            if admission_deferred {
+                "open_instance"
+            } else {
+                "max_wait_reached"
+            }
         }
         Some(state) if !state.unresolved.is_empty() => "evidence_unavailable",
         Some(_) => "not_due",

--- a/crates/orbit-core/src/application/automation/mod.rs
+++ b/crates/orbit-core/src/application/automation/mod.rs
@@ -11,7 +11,7 @@ mod inspect;
 mod provider;
 pub(crate) use direct::record_direct_landing_intent;
 mod source;
-pub use inspect::inspect;
+pub use inspect::{inspect_auto_task, inspect_routine};
 mod task;
 #[cfg(test)]
 mod tests;
@@ -95,8 +95,11 @@ fn evaluate(
     action: Action<'_>,
     mut request: delivery::Evaluation<'_>,
 ) -> Result<AutomationDiagnostic, OrbitError> {
+    let owner = request.trigger.owner_machine.as_deref();
     let owned_here =
-        request.trigger.owner_machine.as_deref() == runtime.automation_machine_identity();
+        owner.is_some_and(|owner| Some(owner) == runtime.automation_machine_identity());
+    let owned_elsewhere =
+        owner.is_some_and(|owner| Some(owner) != runtime.automation_machine_identity());
     // Disable admission on another owner, but reconcile previously admitted work.
     // Preview remains read-only and exposes the actual consumer/baseline.
     request.enabled &= owned_here;
@@ -109,7 +112,7 @@ fn evaluate(
     };
     let mut diagnostic =
         delivery::evaluate(store.as_ref(), &host, request).map_err(automation_error_to_orbit)?;
-    if !owned_here && !dry_run {
+    if owned_elsewhere && !dry_run {
         diagnostic.reason = "owned_elsewhere".into();
     }
     Ok(diagnostic)
@@ -125,14 +128,8 @@ struct Host<'a> {
 }
 impl DeliveryHost for Host<'_> {
     fn admission_deferral(&self) -> Result<Option<String>, AutomationError> {
-        if let Action::Task(definition) = self.action
-            && definition.dedupe == orbit_types::workflow::DedupePolicy::SkipIfOpen
-            && orbit_automation::auto_tasks::scheduler::AutoTaskDispatch::has_open_instance(
-                self.runtime,
-                definition,
-            )?
-        {
-            return Ok(Some("open_instance".into()));
+        if let Action::Task(definition) = self.action {
+            return auto_task_admission_deferral(self.runtime, definition).map_err(Into::into);
         }
         Ok(None)
     }
@@ -186,4 +183,18 @@ impl DeliveryHost for Host<'_> {
             Action::Job(_) => task::job_outcome(self.runtime, &self.source, attempt),
         }
     }
+}
+
+fn auto_task_admission_deferral(
+    runtime: &OrbitRuntime,
+    definition: &AutoTaskDefinition,
+) -> Result<Option<String>, OrbitError> {
+    if definition.dedupe == orbit_types::workflow::DedupePolicy::SkipIfOpen
+        && orbit_automation::auto_tasks::scheduler::AutoTaskDispatch::has_open_instance(
+            runtime, definition,
+        )?
+    {
+        return Ok(Some("open_instance".into()));
+    }
+    Ok(None)
 }

--- a/crates/orbit-core/src/application/automation/tests/consumer.rs
+++ b/crates/orbit-core/src/application/automation/tests/consumer.rs
@@ -392,7 +392,7 @@ fn no_diff_pr_is_zero_but_distinct_revert_pr_is_new_delivery() {
 }
 
 #[test]
-fn only_explicit_machine_owner_can_establish_baseline_and_preview_is_read_only() {
+fn unowned_delivery_is_disabled_and_preview_is_read_only() {
     let runtime = runtime();
     let mut definition = definition(&runtime, "ownership", CoverageClass::IntegratedQaV1);
     let AutoTaskSchedule::Deliveries { deliveries_landed } = &mut definition.schedule else {
@@ -400,7 +400,7 @@ fn only_explicit_machine_owner_can_establish_baseline_and_preview_is_read_only()
     };
     deliveries_landed.owner_machine = None;
     let diagnostic = evaluate_auto_task(&runtime, &definition, false, Utc::now()).unwrap();
-    assert_eq!(diagnostic.reason, "owned_elsewhere");
+    assert_eq!(diagnostic.reason, "disabled");
     assert!(diagnostic.state.is_none());
     let preview = evaluate_auto_task(&runtime, &definition, true, Utc::now()).unwrap();
     assert_eq!(preview.reason, "would_baseline");
@@ -433,6 +433,91 @@ fn only_explicit_machine_owner_can_establish_baseline_and_preview_is_read_only()
             .unwrap()
             .reason,
         "baselined"
+    );
+}
+
+#[test]
+fn inspection_reports_delivery_admission_deferrals_without_mutating_state() {
+    let runtime = runtime();
+    let mut inspection_definition =
+        definition(&runtime, "inspection", CoverageClass::IntegratedQaV1);
+    let baseline = evaluate_auto_task(&runtime, &inspection_definition, false, Utc::now())
+        .unwrap()
+        .state
+        .unwrap();
+    let store = runtime.automation_store().unwrap();
+
+    let before = store.automation_state(&baseline.consumer).unwrap();
+    inspection_definition.template.title = "Changed inspection definition".into();
+    assert_eq!(
+        super::super::inspect_auto_task(&runtime, &inspection_definition, Utc::now())
+            .unwrap()
+            .reason,
+        "definition_changed"
+    );
+    assert_eq!(
+        store.automation_state(&baseline.consumer).unwrap(),
+        before,
+        "inspection must not repair a changed definition"
+    );
+
+    inspection_definition.template.title = "Examine batch".into();
+    let mut pending = baseline.clone();
+    pending.generation = 1;
+    pending.pending_commits = vec!["pending-commit".into()];
+    pending.pending = vec![Delivery {
+        key: "direct:inspection".into(),
+        repository: baseline.repository.clone(),
+        branch: baseline.branch.clone(),
+        before: baseline.observed.clone(),
+        after: baseline.observed.clone(),
+        commits: vec!["pending-commit".into()],
+        task_ids: vec![],
+        evidence_reference: "fixture".into(),
+        evidence_digest: "fixture".into(),
+        landed_at: Utc::now(),
+    }];
+    assert!(store.automation_commit(&baseline, &pending, None).unwrap());
+    runtime.auto_task_mint(&inspection_definition.name).unwrap();
+    let before = store.automation_state(&baseline.consumer).unwrap();
+    assert_eq!(
+        super::super::inspect_auto_task(&runtime, &inspection_definition, Utc::now())
+            .unwrap()
+            .reason,
+        "open_instance"
+    );
+    assert_eq!(
+        store.automation_state(&baseline.consumer).unwrap(),
+        before,
+        "inspection must not admit or advance an open-instance deferral"
+    );
+
+    let AutoTaskSchedule::Deliveries { deliveries_landed } = &mut inspection_definition.schedule
+    else {
+        unreachable!()
+    };
+    inspection_definition.enabled = false;
+    deliveries_landed.owner_machine = None;
+    assert_eq!(
+        super::super::inspect_auto_task(&runtime, &inspection_definition, Utc::now())
+            .unwrap()
+            .reason,
+        "definition_changed",
+        "a changed definition takes precedence over the disabled owner state"
+    );
+
+    let baseline_definition = definition(&runtime, "disabled", CoverageClass::IntegratedQaV1);
+    let mut disabled = baseline_definition;
+    disabled.enabled = false;
+    let AutoTaskSchedule::Deliveries { deliveries_landed } = &mut disabled.schedule else {
+        unreachable!()
+    };
+    deliveries_landed.owner_machine = None;
+    assert_eq!(
+        super::super::inspect_auto_task(&runtime, &disabled, Utc::now())
+            .unwrap()
+            .reason,
+        "disabled"
     );
 }
 

--- a/crates/orbit-core/src/application/routines/status.rs
+++ b/crates/orbit-core/src/application/routines/status.rs
@@ -105,8 +105,8 @@ pub fn routine_statuses_with_providers(
             &registry_view,
         );
         let pinned_to_host = validation.eligible;
-        let automation=routine.definition.trigger.deliveries_landed.as_ref().map(|trigger| {
-            discovered.entries.iter().find(|(_,runtime)|runtime.shared_root()==routine.source_orbit_dir).map_or_else(||serde_json::json!({"reason":"source_unavailable"}),|(_,runtime)|match crate::application::automation::inspect(runtime,"routine",&routine.definition.name,trigger,routine.definition.enabled,now_utc) {Ok(value)=>serde_json::json!(value),Err(error)=>serde_json::json!({"reason":"state_unavailable","error":error.to_string()})})
+        let automation=routine.definition.trigger.deliveries_landed.as_ref().map(|_| {
+            discovered.entries.iter().find(|(_,runtime)|runtime.shared_root()==routine.source_orbit_dir).map_or_else(||serde_json::json!({"reason":"source_unavailable"}),|(_,runtime)|match crate::application::automation::inspect_routine(runtime,&routine.definition,now_utc) {Ok(value)=>serde_json::json!(value),Err(error)=>serde_json::json!({"reason":"state_unavailable","error":error.to_string()})})
         });
         statuses.push(RoutineStatus {
             routine,

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -357,15 +357,8 @@ fn definition_json(
     now: DateTime<Utc>,
 ) -> Value {
     let automation = match &definition.schedule {
-        AutoTaskSchedule::Deliveries { deliveries_landed } => Some(
-            match orbit_core::application::automation::inspect(
-                runtime,
-                "auto-task",
-                &definition.name,
-                deliveries_landed,
-                definition.enabled,
-                now,
-            ) {
+        AutoTaskSchedule::Deliveries { .. } => Some(
+            match orbit_core::application::automation::inspect_auto_task(runtime, definition, now) {
                 Ok(diagnostic) => json!(diagnostic),
                 Err(error) => json!({"reason":"state_unavailable","error":error.to_string()}),
             },

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -148,11 +148,16 @@ input, gaps and validation reason. **Accepted evidence** downloads the accepted
 bytes; replacing the current task artifact does not change that receipt. Usage is
 shown as unknown until an authoritative measurement exists.
 
-Common reasons include `threshold_reached`, `max_wait_reached`, `open_instance`,
-`batch_pending`, `retry_backoff`, `definition_changed`, `history_diverged`,
-`evidence_unavailable`, and validation failures such as `unauthorized_submitter`,
-`batch_or_attempt_mismatch` and `incomplete_examination`. State read failures are
-reported separately; corrupted delivery state is never treated as a new baseline.
+Read-only inspection reports persisted scheduling reasons including
+`awaiting_baseline`, `disabled`, `owned_elsewhere`, `definition_changed`,
+`open_instance`, `threshold_reached`, `max_wait_reached`, `batch_pending`,
+`retry_backoff`, `retry_deadline_expired`, `needs_attention`, and
+`evidence_unavailable`. It does not fetch source or provider evidence: source
+history failures are reported by an evaluation run, not fabricated by inspection.
+Validation failures such as `unauthorized_submitter`, `batch_or_attempt_mismatch`
+and `incomplete_examination` remain attached to the relevant admission or evidence
+operation. State read failures are reported separately; corrupted delivery state is
+never treated as a new baseline.
 
 Observation, admission and coverage are separate durable transitions. A claimed
 batch replays the same task/job action key after a crash. Job admission atomically


### PR DESCRIPTION
## Task

[ORB-11389](https://orbit-cli.com/tasks/ORB-11389) — [qa-sweep] Delivery inspection reports not_due while admission is actually halted by definition_changed or open_instance

### Description

Found by post-merge QA sweep ORB-11377 exercising PR1411 / ORB-11330 (`2c143e01b`) end to end against isolated `/tmp` Orbit roots and Git checkouts. Introduced by that commit.

## Defect

`docs/design/automation-triggers/5_operations.md` §"Inspection and recovery" states that `orbit auto-task show --json`, MCP `orbit.auto_task.show`, routine status/show and the dashboard expose the delivery state, and lists `open_instance`, `definition_changed`, `retry_backoff` and `history_diverged` among the reasons an operator should see there.

Those surfaces are served by `orbit_core::application::automation::inspect` (`crates/orbit-core/src/application/automation/inspect.rs:19-52`), which recomputes a reason from persisted state alone. It never computes the definition epoch, never calls `admission_deferral`, and can therefore never emit `open_instance`, `definition_changed`, `retry_backoff` or `history_diverged`. Instead it reports a healthy-looking reason for a consumer whose admission is fully stopped. The dashboard shares this path (`crates/orbit-web/src/api/auto_tasks.rs`, `definition_json` calls `inspect`).

`--preview` does not close the gap either: `delivery::evaluate` returns `threshold_reached` on the `dry_run` branch (`crates/orbit-automation/src/delivery/mod.rs:193-204`) **before** reaching `host.admission_deferral()` on the next line, so preview cannot surface `open_instance` for the same reason.

## Observed divergences

All three reproduced against the same consumer within one sweep. `<scheduler>` = the reason recorded by `auto_task_scheduler_pipeline`'s `schedule` step, which is what actually happened.

| Real state | `<scheduler>` reason | `auto-task show --json` | `auto-task show --preview --json` |
| --- | --- | --- | --- |
| Definition edited; new admission paused | `definition_changed` | `not_due` | `definition_changed` |
| Prior minted instance still open, `skip_if_open` | `open_instance` | `threshold_reached` | `threshold_reached` |
| Shipped default, `owner_machine` unset, disabled | `owned_elsewhere` | `owned_elsewhere` | — |

`not_due` for a paused definition is the worst case: an operator reading the documented inspection surface concludes automation is healthy and merely idle, while no batch will ever be admitted until the definition is restored.

The third row is a separate but related mislabel: `inspect.rs:19` and `mod.rs:113` both treat `owner_machine != local machine` as `owned_elsewhere`, and `owner_machine` defaults to `null` in the shipped `delivery-qa` / `delivery-code-review` assets. So the out-of-the-box state of both shipped definitions reads as "owned by another machine" when nothing owns them at all, and the fact that they are also `enabled: false` is masked. Setting `owner_machine` to the local machine ID immediately flips the reason to the accurate `disabled`.

## Reproduction

```sh
# Isolated root + checkout with a GitHub-style origin.
orbit --root /tmp/dl/root init --non-interactive --host-name dl --task-prefix DLX
(cd /tmp/dl/repo && git init -q -b agent-main . \
  && git remote add origin https://github.com/example-org/example-repo.git \
  && git commit -q --allow-empty -m initial)
(cd /tmp/dl/repo && orbit --root /tmp/dl/root workspace init)

# Own + enable delivery-qa, then baseline it.
orbit --root /tmp/dl/root auto-task update delivery-qa --deliveries-landed \
  '{"owner_machine":"<machine id from `orbit init` output>","branch":"agent-main","threshold":2,"max_wait_minutes":60,"coverage":"integrated_qa_v1","max_items":10,"retries":1}'
orbit --root /tmp/dl/root auto-task toggle delivery-qa on
orbit --root /tmp/dl/root run job auto_task_scheduler_pipeline --input dry_run=false

# A) definition_changed. Edit the trigger (threshold 2 -> 3), then compare surfaces.
orbit --root /tmp/dl/root auto-task update delivery-qa --deliveries-landed \
  '{"owner_machine":"<same>","branch":"agent-main","threshold":3,"max_wait_minutes":60,"coverage":"integrated_qa_v1","max_items":10,"retries":1}'
RID=$(orbit --root /tmp/dl/root run job auto_task_scheduler_pipeline --input dry_run=false | awk '/Run ID/{print $3}')
orbit --root /tmp/dl/root run show "$RID" --json   # schedule report: reason "definition_changed"
orbit --root /tmp/dl/root auto-task show delivery-qa --json            # automation.reason: "not_due"      <-- wrong
orbit --root /tmp/dl/root auto-task show delivery-qa --preview --json  # automation.reason: "definition_changed"

# B) open_instance. Restore the trigger, land >= threshold attributed PRs so a batch
#    admits and mints a task, leave that task open, land two more.
orbit --root /tmp/dl/root run show "$RID2" --json  # schedule report: reason "open_instance"
orbit --root /tmp/dl/root auto-task show delivery-qa --json            # automation.reason: "threshold_reached"  <-- wrong
orbit --root /tmp/dl/root auto-task show delivery-qa --preview --json  # automation.reason: "threshold_reached"  <-- wrong

# C) owner unset. On a fresh root, with no edits at all:
orbit --root /tmp/dl/root auto-task show delivery-code-review --json   # automation.reason: "owned_elsewhere"  <-- misleading; owner_machine is null and enabled is false
```

The same wrong reasons are served by the dashboard API, e.g. `GET /api/auto-tasks?workspace=<ws_id>` returns `"automation": {"reason": "not_due", ...}` for the paused definition.

## Scope

- **Production impact:** yes — diagnostics only, no data corruption. Persisted state (`baseline`/`observed`/`covered`/`pending`/`unresolved`/`active`) is correct in every case, and the scheduler itself behaves correctly; only the reason string on the operator-facing surfaces is wrong. The functional delivery cycle verified in this sweep (baseline, observation, PR grouping, batch freeze, ref pinning, task mint, `unauthorized_submitter` rejection, authorized acceptance, receipt immutability, failure on a closed task, waiver) was correct throughout.
- **Validation impact:** none. `make ci-fast`, `make ci-lint` and `cargo test -p orbit-automation` (38 passed) are green.

## Suggested direction

Make one evaluator own the reason. Either have `inspect` reuse the dry-run `delivery::evaluate` path (it already exists and is what `--preview` calls) plus the deferral and epoch checks, or move the `dry_run` early return in `delivery::evaluate` below `host.admission_deferral()` and add the epoch/enabled comparisons to `inspect`. Separately, distinguish "no owner configured" from "owned by a different machine" so the shipped disabled defaults read as `disabled`, and keep the documented reason vocabulary in `5_operations.md` in sync with what the inspection surfaces can actually emit.

### Acceptance Criteria

- `orbit auto-task show --json`, MCP `orbit.auto_task.show` and the dashboard report `definition_changed` when a delivery definition edit has paused admission.
- `open_instance` is reported by the inspection surfaces (including `--preview`) when `skip_if_open` is what blocks admission.
- A delivery definition with no `owner_machine` is not reported as `owned_elsewhere`; a disabled unowned definition reads as disabled.
- Regression tests cover each reason at the inspection boundary, and `docs/design/automation-triggers/5_operations.md` matches the reasons the surfaces can emit.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added read-only core delivery inspection for auto-tasks and routines. It now computes the definition epoch, reports definition_changed, derives open_instance from the same admission-deferral rule as scheduling, and exposes persisted retry state without ticking, observing, or admitting work.
- Routed CLI, MCP, routine status, and dashboard callers through the shared inspection boundary; preview now checks admission deferral before returning its dry-run due reason.
- Made unowned delivery definitions inert/disabled rather than owned_elsewhere, while preserving explicit foreign-owner reporting. Updated the operations design documentation to distinguish persisted inspection reasons from source-evaluation failures.
- Added regression coverage for definition changes, open instances, disabled unowned definitions, preview deferral, and state immutability.
Assessment: focused diagnostic repair; all remaining worktree changes are task-scoped.
Validation:
- cargo test -p orbit-core application::automation:: (8 passed)
- cargo test -p orbit-automation (39 passed)
- cargo clippy -p orbit-automation -p orbit-core -p orbit-cli -p orbit-web --all-targets -- -D warnings (passed)
- cargo fmt --all -- --check (passed)
- make ci-lint was attempted but stopped on an unrelated clippy error in crates/orbit-engine/src/executor/automation/ci/tests/collect.rs:1710 (clippy::let_and_return).
- make ci-fast was attempted; its remaining plugin checks fail on pre-existing mirrored skill drift between crates/orbit-core/assets/skills/orbit/references/workflows.md and plugin/skills/orbit/references/workflows.md.
- Removed the 7.0G target build directory created by this run before handoff.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11389-6a9cd830`
- Behind base: 0
- Ahead of base: 1