### PR TITLE
Enforce an optional crew allowlist for explicit ship admission and child dispatch

### DIFF
--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -32,9 +32,12 @@ impl ShipMode {
 #[command(
     about = "Ship backlog or explicitly selected tasks through the gated task pipeline",
     override_usage = "orbit run ship [<TASK_ID>...] [OPTIONS]",
-    after_help = "Examples:\n  orbit run ship\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n  orbit run ship T123 --complete\n\n\
+    after_help = "Examples:\n  orbit run ship\n  orbit run ship T123\n  orbit run ship T123 T456 --mode local\n  orbit run ship T123 --base main\n  orbit run ship T123 --allow-crew sol\n  orbit run ship T123 --complete\n\n\
                   Shipment is asynchronous: this prints the durable run ID and returns. The\n\
                   eventual outcome is not known when it does.\n\n\
+                  `--allow-crew` restricts an explicit shipment to configured crews. It does\n\
+                  not reassign tasks or select a fallback: an excluded current or later-resolved\n\
+                  crew is refused before its provider starts.\n\n\
                   Inspect submitted runs with `orbit run history -j task_auto_pipeline` and\n\
                   `orbit run show <RUN_ID>`."
 )]
@@ -59,6 +62,11 @@ pub struct ShipCommand {
     /// work for the backlog.
     #[arg(long)]
     pub complete: bool,
+    /// Restrict an explicit shipment to these configured crews. Repeatable and
+    /// comma-separated. Every name must be configured; an unknown or empty one
+    /// fails before a run is created. Omitted, shipment remains unrestricted.
+    #[arg(long = "allow-crew", value_name = "CREW", value_delimiter = ',')]
+    pub allow_crew: Vec<String>,
     /// Output as JSON.
     #[arg(long)]
     pub json: bool,
@@ -90,6 +98,7 @@ impl Execute for ShipCommand {
             self.base.as_deref(),
             &self.task_ids,
             self.completion(),
+            &self.allow_crew,
             None,
             self.claim_token.as_deref(),
         )?;
@@ -186,7 +195,13 @@ pub(crate) fn build_ship_run_plan(
     let base = args.base.as_deref().unwrap_or(config_base_branch);
     Ok(WorkflowRunPlan {
         workflow_alias,
-        input: build_ship_input(mode, base, &args.task_ids, args.completion())?,
+        input: build_ship_input(
+            mode,
+            base,
+            &args.task_ids,
+            args.completion(),
+            &args.allow_crew,
+        )?,
     })
 }
 

--- a/crates/orbit-cli/src/command/run/sweep.rs
+++ b/crates/orbit-cli/src/command/run/sweep.rs
@@ -248,6 +248,7 @@ fn sweep_active_workspace(
         // The sweep is an unattended routine: completion is only ever granted by
         // an operator on a single invocation, never implied by a schedule.
         orbit_core::CompletionPolicy::Review,
+        &[],
         Some("ship-sweep"),
         None,
     ) {

--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -12,6 +12,7 @@ fn ship_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipComma
         mode: Some(mode),
         base: base.map(str::to_string),
         complete: false,
+        allow_crew: Vec::new(),
         json: false,
         claim_token: None,
     }
@@ -21,6 +22,18 @@ fn ship_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipComma
 fn completing_ship_args(task_ids: &[&str], mode: ShipMode, base: Option<&str>) -> ShipCommand {
     ShipCommand {
         complete: true,
+        ..ship_args(task_ids, mode, base)
+    }
+}
+
+fn restricted_ship_args(
+    task_ids: &[&str],
+    mode: ShipMode,
+    base: Option<&str>,
+    crews: &[&str],
+) -> ShipCommand {
+    ShipCommand {
+        allow_crew: crews.iter().map(|crew| (*crew).to_string()).collect(),
         ..ship_args(task_ids, mode, base)
     }
 }
@@ -97,6 +110,17 @@ fn explicit_ship_preserves_local_mode_and_base_override() {
             "task_ids": ["T20260425-2010"],
         })
     );
+}
+
+#[test]
+fn explicit_ship_persists_its_crew_restriction() {
+    let plan = build_plan(
+        &restricted_ship_args(&["T20260425-2010"], ShipMode::Pr, None, &["sol"]),
+        "agent-main",
+    )
+    .expect("build plan");
+
+    assert_eq!(plan.input["allowed_crews"], json!(["sol"]));
 }
 
 #[test]
@@ -317,4 +341,22 @@ fn complete_flag_parses_on_ship_and_auto_with_documented_scope() {
         auto_help.contains("Off by default"),
         "`run auto --complete` must document that it is off by default"
     );
+}
+
+#[test]
+fn allow_crew_parses_on_explicit_ship_and_is_documented() {
+    use clap::{Args as _, FromArgMatches};
+
+    let matches = ShipCommand::augment_args(clap::Command::new("ship"))
+        .no_binary_name(true)
+        .try_get_matches_from(["T20260425-2010", "--allow-crew", "sol,terra"])
+        .expect("explicit ship crew restriction parses");
+    let ship = ShipCommand::from_arg_matches(&matches).expect("build ship command");
+    assert_eq!(ship.allow_crew, vec!["sol", "terra"]);
+
+    let help = ShipCommand::augment_args(clap::Command::new("ship"))
+        .render_long_help()
+        .to_string();
+    assert!(help.contains("--allow-crew"));
+    assert!(help.contains("before a run is created"));
 }

--- a/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
+++ b/crates/orbit-core/assets/skills/orbit-orchestrate/references/authorization.md
@@ -10,6 +10,7 @@ authorized delivery through `done`:
 
 ```bash
 orbit run ship <task-id> --complete
+orbit run ship <task-id> --allow-crew <crew-a>,<crew-b>
 orbit run auto --for 3h --concurrency 7 --complete
 orbit run auto --for 3h --concurrency 7 --complete --allow-crew <crew-a>,<crew-b>
 ```
@@ -56,7 +57,9 @@ to raise capacity. Discover whether the installed version supports a live
 update, and follow its advertised command and authority requirements.
 
 `--allow-crew` is an **allowlist**: it permits the named configured crews and
-excludes others. Tasks outside it are skipped, not automatically remapped.
+excludes others. On an explicit `ship`, an excluded task is refused before its
+run is created; on an auto drain, excluded backlog tasks are skipped. Neither
+path automatically remaps a task.
 It is scoped to the run and checked against resolved crew identity, including
 system activities; it does not cancel already-running workers. Diagnose with:
 

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -20,6 +20,7 @@ a filing routine does not itself authorize execution.
 ```bash
 orbit run ship                      # ship ready backlog tasks through the gated pipeline
 orbit run ship <task-id> ...        # ship exactly these
+orbit run ship <task-id> --allow-crew sol # ship exactly these, only on Sol
 orbit run ship --mode local         # implement in a worktree, merge to the base; no PR
 orbit run auto --for 2h             # drain the backlog for a window
 orbit run auto --for 2h --concurrency 8   # ... with 8 tasks in flight at a time
@@ -69,9 +70,10 @@ idempotent when nothing is running. `orbit run show` reports
 already in flight, `orbit run cancel <child-run-id> --confirm` each one —
 do not cancel the coordinator for this.
 
-`--allow-crew` restricts one drain to the crews you name — the lever for a
-provider that is unavailable, rate-limited, or out of budget. It is opt-in and
-scoped to that run's window:
+`--allow-crew` restricts a ship or drain to the crews you name — the lever for
+a provider that is unavailable, rate-limited, or out of budget. For an
+explicit ship it is checked at submission and again before provider dispatch;
+for an auto drain it is opt-in and scoped to that run's window:
 
 - Names must be crews this workspace configures. An unknown or empty one fails
   the command; nothing is dispatched, and no configuration is written.

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -112,7 +112,7 @@ Use with `orbit_task_show`. A task title or an agent's narrative is not completi
 evidence; inspect status and the recorded implementation/validation outcome.
 
 ```json
-{"workspace":"<selector>","task_ids":["<task-id>"],"mode":"pr","base":"<integration-branch>","model":"<agent-family>"}
+{"workspace":"<selector>","task_ids":["<task-id>"],"mode":"pr","base":"<integration-branch>","allowed_crews":["<configured-crew>"],"model":"<agent-family>"}
 ```
 
 Use with `orbit_workflow_ship` only when execution is authorized. At least one

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -425,6 +425,7 @@ fn resolve_workspace_ship_input(
             runtime.workflow_base_branch(),
             &[],
             COMPLETION_IS_NEVER_WORKSPACE_RESOLVED,
+            &[],
         )
         .map_err(|error| DispatchError::DeterministicActionFailed {
             action: action.to_string(),
@@ -437,6 +438,7 @@ fn resolve_workspace_ship_input(
         runtime.workflow_base_branch(),
         &[],
         COMPLETION_IS_NEVER_WORKSPACE_RESOLVED,
+        &[],
     )
     .map_err(|error| DispatchError::DeterministicActionFailed {
         action: action.to_string(),

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -275,6 +275,34 @@ fn ship_tool_inherits_the_shared_in_flight_guard() {
     );
 }
 
+#[test]
+fn ship_tool_parses_and_rejects_an_unknown_crew_allowlist_before_dispatch() {
+    let _env = unmanaged_tool_env_guard();
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let error = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.ship",
+        json!({
+            "task_ids": ["TST-00001"],
+            "mode": "pr",
+            "allowed_crews": ["not-a-configured-crew"],
+        }),
+    )
+    .expect_err("an unknown MCP crew allowlist must fail before dispatch");
+    assert!(
+        error.to_string().contains("not-a-configured-crew"),
+        "{error}"
+    );
+    assert!(
+        runtime
+            .list_job_runs(crate::application::job::JobRunListParams::default())
+            .expect("list runs")
+            .is_empty(),
+        "a rejected MCP allowlist must not create a run"
+    );
+}
+
 /// ORB-10540: the guard is narrow. Inside the same managed envelope that
 /// refuses ship and resume, the read-only verbs still answer — a blanket
 /// in-run denial would break run observation for every agent.

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -36,6 +36,7 @@ pub(super) fn ship(
             .map_or(ShipMode::Pr, |binding| binding.ship_mode),
     };
     let base = optional_string(&input, "base")?;
+    let allowed_crews = parse_string_array_field(&input, "allowed_crews")?;
     let actor = actor(runtime, agent.as_deref(), model.as_deref());
     let claim_token = optional_string(&input, "claim_token")?;
     let invoke = runtime.submit_ship_run(
@@ -45,6 +46,7 @@ pub(super) fn ship(
         // [ORB-11187] Completion authority is an operator decision made at the
         // CLI; this tool surface does not advertise or accept it.
         crate::application::workflow::CompletionPolicy::Review,
+        &allowed_crews,
         Some(&actor),
         claim_token.as_deref(),
     )?;

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -189,6 +189,7 @@ impl OrbitRuntime {
         base_branch: Option<&str>,
         task_ids: &[String],
         completion: crate::application::workflow::CompletionPolicy,
+        allowed_crews: &[String],
         actor: Option<&str>,
         claim_token: Option<&str>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
@@ -198,8 +199,15 @@ impl OrbitRuntime {
         )
         .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'ship'".to_string()))?;
         let base = base_branch.unwrap_or_else(|| self.workflow_base_branch());
-        let input =
-            crate::application::workflow::build_ship_input(mode, base, task_ids, completion)?;
+        let allowed_crews = self.canonical_allowed_crews(allowed_crews)?;
+        let allowlist = self.crew_allowlist(&allowed_crews)?;
+        let input = crate::application::workflow::build_ship_input(
+            mode,
+            base,
+            task_ids,
+            completion,
+            &allowed_crews,
+        )?;
         // Validate explicit selections before inspecting runs or creating a
         // pipeline record. Auto mode intentionally carries no task ids: the
         // worker discovers eligible backlog tasks after it starts.
@@ -209,6 +217,14 @@ impl OrbitRuntime {
                 return Err(OrbitError::InvalidInput(format!(
                     "task '{task_id}' is an epic root and cannot be shipped as a leaf; use `orbit run auto` or `orbit run job epic_pipeline`"
                 )));
+            }
+            if let Some(allowlist) = allowlist.as_ref() {
+                let crew = self.effective_task_crew(&task)?;
+                crate::runtime::engine::crew::enforce_crew_allowlist(
+                    Some(allowlist),
+                    &crew,
+                    &format!("explicit ship task '{task_id}'"),
+                )?;
             }
         }
         if let Some(conflict) = self.in_flight_ship_run_for_tasks(task_ids)? {
@@ -255,7 +271,7 @@ impl OrbitRuntime {
             for_seconds,
             max_active_leaf_runs,
             completion,
-            &self.canonical_auto_drain_crews(allowed_crews)?,
+            &self.canonical_allowed_crews(allowed_crews)?,
         )?;
         self.submit_pipeline_run(workflow.job_id, input, None, actor)
     }
@@ -266,7 +282,7 @@ impl OrbitRuntime {
     /// Canonical registry names are persisted rather than the operator's
     /// spelling, so the durable run input says exactly which configured crews
     /// the window permits regardless of the alias that was typed.
-    pub(super) fn canonical_auto_drain_crews(
+    pub(super) fn canonical_allowed_crews(
         &self,
         allowed_crews: &[String],
     ) -> Result<Vec<String>, OrbitError> {
@@ -274,12 +290,12 @@ impl OrbitRuntime {
         for name in allowed_crews {
             if name.trim().is_empty() {
                 return Err(OrbitError::InvalidInput(
-                    "crew name in the auto-drain allowlist must not be empty".to_string(),
+                    "crew name in the allowlist must not be empty".to_string(),
                 ));
             }
             let Some(resolved) = self.canonical_crew_name(Some(name))? else {
                 return Err(OrbitError::InvalidInput(
-                    "crew name in the auto-drain allowlist must not be empty".to_string(),
+                    "crew name in the allowlist must not be empty".to_string(),
                 ));
             };
             canonical.insert(resolved);

--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -518,19 +518,19 @@ fn auto_drain_crew_allowlist_is_validated_and_canonicalized_at_submission() {
 
     assert!(
         runtime
-            .canonical_auto_drain_crews(&["not-a-configured-crew".to_string()])
+            .canonical_allowed_crews(&["not-a-configured-crew".to_string()])
             .is_err(),
         "an unconfigured crew must fail the submission"
     );
     assert!(
         runtime
-            .canonical_auto_drain_crews(&["  ".to_string()])
+            .canonical_allowed_crews(&["  ".to_string()])
             .is_err(),
         "a blank crew name must fail the submission"
     );
     assert_eq!(
         runtime
-            .canonical_auto_drain_crews(&[])
+            .canonical_allowed_crews(&[])
             .expect("omitting the option is valid"),
         Vec::<String>::new()
     );

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -606,6 +606,111 @@ spec:
     );
 }
 
+/// Explicit shipment validates its selected task's effective crew before a
+/// run can be persisted, then carries the canonical restriction into the
+/// child pipeline for the dispatch-time provider gate.
+#[test]
+fn explicit_ship_crew_allowlist_admits_only_configured_permitted_crews() {
+    let (_root, runtime) = test_runtime_with_named_crews();
+    let jobs_dir = runtime.paths().global_dir.join("resources/jobs");
+    std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
+    std::fs::write(
+        jobs_dir.join("task_auto_pipeline.yaml"),
+        r#"schemaVersion: 2
+kind: Job
+metadata:
+  name: task_auto_pipeline
+spec:
+  state: enabled
+  kind: workflow
+  steps:
+    - id: nap
+      spec:
+        type: deterministic
+        action: sleep
+        config: {}
+"#,
+    )
+    .expect("seed task_auto_pipeline definition");
+    let permitted = runtime
+        .add_task(TaskAddParams {
+            title: "Sol shipment".to_string(),
+            description: "Explicit crew allowlist fixture".to_string(),
+            crew: Some("sol".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("add permitted task");
+    let excluded = runtime
+        .add_task(TaskAddParams {
+            title: "Primary shipment".to_string(),
+            description: "Explicit crew allowlist fixture".to_string(),
+            crew: Some("primary".to_string()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("add excluded task");
+
+    let error = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&excluded.id),
+            CompletionPolicy::Review,
+            &["sol".to_string()],
+            Some("test"),
+            None,
+        )
+        .expect_err("an excluded explicit crew must be refused before persistence");
+    assert!(error.to_string().contains("primary"), "{error}");
+    assert!(error.to_string().contains("sol"), "{error}");
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list runs")
+            .is_empty(),
+        "the excluded task must not create a run"
+    );
+
+    let unknown = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&permitted.id),
+            CompletionPolicy::Review,
+            &["unknown".to_string()],
+            Some("test"),
+            None,
+        )
+        .expect_err("an unknown configured crew must fail before run creation");
+    assert!(unknown.to_string().contains("unknown"), "{unknown}");
+    assert!(
+        runtime
+            .list_job_runs(JobRunListParams::default())
+            .expect("list runs")
+            .is_empty(),
+        "an invalid allowlist must not create a run"
+    );
+
+    let admitted = runtime
+        .submit_ship_run(
+            ShipMode::Local,
+            Some("main"),
+            std::slice::from_ref(&permitted.id),
+            CompletionPolicy::Review,
+            &["sol".to_string()],
+            Some("test"),
+            None,
+        )
+        .expect("the explicitly permitted singleton is submitted");
+    let input = runtime
+        .show_job_run(&admitted.run_id)
+        .expect("show admitted run")
+        .input
+        .expect("persisted input");
+    assert_eq!(input["allowed_crews"], serde_json::json!(["sol"]));
+}
+
 fn wait_for_worker_ownership_outcome(
     runtime: &OrbitRuntime,
     run_id: &str,
@@ -844,6 +949,7 @@ fn ship_submission_refuses_a_task_already_carried_by_a_non_terminal_run() {
             Some("main"),
             std::slice::from_ref(&selected_task_id),
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )
@@ -904,6 +1010,7 @@ fn ship_submission_guard_is_scoped_to_the_selected_tasks() {
                 Some("main"),
                 &task_ids,
                 CompletionPolicy::Review,
+                &[],
                 Some("test"),
                 None,
             )
@@ -933,6 +1040,7 @@ fn ship_submission_refuses_a_missing_explicit_task_before_persisting_a_run() {
             Some("main"),
             std::slice::from_ref(&missing_id),
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )
@@ -980,6 +1088,7 @@ fn ship_submission_refuses_an_epic_root_but_allows_its_child() {
             Some("main"),
             std::slice::from_ref(&epic.id),
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )
@@ -999,6 +1108,7 @@ fn ship_submission_refuses_an_epic_root_but_allows_its_child() {
             Some("main"),
             std::slice::from_ref(&child.id),
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )
@@ -1021,6 +1131,7 @@ fn ship_submission_mixed_explicit_selection_identifies_the_missing_task() {
             Some("main"),
             &[existing_id, missing_id.clone()],
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )

--- a/crates/orbit-core/src/application/workflow.rs
+++ b/crates/orbit-core/src/application/workflow.rs
@@ -47,6 +47,7 @@ pub fn build_ship_input(
     base_branch: &str,
     task_ids: &[String],
     completion: CompletionPolicy,
+    allowed_crews: &[String],
 ) -> Result<Value, OrbitError> {
     if base_branch.trim().is_empty() {
         return Err(OrbitError::InvalidInput(
@@ -88,6 +89,12 @@ pub fn build_ship_input(
             Value::String(completion.as_input_value().to_string()),
         );
     }
+    if !allowed_crews.is_empty() {
+        map.insert(
+            "allowed_crews".to_string(),
+            Value::Array(allowed_crews.iter().cloned().map(Value::String).collect()),
+        );
+    }
     Ok(Value::Object(map))
 }
 
@@ -126,7 +133,7 @@ mod ship_input_tests {
 
     #[test]
     fn build_ship_input_auto_mode_omits_task_ids() {
-        let input = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Review)
+        let input = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Review, &[])
             .expect("input builds");
         assert_eq!(input["mode"], "pr");
         assert_eq!(input["base_branch"], "main");
@@ -141,6 +148,7 @@ mod ship_input_tests {
             "agent-main",
             &task_ids,
             CompletionPolicy::Review,
+            &[],
         )
         .expect("builds");
         assert_eq!(input["mode"], "local");
@@ -151,24 +159,28 @@ mod ship_input_tests {
     #[test]
     fn build_ship_input_rejects_duplicates_blank_ids_and_empty_base() {
         let dup = vec!["T1".to_string(), "T1".to_string()];
-        assert!(build_ship_input(ShipMode::Pr, "main", &dup, CompletionPolicy::Review).is_err());
+        assert!(
+            build_ship_input(ShipMode::Pr, "main", &dup, CompletionPolicy::Review, &[]).is_err()
+        );
 
         let blank = vec!["  ".to_string()];
-        assert!(build_ship_input(ShipMode::Pr, "main", &blank, CompletionPolicy::Review).is_err());
+        assert!(
+            build_ship_input(ShipMode::Pr, "main", &blank, CompletionPolicy::Review, &[]).is_err()
+        );
 
-        assert!(build_ship_input(ShipMode::Pr, "  ", &[], CompletionPolicy::Review).is_err());
+        assert!(build_ship_input(ShipMode::Pr, "  ", &[], CompletionPolicy::Review, &[]).is_err());
     }
 
     #[test]
     fn completion_policy_is_written_only_when_authorized() {
-        let default = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Review)
+        let default = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Review, &[])
             .expect("default input builds");
         assert!(
             default.get("completion").is_none(),
             "an unauthorized submission must keep the pre-ORB-11187 input verbatim"
         );
 
-        let completing = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Done)
+        let completing = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Done, &[])
             .expect("completing input builds");
         assert_eq!(completing["completion"], "done");
     }
@@ -186,6 +198,20 @@ mod ship_input_tests {
         assert!(CompletionPolicy::parse("merged").is_err());
         assert!(!CompletionPolicy::default().completes());
         assert!(CompletionPolicy::Done.completes());
+    }
+
+    #[test]
+    fn allowed_crews_are_persisted_only_when_restricted() {
+        let allowed = build_ship_input(
+            ShipMode::Pr,
+            "main",
+            &["T1".to_string()],
+            CompletionPolicy::Review,
+            &["sol".to_string()],
+        )
+        .expect("input builds");
+
+        assert_eq!(allowed["allowed_crews"], serde_json::json!(["sol"]));
     }
 
     #[test]

--- a/crates/orbit-core/src/runtime/engine/crew.rs
+++ b/crates/orbit-core/src/runtime/engine/crew.rs
@@ -43,14 +43,14 @@ pub(crate) fn select_crew_name<'a>(
     })
 }
 
-/// Run-input key carrying an auto-drain's crew allowlist [ORB-11242].
+/// Run-input key carrying a shipment's crew allowlist [ORB-11242].
 ///
 /// The drain persists it on the run it submits and every pipeline it admits
 /// forwards it, so the *run* input is the authority for the whole window. An
 /// activity input never widens it.
 pub(crate) const ALLOWED_CREWS_INPUT_KEY: &str = "allowed_crews";
 
-/// The configured crews one auto-drain window may launch a provider as
+/// The configured crews one submitted shipment may launch a provider as
 /// [ORB-11242].
 ///
 /// Opt-in and run-scoped: an absent or empty list is no restriction at all, so

--- a/crates/orbit-core/src/runtime/tests/workspace_claim.rs
+++ b/crates/orbit-core/src/runtime/tests/workspace_claim.rs
@@ -40,6 +40,7 @@ fn ship_error(runtime: &OrbitRuntime, claim_token: Option<&str>) -> OrbitError {
             Some("main"),
             &[],
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             claim_token,
         )
@@ -135,6 +136,7 @@ fn a_discovery_mode_submission_carrying_no_task_ids_is_covered() {
             Some("main"),
             &[],
             CompletionPolicy::Review,
+            &[],
             Some("test"),
             None,
         )
@@ -299,6 +301,7 @@ fn a_refused_dispatch_is_recorded_as_denied_without_the_holders_token() {
         Some("main"),
         std::slice::from_ref(&task_id),
         CompletionPolicy::Review,
+        &[],
         Some("test"),
         None,
     );

--- a/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
@@ -67,6 +67,12 @@ impl Tool for OrbitWorkflowShipTool {
                 required: false,
             },
             ToolParam {
+                name: "allowed_crews".to_string(),
+                description: "Optional configured crews this explicit shipment may dispatch; excluded crews are rejected before provider invocation.".to_string(),
+                param_type: "string_list".to_string(),
+                required: false,
+            },
+            ToolParam {
                 name: "claim_token".to_string(),
                 description: "Token for this workspace's exclusive claim, required when another \
                      operator holds one. Falls back to `ORBIT_WORKSPACE_CLAIM_TOKEN`."

--- a/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/tests/mod.rs
@@ -61,6 +61,7 @@ fn ship_schema_is_review_only_and_has_no_retired_review_controls() {
     assert!(!names.contains(&"review"));
     assert!(!names.contains(&"review_crew"));
     assert!(!names.contains(&"completion"));
+    assert!(names.contains(&"allowed_crews"));
     assert!(schema.description.contains("review-only"));
     assert!(schema.description.contains("does not accept completion"));
     assert!(

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -82,6 +82,7 @@ pub(super) async fn ship_workflow_action(
         // (`orbit run ship --complete`); the dashboard does not offer it, so
         // this endpoint always ends successful work at `review`.
         orbit_core::CompletionPolicy::Review,
+        &[],
         Some("dashboard"),
         body.claim_token.as_deref(),
     ) {


### PR DESCRIPTION
## Task

[ORB-11372](https://orbit-cli.com/tasks/ORB-11372) — Enforce an optional crew allowlist for explicit ship admission and child dispatch

### Description

Confirmed explicit-shipment capability gap from Mac orchestration. DANI-10088 ship jrun-20260906-0147 resolved Opus and failed revoked OAuth401 before implementation, despite this session's exclusive Sol/Terra/Luna policy. Task's intervening crew writer is unproven; current deterministic task-pilot apply.rs522-535 writes only selectors/CI admission, so do not assert it changed crew. Task correction+fresh ship0154 resolved Sol. Current explicit orbit run ship help and MCP orbit_workflow_ship schema have no crew restriction; --allow-crew exists only for workspace auto admission and cannot express explicit singleton scope. Implement optional configured-crew allowlist for explicit ship, reusing existing auto allowed_crews contracts. Carry it through admission/child dispatch, reject excluded resolved crews before provider invocation, and expose coherent CLI/MCP/help. The operator's allowlist should be an enforceable run constraint, not advisory agent prose. Preserve existing behavior when omitted; no cross-provider fallback, authentication change, or new dispatcher. All-status exact explicit ship crew allowlist search found no matching task.

### Acceptance Criteria

- Explicit singleton allowed Sol shipment succeeds; Opus selected initially or introduced between submission and child admission is rejected before any excluded provider invocation.
- Unknown configured crew names fail clearly before run creation; persisted input and run diagnostics show enforced allowed crews.
- CLI and MCP accept equivalent explicit crew restriction, reuse existing configured-crew resolution and covered auto semantics; omitted option preserves compatibility.
- Focused admission/child-dispatch regression tests plus required checks pass, with current help and canonical documentation synchronized.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added repeatable `orbit run ship --allow-crew` and the equivalent MCP `allowed_crews` input; canonical configured crew names are persisted only for restricted runs.
- Enforced an explicit selection at shared ship admission, while retaining the existing dispatch-time resolved-crew gate for later task/system-crew changes before provider invocation.
- Preserved unrestricted compatibility across sweep, dashboard, and internal ship-input callers; synchronized MCP schema, CLI help, and Orbit authorization/orchestration references.
- Added focused CLI, MCP-schema/parser, runtime admission, canonicalization, and dispatch-gate regression coverage.
Assessment: scoped implementation is complete; `git diff --check` passes and all remaining worktree changes are task-scoped.
Validation:
- Passed: focused orbit-core admission/MCP tests; existing system-crew dispatch and auto canonicalization regressions; orbit-tools MCP schema test; orbit-cli CLI parser and persisted-input tests.
- `make ci-fast` reached `cargo fmt --all -- --check` and failed only on pre-existing formatting drift in unrelated workspace/init and engine worktree files; none are modified in this task worktree.
- `make ci-lint` was launched twice, but this runner detached long workspace clippy invocations before their terminal output could be captured; the second detached invocation was stopped after confirming focused validation and no source failure. Unrestricted CI should run the canonical full clippy gate.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11372-6a9cdc55`
- Behind base: 0
- Ahead of base: 1