### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1090,6 +1090,20 @@
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
+        "allowed_crews": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Optional configured crews this explicit shipment may dispatch; excluded crews are rejected before provider invocation."
+        },
         "base": {
           "description": "Optional base branch override.",
           "type": "string"


### PR DESCRIPTION
## Task

[ORB-11405](https://orbit-cli.com/tasks/ORB-11405) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `1be84e567a12d5a43293fd50b25d9e94773b9554`
- Normalized error signature (the dedupe identity, not a quote): `test result: failed. <n> passed; <n> failed; <n> ignored; <n> measured; <n> filtered out; finished in <n>.02s`
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-06T05:07:01.960339575+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/34012634113 run `34012634113` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `1be84e567a12d5a43293fd50b25d9e94773b9554`
  - current head of that ref: `unknown`
  - commit actually checked out: `1be84e567a12d5a43293fd50b25d9e94773b9554`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Check / Clippy / Test` (id `101430950239`): https://github.com/danieljhkim/orbit/actions/runs/34012634113/job/101430950239
  - failing step(s): `Run CI guardrails`
  - failed job `Linux Sandbox & Policy Enforcement` (id `101430950306`): https://github.com/danieljhkim/orbit/actions/runs/34012634113/job/101430950306
  - failing step(s): `Run Linux sandbox/policy enforcement tests`
  - failed job `Coverage (informational)` (id `101430950326`): https://github.com/danieljhkim/orbit/actions/runs/34012634113/job/101430950326
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
[...]
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3079338Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3079679Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3079684Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3079770Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3080021Z     mcp_serve_tools_list_matches_production_snapshot
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3080251Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3080524Z test result: FAILED. 47 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 87.02s
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3080876Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T04:59:18.3092625Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34009930022 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34009747379 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34008837130 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34008794229 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34008792061 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34008686641 — superseded_by_newer_workflow_run: newer relevant run 34012634113 at 2026-09-06T04:53:33Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 1,
  "investigation_cursor": 496853,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11331-6a9ce37d",
    "orbit/ORB-11349-6a9cca37",
    "orbit/ORB-11354-6a9ccf69",
    "orbit/ORB-11359-6a9cca37",
    "orbit/ORB-11372-6a9cdc55",
    "orbit/ORB-11373-6a9cd92d",
    "orbit/ORB-11375-6a9ccc26",
    "orbit/ORB-11376-6a9ccad7",
    "orbit/ORB-11379-6a9cd421",
    "orbit/ORB-11381-6a9cd420",
    "orbit/ORB-11382-6a9cd420",
    "orbit/ORB-11383-6a9cd420",
    "orbit/ORB-11385-6a9cd420",
    "orbit/ORB-11386-6a9cd7f4",
    "orbit/ORB-11388-6a9cd7f3",
    "orbit/ORB-11389-6a9cd830",
    "orbit/ORB-11390-6a9cd830",
    "orbit/ORB-11398-6a9cd8e7"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reproduced the CI failure with `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot -- --exact` at the runner checkout `1be84e567a12d5a43293fd50b25d9e94773b9554`; it failed because the production `tools/list` payload had an `allowed_crews` property absent from the checked-in snapshot.
- Regenerated `crates/orbit-cli/tests/snapshots/mcp_tools_list.json` using the repository-provided `ORBIT_MCP_UPDATE_SNAPSHOT=1` command, adding only the missing `orbit_workflow_ship.allowed_crews` schema.
- Confirmed the exact narrow test passes after the snapshot update.
Validation:
- `cargo test -p orbit-cli --test mcp_roundtrip mcp_serve_tools_list_matches_production_snapshot -- --exact` — passed.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- Removed the run-created ignored `target/` build artifacts; final `git status --short` contains only the intended snapshot change.
Assessment: The repository-owned snapshot drift is corrected without weakening the test, workflow, assertion, or lint level.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11405-6a9cf54a`
- Behind base: 0
- Ahead of base: 1