### PR TITLE
[code-review] Trusted-host refusal messages contain runs of literal whitespace from mangled string continuations

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -65,7 +65,9 @@ const SHIP_IN_FLIGHT_SCAN_LIMIT: usize = 200;
 /// YAML path, a resume, or a tool call.
 pub(crate) fn reserved_trusted_host_key_error(job_name: &str) -> OrbitError {
     OrbitError::InvalidInput(format!(
-        "run input for job '{job_name}' set the reserved `{TRUSTED_HOST_ADMISSION_KEY}` field;          trusted host execution is admitted per invocation by the governed `orbit.agent.invoke`          operation and cannot be requested through ordinary job input"
+        "run input for job '{job_name}' set the reserved `{TRUSTED_HOST_ADMISSION_KEY}` field; \
+         trusted host execution is admitted per invocation by the governed `orbit.agent.invoke` \
+         operation and cannot be requested through ordinary job input"
     ))
 }
 

--- a/crates/orbit-core/src/application/job/resume.rs
+++ b/crates/orbit-core/src/application/job/resume.rs
@@ -89,7 +89,9 @@ impl OrbitRuntime {
             .is_some_and(run_input_declares_trusted_host)
         {
             return Err(OrbitError::JobValidation(format!(
-                "job run '{source_run_id}' was an operator-admitted trusted host invocation and                  cannot be resumed; its admission covered that invocation only. Submit a new                  `orbit.agent.invoke` to authorize another one"
+                "job run '{source_run_id}' was an operator-admitted trusted host invocation and \
+                 cannot be resumed; its admission covered that invocation only. Submit a new \
+                 `orbit.agent.invoke` to authorize another one"
             )));
         }
         if !matches!(

--- a/crates/orbit-core/src/application/job/tests/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/tests/agent_invoke.rs
@@ -138,10 +138,11 @@ fn a_federated_operator_cannot_admit_an_invocation() {
         .expect_err("a federated caller must not admit an unsandboxed process");
     match error {
         OrbitError::CapabilityDenied(message) => {
-            assert!(message.contains("hm_remote"), "{message}");
-            assert!(
-                message.contains("only to an operator on the machine"),
-                "{message}"
+            assert_eq!(
+                message,
+                "operation 'orbit.agent.invoke' admits an unsandboxed host process and \
+                 is available only to an operator on the machine that would run it; caller \
+                 'hm_remote' was resolved through mcp-callers.toml"
             );
         }
         other => panic!("expected a capability denial, got {other:?}"),
@@ -278,8 +279,13 @@ fn ordinary_job_input_cannot_carry_a_trusted_host_admission() {
         .expect_err("run input must not be able to manufacture the mode");
     match error {
         OrbitError::InvalidInput(message) => {
-            assert!(message.contains(TRUSTED_HOST_ADMISSION_KEY), "{message}");
-            assert!(message.contains("orbit.agent.invoke"), "{message}");
+            assert_eq!(
+                message,
+                "run input for job 'agent_invoke_pipeline' set the reserved \
+                 `trusted_host_admission` field; trusted host execution is admitted per \
+                 invocation by the governed `orbit.agent.invoke` operation and cannot \
+                 be requested through ordinary job input"
+            );
         }
         other => panic!("expected invalid input, got {other:?}"),
     }
@@ -464,8 +470,15 @@ fn an_admitted_run_cannot_be_resumed() {
         .expect_err("an admission covers one invocation only");
     match error {
         OrbitError::JobValidation(message) => {
-            assert!(message.contains("cannot be resumed"), "{message}");
-            assert!(message.contains("orbit.agent.invoke"), "{message}");
+            assert_eq!(
+                message,
+                format!(
+                    "job run '{}' was an operator-admitted trusted host invocation \
+                     and cannot be resumed; its admission covered that invocation only. \
+                     Submit a new `orbit.agent.invoke` to authorize another one",
+                    run.run_id
+                )
+            );
         }
         other => panic!("expected a job validation refusal, got {other:?}"),
     }

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -151,7 +151,9 @@ impl OrbitRuntime {
             CallerCapabilities::resolve(&CallerEnvelope::from_process_env(session_context));
         if let Some(grant) = caller.remote_caller_grant() {
             let message = format!(
-                "operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process and                  is available only to an operator on the machine that would run it; caller '{}'                  was resolved through {}",
+                "operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process and \
+                 is available only to an operator on the machine that would run it; caller '{}' \
+                 was resolved through {}",
                 grant.caller_machine_id, grant.source,
             );
             tracing::warn!(

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -62,7 +62,9 @@ pub fn run_cli_backend(
     let trusted_host = if spec.trusted_host_execution {
         Some(TrustedHostAdmission::from_run_input(input).ok_or_else(|| {
             DispatchError::CliInvocationPermanent(format!(
-                "activity `{activity_name}` declares trusted host execution but this run carries                  no operator admission; submit it through the governed `orbit.agent.invoke`                  operation"
+                "activity `{activity_name}` declares trusted host execution but this run carries \
+                 no operator admission; submit it through the governed `orbit.agent.invoke` \
+                 operation"
             ))
         })?)
     } else {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -144,9 +144,11 @@ fn a_declared_mode_without_an_admission_fails_closed() {
     .expect_err("an unadmitted invocation must not run");
 
     match error {
-        DispatchError::CliInvocationPermanent(message) => assert!(
-            message.contains("no operator admission"),
-            "the refusal must name the missing admission: {message}"
+        DispatchError::CliInvocationPermanent(message) => assert_eq!(
+            message,
+            "activity `agent_invoke` declares trusted host execution but this run carries \
+             no operator admission; submit it through the governed `orbit.agent.invoke` \
+             operation"
         ),
         other => panic!("expected a permanent refusal, got {other:?}"),
     }


### PR DESCRIPTION
## Task

[ORB-11403](https://orbit-cli.com/tasks/ORB-11403) — [code-review] Trusted-host refusal messages contain runs of literal whitespace from mangled string continuations

### Description

All four refusal messages added by `ede87b338` (#1426, ORB-11354) were written as multi-line Rust string literals without the `\` line-continuation escape, so each embeds an 18-space (or 10-space) run of literal whitespace at every wrapped point. These are the exact messages an operator sees when a trusted-host invocation is refused — the highest-stakes refusals in the new unsandboxed-execution path — and they render as visibly broken text.

## Evidence

- `crates/orbit-core/src/application/job/pipeline.rs:68` (`reserved_trusted_host_key_error`):
  `"run input for job '{job_name}' set the reserved `{TRUSTED_HOST_ADMISSION_KEY}` field;          trusted host execution is admitted per invocation by the governed `orbit.agent.invoke`          operation and cannot be requested through ordinary job input"`
- `crates/orbit-core/src/application/job/resume.rs:92`:
  `"job run '{source_run_id}' was an operator-admitted trusted host invocation and                  cannot be resumed; its admission covered that invocation only. Submit a new                  `orbit.agent.invoke` to authorize another one"`
- `crates/orbit-core/src/runtime/authorization.rs:154` (`admit_agent_invoke`, federated-caller denial):
  `"operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process and                  is available only to an operator on the machine that would run it; caller '{}'                  was resolved through {}"`
- `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:65`:
  `"activity `{activity_name}` declares trusted host execution but this run carries                  no operator admission; submit it through the governed `orbit.agent.invoke`                  operation"`

Each is a single physical source line, so `rustfmt` has nothing to normalize and the CI fmt gate does not catch it. Confirmed with:

```bash
grep -n "cannot be resumed; its admission" crates/orbit-core/src/application/job/resume.rs | cat -A
```

which shows the literal space run rather than a wrapped literal.

## Why it matters

The message on `authorization.rs:154` is additionally copied verbatim into the durable audit record (`record_authorization_event(..., Some(message.clone()))`) and into the returned `OrbitError::CapabilityDenied`, so the whitespace is persisted into the audit trail, not merely printed once.

## Suggested fix

Re-wrap each literal with a trailing `\` continuation, the idiom already used elsewhere in the same files — for example `crates/orbit-core/src/application/job/agent_invoke.rs:228-230` wraps its `cwd`-outside-workspace message correctly with `\`. Assert on the rendered text in the existing tests for these paths so a future re-wrap cannot silently regress.

Found by the post-merge code-review sweep of `47ccc1767a1e235b92f29bc1596408d7dcd25072..1d1c5d8a096ab4d8d5f4a48b10b56ff2a648f796` (ORB-11384).

### Acceptance Criteria

- The four refusal messages at `crates/orbit-core/src/application/job/pipeline.rs:68`, `crates/orbit-core/src/application/job/resume.rs:92`, `crates/orbit-core/src/runtime/authorization.rs:154`, and `crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:65` render with single spaces at every wrap point.
- A test asserts the rendered text of at least the resume refusal and the federated-caller denial, so the message an operator reads is covered rather than only the error variant.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` still pass after the re-wrap.

## Execution Summary

<details>
<summary>Click to expand</summary>

Re-wrapped the four multi-line trusted-host refusal string literals with trailing backslash continuations across crates/orbit-core/src/application/job/pipeline.rs:68, crates/orbit-core/src/application/job/resume.rs:92, crates/orbit-core/src/runtime/authorization.rs:154, and crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs:65, removing runs of whitespace so each wrap point renders with a single space. Updated tests in crates/orbit-core/src/application/job/tests/agent_invoke.rs and crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs to assert the exact rendered refusal text for the federated-caller denial, reserved key error, resume refusal, and unadmitted execution error. Verified that cargo test, cargo fmt --all -- --check, and cargo clippy --workspace --all-targets --all-features -- -D warnings pass cleanly.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11403-6a9cf63e`
- Behind base: 0
- Ahead of base: 1