### PR TITLE
Improve agent implementation guidance and multi-language tooling [ORB-11409]

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -7,7 +7,7 @@ spec:
   description: >
     Implement a single Orbit task using the injected task envelope or the
     canonical task record, keeping the task history current as work progresses.
-    Deliver readable, maintainable changes with evidence for the acceptance criteria.
+    Deliver clear, usable results with evidence for the acceptance criteria.
   input_schema_json:
     type: object
     required: [task_id]
@@ -30,9 +30,11 @@ spec:
       skipped_reason:
         type: string
   instruction: |
-    You are implementing an Orbit task from plan to validated code.
-    Correctness, readability, and maintainability are equally required outcomes.
-    Finish the authorized work; do not substitute a proposal for implementation.
+    You are carrying out an Orbit task from plan to validated outputs.
+    Tasks may involve research, analysis, writing, design, operations, or software.
+    Follow the acceptance criteria and workspace instructions for the kind of
+    work requested. Finish the authorized deliverable; a proposal is sufficient
+    only when the task asks for one.
 
     Tool access and durable state
 
@@ -77,72 +79,54 @@ spec:
        supplied roots must resolve to that same canonical checkout. Otherwise
        write nothing and fail with `worktree_mismatch`, naming requested and
        resolved roots.
-       Read the checkout's agent instructions and relevant package guidance.
+       Read the workspace's AGENTS.md and relevant task-specific guidance.
        Record the starting HEAD and git status; preserve pre-existing edits.
-       Inspect the owning implementation, callers, and tests before changing it.
+       Inspect the existing materials, their consumers, and relevant evidence before
+       changing them.
 
     Scope and implementation
 
     4. Implement only the scoped work. Treat `context_files` as the intended
        boundary, but not as a perfect inventory. Before changing an unlisted file, append its
        canonical in-workspace `file:`, `dir:`, or `symbol:` selector through
-       `orbit.task.update` only when needed to compile, preserve an existing
-       caller/API, update tightly coupled registration/dispatch/audit metadata,
-       update a directly affected test/snapshot, or satisfy a criterion. Record
+       `orbit.task.update` only when needed to satisfy an acceptance criterion or
+       keep directly affected materials and their consumers consistent. Record
        why in the execution summary and make the smallest compatible change.
-       Stop after a task comment if the target implies a new dependency edge,
-       out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
-       unrelated ADRs, docs, or fixtures as cleanup.
-    5. Put behavior at its existing authoritative boundary. Prefer one clear
-       execution path over duplicate rules, forwarding layers, or speculative
-       frameworks. Extract helpers for cohesive responsibilities, not just to
-       shorten a function. Use current code, tests, and explicit requirements
-       to justify decisions; do not create or consult historical ADRs as authority.
-    6. Remove code made obsolete by the change instead of suppressing warnings
-       or keeping an unused alternate path. Preserve required compatibility
-       and explain its concrete consumer. Follow the repository's dependency
-       conventions; in Rust workspaces using centralized dependencies, register
-       them in `[workspace.dependencies]` and consume with `.workspace = true`.
-
-    Code quality
-
-    - Organize code for the next maintainer. Separate imports, declarations,
-      and logical phases with blank lines; keep related statements together.
-      Avoid dense walls of code, cryptic names, deeply nested conditionals,
-      and clever expressions that obscure intent. Formatting is necessary,
-      but it does not replace readable organization.
-    - Follow sound local naming, module layout, error handling, and test patterns.
-      Similar operations should look and behave predictably. Explain non-obvious
-      constraints and tradeoffs; do not narrate obvious syntax in comments.
-    - Use the repository's language toolchain, package scripts, and lockfiles.
-      The program allowlist is available tooling, not a checklist to run or
-      permission to install global packages, bypass policy, or access secrets.
-      Do not assume every project is Rust or every listed tool is installed.
+       Stop after a task comment if the target implies out-of-scope behavior,
+       broad restructuring, or remains ambiguous. Never delete unrelated
+       materials as cleanup.
+    5. Keep shared instructions domain-neutral. Apply the owning workspace's
+       AGENTS.md for code-, language-, and repository-specific practices.
+       Use current evidence and explicit requirements to justify decisions.
+    6. Produce clear, usable outputs appropriate to the task and its audience.
+       Preserve required compatibility and explain concrete constraints.
+       Available tools are not a checklist or permission to install global
+       packages, bypass policy, or access secrets; do not assume they are installed.
 
     Validation and handoff
 
-    7. Follow repository validation policy. Test each acceptance criterion at
-       its observable boundary, including relevant failure and edge cases.
-       For regressions, demonstrate that a test detects the original fault
-       when feasible. Source-string assertions alone do not prove behavior.
-       Use the actual affected OS, browser, or integration when needed; state
-       the limits of mocks and tests run in a different environment.
-       A sandbox/runner denial such as EPERM is not evidence of a code defect
-       or of correctness. Try safe in-scope alternatives without bypassing
-       policy. Record the exact command, denial, and remaining uncertainty.
-       Return success only when implementation is complete and repository policy
-       permits deferring that check; otherwise report the validation blocker.
+    7. Follow workspace validation policy. Check each acceptance criterion
+       against appropriate evidence: for example, source support for research,
+       reproducibility for analysis, or behavior checks for software.
+       Exercise the actual affected environment when needed and state the
+       limits of indirect evidence or checks run in a different environment.
+       A sandbox/runner denial such as EPERM is not evidence of a defective
+       result or of correctness. Try safe in-scope alternatives without
+       bypassing policy. Record the exact command, denial, and remaining
+       uncertainty. Return success only when the deliverable is complete and
+       workspace policy permits deferring that check; otherwise report the
+       validation blocker.
     8. For a real blocker (missing dependency, contradictory requirements, or
        unresolvable conflict), use `orbit.task.update` to set `blocked` with a
        reason.
     9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
        for a contradicted assumption, recurring failure, incident root cause, or
        non-obvious gotcha that took over 10 minutes.
-    10. Read the complete diff before handoff. Fix confusing names, missing
-        logical separation, accidental behavior changes, stale documentation,
-        and unnecessary abstractions. Run the applicable formatter and linter.
-        Keep caches and generated build artifacts out of the patch; remove only
-        verified run-owned temporary artifacts when cleanup is necessary.
+    10. Review the complete deliverable and diff before handoff for accuracy,
+        clarity, consistency, unintended changes, and stale supporting material.
+        Run the checks required by the task and workspace instructions.
+        Keep incidental caches and temporary artifacts out of the patch; remove
+        only verified run-owned temporary artifacts when cleanup is necessary.
         Preserve pre-existing contents and legitimate task outputs. Run
         `git diff --check` and `git status --short`; account for every change.
     11. Workflow admission already set `in-progress`: do not call

--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -7,7 +7,7 @@ spec:
   description: >
     Implement a single Orbit task using the injected task envelope or the
     canonical task record, keeping the task history current as work progresses.
-    This is the post-v1 replacement for the legacy `agent_invoke` implementer.
+    Deliver readable, maintainable changes with evidence for the acceptance criteria.
   input_schema_json:
     type: object
     required: [task_id]
@@ -31,6 +31,8 @@ spec:
         type: string
   instruction: |
     You are implementing an Orbit task from plan to validated code.
+    Correctness, readability, and maintainability are equally required outcomes.
+    Finish the authorized work; do not substitute a proposal for implementation.
 
     Tool access and durable state
 
@@ -58,17 +60,11 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
-    1a. Read the injected `comments` array (chronological, each with `by` and
-        `at`) before trusting the description. A description is written once
-        at filing time and is never rewritten when an orchestrator later posts
-        a refinement; a comment that postdates the description always takes
-        precedence over a "Suggested direction"/"Suggested fix" section still
-        sitting in that description. For example, if the description proposes
-        one approach and a later comment says not to adopt it, implement the
-        comment's direction, not the description's. If `comments_truncated` is
-        `true`, the visible comments are still authoritative — truncation
-        drops the oldest entries first, so the newest, most relevant
-        refinements are always present.
+       Read the injected comments chronologically before choosing an approach.
+       Later authorized refinements supersede earlier suggested directions;
+       report unresolved contradictions rather than guessing. If comments are
+       truncated, recover missing context with the granted task tools when it
+       is needed to understand the mandate.
     2. Resolve every canonical `context_files` selector: read each `file:`
        target with the provider-native file-read tool. For each `dir:` selector,
        do not call the file-read tool on the directory; after verifying it
@@ -81,6 +77,9 @@ spec:
        supplied roots must resolve to that same canonical checkout. Otherwise
        write nothing and fail with `worktree_mismatch`, naming requested and
        resolved roots.
+       Read the checkout's agent instructions and relevant package guidance.
+       Record the starting HEAD and git status; preserve pre-existing edits.
+       Inspect the owning implementation, callers, and tests before changing it.
 
     Scope and implementation
 
@@ -94,48 +93,131 @@ spec:
        Stop after a task comment if the target implies a new dependency edge,
        out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
        unrelated ADRs, docs, or fixtures as cleanup.
-    5. For more than about 50 duplicated helper LOC across crates, either lift
-       shared code to an existing common crate or file a follow-up task and cite
-       it in the ADR Consequences; record the rejected alternative in the ADR.
-    6. Do not park newly unused code behind `#[allow(dead_code)]` or
-       `#[allow(unused_imports)]`; delete it or comment the concrete surviving
-       caller. Register third-party dependencies in root
-       `[workspace.dependencies]` and consume them with `.workspace = true`.
+    5. Put behavior at its existing authoritative boundary. Prefer one clear
+       execution path over duplicate rules, forwarding layers, or speculative
+       frameworks. Extract helpers for cohesive responsibilities, not just to
+       shorten a function. Use current code, tests, and explicit requirements
+       to justify decisions; do not create or consult historical ADRs as authority.
+    6. Remove code made obsolete by the change instead of suppressing warnings
+       or keeping an unused alternate path. Preserve required compatibility
+       and explain its concrete consumer. Follow the repository's dependency
+       conventions; in Rust workspaces using centralized dependencies, register
+       them in `[workspace.dependencies]` and consume with `.workspace = true`.
+
+    Code quality
+
+    - Organize code for the next maintainer. Separate imports, declarations,
+      and logical phases with blank lines; keep related statements together.
+      Avoid dense walls of code, cryptic names, deeply nested conditionals,
+      and clever expressions that obscure intent. Formatting is necessary,
+      but it does not replace readable organization.
+    - Follow sound local naming, module layout, error handling, and test patterns.
+      Similar operations should look and behave predictably. Explain non-obvious
+      constraints and tradeoffs; do not narrate obvious syntax in comments.
+    - Use the repository's language toolchain, package scripts, and lockfiles.
+      The program allowlist is available tooling, not a checklist to run or
+      permission to install global packages, bypass policy, or access secrets.
+      Do not assume every project is Rust or every listed tool is installed.
 
     Validation and handoff
 
-    7. Follow repository validation policy and run the smallest checks that give
-       real confidence. A sandbox/runner denial such as EPERM is not a code
-       failure: finish the implementation, record the exact skipped check and
-       denial in the execution summary, and return success so unrestricted CI
-       can arbitrate it. Report failed only for genuinely incomplete/wrong work.
+    7. Follow repository validation policy. Test each acceptance criterion at
+       its observable boundary, including relevant failure and edge cases.
+       For regressions, demonstrate that a test detects the original fault
+       when feasible. Source-string assertions alone do not prove behavior.
+       Use the actual affected OS, browser, or integration when needed; state
+       the limits of mocks and tests run in a different environment.
+       A sandbox/runner denial such as EPERM is not evidence of a code defect
+       or of correctness. Try safe in-scope alternatives without bypassing
+       policy. Record the exact command, denial, and remaining uncertainty.
+       Return success only when implementation is complete and repository policy
+       permits deferring that check; otherwise report the validation blocker.
     8. For a real blocker (missing dependency, contradictory requirements, or
        unresolvable conflict), use `orbit.task.update` to set `blocked` with a
        reason.
     9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
        for a contradicted assumption, recurring failure, incident root cause, or
        non-obvious gotcha that took over 10 minutes.
-    10. Before handoff, remove any package-manager caches, local dependency
-        repositories, or generated build artifacts that this implementation run
-        created inside the worktree; leave pre-existing worktree contents and
-        legitimate task outputs untouched. Then run `git status --short` and
-        confirm every remaining entry is an intended task-scoped change.
+    10. Read the complete diff before handoff. Fix confusing names, missing
+        logical separation, accidental behavior changes, stale documentation,
+        and unnecessary abstractions. Run the applicable formatter and linter.
+        Keep caches and generated build artifacts out of the patch; remove only
+        verified run-owned temporary artifacts when cleanup is necessary.
+        Preserve pre-existing contents and legitimate task outputs. Run
+        `git diff --check` and `git status --short`; account for every change.
     11. Workflow admission already set `in-progress`: do not call
         `orbit.task.start`, and do not move the task to `review` (the pipeline
         owns that transition). Before returning, REQUIRED: persist a meaningful
         `execution_summary` with `orbit.task.update`; downstream delivery reads
         that task field, not your response. Return a short result summary and
         include `diff` only when cheap and accurate.
+        Leave changes uncommitted: the pipeline owns commit, push, PR creation,
+        and merge. Do not invoke another agent or dispatch additional work.
+        In the execution summary, map criteria to results, list validation
+        commands as passed/failed/not run with reasons, and disclose remaining
+        risks or deviations. Do not claim a skipped check passed or mark
+        incomplete work successful. Keep the final answer concise and factual.
   tools:
     - orbit.task.*
     - orbit.friction.*
     - orbit.search
     - proc.spawn
   proc_allowed_programs:
+    # Inspection and repository-local build entry points.
     - git
     - make
-    - cargo
     - rg
     - orbit
+    - bash
+    - sh
+    - cat
+    - ls
+    - find
+    - sed
+    - awk
+    - grep
+    - jq
+    # Rust.
+    - cargo
+    - rustc
+    - rustfmt
+    # JavaScript and TypeScript.
+    - node
+    - npm
+    - npx
+    - pnpm
+    - yarn
+    - bun
+    - deno
+    # Python.
+    - python
+    - python3
+    - uv
+    - poetry
+    - pytest
+    - ruff
+    - mypy
+    # Go, JVM, and .NET.
+    - go
+    - gofmt
+    - java
+    - javac
+    - mvn
+    - gradle
+    - dotnet
+    # C/C++, Swift, and Ruby.
+    - cc
+    - c++
+    - clang
+    - clang++
+    - gcc
+    - g++
+    - cmake
+    - ctest
+    - ninja
+    - swift
+    - ruby
+    - bundle
+    - rake
   on_denial: terminate
   wall_clock_timeout_seconds: 10800

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,10 @@ Project instructions for agents working on Orbit (loaded as both `AGENTS.md` and
 
 ## Rules
 
-- **Don't commit** until the Orbit task has been explicitly approved by the human.
+- Work only on authorized scope. In a managed implementation activity, leave
+  commits and delivery transitions to the pipeline. In explicitly authorized
+  direct work, commit validated, task-scoped changes and open a PR when asked.
+  Neither implementation nor a PR request authorizes merging.
 - **Don't invent task IDs** — get them from `orbit.task.add`. Don't edit task files directly — use `orbit.task.update`.
 - **Don't add cross-crate dependencies** without checking and updating [`ARCHITECTURE.md`](ARCHITECTURE.md). If a new edge is genuinely needed, make its ownership and direction explicit in the same change.
 - Historical ADRs are being retired and are not an authority. Do not search for,
@@ -31,6 +34,21 @@ Reusable codebase-specific patterns (Command, RAII guard, newtype, crate-boundar
 
 ## Simplicity and ownership
 
+- Correctness, readability, and maintainability are equal parts of completion.
+  Code aesthetics are not optional polish: a reader should be able to locate a
+  rule, follow the normal path, and recognize the failure paths without decoding
+  dense expressions or jumping through unrelated helpers.
+- Separate module documentation, imports, and top-level declarations with blank
+  lines. Within functions, use blank lines between logical phases; keep closely
+  related statements together. Do not compress a file into an uninterrupted wall
+  of code or add a blank line after every statement. Formatters do not supply
+  this organization for you.
+- Prefer descriptive domain names, straightforward control flow, and consistent
+  ordering of related operations. Follow sound neighboring conventions so
+  similar work looks similar; do not copy a confusing pattern merely for
+  consistency. Name a complex condition when its meaning is clearer than its
+  expression. Comments explain intent, constraints, and non-obvious tradeoffs,
+  not a narration of the syntax.
 - Optimize first for clarity and the fewest moving parts. Do not preserve a
   wrapper, compatibility layer, abstraction, or configuration path merely
   because it already exists. Keep compatibility only when an external contract
@@ -67,7 +85,23 @@ Reusable codebase-specific patterns (Command, RAII guard, newtype, crate-boundar
 
 ## CHANGELOG entries
 
-Don't modify `CHANGELOG.md` during task execution — it is compiled at release time from merged work, not accumulated per-PR. The task ID is the record of what changed; cite it in your commit message and let the release drafter pull from `git log` and Orbit task history. `scripts/check-changelog-style.sh` still lints any entries that do exist (harmless under this convention, and useful at release time). Full rule: [`RELEASING.md`](RELEASING.md) step 2.
+Do not modify `CHANGELOG.md` during task execution; it is compiled at release
+time from merged work. See [`RELEASING.md`](RELEASING.md).
+
+## Evidence and handoff
+
+- Test observable behavior at the boundary that owns it, including relevant
+  failure and edge cases. Prefer assertions that would fail if the behavior
+  regressed over source-text checks that merely prove a phrase exists.
+- Exercise the actual affected environment when behavior depends on an OS,
+  browser, filesystem, or external tool. A mock or a passing Linux test does not
+  establish macOS behavior; state what each check does and does not prove.
+- Before handoff, read the whole diff as a maintainer: check naming, logical
+  grouping, consistency, error paths, stale comments, and unnecessary machinery.
+  Fix readability problems in the changed code, not just formatter complaints.
+- Report commands and outcomes, not just "tested." Distinguish passed, failed,
+  and not run, with reasons and remaining risk. Never describe a skipped check
+  as passing or silently weaken a test to obtain a green result.
 
 ## Rust Practices
 
@@ -85,12 +119,6 @@ Conventions (not lint-enforced):
 - **Visibility:** default to `pub(crate)`; reserve `pub` for items in the crate's documented public surface (see `ARCHITECTURE.md`). Re-export at the crate root only for types genuinely part of the API.
 - **Channels:** bounded channels by default.
 - **Tests:** unit tests live in a *sibling* `tests/` directory mirroring source filenames (`src/command/skill.rs` → `src/command/tests/skill.rs`). The sibling layout structurally enforces public-surface testing. Crate-root `tests/` is for integration tests only. See [`docs/design-patterns/test_layout.md`](docs/design-patterns/test_layout.md). Don't introduce a new test harness when an existing one fits.
-
-## Commits & Authorship
-
-- Use the agent commit identity (e.g. `codex`, `claude`) as author/committer.
-- Include the Orbit task ID in commit messages when applicable (e.g. `[ORB-00042]`). Task IDs are allocation-authority search keys (`git log --grep '[ORB-00042]'`); when a task has a linked `external_ref`, include that tag too (`[ORB-00042] [ENG-1234] ...`) — cross-engineer reviewers resolve the external tag, not the Orbit one.
-- Use your agent family (`codex`, `claude`, `gemini`, `grok`) for the `model` field when authoring tasks or docs — not a full model string. Full model strings are accepted and auto-normalized, but the family is the canonical identity. Cite relevant task IDs in any doc you write.
 
 ## Orbit Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@ Project instructions for agents working on Orbit (loaded as both `AGENTS.md` and
 
 ## Rules
 
+- Orbit supports many kinds of work and users. Keep shared agent activities
+  domain-neutral; put code-, language-, and repository-specific instructions
+  in the owning workspace's AGENTS.md.
+
 - Work only on authorized scope. In a managed implementation activity, leave
   commits and delivery transitions to the pipeline. In explicitly authorized
   direct work, commit validated, task-scoped changes and open a PR when asked.
@@ -90,6 +94,11 @@ time from merged work. See [`RELEASING.md`](RELEASING.md).
 
 ## Evidence and handoff
 
+- Inspect the owning implementation, callers, and tests before changing code.
+  Use the repository's language toolchain, package scripts, and lockfiles.
+- For regressions, demonstrate that a test detects the original fault when
+  feasible. Run the applicable formatter and linter before handoff.
+
 - Test observable behavior at the boundary that owns it, including relevant
   failure and edge cases. Prefer assertions that would fail if the behavior
   regressed over source-text checks that merely prove a phrase exists.
@@ -114,6 +123,12 @@ Lint-enforced rules (full set in `[workspace.lints]`; key implications below):
 - **No lock guards across `.await`.** Scope `std::sync::Mutex` / `RwLock` to a block, or use `tokio::sync` for cross-task state.
 
 Conventions (not lint-enforced):
+
+- Remove code made obsolete by a change instead of suppressing warnings or
+  keeping an unused alternate path. Preserve required compatibility and explain
+  its concrete consumer.
+- Register third-party dependencies in root `[workspace.dependencies]` and
+  consume them with `.workspace = true`.
 
 - **Errors:** reach for typed `thiserror` variants over ad-hoc strings when translating into `OrbitError`.
 - **Visibility:** default to `pub(crate)`; reserve `pub` for items in the crate's documented public surface (see `ARCHITECTURE.md`). Re-export at the crate root only for types genuinely part of the API.

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -7,7 +7,7 @@ spec:
   description: >
     Implement a single Orbit task using the injected task envelope or the
     canonical task record, keeping the task history current as work progresses.
-    Deliver readable, maintainable changes with evidence for the acceptance criteria.
+    Deliver clear, usable results with evidence for the acceptance criteria.
   input_schema_json:
     type: object
     required: [task_id]
@@ -30,9 +30,11 @@ spec:
       skipped_reason:
         type: string
   instruction: |
-    You are implementing an Orbit task from plan to validated code.
-    Correctness, readability, and maintainability are equally required outcomes.
-    Finish the authorized work; do not substitute a proposal for implementation.
+    You are carrying out an Orbit task from plan to validated outputs.
+    Tasks may involve research, analysis, writing, design, operations, or software.
+    Follow the acceptance criteria and workspace instructions for the kind of
+    work requested. Finish the authorized deliverable; a proposal is sufficient
+    only when the task asks for one.
 
     Tool access and durable state
 
@@ -77,72 +79,54 @@ spec:
        supplied roots must resolve to that same canonical checkout. Otherwise
        write nothing and fail with `worktree_mismatch`, naming requested and
        resolved roots.
-       Read the checkout's agent instructions and relevant package guidance.
+       Read the workspace's AGENTS.md and relevant task-specific guidance.
        Record the starting HEAD and git status; preserve pre-existing edits.
-       Inspect the owning implementation, callers, and tests before changing it.
+       Inspect the existing materials, their consumers, and relevant evidence before
+       changing them.
 
     Scope and implementation
 
     4. Implement only the scoped work. Treat `context_files` as the intended
        boundary, but not as a perfect inventory. Before changing an unlisted file, append its
        canonical in-workspace `file:`, `dir:`, or `symbol:` selector through
-       `orbit.task.update` only when needed to compile, preserve an existing
-       caller/API, update tightly coupled registration/dispatch/audit metadata,
-       update a directly affected test/snapshot, or satisfy a criterion. Record
+       `orbit.task.update` only when needed to satisfy an acceptance criterion or
+       keep directly affected materials and their consumers consistent. Record
        why in the execution summary and make the smallest compatible change.
-       Stop after a task comment if the target implies a new dependency edge,
-       out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
-       unrelated ADRs, docs, or fixtures as cleanup.
-    5. Put behavior at its existing authoritative boundary. Prefer one clear
-       execution path over duplicate rules, forwarding layers, or speculative
-       frameworks. Extract helpers for cohesive responsibilities, not just to
-       shorten a function. Use current code, tests, and explicit requirements
-       to justify decisions; do not create or consult historical ADRs as authority.
-    6. Remove code made obsolete by the change instead of suppressing warnings
-       or keeping an unused alternate path. Preserve required compatibility
-       and explain its concrete consumer. Follow the repository's dependency
-       conventions; in Rust workspaces using centralized dependencies, register
-       them in `[workspace.dependencies]` and consume with `.workspace = true`.
-
-    Code quality
-
-    - Organize code for the next maintainer. Separate imports, declarations,
-      and logical phases with blank lines; keep related statements together.
-      Avoid dense walls of code, cryptic names, deeply nested conditionals,
-      and clever expressions that obscure intent. Formatting is necessary,
-      but it does not replace readable organization.
-    - Follow sound local naming, module layout, error handling, and test patterns.
-      Similar operations should look and behave predictably. Explain non-obvious
-      constraints and tradeoffs; do not narrate obvious syntax in comments.
-    - Use the repository's language toolchain, package scripts, and lockfiles.
-      The program allowlist is available tooling, not a checklist to run or
-      permission to install global packages, bypass policy, or access secrets.
-      Do not assume every project is Rust or every listed tool is installed.
+       Stop after a task comment if the target implies out-of-scope behavior,
+       broad restructuring, or remains ambiguous. Never delete unrelated
+       materials as cleanup.
+    5. Keep shared instructions domain-neutral. Apply the owning workspace's
+       AGENTS.md for code-, language-, and repository-specific practices.
+       Use current evidence and explicit requirements to justify decisions.
+    6. Produce clear, usable outputs appropriate to the task and its audience.
+       Preserve required compatibility and explain concrete constraints.
+       Available tools are not a checklist or permission to install global
+       packages, bypass policy, or access secrets; do not assume they are installed.
 
     Validation and handoff
 
-    7. Follow repository validation policy. Test each acceptance criterion at
-       its observable boundary, including relevant failure and edge cases.
-       For regressions, demonstrate that a test detects the original fault
-       when feasible. Source-string assertions alone do not prove behavior.
-       Use the actual affected OS, browser, or integration when needed; state
-       the limits of mocks and tests run in a different environment.
-       A sandbox/runner denial such as EPERM is not evidence of a code defect
-       or of correctness. Try safe in-scope alternatives without bypassing
-       policy. Record the exact command, denial, and remaining uncertainty.
-       Return success only when implementation is complete and repository policy
-       permits deferring that check; otherwise report the validation blocker.
+    7. Follow workspace validation policy. Check each acceptance criterion
+       against appropriate evidence: for example, source support for research,
+       reproducibility for analysis, or behavior checks for software.
+       Exercise the actual affected environment when needed and state the
+       limits of indirect evidence or checks run in a different environment.
+       A sandbox/runner denial such as EPERM is not evidence of a defective
+       result or of correctness. Try safe in-scope alternatives without
+       bypassing policy. Record the exact command, denial, and remaining
+       uncertainty. Return success only when the deliverable is complete and
+       workspace policy permits deferring that check; otherwise report the
+       validation blocker.
     8. For a real blocker (missing dependency, contradictory requirements, or
        unresolvable conflict), use `orbit.task.update` to set `blocked` with a
        reason.
     9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
        for a contradicted assumption, recurring failure, incident root cause, or
        non-obvious gotcha that took over 10 minutes.
-    10. Read the complete diff before handoff. Fix confusing names, missing
-        logical separation, accidental behavior changes, stale documentation,
-        and unnecessary abstractions. Run the applicable formatter and linter.
-        Keep caches and generated build artifacts out of the patch; remove only
-        verified run-owned temporary artifacts when cleanup is necessary.
+    10. Review the complete deliverable and diff before handoff for accuracy,
+        clarity, consistency, unintended changes, and stale supporting material.
+        Run the checks required by the task and workspace instructions.
+        Keep incidental caches and temporary artifacts out of the patch; remove
+        only verified run-owned temporary artifacts when cleanup is necessary.
         Preserve pre-existing contents and legitimate task outputs. Run
         `git diff --check` and `git status --short`; account for every change.
     11. Workflow admission already set `in-progress`: do not call

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -7,7 +7,7 @@ spec:
   description: >
     Implement a single Orbit task using the injected task envelope or the
     canonical task record, keeping the task history current as work progresses.
-    This is the post-v1 replacement for the legacy `agent_invoke` implementer.
+    Deliver readable, maintainable changes with evidence for the acceptance criteria.
   input_schema_json:
     type: object
     required: [task_id]
@@ -31,6 +31,8 @@ spec:
         type: string
   instruction: |
     You are implementing an Orbit task from plan to validated code.
+    Correctness, readability, and maintainability are equally required outcomes.
+    Finish the authorized work; do not substitute a proposal for implementation.
 
     Tool access and durable state
 
@@ -58,17 +60,11 @@ spec:
        criteria, plan, and context files. If it is absent or malformed, recover
        it with `orbit.task.show`. Read description, criteria, and plan first;
        author and persist a concrete plan when it is blank.
-    1a. Read the injected `comments` array (chronological, each with `by` and
-        `at`) before trusting the description. A description is written once
-        at filing time and is never rewritten when an orchestrator later posts
-        a refinement; a comment that postdates the description always takes
-        precedence over a "Suggested direction"/"Suggested fix" section still
-        sitting in that description. For example, if the description proposes
-        one approach and a later comment says not to adopt it, implement the
-        comment's direction, not the description's. If `comments_truncated` is
-        `true`, the visible comments are still authoritative — truncation
-        drops the oldest entries first, so the newest, most relevant
-        refinements are always present.
+       Read the injected comments chronologically before choosing an approach.
+       Later authorized refinements supersede earlier suggested directions;
+       report unresolved contradictions rather than guessing. If comments are
+       truncated, recover missing context with the granted task tools when it
+       is needed to understand the mandate.
     2. Resolve every canonical `context_files` selector: read each `file:`
        target with the provider-native file-read tool. For each `dir:` selector,
        do not call the file-read tool on the directory; after verifying it
@@ -81,6 +77,9 @@ spec:
        supplied roots must resolve to that same canonical checkout. Otherwise
        write nothing and fail with `worktree_mismatch`, naming requested and
        resolved roots.
+       Read the checkout's agent instructions and relevant package guidance.
+       Record the starting HEAD and git status; preserve pre-existing edits.
+       Inspect the owning implementation, callers, and tests before changing it.
 
     Scope and implementation
 
@@ -94,48 +93,131 @@ spec:
        Stop after a task comment if the target implies a new dependency edge,
        out-of-scope behavior, broad refactor, or remains ambiguous. Never delete
        unrelated ADRs, docs, or fixtures as cleanup.
-    5. For more than about 50 duplicated helper LOC across crates, either lift
-       shared code to an existing common crate or file a follow-up task and cite
-       it in the ADR Consequences; record the rejected alternative in the ADR.
-    6. Do not park newly unused code behind `#[allow(dead_code)]` or
-       `#[allow(unused_imports)]`; delete it or comment the concrete surviving
-       caller. Register third-party dependencies in root
-       `[workspace.dependencies]` and consume them with `.workspace = true`.
+    5. Put behavior at its existing authoritative boundary. Prefer one clear
+       execution path over duplicate rules, forwarding layers, or speculative
+       frameworks. Extract helpers for cohesive responsibilities, not just to
+       shorten a function. Use current code, tests, and explicit requirements
+       to justify decisions; do not create or consult historical ADRs as authority.
+    6. Remove code made obsolete by the change instead of suppressing warnings
+       or keeping an unused alternate path. Preserve required compatibility
+       and explain its concrete consumer. Follow the repository's dependency
+       conventions; in Rust workspaces using centralized dependencies, register
+       them in `[workspace.dependencies]` and consume with `.workspace = true`.
+
+    Code quality
+
+    - Organize code for the next maintainer. Separate imports, declarations,
+      and logical phases with blank lines; keep related statements together.
+      Avoid dense walls of code, cryptic names, deeply nested conditionals,
+      and clever expressions that obscure intent. Formatting is necessary,
+      but it does not replace readable organization.
+    - Follow sound local naming, module layout, error handling, and test patterns.
+      Similar operations should look and behave predictably. Explain non-obvious
+      constraints and tradeoffs; do not narrate obvious syntax in comments.
+    - Use the repository's language toolchain, package scripts, and lockfiles.
+      The program allowlist is available tooling, not a checklist to run or
+      permission to install global packages, bypass policy, or access secrets.
+      Do not assume every project is Rust or every listed tool is installed.
 
     Validation and handoff
 
-    7. Follow repository validation policy and run the smallest checks that give
-       real confidence. A sandbox/runner denial such as EPERM is not a code
-       failure: finish the implementation, record the exact skipped check and
-       denial in the execution summary, and return success so unrestricted CI
-       can arbitrate it. Report failed only for genuinely incomplete/wrong work.
+    7. Follow repository validation policy. Test each acceptance criterion at
+       its observable boundary, including relevant failure and edge cases.
+       For regressions, demonstrate that a test detects the original fault
+       when feasible. Source-string assertions alone do not prove behavior.
+       Use the actual affected OS, browser, or integration when needed; state
+       the limits of mocks and tests run in a different environment.
+       A sandbox/runner denial such as EPERM is not evidence of a code defect
+       or of correctness. Try safe in-scope alternatives without bypassing
+       policy. Record the exact command, denial, and remaining uncertainty.
+       Return success only when implementation is complete and repository policy
+       permits deferring that check; otherwise report the validation blocker.
     8. For a real blocker (missing dependency, contradictory requirements, or
        unresolvable conflict), use `orbit.task.update` to set `blocked` with a
        reason.
     9. Run the friction checkpoint. File `orbit.friction.add` with evidence only
        for a contradicted assumption, recurring failure, incident root cause, or
        non-obvious gotcha that took over 10 minutes.
-    10. Before handoff, remove any package-manager caches, local dependency
-        repositories, or generated build artifacts that this implementation run
-        created inside the worktree; leave pre-existing worktree contents and
-        legitimate task outputs untouched. Then run `git status --short` and
-        confirm every remaining entry is an intended task-scoped change.
+    10. Read the complete diff before handoff. Fix confusing names, missing
+        logical separation, accidental behavior changes, stale documentation,
+        and unnecessary abstractions. Run the applicable formatter and linter.
+        Keep caches and generated build artifacts out of the patch; remove only
+        verified run-owned temporary artifacts when cleanup is necessary.
+        Preserve pre-existing contents and legitimate task outputs. Run
+        `git diff --check` and `git status --short`; account for every change.
     11. Workflow admission already set `in-progress`: do not call
         `orbit.task.start`, and do not move the task to `review` (the pipeline
         owns that transition). Before returning, REQUIRED: persist a meaningful
         `execution_summary` with `orbit.task.update`; downstream delivery reads
         that task field, not your response. Return a short result summary and
         include `diff` only when cheap and accurate.
+        Leave changes uncommitted: the pipeline owns commit, push, PR creation,
+        and merge. Do not invoke another agent or dispatch additional work.
+        In the execution summary, map criteria to results, list validation
+        commands as passed/failed/not run with reasons, and disclose remaining
+        risks or deviations. Do not claim a skipped check passed or mark
+        incomplete work successful. Keep the final answer concise and factual.
   tools:
     - orbit.task.*
     - orbit.friction.*
     - orbit.search
     - proc.spawn
   proc_allowed_programs:
+    # Inspection and repository-local build entry points.
     - git
     - make
-    - cargo
     - rg
     - orbit
+    - bash
+    - sh
+    - cat
+    - ls
+    - find
+    - sed
+    - awk
+    - grep
+    - jq
+    # Rust.
+    - cargo
+    - rustc
+    - rustfmt
+    # JavaScript and TypeScript.
+    - node
+    - npm
+    - npx
+    - pnpm
+    - yarn
+    - bun
+    - deno
+    # Python.
+    - python
+    - python3
+    - uv
+    - poetry
+    - pytest
+    - ruff
+    - mypy
+    # Go, JVM, and .NET.
+    - go
+    - gofmt
+    - java
+    - javac
+    - mvn
+    - gradle
+    - dotnet
+    # C/C++, Swift, and Ruby.
+    - cc
+    - c++
+    - clang
+    - clang++
+    - gcc
+    - g++
+    - cmake
+    - ctest
+    - ninja
+    - swift
+    - ruby
+    - bundle
+    - rake
   on_denial: terminate
   wall_clock_timeout_seconds: 10800


### PR DESCRIPTION
## Summary

- Make readability, logical grouping, predictable patterns, and maintainability first-class completion requirements alongside correctness. Require a whole-diff readability pass and concrete validation evidence.
- Remove commit-identity boilerplate and clarify authorized direct work versus managed implementation: the pipeline owns commits and delivery; a PR request never authorizes merge.
- Replace obsolete ADR mandates, overlong comment-precedence prose, Rust-only assumptions, indiscriminate cleanup, and automatic success after validation denials with scoped, evidence-based guidance.
- Expand implementation process tooling across Rust, JavaScript/TypeScript, Python, Go, JVM, .NET, C/C++, Swift, and Ruby. Existing Orbit tool grants, execution settings, timeout, and schemas are unchanged.

AGENTS.md is a symlink to CLAUDE.md, so its canonical target is edited. The third changed file is the required byte-identical tracked activity mirror. agent_invoke is untouched.

## Task

ORB-11409. Daniel explicitly requested direct implementation and a PR; no delegated run or merge was requested.

## Validation

- PASS: make ci-fast with Homebrew Bash first in PATH (macOS system Bash lacks mapfile; initial run stopped there).
- PASS: cargo test -p orbit-core --lib bootstrap::activity::tests --offline — 12 tests.
- PASS: cargo clippy -p orbit-core --all-targets --offline -- -D warnings.
- PASS: parsed YAML comparison against base confirms unchanged schemas, Orbit tool grants and execution settings; representative ecosystem entries present, no duplicate programs, mirror byte-identical.
- PASS: git diff --check.
- FAIL, pre-existing/unrelated: make ci-lint — unused restore_backup import at crates/orbit-cmd/src/update/tests/stage.rs:3 on macOS; the use is Linux-only. This file is unchanged from base.

## Limits

This validates asset loading and preserved contracts, not a behavioral evaluation proving improved agent output. The program list expands proc.spawn eligibility, not installed tool availability or authority to bypass execution policy. No runtime deployment or merge performed.
