### PR TITLE
Fix zero-input task-pilot template failure after base_branch default removal

### DIFF
--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -10,9 +10,10 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
-# The base branch is deliberately omitted from the job defaults: an absent or
-# empty input resolves through the owning workspace's `workflow.base_branch`.
-# A non-empty run input remains an explicit override.
+# The base branch carries an empty sentinel in the job defaults so the prepare
+# template always renders. Prepare resolves that empty value through the owning
+# workspace's `workflow.base_branch`; a non-empty run input remains an explicit
+# override.
 # Any successful partition reaches apply even if another agent failed.
 # Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -45,6 +46,7 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
+    base_branch: ""
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -10,9 +10,10 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
-# The base branch is deliberately omitted from the job defaults: an absent or
-# empty input resolves through the owning workspace's `workflow.base_branch`.
-# A non-empty run input remains an explicit override.
+# The base branch carries an empty sentinel in the job defaults so the prepare
+# template always renders. Prepare resolves that empty value through the owning
+# workspace's `workflow.base_branch`; a non-empty run input remains an explicit
+# override.
 # Any successful partition reaches apply even if another agent failed.
 # Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -45,6 +46,7 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
+    base_branch: ""
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -142,10 +142,12 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
-The prepare step fetches the landing branch (`base_branch`, defaulting to
-`workflow.base_branch`) and pins one `source_revision`, preserving primary
-HEAD, index, dirty and untracked files. Remote failure stops before an agent
-call. Each pilot runs in its own detached checkout at that revision, with
+The job carries an empty `base_branch` default so zero-input template rendering
+reaches prepare. Prepare treats an omitted or empty value as
+`workflow.base_branch`, fetches that landing branch, and pins one
+`source_revision` while preserving primary HEAD, index, dirty and untracked
+files. Remote failure stops before an agent call. Each pilot runs in its own
+detached checkout at that revision, with
 its cwd, input paths, and read-only filesystem profile bound there. Task tools
 retain the owning logical workspace, and apply still checks task snapshots
 with compare-and-set on that authority. Inspection checkouts use at most 16

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its zero-input source snapshot uses the owning workspace's `[workflow] base_branch`; pass a non-empty `base_branch` run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its job input uses an empty `base_branch` sentinel so zero-input templates render, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -447,9 +447,9 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_partial_join_partitions(
     let asset = load_job_asset(yaml).expect("task pilot pipeline parses");
     let defaults = asset.spec.default_input.as_ref().expect("default input");
     assert_eq!(defaults["task_ids"], json!([]));
-    assert!(
-        defaults.get("base_branch").is_none(),
-        "zero-input task-pilot runs must resolve the branch from their owning workspace"
+    assert_eq!(
+        defaults["base_branch"], "",
+        "an empty sentinel must satisfy template rendering while leaving branch resolution to prepare"
     );
     assert_eq!(defaults["max_partition_size"], 5);
     assert_eq!(defaults["promotion_authorized"], false);

--- a/crates/orbit-core/src/application/job/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/tests/mod.rs
@@ -2,4 +2,5 @@ mod agent_invoke;
 mod catalog;
 mod exec;
 mod resume;
+mod task_pilot_pipeline;
 mod workspace_auto_pipeline;

--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -1,0 +1,197 @@
+//! Shipped task-pilot job boundary regressions [ORB-11411].
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use orbit_engine::JobOutcome;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::exec::{seed_default_catalogs, try_execute_named_job};
+use crate::OrbitRuntime;
+
+struct TaskPilotJobFixture {
+    _root: TempDir,
+    runtime: OrbitRuntime,
+    repo_root: PathBuf,
+    stale_sha: String,
+    current_sha: String,
+    dirty_status: String,
+}
+
+fn git(current_dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn configure_commits(repo: &Path) {
+    git(repo, &["config", "user.name", "Orbit Test"]);
+    git(repo, &["config", "user.email", "orbit-test@example.com"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+}
+
+fn commit_file(repo: &Path, relative: &str, contents: &str) -> String {
+    let path = repo.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    fs::write(&path, contents).expect("write fixture file");
+    git(repo, &["add", relative]);
+    git(repo, &["commit", "-m", &format!("write {relative}")]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+fn task_pilot_job_fixture(config_branch: &str, remote_branch: &str) -> TaskPilotJobFixture {
+    let config = format!("[workflow]\nbase_branch = {config_branch:?}\n");
+    let root = tempfile::tempdir().expect("create fixture root");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("create global root");
+    fs::create_dir_all(&workspace_root).expect("create workspace root");
+    fs::write(workspace_root.join("config.toml"), config).expect("write workspace config");
+    let runtime =
+        OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
+    seed_default_catalogs(&global_root);
+
+    let remote = root.path().join("remote.git");
+    let publisher = root.path().join("publisher");
+    let remote_path = remote.to_str().expect("UTF-8 remote path");
+    let publisher_path = publisher.to_str().expect("UTF-8 publisher path");
+
+    git(root.path(), &["init", "--bare", remote_path]);
+    git(&repo_root, &["init"]);
+    git(&repo_root, &["checkout", "-b", remote_branch]);
+    configure_commits(&repo_root);
+    fs::write(repo_root.join(".gitignore"), ".orbit/\n").expect("ignore workspace state");
+    fs::create_dir_all(repo_root.join("src")).expect("create source directory");
+    fs::write(repo_root.join("src/base.rs"), "base\n").expect("write base source");
+    git(&repo_root, &["add", ".gitignore", "src/base.rs"]);
+    git(&repo_root, &["commit", "-m", "seed source"]);
+    git(&repo_root, &["remote", "add", "origin", remote_path]);
+    git(&repo_root, &["push", "-u", "origin", remote_branch]);
+    let stale_sha = git(&repo_root, &["rev-parse", "HEAD"]);
+
+    git(
+        root.path(),
+        &[
+            "clone",
+            "--branch",
+            remote_branch,
+            remote_path,
+            publisher_path,
+        ],
+    );
+    configure_commits(&publisher);
+    let current_sha = commit_file(&publisher, "src/remote.rs", "remote update\n");
+    git(&publisher, &["push", "origin", remote_branch]);
+
+    fs::write(repo_root.join("src/base.rs"), "dirty primary\n").expect("dirty primary source");
+    fs::write(repo_root.join("src/untracked.rs"), "untracked\n").expect("write untracked source");
+    let dirty_status = git(&repo_root, &["status", "--short"]);
+
+    TaskPilotJobFixture {
+        _root: root,
+        runtime,
+        repo_root,
+        stale_sha,
+        current_sha,
+        dirty_status,
+    }
+}
+
+fn execute_task_pilot_job(
+    fixture: &TaskPilotJobFixture,
+    input: Value,
+    run_id: &str,
+) -> Result<JobOutcome, orbit_engine::DispatchError> {
+    try_execute_named_job(
+        &fixture.runtime,
+        &fixture.repo_root,
+        &fixture.runtime,
+        "task_pilot_pipeline",
+        input,
+        run_id,
+    )
+}
+
+fn assert_job_resolves_branch(config_branch: &str, input: Value, expected_branch: &str) {
+    let fixture = task_pilot_job_fixture(config_branch, expected_branch);
+    let run_id = format!("task-pilot-{config_branch}-{expected_branch}");
+    let outcome = execute_task_pilot_job(&fixture, input, &run_id)
+        .expect("shipped task-pilot job must render and reach preparation");
+
+    assert!(outcome.success, "pipeline outcome: {outcome:?}");
+    assert_eq!(
+        outcome.pipeline["prepare"]["source"]["base_branch"],
+        expected_branch
+    );
+    assert_eq!(
+        outcome.pipeline["prepare"]["source"]["source_revision"],
+        fixture.current_sha
+    );
+    assert_eq!(
+        git(&fixture.repo_root, &["rev-parse", "HEAD"]),
+        fixture.stale_sha,
+        "preparation must not advance the primary checkout"
+    );
+    assert_eq!(
+        git(&fixture.repo_root, &["status", "--short"]),
+        fixture.dirty_status,
+        "preparation must preserve dirty and untracked primary files"
+    );
+    assert!(!fixture.repo_root.join("src/remote.rs").exists());
+}
+
+#[test]
+fn shipped_task_pilot_job_renders_omitted_and_empty_workspace_branch_inputs() {
+    for (config_branch, input) in [
+        ("main", json!({})),
+        ("main", json!({ "base_branch": "" })),
+        ("agent-main", json!({})),
+        ("agent-main", json!({ "base_branch": "" })),
+    ] {
+        assert_job_resolves_branch(config_branch, input, config_branch);
+    }
+}
+
+#[test]
+fn shipped_task_pilot_job_honors_an_explicit_alternate_branch() {
+    assert_job_resolves_branch("main", json!({ "base_branch": "release" }), "release");
+}
+
+#[test]
+fn shipped_task_pilot_job_rejects_an_unavailable_explicit_branch() {
+    let fixture = task_pilot_job_fixture("main", "main");
+    let error = execute_task_pilot_job(
+        &fixture,
+        json!({ "base_branch": "missing-branch" }),
+        "task-pilot-missing-branch",
+    )
+    .expect_err("an unavailable explicit branch must fail before pilot dispatch");
+    let message = error.to_string();
+
+    assert!(message.contains("could not fetch"), "{message}");
+    assert!(message.contains("missing-branch"), "{message}");
+    assert_eq!(
+        git(&fixture.repo_root, &["rev-parse", "HEAD"]),
+        fixture.stale_sha
+    );
+    assert_eq!(
+        git(&fixture.repo_root, &["status", "--short"]),
+        fixture.dirty_status
+    );
+}

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -142,10 +142,12 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
-The prepare step fetches the landing branch (`base_branch`, defaulting to
-`workflow.base_branch`) and pins one `source_revision`, preserving primary
-HEAD, index, dirty and untracked files. Remote failure stops before an agent
-call. Each pilot runs in its own detached checkout at that revision, with
+The job carries an empty `base_branch` default so zero-input template rendering
+reaches prepare. Prepare treats an omitted or empty value as
+`workflow.base_branch`, fetches that landing branch, and pins one
+`source_revision` while preserving primary HEAD, index, dirty and untracked
+files. Remote failure stops before an agent call. Each pilot runs in its own
+detached checkout at that revision, with
 its cwd, input paths, and read-only filesystem profile bound there. Task tools
 retain the owning logical workspace, and apply still checks task snapshots
 with compare-and-set on that authority. Inspection checkouts use at most 16

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its zero-input source snapshot uses the owning workspace's `[workflow] base_branch`; pass a non-empty `base_branch` run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its job input uses an empty `base_branch` sentinel so zero-input templates render, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |


### PR DESCRIPTION
## Task

[ORB-11411](https://orbit-cli.com/tasks/ORB-11411) — Fix zero-input task-pilot template failure after base_branch default removal

### Description

## Problem
Scheduled task_pilot_pipeline fails before preparation or any agent invocation when the run supplies no base_branch. Preserve workspace-specific branch selection while making the shipped job template render successfully.

## Incident evidence
Authoritative Linux workspace ws_orbit (hm_9ca6004473492f06): jrun-20260906-0601-2, task_pilot_pipeline, input {}, started 2026-09-06T06:01:01.568142713Z, failed after 59 ms with `execution failed: v2 job dispatch: job executor: template render: invalid input: missing input value for 'base_branch'`. Current installed /usr/local/bin/orbit reports 0.18.0. Effective global config is ~/.orbit/config.toml, workspace config is ~/workspace/constellation/codebases/orbit/.orbit/config.toml, workflow.base_branch is agent-main. The live global job ~/.orbit/resources/jobs/task_pilot_pipeline.yaml omits spec.default_input.base_branch but prepare.default_input still references {{ input.base_branch }}. The enabled task-pilot-orbit routine supplies no inputs.

## Exact regression attribution
ORB-11351, PR https://github.com/danieljhkim/orbit/pull/1414, landed commit 94b2f80b00e97933c8038b4fb4cfcbde5fbf5ea0 (2026-09-06 02:14:22 UTC), removed `base_branch: agent-main` from both canonical and workspace job defaults without changing the required prepare-step template lookup. crates/orbit-engine/src/template.rs:131-138 rejects absent keys before prepare_task_pilot can apply workspace fallback. Parent revision had the default; this commit removed it. Later ORB-11331/1be84e567 touched adjacent fields and fan-in but retained the already-broken contract. Source history and the actual failed run establish attribution; no new live job was submitted during diagnosis.

## Constraints
Retain ORB-11351's intended behavior: omitted/empty base branch resolves from the owning workspace; explicit non-empty input overrides it. Do not restore a hard-coded agent-main default or weaken missing-key errors globally. An empty-string default may be sufficient if consistent with current renderer/runtime contracts. Keep canonical and managed artifacts plus affected documentation consistent. Existing source-level preparation tests bypassed the missing template key; add coverage through real job default merging/rendering and deterministic preparation with temporary repositories/fakes. Medium complexity / terra: bounded resource contract and integration-test repair. Filing only; no dispatch requested.

### Acceptance Criteria

- Executing the shipped task_pilot_pipeline with {} through real job input merging and template rendering reaches prepare_task_pilot without a missing base_branch error; a deterministic regression test fails on the pre-fix definition.
- Omitted and empty base_branch inputs resolve to main in a main-only configured workspace and agent-main in an agent-main workspace; explicit alternate-branch input remains honored.
- Tests exercise the job-to-activity boundary rather than calling only the source helper or asserting YAML strings; preserve unavailable-ref failure and source snapshot safety.
- Canonical/managed job definitions and affected documentation agree, relevant targeted tests plus make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added base_branch: "" to both canonical and managed task_pilot_pipeline job defaults. The empty sentinel satisfies strict template rendering while prepare keeps the workspace-specific fallback and explicit non-empty override.
- Added shipped-job boundary tests that load seeded job/activity catalogs, perform real job input merging and template rendering, and execute prepare_task_pilot against temporary remote Git repositories.
- Covered omitted and empty inputs in main and agent-main workspaces, an explicit release override, unavailable-ref failure, and preservation of stale/dirty/untracked primary checkout state.
- Updated canonical and plugin-distributed task-pilot documentation to describe the empty-sentinel contract.

Acceptance criteria:
1. The shipped task_pilot_pipeline executes from {} through real job merging/rendering into prepare_task_pilot. Removing the new canonical default made the regression test fail deterministically with missing input value for base_branch; restoring it passes.
2. Omitted and empty inputs resolve to main or agent-main from workspace configuration, while explicit release remains honored.
3. Tests cross the job-to-activity boundary; unavailable-ref failure and source snapshot safety are asserted there, and the existing task-pilot source suite remains green.
4. Canonical/managed job files and canonical/plugin skill docs compare byte-for-byte; targeted tests, ci-fast, and ci-lint pass.

Validation:
- PASSED: cargo test -p orbit-core task_pilot -- --nocapture (37 passed).
- EXPECTED REGRESSION FAILURE: cargo test -p orbit-core shipped_task_pilot_job_renders_omitted_and_empty_workspace_branch_inputs -- --nocapture after temporarily removing the canonical default; failed with template render: invalid input: missing input value for base_branch. The fix was restored before all passing checks.
- PASSED: make ci-fast.
- PASSED: make ci-lint.
- PASSED: git diff --check.
- PASSED: cmp checks for canonical/managed job YAML and both canonical/plugin documentation mirrors.
- NOT RUN: make ci, per workspace policy reserving the full suite for the PR merge gate.

Assessment: The change is limited to the broken resource contract, regression coverage, and synchronized current documentation. No runtime renderer behavior or global missing-key validation was weakened.
Deviations from original plan: The new boundary regression lives in the application job test module rather than the source-helper test module because it exercises the owning job execution boundary directly.
Remaining risks: None identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11411-6a9d991d`
- Behind base: 0
- Ahead of base: 1