### PR TITLE
Remove fork-storm test cases and prevent recursive test-worker spawning

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -170,68 +170,6 @@ fn managed_run_environment_denies_ship_and_resume_end_to_end() {
     );
 }
 
-/// ORB-10540: the permitted direction, same tools and same operator session,
-/// with the managed-run envelope absent.
-///
-/// Without this the denial test above cannot distinguish a working guard from
-/// one that refuses unconditionally. Both verbs reach the runtime and produce
-/// real runs.
-#[test]
-fn unmanaged_environment_admits_operator_ship_and_resume() {
-    let _env = unmanaged_tool_env_guard();
-    let (_root, runtime, repo_root) = test_runtime();
-    write_ship_job_asset(&runtime);
-    let source_run_id = seed_failed_run(&runtime);
-    let task_ids = seed_ship_tasks(&runtime, &repo_root);
-
-    // The mirror of the denial test's scope assertion: with no envelope there is
-    // no run scope, which is what leaves the guard inert.
-    assert_eq!(
-        build_orbit_tool_host(
-            &runtime,
-            None,
-            None,
-            orbit_types::tool::ToolSessionContext::default()
-        )
-        .task_scope()
-        .run_id,
-        None,
-    );
-
-    let shipped = run_tool_as_operator(&runtime, "orbit.workflow.ship", ship_input(&task_ids))
-        .expect("unmanaged operator ship is admitted");
-    assert_eq!(shipped["workflow"], json!("ship"));
-    assert_eq!(shipped["job_id"], json!(SHIP_JOB));
-    let shipped_run_id = shipped["run_id"].as_str().expect("ship run id").to_string();
-
-    let resumed = run_tool_as_operator(
-        &runtime,
-        "orbit.workflow.run.resume",
-        json!({"id": source_run_id}),
-    )
-    .expect("unmanaged operator resume is admitted");
-    assert_eq!(resumed["workflow"], json!("resume"));
-    assert_eq!(resumed["retry_source_run_id"], json!(source_run_id));
-
-    let resumed_run_id = resumed["run_id"].as_str().expect("resume run id");
-    let stored = runtime
-        .show_job_run(&shipped_run_id)
-        .expect("shipped run is persisted");
-    assert_eq!(stored.job_id, SHIP_JOB);
-    assert_eq!(
-        stored.input.expect("ship input")["task_ids"],
-        json!(task_ids)
-    );
-    assert_eq!(
-        runtime
-            .show_job_run(resumed_run_id)
-            .expect("resumed run is persisted")
-            .retry_source_run_id
-            .as_deref(),
-        Some(source_run_id.as_str())
-    );
-}
-
 /// ORB-10544: `orbit.workflow.ship` is a thin projection of the shared
 /// submission path, so it inherits that path's duplicate-dispatch guard: a task
 /// already carried by a non-terminal run is refused here with the same typed

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1240,20 +1240,28 @@ impl OrbitRuntime {
     fn pipeline_worker_command(&self, run_id: &str) -> Result<Command, OrbitError> {
         let paths = self.paths();
         #[cfg(test)]
-        if let Some(command) = worker_command_override::command(&paths.repo_root, run_id) {
-            return Ok(command);
+        {
+            worker_command_override::command(&paths.repo_root, run_id).ok_or_else(|| {
+                OrbitError::Execution(
+                    "test pipeline worker requires an explicit worker command override".to_string(),
+                )
+            })
         }
-        let current_exe = std::env::current_exe().map_err(|error| {
-            OrbitError::Execution(format!("resolve current orbit executable: {error}"))
-        })?;
-        let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
-        configure_pipeline_worker_command(
-            &mut command,
-            &paths.repo_root,
-            run_id,
-            pipeline_worker_root_override(paths),
-        );
-        Ok(command)
+
+        #[cfg(not(test))]
+        {
+            let current_exe = std::env::current_exe().map_err(|error| {
+                OrbitError::Execution(format!("resolve current orbit executable: {error}"))
+            })?;
+            let mut command = Command::new(resolve_pipeline_worker_executable(current_exe));
+            configure_pipeline_worker_command(
+                &mut command,
+                &paths.repo_root,
+                run_id,
+                pipeline_worker_root_override(paths),
+            );
+            Ok(command)
+        }
     }
 
     pub(crate) fn spawn_pipeline_worker_process(

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -305,81 +305,38 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_child_reaped(worker_pid);
 }
 
-/// [ORB-11116] Two observers can watch children for the same persisted run.
-/// The duplicate exits zero after losing Start, but only the child whose exact
-/// PID is persisted may be treated as the owner by its observer.
-#[cfg(unix)]
+/// Exact worker ownership is a persisted state-machine invariant. Keep this
+/// regression in-process: a detached child is unnecessary to prove that a
+/// second PID cannot replace an already-running owner.
 #[test]
-fn duplicate_worker_exit_leaves_real_owner_authoritative_and_non_terminal() {
+fn duplicate_worker_cannot_replace_the_persisted_owner() {
     let (_root, runtime) = test_runtime();
     let run = runtime
         .stores()
         .jobs()
         .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
         .expect("insert pending run");
-    let owner_release = runtime.paths().logs_dir.join("release-real-owner");
+    let owner_pid = std::process::id();
+    let duplicate_pid = owner_pid
+        .checked_add(1)
+        .expect("process id has a successor");
 
-    let mut owner_command = Command::new("sh");
-    owner_command.env("ORBIT_TEST_OWNER_RELEASE", &owner_release);
-    owner_command.args([
-        "-c",
-        "while [ ! -f \"$ORBIT_TEST_OWNER_RELEASE\" ]; do sleep 0.01; done; exit 0",
-    ]);
-    let owner_log = configure_pipeline_worker_stdio(
-        &mut owner_command,
-        &runtime.paths().logs_dir,
-        &format!("{}-owner", run.run_id),
-    )
-    .expect("configure owner worker log");
-    let owner_pid = runtime
-        .spawn_pipeline_worker_process(&run.run_id, Some("test"), owner_command, owner_log)
-        .expect("spawn real owner fixture");
     assert!(
         runtime
             .stores()
             .jobs()
             .claim_pending_job_run_owner(&run.run_id, owner_pid)
-            .expect("claim real owner")
+            .expect("claim exact owner")
     );
     assert_eq!(
         runtime
             .stores()
             .jobs()
             .mark_job_run_running(&run.run_id, Utc::now(), owner_pid)
-            .expect("start real owner"),
+            .expect("start exact owner"),
         JobRunStartOutcome::Started
     );
 
-    let claimed = wait_for_pipeline_audit_event(&runtime, None, "exact-owner audit", |audit| {
-        audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
-            && audit.target_id.as_deref() == Some(run.run_id.as_str())
-    });
-    let claimed_arguments: serde_json::Value = serde_json::from_str(
-        claimed
-            .arguments_json
-            .as_deref()
-            .expect("claimed audit arguments"),
-    )
-    .expect("parse claimed audit arguments");
-    assert_eq!(claimed_arguments["worker_pid"], owner_pid);
-    assert_eq!(claimed_arguments["owner_pid"], owner_pid);
-
-    let duplicate_release = runtime.paths().logs_dir.join("release-duplicate-worker");
-    let mut duplicate_command = Command::new("sh");
-    duplicate_command.env("ORBIT_TEST_DUPLICATE_RELEASE", &duplicate_release);
-    duplicate_command.args([
-        "-c",
-        "while [ ! -f \"$ORBIT_TEST_DUPLICATE_RELEASE\" ]; do sleep 0.01; done; exit 0",
-    ]);
-    let duplicate_log = configure_pipeline_worker_stdio(
-        &mut duplicate_command,
-        &runtime.paths().logs_dir,
-        &format!("{}-duplicate", run.run_id),
-    )
-    .expect("configure duplicate worker log");
-    let duplicate_pid = runtime
-        .spawn_pipeline_worker_process(&run.run_id, Some("test"), duplicate_command, duplicate_log)
-        .expect("spawn duplicate worker fixture");
     let duplicate_start =
         runtime
             .stores()
@@ -389,120 +346,12 @@ fn duplicate_worker_exit_leaves_real_owner_authoritative_and_non_terminal() {
         matches!(duplicate_start, Err(OrbitError::JobRunStartConflict(_))),
         "duplicate worker must lose the atomic Start race: {duplicate_start:?}"
     );
-    std::fs::write(&duplicate_release, "release").expect("release duplicate worker");
 
-    let duplicate =
-        wait_for_pipeline_audit_event(&runtime, None, "duplicate-worker audit", |audit| {
-            audit.tool_name.as_deref() == Some("pipeline.worker.duplicate")
-                && audit.target_id.as_deref() == Some(run.run_id.as_str())
-        });
-    let duplicate_arguments: serde_json::Value = serde_json::from_str(
-        duplicate
-            .arguments_json
-            .as_deref()
-            .expect("duplicate audit arguments"),
-    )
-    .expect("parse duplicate audit arguments");
-    assert_eq!(duplicate_arguments["worker_pid"], duplicate_pid);
-    assert_eq!(duplicate_arguments["owner_pid"], owner_pid);
-    assert_eq!(duplicate_arguments["exit_status"], "exit status: 0");
-    assert_child_reaped(duplicate_pid);
-
-    let after_duplicate = runtime
-        .show_job_run(&run.run_id)
-        .expect("show run after duplicate exit");
-    assert_eq!(after_duplicate.state, JobRunState::Running);
-    assert_eq!(after_duplicate.pid, Some(owner_pid));
-    assert!(after_duplicate.finished_at.is_none());
-    assert!(after_duplicate.steps.is_empty());
-
-    runtime
-        .stores()
-        .jobs()
-        .finalize_job_run(&run.run_id, JobRunState::Success, Utc::now(), Some(1))
-        .expect("real owner completes run");
-    std::fs::write(&owner_release, "release").expect("release real owner");
-
-    let completed = runtime
-        .show_job_run(&run.run_id)
-        .expect("show completed run");
-    assert_eq!(completed.state, JobRunState::Success);
-    assert!(completed.finished_at.is_some());
-    assert!(completed.steps.is_empty());
-    let false_owner_exit = runtime
-        .list_audit_events(None, None, None, None, 50)
-        .expect("list worker audits")
-        .into_iter()
-        .any(|audit| {
-            audit.tool_name.as_deref() == Some("pipeline.worker.exit")
-                && audit.target_id.as_deref() == Some(run.run_id.as_str())
-        });
-    assert!(
-        !false_owner_exit,
-        "duplicate exit must not be an owner failure"
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn worker_exit_after_mark_running_is_reaped_and_terminalizes_the_run() {
-    let (_root, runtime) = test_runtime();
-    let run = runtime
-        .stores()
-        .jobs()
-        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
-        .expect("insert pending run");
-    let release_path = runtime.paths().logs_dir.join("release-claimed-worker");
-    let mut command = Command::new("sh");
-    command.env("ORBIT_TEST_WORKER_RELEASE", &release_path);
-    command.args([
-        "-c",
-        "while [ ! -f \"$ORBIT_TEST_WORKER_RELEASE\" ]; do sleep 0.01; done; \
-         printf 'post-claim validation exploded\\n' >&2; exit 29",
-    ]);
-    let log_path =
-        configure_pipeline_worker_stdio(&mut command, &runtime.paths().logs_dir, &run.run_id)
-            .expect("configure worker log");
-    let worker_pid = runtime
-        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path)
-        .expect("spawn claimed worker fixture");
-    runtime
-        .stores()
-        .jobs()
-        .claim_pending_job_run_owner(&run.run_id, worker_pid)
-        .expect("claim run owner");
-    assert_eq!(
-        runtime
-            .stores()
-            .jobs()
-            .mark_job_run_running(&run.run_id, Utc::now(), worker_pid)
-            .expect("mark run running"),
-        JobRunStartOutcome::Started
-    );
-    assert_eq!(
-        runtime
-            .show_job_run(&run.run_id)
-            .expect("show running fixture")
-            .state,
-        JobRunState::Running
-    );
-    std::fs::write(&release_path, "release").expect("release claimed worker");
-
-    let terminal = wait_for_worker_terminal(&runtime, &run.run_id);
-    let message = terminal
-        .steps
-        .last()
-        .and_then(|step| step.error_message.as_deref())
-        .expect("post-claim diagnostic");
-    assert_eq!(terminal.state, JobRunState::Failed, "{message}");
-    assert!(terminal.finished_at.is_some());
-    assert!(message.contains("after claiming"), "{message}");
-    assert!(message.contains("exit status: 29"), "{message}");
-    assert!(
-        message.contains("post-claim validation exploded"),
-        "{message}"
-    );
-    assert_child_reaped(worker_pid);
+    let stored = runtime.show_job_run(&run.run_id).expect("show owned run");
+    assert_eq!(stored.state, JobRunState::Running);
+    assert_eq!(stored.pid, Some(owner_pid));
+    assert!(stored.finished_at.is_none());
+    assert!(stored.steps.is_empty());
 }
 
 #[test]

--- a/crates/orbit-core/src/application/tests/job_submission.rs
+++ b/crates/orbit-core/src/application/tests/job_submission.rs
@@ -18,9 +18,9 @@ use crate::OrbitRuntime;
 use crate::application::job::JobRunListParams;
 use crate::application::job::pipeline::{run_definition_snapshot_path, worker_command_override};
 
-/// Long enough that the startup observer cannot terminalize the run while the
-/// submission assertions run, short enough not to outlive the test binary.
-const IDLE_WORKER: &str = "sleep 5";
+/// A finite worker for submission-path assertions. The startup observer reaps
+/// it after the one-second bound, so focused test runs leave no fixture child.
+const IDLE_WORKER: &str = "sleep 1";
 
 fn test_runtime() -> (TempDir, OrbitRuntime) {
     let root = TempDir::new().expect("tempdir");
@@ -136,6 +136,36 @@ fn submission_reports_queued_when_the_job_is_at_its_active_run_limit() {
         invoke.queued,
         "the second run of a max_active_runs=1 job must report queued"
     );
+}
+
+#[test]
+fn test_submission_requires_an_explicit_worker_override_before_spawning() {
+    let (_root, runtime) = test_runtime();
+    seed_catalog_job(&runtime, "qa_submit_missing_override", 1);
+
+    let error = runtime
+        .submit_job_run(
+            "qa_submit_missing_override",
+            serde_json::json!({}),
+            Some("test"),
+        )
+        .expect_err("test builds must not re-exec the libtest binary as a pipeline worker");
+    assert!(
+        error
+            .to_string()
+            .contains("requires an explicit worker command override"),
+        "the submission must fail closed before spawning a worker: {error}"
+    );
+
+    let runs = runtime
+        .list_job_runs(JobRunListParams {
+            job_id: Some("qa_submit_missing_override".to_string()),
+            ..Default::default()
+        })
+        .expect("list submitted runs");
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].state, JobRunState::Interrupted);
+    assert_eq!(runs[0].pid, None, "no worker process may have started");
 }
 
 /// A worker that cannot start is the *submission's* failure: the caller is


### PR DESCRIPTION
## Task

[ORB-11418](https://orbit-cli.com/tasks/ORB-11418) — Remove fork-storm test cases and prevent recursive test-worker spawning

### Description

## Problem
The 2026-09-06 RCA at docs/rca/2026-09-06-recursive-test-worker-fork-storm.md documents a recursive orbit-core libtest worker path that accumulated 382 detached shell waiters and saturated a 14-CPU host (load 393.68). Daniel explicitly requests removal of these dangerous test cases.

Local source inspection confirms unmanaged_environment_admits_operator_ship_and_resume in crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs submits real ship/resume runs without a worker override. application/job/pipeline.rs falls back to current_exe, which is libtest under unit tests. duplicate_worker_exit_leaves_real_owner_authoritative_and_non_terminal in application/tests/job_pipeline.rs launches both ORBIT_TEST_OWNER_RELEASE and ORBIT_TEST_DUPLICATE_RELEASE unbounded shell loops with external sleep 0.01 and success-path release. A further ORBIT_TEST_WORKER_RELEASE fixture in that file uses the same unsafe pattern.

## Scope
Remove the dangerous process-spawning test cases/fixtures and their unused support code, including equivalent sentinel-polling cases in the affected test modules. Preserve meaningful authorization and persisted worker-ownership coverage using deterministic in-process fakes/state transitions where practical; do not retain the unsafe tests behind ignore flags or merely increase their polling interval. Make the test-build pipeline worker command path fail closed when no explicit safe test override exists, so omitted fixture setup cannot re-execute libtest. Keep production CLI worker semantics unchanged.

## Constraints and validation
Inspect current source and remove the hazards before executing affected tests. Do not reproduce the incident or run the existing unsafe broad suite as a baseline. Validate only the repaired focused suites first, in a bounded process scope with timeout and descendant cleanup; capture exit status directly and confirm no worker/test descendants survive. Avoid repeated/backgrounded broad suites. This is medium/terra work: bounded test cleanup plus one test-only spawning guard. Implement in a dedicated worktree from agent-main and prepare a PR for Daniel's approval.

## Related evidence / exclusions
RCA task ORB-11416, lesson task ORB-11414, incident friction F2026-09-042, and visibility task ORB-11415. Host monitoring, automatic throttling/cancellation, and the general task/run completion mismatch are outside this fix; do not claim this task resolves the whole incident friction. Duplicate searches across open and closed tasks found the RCA/lesson work but no matching removal fix.

### Acceptance Criteria

- The named unsafe workflow submission and detached sentinel-loop test cases are removed or replaced with deterministic tests that cannot launch real detached pipeline workers; all ORBIT_TEST_OWNER_RELEASE, ORBIT_TEST_DUPLICATE_RELEASE, and ORBIT_TEST_WORKER_RELEASE unbounded polling fixtures and obsolete helpers are eliminated.
- An audit of the affected job/tool-host test modules identifies and removes equivalent unbounded detached waiter patterns; record inspected paths and any remaining subprocess fixtures with their concrete bounds and cleanup behavior.
- In a test build, requesting a pipeline worker without an explicit safe test override returns a deterministic error before spawning; a focused regression verifies this without launching the current executable. Production worker selection remains unchanged.
- Safe replacement coverage checks the relevant operator authorization and persisted exact-owner/duplicate-worker outcomes using in-process seams where practical; document any intentionally removed coverage rather than rebuilding hazardous subprocess tests.
- After removal, repaired focused tests pass under bounded execution with directly captured exit codes, and process inspection confirms no recursive orbit_core workers or fixture descendants remain. No unsafe pre-fix reproduction or broad baseline suite is executed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the unmanaged ship/resume tool-host test that could submit real pipeline workers without a test worker override.
- Removed the ORBIT_TEST_OWNER_RELEASE, ORBIT_TEST_DUPLICATE_RELEASE, and ORBIT_TEST_WORKER_RELEASE sentinel-loop fixtures. Replaced exact-owner/duplicate-start coverage with an in-process persisted-state test.
- Made test builds fail closed in pipeline_worker_command: an explicit worker-command override is required before any worker process can be spawned. The non-test current-executable production path is unchanged.
- Added a public submission regression proving the no-override error leaves the persisted run interrupted with no PID; bounded idle test workers to one second.

Criteria assessment:
- Hazardous workflow submission and all named sentinel-loop fixtures are absent; focused source audit found no equivalent `while [ ! -f` or `sleep 0.01` patterns under application tests, tool-host tests, or job tests.
- Inspected crates/orbit-core/src/application/tests/job_pipeline.rs, crates/orbit-core/src/application/tests/job_submission.rs, and crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs. Remaining subprocess fixtures are bounded: immediate exit-23 worker is waited/reaped; routine worker sleeps 0.25 seconds and is waited/reaped; job-submission override workers sleep at most one second and are reaped by the startup observer.
- Authorization denial remains covered by managed_run_environment_denies_ship_and_resume_end_to_end. The intentionally removed coverage was timing-dependent duplicate-observer audit/after-running-exit behavior; exact persisted ownership and duplicate admission are now covered without child processes.
- Process inspection after focused tests found no orbit_core or run-pipeline-worker descendants.

Validation:
- PASS: timeout --signal=TERM --kill-after=5s 120s cargo test -p orbit-core 'application::tests::job_submission::' -- --test-threads=1 (9 tests).
- PASS: bounded exact tests for test_submission_requires_an_explicit_worker_override_before_spawning, duplicate_worker_cannot_replace_the_persisted_owner, managed_run_environment_denies_ship_and_resume_end_to_end, worker_exit_before_claim_terminalizes_persisted_run_with_diagnostic, and routine_style_detached_worker_is_claimed_within_ownership_window.
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: git diff --check; forbidden-fixture search; pgrep process inspection.
- NOT RUN: unsafe pre-fix reproduction and broad baseline suite, per task constraint.

Assessment: scoped diff removes the recursive-worker path while retaining deterministic authorization and persisted ownership coverage. No remaining known risk beyond intentionally removing timing-specific detached-observer audit coverage.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11418-6a9d9b05`
- Behind base: 0
- Ahead of base: 1