### PR TITLE
[ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/input.rs
+++ b/crates/orbit-core/src/adapter/tool_host/input.rs
@@ -383,6 +383,17 @@ pub(super) fn parse_string_array_field(
         .collect()
 }
 
+pub(super) fn parse_optional_string_array_field(
+    input: &Value,
+    field: &str,
+) -> Result<Vec<String>, OrbitError> {
+    match input.get(field) {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(Value::Array(items)) if items.is_empty() => Ok(Vec::new()),
+        Some(_) => parse_string_array_field(input, field),
+    }
+}
+
 pub(super) fn parse_optional_poll_interval_seconds(
     input: &Value,
 ) -> Result<Option<u64>, OrbitError> {
@@ -448,6 +459,24 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("`run_ids` must be a string or array of strings"));
+    }
+
+    #[test]
+    fn parse_optional_string_array_field_treats_empty_values_as_unrestricted() {
+        assert_eq!(
+            parse_optional_string_array_field(&json!({}), "allowed_crews").unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            parse_optional_string_array_field(&json!({"allowed_crews": null}), "allowed_crews")
+                .unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            parse_optional_string_array_field(&json!({"allowed_crews": []}), "allowed_crews")
+                .unwrap(),
+            Vec::<String>::new()
+        );
     }
 
     #[test]

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -10,7 +10,7 @@ use serde_json::{Value, json};
 use crate::application::job::{DrainWorkerLimitRequest, JobRunListParams};
 use crate::{OrbitRuntime, ShipMode};
 
-use super::input::parse_string_array_field;
+use super::input::{parse_optional_string_array_field, parse_string_array_field};
 use super::json::serialize_error;
 
 const DEFAULT_RUN_LIST_LIMIT: usize = 25;
@@ -36,7 +36,7 @@ pub(super) fn ship(
             .map_or(ShipMode::Pr, |binding| binding.ship_mode),
     };
     let base = optional_string(&input, "base")?;
-    let allowed_crews = parse_string_array_field(&input, "allowed_crews")?;
+    let allowed_crews = parse_optional_string_array_field(&input, "allowed_crews")?;
     let actor = actor(runtime, agent.as_deref(), model.as_deref());
     let claim_token = optional_string(&input, "claim_token")?;
     let invoke = runtime.submit_ship_run(

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -18,7 +18,7 @@ use crate::application::job::JobRunListParams;
 use crate::application::job::pipeline::{
     configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
     pipeline_worker_profile_file, pipeline_worker_root_override,
-    resolve_pipeline_worker_executable,
+    resolve_pipeline_worker_executable, worker_command_override,
 };
 use crate::application::task::TaskAddParams;
 use crate::application::workflow::{CompletionPolicy, ShipMode};
@@ -66,6 +66,21 @@ model = "sol-model"
     let runtime =
         OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build test runtime");
     (root, runtime)
+}
+
+struct WorkerOverride;
+
+impl WorkerOverride {
+    fn shell(script: &str) -> Self {
+        worker_command_override::set(["sh", "-c", script]);
+        Self
+    }
+}
+
+impl Drop for WorkerOverride {
+    fn drop(&mut self) {
+        worker_command_override::clear();
+    }
 }
 
 fn add_backlog_task(runtime: &OrbitRuntime) -> String {
@@ -461,6 +476,7 @@ spec:
 #[test]
 fn explicit_ship_crew_allowlist_admits_only_configured_permitted_crews() {
     let (_root, runtime) = test_runtime_with_named_crews();
+    let _worker = WorkerOverride::shell("exit 0");
     let jobs_dir = runtime.paths().global_dir.join("resources/jobs");
     std::fs::create_dir_all(&jobs_dir).expect("create jobs dir");
     std::fs::write(

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -1649,6 +1649,7 @@ fn current_heads_and_verified_open_prs_retain_priority_over_other_refs() {
             "integration_branch": "topic",
             "max_investigated_runs": 3,
             "max_checkout_log_reads": 3,
+            "investigation_cursor": 0,
         }),
     )
     .expect("collect");
@@ -1846,6 +1847,7 @@ fn comprehensive_fixture_classifies_merged_prs_unprobed_live_refs_transient_prob
             "max_retired_ref_probes": 2,
             "max_investigated_runs": 5,
             "max_checkout_log_reads": 5,
+            "investigation_cursor": 0,
         }),
     )
     .expect("collect");

--- a/crates/orbit-web/src/state.rs
+++ b/crates/orbit-web/src/state.rs
@@ -750,7 +750,7 @@ impl WsRejection {
     fn inactive(id: &str) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,
-            message: format!("workspace '{id}' is unavailable"),
+            message: format!("workspace '{id}' is inactive; select an active workspace"),
         }
     }
 


### PR DESCRIPTION
## Task

[ORB-11421](https://orbit-cli.com/tasks/ORB-11421) — [ci-failure-sweep] Fix red CI: CI / Check / Clippy / Test / Run CI guardrails

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `CI`
- Failing job: `Check / Clippy / Test`
- Failing step: `Run CI guardrails`
- Commit the runner actually checked out: `90e84fa3617517bc197c6ea846f5503117888846`
- Normalized error signature (the dedupe identity, not a quote): `[1m[91merror[0m: test failed, to rerun pass `-p orbit-core --lib``
- Repository: `danieljhkim/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-06T17:09:35.960727786+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/danieljhkim/orbit/actions/runs/34047137558 run `34047137558` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `90e84fa3617517bc197c6ea846f5503117888846`
  - current head of that ref: `unknown`
  - commit actually checked out: `90e84fa3617517bc197c6ea846f5503117888846`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/usr/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/usr/bin/git log -1 --format=%H`
  - failed job `Check / Clippy / Test` (id `101524102718`): https://github.com/danieljhkim/orbit/actions/runs/34047137558/job/101524102718
  - failing step(s): `Run CI guardrails`
  - failed job `Coverage (informational)` (id `101524102777`): https://github.com/danieljhkim/orbit/actions/runs/34047137558/job/101524102777
  - failing step(s): `Collect workspace coverage`

## Failed-step log excerpt

```
Coverage (informational)	Collect workspace coverage	﻿2026-09-06T16:59:32.0378382Z ##[group]Run cargo llvm-cov --workspace --locked --no-report
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2641686Z test runtime::tests::runtime::workspace_open_reconciles_without_a_complete_managed_run_context ... ok
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2670621Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2710909Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2713885Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2742148Z ---- adapter::tool_host::tests::workflow_tools::ship_tool_inherits_the_shared_in_flight_guard stdout ----
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2771983Z [1m[91merror[0m: test failed, to rerun pass `-p orbit-core --lib`
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2772517Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2801789Z thread 'adapter::tool_host::tests::workflow_tools::ship_tool_inherits_the_shared_in_flight_guard' (79689) panicked at crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs:263:9:
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2803626Z expected ShipRunInFlight, got InvalidInput("missing `allowed_crews`")
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2832300Z error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/runner/work/orbit/orbit/Cargo.toml --target-dir /home/runner/work/orbit/orbit/target/llvm-cov-target --workspace --locked` (exit status: 101)
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2834539Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2860664Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2891306Z ---- adapter::tool_host::tests::workflow_tools::unmanaged_environment_admits_operator_ship_and_resume stdout ----
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2892205Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2921865Z thread 'adapter::tool_host::tests::workflow_tools::unmanaged_environment_admits_operator_ship_and_resume' (79712) panicked at crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs:202:10:
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2951087Z unmanaged operator ship is admitted: InvalidInput("missing `allowed_crews`")
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2980628Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.2981090Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3005217Z failures:
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3006648Z     adapter::tool_host::tests::workflow_tools::ship_tool_inherits_the_shared_in_flight_guard
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3008384Z     adapter::tool_host::tests::workflow_tools::unmanaged_environment_admits_operator_ship_and_resume
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3009194Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3009900Z test result: FAILED. 1038 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 101.26s
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3020651Z 
Coverage (informational)	Collect workspace coverage	2026-09-06T17:06:12.3034777Z ##[error]Process completed with exit code 101.
```

_The excerpt above was truncated at collection. Head and tail are kept; the omitted region is marked inline._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34020038308 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34019144985 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34017718816 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34016633159 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34013588639 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure
- `CI` run https://github.com/danieljhkim/orbit/actions/runs/34013438607 — superseded_by_newer_workflow_run: newer relevant run 34047137558 at 2026-09-06T16:58:40Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 1,
  "current_failures_discovered": 1,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 3,
  "investigation_cursor": 496865,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely"
  ],
  "pull_requests_scanned": 4,
  "refs_scanned": 5,
  "retired_refs": [
    "codex/ORB-11416-rca",
    "codex/agent-guidance-quality",
    "orbit/ORB-11331-6a9ce37d",
    "orbit/ORB-11354-6a9ccf69",
    "orbit/ORB-11365-6a9cf54a",
    "orbit/ORB-11372-6a9cdc55",
    "orbit/ORB-11373-6a9cd92d",
    "orbit/ORB-11379-6a9cd421",
    "orbit/ORB-11386-6a9cd7f4",
    "orbit/ORB-11388-6a9cd7f3",
    "orbit/ORB-11389-6a9cd830",
    "orbit/ORB-11390-6a9cd830",
    "orbit/ORB-11398-6a9cd8e7",
    "orbit/ORB-11403-6a9cf63e",
    "orbit/ORB-11405-6a9cf54a",
    "orbit/ORB-11411-6a9d991d"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `CI` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: completed successfully; worktree remains uncommitted for pipeline handoff.

Changes:
- Fixed the repository root cause: the ship tool's optional allowed_crews field was parsed with a required-array parser, so omitted/null/empty values failed before shared admission guards. Added an optional array parser at the tool-host input boundary while preserving strict validation for non-empty malformed values, and added boundary coverage.
- Updated the explicit crew allowlist application test to install the existing scoped test-worker override required by the test harness.
- Pinned investigation_cursor in two CI collection fixtures so fixed rotation assertions are deterministic rather than dependent on the wall-clock hour.
- Corrected the inactive-workspace HTTP diagnostic to match its documented inactive-workspace contract.

Acceptance criteria:
1. Root cause fixed: the supplied missing allowed_crews failure was reproduced locally before the fix and the parser boundary now accepts unrestricted omission/null/empty input. No workflow, assertion, lint level, or blocking behavior was weakened.
2. Runner-equivalent command: the exact local equivalent `cargo test --tests --manifest-path "$PWD/Cargo.toml" --target-dir "$PWD/target/llvm-cov-target" --workspace --locked` initially failed with the reported core error and subsequent repository-owned fixture/test-contract failures; after the fixes it passed with exit 0.
3. Documented pre-handoff gate: `make ci-fast` passed with exit 0; `make ci-lint` passed with exit 0.
4. Infrastructure assessment: not applicable. The reported failure and the follow-on failures were reproduced locally as repository-owned defects; no GitHub retry was attempted because the execution envelope states this lane cannot reach GitHub.

Targeted validation:
- `cargo fmt --all -- --check`: passed.
- Workflow-tools targeted tests: passed, 7/7.
- Explicit allowlist job-pipeline test: passed, 1/1.
- Both pinned CI collection tests: passed, 1/1 each.
- Inactive workspace selection test: passed, 1/1.
- Full runner-equivalent workspace test: passed, exit 0.
- `git diff --check`: passed.

Review:
- `git status --short` shows only the five intended source files.
- No known remaining repository risks; GitHub-hosted execution was not directly exercised, but the local Linux equivalent and documented gates passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11421-6a9d9f53`
- Behind base: 0
- Ahead of base: 1