### PR TITLE
Sweep Orbit source for readable spacing, logical grouping, and consistent organization

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/mod.rs
+++ b/crates/orbit-automation/src/auto_tasks/mod.rs
@@ -1,4 +1,5 @@
 //! Auto-task definition loading and scheduling policy.
+
 pub mod loader;
 pub mod schedule;
 pub mod scheduler;

--- a/crates/orbit-automation/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/scheduler.rs
@@ -1,4 +1,5 @@
 //! Auto-task scheduling policy with an explicit clock and Core lifecycle adapter.
+
 use super::loader::{AutoTaskLoadError, collect_auto_tasks};
 use super::schedule::{AutoTaskDueDecision, decide_due};
 use chrono::{DateTime, Utc};
@@ -6,6 +7,7 @@ use orbit_common::OrbitError;
 use orbit_store::compose::auto_task::{cursor_state_path, load_cursor_state, upsert_cursor};
 use orbit_types::workflow::{AutoTaskCursor, AutoTaskDefinition, DedupePolicy};
 use std::path::PathBuf;
+
 /// Lifecycle adapter. Core retains task creation, authorization and audit.
 pub trait AutoTaskDispatch {
     fn evaluate_delivery(
@@ -14,11 +16,16 @@ pub trait AutoTaskDispatch {
         dry_run: bool,
         now: DateTime<Utc>,
     ) -> Result<orbit_types::workflow::automation::AutomationDiagnostic, OrbitError>;
+
     fn definition_root(&self) -> PathBuf;
+
     fn state_dir(&self) -> PathBuf;
+
     fn has_open_instance(&self, definition: &AutoTaskDefinition) -> Result<bool, OrbitError>;
+
     fn mint_task(&self, definition: &AutoTaskDefinition) -> Result<String, OrbitError>;
 }
+
 /// Per-definition outcome of one scheduler pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AutoTaskFireReport {
@@ -107,8 +114,9 @@ fn fire_definition(
         let task_id = diagnostic
             .state
             .as_ref()
-            .and_then(|s| s.active.as_ref())
-            .and_then(|a| a.action_id.clone());
+            .and_then(|state| state.active.as_ref())
+            .and_then(|attempt| attempt.action_id.clone());
+
         return Ok(AutoTaskFireReport {
             name: definition.name.clone(),
             action: "delivery",
@@ -118,6 +126,7 @@ fn fire_definition(
             automation: Some(diagnostic),
         });
     }
+
     if !definition.enabled {
         return Ok(skipped(definition, "disabled"));
     }
@@ -187,6 +196,7 @@ fn fire_definition(
             .map(|error| {
                 format!("cursor not advanced; the next pass may fire this slot again: {error}")
             });
+
             Ok(AutoTaskFireReport {
                 name: definition.name.clone(),
                 action: "fired",

--- a/crates/orbit-automation/src/checkpoint.rs
+++ b/crates/orbit-automation/src/checkpoint.rs
@@ -1,7 +1,9 @@
 //! One generation-fenced checkpoint and receipt projection for all consumers.
+
 use crate::AutomationError;
 use orbit_store::contracts::AutomationStoreBackend;
 use orbit_types::workflow::automation::*;
+
 pub(crate) fn commit(
     store: &dyn AutomationStoreBackend,
     old: &AutomationState,
@@ -12,9 +14,11 @@ pub(crate) fn commit(
         .generation
         .checked_add(1)
         .ok_or_else(|| AutomationError::Deferred("generation_exhausted".into()))?;
+
     if !store.automation_commit(old, &next, receipt)? {
         return Err(AutomationError::Deferred("concurrent_evaluation".into()));
     }
+
     Ok(next)
 }
 

--- a/crates/orbit-automation/src/delivery/evidence.rs
+++ b/crates/orbit-automation/src/delivery/evidence.rs
@@ -1,8 +1,10 @@
 //! Deterministic validation of typed examination evidence against frozen input.
+
 use super::digest;
 use crate::AutomationError;
 use chrono::{DateTime, Utc};
 use orbit_types::workflow::automation::*;
+
 /// Facts supplied by Core after task/run authority, provenance and object checks.
 pub struct EvidenceFacts {
     pub bytes: Vec<u8>,
@@ -12,31 +14,40 @@ pub struct EvidenceFacts {
     pub authorized: bool,
     pub source_verified: bool,
 }
+
 pub fn validate(
     attempt: &BatchAttempt,
     facts: &EvidenceFacts,
     now: DateTime<Utc>,
 ) -> Result<AcceptedCoverage, AutomationError> {
     let invalid = |reason: &str| AutomationError::Evidence(reason.into());
+
     if !facts.authorized {
         return Err(invalid("unauthorized_submitter"));
     }
+
     if !facts.source_verified {
         return Err(invalid("source_unverifiable"));
     }
+
     if facts.bytes.len() > 1_048_576 || facts.bytes.is_empty() {
         return Err(invalid("invalid_size"));
     }
+
     let evidence: CoverageEvidence =
         serde_json::from_slice(&facts.bytes).map_err(|e| invalid(&format!("malformed: {e}")))?;
+
     let batch = &attempt.batch;
     let evidence_digest = digest(&facts.bytes);
+
     if evidence_digest != facts.artifact_digest
         || facts.reference.is_empty()
         || facts.submitted_by.is_empty()
     {
         return Err(invalid("provenance_mismatch"));
     }
+
+    // The evidence must name the exact batch and attempt whose input it was frozen against.
     if evidence.schema_version != 1
         || evidence.batch_id != batch.id
         || evidence.consumer != batch.consumer
@@ -48,11 +59,13 @@ pub fn validate(
     {
         return Err(invalid("batch_or_attempt_mismatch"));
     }
+
     if evidence.from_exclusive != batch.from_exclusive
         || evidence.through_inclusive != batch.through_inclusive
     {
         return Err(invalid("revision_mismatch"));
     }
+
     if !evidence.examination_complete
         || evidence.examined_commits != batch.commits
         || evidence.examined_deliveries
@@ -64,6 +77,7 @@ pub fn validate(
     {
         return Err(invalid("incomplete_examination"));
     }
+
     if evidence.checks.is_empty()
         || evidence.checks.iter().any(|check| {
             check.subject.trim().is_empty()
@@ -73,6 +87,7 @@ pub fn validate(
     {
         return Err(invalid("missing_checks"));
     }
+
     Ok(AcceptedCoverage {
         batch_id: batch.id.clone(),
         action_id: evidence.action_id,

--- a/crates/orbit-automation/src/delivery/mod.rs
+++ b/crates/orbit-automation/src/delivery/mod.rs
@@ -1,10 +1,12 @@
 //! One bounded delivery evaluator shared by task and job consumers.
+
 use crate::AutomationError;
 use crate::checkpoint::{commit, diagnostic};
 use chrono::{DateTime, Utc};
 use orbit_store::contracts::AutomationStoreBackend;
 use orbit_types::workflow::automation::*;
 use sha2::{Digest, Sha256};
+
 pub mod evidence;
 mod observe;
 #[cfg(test)]
@@ -15,13 +17,18 @@ pub trait DeliveryHost {
     fn admission_deferral(&self) -> Result<Option<String>, AutomationError> {
         Ok(None)
     }
+
     fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError>;
+
     fn observe(&self, branch: &str, state: &AutomationState)
     -> Result<SourcePage, AutomationError>;
+
     /// Canonical action admission must resolve the same durable key on replay.
     fn admit(&self, attempt: &BatchAttempt) -> Result<String, AutomationError>;
+
     fn outcome(&self, attempt: &BatchAttempt) -> Result<ActionOutcome, AutomationError>;
 }
+
 /// Core's authoritative observation of an admitted task/job.
 pub enum ActionOutcome {
     Pending,
@@ -32,19 +39,23 @@ pub enum ActionOutcome {
         reason: String,
     },
 }
+
 pub fn digest(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
+
 pub fn input_digest(batch: &CoverageBatch) -> Result<String, AutomationError> {
     serde_json::to_vec(batch)
         .map(|bytes| digest(&bytes))
         .map_err(|e| AutomationError::Evidence(e.to_string()))
 }
+
 pub fn definition_epoch<T: serde::Serialize>(definition: &T) -> Result<String, AutomationError> {
     serde_json::to_vec(definition)
         .map(|bytes| digest(&bytes))
         .map_err(|e| AutomationError::Evidence(e.to_string()))
 }
+
 /// Inputs supplied by the existing sweep clock.
 pub struct Evaluation<'a> {
     pub consumer: &'a str,
@@ -54,6 +65,7 @@ pub struct Evaluation<'a> {
     pub dry_run: bool,
     pub now: DateTime<Utc>,
 }
+
 /// Evaluate explicit configuration without another scheduler or ticking loop.
 pub fn evaluate(
     store: &dyn AutomationStoreBackend,
@@ -68,13 +80,17 @@ pub fn evaluate(
         dry_run,
         now,
     } = request;
+
     trigger.validate().map_err(orbit_common::OrbitError::from)?;
+
+    // The first evaluation pins a baseline at the branch head; nothing before it is debt.
     let mut state = match store.automation_state(consumer)? {
         Some(state) => state,
         None => {
             if !enabled && !dry_run {
                 return diagnostic(store, consumer, "disabled", None);
             }
+
             let (repository, head) = host.head(&trigger.branch)?;
             let state = AutomationState {
                 members: None,
@@ -93,9 +109,11 @@ pub fn evaluate(
                 associations: Default::default(),
                 active: None,
             };
+
             if !dry_run {
                 store.automation_initialize(&state)?;
             }
+
             return diagnostic(
                 store,
                 consumer,
@@ -108,16 +126,26 @@ pub fn evaluate(
             );
         }
     };
+
     // Reconcile admitted work even when disabled or a definition was edited.
-    if !dry_run && state.active.as_ref().is_some_and(|a| a.action_id.is_some()) {
+    if !dry_run
+        && state
+            .active
+            .as_ref()
+            .is_some_and(|attempt| attempt.action_id.is_some())
+    {
         state = reconcile(store, host, state, now)?;
     }
+
     if state.epoch != epoch || state.branch != trigger.branch {
         return diagnostic(store, consumer, "definition_changed", Some(state));
     }
+
     if !enabled {
         return diagnostic(store, consumer, "disabled", Some(state));
     }
+
+    // A claim that never reached admission resumes here, subject to its retry budget.
     if let Some(active) = &state.active
         && active.action_id.is_none()
         && active.state == BatchState::Claimed
@@ -125,24 +153,23 @@ pub fn evaluate(
     {
         if active.attempt > 1 && now > active.batch.retry_until {
             let mut next = state.clone();
-            if let Some(a) = &mut next.active {
-                a.state = BatchState::Exhausted;
-                a.reason = Some("retry_deadline_expired".into());
+            if let Some(attempt) = &mut next.active {
+                attempt.state = BatchState::Exhausted;
+                attempt.reason = Some("retry_deadline_expired".into());
             }
+
             state = commit(store, &state, next, None)?;
+
             return diagnostic(store, consumer, "retry_deadline_expired", Some(state));
         }
+
         if active.retry_after.is_some_and(|at| now < at) {
             return diagnostic(store, consumer, "retry_backoff", Some(state));
         }
-        let id = host.admit(active)?;
-        let mut next = state.clone();
-        if let Some(attempt) = &mut next.active {
-            attempt.action_id = Some(id);
-            attempt.state = BatchState::Admitted;
-        }
-        state = commit(store, &state, next, None)?;
+
+        state = admit_active(store, host, &state)?;
     }
+
     // Backpressure pauses observation, never admission of already retained debt.
     if state.pending.len() < 950 && state.pending_commits.len() <= 4800 {
         let page = host.observe(&trigger.branch, &state)?;
@@ -153,6 +180,7 @@ pub fn evaluate(
             commit(store, &state, next, None)?
         };
     }
+
     if let Some(active) = &state.active {
         let reason = match active.state {
             BatchState::Failed => "batch_failed",
@@ -161,10 +189,12 @@ pub fn evaluate(
         };
         return diagnostic(store, consumer, reason, Some(state));
     }
+
     let due_count = state.pending.len() >= trigger.threshold;
     let due_age = state.pending.first().is_some_and(|d| {
         now.signed_duration_since(d.landed_at).num_minutes() >= i64::from(trigger.max_wait_minutes)
     });
+
     if !due_count && !due_age {
         return diagnostic(
             store,
@@ -177,9 +207,11 @@ pub fn evaluate(
             Some(state),
         );
     }
+
     if let Some(reason) = host.admission_deferral()? {
         return diagnostic(store, consumer, &reason, Some(state));
     }
+
     if dry_run {
         return diagnostic(
             store,
@@ -192,6 +224,7 @@ pub fn evaluate(
             Some(state),
         );
     }
+
     // Freeze an oldest prefix. Unattributed neighbors remain explicit obligations.
     let deliveries = state
         .pending
@@ -199,6 +232,7 @@ pub fn evaluate(
         .take(trigger.max_items)
         .cloned()
         .collect::<Vec<_>>();
+
     let through = if state.pending.len() > deliveries.len() {
         deliveries
             .last()
@@ -208,21 +242,25 @@ pub fn evaluate(
     } else {
         state.observed.clone()
     };
+
     let end = state
         .pending_commits
         .iter()
         .position(|sha| sha == &through.commit)
         .ok_or_else(|| AutomationError::Deferred("delivery_boundary_missing".into()))?
         + 1;
+
     let commits = state.pending_commits[..end].to_vec();
+
     if deliveries
         .iter()
-        .any(|d| !d.commits.iter().all(|sha| commits.contains(sha)))
+        .any(|delivery| !delivery.commits.iter().all(|sha| commits.contains(sha)))
     {
         return Err(AutomationError::Deferred(
             "delivery_crosses_boundary".into(),
         ));
     }
+
     let mut batch = CoverageBatch {
         schema_version: 1,
         id: String::new(),
@@ -239,8 +277,12 @@ pub fn evaluate(
         max_attempts: trigger.retries + 1,
         retry_until: now + chrono::Duration::hours(24),
     };
+
+    // The identity digest covers the batch before it carries an id; the frozen input
+    // digest then covers the identified batch that evidence must be checked against.
     batch.id = input_digest(&batch)?;
-    let input_digest = input_digest(&batch)?;
+    let frozen_input_digest = input_digest(&batch)?;
+
     if serde_json::to_vec(&batch)
         .map_err(|e| AutomationError::Evidence(e.to_string()))?
         .len()
@@ -248,30 +290,24 @@ pub fn evaluate(
     {
         return diagnostic(store, consumer, "batch_too_large", Some(state));
     }
+
     let attempt = BatchAttempt {
         action_key: format!("automation:{}:1", batch.id),
         batch,
-        input_digest,
+        input_digest: frozen_input_digest,
         attempt: 1,
         action_id: None,
         state: BatchState::Claimed,
         reason: None,
         retry_after: None,
     };
+
     let mut next = state.clone();
     next.active = Some(attempt);
     state = commit(store, &state, next, None)?;
-    let active = state
-        .active
-        .as_ref()
-        .ok_or_else(|| AutomationError::Deferred("missing_claim".into()))?;
-    let id = host.admit(active)?;
-    let mut next = state.clone();
-    if let Some(attempt) = &mut next.active {
-        attempt.action_id = Some(id);
-        attempt.state = BatchState::Admitted;
-    }
-    state = commit(store, &state, next, None)?;
+
+    state = admit_active(store, host, &state)?;
+
     diagnostic(
         store,
         consumer,
@@ -283,6 +319,28 @@ pub fn evaluate(
         Some(state),
     )
 }
+
+/// Hand the claimed attempt to Core and record the durable action id it resolved.
+fn admit_active(
+    store: &dyn AutomationStoreBackend,
+    host: &dyn DeliveryHost,
+    state: &AutomationState,
+) -> Result<AutomationState, AutomationError> {
+    let active = state
+        .active
+        .as_ref()
+        .ok_or_else(|| AutomationError::Deferred("missing_claim".into()))?;
+    let id = host.admit(active)?;
+
+    let mut next = state.clone();
+    if let Some(attempt) = &mut next.active {
+        attempt.action_id = Some(id);
+        attempt.state = BatchState::Admitted;
+    }
+
+    commit(store, state, next, None)
+}
+
 fn reconcile(
     store: &dyn AutomationStoreBackend,
     host: &dyn DeliveryHost,
@@ -292,12 +350,14 @@ fn reconcile(
     let Some(active) = &state.active else {
         return Ok(state);
     };
+
     if matches!(
         active.state,
         BatchState::Exhausted | BatchState::Failed | BatchState::Waived
     ) {
         return Ok(state);
     }
+
     match host.outcome(active)? {
         ActionOutcome::Pending => Ok(state),
         ActionOutcome::Evidence(facts) => {
@@ -305,22 +365,28 @@ fn reconcile(
                 Ok(receipt) => receipt,
                 Err(error) => {
                     let mut next = state.clone();
-                    if let Some(a) = &mut next.active {
-                        a.reason = Some(error.to_string());
+                    if let Some(attempt) = &mut next.active {
+                        attempt.reason = Some(error.to_string());
                     }
+
                     return commit(store, &state, next, None);
                 }
             };
+
+            // Accepted evidence retires the batch: its commits and every fact keyed to
+            // them leave the pending window, and the covered cursor advances.
             let mut next = state.clone();
             next.covered = active.batch.through_inclusive.clone();
             next.pending_commits = next.pending_commits[active.batch.commits.len()..].to_vec();
-            next.waived.retain(|d| {
-                !d.commits
+            next.waived.retain(|delivery| {
+                !delivery
+                    .commits
                     .iter()
                     .all(|sha| active.batch.commits.contains(sha))
             });
-            next.pending.retain(|d| {
-                !d.commits
+            next.pending.retain(|delivery| {
+                !delivery
+                    .commits
                     .iter()
                     .all(|sha| active.batch.commits.contains(sha))
             });
@@ -329,30 +395,39 @@ fn reconcile(
             next.associations
                 .retain(|sha, _| !active.batch.commits.contains(sha));
             next.active = None;
+
             commit(store, &state, next, Some(&receipt))
         }
         ActionOutcome::Failed { retryable, reason } => {
             let mut next = state.clone();
-            if let Some(a) = &mut next.active {
-                a.reason = Some(reason);
-                if retryable && a.attempt < a.batch.max_attempts && now < a.batch.retry_until {
-                    a.attempt += 1;
-                    a.retry_after = Some(now + chrono::Duration::minutes(5));
-                    a.action_key = format!("automation:{}:{}", a.batch.id, a.attempt);
-                    a.action_id = None;
-                    a.state = BatchState::Claimed;
+            if let Some(attempt) = &mut next.active {
+                attempt.reason = Some(reason);
+
+                let retry_budget_remains = retryable
+                    && attempt.attempt < attempt.batch.max_attempts
+                    && now < attempt.batch.retry_until;
+
+                if retry_budget_remains {
+                    attempt.attempt += 1;
+                    attempt.retry_after = Some(now + chrono::Duration::minutes(5));
+                    attempt.action_key =
+                        format!("automation:{}:{}", attempt.batch.id, attempt.attempt);
+                    attempt.action_id = None;
+                    attempt.state = BatchState::Claimed;
                 } else {
-                    a.state = if retryable {
+                    attempt.state = if retryable {
                         BatchState::Exhausted
                     } else {
                         BatchState::Failed
                     };
                 }
             }
+
             commit(store, &state, next, None)
         }
     }
 }
+
 /// Waive only settled failed/exhausted work; retain its code as a coverage gap.
 pub fn waive(
     store: &dyn AutomationStoreBackend,
@@ -366,6 +441,8 @@ pub fn waive(
             "waiver requires a reason and actor".into(),
         ));
     }
+
+    // Waiving is idempotent: a batch already recorded as waived needs no second write.
     if store
         .automation_waivers(consumer, 100)?
         .iter()
@@ -373,13 +450,16 @@ pub fn waive(
     {
         return Ok(());
     }
+
     let previous = store
         .automation_state(consumer)?
         .ok_or_else(|| AutomationError::Evidence("consumer not found".into()))?;
+
     let active = previous
         .active
         .as_ref()
         .ok_or_else(|| AutomationError::Evidence("no active batch".into()))?;
+
     if active.batch.id != request.batch_id
         || !matches!(active.state, BatchState::Failed | BatchState::Exhausted)
     {
@@ -387,28 +467,32 @@ pub fn waive(
             "only the current settled failed or exhausted batch can be waived".into(),
         ));
     }
+
     let mut next = previous.clone();
     next.generation = previous
         .generation
         .checked_add(1)
         .ok_or_else(|| AutomationError::Deferred("generation_exhausted".into()))?;
     next.active = None;
-    next.pending.retain(|d| {
+    next.pending.retain(|delivery| {
         !active
             .batch
             .deliveries
             .iter()
-            .any(|member| member.key == d.key)
+            .any(|member| member.key == delivery.key)
     });
     next.waived.extend(active.batch.deliveries.clone());
+
     let waiver = BatchWaiver {
         batch_id: request.batch_id.clone(),
         reason: request.reason.clone(),
         by: by.into(),
         at: now,
     };
+
     if !store.automation_waive(&previous, &next, &waiver)? {
         return Err(AutomationError::Deferred("concurrent_evaluation".into()));
     }
+
     Ok(())
 }

--- a/crates/orbit-automation/src/delivery/observe.rs
+++ b/crates/orbit-automation/src/delivery/observe.rs
@@ -1,11 +1,16 @@
 //! Monotonic bounded observation; no observation certifies examination.
+
 use crate::AutomationError;
 use orbit_types::workflow::automation::{AutomationState, SourcePage};
+
 pub(super) fn apply(
     state: &AutomationState,
     page: SourcePage,
 ) -> Result<AutomationState, AutomationError> {
     let invalid = || AutomationError::Deferred("source_page_invalid".into());
+
+    // A page must resume exactly where the cursor stands, stay within its bounds,
+    // and end on the revision it claims to reach.
     if page.from != state.observed
         || page.commits.len() > 200
         || page.deliveries.len() > 50
@@ -17,46 +22,55 @@ pub(super) fn apply(
     {
         return Err(invalid());
     }
+
     let mut next = state.clone();
+
     for sha in &page.commits {
         if next.pending_commits.contains(sha) {
             return Err(invalid());
         }
         next.pending_commits.push(sha.clone());
     }
+
     if next.pending_commits.len() > 5000 {
         return Err(AutomationError::Deferred("source_backpressure".into()));
     }
+
     for (sha, association) in page.associations {
         if next.pending_commits.contains(&sha) {
             next.associations.insert(sha, association);
         }
     }
-    for d in page.deliveries {
-        if d.key.is_empty()
-            || d.repository != state.repository
-            || d.branch != state.branch
-            || d.commits.is_empty()
-            || d.evidence_digest.is_empty()
-            || d.evidence_reference.is_empty()
+
+    for delivery in page.deliveries {
+        if delivery.key.is_empty()
+            || delivery.repository != state.repository
+            || delivery.branch != state.branch
+            || delivery.commits.is_empty()
+            || delivery.evidence_digest.is_empty()
+            || delivery.evidence_reference.is_empty()
         {
             return Err(invalid());
         }
-        if state.waived.iter().any(|old| old.key == d.key) {
+
+        if state.waived.iter().any(|old| old.key == delivery.key) {
             continue;
         }
-        if d.before.tree == d.after.tree {
+
+        if delivery.before.tree == delivery.after.tree {
             continue;
         }
+
         // Late provider evidence only creates debt for still-unexamined content.
-        if !d
+        if !delivery
             .commits
             .iter()
             .any(|sha| next.pending_commits.contains(sha))
         {
             continue;
         }
-        if !d
+
+        if !delivery
             .commits
             .iter()
             .all(|sha| next.pending_commits.contains(sha))
@@ -65,28 +79,34 @@ pub(super) fn apply(
                 "delivery_crosses_boundary".into(),
             ));
         }
-        if let Some(old) = next.pending.iter().find(|old| old.key == d.key) {
-            if old != &d {
+
+        // A repeated key is only tolerable when the provider restated identical evidence.
+        if let Some(old) = next.pending.iter().find(|old| old.key == delivery.key) {
+            if old != &delivery {
                 return Err(AutomationError::Deferred(
                     "delivery_evidence_changed".into(),
                 ));
             }
             continue;
         }
+
         if next
             .pending
             .iter()
-            .any(|old| old.commits.iter().any(|sha| d.commits.contains(sha)))
+            .any(|old| old.commits.iter().any(|sha| delivery.commits.contains(sha)))
         {
             return Err(AutomationError::Deferred(
                 "delivery_grouping_ambiguous".into(),
             ));
         }
-        for sha in &d.commits {
+
+        for sha in &delivery.commits {
             next.unresolved.remove(sha);
         }
-        next.pending.push(d);
+        next.pending.push(delivery);
     }
+
+    // Only commits no delivery accounted for stay recorded as unresolved.
     for (sha, reason) in page.unresolved {
         if next.pending_commits.contains(&sha)
             && !next.pending.iter().any(|d| d.commits.contains(&sha))
@@ -94,14 +114,17 @@ pub(super) fn apply(
             next.unresolved.insert(sha, reason);
         }
     }
+
     next.pending.sort_by_key(|d| {
         next.pending_commits
             .iter()
             .position(|sha| sha == &d.after.commit)
     });
     next.observed = page.through;
+
     if next.pending.len() > 1000 {
         return Err(AutomationError::Deferred("source_backpressure".into()));
     }
+
     Ok(next)
 }

--- a/crates/orbit-automation/src/delivery/tests/evidence.rs
+++ b/crates/orbit-automation/src/delivery/tests/evidence.rs
@@ -20,9 +20,11 @@ fn revision(n: usize) -> SourceRevision {
         tree: format!("t{n}"),
     }
 }
+
 fn now() -> chrono::DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 9, 6, 0, 0, 0).unwrap()
 }
+
 fn trigger() -> DeliveryTrigger {
     DeliveryTrigger {
         owner_machine: Some("fixture-machine".into()),
@@ -34,6 +36,7 @@ fn trigger() -> DeliveryTrigger {
         retries: 1,
     }
 }
+
 fn landing(n: usize) -> Delivery {
     Delivery {
         key: format!("pr:owner/repo:{n}"),
@@ -48,6 +51,7 @@ fn landing(n: usize) -> Delivery {
         landed_at: now(),
     }
 }
+
 struct Host {
     page: Mutex<SourcePage>,
     actions: Mutex<BTreeMap<String, String>>,
@@ -56,6 +60,7 @@ struct Host {
     failed: AtomicBool,
     admission_deferred: AtomicBool,
 }
+
 impl Host {
     fn new() -> Self {
         Self {
@@ -75,6 +80,7 @@ impl Host {
             admission_deferred: AtomicBool::new(false),
         }
     }
+
     fn page(&self, from: usize, to: usize) {
         let commits = (from + 1..=to).map(|n| revision(n).commit).collect();
         *self.page.lock().unwrap() = SourcePage {
@@ -87,6 +93,7 @@ impl Host {
             complete: true,
         };
     }
+
     fn evidence(&self, attempt: &BatchAttempt) {
         let batch = &attempt.batch;
         *self.evidence.lock().unwrap() = Some(CoverageEvidence {
@@ -112,6 +119,7 @@ impl Host {
         });
     }
 }
+
 impl DeliveryHost for Host {
     fn admission_deferral(&self) -> Result<Option<String>, AutomationError> {
         Ok(self
@@ -123,9 +131,11 @@ impl DeliveryHost for Host {
     fn head(&self, _: &str) -> Result<(String, SourceRevision), AutomationError> {
         Ok(("owner/repo".into(), revision(0)))
     }
+
     fn observe(&self, _: &str, _: &AutomationState) -> Result<SourcePage, AutomationError> {
         Ok(self.page.lock().unwrap().clone())
     }
+
     fn admit(&self, a: &BatchAttempt) -> Result<String, AutomationError> {
         let mut actions = self.actions.lock().unwrap();
         let len = actions.len();
@@ -138,6 +148,7 @@ impl DeliveryHost for Host {
         }
         Ok(id)
     }
+
     fn outcome(&self, _: &BatchAttempt) -> Result<ActionOutcome, AutomationError> {
         if self.failed.load(Ordering::SeqCst) {
             return Ok(ActionOutcome::Failed {
@@ -161,6 +172,7 @@ impl DeliveryHost for Host {
         })
     }
 }
+
 fn evaluate(
     store: &dyn AutomationStoreBackend,
     host: &Host,
@@ -181,6 +193,7 @@ fn evaluate(
     )
     .unwrap()
 }
+
 fn setup() -> (Arc<dyn AutomationStoreBackend>, Host, DeliveryTrigger) {
     let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
     let host = Host::new();
@@ -260,6 +273,7 @@ fn frozen_batch_receipt_once_and_later_arrivals_pending() {
     assert_eq!(replay.state.unwrap().covered, revision(2));
     assert_eq!(host.actions.lock().unwrap().len(), 1);
 }
+
 #[test]
 fn bounded_batch_leaves_excess_debt_and_disabled_reconciles() {
     let (store, host, trigger) = setup();
@@ -279,6 +293,7 @@ fn bounded_batch_leaves_excess_debt_and_disabled_reconciles() {
     assert!(state.active.is_none());
     assert_eq!(host.actions.lock().unwrap().len(), 1);
 }
+
 #[test]
 fn crash_after_mint_replays_same_action_key() {
     let (store, host, trigger) = setup();
@@ -315,6 +330,7 @@ fn crash_after_mint_replays_same_action_key() {
     );
     assert_eq!(host.actions.lock().unwrap().len(), 1);
 }
+
 #[test]
 fn retries_exhaust_frozen_budget_without_covering() {
     let (store, host, trigger) = setup();
@@ -355,6 +371,7 @@ fn retries_exhaust_frozen_budget_without_covering() {
     assert_eq!(state.pending.len(), 2);
     assert_eq!(host.actions.lock().unwrap().len(), 2);
 }
+
 #[test]
 fn adversarial_evidence_cannot_manufacture_coverage() {
     let (store, host, trigger) = setup();
@@ -414,6 +431,7 @@ fn adversarial_evidence_cannot_manufacture_coverage() {
     facts.bytes = b"{}".to_vec();
     assert!(delivery::evidence::validate(&attempt, &facts, now()).is_err());
 }
+
 #[test]
 fn no_diff_and_unavailable_provider_do_not_count() {
     let (store, host, trigger) = setup();
@@ -434,6 +452,7 @@ fn no_diff_and_unavailable_provider_do_not_count() {
     assert_eq!(state.unresolved.len(), 1);
     assert_eq!(state.covered, revision(0));
 }
+
 #[test]
 fn concurrent_evaluators_admit_one_action() {
     let (store, host, trigger) = setup();
@@ -476,13 +495,16 @@ struct ReceiptFailure {
     inner: Arc<dyn AutomationStoreBackend>,
     fail: AtomicBool,
 }
+
 impl AutomationStoreBackend for ReceiptFailure {
     fn automation_state(&self, c: &str) -> Result<Option<AutomationState>, OrbitError> {
         self.inner.automation_state(c)
     }
+
     fn automation_initialize(&self, s: &AutomationState) -> Result<bool, OrbitError> {
         self.inner.automation_initialize(s)
     }
+
     fn automation_commit(
         &self,
         a: &AutomationState,
@@ -494,10 +516,12 @@ impl AutomationStoreBackend for ReceiptFailure {
         }
         self.inner.automation_commit(a, b, r)
     }
+
     fn automation_receipts(&self, c: &str, n: usize) -> Result<Vec<AcceptedCoverage>, OrbitError> {
         self.inner.automation_receipts(c, n)
     }
 }
+
 #[test]
 fn receipt_failure_recovers_atomically() {
     let (store, host, trigger) = setup();

--- a/crates/orbit-automation/src/error.rs
+++ b/crates/orbit-automation/src/error.rs
@@ -1,5 +1,7 @@
 //! Typed failures from deterministic automation rules.
+
 use orbit_common::OrbitError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum AutomationError {
     #[error("invalid coverage evidence: {0}")]
@@ -9,6 +11,7 @@ pub enum AutomationError {
     #[error(transparent)]
     Boundary(#[from] OrbitError),
 }
+
 /// Translate once at the Core boundary, preserving invalid evidence as input errors.
 pub fn automation_error_to_orbit(error: AutomationError) -> OrbitError {
     match error {

--- a/crates/orbit-automation/src/lib.rs
+++ b/crates/orbit-automation/src/lib.rs
@@ -3,11 +3,12 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 // Extracted legacy projections retain their existing documentation coverage.
 #![allow(missing_docs)]
+
 pub mod auto_tasks;
 mod checkpoint;
 pub mod delivery;
 mod error;
-pub mod routines;
-pub use error::{AutomationError, automation_error_to_orbit};
-
 pub mod members;
+pub mod routines;
+
+pub use error::{AutomationError, automation_error_to_orbit};

--- a/crates/orbit-automation/src/members/incidents.rs
+++ b/crates/orbit-automation/src/members/incidents.rs
@@ -1,6 +1,8 @@
 //! Causal incident semantics. Missing recovery facts withhold diagnosis.
+
 use crate::{AutomationError, delivery::definition_epoch};
 use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncidentFacts {
     pub workspace: String,
@@ -12,6 +14,9 @@ pub struct IncidentFacts {
     pub diagnostic_origin: bool,
     pub cancellation: bool,
 }
+
+/// Diagnose only when the incident is a settled, still-coupled execution failure;
+/// every other shape withholds with the reason that made it undiagnosable.
 pub fn incident_key(facts: &IncidentFacts) -> Result<String, AutomationError> {
     let withheld = if facts.diagnostic_origin {
         Some("diagnostic_recursion")
@@ -26,14 +31,17 @@ pub fn incident_key(facts: &IncidentFacts) -> Result<String, AutomationError> {
     } else {
         None
     };
+
     if let Some(reason) = withheld {
         return Err(AutomationError::Deferred(reason.into()));
     }
+
     let (Some(episode), Some(cause)) = (&facts.episode, &facts.cause) else {
         return Err(AutomationError::Deferred("incident_unresolved".into()));
     };
     if episode.is_empty() || cause.is_empty() {
         return Err(AutomationError::Deferred("incident_unresolved".into()));
     }
+
     definition_epoch(&(&facts.workspace, episode, cause))
 }

--- a/crates/orbit-automation/src/members/mod.rs
+++ b/crates/orbit-automation/src/members/mod.rs
@@ -1,4 +1,5 @@
 //! State consumers share the sweep, generation-fenced Store and receipt path.
+
 use crate::AutomationError;
 use crate::checkpoint::{commit, diagnostic};
 use crate::delivery::{definition_epoch, digest};
@@ -6,6 +7,7 @@ use chrono::{DateTime, Duration, Utc};
 use orbit_store::contracts::AutomationStoreBackend;
 use orbit_types::workflow::automation::{members::*, *};
 use std::collections::BTreeMap;
+
 pub mod incidents;
 pub mod preparation;
 #[cfg(test)]
@@ -16,6 +18,7 @@ pub struct MemberPage {
     pub withheld: BTreeMap<String, String>,
     pub next: Option<String>,
 }
+
 pub enum MemberOutcome {
     Pending,
     /// Only deterministic apply output with host-verified origin is admissible.
@@ -23,18 +26,25 @@ pub enum MemberOutcome {
     /// Failed requires proof the owner and all applicable recoveries stopped.
     Failed(String),
 }
+
 pub trait MemberHost {
     fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError>;
+
     fn observe(
         &self,
         after: Option<&str>,
         now: DateTime<Utc>,
     ) -> Result<MemberPage, AutomationError>;
+
     fn admission_deferral(&self, member: &StateMember) -> Result<Option<String>, AutomationError>;
+
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError>;
+
     fn admit(&self, attempt: &MemberAttempt) -> Result<String, AutomationError>;
+
     fn outcome(&self, attempt: &MemberAttempt) -> Result<MemberOutcome, AutomationError>;
 }
+
 pub struct MemberEvaluation<'a> {
     pub consumer: &'a str,
     pub epoch: &'a str,
@@ -57,13 +67,16 @@ pub fn evaluate(
         dry_run,
         now,
     } = request;
+
     trigger.validate().map_err(orbit_common::OrbitError::from)?;
+
     let mut state = match store.automation_state(consumer)? {
         Some(state) => state,
         None => {
             if !enabled && !dry_run {
                 return diagnostic(store, consumer, "disabled", None);
             }
+
             let (repository, head) = host.head(&trigger.branch)?;
             let state = AutomationState {
                 members: Some(MemberState::default()),
@@ -82,99 +95,132 @@ pub fn evaluate(
                 associations: BTreeMap::new(),
                 active: None,
             };
+
             if !dry_run && !store.automation_initialize(&state)? {
                 return Err(AutomationError::Deferred("concurrent_evaluation".into()));
             }
+
             state
         }
     };
+
     if state.members.is_none() {
         return diagnostic(store, consumer, "definition_changed", Some(state));
     }
+
     if !dry_run {
         state = reconcile(store, host, state, now)?;
     }
+
     if state.epoch != epoch || state.branch != trigger.branch {
         return diagnostic(store, consumer, "definition_changed", Some(state));
     }
+
     if !enabled {
         return diagnostic(store, consumer, "disabled", Some(state));
     }
+
+    // Absorb one observation page into the pending/withheld working set.
     let mut next = state.clone();
     let members = member_state(&mut next)?;
     let page = host.observe(members.scan_after.as_deref(), now)?;
+
     if page.candidates.len() + page.withheld.len() > 50 {
         return Err(AutomationError::Deferred("source_page_invalid".into()));
     }
+
     for (key, reason) in page.withheld {
         members.pending.remove(&key);
         members.withheld.insert(key, reason);
     }
+
     for mut member in page.candidates {
         if member.key.is_empty() || member.fingerprint.is_empty() || member.task_ids.is_empty() {
             return Err(AutomationError::Deferred("source_page_invalid".into()));
         }
+
         members.withheld.remove(&member.key);
+
+        // Already assessed at exactly this fingerprint: nothing left to apply.
         if members
             .assessed
             .get(&member.key)
-            .is_some_and(|a| a.resulting_fingerprint == member.fingerprint)
+            .is_some_and(|assessed| assessed.resulting_fingerprint == member.fingerprint)
         {
             members.pending.remove(&member.key);
             continue;
         }
+
+        // Re-seeing a member preserves how long it has waited, and an unchanged
+        // fingerprint also preserves when it last changed.
         if let Some(old) = members.pending.get(&member.key) {
             member.first_seen = old.first_seen;
             if old.fingerprint == member.fingerprint {
                 member.changed_at = old.changed_at;
             }
         }
+
         members.pending.insert(member.key.clone(), member);
     }
+
     members.scan_after = page.next;
+
     if members.pending.len() + members.assessed.len() + members.withheld.len() > 1000 {
         return diagnostic(store, consumer, "source_backpressure", Some(state));
     }
+
     state = if dry_run {
         next
     } else {
         commit(store, &state, next, None)?
     };
+
     let members = state
         .members
         .as_ref()
         .ok_or_else(|| AutomationError::Deferred("state_missing".into()))?;
+
+    // An attempt already in flight owns the slot; resume or report it, never start another.
     if let Some(active) = &members.active {
         if active.action_id.is_some() {
             return diagnostic(store, consumer, "batch_pending", Some(state));
         }
+
         if now >= active.deadline {
             return diagnostic(store, consumer, "retry_deadline_expired", Some(state));
         }
+
         if now < active.retry_after {
             return diagnostic(store, consumer, "retry_backoff", Some(state));
         }
+
         return admit(store, host, state, dry_run);
     }
+
+    // A member is due once it has settled for the debounce window, or waited out
+    // the maximum; a member that already failed at this fingerprint is not retried.
     let mut candidates = members
         .pending
         .values()
-        .filter(|m| {
+        .filter(|member| {
             if members
                 .failed
-                .get(&m.key)
-                .is_some_and(|a| a.member.fingerprint == m.fingerprint)
+                .get(&member.key)
+                .is_some_and(|failed| failed.member.fingerprint == member.fingerprint)
             {
                 return false;
             }
-            now.signed_duration_since(m.changed_at).num_minutes()
+
+            now.signed_duration_since(member.changed_at).num_minutes()
                 >= i64::from(trigger.debounce_minutes)
-                || now.signed_duration_since(m.first_seen).num_minutes()
+                || now.signed_duration_since(member.first_seen).num_minutes()
                     >= i64::from(trigger.max_wait_minutes)
         })
         .cloned()
         .collect::<Vec<_>>();
+
     candidates.sort_by(|a, b| a.first_seen.cmp(&b.first_seen).then(a.key.cmp(&b.key)));
+
     if candidates.is_empty() {
         let reason = if members.failed.iter().any(|(key, failed)| {
             members
@@ -187,15 +233,18 @@ pub fn evaluate(
             "debouncing"
         } else if !members.withheld.is_empty() {
             "work_withheld"
-        } else if members.assessed.values().any(|a| !a.ready) {
+        } else if members.assessed.values().any(|assessed| !assessed.ready) {
             "fresh_unready"
         } else {
             "fresh"
         };
         return diagnostic(store, consumer, reason, Some(state));
     }
+
+    // Take the first due member Core will admit; each refusal is recorded as withheld.
     let mut candidate = None;
     let mut next = state.clone();
+
     for member in candidates.into_iter().take(trigger.max_items) {
         if let Some(reason) = host.admission_deferral(&member)? {
             let members = member_state(&mut next)?;
@@ -208,6 +257,7 @@ pub fn evaluate(
             break;
         }
     }
+
     if next != state {
         state = if dry_run {
             next
@@ -215,12 +265,15 @@ pub fn evaluate(
             commit(store, &state, next, None)?
         };
     }
+
     let Some(member) = candidate else {
         return diagnostic(store, consumer, "work_withheld", Some(state));
     };
+
     if dry_run {
         return diagnostic(store, consumer, "would_fire", Some(state));
     }
+
     let id = definition_epoch(&(consumer, epoch, &member, now))?;
     let attempt = MemberAttempt {
         consumer: consumer.into(),
@@ -235,17 +288,21 @@ pub fn evaluate(
         action_id: None,
         exhausted: false,
     };
+
     let mut next = state.clone();
     member_state(&mut next)?.active = Some(attempt);
     state = commit(store, &state, next, None)?;
+
     admit(store, host, state, false)
 }
+
 fn member_state(state: &mut AutomationState) -> Result<&mut MemberState, AutomationError> {
     state
         .members
         .as_mut()
         .ok_or_else(|| AutomationError::Deferred("state_missing".into()))
 }
+
 fn admit(
     store: &dyn AutomationStoreBackend,
     host: &dyn MemberHost,
@@ -256,42 +313,59 @@ fn admit(
     let active = state
         .members
         .as_ref()
-        .and_then(|m| m.active.as_ref())
+        .and_then(|members| members.active.as_ref())
         .ok_or_else(|| AutomationError::Deferred("claim_missing".into()))?;
+
     if let Some(reason) = host.admission_deferral(&active.member)? {
         return diagnostic(store, &consumer, &reason, Some(state));
     }
+
     if dry_run {
         return diagnostic(store, &consumer, "would_fire", Some(state));
     }
+
     let id = host.admit(active)?;
+
     let mut next = state.clone();
     if let Some(active) = &mut member_state(&mut next)?.active {
         active.action_id = Some(id);
     }
+
     let next = commit(store, &state, next, None)?;
+
     diagnostic(store, &consumer, "fired", Some(next))
 }
+
 fn reconcile(
     store: &dyn AutomationStoreBackend,
     host: &dyn MemberHost,
     state: AutomationState,
     now: DateTime<Utc>,
 ) -> Result<AutomationState, AutomationError> {
-    let Some(active) = state.members.as_ref().and_then(|m| m.active.as_ref()) else {
+    let Some(active) = state
+        .members
+        .as_ref()
+        .and_then(|members| members.active.as_ref())
+    else {
         return Ok(state);
     };
+
     if active.exhausted {
         return Ok(state);
     }
+
+    // Before an action id exists the claim is unresolved: adopt one Core already
+    // created, otherwise retire the claim once its input or deadline went stale.
     if active.action_id.is_none() {
         if let Some(id) = host.lookup(active)? {
             let mut next = state.clone();
             if let Some(active) = &mut member_state(&mut next)?.active {
                 active.action_id = Some(id);
             }
+
             return commit(store, &state, next, None);
         }
+
         if now >= active.deadline || host.admission_deferral(&active.member)?.is_some() {
             let mut next = state.clone();
             let members = member_state(&mut next)?;
@@ -303,10 +377,13 @@ fn reconcile(
                 );
                 members.failed.insert(expired.member.key.clone(), expired);
             }
+
             return commit(store, &state, next, None);
         }
+
         return Ok(state);
     }
+
     match host.outcome(active)? {
         MemberOutcome::Pending => Ok(state),
         MemberOutcome::Applied(evidence) => {
@@ -321,8 +398,10 @@ fn reconcile(
                     "member_provenance_mismatch".into(),
                 ));
             }
+
             let bytes = serde_json::to_vec(&evidence)
                 .map_err(|e| AutomationError::Evidence(e.to_string()))?;
+
             let receipt = AcceptedCoverage {
                 batch_id: active.id.clone(),
                 action_id: evidence.action_id.clone(),
@@ -336,6 +415,7 @@ fn reconcile(
                 submitted_by: "system".into(),
                 accepted_at: now,
             };
+
             let mut next = state.clone();
             let members = member_state(&mut next)?;
             members.assessed.insert(
@@ -347,22 +427,31 @@ fn reconcile(
                     receipt_id: receipt.batch_id.clone(),
                 },
             );
+
+            // Only drop the pending entry the evidence actually covers; a newer
+            // fingerprint arrived while this attempt ran and still needs applying.
             if members
                 .pending
                 .get(&active.member.key)
-                .is_some_and(|m| m.fingerprint == active.member.fingerprint)
+                .is_some_and(|pending| pending.fingerprint == active.member.fingerprint)
             {
                 members.pending.remove(&active.member.key);
             }
+
             members.active = None;
+
             commit(store, &state, next, Some(&receipt))
         }
         MemberOutcome::Failed(reason) => {
             let mut next = state.clone();
             let members = member_state(&mut next)?;
             members.withheld.insert(active.member.key.clone(), reason);
+
             if let Some(active) = &mut members.active {
-                if active.attempt < active.max_attempts && now < active.deadline {
+                let retry_budget_remains =
+                    active.attempt < active.max_attempts && now < active.deadline;
+
+                if retry_budget_remains {
                     active.attempt += 1;
                     active.action_id = None;
                     active.action_key = format!("automation:{}:{}", active.id, active.attempt);
@@ -371,13 +460,18 @@ fn reconcile(
                     active.exhausted = true;
                 }
             }
-            if members.active.as_ref().is_some_and(|a| a.exhausted)
+
+            if members
+                .active
+                .as_ref()
+                .is_some_and(|active| active.exhausted)
                 && let Some(exhausted) = members.active.take()
             {
                 members
                     .failed
                     .insert(exhausted.member.key.clone(), exhausted);
             }
+
             commit(store, &state, next, None)
         }
     }

--- a/crates/orbit-automation/src/members/preparation.rs
+++ b/crates/orbit-automation/src/members/preparation.rs
@@ -1,9 +1,13 @@
 //! One material fingerprint used by scheduling, apply and readiness consumers.
+
 use crate::{AutomationError, delivery::definition_epoch};
 use orbit_types::task::{Task, TaskStatus};
 use serde_json::{Value, json};
 
 pub const CONTRACT: &str = "material_v1";
+
+/// Only unstarted work carries material worth fingerprinting, and an explicit
+/// no-diff tag opts a task out entirely.
 pub fn eligible(task: &Task) -> bool {
     matches!(task.status, TaskStatus::Proposed | TaskStatus::Backlog)
         && !task
@@ -11,6 +15,7 @@ pub fn eligible(task: &Task) -> bool {
             .iter()
             .any(|tag| matches!(tag.as_str(), "no-diff-expected" | "no-diff-needed"))
 }
+
 /// Dependency/decision evidence and repository instruction bytes are supplied
 /// by Core. Comments, audit metadata and priority are deliberately absent.
 pub fn fingerprint(
@@ -19,15 +24,20 @@ pub fn fingerprint(
     dependencies: &Value,
     instructions: &str,
 ) -> Result<String, AutomationError> {
+    // Order-insensitive collections are normalized so an equivalent task fingerprints
+    // identically regardless of how its lists were authored.
     let mut selectors = task.context_files.clone();
     selectors.sort();
     selectors.dedup();
+
     let mut tags = task.tags.clone();
     tags.sort();
     tags.dedup();
+
     let mut required_tools = task.required_tools.clone();
     required_tools.sort();
     required_tools.dedup();
+
     definition_epoch(&json!({
         "contract": CONTRACT, "id": task.id, "title": task.title.trim(),
         "description": task.description.trim(), "criteria": task.acceptance_criteria,

--- a/crates/orbit-automation/src/members/tests/mod.rs
+++ b/crates/orbit-automation/src/members/tests/mod.rs
@@ -10,6 +10,7 @@ struct Host {
     deferral: RefCell<Option<String>>,
     lose_ack: RefCell<bool>,
 }
+
 impl Host {
     fn new() -> Self {
         Self {
@@ -22,6 +23,7 @@ impl Host {
         }
     }
 }
+
 impl MemberHost for Host {
     fn head(&self, _: &str) -> Result<(String, SourceRevision), AutomationError> {
         Ok((
@@ -32,6 +34,7 @@ impl MemberHost for Host {
             },
         ))
     }
+
     fn observe(&self, _: Option<&str>, now: DateTime<Utc>) -> Result<MemberPage, AutomationError> {
         Ok(MemberPage {
             candidates: vec![StateMember {
@@ -47,12 +50,15 @@ impl MemberHost for Host {
             next: None,
         })
     }
+
     fn admission_deferral(&self, _: &StateMember) -> Result<Option<String>, AutomationError> {
         Ok(self.deferral.borrow().clone())
     }
+
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError> {
         Ok(self.actions.borrow().get(&attempt.action_key).cloned())
     }
+
     fn admit(&self, attempt: &MemberAttempt) -> Result<String, AutomationError> {
         let id = self
             .actions
@@ -65,6 +71,7 @@ impl MemberHost for Host {
         }
         Ok(id)
     }
+
     fn outcome(&self, _: &MemberAttempt) -> Result<MemberOutcome, AutomationError> {
         if let Some(evidence) = self.evidence.borrow().clone() {
             Ok(MemberOutcome::Applied(evidence))
@@ -75,6 +82,7 @@ impl MemberHost for Host {
         }
     }
 }
+
 fn trigger() -> StateTrigger {
     StateTrigger {
         kind: StateTriggerKind::PreparationEligible,
@@ -87,6 +95,7 @@ fn trigger() -> StateTrigger {
         deadline_minutes: 30,
     }
 }
+
 fn tick(store: &dyn AutomationStoreBackend, host: &Host, minute: i64) -> AutomationDiagnostic {
     evaluate(
         store,
@@ -102,6 +111,7 @@ fn tick(store: &dyn AutomationStoreBackend, host: &Host, minute: i64) -> Automat
     )
     .unwrap()
 }
+
 #[test]
 fn fresh_unready_post_apply_does_not_loop_and_new_material_debounces() {
     let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
@@ -136,6 +146,7 @@ fn fresh_unready_post_apply_does_not_loop_and_new_material_debounces() {
     assert_eq!(tick(store.as_ref(), &host, 61).reason, "debouncing");
     assert_eq!(tick(store.as_ref(), &host, 63).reason, "fired");
 }
+
 #[test]
 fn restart_preserves_attempt_budget_deadline_and_failed_input() {
     let dir = tempfile::tempdir().unwrap();
@@ -172,6 +183,7 @@ fn restart_preserves_attempt_budget_deadline_and_failed_input() {
     assert_eq!(tick(store.as_ref(), &host, 501).reason, "fired");
     assert_eq!(tick(store.as_ref(), &host, 503).reason, "batch_pending");
 }
+
 #[test]
 fn crash_after_admission_recovers_key_before_new_authority_check() {
     let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
@@ -198,6 +210,7 @@ fn crash_after_admission_recovers_key_before_new_authority_check() {
     assert_eq!(tick(store.as_ref(), &host, 3).reason, "batch_pending");
     assert_eq!(host.actions.borrow().len(), 1);
 }
+
 #[test]
 fn forged_member_output_never_advances_coverage() {
     let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
@@ -241,6 +254,7 @@ fn forged_member_output_never_advances_coverage() {
             .is_empty()
     );
 }
+
 #[test]
 fn incident_identity_uses_cause_and_episode_and_requires_settled_authority() {
     use crate::members::incidents::{IncidentFacts, incident_key};

--- a/crates/orbit-automation/src/routines/mod.rs
+++ b/crates/orbit-automation/src/routines/mod.rs
@@ -1,4 +1,5 @@
 //! Routine discovery, placement and deterministic sweep policy.
+
 pub mod due;
 pub mod loader;
 pub mod sweep;

--- a/crates/orbit-automation/src/routines/sweep.rs
+++ b/crates/orbit-automation/src/routines/sweep.rs
@@ -1,4 +1,5 @@
 //! Deterministic routine evaluation, retry and overlap coordination.
+
 use super::due::{DueDecision, due_decision, parse_cron};
 use super::loader::{LoadedRoutine, RoutineCollection, RoutineLoadError};
 #[cfg(test)]
@@ -15,6 +16,7 @@ use orbit_store::contracts::{
 use orbit_types::workflow::{JobRunState, OverlapPolicy};
 use std::collections::BTreeMap;
 use std::path::Path;
+
 /// Core-supplied owner facts, independent of persisted run status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunOwnerLiveness {
@@ -22,6 +24,7 @@ pub enum RunOwnerLiveness {
     Stopped,
     Unknown,
 }
+
 /// Dispatch seam for the sweep. The production impl
 /// (in Core) wraps one `OrbitRuntime` per source workspace and
 /// dispatches through `submit_pipeline_run` / `show_job_run`; tests supply a
@@ -604,6 +607,7 @@ fn sync_unresolved_fires(
                     // policy timeout, otherwise leave for a later pass.
                     _ => timed_out(),
                 };
+
                 if let Some((state, detail)) = outcome {
                     store.routine_mark_fire_outcome(
                         &fire.routine_name,
@@ -617,6 +621,7 @@ fn sync_unresolved_fires(
             _ => {}
         }
     }
+
     Ok(())
 }
 

--- a/crates/orbit-automation/src/routines/tests/sweep.rs
+++ b/crates/orbit-automation/src/routines/tests/sweep.rs
@@ -92,14 +92,17 @@ impl FakeDispatch {
     fn submit_count(&self) -> usize {
         self.submits.borrow().len()
     }
+
     fn set_state(&self, run_id: &str, state: JobRunState) {
         self.states.borrow_mut().insert(run_id.to_string(), state);
     }
+
     fn set_liveness(&self, run_id: &str, liveness: RunOwnerLiveness) {
         self.liveness
             .borrow_mut()
             .insert(run_id.to_string(), liveness);
     }
+
     /// Make the next `submit` calls fail (dispatch-time error) until cleared.
     fn set_fail(&self, fail: bool) {
         self.fail_submit.set(fail);

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/mod.rs
@@ -29,7 +29,9 @@ pub(super) mod workspace_auto;
 
 #[cfg(test)]
 use crate::OrbitRuntime;
+
 #[cfg(test)]
 use orbit_engine::RuntimeHost;
+
 #[cfg(test)]
 use serde_json::Value;

--- a/crates/orbit-core/src/application/auto_tasks/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/scheduler.rs
@@ -1,4 +1,5 @@
 //! Core task lifecycle adapter and scheduler JSON projection.
+
 use crate::OrbitRuntime;
 use crate::application::task::TaskAddParams;
 use chrono::{DateTime, Utc};
@@ -25,9 +26,11 @@ impl AutoTaskDispatch for OrbitRuntime {
     fn definition_root(&self) -> PathBuf {
         self.paths().local_dir.clone()
     }
+
     fn state_dir(&self) -> PathBuf {
         self.paths().state_dir.clone()
     }
+
     fn has_open_instance(&self, definition: &AutoTaskDefinition) -> Result<bool, OrbitError> {
         let tasks = self.list_tasks_by_tags(&[auto_task_tag(&definition.name)])?;
         Ok(tasks.iter().any(|task| {
@@ -37,6 +40,7 @@ impl AutoTaskDispatch for OrbitRuntime {
             )
         }))
     }
+
     fn mint_task(&self, definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
         mint_task(self, definition).map(|task| task.id)
     }

--- a/crates/orbit-core/src/application/auto_tasks/state.rs
+++ b/crates/orbit-core/src/application/auto_tasks/state.rs
@@ -1,3 +1,4 @@
 //! Legacy cursor projections; Store owns their file persistence.
+
 pub use orbit_store::compose::auto_task::{cursor_state_path, load_cursor_state};
 pub use orbit_types::workflow::{AutoTaskCursor, AutoTaskCursorState};

--- a/crates/orbit-core/src/application/automation/direct.rs
+++ b/crates/orbit-core/src/application/automation/direct.rs
@@ -1,4 +1,5 @@
 //! Authorized direct delivery intents are retained before Git mutates the branch.
+
 use super::source::Source;
 use crate::OrbitRuntime;
 use orbit_automation::{AutomationError, automation_error_to_orbit, delivery::digest};
@@ -20,12 +21,16 @@ pub(crate) fn record_direct_landing_intent(
     let after = source
         .revision(&request.after_commit)
         .map_err(automation_error_to_orbit)?;
+
+    // A landing that changed no tree is not a delivery.
     if before.tree == after.tree {
         return Ok(());
     }
+
     source
         .git(&["merge-base", "--is-ancestor", &before.commit, &after.commit])
         .map_err(automation_error_to_orbit)?;
+
     let range = format!("{}..{}", before.commit, after.commit);
     let commits = source
         .git(&["rev-list", "--first-parent", "--reverse", &range])
@@ -33,11 +38,12 @@ pub(crate) fn record_direct_landing_intent(
         .lines()
         .map(str::to_owned)
         .collect::<Vec<_>>();
+
     let run = runtime.show_job_run(&request.run_id)?;
     let task_ids = run
         .input
         .as_ref()
-        .and_then(|v| v.get("task_ids"))
+        .and_then(|input| input.get("task_ids"))
         .and_then(serde_json::Value::as_array)
         .map(|ids| {
             ids.iter()
@@ -46,8 +52,10 @@ pub(crate) fn record_direct_landing_intent(
                 .collect()
         })
         .unwrap_or_default();
+
     let evidence_digest =
         digest(&serde_json::to_vec(request).map_err(|e| OrbitError::InvalidInput(e.to_string()))?);
+
     runtime
         .automation_store()?
         .automation_record_delivery_intent(&Delivery {
@@ -70,27 +78,32 @@ pub(super) fn observe(
     state: &AutomationState,
     page: &mut SourcePage,
 ) -> Result<(), AutomationError> {
+    // This page's commits plus a rotating slice of the still-unresolved ones.
     let mut candidates = page.commits.iter().take(100).cloned().collect::<Vec<_>>();
     let unresolved = state.unresolved.keys().collect::<Vec<_>>();
+
     candidates.extend(
         unresolved
             .iter()
             .cycle()
             .skip((state.generation as usize) % unresolved.len().max(1))
             .take(unresolved.len().min(100))
-            .map(|s| (*s).clone()),
+            .map(|sha| (*sha).clone()),
     );
+
     let available = state
         .pending_commits
         .iter()
         .chain(page.commits.iter())
         .collect::<Vec<_>>();
+
     for delivery in
         store.automation_delivery_intents(&state.repository, &state.branch, &candidates)?
     {
         if !delivery.commits.iter().all(|sha| available.contains(&sha)) {
             continue;
         }
+
         // An intent is not a landing: only exact, reachable source objects qualify.
         if source
             .git(&[
@@ -103,34 +116,42 @@ pub(super) fn observe(
         {
             continue;
         }
+
         if source.revision(&delivery.before.commit)? != delivery.before
             || source.revision(&delivery.after.commit)? != delivery.after
         {
             continue;
         }
+
         let range = format!("{}..{}", delivery.before.commit, delivery.after.commit);
         let actual = source
             .git(&["rev-list", "--first-parent", "--reverse", &range])?
             .lines()
             .map(str::to_owned)
             .collect::<Vec<_>>();
+
         if actual != delivery.commits {
             continue;
         }
+
         for sha in &delivery.commits {
             page.unresolved.remove(sha);
         }
+
         // Two authorities claiming overlapping units are unresolved, never counted twice.
-        if page
-            .deliveries
-            .iter()
-            .any(|d| d.commits.iter().any(|sha| delivery.commits.contains(sha)))
-        {
+        if page.deliveries.iter().any(|other| {
+            other
+                .commits
+                .iter()
+                .any(|sha| delivery.commits.contains(sha))
+        }) {
             return Err(AutomationError::Deferred(
                 "delivery_grouping_ambiguous".into(),
             ));
         }
+
         page.deliveries.push(delivery);
     }
+
     Ok(())
 }

--- a/crates/orbit-core/src/application/automation/incidents.rs
+++ b/crates/orbit-core/src/application/automation/incidents.rs
@@ -1,4 +1,5 @@
 //! Bounded authoritative run lineage and current task-intent evidence.
+
 use crate::{
     OrbitRuntime,
     application::job::{RunOwnerLiveness, run_owner_liveness},
@@ -22,8 +23,12 @@ pub(crate) fn failure_coupled(
     if task.status != TaskStatus::Blocked || task.job_run_id.as_deref() != Some(run_id) {
         return Ok(false);
     }
+
+    // Only the latest status transition counts: an older failure the task has
+    // since moved past is not what is blocking it now.
     let history = runtime.get_task_history(&task.id)?;
     let last = history.iter().rev().find(|entry| entry.to_status.is_some());
+
     Ok(last.is_some_and(|entry| {
         entry.event == "workflow_run_failed"
             && entry.to_status == Some(TaskStatus::Blocked)
@@ -33,9 +38,23 @@ pub(crate) fn failure_coupled(
                 .is_some_and(|note| note.contains(&format!("run_id={run_id},")))
     }))
 }
+
+/// A run created by triage; diagnosing one again would recurse on itself.
+fn is_diagnostic_origin(run: &JobRun) -> bool {
+    run.job_id == "task_triage_pipeline"
+        || run
+            .input
+            .as_ref()
+            .and_then(|input| input.get("automation_origin"))
+            .and_then(Value::as_str)
+            == Some("triage")
+}
+
+/// Walk retry links to the run that started the episode, under a fixed budget.
 fn root(runtime: &OrbitRuntime, run: &JobRun) -> Result<String, AutomationError> {
     let mut current = run.clone();
     let mut seen = BTreeSet::new();
+
     for _ in 0..50 {
         if !seen.insert(current.run_id.clone()) {
             return Err(AutomationError::Deferred("incident_lineage_cycle".into()));
@@ -47,14 +66,17 @@ fn root(runtime: &OrbitRuntime, run: &JobRun) -> Result<String, AutomationError>
             .get_job_run_backend(parent)?
             .ok_or_else(|| AutomationError::Deferred("incident_lineage_missing".into()))?;
     }
+
     Err(AutomationError::Deferred("incident_lineage_budget".into()))
 }
+
 pub(crate) fn observe(
     runtime: &OrbitRuntime,
     task: &Task,
 ) -> Result<(String, Value), AutomationError> {
     observe_with_settlement(runtime, task, true)
 }
+
 fn observe_with_settlement(
     runtime: &OrbitRuntime,
     task: &Task,
@@ -64,20 +86,16 @@ fn observe_with_settlement(
         .job_run_id
         .as_deref()
         .ok_or_else(|| AutomationError::Deferred("human_block".into()))?;
+
     let mut run = runtime.show_job_run(run_id)?;
     let coupled = failure_coupled(runtime, task, run_id)?;
-    let diagnostic_origin = run.job_id == "task_triage_pipeline"
-        || run
-            .input
-            .as_ref()
-            .and_then(|v| v.get("automation_origin"))
-            .and_then(Value::as_str)
-            == Some("triage");
     let cancelled = run.state == JobRunState::Cancelled;
     let failed = matches!(run.state, JobRunState::Failed | JobRunState::Timeout);
+
     let mut path_settled = true;
-    let mut diagnostic_origin = diagnostic_origin;
+    let mut diagnostic_origin = is_diagnostic_origin(&run);
     let mut episode = root(runtime, &run)?;
+
     // A blocking dispatch with a typed terminal child result is explicit
     // causality. Multiple failing children need separate obligations; ambiguous
     // wrapper evidence is withheld instead of guessing from error prose.
@@ -86,78 +104,98 @@ fn observe_with_settlement(
         if !seen.insert(run.run_id.clone()) {
             return Err(AutomationError::Deferred("incident_lineage_cycle".into()));
         }
+
         path_settled &=
             run.state.is_terminal() && run_owner_liveness(&run) == RunOwnerLiveness::Stopped;
-        diagnostic_origin |= run.job_id == "task_triage_pipeline"
-            || run
-                .input
-                .as_ref()
-                .and_then(|v| v.get("automation_origin"))
-                .and_then(Value::as_str)
-                == Some("triage");
+        diagnostic_origin |= is_diagnostic_origin(&run);
+
         let state = runtime.read_run_state(&run.run_id)?;
         path_settled &= state
             .as_ref()
-            .is_none_or(|s| !s.child_dispatches.iter().any(|d| d.phase.is_open()));
+            .is_none_or(|state| !state.child_dispatches.iter().any(|d| d.phase.is_open()));
+
         let children: Vec<_> = state
             .as_ref()
-            .map(|s| {
-                s.child_dispatches
+            .map(|state| {
+                state
+                    .child_dispatches
                     .iter()
-                    .filter(|d| {
-                        d.blocking
-                            && matches!(d.child_status.as_deref(), Some("failed" | "timeout"))
+                    .filter(|dispatch| {
+                        dispatch.blocking
+                            && matches!(
+                                dispatch.child_status.as_deref(),
+                                Some("failed" | "timeout")
+                            )
                     })
                     .collect()
             })
             .unwrap_or_default();
+
         if children.len() > 1 {
             return Err(AutomationError::Deferred("incident_unresolved".into()));
         }
+
         let Some(child) = children.first() else {
             break;
         };
+
         run = runtime.show_job_run(&child.child_run_id)?;
         episode = root(runtime, &run)?;
     }
+
     if seen.len() == 50 {
         return Err(AutomationError::Deferred("incident_lineage_budget".into()));
     }
+
+    // Collect the whole retry tree under the episode root: an incident is only
+    // settled once every run in it has stopped.
     let root_run = runtime
         .get_job_run_backend(&episode)?
         .ok_or_else(|| AutomationError::Deferred("incident_lineage_missing".into()))?;
+
     let mut related = vec![root_run];
     let mut lineage = BTreeSet::from([episode.clone()]);
     let mut index = 0;
+
     while index < related.len() {
         let children = runtime
             .stores()
             .jobs()
             .job_run_retries(&related[index].run_id, 51)?;
+
         if children.len() > 50 || related.len() + children.len() > 1000 {
             return Err(AutomationError::Deferred("incident_scan_budget".into()));
         }
+
         for child in children {
             if lineage.insert(child.run_id.clone()) {
                 related.push(child);
             }
         }
+
         index += 1;
     }
+
     let settled = related
         .iter()
-        .filter(|r| lineage.contains(&r.run_id))
-        .all(|r| r.state.is_terminal() && run_owner_liveness(r) == RunOwnerLiveness::Stopped)
+        .filter(|related| lineage.contains(&related.run_id))
+        .all(|related| {
+            related.state.is_terminal() && run_owner_liveness(related) == RunOwnerLiveness::Stopped
+        })
         && run_owner_liveness(&run) == RunOwnerLiveness::Stopped;
+
     let state = runtime.read_run_state(&run.run_id)?;
     let descendants_settled = state
         .as_ref()
-        .is_none_or(|s| !s.child_dispatches.iter().any(|d| d.phase.is_open()));
+        .is_none_or(|state| !state.child_dispatches.iter().any(|d| d.phase.is_open()));
+
+    // The failing step names the cause; without one the incident stays unresolved.
     let cause = run
         .steps
         .iter()
-        .find(|s| matches!(s.state, JobRunState::Failed | JobRunState::Timeout))
+        .find(|step| matches!(step.state, JobRunState::Failed | JobRunState::Timeout))
         .map(|step| format!("{}:{}:{}", episode, step.step_index, step.target_id));
+
     let key = incident_key(&IncidentFacts {
         workspace: runtime.workspace_id()?,
         episode: Some(episode.clone()),
@@ -168,6 +206,7 @@ fn observe_with_settlement(
         diagnostic_origin,
         cancellation: cancelled || run.state == JobRunState::Cancelled,
     })?;
+
     Ok((
         key,
         json!({"episode":episode,"cause_run_id":run.run_id,"coupled_run_id":run_id,
@@ -188,13 +227,16 @@ pub(crate) fn members(
         },
         1001,
     )?;
+
     if candidates.total > 1000 {
         return Err(AutomationError::Deferred(
             "incident_inventory_budget".into(),
         ));
     }
+
     let mut members: std::collections::BTreeMap<String, Vec<String>> = Default::default();
     let mut unsettled = BTreeSet::new();
+
     for candidate in candidates.items {
         let task = runtime.get_task(&candidate.id)?;
         if let Ok((key, _)) = observe(runtime, &task) {
@@ -203,9 +245,13 @@ pub(crate) fn members(
             unsettled.insert(key);
         }
     }
+
+    // An incident with any still-unsettled member is not yet diagnosable at all.
     members.retain(|key, _| !unsettled.contains(key));
+
     for ids in members.values_mut() {
         ids.sort();
     }
+
     Ok(members)
 }

--- a/crates/orbit-core/src/application/automation/inspect.rs
+++ b/crates/orbit-core/src/application/automation/inspect.rs
@@ -1,4 +1,5 @@
 //! Read-only diagnostics share persisted scheduler state; inspection never ticks.
+
 use crate::OrbitRuntime;
 use chrono::{DateTime, Utc};
 use orbit_automation::delivery;
@@ -16,14 +17,17 @@ pub fn inspect_auto_task(
     let AutoTaskSchedule::Deliveries { deliveries_landed } = &definition.schedule else {
         return Err(OrbitError::InvalidInput("not a delivery definition".into()));
     };
+
     let epoch = delivery::definition_epoch(&(
         &definition.schedule,
         &definition.template,
         definition.dedupe,
     ))
     .map_err(orbit_automation::automation_error_to_orbit)?;
+
     let admission_deferred = matches!(definition.dedupe, DedupePolicy::SkipIfOpen)
         && super::auto_task_admission_deferral(runtime, definition)?.is_some();
+
     inspect(
         runtime,
         "auto-task",
@@ -44,16 +48,20 @@ pub fn inspect_routine(
     if definition.trigger.state.is_some() {
         return super::members::evaluate(runtime, definition, true, now);
     }
+
     let trigger = definition
         .trigger
         .deliveries_landed
         .as_ref()
         .ok_or_else(|| OrbitError::InvalidInput("not a delivery routine".into()))?;
+
     let mut effective_trigger = trigger.clone();
     effective_trigger.retries = effective_trigger.retries.min(definition.policy.retries.max);
+
     let epoch =
         delivery::definition_epoch(&(&definition.trigger, &definition.target, &definition.policy))
             .map_err(orbit_automation::automation_error_to_orbit)?;
+
     inspect(
         runtime,
         "routine",
@@ -80,11 +88,14 @@ fn inspect(
     let consumer = super::consumer_key(runtime, kind, name)?;
     let store = runtime.automation_store()?;
     let state = store.automation_state(&consumer)?;
+
     let owner = trigger.owner_machine.as_deref();
     let owned_here =
         owner.is_some_and(|owner| Some(owner) == runtime.automation_machine_identity());
     let owned_elsewhere =
         owner.is_some_and(|owner| Some(owner) != runtime.automation_machine_identity());
+
+    // Mirrors the evaluator's precedence without advancing any state.
     let reason = match &state {
         None => {
             if !enabled {
@@ -104,10 +115,9 @@ fn inspect(
         Some(_) if owned_elsewhere => "owned_elsewhere",
         Some(_) if !owned_here => "disabled",
         Some(state)
-            if state
-                .active
-                .as_ref()
-                .is_some_and(|a| matches!(a.state, BatchState::Exhausted | BatchState::Failed)) =>
+            if state.active.as_ref().is_some_and(|active| {
+                matches!(active.state, BatchState::Exhausted | BatchState::Failed)
+            }) =>
         {
             "needs_attention"
         }
@@ -136,8 +146,8 @@ fn inspect(
         }
         Some(state) if state.pending.len() >= trigger.threshold => "threshold_reached",
         Some(state)
-            if state.pending.first().is_some_and(|d| {
-                now.signed_duration_since(d.landed_at).num_minutes()
+            if state.pending.first().is_some_and(|oldest| {
+                now.signed_duration_since(oldest.landed_at).num_minutes()
                     >= i64::from(trigger.max_wait_minutes)
             }) =>
         {
@@ -150,6 +160,7 @@ fn inspect(
         Some(state) if !state.unresolved.is_empty() => "evidence_unavailable",
         Some(_) => "not_due",
     };
+
     Ok(AutomationDiagnostic {
         reason: reason.into(),
         state,

--- a/crates/orbit-core/src/application/automation/members.rs
+++ b/crates/orbit-core/src/application/automation/members.rs
@@ -1,4 +1,5 @@
 //! Narrow Core adapter for the shared state scheduling domain.
+
 use super::{consumer_key, preparation, source::Source};
 use crate::OrbitRuntime;
 use chrono::{DateTime, Utc};
@@ -30,7 +31,9 @@ pub(crate) fn evaluate(
         .state
         .as_ref()
         .ok_or_else(|| OrbitError::InvalidInput("not a state routine".into()))?;
+
     let consumer = consumer_key(runtime, "routine", &definition.name)?;
+
     // Timing edits apply to pending work; the active attempt retains its budget.
     let epoch = definition_epoch(&(
         &trigger.kind,
@@ -39,9 +42,12 @@ pub(crate) fn evaluate(
         &definition.target,
     ))
     .map_err(automation_error_to_orbit)?;
+
     let owned = Some(trigger.owner_machine.as_str()) == runtime.automation_machine_identity();
+
     let mut effective = trigger.clone();
     effective.retries = effective.retries.min(definition.policy.retries.max);
+
     members::evaluate(
         runtime.automation_store()?.as_ref(),
         &Host {
@@ -59,14 +65,17 @@ pub(crate) fn evaluate(
     )
     .map_err(automation_error_to_orbit)
 }
+
 struct Host<'a> {
     runtime: &'a OrbitRuntime,
     trigger: &'a StateTrigger,
 }
+
 impl MemberHost for Host<'_> {
     fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError> {
         Source::new(&self.runtime.paths().repo_root).head(branch)
     }
+
     fn observe(
         &self,
         after: Option<&str>,
@@ -76,6 +85,7 @@ impl MemberHost for Host<'_> {
             .map(serde_json::from_str)
             .transpose()
             .map_err(|e| AutomationError::Evidence(format!("invalid task continuation: {e}")))?;
+
         let tasks = self.runtime.task_candidates(
             &TaskListFilter {
                 scan_before,
@@ -89,22 +99,27 @@ impl MemberHost for Host<'_> {
             },
             50,
         )?;
+
         let next = if tasks.total > tasks.items.len() {
             tasks
                 .items
                 .last()
-                .map(|t| serde_json::to_string(&(t.created_at, &t.id)))
+                .map(|last| serde_json::to_string(&(last.created_at, &last.id)))
                 .transpose()
                 .map_err(|e| AutomationError::Evidence(e.to_string()))?
         } else {
             None
         };
+
         let (_, source) = self.head(&self.trigger.branch)?;
+
         let mut candidates = Vec::new();
         let mut incident_inventory = None;
         let mut withheld = BTreeMap::new();
+
         for envelope in tasks.items {
             let task = self.runtime.get_task(&envelope.id)?;
+
             match self.trigger.kind {
                 StateTriggerKind::PreparationEligible => {
                     if !orbit_automation::members::preparation::eligible(&task) {
@@ -132,25 +147,34 @@ impl MemberHost for Host<'_> {
                 StateTriggerKind::ExecutionFailed => {
                     match super::incidents::observe(self.runtime, &task) {
                         Ok((key, evidence)) => {
-                            if candidates.iter().any(|m: &StateMember| m.key == key) {
+                            if candidates
+                                .iter()
+                                .any(|other: &StateMember| other.key == key)
+                            {
                                 continue;
                             }
+
+                            // The full cohort is hydrated at most once per page.
                             if incident_inventory.is_none() {
                                 incident_inventory = Some(super::incidents::members(self.runtime)?);
                             }
+
                             let task_ids = incident_inventory
                                 .as_ref()
                                 .and_then(|inventory| inventory.get(&key))
                                 .cloned()
                                 .unwrap_or_default();
+
                             if task_ids.len() > 50 {
                                 withheld.insert(task.id, "incident_member_budget".into());
                                 continue;
                             }
+
                             if task_ids.is_empty() {
                                 withheld.insert(task.id, "incident_recovery_pending".into());
                                 continue;
                             }
+
                             candidates.push(StateMember {
                                 fingerprint: key.clone(),
                                 key,
@@ -168,18 +192,22 @@ impl MemberHost for Host<'_> {
                 }
             }
         }
+
         Ok(MemberPage {
             candidates,
             withheld,
             next,
         })
     }
+
     fn admission_deferral(&self, member: &StateMember) -> Result<Option<String>, AutomationError> {
         if self.trigger.kind == StateTriggerKind::ExecutionFailed
             && super::incidents::members(self.runtime)?.get(&member.key) != Some(&member.task_ids)
         {
             return Ok(Some("incident_membership_or_recovery_changed".into()));
         }
+
+        // Re-derive the material now: a member whose input moved may not be admitted.
         for id in &member.task_ids {
             let task = self.runtime.get_task(id)?;
             let current = match self.trigger.kind {
@@ -197,12 +225,15 @@ impl MemberHost for Host<'_> {
                     }
                 }
             };
+
             if current != member.fingerprint {
                 return Ok(Some("material_changed".into()));
             }
         }
+
         Ok(None)
     }
+
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError> {
         self.runtime
             .stores()
@@ -210,44 +241,74 @@ impl MemberHost for Host<'_> {
             .automation_job_for_key(&attempt.action_key)
             .map_err(Into::into)
     }
+
     fn admit(&self, attempt: &MemberAttempt) -> Result<String, AutomationError> {
         self.runtime.ensure_coordination_task_write_permitted()?;
+
         let state = self
             .runtime
             .automation_store()?
             .automation_state(&attempt.consumer)?
             .ok_or_else(|| AutomationError::Deferred("claim_missing".into()))?;
-        if state.members.as_ref().and_then(|m| m.active.as_ref()) != Some(attempt) {
+        if state
+            .members
+            .as_ref()
+            .and_then(|members| members.active.as_ref())
+            != Some(attempt)
+        {
             return Err(AutomationError::Deferred("claim_superseded".into()));
         }
+
+        // Pin the source the attempt froze so the run can still reach it later.
         Source::new(&self.runtime.paths().repo_root).git(&[
             "update-ref",
             &format!("refs/orbit/automation/{}", attempt.id),
             &attempt.member.source.commit,
         ])?;
-        self.runtime.submit_automation_pipeline_run(self.trigger.job_name(), json!({
-            "state_automation": attempt, "task_ids": attempt.member.task_ids,
-            "source_revision": attempt.member.source.commit, "base_branch": self.trigger.branch,
-            "max_tasks": attempt.member.task_ids.len(), "promotion_authorized": false,
-            "automation_origin": if self.trigger.kind == StateTriggerKind::ExecutionFailed {"triage"} else {"preparation"},
-        }), &attempt.action_key).map(|r|r.run_id).map_err(Into::into)
+
+        let origin = if self.trigger.kind == StateTriggerKind::ExecutionFailed {
+            "triage"
+        } else {
+            "preparation"
+        };
+
+        self.runtime
+            .submit_automation_pipeline_run(
+                self.trigger.job_name(),
+                json!({
+                    "state_automation": attempt,
+                    "task_ids": attempt.member.task_ids,
+                    "source_revision": attempt.member.source.commit,
+                    "base_branch": self.trigger.branch,
+                    "max_tasks": attempt.member.task_ids.len(),
+                    "promotion_authorized": false,
+                    "automation_origin": origin,
+                }),
+                &attempt.action_key,
+            )
+            .map(|run| run.run_id)
+            .map_err(Into::into)
     }
+
     fn outcome(&self, attempt: &MemberAttempt) -> Result<MemberOutcome, AutomationError> {
         let Some(id) = attempt.action_id.as_deref() else {
             return Ok(MemberOutcome::Pending);
         };
+
         let run = self.runtime.show_job_run(id)?;
         let expected =
             serde_json::to_value(attempt).map_err(|e| AutomationError::Evidence(e.to_string()))?;
+
         if run
             .input
             .as_ref()
-            .and_then(|v| v.get("state_automation"))
-            .and_then(|v| v.get("action_key"))
+            .and_then(|input| input.get("state_automation"))
+            .and_then(|automation| automation.get("action_key"))
             != expected.get("action_key")
         {
             return Err(AutomationError::Evidence("job_input_mismatch".into()));
         }
+
         if let Some(state) = self.runtime.read_run_state(id)? {
             // Only the exact canonical deterministic apply step can provide this
             // record. Agent prose and unrelated output keys are never searched.
@@ -264,6 +325,7 @@ impl MemberHost for Host<'_> {
                 return Ok(MemberOutcome::Applied(evidence));
             }
         }
+
         if run.state.is_terminal()
             && crate::application::job::run_owner_liveness(&run)
                 == crate::application::job::RunOwnerLiveness::Stopped
@@ -272,6 +334,7 @@ impl MemberHost for Host<'_> {
                 "stopped_without_member_evidence".into(),
             ));
         }
+
         Ok(MemberOutcome::Pending)
     }
 }
@@ -281,15 +344,23 @@ pub(crate) fn claim(
     runtime: &OrbitRuntime,
     value: &Value,
 ) -> Result<Option<MemberAttempt>, OrbitError> {
-    let Some(value) = value.get("state_automation").filter(|v| !v.is_null()) else {
+    let Some(value) = value
+        .get("state_automation")
+        .filter(|claim| !claim.is_null())
+    else {
         return Ok(None);
     };
+
     let submitted: MemberAttempt = serde_json::from_value(value.clone())
         .map_err(|e| OrbitError::InvalidInput(e.to_string()))?;
+
     let state = runtime
         .automation_store()?
         .automation_state(&submitted.consumer)?
         .ok_or_else(|| OrbitError::InvalidInput("state claim missing".into()))?;
+
+    // Preparation material is derived from the branch head, so a moved head
+    // invalidates the claim; incident material is not tied to the head.
     if submitted.kind == StateTriggerKind::PreparationEligible
         && Source::new(&runtime.paths().repo_root)
             .head(&state.branch)
@@ -301,10 +372,12 @@ pub(crate) fn claim(
             "state-trigger source changed".into(),
         ));
     }
+
     let active = state
         .members
-        .and_then(|m| m.active)
+        .and_then(|members| members.active)
         .ok_or_else(|| OrbitError::InvalidInput("state claim missing".into()))?;
+
     if active.kind != submitted.kind
         || active.id != submitted.id
         || active.member != submitted.member
@@ -317,5 +390,6 @@ pub(crate) fn claim(
             "state claim stale or expired".into(),
         ));
     }
+
     Ok(Some(active))
 }

--- a/crates/orbit-core/src/application/automation/mod.rs
+++ b/crates/orbit-core/src/application/automation/mod.rs
@@ -1,4 +1,5 @@
 //! Core composition of source facts, existing lifecycle actions and evidence.
+
 use crate::OrbitRuntime;
 use chrono::{DateTime, Utc};
 use orbit_automation::delivery::{self, ActionOutcome, DeliveryHost};
@@ -6,20 +7,23 @@ use orbit_automation::{AutomationError, automation_error_to_orbit};
 use orbit_common::OrbitError;
 use orbit_types::workflow::automation::*;
 use orbit_types::workflow::{AutoTaskDefinition, AutoTaskSchedule, RoutineDefinition};
+
 mod direct;
 pub(crate) mod incidents;
 mod inspect;
 pub(crate) mod members;
 pub(crate) mod preparation;
 mod provider;
-pub(crate) use direct::record_direct_landing_intent;
 mod source;
-pub use inspect::{inspect_auto_task, inspect_routine};
 mod task;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use direct::record_direct_landing_intent;
+pub use inspect::{inspect_auto_task, inspect_routine};
+
 pub const COVERAGE_ARTIFACT: &str = "automation-coverage.json";
+
 /// Identity is machine/workspace-qualified in the authoritative host database.
 pub fn consumer_key(runtime: &OrbitRuntime, kind: &str, name: &str) -> Result<String, OrbitError> {
     let machine = runtime.automation_machine_identity().ok_or_else(|| {
@@ -45,12 +49,14 @@ pub fn evaluate_auto_task(
     else {
         return Err(OrbitError::InvalidInput("not a delivery definition".into()));
     };
+
     let epoch = delivery::definition_epoch(&(
         &definition.schedule,
         &definition.template,
         definition.dedupe,
     ))
     .map_err(automation_error_to_orbit)?;
+
     evaluate(
         runtime,
         Action::Task(definition),
@@ -64,6 +70,7 @@ pub fn evaluate_auto_task(
         },
     )
 }
+
 pub fn evaluate_routine(
     runtime: &OrbitRuntime,
     definition: &RoutineDefinition,
@@ -73,16 +80,21 @@ pub fn evaluate_routine(
     if definition.trigger.state.is_some() {
         return members::evaluate(runtime, definition, dry_run, now);
     }
+
     let trigger = definition
         .trigger
         .deliveries_landed
         .as_ref()
         .ok_or_else(|| OrbitError::InvalidInput("not a delivery routine".into()))?;
+
+    // The routine's retry policy caps whatever the trigger asks for.
     let mut effective_trigger = trigger.clone();
     effective_trigger.retries = effective_trigger.retries.min(definition.policy.retries.max);
+
     let epoch =
         delivery::definition_epoch(&(&definition.trigger, &definition.target, &definition.policy))
             .map_err(automation_error_to_orbit)?;
+
     evaluate(
         runtime,
         Action::Job(definition),
@@ -96,6 +108,7 @@ pub fn evaluate_routine(
         },
     )
 }
+
 fn evaluate(
     runtime: &OrbitRuntime,
     action: Action<'_>,
@@ -109,6 +122,7 @@ fn evaluate(
     // Disable admission on another owner, but reconcile previously admitted work.
     // Preview remains read-only and exposes the actual consumer/baseline.
     request.enabled &= owned_here;
+
     let dry_run = request.dry_run;
     let store = runtime.automation_store()?;
     let host = Host {
@@ -116,33 +130,41 @@ fn evaluate(
         action,
         source: source::Source::new(&runtime.paths().repo_root),
     };
+
     let mut diagnostic =
         delivery::evaluate(store.as_ref(), &host, request).map_err(automation_error_to_orbit)?;
+
     if owned_elsewhere && !dry_run {
         diagnostic.reason = "owned_elsewhere".into();
     }
+
     Ok(diagnostic)
 }
+
 enum Action<'a> {
     Task(&'a AutoTaskDefinition),
     Job(&'a RoutineDefinition),
 }
+
 struct Host<'a> {
     runtime: &'a OrbitRuntime,
     action: Action<'a>,
     source: source::Source<'a>,
 }
+
 impl DeliveryHost for Host<'_> {
     fn admission_deferral(&self) -> Result<Option<String>, AutomationError> {
         if let Action::Task(definition) = self.action {
             return auto_task_admission_deferral(self.runtime, definition).map_err(Into::into);
         }
+
         Ok(None)
     }
 
     fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError> {
         self.source.head(branch)
     }
+
     fn observe(
         &self,
         branch: &str,
@@ -155,10 +177,14 @@ impl DeliveryHost for Host<'_> {
             state,
             &mut page,
         )?;
+
         Ok(page)
     }
+
     fn admit(&self, attempt: &BatchAttempt) -> Result<String, AutomationError> {
         self.runtime.ensure_coordination_task_write_permitted()?;
+
+        // The claim this host was handed must still be the one recorded.
         let state = self
             .runtime
             .automation_store()?
@@ -167,7 +193,9 @@ impl DeliveryHost for Host<'_> {
         if state.active.as_ref() != Some(attempt) {
             return Err(AutomationError::Deferred("claim_superseded".into()));
         }
+
         self.source.retain_batch(&attempt.batch)?;
+
         match self.action {
             Action::Task(definition) => {
                 task::mint(self.runtime, definition, attempt).map_err(Into::into)
@@ -179,10 +207,11 @@ impl DeliveryHost for Host<'_> {
                     serde_json::json!({"automation":attempt}),
                     &attempt.action_key,
                 )
-                .map(|r| r.run_id)
+                .map(|run| run.run_id)
                 .map_err(Into::into),
         }
     }
+
     fn outcome(&self, attempt: &BatchAttempt) -> Result<ActionOutcome, AutomationError> {
         match self.action {
             Action::Task(_) => task::outcome(self.runtime, &self.source, attempt),
@@ -202,5 +231,6 @@ fn auto_task_admission_deferral(
     {
         return Ok(Some("open_instance".into()));
     }
+
     Ok(None)
 }

--- a/crates/orbit-core/src/application/automation/preparation.rs
+++ b/crates/orbit-core/src/application/automation/preparation.rs
@@ -1,4 +1,5 @@
 //! Authoritative task/source inputs for the shared material fingerprint.
+
 use super::source::Source;
 use crate::OrbitRuntime;
 use orbit_automation::{AutomationError, members::preparation};
@@ -11,7 +12,9 @@ pub(crate) fn fingerprint(
     revision: &str,
 ) -> Result<String, AutomationError> {
     let source = Source::new(&runtime.paths().repo_root);
+
     let mut dependencies = Vec::new();
+
     for id in task.dependencies().iter().take(51) {
         if dependencies.len() == 50 {
             return Err(AutomationError::Deferred("dependency_scan_budget".into()));
@@ -22,11 +25,15 @@ pub(crate) fn fingerprint(
             "description": dependency.description, "plan": dependency.plan,
             "refs": dependency.external_refs, "pr_status": dependency.pr_status}));
     }
+
     dependencies.sort_by_key(|value| value["id"].as_str().unwrap_or_default().to_string());
+
     // The pinned tree includes every repository instruction, including nested
     // selectors. Dirty local instructions cannot certify this pinned source.
     let paths = source.git(&["ls-tree", "-r", "--name-only", revision])?;
+
     let mut instructions = Vec::new();
+
     for path in paths
         .lines()
         .filter(|path| matches!(path.rsplit('/').next(), Some("AGENTS.md" | "CLAUDE.md")))
@@ -39,9 +46,12 @@ pub(crate) fn fingerprint(
             source.git(&["show", &format!("{revision}:{path}")])?,
         ));
     }
+
+    // The crew a task would actually run under is part of its material input.
     let assignment = runtime.resolve_crew_for_task(None, task.crew.as_deref())?;
     dependencies.push(json!({"effective_assignment": {"crew": assignment.name,
         "model": assignment.assignment.model, "provider": assignment.assignment.provider}}));
+
     preparation::fingerprint(
         task,
         revision,

--- a/crates/orbit-core/src/application/automation/provider.rs
+++ b/crates/orbit-core/src/application/automation/provider.rs
@@ -1,4 +1,5 @@
 //! Provider identities establish grouping; first-parent commits establish ordering.
+
 use super::source::Source;
 use orbit_automation::{AutomationError, delivery::digest};
 use orbit_types::workflow::automation::*;
@@ -11,6 +12,7 @@ pub(super) fn association(
     branch: &str,
 ) -> Result<DeliveryAssociation, AutomationError> {
     let invalid = || AutomationError::Deferred("provider_identity_missing".into());
+
     let reference = pr["html_url"].as_str().ok_or_else(invalid)?.to_string();
     let anchor = pr["merge_commit_sha"]
         .as_str()
@@ -19,9 +21,10 @@ pub(super) fn association(
     let number = pr["number"].as_u64().ok_or_else(invalid)?;
     let landed_at = pr["merged_at"]
         .as_str()
-        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
-        .map(|t| t.with_timezone(&chrono::Utc))
+        .and_then(|merged_at| chrono::DateTime::parse_from_rfc3339(merged_at).ok())
+        .map(|merged_at| merged_at.with_timezone(&chrono::Utc))
         .ok_or_else(invalid)?;
+
     Ok(DeliveryAssociation {
         key: format!("pr:{repository}:{branch}:{number}"),
         anchor,
@@ -43,30 +46,41 @@ pub(super) fn group(
         .iter()
         .chain(commits)
         .collect::<Vec<_>>();
+
     let mut deliveries = vec![];
+
+    // Each association's anchor commit closes a delivery; walking back over the
+    // commits sharing that association gives the group it landed as.
     for (end, sha) in pending.iter().enumerate() {
-        let Some(Some(a)) = associations.get(*sha) else {
+        let Some(Some(association)) = associations.get(*sha) else {
             continue;
         };
+
         if state
             .pending
             .iter()
             .chain(&state.waived)
-            .any(|d| d.key == a.key)
+            .any(|delivery| delivery.key == association.key)
         {
             continue;
         }
+
         if deliveries.len() == 50 {
             break;
         }
-        if &a.anchor != *sha {
+
+        if &association.anchor != *sha {
             continue;
         }
+
+        // A commit with no association at all leaves the group's start unknown,
+        // so the whole delivery is withheld rather than guessed at.
         let mut start = end;
         let mut unresolved = false;
+
         while start > 0 {
             match associations.get(pending[start - 1]) {
-                Some(Some(previous)) if previous.key == a.key => start -= 1,
+                Some(Some(previous)) if previous.key == association.key => start -= 1,
                 Some(_) => break,
                 None => {
                     unresolved = true;
@@ -74,34 +88,41 @@ pub(super) fn group(
                 }
             }
         }
+
         if unresolved {
             continue;
         }
+
         let before = source.revision(&format!("{}^1", pending[start]))?;
         let after = source.revision(sha)?;
+
         if before.tree == after.tree {
             continue;
         }
+
         let members = pending[start..=end]
             .iter()
             .map(|sha| (*sha).clone())
             .collect::<Vec<_>>();
+
         let evidence_digest = digest(
-            &serde_json::to_vec(&(a, &members, &before, &after))
+            &serde_json::to_vec(&(association, &members, &before, &after))
                 .map_err(|e| AutomationError::Evidence(e.to_string()))?,
         );
+
         deliveries.push(Delivery {
-            key: a.key.clone(),
+            key: association.key.clone(),
             repository: repository.into(),
             branch: branch.into(),
             before,
             after,
             commits: members,
             task_ids: vec![],
-            evidence_reference: a.reference.clone(),
+            evidence_reference: association.reference.clone(),
             evidence_digest,
-            landed_at: a.landed_at,
+            landed_at: association.landed_at,
         });
     }
+
     Ok(deliveries)
 }

--- a/crates/orbit-core/src/application/automation/source.rs
+++ b/crates/orbit-core/src/application/automation/source.rs
@@ -1,4 +1,5 @@
 //! Bounded source facts from Git and provider-owned PR identities.
+
 use orbit_automation::{AutomationError, delivery::digest};
 use orbit_types::workflow::automation::*;
 use serde_json::Value;
@@ -14,6 +15,7 @@ pub(super) struct Source<'a> {
     root: &'a Path,
     started: Instant,
 }
+
 impl<'a> Source<'a> {
     pub(super) fn new(root: &'a Path) -> Self {
         Self {
@@ -21,10 +23,13 @@ impl<'a> Source<'a> {
             started: Instant::now(),
         }
     }
+
+    /// Run one bounded child process, capturing stdout under a size and time budget.
     fn command(&self, program: &str, args: &[&str]) -> Result<String, AutomationError> {
         if self.started.elapsed() > Duration::from_secs(30) {
             return Err(AutomationError::Deferred("source_deadline".into()));
         }
+
         let mut file =
             tempfile::tempfile().map_err(|e| AutomationError::Deferred(e.to_string()))?;
         let output = file
@@ -38,7 +43,9 @@ impl<'a> Source<'a> {
             .stderr(Stdio::null())
             .spawn()
             .map_err(|e| AutomationError::Deferred(format!("evidence_unavailable: {e}")))?;
+
         let start = Instant::now();
+
         loop {
             if let Some(status) = child
                 .try_wait()
@@ -49,30 +56,42 @@ impl<'a> Source<'a> {
                 }
                 break;
             }
-            if start.elapsed() > Duration::from_secs(2)
+
+            let over_budget = start.elapsed() > Duration::from_secs(2)
                 || self.started.elapsed() > Duration::from_secs(30)
-                || file.metadata().map(|m| m.len() > 1_048_576).unwrap_or(true)
-            {
+                || file
+                    .metadata()
+                    .map(|meta| meta.len() > 1_048_576)
+                    .unwrap_or(true);
+
+            if over_budget {
                 let _ = child.kill();
                 let _ = child.wait();
                 return Err(AutomationError::Deferred("source_budget".into()));
             }
+
             std::thread::sleep(Duration::from_millis(10));
         }
+
         file.seek(SeekFrom::Start(0))
             .map_err(|e| AutomationError::Deferred(e.to_string()))?;
+
         let mut result = String::new();
         file.take(1_048_577)
             .read_to_string(&mut result)
             .map_err(|e| AutomationError::Deferred(e.to_string()))?;
+
         if result.len() > 1_048_576 {
             return Err(AutomationError::Deferred("source_budget".into()));
         }
+
         Ok(result.trim().into())
     }
+
     pub(super) fn git(&self, args: &[&str]) -> Result<String, AutomationError> {
         self.command("git", args)
     }
+
     pub(super) fn revision(&self, spec: &str) -> Result<SourceRevision, AutomationError> {
         let commit = self.git(&[
             "rev-parse",
@@ -80,19 +99,26 @@ impl<'a> Source<'a> {
             "--end-of-options",
             &format!("{spec}^{{commit}}"),
         ])?;
+
         let tree = self.git(&[
             "rev-parse",
             "--verify",
             "--end-of-options",
             &format!("{commit}^{{tree}}"),
         ])?;
+
         Ok(SourceRevision { commit, tree })
     }
+
     pub(super) fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError> {
         self.git(&["check-ref-format", "--branch", branch])?;
+
+        // A GitHub remote gives the provider-visible repository name; anything else
+        // is identified by a stable digest of whatever remote or git dir it has.
         let remote = self
             .git(&["config", "--get", "remote.origin.url"])
             .unwrap_or_default();
+
         let normalized = remote.trim_end_matches(".git");
         let repository = if let Some(github) = normalized
             .strip_prefix("https://github.com/")
@@ -107,10 +133,13 @@ impl<'a> Source<'a> {
             };
             format!("git:{}", digest(identity.as_bytes()))
         };
+
         // Observe the configured integration ref, never the executor worktree HEAD.
         let head = self.revision(&format!("refs/heads/{branch}"))?;
+
         Ok((repository, head))
     }
+
     pub(super) fn observe(
         &self,
         branch: &str,
@@ -124,6 +153,7 @@ impl<'a> Source<'a> {
             )
         })
     }
+
     pub(super) fn observe_with_lookup(
         &self,
         branch: &str,
@@ -131,9 +161,11 @@ impl<'a> Source<'a> {
         lookup: &dyn Fn(&str, &str) -> Result<String, AutomationError>,
     ) -> Result<SourcePage, AutomationError> {
         let (repository, head) = self.head(branch)?;
+
         if repository != state.repository {
             return Err(AutomationError::Deferred("repository_changed".into()));
         }
+
         self.git(&[
             "merge-base",
             "--is-ancestor",
@@ -141,18 +173,22 @@ impl<'a> Source<'a> {
             &head.commit,
         ])
         .map_err(|_| AutomationError::Deferred("history_diverged".into()))?;
+
         let range = format!("{}..{}", state.observed.commit, head.commit);
+
         // Count uses bounded output and the same command deadline. Select the oldest
         // page by first-parent distance; reverse+max-count alone selects the newest.
         let count = self
             .git(&["rev-list", "--first-parent", "--count", &range])?
             .parse::<usize>()
             .map_err(|_| AutomationError::Deferred("source_count_invalid".into()))?;
+
         let through = if count > 200 {
             self.revision(&format!("{}~{}", head.commit, count - 200))?
         } else {
             head
         };
+
         let page_range = format!("{}..{}", state.observed.commit, through.commit);
         let commits = self
             .git(&[
@@ -165,8 +201,12 @@ impl<'a> Source<'a> {
             .lines()
             .map(str::to_owned)
             .collect::<Vec<_>>();
+
         let mut unresolved = BTreeMap::new();
         let mut associations = state.associations.clone();
+
+        // Each pass resolves the newest commits plus a rotating slice of the
+        // previously unresolved ones, so no commit is starved of retries.
         let old = state.unresolved.keys().collect::<Vec<_>>();
         let offset = (state.generation as usize) % old.len().max(1);
         let candidates = commits.iter().take(10).chain(
@@ -176,14 +216,18 @@ impl<'a> Source<'a> {
                 .take(old.len().min(10))
                 .copied(),
         );
+
         for sha in candidates {
             if self.started.elapsed() > Duration::from_secs(20) {
                 break;
             }
+
+            // Without a provider-visible repository there is no identity to ask for.
             if repository.starts_with("git:") {
                 unresolved.insert(sha.clone(), "delivery_owner_evidence_pending".into());
                 continue;
             }
+
             let raw = match lookup(&repository, sha) {
                 Ok(raw) => raw,
                 Err(_) => {
@@ -191,18 +235,23 @@ impl<'a> Source<'a> {
                     continue;
                 }
             };
+
             let prs: Value =
                 serde_json::from_str(&raw).map_err(|e| AutomationError::Deferred(e.to_string()))?;
+
+            // Exactly one merged pull request into this branch is an identity;
+            // several are ambiguous and none simply leaves the commit unresolved.
             let matching = prs
                 .as_array()
                 .ok_or_else(|| AutomationError::Deferred("provider_response_invalid".into()))?
                 .iter()
-                .filter(|p| {
-                    p["merged_at"].is_string()
-                        && p["base"]["ref"].as_str() == Some(branch)
-                        && p["base"]["repo"]["full_name"].as_str() == Some(&repository)
+                .filter(|pr| {
+                    pr["merged_at"].is_string()
+                        && pr["base"]["ref"].as_str() == Some(branch)
+                        && pr["base"]["repo"]["full_name"].as_str() == Some(&repository)
                 })
                 .collect::<Vec<_>>();
+
             let association = match matching.as_slice() {
                 [] => None,
                 [pr] => Some(super::provider::association(pr, &repository, branch)?),
@@ -211,18 +260,25 @@ impl<'a> Source<'a> {
                     continue;
                 }
             };
+
             associations.insert(sha.clone(), association);
             unresolved.insert(sha.clone(), "landing_span_pending".into());
         }
+
         let deliveries =
             super::provider::group(self, state, &repository, branch, &commits, &associations)?;
+
         for sha in &commits {
-            if !deliveries.iter().any(|d| d.commits.contains(sha)) {
+            if !deliveries
+                .iter()
+                .any(|delivery| delivery.commits.contains(sha))
+            {
                 unresolved
                     .entry(sha.clone())
                     .or_insert_with(|| "evidence_pending".into());
             }
         }
+
         Ok(SourcePage {
             from: state.observed.clone(),
             through,
@@ -233,31 +289,39 @@ impl<'a> Source<'a> {
             complete: count <= 200,
         })
     }
+
+    /// Pin the batch boundaries so the frozen input stays reachable during review.
     pub(super) fn retain_batch(&self, batch: &CoverageBatch) -> Result<(), AutomationError> {
         let prefix = format!(
             "refs/orbit/automation/{}/{}",
             digest(batch.consumer.as_bytes()),
             batch.id
         );
+
         self.git(&[
             "update-ref",
             &format!("{prefix}/from"),
             &batch.from_exclusive.commit,
         ])?;
+
         self.git(&[
             "update-ref",
             &format!("{prefix}/through"),
             &batch.through_inclusive.commit,
         ])?;
+
         Ok(())
     }
+
     pub(super) fn verify_batch(&self, batch: &CoverageBatch) -> Result<(), AutomationError> {
         if self.revision(&batch.from_exclusive.commit)? != batch.from_exclusive
             || self.revision(&batch.through_inclusive.commit)? != batch.through_inclusive
         {
             return Err(AutomationError::Deferred("source_revision_changed".into()));
         }
+
         let (_, head) = self.head(&batch.branch)?;
+
         self.git(&[
             "merge-base",
             "--is-ancestor",
@@ -265,20 +329,24 @@ impl<'a> Source<'a> {
             &head.commit,
         ])
         .map_err(|_| AutomationError::Deferred("history_diverged".into()))?;
+
         let range = format!(
             "{}..{}",
             batch.from_exclusive.commit, batch.through_inclusive.commit
         );
+
         let actual = self
             .git(&["rev-list", "--first-parent", "--reverse", &range])?
             .lines()
             .map(str::to_owned)
             .collect::<Vec<_>>();
+
         if actual != batch.commits {
             return Err(AutomationError::Deferred(
                 "source_membership_changed".into(),
             ));
         }
+
         Ok(())
     }
 }

--- a/crates/orbit-core/src/application/automation/task.rs
+++ b/crates/orbit-core/src/application/automation/task.rs
@@ -1,4 +1,5 @@
 //! Task/job adapters retain existing creation and evidence provenance boundaries.
+
 use super::{COVERAGE_ARTIFACT, source::Source};
 use crate::OrbitRuntime;
 use orbit_automation::{
@@ -16,8 +17,21 @@ pub(super) fn mint(
     attempt: &BatchAttempt,
 ) -> Result<String, OrbitError> {
     let mut params = crate::application::auto_tasks::scheduler::template_params(definition);
-    params.description.push_str(&format!("\n\nFrozen automation input (inspect these exact revisions):\n```json\n{}\n```\nSubmit versioned coverage evidence as {} with orbit.task.artifact.put. Examination, including findings, must be complete before setting examination_complete=true. Task completion alone does not certify coverage.",serde_json::to_string_pretty(attempt).map_err(|e|OrbitError::InvalidInput(e.to_string()))?,COVERAGE_ARTIFACT));
-    params.description.push_str(&format!("\n\nEvidence template (replace action_id with this task ID and fill actual checks/findings):\n```json\n{}\n```",serde_json::to_string_pretty(&orbit_types::workflow::automation::evidence_template(attempt)).map_err(|e|OrbitError::InvalidInput(e.to_string()))?));
+
+    let invalid = |e: serde_json::Error| OrbitError::InvalidInput(e.to_string());
+    let frozen_input = serde_json::to_string_pretty(attempt).map_err(invalid)?;
+    let evidence_template = serde_json::to_string_pretty(
+        &orbit_types::workflow::automation::evidence_template(attempt),
+    )
+    .map_err(invalid)?;
+
+    params.description.push_str(&format!(
+        "\n\nFrozen automation input (inspect these exact revisions):\n```json\n{frozen_input}\n```\nSubmit versioned coverage evidence as {COVERAGE_ARTIFACT} with orbit.task.artifact.put. Examination, including findings, must be complete before setting examination_complete=true. Task completion alone does not certify coverage."
+    ));
+    params.description.push_str(&format!(
+        "\n\nEvidence template (replace action_id with this task ID and fill actual checks/findings):\n```json\n{evidence_template}\n```"
+    ));
+
     runtime
         .add_task_admitted(params, None, None, Some(&attempt.action_key))
         .map(|task| task.id)
@@ -31,11 +45,14 @@ pub(super) fn outcome(
     let Some(id) = attempt.action_id.as_deref() else {
         return Ok(ActionOutcome::Pending);
     };
+
     let task = runtime.get_task(id)?;
     let artifact = runtime.get_task_artifact(id, COVERAGE_ARTIFACT)?;
+
     if let Some(artifact) = artifact {
         let manifest = runtime.get_task_artifact_manifest(id)?;
-        let provenance = manifest.iter().find(|f| f.path == COVERAGE_ARTIFACT);
+        let provenance = manifest.iter().find(|file| file.path == COVERAGE_ARTIFACT);
+
         if let Some(provenance) = provenance {
             let owner = evidence_owner(runtime, &task, &provenance.sha256)?;
             return Ok(ActionOutcome::Evidence(EvidenceFacts {
@@ -50,6 +67,7 @@ pub(super) fn outcome(
             }));
         }
     }
+
     if matches!(
         task.status,
         TaskStatus::Done | TaskStatus::Rejected | TaskStatus::Archived
@@ -59,8 +77,10 @@ pub(super) fn outcome(
             reason: "task_closed_without_accepted_evidence".into(),
         });
     }
+
     Ok(ActionOutcome::Pending)
 }
+
 pub(super) fn job_outcome(
     runtime: &OrbitRuntime,
     source: &Source<'_>,
@@ -69,27 +89,32 @@ pub(super) fn job_outcome(
     let Some(id) = attempt.action_id.as_deref() else {
         return Ok(ActionOutcome::Pending);
     };
+
     let run = runtime.show_job_run(id)?;
+
     // Only a canonical persisted step result can attest job-only examination.
     let input = run.input.as_ref();
     let expected =
         serde_json::to_value(attempt).map_err(|e| AutomationError::Evidence(e.to_string()))?;
+
     if ["batch", "input_digest", "attempt", "action_key"]
         .iter()
         .any(|key| {
             input
-                .and_then(|v| v.get("automation"))
-                .and_then(|v| v.get(key))
+                .and_then(|input| input.get("automation"))
+                .and_then(|automation| automation.get(key))
                 != expected.get(key)
         })
     {
         return Err(AutomationError::Deferred("job_input_mismatch".into()));
     }
+
+    // The most recent step carrying evidence wins.
     for step in run.steps.iter().rev() {
         if let Some(value) = step
             .agent_response_json
             .as_ref()
-            .and_then(|v| v.get("coverage_evidence"))
+            .and_then(|response| response.get("coverage_evidence"))
         {
             let bytes =
                 serde_json::to_vec(value).map_err(|e| AutomationError::Evidence(e.to_string()))?;
@@ -103,6 +128,7 @@ pub(super) fn job_outcome(
             }));
         }
     }
+
     if matches!(
         run.state,
         JobRunState::Failed
@@ -117,6 +143,7 @@ pub(super) fn job_outcome(
             reason: "job_stopped_without_accepted_evidence".into(),
         });
     }
+
     Ok(ActionOutcome::Pending)
 }
 
@@ -131,19 +158,23 @@ fn evidence_owner(
     let Ok(submission) = serde_json::from_slice::<EvidenceSubmission>(&artifact.content) else {
         return Ok(None);
     };
+
+    // The submission has to name this task, this artifact and this task's run.
     if submission.action_id != task.id
         || submission.evidence_digest != artifact_digest
         || task.job_run_id.as_deref() != Some(&submission.run_id)
     {
         return Ok(None);
     }
+
     let run = runtime.show_job_run(&submission.run_id)?;
     let assigned = run.input.as_ref().is_some_and(|input| {
         input.get("task_id").and_then(serde_json::Value::as_str) == Some(&task.id)
             || input
                 .get("task_ids")
                 .and_then(serde_json::Value::as_array)
-                .is_some_and(|ids| ids.iter().any(|v| v.as_str() == Some(&task.id)))
+                .is_some_and(|ids| ids.iter().any(|id| id.as_str() == Some(&task.id)))
     });
+
     Ok(assigned.then(|| format!("run:{}", submission.run_id)))
 }

--- a/crates/orbit-core/src/application/automation/tests/consumer.rs
+++ b/crates/orbit-core/src/application/automation/tests/consumer.rs
@@ -1,4 +1,5 @@
 //! Real Git + task registry + artifact tool consumer tests, without provider/network I/O.
+
 use super::super::{COVERAGE_ARTIFACT, evaluate_auto_task, record_direct_landing_intent};
 use crate::{
     OrbitRuntime,
@@ -28,12 +29,14 @@ fn git(root: &Path, args: &[&str]) -> String {
     );
     String::from_utf8(result.stdout).unwrap().trim().into()
 }
+
 fn commit(root: &Path, text: &str) -> String {
     std::fs::write(root.join("sample.txt"), text).unwrap();
     git(root, &["add", "sample.txt"]);
     git(root, &["commit", "-m", "fixture change"]);
     git(root, &["rev-parse", "HEAD"])
 }
+
 fn runtime() -> OrbitRuntime {
     let runtime = OrbitRuntime::in_memory()
         .unwrap()
@@ -47,6 +50,7 @@ fn runtime() -> OrbitRuntime {
     commit(root, "baseline");
     runtime
 }
+
 fn definition(
     runtime: &OrbitRuntime,
     name: &str,
@@ -84,6 +88,7 @@ fn definition(
     d.enabled = true;
     d
 }
+
 fn attach(
     runtime: &OrbitRuntime,
     attempt: &BatchAttempt,
@@ -116,6 +121,7 @@ fn attach(
         )
         .unwrap();
 }
+
 #[test]
 fn qa_and_review_accept_only_assigned_artifact_evidence_once() {
     let runtime = runtime();
@@ -237,6 +243,7 @@ fn qa_and_review_accept_only_assigned_artifact_evidence_once() {
         "accepted bytes outlive artifact replacement"
     );
 }
+
 #[test]
 fn direct_intent_does_not_count_before_actual_landing() {
     let runtime = runtime();

--- a/crates/orbit-core/src/application/routines/loader.rs
+++ b/crates/orbit-core/src/application/routines/loader.rs
@@ -1,4 +1,5 @@
 //! Core assembly for explicit routine sources and target catalog resolution.
+
 use crate::OrbitRuntime;
 pub use orbit_automation::routines::loader::{
     LoadedRoutine, RoutineCollection, RoutineLoadError, RoutineOrigin, RoutineSource,

--- a/crates/orbit-store/src/contracts/automation.rs
+++ b/crates/orbit-store/src/contracts/automation.rs
@@ -1,4 +1,5 @@
 //! Atomic scheduler checkpoints and immutable accepted coverage.
+
 use orbit_common::OrbitError;
 use orbit_types::workflow::automation::{AcceptedCoverage, AutomationState, BatchWaiver, Delivery};
 
@@ -13,6 +14,7 @@ pub trait AutomationStoreBackend: Send + Sync {
             "batch waiver persistence unavailable".into(),
         ))
     }
+
     fn automation_waivers(
         &self,
         _consumer: &str,
@@ -37,6 +39,7 @@ pub trait AutomationStoreBackend: Send + Sync {
             "delivery intent persistence unavailable".into(),
         ))
     }
+
     fn automation_delivery_intents(
         &self,
         _repository: &str,

--- a/crates/orbit-store/src/driver/sqlite/automation/intents.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/intents.rs
@@ -1,26 +1,33 @@
 //! Indexed immutable delivery-owner intents; reachability is verified by Core.
+
 use super::{decode, encode};
 use crate::Store;
 use orbit_common::OrbitError;
 use orbit_types::workflow::automation::Delivery;
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
+
 pub(super) fn record(store: &Store, delivery: &Delivery) -> Result<(), OrbitError> {
     if delivery.commits.is_empty() || delivery.commits.len() > 5000 {
         return Err(OrbitError::InvalidInput(
             "direct delivery membership must contain 1..=5000 commits".into(),
         ));
     }
+
     let id = format!("{}:{}", delivery.key, delivery.after.commit);
+
     store.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
         let conn = tx.connection();
+
         let existing: Option<String> = conn
             .query_row(
                 "SELECT delivery_json FROM automation_delivery_intents WHERE record_id=?1",
                 [&id],
-                |r| r.get(0),
+                |row| row.get(0),
             )
             .optional()
             .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        // Intents are immutable: a re-record is a no-op, a changed one is a conflict.
         if let Some(raw) = existing {
             let old: Delivery = decode(&raw)?;
             if old.before != delivery.before
@@ -33,11 +40,13 @@ pub(super) fn record(store: &Store, delivery: &Delivery) -> Result<(), OrbitErro
             }
             return Ok(());
         }
+
         conn.execute(
             "INSERT INTO automation_delivery_intents VALUES (?1,?2,?3,?4)",
             params![id, delivery.repository, delivery.branch, encode(delivery)?],
         )
         .map_err(|e| OrbitError::Store(e.to_string()))?;
+
         for sha in &delivery.commits {
             conn.execute(
                 "INSERT INTO automation_delivery_members VALUES (?1,?2,?3,?4)",
@@ -45,9 +54,11 @@ pub(super) fn record(store: &Store, delivery: &Delivery) -> Result<(), OrbitErro
             )
             .map_err(|e| OrbitError::Store(e.to_string()))?;
         }
+
         Ok(())
     })
 }
+
 pub(super) fn lookup(
     store: &Store,
     repository: &str,
@@ -60,9 +71,35 @@ pub(super) fn lookup(
         ));
     }
     store.with_read_connection(|conn| {
-  let mut found=std::collections::BTreeMap::new();
-  let mut stmt=conn.prepare("SELECT i.record_id,i.delivery_json FROM automation_delivery_members m JOIN automation_delivery_intents i ON i.record_id=m.record_id WHERE m.repository=?1 AND m.branch=?2 AND m.commit_id=?3 LIMIT 51").map_err(|e|OrbitError::Store(e.to_string()))?;
-  for sha in commits {let rows=stmt.query_map(params![repository,branch,sha],|r|Ok((r.get::<_,String>(0)?,r.get::<_,String>(1)?))).map_err(|e|OrbitError::Store(e.to_string()))?;for row in rows {let (id,raw)=row.map_err(|e|OrbitError::Store(e.to_string()))?;found.insert(id,decode(&raw)?);if found.len()>50 {return Err(OrbitError::Store("delivery intent page exceeds limit".into()));}}}
-  Ok(found.into_values().collect())
- })
+        // Keyed by record id so a delivery spanning several requested commits is
+        // returned once.
+        let mut found = std::collections::BTreeMap::new();
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT i.record_id,i.delivery_json FROM automation_delivery_members m JOIN automation_delivery_intents i ON i.record_id=m.record_id WHERE m.repository=?1 AND m.branch=?2 AND m.commit_id=?3 LIMIT 51",
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        for sha in commits {
+            let rows = stmt
+                .query_map(params![repository, branch, sha], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+            for row in rows {
+                let (id, raw) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+                found.insert(id, decode(&raw)?);
+
+                if found.len() > 50 {
+                    return Err(OrbitError::Store(
+                        "delivery intent page exceeds limit".into(),
+                    ));
+                }
+            }
+        }
+
+        Ok(found.into_values().collect())
+    })
 }

--- a/crates/orbit-store/src/driver/sqlite/automation/members.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/members.rs
@@ -1,4 +1,5 @@
 //! State-member invariants use the same transaction and receipt tables.
+
 use orbit_common::OrbitError;
 use orbit_types::workflow::automation::{
     AcceptedCoverage, AutomationState, members::MemberEvidence,
@@ -13,6 +14,9 @@ pub(super) fn validate(
     let invalid = || OrbitError::InvalidInput("invalid member checkpoint transition".into());
     let old = previous.members.as_ref().ok_or_else(invalid)?;
     let new = next.members.as_ref().ok_or_else(invalid)?;
+
+    // A member checkpoint touches member state only; the delivery projection and
+    // its cursors must come through untouched.
     if previous.active.is_some()
         || next.active.is_some()
         || previous.covered != next.covered
@@ -25,6 +29,9 @@ pub(super) fn validate(
     {
         return Err(invalid());
     }
+
+    // A failed record is permanent, except for the one the active attempt just
+    // exhausted itself into.
     for (key, failed) in &old.failed {
         if new.failed.get(key) != Some(failed)
             && !old.active.as_ref().is_some_and(|active| {
@@ -39,6 +46,8 @@ pub(super) fn validate(
             return Err(invalid());
         }
     }
+
+    // An in-flight attempt keeps its identity and may only advance by one retry.
     if let Some(active) = &old.active {
         if let Some(updated) = &new.active {
             if active.consumer != updated.consumer
@@ -61,35 +70,42 @@ pub(super) fn validate(
                 return Err(invalid());
             }
         } else if receipt.is_none()
-            && !new.failed.get(&active.member.key).is_some_and(|a| {
-                a.exhausted
-                    && a.id == active.id
-                    && a.member == active.member
-                    && a.attempt == active.attempt
-                    && a.deadline == active.deadline
+            && !new.failed.get(&active.member.key).is_some_and(|retired| {
+                retired.exhausted
+                    && retired.id == active.id
+                    && retired.member == active.member
+                    && retired.attempt == active.attempt
+                    && retired.deadline == active.deadline
             })
         {
             return Err(invalid());
         }
     }
+
+    // A newly claimed attempt starts at attempt 1, unadmitted, over a pending member.
     if old.active.is_none()
         && let Some(active) = &new.active
         && (active.consumer != previous.consumer
             || active.attempt != 1
             || active.max_attempts == 0
             || active.max_attempts > 6
-            || !new.pending.values().any(|m| m == &active.member)
+            || !new
+                .pending
+                .values()
+                .any(|pending| pending == &active.member)
             || active.action_id.is_some()
             || active.exhausted
             || active.deadline <= active.retry_after)
     {
         return Err(invalid());
     }
+
     if let Some(receipt) = receipt {
         let active = old.active.as_ref().ok_or_else(invalid)?;
         let evidence: MemberEvidence =
             serde_json::from_slice(&receipt.evidence).map_err(|_| invalid())?;
         let bytes = serde_json::to_vec(active).map_err(|_| invalid())?;
+
         if receipt.batch_id != active.id
             || active.action_id.as_ref() != Some(&receipt.action_id)
             || receipt.input_digest != format!("{:x}", Sha256::digest(bytes))
@@ -105,6 +121,8 @@ pub(super) fn validate(
         {
             return Err(invalid());
         }
+
+        // The receipt may add exactly one assessment: the member it just applied.
         let mut expected_assessments = old.assessed.clone();
         expected_assessments.insert(
             active.member.key.clone(),
@@ -113,9 +131,11 @@ pub(super) fn validate(
                 .ok_or_else(invalid)?
                 .clone(),
         );
+
         if expected_assessments != new.assessed {
             return Err(invalid());
         }
+
         let assessment = new.assessed.get(&active.member.key).ok_or_else(invalid)?;
         if assessment.input_fingerprint != evidence.input_fingerprint
             || assessment.resulting_fingerprint != evidence.resulting_fingerprint
@@ -127,5 +147,6 @@ pub(super) fn validate(
     } else if old.assessed != new.assessed {
         return Err(invalid());
     }
+
     Ok(())
 }

--- a/crates/orbit-store/src/driver/sqlite/automation/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/mod.rs
@@ -1,33 +1,45 @@
 //! Automation records in the existing host SQLite database.
+
 use crate::Store;
 use crate::contracts::AutomationStoreBackend;
 use crate::driver::sqlite::migration::FeatureMigration;
 use orbit_common::OrbitError;
-use orbit_types::workflow::automation::{AcceptedCoverage, AutomationState};
+use orbit_types::workflow::automation::{AcceptedCoverage, AutomationState, Delivery};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
 
 pub(crate) fn initialize(store: &Store) -> Result<(), OrbitError> {
-    store.apply_feature_migrations("automation", &[FeatureMigration::new(1, "consumer_checkpoints_and_coverage", |conn| {
-            conn.execute_batch("CREATE TABLE automation_consumers (consumer TEXT PRIMARY KEY, generation INTEGER NOT NULL, state_json TEXT NOT NULL);
+    store.apply_feature_migrations(
+        "automation",
+        &[
+            FeatureMigration::new(1, "consumer_checkpoints_and_coverage", |conn| {
+                conn.execute_batch("CREATE TABLE automation_consumers (consumer TEXT PRIMARY KEY, generation INTEGER NOT NULL, state_json TEXT NOT NULL);
             CREATE TABLE automation_coverage (batch_id TEXT PRIMARY KEY, consumer TEXT NOT NULL, batch_json TEXT NOT NULL, receipt_json TEXT NOT NULL, accepted_at TEXT NOT NULL);
             CREATE INDEX automation_coverage_consumer ON automation_coverage(consumer, accepted_at);
             CREATE TABLE automation_delivery_intents (record_id TEXT PRIMARY KEY, repository TEXT NOT NULL, branch TEXT NOT NULL, delivery_json TEXT NOT NULL);
             CREATE TABLE automation_delivery_members (repository TEXT NOT NULL, branch TEXT NOT NULL, commit_id TEXT NOT NULL, record_id TEXT NOT NULL, PRIMARY KEY(repository,branch,commit_id,record_id));
             CREATE TABLE automation_waivers (batch_id TEXT PRIMARY KEY, consumer TEXT NOT NULL, batch_json TEXT NOT NULL, waiver_json TEXT NOT NULL);
             CREATE TABLE automation_job_keys (workspace_id TEXT NOT NULL, action_key TEXT NOT NULL, run_id TEXT NOT NULL, PRIMARY KEY(workspace_id,action_key));")
-                .map_err(|e| OrbitError::Store(e.to_string()))
-        }), FeatureMigration::new(2, "retry_lineage_index", |conn| {
-            conn.execute_batch("CREATE INDEX IF NOT EXISTS job_runs_retry_lineage ON job_runs(workspace_id,retry_source_run_id)")
+                    .map_err(|e| OrbitError::Store(e.to_string()))
+            }),
+            FeatureMigration::new(2, "retry_lineage_index", |conn| {
+                conn.execute_batch(
+                    "CREATE INDEX IF NOT EXISTS job_runs_retry_lineage ON job_runs(workspace_id,retry_source_run_id)",
+                )
                 .map_err(|error| OrbitError::Store(error.to_string()))
-        })])
+            }),
+        ],
+    )
 }
+
 fn encode<T: serde::Serialize>(value: &T) -> Result<String, OrbitError> {
     serde_json::to_string(value).map_err(|e| OrbitError::Store(e.to_string()))
 }
+
 fn decode<T: serde::de::DeserializeOwned>(raw: &str) -> Result<T, OrbitError> {
     serde_json::from_str(raw)
         .map_err(|e| OrbitError::Store(format!("invalid persisted automation record: {e}")))
 }
+
 impl AutomationStoreBackend for Store {
     fn automation_waive(
         &self,
@@ -37,6 +49,7 @@ impl AutomationStoreBackend for Store {
     ) -> Result<bool, OrbitError> {
         waivers::commit(self, previous, next, waiver)
     }
+
     fn automation_waivers(
         &self,
         consumer: &str,
@@ -51,7 +64,14 @@ impl AutomationStoreBackend for Store {
         batch: &str,
     ) -> Result<Option<AcceptedCoverage>, OrbitError> {
         self.with_read_connection(|conn| {
-            let raw:Option<String>=conn.query_row("SELECT receipt_json FROM automation_coverage WHERE consumer=?1 AND batch_id=?2",params![consumer,batch],|r|r.get(0)).optional().map_err(|e|OrbitError::Store(e.to_string()))?;
+            let raw: Option<String> = conn
+                .query_row(
+                    "SELECT receipt_json FROM automation_coverage WHERE consumer=?1 AND batch_id=?2",
+                    params![consumer, batch],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
             raw.as_deref().map(decode).transpose()
         })
     }
@@ -62,6 +82,7 @@ impl AutomationStoreBackend for Store {
     ) -> Result<(), OrbitError> {
         intents::record(self, delivery)
     }
+
     fn automation_delivery_intents(
         &self,
         repository: &str,
@@ -84,6 +105,7 @@ impl AutomationStoreBackend for Store {
             raw.as_deref().map(decode).transpose()
         })
     }
+
     fn automation_initialize(&self, state: &AutomationState) -> Result<bool, OrbitError> {
         if state
             .members
@@ -112,6 +134,7 @@ impl AutomationStoreBackend for Store {
                 .map_err(|e| OrbitError::Store(e.to_string()))
         })
     }
+
     fn automation_commit(
         &self,
         previous: &AutomationState,
@@ -120,38 +143,84 @@ impl AutomationStoreBackend for Store {
     ) -> Result<bool, OrbitError> {
         validate_transition(previous, next, receipt)?;
         self.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
-            let conn=tx.connection();
-            let changed=conn.execute("UPDATE automation_consumers SET generation=?1,state_json=?2 WHERE consumer=?3 AND generation=?4 AND state_json=?5",params![next.generation,encode(next)?,previous.consumer,previous.generation,encode(previous)?]).map_err(|e|OrbitError::Store(e.to_string()))?;
-            if changed==0 { return Ok(false); }
-            if let Some(receipt)=receipt {
+            let conn = tx.connection();
+
+            // The generation and the exact prior state both fence the write, so a
+            // concurrent evaluation that already moved the consumer changes nothing.
+            let changed = conn
+                .execute(
+                    "UPDATE automation_consumers SET generation=?1,state_json=?2 WHERE consumer=?3 AND generation=?4 AND state_json=?5",
+                    params![
+                        next.generation,
+                        encode(next)?,
+                        previous.consumer,
+                        previous.generation,
+                        encode(previous)?
+                    ],
+                )
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+            if changed == 0 {
+                return Ok(false);
+            }
+
+            if let Some(receipt) = receipt {
                 // Preserve shipped delivery receipt bytes; member records carry
                 // only their frozen action, never the unrelated consumer inventory.
                 let batch_json = if let Some(members) = &previous.members {
                     encode(&serde_json::json!({"state_member": members.active}))?
-                } else { encode(&previous.active)? };
-                conn.execute("INSERT INTO automation_coverage VALUES (?1,?2,?3,?4,?5)",params![receipt.batch_id, previous.consumer,batch_json,encode(receipt)?,receipt.accepted_at.to_rfc3339()]).map_err(|e|OrbitError::Store(e.to_string()))?;
+                } else {
+                    encode(&previous.active)?
+                };
+
+                conn.execute(
+                    "INSERT INTO automation_coverage VALUES (?1,?2,?3,?4,?5)",
+                    params![
+                        receipt.batch_id,
+                        previous.consumer,
+                        batch_json,
+                        encode(receipt)?,
+                        receipt.accepted_at.to_rfc3339()
+                    ],
+                )
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
             }
+
             Ok(true)
         })
     }
+
     fn automation_receipts(
         &self,
         consumer: &str,
         limit: usize,
     ) -> Result<Vec<AcceptedCoverage>, OrbitError> {
         self.with_read_connection(|conn| {
-            let mut stmt=conn.prepare("SELECT receipt_json FROM automation_coverage WHERE consumer=?1 ORDER BY accepted_at DESC,batch_id DESC LIMIT ?2").map_err(|e|OrbitError::Store(e.to_string()))?;
-            let rows=stmt.query_map(params![consumer,limit.min(100)],|r|r.get::<_,String>(0)).map_err(|e|OrbitError::Store(e.to_string()))?;
-            rows.map(|r|decode(&r.map_err(|e|OrbitError::Store(e.to_string()))?)).collect()
+            let mut stmt = conn
+                .prepare(
+                    "SELECT receipt_json FROM automation_coverage WHERE consumer=?1 ORDER BY accepted_at DESC,batch_id DESC LIMIT ?2",
+                )
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(params![consumer, limit.min(100)], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+            rows.map(|row| decode(&row.map_err(|e| OrbitError::Store(e.to_string()))?))
+                .collect()
         })
     }
 }
+
 fn validate_transition(
     previous: &AutomationState,
     next: &AutomationState,
     receipt: Option<&AcceptedCoverage>,
 ) -> Result<(), OrbitError> {
     let invalid = || OrbitError::InvalidInput("invalid automation checkpoint transition".into());
+
     if previous.consumer != next.consumer
         || previous.epoch != next.epoch
         || previous.repository != next.repository
@@ -163,9 +232,13 @@ fn validate_transition(
     {
         return Err(invalid());
     }
+
     if previous.members.is_some() || next.members.is_some() {
         return members::validate(previous, next, receipt);
     }
+
+    // An attempt may gain retries but never swap the batch it was frozen against,
+    // and it may only disappear when a receipt retires it.
     if let Some(old) = &previous.active {
         if let Some(new) = &next.active {
             if old.batch != new.batch
@@ -178,6 +251,7 @@ fn validate_transition(
             return Err(invalid());
         }
     }
+
     if let Some(receipt) = receipt {
         let active = previous.active.as_ref().ok_or_else(invalid)?;
         if active.batch.id != receipt.batch_id
@@ -191,49 +265,56 @@ fn validate_transition(
         {
             return Err(invalid());
         }
+
         use sha2::{Digest, Sha256};
+
         if receipt.evidence_digest != format!("{:x}", Sha256::digest(&receipt.evidence)) {
             return Err(invalid());
         }
-        let remaining = previous
-            .pending
-            .iter()
-            .filter(|d| {
-                !d.commits
-                    .iter()
-                    .all(|sha| active.batch.commits.contains(sha))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        let remaining_waived = previous
-            .waived
-            .iter()
-            .filter(|d| {
-                !d.commits
-                    .iter()
-                    .all(|sha| active.batch.commits.contains(sha))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if next.waived != remaining_waived {
+
+        // Accepting the batch retires exactly the deliveries it fully covered;
+        // anything it only partly covered has to survive the checkpoint.
+        let uncovered = |deliveries: &[Delivery]| {
+            deliveries
+                .iter()
+                .filter(|delivery| {
+                    !delivery
+                        .commits
+                        .iter()
+                        .all(|sha| active.batch.commits.contains(sha))
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        if next.waived != uncovered(&previous.waived) {
             return Err(invalid());
         }
-        if next.pending != remaining {
+
+        if next.pending != uncovered(&previous.pending) {
             return Err(invalid());
         }
+
         if !previous.pending_commits.starts_with(&active.batch.commits)
             || next.pending_commits != previous.pending_commits[active.batch.commits.len()..]
         {
             return Err(invalid());
         }
     } else {
+        // Without a receipt the covered cursor stands still: observation may only
+        // append commits and retain every delivery already pending.
         if previous.waived != next.waived
             || previous.covered != next.covered
             || !next.pending_commits.starts_with(&previous.pending_commits)
-            || previous.pending.iter().any(|d| !next.pending.contains(d))
+            || previous
+                .pending
+                .iter()
+                .any(|delivery| !next.pending.contains(delivery))
         {
             return Err(invalid());
         }
+
+        // A newly claimed batch must be an exact prefix of what is already pending.
         if previous.active.is_none()
             && let Some(active) = &next.active
         {
@@ -246,14 +327,19 @@ fn validate_transition(
                 || batch.commits.is_empty()
                 || !next.pending_commits.starts_with(&batch.commits)
                 || batch.commits.last() != Some(&batch.through_inclusive.commit)
-                || batch.deliveries.iter().any(|d| !next.pending.contains(d))
+                || batch
+                    .deliveries
+                    .iter()
+                    .any(|delivery| !next.pending.contains(delivery))
             {
                 return Err(invalid());
             }
         }
     }
+
     Ok(())
 }
+
 mod intents;
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
@@ -1,5 +1,6 @@
 use crate::{Store, compose};
 use orbit_types::workflow::automation::*;
+
 fn state() -> AutomationState {
     let head = SourceRevision {
         commit: "a".into(),
@@ -23,6 +24,7 @@ fn state() -> AutomationState {
         active: None,
     }
 }
+
 #[test]
 fn compare_exchange_survives_reopen_and_fences_stale_writers() {
     let dir = tempfile::tempdir().unwrap();
@@ -46,6 +48,7 @@ fn compare_exchange_survives_reopen_and_fences_stale_writers() {
         Some(next)
     );
 }
+
 #[test]
 fn observation_cannot_advance_coverage() {
     let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();

--- a/crates/orbit-store/src/driver/sqlite/automation/waivers.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/waivers.rs
@@ -1,9 +1,11 @@
 //! Explicit waiver history and removal from scheduling eligibility are atomic.
+
 use super::{decode, encode};
 use crate::Store;
 use orbit_common::OrbitError;
 use orbit_types::workflow::automation::*;
 use rusqlite::{TransactionBehavior, params};
+
 pub(super) fn commit(
     store: &Store,
     previous: &AutomationState,
@@ -12,17 +14,21 @@ pub(super) fn commit(
 ) -> Result<bool, OrbitError> {
     let invalid = || OrbitError::InvalidInput("invalid batch waiver transition".into());
     let active = previous.active.as_ref().ok_or_else(invalid)?;
+
+    // Rebuild the only checkpoint this waiver may produce and require the caller
+    // to have proposed exactly it.
     let mut expected = previous.clone();
     expected.generation = expected.generation.checked_add(1).ok_or_else(invalid)?;
     expected.active = None;
-    expected.pending.retain(|d| {
+    expected.pending.retain(|delivery| {
         !active
             .batch
             .deliveries
             .iter()
-            .any(|member| member.key == d.key)
+            .any(|member| member.key == delivery.key)
     });
     expected.waived.extend(active.batch.deliveries.clone());
+
     if &expected != next
         || active.batch.id != waiver.batch_id
         || !matches!(active.state, BatchState::Failed | BatchState::Exhausted)
@@ -31,16 +37,61 @@ pub(super) fn commit(
     {
         return Err(invalid());
     }
-    store.with_transaction_behavior(TransactionBehavior::Immediate,|tx| {
-  let conn=tx.connection();let changed=conn.execute("UPDATE automation_consumers SET generation=?1,state_json=?2 WHERE consumer=?3 AND generation=?4 AND state_json=?5",params![next.generation,encode(next)?,previous.consumer,previous.generation,encode(previous)?]).map_err(|e|OrbitError::Store(e.to_string()))?;
-  if changed==0 {return Ok(false);}
-  conn.execute("INSERT INTO automation_waivers VALUES (?1,?2,?3,?4)",params![waiver.batch_id,previous.consumer,encode(active)?,encode(waiver)?]).map_err(|e|OrbitError::Store(e.to_string()))?;Ok(true)
- })
+
+    store.with_transaction_behavior(TransactionBehavior::Immediate, |tx| {
+        let conn = tx.connection();
+
+        let changed = conn
+            .execute(
+                "UPDATE automation_consumers SET generation=?1,state_json=?2 WHERE consumer=?3 AND generation=?4 AND state_json=?5",
+                params![
+                    next.generation,
+                    encode(next)?,
+                    previous.consumer,
+                    previous.generation,
+                    encode(previous)?
+                ],
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        if changed == 0 {
+            return Ok(false);
+        }
+
+        conn.execute(
+            "INSERT INTO automation_waivers VALUES (?1,?2,?3,?4)",
+            params![
+                waiver.batch_id,
+                previous.consumer,
+                encode(active)?,
+                encode(waiver)?
+            ],
+        )
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        Ok(true)
+    })
 }
+
 pub(super) fn list(
     store: &Store,
     consumer: &str,
     limit: usize,
 ) -> Result<Vec<BatchWaiver>, OrbitError> {
-    store.with_read_connection(|conn| {let mut stmt=conn.prepare("SELECT waiver_json FROM automation_waivers WHERE consumer=?1 ORDER BY rowid DESC LIMIT ?2").map_err(|e|OrbitError::Store(e.to_string()))?;let rows=stmt.query_map(params![consumer,limit.min(100)],|r|r.get::<_,String>(0)).map_err(|e|OrbitError::Store(e.to_string()))?;rows.map(|row|decode(&row.map_err(|e|OrbitError::Store(e.to_string()))?)).collect()})
+    store.with_read_connection(|conn| {
+        let mut stmt = conn
+            .prepare(
+                "SELECT waiver_json FROM automation_waivers WHERE consumer=?1 ORDER BY rowid DESC LIMIT ?2",
+            )
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        let rows = stmt
+            .query_map(params![consumer, limit.min(100)], |row| {
+                row.get::<_, String>(0)
+            })
+            .map_err(|e| OrbitError::Store(e.to_string()))?;
+
+        rows.map(|row| decode(&row.map_err(|e| OrbitError::Store(e.to_string()))?))
+            .collect()
+    })
 }

--- a/crates/orbit-types/src/workflow/auto_task_cursor.rs
+++ b/crates/orbit-types/src/workflow/auto_task_cursor.rs
@@ -1,6 +1,8 @@
 //! Legacy auto-task scheduling cursor contracts.
+
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
 /// On-disk shape of `<orbit_dir>/state/auto-tasks.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct AutoTaskCursorState {

--- a/crates/orbit-types/src/workflow/automation/members.rs
+++ b/crates/orbit-types/src/workflow/automation/members.rs
@@ -1,4 +1,5 @@
 //! State-trigger inputs and durable per-member scheduling [ORB-11331].
+
 use super::SourceRevision;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,7 @@ pub enum StateTriggerKind {
     PreparationEligible,
     ExecutionFailed,
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StateTrigger {
@@ -22,6 +24,7 @@ pub struct StateTrigger {
     pub retries: u32,
     pub deadline_minutes: u32,
 }
+
 impl StateTrigger {
     pub fn validate(&self) -> Result<(), super::super::error::WorkflowError> {
         if self.owner_machine.trim().is_empty()
@@ -39,8 +42,10 @@ impl StateTrigger {
                 "state trigger requires owner, branch, positive debounce <= max wait, 1..50 members, retries <= 5 and deadline 1..1440 minutes".into(),
             ));
         }
+
         Ok(())
     }
+
     pub fn job_name(&self) -> &'static str {
         match self.kind {
             StateTriggerKind::PreparationEligible => "task_pilot_pipeline",
@@ -60,6 +65,7 @@ pub struct StateMember {
     pub first_seen: DateTime<Utc>,
     pub changed_at: DateTime<Utc>,
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemberAttempt {
     pub consumer: String,
@@ -74,6 +80,7 @@ pub struct MemberAttempt {
     pub action_id: Option<String>,
     pub exhausted: bool,
 }
+
 /// A single-member action is deliberately also a valid pilot partition. This
 /// makes independently accepted results durable before any other member fails.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -85,6 +92,7 @@ pub struct MemberState {
     pub withheld: BTreeMap<String, String>,
     pub scan_after: Option<String>,
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemberAssessment {
     pub input_fingerprint: String,
@@ -92,6 +100,7 @@ pub struct MemberAssessment {
     pub ready: bool,
     pub receipt_id: String,
 }
+
 /// Deterministic apply evidence, never an agent-authored promotion grant.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemberEvidence {

--- a/crates/orbit-types/src/workflow/automation/mod.rs
+++ b/crates/orbit-types/src/workflow/automation/mod.rs
@@ -1,8 +1,10 @@
 //! Shared delivery-trigger, batch and coverage contracts [ORB-11330].
-pub mod members;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+
+pub mod members;
 
 /// Supported examination contracts; QA and review never share acceptance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,9 +30,11 @@ pub struct DeliveryTrigger {
     #[serde(default)]
     pub retries: u32,
 }
+
 fn default_batch_size() -> usize {
     50
 }
+
 impl DeliveryTrigger {
     pub fn validate(&self) -> Result<(), super::error::WorkflowError> {
         if self.branch.is_empty()
@@ -42,8 +46,11 @@ impl DeliveryTrigger {
             || self.max_wait_minutes == 0
             || self.retries > 5
         {
-            return Err(super::error::WorkflowError::Invalid("delivery trigger requires a branch, 1 <= threshold <= max_items <= 50, positive max_wait_minutes and retries <= 5".into()));
+            return Err(super::error::WorkflowError::Invalid(
+                "delivery trigger requires a branch, 1 <= threshold <= max_items <= 50, positive max_wait_minutes and retries <= 5".into(),
+            ));
         }
+
         Ok(())
     }
 }
@@ -175,6 +182,7 @@ pub struct CoverageEvidence {
     pub checks: Vec<ExaminationCheck>,
     pub findings: Vec<String>,
 }
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExaminationCheck {
@@ -274,6 +282,7 @@ pub struct CoverageReceiptSummary {
     pub submitted_by: String,
     pub accepted_at: DateTime<Utc>,
 }
+
 impl From<AcceptedCoverage> for CoverageReceiptSummary {
     fn from(receipt: AcceptedCoverage) -> Self {
         Self {
@@ -296,6 +305,7 @@ pub struct BatchWaiver {
     pub by: String,
     pub at: DateTime<Utc>,
 }
+
 /// Existing definition-update surface accepts this administrative request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/orbit-web/src/api/automation.rs
+++ b/crates/orbit-web/src/api/automation.rs
@@ -1,4 +1,5 @@
 //! Immutable coverage evidence, scoped to the selected owner workspace.
+
 use super::{map_runtime_error, routines::OperationsQuery};
 use crate::state::DashboardState;
 use axum::{


### PR DESCRIPTION
## Task

[ORB-11419](https://orbit-cli.com/tasks/ORB-11419) — Sweep Orbit source for readable spacing, logical grouping, and consistent organization

### Description

## Problem
Formatter-clean code can still be dense and difficult to scan: module documentation, imports and declarations run together, and functions lack visual separation between validation, state changes and result construction. Daniel requested a codebase-wide cleanup sweep, not another formatting-only pass or guidance edit.

## Scope
Inspect hand-maintained source and tests across Orbit crates, frontend code, and repository scripts. Apply behavior-preserving readability improvements wherever the pattern is present; leave already-clear code alone. Starting examples identified in this conversation are crates/orbit-automation/src/delivery/observe.rs, members/incidents.rs, error.rs, and auto_tasks/scheduler.rs. Reinspect the current versions at execution time. ORB-11409 / PR #1437 supplies related guidance, not proof that source cleanup occurred.

Prioritize meaningful blank lines between module documentation, imports, declarations and distinct function phases; keep related statements together. Improve descriptive local names, explain genuinely complex conditions, and use consistent local organization when it clearly helps comprehension. Do not mechanically insert blank lines after every statement or rewrite every expression. Small helper extractions are acceptable only when a cohesive responsibility becomes clearer and semantics can be verified.

## Constraints
No functional fixes, public API or persisted-format changes, new dependency edges, architecture reshuffling, blanket renames, formatter configuration changes or speculative abstractions. Preserve evaluation order, error paths, locking/lifetimes, asynchronous behavior and user-visible strings. Exclude generated/vendor code, lockfiles, historical records, snapshots whose bytes are contractual, and unrelated docs or instruction edits. Follow current repository/owning-module guidance; historical ADRs are not authority. Use a dedicated worktree from agent-main and coherent module-sized commits, avoiding one opaque mechanical diff. Record deeper design problems separately rather than smuggling them into this sweep. Context selectors are intentionally empty until inspection identifies actual edits.

## Risk and rollback
A broad cleanup can hide semantic drift and collide with concurrent work. Keep each edit explainable, inspect non-whitespace differences explicitly, preserve unrelated changes, and validate affected boundaries. Revert an individual cleanup commit if it introduces a regression. Filing this task does not authorize dispatch or merge.

### Acceptance Criteria

- Execution summary records the source areas inspected, changed and intentionally excluded, with representative before/after examples; coverage extends beyond the four starting files and is not claimed from running a formatter alone.
- Human-readable diff inspection shows clear separation of imports/declarations and meaningful function phases, with consistent local conventions and no arbitrary blank-line or line-count quotas.
- Every non-whitespace change has a specific readability rationale and behavior-preservation evidence; public APIs, stored formats, observable outputs, ordering and concurrency semantics remain unchanged.
- Run repository formatting/lint gates and affected unit/integration tests; use appropriate language tooling for non-Rust changes. Report exact commands, passed/failed/not-run outcomes and pre-existing failures without weakening checks.
- Deliver reviewable module-sized changes and a concise scope/validation summary; deeper refactors and functional defects remain outside the patch.

## Execution Summary

<details>
<summary>Click to expand</summary>

Behavior-preserving readability sweep across 40 hand-maintained Rust files (+1067/-217). No commits; working tree left for the pipeline.

## How scope was chosen
Scripted a repo-wide scan of all tracked .rs files for the reported pattern (module doc run into imports, imports run into declarations, adjacent top-level items with no separator) plus longest-unbroken-line runs. Result: 206 structural sites in 92 files, concentrated overwhelmingly in the recently added automation feature area (orbit-automation 63, orbit-core/application/automation 59, orbit-store/driver/sqlite/automation 16, orbit-types/workflow/automation 14). Older modules in the same crates (routines/loader.rs, routines/due.rs, auto_tasks/loader.rs, auto_tasks/schedule.rs, routines/validation.rs) already follow the convention, so the sweep restores the repository's own local convention rather than imposing a new one.

## Areas inspected and changed
- crates/orbit-automation/src: whole crate. delivery/{mod,observe,evidence}.rs, members/{mod,incidents,preparation}.rs, checkpoint.rs, error.rs, lib.rs, auto_tasks/{mod,scheduler}.rs, routines/{mod,sweep}.rs, and three test modules.
- crates/orbit-core/src/application/automation: all nine source files plus tests/consumer.rs.
- crates/orbit-store/src/driver/sqlite/automation: mod.rs, members.rs, intents.rs, waivers.rs, contracts/automation.rs, tests/checkpoints.rs.
- crates/orbit-types/src/workflow: automation/{mod,members}.rs, auto_task_cursor.rs.
- Single-site fixes: orbit-core auto_tasks/{scheduler,state}.rs, routines/loader.rs, adapter/engine_host/v2_host/mod.rs, orbit-web api/automation.rs.

## Representative before/after
- crates/orbit-store/src/driver/sqlite/automation/waivers.rs:35-39 was three lines at 2-space indent packing five statements and a 310-char SQL call that rustfmt cannot reach (it gives up when a sub-expression exceeds max_width, which is why formatter-clean did not mean readable). Now a normally formatted transaction closure with the SQL literal byte-identical. Same defect fixed in intents.rs lookup() and automation/mod.rs automation_receipt/automation_commit/automation_receipts and initialize().
- crates/orbit-automation/src/delivery/observe.rs was a 100-line unbroken function; now phase-separated (page validation, commit absorption, backpressure, associations, delivery admission, unresolved, ordering, cursor advance) with `d` renamed to `delivery`.
- crates/orbit-automation/src/members/preparation.rs:1-2 module doc ran straight into `use`; the three sort/dedup groups ran together. Now separated with a comment naming why the collections are normalized.

## Non-whitespace changes and their rationale
Every non-whitespace token change was enumerated with a comment-stripping tokenizer diff (HEAD vs worktree) and reviewed individually. They fall into four groups:
1. Local binding renames only, no signature or type change: `d`->`delivery`, `a`->`attempt`/`active`/`association`/`assessed`/`failed`/`retired`, `m`->`member(s)`/`pending`, `r`->`row`/`run`/`related`, `s`->`state`/`step`/`sha`/`merged_at`, `p`->`pr`, `v`->`input`/`automation`/`response`/`claim`, `f`->`file`, `t`->`last`.
2. Named conditions replacing inline ones: `retry_budget_remains` (delivery/mod.rs, members/mod.rs), `over_budget` (core source.rs).
3. Three small extractions removing verbatim duplication: `admit_active` in delivery/mod.rs (two identical 7-line admission blocks), `is_diagnostic_origin` in core incidents.rs (the same 7-line triage-origin expression evaluated twice), and an `uncovered` closure in store automation/mod.rs (`remaining`/`remaining_waived` were the same 9-line filter over two lists).
4. Declaration ordering: module declarations grouped before re-exports in orbit-automation/lib.rs, core automation/mod.rs, types automation/mod.rs.
Plus one rename of a local that shadowed a function it called (`input_digest` -> `frozen_input_digest` in delivery/mod.rs), with a comment explaining why the two digests differ.

## Behavior preservation evidence
- 15 of 40 files verified whitespace/comment-only by tokenizer comparison and by `git diff -w --ignore-blank-lines` returning empty.
- The remaining files' token deltas were read one by one against the list above; nothing else changed.
- User-visible strings: the two minted-task description literals in core automation/task.rs moved from positional `{}` to inline named captures. Verified programmatically that both literals are identical after placeholder normalisation, so the rendered task text is unchanged.
- Persisted formats: SQL literals in store automation/mod.rs and waivers.rs/intents.rs kept byte-identical; FeatureMigration identity is (version, name), not a SQL checksum, so migration identity is untouched. No public API, serde shape, ordering, locking or async semantics changed.

## Validation
- `make ci-fast`: PASSED.
- `make ci-lint` (workspace-wide all-target clippy, warnings denied): PASSED.
- `cargo test -p orbit-automation -p orbit-types -p orbit-store -p orbit-core`: PASSED (1752 tests: 48 + 197 + 413 + 1094).
- `cargo test -p orbit-web`: 309 passed, 1 ignored, after an intermittent failure investigated below.
- `git diff --check`: clean. `git status --short`: 40 modified tracked files, no untracked artifacts.

## Pre-existing failure, not caused by this change
`orbit-web` `api::tests::routines::routine_mutation_denies_an_unidentified_dashboard_caller` (routines.rs:183, expected 403 got 400) fails intermittently under full-suite parallelism. Baselined with this task's single orbit-web line (a blank line after a module doc) reverted to HEAD: the full suite still failed 2 of 3 runs, while the test in isolation passed 4/4 both with and without the change. Filed as friction F2026-09-045.

## Deliberately excluded
- Test files with long unbroken runs that are long JSON/string fixtures rather than dense logic (orbit-web tests/dashboard_assets.rs, orbit-engine cli_runner tests, orbit-exec macos_sandbox tests): the runs are data, not code needing phase separation.
- crates/orbit-automation/src/routines/sweep.rs beyond its header: already comment-rich and well spaced; its 112-line run is mostly explanatory comments.
- Generated/vendor code, lockfiles, snapshots, historical records, docs and instruction files: untouched.

## Deeper issues found and deliberately left out of this sweep
1. `evaluate` in orbit-automation delivery/mod.rs (~225 lines) and `observe`/`evaluate` in members/mod.rs remain long multi-phase functions. They are now phase-separated and commented, but genuinely splitting them is a design change beyond a readability sweep.
2. store automation/mod.rs validate_transition: `related.iter().filter(|r| lineage.contains(&r.run_id))` is always true, since `related` only ever receives runs whose ids were inserted into `lineage`. Removing it is a functional simplification, so it was left alone.
3. orbit-automation auto_tasks/scheduler.rs:64 justifies a decision by citing ADR-0286, which the current repository guidance says is not an authority. Rewriting that rationale is a documentation decision, not a spacing fix.

## Risk
Low. The change is spacing, comments, local names, three duplication-removing extractions, and declaration ordering. Main residual risk is textual conflict with concurrent work in the same automation files; each file's edit is independently revertible.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11419-6a9da8fc`
- Behind base: 0
- Ahead of base: 1