### PR TITLE
Support explicit workspace source-remote rebinding for repository transfers

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -210,12 +210,21 @@ impl Commands {
             ),
             Commands::Workspace(command) => {
                 use super::workspace::WorkspacePublicationSubcommand;
+                use super::workspace::WorkspaceSourceRemoteSubcommand;
                 use super::workspace::WorkspaceSubcommand;
                 let (subcommand, runtime_need, governed) = match &command.command {
                     WorkspaceSubcommand::Init(_) => ("init", RuntimeNeed::Forbidden, false),
                     WorkspaceSubcommand::Sync(_) => ("sync", RuntimeNeed::Forbidden, false),
                     WorkspaceSubcommand::List(_) => ("list", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Show(_) => ("show", RuntimeNeed::Required, false),
+                    WorkspaceSubcommand::SourceRemote(command) => match &command.command {
+                        WorkspaceSourceRemoteSubcommand::Show(_) => {
+                            ("source-remote-show", RuntimeNeed::Required, false)
+                        }
+                        WorkspaceSourceRemoteSubcommand::Rebind(_) => {
+                            ("source-remote-rebind", RuntimeNeed::Required, false)
+                        }
+                    },
                     WorkspaceSubcommand::Role(_) => ("role", RuntimeNeed::Required, false),
                     WorkspaceSubcommand::Publication(command) => match &command.command {
                         WorkspacePublicationSubcommand::Bind(_) => {

--- a/crates/orbit-cli/src/command/workspace/command.rs
+++ b/crates/orbit-cli/src/command/workspace/command.rs
@@ -9,6 +9,7 @@ use super::publication::WorkspacePublicationCommand;
 use super::remove::WorkspaceRemoveArgs;
 use super::role::WorkspaceRoleArgs;
 use super::show::WorkspaceShowArgs;
+use super::source_remote::WorkspaceSourceRemoteCommand;
 use super::sync::WorkspaceSyncArgs;
 use super::teardown::WorkspaceTeardownArgs;
 
@@ -29,6 +30,8 @@ pub enum WorkspaceSubcommand {
     List(WorkspaceListArgs),
     /// Show the current workspace
     Show(WorkspaceShowArgs),
+    /// Inspect or explicitly rebind the source Git remote
+    SourceRemote(WorkspaceSourceRemoteCommand),
     /// Validate or reassert this checkout's declared local role
     Role(WorkspaceRoleArgs),
     /// Manage the owner-local task-publication repository binding
@@ -51,6 +54,7 @@ impl Execute for WorkspaceCommand {
             }
             WorkspaceSubcommand::List(args) => args.execute(runtime),
             WorkspaceSubcommand::Show(args) => args.execute(runtime),
+            WorkspaceSubcommand::SourceRemote(command) => command.execute(runtime),
             WorkspaceSubcommand::Role(args) => args.execute(runtime),
             WorkspaceSubcommand::Publication(command) => command.execute(runtime),
             WorkspaceSubcommand::Remove(args) => args.execute(runtime),

--- a/crates/orbit-cli/src/command/workspace/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/mod.rs
@@ -5,12 +5,14 @@ mod publication;
 mod remove;
 mod role;
 mod show;
+mod source_remote;
 mod support;
 mod sync;
 mod teardown;
 
 pub use command::{WorkspaceCommand, WorkspaceSubcommand};
 pub use publication::WorkspacePublicationSubcommand;
+pub use source_remote::WorkspaceSourceRemoteSubcommand;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cli/src/command/workspace/show.rs
+++ b/crates/orbit-cli/src/command/workspace/show.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use clap::Args;
 use orbit_core::OrbitRuntime;
 use orbit_registry::workspace_registry;
-use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry};
+use orbit_types::workspace::{
+    Workspace, WorkspaceCheckout, WorkspaceRegistry, git_remote_identity, redact_git_remote,
+};
 use serde_json::{Value, json};
 
 use crate::command::{CommandOut, Execute, Payload};
@@ -78,6 +80,11 @@ pub(super) fn workspace_show_json(workspace: &Workspace, checkout: &WorkspaceChe
             "ship_mode": orbit_core::resolved_ship_mode(workspace).as_input_value(),
             "status": workspace.status.to_string(),
             "owner_machine_id": workspace.owner_machine_id,
+            "git_remote": workspace.git_remote.as_deref().map(redact_git_remote),
+            "source_repository_identity": workspace
+                .git_remote
+                .as_deref()
+                .and_then(|remote| git_remote_identity(remote).ok()),
         },
         "checkout": {
             "repo_root": checkout.repo_root.to_string_lossy(),
@@ -111,7 +118,10 @@ pub(super) fn format_workspace_show(workspace: &Workspace, checkout: &WorkspaceC
         output.push_str(&format!("owner_mirror: {replica_owner}\n"));
     }
     if let Some(remote) = &workspace.git_remote {
-        output.push_str(&format!("git_remote:  {remote}\n"));
+        output.push_str(&format!("git_remote:  {}\n", redact_git_remote(remote)));
+        if let Ok(identity) = git_remote_identity(remote) {
+            output.push_str(&format!("source_id:   {identity}\n"));
+        }
     }
     output.push_str(&format!(
         "created_at:  {}\nupdated_at:  {}\n",

--- a/crates/orbit-cli/src/command/workspace/source_remote.rs
+++ b/crates/orbit-cli/src/command/workspace/source_remote.rs
@@ -1,0 +1,188 @@
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_registry::{load_host_identity, workspace_registry};
+use orbit_types::workspace::{
+    Workspace, WorkspaceRegistry, git_remote_identity, redact_git_remote,
+};
+use serde_json::{Value, json};
+
+use crate::command::{CommandOut, Execute, Payload};
+
+#[derive(Args)]
+#[command(
+    about = "Inspect or explicitly rebind a workspace source Git remote",
+    after_long_help = "Repository-move workflow:\n  1. Run `show --json` and save the old remote.\n  2. Run `rebind --remote <URL> --dry-run --json`.\n  3. Apply without `--dry-run`, update the checkout's Git origin separately, then run `show` again to verify.\n  4. To roll back, rebind to the saved old remote. Existing publication bindings must be removed and recreated explicitly; Orbit never rewrites their lineage or snapshots."
+)]
+pub struct WorkspaceSourceRemoteCommand {
+    #[command(subcommand)]
+    pub command: WorkspaceSourceRemoteSubcommand,
+}
+
+#[derive(Subcommand)]
+pub enum WorkspaceSourceRemoteSubcommand {
+    /// Show the registered portable source-repository identity
+    Show(WorkspaceSourceRemoteShowArgs),
+    /// Replace the source remote after a repository transfer
+    Rebind(WorkspaceSourceRemoteRebindArgs),
+}
+
+impl Execute for WorkspaceSourceRemoteCommand {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        match self.command {
+            WorkspaceSourceRemoteSubcommand::Show(args) => args.execute(runtime),
+            WorkspaceSourceRemoteSubcommand::Rebind(args) => args.execute(runtime),
+        }
+    }
+}
+
+#[derive(Args)]
+pub struct WorkspaceSourceRemoteShowArgs {
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for WorkspaceSourceRemoteShowArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let workspace_id = selected_workspace_id(runtime)?;
+        let registry = workspace_registry::load_registry_from(
+            &workspace_registry::registry_path_for(&runtime.global_root()),
+        )?;
+        let workspace =
+            workspace_registry::find_workspace(&registry, &workspace_id).ok_or_else(|| {
+                OrbitError::WorkspaceError(format!("unknown workspace '{workspace_id}'"))
+            })?;
+
+        Ok(Payload::detail(
+            source_remote_json(workspace),
+            format_source_remote(workspace),
+        )
+        .into())
+    }
+}
+
+#[derive(Args)]
+pub struct WorkspaceSourceRemoteRebindArgs {
+    /// New portable Git URL. Credentials, local paths, and remote aliases are refused.
+    #[arg(long, value_name = "URL")]
+    remote: String,
+    /// Validate and report the transition without changing the registry.
+    #[arg(long)]
+    dry_run: bool,
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Execute for WorkspaceSourceRemoteRebindArgs {
+    fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let workspace_id = selected_workspace_id(runtime)?;
+        let global_root = runtime.global_root();
+        let local_machine_id = load_host_identity(&global_root)?.machine_id;
+        let registry_path = workspace_registry::registry_path_for(&global_root);
+        let outcome = rebind_at_registry_path(
+            &registry_path,
+            &workspace_id,
+            &self.remote,
+            &local_machine_id,
+            self.dry_run,
+            workspace_registry::save_registry_to,
+        )?;
+
+        let action = if !outcome.changed {
+            "unchanged"
+        } else if outcome.dry_run {
+            "would_rebind"
+        } else {
+            "rebound"
+        };
+        Ok(Payload::detail(
+            json!({
+                "action": action,
+                "workspace_id": outcome.workspace_id,
+                "changed": outcome.changed,
+                "dry_run": outcome.dry_run,
+                "old": {
+                    "remote": redact_git_remote(&outcome.old_remote),
+                    "repository_identity": outcome.old_repository_identity,
+                },
+                "new": {
+                    "remote": redact_git_remote(&outcome.new_remote),
+                    "repository_identity": outcome.new_repository_identity,
+                },
+            }),
+            format!(
+                "source remote {action} for workspace '{}'\nold:      {}\nold_id:   {}\nnew:      {}\nnew_id:   {}\nchanged:  {}\ndry_run:  {}",
+                outcome.workspace_id,
+                redact_git_remote(&outcome.old_remote),
+                outcome.old_repository_identity.as_deref().unwrap_or("-"),
+                redact_git_remote(&outcome.new_remote),
+                outcome.new_repository_identity,
+                outcome.changed,
+                outcome.dry_run,
+            ),
+        )
+        .into())
+    }
+}
+
+pub(super) fn rebind_at_registry_path(
+    registry_path: &Path,
+    workspace_id: &str,
+    remote: &str,
+    local_machine_id: &str,
+    dry_run: bool,
+    save: impl FnOnce(&WorkspaceRegistry, &Path) -> Result<(), OrbitError>,
+) -> Result<workspace_registry::WorkspaceSourceRemoteRebind, OrbitError> {
+    workspace_registry::with_registry_lock(registry_path, || {
+        let mut registry = workspace_registry::load_registry_from(registry_path)?;
+        let outcome = workspace_registry::rebind_workspace_source_remote(
+            &mut registry,
+            workspace_id,
+            remote,
+            Some(local_machine_id),
+            dry_run,
+        )?;
+        if outcome.changed && !outcome.dry_run {
+            save(&registry, registry_path)?;
+        }
+        Ok(outcome)
+    })
+}
+
+fn selected_workspace_id(runtime: &OrbitRuntime) -> Result<String, OrbitError> {
+    runtime
+        .workspace_runtime_binding()
+        .map(|binding| binding.logical_workspace_id.clone())
+        .map_or_else(|| runtime.workspace_id(), Ok)
+}
+
+fn source_remote_json(workspace: &Workspace) -> Value {
+    let identity = workspace
+        .git_remote
+        .as_deref()
+        .and_then(|remote| git_remote_identity(remote).ok());
+    json!({
+        "workspace_id": workspace.id,
+        "remote": workspace.git_remote.as_deref().map(redact_git_remote),
+        "repository_identity": identity,
+    })
+}
+
+fn format_source_remote(workspace: &Workspace) -> String {
+    let Some(remote) = workspace.git_remote.as_deref() else {
+        return format!(
+            "workspace '{}' has no registered source remote",
+            workspace.id
+        );
+    };
+    let identity = git_remote_identity(remote).ok();
+    format!(
+        "workspace: {}\nremote:    {}\nidentity:  {}",
+        workspace.id,
+        redact_git_remote(remote),
+        identity.as_deref().unwrap_or("-"),
+    )
+}

--- a/crates/orbit-cli/src/command/workspace/tests/mod.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/mod.rs
@@ -1,3 +1,4 @@
 mod init;
 mod publication;
 mod shared_root;
+mod source_remote;

--- a/crates/orbit-cli/src/command/workspace/tests/source_remote.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/source_remote.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use chrono::Utc;
+use orbit_core::OrbitError;
+use orbit_registry::workspace_registry;
+use orbit_types::workspace::{
+    Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspaceRegistry, WorkspaceStatus,
+};
+use tempfile::tempdir;
+
+use super::super::source_remote::rebind_at_registry_path;
+
+fn registry(root: &Path) -> WorkspaceRegistry {
+    WorkspaceRegistry {
+        workspaces: vec![Workspace {
+            id: "ws_orbit".to_string(),
+            name: "orbit".to_string(),
+            owner_machine_id: Some("hm_owner".to_string()),
+            git_remote: Some("git@github.com:example/orbit.git".to_string()),
+            ship_mode: Some("pr".to_string()),
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }],
+        checkouts: vec![WorkspaceCheckout {
+            workspace_id: "ws_orbit".to_string(),
+            repo_root: root.join("repo"),
+            orbit_dir: root.join("repo/.orbit"),
+            role: Some(WorkspaceCheckoutRole::Owner),
+            owner_machine_id: None,
+            path_overrides: vec![root.join("linked")],
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn injected_persistence_failure_leaves_registry_file_unchanged() {
+    let root = tempdir().expect("tempdir");
+    std::fs::write(
+        root.path().join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_owner\"\nhost_id = \"owner\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("host identity");
+    let path = root.path().join("workspaces.json");
+    workspace_registry::save_registry_to(&registry(root.path()), &path)
+        .expect("write fixture registry");
+    let before = std::fs::read(&path).expect("read fixture");
+
+    let error = rebind_at_registry_path(
+        &path,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        "hm_owner",
+        false,
+        |_, _| Err(OrbitError::Io("injected write failure".to_string())),
+    )
+    .expect_err("write failure must surface");
+
+    assert!(error.to_string().contains("injected write failure"));
+    assert_eq!(
+        std::fs::read(&path).expect("read preserved registry"),
+        before
+    );
+}

--- a/crates/orbit-cli/tests/workspace_source_remote.rs
+++ b/crates/orbit-cli/tests/workspace_source_remote.rs
@@ -1,0 +1,266 @@
+#![allow(missing_docs)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! Binary-level coverage for explicit workspace source-remote rebinding.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use orbit_common::test_env;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::tempdir;
+
+const OLD_REMOTE: &str = "git@github.com:example/orbit.git";
+const NEW_REMOTE: &str = "ssh://github.com/example/orbit-renamed.git";
+
+#[test]
+fn owner_can_dry_run_apply_read_back_and_retry_source_remote_rebind() {
+    let home = tempdir().expect("home");
+    let repo = tempdir().expect("repo");
+    init_git_repo(repo.path(), OLD_REMOTE);
+    initialize_workspace(repo.path(), home.path(), "remote-owner");
+
+    let task = run_json(
+        repo.path(),
+        home.path(),
+        &[
+            "task",
+            "add",
+            "--title",
+            "Preserved across source move",
+            "--description",
+            "Disposable source-remote fixture",
+            "--acceptance-criteria",
+            "The task remains readable",
+            "--complexity",
+            "low",
+            "--model",
+            "codex",
+            "--json",
+        ],
+    );
+    let task_id = task["id"].as_str().expect("created task id").to_string();
+
+    let registry_path = home.path().join(".orbit/workspaces.json");
+    let initial_registry: Value =
+        serde_json::from_slice(&fs::read(&registry_path).expect("initial registry"))
+            .expect("parse initial registry");
+    let initial_workspace = initial_registry["workspaces"][0].clone();
+    let initial_checkouts = initial_registry["checkouts"].clone();
+
+    let inspected = run_json(
+        repo.path(),
+        home.path(),
+        &["workspace", "source-remote", "show", "--json"],
+    );
+    assert_eq!(inspected["remote"], OLD_REMOTE);
+    assert_eq!(inspected["repository_identity"], "github.com/example/orbit");
+
+    let before_dry_run = fs::read(&registry_path).expect("registry before dry run");
+    let dry_run = run_json(
+        repo.path(),
+        home.path(),
+        &[
+            "workspace",
+            "source-remote",
+            "rebind",
+            "--remote",
+            NEW_REMOTE,
+            "--dry-run",
+            "--json",
+        ],
+    );
+    assert_eq!(dry_run["action"], "would_rebind");
+    assert_eq!(dry_run["changed"], true);
+    assert_eq!(dry_run["dry_run"], true);
+    assert_eq!(
+        fs::read(&registry_path).expect("registry after dry run"),
+        before_dry_run
+    );
+
+    let applied = run_json(
+        repo.path(),
+        home.path(),
+        &[
+            "workspace",
+            "source-remote",
+            "rebind",
+            "--remote",
+            NEW_REMOTE,
+            "--json",
+        ],
+    );
+    assert_eq!(applied["action"], "rebound");
+    assert_eq!(
+        applied["old"]["repository_identity"],
+        "github.com/example/orbit"
+    );
+    assert_eq!(
+        applied["new"]["repository_identity"],
+        "github.com/example/orbit-renamed"
+    );
+
+    let rebound_registry: Value =
+        serde_json::from_slice(&fs::read(&registry_path).expect("rebound registry"))
+            .expect("parse rebound registry");
+    assert_eq!(
+        rebound_registry["workspaces"][0]["id"],
+        initial_workspace["id"]
+    );
+    assert_eq!(
+        rebound_registry["workspaces"][0]["owner_machine_id"],
+        initial_workspace["owner_machine_id"]
+    );
+    assert_eq!(rebound_registry["checkouts"], initial_checkouts);
+    assert_eq!(rebound_registry["workspaces"][0]["git_remote"], NEW_REMOTE);
+    let preserved_task = run_json(
+        repo.path(),
+        home.path(),
+        &["task", "show", &task_id, "--json"],
+    );
+    assert_eq!(preserved_task["id"], task_id);
+    assert_eq!(preserved_task["title"], "Preserved across source move");
+
+    let before_retry = fs::read(&registry_path).expect("registry before retry");
+    let retry = run_json(
+        repo.path(),
+        home.path(),
+        &[
+            "workspace",
+            "source-remote",
+            "rebind",
+            "--remote",
+            "https://github.com/Example/Orbit-Renamed.git",
+            "--json",
+        ],
+    );
+    assert_eq!(retry["action"], "unchanged");
+    assert_eq!(retry["changed"], false);
+    assert_eq!(
+        fs::read(&registry_path).expect("registry after retry"),
+        before_retry
+    );
+
+    let verified = run_json(
+        repo.path(),
+        home.path(),
+        &["workspace", "source-remote", "show", "--json"],
+    );
+    assert_eq!(verified["remote"], NEW_REMOTE);
+}
+
+#[test]
+fn credential_bearing_rebind_is_redacted_and_does_not_mutate() {
+    let home = tempdir().expect("home");
+    let repo = tempdir().expect("repo");
+    init_git_repo(repo.path(), OLD_REMOTE);
+    initialize_workspace(repo.path(), home.path(), "remote-owner");
+    let registry_path = home.path().join(".orbit/workspaces.json");
+    let before = fs::read(&registry_path).expect("registry before rejection");
+
+    orbit(repo.path(), home.path())
+        .args([
+            "workspace",
+            "source-remote",
+            "rebind",
+            "--remote",
+            "https://operator:supersecret@github.com/example/orbit.git",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("must not contain credentials"))
+        .stderr(predicate::str::contains("supersecret").not());
+
+    assert_eq!(
+        fs::read(&registry_path).expect("registry after rejection"),
+        before
+    );
+}
+
+#[test]
+fn source_remote_help_names_inspection_dry_run_and_rebind() {
+    let home = tempdir().expect("home");
+    let cwd = tempdir().expect("cwd");
+    orbit(cwd.path(), home.path())
+        .args(["workspace", "source-remote", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("show"))
+        .stdout(predicate::str::contains("rebind"))
+        .stdout(predicate::str::contains("verify"))
+        .stdout(predicate::str::contains("roll back"))
+        .stdout(predicate::str::contains("publication bindings"));
+    orbit(cwd.path(), home.path())
+        .args(["workspace", "source-remote", "rebind", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("Credentials"));
+}
+
+fn initialize_workspace(repo: &Path, home: &Path, host_name: &str) {
+    orbit(repo, home)
+        .args([
+            "init",
+            "--non-interactive",
+            "--host-name",
+            host_name,
+            "--task-prefix",
+            "TST",
+        ])
+        .assert()
+        .success();
+    orbit(repo, home)
+        .args([
+            "workspace",
+            "init",
+            "--name",
+            "orbit",
+            "--base-branch",
+            "agent-main",
+        ])
+        .assert()
+        .success();
+}
+
+fn run_json(cwd: &Path, home: &Path, args: &[&str]) -> Value {
+    let output = orbit(cwd, home).args(args).assert().success();
+    serde_json::from_slice(&output.get_output().stdout).expect("parse command JSON")
+}
+
+fn orbit(cwd: &Path, home: &Path) -> assert_cmd::Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env_remove("ORBIT_HOME");
+    command
+}
+
+fn init_git_repo(repo: &Path, remote: &str) {
+    run_git(repo, &["init"]);
+    run_git(repo, &["remote", "add", "origin", remote]);
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git -C {} {} failed: {}",
+        cwd.display(),
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-registry/src/tests/mod.rs
+++ b/crates/orbit-registry/src/tests/mod.rs
@@ -3,3 +3,4 @@
 mod host_identity;
 mod workspace_publication;
 mod workspace_registry;
+mod workspace_source_remote;

--- a/crates/orbit-registry/src/tests/workspace_source_remote.rs
+++ b/crates/orbit-registry/src/tests/workspace_source_remote.rs
@@ -1,0 +1,236 @@
+use std::path::PathBuf;
+
+use chrono::{TimeZone, Utc};
+use orbit_types::workspace::{
+    Workspace, WorkspaceCheckout, WorkspaceCheckoutRole, WorkspacePublicationBinding,
+    WorkspaceRegistry, WorkspaceStatus,
+};
+
+use crate::workspace_registry::rebind_workspace_source_remote;
+
+fn timestamp() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 18, 1, 2, 3)
+        .single()
+        .expect("fixed timestamp")
+}
+
+fn logical_workspace(id: &str, owner_machine_id: Option<&str>) -> Workspace {
+    Workspace {
+        id: id.to_string(),
+        name: id.trim_start_matches("ws_").to_string(),
+        owner_machine_id: owner_machine_id.map(str::to_string),
+        git_remote: Some("git@example.test:orbit/repo.git".to_string()),
+        ship_mode: Some("pr".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: timestamp(),
+        updated_at: timestamp(),
+    }
+}
+
+fn owned_registry() -> WorkspaceRegistry {
+    WorkspaceRegistry {
+        owner_host_ids: [("hm_owner".to_string(), "owner-host".to_string())]
+            .into_iter()
+            .collect(),
+        workspaces: vec![logical_workspace("ws_orbit", Some("hm_owner"))],
+        checkouts: vec![WorkspaceCheckout::owner(
+            "ws_orbit".to_string(),
+            PathBuf::from("/repos/orbit"),
+            PathBuf::from("/repos/orbit/.orbit"),
+        )],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn source_remote_rebind_changes_only_remote_and_updated_at() {
+    let mut registry = owned_registry();
+    let before = registry.clone();
+
+    let outcome = rebind_workspace_source_remote(
+        &mut registry,
+        "orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_owner"),
+        false,
+    )
+    .expect("rebind source remote");
+
+    assert!(outcome.changed);
+    assert!(!outcome.dry_run);
+    assert_eq!(outcome.workspace_id, "ws_orbit");
+    assert_eq!(outcome.old_remote, "git@example.test:orbit/repo.git");
+    assert_eq!(
+        outcome.old_repository_identity.as_deref(),
+        Some("example.test/orbit/repo")
+    );
+    assert_eq!(
+        outcome.new_repository_identity,
+        "github.com/example/orbit-renamed"
+    );
+    assert_eq!(
+        registry.workspaces[0].git_remote.as_deref(),
+        Some("ssh://github.com/example/orbit-renamed.git")
+    );
+    assert!(registry.workspaces[0].updated_at >= before.workspaces[0].updated_at);
+
+    let mut expected_workspace = before.workspaces[0].clone();
+    expected_workspace.git_remote = registry.workspaces[0].git_remote.clone();
+    expected_workspace.updated_at = registry.workspaces[0].updated_at;
+    assert_eq!(registry.workspaces[0], expected_workspace);
+    assert_eq!(registry.checkouts, before.checkouts);
+    assert_eq!(registry.owner_host_ids, before.owner_host_ids);
+}
+
+#[test]
+fn source_remote_rebind_equivalent_retry_is_a_no_op() {
+    let mut registry = owned_registry();
+    registry.workspaces[0].git_remote = Some("git@github.com:Example/Orbit.git".to_string());
+    let before = registry.clone();
+
+    let outcome = rebind_workspace_source_remote(
+        &mut registry,
+        "ws_orbit",
+        "https://github.com/example/orbit.git",
+        Some("hm_owner"),
+        false,
+    )
+    .expect("equivalent retry");
+
+    assert!(!outcome.changed);
+    assert_eq!(registry, before);
+}
+
+#[test]
+fn source_remote_rebind_rejects_invalid_and_credential_bearing_inputs_before_mutation() {
+    for remote in [
+        "/srv/git/orbit.git",
+        "origin",
+        "https://operator:secret@github.com/example/orbit.git",
+    ] {
+        let mut registry = owned_registry();
+        let before = registry.clone();
+        let error = rebind_workspace_source_remote(
+            &mut registry,
+            "ws_orbit",
+            remote,
+            Some("hm_owner"),
+            false,
+        )
+        .expect_err("invalid remote must fail");
+
+        assert_eq!(
+            registry, before,
+            "rejected input mutated registry: {remote}"
+        );
+        assert!(
+            error.to_string().contains("must") || error.to_string().contains("valid Git URL"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !error.to_string().contains("operator:secret"),
+            "credential leaked in error: {error}"
+        );
+    }
+}
+
+#[test]
+fn source_remote_rebind_denies_replica_and_non_owner_before_mutation() {
+    let mut replica = owned_registry();
+    replica.checkouts[0].role = Some(WorkspaceCheckoutRole::Replica);
+    replica.checkouts[0].owner_machine_id = Some("hm_owner".to_string());
+    let before_replica = replica.clone();
+    let error = rebind_workspace_source_remote(
+        &mut replica,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_replica"),
+        false,
+    )
+    .expect_err("replica must be denied");
+    assert!(error.to_string().contains("replica checkout"), "{error}");
+    assert_eq!(replica, before_replica);
+
+    let mut wrong_owner = owned_registry();
+    let before_owner = wrong_owner.clone();
+    let error = rebind_workspace_source_remote(
+        &mut wrong_owner,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_other"),
+        false,
+    )
+    .expect_err("non-owner must be denied");
+    assert!(error.to_string().contains("cannot rebind"), "{error}");
+    assert_eq!(wrong_owner, before_owner);
+}
+
+#[test]
+fn source_remote_rebind_dry_run_reports_change_without_mutation() {
+    let mut registry = owned_registry();
+    let before = registry.clone();
+
+    let outcome = rebind_workspace_source_remote(
+        &mut registry,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_owner"),
+        true,
+    )
+    .expect("dry run");
+
+    assert!(outcome.changed);
+    assert!(outcome.dry_run);
+    assert_eq!(registry, before);
+}
+
+#[test]
+fn source_remote_rebind_refuses_publication_lineage_change_before_mutation() {
+    let mut registry = owned_registry();
+    registry
+        .publication_bindings
+        .push(WorkspacePublicationBinding {
+            workspace_id: "ws_orbit".to_string(),
+            source_repository_fingerprint: "git@example.test:orbit/repo.git".to_string(),
+            publication_remote: "ssh://publication.example.test/orbit-tasks.git".to_string(),
+            publication_branch: "refs/heads/main".to_string(),
+            publication_id: "pub_orbit".to_string(),
+            authority_machine_id: "hm_owner".to_string(),
+            last_success_generation: Some(3),
+            last_success_commit: Some("a".repeat(40)),
+        });
+    let before = registry.clone();
+
+    let error = rebind_workspace_source_remote(
+        &mut registry,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_owner"),
+        false,
+    )
+    .expect_err("publication binding must fail closed");
+    let message = error.to_string();
+
+    assert!(message.contains("publication show --json"), "{message}");
+    assert!(
+        message.contains("publication remove --confirm"),
+        "{message}"
+    );
+    assert!(
+        message.contains("create a new binding explicitly"),
+        "{message}"
+    );
+    assert_eq!(registry, before);
+
+    let error = rebind_workspace_source_remote(
+        &mut registry,
+        "ws_orbit",
+        "ssh://github.com/example/orbit-renamed.git",
+        Some("hm_owner"),
+        true,
+    )
+    .expect_err("dry run must report the same publication blocker");
+    assert!(error.to_string().contains("publication show --json"));
+    assert_eq!(registry, before);
+}

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -8,7 +8,8 @@ use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::identity::{validate_host_id, validate_machine_id};
 use orbit_types::workspace::{
     WORKSPACE_REGISTRY_SCHEMA_VERSION, Workspace, WorkspaceCheckout, WorkspaceCheckoutRole,
-    WorkspaceRegistry, WorkspaceStatus,
+    WorkspaceRegistry, WorkspaceStatus, git_remote_identity, redact_git_remote,
+    validate_source_repository_fingerprint,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -72,6 +73,129 @@ pub fn register_checkout(
     }
     registry.checkouts.push(checkout);
     Ok(())
+}
+
+/// The inspected result of explicitly rebinding one workspace's source remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceSourceRemoteRebind {
+    pub workspace_id: String,
+    pub old_remote: String,
+    pub old_repository_identity: Option<String>,
+    pub new_remote: String,
+    pub new_repository_identity: String,
+    pub changed: bool,
+    pub dry_run: bool,
+}
+
+/// Rebind an owned workspace's portable source-repository identity.
+///
+/// Every refusal happens before the registry is mutated. Publication bindings
+/// deliberately fail closed because their source fingerprint is part of the
+/// published lineage; the operator must remove and recreate that binding
+/// explicitly around a repository move.
+pub fn rebind_workspace_source_remote(
+    registry: &mut WorkspaceRegistry,
+    id_or_name: &str,
+    new_remote: &str,
+    local_machine_id: Option<&str>,
+    dry_run: bool,
+) -> Result<WorkspaceSourceRemoteRebind, OrbitError> {
+    validate_source_repository_fingerprint(new_remote)
+        .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+    let new_repository_identity = git_remote_identity(new_remote)
+        .map_err(|error| OrbitError::InvalidInput(error.to_string()))?;
+
+    let local_machine_id = local_machine_id.ok_or_else(|| {
+        OrbitError::WorkspaceError(
+            "source-remote rebinding requires a local host identity; run `orbit init` first"
+                .to_string(),
+        )
+    })?;
+    validate_machine_id(local_machine_id)?;
+
+    let workspace = find_workspace(registry, id_or_name)
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, id_or_name.to_string()))?;
+    let workspace_id = workspace.id.clone();
+    let old_remote = workspace.git_remote.clone().ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "workspace '{workspace_id}' has no registered source remote; initialize it from a checkout with an origin before rebinding"
+        ))
+    })?;
+    let old_repository_identity = git_remote_identity(&old_remote).ok();
+    let old_remote_is_portable = validate_source_repository_fingerprint(&old_remote).is_ok();
+
+    let checkout = registry
+        .checkouts
+        .iter()
+        .find(|checkout| checkout.workspace_id == workspace_id)
+        .ok_or_else(|| {
+            OrbitError::WorkspaceError(format!(
+                "workspace '{workspace_id}' has no local checkout; source-remote rebinding is owner-local"
+            ))
+        })?;
+    match checkout.role {
+        Some(WorkspaceCheckoutRole::Owner) => {}
+        Some(WorkspaceCheckoutRole::Replica) => {
+            return Err(OrbitError::WorkspaceError(format!(
+                "workspace '{workspace_id}' is a replica checkout; run the source-remote rebind on its declared owner machine"
+            )));
+        }
+        None => {
+            return Err(OrbitError::WorkspaceError(format!(
+                "workspace '{workspace_id}' has no declared local checkout role; reassert its owner role before rebinding the source remote"
+            )));
+        }
+    }
+    let owner_machine_id = workspace.owner_machine_id.as_deref().ok_or_else(|| {
+        OrbitError::WorkspaceError(format!(
+            "workspace '{workspace_id}' has no declared owner; reassert its owner role before rebinding the source remote"
+        ))
+    })?;
+    if owner_machine_id != local_machine_id {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace '{workspace_id}' is owned by machine '{owner_machine_id}'; local machine '{local_machine_id}' cannot rebind its source remote"
+        )));
+    }
+
+    let changed = !old_remote_is_portable
+        || old_repository_identity.as_deref() != Some(&new_repository_identity);
+    let outcome = WorkspaceSourceRemoteRebind {
+        workspace_id: workspace_id.clone(),
+        old_remote,
+        old_repository_identity,
+        new_remote: new_remote.to_string(),
+        new_repository_identity,
+        changed,
+        dry_run,
+    };
+    if !changed {
+        return Ok(outcome);
+    }
+
+    if let Some(binding) = registry
+        .publication_bindings
+        .iter()
+        .find(|binding| binding.workspace_id == workspace_id)
+    {
+        return Err(OrbitError::WorkspaceError(format!(
+            "workspace '{workspace_id}' has publication binding '{}' tied to source '{}'; refusing to rewrite publication lineage. Inspect it with `orbit --workspace {workspace_id} workspace publication show --json`, record its settings, remove it with `orbit --workspace {workspace_id} workspace publication remove --confirm`, perform the source-remote rebind, then create a new binding explicitly",
+            binding.publication_id,
+            redact_git_remote(&binding.source_repository_fingerprint),
+        )));
+    }
+    if dry_run {
+        return Ok(outcome);
+    }
+
+    let workspace = registry
+        .workspaces
+        .iter_mut()
+        .find(|workspace| workspace.id == workspace_id)
+        .ok_or_else(|| OrbitError::not_found(NotFoundKind::Workspace, workspace_id.clone()))?;
+    workspace.git_remote = Some(new_remote.to_string());
+    workspace.updated_at = Utc::now();
+
+    Ok(outcome)
 }
 
 /// Record a machine-local checkout role for an existing logical workspace.

--- a/crates/orbit-registry/src/workspace_registry/mod.rs
+++ b/crates/orbit-registry/src/workspace_registry/mod.rs
@@ -5,10 +5,11 @@ mod io;
 mod publication;
 
 pub use catalog::{
-    WorkspaceRegistryHostContext, assign_checkout_role, find_checkout, find_checkout_by_path,
-    find_workspace, find_workspace_by_path, local_workspaces, parse_workspace_registry,
-    register_checkout, register_workspace, remove_workspace, rename_local_owner_host_id,
-    resolve_logical_workspace, set_path_override, validate_workspace_registry, validate_workspaces,
+    WorkspaceRegistryHostContext, WorkspaceSourceRemoteRebind, assign_checkout_role, find_checkout,
+    find_checkout_by_path, find_workspace, find_workspace_by_path, local_workspaces,
+    parse_workspace_registry, rebind_workspace_source_remote, register_checkout,
+    register_workspace, remove_workspace, rename_local_owner_host_id, resolve_logical_workspace,
+    set_path_override, validate_workspace_registry, validate_workspaces,
 };
 pub use io::{
     global_orbit_dir, load_registry, load_registry_from, registry_path, registry_path_for,

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -2,9 +2,9 @@
 type: runbook
 summary: Locate Orbit state and perform WAL-safe backups, explicit task publication, restores, and task migrations.
 tags: [operations, backup, restore, state, sqlite, task-publication]
-paths: ["crates/orbit-common/src/types/workspace.rs", "crates/orbit-config/src/**", "crates/orbit-registry/**", "crates/orbit-store/**", "crates/orbit-web/src/state.rs"]
+paths: ["crates/orbit-cli/src/command/workspace/source_remote.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-config/src/**", "crates/orbit-registry/**", "crates/orbit-store/**", "crates/orbit-web/src/state.rs"]
 related_features: [orbit-core, remote-access, task-publication]
-related_artifacts: [ORB-10014, ORB-10294, ORB-10473, ORB-11077, ORB-11376]
+related_artifacts: [ORB-10014, ORB-10294, ORB-10473, ORB-11077, ORB-11376, ORB-11426]
 last_validated: 2026-09-06
 ---
 
@@ -157,6 +157,68 @@ file) are first archived beneath
 has no bytes to archive. A parseable identity naming another workspace is still refused,
 even with `--force`. Valid identity, parent-workspace identity, and unrelated registry
 records are not recovery inputs and are not rewritten. [ORB-11376]
+
+### Rebind the source remote after a repository move
+
+Use the source-remote command when a Git repository moves to a different owner, name, or
+host but remains the same logical Orbit workspace. Do not rerun `workspace init`, edit
+`workspaces.json`, or perform a broad URL replacement: the supported operation changes only
+the logical workspace's registered `git_remote`. Workspace ID, owner identity, task bundles,
+checkout roles, and checkout/path registrations remain unchanged.
+
+Inspect the current registration and save the old URL for rollback:
+
+```sh
+ORBIT_WORKSPACE=ws_example
+NEW_SOURCE_REMOTE=git@github.com:new-owner/new-repository.git
+
+orbit --workspace "$ORBIT_WORKSPACE" workspace show --format json
+orbit --workspace "$ORBIT_WORKSPACE" workspace source-remote show --json
+orbit --workspace "$ORBIT_WORKSPACE" workspace publication show --json
+```
+
+Only the declared owner machine can rebind the source remote. Replica checkouts fail closed.
+The new value must be a portable Git URL without embedded credentials; local paths and
+checkout-local aliases such as `origin` are refused. First preview the exact old and new
+repository identities without writing:
+
+```sh
+orbit --workspace "$ORBIT_WORKSPACE" workspace source-remote rebind \
+  --remote "$NEW_SOURCE_REMOTE" --dry-run --json
+```
+
+An existing task-publication binding prevents the write because its stored source fingerprint
+is part of that local binding. Orbit does not rewrite publication lineage or old snapshots as
+part of a source move. Record the complete `workspace publication show --json` output, then
+remove the binding explicitly before retrying:
+
+```sh
+orbit --workspace "$ORBIT_WORKSPACE" workspace publication remove --confirm --json
+orbit --workspace "$ORBIT_WORKSPACE" workspace source-remote rebind \
+  --remote "$NEW_SOURCE_REMOTE" --json
+```
+
+After the repository provider transfer succeeds, update the checkout's Git `origin` separately;
+Orbit does not mutate `.git/config`. Verify both identities and normal workspace resolution:
+
+```sh
+git remote set-url origin "$NEW_SOURCE_REMOTE"
+git remote get-url origin
+orbit --workspace "$ORBIT_WORKSPACE" workspace source-remote show --json
+orbit --workspace "$ORBIT_WORKSPACE" workspace show --format json
+orbit --workspace "$ORBIT_WORKSPACE" task list --limit 1 --format json
+```
+
+If publication was previously configured, use `workspace publication bind` with the captured
+remote, branch, and publication ID after reviewing that they still describe the intended
+dedicated publication repository. This creates a fresh local binding and clears local
+last-success metadata; it does not move, rewrite, or delete snapshots in the publication
+repository. Follow the publication runbook's verification procedure before the next publish.
+
+To roll back, run the same source-remote command with the saved old URL, then restore the
+checkout's `origin`. If a publication binding was already recreated, remove it explicitly
+first; source rebinding never changes that binding automatically. Recreate the old binding
+from the captured settings only after the old source identity is restored.
 
 ## Back up Orbit
 

--- a/docs/runbooks/task-publication.md
+++ b/docs/runbooks/task-publication.md
@@ -2,9 +2,9 @@
 type: runbook
 summary: Bind, authenticate, publish, verify, inspect, and recover an Orbit task-publication repository.
 tags: [operations, backup, recovery, git, task-publication]
-paths: ["crates/orbit-cli/src/command/task/publication.rs", "crates/orbit-cli/src/command/workspace/publication.rs", "crates/orbit-store/src/workflow/task/**"]
+paths: ["crates/orbit-cli/src/command/task/publication.rs", "crates/orbit-cli/src/command/workspace/publication.rs", "crates/orbit-cli/src/command/workspace/source_remote.rs", "crates/orbit-store/src/workflow/task/**"]
 related_features: [task-publication, task-artifacts, host-registry]
-related_artifacts: [ORB-11077, ORB-11142, ORB-11145]
+related_artifacts: [ORB-11077, ORB-11142, ORB-11145, ORB-11426]
 last_validated: 2026-09-04
 ---
 
@@ -63,6 +63,15 @@ orbit --workspace "$ORBIT_WORKSPACE" workspace publication show --json
 The global `--workspace` option must precede `workspace publication` or `task publication`.
 Continue only when the selected registration names the intended owner checkout and source
 remote. A missing binding is expected during first setup.
+
+When the source repository itself moves, do not edit the binding fingerprint or registry by
+hand. `workspace source-remote rebind` refuses a changed source identity while a publication
+binding exists. Capture this command's JSON output, remove the binding explicitly, perform and
+verify the source rebind, then use `workspace publication bind` with the reviewed captured
+remote, branch, and publication ID. The new local binding starts without last-success metadata;
+the operation does not migrate or rewrite any existing publication snapshot. See
+[Rebind the source remote after a repository move](./state-and-backup.md#rebind-the-source-remote-after-a-repository-move)
+for the full inspection, dry-run, verification, and rollback sequence.
 
 ## Choose durable authentication
 


### PR DESCRIPTION
## Task

[ORB-11426](https://orbit-cli.com/tasks/ORB-11426) — Support explicit workspace source-remote rebinding for repository transfers

### Description

Child of Constellation ORB-11422. Implement the smallest supported operation to update an existing registered workspace's canonical git_remote when its GitHub repository moves. Current inspected workspace/init.rs detects origin but updates git_remote only for newly registered workspaces; reverify current code before implementing. Preserve logical workspace ID, owner identity, tasks and checkout roles. Require explicit operator intent, validate portable credential-free remote, report old/new identities, avoid partial writes and reject unauthorized replica changes. Provide dry-run/readback and deterministic tests using disposable fixtures. Inspect existing publication binding constraints: fail closed with actionable guidance if they prevent safe rebind; do not invent history migration or mutate old snapshots. orbit-publications migration is excluded. Dedicated worktree off agent-main, prepare PR for Daniel approval, do not merge/install onto live hosts or perform real org transfer. No broad URL rename in this task.

### Acceptance Criteria

- A supported explicit operation updates an existing workspace source remote while preserving workspace ID, ownership, tasks and checkout registrations.
- Tests prove successful transition, no-op retry, invalid/credential-bearing input refusal, ownership denial, dry-run no mutation and failure atomicity.
- Existing publication bindings are handled explicitly without silently corrupting lineage; unsupported cases fail closed with documented recovery guidance.
- CLI/help and focused operator documentation describe inspection, rebind, verification and rollback for repository moves.
- Relevant tests and formatting checks pass, with a reviewable PR against agent-main and no live identity mutations.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `orbit workspace source-remote show|rebind` with explicit owner-only authorization, portable credential-free URL validation, dry-run/readback output, normalized old/new repository identities, equivalent-remote no-op behavior, and locked atomic registry persistence.
- The rebind changes only `Workspace.git_remote` and `updated_at`; logical workspace ID, owner, checkout registrations/roles, path overrides, and task bundles remain untouched. `workspace show` now exposes a redacted remote plus normalized identity.
- Existing publication bindings fail closed before mutation, including during dry-run, with commands to inspect/remove/recreate the binding. No publication history or snapshot is mutated.
- Added CLI help and operator runbooks covering inspection, dry-run, provider/check-out verification, publication recovery, and rollback.
- Added domain, binary, and injected-write-failure tests using disposable fixtures.

Acceptance criteria:
1. Supported explicit update preserving workspace/task/checkout identity: satisfied by the registry-owned mutation plus binary test that verifies workspace ID, owner, checkouts, and an existing task remain unchanged/readable.
2. Success, no-op retry, invalid/credential refusal, ownership denial, dry-run, and failure atomicity: satisfied by six registry tests, three binary tests, and one injected persistence-failure test.
3. Publication bindings: satisfied by fail-closed domain behavior, dry-run parity, actionable CLI error, and runbook recovery sequence; orbit-publications migration remains excluded.
4. CLI/help and operator docs: satisfied by `source-remote show|rebind`, long help workflow, and updates to state/backup and publication runbooks.
5. Validation and delivery: required local checks passed. Changes remain uncommitted for the managed pipeline to commit and open a reviewable PR against `agent-main`; no live workspace identity, Git remote, publication repository, or provider transfer was mutated.

Validation:
- Passed: `cargo test -p orbit-registry source_remote_rebind -- --nocapture` (6 tests).
- Passed: `cargo test -p orbit-cli --test workspace_source_remote -- --nocapture` (3 binary tests).
- Passed: `cargo test -p orbit-cli command::workspace::tests::source_remote -- --nocapture` (1 injected persistence-failure test).
- Passed: `cargo test -p orbit-cli command::workspace::tests -- --nocapture` (31 workspace command tests).
- Passed: `cargo test -p orbit-cli --test json_output_stability -- --nocapture` (2 tests).
- Passed: `cargo test -p orbit-cli --test workspace_selector -- --nocapture` (4 tests).
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.
- Not run: `make ci`, per workspace policy reserving the full suite for the PR merge gate.

Assessment: The operation is narrow and reversible, places invariants at the registry boundary, avoids cross-crate dependency changes, and keeps publication lineage changes explicit.

Deviations from original plan:
- None in behavior. Tests were split into sibling test modules during maintainer review to respect repository layout and file-size guidance.

Remaining risks:
- Provider-side repository transfer and network authentication were intentionally not exercised; the command only changes Orbit's machine-local registry and intentionally leaves `.git/config` to the operator.
- Recreating a removed publication binding is an explicit operator step and resets local last-success metadata without touching remote snapshots.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11426-6a9db047`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*