### PR TITLE
Prepare constellation-works Orbit URLs and distribution metadata for cutover

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/danieljhkim/orbit/security/advisories/new
+    url: https://github.com/constellation-works/orbit/security/advisories/new
     about: |
       Please report security issues privately via GitHub Security Advisories,
       not as a public issue. See SECURITY.md for scope and what to include.
   - name: Contributing & general questions
-    url: https://github.com/danieljhkim/orbit/blob/main/CONTRIBUTING.md
+    url: https://github.com/constellation-works/orbit/blob/main/CONTRIBUTING.md
     about: |
       Read CONTRIBUTING.md for setup, repository shape, and change
       expectations before opening an issue or pull request.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Checkout tap repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          repository: danieljhkim/homebrew-tap
+          repository: constellation-works/homebrew-tap
           token: ${{ secrets.TAP_GITHUB_TOKEN }}
           path: tap
 
@@ -257,14 +257,14 @@ jobs:
           ARM_SHA="${{ needs.publish-release.outputs.darwin_arm_sha }}"
           INTEL_ASSET="${{ needs.publish-release.outputs.darwin_intel_asset }}"
           INTEL_SHA="${{ needs.publish-release.outputs.darwin_intel_sha }}"
-          BASE_URL="https://github.com/danieljhkim/orbit/releases/download/v${VERSION}"
+          BASE_URL="https://github.com/constellation-works/orbit/releases/download/v${VERSION}"
           FORMULA="tap/Formula/orbit.rb"
 
           mkdir -p tap/Formula
           cat > "$FORMULA" <<RUBY
           class Orbit < Formula
             desc "Local-first agentic workflow engine for agent-driven software delivery"
-            homepage "https://github.com/danieljhkim/orbit"
+            homepage "https://github.com/constellation-works/orbit"
             version "${VERSION}"
             license "MIT"
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the community leaders responsible for enforcement via GitHub Security Advisories at <https://github.com/danieljhkim/orbit/security/advisories/new> — the same private channel listed in [SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the community leaders responsible for enforcement via GitHub Security Advisories at <https://github.com/constellation-works/orbit/security/advisories/new> — the same private channel listed in [SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Everything is incremental: the task layer and audit log work on day one; the doc
 **Prerequisites:** at least one supported agent CLI (Claude Code, Codex, Cursor, or Gemini CLI), authenticated. `orbit run ship` in its default `--mode pr` needs `gh` authenticated; otherwise use `--mode local`. On Linux, complete the [Linux sandbox runbook](docs/runbooks/linux-sandbox.md) after `orbit init`.
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh
-# or: brew install danieljhkim/tap/orbit
+curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh
+# or: brew install constellation-works/tap/orbit
 
 orbit init                                 # global state (~/.orbit)
 cd <repo> && orbit workspace init --mcp    # workspace state + operator-authorized MCP integration
@@ -61,11 +61,11 @@ Use a plugin to attach Orbit's MCP tools and `orbit` skill to one agent without 
 
 ```bash
 # Claude Code
-/plugin marketplace add danieljhkim/orbit
+/plugin marketplace add constellation-works/orbit
 /plugin install orbit
 
 # Codex CLI
-codex plugin marketplace add danieljhkim/orbit --ref main
+codex plugin marketplace add constellation-works/orbit --ref main
 codex plugin add orbit@orbit
 
 # Cursor (local plugin from a checkout)
@@ -83,7 +83,7 @@ Cloning gives you a framework to mold to your team's conventions; everything und
 >
 > 1. Ask me where to clone the Orbit repository (suggest `~/code/orbit`).
 > 2. Verify the Rust toolchain: Orbit's MSRV is `rust-version = "1.89"`. If cargo is missing or older, **stop and ask me before installing anything** (`rustup` modifies the shell profile).
-> 3. Clone `https://github.com/danieljhkim/orbit` into that location and run `make install` (copies `orbit` to `$INSTALL_BIN_DIR`, default `~/.cargo/bin`). Confirm the install path with me first. Verify with `orbit --version`.
+> 3. Clone `https://github.com/constellation-works/orbit` into that location and run `make install` (copies `orbit` to `$INSTALL_BIN_DIR`, default `~/.cargo/bin`). Confirm the install path with me first. Verify with `orbit --version`.
 > 4. Run `orbit init` for global state at `~/.orbit`. On Linux, follow `docs/runbooks/linux-sandbox.md` and require its probe to pass before dispatching agents.
 > 5. From *this* repository, run `orbit workspace init --mcp`. It creates `.orbit/` and registers an **operator-authorized** MCP server with installed agent CLIs. Tell me first if you'd rather it stay agent-only (`orbit mcp init`).
 > 6. Ask me whether to enable semantic search (optional): `orbit semantic install` downloads an embedder companion plus the default model under `~/.orbit/embed/` (macOS arm64 or Linux x86_64/aarch64 with glibc >= 2.38). If I accept and tasks already exist, run `orbit semantic index`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,6 +55,56 @@ ORB-10429 executed this archive ahead of `0.10.0` and produced a validated, work
 - The live `## Unreleased` section never moves; only already-released `## <X.Y.Z>` sections are archived.
 - Cross-link the two locations so neither reads as a dead end: the archive file links back to `CHANGELOG.md`, and `CHANGELOG.md` links forward to `docs/changelogs/` once that directory exists.
 
+## Ownership cutover checklist
+
+This checklist prepares the distribution surface for the transfer; it does not
+authorize a repository transfer, remote mutation, release, npm publication,
+merge, tag, or credential change. Complete it only after the reviewable PR is
+approved and the source-identity migration in ORB-11426 is complete.
+
+1. **Confirm repository availability and identity.** Verify that
+   `https://github.com/constellation-works/orbit` is the canonical repository,
+   that its `agent-main` and `main` branches are available, and that
+   `git remote get-url origin` resolves to the transferred repository. Run
+   `orbit workspace list --all --format json` and confirm that every registered
+   Orbit workspace reports the same canonical source identity after ORB-11426.
+   Do not alter workspace or registry state from this checklist.
+2. **Verify release credentials in their new owner boundary.** An authorized
+   maintainer must confirm Actions access to `ORBIT_RELEASE_SIGNING_KEY_PEM`
+   and `TAP_GITHUB_TOKEN`, write access to
+   `constellation-works/homebrew-tap`, npm publish access plus the required
+   OTP for `@orbit-tools`, and the GitHub permissions needed to create a
+   release. Never paste, log, or rotate those credentials in a PR.
+3. **Validate the checked-in distribution contract before publication.** Run
+   `make release-check`, `./scripts/smoke-npm-install.sh --dry-run-version-assertion`,
+   `./scripts/smoke-plugin-install.sh`, and the managed-asset mirror checks.
+   After the repository is available, explicitly verify the transfer-bound
+   endpoints with:
+
+   ```sh
+   curl --fail --silent --show-error \
+     https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh >/dev/null
+   gh api repos/constellation-works/orbit --jq .full_name
+   gh api repos/constellation-works/homebrew-tap --jq .full_name
+   ```
+
+4. **Publish only immutable release artifacts in order.** Merge the approved
+   preparation PR to `agent-main`, tag that exact merged commit, wait for the
+   release workflow and Homebrew update, then publish the matching npm version
+   once. Tags and npm versions are immutable: never retag, overwrite a release
+   asset, or republish a version to repair a failure. Re-run the versioned npm
+   smoke only after publication as documented in `docs/runbooks/release.md`.
+5. **Rollback by moving forward.** If any post-cutover verification fails,
+   pause promotion and publication where possible, restore the previous source
+   owner only through an authorized transfer decision, and cut a new patch for
+   any already-published artifact. Do not force-push, rewrite tags, delete
+   immutable releases, or modify the personal `danieljhkim/homebrew-tap`.
+
+Historical GitHub URLs in learning records, incident evidence, and completed
+workflow examples intentionally retain their original owner because they name
+immutable provenance. Active installer, release, npm, plugin, MCP, website,
+and current documentation references use `constellation-works`.
+
 ## Release checklist
 
 ### 1. Survey commits since last tag
@@ -222,9 +272,9 @@ Merge with a **merge commit** (`gh pr merge <N> --merge --admin`), not squash or
 If `gh pr merge --merge` errors with `Merge commits are not allowed on this repository`, the repo's `allow_merge_commit` setting is off. Flip it on, merge, restore:
 
 ```sh
-gh api -X PATCH repos/danieljhkim/orbit -f allow_merge_commit=true
+gh api -X PATCH repos/constellation-works/orbit -f allow_merge_commit=true
 gh pr merge <N> --merge --admin
-gh api -X PATCH repos/danieljhkim/orbit -f allow_merge_commit=false
+gh api -X PATCH repos/constellation-works/orbit -f allow_merge_commit=false
 ```
 
 ### 10c. Post-merge: back-merge to `agent-main`
@@ -243,7 +293,7 @@ git push origin agent-main
 
 ```sh
 git push origin origin/main:refs/heads/agent-main
-cat <<'EOF' | gh api -X PUT repos/danieljhkim/orbit/branches/agent-main/protection --input -
+cat <<'EOF' | gh api -X PUT repos/constellation-works/orbit/branches/agent-main/protection --input -
 {
   "required_status_checks": null,
   "enforce_admins": false,
@@ -281,7 +331,7 @@ Pushing a `v*` tag triggers `.github/workflows/release.yml`:
 
 - **`build-release`** — `cargo build -p orbit-cli --release --locked` against four targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`. Tarballs uploaded as workflow artifacts.
 - **`publish-release`** — generates `orbit-checksums.txt` (SHA256) and creates the GitHub Release with the four tarballs + checksum file attached. Release notes are auto-generated by `softprops/action-gh-release`.
-- **`bump-homebrew-tap`** — rewrites `Formula/orbit.rb` in the `danieljhkim/homebrew-tap` repo with the new version and the two macOS SHAs, then pushes via `secrets.TAP_GITHUB_TOKEN`. The formula is **macOS-only**; Linux users go through `install.sh`.
+- **`bump-homebrew-tap`** — rewrites `Formula/orbit.rb` in the `constellation-works/homebrew-tap` repo with the new version and the two macOS SHAs, then pushes via `secrets.TAP_GITHUB_TOKEN`. The formula is **macOS-only**; Linux users go through `install.sh`.
 - **`smoke-install-macos`** / **`smoke-install-ubuntu`** — fetches `install.sh` from the tagged ref (`raw.githubusercontent.com/.../<tag>/install.sh`) and verifies `orbit --version`. Note: `install.sh` rides with the release commit — changes land in the same tag.
 
 The npm publish step was removed from the tag workflow in v0.3.1; the npm proxy package is published manually if needed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Orbit is pre-1.0 and ships from `main`. Security fixes land on `main` and the mo
 
 ## Reporting a Vulnerability
 
-Please report security issues privately via GitHub: open the repository's **Security** tab and choose **Report a vulnerability** ([private vulnerability reporting](https://github.com/danieljhkim/orbit/security/advisories/new)).
+Please report security issues privately via GitHub: open the repository's **Security** tab and choose **Report a vulnerability** ([private vulnerability reporting](https://github.com/constellation-works/orbit/security/advisories/new)).
 
 Do **not** open a public issue, pull request, or discussion for suspected vulnerabilities.
 

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1956,7 +1956,7 @@ fn uninitialized_unbound_mcp_launch_gives_setup_guidance_without_operator_author
         &std::fs::read_to_string(&registry_metadata).expect("read checked-in registry metadata"),
     )
     .expect("parse checked-in registry metadata");
-    assert_eq!(registry["name"], "io.github.danieljhkim/orbit");
+    assert_eq!(registry["name"], "io.github.constellation-works/orbit");
     assert_eq!(registry["packages"][0]["identifier"], "@orbit-tools/cli");
     assert_eq!(
         registry["packages"][0]["packageArguments"],

--- a/crates/orbit-cmd/src/update/channel.rs
+++ b/crates/orbit-cmd/src/update/channel.rs
@@ -99,8 +99,8 @@ impl InstallChannel {
                     .to_string()
             }
             Self::Cargo => format!(
-                "cargo owns this installation; run `cargo install --git https://github.com/danieljhkim/orbit --tag v{target_version} --locked orbit-cli`, \
-                 or reinstall through the managed installer with `curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh`"
+                "cargo owns this installation; run `cargo install --git https://github.com/constellation-works/orbit --tag v{target_version} --locked orbit-cli`, \
+                 or reinstall through the managed installer with `curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh`"
             ),
             Self::LocalBuild => {
                 "this is a local build inside a checkout; update the checkout and rebuild \
@@ -110,7 +110,7 @@ impl InstallChannel {
             Self::Unknown => format!(
                 "Orbit does not recognize the installer that owns this path; \
                  install through the managed installer with \
-                 `curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh`, \
+                 `curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh`, \
                  or set {INSTALL_DIR_ENV} to the directory it owns"
             ),
         };

--- a/crates/orbit-cmd/src/update/source.rs
+++ b/crates/orbit-cmd/src/update/source.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use orbit_common::OrbitError;
 
 /// Repository the HTTP source reads releases from unless overridden.
-pub const DEFAULT_RELEASE_REPO: &str = "danieljhkim/orbit";
+pub const DEFAULT_RELEASE_REPO: &str = "constellation-works/orbit";
 
 /// Environment variable naming a local release mirror directory.
 pub const RELEASE_DIR_ENV: &str = "ORBIT_UPDATE_RELEASE_DIR";

--- a/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
@@ -3,11 +3,11 @@
 What is tunable and where. `orbit config keys` and `orbit config show` expose
 the installed version's supported keys and effective values without a source
 checkout. This reference covers operating choices; for additional prose see
-the [published configuration reference](https://github.com/danieljhkim/orbit/blob/main/docs/CONFIG.md),
+the [published configuration reference](https://github.com/constellation-works/orbit/blob/main/docs/CONFIG.md),
 checking its release against `orbit --version`.
 
 Contributors adding an executor should use the source checkout's
-[executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+[executor onboarding runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/executor-onboarding.md).
 It covers the v2 integration and test seams; this reference is for configuring
 an existing lane.
 

--- a/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/first-run.md
@@ -5,7 +5,7 @@ this when `.orbit/` is absent, when the user is still deciding whether to adopt
 Orbit, or when a second machine or repository needs onboarding.
 
 This reference works without an Orbit source checkout. For release-specific
-installation details, consult the [published README](https://github.com/danieljhkim/orbit#quick-start)
+installation details, consult the [published README](https://github.com/constellation-works/orbit#quick-start)
 and compare the version with `orbit --version`. Do not assume a newer website
 or a locally modified resource catalog matches the installed binary.
 
@@ -26,7 +26,7 @@ Report all three before proposing any install.
 A prebuilt CLI gives you setup, dashboard, and administration commands:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh
 # Alternative when Homebrew is the chosen package manager:
 brew install danieljhkim/tap/orbit
 ```
@@ -46,7 +46,7 @@ before dispatch. Do not disable host protection or enable sandbox fallback to hi
 a failed probe.
 
 To add a provider or deterministic executor to Orbit itself, work in a source
-checkout and follow the [executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+checkout and follow the [executor onboarding runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/executor-onboarding.md).
 Do not change a production login or workspace configuration merely to test a
 new executor.
 

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
@@ -23,7 +23,7 @@ fn private_vcs_boundary_normalizes_repository_and_branch_merge_policy() {
                 }
             }
         }),
-        "danieljhkim/orbit",
+        "constellation-works/orbit",
     )
     .expect("normalize capability response");
 
@@ -31,7 +31,7 @@ fn private_vcs_boundary_normalizes_repository_and_branch_merge_policy() {
         output,
         json!({
             "repository": {
-                "name_with_owner": "danieljhkim/orbit",
+                "name_with_owner": "constellation-works/orbit",
                 "base_branch": "agent-main",
                 "allow_squash_merge": false,
                 "allow_rebase_merge": true,
@@ -58,7 +58,7 @@ fn private_vcs_boundary_fails_closed_on_incomplete_capability_data() {
                 }
             }
         }),
-        "danieljhkim/orbit",
+        "constellation-works/orbit",
     )
     .expect_err("missing mergeCommitAllowed must not be guessed");
 
@@ -78,7 +78,7 @@ fn private_vcs_boundary_does_not_guess_when_base_policy_data_is_missing() {
                 }
             }
         }),
-        "danieljhkim/orbit",
+        "constellation-works/orbit",
     )
     .expect_err("missing baseRef policy data must not imply no protection");
 

--- a/crates/orbit-search/src/commands/mod.rs
+++ b/crates/orbit-search/src/commands/mod.rs
@@ -35,7 +35,7 @@ use crate::vector::{DocEmbeddingSource, VectorStore};
 use crate::{CompanionPaths, ModelSpec, default_model};
 
 pub(crate) const DEFAULT_RELEASE_BASE_URL: &str =
-    "https://github.com/danieljhkim/orbit/releases/latest/download";
+    "https://github.com/constellation-works/orbit/releases/latest/download";
 
 pub(crate) fn parse_model(model: Option<&str>) -> Result<ModelSpec, OrbitError> {
     match model {

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -246,7 +246,7 @@ It also runs both plugin validators and the canonical-skill mirror drift check.
 Missing `npm` or `gh` skips that remote source with a stderr note. Local
 Cargo/npm/plugin/registry-metadata drift always fails.
 
-Claude Code installs through `/plugin marketplace add danieljhkim/orbit` and
+Claude Code installs through `/plugin marketplace add constellation-works/orbit` and
 `/plugin install orbit`; Codex installs through its Git marketplace commands.
 Cursor uses `~/.cursor/plugins/local/orbit` pointing at `plugin/`, whose root
 `plugin.json` and `mcp.json` are the Agent Plugins 1.0 contract. Public Cursor

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-REPO="${ORBIT_INSTALL_REPO:-danieljhkim/orbit}"
+REPO="${ORBIT_INSTALL_REPO:-constellation-works/orbit}"
 BINARY_NAME="orbit"
 CHECKSUM_FILE="orbit-checksums.txt"
 CHECKSUM_SIGNATURE_FILE="orbit-checksums.txt.sig"

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,9 +1,9 @@
 # @orbit-tools/cli
 
-npm binary proxy for the [Orbit](https://github.com/danieljhkim/orbit) CLI.
+npm binary proxy for the [Orbit](https://github.com/constellation-works/orbit) CLI.
 
 On install, downloads the matching prebuilt `orbit` binary from
-[GitHub Releases](https://github.com/danieljhkim/orbit/releases), authenticates
+[GitHub Releases](https://github.com/constellation-works/orbit/releases), authenticates
 the signed `orbit-checksums.txt` with the package-pinned release trust set,
 verifies the archive SHA-256, and exposes it as the `orbit` command.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orbit-tools/cli",
   "version": "0.18.0",
-  "mcpName": "io.github.danieljhkim/orbit",
+  "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {
     "orbit": "bin/orbit.js"
@@ -30,11 +30,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/danieljhkim/orbit.git",
+    "url": "git+https://github.com/constellation-works/orbit.git",
     "directory": "npm"
   },
-  "homepage": "https://github.com/danieljhkim/orbit",
-  "bugs": "https://github.com/danieljhkim/orbit/issues",
+  "homepage": "https://github.com/constellation-works/orbit",
+  "bugs": "https://github.com/constellation-works/orbit/issues",
   "license": "MIT",
   "keywords": [
     "orbit",
@@ -44,7 +44,7 @@
   ],
   "config": {
     "orbit": {
-      "binaryRepo": "danieljhkim/orbit"
+      "binaryRepo": "constellation-works/orbit"
     }
   }
 }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "danieljhkim",
     "url": "https://github.com/danieljhkim"
   },
-  "homepage": "https://github.com/danieljhkim/orbit",
-  "repository": "https://github.com/danieljhkim/orbit",
+  "homepage": "https://github.com/constellation-works/orbit",
+  "repository": "https://github.com/constellation-works/orbit",
   "license": "MIT",
   "keywords": [
     "orbit",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "danieljhkim",
     "url": "https://github.com/danieljhkim"
   },
-  "homepage": "https://github.com/danieljhkim/orbit",
-  "repository": "https://github.com/danieljhkim/orbit",
+  "homepage": "https://github.com/constellation-works/orbit",
+  "repository": "https://github.com/constellation-works/orbit",
   "license": "MIT",
   "keywords": [
     "orbit",
@@ -30,7 +30,7 @@
     "developerName": "danieljhkim",
     "category": "Developer Tools",
     "capabilities": ["MCP", "Skills", "Agent Workflows"],
-    "websiteURL": "https://github.com/danieljhkim/orbit",
+    "websiteURL": "https://github.com/constellation-works/orbit",
     "defaultPrompt": [
       "Create an Orbit task for this change.",
       "Search Orbit for related decisions.",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -7,8 +7,8 @@
     "name": "danieljhkim",
     "url": "https://github.com/danieljhkim"
   },
-  "homepage": "https://github.com/danieljhkim/orbit",
-  "repository": "https://github.com/danieljhkim/orbit",
+  "homepage": "https://github.com/constellation-works/orbit",
+  "repository": "https://github.com/constellation-works/orbit",
   "license": "MIT",
   "keywords": [
     "orbit",

--- a/plugin/skills/orbit/references/setup/configuration.md
+++ b/plugin/skills/orbit/references/setup/configuration.md
@@ -3,11 +3,11 @@
 What is tunable and where. `orbit config keys` and `orbit config show` expose
 the installed version's supported keys and effective values without a source
 checkout. This reference covers operating choices; for additional prose see
-the [published configuration reference](https://github.com/danieljhkim/orbit/blob/main/docs/CONFIG.md),
+the [published configuration reference](https://github.com/constellation-works/orbit/blob/main/docs/CONFIG.md),
 checking its release against `orbit --version`.
 
 Contributors adding an executor should use the source checkout's
-[executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+[executor onboarding runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/executor-onboarding.md).
 It covers the v2 integration and test seams; this reference is for configuring
 an existing lane.
 

--- a/plugin/skills/orbit/references/setup/first-run.md
+++ b/plugin/skills/orbit/references/setup/first-run.md
@@ -5,7 +5,7 @@ this when `.orbit/` is absent, when the user is still deciding whether to adopt
 Orbit, or when a second machine or repository needs onboarding.
 
 This reference works without an Orbit source checkout. For release-specific
-installation details, consult the [published README](https://github.com/danieljhkim/orbit#quick-start)
+installation details, consult the [published README](https://github.com/constellation-works/orbit#quick-start)
 and compare the version with `orbit --version`. Do not assume a newer website
 or a locally modified resource catalog matches the installed binary.
 
@@ -26,7 +26,7 @@ Report all three before proposing any install.
 A prebuilt CLI gives you setup, dashboard, and administration commands:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/danieljhkim/orbit/main/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/constellation-works/orbit/main/install.sh | sh
 # Alternative when Homebrew is the chosen package manager:
 brew install danieljhkim/tap/orbit
 ```
@@ -46,7 +46,7 @@ before dispatch. Do not disable host protection or enable sandbox fallback to hi
 a failed probe.
 
 To add a provider or deterministic executor to Orbit itself, work in a source
-checkout and follow the [executor onboarding runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/executor-onboarding.md).
+checkout and follow the [executor onboarding runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/executor-onboarding.md).
 Do not change a production login or workspace configuration merely to test a
 new executor.
 

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -70,8 +70,8 @@ if [[ -z "$npm_package_version" || "$npm_package_version" == "null" ]]; then
   echo "release-check: $NPM_PACKAGE_JSON has no .version field" >&2
   exit 2
 fi
-if [[ "$mcp_name" != "io.github.danieljhkim/orbit" || "$server_name" != "$mcp_name" ]]; then
-  echo "DRIFT: npm mcpName and server.json name must be io.github.danieljhkim/orbit" >&2
+if [[ "$mcp_name" != "io.github.constellation-works/orbit" || "$server_name" != "$mcp_name" ]]; then
+  echo "DRIFT: npm mcpName and server.json name must be io.github.constellation-works/orbit" >&2
   exit 1
 fi
 if [[ "$server_package" != "$NPM_PKG" || "$server_version" != "$npm_package_version" || "$server_package_version" != "$server_version" ]]; then

--- a/scripts/smoke-npm-install.sh
+++ b/scripts/smoke-npm-install.sh
@@ -72,8 +72,8 @@ npm_package_version="$(node -p "JSON.parse(require('fs').readFileSync('$NPM_PACK
 registry_version="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).version")"
 registry_package_version="$(node -p "JSON.parse(require('fs').readFileSync('$REGISTRY_METADATA', 'utf8')).packages?.[0]?.version ?? ''")"
 
-if [[ "$registry_name" != "io.github.danieljhkim/orbit" || "$npm_mcp_name" != "$registry_name" ]]; then
-  echo "FAIL: registry name and npm mcpName must both be io.github.danieljhkim/orbit" >&2
+if [[ "$registry_name" != "io.github.constellation-works/orbit" || "$npm_mcp_name" != "$registry_name" ]]; then
+  echo "FAIL: registry name and npm mcpName must both be io.github.constellation-works/orbit" >&2
   exit 1
 fi
 if [[ -z "$NPM_PKG" || "$registry_version" != "$npm_package_version" || "$registry_package_version" != "$registry_version" ]]; then

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.danieljhkim/orbit",
+  "name": "io.github.constellation-works/orbit",
   "description": "Orbit's local-first task and workflow registry for coding agents.",
   "repository": {
-    "url": "https://github.com/danieljhkim/orbit",
+    "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
   "version": "0.18.0",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/danieljhkim/orbit',
+          href: 'https://github.com/constellation-works/orbit',
         },
       ],
       tableOfContents: {

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -13,7 +13,7 @@ import Default from '@astrojs/starlight/components/Footer.astro';
       <a href="/getting-started/">Docs</a>
       <a href="/reference/cli/">Reference</a>
       <a href="/how-to/">How-to</a>
-      <a href="https://github.com/danieljhkim/orbit">GitHub</a>
+      <a href="https://github.com/constellation-works/orbit">GitHub</a>
     </nav>
   </div>
 </footer>

--- a/website/src/content/docs/getting-started/install.md
+++ b/website/src/content/docs/getting-started/install.md
@@ -140,7 +140,7 @@ test -x /usr/bin/bwrap
 A run failing with `bwrap: setting up uid map: Permission denied` is this
 prerequisite, not your task. The full procedure, including loading the
 `bwrap-userns-restrict` AppArmor profile, is in the
-[Linux sandbox runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/linux-sandbox.md).
+[Linux sandbox runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/linux-sandbox.md).
 
 ## Configure Orbit
 

--- a/website/src/content/docs/how-to/task-publication.md
+++ b/website/src/content/docs/how-to/task-publication.md
@@ -16,7 +16,7 @@ Two things it deliberately is not:
 - **It is not a full backup.** Audit events, run history, claims, reservations,
   configuration, host identity, and runtime caches are all out of scope. For
   those, back up the global root and database — see the [state and backup
-  runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/state-and-backup.md).
+runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/state-and-backup.md).
 
 ## Before you bind
 
@@ -195,4 +195,4 @@ To move tasks between *unrelated* authorities, use `orbit task export` and
 
 The full operational procedure — credential bridges, identity diagnosis, and
 escalation — is in the [task publication
-runbook](https://github.com/danieljhkim/orbit/blob/main/docs/runbooks/task-publication.md).
+runbook](https://github.com/constellation-works/orbit/blob/main/docs/runbooks/task-publication.md).


### PR DESCRIPTION
## Task

[ORB-11427](https://orbit-cli.com/tasks/ORB-11427) — Prepare constellation-works Orbit URLs and distribution metadata for cutover

### Description

Prepare a reviewable pre-cutover PR for ORB-11422. Replace active danieljhkim/orbit and obsolete constellation-lab-ai ownership references with constellation-works in installer/update release defaults, release workflow, npm metadata, plugin manifests, server.json MCP identity io.github.constellation-works/orbit, website and current documentation. Point Homebrew automation at constellation-works/homebrew-tap while preserving personal tap. Inventory references semantically: preserve historical commits/URLs and immutable scientific/package provenance. Do not blindly rewrite fixtures that describe historical events. Use dedicated worktree off agent-main. ORB-11426 concurrently owns workspace source-remote implementation: do not edit registry or workspace command behavior in this mandate. No merge, tags, package publication, actual remote changes, repository transfer or credential mutation. Keep this PR unmerged until cutover approval and source-remote prerequisite readiness; document commands/tokens and ordering required. Verify current source and package release configuration rather than older notes.

### Acceptance Criteria

- Reviewable PR covers all active owner-qualified install/update, release, npm, plugin, MCP and website/documentation paths with explicit retained-reference rationale.
- Homebrew automation targets constellation-works/homebrew-tap; personal tap is not modified; MCP identity is io.github.constellation-works/orbit.
- Relevant tests, metadata consistency and managed asset mirror checks pass; checks needing not-yet-transferred remote assets are explicitly deferred with executable cutover validation steps.
- PR includes a cutover checklist for repository availability, source identity prerequisite ORB-11426, credentials, immutable release/npm publication and rollback; no cutover mutations or merges occur.
- Changes avoid workspace/registry implementation owned by ORB-11426 and preserve historical provenance.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Repointed active installer, updater, semantic-companion download, release workflow, npm, plugin, MCP, website, issue-template, and current documentation ownership references to `constellation-works/orbit`.
- Changed Homebrew release automation to `constellation-works/homebrew-tap`; no personal tap was changed.
- Set the npm and MCP registry identity to `io.github.constellation-works/orbit`, updated its checked-in round-trip assertion, and synchronized the canonical skill assets to the plugin mirror.
- Added a pre-cutover checklist to `RELEASING.md` covering repository availability, ORB-11426 source identity, credential custody, immutable release/npm ordering, rollback, and executable deferred remote checks.
- Retained immutable provenance URLs in learning records, historical workflow evidence, and historical test fixtures; the checklist states that rationale.

Criteria:
- Active owner-qualified distribution paths are updated; retained historical references are explicitly justified.
- Homebrew automation now targets `constellation-works/homebrew-tap`; MCP metadata and checks agree on `io.github.constellation-works/orbit`.
- Local metadata, managed-skill mirror, tests, formatting, and lint checks passed.
- The cutover checklist documents sequencing and rollback without performing remote, credential, publication, merge, tag, or transfer mutations.
- No workspace/registry implementation was changed; ORB-11426 remains the source-identity prerequisite.

Validation:
- Passed: `./scripts/sync-plugin-skills.sh --check`.
- Passed: `./scripts/release-check.sh` (local metadata consistency; `mcp-publisher` and npm were unavailable, so their checks were deferred by the script).
- Passed: `./scripts/smoke-npm-install.sh --dry-run-version-assertion` and `./scripts/smoke-plugin-install.sh`.
- Passed: `cargo test -p orbit-cmd update::tests`; `cargo test -p orbit-cli --test mcp_roundtrip uninitialized_unbound_mcp_launch_gives_setup_guidance_without_operator_authority`; `cargo test -p orbit-engine executor::automation::vcs::tests::operations`; `cargo test -p orbit-search commands::tests`.
- Passed: `make ci-fast`, `make ci-lint`, and `git diff --check`.
- Deferred: live `constellation-works` repository, Homebrew tap, release assets, and npm publication are intentionally not yet transferred/published. The cutover checklist supplies `curl` and `gh api` commands plus the post-publication smoke sequence.

Assessment: Reviewable pre-cutover-only patch. Remaining risk is external cutover readiness and ORB-11426 completion, both deliberately outside this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11427-6a9db373`
- Behind base: 0
- Ahead of base: 1