### PR TITLE
Treat omitted optional base_branch input as empty during job template binding

### DIFF
--- a/.orbit/resources/jobs/task_pilot_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pilot_pipeline.yaml
@@ -10,10 +10,8 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
-# The base branch carries an empty sentinel in the job defaults so the prepare
-# template always renders. Prepare resolves that empty value through the owning
-# workspace's `workflow.base_branch`; a non-empty run input remains an explicit
-# override.
+# Prepare resolves an omitted base branch through the owning workspace's
+# `workflow.base_branch`; a non-empty run input remains an explicit override.
 # Any successful partition reaches apply even if another agent failed.
 # Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -46,7 +44,6 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
-    base_branch: ""
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pilot_pipeline.yaml
@@ -10,10 +10,8 @@
 # primary HEAD, index, or working files. An unfetchable remote fails before
 # any agent call. Each read-only pilot receives at most five tasks and runs
 # in an invocation-owned checkout at that pinned revision.
-# The base branch carries an empty sentinel in the job defaults so the prepare
-# template always renders. Prepare resolves that empty value through the owning
-# workspace's `workflow.base_branch`; a non-empty run input remains an explicit
-# override.
+# Prepare resolves an omitted base branch through the owning workspace's
+# `workflow.base_branch`; a non-empty run input remains an explicit override.
 # Any successful partition reaches apply even if another agent failed.
 # Apply isolates stale or malformed assessments by partition, applies
 # every independently valid partition, then a guard fails the total run when
@@ -46,7 +44,6 @@ spec:
   default_input:
     task_ids: []
     workspace_path: .
-    base_branch: ""
     max_tasks: 50
     max_partition_size: 5
     promotion_authorized: false

--- a/crates/orbit-core/assets/skills/orbit/references/orchestration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/orchestration.md
@@ -142,8 +142,8 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
-The job carries an empty `base_branch` default so zero-input template rendering
-reaches prepare. Prepare treats an omitted or empty value as
+At the prepare activity boundary, an omitted optional `base_branch` is bound as
+an empty string. Prepare treats an omitted or empty value as
 `workflow.base_branch`, fetches that landing branch, and pins one
 `source_revision` while preserving primary HEAD, index, dirty and untracked
 files. Remote failure stops before an agent call. Each pilot runs in its own

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its job input uses an empty `base_branch` sentinel so zero-input templates render, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -447,9 +447,9 @@ fn task_pilot_pipeline_resolves_system_crew_and_bounded_partial_join_partitions(
     let asset = load_job_asset(yaml).expect("task pilot pipeline parses");
     let defaults = asset.spec.default_input.as_ref().expect("default input");
     assert_eq!(defaults["task_ids"], json!([]));
-    assert_eq!(
-        defaults["base_branch"], "",
-        "an empty sentinel must satisfy template rendering while leaving branch resolution to prepare"
+    assert!(
+        defaults.get("base_branch").is_none(),
+        "branch fallback belongs to the prepare activity, not the job defaults"
     );
     assert_eq!(defaults["max_partition_size"], 5);
     assert_eq!(defaults["promotion_authorized"], false);

--- a/crates/orbit-engine/src/activity_job/catalog.rs
+++ b/crates/orbit-engine/src/activity_job/catalog.rs
@@ -621,6 +621,7 @@ fn resolve_ref(
     Ok(TargetStep {
         spec: activity.spec.clone(),
         activity_name: Some(name.to_string()),
+        input_schema_json: Some(activity.input_schema_json.clone()),
         fs_profile: activity.fs_profile.clone(),
         default_input: r.default_input,
         timeout_seconds: r.timeout_seconds,

--- a/crates/orbit-engine/src/activity_job/job_executor/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/target.rs
@@ -9,7 +9,12 @@ pub(super) fn run_target(
     ctx: &ExecCtx<'_>,
 ) -> Result<StepOutcome, DispatchError> {
     let tctx = ctx.template_ctx();
-    let rendered_input = render_input(t.default_input.as_ref(), &ctx.input, &tctx)?;
+    let rendered_input = render_input(
+        t.default_input.as_ref(),
+        &ctx.input,
+        &tctx,
+        t.input_schema_json.as_ref(),
+    )?;
     // [ORB-10902] Rebind before dispatch so `system_crew: true` reaches the
     // activity input, not only the local copy used to resolve crew settings.
     // Recovery does the same; injection is independent of target spec type.

--- a/crates/orbit-engine/src/activity_job/job_executor/templating.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/templating.rs
@@ -4,9 +4,43 @@ pub(super) fn render_input(
     default_input: Option<&Value>,
     base_input: &Value,
     tctx: &TemplateContext,
+    input_schema: Option<&Value>,
 ) -> Result<Value, DispatchError> {
     let src = default_input.cloned().unwrap_or_else(|| base_input.clone());
-    render_value(&src, tctx)
+    let normalized_context = normalize_optional_string_inputs(tctx, input_schema);
+    render_value(&src, normalized_context.as_ref().unwrap_or(tctx))
+}
+
+/// Make absent optional string inputs explicit only while binding a resolved
+/// catalog activity. Required fields and names outside the activity contract
+/// remain absent, preserving strict template failures for both cases.
+fn normalize_optional_string_inputs(
+    tctx: &TemplateContext,
+    input_schema: Option<&Value>,
+) -> Option<TemplateContext> {
+    let schema = input_schema?.as_object()?;
+    let properties = schema.get("properties")?.as_object()?;
+    let required = schema.get("required").and_then(Value::as_array);
+    let mut input = tctx.input.as_object()?.clone();
+    let mut changed = false;
+
+    for (name, property) in properties {
+        let is_required = required.is_some_and(|fields| {
+            fields
+                .iter()
+                .any(|field| field.as_str().is_some_and(|field| field == name))
+        });
+        let is_string = property.get("type").and_then(Value::as_str) == Some("string");
+        if !is_required && is_string && !input.contains_key(name) {
+            input.insert(name.clone(), Value::String(String::new()));
+            changed = true;
+        }
+    }
+
+    changed.then(|| TemplateContext {
+        input: Value::Object(input),
+        ..tctx.clone()
+    })
 }
 
 pub(super) fn merge_job_input(default_input: Option<&Value>, input: &Value) -> Value {

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -192,6 +192,7 @@ impl Visit for FieldCapture {
 pub(super) enum Action {
     Ok(Value),
     Err(DispatchError),
+    EchoInput,
     SleepOk { ms: u64, value: Value },
     SleepInputMsThenEcho { ms_field: &'static str },
 }
@@ -293,6 +294,7 @@ impl RuntimeHost for ScriptedHost {
         let result = match next {
             Some(Action::Ok(value)) => Ok(value),
             Some(Action::Err(err)) => Err(err),
+            Some(Action::EchoInput) => Ok(input.clone()),
             Some(Action::SleepOk { ms, value }) => {
                 std::thread::sleep(Duration::from_millis(ms));
                 Ok(value)
@@ -355,6 +357,7 @@ pub(super) fn deterministic_target(action: &str) -> TargetStep {
             config: Value::Null,
         }),
         activity_name: None,
+        input_schema_json: None,
         fs_profile: None,
         default_input: None,
         timeout_seconds: 0,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -741,6 +741,7 @@ fn recovery_job(
             body: JobV2StepBody::Target(TargetStep {
                 spec: deterministic_activity(step_action, None).spec,
                 activity_name: None,
+                input_schema_json: None,
                 fs_profile: step_fs_profile.map(str::to_string),
                 default_input: None,
                 timeout_seconds: 0,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/step.rs
@@ -304,6 +304,7 @@ fn agent_implement_shaped_step(id: &str, retry: Option<RetrySpec>) -> JobV2Step 
         body: JobV2StepBody::Target(TargetStep {
             spec: ActivityV2Spec::AgentLoop(spec),
             activity_name: None,
+            input_schema_json: None,
             fs_profile: None,
             default_input: None,
             timeout_seconds: 0,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/target.rs
@@ -117,6 +117,7 @@ fn target_step(spec: ActivityV2Spec) -> TargetStep {
     TargetStep {
         spec,
         activity_name: None,
+        input_schema_json: None,
         fs_profile: None,
         default_input: None,
         timeout_seconds: 0,
@@ -422,6 +423,7 @@ fn agent_loop_step_with_system_crew() -> JobV2Step {
         body: JobV2StepBody::Target(TargetStep {
             spec: ActivityV2Spec::AgentLoop(inline_agent_loop_spec()),
             activity_name: None,
+            input_schema_json: None,
             fs_profile: None,
             default_input: Some(system_crew_default_input()),
             timeout_seconds: 0,
@@ -443,6 +445,7 @@ fn deterministic_step_with_system_crew() -> JobV2Step {
                 config: Value::Null,
             }),
             activity_name: None,
+            input_schema_json: None,
             fs_profile: None,
             default_input: Some(system_crew_default_input()),
             timeout_seconds: 0,

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/templating.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/templating.rs
@@ -22,7 +22,106 @@ fn render_input_supports_legacy_batch_id_from_worktree_output() {
         "batch_id": "{{ steps.worktree.output.batch_id }}",
     });
 
-    let rendered = render_input(Some(&default_input), &Value::Null, &tctx).unwrap();
+    let rendered = render_input(Some(&default_input), &Value::Null, &tctx, None).unwrap();
 
     assert_eq!(rendered, json!({ "batch_id": "jrun-template" }));
+}
+
+#[test]
+fn shipped_task_pilot_binds_omitted_optional_base_branch_and_preserves_override() {
+    let asset = load_job_asset(include_str!(
+        "../../../../../orbit-core/assets/jobs/task_pilot_pipeline.yaml"
+    ))
+    .expect("load shipped task-pilot job");
+    assert_eq!(
+        asset
+            .spec
+            .default_input
+            .as_ref()
+            .and_then(|input| input.get("base_branch")),
+        None,
+        "the shipped job must omit base_branch"
+    );
+
+    let activity = crate::activity_job::load_activity_asset(include_str!(
+        "../../../../../orbit-core/assets/activities/prepare_task_pilot.yaml"
+    ))
+    .expect("load shipped prepare activity");
+    let mut catalog = V2ActivityCatalog::new();
+    catalog.insert(activity.name, activity.spec);
+
+    for (run_id, input, expected_branch) in [
+        ("run-task-pilot-default-branch", json!({}), ""),
+        (
+            "run-task-pilot-explicit-branch",
+            json!({ "base_branch": "release-candidate" }),
+            "release-candidate",
+        ),
+    ] {
+        let mut job = asset.spec.clone();
+        job.steps.truncate(1);
+        resolve_job_catalog_refs_for_execution(&mut job, &catalog)
+            .expect("resolve shipped prepare activity");
+        let host = ScriptedHost::new([("prepare_task_pilot", vec![Action::EchoInput])]);
+        let outcome = execute_job(
+            &job,
+            input,
+            run_id,
+            std::sync::Arc::new(test_writer(run_id)),
+            &host,
+        )
+        .expect("execute shipped prepare binding");
+
+        assert!(outcome.success);
+        assert_eq!(
+            outcome.pipeline["prepare"]["base_branch"],
+            json!(expected_branch)
+        );
+        assert_eq!(host.call_count("prepare_task_pilot"), 1);
+    }
+}
+
+#[test]
+fn missing_required_input_stays_a_template_error() {
+    let default_input = json!({ "required_name": "{{ input.required_name }}" });
+    let schema = json!({
+        "type": "object",
+        "required": ["required_name"],
+        "properties": { "required_name": { "type": "string" } }
+    });
+    let tctx = TemplateContext {
+        input: json!({}),
+        ..TemplateContext::default()
+    };
+
+    let error = render_input(Some(&default_input), &tctx.input, &tctx, Some(&schema))
+        .expect_err("required input must remain absent");
+
+    assert!(
+        error
+            .to_string()
+            .contains("missing input value for 'required_name'")
+    );
+}
+
+#[test]
+fn misspelled_optional_input_path_stays_a_template_error() {
+    let default_input = json!({ "base_branch": "{{ input.base_barnch }}" });
+    let schema = json!({
+        "type": "object",
+        "properties": { "base_branch": { "type": "string" } }
+    });
+    let tctx = TemplateContext {
+        input: json!({}),
+        ..TemplateContext::default()
+    };
+
+    let error = render_input(Some(&default_input), &tctx.input, &tctx, Some(&schema))
+        .expect_err("a path outside the contract must remain absent");
+
+    assert!(
+        error
+            .to_string()
+            .contains("missing input value for 'base_barnch'")
+    );
 }

--- a/crates/orbit-engine/tests/v2_cli_agent.rs
+++ b/crates/orbit-engine/tests/v2_cli_agent.rs
@@ -466,6 +466,7 @@ fn synthetic_loop_session_job() -> JobV2 {
                 trusted_host_execution: false,
             }),
             activity_name: None,
+            input_schema_json: None,
             fs_profile: None,
             default_input: None,
             timeout_seconds: 0,

--- a/crates/orbit-types/src/workflow/activity_job/job_v2.rs
+++ b/crates/orbit-types/src/workflow/activity_job/job_v2.rs
@@ -205,6 +205,10 @@ pub struct TargetStep {
     /// `target: activity:<name>`. Inline specs have no catalog name.
     #[serde(skip)]
     pub activity_name: Option<String>,
+    /// Input contract from the resolved catalog activity. Inline specs have no
+    /// catalog contract, so their template rendering remains strictly literal.
+    #[serde(skip)]
+    pub input_schema_json: Option<Value>,
     #[serde(rename = "fsProfile", default, skip_serializing_if = "Option::is_none")]
     pub fs_profile: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/plugin/skills/orbit/references/orchestration.md
+++ b/plugin/skills/orbit/references/orchestration.md
@@ -142,8 +142,8 @@ can inspect new work without repeating the expensive assessment. Explicit
 selectors, but refuses an ID already prepared by an active run; inspect or
 resume the named run instead.
 
-The job carries an empty `base_branch` default so zero-input template rendering
-reaches prepare. Prepare treats an omitted or empty value as
+At the prepare activity boundary, an omitted optional `base_branch` is bound as
+an empty string. Prepare treats an omitted or empty value as
 `workflow.base_branch`, fetches that landing branch, and pins one
 `source_revision` while preserving primary HEAD, index, dirty and untracked
 files. Remote failure stops before an agent call. Each pilot runs in its own

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -66,7 +66,7 @@ not a rewrite of failed history.
 | `task_local_pipeline` | Implement in a worktree and merge to the configured local base without a PR; optional push. |
 | `task_auto_pipeline` | Discover ready backlog tasks and ship them. |
 | `task_gate_pipeline` | Gated shipment with windowing and starvation handling. |
-| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. Its job input uses an empty `base_branch` sentinel so zero-input templates render, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
+| `task_pilot_pipeline` | Read-only agent preflight plus deterministic validated-selector apply; it defaults to no lifecycle promotion. An omitted optional `base_branch` binds as empty at the prepare activity boundary, then preparation resolves the owning workspace's `[workflow] base_branch`; pass a non-empty run input to inspect another branch. |
 | `task_triage_pipeline` | Diagnose tasks blocked by failed runs. |
 | `epic_pipeline` | Ship an epic and its descendants against one worktree. |
 | `workspace_ship_pipeline` / `workspace_auto_pipeline` | Workspace-scoped wrappers that resolve mode and base branch, then invoke the pipelines above. |


### PR DESCRIPTION
## Task

[ORB-11420](https://orbit-cli.com/tasks/ORB-11420) — Treat omitted optional base_branch input as empty during job template binding

### Description

## Problem
Commit `90e84fa3617517bc197c6ea846f5503117888846` (ORB-11411 / PR #1440) repaired zero-input task-pilot runs by adding `base_branch: ""` to the job's `spec.default_input`. That sentinel makes the strict `{{ input.base_branch }}` lookup render, but it forces resource authors and callers to spell a value whose only meaning is “not supplied.”

The input/template boundary should represent the actual contract: when optional `base_branch` is absent, bind it as an empty string so `prepare_task_pilot` can apply the owning workspace's `workflow.base_branch`. An explicit non-empty branch must remain an override.

## Desired correction
- Remove the empty-string sentinel from the canonical and managed `task_pilot_pipeline` job defaults.
- Make an omitted optional `base_branch` reach the target as `""` at the job/template binding boundary.
- Keep strict missing-value failures for genuinely required inputs and unrelated missing paths; do not globally turn every template typo into an empty string.
- Prefer a contract-aware normalization (for example, using the target input contract) over a `base_branch` name special case in the generic renderer.
- Update the ORB-11411 documentation wording that currently teaches the sentinel workaround.

## Evidence
Before ORB-11411, `task_pilot_pipeline` with `{}` failed before activity execution because `crates/orbit-engine/src/template.rs` rejected the missing `input.base_branch`. The prepare activity already declares `base_branch` optional and already interprets omitted/empty as workspace configuration. ORB-11411's integration coverage proves the downstream branch behavior but currently depends on the YAML sentinel.

## Scope / constraints
This is a successor correction to ORB-11411, not a reopening of its incident response. Preserve canonical/managed asset parity, workspace-specific branch fallback, explicit alternate-branch behavior, unavailable-ref failure, and source snapshot safety.

### Acceptance Criteria

- The shipped `task_pilot_pipeline` has no `base_branch: ""` entry in `spec.default_input`, yet execution with `{}` passes real job input merging and template binding and reaches `prepare_task_pilot` without a missing-value error.
- At the target activity boundary, an omitted optional `base_branch` is observed as the empty string; `prepare_task_pilot` then resolves `main` or `agent-main` from the owning workspace configuration, while an explicit non-empty alternate branch remains unchanged.
- A deterministic engine-level test proves the missing-field behavior and separate negative coverage proves that missing required inputs and unrelated misspelled template paths still fail rather than silently becoming empty.
- Canonical and managed job assets plus the canonical/plugin documentation mirrors remain byte-identical, and the ORB-11411 empty-sentinel wording is removed.
- Relevant targeted tests, `make ci-fast`, `make ci-lint`, and `git diff --check` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Carried each resolved catalog activity input schema to its target binding and normalized only omitted optional string fields to an empty string while rendering that target.
- Removed base_branch from both task-pilot job defaults and replaced the retired workaround language in both canonical/plugin documentation mirrors.
- Added engine regression coverage using the shipped job and prepare activity, plus strict negative coverage for required fields and misspelled paths; updated the shipped catalog assertion.

Acceptance criteria:
1. The shipped job omits base_branch; the engine test executes input {} through real default merging and template binding and dispatches prepare_task_pilot once with base_branch set to empty.
2. Existing Orbit core boundary tests passed for main and agent-main workspace fallback, an explicit release override, and an unavailable explicit branch; the new engine test also verifies the explicit alternate remains unchanged at dispatch.
3. Missing required input and unrelated misspelled path tests both fail with the original strict missing-input error.
4. Canonical/managed job assets and both canonical/plugin documentation mirrors compare byte-identical; the retired sentinel default and wording are absent.
5. All requested validation passed.

Validation:
- PASSED: cargo test -p orbit-engine activity_job::job_executor::tests::templating -- --nocapture (4 passed).
- PASSED: cargo test -p orbit-core application::job::tests::task_pilot_pipeline -- --nocapture (3 passed).
- PASSED: cargo test -p orbit-core application::job::tests::catalog::task_pilot_pipeline_resolves_system_crew_and_bounded_partial_join_partitions -- --nocapture (1 passed).
- PASSED: make ci-fast.
- PASSED: make ci-lint.
- PASSED: git diff --check.
- PASSED: byte comparisons for job and documentation mirrors and repository search for retired sentinel text/default.

Assessment: The normalization is contract-aware and limited to resolved optional string properties. Required properties, unknown names, inline targets without a catalog contract, and unrelated template paths retain strict behavior.
Deviations from original plan:
- Added the resolved target contract carrier and constructor updates outside the initial context list; required so the execution boundary can distinguish optional inputs without a field-name special case. The task context was updated before edits.
Remaining risks: None identified. Changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11420-6a9db72b`
- Behind base: 0
- Ahead of base: 1