### PR TITLE
[BLOCKED] Preserve Codex WebSocket CA trust under macOS sandbox keychain restrictions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,6 +96,20 @@ failing run says which case it hit: Orbit attaches its own attribution to the
 provider's misleading "expired" message, and only recommends re-authenticating
 when the credential really was reachable.
 
+**Sandboxed Codex uses a public file-backed CA bundle on macOS.** The system
+Keychain read denies above prevent Codex's rustls WebSocket client from
+completing native-root discovery even though its HTTPS backend can still
+connect. For a Codex child under `macos-sandbox-exec`, Orbit preserves an
+explicit non-empty `CODEX_CA_CERTIFICATE` first and `SSL_CERT_FILE` second; when neither
+is present, it sets `CODEX_CA_CERTIFICATE=/etc/ssl/cert.pem`. Orbit verifies
+that the selected path is a readable file before launching the child and fails
+with the variable and path when it is not. This supplies public trust anchors;
+it does not disable TLS verification or re-allow `/Library/Keychains`,
+`/System/Library/Keychains`, `~/Library/Keychains`, or any other credential
+directory. Activity `denyRead` rules remain later SBPL clauses and can still
+deny the selected bundle. Other providers, Linux, and bare Codex invocations do
+not receive this Orbit-managed default.
+
 **Environment forwarding to sandboxed/subprocess agents is name-based, not
 value-shaped.** Orbit filters ambient environment variables passed to
 provider subprocesses by matching variable *names* against a fixed list of

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -11,6 +11,7 @@ use orbit_agent::{
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
 use orbit_types::policy::UNRESTRICTED_FS_PROFILE;
+use orbit_types::workflow::ExecutorSandboxKind;
 use orbit_types::workflow::activity_job::{AgentLoopSpec, TrustedHostAdmission, V2AuditEventKind};
 use serde_json::Value;
 
@@ -31,8 +32,9 @@ use super::envelope::{
 };
 use super::inspection::SourceInspection;
 use super::spawn::{
-    PreparedSandbox, linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic,
-    orbit_tool_env, prepare_sandbox_for_dispatch, resolve_provider_launcher,
+    CODEX_CA_CERTIFICATE_ENV, PreparedSandbox, SSL_CERT_FILE_ENV,
+    linux_bwrap_failed_write_diagnostic, macos_keychain_auth_diagnostic, orbit_tool_env,
+    prepare_sandbox_for_dispatch, resolve_provider_launcher,
 };
 use super::supervisor::{
     DEFAULT_WALL_CLOCK_TIMEOUT_SECONDS, SpawnTraceContext, SpawnWithTimeoutRequest,
@@ -369,7 +371,8 @@ pub fn run_cli_backend(
     // starts the CLI. `dispatch_env` is appended last and later entries win, so
     // this run's identity and tool pinning override any same-named value the
     // allowlist forwarded from an outer process. [ORB-10917]
-    let mut child_env = host.agent_subprocess_environment(invocation.required_env_vars);
+    let mut child_env =
+        provider_child_environment(host, &provider, sandbox, invocation.required_env_vars);
     if registry_locator_injected {
         // A host process may itself have been launched with an operator
         // `ORBIT_ROOT`. Do not reinterpret that pinned-data-root input as the
@@ -745,6 +748,30 @@ pub fn run_cli_backend(
             trace,
         }),
     })
+}
+
+/// Compose the provider environment while admitting Codex's two documented
+/// CA-bundle overrides only when Orbit's macOS wrapper needs them.
+///
+/// The variables remain outside the general agent baseline: other providers,
+/// bare Codex invocations, and Linux keep their existing environment surface.
+/// The macOS spawn layer supplies a public system bundle only when neither
+/// explicit value is present.
+pub(crate) fn provider_child_environment(
+    host: &dyn RuntimeHost,
+    provider: &str,
+    sandbox: Option<&super::super::dispatcher::ResolvedSandbox>,
+    required_env_vars: &[&str],
+) -> Vec<(String, String)> {
+    let needs_codex_ca_overrides = provider == "codex"
+        && sandbox.is_some_and(|sandbox| sandbox.kind == ExecutorSandboxKind::MacosSandboxExec);
+    if !needs_codex_ca_overrides {
+        return host.agent_subprocess_environment(required_env_vars);
+    }
+
+    let mut env_names = required_env_vars.to_vec();
+    env_names.extend([CODEX_CA_CERTIFICATE_ENV, SSL_CERT_FILE_ENV]);
+    host.agent_subprocess_environment(&env_names)
 }
 
 pub(super) fn resolved_activity_fs_profile_name(fs_profile: Option<&str>) -> &str {

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -18,6 +18,9 @@ use tempfile::NamedTempFile;
 use super::super::dispatcher::ResolvedSandbox;
 
 const ORBIT_BIN_ENV: &str = "ORBIT_BIN";
+pub(super) const CODEX_CA_CERTIFICATE_ENV: &str = "CODEX_CA_CERTIFICATE";
+pub(super) const SSL_CERT_FILE_ENV: &str = "SSL_CERT_FILE";
+const DEFAULT_MACOS_CA_CERTIFICATE: &str = "/etc/ssl/cert.pem";
 
 /// Conventional `$HOME` bin directories searched when a provider launcher
 /// is not on the inherited `PATH`, and backfilled into a spawned agent's
@@ -738,11 +741,17 @@ pub(crate) fn spawn_macos_sandboxed_with(
     // `orbit_exec::macos_login_keychain_access`. [ORB-10929]
     let profile_text = compile_macos_sandbox_profile(&sandbox.fs_profile, provider)
         .map_err(|err| SpawnError::permanent(err.to_string()))?;
+    let child_env = prepare_macos_codex_ca_environment_with(
+        provider,
+        env,
+        cwd,
+        Path::new(DEFAULT_MACOS_CA_CERTIFICATE),
+    )?;
     let (child, profile_temp) = spawn_under_macos_sandbox(MacosSandboxSpawnRequest {
         profile_text: &profile_text,
         program,
         args,
-        env,
+        env: &child_env,
         cwd,
         stdin: Stdio::piped(),
         stdout: Stdio::piped(),
@@ -753,4 +762,99 @@ pub(crate) fn spawn_macos_sandboxed_with(
         child,
         _profile_temp: Some(profile_temp),
     })
+}
+
+/// Select the CA bundle seen by Codex under Orbit's macOS sandbox.
+///
+/// Denying the system Keychain directories is intentional, but it prevents
+/// rustls-native-certs from completing native root discovery. Codex supports
+/// file-backed trust through `CODEX_CA_CERTIFICATE`, so Orbit supplies macOS's
+/// public bundle when the operator has not selected either documented
+/// override. Explicit values keep their normal precedence and are validated,
+/// never replaced with the fallback after a typo or permissions failure.
+pub(crate) fn prepare_macos_codex_ca_environment_with(
+    provider: &str,
+    env: &[(String, String)],
+    cwd: Option<&Path>,
+    default_ca_certificate: &Path,
+) -> Result<Vec<(String, String)>, SpawnError> {
+    if provider != "codex" {
+        return Ok(env.to_vec());
+    }
+
+    let selected = [CODEX_CA_CERTIFICATE_ENV, SSL_CERT_FILE_ENV]
+        .into_iter()
+        .find_map(|name| {
+            env.iter()
+                .rev()
+                .find(|(candidate, _)| candidate == name)
+                .map(|(_, value)| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(|value| (name, value))
+        });
+    if let Some((name, value)) = selected {
+        validate_ca_certificate_path(
+            name,
+            value,
+            cwd,
+            &format!(
+                "set {name} to a readable PEM CA bundle or unset it so Orbit can use {DEFAULT_MACOS_CA_CERTIFICATE}"
+            ),
+        )?;
+        return Ok(env.to_vec());
+    }
+
+    let value = default_ca_certificate.to_string_lossy().into_owned();
+    validate_ca_certificate_path(
+        CODEX_CA_CERTIFICATE_ENV,
+        &value,
+        cwd,
+        "make the macOS public CA bundle readable or set CODEX_CA_CERTIFICATE or SSL_CERT_FILE to a readable PEM CA bundle",
+    )?;
+
+    let mut child_env = env.to_vec();
+    child_env.push((CODEX_CA_CERTIFICATE_ENV.to_string(), value));
+    Ok(child_env)
+}
+
+fn validate_ca_certificate_path(
+    variable: &str,
+    value: &str,
+    cwd: Option<&Path>,
+    recovery: &str,
+) -> Result<(), SpawnError> {
+    let configured = Path::new(value);
+    let resolved = if configured.is_absolute() {
+        configured.to_path_buf()
+    } else {
+        let base = match cwd {
+            Some(cwd) => cwd.to_path_buf(),
+            None => std::env::current_dir().map_err(|error| {
+                SpawnError::permanent(format!(
+                    "cannot resolve relative {variable} value `{value}` for sandboxed Codex: {error}"
+                ))
+            })?,
+        };
+        base.join(configured)
+    };
+    let metadata = std::fs::metadata(&resolved).map_err(|error| {
+        SpawnError::permanent(format!(
+            "{variable} selects CA bundle `{}` for sandboxed Codex, but Orbit cannot read it: {error}; {recovery}",
+            resolved.display(),
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(SpawnError::permanent(format!(
+            "{variable} selects `{}` for sandboxed Codex, but it is not a CA bundle file; {recovery}",
+            resolved.display()
+        )));
+    }
+    std::fs::File::open(&resolved).map_err(|error| {
+        SpawnError::permanent(format!(
+            "{variable} selects CA bundle `{}` for sandboxed Codex, but Orbit cannot open it: {error}; {recovery}",
+            resolved.display()
+        ))
+    })?;
+
+    Ok(())
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -26,11 +26,11 @@ use super::super::super::dispatcher::DispatchError;
 use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::super::sqlite_sink::V2SqliteSink;
 use super::super::super::workspace::{WorktreeBoundaryGuard, validate_declared_worktree_pair};
-use super::super::orchestrator::resolved_activity_fs_profile_name;
+use super::super::orchestrator::{provider_child_environment, resolved_activity_fs_profile_name};
 use super::super::run_cli_backend;
 use super::test_support::{
-    RecordingSink, TestHost, capture_events, test_agent_loop_spec, test_agent_loop_spec_for,
-    write_executable,
+    RecordingSink, TestHost, capture_events, sandbox_for_test, test_agent_loop_spec,
+    test_agent_loop_spec_for, write_executable,
 };
 
 #[test]
@@ -40,6 +40,58 @@ fn cli_activity_fs_profile_resolver_preserves_named_profile() {
         resolved_activity_fs_profile_name(Some("implementer")),
         "implementer"
     );
+}
+
+fn child_env_value<'a>(env: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    env.iter()
+        .find(|(candidate, _)| candidate == name)
+        .map(|(_, value)| value.as_str())
+}
+
+#[test]
+fn macos_sandboxed_codex_receives_explicit_ca_overrides_from_the_parent() {
+    let _environment = orbit_common::test_env::scoped([
+        ("CODEX_CA_CERTIFICATE", Some("/operator/codex-ca.pem")),
+        ("SSL_CERT_FILE", Some("/operator/ssl-ca.pem")),
+    ]);
+    let host = TestHost::with_command("codex".to_string());
+    let sandbox = sandbox_for_test();
+
+    let env = provider_child_environment(&host, "codex", Some(&sandbox), &["HOME", "PATH"]);
+
+    assert_eq!(
+        child_env_value(&env, "CODEX_CA_CERTIFICATE"),
+        Some("/operator/codex-ca.pem")
+    );
+    assert_eq!(
+        child_env_value(&env, "SSL_CERT_FILE"),
+        Some("/operator/ssl-ca.pem")
+    );
+}
+
+#[test]
+fn codex_ca_overrides_do_not_expand_other_provider_or_linux_environments() {
+    let _environment = orbit_common::test_env::scoped([
+        ("CODEX_CA_CERTIFICATE", Some("/operator/codex-ca.pem")),
+        ("SSL_CERT_FILE", Some("/operator/ssl-ca.pem")),
+    ]);
+    let host = TestHost::with_command("provider".to_string());
+    let macos_sandbox = sandbox_for_test();
+    let linux_sandbox = super::super::super::dispatcher::ResolvedSandbox {
+        kind: orbit_types::workflow::ExecutorSandboxKind::LinuxBwrap,
+        ..sandbox_for_test()
+    };
+
+    for (provider, sandbox) in [
+        ("claude", Some(&macos_sandbox)),
+        ("codex", Some(&linux_sandbox)),
+        ("codex", None),
+    ] {
+        let env = provider_child_environment(&host, provider, sandbox, &["HOME", "PATH"]);
+
+        assert_eq!(child_env_value(&env, "CODEX_CA_CERTIFICATE"), None);
+        assert_eq!(child_env_value(&env, "SSL_CERT_FILE"), None);
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator_macos.rs
@@ -18,6 +18,82 @@ use super::test_support::{
 
 #[cfg(target_os = "macos")]
 #[test]
+fn sandboxed_codex_loads_the_public_ca_bundle_while_private_keychains_stay_denied() {
+    if !sandbox_exec_can_apply_for_test() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let keychains = home.join("Library/Keychains");
+    std::fs::create_dir_all(&keychains).expect("create synthetic keychain directory");
+    std::fs::write(keychains.join("login.keychain-db"), "private fixture")
+        .expect("write synthetic private credential");
+    let _environment = orbit_common::test_env::scoped([
+        ("HOME", Some(home.to_string_lossy().as_ref())),
+        ("CODEX_CA_CERTIFICATE", None),
+        ("SSL_CERT_FILE", None),
+    ]);
+
+    let script = temp.path().join("codex");
+    write_executable(
+        &script,
+        r#"#!/bin/sh
+cat > /dev/null
+if [ "$CODEX_CA_CERTIFICATE" != /etc/ssl/cert.pem ]; then
+  echo "unexpected CODEX_CA_CERTIFICATE=$CODEX_CA_CERTIFICATE" >&2
+  exit 31
+fi
+if [ "${SSL_CERT_FILE+x}" = x ]; then
+  echo "SSL_CERT_FILE should remain unset" >&2
+  exit 32
+fi
+if ! /usr/bin/openssl x509 -in "$CODEX_CA_CERTIFICATE" -noout >/dev/null; then
+  echo "could not load a certificate from the public CA bundle" >&2
+  exit 33
+fi
+if /bin/cat "$HOME/Library/Keychains/login.keychain-db" >/dev/null 2>&1; then
+  echo "private keychain unexpectedly readable" >&2
+  exit 34
+fi
+printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
+"#,
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-codex-ca-load",
+        "codex:gpt-5.5",
+        sink_for_writer,
+    ));
+    let host = TestHost {
+        command: script.display().to_string(),
+        executor_args: Vec::new(),
+        provider_config: HashMap::new(),
+        sandbox: Some(sandbox_for_test()),
+        task_context: None,
+        workspace_root: None,
+        orbit_registry_root: None,
+        orbit_workspace_selector: None,
+    };
+
+    let outcome = run_cli_backend(
+        &host,
+        &test_agent_loop_spec_for("codex", Duration::from_secs(5)),
+        "test_activity",
+        "job-codex-ca-load",
+        audit,
+        &serde_json::json!({"prompt": "hi"}),
+        None,
+    )
+    .expect("sandboxed Codex fixture loads public CA material");
+
+    assert!(outcome.success);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn run_cli_backend_audit_argv_starts_with_sandbox_exec_for_each_provider() {
     if !sandbox_exec_can_apply_for_test() {
         return;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/spawn.rs
@@ -10,8 +10,9 @@ use super::super::super::dispatcher::ResolvedSandbox;
 use super::super::spawn::{
     SpawnError, SpawnedChild, linux_bwrap_failed_write_diagnostic,
     macos_keychain_auth_diagnostic_with, orbit_tool_env_with,
-    prepare_linux_sandbox_for_dispatch_with_probe, reject_unsatisfiable_managed_grants,
-    resolve_provider_launcher_with, spawn_bare, spawn_macos_sandboxed_with,
+    prepare_linux_sandbox_for_dispatch_with_probe, prepare_macos_codex_ca_environment_with,
+    reject_unsatisfiable_managed_grants, resolve_provider_launcher_with, spawn_bare,
+    spawn_macos_sandboxed_with,
 };
 use super::test_support::{sandbox_for_test, sh_args};
 
@@ -106,6 +107,178 @@ fn spawn_bare_gives_the_child_only_the_supplied_environment() {
             "{leaked} must not reach a bare-exec provider child: {child_env}"
         );
     }
+}
+
+fn env_value<'a>(env: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    env.iter()
+        .rev()
+        .find(|(candidate, _)| candidate == name)
+        .map(|(_, value)| value.as_str())
+}
+
+#[test]
+fn macos_codex_ca_environment_supplies_the_readable_public_bundle_by_default() {
+    let fixture = tempdir().expect("tempdir");
+    let bundle = fixture.path().join("public-ca.pem");
+    std::fs::write(
+        &bundle,
+        "-----BEGIN CERTIFICATE-----\nfixture\n-----END CERTIFICATE-----\n",
+    )
+    .expect("write CA fixture");
+    let input = vec![("HOME".to_string(), "/Users/test".to_string())];
+
+    let prepared = prepare_macos_codex_ca_environment_with("codex", &input, None, &bundle)
+        .expect("readable public CA bundle");
+
+    assert_eq!(
+        env_value(&prepared, "CODEX_CA_CERTIFICATE"),
+        Some(bundle.to_string_lossy().as_ref())
+    );
+    assert_eq!(env_value(&prepared, "SSL_CERT_FILE"), None);
+    assert_eq!(env_value(&prepared, "HOME"), Some("/Users/test"));
+}
+
+#[test]
+fn macos_codex_ca_environment_preserves_explicit_override_precedence() {
+    let fixture = tempdir().expect("tempdir");
+    let codex_bundle = fixture.path().join("codex.pem");
+    let ssl_bundle = fixture.path().join("ssl.pem");
+    let default_bundle = fixture.path().join("default.pem");
+    for path in [&codex_bundle, &ssl_bundle, &default_bundle] {
+        std::fs::write(path, "fixture").expect("write CA fixture");
+    }
+    let env = vec![
+        (
+            "SSL_CERT_FILE".to_string(),
+            ssl_bundle.to_string_lossy().into_owned(),
+        ),
+        (
+            "CODEX_CA_CERTIFICATE".to_string(),
+            codex_bundle.to_string_lossy().into_owned(),
+        ),
+    ];
+
+    let prepared = prepare_macos_codex_ca_environment_with("codex", &env, None, &default_bundle)
+        .expect("explicit Codex CA wins");
+
+    assert_eq!(
+        prepared, env,
+        "an explicit environment must not be rewritten"
+    );
+    assert_eq!(
+        env_value(&prepared, "CODEX_CA_CERTIFICATE"),
+        Some(codex_bundle.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        env_value(&prepared, "SSL_CERT_FILE"),
+        Some(ssl_bundle.to_string_lossy().as_ref())
+    );
+}
+
+#[test]
+fn macos_codex_ca_environment_uses_ssl_cert_file_without_injecting_codex_override() {
+    let fixture = tempdir().expect("tempdir");
+    let ssl_bundle = fixture.path().join("ssl.pem");
+    std::fs::write(&ssl_bundle, "fixture").expect("write CA fixture");
+    let env = vec![(
+        "SSL_CERT_FILE".to_string(),
+        ssl_bundle.to_string_lossy().into_owned(),
+    )];
+
+    let prepared = prepare_macos_codex_ca_environment_with(
+        "codex",
+        &env,
+        None,
+        &fixture.path().join("unused-default.pem"),
+    )
+    .expect("explicit SSL bundle wins over Orbit default");
+
+    assert_eq!(prepared, env);
+    assert_eq!(env_value(&prepared, "CODEX_CA_CERTIFICATE"), None);
+}
+
+#[test]
+fn macos_codex_ca_environment_rejects_selected_missing_material() {
+    let fixture = tempdir().expect("tempdir");
+    let default_bundle = fixture.path().join("default.pem");
+    std::fs::write(&default_bundle, "fixture").expect("write CA fixture");
+
+    let env = vec![(
+        "CODEX_CA_CERTIFICATE".to_string(),
+        fixture
+            .path()
+            .join("missing-explicit.pem")
+            .to_string_lossy()
+            .into_owned(),
+    )];
+    let error = prepare_macos_codex_ca_environment_with("codex", &env, None, &default_bundle)
+        .expect_err("invalid explicit material must not fall back");
+
+    assert!(error.permanent);
+    assert!(error.message.contains("CODEX_CA_CERTIFICATE"));
+    assert!(error.message.contains("readable PEM CA bundle"));
+
+    let error = prepare_macos_codex_ca_environment_with(
+        "codex",
+        &[],
+        None,
+        &fixture.path().join("missing-default.pem"),
+    )
+    .expect_err("a missing Orbit default must fail before provider launch");
+    assert!(error.permanent);
+    assert!(error.message.contains("CODEX_CA_CERTIFICATE"));
+    assert!(error.message.contains("missing-default.pem"));
+}
+
+#[test]
+fn macos_codex_ca_environment_treats_empty_overrides_as_unset() {
+    let fixture = tempdir().expect("tempdir");
+    let ssl_bundle = fixture.path().join("ssl.pem");
+    let default_bundle = fixture.path().join("default.pem");
+    std::fs::write(&ssl_bundle, "fixture").expect("write SSL fixture");
+    std::fs::write(&default_bundle, "fixture").expect("write default fixture");
+    let env = vec![
+        ("CODEX_CA_CERTIFICATE".to_string(), String::new()),
+        (
+            "SSL_CERT_FILE".to_string(),
+            ssl_bundle.to_string_lossy().into_owned(),
+        ),
+    ];
+
+    let prepared = prepare_macos_codex_ca_environment_with("codex", &env, None, &default_bundle)
+        .expect("empty Codex override falls back to explicit SSL_CERT_FILE");
+
+    assert_eq!(prepared, env);
+
+    let empty_env = vec![
+        ("CODEX_CA_CERTIFICATE".to_string(), String::new()),
+        ("SSL_CERT_FILE".to_string(), String::new()),
+    ];
+    let prepared =
+        prepare_macos_codex_ca_environment_with("codex", &empty_env, None, &default_bundle)
+            .expect("empty overrides fall back to Orbit public bundle");
+    assert_eq!(
+        env_value(&prepared, "CODEX_CA_CERTIFICATE"),
+        Some(default_bundle.to_string_lossy().as_ref())
+    );
+}
+
+#[test]
+fn macos_codex_ca_environment_does_not_change_other_providers() {
+    let env = vec![(
+        "CODEX_CA_CERTIFICATE".to_string(),
+        "/missing/operator/value.pem".to_string(),
+    )];
+
+    let prepared = prepare_macos_codex_ca_environment_with(
+        "claude",
+        &env,
+        None,
+        std::path::Path::new("/missing/default.pem"),
+    )
+    .expect("Claude CA handling is unchanged");
+
+    assert_eq!(prepared, env);
 }
 
 /// A path the profile *does* grant is not reported as a denial, so the

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -397,6 +397,66 @@ fn compiled_profile_honors_an_activity_keychain_deny_for_claude() {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn compiled_codex_profile_reads_public_ca_material_but_not_private_credentials() {
+    if !sandbox_exec_can_apply() {
+        return;
+    }
+
+    let fixture = SyntheticKeychainHome::create("codex-ca-access");
+    let ssh = fixture.home.path().join(".ssh");
+    std::fs::create_dir_all(&ssh).expect("synthetic ssh directory");
+    let private_key = ssh.join("id_fixture");
+    std::fs::write(&private_key, "private fixture").expect("write synthetic private key");
+    let public_ca = std::path::Path::new("/etc/ssl/cert.pem");
+    assert!(public_ca.is_file(), "macOS public CA bundle must exist");
+
+    let resolved = ResolvedFsProfile {
+        name: "default".to_string(),
+        read: vec![fixture.home_text()],
+        modify: vec![],
+    };
+    let profile_text = compile_with_env(
+        &resolved,
+        "codex",
+        EnvOverrides {
+            home: Some(&fixture.home_text()),
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        can_read_under_profile(&profile_text, public_ca),
+        "Codex must be able to read the public CA file selected by its child environment"
+    );
+    for private in [&fixture.credential, &private_key] {
+        assert!(
+            !can_read_under_profile(&profile_text, private),
+            "private credential must stay denied: {}",
+            private.display()
+        );
+    }
+
+    let denied = ResolvedFsProfile {
+        name: "deny-public-ca".to_string(),
+        read: vec![fixture.home_text(), "!/etc/ssl/cert.pem".to_string()],
+        modify: vec![],
+    };
+    let denied_profile = compile_with_env(
+        &denied,
+        "codex",
+        EnvOverrides {
+            home: Some(&fixture.home_text()),
+            ..Default::default()
+        },
+    );
+    assert!(
+        !can_read_under_profile(&denied_profile, public_ca),
+        "an explicit denyRead must still outrank the public CA default"
+    );
+}
+
 /// A disposable `$HOME` holding a stand-in login keychain, so keychain tests
 /// exercise the real clause set without touching operator credentials.
 #[cfg(target_os = "macos")]

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -135,6 +135,19 @@ The `Sandbox` trait remains the seam for generic `run_process` callers, but CLI-
 
 The macOS wrapper resolves `sandbox-exec` from trusted absolute locations only, currently `/usr/bin/sandbox-exec`; it does not consult `PATH` for either availability checks or process spawn. If the trusted binary is missing, the runner fails closed unless the executor declares `allow_fallback: true`, and the error names the trusted location that was probed ([T20260509-30]).
 
+The wrapper also prepares Codex's TLS trust input before a sandboxed spawn. Its
+system-Keychain denies prevent Codex's rustls WebSocket transport from
+completing native-root discovery, so the child environment admits explicit
+non-empty `CODEX_CA_CERTIFICATE` and `SSL_CERT_FILE` values for this one provider and
+backend. `CODEX_CA_CERTIFICATE` has precedence, followed by `SSL_CERT_FILE`; if
+neither is present Orbit supplies macOS's public `/etc/ssl/cert.pem` through
+`CODEX_CA_CERTIFICATE`. The selected path must be a readable file or dispatch
+fails permanently with an actionable path-specific error. This changes no TLS
+verification setting and no SBPL credential carve-out: keychain and other
+private-directory denies remain intact, as do later activity-authored
+`denyRead` clauses. Bare Codex, other providers, and Linux retain their prior
+environment and spawn behavior. [ORB-11406]
+
 The compiled macOS profile denies by default, allows broad reads required by agent CLIs and system libraries, allows process/signal/ipc/network/sysctl/iokit operations, and allows writes to:
 
 - scratch/cache roots (`/tmp`, `/private/tmp`, `/private/var/folders`, `/dev`, `$HOME/Library/Caches`)
@@ -277,7 +290,11 @@ Risk-weighted regression tests sit beside the implementations they guard
   (`compiled_profile_denies_reads_to_negated_read_path` and
   `compiled_profile_for_realistic_agent_loop_profile_allows_repo_writes_denies_dotenv`)
   exercise an `agent_loop`-shaped profile end-to-end against the kernel
-  sandbox.
+  sandbox. The Codex CA regression additionally runs a real macOS wrapper,
+  loads one certificate from the injected public PEM bundle, and proves
+  synthetic Keychain material stays unreadable; platform-neutral fixtures pin
+  explicit-variable precedence, missing-path errors, and the exact provider /
+  backend environment boundary ([ORB-11406]).
 - `crates/orbit-store/src/file/policy_def_store/` — policy resource
   name tests reject traversal-shaped names such as `../x` before path
   construction and assert no file is written outside the policy store


### PR DESCRIPTION
## Automatic conflict recovery exhausted

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline exhausted its single system-crew conflict-recovery attempt. This PR is intentionally blocked; inspect the recorded attempt and reconcile the named conflict before retrying delivery.

- Task: `ORB-11406`
- Run: `jrun-20260906-1854-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `5d9c83c11fb724d2359bd75e66f4ff206057d625`
- Target base: `c724921a18f61e3ff09cd39feb12af42d478e2e0`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0
```