### PR TITLE
Prepare v0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.19.0
+
+### Breaking Changes
+
+- **Task-pilot activity schemas migrated**: custom `prepare_task_pilot`, `task_pilot`, and `apply_task_pilot_results` payloads must use the current required fields and `succeeded|failed` status contract. ([ORB-11330], [ORB-11331])
+- **CI-failure filing schema migrated**: custom `file_ci_failure_tasks` producers must supply pilot partitions and match evidence under the current activity contract. ([ORB-11331])
+
+### Highlights
+
+- **More provider lanes and effort controls**: crews can forward validated effort settings, and Pi, OpenCode, and Antigravity join the supported executor catalog. ([ORB-11279], [ORB-11286], [ORB-11295], [ORB-11296], [ORB-11299])
+- **Task artifacts render safely**: retrieve task attachments through the new read-only tool, with bounded presentation for validated raster images. ([ORB-11413])
+- **Safer source-remote changes**: inspect or rebind a workspace source remote while preserving workspace, task, and checkout identity. ([ORB-11426])
+- **Operator-controlled agent investigation**: authorized operators can invoke a bounded host-side agent run for diagnostics without changing task delivery state. ([ORB-11354])
+- **Constellation-works distribution cutover**: active distribution references and the pre-release checklist now point to the current project owner. ([ORB-11427])
+
 ## 0.18.0
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-automation"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "croner",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "flate2",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "hostname",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,7 @@ CLI behavior, state layout, or recovery semantics change.
 | [Check Orbit Health](./runbooks/health-checks.md) | Check Orbit workspace, database, dashboard, log-sink, job-run, and routine-clock health. |
 | [Prepare a Linux Host for Sandboxed Dispatch](./runbooks/linux-sandbox.md) | Install and verify the Bubblewrap host prerequisite that Orbit's Linux sandbox fails closed without. |
 | [Inspect and Retain Logs](./runbooks/logging.md) | Locate, filter, rotate, and retain Orbit process and routine-sweep logs. |
+| [Post-v0.18.0 release survey](./runbooks/release-survey.md) | Post-v0.18.0 release survey and breaking-change handoff. |
 | [Release Orbit](./runbooks/release.md) | Cut and verify an Orbit release across agent plugins, Cargo, GitHub artifacts, Homebrew, and npm. |
 | [Inventory and Protect Orbit State](./runbooks/state-and-backup.md) | Locate Orbit state and perform WAL-safe backups, explicit task publication, restores, and task migrations. |
 | [Recover Stuck Job Runs](./runbooks/stuck-job-runs.md) | Diagnose, cancel, resume, or replay pending and running Orbit job runs. |

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "danieljhkim",

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "danieljhkim",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
-  "version": "0.18.0",
+  "version": "0.19.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11434](https://orbit-cli.com/tasks/ORB-11434) — Prepare v0.19.0 release

### Description

Prepare the first constellation-works release, v0.19.0, following RELEASING.md and docs/runbooks/release.md. Daniel explicitly confirmed v0.19.0 on 2026-09-06: ORB-11330/11331 task-pilot and CI activity schemas are breaking; ORB-11299 Antigravity defaults and ORB-11294 cli_command alias to local_shell are compatibility-preserving. Survey ORB-11432 is landed at docs/runbooks/release-survey.md; verify changes since its pinned head for additional release-relevant changes and report new breaking candidates instead of silently classifying.
Use a dedicated worktree from latest origin/agent-main. Bump the seven specified version-bearing files including Cargo.lock without third-party drift. Draft concise consumer-facing CHANGELOG with every confirmed breaking change and 3-6 highlights. Preserve historical changelog. Validate build, ci-fast, ci-lint, release-check, dry-run npm version assertion, plugin install smoke, and managed mirror checks; report actual failures/missing tools without calling them passed. Any smoke fixes needed at tag must be included now. No tag, GitHub release, npm publish, main promotion, MCP publication, credential changes or personal tap modifications in this leaf: orchestrator handles those after landing. Completion through PR merge into agent-main is authorized by Daniel's migration-to-completion request and release confirmation.

### Acceptance Criteria

- Cargo workspace, npm, server.json both versions, all three plugin manifests and workspace lock entries consistently report 0.19.0; no third-party dependency drift.
- CHANGELOG has concise v0.19.0 breaking-schema migration note and 3-6 evidence-backed user-facing highlights following style; frozen sections untouched.
- Run prescribed build, CI and distribution checks; record exact outcomes and blockers; managed mirrors remain consistent.
- Validated scoped candidate delivered via PR into agent-main with exact commit and check evidence; no immutable publication or private/personal repository mutation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Bumped workspace, npm, MCP registry, and all three plugin manifest versions to 0.19.0.
- Refreshed Cargo.lock with exactly 17 Orbit workspace members; no third-party dependency entries moved.
- Added concise 0.19.0 breaking-schema migration notes for the approved task-pilot and CI-failure contracts plus five evidence-backed highlights; released sections remain untouched.
- Regenerated docs/INDEX.md because the committed release-survey runbook was absent from its managed index, which ci-fast detected.

Criteria:
- Version lockstep: satisfied across Cargo.toml, Cargo.lock workspace package entries, npm/package.json, both server.json version fields, and all plugin manifests.
- Changelog: satisfied with two breaking migration bullets and five user-facing highlights.
- Validation and mirrors: satisfied except for the intentionally pre-publication remote-release comparison described below.
- Delivery: scoped uncommitted candidate is ready for the managed pipeline; this activity correctly leaves commit, PR creation, and agent-main delivery to the pipeline.

Survey delta:
- Reviewed d06324053ad858ec9200933834532eff7c138e75..28fbdc7527c3278f4d926a56f3137e44b0589a65. It contains only the landed ORB-11432 release survey; no new release-relevant or breaking candidates were introduced after its pinned head.

Validation:
- Passed: cargo update --workspace (only 17 Orbit workspace packages relocked).
- Passed: make build.
- Passed: make ci-fast (including changelog style, generated docs index, activity asset mirror, plugin-skill mirror, Codex and Agent Plugin validation, and plugin install smoke).
- Passed: make ci-lint.
- Passed: ./scripts/smoke-npm-install.sh --dry-run-version-assertion (mismatch rejection assertion).
- Passed: git diff --check.
- Expected pre-publication failure: make release-check. Structural metadata lockstep passed; mcp-publisher and npm were unavailable, and the remote latest GitHub release is 0.18.0, so the required remote-drift comparison rejected unreleased 0.19.0. Resolving that would require the prohibited tag/release/npm publication steps.

Assessment: focused release candidate with no third-party drift and consistent managed mirrors.
Risks:
- The pipeline must commit this exact nine-file diff and open the authorized PR into agent-main; no commit or PR exists yet because the managed activity owns those transitions.
- The post-publication release-check and network npm smoke remain release-operator responsibilities.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11434-6a9dc0ef`
- Behind base: 0
- Ahead of base: 1