### PR TITLE
Add manual MCP Registry publication using dedicated Actions PAT

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,225 @@
+name: publish-mcp-registry
+
+# Registry publication is deliberately an operator-approved action. A release
+# tag and its public npm package must already exist before this workflow runs.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to publish (for example, v0.19.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release:
+    name: Verify published release tag
+    runs-on: ubuntu-22.04
+    outputs:
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
+    steps:
+      - name: Resolve the published immutable release tag
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "tag must be an explicit vMAJOR.MINOR.PATCH release tag" >&2
+            exit 1
+          fi
+
+          tag_path="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
+          request_json() {
+            curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GITHUB_TOKEN" \
+              "$1"
+          }
+
+          release_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$tag_path")"
+          if ! jq -e --arg tag "$RELEASE_TAG" \
+            '.tag_name == $tag and .draft == false' <<<"$release_json" >/dev/null; then
+            echo "tag must resolve to a published, non-draft GitHub release" >&2
+            exit 1
+          fi
+
+          ref_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/ref/tags/$tag_path")"
+          object_type="$(jq -er '.object.type' <<<"$ref_json")"
+          commit_sha="$(jq -er '.object.sha' <<<"$ref_json")"
+          if [[ "$object_type" == "tag" ]]; then
+            tag_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/tags/$commit_sha")"
+            object_type="$(jq -er '.object.type' <<<"$tag_json")"
+            commit_sha="$(jq -er '.object.sha' <<<"$tag_json")"
+          fi
+          if [[ "$object_type" != "commit" || ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release tag must resolve directly to a commit" >&2
+            exit 1
+          fi
+
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish MCP Registry record
+    needs: verify-release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the verified release commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.verify-release.outputs.commit_sha }}
+
+      - name: Verify the registry and npm publication contract
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_TAG#v}"
+          SERVER_NAME="io.github.constellation-works/orbit"
+          NPM_PACKAGE="@orbit-tools/cli"
+          npm_metadata="$(curl --fail --location --silent --show-error \
+            "https://registry.npmjs.org/%40orbit-tools%2Fcli/$VERSION")"
+
+          if ! jq -e \
+            --arg name "$SERVER_NAME" \
+            --arg package "$NPM_PACKAGE" \
+            --arg version "$VERSION" '
+              .name == $name
+              and .version == $version
+              and (.packages | length == 1)
+              and .packages[0].registryType == "npm"
+              and .packages[0].identifier == $package
+              and .packages[0].version == $version
+              and .packages[0].transport.type == "stdio"
+              and ([.packages[0].packageArguments[] | [.type, .value]] == [["positional", "mcp"], ["positional", "serve"]])
+              and ([.. | strings | select(. == "--operator")] | length == 0)
+            ' server.json >/dev/null; then
+            echo "server.json must match the fixed non-operator registry contract" >&2
+            exit 1
+          fi
+          if ! jq -e --arg version "$VERSION" --arg name "$SERVER_NAME" \
+            '.version == $version and .mcpName == $name' <<<"$npm_metadata" >/dev/null; then
+            echo "published npm package lacks the matching version or MCP ownership marker" >&2
+            exit 1
+          fi
+
+      - name: Download and verify the pinned MCP publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive="$(mktemp)"
+          trap 'rm -f "$archive"' EXIT
+          curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+            'https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz' \
+            --output "$archive"
+          printf '%s  %s\n' \
+            'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc' \
+            "$archive" | sha256sum --check --status -
+          tar xzf "$archive" mcp-publisher
+          chmod 755 mcp-publisher
+
+      - name: Validate registry metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mcp-publisher validate server.json >/dev/null
+          echo "MCP Registry metadata validated"
+
+      - name: Require an active constellation-works owner grant
+        shell: bash
+        env:
+          MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MCP_REGISTRY_PAT_TOKEN:-}" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN is required; grant its owner Organization permissions: Members read" >&2
+            exit 1
+          fi
+
+          page=1
+          membership=''
+          while :; do
+            response="$(curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $MCP_REGISTRY_PAT_TOKEN" \
+              "https://api.github.com/user/memberships/orgs?state=active&per_page=100&page=$page")"
+            selected="$(jq -c '[.[] | select(.organization.login == "constellation-works") | {state, role}]' <<<"$response")"
+            if [[ "$selected" != '[]' ]]; then
+              membership="$selected"
+              break
+            fi
+            if [[ "$(jq 'length' <<<"$response")" -lt 100 ]]; then
+              break
+            fi
+            ((page += 1))
+          done
+
+          if [[ -z "$membership" ]]; then
+            echo "constellation-works membership: state=missing role=missing" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            exit 1
+          fi
+          state="$(jq -er '.[0].state' <<<"$membership")"
+          role="$(jq -er '.[0].role' <<<"$membership")"
+          echo "constellation-works membership: state=$state role=$role"
+          if [[ "$state" != "active" || "$role" != "owner" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            exit 1
+          fi
+
+      - name: Authenticate and publish
+        shell: bash
+        env:
+          MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          publisher_output="$(mktemp)"
+          trap 'rm -f "$publisher_output"' EXIT
+          if ! ./mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN" >"$publisher_output" 2>&1; then
+            echo "MCP Registry authentication failed; verify the dedicated token's owner grant" >&2
+            exit 1
+          fi
+          if ! ./mcp-publisher publish server.json >"$publisher_output" 2>&1; then
+            echo "MCP Registry publication failed; inspect registry availability and validated metadata" >&2
+            exit 1
+          fi
+          echo "MCP Registry publication completed"
+
+      - name: Verify the public registry record
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_TAG#v}"
+          SERVER_NAME="io.github.constellation-works/orbit"
+          server_path="$(jq -rn --arg value "$SERVER_NAME" '$value | @uri')"
+          published="$(curl --fail --location --silent --show-error \
+            "https://registry.modelcontextprotocol.io/v0.1/servers/$server_path/versions/$VERSION")"
+          if ! jq -e --arg name "$SERVER_NAME" --arg version "$VERSION" '
+            .server.name == $name
+            and .server.version == $version
+            and (.server.packages | length == 1)
+            and .server.packages[0].identifier == "@orbit-tools/cli"
+            and .server.packages[0].version == $version
+            and ([.server.packages[0].packageArguments[] | [.type, .value]] == [["positional", "mcp"], ["positional", "serve"]])
+          ' <<<"$published" >/dev/null; then
+            echo "public registry record does not match the expected name, version, and package arguments" >&2
+            exit 1
+          fi
+          echo "Public MCP Registry record matches $SERVER_NAME@$VERSION"

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -145,6 +145,49 @@ date has passed or its `revoked_at` field is set.
    before npm publish and is expected to fail its version assertion; the
    post-publish versioned run must be green.
 
+## Publish the Official MCP Registry record
+
+After the GitHub Release and its matching `@orbit-tools/cli` version are
+public, a repository maintainer may manually dispatch the
+`publish-mcp-registry` workflow. It never runs from a push or tag event.
+
+1. Confirm the release tag is published and non-draft, and that its
+   `server.json`, `npm/package.json`, and public npm metadata all identify
+   `io.github.constellation-works/orbit`, `@orbit-tools/cli`, and the tag
+   version. The registry command remains exactly `mcp serve`; it must not
+   include `--operator`.
+2. In GitHub Actions, select **publish-mcp-registry**, choose a trusted
+   repository ref containing the workflow, and supply the explicit release tag
+   (for example, `v0.19.0`). The workflow resolves that tag to a commit after
+   checking its published, non-draft GitHub Release, then checks out that
+   commit. It does not check out or publish an arbitrary input ref.
+3. Review the public readback step. It verifies the registry name, version,
+   npm package, and fixed `mcp serve` package arguments after publishing.
+
+The workflow's only credential is the repository Actions secret
+`MCP_REGISTRY_PAT_TOKEN`. Keep it dedicated to this purpose: it is used only
+for the GitHub membership preflight and the official `mcp-publisher login
+github --token` exchange. Do not substitute a personal `gh` credential or the
+Homebrew TAP token, and never paste the PAT into workflow inputs or logs.
+
+The preflight calls GitHub's active organization-memberships endpoint and
+requires the selected `constellation-works` membership to be `active` with
+role `owner`. Configure the PAT with read-only GitHub access sufficient to
+read that organization membership: for a fine-grained PAT, select the
+`constellation-works` organization and grant **Organization permissions →
+Members: Read-only**. It needs no write, repository-content, or TAP access;
+the workflow uses its read-only `GITHUB_TOKEN` to inspect the public release.
+Do not broaden the PAT automatically if the preflight fails. A `missing` or
+non-owner result means an organization owner must correct the dedicated
+token's grant before another manual dispatch. The workflow prints only the
+selected membership state and role, never tokens, authorization headers, raw
+JWTs, or raw authentication responses.
+
+The workflow downloads `mcp-publisher` v1.8.1 for Linux amd64 and verifies its
+SHA-256 before validating metadata, authenticating, and publishing. It is safe
+to rerun only after resolving a failed preflight or public-readback error; npm
+versions and release tags are immutable.
+
 ## Continuous npm-install verification
 
 The `smoke-npm-install.yml` workflow runs on macOS and Ubuntu weekly, on every

--- a/scripts/test-mcp-registry-publish-workflow.sh
+++ b/scripts/test-mcp-registry-publish-workflow.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression checks for the manual MCP Registry publication security boundary.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workflow="$repo_root/.github/workflows/publish-mcp-registry.yml"
+
+require() {
+  local description="$1"
+  local text="$2"
+
+  if ! grep --fixed-strings --quiet -- "$text" "$workflow"; then
+    echo "missing $description" >&2
+    exit 1
+  fi
+}
+
+forbid() {
+  local description="$1"
+  local text="$2"
+
+  if grep --fixed-strings --quiet -- "$text" "$workflow"; then
+    echo "forbidden $description" >&2
+    exit 1
+  fi
+}
+
+require "manual trigger" "workflow_dispatch:"
+forbid "automatic push publication" "  push:"
+require "strict release tag validation" "tag must be an explicit vMAJOR.MINOR.PATCH release tag"
+require "published-release check" "published, non-draft GitHub release"
+require "commit-pinned checkout" 'ref: ${{ needs.verify-release.outputs.commit_sha }}'
+forbid "unchecked input checkout" 'ref: ${{ inputs.tag }}'
+require "exact active-membership endpoint" "/user/memberships/orgs?state=active&per_page=100&page=\$page"
+require "owner-role check" '"$state" != "active" || "$role" != "owner"'
+require "pinned publisher version" "releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz"
+require "publisher checksum" "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+require "official token login" './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"'
+require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's owner grant"
+require "public record verification" "registry.modelcontextprotocol.io/v0.1/servers/\$server_path/versions/\$VERSION"
+require "public registry response handling" ".server.name == \$name"
+forbid "secret echo" 'echo "$MCP_REGISTRY_PAT_TOKEN"'
+
+echo "MCP Registry publication workflow checks passed"


### PR DESCRIPTION
## Task

[ORB-11436](https://orbit-cli.com/tasks/ORB-11436) — Add manual MCP Registry publication using dedicated Actions PAT

### Description

Finish the authorized constellation-works migration registry publication path. Daniel added repository Actions secret MCP_REGISTRY_PAT_TOKEN on 2026-09-06T20:30:21Z specifically for MCP Registry publication. Existing local dedicated-token authentication still gets personal-only namespace403 despite verified public active org owner. Implement a manual workflow_dispatch workflow for an explicit immutable release tag (initial v0.19.0), not automatic publishing on arbitrary pushes. Use secret only for official GitHub owner-role preflight and official registry token exchange; never print credentials, auth headers, raw JWTs or unfiltered auth responses. Read-only GitHub token permissions. Do not use broader gh CLI credentials or TAP token.
Verify release tag resolves to published non-draft GitHub release, server name io.github.constellation-works/orbit, npm identity @orbit-tools/cli, both versions match tag, fixed mcp serve no operator, published npm version ownership marker. Pin official mcp-publisher v1.8.1 Linux amd64 archive to SHA256 a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc. Validate metadata then authenticate and publish with supported --token method. Preflight the exact /user/memberships/orgs?state=active endpoint used by registry, handling pagination and emit only selected constellation-works membership state/role and actionable missing-grant error. Do not broaden token permissions automatically. Preserve versions/tags/assets/personal tap. Workflow is operator-triggered; no publish during implementation. Add minimal focused tests and release runbook invocation/troubleshooting. Dedicated worktree PR to agent-main, completion authorized; orchestrator reviews and dispatches after landing. Existing ORB11030 done summary actually says publication blocked and no listing, so this is not duplicate delivered workflow.

### Acceptance Criteria

- Manual workflow validates explicit published immutable tag, matching server/npm identity and versions before publication; no arbitrary ref injection or operator launch.
- Dedicated PAT remains secret; exact owner-role preflight fail-closes with sanitized actionable evidence and no publication on insufficient grant.
- Pinned publisher artifact is checksum verified; official validate/login/publish and public readback verify name/version/package arguments.
- Focused tests and workflow syntax/security checks pass; runbook documents secret permissions and manual usage; scoped PR landed without triggering publication.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added .github/workflows/publish-mcp-registry.yml: an operator-only workflow_dispatch workflow that accepts a strict release tag, requires its published non-draft GitHub Release, resolves that tag to a commit, and checks out only that SHA.
- The workflow validates the exact io.github.constellation-works/orbit and @orbit-tools/cli versioned non-operator mcp serve contract and the public npm ownership marker before publication.
- It downloads official Linux amd64 mcp-publisher v1.8.1, verifies SHA-256 a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc, validates metadata, then uses only MCP_REGISTRY_PAT_TOKEN for the paginated active-membership owner preflight and supported login github --token exchange. Publisher and authentication output is suppressed in favor of sanitized failures.
- Added a focused workflow security regression script and documented manual dispatch, the fine-grained PAT Organization Members: Read-only grant, fail-closed owner check, and public registry readback in docs/runbooks/release.md.
Criteria:
- Manual immutable-tag publication: satisfied by strict tag validation, published non-draft release lookup, commit-SHA checkout, and no push/tag trigger.
- Secret and owner-role preflight: satisfied by paginated exact active-membership query, selected state/role-only output, active-owner gate, and no fallback or permission broadening.
- Publisher and public verification: satisfied by pinned checksum verification, official validate/login/publish commands, npm ownership validation, and public registry response validation of server name/version/package arguments.
- Tests, syntax/security, and runbook: satisfied by focused security checks, YAML parsing, workspace CI checks, and updated runbook. Publication was not invoked; commits and PR delivery remain pipeline-owned.
Validation:
- Passed: ./scripts/test-mcp-registry-publish-workflow.sh (manual trigger, commit pinning, owner check, token/login sanitization, checksum, and public-readback guards).
- Passed: Python YAML parser for .github/workflows/publish-mcp-registry.yml.
- Passed: make ci-fast.
- Passed: make ci-lint (cargo clippy --workspace --all-targets -- -D warnings).
- Passed: git diff --check.
- Not run: actionlint was not installed in the worktree environment. The focused security regression script and YAML parser supplied available workflow validation.
Assessment: The deliverable is scoped to the requested manual publication path. No release, npm publication, registry publication, secret value, or external PR action was triggered.
Design weaknesses / risks:
- Severity: low. Registry authentication and public readback require a real manual dispatch against an already released npm version; intentionally not exercised here to avoid publication. Mitigation: the workflow fails before authentication on all preceding contract checks and performs post-publish public readback.
- Severity: low. GitHub tag mutability must still be protected by repository tag-protection policy; this workflow resolves the selected tag once and checks out its resulting immutable commit SHA.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11436-6a9dcdc9`
- Behind base: 0
- Ahead of base: 1