### PR TITLE
Fix MCP Registry owner preflight to accept GitHub admin role

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -137,7 +137,7 @@ jobs:
           ./mcp-publisher validate server.json >/dev/null
           echo "MCP Registry metadata validated"
 
-      - name: Require an active constellation-works owner grant
+      - name: Require an active constellation-works administrator membership
         shell: bash
         env:
           MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
@@ -145,7 +145,7 @@ jobs:
           set -euo pipefail
 
           if [[ -z "${MCP_REGISTRY_PAT_TOKEN:-}" ]]; then
-            echo "MCP_REGISTRY_PAT_TOKEN is required; grant its owner Organization permissions: Members read" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN is required; select constellation-works and grant Organization permissions: Members read" >&2
             exit 1
           fi
 
@@ -169,14 +169,14 @@ jobs:
 
           if [[ -z "$membership" ]]; then
             echo "constellation-works membership: state=missing role=missing" >&2
-            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works admin membership; do not broaden permissions automatically" >&2
             exit 1
           fi
           state="$(jq -er '.[0].state' <<<"$membership")"
           role="$(jq -er '.[0].role' <<<"$membership")"
           echo "constellation-works membership: state=$state role=$role"
-          if [[ "$state" != "active" || "$role" != "owner" ]]; then
-            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+          if [[ "$state" != "active" || "$role" != "admin" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works admin membership; do not broaden permissions automatically" >&2
             exit 1
           fi
 
@@ -190,7 +190,7 @@ jobs:
           publisher_output="$(mktemp)"
           trap 'rm -f "$publisher_output"' EXIT
           if ! ./mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN" >"$publisher_output" 2>&1; then
-            echo "MCP Registry authentication failed; verify the dedicated token's owner grant" >&2
+            echo "MCP Registry authentication failed; verify the dedicated token's active constellation-works admin membership" >&2
             exit 1
           fi
           if ! ./mcp-publisher publish server.json >"$publisher_output" 2>&1; then

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -172,13 +172,14 @@ Homebrew TAP token, and never paste the PAT into workflow inputs or logs.
 
 The preflight calls GitHub's active organization-memberships endpoint and
 requires the selected `constellation-works` membership to be `active` with
-role `owner`. Configure the PAT with read-only GitHub access sufficient to
+role `admin` (GitHub's API value for an organization administrator). Configure
+the PAT with read-only GitHub access sufficient to
 read that organization membership: for a fine-grained PAT, select the
 `constellation-works` organization and grant **Organization permissions →
 Members: Read-only**. It needs no write, repository-content, or TAP access;
 the workflow uses its read-only `GITHUB_TOKEN` to inspect the public release.
 Do not broaden the PAT automatically if the preflight fails. A `missing` or
-non-owner result means an organization owner must correct the dedicated
+non-admin result means an organization administrator must correct the dedicated
 token's grant before another manual dispatch. The workflow prints only the
 selected membership state and role, never tokens, authorization headers, raw
 JWTs, or raw authentication responses.

--- a/scripts/test-mcp-registry-publish-workflow.sh
+++ b/scripts/test-mcp-registry-publish-workflow.sh
@@ -32,13 +32,142 @@ require "published-release check" "published, non-draft GitHub release"
 require "commit-pinned checkout" 'ref: ${{ needs.verify-release.outputs.commit_sha }}'
 forbid "unchecked input checkout" 'ref: ${{ inputs.tag }}'
 require "exact active-membership endpoint" "/user/memberships/orgs?state=active&per_page=100&page=\$page"
-require "owner-role check" '"$state" != "active" || "$role" != "owner"'
+require "administrator-role check" '"$state" != "active" || "$role" != "admin"'
 require "pinned publisher version" "releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz"
 require "publisher checksum" "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
 require "official token login" './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"'
-require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's owner grant"
+require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's active constellation-works admin membership"
 require "public record verification" "registry.modelcontextprotocol.io/v0.1/servers/\$server_path/versions/\$VERSION"
 require "public registry response handling" ".server.name == \$name"
 forbid "secret echo" 'echo "$MCP_REGISTRY_PAT_TOKEN"'
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+preflight="$temporary_directory/preflight.sh"
+awk '
+  /      - name: Require an active constellation-works administrator membership/ { in_step = 1 }
+  /      - name: Authenticate and publish/ { exit }
+  in_step && /^        run: \|$/ { in_run = 1; next }
+  in_run { sub(/^          /, ""); print }
+' "$workflow" > "$preflight"
+chmod 700 "$preflight"
+
+if ! grep --fixed-strings --quiet -- '"$role" != "admin"' "$preflight"; then
+  echo "extracted production preflight does not require the GitHub admin role" >&2
+  exit 1
+fi
+
+preflight_line="$(grep --line-number --fixed-strings -- 'Require an active constellation-works administrator membership' "$workflow" | cut --delimiter=: --fields=1)"
+publisher_login_line="$(grep --line-number --fixed-strings -- './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"' "$workflow" | cut --delimiter=: --fields=1)"
+if [[ "$preflight_line" -ge "$publisher_login_line" ]]; then
+  echo "membership preflight must run before publisher login" >&2
+  exit 1
+fi
+
+fixture_token='fixture-token-must-not-be-logged'
+raw_auth_payload='fixture-raw-auth-payload-must-not-be-logged'
+mock_bin="$temporary_directory/bin"
+mkdir "$mock_bin"
+
+jq -n '[range(0; 100) | {state: "active", role: "member", organization: {login: ("other-" + tostring)}}]' \
+  > "$temporary_directory/page-one.json"
+jq -n '[{state: "active", role: "admin", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/page-two-admin.json"
+jq -n '[{state: "active", role: "member", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/member.json"
+jq -n '[{state: "active", role: "owner", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/owner.json"
+jq -n '[{state: "pending", role: "admin", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/pending.json"
+jq -n '[{state: "active", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/malformed.json"
+jq -n '[{state: "active", role: "member", organization: {login: "another-org"}}]' \
+  > "$temporary_directory/missing.json"
+
+cat > "$mock_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${!#}"
+printf '%s\n' "$url" >> "$MCP_TEST_REQUEST_LOG"
+
+has_expected_authorization=false
+for argument in "$@"; do
+  if [[ "$argument" == "Authorization: Bearer $MCP_REGISTRY_PAT_TOKEN" ]]; then
+    has_expected_authorization=true
+  fi
+done
+if [[ "$has_expected_authorization" != true ]]; then
+  echo "mock curl did not receive the dedicated authorization header" >&2
+  exit 64
+fi
+
+if [[ "$MCP_TEST_CASE" == "api-error" ]]; then
+  printf '%s\n' "$MCP_TEST_RAW_AUTH_PAYLOAD"
+  echo "simulated GitHub API failure" >&2
+  exit 22
+fi
+
+case "$MCP_TEST_CASE:$url" in
+  admin-page-two:*'page=1') cat "$MCP_TEST_FIXTURES/page-one.json" ;;
+  admin-page-two:*'page=2') cat "$MCP_TEST_FIXTURES/page-two-admin.json" ;;
+  member:*) cat "$MCP_TEST_FIXTURES/member.json" ;;
+  owner:*) cat "$MCP_TEST_FIXTURES/owner.json" ;;
+  pending:*) cat "$MCP_TEST_FIXTURES/pending.json" ;;
+  malformed:*) cat "$MCP_TEST_FIXTURES/malformed.json" ;;
+  missing:*) cat "$MCP_TEST_FIXTURES/missing.json" ;;
+  *) echo "unexpected mock curl request" >&2; exit 64 ;;
+esac
+EOF
+chmod 700 "$mock_bin/curl"
+
+run_preflight_case() {
+  local case_name="$1"
+  local expected_status="$2"
+  local require_page_two="$3"
+  local output="$temporary_directory/$case_name.output"
+  local request_log="$temporary_directory/$case_name.requests"
+  local status
+
+  if PATH="$mock_bin:$PATH" \
+    MCP_REGISTRY_PAT_TOKEN="$fixture_token" \
+    MCP_TEST_CASE="$case_name" \
+    MCP_TEST_FIXTURES="$temporary_directory" \
+    MCP_TEST_REQUEST_LOG="$request_log" \
+    MCP_TEST_RAW_AUTH_PAYLOAD="$raw_auth_payload" \
+    bash "$preflight" >"$output" 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ "$expected_status" == success && "$status" -ne 0 ]]; then
+    echo "preflight case $case_name unexpectedly failed" >&2
+    sed -n '1,80p' "$output" >&2
+    exit 1
+  fi
+  if [[ "$expected_status" == failure && "$status" -eq 0 ]]; then
+    echo "preflight case $case_name unexpectedly succeeded" >&2
+    exit 1
+  fi
+  if [[ "$require_page_two" == true ]] && ! grep --fixed-strings --quiet -- 'page=2' "$request_log"; then
+    echo "preflight case $case_name did not request the second membership page" >&2
+    exit 1
+  fi
+  if grep --fixed-strings --quiet -- "$fixture_token" "$output" \
+    || grep --fixed-strings --quiet -- "$raw_auth_payload" "$output"; then
+    echo "preflight case $case_name exposed a sensitive fixture value" >&2
+    exit 1
+  fi
+}
+
+run_preflight_case admin-page-two success true
+run_preflight_case member failure false
+run_preflight_case owner failure false
+run_preflight_case pending failure false
+run_preflight_case missing failure false
+run_preflight_case malformed failure false
+run_preflight_case api-error failure false
 
 echo "MCP Registry publication workflow checks passed"


### PR DESCRIPTION
## Task

[ORB-11437](https://orbit-cli.com/tasks/ORB-11437) — Fix MCP Registry owner preflight to accept GitHub admin role

### Description

## Problem
ORB-11436 / PR1451 merge95bd09c introduced .github/workflows/publish-mcp-registry.yml testing membership role == owner. GitHub GET /user/memberships/orgs reports organization owners as role admin, so valid dedicated credentials fail closed incorrectly.
## Scope
Correct the production preflight and replace/add meaningful behavioral fixture tests exercising the actual workflow logic (not merely asserting source strings). Cover pagination and sanitized fail-closed behavior. Update runbook owner/API role terminology as needed. Keep manual trigger, immutable release resolution, dedicated secret use, publisher checksum, non-operator contract and publication safety unchanged. No live credential use, no registry publishing, no main promotion or branch-rule changes in leaf. Orchestrator will promote the delivered workflow to main separately after verifying landing. Daniel explicitly authorized filing, delivery and main promotion on 2026-09-06.
## Evidence
https://docs.github.com/en/rest/orgs/members#list-organization-memberships-for-the-authenticated-user documents admin role. Current role != owner rejects active admin. Current workflow absent from main and Actions workflow roster.
## Constraints
Dedicated worktree from agent-main, scoped PR. Do not repair unrelated CI debt. Avoid generalized auth framework; smallest testable seam.

### Acceptance Criteria

- Actual preflight accepts active constellation-works role admin and rejects member, pending, missing and malformed/API-error cases before publisher login.
- Deterministic mocked tests execute production preflight logic including target on page two; reverting admin to owner makes acceptance test fail. No network or real secrets needed.
- Sensitive fixture sentinel tokens/raw auth payloads never appear in test output; no fallback or permission broadening; pinned publisher and manual-only guards preserved.
- Focused tests and relevant checks pass, failures explicitly recorded, scoped PR lands on agent-main. No live registry publication or main rule changes by worker.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Changed the MCP Registry membership preflight to require GitHub’s documented active `admin` role, with fail-closed missing, malformed, and request-error behavior retained.
- Replaced the membership source-text assertion with deterministic mocked execution of the extracted production preflight: an `admin` target on page two succeeds; `member`, legacy `owner`, `pending`, missing, malformed, and API-error cases fail before publisher login. The test also rejects fixture token/raw-response leakage.
- Updated the release runbook to use the GitHub API `admin` role terminology. Manual dispatch, immutable checkout, fixed non-operator contract, pinned publisher checksum, and dedicated-token boundary remain guarded.

Criteria:
- Active `constellation-works` `admin` succeeds and all requested invalid cases fail in the focused behavioral test.
- Pagination is exercised with a 100-record first page and a target on page two; the test uses a PATH-scoped curl mock and no network or real secrets.
- Fixture sentinels are checked against captured output; legacy `owner` is rejected, preventing a fallback or permission broadening.
- Changes remain scoped to the workflow, its focused test, and the release runbook. Delivery/PR landing on `agent-main` is intentionally left to the managed pipeline.

Validation:
- Passed: `bash -n scripts/test-mcp-registry-publish-workflow.sh`
- Passed: `./scripts/test-mcp-registry-publish-workflow.sh`
- Passed: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/publish-mcp-registry.yml", encoding="utf-8")); print("publish-mcp-registry workflow YAML parses")'`
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `git diff --check`
- Not run: live GitHub/registry publication (intentionally prohibited; tests use mocks only).

Assessment: The workflow now matches GitHub’s membership-role API while preserving fail-closed authorization and publication safety. No remaining implementation risk identified; managed delivery owns commit and PR creation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11437-6a9dd5cf`
- Behind base: 0
- Ahead of base: 1