### PR TITLE
Promote MCP Registry publication workflow and admin-role fix

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -137,7 +137,7 @@ jobs:
           ./mcp-publisher validate server.json >/dev/null
           echo "MCP Registry metadata validated"
 
-      - name: Require an active constellation-works owner grant
+      - name: Require an active constellation-works administrator membership
         shell: bash
         env:
           MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
@@ -145,7 +145,7 @@ jobs:
           set -euo pipefail
 
           if [[ -z "${MCP_REGISTRY_PAT_TOKEN:-}" ]]; then
-            echo "MCP_REGISTRY_PAT_TOKEN is required; grant its owner Organization permissions: Members read" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN is required; select constellation-works and grant Organization permissions: Members read" >&2
             exit 1
           fi
 
@@ -169,14 +169,14 @@ jobs:
 
           if [[ -z "$membership" ]]; then
             echo "constellation-works membership: state=missing role=missing" >&2
-            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works admin membership; do not broaden permissions automatically" >&2
             exit 1
           fi
           state="$(jq -er '.[0].state' <<<"$membership")"
           role="$(jq -er '.[0].role' <<<"$membership")"
           echo "constellation-works membership: state=$state role=$role"
-          if [[ "$state" != "active" || "$role" != "owner" ]]; then
-            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+          if [[ "$state" != "active" || "$role" != "admin" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works admin membership; do not broaden permissions automatically" >&2
             exit 1
           fi
 
@@ -190,7 +190,7 @@ jobs:
           publisher_output="$(mktemp)"
           trap 'rm -f "$publisher_output"' EXIT
           if ! ./mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN" >"$publisher_output" 2>&1; then
-            echo "MCP Registry authentication failed; verify the dedicated token's owner grant" >&2
+            echo "MCP Registry authentication failed; verify the dedicated token's active constellation-works admin membership" >&2
             exit 1
           fi
           if ! ./mcp-publisher publish server.json >"$publisher_output" 2>&1; then

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,225 @@
+name: publish-mcp-registry
+
+# Registry publication is deliberately an operator-approved action. A release
+# tag and its public npm package must already exist before this workflow runs.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to publish (for example, v0.19.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release:
+    name: Verify published release tag
+    runs-on: ubuntu-22.04
+    outputs:
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
+    steps:
+      - name: Resolve the published immutable release tag
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "tag must be an explicit vMAJOR.MINOR.PATCH release tag" >&2
+            exit 1
+          fi
+
+          tag_path="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
+          request_json() {
+            curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GITHUB_TOKEN" \
+              "$1"
+          }
+
+          release_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$tag_path")"
+          if ! jq -e --arg tag "$RELEASE_TAG" \
+            '.tag_name == $tag and .draft == false' <<<"$release_json" >/dev/null; then
+            echo "tag must resolve to a published, non-draft GitHub release" >&2
+            exit 1
+          fi
+
+          ref_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/ref/tags/$tag_path")"
+          object_type="$(jq -er '.object.type' <<<"$ref_json")"
+          commit_sha="$(jq -er '.object.sha' <<<"$ref_json")"
+          if [[ "$object_type" == "tag" ]]; then
+            tag_json="$(request_json "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/tags/$commit_sha")"
+            object_type="$(jq -er '.object.type' <<<"$tag_json")"
+            commit_sha="$(jq -er '.object.sha' <<<"$tag_json")"
+          fi
+          if [[ "$object_type" != "commit" || ! "$commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release tag must resolve directly to a commit" >&2
+            exit 1
+          fi
+
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish MCP Registry record
+    needs: verify-release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the verified release commit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.verify-release.outputs.commit_sha }}
+
+      - name: Verify the registry and npm publication contract
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_TAG#v}"
+          SERVER_NAME="io.github.constellation-works/orbit"
+          NPM_PACKAGE="@orbit-tools/cli"
+          npm_metadata="$(curl --fail --location --silent --show-error \
+            "https://registry.npmjs.org/%40orbit-tools%2Fcli/$VERSION")"
+
+          if ! jq -e \
+            --arg name "$SERVER_NAME" \
+            --arg package "$NPM_PACKAGE" \
+            --arg version "$VERSION" '
+              .name == $name
+              and .version == $version
+              and (.packages | length == 1)
+              and .packages[0].registryType == "npm"
+              and .packages[0].identifier == $package
+              and .packages[0].version == $version
+              and .packages[0].transport.type == "stdio"
+              and ([.packages[0].packageArguments[] | [.type, .value]] == [["positional", "mcp"], ["positional", "serve"]])
+              and ([.. | strings | select(. == "--operator")] | length == 0)
+            ' server.json >/dev/null; then
+            echo "server.json must match the fixed non-operator registry contract" >&2
+            exit 1
+          fi
+          if ! jq -e --arg version "$VERSION" --arg name "$SERVER_NAME" \
+            '.version == $version and .mcpName == $name' <<<"$npm_metadata" >/dev/null; then
+            echo "published npm package lacks the matching version or MCP ownership marker" >&2
+            exit 1
+          fi
+
+      - name: Download and verify the pinned MCP publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive="$(mktemp)"
+          trap 'rm -f "$archive"' EXIT
+          curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+            'https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz' \
+            --output "$archive"
+          printf '%s  %s\n' \
+            'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc' \
+            "$archive" | sha256sum --check --status -
+          tar xzf "$archive" mcp-publisher
+          chmod 755 mcp-publisher
+
+      - name: Validate registry metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mcp-publisher validate server.json >/dev/null
+          echo "MCP Registry metadata validated"
+
+      - name: Require an active constellation-works owner grant
+        shell: bash
+        env:
+          MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MCP_REGISTRY_PAT_TOKEN:-}" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN is required; grant its owner Organization permissions: Members read" >&2
+            exit 1
+          fi
+
+          page=1
+          membership=''
+          while :; do
+            response="$(curl --fail --location --silent --show-error \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $MCP_REGISTRY_PAT_TOKEN" \
+              "https://api.github.com/user/memberships/orgs?state=active&per_page=100&page=$page")"
+            selected="$(jq -c '[.[] | select(.organization.login == "constellation-works") | {state, role}]' <<<"$response")"
+            if [[ "$selected" != '[]' ]]; then
+              membership="$selected"
+              break
+            fi
+            if [[ "$(jq 'length' <<<"$response")" -lt 100 ]]; then
+              break
+            fi
+            ((page += 1))
+          done
+
+          if [[ -z "$membership" ]]; then
+            echo "constellation-works membership: state=missing role=missing" >&2
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            exit 1
+          fi
+          state="$(jq -er '.[0].state' <<<"$membership")"
+          role="$(jq -er '.[0].role' <<<"$membership")"
+          echo "constellation-works membership: state=$state role=$role"
+          if [[ "$state" != "active" || "$role" != "owner" ]]; then
+            echo "MCP_REGISTRY_PAT_TOKEN needs an active constellation-works owner grant; do not broaden permissions automatically" >&2
+            exit 1
+          fi
+
+      - name: Authenticate and publish
+        shell: bash
+        env:
+          MCP_REGISTRY_PAT_TOKEN: ${{ secrets.MCP_REGISTRY_PAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          publisher_output="$(mktemp)"
+          trap 'rm -f "$publisher_output"' EXIT
+          if ! ./mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN" >"$publisher_output" 2>&1; then
+            echo "MCP Registry authentication failed; verify the dedicated token's owner grant" >&2
+            exit 1
+          fi
+          if ! ./mcp-publisher publish server.json >"$publisher_output" 2>&1; then
+            echo "MCP Registry publication failed; inspect registry availability and validated metadata" >&2
+            exit 1
+          fi
+          echo "MCP Registry publication completed"
+
+      - name: Verify the public registry record
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_TAG#v}"
+          SERVER_NAME="io.github.constellation-works/orbit"
+          server_path="$(jq -rn --arg value "$SERVER_NAME" '$value | @uri')"
+          published="$(curl --fail --location --silent --show-error \
+            "https://registry.modelcontextprotocol.io/v0.1/servers/$server_path/versions/$VERSION")"
+          if ! jq -e --arg name "$SERVER_NAME" --arg version "$VERSION" '
+            .server.name == $name
+            and .server.version == $version
+            and (.server.packages | length == 1)
+            and .server.packages[0].identifier == "@orbit-tools/cli"
+            and .server.packages[0].version == $version
+            and ([.server.packages[0].packageArguments[] | [.type, .value]] == [["positional", "mcp"], ["positional", "serve"]])
+          ' <<<"$published" >/dev/null; then
+            echo "public registry record does not match the expected name, version, and package arguments" >&2
+            exit 1
+          fi
+          echo "Public MCP Registry record matches $SERVER_NAME@$VERSION"

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -172,13 +172,14 @@ Homebrew TAP token, and never paste the PAT into workflow inputs or logs.
 
 The preflight calls GitHub's active organization-memberships endpoint and
 requires the selected `constellation-works` membership to be `active` with
-role `owner`. Configure the PAT with read-only GitHub access sufficient to
+role `admin` (GitHub's API value for an organization administrator). Configure
+the PAT with read-only GitHub access sufficient to
 read that organization membership: for a fine-grained PAT, select the
 `constellation-works` organization and grant **Organization permissions →
 Members: Read-only**. It needs no write, repository-content, or TAP access;
 the workflow uses its read-only `GITHUB_TOKEN` to inspect the public release.
 Do not broaden the PAT automatically if the preflight fails. A `missing` or
-non-owner result means an organization owner must correct the dedicated
+non-admin result means an organization administrator must correct the dedicated
 token's grant before another manual dispatch. The workflow prints only the
 selected membership state and role, never tokens, authorization headers, raw
 JWTs, or raw authentication responses.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -145,6 +145,49 @@ date has passed or its `revoked_at` field is set.
    before npm publish and is expected to fail its version assertion; the
    post-publish versioned run must be green.
 
+## Publish the Official MCP Registry record
+
+After the GitHub Release and its matching `@orbit-tools/cli` version are
+public, a repository maintainer may manually dispatch the
+`publish-mcp-registry` workflow. It never runs from a push or tag event.
+
+1. Confirm the release tag is published and non-draft, and that its
+   `server.json`, `npm/package.json`, and public npm metadata all identify
+   `io.github.constellation-works/orbit`, `@orbit-tools/cli`, and the tag
+   version. The registry command remains exactly `mcp serve`; it must not
+   include `--operator`.
+2. In GitHub Actions, select **publish-mcp-registry**, choose a trusted
+   repository ref containing the workflow, and supply the explicit release tag
+   (for example, `v0.19.0`). The workflow resolves that tag to a commit after
+   checking its published, non-draft GitHub Release, then checks out that
+   commit. It does not check out or publish an arbitrary input ref.
+3. Review the public readback step. It verifies the registry name, version,
+   npm package, and fixed `mcp serve` package arguments after publishing.
+
+The workflow's only credential is the repository Actions secret
+`MCP_REGISTRY_PAT_TOKEN`. Keep it dedicated to this purpose: it is used only
+for the GitHub membership preflight and the official `mcp-publisher login
+github --token` exchange. Do not substitute a personal `gh` credential or the
+Homebrew TAP token, and never paste the PAT into workflow inputs or logs.
+
+The preflight calls GitHub's active organization-memberships endpoint and
+requires the selected `constellation-works` membership to be `active` with
+role `owner`. Configure the PAT with read-only GitHub access sufficient to
+read that organization membership: for a fine-grained PAT, select the
+`constellation-works` organization and grant **Organization permissions →
+Members: Read-only**. It needs no write, repository-content, or TAP access;
+the workflow uses its read-only `GITHUB_TOKEN` to inspect the public release.
+Do not broaden the PAT automatically if the preflight fails. A `missing` or
+non-owner result means an organization owner must correct the dedicated
+token's grant before another manual dispatch. The workflow prints only the
+selected membership state and role, never tokens, authorization headers, raw
+JWTs, or raw authentication responses.
+
+The workflow downloads `mcp-publisher` v1.8.1 for Linux amd64 and verifies its
+SHA-256 before validating metadata, authenticating, and publishing. It is safe
+to rerun only after resolving a failed preflight or public-readback error; npm
+versions and release tags are immutable.
+
 ## Continuous npm-install verification
 
 The `smoke-npm-install.yml` workflow runs on macOS and Ubuntu weekly, on every

--- a/scripts/test-mcp-registry-publish-workflow.sh
+++ b/scripts/test-mcp-registry-publish-workflow.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression checks for the manual MCP Registry publication security boundary.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workflow="$repo_root/.github/workflows/publish-mcp-registry.yml"
+
+require() {
+  local description="$1"
+  local text="$2"
+
+  if ! grep --fixed-strings --quiet -- "$text" "$workflow"; then
+    echo "missing $description" >&2
+    exit 1
+  fi
+}
+
+forbid() {
+  local description="$1"
+  local text="$2"
+
+  if grep --fixed-strings --quiet -- "$text" "$workflow"; then
+    echo "forbidden $description" >&2
+    exit 1
+  fi
+}
+
+require "manual trigger" "workflow_dispatch:"
+forbid "automatic push publication" "  push:"
+require "strict release tag validation" "tag must be an explicit vMAJOR.MINOR.PATCH release tag"
+require "published-release check" "published, non-draft GitHub release"
+require "commit-pinned checkout" 'ref: ${{ needs.verify-release.outputs.commit_sha }}'
+forbid "unchecked input checkout" 'ref: ${{ inputs.tag }}'
+require "exact active-membership endpoint" "/user/memberships/orgs?state=active&per_page=100&page=\$page"
+require "owner-role check" '"$state" != "active" || "$role" != "owner"'
+require "pinned publisher version" "releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz"
+require "publisher checksum" "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+require "official token login" './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"'
+require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's owner grant"
+require "public record verification" "registry.modelcontextprotocol.io/v0.1/servers/\$server_path/versions/\$VERSION"
+require "public registry response handling" ".server.name == \$name"
+forbid "secret echo" 'echo "$MCP_REGISTRY_PAT_TOKEN"'
+
+echo "MCP Registry publication workflow checks passed"

--- a/scripts/test-mcp-registry-publish-workflow.sh
+++ b/scripts/test-mcp-registry-publish-workflow.sh
@@ -32,13 +32,142 @@ require "published-release check" "published, non-draft GitHub release"
 require "commit-pinned checkout" 'ref: ${{ needs.verify-release.outputs.commit_sha }}'
 forbid "unchecked input checkout" 'ref: ${{ inputs.tag }}'
 require "exact active-membership endpoint" "/user/memberships/orgs?state=active&per_page=100&page=\$page"
-require "owner-role check" '"$state" != "active" || "$role" != "owner"'
+require "administrator-role check" '"$state" != "active" || "$role" != "admin"'
 require "pinned publisher version" "releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz"
 require "publisher checksum" "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
 require "official token login" './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"'
-require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's owner grant"
+require "sanitized publisher authentication failure" "MCP Registry authentication failed; verify the dedicated token's active constellation-works admin membership"
 require "public record verification" "registry.modelcontextprotocol.io/v0.1/servers/\$server_path/versions/\$VERSION"
 require "public registry response handling" ".server.name == \$name"
 forbid "secret echo" 'echo "$MCP_REGISTRY_PAT_TOKEN"'
+
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+preflight="$temporary_directory/preflight.sh"
+awk '
+  /      - name: Require an active constellation-works administrator membership/ { in_step = 1 }
+  /      - name: Authenticate and publish/ { exit }
+  in_step && /^        run: \|$/ { in_run = 1; next }
+  in_run { sub(/^          /, ""); print }
+' "$workflow" > "$preflight"
+chmod 700 "$preflight"
+
+if ! grep --fixed-strings --quiet -- '"$role" != "admin"' "$preflight"; then
+  echo "extracted production preflight does not require the GitHub admin role" >&2
+  exit 1
+fi
+
+preflight_line="$(grep --line-number --fixed-strings -- 'Require an active constellation-works administrator membership' "$workflow" | cut --delimiter=: --fields=1)"
+publisher_login_line="$(grep --line-number --fixed-strings -- './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"' "$workflow" | cut --delimiter=: --fields=1)"
+if [[ "$preflight_line" -ge "$publisher_login_line" ]]; then
+  echo "membership preflight must run before publisher login" >&2
+  exit 1
+fi
+
+fixture_token='fixture-token-must-not-be-logged'
+raw_auth_payload='fixture-raw-auth-payload-must-not-be-logged'
+mock_bin="$temporary_directory/bin"
+mkdir "$mock_bin"
+
+jq -n '[range(0; 100) | {state: "active", role: "member", organization: {login: ("other-" + tostring)}}]' \
+  > "$temporary_directory/page-one.json"
+jq -n '[{state: "active", role: "admin", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/page-two-admin.json"
+jq -n '[{state: "active", role: "member", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/member.json"
+jq -n '[{state: "active", role: "owner", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/owner.json"
+jq -n '[{state: "pending", role: "admin", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/pending.json"
+jq -n '[{state: "active", organization: {login: "constellation-works"}}]' \
+  > "$temporary_directory/malformed.json"
+jq -n '[{state: "active", role: "member", organization: {login: "another-org"}}]' \
+  > "$temporary_directory/missing.json"
+
+cat > "$mock_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${!#}"
+printf '%s\n' "$url" >> "$MCP_TEST_REQUEST_LOG"
+
+has_expected_authorization=false
+for argument in "$@"; do
+  if [[ "$argument" == "Authorization: Bearer $MCP_REGISTRY_PAT_TOKEN" ]]; then
+    has_expected_authorization=true
+  fi
+done
+if [[ "$has_expected_authorization" != true ]]; then
+  echo "mock curl did not receive the dedicated authorization header" >&2
+  exit 64
+fi
+
+if [[ "$MCP_TEST_CASE" == "api-error" ]]; then
+  printf '%s\n' "$MCP_TEST_RAW_AUTH_PAYLOAD"
+  echo "simulated GitHub API failure" >&2
+  exit 22
+fi
+
+case "$MCP_TEST_CASE:$url" in
+  admin-page-two:*'page=1') cat "$MCP_TEST_FIXTURES/page-one.json" ;;
+  admin-page-two:*'page=2') cat "$MCP_TEST_FIXTURES/page-two-admin.json" ;;
+  member:*) cat "$MCP_TEST_FIXTURES/member.json" ;;
+  owner:*) cat "$MCP_TEST_FIXTURES/owner.json" ;;
+  pending:*) cat "$MCP_TEST_FIXTURES/pending.json" ;;
+  malformed:*) cat "$MCP_TEST_FIXTURES/malformed.json" ;;
+  missing:*) cat "$MCP_TEST_FIXTURES/missing.json" ;;
+  *) echo "unexpected mock curl request" >&2; exit 64 ;;
+esac
+EOF
+chmod 700 "$mock_bin/curl"
+
+run_preflight_case() {
+  local case_name="$1"
+  local expected_status="$2"
+  local require_page_two="$3"
+  local output="$temporary_directory/$case_name.output"
+  local request_log="$temporary_directory/$case_name.requests"
+  local status
+
+  if PATH="$mock_bin:$PATH" \
+    MCP_REGISTRY_PAT_TOKEN="$fixture_token" \
+    MCP_TEST_CASE="$case_name" \
+    MCP_TEST_FIXTURES="$temporary_directory" \
+    MCP_TEST_REQUEST_LOG="$request_log" \
+    MCP_TEST_RAW_AUTH_PAYLOAD="$raw_auth_payload" \
+    bash "$preflight" >"$output" 2>&1; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [[ "$expected_status" == success && "$status" -ne 0 ]]; then
+    echo "preflight case $case_name unexpectedly failed" >&2
+    sed -n '1,80p' "$output" >&2
+    exit 1
+  fi
+  if [[ "$expected_status" == failure && "$status" -eq 0 ]]; then
+    echo "preflight case $case_name unexpectedly succeeded" >&2
+    exit 1
+  fi
+  if [[ "$require_page_two" == true ]] && ! grep --fixed-strings --quiet -- 'page=2' "$request_log"; then
+    echo "preflight case $case_name did not request the second membership page" >&2
+    exit 1
+  fi
+  if grep --fixed-strings --quiet -- "$fixture_token" "$output" \
+    || grep --fixed-strings --quiet -- "$raw_auth_payload" "$output"; then
+    echo "preflight case $case_name exposed a sensitive fixture value" >&2
+    exit 1
+  fi
+}
+
+run_preflight_case admin-page-two success true
+run_preflight_case member failure false
+run_preflight_case owner failure false
+run_preflight_case pending failure false
+run_preflight_case missing failure false
+run_preflight_case malformed failure false
+run_preflight_case api-error failure false
 
 echo "MCP Registry publication workflow checks passed"


### PR DESCRIPTION
Promotes ORB-11436 and ORB-11437 to the default branch so the manual registry publication workflow is available. Diff is limited to the workflow, its behavioral regression tests, and release runbook. Fix verified at d5d132cf3431e847df950f21aedff9ac98857c43. Daniel authorized this promotion and a temporary PR-only administrator bypass, with immediate restoration of the original main protections. Does not dispatch registry publication or change release versions.