### PR TITLE
[BLOCKED] Repair macOS public CA explicit-deny regression test after ORB-11406

### DIFF
--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -409,7 +409,14 @@ fn compiled_codex_profile_reads_public_ca_material_but_not_private_credentials()
     std::fs::create_dir_all(&ssh).expect("synthetic ssh directory");
     let private_key = ssh.join("id_fixture");
     std::fs::write(&private_key, "private fixture").expect("write synthetic private key");
-    let public_ca = std::path::Path::new("/etc/ssl/cert.pem");
+    // `/etc` is an alias of `/private/etc` on macOS. `sandbox-exec` evaluates
+    // file predicates against the resolved path, so use the same canonical
+    // spelling for the probe and its explicit deny. This direct compiler test
+    // deliberately supplies already-resolved absolute rules, as production's
+    // policy resolver does for workspace-relative policy entries.
+    let public_ca = std::path::Path::new("/etc/ssl/cert.pem")
+        .canonicalize()
+        .expect("canonicalize macOS public CA bundle");
     assert!(public_ca.is_file(), "macOS public CA bundle must exist");
 
     let resolved = ResolvedFsProfile {
@@ -440,7 +447,7 @@ fn compiled_codex_profile_reads_public_ca_material_but_not_private_credentials()
 
     let denied = ResolvedFsProfile {
         name: "deny-public-ca".to_string(),
-        read: vec![fixture.home_text(), "!/etc/ssl/cert.pem".to_string()],
+        read: vec![fixture.home_text(), format!("!{}", public_ca.display())],
         modify: vec![],
     };
     let denied_profile = compile_with_env(

--- a/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
+++ b/crates/orbit-exec/src/macos_sandbox/tests/compile.rs
@@ -434,7 +434,7 @@ fn compiled_codex_profile_reads_public_ca_material_but_not_private_credentials()
     );
 
     assert!(
-        can_read_under_profile(&profile_text, public_ca),
+        can_read_under_profile(&profile_text, &public_ca),
         "Codex must be able to read the public CA file selected by its child environment"
     );
     for private in [&fixture.credential, &private_key] {
@@ -459,7 +459,7 @@ fn compiled_codex_profile_reads_public_ca_material_but_not_private_credentials()
         },
     );
     assert!(
-        !can_read_under_profile(&denied_profile, public_ca),
+        !can_read_under_profile(&denied_profile, &public_ca),
         "an explicit denyRead must still outrank the public CA default"
     );
 }


### PR DESCRIPTION
## Automatic conflict recovery exhausted

Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline exhausted its single system-crew conflict-recovery attempt. This PR is intentionally blocked; inspect the recorded attempt and reconcile the named conflict before retrying delivery.

- Task: `ORB-11435`
- Run: `jrun-20260906-2146-7`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `d5d132cf3431e847df950f21aedff9ac98857c43`
- Target base: `d5d132cf3431e847df950f21aedff9ac98857c43`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0
```