### PR TITLE
[qa-sweep] Explicit --root cannot override managed ORBIT_WORKSPACE for scratch task commands

### DIFF
--- a/crates/orbit-cli/tests/ambient_authority_isolation.rs
+++ b/crates/orbit-cli/tests/ambient_authority_isolation.rs
@@ -245,6 +245,134 @@ fn an_unscrubbed_child_routes_its_write_into_the_ambient_authority() {
     );
 }
 
+/// An explicit data root is a complete authority boundary even inside a
+/// managed executor. The task-local `--workspace` remains task metadata; the
+/// inherited managed selector must not be resolved in the scratch registry
+/// before the command can use its explicitly selected root and cwd.
+#[test]
+fn explicit_root_allows_a_managed_child_to_round_trip_a_scratch_task_artifact() {
+    let sentinel = Sentinel::new();
+    let before = sentinel.snapshot();
+
+    let scratch = tempdir().expect("scratch tempdir");
+    let home = scratch.path().join("home");
+    let root = scratch.path().join("root");
+    let work = scratch.path().join("work");
+    std::fs::create_dir_all(&home).expect("create scratch home");
+    std::fs::create_dir_all(&work).expect("create scratch workspace");
+
+    let root_arg = root.to_string_lossy().into_owned();
+    let work_arg = work.to_string_lossy().into_owned();
+    let mut command = managed_orbit(&work, &home, &sentinel);
+    run_ok(
+        &mut command,
+        &[
+            "--root",
+            &root_arg,
+            "init",
+            "--non-interactive",
+            "--host-name",
+            "scratch-host",
+            "--task-prefix",
+            "SCR",
+        ],
+        "initialize scratch root",
+    );
+
+    let mut command = managed_orbit(&work, &home, &sentinel);
+    run_ok(
+        &mut command,
+        &[
+            "--root",
+            &root_arg,
+            "workspace",
+            "init",
+            "--name",
+            "scratch-workspace",
+            "--ship-mode",
+            "local",
+        ],
+        "initialize scratch workspace",
+    );
+
+    let mut command = managed_orbit(&work, &home, &sentinel);
+    let created = run_ok(
+        &mut command,
+        &[
+            "--root",
+            &root_arg,
+            "task",
+            "add",
+            "--title",
+            "Scratch artifact round trip",
+            "--description",
+            "Must stay inside the explicit scratch root.",
+            "--complexity",
+            "low",
+            "--workspace",
+            &work_arg,
+            "--json",
+        ],
+        "add scratch task",
+    );
+    let created: Value = serde_json::from_slice(&created.stdout).expect("task add JSON");
+    let task_id = created["id"].as_str().expect("task id");
+
+    let source = work.join("summary.txt");
+    let round_trip = work.join("round-trip.txt");
+    std::fs::write(&source, "stored in scratch\n").expect("write source artifact");
+
+    let source_arg = source.to_string_lossy().into_owned();
+    let mut command = managed_orbit(&work, &home, &sentinel);
+    run_ok(
+        &mut command,
+        &[
+            "--root",
+            &root_arg,
+            "task",
+            "artifact",
+            "put",
+            task_id,
+            &source_arg,
+            "--path",
+            "reports/summary.txt",
+            "--json",
+        ],
+        "store scratch task artifact",
+    );
+
+    let round_trip_arg = round_trip.to_string_lossy().into_owned();
+    let mut command = managed_orbit(&work, &home, &sentinel);
+    run_ok(
+        &mut command,
+        &[
+            "--root",
+            &root_arg,
+            "task",
+            "artifact",
+            "get",
+            task_id,
+            "reports/summary.txt",
+            "--out",
+            &round_trip_arg,
+            "--json",
+        ],
+        "read scratch task artifact",
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&round_trip).expect("read round-trip artifact"),
+        "stored in scratch\n"
+    );
+    assert!(
+        root.join("tasks/workspaces/ws_scratch-workspace")
+            .join(task_id)
+            .is_dir(),
+        "task must be stored in the scratch workspace partition"
+    );
+    sentinel.assert_unchanged(&before);
+}
+
 /// Initialization, creation, and mutation all route to the fixture's own
 /// authority and leave the ambient sentinel byte-for-byte unchanged.
 #[test]
@@ -319,6 +447,20 @@ fn isolated_orbit(cwd: &Path, home: &Path) -> Command {
     test_env::clear_inherited_authority(|name| {
         command.env_remove(name);
     });
+    command
+        .current_dir(cwd)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
+/// A child with a complete, controlled managed-run authority envelope.
+fn managed_orbit(cwd: &Path, home: &Path, sentinel: &Sentinel) -> Command {
+    let mut command = cargo_bin_cmd!("orbit");
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    sentinel.export_authority(&mut command);
     command
         .current_dir(cwd)
         .env("HOME", home)

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -101,10 +101,13 @@ impl RegisteredRuntimeFactory {
     ///
     /// `--workspace` is the workspace selector (name, `ws_*` id, or absolute
     /// checkout path). `--root` stays a data-directory override and is never
-    /// overloaded as a selector. Omitting `--workspace` uses the trusted
-    /// managed `ORBIT_WORKSPACE` envelope when present, otherwise the cwd
-    /// walk. An unknown or mismatched selector fails closed and does not
-    /// fall back to cwd.
+    /// overloaded as a selector. When `--root` is omitted, omitting
+    /// `--workspace` uses the trusted managed `ORBIT_WORKSPACE` envelope when
+    /// present, otherwise the cwd walk. An explicit `--root` instead owns the
+    /// complete registry and workspace-resolution context, so a managed
+    /// selector inherited from the parent cannot escape that root. An unknown
+    /// or mismatched explicit selector fails closed and does not fall back to
+    /// cwd.
     pub fn initialize_with_overrides(
         root_override: Option<&Path>,
         workspace_selector: Option<&str>,
@@ -126,11 +129,17 @@ impl RegisteredRuntimeFactory {
         workspace_selector: Option<&str>,
         read_only: bool,
     ) -> Result<OrbitRuntime, OrbitError> {
-        let selector = workspace_selector
+        let explicit_selector = workspace_selector
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-            .or_else(managed_workspace_selector_from_env);
+            .map(ToOwned::to_owned);
+        let selector = explicit_selector.or_else(|| {
+            if root_override.is_some() {
+                None
+            } else {
+                managed_workspace_selector_from_env()
+            }
+        });
         let Some(selector) = selector else {
             let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let roots = Self::resolve_roots_for_cwd(&cwd, root_override)?;


### PR DESCRIPTION
## Task

[ORB-11417](https://orbit-cli.com/tasks/ORB-11417) — [qa-sweep] Explicit --root cannot override managed ORBIT_WORKSPACE for scratch task commands

### Description

## Problem
In an Orbit-managed agent-executor environment, the injected `ORBIT_WORKSPACE=ws_orbit` selector overrides an explicit `--root /tmp/.../root` and explicit `--workspace /tmp/.../workspace` while running ordinary task commands against a freshly initialized scratch Orbit root. The command fails because it resolves the inherited workspace ID in the scratch registry.

## Observed evidence
Built commit `6703cafca651e58710506acf896f6d04f1279b5c` with `cargo build -p orbit-cli`. In the managed run environment, after successful commands:
```text
orbit --root /tmp/orb11397b-zzb9C0/root init --non-interactive --host-name qa-sweep-b --task-prefix QAB
orbit --root /tmp/orb11397b-zzb9C0/root workspace init --name qa-sweep-workspace-b --ship-mode local
```
`orbit --root /tmp/orb11397b-zzb9C0/root task add ... --workspace /tmp/orb11397b-zzb9C0/workspace --json` returned:
```text
invalid input: unknown workspace selector 'ws_orbit'; pass a registered workspace name, a logical workspace ID, or an absolute local checkout path
```
The environment contained `ORBIT_WORKSPACE=ws_orbit`; `ws_orbit` exists only in the managed host registry, not the new root.

## Reproduction
1. Run an agent-executor activity with `ORBIT_WORKSPACE` set to its assigned workspace.
2. Create a temporary git checkout under `/tmp`.
3. Initialize a temporary Orbit root and that checkout using the documented `orbit --root /tmp/<root> init ...` and `orbit --root /tmp/<root> workspace init` commands.
4. Run `orbit --root /tmp/<root> task add --workspace /tmp/<checkout> ...`.
5. Observe lookup of the inherited selector and failure.

## Impact / scope
Validation impact: blocks the prescribed scratch-root end-to-end workflow from creating a task, so task and artifact CLI paths cannot be exercised in the managed executor without manually unsetting injected environment variables. Production impact: no evidence of failure for normal operators without `ORBIT_WORKSPACE`; this is an executor/environment precedence defect. Unsetting `ORBIT_WORKSPACE`, `ORBIT_REGISTRY_ROOT`, `ORBIT_ACTIVE_TASK_ID`, `ORBIT_TASK_ID`, and `ORBIT_MANAGED_RUN_CONTEXT` allowed the same scratch task/artifact flow to complete, confirming the root cause boundary.

### Acceptance Criteria

- With an inherited managed workspace selector, an explicit --root and explicit scratch --workspace allow task operations to target the scratch workspace.
- An end-to-end scratch root initialization, task creation, and artifact round trip succeeds without requiring users to unset Orbit-managed environment variables.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Made an explicit `--root` a complete authority boundary in the registry runtime: when no explicit top-level workspace selector is supplied, inherited managed `ORBIT_WORKSPACE` is consulted only if `--root` is absent. Explicit workspace selectors still win, and invalid explicit selectors remain fail-closed.
- Added a binary-level managed-environment regression covering scratch root initialization, scratch workspace registration, `task add --workspace <scratch checkout>`, and task artifact put/get with byte-for-byte verification. The test also proves the ambient sentinel registry is unchanged.

Acceptance criteria:
- Explicit root plus scratch task workspace under inherited managed authority: satisfied by the new end-to-end regression; the task is persisted in the scratch workspace partition.
- Scratch initialization/task/artifact round trip without unsetting managed variables: satisfied; every child receives a complete managed envelope, and the round trip succeeds without user-side environment scrubbing.

Assessment: The policy change is confined to the authoritative runtime bootstrap seam and preserves ordinary managed routing when `--root` is omitted. No cross-crate dependency or persisted-format changes.
Validation:
- PASSED: `cargo test -p orbit-cli --test ambient_authority_isolation` (4 tests).
- PASSED: `cargo test -p orbit-cmd registry_runtime` (16 tests).
- REGRESSION PROOF: with only the source fix temporarily reverted, the targeted new test failed at scratch task creation with `unknown workspace selector ws_orb-11300-sentinel`; restoring the fix made it pass.
- PASSED: `make ci-fast`.
- PASSED: `make ci-lint`.
- PASSED: `git diff --check`.
Remaining risks: none identified.
Deviations from original plan: none.
Friction checkpoint: no qualifying friction; no record filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11417-6a9ddf37`
- Behind base: 0
- Ahead of base: 1