### PR TITLE
Report PR failure handoffs without inventing conflict recovery attempts

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -305,6 +305,19 @@ fn blocked_pr_body(
     target_base_sha: &str,
     conflicting_paths: &[String],
 ) -> String {
+    let (heading, summary) = if conflicting_paths.is_empty() {
+        (
+            "Delivery failure handoff",
+            "Orbit preserved and pushed this task's candidate after the shipment pipeline failed. \
+             This PR is intentionally blocked; inspect the recorded failure before retrying delivery.",
+        )
+    } else {
+        (
+            "Merge conflict handoff",
+            "Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. \
+             This PR is intentionally blocked; reconcile the named paths before retrying delivery.",
+        )
+    };
     let conflicts = if conflicting_paths.is_empty() {
         "- None reported; inspect the failed pipeline step before merging.".to_string()
     } else {
@@ -315,11 +328,7 @@ fn blocked_pr_body(
             .join("\n")
     };
     format!(
-        "## Automatic conflict recovery exhausted\n\n\
-         Orbit preserved and pushed this task's pre-rebase candidate after the shipment pipeline \
-         exhausted its single system-crew conflict-recovery attempt. This PR is intentionally \
-         blocked; inspect the recorded attempt and reconcile the named conflict before retrying \
-         delivery.\n\n\
+        "## {heading}\n\n{summary}\n\n\
          - Task: `{task_id}`\n\
          - Run: `{run_id}`\n\
          - Failed step: `{failed_step_id}`\n\

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -393,7 +393,7 @@ fn conflicting_rebase_publishes_clean_pre_rebase_branch_and_blocks_task() {
     );
     let body = host.pr_create_body();
     for expected in [
-        "Automatic conflict recovery exhausted",
+        "Merge conflict handoff",
         "Original base:",
         "Target base:",
         "`src/lib.rs`",
@@ -403,6 +403,10 @@ fn conflicting_rebase_publishes_clean_pre_rebase_branch_and_blocks_task() {
             "blocked PR body missing {expected:?}: {body}"
         );
     }
+    assert!(
+        !body.contains("Automatic conflict recovery exhausted"),
+        "a conflict alone is not evidence that recovery was attempted"
+    );
     let task = host.get_task(task_id).expect("blocked task");
     assert_eq!(task.status, TaskStatus::Blocked);
     assert_eq!(task.github_pr_number(), Some("42"));
@@ -577,6 +581,16 @@ fn non_fast_forward_drift_handoff_commits_dirty_work_and_raises_pr() {
     assert!(
         host.pr_create_body().contains("primary_checkout_drift"),
         "the blocked PR preserves the typed primary-drift classification"
+    );
+    assert!(
+        host.pr_create_body().contains("Delivery failure handoff"),
+        "non-conflict failures receive the generic handoff"
+    );
+    assert!(
+        !host
+            .pr_create_body()
+            .contains("Automatic conflict recovery exhausted"),
+        "non-conflict failures must not claim an unverified recovery attempt"
     );
     let calls = host.vcs_calls();
     assert!(


### PR DESCRIPTION
## Task

[ORB-11438](https://orbit-cli.com/tasks/ORB-11438) — Report PR failure handoffs without inventing conflict recovery attempts

### Description

ORB-11435 / jrun-20260906-2146-7 failed implement_one with macos_validation_unavailable; audit confirms no rebase or recovery agent ran, but PR1454 says Automatic conflict recovery exhausted. ORB-11281 commit b791d7cd2 PR1362 unconditionally changed blocked_pr_body in crates/orbit-engine/src/executor/automation/vcs/failure.rs. Existing decision distinguishes blocked_failure_pr from blocked_conflict_pr but prose does not. Correct handoff prose using verified failure/recovery evidence; preserve candidate publication, original failure and blocked status. Do not weaken completion gates or introduce a new recovery framework.

### Acceptance Criteria

- An implementation or validation failure with no recovery attempt publishes an accurate generic failure handoff and never claims conflict recovery exhausted.
- Actual conflict handoffs report paths and only claim recovery was attempted/exhausted when supported by durable evidence; preserve completion-stage handling.
- Behavioral tests cover non-conflict failure and actual conflict recovery; required repository checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Split blocked PR handoff prose into an accurate generic delivery-failure handoff and a merge-conflict handoff selected from the observed conflicting paths.
- Removed the unconditional claim that system-crew conflict recovery was attempted or exhausted; the terminal handoff does not receive durable recovery-attempt evidence, so it now makes no such claim.
- Extended focused behavioral assertions for non-conflict failure and real rebase-conflict handoffs; completion failure coverage remains intact.
Assessment: Candidate publication, original failure details, conflict paths, blocked status/event, and completion-stage preservation remain unchanged.
Criteria:
- Non-conflict failure: covered by non_fast_forward_drift_handoff_commits_dirty_work_and_raises_pr; asserts generic prose and no invented recovery claim.
- Actual conflict: covered by conflicting_rebase_publishes_clean_pre_rebase_branch_and_blocks_task; asserts recorded path, conflict-specific prose, blocked event, and no unsupported recovery claim.
- Completion stage: covered by completion_failure_preserves_published_candidate_and_review_state.
Validation:
- cargo test -p orbit-engine executor::automation::vcs::pr::tests::handoff: passed (13 tests).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks: The handoff intentionally does not advertise a recovery attempt because its current input has no durable recovery-attempt checkpoint. A future enhancement that threads such evidence into this hook can add evidence-backed recovery wording without changing this behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11438-6a9de24d`
- Behind base: 0
- Ahead of base: 1