### PR TITLE
Preserve declared agent failure codes and explanations in pipeline diagnostics

### DIFF
--- a/crates/orbit-agent/src/lib.rs
+++ b/crates/orbit-agent/src/lib.rs
@@ -71,7 +71,8 @@ pub use providers::{
 pub use runtime::AgentRuntime;
 pub use types::{AgentInvocationSpec, AgentOperation, AgentRequest, AgentResponseStatus};
 pub use types::{
-    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+    DeclaredResponseFailure, is_timeout, parse_and_validate_response,
+    peek_declared_response_failure, peek_response_status, response_envelope_protocol_check,
 };
 pub use types::{
     provider_invocation_diagnostic, response_envelope_json_schema,

--- a/crates/orbit-agent/src/types/mod.rs
+++ b/crates/orbit-agent/src/types/mod.rs
@@ -4,7 +4,8 @@ mod response;
 pub use request::{AgentOperation, AgentRequest};
 pub use response::{AgentInvocationSpec, AgentResponseStatus};
 pub use response::{
-    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+    DeclaredResponseFailure, is_timeout, parse_and_validate_response,
+    peek_declared_response_failure, peek_response_status, response_envelope_protocol_check,
 };
 pub use response::{
     provider_invocation_diagnostic, response_envelope_json_schema,

--- a/crates/orbit-agent/src/types/response.rs
+++ b/crates/orbit-agent/src/types/response.rs
@@ -24,7 +24,8 @@ use orbit_types::telemetry::ToolCallTrace;
 use serde_json::Value;
 
 pub use envelope::{
-    is_timeout, parse_and_validate_response, peek_response_status, response_envelope_protocol_check,
+    DeclaredResponseFailure, is_timeout, parse_and_validate_response,
+    peek_declared_response_failure, peek_response_status, response_envelope_protocol_check,
 };
 pub use protocol_schema::{response_envelope_json_schema, response_envelope_json_schema_arg};
 pub use wrapper::provider_invocation_diagnostic;

--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -9,6 +9,12 @@ use super::protocol_schema::{RESPONSE_ENVELOPE_SCHEMA_VERSION, RESPONSE_ENVELOPE
 use super::wrapper::wrapper_signals;
 use super::{AgentResponseStatus, ResponseParseResult, trace::extract_invocation_trace};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeclaredResponseFailure {
+    pub status: String,
+    pub error: Option<AgentRunError>,
+}
+
 pub fn parse_and_validate_response(exec_result: &ExecutionResult) -> ResponseParseResult {
     match parse_json_envelope(exec_result) {
         Ok(parsed) => Ok(parsed),
@@ -39,6 +45,21 @@ pub fn peek_response_status(stdout: &str) -> Option<String> {
         .rev()
         .find_map(find_agent_response_envelope)?;
     Some(envelope.status)
+}
+
+/// Best-effort lookup of a terminal failure declaration in provider stdout.
+///
+/// Unlike full response validation, this preserves the status when its error
+/// object is absent or malformed. The dispatcher uses that status to fail
+/// closed, while treating unavailable error details as a generic diagnostic.
+/// The returned error is present only when both its code and message are
+/// non-empty strings.
+pub fn peek_declared_response_failure(stdout: &str) -> Option<DeclaredResponseFailure> {
+    let documents = parse_json_documents(stdout).ok()?;
+    documents
+        .iter()
+        .rev()
+        .find_map(find_declared_response_failure)
 }
 
 /// Content-blind check that a provider's stdout *terminated with* a well-formed
@@ -362,6 +383,82 @@ fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> 
         }
         _ => None,
     }
+}
+
+fn find_declared_response_failure(value: &Value) -> Option<DeclaredResponseFailure> {
+    if let Some(failure) = declared_response_failure(value) {
+        return Some(failure);
+    }
+
+    match value {
+        Value::String(raw) => find_declared_response_failure_in_string(raw),
+        Value::Array(items) => items.iter().rev().find_map(find_declared_response_failure),
+        Value::Object(map) => {
+            for key in [
+                "structured_output",
+                "result",
+                "response",
+                "message",
+                "messages",
+                "content",
+                "final",
+                "final_message",
+                "output",
+            ] {
+                if let Some(found) = map.get(key).and_then(find_declared_response_failure) {
+                    return Some(found);
+                }
+            }
+
+            map.values().find_map(find_declared_response_failure)
+        }
+        _ => None,
+    }
+}
+
+fn find_declared_response_failure_in_string(raw: &str) -> Option<DeclaredResponseFailure> {
+    if let Ok(nested) = serde_json::from_str::<Value>(raw)
+        && let Some(failure) = find_declared_response_failure(&nested)
+    {
+        return Some(failure);
+    }
+
+    raw.match_indices('{').find_map(|(start, _)| {
+        let mut deserializer = Deserializer::from_str(&raw[start..]);
+        let nested = Value::deserialize(&mut deserializer).ok()?;
+        find_declared_response_failure(&nested)
+    })
+}
+
+fn declared_response_failure(value: &Value) -> Option<DeclaredResponseFailure> {
+    let object = value.as_object()?;
+    let schema_version = object.get("schemaVersion")?.as_u64()?;
+    if schema_version != RESPONSE_ENVELOPE_SCHEMA_VERSION as u64 {
+        return None;
+    }
+
+    let status = object.get("status")?.as_str()?;
+    if !matches!(status, "failed" | "timeout") {
+        return None;
+    }
+
+    let error = object
+        .get("error")
+        .and_then(Value::as_object)
+        .and_then(|error| {
+            let code = error.get("code")?.as_str()?.trim();
+            let message = error.get("message")?.as_str()?.trim();
+            (!code.is_empty() && !message.is_empty()).then(|| AgentRunError {
+                code: code.to_string(),
+                message: message.to_string(),
+                details: Value::Null,
+            })
+        });
+
+    Some(DeclaredResponseFailure {
+        status: status.to_string(),
+        error,
+    })
 }
 
 fn find_agent_response_envelope_in_string(raw: &str) -> Option<AgentResponseEnvelope> {

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use orbit_agent::{
     Agent, AgentConfig, AgentOperation, AgentRequest, antigravity_terminal_error_diagnostic,
-    normalize_cli_stdout, peek_response_status, project_cli_response,
-    provider_invocation_diagnostic, response_envelope_protocol_check,
+    normalize_cli_stdout, peek_declared_response_failure, peek_response_status,
+    project_cli_response, provider_invocation_diagnostic, response_envelope_protocol_check,
 };
 use orbit_common::process::identity::process_start_identity_token;
 use orbit_common::security::redaction::{PatternRedactor, redact_sensitive_env_text};
@@ -511,7 +511,11 @@ pub fn run_cli_backend(
     let answer_stdout = project_cli_response(&provider, stdout.protocol_bytes());
     let answer_text = String::from_utf8_lossy(answer_stdout.as_ref());
     let trace_stdout_text = String::from_utf8_lossy(trace_stdout.as_ref());
-    let envelope_status = peek_response_status(answer_text.as_ref());
+    let declared_failure = peek_declared_response_failure(answer_text.as_ref());
+    let envelope_status = declared_failure
+        .as_ref()
+        .map(|failure| failure.status.clone())
+        .or_else(|| peek_response_status(answer_text.as_ref()));
     // The operator-facing preview stays on the *raw* capture: normalization
     // drops the session control plane, and that is where a provider puts the
     // policy and authentication failures an operator needs to see.
@@ -622,9 +626,10 @@ pub fn run_cli_backend(
         && matches!(envelope_status.as_deref(), Some("failed") | Some("timeout"))
     {
         Some(with_sandbox_write_attribution(
-            format!(
-                "cli subprocess reported declared envelope status={:?} despite exit 0",
-                envelope_status.as_deref().unwrap_or("unknown")
+            declared_failure_diagnostic(
+                envelope_status.as_deref().unwrap_or("unknown"),
+                declared_failure.as_ref(),
+                &redaction,
             ),
             sandbox_write_diagnostic.as_deref(),
         ))
@@ -818,6 +823,24 @@ fn completion_diagnostic(error: &str, redactor: &PatternRedactor) -> String {
          contract — typically an agent that yielded mid-work — so this step's work is incomplete \
          and only what it persisted before stopping is durable.",
         bounded_diagnostic(error, redactor)
+    )
+}
+
+fn declared_failure_diagnostic(
+    status: &str,
+    failure: Option<&orbit_agent::DeclaredResponseFailure>,
+    redactor: &PatternRedactor,
+) -> String {
+    let prefix =
+        format!("cli subprocess reported declared envelope status={status:?} despite exit 0");
+    let Some(error) = failure.and_then(|failure| failure.error.as_ref()) else {
+        return format!("{prefix}: declared envelope error details unavailable");
+    };
+
+    format!(
+        "{prefix}: error.code={}; error.message={}",
+        bounded_diagnostic(&error.code, redactor),
+        bounded_diagnostic(&error.message, redactor),
     )
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -779,9 +779,26 @@ fn run_cli_backend_keeps_opted_out_declared_failure_advisory() {
 fn run_cli_backend_completion_gate_demotes_a_declared_failure_envelope() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("codex");
+    let envelope = serde_json::json!({
+        "schemaVersion": 1,
+        "status": "failed",
+        "result": {},
+        "error": {
+            "code": "macos_validation_unavailable",
+            "message": format!(
+                "sandbox-exec is unavailable; token=sk-test-redaction {}",
+                "x".repeat(2 * 1024)
+            ),
+        },
+    });
+    let stdout_file = temp.path().join("stdout.json");
+    fs::write(&stdout_file, envelope.to_string()).expect("write envelope fixture");
     write_executable(
         &script,
-        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"blocked\",\"message\":\"cannot proceed\"}}'\n",
+        &format!(
+            "#!/bin/sh\ncat > /dev/null\ncat '{}'\n",
+            stdout_file.display()
+        ),
     );
 
     let sink = Arc::new(RecordingSink::default());
@@ -816,6 +833,16 @@ fn run_cli_backend_completion_gate_demotes_a_declared_failure_envelope() {
     let message = outcome.message.expect("declared failure message");
     assert!(message.contains("declared envelope status"), "{message}");
     assert!(message.contains("failed"), "{message}");
+    assert!(
+        message.contains("error.code=macos_validation_unavailable"),
+        "{message}"
+    );
+    assert!(message.contains("sandbox-exec is unavailable"), "{message}");
+    assert!(!message.contains("sk-test-redaction"), "{message}");
+    assert!(
+        message.len() < 1_300,
+        "diagnostic must remain bounded: {message}"
+    );
 }
 
 /// `timeout` is just as terminal as `failed` when the provider reports it in
@@ -856,6 +883,62 @@ fn run_cli_backend_completion_gate_demotes_a_declared_timeout_envelope() {
     let message = outcome.message.expect("declared timeout message");
     assert!(message.contains("declared envelope status"), "{message}");
     assert!(message.contains("timeout"), "{message}");
+    assert!(message.contains("error.code=deadline"), "{message}");
+    assert!(message.contains("error.message=timed out"), "{message}");
+}
+
+#[test]
+fn run_cli_backend_demotes_declared_failure_with_missing_or_malformed_error_details() {
+    for (fixture, error) in [
+        ("missing", serde_json::Value::Null),
+        ("malformed", serde_json::json!({"code": 42, "message": []})),
+    ] {
+        let temp = tempdir().expect("tempdir");
+        let script = temp.path().join("codex");
+        let envelope = serde_json::json!({
+            "schemaVersion": 1,
+            "status": "failed",
+            "result": {},
+            "error": error,
+        });
+        let stdout_file = temp.path().join("stdout.json");
+        fs::write(&stdout_file, envelope.to_string()).expect("write envelope fixture");
+        write_executable(
+            &script,
+            &format!(
+                "#!/bin/sh\ncat > /dev/null\ncat '{}'\n",
+                stdout_file.display()
+            ),
+        );
+
+        let sink = Arc::new(RecordingSink::default());
+        let sink_for_writer: Arc<dyn AuditSink> = sink;
+        let audit = Arc::new(V2AuditWriter::new(
+            format!("job-declared-failure-{fixture}"),
+            "codex:gpt-5.5",
+            sink_for_writer,
+        ));
+        let host = TestHost::with_command(script.display().to_string());
+
+        let outcome = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(5)),
+            "test_activity",
+            &format!("job-declared-failure-{fixture}"),
+            audit,
+            &serde_json::json!({"task_id": "ORB-11439"}),
+            None,
+        )
+        .expect("run cli backend");
+
+        assert!(!outcome.success, "{fixture} error must still demote exit 0");
+        assert_eq!(outcome.output["response_envelope_status"], "failed");
+        let message = outcome.message.expect("declared failure message");
+        assert!(
+            message.contains("declared envelope error details unavailable"),
+            "{message}"
+        );
+    }
 }
 
 /// A provider that interleaves a wrapped tool's stdout with its own protocol


### PR DESCRIPTION
## Task

[ORB-11439](https://orbit-cli.com/tasks/ORB-11439) — Preserve declared agent failure codes and explanations in pipeline diagnostics

### Description

ORB-11435 / jrun-20260906-2146-7 returned a valid failed envelope with error.code macos_validation_unavailable and a precise missing sandbox-exec explanation. cli_runner/orchestrator.rs:621-630 discards that diagnostic in favor of declared envelope status failed despite exit 0; run and PR handoff lose actionable cause. Preserve bounded redacted error code/message through existing failure diagnostics while retaining fail-closed envelope semantics. Scope is diagnostics only: no retries, success reclassification, or authorization changes. Use actual envelope fixtures including absent/malformed errors and secrets/oversized text.

### Acceptance Criteria

- A failed/timeout envelope remains unsuccessful even with process exit zero, with bounded redacted error code and explanation visible in the terminal diagnostic.
- Missing or malformed error details retain a useful generic diagnostic; untrusted text cannot bypass redaction or length bounds.
- Regression coverage exercises the actual runner path, including macos_validation_unavailable, timeout, and fallback cases; required checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a shared best-effort failure-envelope lookup that retains failed/timeout status even when error details are absent or malformed, while exposing a valid declared code/message.
- CLI runner now fail-closes on declared failure/timeout envelopes that exit 0 and appends bounded, redacted error.code and error.message diagnostics; unavailable details fall back to a generic explanation.
- Added runner-path regressions for macos_validation_unavailable with redaction and length bounds, declared timeout diagnostics, and missing/malformed error fallbacks.
Assessment: The status remains authoritative for failure classification; untrusted error text is redacted and bounded before terminal diagnostics.
Criteria:
- Failed/timeout exit-0 envelopes remain unsuccessful and report declared diagnostics: covered by runner tests for macos_validation_unavailable and timeout.
- Missing/malformed error details fail closed with a generic diagnostic; long secret-shaped input is redacted and bounded: covered by runner fixtures.
- Actual CLI runner regressions cover macOS validation, timeout, and fallback cases.
Validation:
- PASS: cargo test -p orbit-engine --lib (540 passed, 2 ignored: Linux bwrap cases require unavailable unprivileged user namespaces).
- PASS: cargo test -p orbit-agent peek_response_status --lib (4 passed).
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: git diff --check.
Risks: The diagnostic is best-effort only; malformed errors intentionally show the generic fallback rather than untrusted partial fields.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11439-6a9de24d`
- Behind base: 0
- Ahead of base: 1