### PR TITLE
[code-review] Execution-failed automation can starve behind stale incident members

### DIFF
--- a/crates/orbit-automation/src/members/mod.rs
+++ b/crates/orbit-automation/src/members/mod.rs
@@ -27,6 +27,14 @@ pub enum MemberOutcome {
     Failed(String),
 }
 
+pub enum MemberAdmission {
+    Admit,
+    /// The member is still authoritative, but cannot be admitted yet.
+    Withhold(String),
+    /// The member no longer describes authoritative source state.
+    Retire(String),
+}
+
 pub trait MemberHost {
     fn head(&self, branch: &str) -> Result<(String, SourceRevision), AutomationError>;
 
@@ -36,7 +44,7 @@ pub trait MemberHost {
         now: DateTime<Utc>,
     ) -> Result<MemberPage, AutomationError>;
 
-    fn admission_deferral(&self, member: &StateMember) -> Result<Option<String>, AutomationError>;
+    fn admission(&self, member: &StateMember) -> Result<MemberAdmission, AutomationError>;
 
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError>;
 
@@ -140,6 +148,9 @@ pub fn evaluate(
         }
 
         members.withheld.remove(&member.key);
+        for task_id in &member.task_ids {
+            members.withheld.remove(task_id);
+        }
 
         // Already assessed at exactly this fingerprint: nothing left to apply.
         if members
@@ -241,20 +252,25 @@ pub fn evaluate(
         return diagnostic(store, consumer, reason, Some(state));
     }
 
-    // Take the first due member Core will admit; each refusal is recorded as withheld.
+    // Take the first due member Core will admit. Temporary refusals remain
+    // visible, while obsolete source identities are retired from durable state.
     let mut candidate = None;
     let mut next = state.clone();
 
     for member in candidates.into_iter().take(trigger.max_items) {
-        if let Some(reason) = host.admission_deferral(&member)? {
-            let members = member_state(&mut next)?;
-            if reason == "task_ineligible" {
-                members.pending.remove(&member.key);
+        match host.admission(&member)? {
+            MemberAdmission::Admit => {
+                candidate = Some(member);
+                break;
             }
-            members.withheld.insert(member.key, reason);
-        } else {
-            candidate = Some(member);
-            break;
+            MemberAdmission::Withhold(reason) => {
+                member_state(&mut next)?.withheld.insert(member.key, reason);
+            }
+            MemberAdmission::Retire(_) => {
+                let members = member_state(&mut next)?;
+                members.pending.remove(&member.key);
+                members.withheld.remove(&member.key);
+            }
         }
     }
 
@@ -316,8 +332,11 @@ fn admit(
         .and_then(|members| members.active.as_ref())
         .ok_or_else(|| AutomationError::Deferred("claim_missing".into()))?;
 
-    if let Some(reason) = host.admission_deferral(&active.member)? {
-        return diagnostic(store, &consumer, &reason, Some(state));
+    match host.admission(&active.member)? {
+        MemberAdmission::Admit => {}
+        MemberAdmission::Withhold(reason) | MemberAdmission::Retire(reason) => {
+            return diagnostic(store, &consumer, &reason, Some(state));
+        }
     }
 
     if dry_run {
@@ -366,15 +385,21 @@ fn reconcile(
             return commit(store, &state, next, None);
         }
 
-        if now >= active.deadline || host.admission_deferral(&active.member)?.is_some() {
+        let admission = host.admission(&active.member)?;
+        if now >= active.deadline || !matches!(&admission, MemberAdmission::Admit) {
             let mut next = state.clone();
             let members = member_state(&mut next)?;
             if let Some(mut expired) = members.active.take() {
                 expired.exhausted = true;
-                members.withheld.insert(
-                    expired.member.key.clone(),
-                    "input_stale_or_deadline_expired".into(),
-                );
+                if matches!(&admission, MemberAdmission::Retire(_)) {
+                    members.pending.remove(&expired.member.key);
+                    members.withheld.remove(&expired.member.key);
+                } else {
+                    members.withheld.insert(
+                        expired.member.key.clone(),
+                        "input_stale_or_deadline_expired".into(),
+                    );
+                }
                 members.failed.insert(expired.member.key.clone(), expired);
             }
 

--- a/crates/orbit-automation/src/members/tests/mod.rs
+++ b/crates/orbit-automation/src/members/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use orbit_store::{Store, compose};
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::BTreeSet};
 
 struct Host {
     fingerprint: RefCell<String>,
@@ -51,8 +51,13 @@ impl MemberHost for Host {
         })
     }
 
-    fn admission_deferral(&self, _: &StateMember) -> Result<Option<String>, AutomationError> {
-        Ok(self.deferral.borrow().clone())
+    fn admission(&self, _: &StateMember) -> Result<MemberAdmission, AutomationError> {
+        Ok(self
+            .deferral
+            .borrow()
+            .clone()
+            .map(MemberAdmission::Withhold)
+            .unwrap_or(MemberAdmission::Admit))
     }
 
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError> {
@@ -81,6 +86,109 @@ impl MemberHost for Host {
             Ok(MemberOutcome::Pending)
         }
     }
+}
+
+struct SchedulerHost {
+    candidates: RefCell<Vec<StateMember>>,
+    withheld: RefCell<BTreeMap<String, String>>,
+    retired: RefCell<BTreeSet<String>>,
+    admission_checks: RefCell<Vec<String>>,
+    admitted: RefCell<Vec<String>>,
+}
+
+impl SchedulerHost {
+    fn new(candidates: Vec<StateMember>) -> Self {
+        Self {
+            candidates: RefCell::new(candidates),
+            withheld: RefCell::new(BTreeMap::new()),
+            retired: RefCell::new(BTreeSet::new()),
+            admission_checks: RefCell::new(Vec::new()),
+            admitted: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl MemberHost for SchedulerHost {
+    fn head(&self, _: &str) -> Result<(String, SourceRevision), AutomationError> {
+        Ok(("repo".into(), source()))
+    }
+
+    fn observe(&self, _: Option<&str>, _: DateTime<Utc>) -> Result<MemberPage, AutomationError> {
+        Ok(MemberPage {
+            candidates: self.candidates.borrow().clone(),
+            withheld: self.withheld.borrow().clone(),
+            next: None,
+        })
+    }
+
+    fn admission(&self, member: &StateMember) -> Result<MemberAdmission, AutomationError> {
+        self.admission_checks.borrow_mut().push(member.key.clone());
+        if self.retired.borrow().contains(&member.key) {
+            Ok(MemberAdmission::Retire("incident_changed".into()))
+        } else {
+            Ok(MemberAdmission::Admit)
+        }
+    }
+
+    fn lookup(&self, _: &MemberAttempt) -> Result<Option<String>, AutomationError> {
+        Ok(None)
+    }
+
+    fn admit(&self, attempt: &MemberAttempt) -> Result<String, AutomationError> {
+        self.admitted.borrow_mut().push(attempt.member.key.clone());
+        Ok(format!("run-{}", attempt.member.key))
+    }
+
+    fn outcome(&self, _: &MemberAttempt) -> Result<MemberOutcome, AutomationError> {
+        Ok(MemberOutcome::Pending)
+    }
+}
+
+fn source() -> SourceRevision {
+    SourceRevision {
+        commit: "source".into(),
+        tree: "tree".into(),
+    }
+}
+
+fn state_member(key: &str, task_ids: &[&str], first_seen_minute: i64) -> StateMember {
+    StateMember {
+        key: key.into(),
+        task_ids: task_ids.iter().map(|id| (*id).into()).collect(),
+        fingerprint: key.into(),
+        source: source(),
+        evidence: serde_json::json!({}),
+        first_seen: DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+            + Duration::minutes(first_seen_minute),
+        changed_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+            + Duration::minutes(first_seen_minute),
+    }
+}
+
+fn execution_tick(
+    store: &dyn AutomationStoreBackend,
+    host: &SchedulerHost,
+    minute: i64,
+) -> AutomationDiagnostic {
+    let trigger = StateTrigger {
+        kind: StateTriggerKind::ExecutionFailed,
+        max_items: 2,
+        ..trigger()
+    };
+
+    evaluate(
+        store,
+        host,
+        MemberEvaluation {
+            consumer: "host/ws/routine/triage",
+            epoch: "epoch",
+            trigger: &trigger,
+            enabled: true,
+            dry_run: false,
+            now: DateTime::from_timestamp(1_700_000_000, 0).unwrap() + Duration::minutes(minute),
+        },
+    )
+    .unwrap()
 }
 
 fn trigger() -> StateTrigger {
@@ -145,6 +253,76 @@ fn fresh_unready_post_apply_does_not_loop_and_new_material_debounces() {
     *host.evidence.borrow_mut() = None;
     assert_eq!(tick(store.as_ref(), &host, 61).reason, "debouncing");
     assert_eq!(tick(store.as_ref(), &host, 63).reason, "fired");
+}
+
+#[test]
+fn execution_failed_retires_stale_prefix_without_losing_current_diagnostics() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let host = SchedulerHost::new(vec![
+        state_member("old-incident-a", &["task-a"], 0),
+        state_member("old-incident-b", &["task-b"], 0),
+    ]);
+
+    assert_eq!(
+        execution_tick(store.as_ref(), &host, 0).reason,
+        "debouncing"
+    );
+
+    *host.candidates.borrow_mut() = vec![state_member("new-incident", &["task-new"], 1)];
+    *host.withheld.borrow_mut() = BTreeMap::from([
+        ("task-a".into(), "recovery_pending".into()),
+        ("task-b".into(), "human_block".into()),
+    ]);
+    host.retired
+        .borrow_mut()
+        .extend(["old-incident-a".into(), "old-incident-b".into()]);
+
+    assert_eq!(
+        execution_tick(store.as_ref(), &host, 1).reason,
+        "debouncing"
+    );
+
+    let pruned = execution_tick(store.as_ref(), &host, 3);
+    assert_eq!(pruned.reason, "work_withheld");
+    assert_eq!(
+        host.admission_checks.borrow().as_slice(),
+        ["old-incident-a", "old-incident-b"]
+    );
+    let members = pruned.state.unwrap().members.unwrap();
+    assert_eq!(
+        members.pending.keys().cloned().collect::<Vec<_>>(),
+        ["new-incident"]
+    );
+    assert_eq!(
+        members.withheld,
+        BTreeMap::from([
+            ("task-a".into(), "recovery_pending".into()),
+            ("task-b".into(), "human_block".into()),
+        ])
+    );
+
+    let admitted = execution_tick(store.as_ref(), &host, 4);
+    assert_eq!(admitted.reason, "fired");
+    assert_eq!(
+        host.admission_checks.borrow().as_slice(),
+        [
+            "old-incident-a",
+            "old-incident-b",
+            "new-incident",
+            "new-incident"
+        ]
+    );
+    assert_eq!(host.admitted.borrow().as_slice(), ["new-incident"]);
+
+    *host.candidates.borrow_mut() = vec![state_member("recovered-incident", &["task-a"], 5)];
+    *host.withheld.borrow_mut() = BTreeMap::from([("task-b".into(), "human_block".into())]);
+
+    let refreshed = execution_tick(store.as_ref(), &host, 5);
+    assert_eq!(refreshed.reason, "batch_pending");
+    assert_eq!(
+        refreshed.state.unwrap().members.unwrap().withheld,
+        BTreeMap::from([("task-b".into(), "human_block".into())])
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/application/automation/members.rs
+++ b/crates/orbit-core/src/application/automation/members.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use orbit_automation::{
     AutomationError, automation_error_to_orbit,
     delivery::definition_epoch,
-    members::{self, MemberEvaluation, MemberHost, MemberOutcome, MemberPage},
+    members::{self, MemberAdmission, MemberEvaluation, MemberHost, MemberOutcome, MemberPage},
 };
 use orbit_common::OrbitError;
 use orbit_store::contracts::TaskListFilter;
@@ -200,11 +200,13 @@ impl MemberHost for Host<'_> {
         })
     }
 
-    fn admission_deferral(&self, member: &StateMember) -> Result<Option<String>, AutomationError> {
+    fn admission(&self, member: &StateMember) -> Result<MemberAdmission, AutomationError> {
         if self.trigger.kind == StateTriggerKind::ExecutionFailed
             && super::incidents::members(self.runtime)?.get(&member.key) != Some(&member.task_ids)
         {
-            return Ok(Some("incident_membership_or_recovery_changed".into()));
+            return Ok(MemberAdmission::Retire(
+                "incident_membership_or_recovery_changed".into(),
+            ));
         }
 
         // Re-derive the material now: a member whose input moved may not be admitted.
@@ -213,7 +215,7 @@ impl MemberHost for Host<'_> {
             let current = match self.trigger.kind {
                 StateTriggerKind::PreparationEligible => {
                     if !orbit_automation::members::preparation::eligible(&task) {
-                        return Ok(Some("task_ineligible".into()));
+                        return Ok(MemberAdmission::Retire("task_ineligible".into()));
                     }
                     let (_, source) = self.head(&self.trigger.branch)?;
                     preparation::fingerprint(self.runtime, &task, &source.commit)?
@@ -221,17 +223,19 @@ impl MemberHost for Host<'_> {
                 StateTriggerKind::ExecutionFailed => {
                     match super::incidents::observe(self.runtime, &task) {
                         Ok((key, _)) => key,
-                        Err(error) => return Ok(Some(error.to_string())),
+                        Err(error) => {
+                            return Ok(MemberAdmission::Retire(error.to_string()));
+                        }
                     }
                 }
             };
 
             if current != member.fingerprint {
-                return Ok(Some("material_changed".into()));
+                return Ok(MemberAdmission::Retire("material_changed".into()));
             }
         }
 
-        Ok(None)
+        Ok(MemberAdmission::Admit)
     }
 
     fn lookup(&self, attempt: &MemberAttempt) -> Result<Option<String>, AutomationError> {


### PR DESCRIPTION
## Task

[ORB-11443](https://orbit-cli.com/tasks/ORB-11443) — [code-review] Execution-failed automation can starve behind stale incident members

### Description

## Problem
The state-trigger scheduler retains a pending execution-failure member when its incident is no longer admissible. In `crates/orbit-automation/src/members/mod.rs:248-254`, admission deferrals remove pending state only for the literal `task_ineligible`; execution-failure rechecks instead return `incident_membership_or_recovery_changed`, a deferred incident error, or `material_changed` from `crates/orbit-core/src/application/automation/members.rs:203-231`. Because execution-failure member keys are incident hashes rather than task IDs (`members.rs:178-185`), a later observation of the changed incident inserts a new key and cannot replace or remove the old pending entry.

Due candidates are sorted oldest-first and only the first `max_items` are checked (`crates/orbit-automation/src/members/mod.rs:202-222,248`). Once `max_items` old incidents have changed membership, been superseded, or become human blocks before admission, every sweep spends its bounded checks on those permanently stale entries and never reaches newer eligible incidents. The same stale state also contributes to the 1,000-entry backpressure limit at lines 168-170. The shipped operation guidance recommends `max_items: 20` for execution-failed triage, so twenty such transitions can stop all automatic triage even though the routine remains enabled.

## Expected behavior
An execution-failure member that no longer matches authoritative incident membership/material should be retired or replaced without consuming admission capacity forever. Preserve intentional recovery withholding and do not diagnose stale incidents.

### Acceptance Criteria

- A deterministic execution_failed scheduler test proves that an incident which becomes ineligible or changes identity is removed or superseded in durable pending state.
- With at least max_items stale incident members followed by a newly eligible incident, the newly eligible incident is admitted within a bounded sweep rather than starved.
- Withheld diagnostics remain visible for current source members, while obsolete task-ID/incident-key entries are pruned so they cannot accumulate into source_backpressure.
- Relevant orbit-automation/Core tests, make ci-fast, make ci-lint, and git diff --check pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added an explicit member-admission outcome that distinguishes temporary withholding from obsolete source identity.
- Core now marks execution-failure membership/material changes and ineligible preparation inputs as obsolete; the scheduler removes their durable pending/incident-key diagnostics instead of rechecking them forever.
- Candidate observation clears superseded task-ID diagnostics when a current incident becomes eligible, while current source-member withholding remains visible.
- Added a deterministic execution-failed scheduler regression with max_items=2: two older stale incidents are pruned in one bounded sweep, the newer eligible incident fires on the next sweep, and current versus superseded diagnostics are asserted.
Acceptance criteria:
- Durable retirement/supersession: covered by pending and withheld state assertions after the stale-prefix sweep.
- Bounded admission: covered by exact admission-check ordering and next-sweep firing assertions.
- Diagnostic preservation/pruning: covered by recovery_pending/human_block preservation and recovered task-ID cleanup assertions.
- Required validation: all requested commands passed.
Validation:
- PASSED: cargo test -p orbit-automation (49 tests).
- PASSED: cargo test -p orbit-core application::automation::tests (8 tests; unrelated integration binaries filtered as expected).
- PASSED: cargo test -p orbit-automation members::tests::execution_failed_retires_stale_prefix_without_losing_current_diagnostics.
- PASSED: make ci-fast.
- PASSED: make ci-lint.
- PASSED: git diff --check.
Assessment: The change keeps the shared scheduler domain-neutral and places incident obsolescence classification in Core, its authoritative source adapter.
Deviations from original plan: None.
Remaining risks: No external runtime or OS-specific behavior is involved; validation exercised the durable in-memory automation store and workspace-wide lint gates.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11443-6a9de4ad`
- Behind base: 0
- Ahead of base: 1