### PR TITLE
Route routine Dependabot Actions updates to agent-main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "agent-main"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Task

[ORB-11444](https://orbit-cli.com/tasks/ORB-11444) — Route routine Dependabot Actions updates to agent-main

### Description

Live GitHub inspection found open dependency PRs 1280, 958, 957 and 956 all target main. .github/dependabot.yml configures weekly github-actions updates with no target-branch, while Orbit AGENTS.md requires routine task integration on agent-main and reserves main for release promotion/hotfixes. Set the explicit integration target in this repository's Dependabot configuration. Preserve weekly cadence/ecosystem and pinning conventions; do not upgrade actions, retarget or merge existing PRs, publish releases, or change the GitHub default branch. Verify current GitHub configuration syntax against official documentation. Terra is selected for this low-complexity maintenance task under the goal's low-work routing.

### Acceptance Criteria

- The github-actions update entry explicitly targets agent-main while preserving its existing directory and weekly schedule.
- Configuration parses and uses supported Dependabot syntax; relevant repository checks pass.
- No action versions, default branch, release behavior, or existing PR state changes; handoff explains that existing PRs require separate review.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added target-branch: agent-main to the sole github-actions Dependabot update entry in .github/dependabot.yml. The existing directory / and weekly interval are unchanged.

Assessment:
- The one-line configuration change uses GitHub documented Dependabot syntax: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#target-branch

Criteria:
- Explicit agent-main target with preserved directory and weekly schedule: passed.
- Supported syntax and repository checks: passed.
- No action versions, default branch, release behavior, or existing PR state changed: passed; the reviewed diff contains only the target-branch configuration line. Existing Dependabot PRs were neither retargeted nor modified and require separate review.

Validation:
- python3 PyYAML exact-structure parse of .github/dependabot.yml: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
- Ruby YAML parser: not run because ruby is unavailable; PyYAML provided the equivalent parse validation.

Design note:
- Per GitHub documentation, target-branch controls version-update pull requests; Dependabot security updates continue to target the repository default branch.

Remaining risks:
- GitHub will apply this configuration on its next Dependabot evaluation; no live Dependabot run was triggered, and existing pull requests require separate review.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11444-6a9de655`
- Behind base: 0
- Ahead of base: 1