### PR TITLE
Preserve valid task ownership through resumed PR failure handoff

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -20,6 +20,7 @@ use super::push::push_batch_changes_inner;
 
 const CONFLICT_BLOCKED_EVENT: &str = "pr_conflict_blocked";
 const FAILURE_HANDOFF_EVENT: &str = "pr_failure_handoff";
+const FAILURE_HANDOFF_LINEAGE_MAX_HOPS: usize = 64;
 
 /// Terminal hook for `task_pr_pipeline`.
 ///
@@ -58,12 +59,7 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
         )
     })?;
     let task = host.get_task(task_id)?;
-    if task.job_run_id.as_deref() != Some(run_id) {
-        return Err(OrbitError::Execution(format!(
-            "pr_failure_handoff: task '{}' no longer belongs to run '{}'",
-            task.id, run_id
-        )));
-    }
+    ensure_failure_handoff_ownership(host, input, &task, run_id)?;
 
     if failed_step_id == "complete_pr"
         && let Some(pr_number) = task.github_pr_number().map(ToOwned::to_owned)
@@ -199,6 +195,84 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
         "pr_created": pr_created,
         "task_status": "blocked",
     }))
+}
+
+fn ensure_failure_handoff_ownership<H: RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+    task: &orbit_types::task::Task,
+    run_id: &str,
+) -> Result<(), OrbitError> {
+    let task_owner = task.job_run_id.as_deref().ok_or_else(|| {
+        OrbitError::Execution(format!(
+            "pr_failure_handoff: task '{}' has no owning run; refusing handoff for run '{}'",
+            task.id, run_id
+        ))
+    })?;
+    if task_owner == run_id {
+        return Ok(());
+    }
+
+    let worktree = pipeline_step(input, "worktree")?;
+    let checkpoint_owner = input_string_field(worktree, "job_run_id")
+        .or_else(|| input_string_field(worktree, "batch_id"))
+        .ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "pr_failure_handoff: resumed run '{run_id}' has no worktree ownership checkpoint"
+            ))
+        })?;
+    if task_owner != checkpoint_owner {
+        return Err(OrbitError::Execution(format!(
+            "pr_failure_handoff: task '{}' belongs to run '{}', not active run '{}' or worktree checkpoint owner '{}'",
+            task.id, task_owner, run_id, checkpoint_owner
+        )));
+    }
+
+    ensure_retry_descends_from_checkpoint(host, &task.id, run_id, &checkpoint_owner)
+}
+
+fn ensure_retry_descends_from_checkpoint<H: RuntimeHost + ?Sized>(
+    host: &H,
+    task_id: &str,
+    run_id: &str,
+    checkpoint_owner: &str,
+) -> Result<(), OrbitError> {
+    let mut current = host.get_job_run(run_id)?.ok_or_else(|| {
+        OrbitError::Execution(format!(
+            "pr_failure_handoff: cannot verify ownership for task '{task_id}'; active run '{run_id}' was not found"
+        ))
+    })?;
+    let job_id = current.job_id.clone();
+
+    for _ in 0..FAILURE_HANDOFF_LINEAGE_MAX_HOPS {
+        let Some(parent_run_id) = current.retry_source_run_id.as_deref() else {
+            return Err(OrbitError::Execution(format!(
+                "pr_failure_handoff: run '{run_id}' is not a retry descendant of worktree checkpoint owner '{checkpoint_owner}' for task '{task_id}'"
+            )));
+        };
+        let parent = host.get_job_run(parent_run_id)?.ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "pr_failure_handoff: cannot verify ownership for task '{task_id}'; retry ancestor '{parent_run_id}' was not found"
+            ))
+        })?;
+        if parent.job_id != job_id {
+            return Err(OrbitError::Execution(format!(
+                "pr_failure_handoff: retry lineage for run '{run_id}' crosses from job '{job_id}' to job '{}' at run '{}'; refusing handoff for task '{task_id}'",
+                parent.job_id, parent.run_id
+            )));
+        }
+        if parent.run_id == checkpoint_owner {
+            return Ok(());
+        }
+        if parent.run_id == current.run_id {
+            break;
+        }
+        current = parent;
+    }
+
+    Err(OrbitError::Execution(format!(
+        "pr_failure_handoff: run '{run_id}' has no bounded retry lineage to worktree checkpoint owner '{checkpoint_owner}' for task '{task_id}'"
+    )))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/mod.rs
@@ -5,4 +5,5 @@ mod complete;
 mod handoff;
 mod merge;
 mod open;
+mod resume_failure;
 pub(in crate::executor::automation::vcs::pr) mod test_support;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
@@ -1,0 +1,400 @@
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use orbit_agent::loop_engine::audit::{AuditSink, NullSink};
+use orbit_common::OrbitError;
+use orbit_tools::ToolContext;
+use serde_json::{Value, json};
+
+use super::test_support::*;
+use crate::context::{RuntimeHost, TaskAutomationUpdate};
+use crate::executor::automation::vcs::failure::pr_failure_handoff;
+use crate::{DispatchError, V2AuditWriter, execute_job_with_resume};
+use orbit_types::task::{Task, TaskStatus};
+use orbit_types::workflow::activity_job::{
+    ActivityV2, ActivityV2Spec, DeterministicSpec, JobKind, JobV2, JobV2Step, JobV2StepBody,
+    TargetStep,
+};
+use orbit_types::workflow::{JobRun, JobRunState, JobScheduleState, PipelineState};
+
+const TASK_ID: &str = "ORB-RESUMED-FAILURE";
+const CHECKPOINT_RUN_ID: &str = "jrun-checkpoint-owner";
+const FIRST_RESUME_RUN_ID: &str = "jrun-first-resume";
+const SECOND_RESUME_RUN_ID: &str = "jrun-second-resume";
+
+struct ResumeFailureHost {
+    inner: PrOpenTestHost,
+}
+
+impl RuntimeHost for ResumeFailureHost {
+    fn run_deterministic(
+        &self,
+        action: &str,
+        _config: &Value,
+        input: &Value,
+        _tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        match action {
+            "test_partial_repair_failure" => {
+                let workspace_path = input
+                    .get("workspace_path")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| DispatchError::DeterministicActionFailed {
+                        action: action.to_string(),
+                        message: "fixture input is missing workspace_path".to_string(),
+                    })?;
+                let source_dir = Path::new(workspace_path).join("src");
+                fs::create_dir_all(&source_dir).map_err(|error| {
+                    DispatchError::DeterministicActionFailed {
+                        action: action.to_string(),
+                        message: format!("create fixture source directory: {error}"),
+                    }
+                })?;
+                fs::write(
+                    source_dir.join("repaired.rs"),
+                    "pub fn first_repair() {}\npub fn second_repair() {}\n",
+                )
+                .map_err(|error| DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: format!("write fixture partial repair: {error}"),
+                })?;
+                Err(DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: "repaired two ownership calls; required macOS validation remains unavailable"
+                        .to_string(),
+                })
+            }
+            "pr_failure_handoff" => pr_failure_handoff(self, input).map_err(|error| {
+                DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: error.to_string(),
+                }
+            }),
+            _ => Err(DispatchError::DeterministicActionNotRegistered(
+                action.to_string(),
+            )),
+        }
+    }
+
+    fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
+        self.inner.get_job_run(run_id)
+    }
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.inner.get_task(task_id)
+    }
+
+    fn apply_task_automation_update(
+        &self,
+        task_id: &str,
+        update: TaskAutomationUpdate,
+    ) -> Result<(), OrbitError> {
+        self.inner.apply_task_automation_update(task_id, update)
+    }
+
+    fn run_private_vcs_operation(
+        &self,
+        operation: &str,
+        input: Value,
+    ) -> Result<Value, OrbitError> {
+        self.inner.run_private_vcs_operation(operation, input)
+    }
+}
+
+fn task_owned_by(run_id: &str) -> orbit_types::task::Task {
+    let mut task = batch_task(
+        TASK_ID,
+        "Preserve partial repair",
+        "Outcome: failed\nChanges:\n- Repaired two calls before required validation failed.",
+    );
+    task.job_run_id = Some(run_id.to_string());
+    task
+}
+
+fn resumed_failure_input(workspace_path: &std::path::Path, run_id: &str) -> Value {
+    json!({
+        "failed_step_id": "implement_bundle",
+        "activity_name": "agent_implement",
+        "error_code": "macos_validation_unavailable",
+        "error_message": "repaired two ownership calls; required macOS validation remains unavailable",
+        "run_id": run_id,
+        "job_input": {
+            "task_ids": [TASK_ID],
+            "base_branch": "agent-main",
+            "base_sync": "local",
+        },
+        "pipeline": {
+            "worktree": {
+                "workspace_path": workspace_path,
+                "job_run_id": CHECKPOINT_RUN_ID,
+                "base_ref": "agent-main",
+            },
+        },
+    })
+}
+
+fn deterministic_activity(action: &str) -> ActivityV2 {
+    ActivityV2 {
+        description: format!("test action {action}"),
+        input_schema_json: Value::Null,
+        output_schema_json: Value::Null,
+        fs_profile: None,
+        spec: ActivityV2Spec::Deterministic(DeterministicSpec {
+            action: action.to_string(),
+            config: Value::Null,
+        }),
+    }
+}
+
+fn deterministic_step(id: &str, action: &str, default_input: Option<Value>) -> JobV2Step {
+    JobV2Step {
+        id: id.to_string(),
+        when: None,
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(TargetStep {
+            spec: deterministic_activity(action).spec,
+            activity_name: None,
+            input_schema_json: None,
+            fs_profile: None,
+            default_input,
+            timeout_seconds: 0,
+            session: None,
+        }),
+    }
+}
+
+fn resumed_pr_job() -> JobV2 {
+    JobV2 {
+        state: JobScheduleState::Enabled,
+        default_input: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        failure_activity: Some("pr_failure_handoff".to_string()),
+        resolved_failure_activity: Some(deterministic_activity("pr_failure_handoff")),
+        max_active_runs: 1,
+        kind: JobKind::Workflow,
+        steps: vec![
+            deterministic_step("worktree", "unused_worktree_setup", None),
+            deterministic_step(
+                "implement_bundle",
+                "test_partial_repair_failure",
+                Some(json!({
+                    "workspace_path": "{{ steps.worktree.output.workspace_path }}",
+                })),
+            ),
+        ],
+    }
+}
+
+fn completed_worktree_checkpoint(workspace_path: &std::path::Path) -> PipelineState {
+    let input = json!({
+        "task_ids": [TASK_ID],
+        "base_branch": "agent-main",
+        "base_sync": "local",
+    });
+    let worktree = json!({
+        "workspace_path": workspace_path,
+        "job_run_id": CHECKPOINT_RUN_ID,
+        "base_ref": "agent-main",
+    });
+    let mut state = PipelineState::new(
+        CHECKPOINT_RUN_ID.to_string(),
+        "task_pr_pipeline".to_string(),
+        input,
+    );
+    state.record_step(0, JobRunState::Success, Some(worktree.clone()), None);
+    state.sync_pipeline(json!({ "worktree": worktree }));
+    state
+}
+
+#[test]
+fn repeated_resume_failure_publishes_partial_repair_to_the_existing_pr() {
+    let workspace = no_diff_pr_workspace();
+    let host = ResumeFailureHost {
+        inner: PrOpenTestHost::new(
+            vec![task_owned_by(CHECKPOINT_RUN_ID)],
+            workspace.repo.clone(),
+        )
+        .with_existing_pr()
+        .with_job_run(CHECKPOINT_RUN_ID, None)
+        .with_job_run(FIRST_RESUME_RUN_ID, Some(CHECKPOINT_RUN_ID))
+        .with_job_run(SECOND_RESUME_RUN_ID, Some(FIRST_RESUME_RUN_ID)),
+    };
+    let sink: Arc<dyn AuditSink> = Arc::new(NullSink);
+    let writer = Arc::new(V2AuditWriter::new(SECOND_RESUME_RUN_ID, "test-agent", sink));
+
+    let error = execute_job_with_resume(
+        &resumed_pr_job(),
+        json!({
+            "task_ids": [TASK_ID],
+            "base_branch": "agent-main",
+            "base_sync": "local",
+        }),
+        SECOND_RESUME_RUN_ID,
+        writer,
+        &host,
+        Some(&completed_worktree_checkpoint(&workspace.repo)),
+    )
+    .expect_err("the resumed implementation failure remains authoritative");
+
+    assert!(
+        error
+            .to_string()
+            .contains("required macOS validation remains unavailable"),
+        "the original implementation blocker stays authoritative: {error}",
+    );
+    assert!(
+        workspace.repo.join("src/repaired.rs").exists(),
+        "the resumed implementation produced its partial repair",
+    );
+    assert_eq!(host.inner.task_status(TASK_ID), TaskStatus::Blocked);
+    let recovered_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    assert_ne!(
+        recovered_head,
+        git(&workspace.repo, &["rev-parse", "agent-main"]),
+        "failure handoff commits the partial repair",
+    );
+    let push = host
+        .inner
+        .vcs_calls()
+        .into_iter()
+        .find(|call| call.operation == PUSH_OPERATION)
+        .expect("the recovered candidate is published");
+    assert_eq!(push.input["branch"], json!("orbit/test-batch"));
+    assert_eq!(push.input["repo_root"], json!(workspace.repo));
+    assert!(
+        !host
+            .inner
+            .vcs_calls()
+            .iter()
+            .any(|call| call.operation == PR_CREATE_OPERATION),
+        "the existing PR is reused rather than replaced",
+    );
+    let blocker = host
+        .inner
+        .comments_for(TASK_ID)
+        .pop()
+        .expect("precise failure blocker");
+    assert!(blocker.message.contains(SECOND_RESUME_RUN_ID));
+    assert!(blocker.message.contains("implement_bundle"));
+    assert!(
+        blocker.message.contains("pipeline_step_failed"),
+        "{}",
+        blocker.message
+    );
+    assert!(
+        blocker
+            .message
+            .contains("required macOS validation remains unavailable")
+    );
+}
+
+#[test]
+fn unrelated_run_cannot_use_another_runs_checkpoint_to_publish() {
+    let workspace = no_diff_pr_workspace();
+    fs::write(workspace.repo.join("unrelated.txt"), "must stay local\n")
+        .expect("write unrelated candidate");
+    let host = PrOpenTestHost::new(
+        vec![task_owned_by(CHECKPOINT_RUN_ID)],
+        workspace.repo.clone(),
+    )
+    .with_job_run(CHECKPOINT_RUN_ID, None)
+    .with_job_run("jrun-unrelated", None);
+
+    let error = pr_failure_handoff(
+        &host,
+        &resumed_failure_input(&workspace.repo, "jrun-unrelated"),
+    )
+    .expect_err("an unrelated run cannot inherit checkpoint ownership");
+
+    assert!(
+        error.to_string().contains("not a retry descendant"),
+        "{error}"
+    );
+    assert!(host.vcs_calls().is_empty());
+    assert_eq!(host.task_status(TASK_ID), TaskStatus::InProgress);
+    assert!(
+        git(&workspace.repo, &["status", "--porcelain"]).contains("unrelated.txt"),
+        "ownership refusal occurs before candidate mutation",
+    );
+}
+
+#[test]
+fn superseded_resume_cannot_publish_after_task_ownership_moves() {
+    let workspace = no_diff_pr_workspace();
+    fs::write(workspace.repo.join("superseded.txt"), "must stay local\n")
+        .expect("write superseded candidate");
+    let host = PrOpenTestHost::new(
+        vec![task_owned_by("jrun-superseding-owner")],
+        workspace.repo.clone(),
+    )
+    .with_job_run(CHECKPOINT_RUN_ID, None)
+    .with_job_run(FIRST_RESUME_RUN_ID, Some(CHECKPOINT_RUN_ID));
+
+    let error = pr_failure_handoff(
+        &host,
+        &resumed_failure_input(&workspace.repo, FIRST_RESUME_RUN_ID),
+    )
+    .expect_err("a superseded resume cannot publish the new owner's task");
+
+    let message = error.to_string();
+    assert!(message.contains("jrun-superseding-owner"), "{message}");
+    assert!(message.contains(FIRST_RESUME_RUN_ID), "{message}");
+    assert!(message.contains(CHECKPOINT_RUN_ID), "{message}");
+    assert!(host.vcs_calls().is_empty());
+    assert_eq!(host.task_status(TASK_ID), TaskStatus::InProgress);
+    assert!(
+        git(&workspace.repo, &["status", "--porcelain"]).contains("superseded.txt"),
+        "ownership refusal occurs before candidate mutation",
+    );
+}
+
+#[test]
+fn original_run_ownership_still_authorizes_failure_handoff() {
+    let workspace = no_diff_pr_workspace();
+    fs::write(workspace.repo.join("original.txt"), "original candidate\n")
+        .expect("write original candidate");
+    let host = PrOpenTestHost::new(
+        vec![task_owned_by(CHECKPOINT_RUN_ID)],
+        workspace.repo.clone(),
+    );
+
+    let recovered = pr_failure_handoff(
+        &host,
+        &resumed_failure_input(&workspace.repo, CHECKPOINT_RUN_ID),
+    )
+    .expect("the original run retains its direct ownership authority");
+
+    assert_eq!(recovered["decision"], json!("blocked_failure_pr"));
+    assert_eq!(recovered["committed_files"], json!(["original.txt"]));
+    assert_eq!(host.task_status(TASK_ID), TaskStatus::Blocked);
+}
+
+#[test]
+fn resumed_delivery_tail_preserves_the_published_pr() {
+    let workspace = pr_workspace();
+    let mut task = review_batch_task(TASK_ID, Some("codex"), None);
+    task.job_run_id = Some(CHECKPOINT_RUN_ID.to_string());
+    let host = PrOpenTestHost::new(vec![task], workspace.repo.clone())
+        .with_existing_pr()
+        .with_job_run(CHECKPOINT_RUN_ID, None)
+        .with_job_run(FIRST_RESUME_RUN_ID, Some(CHECKPOINT_RUN_ID));
+    let head_before = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    let mut input = resumed_failure_input(&workspace.repo, FIRST_RESUME_RUN_ID);
+    input["failed_step_id"] = json!("complete_pr");
+    input["activity_name"] = json!("pr_complete");
+    input["error_code"] = json!("merge_gate_failed");
+    input["error_message"] = json!("required status check remains pending");
+
+    let recovered = pr_failure_handoff(&host, &input)
+        .expect("retry lineage authorizes completion-tail preservation");
+
+    assert_eq!(recovered["decision"], json!("review_completion_failure"));
+    assert_eq!(recovered["pr_number"], json!("42"));
+    assert_eq!(host.task_status(TASK_ID), TaskStatus::Review);
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), head_before);
+    assert!(host.vcs_calls().is_empty());
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -12,6 +12,7 @@ use orbit_types::task::{
     ExternalRef, Task, TaskArtifact, TaskComment, TaskPriority, TaskStatus, TaskType,
     push_external_ref_if_missing,
 };
+use orbit_types::workflow::{JobRun, JobRunState};
 use serde_json::{Value, json};
 use tempfile::{TempDir, tempdir};
 
@@ -38,6 +39,7 @@ pub struct VcsCall {
 
 pub struct PrOpenTestHost {
     tasks: Mutex<Vec<Task>>,
+    job_runs: Mutex<Vec<JobRun>>,
     comments: Mutex<HashMap<String, Vec<TaskComment>>>,
     vcs_calls: Mutex<Vec<VcsCall>>,
     automation_updates: Mutex<Vec<(String, TaskAutomationUpdate)>>,
@@ -57,6 +59,7 @@ impl PrOpenTestHost {
         let scoreboard_dir = data_root.join("scoreboard");
         Self {
             tasks: Mutex::new(tasks),
+            job_runs: Mutex::new(Vec::new()),
             comments: Mutex::new(HashMap::new()),
             vcs_calls: Mutex::new(Vec::new()),
             automation_updates: Mutex::new(Vec::new()),
@@ -103,6 +106,30 @@ impl PrOpenTestHost {
 
     pub fn with_existing_pr(self) -> Self {
         *self.pr_exists.lock().expect("pr exists lock") = true;
+        self
+    }
+
+    pub fn with_job_run(self, run_id: &str, retry_source_run_id: Option<&str>) -> Self {
+        let now = Utc::now();
+        self.job_runs.lock().expect("job runs lock").push(JobRun {
+            run_id: run_id.to_string(),
+            job_id: "task_pr_pipeline".to_string(),
+            attempt: 1,
+            state: JobRunState::Failed,
+            scheduled_at: now,
+            started_at: Some(now),
+            finished_at: Some(now),
+            duration_ms: Some(1),
+            created_at: now,
+            pid: None,
+            pid_start_time: None,
+            input: None,
+            retry_source_run_id: retry_source_run_id.map(ToOwned::to_owned),
+            knowledge_metrics: None,
+            resolved_crew: None,
+            crew_model: None,
+            steps: Vec::new(),
+        });
         self
     }
 
@@ -208,6 +235,16 @@ impl PrOpenTestHost {
 }
 
 impl RuntimeHost for PrOpenTestHost {
+    fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
+        Ok(self
+            .job_runs
+            .lock()
+            .expect("job runs lock")
+            .iter()
+            .find(|run| run.run_id == run_id)
+            .cloned())
+    }
+
     fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
         self.tasks
             .lock()

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -185,6 +185,13 @@ $ orbit run events jrun-20260704-0928
 │ 2026-07-04T09:28:17Z   run.finished        success                                                         │
 ```
 
+For PR workflows, the reused worktree checkpoint keeps the original run as
+the task/candidate owner. Delivery and terminal failure handoff accept that
+owner only when the active run's durable `retry_source_run_id` chain reaches
+the checkpoint owner. Direct ownership still authorizes the original run.
+An unrelated run, a broken lineage, or a task re-claimed by a superseding run
+fails before Orbit commits, pushes, or updates the task.
+
 Resume needs the job present in the catalog (`orbit job list --all`). A run started from
 a raw YAML path can be resumed only after that YAML is registered under `resources/jobs/`.
 A run with no successful checkpoints degrades to a full replay.


### PR DESCRIPTION
## Task

[ORB-11441](https://orbit-cli.com/tasks/ORB-11441) — Preserve valid task ownership through resumed PR failure handoff

### Description

Live repro: ORB-11435 original run jrun-20260906-2146-7 resumed via authoritative workflow_run_resume as jrun-20260906-2200. Worktree setup correctly skipped as checkpointed, implement_one repaired two calls and reported pending required macOS validation. Terminal pr_failure_handoff failed: task ORB-11435 no longer belongs to run jrun-20260906-2200. Task still holds original run ID and candidate remained uncommitted/unpublished. Owning worker log .orbit/state/logs/jrun-20260906-2200.worker.log records the exact failure. Failure handoff in crates/orbit-engine/src/executor/automation/vcs/failure.rs compares task.job_run_id directly against the new run ID; resumed worktree/delivery checkpoint retains original ownership. Investigate existing resume ownership contract including completed ORB-10470; repair the authoritative resume/handoff boundary without weakening protection against unrelated or superseding runs. Preserve source run lineage, candidate, task identity and original failure. No blind retries or task ID rewrites as a substitute.

### Acceptance Criteria

- An integration test resumes a PR run after completed worktree setup, produces partial repair then fails implementation, and verifies handoff commits/publishes the correct candidate to the existing PR with precise blocker.
- Unrelated/superseding runs remain unable to mutate or publish another task candidate; ownership checks hold across restart and repeated resume.
- Successful delivery-tail resume and original-run behavior remain correct; tests prove lineage/checkpoint ownership rather than bypassing equality checks.
- Required repository checks pass and existing resume documentation reflects the implemented contract.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Failure handoff now preserves the original direct-ownership path and additionally accepts a resumed run only when the task still belongs to the reused worktree checkpoint owner and the active run reaches that owner through a bounded, same-job retry_source_run_id chain. Missing, unrelated, cross-job, broken, and superseded ownership fail before Git, VCS, or task mutations.
- Added an executor integration regression that starts from a completed worktree checkpoint, skips setup, writes a partial repair, fails implementation, and verifies the terminal hook commits/pushes the candidate to the existing PR branch while retaining the original blocker. Added focused coverage for repeated resume lineage, unrelated runs, superseding ownership, original-run behavior, and resumed completion-tail preservation.
- Updated the resume runbook with the checkpoint-owner and retry-lineage contract. Added file:docs/runbooks/stuck-job-runs.md to task context because documentation was an explicit acceptance criterion.

Acceptance criteria:
1. Satisfied: repeated_resume_failure_publishes_partial_repair_to_the_existing_pr executes the resumed pipeline from the worktree checkpoint and verifies candidate commit, push, existing-PR reuse, blocked task, and exact failure details.
2. Satisfied: unrelated_run_cannot_use_another_runs_checkpoint_to_publish and superseded_resume_cannot_publish_after_task_ownership_moves prove refusal occurs before repository/VCS/task mutation; the integration test traverses two resume generations.
3. Satisfied: resumed_delivery_tail_preserves_the_published_pr and original_run_ownership_still_authorizes_failure_handoff retain delivery-tail and direct ownership behavior; existing orbit-core resume tests also prove checkpoint reuse, idempotent reconciliation, and live sibling protection.
4. Satisfied: required checks passed and docs describe the implemented contract.

Validation:
- PASS: cargo test -p orbit-engine resume_failure --lib (5 passed).
- PASS: cargo test -p orbit-engine --lib (544 passed, 2 environment-dependent tests ignored by their existing annotations).
- PASS: cargo test -p orbit-core application::job::tests::resume --lib (6 passed).
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: git diff --check.

Assessment: The check remains fail-closed and adds no second ownership authority: task equality, checkpoint identity, and persisted retry lineage must all agree before a resumed handoff can mutate state.

Remaining risk: Git behavior is exercised against real temporary repositories, while push/PR operations use the existing in-memory private-VCS test boundary; no live GitHub or macOS run was performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11441-6a9de3bb`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*