### PR TITLE
Fix public connect rustdoc linking to private reject_root_override

### DIFF
--- a/crates/orbit-web/src/connect.rs
+++ b/crates/orbit-web/src/connect.rs
@@ -88,8 +88,8 @@ pub struct ConnectArgs {
 ///
 /// A top-level `--root` is rejected rather than ignored: this command reads no
 /// local `.orbit/` state, so there is no data directory for it to override,
-/// and the flag used to name the *remote* workspace here (ORB-11388). See
-/// [`reject_root_override`].
+/// and the flag previously used to name the *remote* workspace is now
+/// `--workspace`.
 pub fn connect(args: ConnectArgs, root_override: Option<&Path>) -> Result<(), OrbitError> {
     reject_root_override(root_override)?;
     let local_port = select_local_port(args.port)?;


### PR DESCRIPTION
## Task

[ORB-11445](https://orbit-cli.com/tasks/ORB-11445) — Fix public connect rustdoc linking to private reject_root_override

### Description

CI run 34062897874 job 101566500342 at checked-out PR1456 head b9194fd57da12149439afeca0a22a72b5ea9972b passed tests but failed cargo documentation with -D warnings: public documentation for connect links to private item reject_root_override at crates/orbit-web/src/connect.rs:92. Current source retains it. git blame attributes the link to ORB-11388 commit 1d1c5d8a096ab4d8d5f4a48b10b56ff2a648f796 PR1432, not ORB-11438. Replace the private intra-doc link with accurate public-facing prose/code formatting; remove task-ID implementation detail from the affected public doc if appropriate. Do not make the helper public, weaken rustdoc warnings, or change root routing.

### Acceptance Criteria

- Public documentation builds with RUSTDOCFLAGS='-D warnings' cargo doc -p orbit-web --no-deps using the repository toolchain.
- The private helper remains private; public docs accurately describe root behavior and runtime behavior is unchanged.
- Required repository gates pass; record scoped doc validation and CI evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated crates/orbit-web/src/connect.rs public `connect` rustdoc to describe the `--root` rejection and `--workspace` replacement without linking to the private `reject_root_override` helper or exposing an internal task identifier.
- Kept `reject_root_override` private and made no runtime changes.

Criteria:
- Public documentation: passed — `RUSTDOCFLAGS='-D warnings' cargo doc -p orbit-web --no-deps` completed successfully.
- Privacy and behavior: passed — reviewed the one-file documentation-only diff; helper visibility and executable code are unchanged.
- Required repository gates: passed — `make ci-fast` and `make ci-lint` completed successfully.

Validation:
- Passed: `RUSTDOCFLAGS='-D warnings' cargo doc -p orbit-web --no-deps`
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `git diff --check`

Assessment: A minimal one-file rustdoc correction removes the invalid private intra-doc link while preserving the documented root-routing behavior.

Risks: None identified; no runtime behavior changed.

Friction checkpoint: No qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11445-6a9de749`
- Behind base: 0
- Ahead of base: 1