### PR TITLE
Update GitHub Actions dependencies with current runner compatibility

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -49,7 +49,7 @@ jobs:
     name: macOS Sandbox
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head SHA, not the branch name GitHub deletes on merge, and
           # not github.sha (the ephemeral merge commit).
@@ -58,7 +58,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: Linux Sandbox & Policy Enforcement
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head SHA, not the branch name GitHub deletes on merge, and
           # not github.sha (the ephemeral merge commit).
@@ -53,7 +53,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -78,7 +78,7 @@ jobs:
     name: MSRV (cargo check on pinned minimum)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head SHA, not the branch name GitHub deletes on merge, and
           # not github.sha (the ephemeral merge commit).
@@ -89,7 +89,7 @@ jobs:
         with:
           toolchain: "1.89"
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -133,7 +133,7 @@ jobs:
           echo "Disk after cleanup:"
           df -h /
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head SHA, not the branch name GitHub deletes on merge, and
           # not github.sha (the ephemeral merge commit).
@@ -148,7 +148,7 @@ jobs:
       # the cache path (it churns near actions/cache's ~10 GB cap and its
       # restore competes with fresh instrumented artifacts + profraw for disk).
       # Only the immutable registry/git deps are cached here.
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -216,7 +216,7 @@ jobs:
           echo "Disk after cleanup:"
           df -h /
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # PR head SHA, not the branch name GitHub deletes on merge, and
           # not github.sha (the ephemeral merge commit).
@@ -227,7 +227,7 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -74,7 +74,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout the verified release commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.verify-release.outputs.commit_sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,14 @@ jobs:
             companion_asset: orbit-search-companion-linux-aarch64
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-05-07)
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -136,7 +136,7 @@ jobs:
       darwin_intel_sha: ${{ steps.metadata.outputs.darwin_intel_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download packaged artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -219,7 +219,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
@@ -243,7 +243,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tap repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: constellation-works/homebrew-tap
           token: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/smoke-npm-install.yml
+++ b/.github/workflows/smoke-npm-install.yml
@@ -34,12 +34,12 @@ jobs:
           - ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,9 +27,9 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm
@@ -87,7 +87,7 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download static site
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
## Task

[ORB-11446](https://orbit-cli.com/tasks/ORB-11446) — Update GitHub Actions dependencies with current runner compatibility

### Description

Current CI job 101566500342 logs warn actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 and actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 target deprecated Node20 and are forced onto Node24. Open Dependabot proposals: #958 cache 6.1.0, #957 checkout 7.0.1, #956 setup-node 7.0.0, #1280 softprops/action-gh-release 3.0.3 (all originally target main). Prepare compatible supported updates on agent-main after checking upstream release notes/action.yml and actual Orbit consumers. Verify runner minimums, credential handling, cache read/write behavior, checkout fork restrictions, Node/npm setup, and release inputs. Preserve immutable SHA pins with version comments, permissions, manual release triggers and existing security boundaries. Do not blindly accept a major version; keep any incompatible action pinned and record the concrete reason. Do not merge/retarget/close existing Dependabot PRs or publish releases; this task supplies one normal integration PR for compatible updates. Avoid application/runtime edits or unrelated workflow redesign.

### Acceptance Criteria

- Every changed action pin is verified against an upstream supported release and compatibility of the affected Orbit workflow; incompatible candidates are documented rather than forced.
- Checkout, cache and Node setup paths validate through applicable workflow checks and ordinary PR CI; release inputs are checked without performing live publication.
- Existing immutable pinning, permission scope, required tests, manual release boundaries and application versions are preserved.
- Repository checks pass and handoff lists adopted versions, precise verification, and any unexercised external release behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated all 12 actions/checkout pins from v4.3.1 to v7.0.1 (3d3c42e5aac5ba805825da76410c181273ba90b1).
- Updated all 6 actions/cache pins from v4.3.0 to v6.1.0 (55cc8345863c7cc4c66a329aec7e433d2d1c52a9).
- Updated both actions/setup-node pins from v4.4.0 to v7.0.0 (820762786026740c76f36085b0efc47a31fe5020).
- Updated softprops/action-gh-release from v2.6.2 to v3.0.3 (efb35369e0ad2afab669f228072c1b0d510eae64).

Acceptance criteria:
1. Upstream verification: GitHub tag-to-commit API resolution and immutable-SHA action.yml reads verified every adopted pin. All four releases use Node 24. Checkout v7 fork blocking applies only to pull_request_target/workflow_run, neither used here; v6 credential persistence remains transparent for shell git commands, and its runner 2.329.0 caveat applies only to authenticated commands inside container actions. Cache v6 retains path/key/restore/post-save behavior and v6.1.0 explicitly makes fork/read-only cache save denial non-fatal. Setup-node v7 retains the exact node-version/cache/cache-dependency-path paths used here; the website cache is explicit and the smoke workflow has no root package.json that could trigger automatic npm caching. Action-gh-release v3.0.3 retains tag_name, name, files, generate_release_notes, and default token behavior. All jobs use GitHub-hosted runners, satisfying the Node 24 runner floor (2.327.1). No proposed candidate was incompatible, so all were adopted.
2. Workflow checks: all six workflow YAML files parsed successfully, every external action remains pinned to a 40-character SHA, and a baseline-normalization check proved that only the four action pins/version comments changed. Website npm ci, check, and build passed with the existing Node/application inputs. MCP publication structural/manual-boundary test and npm smoke version assertion passed. Live GitHub checkout/cache execution remains for ordinary PR CI; no workflow was dispatched.
3. Boundaries preserved: pin-only comparison against starting HEAD 050f1dce9873afe86d2c31c9e035004f0379f45c proves permissions, triggers, refs, tokens, cache keys/paths, release inputs, manual publication, and application versions are unchanged.
4. Repository checks: make ci-fast passed; make ci-lint passed; make release-check passed its local structural/version checks with all checked-in versions at 0.19.0; git diff --check passed.

Validation:
- PASSED: make ci-fast
- PASSED: make ci-lint
- PASSED: ./scripts/test-mcp-registry-publish-workflow.sh
- PASSED: ./scripts/smoke-npm-install.sh --dry-run-version-assertion
- PASSED: npm ci && npm run check && npm run build in website, using a temporary writable npm cache after the default home cache returned EROFS
- PASSED: make release-check for local structural/version invariants; mcp-publisher validation and npm registry lookup were reported skipped by the script, while gh release lookup reported 0.19.0
- PASSED: upstream tag/SHA, Node 24 metadata, consumer-input, runner-floor, credential/fork, and cache read/write assertions against the four upstream GitHub repositories
- PASSED: PyYAML syntax parse, immutable-pin scan, exact pin counts, and pin-only baseline comparison across .github/workflows
- PASSED: git diff --check and final git status review
- NOT RUN: live release publication, MCP publication, Homebrew push, Cloudflare deployment, or workflow dispatch; explicitly outside authorization
- NOT RUN: hosted GitHub Actions execution; expected to run through the pipeline-owned ordinary PR CI

Assessment: Minimal dependency-only workflow update. Immutable pinning and every existing security/release boundary are preserved.

Remaining risk: Node 24 action bundles and real cache restore/save behavior were verified from upstream metadata/documentation but can only be exercised on GitHub-hosted runners in PR CI. Live external publication behavior is intentionally unexercised.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11446-6a9de8b5`
- Behind base: 0
- Ahead of base: 1