### PR TITLE
Expose CI sweep pilot failures and release-only repairs without false success or repeat implementation

### DIFF
--- a/.orbit/resources/activities/file_ci_failure_tasks.yaml
+++ b/.orbit/resources/activities/file_ci_failure_tasks.yaml
@@ -44,8 +44,9 @@ spec:
     successful output includes an `audit` object with counts and identities for
     latest runs, current and investigated failures, created tasks, existing
     dedupe owners, and the findings deferred for incomplete evidence, so
-    partial registration is legible to an operator rather than inferred. The filing entries retain workflow, job, step, runner-tested
-    commit, and source run URLs for the later pilot/admission audit.
+    partial registration is legible to an operator rather than inferred. The
+    filing entries retain workflow, job, step, runner-tested commit, source run
+    IDs/URLs, and ref kinds/branches for the later pilot/admission audit.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -64,7 +65,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidate_count, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
     properties:
       outcome:
         type: string
@@ -78,6 +79,8 @@ spec:
       clusters:
         type: number
       filed_count:
+        type: number
+      pilot_candidate_count:
         type: number
       max_tasks:
         type: number
@@ -101,7 +104,17 @@ spec:
               type: string
             tested_commit:
               type: string
+            run_ids:
+              type: array
             run_urls:
+              type: array
+              items:
+                type: string
+            ref_kinds:
+              type: array
+              items:
+                type: string
+            head_branches:
               type: array
               items:
                 type: string
@@ -113,7 +126,7 @@ spec:
           sweep provenance used by the pilot/admission boundary.
         items:
           type: object
-          required: [task_id, failure_key, workflow, job, step, tested_commit, run_urls]
+          required: [task_id, failure_key, workflow, job, step, tested_commit, run_ids, run_urls, ref_kinds, head_branches]
       skipped_existing:
         type: array
         items:

--- a/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
+++ b/.orbit/resources/jobs/ci_failure_sweep_pipeline.yaml
@@ -20,6 +20,10 @@
 #   assesses current integration relevance, and promotes only warning-free actionable
 #   repairs. A failed pilot, invalid/missing selectors, duplicate or
 #   already-landed finding remains proposed without holding independent pilots.
+# - `require_pilot_success` (deterministic): checks every collected child
+#   result after the all-join. A failed, stale, cancelled, or unavailable pilot
+#   therefore makes the sweep visibly fail after independent successful pilots
+#   have already applied. An empty candidate list remains a successful no-op.
 #
 # Filing by itself carries no promotion authority. This named pipeline passes a
 # literal authorization only after it has selected the exact filed task for its
@@ -120,3 +124,10 @@ spec:
         join:
           mode: all
         collect: pilot_results
+
+    - id: require_pilot_success
+      when: "{{ steps.file.output.pilot_candidate_count }} != 0"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: ci-failure sweep pilot child
+        results: "{{ steps.pilot_results.output }}"

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -44,8 +44,9 @@ spec:
     successful output includes an `audit` object with counts and identities for
     latest runs, current and investigated failures, created tasks, existing
     dedupe owners, and the findings deferred for incomplete evidence, so
-    partial registration is legible to an operator rather than inferred. The filing entries retain workflow, job, step, runner-tested
-    commit, and source run URLs for the later pilot/admission audit.
+    partial registration is legible to an operator rather than inferred. The
+    filing entries retain workflow, job, step, runner-tested commit, source run
+    IDs/URLs, and ref kinds/branches for the later pilot/admission audit.
   input_schema_json:
     type: object
     required: [ci_evidence]
@@ -64,7 +65,7 @@ spec:
           in `skipped_over_cap` rather than dropped silently.
   output_schema_json:
     type: object
-    required: [outcome, clusters, filed_count, filed, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
+    required: [outcome, clusters, filed_count, filed, pilot_candidate_count, pilot_candidates, skipped_existing, skipped_over_cap, deferred, audit]
     properties:
       outcome:
         type: string
@@ -78,6 +79,8 @@ spec:
       clusters:
         type: number
       filed_count:
+        type: number
+      pilot_candidate_count:
         type: number
       max_tasks:
         type: number
@@ -101,7 +104,17 @@ spec:
               type: string
             tested_commit:
               type: string
+            run_ids:
+              type: array
             run_urls:
+              type: array
+              items:
+                type: string
+            ref_kinds:
+              type: array
+              items:
+                type: string
+            head_branches:
               type: array
               items:
                 type: string
@@ -113,7 +126,7 @@ spec:
           sweep provenance used by the pilot/admission boundary.
         items:
           type: object
-          required: [task_id, failure_key, workflow, job, step, tested_commit, run_urls]
+          required: [task_id, failure_key, workflow, job, step, tested_commit, run_ids, run_urls, ref_kinds, head_branches]
       skipped_existing:
         type: array
         items:

--- a/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml
@@ -20,6 +20,10 @@
 #   assesses current integration relevance, and promotes only warning-free actionable
 #   repairs. A failed pilot, invalid/missing selectors, duplicate or
 #   already-landed finding remains proposed without holding independent pilots.
+# - `require_pilot_success` (deterministic): checks every collected child
+#   result after the all-join. A failed, stale, cancelled, or unavailable pilot
+#   therefore makes the sweep visibly fail after independent successful pilots
+#   have already applied. An empty candidate list remains a successful no-op.
 #
 # Filing by itself carries no promotion authority. This named pipeline passes a
 # literal authorization only after it has selected the exact filed task for its
@@ -120,3 +124,10 @@ spec:
         join:
           mode: all
         collect: pilot_results
+
+    - id: require_pilot_success
+      when: "{{ steps.file.output.pilot_candidate_count }} != 0"
+      target: activity:pipeline_success_guard
+      default_input:
+        context: ci-failure sweep pilot child
+        results: "{{ steps.pilot_results.output }}"

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
@@ -96,12 +96,52 @@ pub(super) fn assess(
         })
         .collect::<Vec<_>>();
 
-    let (decision, classification, evidence) = if !already_landed.is_null() {
+    // A release failure may share a cluster with a pull-request run of the
+    // same commit. It is release-only for remediation purposes as long as no
+    // integration-head run is in that cluster.
+    let ref_kinds = filing.get("ref_kinds").and_then(Value::as_array);
+    let release_head_failure = ref_kinds.is_some_and(|kinds| {
+        kinds.iter().any(|kind| kind.as_str() == Some("release"))
+            && !kinds
+                .iter()
+                .any(|kind| kind.as_str() == Some("integration"))
+    });
+    let head_branches = filing
+        .get("head_branches")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    let (decision, classification, evidence) = if !already_landed.is_null() && release_head_failure
+    {
+        (
+            "withhold",
+            "release_promotion_or_hotfix_needed",
+            json!({
+                "red_release": {
+                    "head_branches": head_branches,
+                    "tested_commit": tested_commit,
+                    "run_urls": run_urls,
+                },
+                "covering_repair": already_landed,
+                "required_action": "promote the verified integration repair to the release branch or prepare an authorized hotfix",
+                "automatic_action": "none",
+            }),
+        )
+    } else if !already_landed.is_null() {
         ("withhold", "already_landed", already_landed.clone())
     } else if !duplicate_of.is_null() {
         ("withhold", "duplicate", duplicate_of.clone())
     } else if !warnings.is_empty() {
         ("withhold", "warnings", json!(warnings))
+    } else if disposition == "verified_no_diff" {
+        (
+            "withhold",
+            "covering_proof_missing",
+            json!({
+                "pilot_evidence": assessment.get("evidence").cloned().unwrap_or(Value::Null),
+                "required_action": "provide concrete covering task and commit evidence or return actionable selectors",
+            }),
+        )
     } else if disposition != "selectors" || selectors.is_empty() {
         (
             "withhold",
@@ -138,6 +178,8 @@ pub(super) fn assess(
             "step": step,
             "tested_commit": tested_commit,
             "run_urls": run_urls,
+            "ref_kinds": filing.get("ref_kinds").cloned().unwrap_or_else(|| json!([])),
+            "head_branches": filing.get("head_branches").cloned().unwrap_or_else(|| json!([])),
         },
         "evidence": evidence,
     }))

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -160,6 +160,7 @@ where
             "clusters": 0,
             "filed_count": 0,
             "filed": [],
+            "pilot_candidate_count": 0,
             "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
@@ -309,6 +310,7 @@ where
             "clusters": 0,
             "filed_count": 0,
             "filed": [],
+            "pilot_candidate_count": 0,
             "pilot_candidates": [],
             "skipped_existing": [],
             "skipped_over_cap": [],
@@ -491,6 +493,7 @@ where
         "clusters": clusters.len(),
         "filed_count": filed.len(),
         "filed": filed,
+        "pilot_candidate_count": pilot_candidates.len(),
         "pilot_candidates": pilot_candidates,
         "skipped_existing": skipped_existing,
         "skipped_over_cap": skipped_over_cap,
@@ -764,8 +767,23 @@ impl FailureCluster {
             "job": self.job,
             "step": self.step,
             "tested_commit": self.tested_commit,
+            "run_ids": self.run_ids(),
             "run_urls": self.run_urls(),
+            "ref_kinds": self.distinct_run_strings("ref_kind"),
+            "head_branches": self.distinct_run_strings("head_branch"),
         })
+    }
+
+    fn distinct_run_strings(&self, field: &str) -> Vec<String> {
+        self.runs
+            .iter()
+            .filter_map(|run| run.get(field).and_then(Value::as_str))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
     }
 
     fn title(&self) -> String {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -72,6 +72,17 @@ impl<'a> Assessment<'a> {
             authorized: true,
         }
     }
+
+    fn unproven_no_diff() -> Self {
+        Self {
+            selectors: Vec::new(),
+            disposition: "verified_no_diff",
+            duplicate_of: Value::Null,
+            already_landed: Value::Null,
+            warnings: Vec::new(),
+            authorized: true,
+        }
+    }
 }
 
 fn apply_pilot(
@@ -209,17 +220,18 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
             ..TaskAddParams::default()
         })
         .expect("seed completed repair");
-    let old = file(
-        &runtime,
-        vec![failure(
-            10,
-            "release",
-            "homebrew",
-            "on arm",
-            "release\thomebrew\terror: old arm formula\n",
-            CHECKOUT,
-        )],
+    let mut red_main = failure(
+        10,
+        "release",
+        "homebrew",
+        "on arm",
+        "release\thomebrew\terror: old arm formula\n",
+        CHECKOUT,
     );
+    red_main["head_branch"] = json!("main");
+    red_main["ref_kind"] = json!("release");
+    let red_main_snapshot = vec![red_main];
+    let old = file(&runtime, red_main_snapshot.clone());
     let old_filing = &old["filed"][0];
     let result = apply_pilot(
         &runtime,
@@ -233,7 +245,24 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
     .expect("classify already-landed release failure");
     assert_eq!(
         result["ci_sweep_admission"][0]["classification"],
-        "already_landed"
+        "release_promotion_or_hotfix_needed"
+    );
+    let disposition = &result["ci_sweep_admission"][0];
+    assert_eq!(disposition["source"]["ref_kinds"], json!(["release"]));
+    assert_eq!(disposition["source"]["head_branches"], json!(["main"]));
+    assert_eq!(
+        disposition["evidence"]["red_release"]["tested_commit"],
+        CHECKOUT
+    );
+    assert!(
+        disposition["evidence"]["covering_repair"]["evidence"]
+            .as_str()
+            .is_some_and(|evidence| evidence.contains(&prior.id) && evidence.contains("49740da"))
+    );
+    assert!(
+        disposition["evidence"]["required_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("release branch") && action.contains("hotfix"))
     );
     assert_eq!(
         runtime
@@ -241,6 +270,22 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
             .expect("old task")
             .status,
         TaskStatus::Proposed
+    );
+    assert!(
+        !backlog_task_ids(&runtime).contains(
+            &old_filing["task_id"]
+                .as_str()
+                .expect("release task id")
+                .to_string()
+        )
+    );
+
+    let repeated = file(&runtime, red_main_snapshot);
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(repeated["pilot_candidate_count"], json!(1));
+    assert_eq!(
+        repeated["pilot_candidates"][0]["task_id"],
+        old_filing["task_id"]
     );
 
     let current = file(
@@ -269,6 +314,56 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
             .status,
         TaskStatus::Backlog
     );
+}
+
+#[test]
+fn verified_no_diff_without_covering_proof_stays_uncertain_and_retryable() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let filed = file(
+        &runtime,
+        vec![failure(
+            10,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\terror: current regression\n",
+            CHECKOUT,
+        )],
+    );
+    let filing = &filed["filed"][0];
+    let task_id = filing["task_id"].as_str().expect("task id");
+
+    let result = apply_pilot(&runtime, &repo_root, filing, Assessment::unproven_no_diff())
+        .expect("retain an unproven no-diff assessment");
+
+    assert_eq!(
+        result["ci_sweep_admission"][0]["classification"],
+        "covering_proof_missing"
+    );
+    assert!(
+        result["ci_sweep_admission"][0]["evidence"]["required_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("covering task and commit evidence"))
+    );
+    assert_eq!(
+        runtime.get_task(task_id).expect("task").status,
+        TaskStatus::Proposed
+    );
+
+    let repeated = file(
+        &runtime,
+        vec![failure(
+            11,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\terror: current regression\n",
+            NEXT_HEAD,
+        )],
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(repeated["pilot_candidate_count"], json!(1));
+    assert_eq!(repeated["pilot_candidates"][0]["task_id"], task_id);
 }
 
 #[test]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -162,6 +162,7 @@ fn a_snapshot_that_could_not_look_reports_capability_unavailable_and_files_nothi
 
     assert_eq!(output["outcome"], json!("capability_unavailable"));
     assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["pilot_candidate_count"], json!(0));
     assert_eq!(output["filed"], json!([]));
     assert_eq!(output["clusters"], json!(0));
     // The distinction that matters: this must never read as a clean CI result.
@@ -183,6 +184,7 @@ fn no_current_failure_is_a_clean_no_op_and_not_a_capability_problem() {
 
     assert_eq!(output["outcome"], json!("no_current_failure"));
     assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["pilot_candidate_count"], json!(0));
     assert_ne!(output["outcome"], json!("capability_unavailable"));
     assert_eq!(output["capability"]["authenticated"], json!(true));
     assert!(
@@ -363,6 +365,16 @@ fn a_filed_task_is_a_proposed_bug_carrying_usable_evidence() {
         .first()
         .cloned()
         .expect("one filed task");
+    assert_eq!(output["pilot_candidate_count"], json!(1));
+    assert_eq!(output["pilot_candidates"][0]["run_ids"], json!([10]));
+    assert_eq!(
+        output["pilot_candidates"][0]["ref_kinds"],
+        json!(["integration"])
+    );
+    assert_eq!(
+        output["pilot_candidates"][0]["head_branches"],
+        json!(["agent-main"])
+    );
     let task = runtime.get_task(&task_id).expect("read filed task");
 
     assert_eq!(task.status, TaskStatus::Proposed);

--- a/crates/orbit-core/src/application/job/tests/catalog.rs
+++ b/crates/orbit-core/src/application/job/tests/catalog.rs
@@ -224,7 +224,7 @@ fn ci_failure_sweep_pipeline_pilots_proposed_findings_before_authorized_admissio
         .collect();
     assert_eq!(
         step_ids,
-        ["collect", "file", "pilots"],
+        ["collect", "file", "pilots", "require_pilot_success"],
         "proposed filing must precede pilot admission"
     );
 
@@ -262,6 +262,21 @@ fn ci_failure_sweep_pipeline_pilots_proposed_findings_before_authorized_admissio
     );
     assert_eq!(input["run_input"]["ci_sweep_filing"], "{{ item }}");
     assert_eq!(input["run_input"]["promotion_authorized"], true);
+
+    let JobV2StepBody::TargetRef(require_success) = &asset.spec.steps[3].body else {
+        panic!("CI sweep must guard collected pilot child results");
+    };
+    assert_eq!(require_success.target, "activity:pipeline_success_guard");
+    assert_eq!(
+        asset.spec.steps[3].when.as_deref(),
+        Some("{{ steps.file.output.pilot_candidate_count }} != 0")
+    );
+    let guard_input = require_success
+        .default_input
+        .as_ref()
+        .expect("pilot success guard input");
+    assert_eq!(guard_input["results"], "{{ steps.pilot_results.output }}");
+    assert_eq!(guard_input["context"], "ci-failure sweep pilot child");
 
     let mut resolved = asset.clone();
     resolve_job_target_refs(&mut resolved.spec, &catalog).expect("resolve sweep target refs");

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -665,6 +665,172 @@ impl RuntimeHost for ScriptedGateHost<'_> {
     }
 }
 
+struct ScriptedCiSweepHost<'a> {
+    runtime: &'a OrbitRuntime,
+    empty: bool,
+    invoked_task_ids: Mutex<Vec<String>>,
+    applied_task_ids: Mutex<Vec<String>>,
+}
+
+impl<'a> ScriptedCiSweepHost<'a> {
+    fn new(runtime: &'a OrbitRuntime) -> Self {
+        Self {
+            runtime,
+            empty: false,
+            invoked_task_ids: Mutex::new(Vec::new()),
+            applied_task_ids: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn empty(mut self) -> Self {
+        self.empty = true;
+        self
+    }
+
+    fn invoked_task_ids(&self) -> Vec<String> {
+        self.invoked_task_ids
+            .lock()
+            .expect("invoked task ids")
+            .clone()
+    }
+
+    fn applied_task_ids(&self) -> Vec<String> {
+        self.applied_task_ids
+            .lock()
+            .expect("applied task ids")
+            .clone()
+    }
+}
+
+impl RuntimeHost for ScriptedCiSweepHost<'_> {
+    fn repo_root(&self) -> Result<String, orbit_common::OrbitError> {
+        Ok(self.runtime.paths().repo_root.display().to_string())
+    }
+
+    fn run_deterministic(
+        &self,
+        action: &str,
+        config: &Value,
+        input: &Value,
+        tool_context: ToolContext,
+    ) -> Result<Value, DispatchError> {
+        match action {
+            "collect_ci_evidence" => Ok(json!({
+                "phase": "collected",
+                "ci_evidence": {
+                    "schema_version": 1,
+                    "collected": true,
+                    "capability": {},
+                    "current_failures": [],
+                }
+            })),
+            "file_ci_failure_tasks" => {
+                if self.empty {
+                    return Ok(json!({
+                        "outcome": "no_current_failure",
+                        "clusters": 0,
+                        "filed_count": 0,
+                        "filed": [],
+                        "pilot_candidate_count": 0,
+                        "pilot_candidates": [],
+                        "skipped_existing": [],
+                        "skipped_over_cap": [],
+                        "deferred": [],
+                        "audit": {},
+                    }));
+                }
+                let candidate = |task_id: &str| {
+                    json!({
+                        "task_id": task_id,
+                        "failure_key": format!("failure-{task_id}"),
+                        "cluster_key": format!("cluster-{task_id}"),
+                        "workflow": "CI",
+                        "job": "test",
+                        "step": "cargo test",
+                        "tested_commit": "1111111111111111111111111111111111111111",
+                        "run_ids": [1],
+                        "run_urls": ["https://example.test/run/1"],
+                        "ref_kinds": ["integration"],
+                        "head_branches": ["agent-main"],
+                    })
+                };
+                Ok(json!({
+                    "outcome": "current_failures",
+                    "clusters": 2,
+                    "filed_count": 2,
+                    "filed": [],
+                    "pilot_candidate_count": 2,
+                    "pilot_candidates": [
+                        candidate("ORB-STALE"),
+                        candidate("ORB-APPLIED"),
+                    ],
+                    "skipped_existing": [],
+                    "skipped_over_cap": [],
+                    "deferred": [],
+                    "audit": {},
+                }))
+            }
+            "invoke_and_wait" => {
+                let task_id = input["run_input"]["task_ids"][0]
+                    .as_str()
+                    .expect("pilot task id")
+                    .to_string();
+                self.invoked_task_ids
+                    .lock()
+                    .expect("invoked task ids")
+                    .push(task_id.clone());
+                if task_id == "ORB-STALE" {
+                    Ok(json!({
+                        "run_id": "jrun-pilot-stale",
+                        "status": "failed",
+                        "error": "pilot apply skipped stale task status",
+                    }))
+                } else {
+                    self.applied_task_ids
+                        .lock()
+                        .expect("applied task ids")
+                        .push(task_id);
+                    Ok(json!({
+                        "run_id": "jrun-pilot-applied",
+                        "status": "succeeded",
+                        "error": Value::Null,
+                    }))
+                }
+            }
+            "pipeline_success_guard" => <OrbitRuntime as RuntimeHost>::run_deterministic(
+                self.runtime,
+                action,
+                config,
+                input,
+                tool_context,
+            ),
+            other => Err(DispatchError::DeterministicActionNotRegistered(
+                other.to_string(),
+            )),
+        }
+    }
+
+    fn resolve_cli_executor(&self, provider: &str) -> Result<ResolvedCliExecutor, DispatchError> {
+        <OrbitRuntime as RuntimeHost>::resolve_cli_executor(self.runtime, provider)
+    }
+
+    fn tool_context_for_activity(
+        &self,
+        run_id: Option<&str>,
+        fs_profile: Option<&str>,
+        fs_audit: Option<Arc<dyn FsAuditLogger>>,
+        proc_allowed_programs: Option<&[String]>,
+    ) -> ToolContext {
+        <OrbitRuntime as RuntimeHost>::tool_context_for_activity(
+            self.runtime,
+            run_id,
+            fs_profile,
+            fs_audit,
+            proc_allowed_programs,
+        )
+    }
+}
+
 struct ScriptedEpicHost<'a> {
     runtime: &'a OrbitRuntime,
     descendant_ids: Mutex<Vec<String>>,
@@ -1154,6 +1320,63 @@ fn task_gate_child_failure_still_fails_success_guard() {
     );
     assert!(message.contains("jrun-scripted-child"), "{message}");
     assert!(message.contains("status failed"), "{message}");
+}
+
+#[test]
+fn ci_sweep_parent_fails_for_stale_pilot_after_independent_pilot_applies() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedCiSweepHost::new(&runtime);
+
+    let error = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "ci_failure_sweep_pipeline",
+        json!({
+            "integration_branch": "agent-main",
+            "workspace_path": repo_root,
+        }),
+        "jrun-ci-sweep-partial-pilot",
+    )
+    .expect_err("a stale pilot child must fail the parent sweep");
+
+    let mut invoked = host.invoked_task_ids();
+    invoked.sort();
+    assert_eq!(invoked, ["ORB-APPLIED", "ORB-STALE"], "{error}");
+    assert_eq!(host.applied_task_ids(), ["ORB-APPLIED"]);
+    let message = error.to_string();
+    assert!(
+        message.contains("ci-failure sweep pilot child"),
+        "{message}"
+    );
+    assert!(message.contains("jrun-pilot-stale"), "{message}");
+    assert!(message.contains("status failed"), "{message}");
+}
+
+#[test]
+fn ci_sweep_parent_keeps_a_genuinely_empty_pilot_batch_as_a_successful_no_op() {
+    let (_root, runtime, repo_root, global_root) = test_runtime();
+    seed_default_catalogs(&global_root);
+    let host = ScriptedCiSweepHost::new(&runtime).empty();
+
+    let outcome = try_execute_named_job(
+        &runtime,
+        &repo_root,
+        &host,
+        "ci_failure_sweep_pipeline",
+        json!({
+            "integration_branch": "agent-main",
+            "workspace_path": repo_root,
+        }),
+        "jrun-ci-sweep-empty",
+    )
+    .expect("an empty candidate list is a successful no-op");
+
+    assert!(outcome.success);
+    assert!(host.invoked_task_ids().is_empty());
+    assert!(host.applied_task_ids().is_empty());
+    assert!(outcome.pipeline.get("require_pilot_success").is_none());
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -306,6 +306,54 @@ fn latest_non_failing_run_supersedes_older_failures_on_the_same_head() {
 }
 
 #[test]
+fn green_integration_does_not_suppress_a_red_release_head() {
+    let queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", OLD)
+        .with_runs(vec![vec![
+            run_on_branch(
+                200,
+                "ci",
+                "topic",
+                HEAD,
+                "completed",
+                Some("success"),
+                "2026-08-31T02:00:00Z",
+            ),
+            run_on_branch(
+                100,
+                "ci",
+                "main",
+                OLD,
+                "completed",
+                Some("failure"),
+                "2026-08-31T01:00:00Z",
+            ),
+        ]])
+        .with_run_view("100", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log("100", false, "ci\tbuild\tred release assertion failed\n")
+        .with_log(
+            "100",
+            true,
+            "ci\tCheckout\tHEAD is now at 2222222222222222222222222222222222222222\n",
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(current_ids(&evidence), [100]);
+    assert_eq!(
+        evidence["current_failures"][0]["head_branch"],
+        json!("main")
+    );
+    assert_eq!(
+        evidence["current_failures"][0]["ref_kind"],
+        json!("release")
+    );
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+}
+
+#[test]
 fn unrelated_pull_request_success_does_not_suppress_an_integration_failure() {
     let queries = FakeQueries::authenticated()
         .with_head("topic", HEAD)

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -563,6 +563,14 @@ The executor emits `StepJoin` with per-branch outcomes. If the join policy fails
 
 `fan_out.items` is template-rendered into an array. Workers run concurrently behind a counting semaphore, so `max_workers` is a true concurrency bound, not just metadata. `fan_in.collect` can persist the ordered worker outputs under a separate pipeline key in addition to the step id itself.
 
+Collection does not itself interpret a successful activity call whose payload
+reports a failed child run. A parent that waits on child workflows must pass
+the collected wait entries to `pipeline_success_guard` after fan-in. The CI
+failure sweep does this only when its filer reports a nonzero pilot-candidate
+count: independent successful pilots finish and apply before the guard makes a
+failed, stale, cancelled, interrupted, or timed-out pilot visible as a failed
+sweep, while a genuinely empty candidate list remains a successful no-op.
+
 Workers use isolated pipeline/session maps. The validator rejects any worker template with `session:` because concurrent workers would otherwise share one mutable `Session`.
 
 ### 8.5 `loop`

--- a/docs/design/routines/1_overview.md
+++ b/docs/design/routines/1_overview.md
@@ -119,8 +119,9 @@ fragmentation this feature exists to end.
 - [ORB-10739] — added the disabled `task_pilot` default routine; its zero-input target
   leaves eligibility and bounded partitioning to `prepare_task_pilot`.
 - [ORB-11107] — added the disabled `ci_failure_sweep` default routine, hourly at `5 * * * *`.
-  It targets `job:ci_failure_sweep_pipeline`, whose two deterministic steps collect CI
-  evidence on the host and file each current failure cluster as an ordinary backlog task.
+  It targets `job:ci_failure_sweep_pipeline`, which collects CI evidence on the host,
+  files current failure clusters into proposed quarantine, pilots them independently,
+  and fails visibly if any nonempty pilot batch contains a failed child result.
 - [ORB-00374] — removed the `shell` activity variant and `run_shell` dispatch (fail-closed);
   routines inherit this constraint.
 

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -155,11 +155,23 @@ user-authored and is still reported and preserved in place.
 
 The seeded `ci_failure_sweep` targets `job:ci_failure_sweep_pipeline` hourly at
 `5 * * * *` — deliberately clear of the other defaults' minutes — with `missed_run: skip`
-and `overlap: forbid`. Its two deterministic steps run every GitHub query on the host and
-then file each current, non-stale failure cluster as an ordinary backlog bug task carrying
-that evidence inline, deduped against still-open tasks by failure key. The routine is a
-scheduling surface only: an operator-triggered run of the job behaves identically to a
-scheduled fire.
+and `overlap: forbid`. The pipeline runs every GitHub query on the host, files each
+current, non-stale failure cluster as a proposed bug task carrying that evidence inline,
+dedupes against still-open owners by failure key, and pilots each candidate through the
+existing task-pilot job. The all-join lets independently valid pilots apply even when a
+sibling is stale or fails; a following `pipeline_success_guard` then fails the parent from
+the collected child statuses. The guard is skipped only for a filer-reported zero-candidate
+result, so empty clean/deduped sweeps remain no-ops without hiding failed work.
+
+A release-head failure remains current even when the same workflow is green on the
+integration head: freshness is scoped to workflow and ref for both landing branches. If a
+pilot proves the repair already landed on integration, admission leaves the deduped task in
+proposed quarantine and reports `release_promotion_or_hotfix_needed` with the red release
+SHA/run and the pilot's covering repair evidence. The sweep performs neither release
+promotion nor hotfix dispatch. A no-diff assessment without concrete covering proof is
+reported as `covering_proof_missing` and remains proposed for a later bounded pilot instead
+of being treated as already landed. The routine is a scheduling surface only: an
+operator-triggered run of the job behaves identically to a scheduled fire.
 
 The seeded `ship_sweep` targets `job:workspace_ship_pipeline` with `missed_run: skip` and
 `overlap: forbid`. The wrapper resolves the source runtime's ship mode and configured base


### PR DESCRIPTION
## Task

[ORB-11453](https://orbit-cli.com/tasks/ORB-11453) — Expose CI sweep pilot failures and release-only repairs without false success or repeat implementation

### Description

Observed incident ORB-11450: main at 3d9fc7c65934cdc98cec3954a37e10ba6d387e55 has red macOS Platform run 34060485271; agent-main at 401736f60bfaa613857da1bf35c79a9769d51e06 has green CI 34064896579 and macOS 34064896540, and contains ORB-11435 repair (#1454). Luna pilot jrun-20260906-2251 correctly assessed verified_no_diff/already_landed and empty selectors. Its apply failed stale-task validation because someone changed proposed to backlog during assessment at 22:51:45. Do not assume this status change was an automation defect or undo a user intervention; attribution is unknown. Later implementation jrun-20260906-2254-3 failed git_commit with nothing to commit.

Confirmed reporting gap: parent ci_failure_sweep_pipeline jrun-20260906-2250 is persisted success even though its blocking pilot child failed and no assessment applied. Current canonical CI sweep job ends with pilots fan-in and has no result aggregation guard. Current filer already quarantines proposed and pilot correctly detects already-landed: preserve those working guards.

Implement the smallest coherent CI intake outcome/handoff: aggregate child pilot/apply results so failed/stale/unavailable preparation remains visibly incomplete/retryable instead of an unqualified successful sweep; independent valid findings still progress. For release-head failures whose fix is already on integration, retain the red release evidence and expose an actionable release-promotion/hotfix-needed disposition with covering task/commit evidence when available, without repeatedly dispatching an empty implementation on integration or claiming main is green. Reuse existing task/run evidence and dedupe owners; no second scheduler, no broad no-diff success bypass, no automatic release promotion. Verify whether existing output already covers any requirement and narrow rather than duplicate it.

Inspect current owners: crates/orbit-core/assets/jobs/ci_failure_sweep_pipeline.yaml, v2_host/ci_failure_tasks.rs, task_pilot apply/admission, engine CI evidence. Trace introducing commits/tasks from git history for confirmed reporting defect and record typed regression relation only with evidence. Keep tracked asset mirrors synchronized using repository tooling. No changes to actual CI assertions/required gates and no main/tag/npm mutations. Crew sol: high complexity across workflow outcome semantics, durable evidence and partial-result handling; first high task in session's 50:50 sol/opus allocation.

### Acceptance Criteria

- Deterministic parent workflow tests show a failed/stale child pilot produces a visible incomplete/failure result while independently applied findings remain applied; no successful empty result consumes failed work.
- Fixture with red main and repaired green agent-main retains main failure and surfaces release-only follow-up; no duplicate code repair is auto-admitted and no cross-branch green suppression occurs.
- Missing covering proof remains uncertain/actionable, not silently already-landed; repeats remain deduplicated and bounded.
- Existing stale-task/authority/selector checks remain enforced; unknown manual promotion is not attributed to an invented automation regression.
- Canonical assets and tracked mirrors agree; run focused behavioral tests, make ci-fast and make ci-lint; document exact incident disposition and introducing change evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a conditional ci_failure_sweep_pipeline pipeline_success_guard after pilot fan-in. It checks every child wait result when pilot_candidate_count is nonzero, so failed/stale/cancelled/interrupted/timed-out pilots fail the parent only after independent successful pilots have applied; a genuinely empty candidate batch remains a successful no-op.
- Extended filer output with pilot_candidate_count and immutable run IDs, ref kinds, and head branches. Canonical activity/job assets and tracked workspace mirrors were updated; the canonical job keeps integration_branch empty while the Orbit workspace mirror intentionally keeps agent-main.
- CI pilot admission now reports release_promotion_or_hotfix_needed when a release-head failure has concrete already-landed integration evidence. The output retains red release branch/SHA/run evidence plus the pilot-provided covering repair evidence, leaves the dedupe owner proposed, and performs no implementation, promotion, hotfix, main/tag, or npm mutation.
- A verified_no_diff assessment without already_landed or duplicate proof is classified covering_proof_missing, remains proposed, and is retried through the bounded/deduped pilot path.
- Updated current workflow/routine design documentation and added deterministic parent execution, collector, filer, admission, empty-batch, dedupe, and uncertainty regressions.

Criteria:
1. Parent outcome and partial progress: satisfied. Deterministic execution runs both singleton pilots, records the independent applied result, and fails the parent on the stale child; the empty-batch test proves only an actual zero-candidate result skips the guard.
2. Red main / green agent-main: satisfied. Collector coverage proves a newer green integration run cannot suppress a red release run. Admission coverage retains main and tested-commit/run evidence, reports release_promotion_or_hotfix_needed with ORB/commit evidence, and keeps the task out of backlog.
3. Missing proof and repeats: satisfied. Missing covering proof is explicitly actionable/uncertain; repeat evidence reuses one proposed owner and one bounded pilot candidate instead of filing or admitting another implementation task.
4. Existing safeguards and attribution: satisfied. Focused task_pilot tests cover stale task status, promotion authority, and selector validation. The observed proposed-to-backlog change during jrun-20260906-2251 remains actor-unknown and is not attributed to automation.
5. Assets, validation, and incident evidence: satisfied. Activity mirrors are byte-identical; job mirrors differ only by the intentional integration_branch override.

Incident disposition:
- Release main remains evidenced red at 3d9fc7c65934cdc98cec3954a37e10ba6d387e55 (macOS Platform run 34060485271); agent-main at 401736f60bfaa613857da1bf35c79a9769d51e06 is green (CI 34064896579, macOS 34064896540) and contains ORB-11435/#1454. This change reports release promotion/hotfix as follow-up and does not claim main is green.
- Git blame and commit inspection identify 9887f5dad27be526d3454655965e4a6044cdc391 / ORB-11225 as introducing the pilot fan-out without a parent result guard. source_task_id is recorded as ORB-11225. The unrelated manual status transition remains unattributed.

Validation:
- cargo test -p orbit-core ci_failure --lib — passed, 34 tests.
- cargo test -p orbit-core task_pilot --lib — passed, 37 tests.
- cargo test -p orbit-core ci_sweep_parent_ --lib — passed, 2 tests.
- cargo test -p orbit-engine executor::automation::ci::tests --lib — passed, 37 tests.
- make ci-fast — passed, including formatting, guardrails, and activity mirror check.
- make ci-lint — passed; workspace/all-target Clippy with warnings denied.
- git diff --check — passed.
- git status --short — expected 14 task-scoped modified files; starting worktree was clean.

Assessment: The change reuses the existing guard and admission boundary, adds no scheduler or automatic release operation, preserves independent progress and existing authority/staleness/selector rules, and keeps current documentation aligned.

Remaining risk: Release-only classification depends on the read-only pilot supplying concrete already_landed evidence, as designed. When it cannot, the durable proposed task and covering_proof_missing result remain retryable rather than being auto-admitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11453-6a9df98d`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*