### PR TITLE
Parse Grok completion from final response text rather than unrelated wrapper fields

### DIFF
--- a/crates/orbit-agent/src/providers/grok/grok_output.rs
+++ b/crates/orbit-agent/src/providers/grok/grok_output.rs
@@ -1,0 +1,30 @@
+//! Projects Grok CLI JSON wrappers onto their final answer text.
+//!
+//! `grok --output-format json` returns one wrapper object. Its `text` field
+//! is the model's final answer; `thought`, tool metadata, and usage are
+//! invocation telemetry and must not provide Orbit completion evidence.
+
+use serde_json::Value;
+
+/// Return the final answer when `stdout` is a recognized Grok JSON wrapper.
+///
+/// `None` keeps the legacy provider-agnostic path for direct Orbit envelopes
+/// and multi-document output. A recognized wrapper with missing or malformed
+/// `text` returns empty bytes so unrelated wrapper fields cannot take over.
+pub(crate) fn project_grok_response(stdout: &[u8]) -> Option<Vec<u8>> {
+    let wrapper = serde_json::from_slice::<Value>(stdout).ok()?;
+    let wrapper = wrapper.as_object()?;
+
+    if !wrapper.contains_key("text") && !wrapper.contains_key("stopReason") {
+        return None;
+    }
+
+    Some(
+        wrapper
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .as_bytes()
+            .to_vec(),
+    )
+}

--- a/crates/orbit-agent/src/providers/grok/mod.rs
+++ b/crates/orbit-agent/src/providers/grok/mod.rs
@@ -1,6 +1,8 @@
 mod grok_cli;
+mod grok_output;
 mod grok_runtime;
 
+pub(crate) use grok_output::project_grok_response;
 pub(crate) use grok_runtime::GrokFactory;
 
 #[cfg(test)]

--- a/crates/orbit-agent/src/providers/grok/tests/grok_output.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/grok_output.rs
@@ -1,0 +1,122 @@
+#![allow(missing_docs)]
+
+use orbit_types::tool::ExecutionResult;
+
+use crate::providers::project_cli_response;
+use crate::types::{AgentResponseStatus, parse_and_validate_response};
+
+const SUCCESS: &str =
+    r#"{"schemaVersion":1,"status":"success","result":{"source":"final-text"},"error":null}"#;
+const FAILURE: &str = r#"{"schemaVersion":1,"status":"failed","result":{},"error":{"code":"final_failure","message":"the final answer failed","details":null}}"#;
+const TIMEOUT: &str = r#"{"schemaVersion":1,"status":"timeout","result":{},"error":{"code":"final_timeout","message":"the final answer timed out","details":null}}"#;
+
+fn projected(stdout: &str) -> String {
+    String::from_utf8(project_cli_response("grok", stdout.as_bytes()).into_owned())
+        .expect("utf8 projected response")
+}
+
+fn exec_result(stdout: String, exit_code: i32) -> ExecutionResult {
+    ExecutionResult {
+        success: exit_code == 0,
+        stdout,
+        stderr: String::new(),
+        exit_code: Some(exit_code),
+        duration_ms: 1,
+        output: None,
+    }
+}
+
+#[test]
+fn grok_final_text_is_the_only_completion_authority() {
+    let stdout = serde_json::json!({
+        "text": SUCCESS,
+        "stopReason": "EndTurn",
+        "thought": format!("ignored reasoning: {FAILURE}"),
+        "toolCalls": [{"result": FAILURE}],
+        "usage": {"metadata": SUCCESS},
+        "sessionId": "session-fixture",
+        "requestId": "request-fixture",
+    })
+    .to_string();
+
+    let response = projected(&stdout);
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec_result(response, 0)).expect("final text parses");
+
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(envelope.result.expect("result")["source"], "final-text");
+}
+
+#[test]
+fn grok_final_failure_overrides_success_shaped_metadata() {
+    let stdout = serde_json::json!({
+        "text": FAILURE,
+        "stopReason": "EndTurn",
+        "thought": SUCCESS,
+        "usage": {"result": SUCCESS},
+    })
+    .to_string();
+
+    let (envelope, status, _) = parse_and_validate_response(&exec_result(projected(&stdout), 1))
+        .expect("final failure parses");
+
+    assert_eq!(status, AgentResponseStatus::Failed);
+    assert_eq!(
+        envelope.error.expect("failure detail").code,
+        "final_failure"
+    );
+}
+
+#[test]
+fn grok_final_timeout_overrides_success_shaped_metadata() {
+    let stdout = serde_json::json!({
+        "text": TIMEOUT,
+        "stopReason": "EndTurn",
+        "thought": SUCCESS,
+        "usage": {"result": SUCCESS},
+    })
+    .to_string();
+    let mut execution = exec_result(projected(&stdout), 1);
+    execution.stderr = "process timed out".to_string();
+
+    let (envelope, status, _) =
+        parse_and_validate_response(&execution).expect("final timeout parses");
+
+    assert_eq!(status, AgentResponseStatus::Timeout);
+    assert_eq!(envelope.status, "timeout");
+}
+
+#[test]
+fn malformed_or_missing_grok_final_text_has_no_completion_evidence() {
+    for wrapper in [
+        serde_json::json!({
+            "stopReason": "EndTurn",
+            "thought": SUCCESS,
+            "toolCalls": [{"result": SUCCESS}],
+        }),
+        serde_json::json!({
+            "text": {"unexpected": SUCCESS},
+            "stopReason": "EndTurn",
+            "usage": {"result": SUCCESS},
+        }),
+    ] {
+        assert!(projected(&wrapper.to_string()).is_empty());
+    }
+}
+
+#[test]
+fn direct_and_streaming_envelopes_keep_the_existing_parser_boundary() {
+    for stdout in [SUCCESS.to_string(), format!("{SUCCESS}\n{SUCCESS}")] {
+        assert_eq!(projected(&stdout), stdout);
+    }
+}
+
+#[test]
+fn other_provider_responses_are_unchanged() {
+    for provider in ["claude", "gemini", "ollama"] {
+        let projected = project_cli_response(provider, SUCCESS.as_bytes());
+
+        assert!(matches!(projected, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(projected.as_ref(), SUCCESS.as_bytes());
+    }
+}

--- a/crates/orbit-agent/src/providers/grok/tests/mod.rs
+++ b/crates/orbit-agent/src/providers/grok/tests/mod.rs
@@ -1,1 +1,2 @@
 mod grok_cli;
+mod grok_output;

--- a/crates/orbit-agent/src/providers/mod.rs
+++ b/crates/orbit-agent/src/providers/mod.rs
@@ -82,10 +82,11 @@ pub fn normalize_cli_stdout<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8
 /// response-envelope projection.
 ///
 /// Invocation traces and diagnostics continue to use [`normalize_cli_stdout`]
-/// so usage, tool traffic, and provider failures remain observable. Codex and
-/// Copilot need a narrower view because their JSONL streams also contain
-/// reasoning and tool payloads that may quote an unrelated Orbit envelope.
-/// Other providers retain their existing normalized response boundary.
+/// so usage, tool traffic, and provider failures remain observable. Codex,
+/// Copilot, and Grok need a narrower view because their provider wrappers can
+/// carry reasoning and tool payloads that may quote an unrelated Orbit
+/// envelope. Other providers retain their existing normalized response
+/// boundary.
 /// [ORB-11348]
 pub fn project_cli_response<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8]> {
     match provider {
@@ -93,6 +94,9 @@ pub fn project_cli_response<'a>(provider: &str, stdout: &'a [u8]) -> Cow<'a, [u8
             codex::project_codex_response(stdout).map_or_else(|| Cow::Borrowed(stdout), Cow::Owned)
         }
         "copilot" => Cow::Owned(copilot::project_copilot_response(stdout)),
+        "grok" => {
+            grok::project_grok_response(stdout).map_or_else(|| Cow::Borrowed(stdout), Cow::Owned)
+        }
         _ => normalize_cli_stdout(provider, stdout),
     }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -3661,6 +3661,92 @@ fn run_cli_backend_passes_model_to_grok_and_captures_well_formed_stdout() {
 }
 
 #[test]
+fn run_cli_backend_uses_grok_final_text_not_wrapper_metadata() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    let grok_stdout = serde_json::json!({
+        "text": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"final-text\"},\"error\":null}",
+        "stopReason": "EndTurn",
+        "thought": "{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"metadata\",\"message\":\"ignore\",\"details\":null}}",
+        "toolCalls": [{"result": "{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"tool\",\"message\":\"ignore\",\"details\":null}}"}],
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{grok_stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-final-text",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.require_completion_envelope = true;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "test_activity",
+        "job-grok-final-text",
+        audit,
+        &serde_json::json!({"prompt": "respond"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(outcome.output["source"], "final-text");
+    assert_eq!(outcome.output["response_envelope_status"], "success");
+}
+
+#[test]
+fn run_cli_backend_preserves_grok_failed_final_text() {
+    let temp = tempdir().expect("tempdir");
+    let script = temp.path().join("grok");
+    let grok_stdout = serde_json::json!({
+        "text": "{\"schemaVersion\":1,\"status\":\"failed\",\"result\":{},\"error\":{\"code\":\"final_failure\",\"message\":\"final answer failed\",\"details\":null}}",
+        "stopReason": "EndTurn",
+        "thought": "{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"source\":\"metadata\"},\"error\":null}",
+    })
+    .to_string();
+    write_executable(
+        &script,
+        &format!("#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' '{grok_stdout}'\n"),
+    );
+
+    let sink = Arc::new(RecordingSink::default());
+    let sink_for_writer: Arc<dyn AuditSink> = sink;
+    let audit = Arc::new(V2AuditWriter::new(
+        "job-grok-final-failure",
+        "grok:grok-build",
+        sink_for_writer,
+    ));
+    let host = TestHost::with_command(script.display().to_string());
+    let mut spec = test_agent_loop_spec_for("grok", Duration::from_secs(5));
+    spec.require_completion_envelope = true;
+
+    let outcome = run_cli_backend(
+        &host,
+        &spec,
+        "test_activity",
+        "job-grok-final-failure",
+        audit,
+        &serde_json::json!({"prompt": "respond"}),
+        None,
+    )
+    .expect("run cli backend");
+
+    assert!(!outcome.success);
+    assert_eq!(outcome.output["response_envelope_status"], "failed");
+    let message = outcome.message.expect("failed final answer diagnostic");
+    assert!(message.contains("final_failure"), "{message}");
+}
+
+#[test]
 fn run_cli_backend_exports_runtime_identity_for_subprocess_tools() {
     let temp = tempdir().expect("tempdir");
     let script = temp.path().join("grok");


### PR DESCRIPTION
## Task

[ORB-11455](https://orbit-cli.com/tasks/ORB-11455) — Parse Grok completion from final response text rather than unrelated wrapper fields

### Description

Observed jrun-20260906-2332-3 / ORB-11452 completed implementation and persisted success; preserved candidate PR #1463. Provider stdout is a JSON wrapper with keys text, stopReason, sessionId, requestId, thought, usage, etc. The text field contains final Orbit schemaVersion 1 status success. Orbit instead declared worktree_mismatch failure from an unrelated non-answer field. Host git rev-parse verified the supplied dedicated worktree root is correct. This false failure blocks throughput despite valid final output.

Inspect the provider answer projection and shared response parser (orbit-agent and engine cli_runner/envelope.rs/orchestrator.rs). Correct the authoritative answer extraction boundary so supported Grok wrapper final text is interpreted; unrelated wrapper fields, tool output and metadata must not become completion authority. Preserve actual final failed/timeout envelopes, absent/malformed output semantics and other providers. Do not weaken deterministic task/delivery validation or enforce new agent prose shapes. Reuse current normalization seam.

Use minimal synthetic provider wrappers for regression fixtures, not a copy of raw agent internals or private logs. Exact source evidence is available via run logs on the host; only outcome/channel structure is relevant. Trace the introducing commit/task and attach regression provenance only with proof. Medium-low/Terra: bounded parser/projection correction with existing provider fixtures. No Cursor implementation changes in this task.

### Acceptance Criteria

- A Grok wrapper with successful final text and conflicting non-answer fields produces success; a failed final text with success elsewhere retains the failure and correct diagnostic.
- Tests cover unrelated tool/metadata fields, malformed/missing final text, streaming/wrapper forms currently supported, and other-provider compatibility at the owning parser boundary.
- Engine invocation regression confirms no false worktree_mismatch from non-answer fields and preserves real failed/timeout responses.
- No arbitrary output scanning or generic bypass of deterministic delivery gates; focused tests and make ci-fast/make ci-lint pass.
- Record exact introducing-change evidence and validation without embedding raw private reasoning in fixtures/docs.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added Grok-specific answer projection: a recognized JSON wrapper exposes only its final `text` string to the shared response-envelope parser; absent or non-string final text produces no completion evidence. Raw wrappers remain available for trace and diagnostics.
- Kept direct and multi-document envelope fallback plus non-Grok provider behavior unchanged; no generic envelope-parser or delivery-gate changes.
- Added synthetic provider and CLI-runner regressions for conflicting thought/tool/usage metadata, final failed and timeout envelopes, malformed or missing text, and other-provider compatibility.

Provenance:
- `737564f5c1dab699753ff4e4ac158e62f35dc09b` (ORB-11348) introduced provider-specific answer projection for Codex/Copilot while Grok retained the generic wrapper traversal. The verified Grok wrapper shape made unrelated fields completion authority, so this task records ORB-11348 as the source task.

Criteria assessment:
- Success and failed final text with conflicting wrapper fields: covered at the provider boundary and through CLI invocation; failed final text remains `response_envelope_status=failed` with its final failure diagnostic.
- Unrelated metadata/tool fields, missing/malformed text, direct/multi-document forms, timeout, and other providers: covered by focused unit tests.
- Engine invocation regression: covers final-text success with conflicting failed metadata and final-text failure with conflicting success metadata, preventing false downstream worktree diagnostics.
- Deterministic delivery gates: unchanged; no arbitrary stdout scan was added.

Validation:
- PASS: `cargo fmt`
- PASS: `cargo test -p orbit-agent grok_output` (6 tests)
- PASS: `cargo test -p orbit-agent` (162 tests)
- PASS: `cargo test -p orbit-engine grok_final_text` and `cargo test -p orbit-engine grok_failed_final_text`
- PASS: `cargo test -p orbit-engine --quiet` (548 unit + 9 integration tests; 2 ignored)
- PASS: `make ci-fast`
- PASS: `make ci-lint`
- PASS: `git diff --check`

Risk: Projection intentionally recognizes only Grok JSON wrappers carrying `text` or `stopReason`; non-wrapper direct and multi-document output remains on the established generic parser path.

Assessment: Minimal provider-boundary correction with synthetic fixtures only; raw run content and deterministic task/delivery validation remain untouched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11455-6a9dfd35`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*