### PR TITLE
Replace yanked der 0.8.0 in the Cargo lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "pem-rfc7468",


### PR DESCRIPTION
## Task

[ORB-11463](https://orbit-cli.com/tasks/ORB-11463) — Replace yanked der 0.8.0 in the Cargo lockfile

### Description

New upstream dependency failure observed while promoting validated source: GitHub CI run34071418921 job101589356045 at2026-09-07T01:11:12Z reports error[yanked]: detected yanked crate (try cargo update -p der), Cargo.lock der0.8.0. 4311 tests and all doctests passed before cargo-deny failed; the same source's earlier integration CI34071132738 passed. Another candidate run34072269903 also reports failed guardrails; verify exact diagnosis and actual checkout before using as corroboration. Current promotion PR1469 pins b31e5295; this evidence supersedes any blanket statement that its dependency audit is still green.

Find the dependency path and the registry's current non-yanked compatible version. Make the smallest safe Cargo.lock/dependency update; prefer compatible patch replacement, account for pre-release RustCrypto constraints and MSRV. Do not suppress yanked advisories or remove cargo-deny. Validate affected consumers and current dependency audit with fresh registry data, then ci-fast/ci-lint and relevant CI. Record upstream reason if available without inventing a repository regression source task. This repair may land on agent-main while the pinned production promotion remains separate; orchestrator will incorporate the verified fix as needed.

### Acceptance Criteria

- Lockfile no longer contains the yanked der0.8.0 and resolves a compatible non-yanked release with minimal unrelated churn.
- Affected dependency consumers, MSRV checks and cargo-deny pass using current registry/advisory data; denial policy is unchanged.
- make ci-fast and make ci-lint pass; record actual CI checkout and green affected audit result after publication.
- Explain upstream yank/dependency path and any remaining vulnerability or compatibility constraint; do not assign invented introducing task provenance.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated only Cargo.lock: der 0.8.0 (yanked) -> 0.8.1, its current compatible non-yanked patch release; cargo-deny policy and deny.toml are unchanged.

Criteria and evidence:
- Lockfile churn is one package version/checksum. Fresh registry metadata reported der 0.8.1 as latest; cargo tree --locked --invert der resolved 0.8.1.
- Dependency path is orbit-common -> rsa 0.10.0-rc.18 -> pkcs1/pkcs8/spki -> der. The RustCrypto pre-release graph permits the 0.8.x patch; der 0.8.1 declares Rust 1.85 and the workspace MSRV is 1.89.
- cargo deny check passed with current registry/advisory data (advisories, bans, licenses, sources all ok); existing non-failing unmatched-ignore/license warnings remain and no policy was weakened.
- MSRV validation passed: isolated rustc 1.89.0 cargo check --workspace --locked.
- make ci-fast passed; make ci-lint passed; git diff --check passed.
- GitHub CI after publication: not run/recorded because this managed activity leaves publication to the pipeline. The granted github.run.view/logs tool was policy-denied, so the cited failed-run checkout and a subsequently green published audit could not be independently retrieved here.

Assessment: minimal lockfile-only repair, with no invented introducing-task provenance.

Risks / follow-up:
- The pipeline should record the actual published checkout and successful cargo-deny CI job after it commits this lockfile change.
- The dependency path retains RustCrypto release-candidate dependencies by existing manifest choice; this patch does not expand that compatibility surface.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11463-6a9e14de`
- Behind base: 0
- Ahead of base: 1