### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -477,6 +477,10 @@ impl RuntimeHost for FailureHandoffHost<'_> {
 fn failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error() {
     let (_root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
+    let run_id = Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_default()
+        .to_string();
     let worktree_activity = global_root.join("resources/activities/worktree_setup.yaml");
     let activity_yaml = std::fs::read_to_string(&worktree_activity)
         .expect("read seeded worktree activity")
@@ -495,7 +499,7 @@ fn failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_erro
             "base_sync": "local",
             "review": false,
         }),
-        "run-pr-failure-handoff",
+        &run_id,
     )
     .expect_err("the seeded worktree failure must terminalize the run");
 


### PR DESCRIPTION
## Task

[ORB-11478](https://orbit-cli.com/tasks/ORB-11478) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#163`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `3d9fc7c65934cdc98cec3954a37e10ba6d387e55`
- Location: `crates/orbit-core/src/application/job/tests/exec.rs` line 498
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/163

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/exec.rs` line 498 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/job/tests/exec.rs` so the failure-handoff test uses a runtime-generated nanosecond timestamp as its job run ID.
- This removes the fixed string from the data flow into retry jitter's seed/salt input while preserving the same pipeline setup, failure, and original-error assertions.
- No suppression, dismissal, exclusion, or production behavior change was introduced.

Acceptance criteria:
- CodeQL finding remediation: addressed at the reported test location by removing the hard-coded value from the salt data flow.
- Intended behavior: focused regression test passed; the failure handoff still runs and the original worktree error remains authoritative.
- Validation/security: repository guardrails and workspace lint passed; source review confirms the reported literal is absent. Local CodeQL is unavailable, so a standalone local CodeQL scan was not run; the repository's CodeQL workflow remains the authoritative confirmation on CI.

Validation:
- PASS: `cargo test -p orbit-core failed_pr_pipeline_dispatches_the_failure_handoff_and_keeps_the_original_error`
- PASS: `make ci-fast`
- PASS: `make ci-lint`
- PASS: `git diff --check`
- PASS: targeted `rg` review confirmed `run-pr-failure-handoff` is absent and the runtime-generated ID is used.
- NOT RUN: local CodeQL scan — `codeql` is not installed in this environment.

Assessment: Minimal, task-scoped test-fixture change with no unrelated edits. Remaining risk is limited to CI CodeQL confirmation, which cannot be reproduced locally in this worktree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11478-6a9e3273`
- Behind base: 0
- Ahead of base: 1