### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -1186,6 +1186,9 @@ fn task_gate_noops_when_task_reaches_review_after_reservation() {
         reserve_calls: AtomicUsize::new(0),
     };
 
+    // The production retry path uses the run ID as a jitter salt. Reuse the
+    // store-generated fixture task ID here so the test does not feed a
+    // hard-coded value into that cryptographic data flow.
     let outcome = execute_gate_job(
         &runtime,
         &repo_root,
@@ -1194,7 +1197,7 @@ fn task_gate_noops_when_task_reaches_review_after_reservation() {
             "task_ids": [task_id.clone()],
             "mode": "pr",
         }),
-        "jrun-gate-review-stale",
+        task_id.as_str(),
     );
 
     assert!(outcome.success);


### PR DESCRIPTION
## Task

[ORB-11481](https://orbit-cli.com/tasks/ORB-11481) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#166`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `3d9fc7c65934cdc98cec3954a37e10ba6d387e55`
- Location: `crates/orbit-core/src/application/job/tests/exec.rs` line 1027
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/166

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/exec.rs` line 1027 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated crates/orbit-core/src/application/job/tests/exec.rs in task_gate_noops_when_task_reaches_review_after_reservation to pass the store-generated task ID as the job run ID instead of the hard-coded jrun-gate-review-stale value.
- The production retry path uses the run ID as the jitter salt; the runtime-generated fixture ID removes the constant source-to-salt flow while preserving the stale-task no-op behavior.
Assessment: Scoped, behavior-preserving test-fixture remediation; no suppressions, exclusions, or production behavior changes.

Acceptance criteria:
- Hard-coded cryptographic value finding: satisfied; the flagged hard-coded run ID was removed at the affected historical location.
- Intended behavior: satisfied; the stale gate test and all 28 tests in application::job::tests::exec pass.
- Validation/security: repository gates and targeted source verification pass. Direct CodeQL CLI execution was not run because codeql is not installed in this checkout and the repository has no local CodeQL workflow/database; the flagged literal is absent and the run-ID argument is now dynamic.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-core task_gate_noops_when_task_reaches_review_after_reservation: passed, 1 test.
- cargo test -p orbit-core application::job::tests::exec::: passed, 28 tests.
- make ci-fast: passed, including repository guardrails and test-installer-security.
- make ci-lint: passed, workspace clippy with warnings denied.
- rg check for jrun-gate-review-stale in the affected file: passed, no matches.
- git diff --check: passed.

Remaining risk: A hosted CodeQL rerun is still needed for direct scanner confirmation; local source/data-flow evidence shows the reported constant-to-salt path is removed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11481-6a9e3273`
- Behind base: 0
- Ahead of base: 1