### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/task_pilot_…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -130,7 +130,10 @@ fn execute_task_pilot_job(
 
 fn assert_job_resolves_branch(config_branch: &str, input: Value, expected_branch: &str) {
     let fixture = task_pilot_job_fixture(config_branch, expected_branch);
-    let run_id = format!("task-pilot-{config_branch}-{expected_branch}");
+    // Keep branch fixtures out of the execution identity. The identity is
+    // used to seed non-cryptographic retry jitter, so test branch literals
+    // must not flow into it as though they were cryptographic salt.
+    let run_id = std::process::id().to_string();
     let outcome = execute_task_pilot_job(&fixture, input, &run_id)
         .expect("shipped task-pilot job must render and reach preparation");
 


### PR DESCRIPTION
## Task

[ORB-11472](https://orbit-cli.com/tasks/ORB-11472) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/task_pilot_…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#157`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `3d9fc7c65934cdc98cec3954a37e10ba6d387e55`
- Location: `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs` line 162
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/157

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs` line 162 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs` so the isolated test fixture derives its execution run ID from the process ID instead of formatting configured branch literals into it.
- Preserved all branch-resolution assertions and the existing three regression scenarios; this removes the hard-coded branch-to-`JitterRng::seeded(...)` data flow without suppressing CodeQL.

Acceptance criteria:
- Remediated the flagged `rust/hard-coded-cryptographic-value` path at the reported test location with a real data-flow fix; no suppression, dismissal, or exclusion was added.
- Targeted tests passed 3/3, covering omitted, empty, explicit alternate, and unavailable branch behavior.
- Source review confirms branch literals no longer contribute to the execution identity passed through the retry-jitter salt-named parameter. The local CodeQL CLI is unavailable, so scanner confirmation must occur in CI.

Validation:
- PASS: `cargo test -p orbit-core --lib shipped_task_pilot_job -- --nocapture`
- PASS: `make ci-fast`
- PASS: `make ci-lint`
- PASS: `cargo deny check ban license sources`
- NOT RUN: CodeQL CLI scan; `codeql` is not installed in this environment.
- FAILED/ENVIRONMENT: `make audit` and `cargo deny check --disable-fetch`; cargo-deny could not acquire `~/.cargo/advisory-dbs/db.lock` because the shared path is read-only. The successful ban/license/source checks remain recorded separately.

Assessment: The change is minimal, behavior-preserving, formatted, lint-clean, and limited to the flagged test file. `git diff --check` passed and the worktree contains only that task-scoped modification.

Remaining risk: Full CodeQL and advisory-database validation require the repository CI/host environment with those tools and writable advisory state.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11472-6a9e31f8`
- Behind base: 0
- Ahead of base: 1