### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/task_pilot_…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -130,8 +130,13 @@ fn execute_task_pilot_job(
 
 fn assert_job_resolves_branch(config_branch: &str, input: Value, expected_branch: &str) {
     let fixture = task_pilot_job_fixture(config_branch, expected_branch);
-    let run_id = format!("task-pilot-{config_branch}-{expected_branch}");
-    let outcome = execute_task_pilot_job(&fixture, input, &run_id)
+    let run_id = fixture
+        ._root
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("fixture root has a UTF-8 basename");
+    let outcome = execute_task_pilot_job(&fixture, input, run_id)
         .expect("shipped task-pilot job must render and reach preparation");
 
     assert!(outcome.success, "pipeline outcome: {outcome:?}");
@@ -182,12 +187,15 @@ fn shipped_task_pilot_job_honors_an_explicit_alternate_branch() {
 #[test]
 fn shipped_task_pilot_job_rejects_an_unavailable_explicit_branch() {
     let fixture = task_pilot_job_fixture("main", "main");
-    let error = execute_task_pilot_job(
-        &fixture,
-        json!({ "base_branch": "missing-branch" }),
-        "task-pilot-missing-branch",
-    )
-    .expect_err("an unavailable explicit branch must fail before pilot dispatch");
+    let run_id = fixture
+        ._root
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("fixture root has a UTF-8 basename");
+    let error =
+        execute_task_pilot_job(&fixture, json!({ "base_branch": "missing-branch" }), run_id)
+            .expect_err("an unavailable explicit branch must fail before pilot dispatch");
     let message = error.to_string();
 
     assert!(message.contains("could not fetch"), "{message}");


### PR DESCRIPTION
## Task

[ORB-11474](https://orbit-cli.com/tasks/ORB-11474) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/task_pilot_…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#159`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `3d9fc7c65934cdc98cec3954a37e10ba6d387e55`
- Location: `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs` line 164
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/159

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs` line 164 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- In `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs`, replaced branch-derived and hard-coded task-pilot run IDs with each fixture's runtime-generated temporary-directory basename.
- This preserves pipeline behavior and test isolation while removing the hard-coded branch literals from the data flow into `JitterRng::seeded(...)`'s salt parameter; the rejected-branch test still exercises the same unavailable branch assertion.

Assessment: The flagged test now uses runtime-generated, path-safe run IDs. The affected three tests pass, and the only worktree change is the scoped test file.

Acceptance criteria:
- CodeQL hard-coded cryptographic value remediation: satisfied in source; no `task-pilot-` run-ID literals remain and the flagged branch values no longer flow into the jitter salt.
- Intended behavior: satisfied; all three task-pilot pipeline tests pass with the same branch-resolution, dirty-worktree, and failure assertions.
- Validation/security: `cargo test -p orbit-core --locked application::job::tests::task_pilot_pipeline` passed (3 tests); `make ci-fast` passed; `make ci-lint` passed; `git diff --check` passed. The CodeQL CLI is not installed in this environment, so a direct local CodeQL rerun was not available; the repository's external CodeQL workflow remains the final scan confirmation.

Risks or deviations:
- No production code or configuration was changed. Direct CodeQL alert re-analysis was not run because this task explicitly does not require agent-side GitHub access and no local `codeql` executable is available.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11474-6a9e31f8`
- Behind base: 0
- Ahead of base: 1