### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -240,7 +240,7 @@ impl RuntimeHost for ScriptedWorkspaceAutoHost<'_> {
 /// finished.
 #[test]
 fn workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running() {
-    let (_root, runtime, repo_root, global_root) = test_runtime();
+    let (root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
     let host = ScriptedWorkspaceAutoHost::new(&runtime, WorkspaceAutoScenario::KeepsDispatching);
     let input = json!({
@@ -249,16 +249,19 @@ fn workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running() {
         "poll_sleep_seconds": 0,
         "idle_sleep_seconds": 0,
     });
+    // Keep the fixture's persisted job id unique. The engine uses the run id
+    // as retry-jitter salt, and a hard-coded job id can reach that seed through
+    // the run-id collision fallback.
+    let fixture_job_id = root
+        .path()
+        .file_name()
+        .expect("test tempdir has a final path component")
+        .to_string_lossy()
+        .into_owned();
     let run = runtime
         .stores()
         .jobs()
-        .insert_job_run(
-            "workspace_auto_pipeline",
-            1,
-            Utc::now(),
-            Some(input.clone()),
-            None,
-        )
+        .insert_job_run(&fixture_job_id, 1, Utc::now(), Some(input.clone()), None)
         .expect("insert workspace auto run");
     runtime
         .write_run_state(


### PR DESCRIPTION
## Task

[ORB-11480](https://orbit-cli.com/tasks/ORB-11480) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#165`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `3d9fc7c65934cdc98cec3954a37e10ba6d387e55`
- Location: `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 256
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/165

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 256 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Remediated the CodeQL hard-coded cryptographic value data flow in `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` by replacing the flagged literal persisted job ID with the randomized temporary-directory component already created by the fixture.
- Preserved execution of the real `workspace_auto_pipeline` asset and all existing assertions; no suppression, dismissal, exclusion, dependency, or production behavior change was added.
- Final diff is limited to the authorized test file (11 insertions, 8 deletions); starting HEAD remains `1807da45c824f03b798adb45d842bc657e8e8d70`.

Acceptance criteria:
- CodeQL rule remediation: satisfied in source; the flagged hard-coded job-ID value no longer flows into the run-ID/retry-jitter salt path.
- Intended behavior: satisfied; focused workspace-auto coverage passes all 38 tests.
- Validation/security: repository gates pass. `cargo fmt --all -- --check`, `git diff --check`, `cargo test -p orbit-core --lib workspace_auto` (38 passed, 0 failed), `make ci-fast`, and `make ci-lint` all passed. Local CodeQL CLI was not installed, so a direct CodeQL database scan and GitHub alert refresh were not run; source inspection confirmed no hard-coded value remains at the affected call site. `cargo deny check` was attempted but failed before analysis because `~/.cargo/advisory-dbs/db.lock` is on a read-only path.

Assessment: Minimal, behavior-preserving fixture remediation with no unrelated changes. Remaining risk is limited to requiring the repository/GitHub CodeQL environment to re-run the rule and close the existing alert.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11480-6a9e3274`
- Behind base: 0
- Ahead of base: 1