### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/task_pilot_…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
@@ -12,7 +12,7 @@ use super::exec::{seed_default_catalogs, try_execute_named_job};
 use crate::OrbitRuntime;
 
 struct TaskPilotJobFixture {
-    _root: TempDir,
+    root: TempDir,
     runtime: OrbitRuntime,
     repo_root: PathBuf,
     stale_sha: String,
@@ -104,7 +104,7 @@ fn task_pilot_job_fixture(config_branch: &str, remote_branch: &str) -> TaskPilot
     let dirty_status = git(&repo_root, &["status", "--short"]);
 
     TaskPilotJobFixture {
-        _root: root,
+        root,
         runtime,
         repo_root,
         stale_sha,
@@ -176,10 +176,19 @@ fn shipped_task_pilot_job_honors_an_explicit_alternate_branch() {
 #[test]
 fn shipped_task_pilot_job_rejects_an_unavailable_explicit_branch() {
     let fixture = task_pilot_job_fixture("main", "main");
+    // The executor uses the run ID to salt retry jitter, so derive this test
+    // ID from tempfile's OS-backed random fixture name instead of hard-coding it.
+    let run_id = fixture
+        .root
+        .path()
+        .file_name()
+        .expect("fixture root has a basename")
+        .to_string_lossy()
+        .into_owned();
     let error = execute_task_pilot_job(
         &fixture,
         json!({ "base_branch": "missing-branch" }),
-        "task-pilot-missing-branch",
+        &run_id,
     )
     .expect_err("an unavailable explicit branch must fail before pilot dispatch");
     let message = error.to_string();


### PR DESCRIPTION
## Merge conflict handoff

Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. This PR is intentionally blocked; reconcile the named paths before retrying delivery.

- Task: `ORB-11479`
- Run: `jrun-20260907-0341-12`
- Failed step: `sync_base`
- Error code: `recoverable_vcs_conflict`
- Original base: `1807da45c824f03b798adb45d842bc657e8e8d70`
- Target base: `10af2f050e0afd89b443bdb032affdc0bffc2103`

## Conflicting paths

- `crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs`

## Failure

```text
recoverable VCS conflict during 'git_rebase': original base '1807da45c824f03b798adb45d842bc657e8e8d70', target base '10af2f050e0afd89b443bdb032affdc0bffc2103'; rebase of 'orbit/ORB-11479-6a9e3273' onto checkpoint '10af2f050e0afd89b443bdb032affdc0bffc2103' stopped with conflicts; conflicting paths: crates/orbit-core/src/application/job/tests/task_pilot_pipeline.rs
```