### PR TITLE
Bump release metadata to 0.19.2 without tagging or publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbit-agent"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-automation"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "croner",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cli"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-cmd"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "flate2",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-common"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-config"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "orbit-common",
  "orbit-types",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-core"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-engine"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "jsonschema",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-exec"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "libc",
  "orbit-common",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-mcp"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-policy"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-registry"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "hostname",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-search"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-store"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "blake3",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-tools"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "orbit-common",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-types"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "orbit-web"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.2"
 edition = "2024"
 license = "MIT"
 # MSRV [ORB-10010]: edition 2024 requires >= 1.85; the highest `rust-version`

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-tools/cli",
-  "version": "0.19.0",
+  "version": "0.19.2",
   "mcpName": "io.github.constellation-works/orbit",
   "description": "npm proxy for the Orbit CLI. Downloads the matching native binary from GitHub Releases on install and forwards all invocations.",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.19.0",
+  "version": "0.19.2",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface, skills, and orchestration subagents to Claude Code.",
   "author": {
     "name": "constellation-works",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit",
-  "version": "0.19.0",
+  "version": "0.19.2",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP task and knowledge surface plus workflow skills to Codex.",
   "author": {
     "name": "constellation-works",
@@ -20,7 +20,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
     }
   },
   "interface": {

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "orbit": {
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
     }
   }
 }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -4,7 +4,7 @@
     "orbit": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@orbit-tools/cli@0.19.0", "mcp", "serve"]
+      "args": ["-y", "@orbit-tools/cli@0.19.2", "mcp", "serve"]
     }
   }
 }

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "orbit",
-  "version": "0.19.0",
+  "version": "0.19.2",
   "description": "Task and activity orchestration for AI coding agents. Adds Orbit's MCP tool surface and shared workflow skills to compatible clients.",
   "author": {
     "name": "constellation-works",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/constellation-works/orbit",
     "source": "github"
   },
-  "version": "0.19.0",
+  "version": "0.19.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@orbit-tools/cli",
-      "version": "0.19.0",
+      "version": "0.19.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Task

[ORB-11485](https://orbit-cli.com/tasks/ORB-11485) — Bump release metadata to 0.19.2 without tagging or publishing

### Description

Daniel explicitly requests the next source version bump, choosing 0.19.2 because he already tagged and pushed. Live GitHub tags verified 2026-09-07: v0.19.1 exists; v0.19.2 is absent. Update all active release version surfaces in lockstep using the repository's existing bump mechanism and policy, including Cargo workspace/lock, npm/package.json, server.json, plugin manifests and exact MCP launch pins where applicable. Preserve historical versions/provenance. Inspect current agent-main first; if an equivalent bump has landed, report no-diff with evidence. Dedicated worktree from agent-main, task-scoped PR. No promotion to main, release tag creation/mutation, release workflow trigger, npm publication, or marketplace submission; Daniel retains release execution. Validate the complete version contract via make release-check and relevant plugin validator/smoke checks. Do not weaken checks to accommodate unrelated failures.

### Acceptance Criteria

- All active release-version surfaces and exact plugin launch pins consistently use 0.19.2, with historical references preserved.
- make release-check and applicable plugin validation/smoke checks run; report any failures precisely and verify the diff contains only the version bump and necessary lock metadata.
- Deliver the validated task-scoped change to agent-main under this session's completion approval; do not tag, publish, trigger releases, or promote to main.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the active release version in Cargo.toml, npm/package.json, server.json (including its npm package entry), and all three plugin manifests from 0.19.0 to 0.19.2.
- Updated the exact npx MCP launch pins in plugin/.mcp.json, plugin/mcp.json, and plugin/.codex-plugin/plugin.json to @orbit-tools/cli@0.19.2.
- Ran the repository-prescribed cargo update --workspace; Cargo.lock changed only the 17 local Orbit package versions to 0.19.2, with no third-party dependency drift.
- Preserved historical version references and unrelated baseline history. The final diff is limited to the nine task-scoped files.

Acceptance criteria:
- Active release surfaces and exact plugin launch pins consistently use 0.19.2: satisfied. Local release-check output confirms Cargo.toml, npm/package.json, server.json, and all three plugin manifests agree; plugin validators also confirm launch parity.
- Required validation and scope verification: plugin validation/test/smoke checks passed; git diff --check passed; make release-check ran its local checks successfully but exited non-zero because npm view @orbit-tools/cli version was unreachable and the latest available GitHub release tag is v0.19.1, producing the precise expected pre-publication remote drift. mcp-publisher was not installed, so structural registry validation ran and publisher validation was deferred to release CI.
- Delivery constraints: satisfied for this executor. Changes remain uncommitted and ready for the pipeline to deliver to agent-main; no tag, publication, release trigger, marketplace submission, or main promotion was performed.

Validation:
- PASS: cargo update --workspace (17 local package entries updated; 163 dependencies unchanged).
- PASS: ./scripts/test-validate-codex-plugin.sh.
- PASS: ./scripts/test-validate-agent-plugin.sh.
- PASS: ./scripts/smoke-plugin-install.sh (Claude/Codex scratch assets and Cursor Agent Plugins 1.0 contract; headless Cursor execution unavailable by repository design).
- PASS: git diff e03120f703919c47bc5c237731e42799623843ce --check.
- PASS: final diff-name scope assertion for Cargo.lock, Cargo.toml, npm/package.json, server.json, and the five plugin files.
- FAILED (environment/release state, not local metadata): make release-check; npm registry lookup failed as unreachable and GitHub latest release remained v0.19.1, while all local consistency checks passed.

Assessment: The task-scoped version bump is complete and internally consistent. Remaining risk is external release state: the exact 0.19.2 launch pins will not resolve from npm until Daniel publishes the matching package/release. Changes are intentionally left uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11485-6a9e362f`
- Behind base: 0
- Ahead of base: 1