### PR TITLE
Revise CONTRIBUTING.md: Orbit does not accept external pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,13 @@
-# Contributing to Orbit
+# Orbit Internal Development Standards
 
-Thanks for contributing to Orbit.
+Orbit does not accept external pull requests. Development follows a
+single-writer pipeline that executes on a trusted host; running submitted code
+from an untrusted branch there would expose the maintainer's credentials.
+Unsolicited pull requests will be closed.
+
+GitHub issues remain open for bug reports and feature requests. Outside input
+reaches Orbit through issues; implementation is handled by the maintainer and
+Orbit's own agents.
 
 ## Principles
 
@@ -15,7 +22,8 @@ Thanks for contributing to Orbit.
 cargo test --workspace
 ```
 
-Use targeted tests while iterating, then run the full workspace suite before landing a change.
+Use targeted tests while iterating, then run the full workspace suite before
+landing an internal change.
 
 ## Toolchain (MSRV)
 
@@ -70,7 +78,7 @@ on every PR (via `scripts/ci-guardrails.sh`) and locally with `make audit`. The
 policy lives in [`deny.toml`](deny.toml): it denies crates with an open RUSTSEC
 advisory or a yanked version, and restricts licenses to a reviewed allow-list.
 
-Run it before landing a dependency change:
+Run it before landing an internal dependency change:
 
 ```bash
 cargo install cargo-deny --locked   # one-time


### PR DESCRIPTION
## Task

[ORB-11447](https://orbit-cli.com/tasks/ORB-11447) — Revise CONTRIBUTING.md: Orbit does not accept external pull requests

### Description

`constellation-works/orbit` is a public repository, but Orbit is developed as a **single-writer** system: all changes land on `agent-main` through the owner's autonomous agent pipeline, executing on a trusted, privately-hosted machine. Accepting outside pull requests is incompatible with that model — both operationally (the pipeline has no auto-discovery path for externally-authored branches, so such PRs are invisible to it and simply rot) and on security grounds (dispatching an agent onto an untrusted contributor's branch would execute submitted code on the maintainer's own host with its credentials).

Today's [CONTRIBUTING.md](CONTRIBUTING.md) reads as an open-source contributor onboarding document ("Thanks for contributing to Orbit"), which sets an expectation the project will not honor.

Revise it to state the policy plainly and to reframe the rest of the file for its real audience.

**1. State the policy up front.** Replace the opening with a short, non-apologetic statement that Orbit does not accept external pull requests, and why (single-writer pipeline, trusted-host execution). Unsolicited PRs will be closed. Keep the tone matter-of-fact — this is a stated development model, not a rebuke of contributors.

**2. Keep issue reports as the open channel.** Bug reports and feature requests via GitHub issues remain welcome and are the way outside input reaches the project. (If the intent is to close issues too, that is a separate decision — do not assume it here.)

**3. Reframe, do not delete, the existing technical content.** Most of the file is genuinely load-bearing internal standards, not contributor instructions. Retitle the document and its framing so these read as **internal development standards** that the maintainer and Orbit's own agents follow:

- Principles
- Setup / `cargo test --workspace`
- Toolchain (MSRV) and the `rust-version` + workflow `MSRV` bump rule
- Testing & Coverage, including the per-crate coverage targets table
- Repository Shape
- Change Expectations
- Supply-chain (`cargo-deny`), the license allow-list rule, and the advisory time-boxing rule
- Orbit State (`.orbit/`) handling
- Commits, including the agent commit identity rule

Adjust wording that presumes an external reader ("before landing a change" in a PR sense, "in the same PR") only where it now reads wrong — the CI facts themselves are still accurate, since `ws_orbit` is `ship_mode: pr` and internal changes are still PR-gated into `agent-main`. Do not weaken or drop any of the supply-chain or MSRV rules.

**Scope:** `CONTRIBUTING.md` only. Do not add a PR template, modify workflows, change repository settings, or edit `README.md` as part of this task.

### Acceptance Criteria

- CONTRIBUTING.md opens with a clear statement that external pull requests are not accepted, with a brief reason (single-writer pipeline, trusted-host execution).
- The document is reframed as internal development standards rather than external contributor onboarding, including its title and introductory framing.
- GitHub issues are named as the channel that remains open for bug reports and feature requests.
- All existing technical content is preserved in substance: Principles, Setup, MSRV rule, Testing & Coverage with the per-crate targets table, Repository Shape, Change Expectations, cargo-deny supply-chain rules (license allow-list and advisory time-boxing), Orbit State, and Commits with the agent identity rule.
- No supply-chain, MSRV, or coverage rule is weakened, and no internal CI fact is made inaccurate.
- Only CONTRIBUTING.md is modified; no PR template, workflow, README, or repository setting is changed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Renamed CONTRIBUTING.md to “Orbit Internal Development Standards” and replaced the contributor-onboarding opening with the policy that external pull requests are not accepted, including the single-writer pipeline and trusted-host execution reasons; unsolicited pull requests will be closed.
- Identified GitHub issues as the open channel for bug reports and feature requests.
- Reframed the setup and cargo-deny landing guidance as internal changes while preserving all existing technical standards and wording substance.

Assessment: All acceptance criteria are satisfied. Principles, Setup and `cargo test --workspace`, MSRV/rust-version synchronization, Testing & Coverage and all three per-crate targets, Repository Shape, Change Expectations, cargo-deny license and advisory rules, Orbit State, and Commits with the agent identity rule remain present and unchanged in substance. No supply-chain, MSRV, coverage, or CI rule was weakened or made inaccurate.

Validation:
- PASS — `pwd -P` and `git rev-parse --show-toplevel`: both resolve to the supplied worktree.
- PASS — targeted content search confirmed required headings, commands, rules, targets, and CI references remain present.
- PASS — cross-checked the documented MSRV, coverage, and cargo-deny facts against `Cargo.toml`, `.github/workflows/ci.yml`, `scripts/ci-guardrails.sh`, and `deny.toml`.
- PASS — `git diff --check`.
- PASS — `make ci-fast`.
- PASS — `make ci-lint`.
- PASS — `git diff --name-only` and `git status --short`: only `CONTRIBUTING.md` is modified.

Remaining risks or deviations: None identified. Full workspace tests and cargo-deny audit were not run because this is a documentation-only change with no dependency or runtime behavior changes; the required fast and lint checks passed. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11447-6a9e368e`
- Behind base: 0
- Ahead of base: 1