### PR TITLE
Prevent configured sweep cadence from silently skipping enabled cron routines

### DIFF
--- a/crates/orbit-automation/src/routines/due.rs
+++ b/crates/orbit-automation/src/routines/due.rs
@@ -13,9 +13,25 @@ use orbit_common::OrbitError;
 use orbit_types::workflow::MissedRunPolicy;
 
 /// How far past its scheduled slot a fire still counts as "natural" for
-/// `missed_run: skip`. Two sweep intervals: tolerates one slow or skipped
-/// sweep without reclassifying the slot as missed.
+/// `missed_run: skip` at the default 60-second sweep cadence. Two sweep
+/// intervals tolerate one slow or skipped sweep without reclassifying the
+/// slot as missed.
 pub const NATURAL_SLOT_GRACE_SECONDS: i64 = 120;
+
+/// Derive the natural-slot grace from the cadence of the host clock that
+/// invokes the sweep. The scheduler permits one missed or delayed poll, so a
+/// slot remains natural for two configured cadence intervals. The default
+/// cadence deliberately preserves [`NATURAL_SLOT_GRACE_SECONDS`].
+pub fn natural_slot_grace_for_cadence(cadence_seconds: u64) -> Result<Duration, OrbitError> {
+    let seconds = cadence_seconds.checked_mul(2).ok_or_else(|| {
+        OrbitError::InvalidInput("sweep cadence is too large for natural-slot grace".to_string())
+    })?;
+    let seconds = i64::try_from(seconds).map_err(|_| {
+        OrbitError::InvalidInput("sweep cadence is too large for natural-slot grace".to_string())
+    })?;
+
+    Ok(Duration::seconds(seconds))
+}
 
 /// Outcome of the due check for one routine on one sweep pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,6 +78,25 @@ pub fn due_decision<Tz: TimeZone>(
     lower_bound: &DateTime<Tz>,
     now: &DateTime<Tz>,
 ) -> Result<DueDecision<Tz>, OrbitError> {
+    due_decision_with_grace(
+        cron,
+        missed_run,
+        lower_bound,
+        now,
+        Duration::seconds(NATURAL_SLOT_GRACE_SECONDS),
+    )
+}
+
+/// Decide whether a routine is due with the natural-slot grace supplied by
+/// the host sweep clock. Non-routine callers retain [`due_decision`]'s
+/// default cadence behavior.
+pub fn due_decision_with_grace<Tz: TimeZone>(
+    cron: &Cron,
+    missed_run: MissedRunPolicy,
+    lower_bound: &DateTime<Tz>,
+    now: &DateTime<Tz>,
+    natural_slot_grace: Duration,
+) -> Result<DueDecision<Tz>, OrbitError> {
     // Latest scheduled slot at or before now.
     let previous = cron
         .find_previous_occurrence(now, true)
@@ -77,7 +112,7 @@ pub fn due_decision<Tz: TimeZone>(
     }
 
     let age = now.clone().signed_duration_since(previous.clone());
-    let natural = age <= Duration::seconds(NATURAL_SLOT_GRACE_SECONDS);
+    let natural = age <= natural_slot_grace;
     if natural {
         return Ok(DueDecision::Fire {
             slot: previous,

--- a/crates/orbit-automation/src/routines/sweep.rs
+++ b/crates/orbit-automation/src/routines/sweep.rs
@@ -1,6 +1,8 @@
 //! Deterministic routine evaluation, retry and overlap coordination.
 
-use super::due::{DueDecision, due_decision, parse_cron};
+use super::due::{
+    DueDecision, due_decision_with_grace, natural_slot_grace_for_cadence, parse_cron,
+};
 use super::loader::{LoadedRoutine, RoutineCollection, RoutineLoadError};
 #[cfg(test)]
 use super::validation::RoutineHostIdentity;
@@ -62,10 +64,23 @@ pub trait RoutineDispatch {
 }
 
 /// Options for one sweep pass.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct SweepOptions {
     /// Report what would fire without recording or dispatching anything.
     pub dry_run: bool,
+    /// Cadence of the host clock that invokes this pass. The production
+    /// assembly supplies the configured clock cadence; deterministic callers
+    /// use the compatible 60-second default.
+    pub sweep_cadence_seconds: u64,
+}
+
+impl Default for SweepOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            sweep_cadence_seconds: 60,
+        }
+    }
 }
 
 /// Per-routine outcome of one sweep pass.
@@ -303,11 +318,13 @@ fn sweep_routine(
     let lower_bound_raw = cursor.last_slot.as_deref().unwrap_or(&cursor.baseline_at);
     let lower_bound = parse_rfc3339(lower_bound_raw)?.with_timezone(&Local);
 
-    match due_decision(
+    let natural_slot_grace = natural_slot_grace_for_cadence(options.sweep_cadence_seconds)?;
+    match due_decision_with_grace(
         &cron,
         definition.trigger.missed_run,
         &lower_bound,
         &now_local,
+        natural_slot_grace,
     )? {
         DueDecision::Fire { slot, .. } => {
             let slot_utc = slot.with_timezone(&Utc).to_rfc3339();

--- a/crates/orbit-automation/src/routines/tests/due.rs
+++ b/crates/orbit-automation/src/routines/tests/due.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, TimeZone, Utc};
 
-use super::super::due::{DueDecision, due_decision, parse_cron};
+use super::super::due::{
+    DueDecision, NATURAL_SLOT_GRACE_SECONDS, due_decision, due_decision_with_grace,
+    natural_slot_grace_for_cadence, parse_cron,
+};
 use orbit_types::workflow::MissedRunPolicy;
 
 fn at(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> DateTime<Utc> {
@@ -39,6 +42,117 @@ fn natural_slot_fires_within_grace() {
         DueDecision::Fire {
             slot: at(2026, 7, 2, 22, 0, 0),
             is_catch_up: false,
+        }
+    );
+}
+
+#[test]
+fn default_cadence_keeps_its_existing_two_minute_natural_window() {
+    let cron = parse_cron("0 * * * *").expect("cron");
+    let lower = at(2026, 7, 2, 21, 0, 0);
+
+    let final_natural = due_decision(
+        &cron,
+        MissedRunPolicy::Skip,
+        &lower,
+        &at(2026, 7, 2, 22, 2, 0),
+    )
+    .expect("decision");
+    assert!(matches!(
+        final_natural,
+        DueDecision::Fire {
+            is_catch_up: false,
+            ..
+        }
+    ));
+
+    let first_missed = due_decision(
+        &cron,
+        MissedRunPolicy::Skip,
+        &lower,
+        &at(2026, 7, 2, 22, 2, 1),
+    )
+    .expect("decision");
+    assert_eq!(first_missed, DueDecision::NotDue);
+    assert_eq!(NATURAL_SLOT_GRACE_SECONDS, 120);
+}
+
+#[test]
+fn configured_cadence_keeps_the_incident_slot_natural_once() {
+    let cron = parse_cron("5 * * * *").expect("cron");
+    let lower = at(2026, 9, 7, 0, 5, 0);
+    let grace = natural_slot_grace_for_cadence(300).expect("five-minute grace");
+
+    // The production incident polled before the 01:05 slot, then again at
+    // 01:08:43. The 223-second-old slot is still an ordinary fire, not a
+    // catch-up, under the configured five-minute clock.
+    let legacy_decision = due_decision(
+        &cron,
+        MissedRunPolicy::Skip,
+        &lower,
+        &at(2026, 9, 7, 1, 8, 43),
+    )
+    .expect("legacy decision");
+    assert_eq!(legacy_decision, DueDecision::NotDue);
+
+    let decision = due_decision_with_grace(
+        &cron,
+        MissedRunPolicy::Skip,
+        &lower,
+        &at(2026, 9, 7, 1, 8, 43),
+        grace,
+    )
+    .expect("decision");
+    assert_eq!(
+        decision,
+        DueDecision::Fire {
+            slot: at(2026, 9, 7, 1, 5, 0),
+            is_catch_up: false,
+        }
+    );
+}
+
+#[test]
+fn cadence_grace_handles_poll_phase_without_masking_real_downtime() {
+    let cron = parse_cron("5 * * * *").expect("cron");
+    let lower = at(2026, 9, 7, 0, 5, 0);
+    let grace = natural_slot_grace_for_cadence(300).expect("five-minute grace");
+
+    for now in [at(2026, 9, 7, 1, 5, 5), at(2026, 9, 7, 1, 8, 43)] {
+        let decision = due_decision_with_grace(&cron, MissedRunPolicy::Skip, &lower, &now, grace)
+            .expect("decision");
+        assert!(matches!(
+            decision,
+            DueDecision::Fire {
+                is_catch_up: false,
+                ..
+            }
+        ));
+    }
+
+    let after_one_delayed_poll = due_decision_with_grace(
+        &cron,
+        MissedRunPolicy::Skip,
+        &lower,
+        &at(2026, 9, 7, 1, 15, 1),
+        grace,
+    )
+    .expect("decision");
+    assert_eq!(after_one_delayed_poll, DueDecision::NotDue);
+
+    let catch_up = due_decision_with_grace(
+        &cron,
+        MissedRunPolicy::CatchUpOnce,
+        &lower,
+        &at(2026, 9, 7, 1, 15, 1),
+        grace,
+    )
+    .expect("decision");
+    assert_eq!(
+        catch_up,
+        DueDecision::Fire {
+            slot: at(2026, 9, 7, 1, 5, 0),
+            is_catch_up: true,
         }
     );
 }

--- a/crates/orbit-automation/src/routines/tests/sweep.rs
+++ b/crates/orbit-automation/src/routines/tests/sweep.rs
@@ -222,6 +222,62 @@ fn same_slot_second_sweep_does_not_double_fire() {
     assert_eq!(dispatch.submit_count(), 1);
 }
 
+#[test]
+fn five_minute_clock_fires_the_incident_slot_once_after_a_phase_gap() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let coll = collection(vec![routine("hourly", "5 * * * *", true, "allow", 0)]);
+    store
+        .routine_record_baseline("hourly", &ts(2026, 9, 7, 0, 5, 0).to_rfc3339())
+        .expect("baseline");
+    let options = SweepOptions {
+        sweep_cadence_seconds: 300,
+        ..SweepOptions::default()
+    };
+
+    // The first poll is before the 01:05 slot. The next poll is 305 seconds
+    // later, matching the observed 01:03:38 -> 01:08:43 phase gap.
+    let before_slot = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        options,
+        ts(2026, 9, 7, 1, 3, 38),
+    )
+    .expect("pre-slot sweep");
+    assert_eq!(before_slot[0].reason.as_deref(), Some("not_due"));
+
+    let fired = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        options,
+        ts(2026, 9, 7, 1, 8, 43),
+    )
+    .expect("delayed sweep");
+    assert_eq!(fired[0].action, "fired");
+    assert_eq!(fired[0].slot.as_deref(), Some("2026-09-07T01:05:00+00:00"));
+
+    let later_poll = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        options,
+        ts(2026, 9, 7, 1, 13, 43),
+    )
+    .expect("later sweep");
+    assert_eq!(later_poll[0].reason.as_deref(), Some("not_due"));
+    assert_eq!(dispatch.submit_count(), 1, "one ordinary fire for the slot");
+    assert_eq!(
+        fires(&store, "hourly").len(),
+        1,
+        "one persisted fire intent"
+    );
+}
+
 // ---- toggles --------------------------------------------------------------
 
 #[test]
@@ -686,7 +742,10 @@ fn dry_run_records_no_state() {
         HOST,
         &coll,
         &dispatch,
-        SweepOptions { dry_run: true },
+        SweepOptions {
+            dry_run: true,
+            ..SweepOptions::default()
+        },
         ts(2026, 1, 1, 0, 5, 10),
     )
     .unwrap();
@@ -722,7 +781,10 @@ fn state_and_temporal_owners_of_same_pipeline_are_withheld_in_preview() {
         HOST,
         &collection(vec![legacy, state]),
         &FakeDispatch::default(),
-        SweepOptions { dry_run: true },
+        SweepOptions {
+            dry_run: true,
+            ..SweepOptions::default()
+        },
         ts(2026, 9, 6, 0, 0, 0),
     )
     .unwrap();

--- a/crates/orbit-cli/src/command/sweep.rs
+++ b/crates/orbit-cli/src/command/sweep.rs
@@ -82,6 +82,7 @@ impl SweepCommand {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
         let options = SweepOptions {
             dry_run: self.dry_run,
+            ..SweepOptions::default()
         };
         let outcome = run_sweep_for_selected_root(root_override, options)?;
 

--- a/crates/orbit-core/src/application/routines/sweep.rs
+++ b/crates/orbit-core/src/application/routines/sweep.rs
@@ -12,6 +12,7 @@ use super::loader::{RoutineLoadError, RoutineWorkspaceProvider, collect_routines
 use super::validation::{RoutinePlacementProjection, RoutinePlacementProvider};
 use crate::OrbitRuntime;
 use crate::application::job::run_owner_liveness;
+use crate::application::routines::clock::load_clock_settings;
 use chrono::Utc;
 use orbit_automation::routines::sweep::run_sweep_core_with_registry;
 pub use orbit_automation::routines::sweep::{
@@ -132,6 +133,10 @@ pub fn run_sweep_at_with_providers(
     };
 
     let store = super::open_routine_store(global_root)?;
+    // The OS unit and due calculation share this host-local setting. A
+    // configured five-minute clock therefore keeps a slot natural for two
+    // five-minute intervals instead of retaining the old 120-second default.
+    let options = configured_sweep_options(global_root, options)?;
     let now_utc = Utc::now();
     let RoutinePlacementProjection {
         local_host,
@@ -171,5 +176,18 @@ pub fn run_sweep_at_with_providers(
         lock_busy: false,
         reports,
         load_errors,
+    })
+}
+
+/// Bind a routine sweep to the same cadence the host clock installer renders.
+/// Kept separate so the production path and its configuration test share one
+/// explicit boundary.
+pub(crate) fn configured_sweep_options(
+    global_root: &Path,
+    options: SweepOptions,
+) -> Result<SweepOptions, OrbitError> {
+    Ok(SweepOptions {
+        sweep_cadence_seconds: load_clock_settings(global_root)?.cadence_seconds,
+        ..options
     })
 }

--- a/crates/orbit-core/src/application/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/application/routines/tests/sweep.rs
@@ -1,5 +1,8 @@
+use crate::application::routines::clock::{ClockSettings, save_clock_settings};
 use crate::application::routines::loader::{DiscoveredWorkspaces, RoutineWorkspaceProvider};
-use crate::application::routines::sweep::{SweepOptions, run_sweep_at_with_providers};
+use crate::application::routines::sweep::{
+    SweepOptions, configured_sweep_options, run_sweep_at_with_providers,
+};
 use crate::application::routines::validation::{
     RoutineHostIdentity, RoutinePlacementProjection, RoutinePlacementProvider,
 };
@@ -43,4 +46,24 @@ fn busy_lock_returns_before_remote_providers_are_loaded() {
     assert!(outcome.lock_busy);
     assert_eq!(outcome.machine_id, "hm_local");
     assert_eq!(outcome.host_id, "local");
+}
+
+#[test]
+fn production_sweep_options_follow_the_host_clock_cadence() {
+    let root = tempfile::tempdir().expect("root");
+
+    let default_options = configured_sweep_options(root.path(), SweepOptions::default())
+        .expect("default clock settings");
+    assert_eq!(default_options.sweep_cadence_seconds, 60);
+
+    save_clock_settings(
+        root.path(),
+        ClockSettings {
+            cadence_seconds: 300,
+        },
+    )
+    .expect("configured clock settings");
+    let configured_options = configured_sweep_options(root.path(), SweepOptions::default())
+        .expect("configured clock settings");
+    assert_eq!(configured_options.sweep_cadence_seconds, 300);
 }

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -258,8 +258,11 @@ Per pass:
    (last slot, else the first-observation baseline — a routine never fires for slots that
    predate its registration on this host; the first sweep records the baseline and fires
    nothing). Due-ness is O(1) via previous-occurrence lookup, never a walk over every
-   missed slot; `missed_run` policy decides gaps. A slot is "natural" within a 120s grace
-   of its scheduled time.
+   missed slot; `missed_run` policy decides gaps. A slot is "natural" for two configured
+   clock-cadence intervals after its scheduled time: the default 60s clock therefore keeps
+   the existing 120s grace, while a configured 300s clock keeps a slot natural for 600s.
+   This admits one delayed or missed poll without turning genuine downtime into a `skip`
+   fire.
 7. For each due routine: check `overlap` against in-flight fires, record the fire intent
    (idempotency key: routine name + scheduled slot + attempt, transactionally with the
    cursor advance), then dispatch the target via `submit_pipeline_run` in the routine's
@@ -308,7 +311,7 @@ shows all three columns plus computed next-due, so "why didn't this fire?" is on
 The OS owns the wake-up; Orbit owns everything else. `orbit routine init --install-clock`
 renders and installs the platform unit:
 
-- **macOS** — a launchd agent (`com.orbit.sweep`) with `StartInterval` 60s. launchd also
+- **macOS** — a launchd agent (`com.orbit.sweep`) with `StartInterval=<cadence>`. launchd also
   fires on wake, which pairs with `missed_run: catch_up_once` for laptop sleep gaps.
 - **Linux** — `orbit-sweep.timer` combines `OnActiveSec=<cadence>` with
   `OnUnitActiveSec=<cadence>` plus a oneshot service. Every timer activation (fresh install,
@@ -321,6 +324,10 @@ renders and installs the platform unit:
   triggers deliberately do not replay timer events missed while the manager or host was
   down. The first sweep after restart evaluates each routine's cursor, so `catch_up_once`
   collapses missed cron slots to one fire and `skip` waits for the next natural slot.
+  Every sweep loads the same `clock.toml` cadence used to render the native timer, so
+  changing the clock from 60s to 300s changes its natural-slot grace from 120s to 600s.
+  The configured wake-up cost, routine enable/pause state, and host pinning are otherwise
+  unchanged.
 
 There is no resident Orbit daemon. Sub-minute triggers and event triggers are explicitly
 out of v1 scope for this reason.


### PR DESCRIPTION
## Task

[ORB-11464](https://orbit-cli.com/tasks/ORB-11464) — Prevent configured sweep cadence from silently skipping enabled cron routines

### Description

Live ws_orbit incident, 2026-09-07 01:52 UTC: ci-failure-sweep-orbit is enabled/effective, pinned to dk-server-1, cron 5 * * * *, missed_run skip. Latest scheduled fire is jrun-20260906-2306 for23:05; manual repaired pipeline0051 succeeded. Host systemd orbit-sweep.timer uses OnActiveSec=300s, OnUnitActiveSec=300s, AccuracySec=5s. Journal shows01:03:38 and01:08:43 sweeps (then five-minute polling), all reporting26 routines,nothing due. The01:05 slot is223 seconds old at the next poll.

Current crates/orbit-automation/src/routines/due.rs hard-codes NATURAL_SLOT_GRACE_SECONDS=120 with a comment describing two sweep intervals. due_decision skips any older slot under MissedRunPolicy::Skip. The five-minute configurable clock can therefore silently miss healthy enabled hourly routines depending on phase. ORB-10720 introduced configurable cadence via fea741ac5 / PR936, followed by test coverage7782d7ebd / PR937; verify the exact causal history before assigning source_task_id.

Repair the contract between effective host clock cadence and natural-slot lateness. Preserve the user's configured wakeup cost and per-routine skip/catch-up semantics; do not simply force every host back to60s or switch all routines tocatch_up_once. Derive a justified tolerance from the effective cadence (including expected jitter/one delayed poll) or an equivalent existing-owner solution. Preserve slot identity, idempotency, first-observation floor, overlap safety and genuine downtime skipping. Keep default60s behavior compatible. No new scheduler/store. Relevant deployment observation must demonstrate a scheduled CI sweep, not just a manual job run.

### Acceptance Criteria

- Deterministic tests reproduce the exact01:03:38 ->01:08:43 polling gap around01:05 and prove one ordinary fire at configured300s cadence.
- Cover60s default, varied polling phases/jitter, duplicate prevention, genuine downtime under skip, catch_up_once and initial registration floor.
- Clock configuration and due calculation agree through production wiring on supported host paths; preserve configured cadence and routine enable/pause/host-pin semantics.
- Run owning tests and ci-fast/ci-lint; deploy through authorized workflow and observe an actual scheduled ci_failure_sweep_pipeline run with correct slot and outcome before claiming unattended health.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Derived routine natural-slot grace from two host clock cadence intervals, preserving the existing 120-second default at 60 seconds and using 600 seconds at 300 seconds.
- Loaded the authoritative clock.toml setting in production sweep assembly before due evaluation.
- Added deterministic incident, phase/jitter, duplicate, skip/catch-up, default-window, registration-floor, and clock-wiring coverage; updated the live routines design.

Assessment: The configured host wake-up cadence now directly governs the ordinary-fire window without changing routine enable, pause, host-pin, slot identity, overlap, or missed-run semantics.

Criteria:
- Exact 01:03:38 to 01:08:43 incident gap: passed; one ordinary 01:05 fire is asserted at 300-second cadence.
- Default, phase/jitter, duplicate prevention, skip downtime, catch_up_once, and initial floor: passed in deterministic due and sweep tests.
- Production clock configuration wiring and routine semantics: passed via core configuration-boundary coverage plus existing toggle/overlap tests.
- Owning tests, ci-fast, and ci-lint: passed. Deployment and scheduled ci_failure_sweep_pipeline observation: not run; this managed activity has no authorized deployment/workflow tool and the pipeline owns delivery. Unattended health is not claimed.

Validation:
- cargo test -p orbit-automation routines::tests::due --lib: passed (11 tests).
- cargo test -p orbit-automation routines::tests::sweep --lib: passed (14 tests).
- cargo test -p orbit-core application::routines::tests::sweep --lib: passed (2 tests).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.

Source history: verified ORB-10720 as source_task_id: fea741ac5 / PR #936 introduced configurable clock cadence, and 7782d7ebd / PR #937 added its deterministic clock coverage.

Remaining risk: authorized delivery must deploy to agent-main and observe a genuinely scheduled ci_failure_sweep_pipeline run at its expected slot with its recorded outcome before unattended health can be asserted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11464-6a9e360f`
- Behind base: 0
- Ahead of base: 1