### PR TITLE
Enable and verify HSTS for orbit-cli.com

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Build website
         run: npm run build
 
+      - name: Check transport-security policy
+        run: |
+          set -euo pipefail
+          test -f dist/_headers
+          grep -Fx 'Strict-Transport-Security: max-age=31536000' dist/_headers
+
       - name: Attach publication provenance
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         env:
@@ -155,3 +161,35 @@ jobs:
           test -n "$DEPLOYMENT_URL"
           verify_site "$DEPLOYMENT_URL"
           verify_site "$PUBLIC_URL"
+
+          verify_hsts() {
+            local url="$1"
+            local expected_status="$2"
+            local headers
+            local status
+
+            headers="$(mktemp)"
+            status="$(curl --silent --show-error --max-time 20 \
+              --dump-header "$headers" --output /dev/null --write-out '%{http_code}' "$url")"
+            test "$status" = "$expected_status"
+            grep -Eiq '^strict-transport-security:[[:space:]]*max-age=31536000[[:space:]]*$' "$headers"
+            rm -f "$headers"
+          }
+
+          verify_http_redirect() {
+            local headers
+            local status
+
+            headers="$(mktemp)"
+            status="$(curl --silent --show-error --max-time 20 \
+              --dump-header "$headers" --output /dev/null --write-out '%{http_code}' http://orbit-cli.com/)"
+            test "$status" -ge 301
+            test "$status" -le 399
+            grep -Eiq '^location:[[:space:]]*https://orbit-cli\.com/' "$headers"
+            rm -f "$headers"
+          }
+
+          verify_hsts "$PUBLIC_URL/" 200
+          verify_hsts "$PUBLIC_URL/getting-started/install/" 200
+          verify_hsts "$PUBLIC_URL/hsts-verification-missing-route" 404
+          verify_http_redirect

--- a/docs/runbooks/website-validation.md
+++ b/docs/runbooks/website-validation.md
@@ -248,7 +248,19 @@ deployments are serialized, use only `contents: read` and `deployments: write`,
 and are recorded in both the Actions run and GitHub Deployments. The final step
 checks the unique homepage headline, the delivery-mode setup explorer, the
 install route, and the expected source revision at both the deployment URL and
-`orbit-cli.com`.
+`orbit-cli.com`. It also checks the Pages `_headers` artifact during build, then
+checks the deployed custom domain for `Strict-Transport-Security:
+max-age=31536000` on homepage and install-route 200 responses and on a 404
+response. Finally, it checks that `http://orbit-cli.com/` redirects to the
+canonical HTTPS domain.
+
+The static `website/public/_headers` file is the sole repository-owned HSTS
+policy. Its one-year max-age intentionally does not use `includeSubDomains` or
+`preload`; the repository has not established that every subdomain is HTTPS-ready
+and under compatible operational ownership. HTTP redirect behavior belongs to the
+externally managed Cloudflare zone rather than the Pages artifact. Treat a failed
+redirect check as an external-zone configuration issue, not a reason to add a
+second redirect mechanism to the site.
 
 ### Operate and recover
 

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -154,7 +154,9 @@ Each section has an index page that lists its children with one-line description
   path directly uploads to the existing Pages project identified by the protected
   production environment, and publishes only from the release/production `main`
   branch. The `orbit-cli.com` DNS remains externally managed; publication neither
-  provisions hosting nor edits DNS. See ORB-11379.
+  provisions hosting nor edits DNS. Cloudflare Pages applies the repository-owned
+  `public/_headers` policy to HTTPS responses; the externally managed Cloudflare
+  zone owns HTTP-to-HTTPS redirection. See ORB-11379.
 - **Repo layout:** new top-level `website/` directory, independent of the Rust workspace
 
 ### 5.1 Why Starlight over Nextra

--- a/website/README.md
+++ b/website/README.md
@@ -31,6 +31,21 @@ the source commit, and verifies the deployment URL plus
 `https://orbit-cli.com` before succeeding. The published `/deployment.json`
 records the source revision and Actions run URL.
 
+## Transport security
+
+`public/_headers` is the sole repository-owned response-header policy. Cloudflare
+Pages copies it to the static-output root and applies its `Strict-Transport-Security:
+max-age=31536000` rule to every HTTPS route, including static error responses.
+The bounded one-year policy deliberately omits `includeSubDomains` and `preload`:
+the repository does not establish HTTPS readiness or operational ownership for
+every subdomain.
+
+HTTP-to-HTTPS redirection is owned by the externally managed Cloudflare zone,
+not by the Pages artifact. The production publish job verifies both that redirect
+and HSTS on representative success and 404 responses after each deployment.
+Changing either responsibility requires updating the workflow and the [website
+validation runbook](../docs/runbooks/website-validation.md) in the same change.
+
 Build success is not publication success. The `Check and build` job proves only
 that Astro produced static output; the separate `Publish to Cloudflare Pages`
 job and its GitHub Deployment record prove upload and post-deploy verification.

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Strict-Transport-Security: max-age=31536000


### PR DESCRIPTION
## Task

[ORB-11461](https://orbit-cli.com/tasks/ORB-11461) — Enable and verify HSTS for orbit-cli.com

### Description

User security scan reports Moderate severity Domains without HSTS for orbit-cli.com (2026-08-20 19:41:02). Live operator HEAD https://orbit-cli.com/ on 2026-09-07 01:22 UTC returned HTTP200 via Cloudflare with no Strict-Transport-Security header. Public security.txt404 responses also lacked it.

Identify the authoritative response-header configuration at Cloudflare/Pages and the repository deployment path. Implement a maintainable HSTS policy for the production domain, ensuring the header actually reaches HTTPS responses and HTTP redirects to HTTPS. Use a bounded rollout suited to the verified domain; do not enable includeSubDomains or request preload until subdomain HTTPS readiness and operational ownership are established. Avoid duplicate/conflicting edge and origin policies. Document where the policy is owned and validate production after deployment. ORB-11458 tracks the currently missing production CLOUDFLARE_PAGES_PROJECT setting; reuse that deployment remediation if needed rather than inventing a Pages project.

### Acceptance Criteria

- Production HTTPS responses carry a valid Strict-Transport-Security policy, with deliberate max-age and verified coverage of representative success, redirect and error responses.
- HTTP redirects safely to canonical HTTPS; no HTTP-only dependencies or verified supported subdomains are broken.
- includeSubDomains/preload are used only if their domain-wide prerequisites are established; the initial fix does not require guessing those prerequisites.
- Relevant config/build checks pass; attach deployed response-header and scanner verification, or accurately record an external deployment blocker.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the sole repository-owned Cloudflare Pages response-header policy at website/public/_headers: Strict-Transport-Security: max-age=31536000 for every HTTPS route. The bounded policy deliberately omits includeSubDomains and preload.
- Extended the Website workflow to check that the built artifact contains the policy and, after production deployment, to require HSTS on homepage and install-route 200 responses plus a 404 response, and to require HTTP to redirect to canonical HTTPS.
- Documented Pages header ownership versus external Cloudflare-zone redirect ownership in the website README, design record, and validation runbook.

Criteria assessment:
- HTTPS HSTS policy: satisfied in the deployable artifact; post-deploy checks cover representative 200 and 404 HTTPS responses.
- HTTP redirect and dependencies: current live check returned 301 Location: https://orbit-cli.com/; source scan found no HTTP content dependencies (only SVG XML namespaces). The workflow preserves and verifies that redirect.
- Domain-wide directives: satisfied; includeSubDomains and preload are intentionally absent pending verified domain-wide HTTPS readiness and ownership.
- Validation and production evidence: local config/build checks passed. Live checks at 2026-09-07 04:21 UTC still showed no HSTS on HTTPS 200 or 404 responses, while the HTTP redirect was correct. ORB-11458 recorded that the protected production environment has no CLOUDFLARE_PAGES_PROJECT, so this change cannot be deployed or scanner-verified until an authorized Cloudflare owner identifies the existing Pages project and restores that variable. No project, credentials, DNS, or main promotion was invented.

Validation:
- Passed: npm_config_cache=<temporary> npm --prefix website ci; npm --prefix website run check; npm --prefix website run build; built dist/_headers contained the exact HSTS policy.
- Passed: extracted deployment verification shell parsed with bash -n.
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: git diff --check.
- Not run: deployed HSTS/scanner verification, blocked by the missing production Pages-project configuration above.

Assessment: focused static Pages policy with one authoritative header source and deployment-bound production assertions; changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11461-6a9e3ad4`
- Behind base: 0
- Ahead of base: 1