### PR TITLE
Publish a maintained security.txt for orbit-cli.com

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Build website
         run: npm run build
 
+      - name: Validate security.txt
+        run: |
+          npm run validate:security-txt -- public/.well-known/security.txt
+          npm run validate:security-txt -- dist/.well-known/security.txt
+
       - name: Check transport-security policy
         run: |
           set -euo pipefail
@@ -161,6 +166,26 @@ jobs:
           test -n "$DEPLOYMENT_URL"
           verify_site "$DEPLOYMENT_URL"
           verify_site "$PUBLIC_URL"
+
+          verify_security_txt() {
+            local base_url="${1%/}"
+            local body
+            local headers
+            local status
+
+            body="$(mktemp)"
+            headers="$(mktemp)"
+            status="$(curl --silent --show-error --max-time 20 \
+              --dump-header "$headers" --output "$body" --write-out '%{http_code}' \
+              "$base_url/.well-known/security.txt")"
+            test "$status" = 200
+            grep -Eiq '^content-type:[[:space:]]*text/plain(?:;|$)' "$headers"
+            node website/scripts/validate-security-txt.mjs "$body"
+            rm -f "$body" "$headers"
+          }
+
+          verify_security_txt "$DEPLOYMENT_URL"
+          verify_security_txt "$PUBLIC_URL"
 
           verify_hsts() {
             local url="$1"

--- a/docs/runbooks/website-validation.md
+++ b/docs/runbooks/website-validation.md
@@ -154,6 +154,19 @@ export PREVIEW_URL="http://127.0.0.1:$PREVIEW_PORT"
 curl --fail --silent --show-error "$PREVIEW_URL/" >/dev/null
 ```
 
+For security.txt changes, validate both the source and generated static asset:
+
+```bash
+npm --prefix "$REPO/website" run validate:security-txt -- public/.well-known/security.txt
+npm --prefix "$REPO/website" run validate:security-txt -- dist/.well-known/security.txt
+```
+
+The validator rejects missing or malformed RFC 9116 fields, invalid or expired
+`Expires`, non-HTTPS `Contact`/`Policy` URIs, an incorrect `Canonical`, invalid
+UTF-8, and HTML fallback content. The Orbit maintainers own renewal: review the
+file before its `Expires` timestamp and renew it annually. A local build proves
+only that the asset is packaged; it does not prove public publication.
+
 Launch Chromium through the staged Playwright package at both representative desktop and
 mobile sizes. The following smoke check records HTTP status, heading, rendered text length,
 console/page errors, and horizontal overflow; extend `PAGES` with the routes changed by the
@@ -283,6 +296,22 @@ second redirect mechanism to the site.
    `https://orbit-cli.com/getting-started/install/`. Fetch
    `https://orbit-cli.com/deployment.json` and compare `sourceRevision` with the
    workflow's `github.sha` before declaring publication successful.
+
+For the security document, independently check the canonical endpoint after the
+production workflow succeeds:
+
+```bash
+curl --fail --show-error --silent --dump-header /tmp/security-txt.headers \
+  https://orbit-cli.com/.well-known/security.txt
+grep -Eiq '^content-type:[[:space:]]*text/plain(?:;|$)' /tmp/security-txt.headers
+```
+
+Then rerun the security scan. A 404, HTML response, stale `Expires`, or failed
+scan remains an external publication issue until the exact `main` artifact is
+published and verified. The production workflow performs the same status,
+`text/plain`, and body validation against both the deployment URL and the
+custom domain. Do not treat the local `dist/.well-known/security.txt` check as
+public deployment evidence.
 
 If the workflow has not yet reached `main`, the exact existing project mapping
 has not been confirmed, or the environment credentials are missing or invalid,

--- a/website/README.md
+++ b/website/README.md
@@ -31,6 +31,16 @@ the source commit, and verifies the deployment URL plus
 `https://orbit-cli.com` before succeeding. The published `/deployment.json`
 records the source revision and Actions run URL.
 
+The published `/.well-known/security.txt` is the canonical security-reporting
+document. Its `Contact` points to GitHub's private vulnerability-reporting form,
+matching [SECURITY.md](../SECURITY.md); its `Policy` points to that policy. The
+Orbit maintainers own renewal: review the file before the `Expires` timestamp
+and renew it annually when the reporting channel or policy changes.
+`npm run validate:security-txt` checks the source file, and the workflow checks
+both the source and built asset. After publication, the workflow also requires
+the deployment URL and `orbit-cli.com` to return this asset as UTF-8 `text/plain`
+and validates the response body.
+
 ## Transport security
 
 `public/_headers` is the sole repository-owned response-header policy. Cloudflare

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,8 @@
     "prepreview": "node ./scripts/clean-legacy-metrics.mjs",
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
     "precheck": "node ./scripts/clean-legacy-metrics.mjs",
-    "check": "ASTRO_TELEMETRY_DISABLED=1 astro check"
+    "check": "ASTRO_TELEMETRY_DISABLED=1 astro check",
+    "validate:security-txt": "node ./scripts/validate-security-txt.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.3",

--- a/website/public/.well-known/security.txt
+++ b/website/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://github.com/constellation-works/orbit/security/advisories/new
+Expires: 2027-09-07T00:00:00Z
+Canonical: https://orbit-cli.com/.well-known/security.txt
+Policy: https://github.com/constellation-works/orbit/blob/main/SECURITY.md

--- a/website/scripts/validate-security-txt.mjs
+++ b/website/scripts/validate-security-txt.mjs
@@ -1,0 +1,120 @@
+import { readFile } from 'node:fs/promises';
+
+const filePath = process.argv[2] ?? 'public/.well-known/security.txt';
+const errors = [];
+
+let content;
+
+try {
+  const bytes = await readFile(filePath);
+  content = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+} catch (error) {
+  errors.push(`${filePath} must be a readable UTF-8 file: ${error.message}`);
+}
+
+if (content !== undefined) {
+  if (/^\uFEFF/u.test(content)) {
+    errors.push('the file must not begin with a UTF-8 byte-order mark');
+  }
+
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/u.test(content)) {
+    errors.push('the file contains a disallowed control character');
+  }
+
+  if (/<\s*(?:!doctype|html|head|body)\b/i.test(content)) {
+    errors.push('the file must contain plain text, not an HTML document');
+  }
+
+  const fields = new Map();
+  for (const [index, rawLine] of content.split('\n').entries()) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+
+    if (line === '' || line.startsWith('#')) {
+      continue;
+    }
+
+    const match = /^(?<name>[A-Za-z][A-Za-z0-9-]*):[ \t]+(?<value>\S(?:.*\S)?)$/u.exec(line);
+    if (!match) {
+      errors.push(`line ${index + 1} is not an RFC 9116 field`);
+      continue;
+    }
+
+    const name = match.groups.name;
+    const value = match.groups.value;
+    const values = fields.get(name.toLowerCase()) ?? [];
+    values.push(value);
+    fields.set(name.toLowerCase(), values);
+  }
+
+  const valuesFor = name => fields.get(name) ?? [];
+  const contacts = valuesFor('contact');
+  const expires = valuesFor('expires');
+  const canonicals = valuesFor('canonical');
+  const policies = valuesFor('policy');
+
+  if (contacts.length === 0) {
+    errors.push('Contact is required');
+  }
+
+  for (const contact of contacts) {
+    try {
+      const url = new URL(contact);
+      if (url.protocol !== 'https:') {
+        errors.push(`Contact must use HTTPS: ${contact}`);
+      }
+    } catch {
+      errors.push(`Contact must be an absolute URI: ${contact}`);
+    }
+  }
+
+  if (expires.length !== 1) {
+    errors.push('exactly one Expires field is required');
+  } else if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u.test(expires[0])) {
+    errors.push('Expires must be an RFC 3339 UTC timestamp');
+  } else {
+    const expiresAt = Date.parse(expires[0]);
+    if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+      errors.push(`Expires must be in the future: ${expires[0]}`);
+    }
+  }
+
+  if (canonicals.length === 0) {
+    errors.push('Canonical is required');
+  }
+
+  for (const canonical of canonicals) {
+    try {
+      const url = new URL(canonical);
+      if (url.href !== 'https://orbit-cli.com/.well-known/security.txt') {
+        errors.push(`Canonical must identify the public security.txt URL: ${canonical}`);
+      }
+    } catch {
+      errors.push(`Canonical must be an absolute URI: ${canonical}`);
+    }
+  }
+
+  if (policies.length === 0) {
+    errors.push('Policy is required');
+  }
+
+  for (const policy of policies) {
+    try {
+      const url = new URL(policy);
+      if (url.protocol !== 'https:') {
+        errors.push(`Policy must use HTTPS: ${policy}`);
+      }
+    } catch {
+      errors.push(`Policy must be an absolute URI: ${policy}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Invalid security.txt at ${filePath}:`);
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Valid security.txt: ${filePath}`);


### PR DESCRIPTION
## Task

[ORB-11462](https://orbit-cli.com/tasks/ORB-11462) — Publish a maintained security.txt for orbit-cli.com

### Description

User security scan reports Low severity Security.txt not configured for orbit-cli.com (2026-09-03 10:48:07). Live operator HEAD checks on 2026-09-07 01:22 UTC returned HTTP404 for both https://orbit-cli.com/.well-known/security.txt and /security.txt. The repository has SECURITY.md but no security.txt static asset in website/public at inspected origin/agent-main.

Add a standards-compliant security.txt to the actual website build and publish it at /.well-known/security.txt over HTTPS. Use the existing verified vulnerability reporting channel from SECURITY.md or confirmed maintainer policy; do not invent a mailbox or expose private contact information. Include valid Contact and Expires fields plus appropriate Canonical/Policy fields, and define who renews it before expiry. Ensure the build copies the well-known path as plain text rather than an HTML SPA fallback. An optional legacy /security.txt redirect may point to the canonical location. ORB-11458 owns the current missing production Pages-project configuration; link deployment evidence and do not mark publication complete from a local build alone.

### Acceptance Criteria

- The canonical HTTPS /.well-known/security.txt returns200, UTF-8 plain text, a working verified Contact and valid future Expires, with RFC9116-compatible content.
- Content matches the repository's actual security-reporting policy; any Canonical/Policy references resolve appropriately.
- Website build preserves the .well-known asset and focused validation detects missing/expired/malformed required fields; renewal ownership is documented.
- Verify the deployed endpoint and rescan, or explicitly preserve the external deployment blocker; do not claim a local asset is publicly published.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added website/public/.well-known/security.txt with the verified private GitHub vulnerability-reporting Contact, a future RFC 3339 Expires timestamp, the canonical HTTPS URL, and the repository SECURITY.md Policy URL.
- Added website/scripts/validate-security-txt.mjs and the npm validation script. It strictly decodes UTF-8 and rejects missing/malformed RFC 9116 fields, expired Expires, non-HTTPS Contact/Policy URIs, incorrect Canonical, control characters, and HTML fallback content.
- Wired source/build validation and deployed-URL/custom-domain status, text/plain, and body validation into .github/workflows/website.yml. Documented maintainer renewal ownership and local-versus-public deployment evidence in website/README.md and docs/runbooks/website-validation.md.
Assessment: The scoped repository deliverable is complete, readable, and maintains one canonical publication path. The asset is copied unchanged by Astro into dist/.well-known/security.txt.
Criteria:
- RFC 9116 content and policy alignment: satisfied locally; source and built assets validate, Contact returned HTTP 302 and Policy returned HTTP 200 during checks.
- Build preservation and focused validation: satisfied; source/dist validation passed, local preview returned HTTP 200 with Content-Type text/plain, and malformed/expired plus invalid-UTF-8 fixtures were rejected.
- Renewal ownership: satisfied; Orbit maintainers are documented as owners, with annual review before Expires.
- Public publication: external blocker preserved explicitly. https://orbit-cli.com/.well-known/security.txt returned HTTP 404 with an HTML 404 page on 2026-09-07; no local build is claimed as public publication. The post-promotion security rescan was not run because the endpoint is not deployed.
Validation:
- PASS: npm --prefix website ci (using a run-local npm cache after the default cache was read-only).
- PASS: npm --prefix website run check (0 errors, 0 warnings, 0 hints).
- PASS: npm --prefix website run build.
- PASS: npm --prefix website run validate:security-txt -- public/.well-known/security.txt.
- PASS: npm --prefix website run validate:security-txt -- dist/.well-known/security.txt.
- PASS: local preview curl of /.well-known/security.txt (HTTP 200, text/plain, expected body).
- PASS: file --mime-type confirms source and dist are text/plain.
- PASS: validator negative fixtures reject expired/malformed fields and invalid UTF-8.
- PASS: make ci-fast.
- PASS: make ci-lint.
- PASS: git diff --check.
- NOT RUN: deployed rescan; the live endpoint is still externally unpublished.
Remaining risk/deviation: Merge/publish through the existing main-only Cloudflare Pages workflow after the production Pages project and credentials blocker owned by ORB-11458 is resolved, then require the workflow's live security.txt check and rerun the external security scan.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11462-6a9e3d05`
- Behind base: 0
- Ahead of base: 1