### PR TITLE
Allow explicitly authorized Mac operators to invoke agents on the owning Linux host

### DIFF
--- a/crates/orbit-cli/src/command/mcp/callers.rs
+++ b/crates/orbit-cli/src/command/mcp/callers.rs
@@ -145,6 +145,14 @@ fn list(path: &Path) -> CommandOut {
         if let Some(fingerprint) = &row.ssh_key_fingerprint {
             println!("    ssh_key_fingerprint: {fingerprint}");
         }
+        println!(
+            "    agent_invoke: {}",
+            if row.agent_invoke {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
     }
     Ok(CommandOutput::Silent)
 }
@@ -189,6 +197,15 @@ fn check(path: &Path, machine_id: &str) -> CommandOut {
             capability_list(&grant.elsewhere)
         );
     }
+    println!(
+        "agent_invoke: {}",
+        if grant.agent_invoke {
+            "configured for the listed workspaces; admission additionally requires a key-bound \
+             session"
+        } else {
+            "not granted"
+        }
+    );
     // Both requests, because the grant is a ceiling and the caller's argv is
     // the other half of the intersection: printing only one would read as the
     // answer to a question the caller did not ask.
@@ -308,6 +325,11 @@ fn authorize(global_root: &Path, callers_path: &Path, args: &CallersAuthorizeArg
         "The forced command requests operator authority, but does not grant it: the matched row \
          in the callers file remains the ceiling, so agent-only and deny rows cannot become \
          operator sessions."
+    );
+    eprintln!(
+        "Remote `orbit.agent.invoke` remains denied unless the matched row also sets \
+         `agent_invoke = true`, grants `operator`, pins this key, and narrows `workspaces` to the \
+         destination workspace IDs. That extra grant never comes from the file default."
     );
     // The row guidance is written against what is actually in the file: a
     // template that restated `capabilities` would invite an operator to paste

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -45,8 +45,8 @@ struct McpWorkspace {
 }
 
 /// Write an executable no-op named `name` into `bin`, standing in for an agent
-/// CLI during detection. Nothing in these tests dispatches an agent, so the
-/// stub only has to exist and be executable.
+/// CLI during detection. Tests that dispatch overwrite it with a response
+/// fixture before starting the server.
 fn plant_agent_cli_stub(bin: &Path, name: &str) {
     std::fs::create_dir_all(bin).expect("create stub CLI directory");
     let stub = bin.join(name);
@@ -57,6 +57,17 @@ fn plant_agent_cli_stub(bin: &Path, name: &str) {
         std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
             .expect("mark the stub agent CLI executable");
     }
+}
+
+fn plant_agent_response_stub(bin: &Path, name: &str) {
+    plant_agent_cli_stub(bin, name);
+    let stub = bin.join(name);
+    std::fs::write(
+        &stub,
+        "#!/bin/sh\ncat > /dev/null\nprintf '%s\\n' \
+         '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"summary\":\"remote probe complete\"},\"error\":null}'\n",
+    )
+    .expect("write response stub");
 }
 
 /// `PATH` with the fixture's stub directory first, so agent detection sees the
@@ -1319,6 +1330,160 @@ ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
         denied["code"], "capability_denied",
         "the generated request must not raise a deny grant: {denied}"
     );
+}
+
+/// A destination can delegate exactly the trusted-host operation without
+/// turning every remote operator into an unsandboxed dispatcher.
+/// This crosses the destination-issued forced command, real MCP transport,
+/// workspace routing, durable run submission, worker, response projection,
+/// and revocation-on-reconnect boundaries.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_key_bound_remote_operator_invokes_an_agent_only_in_the_granted_workspace() {
+    let workspace = McpWorkspace::init();
+    plant_agent_response_stub(&McpWorkspace::stub_bin_dir(&workspace.home), "codex");
+    let registry: Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.home.join(".orbit/workspaces.json"))
+            .expect("read workspace registry"),
+    )
+    .expect("parse workspace registry");
+    let workspace_id = registry["workspaces"][0]["id"]
+        .as_str()
+        .expect("workspace id");
+
+    let Some(generated) = generated_forced_command(&workspace) else {
+        return;
+    };
+
+    write_callers(
+        &workspace,
+        &format!(
+            r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_caller"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_wrong"]
+ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
+agent_invoke = true
+"#,
+        ),
+    );
+    let mut wrong_workspace = workspace.serve_with_generated_command(&generated);
+    let denied = wrong_workspace.call_tool_err(
+        "orbit_agent_invoke",
+        json!({
+            "prompt": "read-only remote probe",
+            "cwd": workspace.work,
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(denied["code"], "capability_denied", "{denied}");
+    drop(wrong_workspace);
+
+    write_callers(
+        &workspace,
+        &format!(
+            r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_caller"
+capabilities = ["agent", "operator"]
+workspaces = ["{workspace_id}"]
+ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
+agent_invoke = true
+"#,
+        ),
+    );
+    let mut granted = workspace.serve_with_generated_command(&generated);
+    let submitted = granted.call_tool_ok(
+        "orbit_agent_invoke",
+        json!({
+            "prompt": "read-only remote probe",
+            "cwd": workspace.work,
+            "timeout_seconds": 30,
+            "model": "codex",
+        }),
+    );
+    assert_eq!(submitted["authorized_by"], "hm_caller");
+    assert_eq!(submitted["authorizer_provenance"], "remote-grant");
+    assert_eq!(submitted["caller_machine_id"], "hm_caller");
+    assert_eq!(submitted["caller_identity"], "key-bound");
+    assert_eq!(
+        submitted["workspace_path"],
+        workspace.work.display().to_string()
+    );
+    assert_eq!(submitted["timeout_seconds"], 30);
+    let run_id = submitted["run_id"].as_str().expect("run id").to_string();
+
+    let deadline = Instant::now() + RESPONSE_TIMEOUT;
+    let terminal = loop {
+        let shown = granted.call_tool_ok("orbit_workflow_run_show", json!({ "id": run_id }));
+        if matches!(
+            shown["state"].as_str(),
+            Some("success" | "failed" | "timeout" | "cancelled" | "interrupted")
+        ) {
+            break shown;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "agent invocation did not finish: {shown}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(terminal["state"], "success", "{terminal}");
+    assert_eq!(terminal["agent_invocation"]["completed_envelope"], true);
+    assert_eq!(
+        terminal["agent_invocation"]["summary"],
+        "remote probe complete"
+    );
+
+    let connection =
+        Connection::open(workspace.home.join(".orbit/orbit.db")).expect("open destination store");
+    let input_json: String = connection
+        .query_row(
+            "SELECT input_json FROM job_runs WHERE run_id = ?1",
+            [&run_id],
+            |row| row.get(0),
+        )
+        .expect("persisted invocation input");
+    let input: Value = serde_json::from_str(&input_json).expect("parse invocation input");
+    let admission = &input["trusted_host_admission"];
+    assert_eq!(admission["caller_machine_id"], "hm_caller");
+    assert_eq!(admission["caller_identity"], "key-bound");
+    assert_eq!(
+        admission["workspace_path"],
+        workspace.work.display().to_string()
+    );
+    drop(granted);
+
+    write_callers(
+        &workspace,
+        &format!(
+            r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_caller"
+capabilities = ["agent", "operator"]
+workspaces = ["{workspace_id}"]
+ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
+agent_invoke = false
+"#,
+        ),
+    );
+    let mut revoked = workspace.serve_with_generated_command(&generated);
+    let denied = revoked.call_tool_err(
+        "orbit_agent_invoke",
+        json!({
+            "prompt": "must not run",
+            "cwd": workspace.work,
+            "timeout_seconds": 30,
+        }),
+    );
+    assert_eq!(denied["code"], "capability_denied", "{denied}");
 }
 
 /// [ORB-11184] A separate ordinary same-UID process scans every process's argv

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Track it with `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, and dispatches nothing.",
+    "description": "Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Remote callers also require a destination-issued key-bound identity and an explicit workspace-scoped `agent_invoke` grant. Track it with `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, and dispatches nothing.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -281,7 +281,7 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         // run exists to stay inside. A run that could admit itself would be a
         // sandbox escape wearing an authorization.
         allowed: &[McpCapability::Operator],
-        rationale: "an agent invocation runs a provider subprocess on the host outside the executor sandbox, so only a present operator may admit one",
+        rationale: "an agent invocation runs a provider subprocess on the host outside the executor sandbox, so it requires a local operator or an explicitly granted key-bound remote operator",
     },
     GovernedOperation {
         id: "orbit.command.exec",

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -119,7 +119,9 @@ These runs execute their provider subprocess outside the executor sandbox by
 explicit per-invocation operator admission, so a sandbox-denial diagnostic is
 never the explanation for one failing. The run trail records the admission as a
 `trusted_host.execution_admitted` audit event naming the authorizing operator
-and the working directory. They are deliberately **not resumable**: the
+and the working directory. For remote admission it also records the
+destination-resolved caller machine ID and key-bound identity proof. They are
+deliberately **not resumable**: the
 admission covered one invocation, so submit a new one rather than resuming.
 
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.

--- a/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
@@ -76,6 +76,38 @@ the destination grant, with ordinary tool policy still enforced. A malformed
 file fails closed. Inspect the check result and session audit evidence when a
 workflow tool is absent or denied; do not treat changing remote argv as a fix.
 
+### Remote host-agent invocation
+
+Remote `orbit_agent_invoke` is a narrower grant than remote operator access.
+The destination accepts it only for a key-bound SSH MCP identity, and only when
+the matched caller row explicitly enables the operation on named workspaces:
+
+```toml
+default = "deny"
+
+[[callers]]
+machine_id = "<caller-machine-id>"
+label = "<display-name>"
+capabilities = ["agent", "operator"]
+workspaces = ["<allowed-workspace-id>"]
+ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
+agent_invoke = true
+```
+
+All four restrictions are required: operator capability, an explicit workspace
+list, a pinned SSH key, and `agent_invoke = true`. The file default can never
+grant this operation. Generate and install the destination-issued forced
+command with `orbit mcp callers authorize`, then reconnect the MCP session so
+it resolves the current policy. `orbit mcp callers check <caller-machine-id>`
+shows the configured scope. To revoke, remove the row or set
+`agent_invoke = false`, then reconnect; the next invocation is denied.
+
+This is an authenticated caller and an accident-resistant admission path, not
+process isolation. The invoked provider still runs outside Orbit's filesystem
+sandbox as the same operating-system user as the destination Orbit process and
+can access everything that user can. Keep the prompt read-only when that is the
+intent; a tool declaration does not confine the provider's own shell.
+
 There are two identity strengths. Ordinary SSH proxy identity is a self-asserted
 audit label, suitable for cooperative operators with shell access; it is not
 proof against a caller naming a different machine. Key-bound acceptance uses a

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -72,9 +72,11 @@ What it is not:
 
 - It is **not** a task, and it performs no task transition. It does not commit,
   push, open or merge a pull request, or dispatch further work.
-- It is **not** available to a managed run or to a federated caller. Each
-  invocation is admitted separately by an operator present on the machine that
-  will run it, and the admission covers that invocation only.
+- It is **not** available to a managed run. A local operator may admit one
+  directly. A remote operator may admit one only through a destination-issued,
+  key-bound SSH MCP identity whose callers-file row explicitly enables
+  `agent_invoke` for the resolved workspace. Ordinary remote `operator`
+  capability is not enough. Each admission covers one invocation only.
 - It is **not** resumable. A resumed run would carry an admission nobody granted
   now; submit a new invocation instead.
 
@@ -91,8 +93,10 @@ without terminating its envelope stopped mid-turn: the run records `failed`, and
 the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
-See [remote-access.md](setup/remote-access.md). Do not relaunch a server with
-more privileges to work around a denied call.
+The durable admission and `trusted_host.execution_admitted` event retain the
+destination-resolved caller machine ID, its key-bound identity proof, the
+workspace checkout, and cwd. See [remote-access.md](setup/remote-access.md). Do
+not relaunch a server with more privileges to work around a denied call.
 
 ## Common MCP arguments
 

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -74,7 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
-| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation operator admission, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit key-bound remote callers-file grant, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.

--- a/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
@@ -48,6 +48,8 @@ pub(super) fn invoke(
         "timeout_seconds": submission.timeout_seconds,
         "authorized_by": submission.admission.authorized_by,
         "authorizer_provenance": submission.admission.authorizer_provenance,
+        "caller_machine_id": submission.admission.caller_machine_id,
+        "caller_identity": submission.admission.caller_identity,
         "workspace_path": submission.admission.workspace_path,
         "cwd": submission.admission.cwd,
         "sandboxed": false,

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -71,8 +71,8 @@ struct RuntimeOrbitToolHost {
     /// The tool chokepoint resolves capabilities before dispatch, but its
     /// answer is a yes/no it does not pass on. `orbit.agent.invoke` needs the
     /// caller itself, because it records the authorizing operator on a durable
-    /// admission and refuses federated callers the ordinary registry would
-    /// allow.
+    /// admission and verifies the operation-specific identity and workspace
+    /// scope of a remote caller the ordinary registry would otherwise allow.
     session_context: ToolSessionContext,
 }
 

--- a/crates/orbit-core/src/application/job/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/agent_invoke.rs
@@ -141,21 +141,34 @@ impl OrbitRuntime {
         &self,
         request: AgentInvokeRequest<'_>,
     ) -> Result<AgentInvokeSubmission, OrbitError> {
-        let provenance = self.admit_agent_invoke(request.session_context)?;
+        let authorizer = self.admit_agent_invoke(request.session_context)?;
 
         let prompt = require_non_empty(request.prompt, "prompt")?;
         let cwd = self.resolve_invocation_cwd(request.cwd)?;
         let crew = self.canonical_crew_name(request.crew)?;
         let timeout_seconds = resolve_timeout(request.timeout_seconds)?;
-        let actor = request
+        let requested_actor = request
             .actor
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map_or_else(|| self.actor_label().to_string(), ToOwned::to_owned);
+        let actor = authorizer
+            .remote_caller
+            .as_ref()
+            .map(|grant| grant.caller_machine_id.clone())
+            .unwrap_or(requested_actor);
 
         let admission = TrustedHostAdmission {
             authorized_by: actor.clone(),
-            authorizer_provenance: provenance.to_string(),
+            authorizer_provenance: authorizer.provenance.to_string(),
+            caller_machine_id: authorizer
+                .remote_caller
+                .as_ref()
+                .map(|grant| grant.caller_machine_id.clone()),
+            caller_identity: authorizer
+                .remote_caller
+                .as_ref()
+                .map(|grant| grant.identity),
             authorized_at: Utc::now().to_rfc3339(),
             workspace_path: self.paths().repo_root.display().to_string(),
             cwd: cwd.display().to_string(),

--- a/crates/orbit-core/src/application/job/tests/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/tests/agent_invoke.rs
@@ -13,7 +13,9 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 use orbit_common::OrbitError;
-use orbit_types::tool::{McpCapability, RemoteCallerGrant, ToolSessionContext};
+use orbit_types::tool::{
+    CallerIdentityProof, McpCapability, RemoteCallerGrant, ToolSessionContext,
+};
 use orbit_types::workflow::activity_job::TRUSTED_HOST_ADMISSION_KEY;
 use orbit_types::workflow::{JobRun, JobRunState};
 use serde_json::{Value, json};
@@ -62,15 +64,19 @@ fn runner_session() -> ToolSessionContext {
     }
 }
 
-/// A federated caller the destination granted full operator capability.
-fn federated_operator_session() -> ToolSessionContext {
+/// A remote caller the destination granted operator capability.
+fn remote_operator_session(
+    identity: CallerIdentityProof,
+    agent_invoke: bool,
+) -> ToolSessionContext {
     ToolSessionContext {
         effective_capabilities: [McpCapability::Operator].into_iter().collect(),
         remote_caller_grant: Some(RemoteCallerGrant {
             caller_machine_id: "hm_remote".to_string(),
             granted_capabilities: [McpCapability::Operator].into_iter().collect(),
             source: "mcp-callers.toml".to_string(),
-            identity: Default::default(),
+            identity,
+            agent_invoke,
         }),
         ..ToolSessionContext::default()
     }
@@ -101,6 +107,17 @@ fn assert_denied(error: OrbitError, expectation: &str) {
 // ---------------------------------------------------------------- admission
 
 #[test]
+fn a_local_operator_session_keeps_the_existing_admission_path() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let authorizer = runtime
+        .admit_agent_invoke(&operator_session())
+        .expect("a local operator remains compatible");
+
+    assert_eq!(authorizer.provenance.to_string(), "session");
+    assert!(authorizer.remote_caller.is_none());
+}
+
+#[test]
 fn an_agent_session_cannot_admit_an_invocation() {
     let (_root, runtime, repo_root) = test_runtime();
     let session = agent_session();
@@ -127,27 +144,77 @@ fn a_runs_own_runner_grant_cannot_admit_an_invocation() {
 }
 
 #[test]
-fn a_federated_operator_cannot_admit_an_invocation() {
-    // A destination-side grant may legitimately carry `operator` for ordinary
-    // operator work, but it cannot assert "a person is present on the machine
-    // that would run this process", which is what the mode requires.
+fn a_self_asserted_remote_operator_cannot_admit_an_invocation() {
     let (_root, runtime, repo_root) = test_runtime();
-    let session = federated_operator_session();
+    let session = remote_operator_session(CallerIdentityProof::SelfAsserted, true);
     let error = runtime
         .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
-        .expect_err("a federated caller must not admit an unsandboxed process");
+        .expect_err("a spoofable remote identity must not admit an unsandboxed process");
     match error {
         OrbitError::CapabilityDenied(message) => {
-            assert_eq!(
-                message,
-                "operation 'orbit.agent.invoke' admits an unsandboxed host process and \
-                 is available only to an operator on the machine that would run it; caller \
-                 'hm_remote' was resolved through mcp-callers.toml"
+            assert!(
+                message.contains("identity is self-asserted"),
+                "the refusal must explain why the remote identity is insufficient: {message}"
             );
         }
         other => panic!("expected a capability denial, got {other:?}"),
     }
     assert_no_run_created(&runtime);
+}
+
+#[test]
+fn a_key_bound_remote_operator_still_needs_the_explicit_operation_grant() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let session = remote_operator_session(CallerIdentityProof::KeyBound, false);
+    let error = runtime
+        .admit_agent_invoke(&session)
+        .expect_err("operator capability alone must not grant unsandboxed remote execution");
+
+    match error {
+        OrbitError::CapabilityDenied(message) => assert!(
+            message.contains("does not enable `agent_invoke`"),
+            "the refusal must name the missing destination grant: {message}"
+        ),
+        other => panic!("expected a capability denial, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_explicit_key_bound_remote_grant_preserves_the_real_caller() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let session = remote_operator_session(CallerIdentityProof::KeyBound, true);
+
+    let authorizer = runtime
+        .admit_agent_invoke(&session)
+        .expect("the explicit authenticated remote grant admits one invocation");
+    let remote = authorizer
+        .remote_caller
+        .expect("remote admission retains destination-resolved caller facts");
+
+    assert_eq!(authorizer.provenance.to_string(), "remote-grant");
+    assert_eq!(remote.caller_machine_id, "hm_remote");
+    assert_eq!(remote.identity, CallerIdentityProof::KeyBound);
+    assert!(remote.agent_invoke);
+}
+
+#[test]
+fn revoking_the_remote_operation_grant_denies_the_next_invocation() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let mut session = remote_operator_session(CallerIdentityProof::KeyBound, true);
+    runtime
+        .admit_agent_invoke(&session)
+        .expect("the initial explicit grant is admitted");
+
+    session
+        .remote_caller_grant
+        .as_mut()
+        .expect("remote grant")
+        .agent_invoke = false;
+    let error = runtime
+        .admit_agent_invoke(&session)
+        .expect_err("revocation must deny the next admission");
+
+    assert_denied(error, "revoked remote operation grant");
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -1,4 +1,4 @@
-//! The runtime half of the capability chokepoint [ADR-0260, ORB-10453].
+//! The runtime half of the capability chokepoint.
 //!
 //! `orbit-common::authorization` owns the registry and the decision; this
 //! module owns the two things a decision needs a runtime for — reading the
@@ -25,7 +25,9 @@ use orbit_common::governance::authorization::{
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_store::contracts::AuditEventInsertParams;
 use orbit_types::telemetry::AuditEventStatus;
-use orbit_types::tool::{McpCapability, ToolSessionContext};
+use orbit_types::tool::{
+    CallerIdentityProof, McpCapability, RemoteCallerGrant, ToolSessionContext,
+};
 
 use crate::OrbitRuntime;
 use crate::runtime::tool_exec::CapabilityEnforcement;
@@ -33,6 +35,13 @@ use crate::runtime::tool_exec::CapabilityEnforcement;
 /// Canonical tool name of the trusted-host agent invocation, named once so the
 /// admission and the governed-operation registry cannot drift apart.
 pub(crate) const AGENT_INVOKE_OPERATION_ID: &str = "orbit.agent.invoke";
+
+/// Identity facts retained after trusted-host admission.
+#[derive(Debug)]
+pub(crate) struct AgentInvokeAuthorizer {
+    pub(crate) provenance: CallerProvenance,
+    pub(crate) remote_caller: Option<RemoteCallerGrant>,
+}
 
 impl OrbitRuntime {
     /// Authorize a governed tool call, then require destination-granted remote
@@ -133,46 +142,75 @@ impl OrbitRuntime {
     ///   agent shelling out to the CLI look like nothing at all. Resolving the
     ///   process envelope here means a managed run's `ORBIT_MANAGED_RUN_CONTEXT`
     ///   resolves as `agent`, and an agent is refused.
-    /// * **Remote callers are refused outright.** A destination-side grant may
-    ///   legitimately carry `operator` for ordinary operator work, but "an
-    ///   operator is present on this machine" is exactly what admitting an
-    ///   unsandboxed local subprocess requires, and a federated grant cannot
-    ///   assert it. This is narrower than [`authorize`] on purpose.
+    /// * **Remote callers need an operation-specific, workspace-scoped grant.**
+    ///   `operator` alone remains insufficient. The caller must have a
+    ///   destination-issued key-bound identity and the matched callers-file row
+    ///   must explicitly enable `agent_invoke` for the resolved workspace.
     pub(crate) fn admit_agent_invoke(
         &self,
         session_context: &ToolSessionContext,
-    ) -> Result<CallerProvenance, OrbitError> {
+    ) -> Result<AgentInvokeAuthorizer, OrbitError> {
         let operation = governed_tool(AGENT_INVOKE_OPERATION_ID).ok_or_else(|| {
             OrbitError::Execution(format!(
                 "'{AGENT_INVOKE_OPERATION_ID}' is missing from the governed operation registry"
             ))
         })?;
-        let caller =
-            CallerCapabilities::resolve(&CallerEnvelope::from_process_env(session_context));
+        let envelope = CallerEnvelope::from_process_env(session_context);
+        let caller = CallerCapabilities::resolve(&envelope);
+        self.decide_with_envelope(operation, envelope)?;
+
         if let Some(grant) = caller.remote_caller_grant() {
-            let message = format!(
-                "operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process and \
-                 is available only to an operator on the machine that would run it; caller '{}' \
-                 was resolved through {}",
-                grant.caller_machine_id, grant.source,
-            );
-            tracing::warn!(
-                target: "orbit.authorization",
-                operation = AGENT_INVOKE_OPERATION_ID,
-                provenance = %caller.provenance(),
-                caller_machine_id = grant.caller_machine_id,
-                "trusted host admission denied to a federated caller"
-            );
-            self.record_authorization_event(
-                AGENT_INVOKE_OPERATION_ID,
-                &caller,
-                AuditEventStatus::Denied,
-                Some(message.clone()),
-            );
-            return Err(OrbitError::CapabilityDenied(message));
+            if grant.identity != CallerIdentityProof::KeyBound {
+                return self.deny_remote_agent_invoke(
+                    &caller,
+                    grant,
+                    "the caller identity is self-asserted; use the destination-issued key-bound \
+                     SSH acceptance path",
+                );
+            }
+            if !grant.agent_invoke {
+                return self.deny_remote_agent_invoke(
+                    &caller,
+                    grant,
+                    "the matched destination policy does not enable `agent_invoke` for this \
+                     workspace",
+                );
+            }
         }
-        self.decide_with_envelope(operation, CallerEnvelope::from_process_env(session_context))?;
-        Ok(caller.provenance())
+
+        Ok(AgentInvokeAuthorizer {
+            provenance: caller.provenance(),
+            remote_caller: caller.remote_caller_grant().cloned(),
+        })
+    }
+
+    fn deny_remote_agent_invoke(
+        &self,
+        caller: &CallerCapabilities,
+        grant: &RemoteCallerGrant,
+        reason: &str,
+    ) -> Result<AgentInvokeAuthorizer, OrbitError> {
+        let message = format!(
+            "operation '{AGENT_INVOKE_OPERATION_ID}' admits an unsandboxed host process; remote \
+             caller '{}' was denied because {reason}. The destination controls this grant in {}",
+            grant.caller_machine_id, grant.source,
+        );
+        tracing::warn!(
+            target: "orbit.authorization",
+            operation = AGENT_INVOKE_OPERATION_ID,
+            provenance = %caller.provenance(),
+            caller_machine_id = grant.caller_machine_id,
+            caller_identity = %grant.identity,
+            agent_invoke = grant.agent_invoke,
+            "trusted host admission denied to a remote caller"
+        );
+        self.record_authorization_event(
+            AGENT_INVOKE_OPERATION_ID,
+            caller,
+            AuditEventStatus::Denied,
+            Some(message.clone()),
+        );
+        Err(OrbitError::CapabilityDenied(message))
     }
 
     /// Authorize a governed CLI command, or pass an ungoverned one through.
@@ -297,6 +335,7 @@ impl OrbitRuntime {
                     // only the grant would leave a reader to assume whether
                     // the caller had to hold a key to select it [ORB-11053].
                     "caller_identity": grant.identity,
+                    "agent_invoke": grant.agent_invoke,
                 })
                 .to_string()
             }),

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -290,6 +290,8 @@ pub fn run_cli_backend(
             provider = %provider,
             authorized_by = %admission.authorized_by,
             authorizer_provenance = %admission.authorizer_provenance,
+            caller_machine_id = admission.caller_machine_id.as_deref(),
+            caller_identity = admission.caller_identity.map(|identity| identity.to_string()),
             workspace_path = %admission.workspace_path,
             cwd = %admission.cwd,
             "starting an operator-admitted provider subprocess outside the executor sandbox"
@@ -299,6 +301,8 @@ pub fn run_cli_backend(
             activity_name: activity_name.to_string(),
             authorized_by: admission.authorized_by.clone(),
             authorizer_provenance: admission.authorizer_provenance.clone(),
+            caller_machine_id: admission.caller_machine_id.clone(),
+            caller_identity: admission.caller_identity,
             authorized_at: admission.authorized_at.clone(),
             workspace_path: admission.workspace_path.clone(),
             cwd: admission.cwd.clone(),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use orbit_agent::loop_engine::audit::AuditSink;
+use orbit_types::tool::CallerIdentityProof;
 use orbit_types::workflow::activity_job::{
     TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission, V2AuditEventKind,
 };
@@ -20,8 +21,10 @@ use super::test_support::{RecordingSink, TestHost, test_agent_loop_spec, write_e
 
 fn admission() -> TrustedHostAdmission {
     TrustedHostAdmission {
-        authorized_by: "human".to_string(),
-        authorizer_provenance: "interactive-terminal".to_string(),
+        authorized_by: "hm_mac".to_string(),
+        authorizer_provenance: "remote-grant".to_string(),
+        caller_machine_id: Some("hm_mac".to_string()),
+        caller_identity: Some(CallerIdentityProof::KeyBound),
         authorized_at: "2026-09-06T00:00:00Z".to_string(),
         workspace_path: "/checkout".to_string(),
         cwd: "/checkout".to_string(),
@@ -84,21 +87,27 @@ fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
                 activity_name,
                 authorized_by,
                 authorizer_provenance,
+                caller_machine_id,
+                caller_identity,
                 cwd,
                 ..
             } => Some((
                 activity_name.clone(),
                 authorized_by.clone(),
                 authorizer_provenance.clone(),
+                caller_machine_id.clone(),
+                *caller_identity,
                 cwd.clone(),
             )),
             _ => None,
         })
         .expect("an unsandboxed invocation must announce itself in the run trail");
     assert_eq!(admitted.0, "agent_invoke");
-    assert_eq!(admitted.1, "human");
-    assert_eq!(admitted.2, "interactive-terminal");
-    assert_eq!(admitted.3, "/checkout");
+    assert_eq!(admitted.1, "hm_mac");
+    assert_eq!(admitted.2, "remote-grant");
+    assert_eq!(admitted.3.as_deref(), Some("hm_mac"));
+    assert_eq!(admitted.4, Some(CallerIdentityProof::KeyBound));
+    assert_eq!(admitted.5, "/checkout");
 
     // The absence of a sandbox is stated, not left to be inferred from a
     // missing field, so a reader can tell it apart from an executor that never

--- a/crates/orbit-mcp/src/remote/callers.rs
+++ b/crates/orbit-mcp/src/remote/callers.rs
@@ -97,6 +97,11 @@ pub struct CallerRow {
     /// not evidence of a mismatch.
     #[serde(default)]
     pub ssh_key_fingerprint: Option<String>,
+    /// Explicitly admits `orbit.agent.invoke` for this caller on the row's
+    /// narrowed workspaces. Requires operator capability, a workspace
+    /// narrowing, and a key-bound identity.
+    #[serde(default)]
+    pub agent_invoke: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
@@ -192,6 +197,37 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
                     row.machine_id
                 ),
             ));
+        }
+        if row.agent_invoke {
+            if !row.capabilities.iter().any(|value| value == "operator") {
+                return Err(invalid(
+                    path,
+                    format!(
+                        "caller '{}' enables `agent_invoke` without the `operator` capability",
+                        row.machine_id
+                    ),
+                ));
+            }
+            if row.workspaces.is_none() {
+                return Err(invalid(
+                    path,
+                    format!(
+                        "caller '{}' enables `agent_invoke` without a `workspaces` narrowing; \
+                         remote trusted-host execution must name its destination workspaces",
+                        row.machine_id
+                    ),
+                ));
+            }
+            if row.ssh_key_fingerprint.is_none() {
+                return Err(invalid(
+                    path,
+                    format!(
+                        "caller '{}' enables `agent_invoke` without `ssh_key_fingerprint`; \
+                         remote trusted-host execution requires a key-bound caller identity",
+                        row.machine_id
+                    ),
+                ));
+            }
         }
     }
     Ok(())
@@ -304,6 +340,9 @@ pub struct ResolvedCallerGrant {
     /// The `ws_*` IDs [`Self::granted`] applies to. `None` means every
     /// workspace on this destination.
     pub workspaces: Option<BTreeSet<String>>,
+    /// Whether the matched row explicitly admits trusted-host agent
+    /// invocation on its covered workspaces.
+    pub agent_invoke: bool,
     /// Whether a row matched, or the file default answered.
     pub matched: bool,
 }
@@ -324,6 +363,15 @@ impl ResolvedCallerGrant {
             }
             _ => self.granted.clone(),
         }
+    }
+
+    /// Whether the explicit agent-invocation grant covers `workspace_id`.
+    pub fn agent_invoke_for_workspace(&self, workspace_id: Option<&str>) -> bool {
+        self.agent_invoke
+            && match (&self.workspaces, workspace_id) {
+                (Some(covered), Some(workspace_id)) => covered.contains(workspace_id),
+                (Some(_), None) | (None, _) => false,
+            }
     }
 }
 
@@ -349,6 +397,7 @@ impl CallersFile {
                 granted: default.clone(),
                 elsewhere: default,
                 workspaces: None,
+                agent_invoke: false,
                 matched: false,
             };
         };
@@ -371,6 +420,7 @@ impl CallersFile {
                 .workspaces
                 .as_ref()
                 .map(|workspaces| workspaces.iter().cloned().collect()),
+            agent_invoke: row.agent_invoke,
             matched: true,
         }
     }
@@ -519,6 +569,7 @@ impl SessionCapabilityPolicy {
             granted_capabilities: grant.for_workspace(workspace_id),
             source: CALLERS_FILE_DISPLAY.to_string(),
             identity: grant.identity,
+            agent_invoke: grant.agent_invoke_for_workspace(workspace_id),
         })
     }
 

--- a/crates/orbit-mcp/src/remote/tests/callers.rs
+++ b/crates/orbit-mcp/src/remote/tests/callers.rs
@@ -236,6 +236,89 @@ workspaces = ["ws_orbit"]
 }
 
 #[test]
+fn agent_invoke_is_an_explicit_key_bound_workspace_grant() {
+    let (_dir, path) = write(&format!(
+        r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_beta"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_orbit"]
+ssh_key_fingerprint = "{PINNED}"
+agent_invoke = true
+"#,
+    ));
+    let file = load_callers(&path).expect("scoped remote invocation grant");
+    let policy = SessionCapabilityPolicy::from_grant(
+        McpSessionAuthority::Operator,
+        file.resolve(&RemoteCallerIdentity::key_bound(
+            "hm_beta",
+            observed(PINNED),
+        )),
+    );
+
+    let on_workspace = policy
+        .grant_for(Some("ws_orbit"))
+        .expect("remote grant on workspace");
+    assert!(on_workspace.agent_invoke);
+    assert_eq!(on_workspace.identity, CallerIdentityProof::KeyBound);
+
+    let elsewhere = policy
+        .grant_for(Some("ws_other"))
+        .expect("remote grant outside narrowing");
+    assert!(!elsewhere.agent_invoke);
+    assert!(policy.effective_for(Some("ws_other")).is_empty());
+}
+
+#[test]
+fn incomplete_agent_invoke_grants_fail_the_callers_file_closed() {
+    for (contents, expected) in [
+        (
+            format!(
+                r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent"]
+workspaces = ["ws_orbit"]
+ssh_key_fingerprint = "{PINNED}"
+agent_invoke = true
+"#,
+            ),
+            "operator",
+        ),
+        (
+            format!(
+                r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+ssh_key_fingerprint = "{PINNED}"
+agent_invoke = true
+"#,
+            ),
+            "workspaces",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_orbit"]
+agent_invoke = true
+"#
+            .to_string(),
+            "ssh_key_fingerprint",
+        ),
+    ] {
+        let (_dir, path) = write(&contents);
+        let error = load_callers(&path).expect_err("incomplete grant must fail closed");
+
+        assert!(error.to_string().contains(expected), "{error}");
+    }
+}
+
+#[test]
 fn a_local_session_keeps_argv_authority_and_stamps_no_grant() {
     let policy = SessionCapabilityPolicy::local(McpSessionAuthority::Operator);
     let mut context = ToolSessionContext::default();

--- a/crates/orbit-tools/src/builtin/orbit/agent.rs
+++ b/crates/orbit-tools/src/builtin/orbit/agent.rs
@@ -73,7 +73,9 @@ impl Tool for OrbitAgentInvokeTool {
                 "Submit an asynchronous agent invocation for exploration or debugging and return \
                  its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as \
                  the same OS user as Orbit, so it can reach anything that user can; it is \
-                 admitted per invocation and requires operator capability. Track it with \
+                 admitted per invocation and requires operator capability. Remote callers also \
+                 require a destination-issued key-bound identity and an explicit workspace-scoped \
+                 `agent_invoke` grant. Track it with \
                  `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop \
                  it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, \
                  and dispatches nothing."

--- a/crates/orbit-types/src/tool/definition.rs
+++ b/crates/orbit-types/src/tool/definition.rs
@@ -148,6 +148,13 @@ pub struct RemoteCallerGrant {
     /// How [`Self::caller_machine_id`] was established [ORB-11053].
     #[serde(default)]
     pub identity: CallerIdentityProof,
+    /// Whether the destination explicitly permits this caller to submit the
+    /// trusted-host agent-invocation operation in the resolved workspace.
+    ///
+    /// This stays separate from `operator`: ordinary operator capability does
+    /// not imply permission to start an unsandboxed provider process remotely.
+    #[serde(default)]
+    pub agent_invoke: bool,
 }
 
 /// How a destination established the caller identity it resolved a grant for.

--- a/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
+++ b/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
@@ -194,6 +194,12 @@ pub enum V2AuditEventKind {
         authorized_by: String,
         /// How the authorization chokepoint resolved that operator.
         authorizer_provenance: String,
+        /// Destination-resolved remote caller, absent for local admission.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        caller_machine_id: Option<String>,
+        /// How the destination established the remote caller identity.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        caller_identity: Option<crate::tool::CallerIdentityProof>,
         /// RFC 3339 timestamp the admission was stamped.
         authorized_at: String,
         /// Canonical checkout the invocation was admitted against.

--- a/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
@@ -9,6 +9,8 @@ fn admission() -> TrustedHostAdmission {
     TrustedHostAdmission {
         authorized_by: "human".to_string(),
         authorizer_provenance: "interactive-terminal".to_string(),
+        caller_machine_id: None,
+        caller_identity: None,
         authorized_at: "2026-09-06T00:00:00Z".to_string(),
         workspace_path: "/checkout".to_string(),
         cwd: "/checkout/crates".to_string(),

--- a/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
@@ -32,6 +32,7 @@
 //! definition that declares the flag without an admission fails closed rather
 //! than degrading to a sandboxed run, so a broken admission path is loud.
 
+use crate::tool::CallerIdentityProof;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -57,6 +58,14 @@ pub struct TrustedHostAdmission {
     /// How the authorization chokepoint resolved that operator
     /// (`interactive-terminal`, `operator-override`, `session`).
     pub authorizer_provenance: String,
+    /// Destination-resolved remote caller identity, when this admission came
+    /// through authenticated SSH MCP rather than a local operator surface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_machine_id: Option<String>,
+    /// Strength of the remote identity proof. Remote admission requires
+    /// `key-bound`; it is retained so the durable run proves that decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_identity: Option<CallerIdentityProof>,
     /// RFC 3339 timestamp of the admission.
     pub authorized_at: String,
     /// Canonical workspace checkout the invocation was admitted against.

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -148,7 +148,8 @@ Three differences matter when triaging one:
   operating-system user as Orbit, admitted per invocation by an operator. A sandbox
   denial is never the explanation for one failing, and the admission is recorded as a
   `trusted_host.execution_admitted` audit event naming the authorizing operator, the
-  workspace, and the working directory.
+  workspace, and the working directory. Remote admissions also retain the
+  destination-resolved caller machine ID and key-bound identity proof.
 - **Cancel it the ordinary way.** `orbit run cancel <run_id>` signals the owner process
   (TERM then KILL) and terminates the process tree, exactly as for any other run.
 - **It cannot be resumed.** `orbit job resume` and `submit_resume_run` refuse a run that

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -119,7 +119,9 @@ These runs execute their provider subprocess outside the executor sandbox by
 explicit per-invocation operator admission, so a sandbox-denial diagnostic is
 never the explanation for one failing. The run trail records the admission as a
 `trusted_host.execution_admitted` audit event naming the authorizing operator
-and the working directory. They are deliberately **not resumable**: the
+and the working directory. For remote admission it also records the
+destination-resolved caller machine ID and key-bound identity proof. They are
+deliberately **not resumable**: the
 admission covered one invocation, so submit a new one rather than resuming.
 
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.

--- a/plugin/skills/orbit/references/setup/remote-access.md
+++ b/plugin/skills/orbit/references/setup/remote-access.md
@@ -76,6 +76,38 @@ the destination grant, with ordinary tool policy still enforced. A malformed
 file fails closed. Inspect the check result and session audit evidence when a
 workflow tool is absent or denied; do not treat changing remote argv as a fix.
 
+### Remote host-agent invocation
+
+Remote `orbit_agent_invoke` is a narrower grant than remote operator access.
+The destination accepts it only for a key-bound SSH MCP identity, and only when
+the matched caller row explicitly enables the operation on named workspaces:
+
+```toml
+default = "deny"
+
+[[callers]]
+machine_id = "<caller-machine-id>"
+label = "<display-name>"
+capabilities = ["agent", "operator"]
+workspaces = ["<allowed-workspace-id>"]
+ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
+agent_invoke = true
+```
+
+All four restrictions are required: operator capability, an explicit workspace
+list, a pinned SSH key, and `agent_invoke = true`. The file default can never
+grant this operation. Generate and install the destination-issued forced
+command with `orbit mcp callers authorize`, then reconnect the MCP session so
+it resolves the current policy. `orbit mcp callers check <caller-machine-id>`
+shows the configured scope. To revoke, remove the row or set
+`agent_invoke = false`, then reconnect; the next invocation is denied.
+
+This is an authenticated caller and an accident-resistant admission path, not
+process isolation. The invoked provider still runs outside Orbit's filesystem
+sandbox as the same operating-system user as the destination Orbit process and
+can access everything that user can. Keep the prompt read-only when that is the
+intent; a tool declaration does not confine the provider's own shell.
+
 There are two identity strengths. Ordinary SSH proxy identity is a self-asserted
 audit label, suitable for cooperative operators with shell access; it is not
 proof against a caller naming a different machine. Key-bound acceptance uses a

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -72,9 +72,11 @@ What it is not:
 
 - It is **not** a task, and it performs no task transition. It does not commit,
   push, open or merge a pull request, or dispatch further work.
-- It is **not** available to a managed run or to a federated caller. Each
-  invocation is admitted separately by an operator present on the machine that
-  will run it, and the admission covers that invocation only.
+- It is **not** available to a managed run. A local operator may admit one
+  directly. A remote operator may admit one only through a destination-issued,
+  key-bound SSH MCP identity whose callers-file row explicitly enables
+  `agent_invoke` for the resolved workspace. Ordinary remote `operator`
+  capability is not enough. Each admission covers one invocation only.
 - It is **not** resumable. A resumed run would carry an admission nobody granted
   now; submit a new invocation instead.
 
@@ -91,8 +93,10 @@ without terminating its envelope stopped mid-turn: the run records `failed`, and
 the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
-See [remote-access.md](setup/remote-access.md). Do not relaunch a server with
-more privileges to work around a denied call.
+The durable admission and `trusted_host.execution_admitted` event retain the
+destination-resolved caller machine ID, its key-bound identity proof, the
+workspace checkout, and cwd. See [remote-access.md](setup/remote-access.md). Do
+not relaunch a server with more privileges to work around a denied call.
 
 ## Common MCP arguments
 

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -74,7 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
-| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation operator admission, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit key-bound remote callers-file grant, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.


### PR DESCRIPTION
## Task

[ORB-11492](https://orbit-cli.com/tasks/ORB-11492) — Allow explicitly authorized Mac operators to invoke agents on the owning Linux host

### Description

Daniel explicitly requests agent_invoke from his Mac with execution on dk-server-1 through orbit-linux, and approves implementation and delivery. Live probe on 2026-09-07 via authoritative MCP, ws_orbit, crew luna, bounded read-only prompt and cwd ~/workspace/constellation/codebases/orbit returned capability_denied: operation orbit.agent.invoke admits an unsandboxed host process and is available only to an operator on the machine that would run it; caller hm_ba054a1a8fbfb914 was resolved through ~/.orbit/mcp-callers.toml. No agent launched. This is an intentional existing local-only contract from ORB-11354, now a user-requested scoped capability extension, not a transport bug.

Inspect current caller authorization and invocation admission. Support an explicit destination-controlled grant for the authenticated Mac operator, using the existing caller policy/operation governance seams rather than a new authorization subsystem or spoofing local identity. Preserve truthful remote caller and destination provenance, authoritative workspace routing, per-invocation admission, bounded timeout/idempotency and existing output/cancel behavior. Do not automatically grant all remote callers or managed children unsandboxed execution. Same-user host access is the actual boundary; document it candidly. Existing ungranted remote callers, managed workers, ordinary job input/resume, wrong workspace and malformed/spoofed identities must remain denied. Keep Linux local operator behavior compatible. No recursive dispatch or task/git/PR mutation by the invoked exploration agent.

Prepare task-scoped implementation and validation on agent-main through normal pipeline. Source completion must identify the minimal destination policy setup and installed-runtime smoke still needed; orchestrator will install and verify a Luna read-only invocation from this actual Mac MCP session. No releases, tags, npm publishing, main promotion, or broad caller-policy weakening. Rollback is revoking the scoped grant and reverting the change. Sol/hard because the change crosses authenticated remote caller and unsandboxed execution admission boundaries.

### Acceptance Criteria

- An explicitly granted authenticated Mac operator can invoke a bounded Luna agent on dk-server-1 through the authoritative MCP; persisted run identifies real remote caller, destination workspace, and terminal response.
- Deterministic tests cover granted remote operator success and denial for ungranted remote callers, managed callers, spoofed identity, wrong workspace, reserved job input and resume; local operator behavior remains compatible.
- Reuse existing caller policy and operation governance; no implicit blanket grants or policy bypass, and revocation denies subsequent invocations.
- Owning tests and ci-fast/ci-lint pass. Update current tool contract/docs and report required deployed-runtime setup separately from source completion.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added a destination-controlled agent_invoke = true caller-policy grant. It is valid only with operator, an explicit workspaces narrowing, and ssh_key_fingerprint; the file default never grants it.
- Kept orbit.agent.invoke under the existing governed-operation operator check, then added narrower per-invocation remote admission: only a destination-issued key-bound identity with the operation grant on the resolved workspace may proceed. Agent, runner/managed, self-asserted/spoofable, ungranted, and wrong-workspace callers remain denied.
- Persisted the destination-resolved caller machine ID and identity proof in the trusted-host admission and audit event. Remote submissions attribute authorized_by to that caller rather than caller-supplied model metadata; workspace, cwd, timeout, terminal response status, bounded preview, and output reference remain on the existing durable run path.
- Updated the MCP tool description/snapshot, caller list/check/authorize guidance, canonical and plugin-mirrored Orbit skill docs, and the runbook. The docs state the same-OS-user boundary and reconnect requirement after caller-policy edits.
- Expanded task context to the authoritative caller-policy schema, remote grant transport type, governance registry/tests, caller CLI, tool-host consumer, and generated MCP contract snapshot because those directly own or consume the new grant.

Acceptance criteria:
1. Source complete: authenticated remote admission, authoritative workspace routing, bounded run submission, truthful persisted caller/workspace provenance, and terminal response projection are implemented. The protected-SSH MCP integration test verifies the full path when the runner can establish the Linux setgid boundary; this runner reports NoNewPrivs: 1, so the deterministic policy/admission/audit/result tests are the local source evidence and the installed-host smoke remains required below.
2. Covered: explicit key-bound remote success; missing operation grant; self-asserted identity; wrong workspace; revocation on a newly resolved session; local operator compatibility; agent and runner/managed denial; reserved ordinary job input; non-resumability; bounded timeout; response-envelope success/failure.
3. Existing caller policy and governed operation are reused. No default or blanket remote grant was added. Revoking/removing the row (or setting agent_invoke = false) and reconnecting causes the next invocation to deny.
4. Tool contract and current docs are updated; all required local checks passed.

Validation:
- PASSED: cargo test -p orbit-mcp remote::tests::callers (22 tests).
- PASSED: cargo test -p orbit-core application::job::tests::agent_invoke (21 tests).
- PASSED: cargo test -p orbit-engine activity_job::cli_runner::tests::trusted_host (6 tests).
- PASSED: cargo test -p orbit-common governance::tests::authorization (19 tests).
- PASSED: cargo test -p orbit-types workflow::activity_job::tests::trusted_host (6 tests).
- PASSED: cargo test -p orbit-cli --test mcp_roundtrip (49 tests); the protected-launch success branch is environment-gated and this runner has NoNewPrivs: 1.
- PASSED: make ci-fast.
- PASSED: make ci-lint.
- PASSED: git diff --check.
- NOT RUN: actual Mac to dk-server-1 Luna invocation; deliberately reserved for the installed-runtime smoke after source delivery.

Required deployed-runtime setup and smoke:
- On dk-server-1, install the delivered Orbit binary and refresh the protected Tier-2 SSH MCP launcher/forced-command line.
- In destination ~/.orbit/mcp-callers.toml, configure caller hm_ba054a1a8fbfb914 with capabilities = [agent, operator], workspaces = [ws_orbit], the Mac public-key ssh_key_fingerprint, and agent_invoke = true; keep default = deny.
- Reconnect the actual Mac MCP session, invoke orbit_agent_invoke against the host-qualified ws_orbit selector with crew = luna, an absolute dk-server-1 Orbit checkout cwd, a bounded timeout, and a read-only/no-dispatch/no-task-or-git-mutation prompt.
- Poll orbit_workflow_run_show to terminal and verify authorized_by/caller_machine_id = hm_ba054a1a8fbfb914, caller_identity = key-bound, the dk-server-1 workspace/cwd, completed_envelope = true, and the terminal summary/output reference.
- Rollback: set agent_invoke = false or remove the scoped row, reconnect, verify denial, and revert this source change if the capability is withdrawn.

Assessment: The change keeps the exceptional unsandboxed path narrow and auditable. Remaining risk is operational only: the real Mac/dk-server-1 key binding, Luna crew, installed launcher, and terminal response must be verified after deployment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11492-6a9e44d6`
- Behind base: 0
- Ahead of base: 1