### PR TITLE
Include model-aware Orchestrated-By attribution in task commit trailers

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/attribution.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/attribution.rs
@@ -1,0 +1,38 @@
+use std::collections::BTreeSet;
+
+use orbit_types::identity::agent_from_model;
+use orbit_types::task::Task;
+
+/// Render task-scoped orchestration attribution. `created_by` carries the
+/// actor's exact model at task creation; it is relevant here only when the
+/// task also records an explicit orchestrator. That prevents creation or
+/// implementation attribution from being mistaken for orchestration.
+pub(super) fn orchestration_trailer(tasks: &[Task]) -> Option<String> {
+    let values = tasks
+        .iter()
+        .filter_map(orchestration_attribution)
+        .collect::<BTreeSet<_>>();
+
+    (!values.is_empty()).then(|| {
+        format!(
+            "Orchestrated-By: {}",
+            values.into_iter().collect::<Vec<_>>().join(", ")
+        )
+    })
+}
+
+fn orchestration_attribution(task: &Task) -> Option<String> {
+    let orchestrator = trailer_value(task.orchestrator.as_deref())?;
+    let model = task
+        .created_by
+        .as_deref()
+        .and_then(|value| trailer_value(Some(value)))
+        .filter(|value| agent_from_model(value).is_some());
+
+    model.or(Some(orchestrator))
+}
+
+fn trailer_value(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    (!value.is_empty() && !value.contains(['\r', '\n'])).then(|| value.to_string())
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/message.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/message.rs
@@ -1,5 +1,7 @@
 use orbit_types::task::{Task, TaskType};
 
+use super::super::attribution::orchestration_trailer;
+
 const BATCH_SUBJECT_BUDGET: usize = 72;
 const ELLIPSIS: char = '…';
 
@@ -9,6 +11,7 @@ pub(super) fn task_commit_message(task: &Task) -> String {
         message.push_str("\n\n");
         message.push_str(&summary);
     }
+    append_orchestration_trailers(&mut message, std::slice::from_ref(task));
     message
 }
 
@@ -23,6 +26,7 @@ pub(super) fn finalize_commit_message(tasks: &[Task]) -> String {
             message.push_str("\n\n");
             message.push_str(&summary);
         }
+        append_orchestration_trailers(&mut message, tasks);
         return message;
     }
 
@@ -41,7 +45,9 @@ pub(super) fn finalize_commit_message(tasks: &[Task]) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
-    format!("fix: finalize ship batch [{ids_joined}]\n\n{summaries}")
+    let mut message = format!("fix: finalize ship batch [{ids_joined}]\n\n{summaries}");
+    append_orchestration_trailers(&mut message, tasks);
+    message
 }
 
 pub(super) fn batch_commit_message(task: &Task) -> String {
@@ -108,7 +114,19 @@ fn batch_commit_trailers(task: &Task) -> Vec<String> {
     if let Some(implemented_by) = task.implemented_by.as_deref() {
         trailers.push(format!("Implemented-By: {implemented_by}"));
     }
+    if let Some(trailer) = orchestration_trailer(std::slice::from_ref(task)) {
+        trailers.push(trailer);
+    }
     trailers
+}
+
+fn append_orchestration_trailers(message: &mut String, tasks: &[Task]) {
+    let Some(trailer) = orchestration_trailer(tasks) else {
+        return;
+    };
+
+    message.push_str("\n\n");
+    message.push_str(&trailer);
 }
 
 fn execution_summary_paragraph(task: &Task) -> Option<String> {

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
@@ -136,6 +136,33 @@ fn git_commit_without_resolved_model_uses_generic_fallback_and_no_local_config()
 }
 
 #[test]
+fn git_commit_per_task_preserves_orchestration_attribution_in_the_source_message() {
+    let temp = initialized_git_repo();
+    let workspace = temp.path();
+    fs::create_dir_all(workspace.join("src")).unwrap();
+    fs::write(workspace.join("src/task.txt"), "orchestrated work\n").unwrap();
+
+    let mut task = task_with_file("T1", "Implement one task", "src/task.txt", "gpt-5.6-terra");
+    task.orchestrator = Some("sol".to_string());
+    task.created_by = Some("gpt-5.6-sol".to_string());
+    let host =
+        CommitTestHost::new(vec![task], workspace.to_path_buf()).with_crew_model("gpt-5.6-terra");
+    let input = json!({
+        "scope": "per_task",
+        "job_run_id": "batch-1",
+        "workspace_path": workspace.to_string_lossy().to_string(),
+        "completed_task_ids": ["T1"],
+    });
+
+    git_commit(&host, &input).expect("per-task commit succeeds");
+
+    assert_eq!(
+        git_output(workspace, &["log", "-1", "--format=%B"]).expect("read source commit message"),
+        "[T1] Implement one task\n\nOrchestrated-By: gpt-5.6-sol"
+    );
+}
+
+#[test]
 fn git_commit_treats_bare_configured_model_as_opaque() {
     let temp = initialized_git_repo();
     let workspace = temp.path();

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use orbit_types::task::{ExternalRef, Task, TaskPriority, TaskStatus, TaskType};
 
-use super::super::message::batch_commit_message;
+use super::super::message::{batch_commit_message, finalize_commit_message, task_commit_message};
 
 #[test]
 fn batch_commit_subject_uses_task_type() {
@@ -147,6 +147,77 @@ fn batch_commit_trailers_omit_missing_fields() {
     assert_eq!(
         batch_commit_message(&neither),
         "refactor: No trailers [ORB-00107]"
+    );
+}
+
+#[test]
+fn orchestration_trailer_prefers_the_recorded_creation_model_over_its_alias() {
+    let mut task = task_with_type(TaskType::Feature, "Attribute orchestration");
+    task.orchestrator = Some("terra".to_string());
+    task.created_by = Some("gpt-5.6-sol".to_string());
+    task.implemented_by = Some("gpt-5.6-terra".to_string());
+
+    assert_eq!(
+        batch_commit_message(&task),
+        "feat: Attribute orchestration [ORB-00107]\n\nImplemented-By: gpt-5.6-terra\nOrchestrated-By: gpt-5.6-sol"
+    );
+}
+
+#[test]
+fn orchestration_trailer_uses_alias_without_a_reliable_model_and_omits_unattributed_tasks() {
+    let mut alias_only = task_with_type(TaskType::Feature, "Keep legacy attribution truthful");
+    alias_only.orchestrator = Some("terra".to_string());
+    alias_only.created_by = Some("codex".to_string());
+
+    assert_eq!(
+        batch_commit_message(&alias_only),
+        "feat: Keep legacy attribution truthful [ORB-00107]\n\nOrchestrated-By: terra"
+    );
+
+    let mut no_orchestration = task_with_type(TaskType::Feature, "Do not infer orchestration");
+    no_orchestration.created_by = Some("gpt-5.6-sol".to_string());
+    assert_eq!(
+        batch_commit_message(&no_orchestration),
+        "feat: Do not infer orchestration [ORB-00107]"
+    );
+}
+
+#[test]
+fn orchestration_trailers_are_deterministic_and_preserved_on_task_and_finalize_messages() {
+    let mut first = task_with_type(TaskType::Feature, "First task");
+    first.id = "ORB-00108".to_string();
+    first.orchestrator = Some("sol".to_string());
+    first.created_by = Some("gpt-5.6-sol".to_string());
+
+    let mut second = task_with_type(TaskType::Feature, "Second task");
+    second.id = "ORB-00109".to_string();
+    second.orchestrator = Some("terra".to_string());
+    second.created_by = Some("gpt-5.6-terra".to_string());
+
+    let mut duplicate = task_with_type(TaskType::Feature, "Duplicate orchestrator");
+    duplicate.id = "ORB-00110".to_string();
+    duplicate.orchestrator = Some("another-sol-alias".to_string());
+    duplicate.created_by = Some("gpt-5.6-sol".to_string());
+
+    assert_eq!(
+        task_commit_message(&first),
+        "[ORB-00108] First task\n\nOrchestrated-By: gpt-5.6-sol"
+    );
+    assert_eq!(
+        finalize_commit_message(&[second.clone(), duplicate, first]),
+        "fix: finalize ship batch [ORB-00109, ORB-00110, ORB-00108]\n\n- ORB-00109: Second task\n- ORB-00110: Duplicate orchestrator\n- ORB-00108: First task\n\nOrchestrated-By: gpt-5.6-sol, gpt-5.6-terra"
+    );
+}
+
+#[test]
+fn orchestration_trailer_never_allows_a_recorded_value_to_add_a_new_trailer_line() {
+    let mut task = task_with_type(TaskType::Feature, "Protect trailer formatting");
+    task.orchestrator = Some("terra\nInjected-By: attacker".to_string());
+    task.created_by = Some("gpt-5.6-sol\nInjected-By: attacker".to_string());
+
+    assert_eq!(
+        batch_commit_message(&task),
+        "feat: Protect trailer formatting [ORB-00107]"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/mod.rs
@@ -1,3 +1,4 @@
+mod attribution;
 mod base_obsolescence;
 mod commit;
 mod delivery_marker;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/body.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/body.rs
@@ -2,6 +2,7 @@ use orbit_types::task::Task;
 
 use crate::context::PrConfig;
 
+use super::super::attribution::orchestration_trailer;
 use super::super::freshness::BranchFreshness;
 
 pub(super) const GITHUB_PR_BODY_BYTE_LIMIT: usize = 65_536;
@@ -25,6 +26,10 @@ pub(super) fn build_batch_pr_body(
     if let Some(signature) = batch_pr_signature(tasks, pr_opener_model) {
         body.push_str("\n\n");
         body.push_str(&signature);
+    }
+    if let Some(trailer) = orchestration_trailer(tasks) {
+        body.push_str("\n\n");
+        body.push_str(&trailer);
     }
 
     bound_pr_body(body, tasks)

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
@@ -263,6 +263,26 @@ fn single_task_pr_body_matches_snapshot() {
 }
 
 #[test]
+fn generated_pr_body_keeps_task_orchestration_attribution_for_squash_delivery() {
+    let mut task = task_with_contract(
+        "ORB-10474",
+        "Preserve orchestration",
+        "Done.",
+        "Keep the task's creation attribution in the generated delivery message.",
+        &[],
+        None,
+    );
+    task.orchestrator = Some("sol".to_string());
+    task.created_by = Some("gpt-5.6-sol".to_string());
+    task.implemented_by = Some("gpt-5.6-terra".to_string());
+
+    let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
+
+    assert!(body.ends_with("Orchestrated-By: gpt-5.6-sol"), "{body}");
+    assert!(!body.contains("Orchestrated-By: gpt-5.6-terra"), "{body}");
+}
+
+#[test]
 fn single_task_pr_body_uses_contract_first_layout() {
     let body = build_batch_pr_body(
         &[task_with_contract(


### PR DESCRIPTION
## Task

[ORB-11494](https://orbit-cli.com/tasks/ORB-11494) — Include model-aware Orchestrated-By attribution in task commit trailers

### Description

Daniel requests Orchestrated-By alongside Planned-By and Implemented-By in task commit messages, and explicitly prefers a model name. Screenshot example is ORB-11483 with Planned-By: codex / Implemented-By: codex but no orchestration trailer. Current agent-main git grep finds only Planned-By and Implemented-By emission in crates/orbit-engine/src/executor/automation/vcs/commit/message.rs:106-109 and no Orchestrated-By. Existing task orchestrator metadata and MCP session default were introduced by ORB-10580/10587 and ORB-11313; use their current code contract, not historical ADR authority.

Add optional Orchestrated-By emission when truthful orchestration attribution exists. Prefer the recorded orchestrator model identifier over a generic provider family or crew alias. Survey existing task/provenance projections for available model identity; if a configured crew model must be resolved, preserve when/how it was resolved and do not misrepresent a later configuration lookup as the actual historical model. Do not substitute execution crew/implemented_by for orchestrator or invent a model from generic codex. An explicit existing orchestrator alias can remain a truthful fallback when a model is unavailable; absent attribution omits the trailer. Keep execution selection, authority and provenance separate, preserve explicit task attribution precedence, and keep legacy tasks readable. Use existing attribution and commit-rendering seams; avoid broad metadata redesign. If minimal plumbing is necessary, task-pilot should identify additional real modification targets.

Handle multiple tasks deterministically without conflating different orchestrators, deduplicate identical model values, and preserve existing trailer formatting/sanitization. Verify source commit and eventual squash/PR delivery retain attribution through the existing path. No rewriting, amending or force-pushing historical commits to backfill trailers. Existing Planned-By and Implemented-By behavior remains compatible; the user specifically requested adding Orchestrated-By, not fabricated upgrades of old provider-only records. Terra/medium for bounded provenance-to-renderer integration; source delivery authorized under current --complete session, no releases/main promotion.

### Acceptance Criteria

- A task with recorded orchestrator model identity emits Orchestrated-By using that model name, independent of its implementing model.
- Known orchestrator alias with no reliable model uses a truthful existing attribution fallback; absent orchestration data emits no trailer and never invents model identity.
- Focused tests cover model preference, missing attribution, distinct execution/orchestration values, deterministic multi-task handling, and existing trailer formatting protections.
- Validate the actual task commit/delivery message path and required repository checks; do not rewrite existing history.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added task-scoped Orchestrated-By rendering that uses the recorded creation model when it is a concrete model, falls back to the explicit orchestrator alias when that model is unavailable, and omits unattributed tasks.
- Reused the renderer for per-task, batch, finalize, and generated PR-body paths so a GitHub squash delivery retains the trailer.
- Added focused coverage for model preference over implementation, alias fallback, omission, deterministic multi-task deduplication, newline protection, source commit emission, and generated PR delivery.

Criteria:
- Recorded orchestration model: emitted independently of implemented_by; covered by commit and PR-body tests.
- Fallback and absence: alias fallback and no-trailer behavior covered without runtime crew/config lookups.
- Formatting and multi-task handling: lexical BTreeSet ordering, deduplication, and CR/LF rejection covered.
- Delivery path: per-task git commit and generated PR body exercised; no history was rewritten.

Validation:
- PASS: cargo fmt --check
- PASS: cargo test -p orbit-engine executor::automation::vcs::commit::tests -- --nocapture (53 tests)
- PASS: cargo test -p orbit-engine executor::automation::vcs::pr::tests::body::generated_pr_body_keeps_task_orchestration_attribution_for_squash_delivery -- --nocapture
- PASS: make ci-fast
- PASS: make ci-lint
- PASS: git diff --check

Assessment: The change remains confined to the existing VCS attribution and rendering boundary. It intentionally does not look up current crew configuration at commit time, so legacy records remain truthful; its remaining limitation is that a configured-but-absent model records the existing alias rather than inventing a model.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11494-6a9e4c2e`
- Behind base: 0
- Ahead of base: 1