### PR TITLE
Expose bounded recovery-attempt diagnostics through authoritative workflow run show

### DIFF
--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -38,6 +38,21 @@ orbit run trace <run_id>
 orbit run logs <run_id> --json
 ```
 
+### Inspect recovery evidence before falling back to audit files
+
+The authoritative run-show response includes `recovery_attempts`, a bounded
+projection of persisted `step.recovery_attempted` events. Its `state` is
+`unavailable` for legacy runs with no v2 audit trail, `not_attempted` when a
+trail exists but recovery did not run, or `recorded` when `items` contain
+attempts. Each item names the durable run/event and failed-step identifiers,
+the recovery activity, outcome, failure phase, and a redacted bounded
+diagnostic. `limit` and `truncated` say when older attempts were omitted.
+
+Keep `error_code` and `error_message` from the run itself as the original
+workflow failure. A recovery attempt is secondary evidence: `succeeded` does
+not rewrite that original failure, and a failed `authorization`, preparation,
+`dispatch`, or `activity` attempt explains why recovery did not complete.
+
 ### Verify model routing before reading logs
 
 `orbit run show <run_id> --json` separates three identities: `requested_crew`

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -15,7 +15,7 @@ use super::super::test_support::{
     create_task, managed_tool_env_guard, run_tool_as_operator, test_runtime,
     unmanaged_tool_env_guard,
 };
-use crate::OrbitRuntime;
+use crate::{OrbitRuntime, V2AuditEventInsertParams};
 
 /// The default-named ship job. Loaded from the *global* orbit root, so a
 /// fixture has to seed it there rather than in the workspace's `.orbit`.
@@ -107,6 +107,47 @@ fn capability_denial(result: Result<Value, OrbitError>) -> String {
         Err(error) => panic!("expected a capability denial, got {error:?}"),
         Ok(value) => panic!("expected a capability denial, got {value}"),
     }
+}
+
+fn seed_recovery_attempt(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    event_id: &str,
+    recovery_succeeded: bool,
+    failure_phase: Option<&str>,
+    error_message: Option<&str>,
+) {
+    let event = json!({
+        "schemaVersion": 1,
+        "event_type": "step.recovery_attempted",
+        "event_id": event_id,
+        "ts": "2026-09-07T05:25:00Z",
+        "run_id": run_id,
+        "agent_identity": "codex",
+        "body_kind": "step_recovery_attempted",
+        "step_id": "implement_one",
+        "recovery_activity": "step_failure_recovery",
+        "recovery_succeeded": recovery_succeeded,
+        "failure_phase": failure_phase,
+        "error_message": error_message,
+    });
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: event_id.to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "step.recovery_attempted".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339("2026-09-07T05:25:00Z")
+                .expect("fixture timestamp")
+                .with_timezone(&Utc),
+            run_id: run_id.to_string(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: event.to_string(),
+        })
+        .expect("seed recovery attempt audit event");
 }
 
 /// ORB-10540: the in-run denial, driven by the environment rather than by a
@@ -308,6 +349,68 @@ fn operator_can_observe_runs_and_agent_denial_is_audited() {
         event.command == "authorization"
             && event.target_id.as_deref() == Some("orbit.workflow.run.show")
     }));
+}
+
+#[test]
+fn mcp_run_show_projects_bounded_recovery_evidence_without_replacing_run_error() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert run");
+    let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789";
+    seed_recovery_attempt(
+        &runtime,
+        &run.run_id,
+        "evt-recovery-failed",
+        false,
+        Some("dispatch"),
+        Some(&format!("recovery launcher refused {secret}")),
+    );
+    seed_recovery_attempt(
+        &runtime,
+        &run.run_id,
+        "evt-recovery-success",
+        true,
+        None,
+        None,
+    );
+
+    let shown = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": run.run_id}),
+    )
+    .expect("operator run show");
+
+    assert_eq!(shown["run_id"], json!(run.run_id));
+    assert_eq!(shown["error_message"], Value::Null);
+    assert_eq!(shown["recovery_attempts"]["state"], json!("recorded"));
+    assert_eq!(shown["recovery_attempts"]["limit"], json!(8));
+    assert_eq!(shown["recovery_attempts"]["truncated"], json!(false));
+    assert_eq!(
+        shown["recovery_attempts"]["items"][0]["run_id"],
+        json!(run.run_id)
+    );
+    assert_eq!(
+        shown["recovery_attempts"]["items"][0]["failed_step_id"],
+        json!("implement_one")
+    );
+    assert_eq!(
+        shown["recovery_attempts"]["items"][0]["failure_phase"],
+        json!("dispatch")
+    );
+    assert!(
+        !shown["recovery_attempts"]["items"][0]["diagnostic"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(secret)
+    );
+    assert_eq!(
+        shown["recovery_attempts"]["items"][1]["outcome"],
+        json!("succeeded")
+    );
 }
 
 /// [ORB-10971] CLI, MCP, dashboard API, and audit must agree on lineage. This

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -239,5 +239,35 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
         state.as_ref().map(|state| &state.step_outputs),
     ))
     .map_err(serialize_error("serialize agent invocation result"))?;
+    // Recovery evidence remains separate from the run and step errors above:
+    // a successful or failed recovery attempt never rewrites the original
+    // workflow failure that triggered it. Older/unreadable audit trails remain
+    // observable as `unavailable` rather than making existing run-show callers
+    // fail their ordinary durable run read.
+    let recovery_attempts = runtime.collect_run_recovery_attempts(&run.run_id).ok();
+    value["recovery_attempts"] = match recovery_attempts {
+        Some(attempts) => json!({
+            "state": attempts.state,
+            "limit": attempts.limit,
+            "truncated": attempts.truncated,
+            "items": attempts.attempts.into_iter().map(|attempt| json!({
+                "run_id": attempt.run_id,
+                "event_id": attempt.event_id,
+                "attempted_at": attempt.attempted_at.map(|value| value.to_rfc3339()),
+                "failed_step_id": attempt.failed_step_id,
+                "recovery_activity": attempt.recovery_activity,
+                "outcome": attempt.outcome,
+                "failure_phase": attempt.failure_phase,
+                "diagnostic": attempt.diagnostic,
+                "diagnostic_truncated": attempt.diagnostic_truncated,
+            })).collect::<Vec<_>>(),
+        }),
+        None => json!({
+            "state": "unavailable",
+            "limit": 8,
+            "truncated": false,
+            "items": [],
+        }),
+    };
     Ok(value)
 }

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
 use orbit_common::process::identity::{ProcessLiveness, probe_process_liveness};
+use orbit_common::security::redaction::redact_all;
 use orbit_common::storage::blob_store::BlobStore;
 use serde_json::Value;
 
@@ -43,6 +44,39 @@ pub struct RunAuditStep {
     pub outcome: Option<String>,
     pub error_message: Option<String>,
 }
+
+/// A bounded, operator-facing recovery attempt reconstructed from the v2 audit
+/// trail. It intentionally excludes activity input and provider transcript
+/// blobs: those can contain unrelated or unbounded material and are not needed
+/// to distinguish a recovery failure from the original failed workflow step.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunRecoveryAttempt {
+    pub run_id: String,
+    pub event_id: String,
+    pub attempted_at: Option<DateTime<Utc>>,
+    pub failed_step_id: String,
+    pub recovery_activity: String,
+    pub outcome: String,
+    pub failure_phase: Option<String>,
+    pub diagnostic: Option<String>,
+    pub diagnostic_truncated: bool,
+}
+
+/// The recovery portion of a run's persisted audit trail.
+///
+/// `unavailable` means the run has no v2 audit evidence (common for legacy
+/// runs), while `not_attempted` means audit evidence exists but records no
+/// recovery attempt. Neither state is a successful recovery.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunRecoveryAttempts {
+    pub state: &'static str,
+    pub attempts: Vec<RunRecoveryAttempt>,
+    pub limit: usize,
+    pub truncated: bool,
+}
+
+const MAX_RECOVERY_ATTEMPTS: usize = 8;
+const MAX_RECOVERY_DIAGNOSTIC_CHARS: usize = 1024;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RunCliInvocationRecord {
@@ -334,6 +368,46 @@ impl OrbitRuntime {
         Ok(steps)
     }
 
+    /// Recover the most recent bounded recovery-attempt evidence for a run.
+    ///
+    /// The event writer independently redacts and bounds its diagnostic, but
+    /// the projection applies the same safety boundary again because durable
+    /// audit rows can predate that writer behavior.
+    pub fn collect_run_recovery_attempts(
+        &self,
+        run_id: &str,
+    ) -> Result<RunRecoveryAttempts, OrbitError> {
+        let events = self.collect_run_audit_events(run_id)?;
+        let audit_state = if events.is_empty() {
+            "unavailable"
+        } else {
+            "not_attempted"
+        };
+        let total = events
+            .iter()
+            .filter(|event| event.body_kind.as_deref() == Some("step_recovery_attempted"))
+            .count();
+        let mut attempts = events
+            .into_iter()
+            .filter(|event| event.body_kind.as_deref() == Some("step_recovery_attempted"))
+            .filter_map(|event| recovery_attempt_from_event(run_id, event))
+            .rev()
+            .take(MAX_RECOVERY_ATTEMPTS)
+            .collect::<Vec<_>>();
+        attempts.reverse();
+
+        Ok(RunRecoveryAttempts {
+            state: if attempts.is_empty() {
+                audit_state
+            } else {
+                "recorded"
+            },
+            attempts,
+            limit: MAX_RECOVERY_ATTEMPTS,
+            truncated: total > MAX_RECOVERY_ATTEMPTS,
+        })
+    }
+
     pub fn collect_run_cli_invocations(
         &self,
         run_id: &str,
@@ -480,6 +554,58 @@ fn enclosing_step_id(event: &Value, events: &HashMap<String, Value>) -> Option<S
             .map(str::to_string);
     }
     None
+}
+
+fn recovery_attempt_from_event(run_id: &str, event: RunAuditEvent) -> Option<RunRecoveryAttempt> {
+    let failed_step_id = event.raw.get("step_id")?.as_str()?.to_string();
+    let recovery_activity = event.raw.get("recovery_activity")?.as_str()?.to_string();
+    let recovery_succeeded = event.raw.get("recovery_succeeded")?.as_bool()?;
+    let (diagnostic, diagnostic_truncated) = event
+        .raw
+        .get("error_message")
+        .and_then(Value::as_str)
+        .map(bounded_recovery_diagnostic)
+        .map_or((None, false), |(diagnostic, truncated)| {
+            (Some(diagnostic), truncated)
+        });
+
+    Some(RunRecoveryAttempt {
+        run_id: event
+            .raw
+            .get("run_id")
+            .and_then(Value::as_str)
+            .unwrap_or(run_id)
+            .to_string(),
+        event_id: event.event_id,
+        attempted_at: event.timestamp,
+        failed_step_id,
+        recovery_activity,
+        outcome: if recovery_succeeded {
+            "succeeded".to_string()
+        } else {
+            "failed".to_string()
+        },
+        failure_phase: event
+            .raw
+            .get("failure_phase")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        diagnostic,
+        diagnostic_truncated,
+    })
+}
+
+fn bounded_recovery_diagnostic(raw: &str) -> (String, bool) {
+    let redacted = redact_all(raw);
+    let mut bounded = redacted
+        .chars()
+        .take(MAX_RECOVERY_DIAGNOSTIC_CHARS)
+        .collect::<String>();
+    let truncated = bounded.chars().count() < redacted.chars().count();
+    if truncated {
+        bounded.push('…');
+    }
+    (bounded, truncated)
 }
 
 fn read_blob_text(blob_store: &BlobStore, blob_ref: &str) -> Result<String, OrbitError> {

--- a/crates/orbit-core/src/runtime/tests/run_audit.rs
+++ b/crates/orbit-core/src/runtime/tests/run_audit.rs
@@ -256,6 +256,158 @@ fn collect_run_audit_steps_reads_step_finished_error_message_and_tolerates_absen
 }
 
 #[test]
+fn recovery_attempt_projection_distinguishes_outcomes_and_redacts_diagnostics() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-recovery-outcomes";
+    let secret = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789";
+    seed_v2_audit_events(
+        &runtime,
+        run_id,
+        [
+            json!({
+                "event_id": "evt-run",
+                "body_kind": "run_started"
+            }),
+            json!({
+                "event_id": "evt-preparation",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+                "failure_phase": "preparation",
+                "error_message": format!("fixture preparation rejected {secret}")
+            }),
+            json!({
+                "event_id": "evt-dispatch",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+                "failure_phase": "dispatch",
+                "error_message": "launcher refused recovery"
+            }),
+            json!({
+                "event_id": "evt-activity",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+                "failure_phase": "activity",
+                "error_message": "recovery activity returned failure"
+            }),
+            json!({
+                "event_id": "evt-denied",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+                "failure_phase": "authorization",
+                "error_message": "recovery admission denied"
+            }),
+            json!({
+                "event_id": "evt-success",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": true
+            }),
+        ],
+    );
+
+    let attempts = runtime
+        .collect_run_recovery_attempts(run_id)
+        .expect("collect recovery attempts");
+
+    assert_eq!(attempts.state, "recorded");
+    assert_eq!(attempts.limit, 8);
+    assert!(!attempts.truncated);
+    assert_eq!(attempts.attempts.len(), 5);
+    assert_eq!(attempts.attempts[0].run_id, run_id);
+    assert_eq!(attempts.attempts[0].event_id, "evt-preparation");
+    assert_eq!(attempts.attempts[0].failed_step_id, "sync_base");
+    assert_eq!(
+        attempts.attempts[0].failure_phase.as_deref(),
+        Some("preparation")
+    );
+    assert!(
+        !attempts.attempts[0]
+            .diagnostic
+            .as_deref()
+            .unwrap_or_default()
+            .contains(secret)
+    );
+    assert_eq!(
+        attempts.attempts[1].failure_phase.as_deref(),
+        Some("dispatch")
+    );
+    assert_eq!(
+        attempts.attempts[2].failure_phase.as_deref(),
+        Some("activity")
+    );
+    assert_eq!(
+        attempts.attempts[3].failure_phase.as_deref(),
+        Some("authorization")
+    );
+    assert_eq!(attempts.attempts[4].outcome, "succeeded");
+    assert_eq!(attempts.attempts[4].failure_phase, None);
+    assert_eq!(attempts.attempts[4].diagnostic, None);
+}
+
+#[test]
+fn recovery_attempt_projection_bounds_history_and_marks_legacy_absence() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-recovery-bounded";
+    let events = (0..9)
+        .map(|index| {
+            json!({
+                "event_id": format!("evt-recovery-{index}"),
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+                "failure_phase": "dispatch",
+                "error_message": "x".repeat(1100)
+            })
+        })
+        .collect::<Vec<_>>();
+    seed_v2_audit_events(&runtime, run_id, events);
+
+    let bounded = runtime
+        .collect_run_recovery_attempts(run_id)
+        .expect("collect bounded attempts");
+    assert_eq!(bounded.attempts.len(), 8);
+    assert!(bounded.truncated);
+    assert_eq!(bounded.attempts[0].event_id, "evt-recovery-1");
+    assert!(bounded.attempts[0].diagnostic_truncated);
+    assert_eq!(
+        bounded.attempts[0]
+            .diagnostic
+            .as_deref()
+            .unwrap_or_default()
+            .chars()
+            .count(),
+        1025
+    );
+
+    let legacy = runtime
+        .collect_run_recovery_attempts("jrun-legacy")
+        .expect("collect legacy absence");
+    assert_eq!(legacy.state, "unavailable");
+    assert!(legacy.attempts.is_empty());
+
+    seed_v2_audit_events(
+        &runtime,
+        "jrun-no-recovery",
+        [json!({"event_id": "evt-run", "body_kind": "run_started"})],
+    );
+    let not_attempted = runtime
+        .collect_run_recovery_attempts("jrun-no-recovery")
+        .expect("collect no recovery attempt");
+    assert_eq!(not_attempted.state, "not_attempted");
+    assert!(not_attempted.attempts.is_empty());
+}
+
+#[test]
 fn malformed_jsonl_and_missing_blobs_are_tolerated() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let run_id = "jrun-tolerant";

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -38,6 +38,21 @@ orbit run trace <run_id>
 orbit run logs <run_id> --json
 ```
 
+### Inspect recovery evidence before falling back to audit files
+
+The authoritative run-show response includes `recovery_attempts`, a bounded
+projection of persisted `step.recovery_attempted` events. Its `state` is
+`unavailable` for legacy runs with no v2 audit trail, `not_attempted` when a
+trail exists but recovery did not run, or `recorded` when `items` contain
+attempts. Each item names the durable run/event and failed-step identifiers,
+the recovery activity, outcome, failure phase, and a redacted bounded
+diagnostic. `limit` and `truncated` say when older attempts were omitted.
+
+Keep `error_code` and `error_message` from the run itself as the original
+workflow failure. A recovery attempt is secondary evidence: `succeeded` does
+not rewrite that original failure, and a failed `authorization`, preparation,
+`dispatch`, or `activity` attempt explains why recovery did not complete.
+
 ### Verify model routing before reading logs
 
 `orbit run show <run_id> --json` separates three identities: `requested_crew`


### PR DESCRIPTION
## Task

[ORB-11495](https://orbit-cli.com/tasks/ORB-11495) — Expose bounded recovery-attempt diagnostics through authoritative workflow run show

### Description

Live visibility gap blocks accurate orchestration of recovery. Installed d418cbdf runtime retried ORB-11472 source jrun-20260907-0339-14 as jrun-20260907-0523; terminal state failed at 2026-09-07T05:25:03Z. Authoritative orbit_workflow_run_show returns one wrapper step target_id task_pr_pipeline, original RecoverableVcsConflict, and agent_invocation=null; no recovery attempt phase/diagnostic or nested failed step. ORB-11489 added backward-compatible failure_phase/error_message to recovery audit events, but these are unavailable through the connected MCP run-show projection. The original typed conflict must stay preserved; it alone cannot explain why the recovery activity failed or was denied. Automatic approval previously rejected CLI run show for durable state because this workspace requires authoritative MCP reads; no MCP event/log/trace read operation is currently exposed. Do not work around that restriction with a shadow store or orchestration CLI fallback.

Extend the existing authoritative workflow run inspection seam with a bounded structured projection of persisted recovery attempt evidence, including failed step/activity, attempt outcome, failure phase and redacted diagnostic when present; optionally a bounded persisted nested-step summary if needed to make the context actionable. Reuse current run/audit ownership and storage readers, not a new log/index/diagnostic database. Preserve original failure independently and distinguish absent/legacy audit data from successful recovery. Include stable run/step identifiers and truncation/limit information; avoid dumping provider logs, secrets or unbounded historical audit content. Preserve workspace/caller authorization, missing/wrong-workspace behavior and existing consumers. Relevant actual run is a verification target after install, not a test fixture dependency.

Use deterministic persisted-event fixtures covering failed preparation, dispatch, activity, denied recovery, successful recovery and legacy absence. Validate source behavior through registered tool/MCP integration. Update current tool contract/docs as necessary. Terraform/provider infrastructure or remote privilege changes are out of scope. Terra/medium for existing read-only projection plumbing. Delivery authorized to agent-main under --complete; no releases or main promotion.

### Acceptance Criteria

- Authoritative MCP workflow_run_show exposes enough persisted recovery evidence to distinguish no attempt, denied/preparation/dispatch/activity failure and success while retaining the original workflow error.
- Bounded deterministic integration fixtures verify projection, redaction, truncation, legacy absence, and workspace/caller authorization; no unbounded raw provider log exposure.
- Existing run-show clients remain compatible and no parallel persistence or CLI fallback is introduced.
- Owning checks plus ci-fast/ci-lint pass; after installation use jrun-20260907-0523 to establish the actual remaining recovery failure, without inventing its cause.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `recovery_attempts` to the authoritative workflow run show/list projection, derived only from persisted v2 audit events. The projection reports legacy/no-attempt/recorded state, stable run/event/step identifiers, recovery activity and outcome, phase, bounded redacted diagnostics, and item truncation metadata.
- Preserved original run and step error fields independently; audit read failures degrade recovery evidence to `unavailable` without breaking existing run-show clients.
- Added deterministic persisted-event coverage for preparation, dispatch, activity, authorization-denied, success, legacy/no-attempt, redaction, and bounded history; added registered-tool integration coverage and synchronized recovery-debugging documentation.
Assessment: bounded read-only projection with no new persistence, CLI fallback, or dependency edge.
Criteria:
- Recovery outcomes and original workflow failure are independently exposed: satisfied by `recovery_attempts` plus existing run error fields and focused integration test.
- Bounded deterministic fixtures/redaction/legacy and caller authorization: satisfied by runtime fixtures and existing registered-tool authorization coverage.
- Compatibility/no parallel persistence: satisfied; existing payload fields retained and only current v2 audit readers are used.
- Validation: PASSED `cargo fmt --check`; PASSED `cargo test -p orbit-core runtime::tests::run_audit --lib`; PASSED `cargo test -p orbit-core adapter::tool_host::tests::workflow_tools --lib`; PASSED `make ci-fast`; PASSED `make ci-lint`; PASSED `git diff --check`.
- Installed-source MCP verification: built `target/debug/orbit` and invoked `orbit_workflow_run_show` for `jrun-20260907-0523` through `target/debug/orbit mcp serve --operator --workspace ws_orbit`. The authoritative MCP response was `policy_denied`: `tool orbit.workflow.run.show is not in the activity allowlist`. This establishes the remaining recovery visibility failure as an allowlist denial in this managed environment; no cause beyond that returned error is claimed.
Risks: the actual run could not be projected because the authoritative MCP policy denied the read; no CLI/store fallback was used.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11495-6a9e4d5e`
- Behind base: 0
- Ahead of base: 1