### PR TITLE
Keep task creator model separate from Orchestrated-By identity

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/attribution.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/attribution.rs
@@ -1,12 +1,10 @@
 use std::collections::BTreeSet;
 
-use orbit_types::identity::agent_from_model;
 use orbit_types::task::Task;
 
-/// Render task-scoped orchestration attribution. `created_by` carries the
-/// actor's exact model at task creation; it is relevant here only when the
-/// task also records an explicit orchestrator. That prevents creation or
-/// implementation attribution from being mistaken for orchestration.
+/// Render task-scoped orchestration attribution from the explicit ownership
+/// record. Creation and implementation provenance are separate identities, so
+/// neither can establish a model for the task's orchestrator.
 pub(super) fn orchestration_trailer(tasks: &[Task]) -> Option<String> {
     let values = tasks
         .iter()
@@ -22,14 +20,7 @@ pub(super) fn orchestration_trailer(tasks: &[Task]) -> Option<String> {
 }
 
 fn orchestration_attribution(task: &Task) -> Option<String> {
-    let orchestrator = trailer_value(task.orchestrator.as_deref())?;
-    let model = task
-        .created_by
-        .as_deref()
-        .and_then(|value| trailer_value(Some(value)))
-        .filter(|value| agent_from_model(value).is_some());
-
-    model.or(Some(orchestrator))
+    trailer_value(task.orchestrator.as_deref())
 }
 
 fn trailer_value(value: Option<&str>) -> Option<String> {

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/author.rs
@@ -158,7 +158,7 @@ fn git_commit_per_task_preserves_orchestration_attribution_in_the_source_message
 
     assert_eq!(
         git_output(workspace, &["log", "-1", "--format=%B"]).expect("read source commit message"),
-        "[T1] Implement one task\n\nOrchestrated-By: gpt-5.6-sol"
+        "[T1] Implement one task\n\nOrchestrated-By: sol"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/message.rs
@@ -151,10 +151,10 @@ fn batch_commit_trailers_omit_missing_fields() {
 }
 
 #[test]
-fn orchestration_trailer_prefers_the_recorded_creation_model_over_its_alias() {
+fn orchestration_trailer_preserves_an_explicit_model_shaped_orchestrator() {
     let mut task = task_with_type(TaskType::Feature, "Attribute orchestration");
-    task.orchestrator = Some("terra".to_string());
-    task.created_by = Some("gpt-5.6-sol".to_string());
+    task.orchestrator = Some("gpt-5.6-sol".to_string());
+    task.created_by = Some("gpt-5.6-terra".to_string());
     task.implemented_by = Some("gpt-5.6-terra".to_string());
 
     assert_eq!(
@@ -164,7 +164,19 @@ fn orchestration_trailer_prefers_the_recorded_creation_model_over_its_alias() {
 }
 
 #[test]
-fn orchestration_trailer_uses_alias_without_a_reliable_model_and_omits_unattributed_tasks() {
+fn orchestration_trailer_uses_the_explicit_alias_after_pre_execution_reassignment() {
+    let mut task = task_with_type(TaskType::Feature, "Respect reassigned orchestration");
+    task.created_by = Some("gpt-5.6-sol".to_string());
+    task.orchestrator = Some("terra".to_string());
+
+    assert_eq!(
+        batch_commit_message(&task),
+        "feat: Respect reassigned orchestration [ORB-00107]\n\nOrchestrated-By: terra"
+    );
+}
+
+#[test]
+fn orchestration_trailer_uses_alias_without_a_model_and_omits_unattributed_tasks() {
     let mut alias_only = task_with_type(TaskType::Feature, "Keep legacy attribution truthful");
     alias_only.orchestrator = Some("terra".to_string());
     alias_only.created_by = Some("codex".to_string());
@@ -201,11 +213,11 @@ fn orchestration_trailers_are_deterministic_and_preserved_on_task_and_finalize_m
 
     assert_eq!(
         task_commit_message(&first),
-        "[ORB-00108] First task\n\nOrchestrated-By: gpt-5.6-sol"
+        "[ORB-00108] First task\n\nOrchestrated-By: sol"
     );
     assert_eq!(
         finalize_commit_message(&[second.clone(), duplicate, first]),
-        "fix: finalize ship batch [ORB-00109, ORB-00110, ORB-00108]\n\n- ORB-00109: Second task\n- ORB-00110: Duplicate orchestrator\n- ORB-00108: First task\n\nOrchestrated-By: gpt-5.6-sol, gpt-5.6-terra"
+        "fix: finalize ship batch [ORB-00109, ORB-00110, ORB-00108]\n\n- ORB-00109: Second task\n- ORB-00110: Duplicate orchestrator\n- ORB-00108: First task\n\nOrchestrated-By: another-sol-alias, sol, terra"
     );
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/body.rs
@@ -263,12 +263,12 @@ fn single_task_pr_body_matches_snapshot() {
 }
 
 #[test]
-fn generated_pr_body_keeps_task_orchestration_attribution_for_squash_delivery() {
+fn generated_pr_body_keeps_explicit_orchestration_attribution_for_squash_delivery() {
     let mut task = task_with_contract(
         "ORB-10474",
         "Preserve orchestration",
         "Done.",
-        "Keep the task's creation attribution in the generated delivery message.",
+        "Keep the task's explicit orchestration attribution in the generated delivery message.",
         &[],
         None,
     );
@@ -278,7 +278,8 @@ fn generated_pr_body_keeps_task_orchestration_attribution_for_squash_delivery() 
 
     let body = build_batch_pr_body(&[task], &freshness(), &[], &test_pr_config(None), None);
 
-    assert!(body.ends_with("Orchestrated-By: gpt-5.6-sol"), "{body}");
+    assert!(body.ends_with("Orchestrated-By: sol"), "{body}");
+    assert!(!body.contains("Orchestrated-By: gpt-5.6-sol"), "{body}");
     assert!(!body.contains("Orchestrated-By: gpt-5.6-terra"), "{body}");
 }
 


### PR DESCRIPTION
## Task

[ORB-11497](https://orbit-cli.com/tasks/ORB-11497) — Keep task creator model separate from Orchestrated-By identity

### Description

Independent exact-merge inspection of ORB-11494/PR1492 at a13830c2f928453bc03e07f03aadf57c0b8d4d78 found a concrete wrong-attribution case. In crates/orbit-engine/src/executor/automation/vcs/attribution.rs, orchestration_attribution requires any task.orchestrator, then uses task.created_by whenever agent_from_model recognizes that value, via model.or(Some(orchestrator)). Merely having an explicit orchestrator does not prove that the creator is that orchestrator. Example: task.created_by=gpt-5.6-sol and task.orchestrator=opus yields Orchestrated-By: gpt-5.6-sol, even though explicit orchestration ownership is opus. An orchestrator can also change before execution; ORB-10580 and ORB-11313 preserve that distinct metadata/precedence. This is a source-proven counterexample; do not fabricate a live affected commit.

Correct the common renderer/provenance boundary so Orchestrated-By never borrows an unrelated creator or implementer model. Prefer a reliably recorded model tied to the actual orchestration attribution if one exists. If current metadata cannot establish that link, use the explicit orchestrator alias truthfully rather than guessing from created_by or looking up today's mutable crew configuration as historical fact. Preserve model preference when it really is available; if minimal recorded orchestration-model plumbing is already supported, reuse it and keep changes pre-execution/legacy compatible. Do not introduce a broad attribution redesign merely to avoid a truthful fallback. Existing omission, deterministic multi-task formatting, newline protections and source/PR squash paths must remain correct. Add regression coverage for different creator/orchestrator, orchestrator reassignment, and unchanged model-aware valid cases. No history rewriting or backfill of guessed identities. Daniel requested Orchestrated-By with model preferred; correctness of that identity is required, not just trailer presence.

### Acceptance Criteria

- Different creator and orchestrator identities never emit the creator model as Orchestrated-By solely because it is model-shaped.
- A reliably recorded model associated with orchestration is preferred when available; absent such evidence uses the explicit orchestrator alias, and absent orchestration omits the trailer.
- Regression coverage includes creator/orchestrator mismatch and pre-execution reassignment, with existing multi-task/formatting/source/PR delivery behavior retained.
- Owning checks plus ci-fast/ci-lint pass; no historical identity is guessed or rewritten.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rendered Orchestrated-By exclusively from the task’s explicit orchestrator record, so creator and implementer identities cannot be misattributed as orchestration.
- Retained an explicitly recorded model-shaped orchestrator value and otherwise emits the truthful configured alias; omitted orchestration remains omitted.
- Updated source-commit, deterministic multi-task, reassignment, and generated PR squash-delivery regressions.

Criteria:
- Creator/orchestrator mismatch: covered by an explicit model-shaped orchestrator with a distinct creator, plus source and PR delivery assertions that a creator model is not emitted.
- Model preference/fallback/omission: explicit model-shaped orchestrator is preserved; aliases are used when no recorded orchestrator model exists; no-orchestration behavior remains covered.
- Reassignment and formatting: pre-execution reassignment renders the current explicit alias; deterministic multi-task ordering, deduplication, and newline protection remain covered.
- Historical integrity: no task history was rewritten and no current crew configuration is looked up.

Validation:
- PASS: cargo fmt --all -- --check
- PASS: cargo test -p orbit-engine executor::automation::vcs::commit::tests -- --nocapture (54 tests)
- PASS: cargo test -p orbit-engine executor::automation::vcs::pr::tests::body::generated_pr_body_keeps_explicit_orchestration_attribution_for_squash_delivery -- --nocapture
- PASS: make ci-fast
- PASS: make ci-lint
- PASS: git diff --check

Assessment: The renderer stays at the shared VCS provenance boundary and uses only durable task data. The task model has no separate persisted orchestration-model field, so aliases remain the truthful fallback rather than guessing or resolving mutable crew configuration. Starting worktree was clean; final diff contains only the four scoped attribution and test files.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11497-6a9e5089`
- Behind base: 0
- Ahead of base: 1