### PR TITLE
Support an explicit cooperative SSH operator grant for remote agent invocation

### DIFF
--- a/crates/orbit-cli/src/command/mcp/callers.rs
+++ b/crates/orbit-cli/src/command/mcp/callers.rs
@@ -18,7 +18,7 @@ use orbit_mcp::{
     federated,
 };
 use orbit_types::identity::validate_machine_id;
-use orbit_types::tool::McpCapability;
+use orbit_types::tool::{McpCapability, RemoteAgentInvokeMode};
 
 use crate::command::{CommandOut, CommandOutput};
 
@@ -148,7 +148,10 @@ fn list(path: &Path) -> CommandOut {
         println!(
             "    agent_invoke: {}",
             if row.agent_invoke {
-                "enabled"
+                match row.agent_invoke_mode.unwrap_or_default() {
+                    RemoteAgentInvokeMode::KeyBound => "enabled (key-bound)",
+                    RemoteAgentInvokeMode::Cooperative => "enabled (cooperative)",
+                }
             } else {
                 "disabled"
             }
@@ -177,8 +180,10 @@ fn check(path: &Path, machine_id: &str) -> CommandOut {
     println!("granted: [{}]", capability_list(&grant.granted));
     match &grant.pinned_fingerprint {
         Some(fingerprint) => println!(
-            "identity: key-bound to {fingerprint} where this machine can observe the \
-             authenticating key"
+            "identity pin: {fingerprint}, enforced where this machine can observe the \
+             authenticating key. The identity itself is key-bound only on the \
+             destination-issued forced-command path; the ordinary SSH proxy remains \
+             self-asserted."
         ),
         None => println!(
             "identity: self-asserted — this row is selected by a name, so any caller that \
@@ -199,11 +204,16 @@ fn check(path: &Path, machine_id: &str) -> CommandOut {
     }
     println!(
         "agent_invoke: {}",
-        if grant.agent_invoke {
-            "configured for the listed workspaces; admission additionally requires a key-bound \
-             session"
-        } else {
-            "not granted"
+        match grant.agent_invoke_mode {
+            Some(RemoteAgentInvokeMode::KeyBound) => {
+                "configured for the listed workspaces in key-bound mode; admission requires a \
+                 destination-issued forced-command session"
+            }
+            Some(RemoteAgentInvokeMode::Cooperative) => {
+                "configured for the listed workspaces in cooperative mode; identity remains \
+                 self-asserted and the SSH OS-account/operator channel is the trust boundary"
+            }
+            None => "not granted",
         }
     );
     // Both requests, because the grant is a ceiling and the caller's argv is
@@ -328,8 +338,11 @@ fn authorize(global_root: &Path, callers_path: &Path, args: &CallersAuthorizeArg
     );
     eprintln!(
         "Remote `orbit.agent.invoke` remains denied unless the matched row also sets \
-         `agent_invoke = true`, grants `operator`, pins this key, and narrows `workspaces` to the \
-         destination workspace IDs. That extra grant never comes from the file default."
+         `agent_invoke = true`, grants `operator`, and narrows `workspaces` to the destination \
+         workspace IDs. The omitted `agent_invoke_mode` remains strict and requires this pinned \
+         key. A destination owner may instead set `agent_invoke_mode = \"cooperative\"` for an \
+         existing same-OS-account SSH operator channel; that records a self-asserted identity and \
+         is not Tier 2. The operation grant never comes from the file default."
     );
     // The row guidance is written against what is actually in the file: a
     // template that restated `capabilities` would invite an operator to paste

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1486,6 +1486,96 @@ agent_invoke = false
     assert_eq!(denied["code"], "capability_denied", "{denied}");
 }
 
+/// The destination may deliberately trust the existing SSH operator channel
+/// when both ends cooperate through the same OS account. The invocation is
+/// still workspace- and operation-scoped, while its output and durable
+/// admission must say `cooperative` and `self-asserted`, never `key-bound`.
+#[test]
+fn a_cooperative_ssh_operator_invocation_records_its_actual_trust_boundary() {
+    let workspace = McpWorkspace::init();
+    plant_agent_response_stub(&McpWorkspace::stub_bin_dir(&workspace.home), "codex");
+    let registry: Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.home.join(".orbit/workspaces.json"))
+            .expect("read workspace registry"),
+    )
+    .expect("parse workspace registry");
+    let workspace_id = registry["workspaces"][0]["id"]
+        .as_str()
+        .expect("workspace id");
+
+    write_callers(
+        &workspace,
+        &format!(
+            r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_caller"
+capabilities = ["agent", "operator"]
+workspaces = ["{workspace_id}"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+"#,
+        ),
+    );
+    let mut cooperative = workspace.serve_with_args_and_env(
+        &["--operator", "--remote-caller-machine-id", "hm_caller"],
+        &[("SSH_CONNECTION", "192.0.2.8 43100 198.51.100.2 22")],
+    );
+    let submitted = cooperative.call_tool_ok(
+        "orbit_agent_invoke",
+        json!({
+            "prompt": "read-only cooperative probe",
+            "cwd": workspace.work,
+            "crew": "system",
+            "timeout_seconds": 30,
+            "model": "codex",
+        }),
+    );
+
+    assert_eq!(submitted["authorized_by"], "hm_caller");
+    assert_eq!(submitted["authorizer_provenance"], "remote-grant");
+    assert_eq!(submitted["caller_machine_id"], "hm_caller");
+    assert_eq!(submitted["caller_identity"], "self-asserted");
+    assert_eq!(submitted["agent_invoke_mode"], "cooperative");
+    let run_id = submitted["run_id"].as_str().expect("run id").to_string();
+
+    let deadline = Instant::now() + RESPONSE_TIMEOUT;
+    loop {
+        let shown = cooperative.call_tool_ok("orbit_workflow_run_show", json!({ "id": run_id }));
+        if matches!(
+            shown["state"].as_str(),
+            Some("success" | "failed" | "timeout" | "cancelled" | "interrupted")
+        ) {
+            assert_eq!(shown["state"], "success", "{shown}");
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "cooperative agent invocation did not finish: {shown}"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let connection =
+        Connection::open(workspace.home.join(".orbit/orbit.db")).expect("destination store");
+    let input_json: String = connection
+        .query_row(
+            "SELECT input_json FROM job_runs WHERE run_id = ?1",
+            [&run_id],
+            |row| row.get(0),
+        )
+        .expect("persisted invocation input");
+    let input: Value = serde_json::from_str(&input_json).expect("parse invocation input");
+    let admission = &input["trusted_host_admission"];
+    assert_eq!(admission["caller_identity"], "self-asserted");
+    assert_eq!(admission["agent_invoke_mode"], "cooperative");
+    assert_eq!(
+        admission["workspace_path"],
+        workspace.work.display().to_string()
+    );
+}
+
 /// [ORB-11184] A separate ordinary same-UID process scans every process's argv
 /// and environment continuously while the generated protected launcher starts
 /// repeated legitimate destinations. The kernel boundary exists at exec, so

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Remote callers also require a destination-issued key-bound identity and an explicit workspace-scoped `agent_invoke` grant. Track it with `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, and dispatches nothing.",
+    "description": "Submit an asynchronous agent invocation for exploration or debugging and return its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as the same OS user as Orbit, so it can reach anything that user can; it is admitted per invocation and requires operator capability. Remote callers also require an explicit destination-owned, workspace-scoped `agent_invoke` grant; its default mode requires a key-bound identity, while an explicit cooperative mode trusts the same-OS-account SSH operator channel and records identity as self-asserted. Track it with `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, and dispatches nothing.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {

--- a/crates/orbit-common/src/governance/authorization.rs
+++ b/crates/orbit-common/src/governance/authorization.rs
@@ -281,7 +281,7 @@ pub const GOVERNED_OPERATIONS: &[GovernedOperation] = &[
         // run exists to stay inside. A run that could admit itself would be a
         // sandbox escape wearing an authorization.
         allowed: &[McpCapability::Operator],
-        rationale: "an agent invocation runs a provider subprocess on the host outside the executor sandbox, so it requires a local operator or an explicitly granted key-bound remote operator",
+        rationale: "an agent invocation runs a provider subprocess on the host outside the executor sandbox, so it requires a local operator or an explicitly scoped remote operator grant",
     },
     GovernedOperation {
         id: "orbit.command.exec",

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -135,8 +135,9 @@ explicit per-invocation operator admission, so a sandbox-denial diagnostic is
 never the explanation for one failing. The run trail records the admission as a
 `trusted_host.execution_admitted` audit event naming the authorizing operator
 and the working directory. For remote admission it also records the
-destination-resolved caller machine ID and key-bound identity proof. They are
-deliberately **not resumable**: the
+destination-resolved caller machine ID, remote invocation mode, and actual
+identity proof. A cooperative grant is recorded as `cooperative` plus
+`self-asserted`, never as key-bound. They are deliberately **not resumable**: the
 admission covered one invocation, so submit a new one rather than resuming.
 
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.

--- a/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
@@ -79,8 +79,9 @@ workflow tool is absent or denied; do not treat changing remote argv as a fix.
 ### Remote host-agent invocation
 
 Remote `orbit_agent_invoke` is a narrower grant than remote operator access.
-The destination accepts it only for a key-bound SSH MCP identity, and only when
-the matched caller row explicitly enables the operation on named workspaces:
+The matched caller row must explicitly enable the operation on named
+workspaces and grant operator capability. Omission of `agent_invoke_mode`
+preserves the strict key-bound mode:
 
 ```toml
 default = "deny"
@@ -94,19 +95,51 @@ ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
 agent_invoke = true
 ```
 
-All four restrictions are required: operator capability, an explicit workspace
-list, a pinned SSH key, and `agent_invoke = true`. The file default can never
-grant this operation. Generate and install the destination-issued forced
-command with `orbit mcp callers authorize`, then reconnect the MCP session so
-it resolves the current policy. `orbit mcp callers check <caller-machine-id>`
-shows the configured scope. To revoke, remove the row or set
+The destination can instead opt one row into the existing cooperative SSH
+operator channel without Tier-2 infrastructure:
+
+```toml
+default = "deny"
+
+[[callers]]
+machine_id = "<caller-machine-id>"
+label = "<display-name>"
+capabilities = ["agent", "operator"]
+workspaces = ["<allowed-workspace-id>"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+```
+
+This is an explicit destination-owner statement that callers using the same
+SSH OS account cooperate. The machine ID remains self-asserted: any peer able
+to start the same non-interactive SSH operator session can name another row.
+The policy prevents accidental use and limits Orbit's admission to the named
+workspace and one invocation; it does not isolate mutually malicious peers who
+share the account and already control that account's files and processes.
+Never describe a cooperative admission as key-bound.
+
+For either mode, install the updated Orbit binary on the destination, review
+and edit `~/.orbit/mcp-callers.toml` there, run `orbit mcp callers check
+<caller-machine-id>`, then close and recreate the calling MCP connection. A
+live session keeps the policy loaded at establishment. For strict mode, first
+generate and install the destination-issued forced command with `orbit mcp
+callers authorize`. To revoke either mode, remove the row or set
 `agent_invoke = false`, then reconnect; the next invocation is denied.
 
-This is an authenticated caller and an accident-resistant admission path, not
-process isolation. The invoked provider still runs outside Orbit's filesystem
-sandbox as the same operating-system user as the destination Orbit process and
-can access everything that user can. Keep the prompt read-only when that is the
-intent; a tool declaration does not confine the provider's own shell.
+After reconnecting, a minimal smoke is one short, read-only invocation with an
+explicit destination workspace selector, checkout `cwd`, bounded timeout, and
+the configured Luna crew. Ask it to report one harmless fact and explicitly not
+to modify files or start other work. Verify the submission and
+`trusted_host.execution_admitted` event report `agent_invoke_mode = "cooperative"`
+with `caller_identity = "self-asserted"` (or both fields as `key-bound` in
+strict mode), and verify the run reaches a terminal state.
+
+Strict mode is an authenticated caller and accident-resistant admission path;
+neither mode is process isolation. The invoked provider runs outside Orbit's
+filesystem sandbox as the same operating-system user as the destination Orbit
+process and can access everything that user can. Keep the prompt read-only when
+that is the intent; a tool declaration does not confine the provider's own
+shell.
 
 There are two identity strengths. Ordinary SSH proxy identity is a self-asserted
 audit label, suitable for cooperative operators with shell access; it is not

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -73,10 +73,12 @@ What it is not:
 - It is **not** a task, and it performs no task transition. It does not commit,
   push, open or merge a pull request, or dispatch further work.
 - It is **not** available to a managed run. A local operator may admit one
-  directly. A remote operator may admit one only through a destination-issued,
-  key-bound SSH MCP identity whose callers-file row explicitly enables
-  `agent_invoke` for the resolved workspace. Ordinary remote `operator`
-  capability is not enough. Each admission covers one invocation only.
+  directly. A remote operator also needs a callers-file row that explicitly
+  enables `agent_invoke` for the resolved workspace. The omitted mode requires
+  a destination-issued key-bound SSH identity; an explicit `cooperative` mode
+  instead trusts the existing same-OS-account SSH operator channel and records
+  its machine ID as self-asserted. Ordinary remote `operator` capability is not
+  enough. Each admission covers one invocation only.
 - It is **not** resumable. A resumed run would carry an admission nobody granted
   now; submit a new invocation instead.
 
@@ -94,9 +96,10 @@ the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 The durable admission and `trusted_host.execution_admitted` event retain the
-destination-resolved caller machine ID, its key-bound identity proof, the
-workspace checkout, and cwd. See [remote-access.md](setup/remote-access.md). Do
-not relaunch a server with more privileges to work around a denied call.
+destination-resolved caller machine ID, the invocation mode, the actual
+identity proof (`key-bound` or `self-asserted`), the workspace checkout, and
+cwd. See [remote-access.md](setup/remote-access.md). Do not relaunch a server
+with more privileges to work around a denied call.
 
 ## Common MCP arguments
 

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -74,7 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
-| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit key-bound remote callers-file grant, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit workspace-scoped remote callers-file grant (strict key-bound by default, or explicitly cooperative on a same-account SSH operator channel), changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.

--- a/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/agent_tools.rs
@@ -50,6 +50,7 @@ pub(super) fn invoke(
         "authorizer_provenance": submission.admission.authorizer_provenance,
         "caller_machine_id": submission.admission.caller_machine_id,
         "caller_identity": submission.admission.caller_identity,
+        "agent_invoke_mode": submission.admission.agent_invoke_mode,
         "workspace_path": submission.admission.workspace_path,
         "cwd": submission.admission.cwd,
         "sandboxed": false,

--- a/crates/orbit-core/src/application/job/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/agent_invoke.rs
@@ -169,6 +169,10 @@ impl OrbitRuntime {
                 .remote_caller
                 .as_ref()
                 .map(|grant| grant.identity),
+            agent_invoke_mode: authorizer
+                .remote_caller
+                .as_ref()
+                .and_then(|grant| grant.agent_invoke_mode),
             authorized_at: Utc::now().to_rfc3339(),
             workspace_path: self.paths().repo_root.display().to_string(),
             cwd: cwd.display().to_string(),

--- a/crates/orbit-core/src/application/job/tests/agent_invoke.rs
+++ b/crates/orbit-core/src/application/job/tests/agent_invoke.rs
@@ -14,7 +14,8 @@ use std::path::PathBuf;
 use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_types::tool::{
-    CallerIdentityProof, McpCapability, RemoteCallerGrant, ToolSessionContext,
+    CallerIdentityProof, McpCapability, RemoteAgentInvokeMode, RemoteCallerGrant,
+    ToolSessionContext,
 };
 use orbit_types::workflow::activity_job::TRUSTED_HOST_ADMISSION_KEY;
 use orbit_types::workflow::{JobRun, JobRunState};
@@ -68,6 +69,7 @@ fn runner_session() -> ToolSessionContext {
 fn remote_operator_session(
     identity: CallerIdentityProof,
     agent_invoke: bool,
+    agent_invoke_mode: Option<RemoteAgentInvokeMode>,
 ) -> ToolSessionContext {
     ToolSessionContext {
         effective_capabilities: [McpCapability::Operator].into_iter().collect(),
@@ -77,6 +79,7 @@ fn remote_operator_session(
             source: "mcp-callers.toml".to_string(),
             identity,
             agent_invoke,
+            agent_invoke_mode,
         }),
         ..ToolSessionContext::default()
     }
@@ -146,7 +149,7 @@ fn a_runs_own_runner_grant_cannot_admit_an_invocation() {
 #[test]
 fn a_self_asserted_remote_operator_cannot_admit_an_invocation() {
     let (_root, runtime, repo_root) = test_runtime();
-    let session = remote_operator_session(CallerIdentityProof::SelfAsserted, true);
+    let session = remote_operator_session(CallerIdentityProof::SelfAsserted, true, None);
     let error = runtime
         .submit_agent_invoke_run(request(&repo_root.display().to_string(), &session))
         .expect_err("a spoofable remote identity must not admit an unsandboxed process");
@@ -165,7 +168,7 @@ fn a_self_asserted_remote_operator_cannot_admit_an_invocation() {
 #[test]
 fn a_key_bound_remote_operator_still_needs_the_explicit_operation_grant() {
     let (_root, runtime, _repo_root) = test_runtime();
-    let session = remote_operator_session(CallerIdentityProof::KeyBound, false);
+    let session = remote_operator_session(CallerIdentityProof::KeyBound, false, None);
     let error = runtime
         .admit_agent_invoke(&session)
         .expect_err("operator capability alone must not grant unsandboxed remote execution");
@@ -182,7 +185,7 @@ fn a_key_bound_remote_operator_still_needs_the_explicit_operation_grant() {
 #[test]
 fn an_explicit_key_bound_remote_grant_preserves_the_real_caller() {
     let (_root, runtime, _repo_root) = test_runtime();
-    let session = remote_operator_session(CallerIdentityProof::KeyBound, true);
+    let session = remote_operator_session(CallerIdentityProof::KeyBound, true, None);
 
     let authorizer = runtime
         .admit_agent_invoke(&session)
@@ -198,9 +201,30 @@ fn an_explicit_key_bound_remote_grant_preserves_the_real_caller() {
 }
 
 #[test]
+fn an_explicit_cooperative_remote_operator_retains_self_asserted_provenance() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let session = remote_operator_session(
+        CallerIdentityProof::SelfAsserted,
+        true,
+        Some(RemoteAgentInvokeMode::Cooperative),
+    );
+
+    let authorizer = runtime
+        .admit_agent_invoke(&session)
+        .expect("the destination explicitly trusted its cooperative SSH operator channel");
+    let remote = authorizer.remote_caller.expect("remote caller facts");
+
+    assert_eq!(remote.identity, CallerIdentityProof::SelfAsserted);
+    assert_eq!(
+        remote.agent_invoke_mode,
+        Some(RemoteAgentInvokeMode::Cooperative)
+    );
+}
+
+#[test]
 fn revoking_the_remote_operation_grant_denies_the_next_invocation() {
     let (_root, runtime, _repo_root) = test_runtime();
-    let mut session = remote_operator_session(CallerIdentityProof::KeyBound, true);
+    let mut session = remote_operator_session(CallerIdentityProof::KeyBound, true, None);
     runtime
         .admit_agent_invoke(&session)
         .expect("the initial explicit grant is admitted");

--- a/crates/orbit-core/src/runtime/authorization.rs
+++ b/crates/orbit-core/src/runtime/authorization.rs
@@ -26,7 +26,8 @@ use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_store::contracts::AuditEventInsertParams;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::{
-    CallerIdentityProof, McpCapability, RemoteCallerGrant, ToolSessionContext,
+    CallerIdentityProof, McpCapability, RemoteAgentInvokeMode, RemoteCallerGrant,
+    ToolSessionContext,
 };
 
 use crate::OrbitRuntime;
@@ -144,8 +145,11 @@ impl OrbitRuntime {
     ///   resolves as `agent`, and an agent is refused.
     /// * **Remote callers need an operation-specific, workspace-scoped grant.**
     ///   `operator` alone remains insufficient. The caller must have a
-    ///   destination-issued key-bound identity and the matched callers-file row
-    ///   must explicitly enable `agent_invoke` for the resolved workspace.
+    ///   matched callers-file row must explicitly enable `agent_invoke` for the
+    ///   resolved workspace. The default mode still requires a
+    ///   destination-issued key-bound identity; only an explicit cooperative
+    ///   mode accepts the self-asserted identity of the existing same-account
+    ///   SSH operator channel.
     pub(crate) fn admit_agent_invoke(
         &self,
         session_context: &ToolSessionContext,
@@ -160,20 +164,25 @@ impl OrbitRuntime {
         self.decide_with_envelope(operation, envelope)?;
 
         if let Some(grant) = caller.remote_caller_grant() {
-            if grant.identity != CallerIdentityProof::KeyBound {
-                return self.deny_remote_agent_invoke(
-                    &caller,
-                    grant,
-                    "the caller identity is self-asserted; use the destination-issued key-bound \
-                     SSH acceptance path",
-                );
-            }
             if !grant.agent_invoke {
                 return self.deny_remote_agent_invoke(
                     &caller,
                     grant,
                     "the matched destination policy does not enable `agent_invoke` for this \
                      workspace",
+                );
+            }
+            let mode = grant.agent_invoke_mode.unwrap_or_default();
+            if mode == RemoteAgentInvokeMode::KeyBound
+                && grant.identity != CallerIdentityProof::KeyBound
+            {
+                return self.deny_remote_agent_invoke(
+                    &caller,
+                    grant,
+                    "the caller identity is self-asserted and the grant's default key-bound mode \
+                     requires the destination-issued SSH acceptance path; the destination owner \
+                     may instead select `agent_invoke_mode = \"cooperative\"` for a trusted \
+                     same-OS-account operator channel",
                 );
             }
         }
@@ -202,6 +211,7 @@ impl OrbitRuntime {
             caller_machine_id = grant.caller_machine_id,
             caller_identity = %grant.identity,
             agent_invoke = grant.agent_invoke,
+            agent_invoke_mode = grant.agent_invoke_mode.map(|mode| mode.to_string()),
             "trusted host admission denied to a remote caller"
         );
         self.record_authorization_event(
@@ -336,6 +346,7 @@ impl OrbitRuntime {
                     // the caller had to hold a key to select it [ORB-11053].
                     "caller_identity": grant.identity,
                     "agent_invoke": grant.agent_invoke,
+                    "agent_invoke_mode": grant.agent_invoke_mode,
                 })
                 .to_string()
             }),

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -292,6 +292,7 @@ pub fn run_cli_backend(
             authorizer_provenance = %admission.authorizer_provenance,
             caller_machine_id = admission.caller_machine_id.as_deref(),
             caller_identity = admission.caller_identity.map(|identity| identity.to_string()),
+            agent_invoke_mode = admission.agent_invoke_mode.map(|mode| mode.to_string()),
             workspace_path = %admission.workspace_path,
             cwd = %admission.cwd,
             "starting an operator-admitted provider subprocess outside the executor sandbox"
@@ -303,6 +304,7 @@ pub fn run_cli_backend(
             authorizer_provenance: admission.authorizer_provenance.clone(),
             caller_machine_id: admission.caller_machine_id.clone(),
             caller_identity: admission.caller_identity,
+            agent_invoke_mode: admission.agent_invoke_mode,
             authorized_at: admission.authorized_at.clone(),
             workspace_path: admission.workspace_path.clone(),
             cwd: admission.cwd.clone(),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use orbit_agent::loop_engine::audit::AuditSink;
-use orbit_types::tool::CallerIdentityProof;
+use orbit_types::tool::{CallerIdentityProof, RemoteAgentInvokeMode};
 use orbit_types::workflow::activity_job::{
     TRUSTED_HOST_ADMISSION_KEY, TrustedHostAdmission, V2AuditEventKind,
 };
@@ -25,6 +25,7 @@ fn admission() -> TrustedHostAdmission {
         authorizer_provenance: "remote-grant".to_string(),
         caller_machine_id: Some("hm_mac".to_string()),
         caller_identity: Some(CallerIdentityProof::KeyBound),
+        agent_invoke_mode: Some(RemoteAgentInvokeMode::KeyBound),
         authorized_at: "2026-09-06T00:00:00Z".to_string(),
         workspace_path: "/checkout".to_string(),
         cwd: "/checkout".to_string(),
@@ -89,6 +90,7 @@ fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
                 authorizer_provenance,
                 caller_machine_id,
                 caller_identity,
+                agent_invoke_mode,
                 cwd,
                 ..
             } => Some((
@@ -97,6 +99,7 @@ fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
                 authorizer_provenance.clone(),
                 caller_machine_id.clone(),
                 *caller_identity,
+                *agent_invoke_mode,
                 cwd.clone(),
             )),
             _ => None,
@@ -107,7 +110,8 @@ fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
     assert_eq!(admitted.2, "remote-grant");
     assert_eq!(admitted.3.as_deref(), Some("hm_mac"));
     assert_eq!(admitted.4, Some(CallerIdentityProof::KeyBound));
-    assert_eq!(admitted.5, "/checkout");
+    assert_eq!(admitted.5, Some(RemoteAgentInvokeMode::KeyBound));
+    assert_eq!(admitted.6, "/checkout");
 
     // The absence of a sandbox is stated, not left to be inferred from a
     // missing field, so a reader can tell it apart from an executor that never
@@ -128,6 +132,47 @@ fn an_admitted_invocation_runs_without_a_sandbox_and_records_its_authorizer() {
         backend.1.as_deref(),
         Some("write_unrestricted_trusted_host")
     );
+}
+
+#[test]
+fn a_cooperative_admission_is_audited_as_self_asserted_not_key_bound() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let mut spec = test_agent_loop_spec(Duration::from_secs(10));
+    spec.trusted_host_execution = true;
+    let (audit, _sink) = writer("job-trusted-cooperative");
+    let mut input = admitted_input();
+    input[TRUSTED_HOST_ADMISSION_KEY]["caller_identity"] =
+        serde_json::json!(CallerIdentityProof::SelfAsserted);
+    input[TRUSTED_HOST_ADMISSION_KEY]["agent_invoke_mode"] =
+        serde_json::json!(RemoteAgentInvokeMode::Cooperative);
+
+    run_cli_backend(
+        &host,
+        &spec,
+        "agent_invoke",
+        "job-trusted-cooperative",
+        audit.clone(),
+        &input,
+        None,
+    )
+    .expect("cooperative admission runs");
+
+    let events = audit.events_snapshot().expect("events snapshot");
+    let (identity, mode) = events
+        .iter()
+        .find_map(|event| match &event.kind {
+            V2AuditEventKind::TrustedHostExecutionAdmitted {
+                caller_identity,
+                agent_invoke_mode,
+                ..
+            } => Some((*caller_identity, *agent_invoke_mode)),
+            _ => None,
+        })
+        .expect("trusted-host admission event");
+
+    assert_eq!(identity, Some(CallerIdentityProof::SelfAsserted));
+    assert_eq!(mode, Some(RemoteAgentInvokeMode::Cooperative));
 }
 
 /// The dangerous combination: the asset claims the mode, nothing admitted it.

--- a/crates/orbit-mcp/src/remote/callers.rs
+++ b/crates/orbit-mcp/src/remote/callers.rs
@@ -21,8 +21,11 @@
 //! `--remote-caller-machine-id` is a label the caller chooses, so a caller that
 //! can reach this destination can also name a different row. That is an
 //! accident guard, in keeping with the governance kernel's doctrine — strictly
-//! stronger than a caller-authored grant, and not a boundary anything may be
-//! relaxed against.
+//! stronger than a caller-authored grant, and not an authenticated boundary.
+//! The only trusted-host exception is a destination owner's explicit
+//! operation-specific `cooperative` mode, which accepts that limitation for
+//! operators already sharing the destination OS account and records it
+//! candidly.
 //!
 //! Under Tier 2 [ORB-11053] the destination pins the identity to a key in its
 //! own `authorized_keys`, sshd authenticates that key, and the forced command
@@ -38,7 +41,9 @@ use std::path::{Path, PathBuf};
 use orbit_common::OrbitError;
 use orbit_common::protocol::toml::escape_basic_string;
 use orbit_types::identity::validate_machine_id;
-use orbit_types::tool::{CallerIdentityProof, McpCapability, RemoteCallerGrant};
+use orbit_types::tool::{
+    CallerIdentityProof, McpCapability, RemoteAgentInvokeMode, RemoteCallerGrant,
+};
 use serde::Deserialize;
 
 use super::identity::McpSessionAuthority;
@@ -99,9 +104,15 @@ pub struct CallerRow {
     pub ssh_key_fingerprint: Option<String>,
     /// Explicitly admits `orbit.agent.invoke` for this caller on the row's
     /// narrowed workspaces. Requires operator capability, a workspace
-    /// narrowing, and a key-bound identity.
+    /// narrowing, and a key-bound identity unless the destination explicitly
+    /// selects the cooperative same-account mode below.
     #[serde(default)]
     pub agent_invoke: bool,
+    /// Trust model for `agent_invoke`. Omission preserves strict key-bound
+    /// admission; `cooperative` deliberately accepts the self-asserted caller
+    /// label on the existing SSH operator channel.
+    #[serde(default)]
+    pub agent_invoke_mode: Option<RemoteAgentInvokeMode>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
@@ -218,7 +229,9 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
                     ),
                 ));
             }
-            if row.ssh_key_fingerprint.is_none() {
+            if row.agent_invoke_mode.unwrap_or_default() == RemoteAgentInvokeMode::KeyBound
+                && row.ssh_key_fingerprint.is_none()
+            {
                 return Err(invalid(
                     path,
                     format!(
@@ -228,6 +241,15 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
                     ),
                 ));
             }
+        } else if row.agent_invoke_mode.is_some() {
+            return Err(invalid(
+                path,
+                format!(
+                    "caller '{}' sets `agent_invoke_mode` without enabling `agent_invoke`; the \
+                     mode only qualifies that operation-specific grant",
+                    row.machine_id
+                ),
+            ));
         }
     }
     Ok(())
@@ -343,6 +365,8 @@ pub struct ResolvedCallerGrant {
     /// Whether the matched row explicitly admits trusted-host agent
     /// invocation on its covered workspaces.
     pub agent_invoke: bool,
+    /// Trust mode selected for agent invocation, when it is enabled.
+    pub agent_invoke_mode: Option<RemoteAgentInvokeMode>,
     /// Whether a row matched, or the file default answered.
     pub matched: bool,
 }
@@ -373,6 +397,15 @@ impl ResolvedCallerGrant {
                 (Some(_), None) | (None, _) => false,
             }
     }
+
+    /// The selected trust mode when the operation grant covers `workspace_id`.
+    pub fn agent_invoke_mode_for_workspace(
+        &self,
+        workspace_id: Option<&str>,
+    ) -> Option<RemoteAgentInvokeMode> {
+        self.agent_invoke_for_workspace(workspace_id)
+            .then_some(self.agent_invoke_mode.unwrap_or_default())
+    }
 }
 
 impl CallersFile {
@@ -398,6 +431,7 @@ impl CallersFile {
                 elsewhere: default,
                 workspaces: None,
                 agent_invoke: false,
+                agent_invoke_mode: None,
                 matched: false,
             };
         };
@@ -421,6 +455,9 @@ impl CallersFile {
                 .as_ref()
                 .map(|workspaces| workspaces.iter().cloned().collect()),
             agent_invoke: row.agent_invoke,
+            agent_invoke_mode: row
+                .agent_invoke
+                .then_some(row.agent_invoke_mode.unwrap_or_default()),
             matched: true,
         }
     }
@@ -570,6 +607,7 @@ impl SessionCapabilityPolicy {
             source: CALLERS_FILE_DISPLAY.to_string(),
             identity: grant.identity,
             agent_invoke: grant.agent_invoke_for_workspace(workspace_id),
+            agent_invoke_mode: grant.agent_invoke_mode_for_workspace(workspace_id),
         })
     }
 

--- a/crates/orbit-mcp/src/remote/tests/callers.rs
+++ b/crates/orbit-mcp/src/remote/tests/callers.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use orbit_common::OrbitError;
-use orbit_types::tool::{McpCapability, ToolSessionContext};
+use orbit_types::tool::{McpCapability, RemoteAgentInvokeMode, ToolSessionContext};
 
 use orbit_types::tool::CallerIdentityProof;
 
@@ -263,11 +263,49 @@ agent_invoke = true
         .expect("remote grant on workspace");
     assert!(on_workspace.agent_invoke);
     assert_eq!(on_workspace.identity, CallerIdentityProof::KeyBound);
+    assert_eq!(
+        on_workspace.agent_invoke_mode,
+        Some(RemoteAgentInvokeMode::KeyBound),
+        "omitting the new mode must preserve the original strict behavior"
+    );
 
     let elsewhere = policy
         .grant_for(Some("ws_other"))
         .expect("remote grant outside narrowing");
     assert!(!elsewhere.agent_invoke);
+    assert!(policy.effective_for(Some("ws_other")).is_empty());
+}
+
+#[test]
+fn cooperative_agent_invoke_is_explicit_and_workspace_scoped() {
+    let (_dir, path) = write(
+        r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_beta"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_orbit"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+"#,
+    );
+    let file = load_callers(&path).expect("cooperative invocation grant");
+    let policy = SessionCapabilityPolicy::from_grant(
+        McpSessionAuthority::Operator,
+        file.resolve(&caller("hm_beta")),
+    );
+
+    let on_workspace = policy.grant_for(Some("ws_orbit")).expect("remote grant");
+    assert_eq!(on_workspace.identity, CallerIdentityProof::SelfAsserted);
+    assert_eq!(
+        on_workspace.agent_invoke_mode,
+        Some(RemoteAgentInvokeMode::Cooperative)
+    );
+
+    let elsewhere = policy.grant_for(Some("ws_other")).expect("remote grant");
+    assert!(!elsewhere.agent_invoke);
+    assert_eq!(elsewhere.agent_invoke_mode, None);
     assert!(policy.effective_for(Some("ws_other")).is_empty());
 }
 
@@ -309,6 +347,29 @@ agent_invoke = true
 "#
             .to_string(),
             "ssh_key_fingerprint",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_orbit"]
+agent_invoke_mode = "cooperative"
+"#
+            .to_string(),
+            "without enabling `agent_invoke`",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+workspaces = ["ws_orbit"]
+agent_invoke = true
+agent_invoke_mode = "invented"
+"#
+            .to_string(),
+            "unknown variant",
         ),
     ] {
         let (_dir, path) = write(&contents);

--- a/crates/orbit-tools/src/builtin/orbit/agent.rs
+++ b/crates/orbit-tools/src/builtin/orbit/agent.rs
@@ -74,8 +74,10 @@ impl Tool for OrbitAgentInvokeTool {
                  its run ID. The agent runs on the host outside Orbit's filesystem sandbox, as \
                  the same OS user as Orbit, so it can reach anything that user can; it is \
                  admitted per invocation and requires operator capability. Remote callers also \
-                 require a destination-issued key-bound identity and an explicit workspace-scoped \
-                 `agent_invoke` grant. Track it with \
+                 require an explicit destination-owned, workspace-scoped `agent_invoke` grant; \
+                 its default mode requires a key-bound identity, while an explicit cooperative \
+                 mode trusts the same-OS-account SSH operator channel and records identity as \
+                 self-asserted. Track it with \
                  `orbit.workflow.run.show`, read output with `orbit run logs <RUN_ID>`, and stop \
                  it with `orbit run cancel <RUN_ID>`. It changes no task, opens no pull request, \
                  and dispatches nothing."

--- a/crates/orbit-types/src/tool/definition.rs
+++ b/crates/orbit-types/src/tool/definition.rs
@@ -155,6 +155,38 @@ pub struct RemoteCallerGrant {
     /// not imply permission to start an unsandboxed provider process remotely.
     #[serde(default)]
     pub agent_invoke: bool,
+    /// Destination-selected trust mode for [`Self::agent_invoke`]. `None`
+    /// preserves the original strict key-bound behavior for older envelopes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_invoke_mode: Option<RemoteAgentInvokeMode>,
+}
+
+/// Trust model a destination selected for remote trusted-host invocation.
+///
+/// This is operation-specific rather than a property of the whole caller row:
+/// ordinary remote operator operations keep their existing authorization, and
+/// enabling the cooperative mode does not make a self-asserted identity
+/// key-bound.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum RemoteAgentInvokeMode {
+    /// Require the destination-issued forced-command identity introduced with
+    /// the original remote agent-invocation grant.
+    #[default]
+    KeyBound,
+    /// Trust the existing SSH OS-account/operator channel while recording the
+    /// caller machine ID as self-asserted. This is an accident-prevention
+    /// boundary between cooperating users of the same account, not isolation.
+    Cooperative,
+}
+
+impl Display for RemoteAgentInvokeMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::KeyBound => "key-bound",
+            Self::Cooperative => "cooperative",
+        })
+    }
 }
 
 /// How a destination established the caller identity it resolved a grant for.

--- a/crates/orbit-types/src/tool/mod.rs
+++ b/crates/orbit-types/src/tool/mod.rs
@@ -6,7 +6,7 @@ pub use error::ToolError;
 
 pub use definition::{
     CallerIdentityProof, ExecutionResult, McpCapability, McpToolDefinition, McpToolDefinitionError,
-    McpToolScope, McpTransport, RemoteCallerGrant, StoredTool, ToolParam, ToolSchema,
-    ToolSessionContext, is_exact_canonical_tool_name, mcp_advertised_tool_name,
+    McpToolScope, McpTransport, RemoteAgentInvokeMode, RemoteCallerGrant, StoredTool, ToolParam,
+    ToolSchema, ToolSessionContext, is_exact_canonical_tool_name, mcp_advertised_tool_name,
     validate_mcp_tool_definitions,
 };

--- a/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
+++ b/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
@@ -200,6 +200,9 @@ pub enum V2AuditEventKind {
         /// How the destination established the remote caller identity.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         caller_identity: Option<crate::tool::CallerIdentityProof>,
+        /// Destination-selected trust mode for the remote invocation grant.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        agent_invoke_mode: Option<crate::tool::RemoteAgentInvokeMode>,
         /// RFC 3339 timestamp the admission was stamped.
         authorized_at: String,
         /// Canonical checkout the invocation was admitted against.

--- a/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/tests/trusted_host.rs
@@ -11,6 +11,7 @@ fn admission() -> TrustedHostAdmission {
         authorizer_provenance: "interactive-terminal".to_string(),
         caller_machine_id: None,
         caller_identity: None,
+        agent_invoke_mode: None,
         authorized_at: "2026-09-06T00:00:00Z".to_string(),
         workspace_path: "/checkout".to_string(),
         cwd: "/checkout/crates".to_string(),

--- a/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
+++ b/crates/orbit-types/src/workflow/activity_job/trusted_host.rs
@@ -32,7 +32,7 @@
 //! definition that declares the flag without an admission fails closed rather
 //! than degrading to a sandboxed run, so a broken admission path is loud.
 
-use crate::tool::CallerIdentityProof;
+use crate::tool::{CallerIdentityProof, RemoteAgentInvokeMode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -59,13 +59,19 @@ pub struct TrustedHostAdmission {
     /// (`interactive-terminal`, `operator-override`, `session`).
     pub authorizer_provenance: String,
     /// Destination-resolved remote caller identity, when this admission came
-    /// through authenticated SSH MCP rather than a local operator surface.
+    /// through SSH MCP rather than a local operator surface. The separate
+    /// proof and mode fields state whether that identity was authenticated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_machine_id: Option<String>,
-    /// Strength of the remote identity proof. Remote admission requires
-    /// `key-bound`; it is retained so the durable run proves that decision.
+    /// Strength of the remote identity proof. It is retained independently of
+    /// the operation's trust mode so cooperative/self-asserted and key-bound
+    /// admissions cannot be confused in the durable run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caller_identity: Option<CallerIdentityProof>,
+    /// Destination-selected remote invocation trust mode. Absent for local
+    /// operator admissions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_invoke_mode: Option<RemoteAgentInvokeMode>,
     /// RFC 3339 timestamp of the admission.
     pub authorized_at: String,
     /// Canonical workspace checkout the invocation was admitted against.

--- a/docs/design/federated-mcp/specs/caller-authorization.md
+++ b/docs/design/federated-mcp/specs/caller-authorization.md
@@ -1,7 +1,7 @@
 ---
 type: design
-summary: "Spec: destination-side caller authorization — the callers file (Tier 1), requested-vs-granted authority, and key-bound caller identity via an authorized_keys forced command (Tier 2). Both shipped."
-last_validated: 2026-09-04
+summary: "Spec: destination-side caller authorization — the callers file (Tier 1), explicit cooperative host invocation, and key-bound caller identity via an authorized_keys forced command (Tier 2)."
+last_validated: 2026-09-07
 title: Spec — Destination-side caller authorization
 owner: claude
 status: Draft
@@ -59,6 +59,14 @@ machine_id   = "hm_beta"
 capabilities = ["agent", "operator"]
 workspaces   = ["ws_orbit", "ws_constellation"]
 ssh_key_fingerprint = "SHA256:…"
+agent_invoke = true
+
+[[callers]]
+machine_id   = "hm_cooperative"
+capabilities = ["agent", "operator"]
+workspaces   = ["ws_orbit"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
 
 [[callers]]
 machine_id   = "hm_gamma"
@@ -74,6 +82,8 @@ Row keys:
 | `label` | no | Operator-facing display name. Never an identity input. |
 | `workspaces` | no | Narrows the grant to these logical `ws_*` IDs. Omitted means every workspace on this destination. |
 | `ssh_key_fingerprint` | no | Binds the row to a key sshd authenticated, in the `SHA256:…` form `ssh-keygen -l` prints. See Tier 2. |
+| `agent_invoke` | no | Explicitly grants remote trusted-host agent invocation on the listed workspaces. Requires `operator` and a workspace list. |
+| `agent_invoke_mode` | no | Trust model for `agent_invoke`: omitted or `key-bound` preserves strict Tier-2 admission; `cooperative` accepts the existing same-OS-account SSH operator channel while retaining a self-asserted identity proof. Invalid without `agent_invoke = true`. |
 
 File-level invariants:
 
@@ -82,6 +92,7 @@ File-level invariants:
 3. An unknown key, an unknown capability value, an empty `capabilities`, a `default` other than `agent` or `deny`, a malformed `machine_id`, or an `ssh_key_fingerprint` that is not a well-formed `SHA256:` digest invalidates the file at load. A malformed file is never served as if absent. The fingerprint format is checked here rather than at comparison time because a fingerprint in the wrong shape — an `MD5:` one, most plausibly — would otherwise never match and would present as a key mismatch on every session.
 4. `runner` is not a grantable value. It is stamped in-process by a managed run and can never arrive over a transport.
 5. Load happens once per server process, at startup, alongside identity resolution. A session's ceiling does not change under it mid-session.
+6. `agent_invoke = true` additionally requires `operator` and an explicit `workspaces` list. Its default/key-bound mode also requires `ssh_key_fingerprint`. `agent_invoke_mode = "cooperative"` is the only mode that may omit the fingerprint; an unknown mode or a mode without the operation grant invalidates the file.
 
 ## Remote origination is decided by the destination, not by argv
 
@@ -113,6 +124,32 @@ Invariants:
 3. **`default = "deny"` yields the empty set**, and every governed operation therefore refuses, along with every ungoverned tool that requires `agent`. Ambiguity fails closed, matching `CallerCapabilities::resolve`.
 4. **A `workspaces` narrowing is evaluated per call**, against the resolved workspace of that call, not at session establishment. A session may hold `operator` for one workspace and `agent` for another on the same destination. Outside the listed workspaces the row falls back to the file `default`, not to a fixed `agent` — otherwise a narrowed row under `default = "deny"` would grant more elsewhere than the file's own floor. A call that resolves no workspace takes the unnarrowed grant; every governed operation is workspace-scoped, so such a call is a discovery call the narrowing has nothing to say about.
 5. **Resolution is session-only.** The MCP chokepoint's `CapabilityResolution::SessionOnly` is unchanged: `ORBIT_OPERATOR` in the destination's environment stays inert on the MCP surface, and must not become a way to re-raise a session the callers file capped.
+
+## Operation-specific remote agent invocation
+
+Remote trusted-host invocation adds admission rules after ordinary capability
+resolution. Every remote caller needs `operator`, `agent_invoke = true`, and a
+row narrowed to the resolved logical workspace. The file default never grants
+the operation, the admission covers one invocation, the timeout remains
+bounded, ordinary job input cannot supply the reserved admission, and a run
+carrying an admission cannot be resumed.
+
+Omitting `agent_invoke_mode` preserves the shipped strict behavior: the row
+must pin a fingerprint and the session's identity proof must be `key-bound`.
+The destination owner may instead declare `agent_invoke_mode = "cooperative"`.
+That mode trusts the existing non-interactive SSH operator channel under one OS
+account. It is useful where the cooperating remote operator already has the
+same shell authority as Orbit and Tier-2's dedicated account, root-managed
+authorized keys, and protected launcher would not add isolation required by
+the workflow.
+
+Cooperative mode is deliberately candid about its boundary. The caller's
+`machine_id` remains self-asserted and another peer able to use the same SSH
+account can name the row. The mode is an accident-prevention policy among
+cooperating same-account operators, not protection from a malicious peer who
+already controls that account's files and processes. It must never stamp or be
+reported as `key-bound`, and it does not relax authorization for other
+operations or workspaces.
 
 ## Tier 2: key-bound caller identity
 
@@ -151,7 +188,7 @@ The rendered line carries `no-pty,no-port-forwarding,no-agent-forwarding,no-X11-
 1. A denial names the file, the resolved caller, and the requirement: `caller 'hm_alpha' is granted [agent] by ~/.orbit/mcp-callers.toml on the machine that executes this call; 'orbit.command.exec' requires operator`. A refused caller must be able to act on the message without reading Orbit's source, and must not be advised a remedy it cannot reach — neither `ORBIT_OPERATOR` nor `--operator` on the calling side raises this ceiling.
 2. A new `CallerProvenance::RemoteGrant` distinguishes "the destination's callers file granted this" from a local `Session` stamp. Provenance is recorded, never discarded, so the trail can separate the two.
 3. The audit envelope records the resolved caller identity, the granted set, and the effective set. Recording only the effective set would make a downgrade indistinguishable from a caller that never asked. On the `command = 'authorization'` row the effective set is `capabilities_json` and `subcommand` is the provenance (`remote-grant`); the caller, granted set, file, and `caller_identity` are recorded together in `arguments_json`.
-4. `caller_identity` is `key-bound` or `self-asserted`, and it is what keeps the two tiers apart in the trail. Both tiers produce a grant that looks identical once resolved, so a trail recording only the grant would leave a reader to assume whether the caller had to hold a key to select the row.
+4. `caller_identity` is `key-bound` or `self-asserted`, and it is what keeps the two identity tiers apart in the trail. For trusted-host invocation, `agent_invoke_mode` independently records `key-bound` or `cooperative`; the durable admission and `trusted_host.execution_admitted` event retain both fields, the destination workspace, the authorizing operator, and the per-invocation working directory/bound. Recording only the grant or only the mode would leave a reader to assume how the caller was identified.
 5. `orbit mcp callers list` prints the loaded rows and the default. `orbit mcp callers check <machine_id>` prints what a session from that caller would resolve to, without serving one, and says whether the row is key-bound or selected by a name alone.
 6. Caller authorization is decided at **session establishment**, and the per-call `workspaces` narrowing at the existing governance chokepoint. Neither enters the routing precedence ladder in [federated-workspace-mcp.md](./federated-workspace-mcp.md), which classifies calls that have already been admitted.
 
@@ -174,4 +211,4 @@ A missing callers file must not silently preserve today's behavior, because toda
 
 ## Agent Signature
 
-Drafted by claude, 2026-08-29, from a read of `crates/orbit-mcp/src/remote/identity.rs`, `crates/orbit-mcp/src/federated/`, `crates/orbit-cli/src/command/mcp/`, and `crates/orbit-common/src/governance/authorization.rs`. Tier 1 implemented by claude, 2026-08-29 [ORB-11052]; the decision entry is [An MCP session's authority is declared by the destination, not requested by the caller](../4_decisions.md#an-mcp-sessions-authority-is-declared-by-the-destination-not-requested-by-the-caller). Tier 2 implemented by claude, 2026-08-29 [ORB-11053] in `crates/orbit-mcp/src/remote/ssh_auth.rs`, with its pre-userspace launch boundary corrected by codex, 2026-09-04 [ORB-11184] and demonstrated in `crates/orbit-cli/tests/mcp_roundtrip.rs`; its decision entry is [A caller identity is only as strong as the key sshd checked for it](../4_decisions.md#a-caller-identity-is-only-as-strong-as-the-key-sshd-checked-for-it).
+Drafted by claude, 2026-08-29, from a read of `crates/orbit-mcp/src/remote/identity.rs`, `crates/orbit-mcp/src/federated/`, `crates/orbit-cli/src/command/mcp/`, and `crates/orbit-common/src/governance/authorization.rs`. Tier 1 implemented by claude, 2026-08-29 [ORB-11052]; the decision entry is [An MCP session's authority is declared by the destination, not requested by the caller](../4_decisions.md#an-mcp-sessions-authority-is-declared-by-the-destination-not-requested-by-the-caller). Tier 2 implemented by claude, 2026-08-29 [ORB-11053] in `crates/orbit-mcp/src/remote/ssh_auth.rs`, with its pre-userspace launch boundary corrected by codex, 2026-09-04 [ORB-11184] and demonstrated in `crates/orbit-cli/tests/mcp_roundtrip.rs`; its decision entry is [A caller identity is only as strong as the key sshd checked for it](../4_decisions.md#a-caller-identity-is-only-as-strong-as-the-key-sshd-checked-for-it). The operation-specific cooperative SSH mode and its truthful audit provenance were implemented by codex, 2026-09-07 [ORB-11496].

--- a/docs/runbooks/stuck-job-runs.md
+++ b/docs/runbooks/stuck-job-runs.md
@@ -149,7 +149,9 @@ Three differences matter when triaging one:
   denial is never the explanation for one failing, and the admission is recorded as a
   `trusted_host.execution_admitted` audit event naming the authorizing operator, the
   workspace, and the working directory. Remote admissions also retain the
-  destination-resolved caller machine ID and key-bound identity proof.
+  destination-resolved caller machine ID, invocation mode, and actual identity proof:
+  strict grants are `key-bound`; explicitly cooperative same-OS-account SSH grants are
+  `cooperative` and `self-asserted`.
 - **Cancel it the ordinary way.** `orbit run cancel <run_id>` signals the owner process
   (TERM then KILL) and terminates the process tree, exactly as for any other run.
 - **It cannot be resumed.** `orbit job resume` and `submit_resume_run` refuse a run that

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -135,8 +135,9 @@ explicit per-invocation operator admission, so a sandbox-denial diagnostic is
 never the explanation for one failing. The run trail records the admission as a
 `trusted_host.execution_admitted` audit event naming the authorizing operator
 and the working directory. For remote admission it also records the
-destination-resolved caller machine ID and key-bound identity proof. They are
-deliberately **not resumable**: the
+destination-resolved caller machine ID, remote invocation mode, and actual
+identity proof. A cooperative grant is recorded as `cooperative` plus
+`self-asserted`, never as key-bound. They are deliberately **not resumable**: the
 admission covered one invocation, so submit a new one rather than resuming.
 
 For recurring signatures and known remedies, read [common-failures.md](common-failures.md) after the initial classification — keep this file focused on investigation flow; add new patterns there.

--- a/plugin/skills/orbit/references/setup/remote-access.md
+++ b/plugin/skills/orbit/references/setup/remote-access.md
@@ -79,8 +79,9 @@ workflow tool is absent or denied; do not treat changing remote argv as a fix.
 ### Remote host-agent invocation
 
 Remote `orbit_agent_invoke` is a narrower grant than remote operator access.
-The destination accepts it only for a key-bound SSH MCP identity, and only when
-the matched caller row explicitly enables the operation on named workspaces:
+The matched caller row must explicitly enable the operation on named
+workspaces and grant operator capability. Omission of `agent_invoke_mode`
+preserves the strict key-bound mode:
 
 ```toml
 default = "deny"
@@ -94,19 +95,51 @@ ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
 agent_invoke = true
 ```
 
-All four restrictions are required: operator capability, an explicit workspace
-list, a pinned SSH key, and `agent_invoke = true`. The file default can never
-grant this operation. Generate and install the destination-issued forced
-command with `orbit mcp callers authorize`, then reconnect the MCP session so
-it resolves the current policy. `orbit mcp callers check <caller-machine-id>`
-shows the configured scope. To revoke, remove the row or set
+The destination can instead opt one row into the existing cooperative SSH
+operator channel without Tier-2 infrastructure:
+
+```toml
+default = "deny"
+
+[[callers]]
+machine_id = "<caller-machine-id>"
+label = "<display-name>"
+capabilities = ["agent", "operator"]
+workspaces = ["<allowed-workspace-id>"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+```
+
+This is an explicit destination-owner statement that callers using the same
+SSH OS account cooperate. The machine ID remains self-asserted: any peer able
+to start the same non-interactive SSH operator session can name another row.
+The policy prevents accidental use and limits Orbit's admission to the named
+workspace and one invocation; it does not isolate mutually malicious peers who
+share the account and already control that account's files and processes.
+Never describe a cooperative admission as key-bound.
+
+For either mode, install the updated Orbit binary on the destination, review
+and edit `~/.orbit/mcp-callers.toml` there, run `orbit mcp callers check
+<caller-machine-id>`, then close and recreate the calling MCP connection. A
+live session keeps the policy loaded at establishment. For strict mode, first
+generate and install the destination-issued forced command with `orbit mcp
+callers authorize`. To revoke either mode, remove the row or set
 `agent_invoke = false`, then reconnect; the next invocation is denied.
 
-This is an authenticated caller and an accident-resistant admission path, not
-process isolation. The invoked provider still runs outside Orbit's filesystem
-sandbox as the same operating-system user as the destination Orbit process and
-can access everything that user can. Keep the prompt read-only when that is the
-intent; a tool declaration does not confine the provider's own shell.
+After reconnecting, a minimal smoke is one short, read-only invocation with an
+explicit destination workspace selector, checkout `cwd`, bounded timeout, and
+the configured Luna crew. Ask it to report one harmless fact and explicitly not
+to modify files or start other work. Verify the submission and
+`trusted_host.execution_admitted` event report `agent_invoke_mode = "cooperative"`
+with `caller_identity = "self-asserted"` (or both fields as `key-bound` in
+strict mode), and verify the run reaches a terminal state.
+
+Strict mode is an authenticated caller and accident-resistant admission path;
+neither mode is process isolation. The invoked provider runs outside Orbit's
+filesystem sandbox as the same operating-system user as the destination Orbit
+process and can access everything that user can. Keep the prompt read-only when
+that is the intent; a tool declaration does not confine the provider's own
+shell.
 
 There are two identity strengths. Ordinary SSH proxy identity is a self-asserted
 audit label, suitable for cooperative operators with shell access; it is not

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -73,10 +73,12 @@ What it is not:
 - It is **not** a task, and it performs no task transition. It does not commit,
   push, open or merge a pull request, or dispatch further work.
 - It is **not** available to a managed run. A local operator may admit one
-  directly. A remote operator may admit one only through a destination-issued,
-  key-bound SSH MCP identity whose callers-file row explicitly enables
-  `agent_invoke` for the resolved workspace. Ordinary remote `operator`
-  capability is not enough. Each admission covers one invocation only.
+  directly. A remote operator also needs a callers-file row that explicitly
+  enables `agent_invoke` for the resolved workspace. The omitted mode requires
+  a destination-issued key-bound SSH identity; an explicit `cooperative` mode
+  instead trusts the existing same-OS-account SSH operator channel and records
+  its machine ID as self-asserted. Ordinary remote `operator` capability is not
+  enough. Each admission covers one invocation only.
 - It is **not** resumable. A resumed run would carry an admission nobody granted
   now; submit a new invocation instead.
 
@@ -94,9 +96,10 @@ the exit code alone is never evidence the investigation succeeded.
 
 Remote sessions are additionally capped by the destination's caller policy.
 The durable admission and `trusted_host.execution_admitted` event retain the
-destination-resolved caller machine ID, its key-bound identity proof, the
-workspace checkout, and cwd. See [remote-access.md](setup/remote-access.md). Do
-not relaunch a server with more privileges to work around a denied call.
+destination-resolved caller machine ID, the invocation mode, the actual
+identity proof (`key-bound` or `self-asserted`), the workspace checkout, and
+cwd. See [remote-access.md](setup/remote-access.md). Do not relaunch a server
+with more privileges to work around a denied call.
 
 ## Common MCP arguments
 

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -74,7 +74,7 @@ not a rewrite of failed history.
 | `ci_failure_sweep_pipeline` | File GitHub Actions findings as proposed, pilot them, and admit only current warning-free repairs to backlog; never implements them. |
 | `dependabot_alert_sweep_pipeline` | Collect Dependabot/code/secret-scanning evidence and file remediation tasks. |
 | `worktree_gc_pipeline` | Reclaim settled worktrees. |
-| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit key-bound remote callers-file grant, changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
+| `agent_invoke_pipeline` | One operator-admitted agent invocation for exploration or debugging, run on the host outside the executor sandbox. Submit it with `orbit run agent` / `orbit_agent_invoke`, never `orbit run job`: it needs a per-invocation local admission or an explicit workspace-scoped remote callers-file grant (strict key-bound by default, or explicitly cooperative on a same-account SSH operator channel), changes no task, and is not resumable. See [tool-surface.md](tool-surface.md). |
 
 Inspect any of them with `orbit job show <id>` before invoking — the step list is
 the contract.


### PR DESCRIPTION
## Task

[ORB-11496](https://orbit-cli.com/tasks/ORB-11496) — Support an explicit cooperative SSH operator grant for remote agent invocation

### Description

Follow-up to ORB-11492/PR1491, source e03f23aa7edc8dfe3fe591f67139a34cfa73944c. Daniel requests agent_invoke from his Mac executing on dk-server-1, explicitly grants full approval, and asks the orchestrator to use best judgment while he is preoccupied. Live destination setup has a caller row hm_ba054a1a8fbfb914 labeled Daniels-Mac-mini.local with capabilities [agent, operator], no workspace narrowing/key fingerprint/agent_invoke flag, and no dedicated Orbit login account. Current connection uses the existing trusted SSH/operator path. ORB-11492 requires Tier-2 key binding, which entails a new login account/root-managed authorized keys/setgid launcher and reconnect; that operational requirement is not inherent in the requested cooperative same-OS-account workflow. The orchestrator asked an optional preference and, after several minutes without an answer, selected the existing trusted SSH/operator connection as the stated default. Do not describe this as Daniel explicitly choosing a weaker identity mode.

Extend the existing per-caller invocation policy to allow an explicitly opted-in cooperative SSH operator mode for named workspaces. Preserve the strict key-bound mode from ORB-11492; ordinary agent_invoke=true/key-bound behavior and ungranted remote denials must not silently broaden. The destination owner must explicitly declare trust in the existing SSH OS-account/operator channel for this caller row; default/omitted mode remains strict. This cooperative mode does not cryptographically authenticate machine_id: record actual self-asserted identity proof and trustworthy SSH/account boundary candidly, never label it key-bound or infer a real model from the caller. Same-account shell operators already control host resources; this policy is an accident-prevention boundary within that cooperative trust model, not isolation against malicious peers sharing the account.

Require current operator capability, explicit workspace allowlist and per-operation grant/mode, per-invocation admission, bounded timeout and unchanged task/run protections. Managed/agent callers, ungranted rows, wrong workspace, malformed policy, ordinary job inputs and resume remain denied. Preserve existing key-bound guarantees and truthful audit/result provenance. Avoid a new authorization subsystem, wrappers or spoofed local identity. Do not configure production caller policy inside the implementation worker; provide exact minimal reviewed configuration and reconnect procedure for the orchestrator after source delivery. Do not change global default policy or grant unrelated workspaces. Live smoke uses the actual Mac MCP connection and Luna read-only prompt after installation/reconnect. Source delivery authorized to agent-main with --complete; no release/main promotion.

### Acceptance Criteria

- An explicit destination-owned cooperative SSH/operator invocation mode permits the scoped trusted remote operator while the default remains strict and existing key-bound mode remains unchanged.
- Tests verify managed/agent, ungranted, wrong-workspace, malformed-policy, reserved-input and resume denials; no caller-provided local/key-bound identity spoofing is accepted.
- Audit and run output truthfully identify cooperative/self-asserted identity separately from key-bound identity and preserve destination workspace, operator authority and per-invocation bounds.
- Current docs and minimal deployment example explain the same-OS-account trust boundary without requiring Tier-2 infrastructure for cooperative mode; owning checks plus ci-fast/ci-lint pass.
- Preserve existing general caller/operator access independently of the invocation workspace grant: enabling invocation only for ws_orbit must neither grant invocation to unrelated workspaces nor revoke previously allowed ordinary operator access there.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added destination-owned `agent_invoke_mode = "cooperative"` for caller rows that also grant operator, explicitly enable `agent_invoke`, and name allowed workspaces. Omitted mode remains strict/key-bound and still requires a pinned key; existing key-bound admission is unchanged.
- Carried the resolved invocation mode beside the actual caller identity proof through remote grants, authorization evidence, durable trusted-host admission, tool output, tracing, and `trusted_host.execution_admitted` audit events.
- Added caller-policy, admission, engine-audit, and real MCP roundtrip coverage for cooperative success plus existing strict/default, agent/managed-run, ungranted, wrong-workspace, malformed-policy, reserved-input, resume, caller-identity, and copied-fingerprint denials.
- Updated canonical and plugin skill guidance, tool schema snapshot, CLI diagnostics, the stuck-run runbook, and the caller-authorization design spec with the same-OS-account trust boundary, minimal reviewed config, reconnect/revocation procedure, and deferred read-only Luna smoke.
- Added `file:crates/orbit-types/src/tool/mod.rs` to task scope because the shared invocation-mode contract must be exported from its owning module.

Acceptance criteria:
1. Explicit cooperative mode: satisfied by `RemoteAgentInvokeMode`, fail-closed caller-file validation, workspace-scoped grant stamping, and canonical admission; omitted/legacy `agent_invoke = true` resolves to key-bound.
2. Denials and spoof resistance: satisfied by unit and MCP roundtrip coverage; caller argv cannot claim local/key-bound proof, managed/agent and runner grants cannot admit, and ordinary/resume/reserved paths remain refused.
3. Truthful provenance and bounds: satisfied; cooperative runs report `agent_invoke_mode = "cooperative"` and `caller_identity = "self-asserted"`, strict runs report key-bound, while destination workspace/cwd/operator attribution and timeout bounds remain in durable run/audit output.
4. Documentation and checks: satisfied in canonical/plugin mirrors, remote-access example, design spec, runbook, and advertised tool text.

Validation:
- PASSED: `cargo test -p orbit-mcp remote::tests::callers --no-fail-fast` (23 tests).
- PASSED: `cargo test -p orbit-core application::job::tests::agent_invoke --no-fail-fast` (22 tests).
- PASSED: `cargo test -p orbit-common governance::tests::authorization --no-fail-fast` (19 tests).
- PASSED: `cargo test -p orbit-types workflow::activity_job::tests::trusted_host --no-fail-fast` (6 tests).
- PASSED: `cargo test -p orbit-engine activity_job::cli_runner::tests::trusted_host --no-fail-fast` (7 tests).
- PASSED: `cargo test -p orbit-cli --test mcp_roundtrip --no-fail-fast` (50 tests, including cooperative end-to-end, key-bound preservation, wrong-workspace, ungranted, and identity-spoof coverage).
- PASSED: `make ci-fast`.
- PASSED: `make ci-lint`.
- PASSED: `git diff --check`.
- Initial focused cooperative roundtrip failed because the fixture selected an unmatched host-default crew; the test was corrected to select the seeded `system` crew, then the focused and full roundtrip suites passed.

Assessment: The change adds one operation-specific policy seam and reuses existing caller resolution/admission boundaries; it does not add an authorization subsystem or broaden defaults.

Remaining risks / deviations:
- NOT RUN: live Mac-to-dk-server-1 Luna smoke, installation, production caller-file edit, and reconnect. The task explicitly reserves those post-source delivery operations for the orchestrator; current docs provide the exact cooperative row and reconnect verification procedure.
- No production policy or global default was changed. No commit was created; pipeline delivery owns commit and review transition.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11496-6a9e502c`
- Behind base: 0
- Ahead of base: 1