### PR TITLE
Scope remote agent invocation independently of ordinary caller access

### DIFF
--- a/crates/orbit-cli/src/command/mcp/callers.rs
+++ b/crates/orbit-cli/src/command/mcp/callers.rs
@@ -142,6 +142,9 @@ fn list(path: &Path) -> CommandOut {
         if let Some(workspaces) = &row.workspaces {
             println!("    workspaces: {}", workspaces.join(", "));
         }
+        if let Some(workspaces) = &row.agent_invoke_workspaces {
+            println!("    agent_invoke_workspaces: {}", workspaces.join(", "));
+        }
         if let Some(fingerprint) = &row.ssh_key_fingerprint {
             println!("    ssh_key_fingerprint: {fingerprint}");
         }
@@ -202,20 +205,19 @@ fn check(path: &Path, machine_id: &str) -> CommandOut {
             capability_list(&grant.elsewhere)
         );
     }
-    println!(
-        "agent_invoke: {}",
-        match grant.agent_invoke_mode {
-            Some(RemoteAgentInvokeMode::KeyBound) => {
-                "configured for the listed workspaces in key-bound mode; admission requires a \
-                 destination-issued forced-command session"
-            }
-            Some(RemoteAgentInvokeMode::Cooperative) => {
-                "configured for the listed workspaces in cooperative mode; identity remains \
-                 self-asserted and the SSH OS-account/operator channel is the trust boundary"
-            }
-            None => "not granted",
-        }
-    );
+    match (&grant.agent_invoke_workspaces, grant.agent_invoke_mode) {
+        (Some(workspaces), Some(RemoteAgentInvokeMode::KeyBound)) => println!(
+            "agent_invoke: configured for {} in key-bound mode; admission requires a \
+             destination-issued forced-command session",
+            workspaces.iter().cloned().collect::<Vec<_>>().join(", ")
+        ),
+        (Some(workspaces), Some(RemoteAgentInvokeMode::Cooperative)) => println!(
+            "agent_invoke: configured for {} in cooperative mode; identity remains self-asserted \
+             and the SSH OS-account/operator channel is the trust boundary",
+            workspaces.iter().cloned().collect::<Vec<_>>().join(", ")
+        ),
+        _ => println!("agent_invoke: not granted"),
+    }
     // Both requests, because the grant is a ceiling and the caller's argv is
     // the other half of the intersection: printing only one would read as the
     // answer to a question the caller did not ask.

--- a/crates/orbit-cli/tests/mcp_roundtrip.rs
+++ b/crates/orbit-cli/tests/mcp_roundtrip.rs
@@ -1364,13 +1364,18 @@ default = "deny"
 [[callers]]
 machine_id = "hm_caller"
 capabilities = ["agent", "operator"]
-workspaces = ["ws_wrong"]
 ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
 agent_invoke = true
+agent_invoke_workspaces = ["ws_wrong"]
 "#,
         ),
     );
     let mut wrong_workspace = workspace.serve_with_generated_command(&generated);
+    assert_eq!(
+        wrong_workspace.call_tool_ok("orbit_workflow_run_list", json!({}))["items"],
+        json!([]),
+        "the invocation-only scope must not reduce ordinary operator access"
+    );
     let denied = wrong_workspace.call_tool_err(
         "orbit_agent_invoke",
         json!({
@@ -1391,9 +1396,9 @@ default = "deny"
 [[callers]]
 machine_id = "hm_caller"
 capabilities = ["agent", "operator"]
-workspaces = ["{workspace_id}"]
 ssh_key_fingerprint = "{CALLER_KEY_FINGERPRINT}"
 agent_invoke = true
+agent_invoke_workspaces = ["{workspace_id}"]
 "#,
         ),
     );
@@ -1512,9 +1517,9 @@ default = "deny"
 [[callers]]
 machine_id = "hm_caller"
 capabilities = ["agent", "operator"]
-workspaces = ["{workspace_id}"]
 agent_invoke = true
 agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["{workspace_id}"]
 "#,
         ),
     );

--- a/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/remote-access.md
@@ -90,9 +90,9 @@ default = "deny"
 machine_id = "<caller-machine-id>"
 label = "<display-name>"
 capabilities = ["agent", "operator"]
-workspaces = ["<allowed-workspace-id>"]
 ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
 agent_invoke = true
+agent_invoke_workspaces = ["<invocation-workspace-id>"]
 ```
 
 The destination can instead opt one row into the existing cooperative SSH
@@ -105,9 +105,9 @@ default = "deny"
 machine_id = "<caller-machine-id>"
 label = "<display-name>"
 capabilities = ["agent", "operator"]
-workspaces = ["<allowed-workspace-id>"]
 agent_invoke = true
 agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["<invocation-workspace-id>"]
 ```
 
 This is an explicit destination-owner statement that callers using the same
@@ -117,6 +117,21 @@ The policy prevents accidental use and limits Orbit's admission to the named
 workspace and one invocation; it does not isolate mutually malicious peers who
 share the account and already control that account's files and processes.
 Never describe a cooperative admission as key-bound.
+
+`agent_invoke_workspaces` is independent from ordinary `workspaces`. When a
+caller already has general operator access, add the operation scope without
+narrowing that access. Leave its existing capabilities and absent `workspaces`
+unchanged, then add only:
+
+```toml
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["ws_orbit"]
+```
+
+Omitting `agent_invoke_workspaces` preserves the older behavior where
+`workspaces` is also the invocation scope. Empty, malformed, or unknown scope
+shapes fail closed.
 
 For either mode, install the updated Orbit binary on the destination, review
 and edit `~/.orbit/mcp-callers.toml` there, run `orbit mcp callers check

--- a/crates/orbit-mcp/src/remote/callers.rs
+++ b/crates/orbit-mcp/src/remote/callers.rs
@@ -102,12 +102,14 @@ pub struct CallerRow {
     /// not evidence of a mismatch.
     #[serde(default)]
     pub ssh_key_fingerprint: Option<String>,
-    /// Explicitly admits `orbit.agent.invoke` for this caller on the row's
-    /// narrowed workspaces. Requires operator capability, a workspace
-    /// narrowing, and a key-bound identity unless the destination explicitly
-    /// selects the cooperative same-account mode below.
+    /// Explicitly admits `orbit.agent.invoke` for this caller on its
+    /// operation-specific workspace scope. When the independent scope is
+    /// absent, `workspaces` remains the legacy invocation scope.
     #[serde(default)]
     pub agent_invoke: bool,
+    /// Narrows `agent_invoke` without narrowing ordinary capabilities.
+    #[serde(default)]
+    pub agent_invoke_workspaces: Option<Vec<String>>,
     /// Trust model for `agent_invoke`. Omission preserves strict key-bound
     /// admission; `cooperative` deliberately accepts the self-asserted caller
     /// label on the existing SSH operator channel.
@@ -172,30 +174,13 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
             )
         })?;
         parse_capabilities(row, path)?;
-        if let Some(workspaces) = &row.workspaces {
-            if workspaces.is_empty() {
-                return Err(invalid(
-                    path,
-                    format!(
-                        "caller '{}' has an empty `workspaces` list; omit the key to grant every \
-                         workspace on this destination",
-                        row.machine_id
-                    ),
-                ));
-            }
-            for workspace in workspaces {
-                if !workspace.starts_with("ws_") {
-                    return Err(invalid(
-                        path,
-                        format!(
-                            "caller '{}' narrows to '{workspace}', which is not a logical \
-                             workspace ID; `workspaces` takes `ws_*` IDs",
-                            row.machine_id
-                        ),
-                    ));
-                }
-            }
-        }
+        validate_workspace_scope(row, row.workspaces.as_deref(), "workspaces", path)?;
+        validate_workspace_scope(
+            row,
+            row.agent_invoke_workspaces.as_deref(),
+            "agent_invoke_workspaces",
+            path,
+        )?;
         if let Some(defect) = row
             .ssh_key_fingerprint
             .as_deref()
@@ -219,12 +204,12 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
                     ),
                 ));
             }
-            if row.workspaces.is_none() {
+            if row.workspaces.is_none() && row.agent_invoke_workspaces.is_none() {
                 return Err(invalid(
                     path,
                     format!(
-                        "caller '{}' enables `agent_invoke` without a `workspaces` narrowing; \
-                         remote trusted-host execution must name its destination workspaces",
+                        "caller '{}' enables `agent_invoke` without a workspace scope; set \
+                         `agent_invoke_workspaces` or the legacy `workspaces` narrowing",
                         row.machine_id
                     ),
                 ));
@@ -241,12 +226,46 @@ fn validate_callers(file: &CallersFile, path: &Path) -> Result<(), OrbitError> {
                     ),
                 ));
             }
-        } else if row.agent_invoke_mode.is_some() {
+        } else if row.agent_invoke_mode.is_some() || row.agent_invoke_workspaces.is_some() {
             return Err(invalid(
                 path,
                 format!(
-                    "caller '{}' sets `agent_invoke_mode` without enabling `agent_invoke`; the \
-                     mode only qualifies that operation-specific grant",
+                    "caller '{}' sets an agent-invocation option without enabling `agent_invoke`; \
+                     those options only qualify that operation-specific grant",
+                    row.machine_id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_workspace_scope(
+    row: &CallerRow,
+    workspaces: Option<&[String]>,
+    field: &str,
+    path: &Path,
+) -> Result<(), OrbitError> {
+    let Some(workspaces) = workspaces else {
+        return Ok(());
+    };
+    if workspaces.is_empty() {
+        return Err(invalid(
+            path,
+            format!(
+                "caller '{}' has an empty `{field}` list; omit the key rather than granting no \
+                 workspaces",
+                row.machine_id
+            ),
+        ));
+    }
+    for workspace in workspaces {
+        if !workspace.starts_with("ws_") {
+            return Err(invalid(
+                path,
+                format!(
+                    "caller '{}' narrows `{field}` to '{workspace}', which is not a logical \
+                     workspace ID; workspace scopes take `ws_*` IDs",
                     row.machine_id
                 ),
             ));
@@ -362,9 +381,10 @@ pub struct ResolvedCallerGrant {
     /// The `ws_*` IDs [`Self::granted`] applies to. `None` means every
     /// workspace on this destination.
     pub workspaces: Option<BTreeSet<String>>,
-    /// Whether the matched row explicitly admits trusted-host agent
-    /// invocation on its covered workspaces.
+    /// Whether the matched row explicitly admits trusted-host agent invocation.
     pub agent_invoke: bool,
+    /// The `ws_*` IDs the explicit agent-invocation grant applies to.
+    pub agent_invoke_workspaces: Option<BTreeSet<String>>,
     /// Trust mode selected for agent invocation, when it is enabled.
     pub agent_invoke_mode: Option<RemoteAgentInvokeMode>,
     /// Whether a row matched, or the file default answered.
@@ -392,7 +412,7 @@ impl ResolvedCallerGrant {
     /// Whether the explicit agent-invocation grant covers `workspace_id`.
     pub fn agent_invoke_for_workspace(&self, workspace_id: Option<&str>) -> bool {
         self.agent_invoke
-            && match (&self.workspaces, workspace_id) {
+            && match (&self.agent_invoke_workspaces, workspace_id) {
                 (Some(covered), Some(workspace_id)) => covered.contains(workspace_id),
                 (Some(_), None) | (None, _) => false,
             }
@@ -431,6 +451,7 @@ impl CallersFile {
                 elsewhere: default,
                 workspaces: None,
                 agent_invoke: false,
+                agent_invoke_workspaces: None,
                 agent_invoke_mode: None,
                 matched: false,
             };
@@ -455,6 +476,11 @@ impl CallersFile {
                 .as_ref()
                 .map(|workspaces| workspaces.iter().cloned().collect()),
             agent_invoke: row.agent_invoke,
+            agent_invoke_workspaces: row
+                .agent_invoke_workspaces
+                .as_ref()
+                .or(row.workspaces.as_ref())
+                .map(|workspaces| workspaces.iter().cloned().collect()),
             agent_invoke_mode: row
                 .agent_invoke
                 .then_some(row.agent_invoke_mode.unwrap_or_default()),

--- a/crates/orbit-mcp/src/remote/tests/callers.rs
+++ b/crates/orbit-mcp/src/remote/tests/callers.rs
@@ -310,6 +310,42 @@ agent_invoke_mode = "cooperative"
 }
 
 #[test]
+fn invocation_workspace_scope_does_not_narrow_ordinary_operator_access() {
+    let (_dir, path) = write(
+        r#"
+default = "deny"
+
+[[callers]]
+machine_id = "hm_beta"
+capabilities = ["agent", "operator"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["ws_orbit"]
+"#,
+    );
+    let file = load_callers(&path).expect("independent invocation scope");
+    let policy = SessionCapabilityPolicy::from_grant(
+        McpSessionAuthority::Operator,
+        file.resolve(&caller("hm_beta")),
+    );
+
+    assert_eq!(policy.effective_for(Some("ws_orbit")), operator());
+    assert_eq!(policy.effective_for(Some("ws_other")), operator());
+    assert!(
+        policy
+            .grant_for(Some("ws_orbit"))
+            .expect("remote grant")
+            .agent_invoke
+    );
+    assert!(
+        !policy
+            .grant_for(Some("ws_other"))
+            .expect("remote grant")
+            .agent_invoke
+    );
+}
+
+#[test]
 fn incomplete_agent_invoke_grants_fail_the_callers_file_closed() {
     for (contents, expected) in [
         (
@@ -336,6 +372,50 @@ agent_invoke = true
 "#,
             ),
             "workspaces",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = []
+"#
+            .to_string(),
+            "agent_invoke_workspaces",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+agent_invoke_workspaces = ["ws_orbit"]
+"#
+            .to_string(),
+            "without enabling `agent_invoke`",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["orbit"]
+"#
+            .to_string(),
+            "agent_invoke_workspaces",
+        ),
+        (
+            r#"
+[[callers]]
+machine_id = "hm_alpha"
+capabilities = ["agent", "operator"]
+agent_invoke_workspcaes = ["ws_orbit"]
+"#
+            .to_string(),
+            "unknown field",
         ),
         (
             r#"

--- a/docs/design/federated-mcp/specs/caller-authorization.md
+++ b/docs/design/federated-mcp/specs/caller-authorization.md
@@ -82,7 +82,8 @@ Row keys:
 | `label` | no | Operator-facing display name. Never an identity input. |
 | `workspaces` | no | Narrows the grant to these logical `ws_*` IDs. Omitted means every workspace on this destination. |
 | `ssh_key_fingerprint` | no | Binds the row to a key sshd authenticated, in the `SHA256:…` form `ssh-keygen -l` prints. See Tier 2. |
-| `agent_invoke` | no | Explicitly grants remote trusted-host agent invocation on the listed workspaces. Requires `operator` and a workspace list. |
+| `agent_invoke` | no | Explicitly grants remote trusted-host agent invocation on the operation's workspace scope. Requires `operator` and a workspace scope. |
+| `agent_invoke_workspaces` | no | Narrows `agent_invoke` to logical `ws_*` IDs without narrowing ordinary capabilities. Omitted preserves the legacy `workspaces` scope. |
 | `agent_invoke_mode` | no | Trust model for `agent_invoke`: omitted or `key-bound` preserves strict Tier-2 admission; `cooperative` accepts the existing same-OS-account SSH operator channel while retaining a self-asserted identity proof. Invalid without `agent_invoke = true`. |
 
 File-level invariants:
@@ -92,7 +93,7 @@ File-level invariants:
 3. An unknown key, an unknown capability value, an empty `capabilities`, a `default` other than `agent` or `deny`, a malformed `machine_id`, or an `ssh_key_fingerprint` that is not a well-formed `SHA256:` digest invalidates the file at load. A malformed file is never served as if absent. The fingerprint format is checked here rather than at comparison time because a fingerprint in the wrong shape — an `MD5:` one, most plausibly — would otherwise never match and would present as a key mismatch on every session.
 4. `runner` is not a grantable value. It is stamped in-process by a managed run and can never arrive over a transport.
 5. Load happens once per server process, at startup, alongside identity resolution. A session's ceiling does not change under it mid-session.
-6. `agent_invoke = true` additionally requires `operator` and an explicit `workspaces` list. Its default/key-bound mode also requires `ssh_key_fingerprint`. `agent_invoke_mode = "cooperative"` is the only mode that may omit the fingerprint; an unknown mode or a mode without the operation grant invalidates the file.
+6. `agent_invoke = true` additionally requires `operator` and an explicit workspace scope: `agent_invoke_workspaces`, or legacy `workspaces` when the new key is omitted. Both scopes reject empty or non-`ws_*` lists. Its default/key-bound mode also requires `ssh_key_fingerprint`. `agent_invoke_mode = "cooperative"` is the only mode that may omit the fingerprint; an unknown mode or invocation-only option without the operation grant invalidates the file.
 
 ## Remote origination is decided by the destination, not by argv
 
@@ -128,11 +129,26 @@ Invariants:
 ## Operation-specific remote agent invocation
 
 Remote trusted-host invocation adds admission rules after ordinary capability
-resolution. Every remote caller needs `operator`, `agent_invoke = true`, and a
-row narrowed to the resolved logical workspace. The file default never grants
+resolution. Every remote caller needs `operator`, `agent_invoke = true`, and an
+invocation scope covering the resolved logical workspace. `agent_invoke_workspaces`
+keeps that exception independent from ordinary `workspaces`; omitting it preserves
+the original behavior of using `workspaces` for both. The file default never grants
 the operation, the admission covers one invocation, the timeout remains
 bounded, ordinary job input cannot supply the reserved admission, and a run
 carrying an admission cannot be resumed.
+
+For the existing trusted Mac caller on `dk-server-1`, whose row already has
+`capabilities = ["agent", "operator"]` and no `workspaces` narrowing, the
+minimal nonbreaking cooperative configuration is:
+
+```toml
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["ws_orbit"]
+```
+
+These keys are added to the existing `hm_ba054a1a8fbfb914` row; production
+installation and reconnect remain an operator action.
 
 Omitting `agent_invoke_mode` preserves the shipped strict behavior: the row
 must pin a fingerprint and the session's identity proof must be `key-bound`.

--- a/plugin/skills/orbit/references/setup/remote-access.md
+++ b/plugin/skills/orbit/references/setup/remote-access.md
@@ -90,9 +90,9 @@ default = "deny"
 machine_id = "<caller-machine-id>"
 label = "<display-name>"
 capabilities = ["agent", "operator"]
-workspaces = ["<allowed-workspace-id>"]
 ssh_key_fingerprint = "SHA256:<caller-public-key-fingerprint>"
 agent_invoke = true
+agent_invoke_workspaces = ["<invocation-workspace-id>"]
 ```
 
 The destination can instead opt one row into the existing cooperative SSH
@@ -105,9 +105,9 @@ default = "deny"
 machine_id = "<caller-machine-id>"
 label = "<display-name>"
 capabilities = ["agent", "operator"]
-workspaces = ["<allowed-workspace-id>"]
 agent_invoke = true
 agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["<invocation-workspace-id>"]
 ```
 
 This is an explicit destination-owner statement that callers using the same
@@ -117,6 +117,21 @@ The policy prevents accidental use and limits Orbit's admission to the named
 workspace and one invocation; it does not isolate mutually malicious peers who
 share the account and already control that account's files and processes.
 Never describe a cooperative admission as key-bound.
+
+`agent_invoke_workspaces` is independent from ordinary `workspaces`. When a
+caller already has general operator access, add the operation scope without
+narrowing that access. Leave its existing capabilities and absent `workspaces`
+unchanged, then add only:
+
+```toml
+agent_invoke = true
+agent_invoke_mode = "cooperative"
+agent_invoke_workspaces = ["ws_orbit"]
+```
+
+Omitting `agent_invoke_workspaces` preserves the older behavior where
+`workspaces` is also the invocation scope. Empty, malformed, or unknown scope
+shapes fail closed.
 
 For either mode, install the updated Orbit binary on the destination, review
 and edit `~/.orbit/mcp-callers.toml` there, run `orbit mcp callers check


### PR DESCRIPTION
## Task

[ORB-11500](https://orbit-cli.com/tasks/ORB-11500) — Scope remote agent invocation independently of ordinary caller access

### Description

Complete the deployment constraint added to ORB-11496 while it was running but omitted from its final source implementation. Daniel wants agent_invoke from his existing trusted Mac SSH/operator connection on dk-server-1; retain existing general operator access while granting this exceptional invocation only for ws_orbit. Actual destination caller hm_ba054a1a8fbfb914 currently has capabilities=[agent,operator], no workspaces narrowing, no invocation grant, and file default=agent. No production policy has been changed.

Verified PR1496 merge 8c6ab16fcbac81da1aa61187f54bede4480e1cb8: crates/orbit-mcp/src/remote/callers.rs:222 requires row.workspaces for agent_invoke; ResolvedCallerGrant::agent_invoke_for_workspace at393-398 reuses the same workspaces set as ordinary capability resolution. Narrowing that row to [ws_orbit] would drop existing operator access elsewhere to the file default. Enumerating all workspaces would instead grant invocation outside the requested scope and restrict future ordinary access. Neither is acceptable. Existing strict/key-bound and cooperative modes remain useful and must be retained.

Add the smallest compatible per-operation workspace-scoping seam in the existing caller policy owner. Keep the general caller grant unchanged; allow an explicit invocation-only workspace list while preserving legacy behavior when the new override is absent. Reuse existing workspace canonicalization, validation, resolved-grant stamping, admission and audit paths. Effective invocation must still require operator capability on the target workspace plus the invocation grant/mode and invocation workspace coverage; no implicit intersection bypass or broader defaults. No new authorization framework, duplicate caller entries or configuration workaround. Update diagnostic/config examples and necessary projections only. Provide an exact minimal nonbreaking config for the actual Mac row, but leave production edits/install/reconnect to the orchestrator.

Terra/medium: bounded caller-file parsing and scope-resolution extension, with real MCP policy tests. Delivery authorized with --complete to agent-main; no releases/main promotion.

### Acceptance Criteria

- A caller retaining its existing ordinary operator grant can enable remote invocation only for ws_orbit without granting invocation elsewhere or reducing ordinary access elsewhere.
- Absent new per-operation scope preserves legacy policy semantics; malformed/empty/unknown scope shapes fail closed and invocation still requires the ordinary operator grant on the target workspace.
- Deterministic caller-policy and actual MCP tests cover separate scopes, strict/cooperative modes, wrong workspace, defaults and revocation without unrelated authority changes.
- Current docs/config diagnostics explain the independent scope; owning checks and ci-fast/ci-lint pass, with production policy unchanged during implementation.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added optional `agent_invoke_workspaces` to the destination callers-file row. It scopes only remote agent invocation; omitted scope retains legacy use of ordinary `workspaces`.
- Validated empty, malformed, unknown, and orphaned invocation-scope configuration fail closed. Invocation remains gated by the existing effective operator capability plus the operation grant and its resolved workspace coverage.
- Updated caller diagnostics, real key-bound/cooperative MCP tests, policy tests, and canonical/plugin-mirrored remote-access guidance. The design spec includes the exact additive cooperative configuration for `hm_ba054a1a8fbfb914`; no production callers file, installation, or reconnect was changed.

Criteria:
- Independent ordinary and invocation scope: policy and real MCP tests prove a general operator row retains ordinary access while invocation is denied outside its invocation-only workspace.
- Legacy/default/fail-closed behavior: caller-policy tests retain legacy `workspaces` behavior and cover empty, malformed, unknown, missing-grant, strict, and cooperative cases.
- End-to-end behavior: key-bound test covers wrong workspace, successful scoped admission, and revocation; cooperative test covers independently scoped admission and truthful identity/mode output.
- Documentation and checks: caller diagnostics and both shipped remote-access copies describe the separate scope; the exact requested row addition is documented in the design spec.

Validation passed:
- `cargo test -p orbit-mcp remote::tests::callers --no-fail-fast`
- `cargo test -p orbit-cli --test mcp_roundtrip a_key_bound_remote_operator_invokes_an_agent_only_in_the_granted_workspace -- --exact`
- `cargo test -p orbit-cli --test mcp_roundtrip a_cooperative_ssh_operator_invocation_records_its_actual_trust_boundary -- --exact`
- `make ci-fast`
- `make ci-lint`
- `git diff --check`

Assessment: Small compatible caller-policy extension; no cross-crate dependency or production policy change. The only added context file is the required plugin-skill mirror synchronized by ci-fast.

Risks: Production rollout remains intentionally deferred to the operator; a live MCP session must reconnect after the documented callers-file update.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11500-6a9e5877`
- Behind base: 0
- Ahead of base: 1