### PR TITLE
Complete recovered rebases without granting agents broad Git metadata writes

### DIFF
--- a/.orbit/resources/activities/.orbit-managed-assets.json
+++ b/.orbit/resources/activities/.orbit-managed-assets.json
@@ -16,7 +16,7 @@
     "list_triage_candidates": "60f57fb9a4ba2d9bc98e1a1ec09cb705f9510457118bab2e0279337860a17014",
     "pipeline_success_guard": "67e8ee792ef815a9cf5d5b352a4bf5776ad24cd770e47cc1202b2d9b80cf1a1d",
     "pr_complete": "e781a352370279a206accf784da8fc542163549b6d78d9b64ab0b81a4da23bbb",
-    "pr_conflict_recovery": "08e0be2c667c595310c4991fb494c7b6422c948583f4c187d10e067629c13940",
+    "pr_conflict_recovery": "c10631bf400868a97b480cdc8e8ede542961a98d8efa23b56869b6afea2422a0",
     "pr_failure_handoff": "e61af5b5fd2e67c478649ad0ac1ecf56dbca30cb4867282eaa51676928aa50d9",
     "pr_open": "bdf78aab3b274842bc41be9fdd41c0d68b273bae3cc0734088d84427a2250a2f",
     "pr_prepare": "61d50662aa90e7abaa8138979ca6d806ed7b39091cf71c81a7d8e09449ec94ff",

--- a/.orbit/resources/activities/pr_conflict_recovery.yaml
+++ b/.orbit/resources/activities/pr_conflict_recovery.yaml
@@ -7,9 +7,8 @@ spec:
   description: >
     Leaf recovery for a typed task-PR rebase conflict, including one discovered
     after PR publication during authorized completion. It uses the configured
-    system crew to reconcile the live candidate against its pinned target base,
-    validate the result, and leave the failed step ready for one executor-owned
-    retry.
+    system crew to repair only the live conflict files. The host executor then
+    validates, stages, and continues the pinned rebase before one retry.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -73,13 +72,11 @@ spec:
         type: string
       system_crew:
         type: boolean
-  # Advisory only. The executor judges recovery by retrying the deterministic
-  # rebase step once against the durable Git state.
+  # Advisory only. Neither this result nor any agent-returned flag authorizes
+  # Git mutation; the host boundary and deterministic retry judge recovery.
   output_schema_json:
     type: object
     properties:
-      recovered:
-        type: boolean
       summary:
         type: string
       validations:
@@ -111,16 +108,19 @@ spec:
        acceptance criteria, candidate changes, and both sides of the conflict.
        Preserve the candidate intent and the target-base changes. Do not take a
        whole-file side merely to make the index clean.
-    3. Stage only the resolutions and continue the existing rebase. Do not
-       start a new rebase onto a moving branch name: the supplied
-       `target_base_sha` is authoritative for this attempt.
-    4. Verify that no unmerged index entry or rebase state remains, that the
-       target base SHA is an ancestor of the recovered branch, and that the
-       task candidate is still present. Run focused affected tests followed by
-       the repository-required `make ci-fast` and `make ci-lint` gates. For a
-       completion conflict, do not push or merge; the retried completion step
-       verifies the pinned rewrite, uses the existing remote lease, and reuses
-       the same PR.
+    3. Do not stage, commit, continue, abort, or restart the rebase, and do not
+       write any Git metadata. The managed sandbox intentionally keeps the
+       linked-worktree Git directory read-only. After your successful terminal
+       response, Orbit's host boundary revalidates live run/task/worktree,
+       branch, original HEAD, base, rebase, and conflict-path identity; it then
+       stages exactly the supplied conflict paths and continues the existing
+       rebase onto `target_base_sha`.
+    4. Confirm every supplied conflict file is fully repaired and no unrelated
+       path changed. Run focused affected tests followed by the repository-
+       required `make ci-fast` and `make ci-lint` gates. For a completion
+       conflict, do not push or merge; the retried completion step verifies the
+       host-owned pinned rewrite, uses the existing remote lease, and reuses the
+       same PR.
     5. Return success only after those checks pass. On ambiguity, validation
        failure, a concurrently changed branch/base checkpoint, or exhausted
        resolution, preserve the current evidence and return failed. The job's
@@ -128,7 +128,8 @@ spec:
        candidate branch/PR, and block the task with the original evidence.
 
     Return exactly one Orbit response envelope. Result fields are advisory;
-    durable Git state and the executor's deterministic retry decide recovery.
+    durable Git state and the executor's host-owned continuation plus
+    deterministic retry decide recovery.
   tools:
     - orbit.task.*
     - proc.spawn

--- a/crates/orbit-core/assets/activities/pr_conflict_recovery.yaml
+++ b/crates/orbit-core/assets/activities/pr_conflict_recovery.yaml
@@ -7,9 +7,8 @@ spec:
   description: >
     Leaf recovery for a typed task-PR rebase conflict, including one discovered
     after PR publication during authorized completion. It uses the configured
-    system crew to reconcile the live candidate against its pinned target base,
-    validate the result, and leave the failed step ready for one executor-owned
-    retry.
+    system crew to repair only the live conflict files. The host executor then
+    validates, stages, and continues the pinned rebase before one retry.
   input_schema_json:
     type: object
     additionalProperties: false
@@ -73,13 +72,11 @@ spec:
         type: string
       system_crew:
         type: boolean
-  # Advisory only. The executor judges recovery by retrying the deterministic
-  # rebase step once against the durable Git state.
+  # Advisory only. Neither this result nor any agent-returned flag authorizes
+  # Git mutation; the host boundary and deterministic retry judge recovery.
   output_schema_json:
     type: object
     properties:
-      recovered:
-        type: boolean
       summary:
         type: string
       validations:
@@ -111,16 +108,19 @@ spec:
        acceptance criteria, candidate changes, and both sides of the conflict.
        Preserve the candidate intent and the target-base changes. Do not take a
        whole-file side merely to make the index clean.
-    3. Stage only the resolutions and continue the existing rebase. Do not
-       start a new rebase onto a moving branch name: the supplied
-       `target_base_sha` is authoritative for this attempt.
-    4. Verify that no unmerged index entry or rebase state remains, that the
-       target base SHA is an ancestor of the recovered branch, and that the
-       task candidate is still present. Run focused affected tests followed by
-       the repository-required `make ci-fast` and `make ci-lint` gates. For a
-       completion conflict, do not push or merge; the retried completion step
-       verifies the pinned rewrite, uses the existing remote lease, and reuses
-       the same PR.
+    3. Do not stage, commit, continue, abort, or restart the rebase, and do not
+       write any Git metadata. The managed sandbox intentionally keeps the
+       linked-worktree Git directory read-only. After your successful terminal
+       response, Orbit's host boundary revalidates live run/task/worktree,
+       branch, original HEAD, base, rebase, and conflict-path identity; it then
+       stages exactly the supplied conflict paths and continues the existing
+       rebase onto `target_base_sha`.
+    4. Confirm every supplied conflict file is fully repaired and no unrelated
+       path changed. Run focused affected tests followed by the repository-
+       required `make ci-fast` and `make ci-lint` gates. For a completion
+       conflict, do not push or merge; the retried completion step verifies the
+       host-owned pinned rewrite, uses the existing remote lease, and reuses the
+       same PR.
     5. Return success only after those checks pass. On ambiguity, validation
        failure, a concurrently changed branch/base checkpoint, or exhausted
        resolution, preserve the current evidence and return failed. The job's
@@ -128,7 +128,8 @@ spec:
        candidate branch/PR, and block the task with the original evidence.
 
     Return exactly one Orbit response envelope. Result fields are advisory;
-    durable Git state and the executor's deterministic retry decide recovery.
+    durable Git state and the executor's host-owned continuation plus
+    deterministic retry decide recovery.
   tools:
     - orbit.task.*
     - proc.spawn

--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -198,6 +198,22 @@ impl RuntimeHost for OrbitRuntime {
         OrbitRuntime::settle_step_recovery(self, run_id, step_id, elapsed_seconds)
     }
 
+    fn validate_step_recovery_mutation(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        task_ids: &[String],
+        workspace_path: &std::path::Path,
+    ) -> Result<(), OrbitError> {
+        OrbitRuntime::validate_step_recovery_mutation(
+            self,
+            run_id,
+            step_id,
+            task_ids,
+            workspace_path,
+        )
+    }
+
     fn authorize_task_completion(
         &self,
         run_id: &str,

--- a/crates/orbit-core/src/application/operation/recovery.rs
+++ b/crates/orbit-core/src/application/operation/recovery.rs
@@ -13,9 +13,11 @@ use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_engine::{RuntimeHost, StepRecoveryAdmission, TaskAutomationUpdate};
 use orbit_store::contracts::{RecoveryBudget, RecoveryReserveRequest};
+use orbit_types::task::TaskStatus;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::workflow::{
-    JobRun, OperationAdmission, RecoveryEpisodeKind, RecoveryLedger, RecoveryReservation,
+    JobRun, JobRunState, OperationAdmission, RecoveryEpisodeKind, RecoveryLedger,
+    RecoveryReservation,
 };
 use serde_json::{Value, json};
 
@@ -152,6 +154,144 @@ impl OrbitRuntime {
             }
         }
         Ok(())
+    }
+
+    /// Authenticate the active run, tasks, and inherited worktree checkpoint
+    /// immediately before executor-owned recovery writes Git metadata.
+    pub(crate) fn validate_step_recovery_mutation(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        task_ids: &[String],
+        workspace_path: &std::path::Path,
+    ) -> Result<(), OrbitError> {
+        let run = self.get_job_run_backend(run_id)?.ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "step recovery '{step_id}' has no durable run '{run_id}'"
+            ))
+        })?;
+        if run.state != JobRunState::Running {
+            return Err(OrbitError::Execution(format!(
+                "step recovery '{step_id}' refuses Git mutation for run '{run_id}' in state '{}'",
+                run.state
+            )));
+        }
+
+        let mut expected_task_ids = run_task_ids(&run);
+        let mut observed_task_ids = task_ids.to_vec();
+        expected_task_ids.sort();
+        expected_task_ids.dedup();
+        observed_task_ids.sort();
+        observed_task_ids.dedup();
+        if expected_task_ids != observed_task_ids {
+            return Err(OrbitError::Execution(format!(
+                "step recovery '{step_id}' task lineage does not match run '{run_id}'"
+            )));
+        }
+        let mut task_owner = None;
+        for task_id in &observed_task_ids {
+            let task = self.get_task(task_id)?;
+            let owner = task.job_run_id.as_deref().ok_or_else(|| {
+                OrbitError::Execution(format!(
+                    "step recovery '{step_id}' task '{task_id}' has no active run owner"
+                ))
+            })?;
+            if !matches!(task.status, TaskStatus::InProgress | TaskStatus::Review) {
+                return Err(OrbitError::Execution(format!(
+                    "step recovery '{step_id}' task '{task_id}' is no longer owned by active run '{run_id}'"
+                )));
+            }
+            match task_owner.as_deref() {
+                None => task_owner = Some(owner.to_string()),
+                Some(current) if current == owner => {}
+                Some(_) => {
+                    return Err(OrbitError::Execution(format!(
+                        "step recovery '{step_id}' tasks do not share one worktree owner"
+                    )));
+                }
+            }
+        }
+
+        let state = self.read_run_state(run_id)?.ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "step recovery '{step_id}' run '{run_id}' has no durable pipeline state"
+            ))
+        })?;
+        let worktree = state.pipeline.get("worktree").ok_or_else(|| {
+            OrbitError::Execution(format!(
+                "step recovery '{step_id}' run '{run_id}' has no worktree checkpoint"
+            ))
+        })?;
+        let checkpoint_path = worktree
+            .get("workspace_path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                OrbitError::Execution(format!(
+                    "step recovery '{step_id}' run '{run_id}' has no checkpointed workspace path"
+                ))
+            })?;
+        let checkpoint_path = std::fs::canonicalize(checkpoint_path).map_err(|error| {
+            OrbitError::Execution(format!(
+                "step recovery '{step_id}' cannot resolve checkpointed workspace '{checkpoint_path}': {error}"
+            ))
+        })?;
+        let requested_path = workspace_path.canonicalize().map_err(|error| {
+            OrbitError::Execution(format!(
+                "step recovery '{step_id}' cannot resolve assigned workspace '{}': {error}",
+                workspace_path.display()
+            ))
+        })?;
+        if checkpoint_path != requested_path {
+            return Err(OrbitError::Execution(format!(
+                "step recovery '{step_id}' assigned workspace '{}' does not match run '{run_id}' checkpoint '{}'",
+                requested_path.display(),
+                checkpoint_path.display()
+            )));
+        }
+
+        let checkpoint_owner = worktree
+            .get("job_run_id")
+            .or_else(|| worktree.get("batch_id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                OrbitError::Execution(format!(
+                    "step recovery '{step_id}' run '{run_id}' has no worktree checkpoint owner"
+                ))
+            })?;
+        if task_owner.as_deref() != Some(checkpoint_owner) {
+            return Err(OrbitError::Execution(format!(
+                "step recovery '{step_id}' task owner does not match worktree owner '{checkpoint_owner}'"
+            )));
+        }
+        if !self.run_descends_from(run, checkpoint_owner)? {
+            return Err(OrbitError::Execution(format!(
+                "step recovery '{step_id}' worktree owner '{checkpoint_owner}' is outside run '{run_id}' retry lineage"
+            )));
+        }
+        Ok(())
+    }
+
+    fn run_descends_from(
+        &self,
+        mut run: JobRun,
+        expected_ancestor: &str,
+    ) -> Result<bool, OrbitError> {
+        let mut visited = std::collections::BTreeSet::new();
+        loop {
+            if run.run_id == expected_ancestor {
+                return Ok(true);
+            }
+            if !visited.insert(run.run_id.clone()) {
+                return Ok(false);
+            }
+            let Some(parent_id) = run.retry_source_run_id.as_deref() else {
+                return Ok(false);
+            };
+            let Some(parent) = self.get_job_run_backend(parent_id)? else {
+                return Ok(false);
+            };
+            run = parent;
+        }
     }
 
     fn reserve_recovery(

--- a/crates/orbit-core/src/application/operation/tests/pipeline.rs
+++ b/crates/orbit-core/src/application/operation/tests/pipeline.rs
@@ -8,13 +8,13 @@ use std::collections::BTreeMap;
 use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_config::OperationLayer;
-use orbit_engine::{RuntimeHost, StepRecoveryAdmission};
+use orbit_engine::{RuntimeHost, StepRecoveryAdmission, TaskAutomationUpdate};
 use orbit_tools::ToolContext;
 use orbit_types::task::TaskStatus;
 use orbit_types::workflow::automation::members::{MemberAssessment, MemberState};
 use orbit_types::workflow::automation::{AutomationState, SourceRevision};
 use orbit_types::workflow::{
-    GrantRights, JobRun, OPERATION_ADMISSION_KEY, OperationAdmission, OperationGrant,
+    GrantRights, JobRun, JobRunState, OPERATION_ADMISSION_KEY, OperationAdmission, OperationGrant,
 };
 use serde_json::{Value, json};
 
@@ -553,6 +553,153 @@ fn recovery_budget_spans_step_hooks_and_triage_and_escalates_when_spent() {
         .expect("ledger exists");
     assert_eq!(ledger.episodes.len(), 2);
     assert_eq!(ledger.consumed_seconds, 90);
+}
+
+#[test]
+fn recovery_git_mutation_requires_live_task_run_and_worktree_lineage() {
+    let cancelled_fixture = fixture(AUTONOMOUS_DONE);
+    let runtime = &cancelled_fixture.runtime;
+    let task = seed_task(runtime, "recoverable owner", TaskStatus::Backlog);
+    let grant = enable(
+        runtime,
+        std::slice::from_ref(&task.id),
+        all_rights(),
+        OperationLayer::default(),
+    );
+    let (drain, _) = start_drain(runtime, &grant.id);
+    let child = submitted_run(runtime, admit_leaf(runtime, &drain.run_id, &task.id));
+    let mut state = runtime
+        .read_run_state(&child.run_id)
+        .expect("read child state")
+        .expect("child pipeline state");
+    state.sync_pipeline(json!({
+        "worktree": {
+            "workspace_path": cancelled_fixture.repo,
+            "job_run_id": child.run_id,
+        }
+    }));
+    runtime
+        .write_run_state(&child.run_id, &state)
+        .expect("checkpoint assigned worktree");
+
+    let cancelled = runtime
+        .cancel_job_run(&child.run_id)
+        .expect("cancel pending child");
+    assert_eq!(cancelled.final_state, "cancelled");
+    let error = runtime
+        .validate_step_recovery_mutation(
+            &child.run_id,
+            "sync_base",
+            std::slice::from_ref(&task.id),
+            &cancelled_fixture.repo,
+        )
+        .expect_err("cancelled run must not mutate Git");
+    assert!(error.to_string().contains("state 'cancelled'"), "{error}");
+
+    let other = cancelled_fixture.repo.join("other");
+    std::fs::create_dir(&other).expect("other directory");
+    let mismatch = runtime
+        .validate_step_recovery_mutation(
+            &child.run_id,
+            "sync_base",
+            std::slice::from_ref(&task.id),
+            &other,
+        )
+        .expect_err("cancelled state remains authoritative before path mismatch");
+    assert!(
+        mismatch.to_string().contains("state 'cancelled'"),
+        "{mismatch}"
+    );
+
+    let live_fixture = fixture(AUTONOMOUS_DONE);
+    let live_runtime = &live_fixture.runtime;
+    let live_task = seed_task(live_runtime, "live recovery owner", TaskStatus::Backlog);
+    let live_grant = enable(
+        live_runtime,
+        std::slice::from_ref(&live_task.id),
+        all_rights(),
+        OperationLayer::default(),
+    );
+    let (live_drain, _) = start_drain(live_runtime, &live_grant.id);
+    let live_child = submitted_run(
+        live_runtime,
+        admit_leaf(live_runtime, &live_drain.run_id, &live_task.id),
+    );
+    live_runtime
+        .apply_task_automation_update(
+            &live_task.id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::InProgress),
+                job_run_id: Some(live_child.run_id.clone()),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("couple task to recovery owner");
+    let live_retry = live_runtime
+        .insert_job_run(
+            &live_child.job_id,
+            live_child.attempt + 1,
+            Utc::now(),
+            live_child.input.clone(),
+            Some(live_child.run_id.clone()),
+        )
+        .expect("insert recovery retry");
+    live_runtime
+        .mark_job_run_running(&live_retry.run_id, Utc::now(), std::process::id())
+        .expect("mark recovery retry running");
+    let mut live_state = orbit_types::workflow::PipelineState::new(
+        live_retry.run_id.clone(),
+        live_retry.job_id.clone(),
+        live_retry.input.clone().expect("retry input"),
+    );
+    live_state.sync_pipeline(json!({
+        "worktree": {
+            "workspace_path": live_fixture.repo,
+            "job_run_id": live_child.run_id,
+        }
+    }));
+    live_runtime
+        .write_run_state(&live_retry.run_id, &live_state)
+        .expect("checkpoint live worktree");
+
+    live_runtime
+        .validate_step_recovery_mutation(
+            &live_retry.run_id,
+            "sync_base",
+            std::slice::from_ref(&live_task.id),
+            &live_fixture.repo,
+        )
+        .expect("matching live ownership permits host mutation");
+    let wrong_tasks = live_runtime
+        .validate_step_recovery_mutation(
+            &live_retry.run_id,
+            "sync_base",
+            &["ORB-unrelated".to_string()],
+            &live_fixture.repo,
+        )
+        .expect_err("run task identity must match");
+    assert!(
+        wrong_tasks.to_string().contains("task lineage"),
+        "{wrong_tasks}"
+    );
+    let wrong_path = live_runtime
+        .validate_step_recovery_mutation(
+            &live_retry.run_id,
+            "sync_base",
+            std::slice::from_ref(&live_task.id),
+            &live_fixture.repo.join(".orbit"),
+        )
+        .expect_err("assigned path must match the worktree checkpoint");
+    assert!(
+        wrong_path.to_string().contains("does not match"),
+        "{wrong_path}"
+    );
+    live_runtime
+        .finalize_job_run(&live_retry.run_id, JobRunState::Success, Utc::now(), None)
+        .expect("finalize live fixture run");
+    live_runtime
+        .cancel_job_run(&live_child.run_id)
+        .expect("cancel source fixture run");
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -111,7 +111,7 @@ pub fn run_cli_backend(
     audit.emit_lossy(V2AuditEventKind::ToolAllowlistHarnessDelegated {
         provider: provider.clone(),
         task_id: task_id.map(ToOwned::to_owned),
-        task_ids,
+        task_ids: task_ids.clone(),
         requested_tools: activity_tools.requested_tools.clone(),
         effective_tools: activity_tools.effective_tools.clone(),
         tools: activity_tools.effective_tools.clone(),
@@ -451,7 +451,12 @@ pub fn run_cli_backend(
         Ok(result) => result,
         Err(err) => {
             if let Some(boundary) = worktree_boundary.take() {
-                boundary.verify()?;
+                boundary.verify_after_provider(
+                    host,
+                    false,
+                    input.get("failed_step_id").and_then(Value::as_str),
+                    &task_ids,
+                )?;
             }
             // Spawn-layer classification (ORB-10006): executable missing /
             // permission denied fail fast; resource exhaustion (EAGAIN,
@@ -487,14 +492,6 @@ pub fn run_cli_backend(
         harness_version: None,
         timed_out,
     });
-
-    // Verify the write boundary after recording the terminal provider event
-    // but before its success/failure classification can reach the DAG. The
-    // integrity error deliberately takes precedence over exit zero, nonzero,
-    // and timeout outcomes.
-    if let Some(boundary) = worktree_boundary {
-        boundary.verify()?;
-    }
 
     // Provider output is not the system of record for artifact-backed
     // activities: task state, review threads, git state, and deterministic
@@ -589,6 +586,20 @@ pub fn run_cli_backend(
         && !completion_protocol_violation
         && !completion_status_failure
         && (!spec.require_response_envelope || response_envelope_valid);
+
+    // A conflict-recovery provider repairs files only. Once its process has
+    // satisfied the activity completion contract, the host-side boundary
+    // independently revalidates live ownership, stages exactly the conflict
+    // set, and continues the checkpointed rebase. No response result field is
+    // consulted. Ordinary providers retain the same post-run integrity check.
+    if let Some(boundary) = worktree_boundary {
+        boundary.verify_after_provider(
+            host,
+            success,
+            input.get("failed_step_id").and_then(Value::as_str),
+            &task_ids,
+        )?;
+    }
     let trace = parse_cli_invocation_trace(
         trace_stdout.as_ref(),
         stderr.protocol_bytes(),

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/mod.rs
@@ -6,6 +6,7 @@ mod inspection;
 mod orchestrator;
 #[cfg(target_os = "macos")]
 mod orchestrator_macos;
+mod rebase_recovery;
 mod spawn;
 mod supervisor;
 pub(in crate::activity_job::cli_runner) mod test_support;

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/orchestrator.rs
@@ -3135,19 +3135,19 @@ fn primary_escape_is_checked_after_nonzero_exit_and_timeout() {
     }
 }
 
-struct LinkedWorktreeFixture {
+pub(super) struct LinkedWorktreeFixture {
     temp: TempDir,
-    primary: PathBuf,
-    assigned: PathBuf,
+    pub(super) primary: PathBuf,
+    pub(super) assigned: PathBuf,
 }
 
 impl LinkedWorktreeFixture {
-    fn root(&self) -> &Path {
+    pub(super) fn root(&self) -> &Path {
         self.temp.path()
     }
 }
 
-fn linked_worktree_fixture() -> LinkedWorktreeFixture {
+pub(super) fn linked_worktree_fixture() -> LinkedWorktreeFixture {
     let temp = tempdir().expect("fixture tempdir");
     let primary = temp.path().join("primary");
     let assigned = temp.path().join("assigned");
@@ -3223,7 +3223,7 @@ fn write_worktree_file(root: &Path, path: &str, contents: &str) -> PathBuf {
     target
 }
 
-fn git_ok(repo: &Path, args: &[&str]) {
+pub(super) fn git_ok(repo: &Path, args: &[&str]) {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
@@ -3239,7 +3239,7 @@ fn git_ok(repo: &Path, args: &[&str]) {
     );
 }
 
-fn git_bytes(repo: &Path, args: &[&str]) -> Vec<u8> {
+pub(super) fn git_bytes(repo: &Path, args: &[&str]) -> Vec<u8> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo)
@@ -3256,7 +3256,7 @@ fn git_bytes(repo: &Path, args: &[&str]) -> Vec<u8> {
     output.stdout
 }
 
-fn test_audit(run_id: &str, provider: &str) -> Arc<V2AuditWriter> {
+pub(super) fn test_audit(run_id: &str, provider: &str) -> Arc<V2AuditWriter> {
     let sink: Arc<dyn AuditSink> = Arc::new(RecordingSink::default());
     Arc::new(V2AuditWriter::new(
         run_id,
@@ -3412,7 +3412,7 @@ fn render_asset_value(value: &serde_json::Value, context: &TemplateContext) -> s
     }
 }
 
-fn worktree_input(fixture: &LinkedWorktreeFixture, task_id: &str) -> serde_json::Value {
+pub(super) fn worktree_input(fixture: &LinkedWorktreeFixture, task_id: &str) -> serde_json::Value {
     serde_json::json!({
         "prompt": "implement",
         "task_id": task_id,
@@ -4731,95 +4731,4 @@ fn run_cli_backend_accepts_a_structured_output_envelope_from_a_tool_using_run() 
     assert!(outcome.success, "{:?}", outcome.message);
     assert_eq!(outcome.output["completion_envelope_satisfied"], true);
     assert_eq!(outcome.output["response_envelope_status"], "success");
-}
-
-#[test]
-fn conflict_recovery_can_complete_only_its_checkpointed_rebase() {
-    let git_head = |repo: &Path| {
-        String::from_utf8(git_bytes(repo, &["rev-parse", "HEAD"]))
-            .unwrap()
-            .trim()
-            .to_string()
-    };
-    for wrong_checkpoint in [false, true] {
-        let fixture = linked_worktree_fixture();
-        fs::write(fixture.assigned.join("README.md"), "candidate\n").unwrap();
-        git_ok(&fixture.assigned, &["add", "README.md"]);
-        git_ok(&fixture.assigned, &["commit", "-m", "candidate intent"]);
-        let original = git_head(&fixture.assigned);
-        fs::write(fixture.primary.join("README.md"), "target\n").unwrap();
-        git_ok(&fixture.primary, &["add", "README.md"]);
-        git_ok(&fixture.primary, &["commit", "-m", "target change"]);
-        let target = git_head(&fixture.primary);
-        let stopped = Command::new("git")
-            .arg("-C")
-            .arg(&fixture.assigned)
-            .args(["rebase", &target])
-            .output()
-            .unwrap();
-        assert!(!stopped.status.success());
-        let script = fixture.root().join("codex");
-        write_executable(
-            &script,
-            r##"#!/bin/sh
-set -eu
-cat > /dev/null
-printf 'candidate and target\n' > README.md
-git add README.md
-git -c core.editor=true rebase --continue >&2
-printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
-"##,
-        );
-        let mut host = TestHost::with_command(script.display().to_string());
-        host.workspace_root = Some(fixture.primary.clone());
-        let mut input = worktree_input(&fixture, "T-recovery");
-        input["run_id"] = serde_json::json!("run-rebase-recovery");
-        input["recovery_kind"] = serde_json::json!("vcs_conflict");
-        input["operation"] = serde_json::json!("git_rebase");
-        input["target_base_sha"] =
-            serde_json::json!(if wrong_checkpoint { &original } else { &target });
-        input["failed_step_input"] = serde_json::json!({
-            "head": "orbit-integrity-test", "head_sha": original,
-        });
-        let audit = test_audit("run-rebase-recovery", "codex");
-        let outcome = run_cli_backend(
-            &host,
-            &test_agent_loop_spec(Duration::from_secs(30)),
-            "pr_conflict_recovery",
-            "run-rebase-recovery",
-            audit.clone(),
-            &input,
-            None,
-        );
-        if wrong_checkpoint {
-            let error = outcome.unwrap_err().to_string();
-            assert!(error.contains("existing rebase matching"), "{error}");
-            assert!(
-                !audit
-                    .events_snapshot()
-                    .unwrap()
-                    .iter()
-                    .any(|event| matches!(
-                        event.kind,
-                        V2AuditEventKind::CliInvocationStarted { .. }
-                    ))
-            );
-            assert!(
-                String::from_utf8_lossy(&git_bytes(&fixture.assigned, &["ls-files", "-u"]))
-                    .contains("README.md")
-            );
-        } else {
-            assert!(outcome.unwrap().success);
-            assert_eq!(
-                fs::read_to_string(fixture.assigned.join("README.md")).unwrap(),
-                "candidate and target\n"
-            );
-            assert_ne!(git_head(&fixture.assigned), original);
-            git_ok(
-                &fixture.assigned,
-                &["merge-base", "--is-ancestor", &target, "HEAD"],
-            );
-            assert_eq!(git_head(&fixture.primary), target);
-        }
-    }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/rebase_recovery.rs
@@ -1,0 +1,312 @@
+#![allow(missing_docs)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use orbit_types::workflow::activity_job::V2AuditEventKind;
+
+use super::super::run_cli_backend;
+use super::orchestrator::{
+    LinkedWorktreeFixture, git_bytes, git_ok, linked_worktree_fixture, test_audit, worktree_input,
+};
+use super::test_support::{TestHost, test_agent_loop_spec, write_executable};
+
+#[test]
+fn conflict_recovery_host_completes_only_its_checkpointed_rebase() {
+    for wrong_checkpoint in [false, true] {
+        let recovery = stopped_rebase_fixture(false);
+        let script = recovery.fixture.root().join("codex");
+        write_executable(
+            &script,
+            r##"#!/bin/sh
+set -eu
+cat > /dev/null
+printf 'candidate and target\n' > README.md
+printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
+"##,
+        );
+        let mut host = TestHost::with_command(script.display().to_string());
+        host.workspace_root = Some(recovery.fixture.primary.clone());
+        let mut input = conflict_recovery_input(&recovery);
+        if wrong_checkpoint {
+            input["target_base_sha"] = serde_json::json!(recovery.original);
+        }
+        let audit = test_audit("run-rebase-recovery", "codex");
+        let outcome = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(30)),
+            "pr_conflict_recovery",
+            "run-rebase-recovery",
+            audit.clone(),
+            &input,
+            None,
+        );
+        if wrong_checkpoint {
+            let error = outcome.unwrap_err().to_string();
+            assert!(error.contains("existing rebase matching"), "{error}");
+            assert!(
+                !audit
+                    .events_snapshot()
+                    .unwrap()
+                    .iter()
+                    .any(|event| matches!(
+                        event.kind,
+                        V2AuditEventKind::CliInvocationStarted { .. }
+                    ))
+            );
+            assert!(
+                String::from_utf8_lossy(&git_bytes(
+                    &recovery.fixture.assigned,
+                    &["ls-files", "-u"]
+                ))
+                .contains("README.md")
+            );
+        } else {
+            assert!(outcome.unwrap().success);
+            assert_eq!(
+                fs::read_to_string(recovery.fixture.assigned.join("README.md")).unwrap(),
+                "candidate and target\n"
+            );
+            assert_ne!(git_head(&recovery.fixture.assigned), recovery.original);
+            git_ok(
+                &recovery.fixture.assigned,
+                &["merge-base", "--is-ancestor", &recovery.target, "HEAD"],
+            );
+            assert_eq!(git_head(&recovery.fixture.primary), recovery.target);
+        }
+    }
+}
+
+#[test]
+fn conflict_recovery_refuses_incomplete_or_out_of_scope_agent_edits() {
+    for (name, body, expected) in [
+        (
+            "incomplete",
+            "printf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{\"recovered\":true},\"error\":null}'\n",
+            "were not repaired",
+        ),
+        (
+            "out-of-scope",
+            "printf 'candidate and target\\n' > README.md\nprintf 'unexpected\\n' > EXTRA.md\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+            "outside the authorized conflict set",
+        ),
+    ] {
+        let recovery = stopped_rebase_fixture(false);
+        let script = recovery.fixture.root().join("codex");
+        write_executable(
+            &script,
+            &format!("#!/bin/sh\nset -eu\ncat > /dev/null\n{body}"),
+        );
+        let mut host = TestHost::with_command(script.display().to_string());
+        host.workspace_root = Some(recovery.fixture.primary.clone());
+
+        let error = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(30)),
+            "pr_conflict_recovery",
+            "run-rebase-recovery",
+            test_audit(&format!("run-rebase-recovery-{name}"), "codex"),
+            &conflict_recovery_input(&recovery),
+            None,
+        )
+        .expect_err("host must reject incomplete or unrelated edits");
+
+        assert!(error.to_string().contains(expected), "{error}");
+        assert_eq!(
+            git_head(&recovery.fixture.assigned),
+            git_head(&recovery.fixture.primary),
+            "stopped rebase HEAD remains at its target until host continuation"
+        );
+        assert!(!git_bytes(&recovery.fixture.assigned, &["ls-files", "-u"]).is_empty());
+    }
+}
+
+#[test]
+fn conflict_recovery_rechecks_live_ownership_before_git_mutation() {
+    for (key, reason) in [
+        ("recovery_mutation_denied", "run was cancelled"),
+        ("recovery_authorization_denied", "grant_revoked"),
+    ] {
+        let recovery = stopped_rebase_fixture(false);
+        let script = recovery.fixture.root().join("codex");
+        write_executable(
+            &script,
+            "#!/bin/sh\nset -eu\ncat > /dev/null\nprintf 'candidate and target\\n' > README.md\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+        );
+        let mut host = TestHost::with_command(script.display().to_string());
+        host.workspace_root = Some(recovery.fixture.primary.clone());
+        let mut task_context = serde_json::json!({ "id": "T-recovery" });
+        task_context[key] = serde_json::json!(reason);
+        host.task_context = Some(task_context);
+
+        let error = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(30)),
+            "pr_conflict_recovery",
+            "run-rebase-recovery",
+            test_audit("run-rebase-recovery-refused", "codex"),
+            &conflict_recovery_input(&recovery),
+            None,
+        )
+        .expect_err("stale ownership or revoked authorization must refuse host continuation");
+
+        assert!(error.to_string().contains(reason), "{error}");
+        assert!(!git_bytes(&recovery.fixture.assigned, &["ls-files", "-u"]).is_empty());
+    }
+}
+
+#[test]
+fn completion_conflict_recovery_requires_preserved_candidate_and_pr_identity() {
+    for stale_candidate in [false, true] {
+        let recovery = stopped_rebase_fixture(false);
+        let script = recovery.fixture.root().join("codex");
+        write_executable(
+            &script,
+            "#!/bin/sh\nset -eu\ncat > /dev/null\nprintf 'candidate and target\\n' > README.md\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+        );
+        let mut host = TestHost::with_command(script.display().to_string());
+        host.workspace_root = Some(recovery.fixture.primary.clone());
+        let mut input = conflict_recovery_input(&recovery);
+        input["failed_step_id"] = serde_json::json!("complete_pr");
+        input["activity_name"] = serde_json::json!("pr_complete");
+        input["failed_step_input"] = serde_json::json!({
+            "head": "orbit-integrity-test",
+            "published_head_sha": if stale_candidate {
+                &recovery.original_base
+            } else {
+                &recovery.original
+            },
+            "completion": "done",
+            "pr_number": "1482",
+            "base": recovery.base_ref,
+            "base_sync": "local",
+        });
+
+        let outcome = run_cli_backend(
+            &host,
+            &test_agent_loop_spec(Duration::from_secs(30)),
+            "pr_conflict_recovery",
+            "run-rebase-recovery",
+            test_audit("run-completion-conflict-recovery", "codex"),
+            &input,
+            None,
+        );
+        if stale_candidate {
+            let error = outcome.expect_err("changed published candidate must fail before spawn");
+            assert!(
+                error.to_string().contains("existing rebase matching"),
+                "{error}"
+            );
+            assert!(!git_bytes(&recovery.fixture.assigned, &["ls-files", "-u"]).is_empty());
+        } else {
+            assert!(outcome.expect("completion recovery").success);
+            git_ok(
+                &recovery.fixture.assigned,
+                &["merge-base", "--is-ancestor", &recovery.target, "HEAD"],
+            );
+        }
+    }
+}
+
+#[test]
+fn conflict_recovery_reports_additional_conflicts_without_a_second_agent_attempt() {
+    let recovery = stopped_rebase_fixture(true);
+    let script = recovery.fixture.root().join("codex");
+    write_executable(
+        &script,
+        "#!/bin/sh\nset -eu\ncat > /dev/null\nprintf 'candidate one and target\\n' > README.md\nprintf '%s\\n' '{\"schemaVersion\":1,\"status\":\"success\",\"result\":{},\"error\":null}'\n",
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(recovery.fixture.primary.clone());
+
+    let error = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(30)),
+        "pr_conflict_recovery",
+        "run-rebase-recovery",
+        test_audit("run-rebase-recovery-additional", "codex"),
+        &conflict_recovery_input(&recovery),
+        None,
+    )
+    .expect_err("a later commit conflict must remain diagnosable");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("additional_conflicting_paths"),
+        "{message}"
+    );
+    assert!(message.contains("README.md"), "{message}");
+    assert!(!git_bytes(&recovery.fixture.assigned, &["ls-files", "-u"]).is_empty());
+}
+
+struct StoppedRebaseFixture {
+    fixture: LinkedWorktreeFixture,
+    original: String,
+    original_base: String,
+    base_ref: String,
+    target: String,
+}
+
+fn stopped_rebase_fixture(additional_candidate_commit: bool) -> StoppedRebaseFixture {
+    let fixture = linked_worktree_fixture();
+    let original_base = git_head(&fixture.assigned);
+    let base_ref = String::from_utf8(git_bytes(&fixture.primary, &["branch", "--show-current"]))
+        .unwrap()
+        .trim()
+        .to_string();
+    fs::write(fixture.assigned.join("README.md"), "candidate one\n").unwrap();
+    git_ok(&fixture.assigned, &["add", "README.md"]);
+    git_ok(&fixture.assigned, &["commit", "-m", "candidate one"]);
+    if additional_candidate_commit {
+        fs::write(fixture.assigned.join("README.md"), "candidate two\n").unwrap();
+        git_ok(&fixture.assigned, &["add", "README.md"]);
+        git_ok(&fixture.assigned, &["commit", "-m", "candidate two"]);
+    }
+    let original = git_head(&fixture.assigned);
+    fs::write(fixture.primary.join("README.md"), "target\n").unwrap();
+    git_ok(&fixture.primary, &["add", "README.md"]);
+    git_ok(&fixture.primary, &["commit", "-m", "target change"]);
+    let target = git_head(&fixture.primary);
+    let stopped = Command::new("git")
+        .arg("-C")
+        .arg(&fixture.assigned)
+        .args(["rebase", &target])
+        .output()
+        .unwrap();
+    assert!(!stopped.status.success());
+    StoppedRebaseFixture {
+        fixture,
+        original,
+        original_base,
+        base_ref,
+        target,
+    }
+}
+
+fn conflict_recovery_input(recovery: &StoppedRebaseFixture) -> serde_json::Value {
+    let mut input = worktree_input(&recovery.fixture, "T-recovery");
+    input["run_id"] = serde_json::json!("run-rebase-recovery");
+    input["failed_step_id"] = serde_json::json!("sync_base");
+    input["activity_name"] = serde_json::json!("git_rebase");
+    input["recovery_kind"] = serde_json::json!("vcs_conflict");
+    input["operation"] = serde_json::json!("git_rebase");
+    input["original_base_sha"] = serde_json::json!(recovery.original_base);
+    input["target_base_sha"] = serde_json::json!(recovery.target);
+    input["conflicting_paths"] = serde_json::json!(["README.md"]);
+    input["failed_step_input"] = serde_json::json!({
+        "head": "orbit-integrity-test",
+        "head_sha": recovery.original,
+        "base_ref": recovery.base_ref,
+        "base_sha": recovery.target,
+    });
+    input
+}
+
+fn git_head(repo: &Path) -> String {
+    String::from_utf8(git_bytes(repo, &["rev-parse", "HEAD"]))
+        .unwrap()
+        .trim()
+        .to_string()
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -11,9 +11,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use orbit_common::test_fixtures::TEST_CODEX_MODEL;
+use orbit_common::{OrbitError, test_fixtures::TEST_CODEX_MODEL};
 
-use crate::context::{CrewConfig, ResolvedActivityTools};
+use crate::context::{CrewConfig, ResolvedActivityTools, StepRecoveryAdmission};
 use orbit_agent::loop_engine::audit::{AuditSink, LoopAuditEvent};
 use orbit_common::observability::logging::RedactingFields;
 #[cfg(target_os = "macos")]
@@ -293,6 +293,42 @@ impl RuntimeHost for TestHost {
 
     fn task_context_for_agent_input(&self, _input: &Value) -> Result<Option<Value>, DispatchError> {
         Ok(self.task_context.clone())
+    }
+
+    fn validate_step_recovery_mutation(
+        &self,
+        _run_id: &str,
+        _step_id: &str,
+        _task_ids: &[String],
+        _workspace_path: &Path,
+    ) -> Result<(), OrbitError> {
+        match self
+            .task_context
+            .as_ref()
+            .and_then(|context| context.get("recovery_mutation_denied"))
+            .and_then(Value::as_str)
+        {
+            Some(reason) => Err(OrbitError::Execution(reason.to_string())),
+            None => Ok(()),
+        }
+    }
+
+    fn authorize_step_recovery(
+        &self,
+        _run_id: &str,
+        _step_id: &str,
+    ) -> Result<StepRecoveryAdmission, OrbitError> {
+        match self
+            .task_context
+            .as_ref()
+            .and_then(|context| context.get("recovery_authorization_denied"))
+            .and_then(Value::as_str)
+        {
+            Some(reason) => Ok(StepRecoveryAdmission::Denied {
+                reason: reason.to_string(),
+            }),
+            None => Ok(StepRecoveryAdmission::Allowed),
+        }
     }
 
     fn resolve_activity_tools(

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -257,6 +257,20 @@ fn pr_recovery_projects_rendered_candidate_context_without_overriding_run_author
         "/../orbit-core/assets/activities/pr_conflict_recovery.yaml"
     )))
     .unwrap();
+    let ActivityV2Spec::AgentLoop(agent) = &asset.spec.spec else {
+        panic!("conflict recovery must remain an agent leaf")
+    };
+    assert!(
+        agent
+            .instruction
+            .contains("Do not stage, commit, continue, abort")
+    );
+    assert!(
+        asset.spec.output_schema_json["properties"]
+            .get("recovered")
+            .is_none(),
+        "agent output cannot claim Git recovery authority"
+    );
     let schema = jsonschema::JSONSchema::compile(&asset.spec.input_schema_json).unwrap();
     let mut agent_input = input.clone();
     agent_input.as_object_mut().unwrap().remove("step_id");
@@ -462,7 +476,10 @@ fn typed_vcs_conflict_invokes_pr_recovery_once_and_retries_the_same_step_once() 
                 Ok(json!({"decision": "reused_recovery"})),
             ],
         ),
-        ("pr_conflict_recovery", vec![Ok(json!({"recovered": true}))]),
+        (
+            "pr_conflict_recovery",
+            vec![Ok(json!({"recovered": false}))],
+        ),
     ]);
     let mut job = recovery_job(None, None, "flaky", None, 4);
     job.steps[0].recovery_activity = Some("pr_conflict_recovery".to_string());
@@ -544,17 +561,26 @@ fn exhausted_pr_conflict_recovery_preserves_the_original_typed_error() {
     job.steps[0].resolved_recovery_activity =
         Some(deterministic_activity("pr_conflict_recovery", None));
 
+    let writer = Arc::new(test_writer("run-pr-conflict-exhausted"));
     let error = execute_job(
         &job,
         Value::Null,
         "run-pr-conflict-exhausted",
-        Arc::new(test_writer("run-pr-conflict-exhausted")),
+        writer.clone(),
         &host,
     )
     .expect_err("failed recovery must preserve the typed conflict");
 
     assert_eq!(error.to_string(), conflict.to_string());
     assert_eq!(host.actions(), vec!["flaky", "pr_conflict_recovery"]);
+    let event = serde_json::to_value(recovery_events(&writer.events_snapshot().unwrap())[0])
+        .expect("serialize recovery event");
+    assert_eq!(event["failure_phase"], "dispatch");
+    assert!(
+        event["error_message"]
+            .as_str()
+            .is_some_and(|message| message.contains("validation failed"))
+    );
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -7,7 +7,13 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
+use crate::context::RuntimeHost;
+
 use super::dispatcher::DispatchError;
+
+mod rebase_recovery;
+
+use rebase_recovery::RebaseRecoveryCheckpoint;
 
 pub fn resolve_subprocess_cwd(
     input: &Value,
@@ -390,11 +396,6 @@ pub(crate) struct WorktreeBoundaryGuard {
     rebase_recovery: Option<RebaseRecoveryCheckpoint>,
 }
 
-struct RebaseRecoveryCheckpoint {
-    branch: String,
-    target_base_sha: String,
-}
-
 impl WorktreeBoundaryGuard {
     pub(crate) fn capture(
         input: &Value,
@@ -591,108 +592,6 @@ impl WorktreeBoundaryGuard {
         }))
     }
 
-    /// Only the dedicated conflict-recovery dispatcher calls this method.
-    /// Admit completion of the already stopped, checkpoint-matching rebase;
-    /// ordinary implementing agents retain the no-history-change invariant.
-    pub(crate) fn authorize_rebase_completion(
-        &mut self,
-        input: &Value,
-    ) -> Result<(), DispatchError> {
-        let invalid = || {
-            DispatchError::CliInvocationPermanent(
-                "conflict recovery requires an existing rebase matching the prepared branch, \
-                 original HEAD and pinned target base"
-                    .to_string(),
-            )
-        };
-        if input.get("recovery_kind").and_then(Value::as_str) != Some("vcs_conflict")
-            || input.get("operation").and_then(Value::as_str) != Some("git_rebase")
-        {
-            return Err(invalid());
-        }
-        let prepared = input.get("failed_step_input").ok_or_else(invalid)?;
-        let branch = prepared
-            .get("head")
-            .and_then(Value::as_str)
-            .ok_or_else(invalid)?;
-        let original = prepared
-            .get("head_sha")
-            .and_then(Value::as_str)
-            .ok_or_else(invalid)?;
-        let target = input
-            .get("target_base_sha")
-            .and_then(Value::as_str)
-            .ok_or_else(invalid)?;
-        let expected_ref = format!("refs/heads/{branch}");
-        if git_stdout(
-            &self.assigned_root,
-            &["rev-parse", "--verify", &expected_ref],
-        )? != original
-        {
-            return Err(invalid());
-        }
-        for backend in ["rebase-merge", "rebase-apply"] {
-            let path = git_stdout(
-                &self.assigned_root,
-                &["rev-parse", "--path-format=absolute", "--git-path", backend],
-            )?;
-            let path = Path::new(&path);
-            if !path.is_dir() {
-                continue;
-            }
-            let read = |name: &str| {
-                fs::read_to_string(path.join(name)).map(|text| text.trim().to_string())
-            };
-            if read("head-name").ok().as_deref() != Some(expected_ref.as_str())
-                || read("orig-head").ok().as_deref() != Some(original)
-                || read("onto").ok().as_deref() != Some(target)
-            {
-                return Err(invalid());
-            }
-            self.rebase_recovery = Some(RebaseRecoveryCheckpoint {
-                branch: branch.to_string(),
-                target_base_sha: target.to_string(),
-            });
-            return Ok(());
-        }
-        Err(invalid())
-    }
-
-    fn completed_authorized_rebase(
-        &self,
-        after: &GitWorktreeFingerprint,
-    ) -> Result<bool, DispatchError> {
-        let Some(checkpoint) = &self.rebase_recovery else {
-            return Ok(false);
-        };
-        if after.branch.as_deref() != Some(checkpoint.branch.as_str())
-            || !after.dirty_paths.is_empty()
-        {
-            return Ok(false);
-        }
-        for backend in ["rebase-merge", "rebase-apply"] {
-            let path = git_stdout(
-                &self.assigned_root,
-                &["rev-parse", "--path-format=absolute", "--git-path", backend],
-            )?;
-            if Path::new(&path).exists() {
-                return Ok(false);
-            }
-        }
-        Ok(after.head != checkpoint.target_base_sha
-            && git_output_raw(
-                &self.assigned_root,
-                &[
-                    "merge-base",
-                    "--is-ancestor",
-                    &checkpoint.target_base_sha,
-                    "HEAD",
-                ],
-            )?
-            .status
-            .success())
-    }
-
     /// Compare both monitored checkouts after the provider reaches any
     /// terminal outcome. A primary delta is benign in exactly two shapes: a
     /// proven same-branch fast-forward, or a stationary HEAD whose only
@@ -703,6 +602,24 @@ impl WorktreeBoundaryGuard {
     /// primary dirt overlapping the run, and unapproved history changes in the
     /// assigned worktree remain typed, fail-closed violations. Only completion
     /// of an explicitly admitted stopped rebase permits assigned history changes.
+    pub(crate) fn verify_after_provider(
+        self,
+        host: &dyn RuntimeHost,
+        recovery_succeeded: bool,
+        recovery_step_id: Option<&str>,
+        task_ids: &[String],
+    ) -> Result<(), DispatchError> {
+        if self.rebase_recovery.is_some() && recovery_succeeded {
+            let step_id = recovery_step_id.ok_or_else(|| {
+                DispatchError::CliInvocationPermanent(
+                    "conflict recovery is missing its failed step identity".to_string(),
+                )
+            })?;
+            self.complete_rebase_recovery(host, step_id, task_ids)?;
+        }
+        self.verify()
+    }
+
     pub(crate) fn verify(self) -> Result<(), DispatchError> {
         let assigned_after = git_fingerprint(&self.assigned_root)?;
         let primary_after = git_fingerprint(&self.primary_root)?;

--- a/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
@@ -1,0 +1,404 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+use crate::context::{RuntimeHost, StepRecoveryAdmission};
+
+use super::{
+    DispatchError, GitWorktreeFingerprint, WorktreeBoundaryGuard, changed_paths, git_command_error,
+    git_fingerprint, git_output_raw, git_stdout, git_stdout_bytes, nul_paths,
+    primary_dirt_mutations, safe_relative_path,
+};
+
+pub(super) struct RebaseRecoveryCheckpoint {
+    branch: String,
+    original_head: String,
+    original_base_sha: String,
+    base_ref: String,
+    target_base_sha: String,
+    conflicting_paths: Vec<String>,
+}
+
+impl WorktreeBoundaryGuard {
+    /// Admit file repair for the already stopped, checkpoint-matching rebase.
+    /// The provider remains unable to write Git metadata; after it exits, the
+    /// host boundary independently validates and completes this checkpoint.
+    pub(crate) fn authorize_rebase_completion(
+        &mut self,
+        input: &Value,
+    ) -> Result<(), DispatchError> {
+        let invalid = || {
+            DispatchError::CliInvocationPermanent(
+                "conflict recovery requires an existing rebase matching the prepared branch, \
+                 original HEAD and pinned target base"
+                    .to_string(),
+            )
+        };
+        if input.get("recovery_kind").and_then(Value::as_str) != Some("vcs_conflict")
+            || input.get("operation").and_then(Value::as_str) != Some("git_rebase")
+        {
+            return Err(invalid());
+        }
+        let prepared = input.get("failed_step_input").ok_or_else(invalid)?;
+        let branch = prepared
+            .get("head")
+            .and_then(Value::as_str)
+            .ok_or_else(invalid)?;
+        let original = prepared
+            .get("head_sha")
+            .or_else(|| prepared.get("published_head_sha"))
+            .and_then(Value::as_str)
+            .ok_or_else(invalid)?;
+        let original_base_sha = input
+            .get("original_base_sha")
+            .and_then(Value::as_str)
+            .ok_or_else(invalid)?;
+        let target = input
+            .get("target_base_sha")
+            .and_then(Value::as_str)
+            .ok_or_else(invalid)?;
+        let base_ref = prepared
+            .get("base_ref")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| completion_recovery_base_ref(prepared))
+            .ok_or_else(invalid)?;
+        let prepared_target = prepared
+            .get("base_sha")
+            .and_then(Value::as_str)
+            .unwrap_or(target);
+        validate_failed_step_identity(input, prepared, original).ok_or_else(invalid)?;
+        if prepared_target != target
+            || git_stdout(&self.assigned_root, &["rev-parse", "--verify", &base_ref])? != target
+            || git_stdout(&self.assigned_root, &["merge-base", original, target])?
+                != original_base_sha
+        {
+            return Err(invalid());
+        }
+        let conflicting_paths = recovery_conflicting_paths(input).ok_or_else(invalid)?;
+        if unmerged_paths(&self.assigned_root)? != conflicting_paths {
+            return Err(invalid());
+        }
+        let expected_ref = format!("refs/heads/{branch}");
+        if git_stdout(
+            &self.assigned_root,
+            &["rev-parse", "--verify", &expected_ref],
+        )? != original
+        {
+            return Err(invalid());
+        }
+        for backend in ["rebase-merge", "rebase-apply"] {
+            let path = git_stdout(
+                &self.assigned_root,
+                &["rev-parse", "--path-format=absolute", "--git-path", backend],
+            )?;
+            let path = Path::new(&path);
+            if !path.is_dir() {
+                continue;
+            }
+            let read = |name: &str| {
+                fs::read_to_string(path.join(name)).map(|text| text.trim().to_string())
+            };
+            if read("head-name").ok().as_deref() != Some(expected_ref.as_str())
+                || read("orig-head").ok().as_deref() != Some(original)
+                || read("onto").ok().as_deref() != Some(target)
+            {
+                return Err(invalid());
+            }
+            self.rebase_recovery = Some(RebaseRecoveryCheckpoint {
+                branch: branch.to_string(),
+                original_head: original.to_string(),
+                original_base_sha: original_base_sha.to_string(),
+                base_ref,
+                target_base_sha: target.to_string(),
+                conflicting_paths,
+            });
+            return Ok(());
+        }
+        Err(invalid())
+    }
+
+    pub(super) fn completed_authorized_rebase(
+        &self,
+        after: &GitWorktreeFingerprint,
+    ) -> Result<bool, DispatchError> {
+        let Some(checkpoint) = &self.rebase_recovery else {
+            return Ok(false);
+        };
+        if after.branch.as_deref() != Some(checkpoint.branch.as_str()) {
+            return Ok(false);
+        }
+        for backend in ["rebase-merge", "rebase-apply"] {
+            let path = git_stdout(
+                &self.assigned_root,
+                &["rev-parse", "--path-format=absolute", "--git-path", backend],
+            )?;
+            if Path::new(&path).exists() {
+                return Ok(false);
+            }
+        }
+        Ok(after.head != checkpoint.target_base_sha
+            && git_output_raw(
+                &self.assigned_root,
+                &[
+                    "merge-base",
+                    "--is-ancestor",
+                    &checkpoint.target_base_sha,
+                    "HEAD",
+                ],
+            )?
+            .status
+            .success())
+    }
+
+    pub(super) fn complete_rebase_recovery(
+        &self,
+        host: &dyn RuntimeHost,
+        step_id: &str,
+        task_ids: &[String],
+    ) -> Result<(), DispatchError> {
+        let checkpoint = self.rebase_recovery.as_ref().ok_or_else(|| {
+            DispatchError::CliInvocationPermanent(
+                "conflict recovery has no authenticated rebase checkpoint".to_string(),
+            )
+        })?;
+        let invalid = |reason: &str| {
+            DispatchError::CliInvocationPermanent(format!(
+                "conflict recovery refused host Git continuation: {reason}"
+            ))
+        };
+
+        let after_agent = git_fingerprint(&self.assigned_root)?;
+        if after_agent.head != self.assigned_before.head
+            || after_agent.branch != self.assigned_before.branch
+            || after_agent.index_sha256 != self.assigned_before.index_sha256
+        {
+            return Err(invalid(
+                "the provider changed HEAD, branch, or index instead of only repairing files",
+            ));
+        }
+        let changed = changed_paths(&self.assigned_root, &self.assigned_before, &after_agent);
+        if changed
+            .iter()
+            .any(|path| !checkpoint.conflicting_paths.contains(path))
+        {
+            return Err(invalid(
+                "the provider changed a path outside the authorized conflict set",
+            ));
+        }
+        if checkpoint
+            .conflicting_paths
+            .iter()
+            .any(|path| !changed.contains(path))
+        {
+            return Err(invalid(
+                "one or more authorized conflict files were not repaired",
+            ));
+        }
+        self.validate_rebase_checkpoint(checkpoint, &invalid)?;
+        if unmerged_paths(&self.assigned_root)? != checkpoint.conflicting_paths {
+            return Err(invalid(
+                "the live unmerged paths changed after provider execution",
+            ));
+        }
+
+        let mut diff_check_args = vec!["diff", "--check", "--"];
+        diff_check_args.extend(checkpoint.conflicting_paths.iter().map(String::as_str));
+        let diff_check = git_output_raw(&self.assigned_root, &diff_check_args)?;
+        if !diff_check.status.success() {
+            return Err(invalid(
+                "a repaired file still contains conflict markers or whitespace errors",
+            ));
+        }
+
+        host.validate_step_recovery_mutation(&self.run_id, step_id, task_ids, &self.assigned_root)
+            .map_err(|error| {
+                invalid(&format!(
+                    "live run/task/worktree ownership changed: {error}"
+                ))
+            })?;
+        if let StepRecoveryAdmission::Denied { reason } = host
+            .authorize_step_recovery(&self.run_id, step_id)
+            .map_err(|error| invalid(&format!("recovery authorization recheck failed: {error}")))?
+        {
+            return Err(invalid(&format!(
+                "recovery authorization was revoked: {reason}"
+            )));
+        }
+
+        let mut add_args = vec!["add", "--"];
+        add_args.extend(checkpoint.conflicting_paths.iter().map(String::as_str));
+        git_mutation(&self.assigned_root, &add_args)?;
+        if !unmerged_paths(&self.assigned_root)?.is_empty() {
+            return Err(invalid(
+                "staging the authorized conflict set left unresolved entries",
+            ));
+        }
+        let continued = git_mutation_output(
+            &self.assigned_root,
+            &["-c", "core.editor=true", "rebase", "--continue"],
+        )?;
+        if !continued.status.success() {
+            let additional = unmerged_paths(&self.assigned_root)?;
+            let diagnostic = String::from_utf8_lossy(&continued.stderr)
+                .trim()
+                .to_string();
+            return Err(invalid(&format!(
+                "rebase --continue failed; additional_conflicting_paths={additional:?}; diagnostic={diagnostic}"
+            )));
+        }
+
+        let completed = git_fingerprint(&self.assigned_root)?;
+        if !self.completed_authorized_rebase(&completed)? {
+            return Err(invalid(
+                "continued rebase did not leave the checkpointed branch on the pinned base with a candidate commit",
+            ));
+        }
+        let unrelated_mutations = primary_dirt_mutations(&self.assigned_before, &completed)
+            .into_iter()
+            .filter(|path| !checkpoint.conflicting_paths.contains(path))
+            .collect::<Vec<_>>();
+        if !unrelated_mutations.is_empty() {
+            return Err(invalid(&format!(
+                "host continuation changed unrelated paths: {unrelated_mutations:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_rebase_checkpoint(
+        &self,
+        checkpoint: &RebaseRecoveryCheckpoint,
+        invalid: &impl Fn(&str) -> DispatchError,
+    ) -> Result<(), DispatchError> {
+        let expected_ref = format!("refs/heads/{}", checkpoint.branch);
+        if git_stdout(
+            &self.assigned_root,
+            &["rev-parse", "--verify", &expected_ref],
+        )? != checkpoint.original_head
+            || git_stdout(
+                &self.assigned_root,
+                &["rev-parse", "--verify", &checkpoint.base_ref],
+            )? != checkpoint.target_base_sha
+            || git_stdout(
+                &self.assigned_root,
+                &[
+                    "merge-base",
+                    &checkpoint.original_head,
+                    &checkpoint.target_base_sha,
+                ],
+            )? != checkpoint.original_base_sha
+        {
+            return Err(invalid(
+                "branch, original HEAD, original base, or pinned base moved",
+            ));
+        }
+        for backend in ["rebase-merge", "rebase-apply"] {
+            let path = git_stdout(
+                &self.assigned_root,
+                &["rev-parse", "--path-format=absolute", "--git-path", backend],
+            )?;
+            let path = Path::new(&path);
+            if !path.is_dir() {
+                continue;
+            }
+            let read = |name: &str| {
+                fs::read_to_string(path.join(name)).map(|text| text.trim().to_string())
+            };
+            if read("head-name").ok().as_deref() == Some(expected_ref.as_str())
+                && read("orig-head").ok().as_deref() == Some(checkpoint.original_head.as_str())
+                && read("onto").ok().as_deref() == Some(checkpoint.target_base_sha.as_str())
+            {
+                return Ok(());
+            }
+        }
+        Err(invalid(
+            "the stopped rebase metadata no longer matches its checkpoint",
+        ))
+    }
+}
+
+fn validate_failed_step_identity(input: &Value, prepared: &Value, original: &str) -> Option<()> {
+    let activity_name = input.get("activity_name")?.as_str()?;
+    let failed_step_id = input.get("failed_step_id")?.as_str()?;
+    if !matches!(
+        (failed_step_id, activity_name),
+        ("sync_base", "git_rebase") | ("complete_pr", "pr_complete")
+    ) {
+        return None;
+    }
+    if activity_name == "pr_complete"
+        && (prepared.get("completion")?.as_str()? != "done"
+            || prepared.get("published_head_sha")?.as_str()? != original
+            || prepared.get("pr_number")?.as_str()?.is_empty())
+    {
+        return None;
+    }
+    Some(())
+}
+
+fn recovery_conflicting_paths(input: &Value) -> Option<Vec<String>> {
+    let values = input.get("conflicting_paths")?.as_array()?;
+    let mut paths = Vec::with_capacity(values.len());
+    for value in values {
+        let path = value.as_str()?;
+        safe_relative_path(path).ok()?;
+        paths.push(path.to_string());
+    }
+    if paths.is_empty() {
+        return None;
+    }
+    let original_len = paths.len();
+    paths.sort();
+    paths.dedup();
+    (paths.len() == original_len).then_some(paths)
+}
+
+fn completion_recovery_base_ref(prepared: &Value) -> Option<String> {
+    let base = prepared.get("base")?.as_str()?;
+    match prepared.get("base_sync").and_then(Value::as_str) {
+        Some("local") => Some(base.to_string()),
+        Some("remote") | None => Some(format!(
+            "refs/remotes/origin/{}",
+            base.strip_prefix("origin/").unwrap_or(base)
+        )),
+        Some(_) => None,
+    }
+}
+
+fn unmerged_paths(root: &Path) -> Result<Vec<String>, DispatchError> {
+    let mut paths = nul_paths(&git_stdout_bytes(
+        root,
+        &["diff", "--name-only", "-z", "--diff-filter=U", "--"],
+    )?);
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn git_mutation(root: &Path, args: &[&str]) -> Result<(), DispatchError> {
+    let output = git_mutation_output(root, args)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(git_command_error(root, args, &output))
+    }
+}
+
+fn git_mutation_output(root: &Path, args: &[&str]) -> Result<Output, DispatchError> {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .output()
+        .map_err(|error| {
+            DispatchError::CliInvocationPermanent(format!(
+                "mutate Git state in '{}' with `git {}`: {error}",
+                root.display(),
+                args.join(" ")
+            ))
+        })
+}

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -244,6 +244,20 @@ pub trait RuntimeHost: Send + Sync {
     ) -> Result<(), OrbitError> {
         Ok(())
     }
+    /// Revalidate the live owner immediately before a recovery hook asks the
+    /// host process to mutate Git metadata. Agent subprocesses cannot confer
+    /// this authority through their response payload.
+    fn validate_step_recovery_mutation(
+        &self,
+        _run_id: &str,
+        _step_id: &str,
+        _task_ids: &[String],
+        _workspace_path: &Path,
+    ) -> Result<(), OrbitError> {
+        Err(unsupported_runtime_capability(
+            "validate_step_recovery_mutation",
+        ))
+    }
     /// Recheck the run's authority immediately before the guarded
     /// `review -> done` transition. An error refuses completion.
     fn authorize_task_completion(

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -219,11 +219,19 @@ other phase checkpoints. The run ID comes from the executor. This lets normal
 task-context loading, worktree-pair validation, and sandbox preparation use the
 same assignment as the failed step; no primary-checkout fallback is needed.
 System-crew selection still enforces the original run's crew allowlist.
-The dedicated conflict-recovery leaf may finish the already stopped rebase only
-when its Git metadata matches the prepared branch, original HEAD, and pinned
-target SHA. The boundary requires a clean result on that same branch with the
-target as an ancestor and a remaining candidate commit. Ordinary providers
-still cannot move HEAD; primary-checkout drift checks apply to recovery too.
+The dedicated conflict-recovery leaf edits conflict files only. Its managed
+sandbox deliberately retains the read-only linked-worktree Git metadata
+boundary: the leaf does not stage, abort, continue, or restart a rebase. After
+a successful terminal invocation, the host-side worktree boundary rechecks the
+live run and task owner, retry-lineage worktree checkpoint, prepared branch,
+original HEAD and merge base, pinned target ref and SHA, stopped-rebase
+metadata, and exact unmerged path set. It rejects incomplete or out-of-scope
+file edits, stages only that authenticated set, and runs one `rebase
+--continue`. A later conflict or changed/cancelled owner remains a failed
+recovery; the terminal handoff keeps the original error and preserved
+candidate/PR evidence. The boundary finally requires the target as an ancestor
+and a remaining candidate commit. Ordinary providers still cannot move HEAD;
+primary-checkout drift checks apply to recovery too.
 
 `step.recovery_attempted` retains a bounded, redacted `error_message` and
 `failure_phase` when authorization, input preparation, crew resolution, dispatch,
@@ -232,7 +240,7 @@ events and successful attempts. They supplement the original step conflict,
 which remains the returned error and terminal handoff evidence. An admitted
 attempt settles its recovery budget even when preparation fails before launch.
 
-After [ORB-10382], a recovery activity's structured result is **advisory only**, and its `output_schema_json` declares no `required` fields to keep it that way. A `recovery_activity` is a step attribute rather than a step, so it has no step id and no `{{ steps.<id>.output.* }}` template can consume it; `attempt_recovery_activity` gates the executor's single post-recovery attempt on dispatch success, never on a returned `recovered` field. For `pr_conflict_recovery`, success is established when the deterministic `git_rebase` retry verifies a clean index, no stopped rebase, the pinned target-base ancestry, and the expected branch rewrite; later push/open/promote/complete checkpoints remain the normal authorities.
+After [ORB-10382], a recovery activity's structured result is **advisory only**, and its `output_schema_json` declares no `required` fields to keep it that way. A `recovery_activity` is a step attribute rather than a step, so it has no step id and no `{{ steps.<id>.output.* }}` template can consume it; `attempt_recovery_activity` gates the executor's single post-recovery attempt on dispatch success, never on a returned `recovered` field. `pr_conflict_recovery` no longer advertises such a field at all. Its host-side continuation is authorized by the executor-selected activity and authenticated checkpoints, not response JSON. Final success is established when the deterministic `git_rebase` retry verifies a clean index, no stopped rebase, pinned target-base ancestry, and the expected branch rewrite; later push/open/promote/complete checkpoints remain the normal authorities.
 
 After [ORB-10499], that post-recovery attempt is identified as the source of the "duplicate implement invocation" reported in [F2026-07-174], and an implement invocation can now cancel itself once its task stops accepting writes. The audit trail of the reported run settles the dispatch question the friction could not: the two `implement_one` invocations were serial and deliberate, not concurrent. Attempt #1 exited 0 with `timed_out: false` and was classified `error`, `step_failure_recovery` reported success, `step.recovery_attempted` fired, and attempt #2 ran 848s to completion — after which `commit` reported `skipped_no_diff_expected`. So there is no double-dispatch bug and no retry-after-perceived-timeout policy, only the executor's bounded post-recovery attempt working as designed. Why attempt #2's work was unpersistable is a separate fact the friction conflated with the first: the task's own history shows `status_changed` and then `review_approved` landing *inside* attempt #2's window, attributable to no step of the run — `promote_no_diff` did not run until the end — and recorded against actor `unknown`, so which actor promoted it is not recoverable from the evidence and is deliberately not asserted. What both halves share is one assumption: that an implement invocation is the only actor on its task for the duration of its run. The executor assumes a step classified as failed leaves its task untouched, and the agent assumes its dispatch-time envelope stays valid until its final write. The fix keeps the re-dispatch — most failed attempts do leave the task unfinished — and instead makes the invocation able to see its situation. `agent_task_context_json` injects `status` and `terminal` into the `task` envelope (`terminal` mirroring the `update_task` write gate, where `Done` refuses every non-comment mutation and `Archived` refuses everything but a bare restore), and `agent_implement`'s instruction opens with a terminal-task precheck that stops before resolving context files and returns `success` with `skipped_reason: "task_terminal"`. Because the reported task went terminal mid-run, the dispatch-time snapshot alone is not sufficient: the contract also requires re-reading status through `orbit.task.show` at each checkpoint where the remaining work is still expensive, and treats a terminal-status write rejection as a stop rather than something to retry around. The guard is advisory in the sense of [L-0115] — the executor still gates on durable state and still pays subprocess startup — and an engine-side claim/lock refusing the re-dispatch outright was rejected both as hard-coding a task-lifecycle judgment into the generic step executor and as ineffective here, since the task was still `in-progress` when attempt #2 was dispatched.
 
@@ -270,17 +278,16 @@ After [ORB-10363], `JobV2.failure_activity` is a terminal, best-effort hook dist
 
 The preserved live ORB-11472 / PR1478 incident is an installed-runtime follow-up, not validation performed by [ORB-11488]. After this change is merged to `agent-main` and that build is installed on the owning host, first verify `orbit run show jrun-20260907-0339-14 --json` still names ORB-11472 and its preserved worktree/branch, and verify `gh pr view 1478 --json number,state,mergeStateStatus,headRefName,baseRefName` still reports the same open candidate. Then run `orbit job resume jrun-20260907-0339-14 --json` and retain the returned descendant run ID. Resume reuses successful publication and promotion checkpoints but resolves the current `complete_pr` definition, so the installed typed recovery path—not a blind retry of the old failed process—must perform any repair. Finally, verify the descendant run succeeded, PR1478 is `MERGED`, ORB-11472 is `done`, and its task branch was updated once rather than replaced by a new branch or PR. Until those host-side checks are recorded, source tests establish the recovery mechanism only; they do not establish that PR1478 recovered live.
 
-The ORB-11479 / PR1481 stale-`sync_base` incident likewise remains an
-installed-runtime verification target for [ORB-11493]. The observed deployed
-revision was `21b64aac2987379660b802aa741514e230e16f62` (executable SHA-256
-`87ad10a1b0a123a0635758c45efc9e5740efc203060c7d970330c8bb2fcc097d`), and
-the preserved source is `jrun-20260907-0341-12` through failed resume
-`jrun-20260907-0504`. After an ORB-11493 build is installed, verify those runs,
-the preserved branch, and PR1481 still agree before resuming the failed run.
-The descendant must show a new `prepare_branch.resume_refresh`, enter typed
-conflict recovery if Git proves unmerged entries, reuse PR1481, and complete
-only under its retained `completion: done` authority. Source tests do not prove
-that host-side recovery, so it remains required after delivery.
+The ORB-11479 / PR1481 and ORB-11477 / PR1482 preserved conflicts remain
+installed-runtime verification targets. Source tests exercise the host
+continuation boundary, but do not prove the installed Linux sandbox/process
+composition or a same-PR GitHub completion. After deploying this change, the
+orchestrator must select an eligible, unconsumed recovery checkpoint, verify
+its run/task/worktree/branch/base and open PR identity, resume it without
+restarting implementation, and record that the real sandboxed leaf edits files
+while the host completes Git metadata mutation. The descendant must reuse and
+complete the same PR under retained `completion: done` authority. A consumed
+checkpoint must not be blindly replayed or have its history reset.
 
 After [ORB-10385] / [The runtime reports its deterministic-action registry, and job validation gates on it](./4_decisions.md#the-runtime-reports-its-deterministic-action-registry-and-job-validation-gates-on-it), a job's reachable deterministic actions are checked against the executing runtime before its first step runs. `RuntimeHost::has_deterministic_action` reports the shared typed registry; `validate_job_deterministic_actions` walks the job's `recovery_activity`, `failure_activity`, every step's `recovery_activity`, and every resolved deterministic target (recursing through `parallel:`, `fan_out:`, and `loop:`) and fails the run with `DeterministicActionUnavailable` naming both the activity and the action. Because the check runs inside `execute_job_with_resume` ahead of step one, the run never reaches `worktree_setup`, so no task is admitted and no worktree is created. Unknown actions are never skipped, and the default trait implementation reports `true`, so a host that cannot enumerate its registry keeps surfacing the miss at dispatch. The gate does not weaken the failure hook: an action that becomes unavailable after admission still leaves the original failed-step error authoritative.
 


### PR DESCRIPTION
## Task

[ORB-11499](https://orbit-cli.com/tasks/ORB-11499) — Complete recovered rebases without granting agents broad Git metadata writes

### Description

Verified live remaining recovery failure after ORB-11489/11488/11493. Installed 7da76247178623303935deee90e061fa1ed3f3f9, executable SHA256 07730cc7ed3e37dbefafe034a9568355b636d11b8d8ab9c1547538671035482d. Authoritative resume of jrun-20260907-0504 created jrun-20260907-0604 for preserved ORB-11479/PR1481. OS process tree proved a real Codex provider under bwrap in original worktree orbit-jrun-20260907-0341-12. At 06:08:08Z the recovery leaf recorded through task MCP: it resolved the sole task_pilot_pipeline.rs conflict preserving pinned-base fixture changes and runtime-derived TempDir salt, but shell git and authorized proc.spawn git both failed creating index.lock with Read-only file system because .git/worktrees/orbit-jrun-20260907-0341-12 is mounted read-only. Parent failed at 06:08:22Z and preserved PR1481. This is actual runtime evidence, not an inferred launch failure. ORB-11489 explicitly warned that its unsandboxed Git fixture did not prove common Git metadata writes in the real sandbox.

Repair the existing recovery/Git ownership boundary. Prefer keeping the agent responsible for conflict-file edits and letting the existing deterministic host VCS owner validate, stage only the authorized conflict paths and continue the checkpoint-matching rebase outside the agent sandbox. Reuse existing typed conflict, failed-step checkpoint, run/task/worktree ownership, rebase and retry seams; do not introduce another recovery engine or depend on an agent-returned JSON recovered flag. If a narrowly owned metadata grant is instead demonstrably simpler and safe, justify its exact writable scope and preserve unrelated primary/other-worktree/ref/config/object protections; never bind the entire primary .git writable or weaken global sandbox policy. The real sandbox currently preventing metadata mutation is expected policy, so do not frame a broad permission bypass as the fix.

Require pinned branch/original HEAD/base/rebase state and task/run lineage validation immediately before deterministic mutation. Preserve unrelated modifications, original error/audit evidence, completion authorization and bounded retry/multiple-conflict behavior. A failed or incomplete resolution must remain a preserved, diagnosable candidate, not silently staged arbitrary files or marked done. Align activity instructions with the actual capability: do not demand git operations the leaf cannot perform. Validate the real sandbox/host boundary, not merely an unsandboxed provider fixture; deterministic sandbox-policy fixtures can supplement but must state environment-gated native execution honestly.

After source delivery the orchestrator will verify a preserved PR natively without restarting implementation. ORB-11479 now has a consumed checkpoint refresh; inspect bounded retry eligibility rather than blindly replaying it or resetting history. ORB-11477/PR1482 remains an unresumed preserved conflict candidate for a separate eligible native test. No source_task_id until actual introducing change is established. Authorized --complete delivery to agent-main; no releases/main promotion.

### Acceptance Criteria

- A real conflict-file resolution can complete its checkpoint-matching rebase through the owning deterministic Git boundary while the managed agent sandbox retains protection of unrelated Git metadata.
- Tests cover actual assigned worktree/branch/base identity, conflict-path scope, incomplete resolution, stale ownership/cancellation, additional conflicts, and bounded retries; arbitrary agent JSON cannot authorize completion.
- The activity contract matches permitted leaf actions, and original failure plus recovery diagnostics/candidate/PR identity remain preserved on refusal.
- Owning checks and ci-fast/ci-lint pass; installed verification must demonstrate sandboxed recovery and same-PR completion for an eligible preserved candidate, separately from source tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented host-owned completion of authenticated conflict rebases while leaving the recovery agent's linked-worktree Git metadata read-only.

Acceptance criteria:
1. Real conflict resolution boundary: pr_conflict_recovery now admits only a stopped rebase matching the executor-supplied failed step, assigned branch, original HEAD and merge base, pinned base ref/SHA, and exact current unmerged paths. After a successful agent response, the host verifies that only every authorized conflict file changed and HEAD/branch/index did not, rechecks durable run/task/retry-lineage/worktree ownership and recovery authorization, stages only those paths, and continues the existing rebase. Primary and unrelated Git metadata protections remain unchanged.
2. Authority and refusal coverage: new focused linked-worktree tests cover matching and stale branch/base checkpoints, incomplete resolution, out-of-scope edits, cancellation/ownership refusal, grant revocation, completion candidate/PR identity, and later conflicts. Core tests cover a live resumed-run lineage plus task/worktree mismatches. The existing bounded retry test now returns recovered=false and still retries from durable state, proving arbitrary result JSON is not authority. The RuntimeHost mutation capability defaults closed.
3. Activity contract and evidence: canonical and embedded pr_conflict_recovery assets now instruct the leaf to edit files only and prohibit stage/commit/rebase metadata operations; the advisory recovered output field was removed and the managed asset digest updated. Exhaustion tests assert original typed failure and recovery failure-phase/diagnostic preservation; existing PR handoff tests verify the published candidate, PR, and review state remain preserved.
4. Checks and installed verification: source/fixture checks passed. Installed native recovery of an eligible preserved ORB-11479/PR1481 or ORB-11477/PR1482 candidate was not run from this source executor; as required, it remains an orchestrator follow-through after build installation and must not replay the consumed checkpoint blindly.

Validation passed:
- cargo test -p orbit-engine conflict_recovery --no-fail-fast
- cargo test -p orbit-core recovery_git_mutation_requires_live_task_run_and_worktree_lineage
- cargo test -p orbit-engine typed_vcs_conflict_invokes_pr_recovery_once_and_retries_the_same_step_once
- cargo test -p orbit-engine recovered_rebase_continues_remaining_handoff_phases_without_replay
- cargo test -p orbit-engine published_pr_conflict_reuses_pinned_rebase_branch_and_pr_on_completion_retry
- cargo test -p orbit-engine completion_failure_preserves_published_candidate_and_review_state
- make ci-fast
- make ci-lint
- git diff --check
- sha256sum confirmed both activity copies equal manifest digest c10631bf400868a97b480cdc8e8ede542961a98d8efa23b56869b6afea2422a0

Review/handoff:
- Starting HEAD: 8c6ab16fcbac81da1aa61187f54bede4480e1cb8
- Worktree started clean.
- 14 tracked files changed plus 2 task-owned new Rust modules; no unrelated or temporary artifacts.
- Changes are intentionally uncommitted for the delivery pipeline.
- Remaining risk is limited to the explicitly separate installed Linux sandbox and same-PR completion verification described above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11499-6a9e5876`
- Behind base: 0
- Ahead of base: 1

*authored by: codex*