### PR TITLE
Use concrete failure diagnostics for stable CI sweep signatures

### DIFF
--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -10,7 +10,11 @@ spec:
     (workflow, failing job, failing step, normalized error signature, and the
     commit the runner actually tested) so one regression repeated across a push
     run and a pull-request run of the same commit becomes one task rather than
-    several. Current failures may include already-failed jobs from an
+    several. The normalized signature prefers a concrete test/panic diagnostic
+    over ANSI styling, generic cancellation/process/cargo trailers, and
+    assertion payload help text; the filed description still carries the raw
+    excerpt. With no concrete line the step name is used and labelled as a
+    fallback. Current failures may include already-failed jobs from an
     in-flight workflow when that evidence is complete; a pending check is
     never present in the snapshot as a current failure and must not be filed. Each surviving cluster is filed at `status: proposed` with the
     collected evidence rendered inline in the description, so the implementing

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -87,7 +87,10 @@ empty selectors, pilot failure, duplicates, already-landed
 work, conflicts, and warnings leave that task proposed without blocking other
 pilot children. A standalone task-pilot run has no promotion authority. The
 source run/job/SHA/step remains in the task description, while parent and child
-run state retain the pilot run ID, result, and admission decision.
+run state retain the pilot run ID, result, and admission decision. Filing
+clusters by a normalized error signature that prefers a concrete test or panic
+identity over ANSI styling, generic runner/cargo/nextest trailers, and
+assertion payload help text; the raw excerpt stays in the description.
 
 ### The `completion` input
 

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -88,8 +88,8 @@ work, conflicts, and warnings leave that task proposed without blocking other
 pilot children. A standalone task-pilot run has no promotion authority. The
 source run/job/SHA/step remains in the task description, while parent and child
 run state retain the pilot run ID, result, and admission decision. Filing
-clusters by a normalized error signature that prefers a concrete test or panic
-identity over ANSI styling, generic runner/cargo/nextest trailers, and
+clusters failures by a normalized error signature that prefers a concrete test
+or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
 ### The `completion` input

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1201,35 +1201,42 @@ const ERROR_MARKERS: &[&str] = &[
 /// Reduce a failed-step log to one normalized line that survives a rerun.
 ///
 /// Reruns of the same regression differ in timestamps, durations, run numbers,
-/// and paths under a run-specific temp directory. Normalizing those away is
-/// what lets an hourly sweep recognize the same root cause instead of filing it
-/// again every hour. Prefer an `##[error]`-annotated line over an unanchored
-/// marker substring, except that GitHub's generic runner-completion annotation
-/// yields to a specific unannotated diagnostic immediately before it. Never
-/// sign off runner-bookkeeping (checkout, group headers, `env:`/`with:` dumps)
-/// or libtest success/section lines whose names happen to contain a marker
-/// word. With no usable line the step name alone is the signature — weaker,
-/// but stable, and still scoped by workflow and job.
+/// ANSI styling, and paths under a run-specific temp directory. Normalizing
+/// those away is what lets an hourly sweep recognize the same root cause
+/// instead of filing it again every hour.
+///
+/// Preference order, so a generic wrapper cannot fragment one evidenced
+/// failure or collapse distinct ones:
+/// 1. A concrete test/panic identity (`thread '…' panicked`, `test … FAILED`,
+///    nextest `FAIL […]`, a name listed after libtest `failures:`).
+/// 2. A specific `##[error]` annotation.
+/// 3. Any remaining marker diagnostic (compiler `error:`, `assertion failed`).
+/// 4. The nearest unannotated content line before a generic trailer.
+/// 5. The failing step name, labelled as a fallback — used when the excerpt
+///    only has wrappers, bookkeeping, or assertion payload.
+///
+/// Generic trailers include GitHub's process-completed / `The process '…'
+/// failed with exit code` / action-failed annotations, cargo's
+/// `test failed, to rerun pass` wrappers, and nextest cancellation/summary
+/// lines. Assertion `left:`/`right:` dumps are not signatures even when they
+/// contain marker words. Raw excerpt bytes stay in the filed description;
+/// ANSI is stripped only for classification and the normalized signature.
 fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
     let lines = classify_log_lines(log_excerpt);
-    for (kind, line) in &lines {
-        if *kind == LineKind::ErrorAnnotated {
+    for wanted in [
+        LineKind::ConcreteDiagnostic,
+        LineKind::ErrorAnnotated,
+        LineKind::Marker,
+    ] {
+        if let Some((_, line)) = lines.iter().find(|(kind, _)| *kind == wanted) {
             return ErrorSignature {
-                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
-                step_fallback: false,
-            };
-        }
-    }
-    for (kind, line) in &lines {
-        if *kind == LineKind::Marker {
-            return ErrorSignature {
-                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                text: normalize_signature(&signature_payload(line)),
                 step_fallback: false,
             };
         }
     }
     for (index, (kind, _)) in lines.iter().enumerate() {
-        if *kind != LineKind::RunnerCompletion {
+        if *kind != LineKind::GenericTrailer {
             continue;
         }
         if let Some((_, line)) = lines[..index]
@@ -1238,15 +1245,7 @@ fn error_signature(log_excerpt: &str, step: &str) -> ErrorSignature {
             .find(|(kind, line)| *kind == LineKind::Content && is_diagnostic_content(line))
         {
             return ErrorSignature {
-                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
-                step_fallback: false,
-            };
-        }
-    }
-    for (kind, line) in &lines {
-        if *kind == LineKind::RunnerCompletion {
-            return ErrorSignature {
-                text: normalize_signature(&log_payload(line).to_ascii_lowercase()),
+                text: normalize_signature(&signature_payload(line)),
                 step_fallback: false,
             };
         }
@@ -1267,8 +1266,9 @@ enum LineKind {
     RunCommand,
     ParamDump,
     EndGroup,
+    ConcreteDiagnostic,
     ErrorAnnotated,
-    RunnerCompletion,
+    GenericTrailer,
     Marker,
     Bookkeeping,
     Content,
@@ -1301,7 +1301,12 @@ fn render_failed_step_excerpt(log: &str, max_bytes: usize) -> FailedStepExcerpt 
 
     let anchor = lines
         .iter()
-        .position(|(kind, _)| matches!(kind, LineKind::ErrorAnnotated | LineKind::RunnerCompletion))
+        .position(|(kind, _)| {
+            matches!(
+                kind,
+                LineKind::ConcreteDiagnostic | LineKind::ErrorAnnotated | LineKind::GenericTrailer
+            )
+        })
         .or_else(|| lines.iter().position(|(kind, _)| *kind == LineKind::Marker));
 
     let Some(anchor_idx) = anchor else {
@@ -1337,9 +1342,10 @@ fn render_failed_step_excerpt(log: &str, max_bytes: usize) -> FailedStepExcerpt 
 
 fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
     let mut in_param_block = false;
+    let mut after_failures_header = false;
     let mut out = Vec::new();
     for line in log.lines() {
-        let payload = log_payload(line);
+        let payload = signature_payload(line);
         let trimmed = payload.trim();
         let lowered = trimmed.to_ascii_lowercase();
         let indented = payload.starts_with(' ') || payload.starts_with('\t');
@@ -1356,21 +1362,38 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
             LineKind::ParamDump
         } else {
             in_param_block = false;
-            if is_generic_runner_completion(&lowered) {
-                LineKind::RunnerCompletion
+            if is_generic_trailer(&lowered) {
+                LineKind::GenericTrailer
             } else if lowered.contains("##[error]") {
                 LineKind::ErrorAnnotated
             } else if is_runner_bookkeeping(&lowered) || lowered.contains("##[group]") {
                 LineKind::Bookkeeping
-            } else if is_error_marker_line(&lowered) {
+            } else if is_concrete_diagnostic(&payload, &lowered, after_failures_header) {
+                LineKind::ConcreteDiagnostic
+            } else if is_error_marker_line(&lowered) && !is_assertion_payload(&lowered) {
                 LineKind::Marker
             } else {
                 LineKind::Content
             }
         };
+        if lowered == "failures:" || lowered == "errors:" {
+            after_failures_header = true;
+        } else if is_libtest_stdout_header(&lowered) || lowered.starts_with("test result:") {
+            after_failures_header = false;
+        }
         out.push((kind, line));
     }
     out
+}
+
+fn is_generic_trailer(lowered: &str) -> bool {
+    is_generic_runner_completion(lowered)
+        || is_generic_process_failed(lowered)
+        || is_generic_action_failed(lowered)
+        || is_cargo_test_wrapper(lowered)
+        || is_nextest_cancellation(lowered)
+        || is_nextest_summary(lowered)
+        || lowered.contains("tests were not run due to test failure")
 }
 
 fn is_generic_runner_completion(lowered: &str) -> bool {
@@ -1387,9 +1410,117 @@ fn is_generic_runner_completion(lowered: &str) -> bool {
     !exit_code.is_empty() && exit_code.chars().all(|ch| ch.is_ascii_digit())
 }
 
+fn is_generic_process_failed(lowered: &str) -> bool {
+    let Some(message) = lowered.trim().strip_prefix("##[error]") else {
+        return false;
+    };
+    let message = message.trim().trim_end_matches('.');
+    let Some(rest) = message.strip_prefix("the process ") else {
+        return false;
+    };
+    rest.contains(" failed with exit code ")
+}
+
+fn is_generic_action_failed(lowered: &str) -> bool {
+    let Some(message) = lowered.trim().strip_prefix("##[error]") else {
+        return false;
+    };
+    let message = message
+        .trim()
+        .trim_start_matches(|ch: char| !ch.is_ascii_alphabetic());
+    message == "action failed"
+}
+
+fn is_cargo_test_wrapper(lowered: &str) -> bool {
+    let message = lowered
+        .trim()
+        .strip_prefix("error:")
+        .map(str::trim)
+        .unwrap_or_else(|| lowered.trim());
+    message.starts_with("test failed, to rerun pass")
+        || message == "test run failed"
+        || message.starts_with("process didn't exit successfully:")
+}
+
+fn is_nextest_cancellation(lowered: &str) -> bool {
+    lowered
+        .trim()
+        .trim_end_matches(':')
+        .trim()
+        .starts_with("cancelling due to test failure")
+}
+
+fn is_nextest_summary(lowered: &str) -> bool {
+    let trimmed = lowered.trim();
+    trimmed.starts_with("summary [") && trimmed.contains("tests run:")
+}
+
+fn is_concrete_diagnostic(payload: &str, lowered: &str, after_failures_header: bool) -> bool {
+    is_panic_line(lowered)
+        || is_failed_test_result(lowered)
+        || is_nextest_fail_line(lowered)
+        || is_libtest_listed_failure_name(payload, after_failures_header)
+}
+
+fn is_panic_line(lowered: &str) -> bool {
+    lowered.contains("panicked at")
+        && (lowered.contains("thread '") || lowered.contains("thread \""))
+}
+
+fn is_failed_test_result(lowered: &str) -> bool {
+    let Some(rest) = lowered.strip_prefix("test ") else {
+        return false;
+    };
+    let Some((_, status)) = rest.rsplit_once(" ... ") else {
+        return false;
+    };
+    let status = status.trim();
+    status == "failed" || status.starts_with("failed ")
+}
+
+fn is_nextest_fail_line(lowered: &str) -> bool {
+    let Some(rest) = lowered.trim().strip_prefix("fail") else {
+        return false;
+    };
+    rest.trim_start().starts_with('[')
+}
+
+fn is_libtest_stdout_header(lowered: &str) -> bool {
+    let trimmed = lowered.trim();
+    trimmed.starts_with("---- ")
+        && (trimmed.ends_with(" stdout ----") || trimmed.ends_with(" stderr ----"))
+}
+
+fn is_libtest_listed_failure_name(payload: &str, after_failures_header: bool) -> bool {
+    if !after_failures_header {
+        return false;
+    }
+    let indented = payload.starts_with(' ') || payload.starts_with('\t');
+    if !indented {
+        return false;
+    }
+    let trimmed = payload.trim();
+    !trimmed.is_empty()
+        && !trimmed.contains(' ')
+        && !trimmed.starts_with("----")
+        && !trimmed.starts_with("thread")
+        && !trimmed.starts_with("error")
+        && !trimmed.starts_with("note:")
+        && !trimmed.starts_with("assertion")
+}
+
+fn is_assertion_payload(lowered: &str) -> bool {
+    let trimmed = lowered.trim_start();
+    trimmed.starts_with("left:")
+        || trimmed.starts_with("right:")
+        || trimmed.starts_with("left =")
+        || trimmed.starts_with("right =")
+}
+
 fn is_diagnostic_content(line: &str) -> bool {
-    let payload = log_payload(line).trim();
-    !payload.is_empty() && !payload.starts_with("##[")
+    let payload = signature_payload(line);
+    let trimmed = payload.trim();
+    !trimmed.is_empty() && !trimmed.starts_with("##[")
 }
 
 fn is_run_command_payload(payload: &str) -> bool {
@@ -1521,6 +1652,60 @@ fn log_payload(line: &str) -> &str {
         Some((first, tail)) if first.contains('T') && first.ends_with('Z') => tail,
         _ => rest,
     }
+}
+
+/// Payload used for classification and the normalized signature: runner
+/// columns removed, ANSI styling stripped. The filed excerpt keeps the raw
+/// line so evidence is not discarded.
+fn signature_payload(line: &str) -> String {
+    strip_ansi_sequences(log_payload(line)).to_ascii_lowercase()
+}
+
+/// CSI/OSC sequences only. The raw log line remains in the task description.
+fn strip_ansi_sequences(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != 0x1b {
+            let len = input[i..].chars().next().map_or(1, char::len_utf8);
+            out.push_str(&input[i..i + len]);
+            i += len;
+            continue;
+        }
+        i += 1;
+        if i >= bytes.len() {
+            break;
+        }
+        match bytes[i] {
+            b'[' => {
+                i += 1;
+                while i < bytes.len() {
+                    let byte = bytes[i];
+                    i += 1;
+                    if (0x40..=0x7e).contains(&byte) {
+                        break;
+                    }
+                }
+            }
+            b']' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == 0x07 {
+                        i += 1;
+                        break;
+                    }
+                    if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    out
 }
 
 /// Collapse the parts of a log line that vary between identical failures.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -1346,10 +1346,9 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
     let mut out = Vec::new();
     for line in log.lines() {
         let payload = signature_payload(line);
-        let trimmed = payload.trim();
-        let lowered = trimmed.to_ascii_lowercase();
+        let lowered = payload.trim();
         let indented = payload.starts_with(' ') || payload.starts_with('\t');
-        let kind = if is_run_command_payload(trimmed) {
+        let kind = if is_run_command_payload(lowered) {
             in_param_block = false;
             LineKind::RunCommand
         } else if lowered.contains("##[endgroup]") {
@@ -1358,19 +1357,19 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
         } else if lowered == "env:" || lowered == "with:" {
             in_param_block = true;
             LineKind::ParamDump
-        } else if in_param_block && (indented || trimmed.is_empty()) {
+        } else if in_param_block && (indented || lowered.is_empty()) {
             LineKind::ParamDump
         } else {
             in_param_block = false;
-            if is_generic_trailer(&lowered) {
+            if is_generic_trailer(lowered) {
                 LineKind::GenericTrailer
             } else if lowered.contains("##[error]") {
                 LineKind::ErrorAnnotated
-            } else if is_runner_bookkeeping(&lowered) || lowered.contains("##[group]") {
+            } else if is_runner_bookkeeping(lowered) || lowered.contains("##[group]") {
                 LineKind::Bookkeeping
-            } else if is_concrete_diagnostic(&payload, &lowered, after_failures_header) {
+            } else if is_concrete_diagnostic(&payload, lowered, after_failures_header) {
                 LineKind::ConcreteDiagnostic
-            } else if is_error_marker_line(&lowered) && !is_assertion_payload(&lowered) {
+            } else if is_error_marker_line(lowered) && !is_assertion_payload(lowered) {
                 LineKind::Marker
             } else {
                 LineKind::Content
@@ -1378,7 +1377,7 @@ fn classify_log_lines(log: &str) -> Vec<(LineKind, &str)> {
         };
         if lowered == "failures:" || lowered == "errors:" {
             after_failures_header = true;
-        } else if is_libtest_stdout_header(&lowered) || lowered.starts_with("test result:") {
+        } else if is_libtest_stdout_header(lowered) || lowered.starts_with("test result:") {
             after_failures_header = false;
         }
         out.push((kind, line));
@@ -1655,60 +1654,56 @@ fn log_payload(line: &str) -> &str {
 }
 
 /// Payload used for classification and the normalized signature: runner
-/// columns removed, ANSI styling stripped. The filed excerpt keeps the raw
-/// line so evidence is not discarded.
+/// columns removed, ANSI styling stripped, lowercased. The filed excerpt keeps
+/// the raw line so evidence is not discarded.
 fn signature_payload(line: &str) -> String {
     strip_ansi_sequences(log_payload(line)).to_ascii_lowercase()
 }
 
 /// CSI/OSC sequences only. The raw log line remains in the task description.
+///
+/// Walks characters rather than bytes: a truncated or malformed escape in a
+/// runner log must not split a multi-byte character.
 fn strip_ansi_sequences(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] != 0x1b {
-            let len = input[i..].chars().next().map_or(1, char::len_utf8);
-            out.push_str(&input[i..i + len]);
-            i += len;
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            out.push(ch);
             continue;
         }
-        i += 1;
-        if i >= bytes.len() {
-            break;
-        }
-        match bytes[i] {
-            b'[' => {
-                i += 1;
-                while i < bytes.len() {
-                    let byte = bytes[i];
-                    i += 1;
-                    if (0x40..=0x7e).contains(&byte) {
+        match chars.next() {
+            // CSI: parameters and intermediates, then one final character.
+            Some('[') => {
+                for ch in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&ch) {
                         break;
                     }
                 }
             }
-            b']' => {
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == 0x07 {
-                        i += 1;
+            // OSC: runs to BEL or the ST terminator.
+            Some(']') => {
+                while let Some(ch) = chars.next() {
+                    if ch == '\u{07}' {
                         break;
                     }
-                    if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' {
-                        i += 2;
+                    if ch == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
                         break;
                     }
-                    i += 1;
                 }
             }
-            _ => i += 1,
+            // A lone escape, or a two-character sequence: drop both.
+            _ => {}
         }
     }
     out
 }
 
-/// Collapse the parts of a log line that vary between identical failures.
+/// Collapse the parts of a log line that vary between identical failures:
+/// bare numbers, long hex blobs, and measurements whose unit is the only
+/// stable part (nextest's `FAIL [ 1.399s]` is a different duration on every
+/// rerun of the same failing test).
 fn normalize_signature(lowered: &str) -> String {
     let mut out = String::with_capacity(lowered.len());
     let mut chars = lowered.chars().peekable();
@@ -1719,14 +1714,19 @@ fn normalize_signature(lowered: &str) -> String {
             while chars.peek().is_some_and(char::is_ascii_alphanumeric) {
                 token.push(chars.next().unwrap_or_default());
             }
-            let replacement = if token.chars().all(|c| c.is_ascii_digit()) {
-                "<n>"
+            // The token is ASCII alphanumeric, so a digit count indexes it directly.
+            let digits = token.chars().take_while(char::is_ascii_digit).count();
+            if digits == token.len() {
+                out.push_str("<n>");
             } else if token.len() >= 7 && token.chars().all(|c| c.is_ascii_hexdigit()) {
-                "<hex>"
+                out.push_str("<hex>");
+            } else if digits > 0 && token[digits..].chars().all(|c| c.is_ascii_alphabetic()) {
+                // A measurement such as `399s` or `250ms`: keep the unit, drop the count.
+                out.push_str("<n>");
+                out.push_str(&token[digits..]);
             } else {
-                token.as_str()
-            };
-            out.push_str(replacement);
+                out.push_str(&token);
+            }
             last_was_space = false;
             continue;
         }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -1269,6 +1269,449 @@ fn distinct_rust_panics_with_the_same_passing_preamble_keep_distinct_keys() {
     );
 }
 
+fn ansi_bold_red(text: &str) -> String {
+    format!("\u{1b}[31;1m{text}\u{1b}[0m")
+}
+
+fn github_line(job: &str, step: &str, payload: &str) -> String {
+    format!("{job}\t{step}\t2026-09-07T07:24:42.8592482Z {payload}\n")
+}
+
+/// ORB-11509: nextest cancellation and summary wrap a FAIL line. ANSI styling
+/// must not become the signature, and colored/uncolored logs must match.
+fn orb_11509_style_nextest_log(colored: bool, failing: &str) -> String {
+    let job = "Check / Clippy / Test";
+    let step = "Run CI guardrails";
+    let paint = |text: &str, color: bool| {
+        if color {
+            ansi_bold_red(text)
+        } else {
+            text.to_string()
+        }
+    };
+    let mut out = String::new();
+    out.push_str(&github_line(job, step, "##[group]Run cargo nextest run"));
+    out.push_str(&github_line(
+        job,
+        step,
+        "test mcp_serve_error_paths_return_tool_errors_and_keep_serving ... ok",
+    ));
+    out.push_str(&github_line(
+        job,
+        step,
+        &format!(
+            "{} due to {}: ",
+            paint("  Cancelling", colored),
+            paint("test failure", colored)
+        ),
+    ));
+    out.push_str(&github_line(job, step, "────────────"));
+    out.push_str(&github_line(
+        job,
+        step,
+        &format!(
+            "{} [ 177.529s] 2786/4410 tests run: 2785 passed (2 slow), 1 failed, 10 skipped",
+            paint("     Summary", colored)
+        ),
+    ));
+    out.push_str(&github_line(
+        job,
+        step,
+        &format!(
+            "{} [   1.399s] (2786/4410) {} {}",
+            paint("        FAIL", colored),
+            paint("orbit-cli::output_goldens", colored),
+            paint(failing, colored)
+        ),
+    ));
+    out.push_str(&github_line(
+        job,
+        step,
+        "warning: 1624/4410 tests were not run due to test failure (run with --no-fail-fast to run all tests)",
+    ));
+    out.push_str(&github_line(
+        job,
+        step,
+        &format!("{}: test run failed", paint("error", colored)),
+    ));
+    out.push_str(&github_line(
+        job,
+        step,
+        "##[error]Process completed with exit code 100.",
+    ));
+    out
+}
+
+/// ORB-11470 / ORB-11467: cargo's colored `error: test failed, to rerun pass`
+/// trailer can appear before the panic when the excerpt is a recovered job log.
+fn orb_11470_style_macos_log(failing: &str, cargo_before_panic: bool) -> String {
+    let job = "macOS Sandbox";
+    let step = "Run orbit-exec sandbox tests (real sandbox-exec)";
+    let prefix = |payload: &str| github_line(job, step, payload);
+    let cargo = format!(
+        "{}: test failed, to rerun pass `-p orbit-exec --lib`",
+        ansi_bold_red("error")
+    );
+    let header = format!("---- {failing} stdout ----");
+    let panic = format!(
+        "thread '{failing}' (14083) panicked at crates/orbit-exec/src/macos_sandbox/tests/compile.rs:454:5:"
+    );
+    let mut out = String::new();
+    out.push_str(&prefix("##[group]Run cargo test -p orbit-exec --locked"));
+    out.push_str(&prefix(
+        "test macos_sandbox::tests::spawn::spawn_under_macos_sandbox_runs_program_in_provided_cwd ... ok",
+    ));
+    out.push_str(&prefix("failures:"));
+    out.push_str(&prefix(&header));
+    if cargo_before_panic {
+        out.push_str(&prefix(&cargo));
+        out.push_str(&prefix(&panic));
+    } else {
+        out.push_str(&prefix(&panic));
+        out.push_str(&prefix(&cargo));
+    }
+    out.push_str(&prefix(
+        "an explicit denyRead must still outrank the public CA default",
+    ));
+    out.push_str(&prefix("failures:"));
+    out.push_str(&prefix(&format!("    {failing}")));
+    out.push_str(&prefix(
+        "test result: FAILED. 67 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.57s",
+    ));
+    out.push_str(&prefix("##[error]Process completed with exit code 101."));
+    out
+}
+
+/// ORB-11498 / ORB-11502: golden assertion payload quotes github.run.logs help
+/// text containing `failed steps`. The failing test name is in the libtest
+/// summary list; the panic line is omitted as in a head/tail truncated excerpt.
+fn orb_11498_style_golden_log(failing: &str) -> String {
+    let job = "Coverage (informational)";
+    let step = "Collect workspace coverage";
+    let prefix = |payload: &str| github_line(job, step, payload);
+    let mut out = String::new();
+    out.push_str(&prefix(
+        "##[group]Run cargo llvm-cov --workspace --locked --no-report",
+    ));
+    out.push_str(&prefix(
+        "test no_ansi_escapes_under_any_color_configuration ... ok",
+    ));
+    out.push_str(&prefix(
+        r#"        "description": "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is drained incrementally; checkout extraction stops after 8 MiB.""#,
+    ));
+    out.push_str(&prefix(
+        r#"  right: "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence.""#,
+    ));
+    out.push_str(&prefix("failures:"));
+    out.push_str(&prefix(&format!("    {failing}")));
+    out.push_str(&prefix(
+        "test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.64s",
+    ));
+    out.push_str(&prefix(
+        "error: test failed, to rerun pass `-p orbit-cli --test output_goldens`",
+    ));
+    out.push_str(&prefix(
+        "error: process didn't exit successfully: `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test --tests` (exit status: 101)",
+    ));
+    out.push_str(&prefix("##[error]Process completed with exit code 101."));
+    out
+}
+
+/// ORB-11513: Wrangler colored `[ERROR]` plus the missing-field diagnostic,
+/// then GitHub's generic `The process 'npx' failed with exit code`.
+fn orb_11513_style_wrangler_log(title: &str, detail: &str) -> String {
+    let job = "Publish to Cloudflare Pages";
+    let step = "Deploy static site";
+    let prefix = |payload: &str| github_line(job, step, payload);
+    let wrangler_error = format!(
+        "\u{1b}[31m✘ \u{1b}[41;31m[\u{1b}[41;97mERROR\u{1b}[41;31m]\u{1b}[0m \u{1b}[1m{title}:\u{1b}[0m"
+    );
+    let mut out = String::new();
+    out.push_str(&prefix(
+        "##[group]Run cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0",
+    ));
+    out.push_str(&prefix(&wrangler_error));
+    out.push_str(&prefix(&format!(
+        "    - Missing top-level field \"name\" in configuration file. {detail}"
+    )));
+    out.push_str(&prefix(
+        "##[error]The process '/usr/local/bin/npx' failed with exit code 1",
+    ));
+    out.push_str(&prefix("##[error]🚨 Action failed"));
+    out
+}
+
+#[test]
+fn colored_and_uncolored_nextest_cancellation_share_the_fail_identity() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    const FAILING: &str = "plain_and_json_forms_match_their_goldens";
+    let colored = orb_11509_style_nextest_log(true, FAILING);
+    let plain = orb_11509_style_nextest_log(false, FAILING);
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10, "CI", "Check / Clippy / Test", "Run CI guardrails", &colored, CHECKOUT,
+        )])}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+    let task_id = filed_task_ids(&first).remove(0);
+    let signature = signature_line(
+        &runtime
+            .get_task(&task_id)
+            .expect("read filed task")
+            .description,
+    )
+    .to_ascii_lowercase();
+    assert!(
+        signature.contains(FAILING) && signature.contains("fail"),
+        "nextest FAIL line must be the signature: {signature}"
+    );
+    assert!(
+        !signature.contains("cancelling")
+            && !signature.contains("process completed")
+            && !signature.contains("test run failed")
+            && !signature.contains('\u{1b}'),
+        "cancellation, cargo trailer, and ANSI must not be the signature: {signature}"
+    );
+    assert!(
+        runtime
+            .get_task(&task_id)
+            .expect("read filed task")
+            .description
+            .contains("Cancelling"),
+        "raw colored excerpt must remain in the description"
+    );
+
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            11, "CI", "Check / Clippy / Test", "Run CI guardrails", &plain, NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(
+        repeated["skipped_existing"][0]["failure_key"], first["filed"][0]["failure_key"],
+        "colored and uncolored nextest FAIL logs must share a failure key"
+    );
+}
+
+#[test]
+fn distinct_nextest_fail_lines_in_the_same_job_keep_distinct_keys() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let foo = orb_11509_style_nextest_log(true, "plain_and_json_forms_match_their_goldens");
+    let bar = orb_11509_style_nextest_log(false, "another_golden_does_not_match");
+
+    let output = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![
+            failure(10, "CI", "Check / Clippy / Test", "Run CI guardrails", &foo, CHECKOUT),
+            failure(11, "CI", "Check / Clippy / Test", "Run CI guardrails", &bar, CHECKOUT),
+        ])}),
+    );
+    assert_eq!(output["filed_count"], json!(2));
+    let filed = output["filed"].as_array().expect("filed");
+    assert_ne!(filed[0]["failure_key"], filed[1]["failure_key"]);
+}
+
+#[test]
+fn cargo_test_failed_trailer_does_not_outrank_the_panic() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    const FAILING: &str = "macos_sandbox::tests::compile::compiled_codex_profile_reads_public_ca_material_but_not_private_credentials";
+    let trailer_first = orb_11470_style_macos_log(FAILING, true);
+    let panic_first = orb_11470_style_macos_log(FAILING, false);
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "macOS Platform",
+            "macOS Sandbox",
+            "Run orbit-exec sandbox tests (real sandbox-exec)",
+            &trailer_first,
+            CHECKOUT,
+        )])}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+    let signature = signature_line(
+        &runtime
+            .get_task(&filed_task_ids(&first)[0])
+            .expect("read filed task")
+            .description,
+    )
+    .to_ascii_lowercase();
+    assert!(
+        signature.contains(FAILING) && signature.contains("panicked"),
+        "panic must outrank the cargo trailer: {signature}"
+    );
+    assert!(
+        !signature.contains("to rerun pass") && !signature.contains("process completed"),
+        "cargo/github wrappers must not be the signature: {signature}"
+    );
+
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            11,
+            "macOS Platform",
+            "macOS Sandbox",
+            "Run orbit-exec sandbox tests (real sandbox-exec)",
+            &panic_first,
+            NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(
+        repeated["skipped_existing"][0]["failure_key"],
+        first["filed"][0]["failure_key"]
+    );
+}
+
+#[test]
+fn golden_assertion_help_text_does_not_outrank_the_failing_test_name() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    const FAILING: &str = "plain_and_json_forms_match_their_goldens";
+    let log = orb_11498_style_golden_log(FAILING);
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "CI",
+            "Coverage (informational)",
+            "Collect workspace coverage",
+            &log,
+            CHECKOUT,
+        )])}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+    let task_id = filed_task_ids(&first).remove(0);
+    let description = runtime
+        .get_task(&task_id)
+        .expect("read filed task")
+        .description;
+    let signature = signature_line(&description).to_ascii_lowercase();
+    assert!(
+        signature.contains(FAILING),
+        "listed golden test name must be the signature: {signature}"
+    );
+    assert!(
+        !signature.contains("failed steps")
+            && !signature.contains("bounded excerpt")
+            && !signature.contains("to rerun pass"),
+        "assertion payload and cargo trailer must not be the signature: {signature}"
+    );
+    assert!(
+        description.contains("failed steps by default"),
+        "raw assertion payload must remain in the excerpt"
+    );
+
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            11,
+            "CI",
+            "Coverage (informational)",
+            "Collect workspace coverage",
+            &log,
+            NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(repeated["filed_count"], json!(0));
+}
+
+#[test]
+fn wrangler_error_outranks_generic_npx_process_failed() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let missing_name = orb_11513_style_wrangler_log(
+        "Running configuration file validation for Pages",
+        "Pages requires the name of your project.",
+    );
+    let missing_pages = orb_11513_style_wrangler_log(
+        "Failed to publish your Function",
+        "Pages build output directory is missing.",
+    );
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10,
+            "Website",
+            "Publish to Cloudflare Pages",
+            "Deploy static site",
+            &missing_name,
+            CHECKOUT,
+        )])}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+    let signature = signature_line(
+        &runtime
+            .get_task(&filed_task_ids(&first)[0])
+            .expect("read filed task")
+            .description,
+    )
+    .to_ascii_lowercase();
+    assert!(
+        signature.contains("configuration file validation")
+            || signature.contains("missing top-level field"),
+        "wrangler diagnostic must outrank npx process-failed: {signature}"
+    );
+    assert!(
+        !signature.contains("usr/local/bin/npx") && !signature.contains("action failed"),
+        "generic process/action trailers must not be the signature: {signature}"
+    );
+
+    let second = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![
+            failure(
+                11,
+                "Website",
+                "Publish to Cloudflare Pages",
+                "Deploy static site",
+                &missing_pages,
+                CHECKOUT,
+            ),
+        ])}),
+    );
+    assert_eq!(second["filed_count"], json!(1));
+    assert_ne!(
+        first["filed"][0]["failure_key"], second["filed"][0]["failure_key"],
+        "distinct wrangler diagnostics in the same job must not collapse"
+    );
+}
+
+#[test]
+fn generic_only_truncated_excerpt_labels_step_name_fallback() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = format!(
+        "{}{}{}",
+        github_line("build", "cargo test", "##[group]Run cargo test"),
+        github_line(
+            "build",
+            "cargo test",
+            "error: test failed, to rerun pass `-p orbit-exec --lib`",
+        ),
+        github_line(
+            "build",
+            "cargo test",
+            "##[error]Process completed with exit code 101.",
+        ),
+    );
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let signature = signature_line(&description);
+    assert!(
+        signature.contains("step-name fallback"),
+        "generic-only excerpt must label fallback uncertainty: {signature}"
+    );
+    assert!(
+        description.contains("test failed, to rerun pass")
+            && description.contains("Process completed with exit code 101."),
+        "raw generic trailers must remain in the excerpt:\n{description}"
+    );
+}
+
 #[test]
 fn query_error_prevents_filing_and_remains_retryable() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -1279,7 +1279,10 @@ fn github_line(job: &str, step: &str, payload: &str) -> String {
 
 /// ORB-11509: nextest cancellation and summary wrap a FAIL line. ANSI styling
 /// must not become the signature, and colored/uncolored logs must match.
-fn orb_11509_style_nextest_log(colored: bool, failing: &str) -> String {
+///
+/// `elapsed` is the per-test duration nextest prints in the FAIL line; it
+/// differs on every rerun of the same regression.
+fn orb_11509_style_nextest_log(colored: bool, failing: &str, elapsed: &str) -> String {
     let job = "Check / Clippy / Test";
     let step = "Run CI guardrails";
     let paint = |text: &str, color: bool| {
@@ -1318,7 +1321,7 @@ fn orb_11509_style_nextest_log(colored: bool, failing: &str) -> String {
         job,
         step,
         &format!(
-            "{} [   1.399s] (2786/4410) {} {}",
+            "{} [   {elapsed}] (2786/4410) {} {}",
             paint("        FAIL", colored),
             paint("orbit-cli::output_goldens", colored),
             paint(failing, colored)
@@ -1445,8 +1448,8 @@ fn orb_11513_style_wrangler_log(title: &str, detail: &str) -> String {
 fn colored_and_uncolored_nextest_cancellation_share_the_fail_identity() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     const FAILING: &str = "plain_and_json_forms_match_their_goldens";
-    let colored = orb_11509_style_nextest_log(true, FAILING);
-    let plain = orb_11509_style_nextest_log(false, FAILING);
+    let colored = orb_11509_style_nextest_log(true, FAILING, "1.399s");
+    let plain = orb_11509_style_nextest_log(false, FAILING, "1.399s");
 
     let first = file(
         &runtime,
@@ -1496,11 +1499,68 @@ fn colored_and_uncolored_nextest_cancellation_share_the_fail_identity() {
     );
 }
 
+/// A colored log can reach the sweep with an escape sequence cut short — the
+/// stripper must not split the multi-byte character that follows it.
+#[test]
+fn a_truncated_escape_before_a_multibyte_character_still_files() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let log = format!(
+        "{}{}{}",
+        github_line("build", "cargo test", "##[group]Run cargo nextest run"),
+        github_line("build", "cargo test", "\u{1b}────────────"),
+        github_line(
+            "build",
+            "cargo test",
+            "    FAIL [   1.399s] orbit-core truncated_escape_case",
+        ),
+    );
+
+    let (_output, description) = filed_description(&runtime, &log);
+    let signature = signature_line(&description).to_ascii_lowercase();
+    assert!(
+        signature.contains("truncated_escape_case"),
+        "the FAIL identity must survive a truncated escape: {signature}"
+    );
+}
+
+#[test]
+fn nextest_fail_durations_do_not_fragment_one_regression() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    const FAILING: &str = "plain_and_json_forms_match_their_goldens";
+    let first_run = orb_11509_style_nextest_log(true, FAILING, "1.399s");
+    let rerun = orb_11509_style_nextest_log(true, FAILING, "2.004s");
+
+    let first = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            10, "CI", "Check / Clippy / Test", "Run CI guardrails", &first_run, CHECKOUT,
+        )])}),
+    );
+    assert_eq!(first["filed_count"], json!(1));
+
+    let repeated = file(
+        &runtime,
+        json!({"ci_evidence": snapshot(vec![failure(
+            11, "CI", "Check / Clippy / Test", "Run CI guardrails", &rerun, NEXT_HEAD,
+        )])}),
+    );
+    assert_eq!(
+        repeated["filed_count"],
+        json!(0),
+        "a rerun of the same test must not file a second task"
+    );
+    assert_eq!(
+        repeated["skipped_existing"][0]["failure_key"], first["filed"][0]["failure_key"],
+        "the per-test duration must not change the failure key"
+    );
+}
+
 #[test]
 fn distinct_nextest_fail_lines_in_the_same_job_keep_distinct_keys() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
-    let foo = orb_11509_style_nextest_log(true, "plain_and_json_forms_match_their_goldens");
-    let bar = orb_11509_style_nextest_log(false, "another_golden_does_not_match");
+    let foo =
+        orb_11509_style_nextest_log(true, "plain_and_json_forms_match_their_goldens", "1.399s");
+    let bar = orb_11509_style_nextest_log(false, "another_golden_does_not_match", "2.004s");
 
     let output = file(
         &runtime,

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -87,7 +87,10 @@ empty selectors, pilot failure, duplicates, already-landed
 work, conflicts, and warnings leave that task proposed without blocking other
 pilot children. A standalone task-pilot run has no promotion authority. The
 source run/job/SHA/step remains in the task description, while parent and child
-run state retain the pilot run ID, result, and admission decision.
+run state retain the pilot run ID, result, and admission decision. Filing
+clusters by a normalized error signature that prefers a concrete test or panic
+identity over ANSI styling, generic runner/cargo/nextest trailers, and
+assertion payload help text; the raw excerpt stays in the description.
 
 ### The `completion` input
 

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -88,8 +88,8 @@ work, conflicts, and warnings leave that task proposed without blocking other
 pilot children. A standalone task-pilot run has no promotion authority. The
 source run/job/SHA/step remains in the task description, while parent and child
 run state retain the pilot run ID, result, and admission decision. Filing
-clusters by a normalized error signature that prefers a concrete test or panic
-identity over ANSI styling, generic runner/cargo/nextest trailers, and
+clusters failures by a normalized error signature that prefers a concrete test
+or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
 ### The `completion` input


### PR DESCRIPTION
## Task

[ORB-11518](https://orbit-cli.com/tasks/ORB-11518) — Use concrete failure diagnostics for stable CI sweep signatures

### Description

Backlog evidence shows CI signatures still select presentation noise: ORB-11509 normalized signature is ANSI-styled 'Cancelling due to test failure'; ORB-11498 and ORB-11502 select a golden-output documentation line about bounded GitHub log excerpts rather than the failing golden test identity. ORB-11470 selects generic cargo test failed trailer while ORB-11467 uses the actual macOS panic. Current error_signature in crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs takes the first ErrorAnnotated then Marker, and existing failure_key includes workflow/job/step/signature. Inspect full stored evidence and prior ORB-11341 before change. Improve the existing diagnostic extraction narrowly so ANSI style, generic cancellation/trailers, and assertion payload help text do not fragment one evidenced failure across repeated observations. Do not collapse unrelated failures by job title alone, invent broad fuzzy dedupe, or discard raw evidence. Add deterministic fixtures drawn from these cases and maintain legacy dedupe compatibility where needed. Trace actual introducing change/task. Grok assigned medium: bounded parser and tests, escalate scope only with evidence.

### Acceptance Criteria

- Equivalent colored/uncolored, cancellation/trailer and golden assertion fixtures choose a stable concrete failing test/diagnostic identity where present; generic lines do not outrank root diagnostic.
- Distinct concrete failures in the same job/step retain distinct identities; incomplete/truncated excerpts preserve explicit fallback uncertainty.
- Existing passing-test-name and runner-bookkeeping exclusions pass; repeat filer fixtures demonstrate no duplicate for equivalent diagnostics.
- Focused tests, make ci-fast and make ci-lint pass; raw evidence remains available and current docs reflect behavior.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `error_signature` now ranks a concrete test/panic identity (nextest FAIL, `thread '...' panicked`, `test ... FAILED`, libtest `failures:` name) above specific `##[error]` annotations and remaining marker lines. ANSI CSI is stripped only for classification and the normalized signature; the filed excerpt keeps raw bytes.
- Generic wrappers are `GenericTrailer`, not signatures when anything better exists: GitHub process-completed / `The process '...' failed with exit code` / action-failed, cargo `test failed, to rerun pass` / `test run failed` / `process didn't exit successfully`, nextest cancelling/summary/not-run-due-to-failure. Assertion `left:`/`right:` dumps are not Marker hits. Generic-only excerpts use the existing labelled step-name fallback.
- Fixtures drawn from ORB-11509 (colored vs uncolored nextest cancellation), ORB-11470/ORB-11467 (cargo trailer vs panic), ORB-11498/ORB-11502 (golden assertion payload vs `plain_and_json_forms_match_their_goldens`), ORB-11513 (Wrangler `[ERROR]` vs npx process-failed). Repeat-filer cases reuse the key; distinct FAIL/panic/Wrangler titles in the same job/step stay distinct.
- Activity description and both skill `workflows.md` copies state the selection rule. `failure_key` hashing is unchanged (workflow/job/step/signature).
Introducing lineage: first-ErrorAnnotated-then-Marker from ORB-11107; generic `Process completed` split in ORB-11132; passing-test exclusion in ORB-11341. Remaining live gap was ANSI, other wrappers, and assertion payload.
Assessment: Bounded ranking on the existing LineKind seam. Did not add fuzzy job-title dedupe or drop raw evidence.

Criteria:
- Colored/uncolored, cancellation/trailer, golden assertion choose concrete identity; generics do not outrank — met (nextest FAIL, panic, listed golden name, Wrangler `[ERROR]`).
- Distinct concrete failures keep distinct keys; truncated generic-only excerpts label step-name fallback — met.
- Passing-test and bookkeeping exclusions still pass; repeat filer does not duplicate equivalent diagnostics — met.
- Focused tests, ci-fast, ci-lint pass; raw excerpts still in descriptions; docs updated — met.

Validation:
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure_tasks`: passed (36 tests).
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::sweep_duplicate_tasks`: passed (12 tests).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
Friction checkpoint: none filed.
Remaining risk: historical tasks filed under the old generic/ANSI keys will not match the new signature, so a still-red run may file a new task rather than attach to the old owner. That is the repair. Two generic-only excerpts of the same job/step still share the weaker step-name fallback.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11518-6a9f0aae`
- Behind base: 0
- Ahead of base: 2

Orchestrated-By: astra