### PR TITLE
Withhold release-publication work from automatic CI repair admission

### DIFF
--- a/.orbit/resources/activities/task_pilot.yaml
+++ b/.orbit/resources/activities/task_pilot.yaml
@@ -98,6 +98,13 @@ spec:
               properties:
                 evidence:
                   type: string
+            release_action_required:
+              type: [object, "null"]
+              properties:
+                action:
+                  type: string
+                evidence:
+                  type: string
             adr_conflicts:
               type: array
               items:
@@ -158,15 +165,29 @@ spec:
        old release whose repair is already present must be `verified_no_diff`
        with `already_landed` set to an object containing concrete `evidence`;
        do not return executable selectors for it.
+       When the failure's only correct repair is an operator-reserved release
+       action rather than a repository change — a version, tag, or artifact the
+       repository already records but the operator has not published or
+       promoted yet, so the job resolves something that does not exist outside
+       this repository — return `verified_no_diff` and set
+       `release_action_required` to `{"action":"...","evidence":"..."}` naming
+       that action. Never propose editing versions, tags, or publication
+       metadata to make such a job pass. This is about the intended repair, not
+       about which files it would touch: a defect the repository itself owns —
+       a wrong dependency requirement, a broken manifest, a packaging script
+       bug — is ordinary work, so return its selectors and leave
+       `release_action_required` null.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
-       `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
-       name kept for consumer compatibility — populate it only with concrete
-       current-code or current-contract conflicts and their evidence; a
-       historical ADR is not by itself a reason to block or reshape work),
-       `utility_warnings`, and `surface_warnings`. Each of these four fields is
-       an array of plain strings, one string per finding combining the finding
-       and its citation — for example a non-empty adr_conflicts entry reads
+       `duplicate_of`, `already_landed`, `release_action_required`,
+       `adr_conflicts` (a legacy output field name kept for consumer
+       compatibility — populate it only with concrete current-code or
+       current-contract conflicts and their evidence; a historical ADR is not
+       by itself a reason to block or reshape work), `utility_warnings`, and
+       `surface_warnings`. Each of `blocked_by`, `adr_conflicts`,
+       `utility_warnings`, and `surface_warnings` is an array of plain strings,
+       one string per finding combining the finding and its citation — for
+       example a non-empty adr_conflicts entry reads
        ["the module this task would change still exports the type it removes
        (verified via rg -n 'pub use Bar' at source_revision)"]; never an array
        of objects. Cite evidence for duplicates, already-landed work, and any
@@ -175,9 +196,10 @@ spec:
        the failure is from the current integration revision and the defect is
        still present, leave `duplicate_of` and `already_landed` null and return
        the selectors for the current repair. Use
-       `{"task_id":"...","evidence":"..."}` for a duplicate and
-       `{"evidence":"..."}` for already-landed work; a bare boolean is not
-       auditable.
+       `{"task_id":"...","evidence":"..."}` for a duplicate,
+       `{"evidence":"..."}` for already-landed work, and
+       `{"action":"...","evidence":"..."}` for a required release action; a
+       bare boolean is not auditable.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,
@@ -202,6 +224,7 @@ spec:
         "blocked_by":[],
         "duplicate_of":null,
         "already_landed":null,
+        "release_action_required":null,
         "adr_conflicts":[],
         "utility_warnings":[],
         "surface_warnings":[]

--- a/crates/orbit-core/assets/activities/task_pilot.yaml
+++ b/crates/orbit-core/assets/activities/task_pilot.yaml
@@ -98,6 +98,13 @@ spec:
               properties:
                 evidence:
                   type: string
+            release_action_required:
+              type: [object, "null"]
+              properties:
+                action:
+                  type: string
+                evidence:
+                  type: string
             adr_conflicts:
               type: array
               items:
@@ -158,15 +165,29 @@ spec:
        old release whose repair is already present must be `verified_no_diff`
        with `already_landed` set to an object containing concrete `evidence`;
        do not return executable selectors for it.
+       When the failure's only correct repair is an operator-reserved release
+       action rather than a repository change — a version, tag, or artifact the
+       repository already records but the operator has not published or
+       promoted yet, so the job resolves something that does not exist outside
+       this repository — return `verified_no_diff` and set
+       `release_action_required` to `{"action":"...","evidence":"..."}` naming
+       that action. Never propose editing versions, tags, or publication
+       metadata to make such a job pass. This is about the intended repair, not
+       about which files it would touch: a defect the repository itself owns —
+       a wrong dependency requirement, a broken manifest, a packaging script
+       bug — is ordinary work, so return its selectors and leave
+       `release_action_required` null.
     5. Report recommendations only; do not apply them:
        `recommended_crew`, `recommended_complexity`, real `blocked_by` task IDs,
-       `duplicate_of`, `already_landed`, `adr_conflicts` (a legacy output field
-       name kept for consumer compatibility — populate it only with concrete
-       current-code or current-contract conflicts and their evidence; a
-       historical ADR is not by itself a reason to block or reshape work),
-       `utility_warnings`, and `surface_warnings`. Each of these four fields is
-       an array of plain strings, one string per finding combining the finding
-       and its citation — for example a non-empty adr_conflicts entry reads
+       `duplicate_of`, `already_landed`, `release_action_required`,
+       `adr_conflicts` (a legacy output field name kept for consumer
+       compatibility — populate it only with concrete current-code or
+       current-contract conflicts and their evidence; a historical ADR is not
+       by itself a reason to block or reshape work), `utility_warnings`, and
+       `surface_warnings`. Each of `blocked_by`, `adr_conflicts`,
+       `utility_warnings`, and `surface_warnings` is an array of plain strings,
+       one string per finding combining the finding and its citation — for
+       example a non-empty adr_conflicts entry reads
        ["the module this task would change still exports the type it removes
        (verified via rg -n 'pub use Bar' at source_revision)"]; never an array
        of objects. Cite evidence for duplicates, already-landed work, and any
@@ -175,9 +196,10 @@ spec:
        the failure is from the current integration revision and the defect is
        still present, leave `duplicate_of` and `already_landed` null and return
        the selectors for the current repair. Use
-       `{"task_id":"...","evidence":"..."}` for a duplicate and
-       `{"evidence":"..."}` for already-landed work; a bare boolean is not
-       auditable.
+       `{"task_id":"...","evidence":"..."}` for a duplicate,
+       `{"evidence":"..."}` for already-landed work, and
+       `{"action":"...","evidence":"..."}` for a required release action; a
+       bare boolean is not auditable.
 
     Hard bounds:
     - Never update a task, transition lifecycle state, promote, dispatch,
@@ -202,6 +224,7 @@ spec:
         "blocked_by":[],
         "duplicate_of":null,
         "already_landed":null,
+        "release_action_required":null,
         "adr_conflicts":[],
         "utility_warnings":[],
         "surface_warnings":[]

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_admission.rs
@@ -110,18 +110,37 @@ pub(super) fn assess(
         .get("head_branches")
         .cloned()
         .unwrap_or_else(|| json!([]));
+    let red_failure = json!({
+        "head_branches": head_branches,
+        "tested_commit": tested_commit,
+        "run_urls": run_urls,
+    });
+    let release_action = release_action_required(action, task_id, assessment)?;
 
-    let (decision, classification, evidence) = if !already_landed.is_null() && release_head_failure
-    {
+    // Both release-scoped outcomes are withheld by the same owner: this sweep
+    // performs no release operation, so a failure whose correct repair is
+    // promotion, a tag, or a publication is reported as that operator action
+    // instead of being converted into automatic repository edits.
+    let (decision, classification, evidence) = if let Some(finding) = release_action {
+        (
+            "withhold",
+            "release_publication_or_operator_action_needed",
+            json!({
+                "red_failure": red_failure,
+                "pilot_finding": finding,
+                "required_action": finding["action"],
+                "automatic_action": "none",
+                // Carried verbatim: a proposed repair the pilot itself ruled
+                // out is evidence of what was refused, not admitted work.
+                "withheld_selectors": selectors,
+            }),
+        )
+    } else if !already_landed.is_null() && release_head_failure {
         (
             "withhold",
             "release_promotion_or_hotfix_needed",
             json!({
-                "red_release": {
-                    "head_branches": head_branches,
-                    "tested_commit": tested_commit,
-                    "run_urls": run_urls,
-                },
+                "red_release": red_failure,
                 "covering_repair": already_landed,
                 "required_action": "promote the verified integration repair to the release branch or prepare an authorized hotfix",
                 "automatic_action": "none",
@@ -183,6 +202,40 @@ pub(super) fn assess(
         },
         "evidence": evidence,
     }))
+}
+
+/// The pilot's explicit finding that a failure's only correct repair is an
+/// operator-reserved release action — publishing or tagging a version this
+/// repository already records, for example — rather than a change the
+/// repository owns. Admission never infers this from which files a proposed
+/// repair would touch: an ordinary packaging or dependency defect that a
+/// repository edit does fix stays eligible for promotion [ORB-11517].
+fn release_action_required<'a>(
+    action: &str,
+    task_id: &str,
+    assessment: &'a Value,
+) -> Result<Option<&'a Value>, DispatchError> {
+    let Some(finding) = assessment
+        .get("release_action_required")
+        .filter(|finding| !finding.is_null())
+    else {
+        return Ok(None);
+    };
+    if !recommendation_has_evidence(finding) {
+        return Err(action_failed(
+            action,
+            format!("task {task_id} release_action_required must include concrete evidence"),
+        ));
+    }
+    if required_string(finding, "action", action).is_err() {
+        return Err(action_failed(
+            action,
+            format!(
+                "task {task_id} release_action_required must name the required operator action"
+            ),
+        ));
+    }
+    Ok(Some(finding))
 }
 
 fn recommendation_has_evidence(value: &Value) -> bool {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot.rs
@@ -491,6 +491,32 @@ fn validate_after_selectors(
     Ok(())
 }
 
+/// Whether a validated assessment leaves the task ready for the state
+/// automation to promote it on its own. Actionable selectors are necessary but
+/// not sufficient: any finding that names other work, or an action outside
+/// what this repository owns — a duplicate, a repair that already landed, or
+/// an operator-reserved release action — keeps that decision with a human
+/// [ORB-11517].
+pub(super) fn member_ready(assessment: &Value) -> bool {
+    assessment["disposition"] == "selectors"
+        && [
+            "blocked_by",
+            "adr_conflicts",
+            "utility_warnings",
+            "surface_warnings",
+        ]
+        .iter()
+        .all(|field| {
+            assessment
+                .get(field)
+                .and_then(Value::as_array)
+                .is_some_and(Vec::is_empty)
+        })
+        && ["duplicate_of", "already_landed", "release_action_required"]
+            .iter()
+            .all(|field| assessment.get(field).is_none_or(Value::is_null))
+}
+
 fn validate_recommendations(
     action: &str,
     task_id: &str,

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -14,7 +14,7 @@ use crate::application::task::TaskUpdateParams;
 
 use super::source::SourceSnapshot;
 use super::{
-    action_failed, requested_workspace_root, required_string, required_string_array,
+    action_failed, member_ready, requested_workspace_root, required_string, required_string_array,
     string_array_value, validate_after_selectors, validate_recommendations,
 };
 
@@ -485,23 +485,7 @@ pub(in super::super) fn apply(
             member_key: claim.member.key,
             input_fingerprint: claim.member.fingerprint,
             resulting_fingerprint: resulting.clone(),
-            ready: assessment["disposition"] == "selectors"
-                && [
-                    "blocked_by",
-                    "adr_conflicts",
-                    "utility_warnings",
-                    "surface_warnings",
-                ]
-                .iter()
-                .all(|field| {
-                    assessment
-                        .get(field)
-                        .and_then(Value::as_array)
-                        .is_some_and(Vec::is_empty)
-                })
-                && ["duplicate_of", "already_landed"]
-                    .iter()
-                    .all(|field| assessment.get(field).is_none_or(Value::is_null)),
+            ready: member_ready(assessment),
             result: assessment.clone(),
         })
     });

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_admission.rs
@@ -32,6 +32,7 @@ struct Assessment<'a> {
     disposition: &'a str,
     duplicate_of: Value,
     already_landed: Value,
+    release_action_required: Value,
     warnings: Vec<&'a str>,
     authorized: bool,
 }
@@ -43,6 +44,7 @@ impl<'a> Assessment<'a> {
             disposition: "selectors",
             duplicate_of: Value::Null,
             already_landed: Value::Null,
+            release_action_required: Value::Null,
             warnings: Vec::new(),
             authorized,
         }
@@ -54,6 +56,7 @@ impl<'a> Assessment<'a> {
             disposition: "verified_no_diff",
             duplicate_of: Value::Null,
             already_landed: json!({"evidence": evidence}),
+            release_action_required: Value::Null,
             warnings: Vec::new(),
             authorized: true,
         }
@@ -68,6 +71,7 @@ impl<'a> Assessment<'a> {
                 "evidence": "an open task already owns the same current repair",
             }),
             already_landed: Value::Null,
+            release_action_required: Value::Null,
             warnings: vec!["duplicate task must be inspected before reconsideration"],
             authorized: true,
         }
@@ -79,6 +83,31 @@ impl<'a> Assessment<'a> {
             disposition: "verified_no_diff",
             duplicate_of: Value::Null,
             already_landed: Value::Null,
+            release_action_required: Value::Null,
+            warnings: Vec::new(),
+            authorized: true,
+        }
+    }
+
+    /// The incident shape: a job resolves a version this repository records
+    /// but nobody published, and the pilot reports the publication as the
+    /// required action. Passing selectors reproduces the pilot that proposed
+    /// editing the version-lockstep files anyway; passing none reproduces the
+    /// contract the activity now asks for.
+    fn pending_publication(selectors: Vec<&'a str>) -> Self {
+        Self {
+            disposition: if selectors.is_empty() {
+                "verified_no_diff"
+            } else {
+                "selectors"
+            },
+            selectors,
+            duplicate_of: Value::Null,
+            already_landed: Value::Null,
+            release_action_required: json!({
+                "action": "publish the recorded release version, or withdraw the recorded bump, as a release operation",
+                "evidence": "the smoke job resolves the version this repository already records, and the registry has no such published version",
+            }),
             warnings: Vec::new(),
             authorized: true,
         }
@@ -126,6 +155,7 @@ fn apply_pilot(
                         "blocked_by": [],
                         "duplicate_of": assessment.duplicate_of,
                         "already_landed": assessment.already_landed,
+                        "release_action_required": assessment.release_action_required,
                         "adr_conflicts": [],
                         "utility_warnings": assessment.warnings,
                         "surface_warnings": [],
@@ -311,6 +341,135 @@ fn already_landed_release_stays_proposed_but_distinct_current_regression_advance
         runtime
             .get_task(current_filing["task_id"].as_str().expect("current id"))
             .expect("current task")
+            .status,
+        TaskStatus::Backlog
+    );
+}
+
+#[test]
+fn pending_release_publication_withholds_promotion_and_names_the_operator_action() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "release/version.json");
+    write_workspace_file(&repo_root, "packaging/package.json");
+    write_workspace_file(&repo_root, "Cargo.toml");
+    let unpublished_version = concat!(
+        "smoke\tnpm install\tnpm error code ETARGET\n",
+        "smoke\tnpm install\tnpm error notarget No matching version found for @acme/cli@9.9.9.\n",
+    );
+    let filed = file(
+        &runtime,
+        vec![failure(
+            20,
+            "smoke-npm-install",
+            "smoke",
+            "npm install",
+            unpublished_version,
+            CHECKOUT,
+        )],
+    );
+    let filing = &filed["filed"][0];
+    let task_id = filing["task_id"].as_str().expect("task id");
+
+    let proposed_version_edits = apply_pilot(
+        &runtime,
+        &repo_root,
+        filing,
+        Assessment::pending_publication(vec![
+            "file:release/version.json",
+            "file:packaging/package.json",
+        ]),
+    )
+    .expect("apply a pilot that proposed release metadata edits");
+
+    let admission = &proposed_version_edits["ci_sweep_admission"][0];
+    assert_eq!(admission["decision"], "withhold");
+    assert_eq!(
+        admission["classification"],
+        "release_publication_or_operator_action_needed"
+    );
+    assert_eq!(admission["evidence"]["automatic_action"], "none");
+    assert!(
+        admission["evidence"]["required_action"]
+            .as_str()
+            .is_some_and(|required| required.contains("publish")),
+        "{admission}"
+    );
+    assert_eq!(
+        admission["evidence"]["withheld_selectors"],
+        json!(["file:release/version.json", "file:packaging/package.json"])
+    );
+    assert_eq!(
+        admission["evidence"]["red_failure"]["tested_commit"],
+        CHECKOUT
+    );
+    assert_eq!(admission["source"]["workflow"], "smoke-npm-install");
+    assert_eq!(
+        runtime.get_task(task_id).expect("task").status,
+        TaskStatus::Proposed
+    );
+    assert!(!backlog_task_ids(&runtime).contains(&task_id.to_string()));
+
+    // The contract shape the activity now asks for reaches the same owner
+    // instead of the unproven-no-diff disposition.
+    let reported_without_selectors = apply_pilot(
+        &runtime,
+        &repo_root,
+        filing,
+        Assessment::pending_publication(Vec::new()),
+    )
+    .expect("apply a pilot that returned no repository work");
+    assert_eq!(
+        reported_without_selectors["ci_sweep_admission"][0]["classification"],
+        "release_publication_or_operator_action_needed"
+    );
+
+    // Repeated unchanged evidence keeps one owner with the preserved failure
+    // and is re-piloted; it is never reported as a clean sweep.
+    let repeated = file(
+        &runtime,
+        vec![failure(
+            21,
+            "smoke-npm-install",
+            "smoke",
+            "npm install",
+            unpublished_version,
+            NEXT_HEAD,
+        )],
+    );
+    assert_eq!(repeated["outcome"], "current_failures");
+    assert_eq!(repeated["filed_count"], json!(0));
+    assert_eq!(repeated["pilot_candidate_count"], json!(1));
+    assert_eq!(repeated["pilot_candidates"][0]["task_id"], task_id);
+
+    // No filename denylist: a repository-owned dependency contract defect in
+    // the same kind of manifest stays eligible once a pilot establishes it.
+    let owned = file(
+        &runtime,
+        vec![failure(
+            22,
+            "ci",
+            "build",
+            "cargo build",
+            "ci\tbuild\terror: failed to select a version for the requirement\n",
+            CHECKOUT,
+        )],
+    );
+    let owned_filing = &owned["filed"][0];
+    let admitted = apply_pilot(
+        &runtime,
+        &repo_root,
+        owned_filing,
+        Assessment::actionable("file:Cargo.toml", true),
+    )
+    .expect("admit a repository-owned dependency repair");
+    assert_eq!(
+        admitted["ci_sweep_admission"][0]["classification"],
+        "current_actionable_regression"
+    );
+    assert_eq!(
+        runtime
+            .get_task(owned_filing["task_id"].as_str().expect("owned task id"))
+            .expect("owned task")
             .status,
         TaskStatus::Backlog
     );

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -3,7 +3,7 @@ use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::{JobRunState, PipelineState};
 use serde_json::{Value, json};
 
-use super::super::task_pilot::{apply, prepare};
+use super::super::task_pilot::{apply, member_ready, prepare};
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::{
     runtime_with_workspace_layout, write_workspace_file,
@@ -106,6 +106,37 @@ fn partition_result(partition_index: usize, task_ids: &[String], tasks: Vec<Valu
         "tasks": tasks,
         "summary": "fixture partition",
     })
+}
+
+#[test]
+fn automatic_readiness_requires_selectors_and_no_deferring_finding() {
+    let mut assessment = json!({
+        "task_id": "ORB-FIXTURE",
+        "disposition": "selectors",
+        "context_files_after": ["file:src/existing.rs"],
+        "blocked_by": [],
+        "duplicate_of": null,
+        "already_landed": null,
+        "release_action_required": null,
+        "adr_conflicts": [],
+        "utility_warnings": [],
+        "surface_warnings": [],
+    });
+    assert!(member_ready(&assessment));
+
+    // A pilot may return the selectors it would change and still report that
+    // the correct repair is an operator-reserved release action. That finding
+    // withholds automatic promotion the same way a duplicate does.
+    assessment["release_action_required"] = json!({
+        "action": "publish the recorded release version as a release operation",
+        "evidence": "the failing job resolves a version this repository records but never published",
+    });
+    assert!(!member_ready(&assessment));
+
+    assessment["release_action_required"] = Value::Null;
+    assert!(member_ready(&assessment));
+    assessment["disposition"] = json!("verified_no_diff");
+    assert!(!member_ready(&assessment));
 }
 
 #[test]

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -173,6 +173,19 @@ reported as `covering_proof_missing` and remains proposed for a later bounded pi
 of being treated as already landed. The routine is a scheduling surface only: an
 operator-triggered run of the job behaves identically to a scheduled fire.
 
+Publication shares that release boundary. A job can fail because the repository already
+records a version, tag, or artifact its operator has not published or promoted yet; the
+only correct repair is that release action, which this sweep never performs. The pilot
+states that intent explicitly by returning `release_action_required` with the action and
+its evidence, and admission then reports
+`release_publication_or_operator_action_needed` — carrying the red run, the pilot's
+finding, and any selectors it withheld — while the deduped task stays in proposed
+quarantine and keeps owning the preserved failure evidence. Admission never infers this
+from which files a proposed repair would touch, so a defect the repository does own — a
+wrong dependency requirement, a broken manifest, a packaging script bug — remains eligible
+for ordinary promotion. The same finding also clears the state automation's readiness flag,
+so neither promotion path can turn a pending publication into automatic version edits.
+
 The seeded `ship_sweep` targets `job:workspace_ship_pipeline` with `missed_run: skip` and
 `overlap: forbid`. The wrapper resolves the source runtime's ship mode and configured base
 branch, invokes and waits for `task_auto_pipeline` without explicit task IDs, and guards


### PR DESCRIPTION
## Task

[ORB-11517](https://orbit-cli.com/tasks/ORB-11517) — Withhold release-publication work from automatic CI repair admission

### Description

Confirmed unsafe admission: ORB-11512, pilot jrun-20260907-1807, was promoted current_actionable_regression because it selected nine version-lockstep files to repair npm ETARGET for unpublished @orbit-tools/cli@0.19.2. Its pilot evidence explicitly recognizes b7099a8ca 'Bump release metadata to 0.19.2 without tagging or publishing', but treats this as repository version drift. Daniel reserves release versions/tags/publication; ordinary CI admission must not convert a pending publication into automatic version edits. The orchestrator returned ORB-11512 to proposed. Add a narrow evidence-backed release/operator-action disposition in existing CI pilot/admission contract, with preserved failure evidence and dedupe owner. Do not hardcode Orbit package/file names or block legitimate Cargo.toml dependency repairs; classify intended action, not file presence alone. Reuse the existing release-only disposition owner from ORB-11453. Independent integration-branch propagation is tracked ORB-11516; this task addresses publication intent even when branch labels are correct. Trace introduction with source evidence, keep code readable and docs aligned. Opus assigned for hard semantic admission work with a narrow existing owner. No release operation is authorized.

Recovery authorized 2026-09-07: Daniel disabled the broken before-PR review gate. Prior candidate 46a393c0382bd32ed0642c7c83d966af00556bbb was preserved/pushed on orbit/ORB-11517-6a9f0b90; previous reviewer reported zero findings but deterministic settlement rejected validation bookkeeping. A fresh run must capture review timing none. Reuse the preserved candidate changes as the starting repair, inspect against current agent-main, preserve the prior correct changes and truthful validation evidence, and only revalidate what the candidate/base changes require. Do not restart analysis from scratch, fabricate a review certificate, or perform any deployment/release. Standard pipeline owns commits and PR completion.

### Acceptance Criteria

- Deterministic incident fixture with intentionally unpublished version and ETARGET withholds promotion and records explicit operator/publication action; selectors alone do not turn it into current_actionable_regression.
- Actual repository-owned package/version contract bugs remain eligible when repair evidence establishes them; no broad filename denylist.
- Repeated unchanged evidence retains one owner and an actionable disposition; source failure is never called green.
- Focused pilot/admission tests and make ci-fast/make ci-lint pass; no versions/tags/publications changed.

## Execution Summary

<details>
<summary>Click to expand</summary>

Withheld release-publication work from automatic CI repair admission.

Recovery run jrun-20260907-1931: the preserved candidate 46a393c0382bd32ed0642c7c83d966af00556bbb (branch orbit/ORB-11517-6a9f0b90) was based on the same commit as this worktree's HEAD (f8c156f06), so its diff was reapplied verbatim to the working tree with `git apply` — no conflicts, no re-analysis. The only new edit is a prose rewrap of one 120-column instruction line in both task_pilot.yaml mirrors (line lengths in that block are otherwise ~80). All validation below was re-run on the resulting tree; nothing is carried over as an unverified claim.

What changed
- `ci_failure_admission::assess` now reads an optional pilot finding `release_action_required` ({action, evidence}). When present it must carry concrete evidence and name the operator action, and it takes precedence over every other outcome: decision `withhold`, classification `release_publication_or_operator_action_needed`, evidence carrying the red run (`red_failure`), the pilot finding, `required_action`, `automatic_action: none`, and the `withheld_selectors` the pilot proposed. Selectors alone therefore no longer reach `current_actionable_regression` when the pilot has reported a pending publication.
- Both release-scoped withholds now sit in one owner (the ORB-11453 branch) and share one `red_failure`/`red_release` evidence value; the existing already-landed release-head branch is unchanged in behavior.
- The pilot readiness rule moved from `task_pilot/apply.rs` into `task_pilot::member_ready` (its owning module) and now also clears `ready` on `release_action_required`, so the state-automation promotion path in `application/operation/promotion.rs` cannot promote a pending publication either.
- `task_pilot` activity (both mirrors): new optional `release_action_required` output field, plus instruction text telling the pilot to classify the intended repair — a version/tag/artifact the repository records but the operator has not published or promoted is an operator action with no repository diff, while a repository-owned defect (wrong dependency requirement, broken manifest, packaging script bug) keeps returning selectors. No package or filename is named anywhere; admission never infers intent from touched files.
- `docs/design/routines/2_design.md` documents the publication branch alongside the existing release paragraph.

Introduction traced: the promote path is the ORB-11453 admission chain (f93f8b285); the ORB-11512 incident (pilot jrun-20260907-1807) reached `current_actionable_regression` because nothing in that chain distinguished a repository-owned repair from a pending publication, and its own evidence about the untagged/unpublished bump was only free text.

Acceptance criteria
1. Met — `tests/ci_failure_admission.rs::pending_release_publication_withholds_promotion_and_names_the_operator_action` reconstructs the incident (ETARGET-style unpublished version, pilot returning version-lockstep selectors) and asserts withhold, the classification, `required_action`, `withheld_selectors`, the red run, and that the task stays `proposed` and out of backlog. The no-selector shape reaches the same owner instead of `covering_proof_missing`.
2. Met — the same test admits `file:Cargo.toml` for a repository-owned dependency-resolution failure (classification `current_actionable_regression`, task promoted to backlog). No filename or package list exists in the code.
3. Met — repeating the unchanged evidence files 0 new tasks, reports outcome `current_failures`, and returns the same single task as the pilot candidate; the disposition names the operator action rather than reporting a clean sweep.
4. Met — see validation below. No version, tag, publication, or release metadata was touched (`git status --short` lists only the 8 files above).

Validation (all re-run in this worktree on the final tree)
- passed: `cargo test -p orbit-core --lib -- adapter::engine_host::v2_host::tests::ci_failure_admission adapter::engine_host::v2_host::tests::task_pilot` — 35 passed, 0 failed.
- passed: `make ci-fast` (exit 0), including `scripts/sync-activity-assets.sh --check` (mirrors identical after the rewrap).
- passed: `make ci-lint` (exit 0, warnings denied).
- passed (negative check): with `release_action_required(...)` forced to `None`, `pending_release_publication_withholds_promotion_and_names_the_operator_action` fails with left `"promote"`, right `"withhold"`; the source file was restored and the final test run above is on the restored tree.
- passed: `git diff --check` (exit 0), no whitespace errors, no stray artifacts.
- not run: full `make ci` (workspace policy: CI owns it on the PR).

Scope note: `task_pilot/apply.rs` is in `context_files` (added in the prior run) because the readiness rule it computed had to move to its owner and account for the new finding, otherwise the state-automation promotion path stayed open.

Risks/deviations: the classification depends on the pilot reporting the finding, which is a semantic judgment the deterministic boundary cannot make without matching package names or file paths — the task explicitly rules that out. A withheld decision is recorded in the sweep run output (as with the existing release owner), not as a task comment, so repeated sweeps do not accumulate comments on the same owner. Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11517-6a9f10f7`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra