### PR TITLE
Fix website Pages deployment failing on missing Wrangler project name

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -53,7 +53,8 @@ jobs:
         run: |
           set -euo pipefail
           test -f dist/_headers
-          grep -Fx 'Strict-Transport-Security: max-age=31536000' dist/_headers
+          # ORB-11461 / e2454bcb0: Cloudflare emits the policy with indentation.
+          grep -E '^[[:space:]]*Strict-Transport-Security: max-age=31536000$' dist/_headers
 
       - name: Attach publication provenance
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/docs/runbooks/website-validation.md
+++ b/docs/runbooks/website-validation.md
@@ -239,6 +239,17 @@ who currently owns the external account, which project owns the custom domain,
 or that repository secrets exist. Do not create a project, rotate or invent
 credentials, or edit DNS as part of website publication.
 
+Wrangler's Pages configuration validation still requires a top-level `name`, so
+`website/wrangler.toml` keeps `name = "orbit-website"`. Treat that value as a
+validation placeholder rather than the deployment target: the publish job always
+passes `--project-name` from the protected `CLOUDFLARE_PAGES_PROJECT` variable,
+which overrides the configured name, so the project still comes from the
+environment instead of the repository. Deleting the field to avoid restating an
+untrusted name breaks publication rather than hardening it. ORB-11379 removed it
+in commit `86d48ebd212a9a7d6f2f36ae25312f6e81e11105` (PR #1425), and `main`
+publication then failed Pages configuration validation with `Missing top-level
+field "name" in configuration file` until ORB-11511 restored it.
+
 ORB-11379 recorded the publication gap on 2026-09-06:
 
 - `.github/workflows/website.yml` had only a pull-request build trigger and no

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -1,2 +1,6 @@
+# Wrangler's Pages configuration validation requires a top-level name. The
+# publish workflow overrides it with --project-name from the protected
+# CLOUDFLARE_PAGES_PROJECT variable; see docs/runbooks/website-validation.md.
+name = "orbit-website"
 compatibility_date = "2026-05-04"
 pages_build_output_dir = "./dist"


### PR DESCRIPTION
## Task

[ORB-11511](https://orbit-cli.com/tasks/ORB-11511) — Fix website Pages deployment failing on missing Wrangler project name

### Description

The user reports website publication failing on 2026-09-07 for commit a93caa13890764380e184d996fa709b1bcbe278c. cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 installs Wrangler 4.129.0 and runs `wrangler pages deploy dist --project-name=orbit-website --branch=main --commit-hash=a93caa13890764380e184d996fa709b1bcbe278c`. It exits 1 during Pages configuration validation: `Missing top-level field "name" in configuration file.` Log path supplied: /home/runner/.config/.wrangler/logs/wrangler-2026-09-07_18-02-42_816.log. No CI run URL was supplied.

Local source inspection confirms website/wrangler.toml contains only compatibility_date and pages_build_output_dir; .github/workflows/website.yml runs from website with Wrangler pinned to 4.129.0 and supplies --project-name. Git show establishes that commit 86d48ebd212a9a7d6f2f36ae25312f6e81e11105 (ORB-11379, PR #1425) removed `name = "orbit-website"`. This is the evidence-backed regression source, not an authentication failure.

Restore the required top-level Pages project identity and reconcile it with the workflow's existing target selection so the configuration and command agree. Keep the fix narrow and retain deployment revision/custom-domain verification. Validate with the pinned Wrangler version using a supported non-publishing validation route; do not claim a production deployment was verified from a build or config check alone. If actual publication verification is still pending, report that explicitly. Prepare in a dedicated Orbit worktree from agent-main under current delivery policy. Filing only: proposed and undispatched; no deployment or release is authorized by this request.

Authorized review repair decision (2026-09-07): review rvw-9b973aa9d6c9-1 correctly found the HSTS build assertion cannot match the required indentation. Include its narrow fix in .github/workflows/website.yml as part of this task. Preserve exact max-age and indentation-aware matching; do not weaken HSTS itself. Record separate provenance ORB-11461/e2454bcb0 for this assertion defect. Preserve the original name repair and the reviewer's documentation reconciliation, available on pushed branch orbit/ORB-11511-6a9f09ba at cdb15fb381452271e3ba91ccc8002f79e2b77066 (implementation f43aa562d415d7d0495b983d5fc2d68b86204c75). On the fresh pipeline worktree read that candidate diff and reproduce its necessary changes plus the assertion fix; no manual git writes or release/deploy operations. Correct the execution summary: the previous HSTS PASS claim was inaccurate. Validate the exact workflow assertion against a freshly built dist/_headers, including failing missing/wrong-value cases. Then independent review must run again under the remaining lineage budget. The initial 'filing only' statement describes the original creation request; Daniel subsequently authorized execution and complete-mode delivery in this orchestration session.

Recovery authorized 2026-09-07: Daniel disabled the broken before-PR review gate. Prior candidate 104a95b8c3bd91424c759efb12e45e2d582bcdf9 was preserved/pushed on orbit/ORB-11511-6a9f0d03; previous reviewer reported zero findings but deterministic settlement rejected validation bookkeeping. A fresh run must capture review timing none. Reuse the preserved candidate changes as the starting repair, inspect against current agent-main, preserve the prior correct changes and truthful validation evidence, and only revalidate what the candidate/base changes require. Do not restart analysis from scratch, fabricate a review certificate, or perform any deployment/release. Standard pipeline owns commits and PR completion.

### Acceptance Criteria

- The Pages configuration contains a valid top-level project name matching the intended orbit-website deployment, with any workflow override behavior explicitly reconciled.
- Validation using Wrangler 4.129.0 demonstrates that the reported missing-name error is resolved without publishing as a side effect; the website build and relevant existing workflow checks pass.
- Existing deployment SHA and custom-domain verification remain intact; the execution summary distinguishes local validation from any separately authorized live deployment.
- The bounded diff preserves the ORB-11379 Wrangler repair and reviewer documentation reconciliation, fixes the HSTS assertion with ORB-11461 provenance, and records exact validation outcomes including correction of the prior false HSTS PASS claim.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restored the required top-level `name = "orbit-website"` in `website/wrangler.toml`, with comments documenting that Wrangler requires the field for validation and that the publish workflow's protected `CLOUDFLARE_PAGES_PROJECT` value remains the deployment target.
- Preserved `--project-name`, `--branch=main`, `--commit-hash=${{ github.sha }}`, `EXPECTED_REVISION`, deployment URL checks, and `https://orbit-cli.com` custom-domain verification.
- Preserved the ORB-11511 documentation reconciliation, including ORB-11379, commit `86d48ebd212a9a7d6f2f36ae25312f6e81e11105`, PR #1425, and the validation-placeholder explanation.
- Repaired the ORB-11461 / `e2454bcb0` HSTS build assertion to accept the required indentation while requiring the exact `max-age=31536000` value. The HSTS policy was not weakened.

Acceptance criteria:
- Pages configuration identity: PASS. The top-level project name is present exactly once, and workflow target selection remains explicitly overridden by the protected existing-project variable.
- Wrangler/build/workflow validation: PASS. Website `npm ci`, `npm run check`, `npm run build`, both security.txt validations, the exact HSTS assertion fixtures, `make ci-fast`, and `make ci-lint` passed. Wrangler 4.129.0 ran the exact Pages deploy command with empty credentials, reached the expected missing-token guard, reported no missing-name error, and produced no upload or publication output. The first run also encountered the host's read-only default Wrangler log directory; the same command was rerun with a writable task-scoped XDG config directory and passed cleanly.
- Deployment SHA/custom-domain preservation: PASS by source/invariant checks for the commit SHA, expected revision, deployment URL, custom-domain URL, and HSTS/custom-domain verification paths. Live Cloudflare publication and live domain verification were not run or authorized.
- Bounded diff/provenance: PASS. Only `.github/workflows/website.yml`, `website/wrangler.toml`, and `docs/runbooks/website-validation.md` changed (17 additions, 1 deletion). The prior execution summary's false HSTS PASS claim is corrected: the old `grep -Fx` assertion was reproduced as non-matching against the indented good line; the indentation-aware assertion passed, and missing/wrong-value fixtures were rejected.

Validation:
- PASS: `export PATH=~/.nvm/versions/node/v24.18.0/bin:$PATH; npm_config_cache=/tmp/orbit-11511-npm-cache npm --prefix website ci`.
- PASS: `npm --prefix website run check`.
- PASS: `npm --prefix website run build`.
- PASS: `npm --prefix website run validate:security-txt -- public/.well-known/security.txt`.
- PASS: `npm --prefix website run validate:security-txt -- dist/.well-known/security.txt`.
- PASS: exact workflow HSTS assertion against freshly built `dist/_headers`, plus good, missing, and wrong-value fixtures.
- PASS: Wrangler `4.129.0` exact Pages deploy command with empty credentials and no publication side effect.
- PASS: `make ci-fast`.
- PASS: `make ci-lint`.
- PASS: `git diff --check`, final diff review, status review, and workflow/config/documentation invariant checks.
- NOT RUN: live Cloudflare publication and live custom-domain reachability verification; intentionally outside this execution.

Assessment: The narrow configuration repair, ORB-11511 reviewer documentation reconciliation, and authorized ORB-11461 HSTS assertion repair are complete. Remaining risk is limited to external Cloudflare credentials, configured production-project state, and live domain state. Changes remain uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11511-6a9f10f4`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra