### PR TITLE
[code-review] Reviewer scope check rejects canonical symbol selectors

### DIFF
--- a/crates/orbit-core/src/application/review/gate.rs
+++ b/crates/orbit-core/src/application/review/gate.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 use orbit_automation::review::{combined_task_meaning_digest, task_meaning_digest};
 use orbit_common::OrbitError;
+use orbit_common::fs::selector::overlaps;
 use orbit_engine::DispatchError;
 use orbit_engine::review_gate::{
     CandidateIdentity, candidate_identity, commit_reviewer_repairs, uncommitted_paths,
@@ -988,22 +989,17 @@ fn selectors_only_grew(
     Ok(restored_digest == attempt.task_meaning_digest)
 }
 
-/// A repair path is in scope when a task selector names it or a directory
-/// selector contains it. Selector spellings follow the task contract:
-/// `file:<path>`, `dir:<path>`, or a bare path.
+/// A repair path is in scope when a task selector's filesystem anchor names
+/// it or a directory/legacy selector contains it. Matching uses the shared
+/// selector grammar, so `symbol:<path>#<symbol>:<kind>` authorizes the
+/// backing file even when `<symbol>` contains `::`.
 fn path_in_scope(path: &str, tasks: &[Task]) -> bool {
     let path = path.trim_start_matches("./");
+    let changed = format!("file:{path}");
     tasks.iter().any(|task| {
-        task.context_files.iter().any(|selector| {
-            let (kind, target) = selector.split_once(':').unwrap_or(("", selector.as_str()));
-            let target = target.trim().trim_start_matches("./").trim_end_matches('/');
-            match kind {
-                "dir" => path == target || path.starts_with(&format!("{target}/")),
-                "file" => path == target,
-                "symbol" => target.split("::").next().is_some_and(|file| path == file),
-                _ => path == target || path.starts_with(&format!("{target}/")),
-            }
-        })
+        task.context_files
+            .iter()
+            .any(|selector| overlaps(selector, &changed))
     })
 }
 

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -91,6 +91,32 @@ impl Gated {
             &["log", "-1", "--format=%an <%ae>", spec],
         )
     }
+
+    fn rescope(&self, selectors: &[&str]) {
+        self.fixture
+            .runtime
+            .update_task(
+                &self.task_id,
+                TaskUpdateParams {
+                    context_files: Some(
+                        selectors
+                            .iter()
+                            .map(|selector| (*selector).into())
+                            .collect(),
+                    ),
+                    ..TaskUpdateParams::default()
+                },
+            )
+            .expect("rescope");
+    }
+
+    fn context_files(&self) -> Vec<String> {
+        self.fixture
+            .runtime
+            .get_task(&self.task_id)
+            .expect("task")
+            .context_files
+    }
 }
 
 #[test]
@@ -246,6 +272,75 @@ fn reviewer_repairs_land_as_separate_attributed_commits_and_bind_the_final_tree(
             .len(),
         1
     );
+}
+
+#[test]
+fn a_repair_in_a_canonical_symbol_selector_file_passes_without_a_redundant_file_selector() {
+    let gated = gated_fixture(GATED_CONFIG);
+    gated.rescope(&["symbol:src.txt#run:function"]);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    fs::write(
+        gated.fixture.repo.join("src.txt"),
+        "implementation target\nimplemented\nrepaired\n",
+    )
+    .expect("repair");
+    write_report(
+        &gated.fixture.runtime,
+        &gated.task_id,
+        &report(attempt_id, ReviewVerdict::PassedWithRepairs, true),
+    );
+    let settled = gated.settle(&admission).expect("settle");
+    assert_eq!(settled["gate"], "passed");
+    assert_eq!(settled["verdict"], "passed_with_repairs");
+    assert_eq!(
+        gated.context_files(),
+        vec!["symbol:src.txt#run:function".to_string()],
+        "a symbol selector already authorizes its backing file"
+    );
+}
+
+#[test]
+fn qualified_rust_symbol_selectors_share_the_file_anchor_and_unrelated_paths_still_downgrade() {
+    let gated = gated_fixture(GATED_CONFIG);
+    gated.rescope(&["symbol:src.txt#orbit_core::run:function"]);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    fs::write(
+        gated.fixture.repo.join("src.txt"),
+        "implementation target\nimplemented\nrepaired\n",
+    )
+    .expect("repair");
+    write_report(
+        &gated.fixture.runtime,
+        &gated.task_id,
+        &report(attempt_id, ReviewVerdict::PassedWithRepairs, true),
+    );
+    let settled = gated.settle(&admission).expect("settle");
+    assert_eq!(settled["gate"], "passed");
+    assert_eq!(settled["verdict"], "passed_with_repairs");
+
+    let unrelated = gated_fixture(GATED_CONFIG);
+    unrelated.rescope(&["symbol:src.txt#orbit_core::run:function"]);
+    let admission = unrelated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+    fs::write(
+        unrelated.fixture.repo.join("README.md"),
+        "out of scope repair\n",
+    )
+    .expect("edit");
+    write_report(
+        &unrelated.fixture.runtime,
+        &unrelated.task_id,
+        &report(attempt_id, ReviewVerdict::PassedWithRepairs, true),
+    );
+    let error = unrelated.settle(&admission).expect_err("out of scope");
+    let message = error.to_string();
+    assert!(message.contains("repair_out_of_scope"), "{message}");
+    assert!(message.contains("README.md"), "{message}");
+    assert_eq!(unrelated.certificate().verdict, ReviewVerdict::Incomplete);
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11522](https://orbit-cli.com/tasks/ORB-11522) — [code-review] Reviewer scope check rejects canonical symbol selectors

### Description

## Problem
A reviewer repair in the file named by a canonical symbol selector is incorrectly classified as out of scope. The gate commits the repair, downgrades the report to incomplete, and blocks PR publication.

## Live evidence
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24:
- crates/orbit-core/src/application/review/gate.rs:1003 handles symbol targets with target.split("::").next(). For symbol:src/lib.rs#run:function, that produces src/lib.rs#run:function, which can never equal the changed Git path src/lib.rs.
- The authoritative parser in crates/orbit-common/src/fs/selector.rs:139 and :163-194 uses symbol:<path>#<symbol>:<kind>, including Rust symbols containing ::. Its file-anchor helpers already strip this metadata.
- gate.rs:851-857 feeds this mismatch into out_of_scope and :899-905 downgrades otherwise valid repairs.

Use the existing selector/file-anchor semantics rather than another ad hoc grammar. A reviewer should not need to append a redundant file selector merely to repair a symbol that is already authorized. Existing gate tests use file:src.txt and therefore miss the canonical symbol path.

### Acceptance Criteria

- A passing reviewer report with an actual repair in a canonical symbol selector's file settles as passed_with_repairs without adding a redundant file selector.
- Qualified Rust symbol names containing :: resolve to the same authoritative file anchor, while unrelated paths still downgrade the verdict.
- Add behavior tests through review_gate_settle and run make ci-fast and make ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `path_in_scope` now matches reviewer repair paths through `orbit_common::fs::selector::overlaps` against `file:<git-path>` instead of `target.split("::").next()`. Canonical `symbol:<path>#<symbol>:<kind>` selectors authorize the backing file, including qualified Rust names with `::`.
- Added `review_gate_settle` tests: a repair under `symbol:src.txt#run:function` (no redundant `file:` selector) settles `passed_with_repairs`; `symbol:src.txt#orbit_core::run:function` does the same; an unrelated `README.md` repair still downgrades with `repair_out_of_scope`.
Assessment: The gate now reuses the shared selector file-anchor grammar rather than a second ad hoc parser. Scope is limited to the two listed files; directory/legacy containment and out-of-scope downgrade are preserved.

Criteria:
- Passing report with a repair in a canonical symbol selector's file settles `passed_with_repairs` without adding a file selector: met (`a_repair_in_a_canonical_symbol_selector_file_passes_without_a_redundant_file_selector`).
- Qualified Rust `::` symbols share the file anchor; unrelated paths still downgrade: met (`qualified_rust_symbol_selectors_share_the_file_anchor_and_unrelated_paths_still_downgrade`).
- Behavior tests through `review_gate_settle` plus `make ci-fast` and `make ci-lint`: met.

Validation:
- `cargo test -p orbit-core --lib -- symbol_selector`: passed (3 tests, including the two new gate tests).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed. Uncommitted: `gate.rs`, `tests/gate.rs`.

Friction: none filed.
Remaining risks: none identified. Existing `file:` repair coverage was not re-run as a named filter; `ci-lint` compiled the tests with `-D warnings`. Left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11522-6a9f0fbe`
- Behind base: 0
- Ahead of base: 1