### PR TITLE
[code-review] Before-PR policy rejects the local child pipelines needed to assemble an epic

### DIFF
--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -66,6 +66,9 @@ spec:
               items: "{{ steps.descendants.output.task_ids }}"
               max_iterations: 256
               steps:
+                # Intermediate assembly onto the epic branch, not local-only
+                # final delivery. A before-pr snapshot is inherited and the
+                # combined candidate is gated later [ORB-11521].
                 - id: land_child
                   target: activity:invoke_and_wait
                   timeout_seconds: 7200

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -66,6 +66,9 @@ spec:
               items: "{{ steps.descendants.output.task_ids }}"
               max_iterations: 256
               steps:
+                # Intermediate assembly onto the epic branch, not local-only
+                # final delivery. A before-pr snapshot is inherited and the
+                # combined candidate is gated later [ORB-11521].
                 - id: land_child
                   target: activity:invoke_and_wait
                   timeout_seconds: 7200

--- a/crates/orbit-core/src/application/review/admission.rs
+++ b/crates/orbit-core/src/application/review/admission.rs
@@ -6,6 +6,9 @@
 //! captured policy; every other delivery run resolves from workspace
 //! configuration at that moment. Ordinary input naming the reserved key is
 //! refused, and a resume carries its persisted input forward unchanged.
+//! `before-pr` on `task_local_pipeline` is local-only final delivery except
+//! when the parent job is `epic_pipeline`, which assembles onto an epic
+//! branch and still gates the combined PR-bound candidate.
 
 use chrono::Utc;
 use orbit_common::OrbitError;
@@ -16,7 +19,7 @@ use orbit_types::workflow::{
 };
 use serde_json::Value;
 
-use super::{LOCAL_ROUTE_JOB, REVIEW_ADMITTED_JOBS};
+use super::{EPIC_JOB, LOCAL_ROUTE_JOB, REVIEW_ADMITTED_JOBS};
 use crate::OrbitRuntime;
 use crate::application::operation::captured_policy;
 
@@ -47,9 +50,9 @@ pub(crate) fn install_review_admission(
         return Ok(());
     }
 
-    let inherited = match parent_run_id {
-        Some(parent_run_id) => parent_review_admission(runtime, parent_run_id)?,
-        None => None,
+    let (inherited, parent_job) = match parent_run_id {
+        Some(parent_run_id) => parent_review_lineage(runtime, parent_run_id)?,
+        None => (None, None),
     };
     if inherited.is_none() && declares_review_admission(input) {
         return Err(reserved_review_key_error(job_name));
@@ -59,7 +62,10 @@ pub(crate) fn install_review_admission(
         Some(admission) => admission,
         None => resolve_from_authority(runtime, input)?,
     };
-    if job_name == LOCAL_ROUTE_JOB && admission.timing == ReviewTiming::BeforePr {
+    if job_name == LOCAL_ROUTE_JOB
+        && admission.timing == ReviewTiming::BeforePr
+        && parent_job.as_deref() != Some(EPIC_JOB)
+    {
         return Err(OrbitError::InvalidInput(
             "operation.review_policy 'before-pr' holds PR creation for a reviewer and has no \
              meaning on the local-only delivery route; ship through the PR route or choose \
@@ -80,21 +86,23 @@ pub(crate) fn install_review_admission(
     Ok(())
 }
 
-/// The snapshot a parent run persisted, if it carries one.
-fn parent_review_admission(
+/// The snapshot a parent run persisted, if it carries one, together with
+/// the parent job id used to recognize epic assembly.
+fn parent_review_lineage(
     runtime: &OrbitRuntime,
     parent_run_id: &str,
-) -> Result<Option<ReviewAdmission>, OrbitError> {
+) -> Result<(Option<ReviewAdmission>, Option<String>), OrbitError> {
     let Some(parent) = runtime.get_job_run_backend(parent_run_id)? else {
-        return Ok(None);
+        return Ok((None, None));
     };
-    parent
+    let admission = parent
         .input
         .as_ref()
         .map(ReviewAdmission::from_run_input)
         .transpose()
-        .map_err(OrbitError::InvalidInput)
-        .map(Option::flatten)
+        .map_err(OrbitError::InvalidInput)?
+        .flatten();
+    Ok((admission, Some(parent.job_id)))
 }
 
 /// Resolve from the grant a run was admitted under, else from the workspace

--- a/crates/orbit-core/src/application/review/mod.rs
+++ b/crates/orbit-core/src/application/review/mod.rs
@@ -51,8 +51,16 @@ pub(crate) const REVIEW_ADMITTED_JOBS: &[&str] = &[
     "epic_pipeline",
 ];
 
-/// The job that delivers locally and therefore cannot honour `before-pr`.
+/// The job that delivers locally and therefore cannot honour `before-pr`
+/// as a final route. A parent-authorized [`EPIC_JOB`] child may still use
+/// it to assemble onto the epic branch; the epic's own gate remains the
+/// before-pr checkpoint.
 pub(crate) const LOCAL_ROUTE_JOB: &str = "task_local_pipeline";
+
+/// The job that assembles descendants locally and then reviews the combined
+/// PR-bound candidate. Its child `task_local_pipeline` submissions are
+/// intermediate landing, not local-only final delivery.
+pub(crate) const EPIC_JOB: &str = "epic_pipeline";
 
 /// One candidate lineage: the task set delivered together against a base.
 pub(crate) fn lineage_key(workspace_id: &str, task_ids: &[String], base: &str) -> String {

--- a/crates/orbit-core/src/application/review/tests/admission.rs
+++ b/crates/orbit-core/src/application/review/tests/admission.rs
@@ -3,8 +3,28 @@
 use orbit_types::workflow::{REVIEW_ADMISSION_KEY, ReviewAdmission, ReviewTiming};
 use serde_json::json;
 
-use super::{GATED_CONFIG, fixture, seed_task};
-use crate::application::review::install_review_admission;
+use super::{GATED_CONFIG, admit_input, fixture, implement_candidate, seed_task};
+use crate::application::job::pipeline::{
+    ChildPipelineAdmission, ChildSubmission, worker_command_override,
+};
+use crate::application::review::{install_review_admission, review_gate_admit};
+
+/// Replaces the detached pipeline worker so child submission can persist a
+/// run without re-executing the test binary.
+struct WorkerOverride;
+
+impl WorkerOverride {
+    fn install() -> Self {
+        worker_command_override::set(["sh", "-c", "sleep 1"]);
+        Self
+    }
+}
+
+impl Drop for WorkerOverride {
+    fn drop(&mut self) {
+        worker_command_override::clear();
+    }
+}
 
 #[test]
 fn delivery_submissions_capture_the_effective_policy_with_its_sources() {
@@ -125,4 +145,137 @@ fn before_pr_is_refused_on_the_local_only_route() {
     install_review_admission(&runtime, "task_local_pipeline", &mut local, None, false)
         .expect("after-landing is fine locally");
     assert_eq!(local["review"]["timing"], "after-landing");
+}
+
+#[test]
+fn epic_parent_assembles_a_local_child_under_before_pr() {
+    let fixture = fixture(GATED_CONFIG);
+    let runtime = &fixture.runtime;
+    let epic = seed_task(runtime, "epic");
+    let parent = super::admitted_run(runtime, "epic_pipeline", std::slice::from_ref(&epic.id));
+
+    let mut child = json!({ "task_ids": ["ORB-CHILD"] });
+    install_review_admission(
+        runtime,
+        "task_local_pipeline",
+        &mut child,
+        Some(&parent.run_id),
+        false,
+    )
+    .expect("epic assembly is not local-only final delivery");
+    let inherited = ReviewAdmission::from_run_input(&child)
+        .expect("readable")
+        .expect("present");
+    let captured = ReviewAdmission::from_run_input(parent.input.as_ref().expect("parent input"))
+        .expect("readable")
+        .expect("present");
+    assert_eq!(inherited, captured);
+    assert_eq!(inherited.timing, ReviewTiming::BeforePr);
+}
+
+#[test]
+fn non_epic_parent_cannot_assemble_local_child_under_before_pr() {
+    let fixture = fixture(GATED_CONFIG);
+    let runtime = &fixture.runtime;
+    let leaf = seed_task(runtime, "leaf");
+    let parent = super::admitted_run(
+        runtime,
+        "task_auto_pipeline",
+        std::slice::from_ref(&leaf.id),
+    );
+
+    let mut child = json!({ "task_ids": [leaf.id] });
+    let error = install_review_admission(
+        runtime,
+        "task_local_pipeline",
+        &mut child,
+        Some(&parent.run_id),
+        false,
+    )
+    .expect_err("ordinary local-only child still refused");
+    assert!(
+        error
+            .to_string()
+            .contains("no meaning on the local-only delivery route"),
+        "{error}"
+    );
+}
+
+#[test]
+fn caller_shaped_input_cannot_claim_an_epic_assembly_exemption() {
+    let fixture = fixture(GATED_CONFIG);
+    let runtime = &fixture.runtime;
+    let mut forged = json!({
+        "task_ids": ["ORB-1"],
+        "parent_run_id": "jrun-forged-epic",
+        "job_name": "epic_pipeline",
+        "epic_assembly": true,
+    });
+    let error = install_review_admission(runtime, "task_local_pipeline", &mut forged, None, false)
+        .expect_err("ordinary input cannot claim the exemption");
+    assert!(
+        error
+            .to_string()
+            .contains("no meaning on the local-only delivery route"),
+        "{error}"
+    );
+}
+
+#[test]
+fn pr_bound_epic_submits_a_local_child_then_gates_the_combined_candidate() {
+    let fixture = fixture(GATED_CONFIG);
+    let runtime = &fixture.runtime;
+    let epic = seed_task(runtime, "epic");
+    let child = seed_task(runtime, "child");
+    let parent = super::admitted_run(runtime, "epic_pipeline", std::slice::from_ref(&epic.id));
+    runtime
+        .seed_v2_pipeline_run(&parent, parent.input.as_ref().expect("parent input"), None)
+        .expect("parent pipeline state");
+    implement_candidate(&fixture.repo, &epic.id);
+
+    let _worker = WorkerOverride::install();
+    let submission = runtime
+        .submit_child_pipeline_run(
+            "task_local_pipeline",
+            json!({
+                "task_ids": [child.id],
+                "base_branch": "epic/branch",
+                "base_sync": "local",
+                "auto_push": false,
+                "landing_branch": "main",
+                "terminal_status": "done",
+            }),
+            None,
+            Some("tester"),
+            &ChildPipelineAdmission {
+                parent_run_id: parent.run_id.clone(),
+                parent_step_id: Some("land_child".to_string()),
+                action: "invoke_and_wait".to_string(),
+                blocking: true,
+            },
+        )
+        .expect("epic child local pipeline is admitted");
+    let ChildSubmission::Submitted(result) = submission else {
+        panic!("expected a submitted child, got {submission:?}");
+    };
+    let child_run = runtime.show_job_run(&result.run_id).expect("child run");
+    let inherited = ReviewAdmission::from_run_input(child_run.input.as_ref().expect("child input"))
+        .expect("readable")
+        .expect("present");
+    assert_eq!(inherited.timing, ReviewTiming::BeforePr);
+    assert_eq!(child_run.job_id, "task_local_pipeline");
+
+    let admission = review_gate_admit(
+        runtime,
+        "review_gate_admit",
+        &admit_input(
+            &parent.run_id,
+            std::slice::from_ref(&epic.id),
+            &fixture.repo,
+        ),
+    )
+    .expect("epic gate admits the combined candidate");
+    assert_eq!(admission["applies"], true);
+    assert_eq!(admission["decision"], "admitted");
+    assert_eq!(admission["reviewer"]["crew"], "reviewers");
 }

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -220,8 +220,12 @@ from the workspace preferences at that moment. Ordinary input naming the
 reserved `review` key is refused, and a resume keeps its persisted input, so
 rolling a preference back to `none` never weakens a gate that is already
 active and switching to `before-pr` never gates a run already admitted.
-`before-pr` is refused at submission for `task_local_pipeline`; the epic
-pipeline refuses it when its route resolves to local.
+`before-pr` is refused at submission for ordinary `task_local_pipeline`
+delivery. A parent-authorized `epic_pipeline` child may still assemble
+locally onto the epic branch: it inherits the captured snapshot unchanged,
+and the epic's own before-PR gate remains mandatory on the combined
+candidate. Caller-shaped input cannot claim that assembly exemption. The
+epic pipeline itself refuses `before-pr` when its route resolves to local.
 
 ### The gate
 


### PR DESCRIPTION
## Task

[ORB-11521](https://orbit-cli.com/tasks/ORB-11521) — [code-review] Before-PR policy rejects the local child pipelines needed to assemble an epic

### Description

## Problem
A PR-bound epic with unfinished descendants cannot assemble under before-pr review. Its child tasks are intentionally delivered locally to the epic branch, but the new admission rule treats those intermediate deliveries as forbidden local-only final delivery.

## Live evidence
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24:
- crates/orbit-core/assets/jobs/epic_pipeline.yaml:69-82 invokes task_local_pipeline for each descendant, using the epic branch as base and the real integration branch as landing_branch.
- crates/orbit-core/src/application/job/pipeline.rs:772-778 installs review admission for child submissions with the parent_run_id.
- crates/orbit-core/src/application/review/admission.rs:50-62 inherits the parent's before-pr snapshot and then unconditionally refuses task_local_pipeline. If no inherited snapshot were found, the same configured workspace policy is resolved instead, so the child is still refused.
- The final combined epic review is later in epic_pipeline.yaml:168-202 and is never reached.

## Expected behavior
Distinguish authorized intermediate assembly onto an epic branch from local-only final delivery. Keep the final PR-bound epic gate mandatory; do not solve this by dropping or weakening the captured review policy on arbitrary child submissions. This is a separate defect from the epic gate's stable-ID admission lookup. Existing admission tests separately cover inheritance and standalone local rejection, not this combined pipeline path.

### Acceptance Criteria

- A PR-bound epic carrying before-pr can assemble at least one unfinished child locally, then review the complete combined candidate before publication.
- An ordinary local-only task delivery with before-pr remains refused; caller-shaped input cannot claim an epic assembly exemption.
- Regression tests exercise parent authority, actual local child submission, and final epic gate; required formatting/lint checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `install_review_admission` still captures/inherits the before-pr snapshot on every delivery submission. The local-route refusal now applies only when the parent is missing or is not `epic_pipeline`, so a parent-authorized epic child can assemble onto the epic branch.
- Ordinary `task_local_pipeline` (no parent, non-epic parent, or caller-shaped input naming fake parent/assembly fields) remains refused.
- The epic's own `review_gate_admit` path is unchanged and still mandatory for the combined PR-bound candidate.
- Current operations doc and land_child comments describe the assembly vs final-delivery split.

Assessment: Small, targeted admission-boundary fix. Parent authority comes from the persisted parent job id, not from job input, so callers cannot claim the exemption.

Criteria:
- PR-bound epic can assemble a local child then gate the combined candidate: met. `pr_bound_epic_submits_a_local_child_then_gates_the_combined_candidate` submits a real `task_local_pipeline` child under an `epic_pipeline` parent and then `review_gate_admit` with `mode: pr` applies.
- Ordinary local-only before-pr stays refused; caller-shaped input cannot claim exemption: met. Standalone local, non-epic parent, and forged `parent_run_id`/`epic_assembly` input all still fail with the local-route error.
- Regression tests plus formatting/lint: met.

Validation:
- `cargo test -p orbit-core --lib -- application::review::tests::admission epic_pipeline`: passed (19 tests, including new admission cases and existing epic pipeline tests)
- `cargo test -p orbit-core --lib application::review::tests::gate`: passed (11 tests)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

Strategic decisions:
- Exemption is parent `job_id == epic_pipeline` from the store, not a new input flag. Snapshot inheritance is unchanged; the policy is not dropped or weakened on arbitrary children.
- Did not change the epic gate's worktree-token admission lookup (ORB-11520).

Design weaknesses / risks:
- Severity: low. The new combined test calls `review_gate_admit` with the epic job run id. Production YAML still passes `steps.worktree.output.job_run_id` (`epic-<task>`), which is the separate stable-ID defect.
- Scripted `epic_pipeline` exec tests still stub `invoke_and_wait`; they do not re-hit admission. The production child path is `submit_child_pipeline_run`, which the new test exercises.

Deviations from original plan:
- `crates/orbit-core/src/application/job/tests/exec.rs` was listed as context and left unchanged. Combined-path coverage lives at the real child-submission boundary in admission tests rather than through the scripted epic host.

Recommended follow-ups:
- ORB-11520: epic gate should read admission from the job run that captured the policy, not the worktree token.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11521-6a9f1202`
- Behind base: 0
- Ahead of base: 1