### PR TITLE
Bind CI failure signatures and excerpts to the actual failing job

### DIFF
--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -12,8 +12,17 @@ spec:
     rather than assuming branch names; separates the event-reported SHA, the
     ref's current head, and the commit the runner actually checked out; and
     reports every bound it hit in `truncation` rather than silently returning
-    less. Checkout identity is extracted while the full runner-log stream is
-    drained, before the human excerpt is truncated; extraction scans at most
+    less. Schema version 2 emits one current-failure row per failed job, with
+    job_id and log_job_id binding the diagnostic and checkout provenance to
+    that job. Both failed-step and checkout reads explicitly select the job;
+    a fallback may only supply that same job. The global max_job_log_reads
+    budget defaults to 6 (maximum 25), with stable job ordering and a rotating
+    overflow slot. Each read retains the existing timeout, excerpt/scan bounds
+    and one-job fallback. Missing or truncated diagnostic evidence and exhausted
+    job/checkout budgets defer that job with job-scoped retryable errors;
+    complete sibling jobs still progress. Checkout identity is extracted while
+    the full runner-log stream is drained, before the human excerpt is truncated;
+    extraction scans at most
     8 MiB per log and records incomplete evidence rather than guessing.
     Workflow runs are listed repository-wide in one query. `latest_runs`
     records the newest run of each workflow for audit, ordered by creation
@@ -23,9 +32,9 @@ spec:
     unrelated pull-request run cannot erase a landing-branch failure, and a
     genuinely newer completed non-unsuccessful check of the same identity
     (or a landing-branch success, for non-landing noise) does suppress it.
-    Already-failed jobs inside an in-flight workflow become current once
-    their evidence is complete; a pending check alone is never a repair
-    task. Incomplete mixed-state logs stay in `retryable_errors` until a
+    Already-failed jobs inside an in-flight workflow remain visible as current;
+    only complete job evidence may be filed. A pending check alone is never a
+    repair task. Incomplete mixed-state logs stay in `retryable_errors` until a
     later sweep can finish them. A red run on a branch that is neither a
     scanned head nor present on origin is reported as
     `ref_no_longer_exists` rather than current: its pull request merged or
@@ -41,7 +50,8 @@ spec:
     the overflow by `investigation_cursor`, so a candidate below the cap is
     investigated within one rotation instead of never. Discovery or investigation failures are
     bounded, redacted, and emitted in `retryable_errors`; the filing step
-    rejects such a snapshot so it cannot be mistaken for a clean result.
+    defers affected jobs (or rejects discovery-wide gaps) so missing evidence
+    cannot be mistaken for a clean result.
     When no GitHub client is available or authenticated the snapshot carries
     `collected: false` and gathers nothing further, so a caller can never
     mistake it for a clean CI result.
@@ -83,8 +93,16 @@ spec:
           sweep; pin it to make a sweep's selection reproducible.
       log_max_bytes:
         type: number
+      max_job_log_reads:
+        type: number
+        description: >
+          Global cap on failed-job log reads, default 6, maximum 25. Overflow
+          jobs remain deferred; investigation_cursor rotates the last slot.
       max_checkout_log_reads:
         type: number
+        description: >
+          Global cap on additional checkout reads, each narrowed to the same
+          failed job. Default 3, maximum 25.
   output_schema_json:
     type: object
     required: [phase, ci_evidence]

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -34,10 +34,15 @@ spec:
     failure reports `no_current_failure` and files nothing, and anything else
     reports `current_failures` with what it filed, skipped as already open,
     left unfiled at the `max_tasks` cap, or deferred for incomplete evidence.
-    Retryable failures are separated by blast radius. One that names a run —
-    an exhausted investigation budget, an unreadable log, incomplete checkout
-    identity — defers only that finding: it appears in `deferred` with its
-    reasons, is excluded from clustering, and is left for a later sweep, while
+    Schema version 2 requires one job per failure row, matching diagnostic
+    and checkout job identities, one known failed step, and complete untruncated
+    diagnostic evidence. Legacy version-1 run-scoped snapshots remain readable
+    for audit but their failures are deferred for recollection; no job ordering
+    inference or event/PR head substitution is allowed. Retryable failures are
+    separated by blast radius. One that names a job defers only that job.
+    One that names only a run, such as an exhausted run investigation budget
+    or unreadable job metadata, defers that run's findings. Each appears in
+    `deferred` with its reasons and is excluded from clustering, while
     every complete finding in the same snapshot still files and dedupes. One
     that names no run — a repository, run-listing, or pull-request-listing
     read, a registration, dedupe-lookup, or task-creation failure — leaves the
@@ -170,13 +175,15 @@ spec:
         type: array
         description: >
           Current failures left unfiled because their own evidence is
-          incomplete. Each entry carries the run it is about and the bounded
+          incomplete. Each entry carries the run and job it is about and bounded
           retryable reasons, so the gap stays visible and a later sweep can
           finish it.
         items:
           type: object
           required: [run_id, reasons]
           properties:
+            job_id:
+              type: [number, "null"]
             run_id:
               oneOf:
                 - type: number

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -92,6 +92,24 @@ clusters failures by a normalized error signature that prefers a concrete test
 or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
+CI evidence schema 2 binds each failure row to one failed job: both log scopes
+select that job, and checkout provenance carries its job ID. Diagnostic excerpts
+that are missing or truncated, unknown/ambiguous failed steps, incomplete
+checkout identity, and exhausted read budgets defer that job; complete siblings
+still file. `max_job_log_reads` caps failed-job reads across the snapshot (default
+6, maximum 25); `max_checkout_log_reads` separately caps additional same-job
+checkout reads (default 3, maximum 25). The rotating investigation slot also
+rotates overflow jobs in stable ID order. Legacy schema-1 failures require
+recollection because their run-wide logs and checkout scans cannot establish
+job attribution. Neither event nor PR head can substitute for runner checkout.
+
+Read-only verification: inspect the run's job metadata with `gh run view <run>
+--json databaseId,jobs --repo <owner/repo>`, then use the production bounded log
+reader with explicit `run`, `job`, and `scope` for each failed job. Compare each
+row's job ID, diagnostic, and checkout provenance with that supplying job; repeat
+with reversed metadata order and a one-job budget. Do not download whole logs
+into memory or use a sweep that files tasks merely to verify collection.
+
 ### The `completion` input
 
 Every pipeline above that ships a task takes a `completion` input, defaulting to

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -50,7 +50,7 @@ const OUTCOME_NO_CURRENT_FAILURE: &str = "no_current_failure";
 const OUTCOME_CURRENT_FAILURES: &str = "current_failures";
 
 /// Snapshot schema this step knows how to read.
-const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+const SUPPORTED_SCHEMA_VERSION: u64 = 2;
 
 /// Provenance tag: every task this step files carries it.
 pub(crate) const CI_FAILURE_TAG: &str = "ci-failure-sweep";
@@ -139,7 +139,7 @@ where
     let schema_version = evidence
         .get("schema_version")
         .and_then(Value::as_u64)
-        .unwrap_or(SUPPORTED_SCHEMA_VERSION);
+        .unwrap_or(1);
     if schema_version > SUPPORTED_SCHEMA_VERSION {
         return Err(OrbitError::InvalidInput(format!(
             "ci_evidence schema version {schema_version} is newer than the supported version \
@@ -217,6 +217,7 @@ where
             "stage": "registration",
             "operation": "current_failure_not_investigated",
             "run_id": failure.get("run_id"),
+            "job_id": failure.get("job_id"),
             "retryable": true,
             "message": "a current CI failure has no complete investigation and cannot be filed safely",
         });
@@ -240,7 +241,7 @@ where
             retryable_errors,
         ));
     }
-    let (complete, mut deferred) = split_deferred_failures(&failures, &run_errors);
+    let (complete, mut deferred) = split_deferred_failures(&failures, &run_errors, schema_version);
     // A run-scoped retryable error whose run never made it into
     // `current_failures` at all — an in-flight run with an observed failed
     // job but logs collection could not read yet — has no failure row for
@@ -516,7 +517,7 @@ fn run_id_key(entry: &Value) -> Option<String> {
 
 /// Split retryable errors by blast radius.
 ///
-/// An error that names a run spoils that run's finding and nothing else. An
+/// A job error affects only that job; a run error affects all its jobs. An
 /// error that names none — a repository read, a run listing, a pull-request
 /// listing — leaves the whole snapshot in doubt: any finding it did produce
 /// could be missing the newer run that would have superseded it, so filing
@@ -537,25 +538,45 @@ fn partition_retryable_errors(errors: &[Value]) -> (usize, BTreeMap<String, Vec<
 /// incomplete.
 ///
 /// Per-finding evidence requirements are unchanged: a failure is filed only
-/// when collection investigated it fully and no error is recorded against its
-/// run. What changes is that a deferred failure now says so in its own entry
+/// when collection investigated it fully and no applicable job or run error
+/// is recorded. What changes is that a deferred failure now says so in its own entry
 /// instead of silently withholding its neighbours.
 fn split_deferred_failures(
     failures: &[Value],
     run_errors: &BTreeMap<String, Vec<Value>>,
+    schema_version: u64,
 ) -> (Vec<Value>, Vec<Value>) {
     let mut complete = Vec::new();
     let mut deferred = Vec::new();
     for failure in failures {
-        let reasons = run_id_key(failure)
-            .and_then(|run_id| run_errors.get(&run_id).cloned())
-            .unwrap_or_default();
+        let mut reasons = run_id_key(failure)
+            .and_then(|run_id| run_errors.get(&run_id))
+            .into_iter()
+            .flatten()
+            .filter(|error| {
+                error.get("job_id").is_none_or(Value::is_null)
+                    || error.get("job_id") == failure.get("job_id")
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if reasons.is_empty()
+            && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+            && let Some(message) = job_evidence_gap(failure, schema_version)
+        {
+            reasons.push(json!({
+                "stage": "registration", "operation": "job_evidence_identity",
+                "run_id": failure.get("run_id"), "job_id": failure.get("job_id"),
+                "retryable": true, "message": message,
+            }));
+        }
         let investigated = failure.get("investigated").and_then(Value::as_bool) == Some(true);
         if reasons.is_empty() && investigated {
             complete.push(failure.clone());
             continue;
         }
         deferred.push(json!({
+            "job_id": failure.get("job_id"),
+            "failed_jobs": failure.get("failed_jobs"),
             "run_id": failure.get("run_id"),
             "url": failure.get("url"),
             "workflow": failure.get("workflow"),
@@ -577,6 +598,62 @@ fn split_deferred_failures(
         }));
     }
     (complete, deferred)
+}
+
+/// Old snapshots did not bind the run log or its checkout scan to the named
+/// job. They remain readable audit evidence, but must be recollected before
+/// filing; inferring attribution from job order would repeat the original bug.
+fn job_evidence_gap(failure: &Value, schema_version: u64) -> Option<&'static str> {
+    if schema_version < 2 {
+        return Some("legacy run-scoped evidence has no verified job binding; recollect this run");
+    }
+    let Some(job_id) = failure.get("job_id").and_then(Value::as_u64) else {
+        return Some("failure has no numeric job identity");
+    };
+    let jobs = failure.get("failed_jobs").and_then(Value::as_array);
+    let Some(job) = jobs
+        .filter(|jobs| jobs.len() == 1)
+        .and_then(|jobs| jobs.first())
+    else {
+        return Some("failure must identify exactly one supplying job");
+    };
+    if job.get("job_id").and_then(Value::as_u64) != Some(job_id)
+        || failure.get("log_job_id").and_then(Value::as_u64) != Some(job_id)
+    {
+        return Some("diagnostic evidence is not bound to the named job");
+    }
+    if job
+        .get("failed_steps")
+        .and_then(Value::as_array)
+        .is_none_or(|steps| steps.len() != 1)
+    {
+        return Some("failed step identity is missing or ambiguous within this job");
+    }
+    if value_string(failure, "log_excerpt").trim().is_empty()
+        || failure.get("log_truncated").and_then(Value::as_bool) != Some(false)
+    {
+        return Some("job diagnostic evidence is missing or truncated");
+    }
+    if value_string(failure, "log_source") == "job_api_log"
+        && failure
+            .get("log_source_jobs")
+            .and_then(Value::as_array)
+            .is_none_or(|jobs| jobs.len() != 1 || jobs[0]["job_id"].as_u64() != Some(job_id))
+    {
+        return Some("fallback log evidence belongs to a different or unknown job");
+    }
+    let identity = &failure["checkout_identity"];
+    if identity["provenance"]["job_id"].as_u64() != Some(job_id)
+        || identity["provenance"]["complete"].as_bool() != Some(true)
+        || identity["state"] != "observed"
+        || failure
+            .get("actual_checkout_shas")
+            .and_then(Value::as_array)
+            .is_none_or(|shas| shas.len() != 1)
+    {
+        return Some("checkout identity is not completely observed for this job");
+    }
+    None
 }
 
 /// The deferred entries flattened back into the error list shape, for the
@@ -683,6 +760,7 @@ fn normalize_retryable_error(error: Value) -> Value {
             .and_then(Value::as_str)
             .unwrap_or("unknown"),
         "run_id": error.get("run_id").cloned().unwrap_or(Value::Null),
+        "job_id": error.get("job_id").cloned().unwrap_or(Value::Null),
         "retryable": true,
         "message": bounded_error(
             error
@@ -1156,7 +1234,7 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
         .collect()
 }
 
-/// The first failing job and step named by the snapshot.
+/// The single job and step whose evidence passed registration.
 fn failing_job_and_step(failure: &Value) -> (String, String) {
     let Some(job) = failure
         .get("failed_jobs")
@@ -1174,8 +1252,8 @@ fn failing_job_and_step(failure: &Value) -> (String, String) {
     (value_string(job, "name"), step)
 }
 
-/// The commit under test: what the runner checked out when that is evidenced,
-/// falling back to the SHA the event reported.
+/// The observed checkout, validated before clustering. Event and PR heads
+/// are never substitutes for the commit the supplying job tested.
 fn tested_commit(failure: &Value) -> String {
     failure
         .get("actual_checkout_shas")
@@ -1183,7 +1261,7 @@ fn tested_commit(failure: &Value) -> String {
         .and_then(|shas| shas.first())
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
-        .unwrap_or_else(|| value_string(failure, "event_reported_head_sha"))
+        .unwrap_or_default()
 }
 
 /// Lines a runner emits when something breaks.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -54,6 +54,9 @@ pub(super) fn failure(
 ) -> Value {
     json!({
         "run_id": run_id,
+        "job_id": 900 + run_id,
+        "log_job_id": 900 + run_id,
+        "checkout_identity": {"state": "observed", "provenance": {"job_id": 900 + run_id, "complete": true}},
         "workflow": workflow,
         "title": format!("{workflow} on {HEAD}"),
         "status": "completed",
@@ -86,7 +89,7 @@ pub(super) fn failure(
 pub(super) fn snapshot(current: Vec<Value>) -> Value {
     let latest = current.clone();
     json!({
-        "schema_version": 1,
+        "schema_version": 2,
         "collected": true,
         "outcome_hint": if current.is_empty() { "no_current_failure" } else { "current_failures" },
         "capability": {
@@ -148,7 +151,7 @@ fn a_snapshot_that_could_not_look_reports_capability_unavailable_and_files_nothi
     let output = file(
         &runtime,
         json!({"ci_evidence": {
-            "schema_version": 1,
+            "schema_version": 2,
             "collected": false,
             "outcome_hint": "capability_unavailable",
             "capability": {
@@ -428,6 +431,10 @@ fn an_excerpt_recovered_from_a_job_log_is_labelled_as_the_whole_job_log() {
     );
     // Collection could not read the run-scoped failed-step log and recovered
     // the excerpt from the failed job's own log instead.
+    recovered["job_id"] = json!(101_560_010_340_u64);
+    recovered["log_job_id"] = recovered["job_id"].clone();
+    recovered["failed_jobs"][0]["job_id"] = recovered["job_id"].clone();
+    recovered["checkout_identity"]["provenance"]["job_id"] = recovered["job_id"].clone();
     recovered["log_source"] = json!("job_api_log");
     recovered["log_source_jobs"] = json!([{
         "job_id": 101_560_010_340_u64,
@@ -477,6 +484,9 @@ fn live_run_fixture_files_once_with_complete_actionable_evidence() {
         ),
         SHA,
     );
+    live["job_id"] = json!(JOB_ID);
+    live["log_job_id"] = json!(JOB_ID);
+    live["checkout_identity"]["provenance"]["job_id"] = json!(JOB_ID);
     live["url"] = json!(RUN_URL);
     live["event_reported_head_sha"] = json!(SHA);
     live["current_ref_head_sha"] = json!(SHA);
@@ -2007,5 +2017,136 @@ fn a_finding_whose_own_run_failed_a_query_is_deferred_not_filed_from_partial_evi
     assert_eq!(
         deferred[0]["reasons"][0]["operation"],
         json!("checkout_evidence")
+    );
+}
+
+fn two_job_findings() -> Vec<Value> {
+    let first = failure(
+        10,
+        "CI",
+        "Clippy",
+        "Run guardrails",
+        "error: unused import",
+        CHECKOUT,
+    );
+    let mut second = failure(
+        10,
+        "CI",
+        "Coverage",
+        "Collect coverage",
+        "test output_goldens FAILED",
+        NEXT_HEAD,
+    );
+    second["job_id"] = json!(920);
+    second["log_job_id"] = json!(920);
+    second["failed_jobs"][0]["job_id"] = json!(920);
+    second["checkout_identity"]["provenance"]["job_id"] = json!(920);
+    vec![first, second]
+}
+
+#[test]
+fn two_failed_jobs_file_distinct_correct_findings_regardless_of_order() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let findings = two_job_findings();
+    let first = file(&runtime, json!({"ci_evidence": snapshot(findings.clone())}));
+    assert_eq!(first["filed_count"], 2);
+    let ids = filed_task_ids(&first);
+    let clippy = runtime.get_task(&ids[0]).expect("clippy task");
+    let coverage = runtime.get_task(&ids[1]).expect("coverage task");
+    assert!(clippy.title.contains("Clippy"));
+    assert!(clippy.description.contains("unused import"));
+    assert!(!clippy.description.contains("output_goldens"));
+    assert!(coverage.title.contains("Coverage"));
+    assert!(coverage.description.contains("output_goldens"));
+    assert!(!coverage.description.contains("unused import"));
+    assert_ne!(
+        first["filed"][0]["failure_key"],
+        first["filed"][1]["failure_key"]
+    );
+    assert_eq!(first["filed"][0]["tested_commit"], CHECKOUT);
+    assert_eq!(first["filed"][1]["tested_commit"], NEXT_HEAD);
+    let mut reversed = findings;
+    reversed.reverse();
+    let second = file(&runtime, json!({"ci_evidence": snapshot(reversed)}));
+    assert_eq!(second["filed_count"], 0);
+    assert_eq!(
+        second["skipped_existing"].as_array().expect("skips").len(),
+        2
+    );
+}
+
+#[test]
+fn one_jobs_retryable_error_defers_only_that_job() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut findings = two_job_findings();
+    findings[0]["investigated"] = json!(false);
+    let mut evidence = snapshot(findings);
+    evidence["retryable_errors"] = json!([{
+        "run_id": 10, "job_id": 910, "operation": "run_logs", "message": "job log unavailable",
+    }]);
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+    assert_eq!(output["filed_count"], 1);
+    assert_eq!(output["filed"][0]["job"], "Coverage");
+    assert_eq!(output["deferred"][0]["job_id"], 910);
+    assert_eq!(output["deferred"][0]["reasons"][0]["job_id"], 910);
+    assert_eq!(output["deferred"].as_array().expect("deferred").len(), 1);
+}
+
+#[test]
+fn unbound_legacy_and_incomplete_job_snapshots_require_recollection() {
+    for defect in [
+        "legacy",
+        "fallback",
+        "checkout",
+        "truncated",
+        "missing",
+        "steps",
+    ] {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let mut findings = two_job_findings();
+        findings.truncate(1);
+        let mut evidence = snapshot(findings);
+        let finding = &mut evidence["current_failures"][0];
+        match defect {
+            "fallback" => {
+                finding["log_source"] = json!("job_api_log");
+                finding["log_source_jobs"] = json!([{"job_id": 920}]);
+            }
+            "checkout" => finding["checkout_identity"]["provenance"]["job_id"] = json!(920),
+            "truncated" => finding["log_truncated"] = json!(true),
+            "missing" => finding["log_excerpt"] = json!(""),
+            "steps" => {
+                finding["failed_jobs"][0]["failed_steps"] = json!([{"name": "A"}, {"name": "B"}])
+            }
+            _ => evidence["schema_version"] = json!(1),
+        }
+        let error = file_error(&runtime, json!({"ci_evidence": evidence}));
+        assert!(error.contains("job_evidence_identity"), "{defect}: {error}");
+        assert!(
+            runtime
+                .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+                .expect("tasks")
+                .is_empty()
+        );
+    }
+}
+
+#[test]
+fn legacy_multi_job_snapshot_cannot_label_coverage_log_as_clippy() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let findings = two_job_findings();
+    let mut combined = findings[0].clone();
+    combined["failed_jobs"] =
+        json!([findings[0]["failed_jobs"][0], findings[1]["failed_jobs"][0],]);
+    combined["log_excerpt"] = json!("Coverage\tCollect coverage\ttest output_goldens FAILED\n");
+    let mut evidence = snapshot(vec![combined]);
+    evidence["schema_version"] = json!(1);
+    let error = file_error(&runtime, json!({"ci_evidence": evidence}));
+    assert!(error.contains("legacy run-scoped evidence"), "{error}");
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("tasks")
+            .is_empty()
     );
 }

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -23,7 +23,8 @@ use orbit_common::OrbitError;
 use orbit_common::security::redaction::redact_all;
 use serde_json::{Value, json};
 
-use super::query::{CiQueries, LogScope};
+use super::investigate::investigate;
+use super::query::CiQueries;
 use super::{
     OUTCOME_CAPABILITY_UNAVAILABLE, OUTCOME_CURRENT_FAILURES, OUTCOME_NO_CURRENT_FAILURE,
     OUTCOME_RETRYABLE_ERROR, bounded_u64, optional_input_string, unsuccessful_conclusion,
@@ -31,7 +32,7 @@ use super::{
 
 /// Snapshot schema version. Bump when a consumer would misread an older
 /// snapshot; `file_ci_failure_tasks` reads this field before anything else.
-pub(super) const CI_EVIDENCE_SCHEMA_VERSION: u64 = 1;
+pub(super) const CI_EVIDENCE_SCHEMA_VERSION: u64 = 2;
 
 /// Cap on the single repository-wide run listing. This is a whole-repository
 /// budget, not a per-ref one: it has to be deep enough that the integration
@@ -49,6 +50,9 @@ const MAX_LOG_MAX_BYTES: u64 = 262_144;
 /// Cap on full-log reads taken purely to evidence a checkout commit. The
 /// failed-step log usually lacks it, and a full log can be tens of megabytes.
 const DEFAULT_MAX_CHECKOUT_LOG_READS: u64 = 3;
+/// Global cap on diagnostic reads, each bound to one failed job.
+const DEFAULT_MAX_JOB_LOG_READS: u64 = 6;
+const MAX_MAX_JOB_LOG_READS: u64 = 25;
 /// Cap on origin probes for branches no scanned head covers. One probe per
 /// distinct branch, and only for branches that actually carry a red run.
 const DEFAULT_MAX_RETIRED_REF_PROBES: u64 = 20;
@@ -82,16 +86,17 @@ struct ScannedRef {
     pr_url: Option<Value>,
 }
 
-struct Bounds {
+pub(super) struct Bounds {
     max_runs: u64,
     max_pull_requests: u64,
     max_investigated_runs: usize,
-    log_max_bytes: usize,
-    max_checkout_log_reads: usize,
+    pub(super) log_max_bytes: usize,
+    pub(super) max_checkout_log_reads: usize,
+    pub(super) max_job_log_reads: usize,
     max_retired_ref_probes: usize,
     /// Which overflow candidate this sweep spends its rotating investigation
     /// slot on. Taken from the collection hour unless the caller pins it.
-    investigation_cursor: u64,
+    pub(super) investigation_cursor: u64,
 }
 
 fn bounds_from_input(input: &Value) -> Result<Bounds, OrbitError> {
@@ -114,6 +119,12 @@ fn bounds_from_input(input: &Value) -> Result<Bounds, OrbitError> {
             "log_max_bytes",
             DEFAULT_LOG_MAX_BYTES,
             MAX_LOG_MAX_BYTES,
+        )? as usize,
+        max_job_log_reads: bounded_u64(
+            input,
+            "max_job_log_reads",
+            DEFAULT_MAX_JOB_LOG_READS,
+            MAX_MAX_JOB_LOG_READS,
         )? as usize,
         max_checkout_log_reads: bounded_u64(
             input,
@@ -289,20 +300,24 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         }
     }
     let mut checkout_log_reads = 0usize;
+    let mut job_log_reads = 0usize;
+    let mut findings = Vec::new();
     for (index, failure) in inspect.iter_mut().enumerate() {
         if !selected.contains(&index) {
             failure["investigated"] = json!(false);
+            findings.push(failure.clone());
             continue;
         }
-        investigate(
+        findings.extend(investigate(
             queries,
             failure,
             &bounds,
             &mut checkout_log_reads,
+            &mut job_log_reads,
             &mut retryable_errors,
-        );
+        ));
     }
-    current = inspect
+    current = findings
         .into_iter()
         .filter(is_actionable_current_failure)
         .collect();
@@ -372,6 +387,8 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "current_failures_investigation_attempted": attempted,
             "current_failures_investigated": investigated_count,
             "log_max_bytes": bounds.log_max_bytes,
+            "job_log_reads": job_log_reads,
+            "max_job_log_reads": bounds.max_job_log_reads,
             "checkout_log_reads": checkout_log_reads,
             "max_checkout_log_reads": bounds.max_checkout_log_reads,
             "retired_refs": probes.retired.iter().collect::<Vec<_>>(),
@@ -632,7 +649,7 @@ fn probe_slots(candidates: usize, budget: usize, cursor: u64) -> std::collection
 /// that gate delivery still go first, and every other candidate is reached
 /// within one rotation instead of never. With a budget of one there is nothing
 /// to rotate and the highest-ranked candidate keeps the slot.
-fn investigation_slots(
+pub(super) fn investigation_slots(
     candidates: usize,
     budget: usize,
     cursor: u64,
@@ -806,7 +823,7 @@ fn run_branch(run: &Value) -> &str {
     run.get("head_branch").and_then(Value::as_str).unwrap_or("")
 }
 
-fn run_is_completed(run: &Value) -> bool {
+pub(super) fn run_is_completed(run: &Value) -> bool {
     run.get("status").and_then(Value::as_str) == Some("completed")
 }
 
@@ -825,7 +842,7 @@ fn is_actionable_current_failure(failure: &Value) -> bool {
     if run_is_completed(failure) {
         return run_is_unsuccessful(failure);
     }
-    has_failed_jobs(failure) && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+    has_failed_jobs(failure)
 }
 
 /// A red run on a branch origin no longer has. Not superseded by a newer run —
@@ -932,229 +949,7 @@ fn sort_current_failures(failures: &mut [Value]) {
     });
 }
 
-/// Fill one current failure in with its failed jobs, steps, bounded log, and
-/// the commit its runner actually checked out.
-fn investigate<Q: CiQueries + ?Sized>(
-    queries: &Q,
-    failure: &mut Value,
-    bounds: &Bounds,
-    checkout_log_reads: &mut usize,
-    retryable_errors: &mut Vec<Value>,
-) {
-    let Some(run_id) = failure
-        .get("run_id")
-        .and_then(Value::as_u64)
-        .map(|id| id.to_string())
-    else {
-        push_retryable_error(
-            retryable_errors,
-            "registration",
-            "run_identity",
-            None,
-            "current failure has no numeric run_id",
-        );
-        return;
-    };
-    let errors_before = retryable_errors.len();
-
-    match queries.run_view(&run_id) {
-        Ok(view) => {
-            let failed_jobs = view.get("failed_jobs").cloned().unwrap_or(json!([]));
-            let empty = failed_jobs.as_array().is_none_or(Vec::is_empty);
-            if empty && run_is_completed(failure) {
-                push_retryable_error(
-                    retryable_errors,
-                    "registration",
-                    "run_view",
-                    failure.get("run_id"),
-                    "failed run returned no failed jobs",
-                );
-            }
-            failure["failed_jobs"] = failed_jobs;
-            // A pending in-flight check is not a repair task. Do not fetch
-            // logs or consume checkout budget until a job has actually failed.
-            if empty && !run_is_completed(failure) {
-                failure["investigated"] = json!(true);
-                return;
-            }
-        }
-        Err(error) => {
-            push_retryable_error(
-                retryable_errors,
-                "investigation",
-                "run_view",
-                failure.get("run_id"),
-                &error.to_string(),
-            );
-            if !run_is_completed(failure) {
-                failure["investigated"] = json!(false);
-                return;
-            }
-        }
-    }
-
-    match queries.run_logs(&run_id, LogScope::Failed, bounds.log_max_bytes) {
-        Ok(log) => {
-            failure["log_excerpt"] = json!(log.text);
-            failure["log_truncated"] = json!(log.truncated);
-            failure["log_total_bytes"] = json!(log.total_bytes);
-            failure["log_returned_bytes"] = json!(log.returned_bytes);
-            failure["log_scope"] = json!("failed");
-            failure["log_source"] = json!(log.source);
-            failure["log_source_jobs"] = json!(log.source_jobs);
-            failure["actual_checkout_shas"] = json!(log.checkout_commits);
-            failure["checkout_evidence"] = json!(log.checkout_evidence);
-            failure["checkout_evidence_scope"] = json!("failed");
-            set_checkout_identity(failure, "failed", &log);
-            // A read that ends with no text at all is not a captured excerpt,
-            // and the per-job fallback has already had its turn. Record why,
-            // so the filed task can say what is missing and the sweep never
-            // reads silence as a clean run.
-            if log.text.trim().is_empty() {
-                push_retryable_error(
-                    retryable_errors,
-                    "investigation",
-                    "run_logs",
-                    failure.get("run_id"),
-                    &with_fallback_cause("query returned no failed-step log text", &log),
-                );
-            }
-        }
-        Err(error) => {
-            push_retryable_error(
-                retryable_errors,
-                "investigation",
-                "run_logs",
-                failure.get("run_id"),
-                &error.to_string(),
-            );
-        }
-    }
-
-    // The checkout step normally succeeds, so it is absent from the
-    // failed-step log. One full-log read per run, within a hard budget,
-    // recovers the commit under test; past the budget we say so rather than
-    // leaving the field silently empty.
-    let needs_checkout = failure
-        .get("actual_checkout_shas")
-        .and_then(Value::as_array)
-        .is_none_or(Vec::is_empty)
-        || failure
-            .get("checkout_evidence_complete")
-            .and_then(Value::as_bool)
-            != Some(true);
-    if !needs_checkout {
-        failure["investigated"] = json!(retryable_errors.len() == errors_before);
-        return;
-    }
-    if *checkout_log_reads >= bounds.max_checkout_log_reads {
-        failure["checkout_evidence_scope"] = json!("skipped_budget_exhausted");
-        push_retryable_error(
-            retryable_errors,
-            "investigation",
-            "checkout_evidence_budget",
-            failure.get("run_id"),
-            "actual checkout SHA was not collected because max_checkout_log_reads was exhausted",
-        );
-        failure["investigated"] = json!(false);
-        return;
-    }
-    *checkout_log_reads += 1;
-    match queries.run_logs(&run_id, LogScope::All, bounds.log_max_bytes) {
-        Ok(log) => {
-            failure["actual_checkout_shas"] = json!(log.checkout_commits);
-            failure["checkout_evidence"] = json!(log.checkout_evidence);
-            failure["checkout_evidence_scope"] = json!("all");
-            set_checkout_identity(failure, "all", &log);
-            // A genuinely incomplete scan (the source-byte cap, or a dropped
-            // overlong line that could have carried checkout identity) stays
-            // fail-closed even when one SHA was already found: it cannot rule
-            // out a later, conflicting identity past whatever it didn't
-            // manage to read. Only a *display* cap (evidence line/commit
-            // count, or an overlong line unrelated to checkout) is exempt —
-            // that never touches `checkout_evidence_complete`.
-            if !log.checkout_evidence_complete {
-                push_retryable_error(
-                    retryable_errors,
-                    "registration",
-                    "checkout_evidence",
-                    failure.get("run_id"),
-                    "checkout evidence scan reached its hard limit; actual checkout identity is incomplete",
-                );
-            } else if log.checkout_commits.is_empty() {
-                push_retryable_error(
-                    retryable_errors,
-                    "registration",
-                    "checkout_evidence",
-                    failure.get("run_id"),
-                    &with_fallback_cause("run logs contained no actual checkout SHA", &log),
-                );
-            }
-        }
-        Err(error) => {
-            failure["checkout_evidence_scope"] = json!("unavailable");
-            push_retryable_error(
-                retryable_errors,
-                "investigation",
-                "run_logs_all",
-                failure.get("run_id"),
-                &error.to_string(),
-            );
-        }
-    }
-    failure["investigated"] = json!(retryable_errors.len() == errors_before);
-}
-
-/// An evidence gap, extended with the fallback's own outcome when there was
-/// one.
-///
-/// An empty log read is not proof that a run's logs expired: it is also how
-/// the `gh run view --log*` blind spot presents, and the per-job fallback runs
-/// precisely then. Whichever way the gap arose, the reader is told which query
-/// fell short rather than being left to assume retention.
-fn with_fallback_cause(gap: &str, log: &super::query::RunLog) -> String {
-    match &log.fallback_error {
-        Some(reason) => format!("{gap}; the per-job log fallback recovered none either: {reason}"),
-        None => gap.to_string(),
-    }
-}
-
-fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::RunLog) {
-    let state = if !log.checkout_evidence_complete {
-        "incomplete"
-    } else {
-        match log.checkout_commits.len() {
-            0 => "missing",
-            1 => "observed",
-            _ => "ambiguous",
-        }
-    };
-    failure["checkout_evidence_complete"] = json!(log.checkout_evidence_complete);
-    failure["checkout_evidence_scanned_bytes"] = json!(log.checkout_evidence_scanned_bytes);
-    failure["checkout_evidence_source_truncated"] = json!(log.checkout_evidence_source_truncated);
-    failure["checkout_evidence_display_truncated"] = json!(log.checkout_evidence_display_truncated);
-    failure["checkout_identity"] = json!({
-        "state": state,
-        "observed_shas": log.checkout_commits,
-        "provenance": {
-            "source": "runner_log",
-            // Which query the runner log was read through, and the job whose
-            // own log supplied it when the run-scoped read returned nothing.
-            "read_via": log.source,
-            "jobs": log.source_jobs,
-            "scope": scope,
-            "complete": log.checkout_evidence_complete,
-            "scanned_bytes": log.checkout_evidence_scanned_bytes,
-            "source_truncated": log.checkout_evidence_source_truncated,
-            // Display caps (evidence line/commit count, or an unrelated
-            // overlong line) reduce what is reported without bearing on
-            // whether identity itself was captured; see `complete` for that.
-            "display_truncated": log.checkout_evidence_display_truncated,
-        },
-    });
-}
-
-fn push_retryable_error(
+pub(super) fn push_retryable_error(
     errors: &mut Vec<Value>,
     stage: &str,
     operation: &str,

--- a/crates/orbit-engine/src/executor/automation/ci/investigate.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/investigate.rs
@@ -1,0 +1,328 @@
+//! Job-bound diagnostic and checkout evidence for current CI failures.
+
+use serde_json::{Value, json};
+
+use super::collect::{Bounds, investigation_slots, push_retryable_error, run_is_completed};
+use super::query::{CiQueries, LogScope};
+
+/// Inspect each failed job independently. The row keeps run freshness metadata,
+/// but all diagnostic and checkout fields belong only to its named job.
+pub(super) fn investigate<Q: CiQueries + ?Sized>(
+    queries: &Q,
+    failure: &Value,
+    bounds: &Bounds,
+    checkout_log_reads: &mut usize,
+    job_log_reads: &mut usize,
+    retryable_errors: &mut Vec<Value>,
+) -> Vec<Value> {
+    let Some(run_id) = failure.get("run_id").and_then(Value::as_u64) else {
+        push_retryable_error(
+            retryable_errors,
+            "registration",
+            "run_identity",
+            None,
+            "current failure has no numeric run_id",
+        );
+        return vec![failure.clone()];
+    };
+    let view = match queries.run_view(&run_id.to_string()) {
+        Ok(view) => view,
+        Err(error) => {
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_view",
+                failure.get("run_id"),
+                &error.to_string(),
+            );
+            return vec![failure.clone()];
+        }
+    };
+    let jobs = view
+        .get("failed_jobs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if jobs.is_empty() {
+        if run_is_completed(failure) {
+            push_retryable_error(
+                retryable_errors,
+                "registration",
+                "run_view",
+                failure.get("run_id"),
+                "failed run returned no failed jobs",
+            );
+        }
+        return vec![failure.clone()];
+    }
+
+    let remaining_reads = bounds.max_job_log_reads.saturating_sub(*job_log_reads);
+    let selected = if remaining_reads == 1 {
+        // Runs reserve a single slot for integration priority. Within a run,
+        // equally relevant failed jobs must rotate even with only one read.
+        std::collections::BTreeSet::from([
+            (bounds.investigation_cursor % jobs.len() as u64) as usize
+        ])
+    } else {
+        investigation_slots(jobs.len(), remaining_reads, bounds.investigation_cursor)
+    };
+    let mut findings = Vec::new();
+    // Stable numeric identity makes a provider's job ordering irrelevant to
+    // which findings receive the bounded reads on repeated sweeps.
+    let mut jobs = jobs;
+    jobs.sort_by_key(|job| job.get("job_id").and_then(Value::as_u64));
+    for (index, job) in jobs.into_iter().enumerate() {
+        let mut finding = failure.clone();
+        finding["job_id"] = job.get("job_id").cloned().unwrap_or(Value::Null);
+        finding["failed_jobs"] = json!([job]);
+        let mut errors = Vec::new();
+        if !selected.contains(&index) {
+            push_retryable_error(
+                &mut errors,
+                "investigation",
+                "job_log_budget",
+                failure.get("run_id"),
+                "job evidence was not collected because max_job_log_reads was exhausted",
+            );
+        } else if let Some(job_id) = finding["job_id"].as_u64() {
+            *job_log_reads += 1;
+            investigate_job(
+                queries,
+                &mut finding,
+                job_id,
+                bounds,
+                checkout_log_reads,
+                &mut errors,
+            );
+        } else {
+            push_retryable_error(
+                &mut errors,
+                "registration",
+                "job_identity",
+                failure.get("run_id"),
+                "failed job has no numeric job_id",
+            );
+        }
+        for error in &mut errors {
+            error["job_id"] = finding["job_id"].clone();
+        }
+        finding["investigated"] = json!(errors.is_empty());
+        finding["evidence_state"] = json!(if errors.is_empty() {
+            "complete"
+        } else {
+            "deferred"
+        });
+        retryable_errors.extend(errors);
+        findings.push(finding);
+    }
+    findings
+}
+
+fn investigate_job<Q: CiQueries + ?Sized>(
+    queries: &Q,
+    failure: &mut Value,
+    job_id: u64,
+    bounds: &Bounds,
+    checkout_log_reads: &mut usize,
+    retryable_errors: &mut Vec<Value>,
+) {
+    let run_id = failure["run_id"].to_string();
+    match queries.run_logs(&run_id, job_id, LogScope::Failed, bounds.log_max_bytes) {
+        Ok(log) => {
+            if !log_belongs_to_job(&log, job_id) {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "log_job_identity",
+                    failure.get("run_id"),
+                    "log source does not belong to the requested failed job",
+                );
+                return;
+            }
+            failure["log_job_id"] = json!(job_id);
+            if log.truncated {
+                push_retryable_error(
+                    retryable_errors,
+                    "investigation",
+                    "job_log_truncated",
+                    failure.get("run_id"),
+                    "job log excerpt is truncated; diagnostic evidence is incomplete",
+                );
+            }
+            failure["log_excerpt"] = json!(log.text);
+            failure["log_truncated"] = json!(log.truncated);
+            failure["log_total_bytes"] = json!(log.total_bytes);
+            failure["log_returned_bytes"] = json!(log.returned_bytes);
+            failure["log_scope"] = json!("failed");
+            failure["log_source"] = json!(log.source);
+            failure["log_source_jobs"] = json!(log.source_jobs);
+            failure["actual_checkout_shas"] = json!(log.checkout_commits);
+            failure["checkout_evidence"] = json!(log.checkout_evidence);
+            failure["checkout_evidence_scope"] = json!("failed");
+            set_checkout_identity(failure, "failed", &log);
+            // A read that ends with no text at all is not a captured excerpt,
+            // and the per-job fallback has already had its turn. Record why,
+            // so the filed task can say what is missing and the sweep never
+            // reads silence as a clean run.
+            if log.text.trim().is_empty() {
+                push_retryable_error(
+                    retryable_errors,
+                    "investigation",
+                    "run_logs",
+                    failure.get("run_id"),
+                    &with_fallback_cause("query returned no failed-step log text", &log),
+                );
+            }
+        }
+        Err(error) => {
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_logs",
+                failure.get("run_id"),
+                &error.to_string(),
+            );
+        }
+    }
+
+    // The checkout step normally succeeds, so it is absent from the
+    // failed-step log. One full-log read per job, within a global hard budget,
+    // recovers the commit under test; past the budget we say so rather than
+    // leaving the field silently empty.
+    let needs_checkout = failure
+        .get("actual_checkout_shas")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty)
+        || failure
+            .get("checkout_evidence_complete")
+            .and_then(Value::as_bool)
+            != Some(true);
+    if !needs_checkout {
+        return;
+    }
+    if *checkout_log_reads >= bounds.max_checkout_log_reads {
+        failure["checkout_evidence_scope"] = json!("skipped_budget_exhausted");
+        push_retryable_error(
+            retryable_errors,
+            "investigation",
+            "checkout_evidence_budget",
+            failure.get("run_id"),
+            "actual checkout SHA was not collected because max_checkout_log_reads was exhausted",
+        );
+        return;
+    }
+    *checkout_log_reads += 1;
+    match queries.run_logs(&run_id, job_id, LogScope::All, bounds.log_max_bytes) {
+        Ok(log) => {
+            if !log_belongs_to_job(&log, job_id) {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "checkout_job_identity",
+                    failure.get("run_id"),
+                    "checkout log source does not belong to the requested failed job",
+                );
+                return;
+            }
+            failure["actual_checkout_shas"] = json!(log.checkout_commits);
+            failure["checkout_evidence"] = json!(log.checkout_evidence);
+            failure["checkout_evidence_scope"] = json!("all");
+            set_checkout_identity(failure, "all", &log);
+            // A genuinely incomplete scan (the source-byte cap, or a dropped
+            // overlong line that could have carried checkout identity) stays
+            // fail-closed even when one SHA was already found: it cannot rule
+            // out a later, conflicting identity past whatever it didn't
+            // manage to read. Only a *display* cap (evidence line/commit
+            // count, or an overlong line unrelated to checkout) is exempt —
+            // that never touches `checkout_evidence_complete`.
+            if !log.checkout_evidence_complete {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "checkout_evidence",
+                    failure.get("run_id"),
+                    "checkout evidence scan reached its hard limit; actual checkout identity is incomplete",
+                );
+            } else if log.checkout_commits.is_empty() {
+                push_retryable_error(
+                    retryable_errors,
+                    "registration",
+                    "checkout_evidence",
+                    failure.get("run_id"),
+                    &with_fallback_cause("run logs contained no actual checkout SHA", &log),
+                );
+            }
+        }
+        Err(error) => {
+            failure["checkout_evidence_scope"] = json!("unavailable");
+            push_retryable_error(
+                retryable_errors,
+                "investigation",
+                "run_logs_all",
+                failure.get("run_id"),
+                &error.to_string(),
+            );
+        }
+    }
+}
+
+/// The primary read is explicitly narrowed with --job. A fallback must name
+/// exactly that job; it may never lend another job's checkout or diagnostic.
+fn log_belongs_to_job(log: &super::query::RunLog, job_id: u64) -> bool {
+    if log.source == orbit_tools::github_cli::SOURCE_RUN_LOG {
+        return log.source_jobs.is_empty();
+    }
+    log.source == orbit_tools::github_cli::SOURCE_JOB_API_LOG
+        && log.source_jobs.len() == 1
+        && log.source_jobs[0].get("job_id").and_then(Value::as_u64) == Some(job_id)
+}
+
+/// An evidence gap, extended with the fallback's own outcome when there was
+/// one.
+///
+/// An empty log read is not proof that a run's logs expired: it is also how
+/// the `gh run view --log*` blind spot presents, and the per-job fallback runs
+/// precisely then. Whichever way the gap arose, the reader is told which query
+/// fell short rather than being left to assume retention.
+fn with_fallback_cause(gap: &str, log: &super::query::RunLog) -> String {
+    match &log.fallback_error {
+        Some(reason) => format!("{gap}; the per-job log fallback recovered none either: {reason}"),
+        None => gap.to_string(),
+    }
+}
+
+fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::RunLog) {
+    let state = if !log.checkout_evidence_complete {
+        "incomplete"
+    } else {
+        match log.checkout_commits.len() {
+            0 => "missing",
+            1 => "observed",
+            _ => "ambiguous",
+        }
+    };
+    failure["checkout_evidence_complete"] = json!(log.checkout_evidence_complete);
+    failure["checkout_evidence_scanned_bytes"] = json!(log.checkout_evidence_scanned_bytes);
+    failure["checkout_evidence_source_truncated"] = json!(log.checkout_evidence_source_truncated);
+    failure["checkout_evidence_display_truncated"] = json!(log.checkout_evidence_display_truncated);
+    failure["checkout_identity"] = json!({
+        "state": state,
+        "observed_shas": log.checkout_commits,
+        "provenance": {
+            "source": "runner_log",
+            "job_id": failure.get("job_id"),
+            // Which query the runner log was read through, and the job whose
+            // own log supplied it when the run-scoped read returned nothing.
+            "read_via": log.source,
+            "jobs": log.source_jobs,
+            "scope": scope,
+            "complete": log.checkout_evidence_complete,
+            "scanned_bytes": log.checkout_evidence_scanned_bytes,
+            "source_truncated": log.checkout_evidence_source_truncated,
+            // Display caps (evidence line/commit count, or an unrelated
+            // overlong line) reduce what is reported without bearing on
+            // whether identity itself was captured; see `complete` for that.
+            "display_truncated": log.checkout_evidence_display_truncated,
+        },
+    });
+}

--- a/crates/orbit-engine/src/executor/automation/ci/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/mod.rs
@@ -21,6 +21,7 @@
 //! [`OUTCOME_RETRYABLE_ERROR`] (a bounded discovery or investigation failed).
 
 mod collect;
+mod investigate;
 mod query;
 
 pub(in crate::executor::automation) use query::AuthStatus;

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -61,6 +61,7 @@ pub(super) struct RunLog {
     /// after the run-scoped read came back empty.
     pub(super) source: String,
     /// Identity of the job whose log was read, when the fallback supplied it.
+    /// Primary reads are bound by the explicit job_id query argument.
     pub(super) source_jobs: Vec<Value>,
     /// Why the fallback recovered nothing. Present only when the read ends
     /// with no text at all, so the run's evidence gap can name its own cause.
@@ -94,6 +95,7 @@ pub(super) trait CiQueries {
     fn run_logs(
         &self,
         run_id: &str,
+        job_id: u64,
         scope: LogScope,
         max_bytes: usize,
     ) -> Result<RunLog, OrbitError>;
@@ -199,20 +201,31 @@ impl CiQueries for HostCiQueries {
     fn run_view(&self, run_id: &str) -> Result<Value, OrbitError> {
         let request = github_cli::run_view_request(&json!({"run": run_id}))?;
         let stdout = self.run_gh(request, "gh run view")?;
-        Ok(github_cli::project_run_view(&github_cli::parse_gh_json(
-            &stdout,
-            "gh run view",
-        )?))
+        let view =
+            github_cli::project_run_view(&github_cli::parse_gh_json(&stdout, "gh run view")?);
+        if view
+            .get("run_id")
+            .and_then(Value::as_u64)
+            .map(|id| id.to_string())
+            .as_deref()
+            != Some(run_id)
+        {
+            return Err(OrbitError::Execution(
+                "gh run view returned a different or missing run identity".to_string(),
+            ));
+        }
+        Ok(view)
     }
 
     fn run_logs(
         &self,
         run_id: &str,
+        job_id: u64,
         scope: LogScope,
         max_bytes: usize,
     ) -> Result<RunLog, OrbitError> {
         let requests = github_cli::RunLogRequests::from_input(
-            &json!({"run": run_id, "scope": scope.as_str()}),
+            &json!({"run": run_id, "job": job_id, "scope": scope.as_str()}),
         )?
         .in_directory(&self.repo_root.to_string_lossy());
         let read = github_cli::read_run_log(&requests, github_cli::LogReadBounds::new(max_bytes))?;

--- a/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/collect.rs
@@ -798,11 +798,11 @@ fn investigation_failure_keeps_the_current_run_visible_and_retryable() {
     );
     assert_eq!(evidence["summary"]["current_failures"], json!(1));
     assert_eq!(evidence["summary"]["investigated_failures"], json!(0));
-    assert!(
-        evidence["summary"]["retryable_errors"]
-            .as_u64()
-            .is_some_and(|count| count >= 3)
-    );
+    // Without verified job metadata, no diagnostic or checkout read is safe.
+    assert_eq!(evidence["summary"]["retryable_errors"], 1);
+    assert_eq!(evidence["retryable_errors"][0]["operation"], "run_view");
+    assert_eq!(evidence["truncation"]["job_log_reads"], 0);
+    assert_eq!(evidence["truncation"]["checkout_log_reads"], 0);
 }
 
 /// ORB-11248: a matrix workflow with enough jobs pushes the checkout-evidence
@@ -1204,9 +1204,14 @@ fn incomplete_mixed_state_evidence_stays_retryable_until_logs_are_available() {
 
     assert_eq!(
         current_ids(&evidence),
-        Vec::<u64>::new(),
-        "incomplete mixed-state evidence must not become a repair task: {evidence}"
+        vec![40],
+        "the already-failed job remains visible with a deferred evidence state: {evidence}"
     );
+    assert_eq!(
+        evidence["current_failures"][0]["evidence_state"],
+        "deferred"
+    );
+    assert_eq!(evidence["current_failures"][0]["investigated"], false);
     assert_eq!(in_flight_ids(&evidence), [40]);
     assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
     let errors = evidence["retryable_errors"]

--- a/crates/orbit-engine/src/executor/automation/ci/tests/log_fallback.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/log_fallback.rs
@@ -182,7 +182,12 @@ fn one_runs_failed_fallback_does_not_withhold_anothers_complete_finding() {
             true,
             "job 101560010340 (`docs`): Not Found (HTTP 404)",
         )
-        .with_job_log_fallback("11", false, &job_log(), vec![source_job()]);
+        .with_job_log_fallback(
+            "11",
+            false,
+            &job_log(),
+            vec![json!({"job_id": 202, "name": "build", "conclusion": "failure"})],
+        );
 
     let evidence = collect(&queries, &input()).expect("collect");
 
@@ -207,5 +212,159 @@ fn one_runs_failed_fallback_does_not_withhold_anothers_complete_finding() {
             .all(|error| error["run_id"] == json!(10)),
         "run 11's evidence is complete, so it owns no error: {}",
         evidence["retryable_errors"]
+    );
+}
+
+fn two_job_queries(reverse: bool) -> FakeQueries {
+    let mut jobs = vec![failed_job(201, "Clippy"), failed_job(202, "Coverage")];
+    if reverse {
+        jobs.reverse();
+    }
+    let mut queries = FakeQueries::authenticated()
+        .with_head("topic", HEAD)
+        .with_head("main", HEAD)
+        .with_runs(vec![vec![failing_run(10)]])
+        .with_run_view("10", json!({"failed_jobs": jobs}));
+    for (job, sha, diagnostic) in [
+        (201, CHECKOUT, "error: unused import"),
+        (202, HEAD, "test output_goldens FAILED"),
+    ] {
+        queries.job_logs.insert(
+            ("10".to_string(), job, false),
+            format!("HEAD is now at {sha}\n{diagnostic}\n"),
+        );
+    }
+    queries
+}
+
+#[test]
+fn different_jobs_keep_their_own_diagnostic_and_checkout_in_either_order() {
+    for reverse in [false, true] {
+        let evidence = collect(&two_job_queries(reverse), &input()).expect("collect");
+        let jobs = evidence["current_failures"].as_array().expect("jobs");
+        assert_eq!(jobs.len(), 2);
+        for (job, sha, diagnostic, excluded) in [
+            (&jobs[0], CHECKOUT, "unused import", "output_goldens"),
+            (&jobs[1], HEAD, "output_goldens", "unused import"),
+        ] {
+            assert_eq!(job["evidence_state"], "complete");
+            assert_eq!(job["actual_checkout_shas"], json!([sha]));
+            assert_eq!(
+                job["checkout_identity"]["provenance"]["job_id"],
+                job["job_id"]
+            );
+            assert_eq!(job["log_job_id"], job["job_id"]);
+            let log = job["log_excerpt"].as_str().expect("log");
+            assert!(log.contains(diagnostic));
+            assert!(!log.contains(excluded));
+        }
+        assert_eq!(evidence["truncation"]["job_log_reads"], 2);
+    }
+}
+
+#[test]
+fn a_fallback_for_only_one_job_never_supplies_its_siblings_evidence() {
+    let queries = two_job_queries(false).with_job_log_fallback(
+        "10",
+        false,
+        &job_log(),
+        vec![json!({"job_id": 202, "name": "Coverage"})],
+    );
+    let evidence = collect(&queries, &input()).expect("collect");
+    let jobs = &evidence["current_failures"];
+    assert_eq!(jobs[0]["job_id"], 201);
+    assert_eq!(jobs[0]["evidence_state"], "deferred");
+    assert!(jobs[0].get("log_excerpt").is_none());
+    assert_eq!(jobs[0]["actual_checkout_shas"], json!([]));
+    assert_eq!(jobs[1]["evidence_state"], "complete");
+    assert_eq!(jobs[1]["actual_checkout_shas"], json!([CHECKOUT]));
+    assert!(
+        evidence["retryable_errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .all(|error| error["job_id"] == 201)
+    );
+}
+
+#[test]
+fn job_budget_rotates_without_swapping_evidence_and_truncation_is_deferred() {
+    for cursor in 0..2 {
+        let evidence = collect(&two_job_queries(false), &json!({
+            "integration_branch": "topic", "max_job_log_reads": 1, "investigation_cursor": cursor,
+        })).expect("collect");
+        assert_eq!(evidence["truncation"]["job_log_reads"], 1);
+        let jobs = evidence["current_failures"].as_array().expect("jobs");
+        assert_eq!(jobs[cursor]["evidence_state"], "complete");
+        assert_eq!(jobs[1 - cursor]["evidence_state"], "deferred");
+        assert_eq!(
+            evidence["retryable_errors"][0]["operation"],
+            "job_log_budget"
+        );
+    }
+    let mut queries = two_job_queries(false);
+    queries.job_logs.insert(
+        ("10".to_string(), 201, false),
+        format!("{}\n{}", job_log(), "noise\n".repeat(100)),
+    );
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "topic", "log_max_bytes": 128}),
+    )
+    .expect("collect");
+    assert_eq!(evidence["current_failures"][0]["log_truncated"], true);
+    assert_eq!(
+        evidence["current_failures"][0]["evidence_state"],
+        "deferred"
+    );
+    assert_eq!(
+        evidence["current_failures"][1]["evidence_state"],
+        "complete"
+    );
+}
+
+#[test]
+fn checkout_fallback_is_bound_to_its_job_and_missing_logs_leave_siblings_complete() {
+    let mut queries = two_job_queries(false);
+    queries.job_logs.insert(
+        ("10".to_string(), 201, false),
+        "error: unused import\n".to_string(),
+    );
+    queries.job_logs.insert(
+        ("10".to_string(), 202, false),
+        "test output_goldens FAILED\n".to_string(),
+    );
+    let queries =
+        queries.with_job_log_fallback("10", true, &job_log(), vec![json!({"job_id": 202})]);
+    let evidence = collect(&queries, &input()).expect("collect");
+    let jobs = &evidence["current_failures"];
+    assert_eq!(jobs[0]["evidence_state"], "deferred");
+    assert_eq!(jobs[0]["actual_checkout_shas"], json!([]));
+    assert_eq!(jobs[1]["evidence_state"], "complete");
+    assert_eq!(jobs[1]["checkout_identity"]["provenance"]["job_id"], 202);
+    assert_eq!(jobs[1]["actual_checkout_shas"], json!([CHECKOUT]));
+    assert_ne!(jobs[1]["actual_checkout_shas"], json!([HEAD]));
+    assert_eq!(
+        evidence["retryable_errors"][0]["operation"],
+        "checkout_job_identity"
+    );
+
+    let mut queries = two_job_queries(false);
+    queries.job_logs.remove(&("10".to_string(), 201, false));
+    let evidence = collect(&queries, &input()).expect("collect");
+    assert_eq!(
+        evidence["current_failures"][0]["evidence_state"],
+        "deferred"
+    );
+    assert_eq!(
+        evidence["current_failures"][1]["evidence_state"],
+        "complete"
+    );
+    assert!(
+        evidence["retryable_errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .all(|error| error["job_id"] == 201)
     );
 }

--- a/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/support.rs
@@ -23,6 +23,7 @@ pub(super) struct FakeQueries {
     /// page, so a test can make CI progress between calls.
     pub(super) runs: Mutex<Vec<Vec<Value>>>,
     pub(super) run_views: HashMap<String, Value>,
+    pub(super) job_logs: HashMap<(String, u64, bool), String>,
     pub(super) logs: HashMap<(String, bool), String>,
     pub(super) repository_runs_error: Option<String>,
     pub(super) run_view_errors: HashMap<String, String>,
@@ -188,6 +189,7 @@ impl CiQueries for FakeQueries {
     fn run_logs(
         &self,
         run_id: &str,
+        job_id: u64,
         scope: LogScope,
         max_bytes: usize,
     ) -> Result<RunLog, OrbitError> {
@@ -204,7 +206,12 @@ impl CiQueries for FakeQueries {
             log.source_jobs = jobs.clone();
             return Ok(log);
         }
-        let raw = self.logs.get(&key).cloned().unwrap_or_default();
+        let raw = self
+            .job_logs
+            .get(&(run_id.to_string(), job_id, scope == LogScope::All))
+            .or_else(|| self.logs.get(&key))
+            .cloned()
+            .unwrap_or_default();
         let mut log = super::super::query::bounded_run_log(&raw, max_bytes);
         log.fallback_error = self.log_fallback_errors.get(&key).cloned();
         Ok(log)

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -92,6 +92,24 @@ clusters failures by a normalized error signature that prefers a concrete test
 or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
+CI evidence schema 2 binds each failure row to one failed job: both log scopes
+select that job, and checkout provenance carries its job ID. Diagnostic excerpts
+that are missing or truncated, unknown/ambiguous failed steps, incomplete
+checkout identity, and exhausted read budgets defer that job; complete siblings
+still file. `max_job_log_reads` caps failed-job reads across the snapshot (default
+6, maximum 25); `max_checkout_log_reads` separately caps additional same-job
+checkout reads (default 3, maximum 25). The rotating investigation slot also
+rotates overflow jobs in stable ID order. Legacy schema-1 failures require
+recollection because their run-wide logs and checkout scans cannot establish
+job attribution. Neither event nor PR head can substitute for runner checkout.
+
+Read-only verification: inspect the run's job metadata with `gh run view <run>
+--json databaseId,jobs --repo <owner/repo>`, then use the production bounded log
+reader with explicit `run`, `job`, and `scope` for each failed job. Compare each
+row's job ID, diagnostic, and checkout provenance with that supplying job; repeat
+with reversed metadata order and a one-job budget. Do not download whole logs
+into memory or use a sweep that files tasks merely to verify collection.
+
 ### The `completion` input
 
 Every pipeline above that ships a task takes a `completion` input, defaulting to


### PR DESCRIPTION
## Task

[ORB-11519](https://orbit-cli.com/tasks/ORB-11519) — Bind CI failure signatures and excerpts to the actual failing job

### Description

Confirmed live mismatch: ORB-11498 is titled CI / Check / Clippy / Test / Run CI guardrails, but its stored excerpt consists of Coverage (informational) / Collect workspace coverage lines and output_goldens failure. ORB-11502 subsequently filed the Coverage case. Current collect.rs investigate reads one run-wide failed log into failure.log_excerpt, while ci_failure_tasks.rs cluster_failures calls failing_job_and_step once and signs that whole log. Thus a multi-job run can attach another job's error to the first job, and does not faithfully represent independent failed jobs. Inspect ORB-11113 and ORB-11454 (already delivered) and trace the introducing task/commit. Repair the existing collector-to-filer evidence boundary so each filed cluster's job/step/checkout/signature belongs to its evidence, with bounded read budget and honest incomplete/deferred states. Do not fetch unbounded logs, treat absent evidence as green, or introduce a parallel collector. Preserve raw provenance and compatibility with old snapshots via explicit safe handling. Coordinate file overlap with ORB-11518 (signature extraction); serial dependency is acceptable. Astra assigned hard because this spans collection budgets, multi-job evidence identity and filer compatibility. No releases.

### Acceptance Criteria

- Deterministic two-failed-job fixture with different errors produces job-correct evidence/signatures and distinct findings; swapping job order cannot swap the meaning.
- A fallback log from only one job cannot be attributed to another; missing/truncated/over-budget job evidence is explicitly deferred and independent complete jobs progress.
- Checkout evidence remains tied to the supplying job and never substitutes PR/event head; existing bounded-log, freshness and partial-failure tests pass.
- Current docs/assets aligned; focused tests plus make ci-fast/make ci-lint pass. Record root cause and read-only live verification method.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- CI evidence schema 2 emits a separate current-failure row for each failed job. HostCiQueries validates the run identity and explicitly passes --job on both failed-step and checkout reads through the existing orbit-tools bounded reader. Fallback identity must match that job. Diagnostic log_job_id and checkout provenance.job_id bind both evidence sources to the supplying job.
- Added a global max_job_log_reads cap (default 6, maximum 25); preserved the separate checkout cap (default 3, maximum 25), existing redaction, stream/excerpt/checkout-scan limits and process timeouts. Stable job-ID ordering and a rotating overflow slot, including a one-read budget, make provider ordering irrelevant. Missing/truncated/over-budget job evidence stays deferred; raw captured excerpts and checkout provenance remain in the snapshot.
- Filer preserves job_id during retryable-error normalization and defers only applicable job/run errors. Registration requires one supplying job and one known failed step, untruncated nonempty diagnostic evidence, and complete observed checkout identity for that job. Removed the event-head fallback from tested_commit. Schema-1 snapshots remain readable but their unbound failures require recollection rather than guessed attribution.
- Preserved ORB-11518's diagnostic selection and dedupe algorithm. Both task activity assets and both current workflow reference copies describe the contract and read-only verification method.
- Extracted the cohesive job investigation phase into ci/investigate.rs from the already long collector. Existing collection/fallback tests remain the behavior boundary. No crate dependency added.

Criteria:
1. Met: deterministic two-failed-job collection fixtures retain distinct errors and checkout commits in either metadata order; filer creates separate Clippy and Coverage findings with distinct keys, correct tested commits and excerpts. Reversing the findings dedupes both against their correct existing owners.
2. Met: fallback from only one job cannot supply a sibling's diagnostic or checkout. Tests cover unavailable/empty evidence, truncated excerpts, per-job budget exhaustion and rotation, and one job's retryable error allowing its complete sibling to file.
3. Met: diagnostic and full-log checkout queries both select the same job; source checks reject foreign fallback identity. Existing checkout scan/display bounds, PR/event versus actual checkout distinction, freshness, mixed-state, partial-failure and dedupe tests pass. Incomplete already-failed jobs in running workflows now remain visible with evidence_state=deferred and investigated=false; they cannot become repair tasks.
4. Met: docs/assets aligned, focused tests and both required gates passed. Root cause and live read-only method/evidence recorded below.

Validation:
- PASSED cargo fmt --all.
- PASSED cargo test -p orbit-engine --lib executor::automation::ci::tests (44 tests).
- PASSED cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure_tasks (42 tests).
- PASSED cargo test -p orbit-tools --lib builtin::github::tests (50 tests, including bounded streaming and fake-gh fallback/identity cases).
- PASSED cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::sweep_duplicate_tasks (12 tests).
- PASSED cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure_admission (4 tests).
- PASSED make ci-fast on final files; includes asset/skill synchronization and guardrails.
- PASSED make ci-lint on final files (workspace, all targets, warnings denied; final run 21.66s).
- PASSED git diff --check and final git status --short; all 13 changed/new files are accounted for.
- EXPECTED FAILURE demonstrating original defect: cargo test -p orbit-core --lib legacy_multi_job_snapshot_cannot_label_coverage_log_as_clippy with only the filer temporarily restored from starting HEAD exited 101 because the original implementation filed a Coverage log as Clippy. Fixed filer restored immediately; final suite passes this test.
- Earlier collector run exposed two expected old-contract assertions (reading logs after failed job metadata; excluding incomplete mixed-state rows) plus the genuine one-slot job-rotation gap. Assertions now prove the repaired behavior and the rotation implementation is fixed; final 44-test suite passed.
- Live probe initially failed to link because two Cargo feature builds produced different serde_json crate identities; relinked against the matching existing dependency artifact and succeeded. This was probe setup, not a source/test defect.
- NOT RUN full make ci: repository policy reserves the canonical full gate for PR CI. No workflow reruns, production sweep/task filings, deployment, release, commit, push or delivery transition performed.

Root cause and provenance:
Starting checkout was clean at 7dbd5d0481e7b7995a342d540ff2fedf27155667; pwd -P and git rev-parse --show-toplevel matched both envelope roots. git log -S failing_job_and_step traces the mismatch to c541ba2dd, ORB-11107 (source_task_id set). Its collector supplied one run-wide log while the filer picked failed_jobs.first(). ORB-11113 repaired which diagnostic to select, and ORB-11454 recovered only one job's log without changing this attribution boundary. ORB-11518 was already done and present at starting HEAD; its signature parser remains unchanged.

Read-only live verification:
- PASSED gh run view 34088641333 --repo constellation-works/orbit --json databaseId,jobs --jq '{run_id: .databaseId, failed_jobs: [.jobs[] | select(.conclusion == "failure") | {job_id: .databaseId, name, url, failed_steps: [.steps[] | select(.conclusion == "failure") | .name]}]}'.
- Confirmed job 101637482879 = Check / Clippy / Test / Run CI guardrails; job 101637483141 = Coverage (informational) / Collect workspace coverage. These match the stored ORB-11498 incident.
- A temporary scratch probe linked the existing production orbit_tools::github_cli library and called RunLogRequests::from_input({run:"34088641333",job:<id>,scope:"failed"|"all",repo:"constellation-works/orbit"}) followed by read_run_log(..., LogReadBounds::new(16384)) for both jobs. All four read-only calls succeeded via job_api_log with exactly the requested source job.
- Clippy source: 679763 bytes, returned 16448 bounded excerpt bytes, runner completion exit code 100. Coverage source: 182106 bytes, returned 16448 bounded excerpt bytes, failing test summary and exit code 101. Both scans completely observed checkout 7da76247178623303935deee90e061fa1ed3f3f9 from their own logs. Both diagnostic excerpts are truncated and therefore intentionally deferred by the repaired contract. The 64 extra returned bytes are the existing omission marker, not a raised cap.
- Scratch source/executable removed; no probe artifacts are in the patch. Live verification exercised the shared production reader, not an installed end-to-end sweep that would write tasks.

Scope/risks:
Selectors were extended before edits for collect_ci_evidence.yaml and both current workflows.md copies (wire contract/bounds docs), plus the existing CI directory for the new investigation module and its registration. The patch contains 12 modified tracked files and one new module; all are task-scoped and uncommitted.
Strict deferral of truncated diagnostics is intentional per acceptance criteria: verbose whole-job fallback logs, including this incident, cannot be filed from incomplete diagnostic evidence. Checkout-only excerpt truncation is still permitted when its separate bounded scan completed. Multiple failed steps in one job are explicitly deferred rather than assigning a whole-job signature to an arbitrary step. Older snapshots need recollection. No event/PR-head substitution or wider byte budget was introduced.
Assessment: the repair keeps one canonical bounded log-reading path, binds evidence at collection, and enforces attribution before filing. Friction checkpoint recorded the confirmed incident root cause as F2026-09-052. Pipeline owns review, commit and delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11519-6a9f1173`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra