### PR TITLE
[code-review] Covered-only delivery prefixes eventually stall observation permanently

### DIFF
--- a/crates/orbit-automation/src/delivery/mod.rs
+++ b/crates/orbit-automation/src/delivery/mod.rs
@@ -171,6 +171,10 @@ pub fn evaluate(
         state = admit_active(store, host, &state)?;
     }
 
+    // Proven-covered prefixes are not debt. Retire them before backpressure so
+    // an already-stalled excluded-only consumer can observe again.
+    state = retire_covered_prefix(store, state, dry_run)?;
+
     // Backpressure pauses observation, never admission of already retained debt.
     if state.pending.len() < 950 && state.pending_commits.len() <= 4800 {
         let page = host.observe(&trigger.branch, &state)?;
@@ -180,6 +184,7 @@ pub fn evaluate(
         } else {
             commit(store, &state, next, None)?
         };
+        state = retire_covered_prefix(store, state, dry_run)?;
     }
 
     if let Some(active) = &state.active {
@@ -356,6 +361,21 @@ fn admit_active(
     }
 
     commit(store, state, next, None)
+}
+
+fn retire_covered_prefix(
+    store: &dyn AutomationStoreBackend,
+    state: AutomationState,
+    dry_run: bool,
+) -> Result<AutomationState, AutomationError> {
+    let Some(next) = observe::retire_excluded_prefix(&state) else {
+        return Ok(state);
+    };
+    if dry_run {
+        Ok(next)
+    } else {
+        commit(store, &state, next, None)
+    }
 }
 
 fn reconcile(

--- a/crates/orbit-automation/src/delivery/observe.rs
+++ b/crates/orbit-automation/src/delivery/observe.rs
@@ -4,6 +4,7 @@ use crate::AutomationError;
 use orbit_types::workflow::automation::{
     AutomationState, CoverageClass, ExcludedDelivery, SourcePage,
 };
+use std::collections::HashSet;
 
 pub(super) fn apply(
     state: &AutomationState,
@@ -154,4 +155,102 @@ pub(super) fn apply(
     }
 
     Ok(next)
+}
+
+/// Drop a proven-covered prefix so it cannot stall later observation.
+///
+/// This advances the scheduling cursor only. It does not write an examination
+/// receipt or turn excluded landings into review debt.
+pub(super) fn retire_excluded_prefix(state: &AutomationState) -> Option<AutomationState> {
+    if state.active.is_some() {
+        return None;
+    }
+
+    let end = excluded_prefix_len(state)?;
+    let prefix = &state.pending_commits[..end];
+    let last = prefix.last()?;
+    let covered = state
+        .excluded
+        .iter()
+        .find(|excluded| {
+            &excluded.delivery.after.commit == last
+                && excluded
+                    .delivery
+                    .commits
+                    .iter()
+                    .all(|sha| prefix.contains(sha))
+        })?
+        .delivery
+        .after
+        .clone();
+
+    let mut next = state.clone();
+    next.covered = covered;
+    next.pending_commits = state.pending_commits[end..].to_vec();
+    next.excluded.retain(|excluded| {
+        !excluded
+            .delivery
+            .commits
+            .iter()
+            .all(|sha| prefix.contains(sha))
+    });
+    next.unresolved
+        .retain(|sha, _| !prefix.iter().any(|commit| commit == sha));
+    next.associations
+        .retain(|sha, _| !prefix.iter().any(|commit| commit == sha));
+    Some(next)
+}
+
+fn excluded_prefix_len(state: &AutomationState) -> Option<usize> {
+    let pending: HashSet<&str> = state
+        .pending
+        .iter()
+        .flat_map(|delivery| delivery.commits.iter().map(String::as_str))
+        .collect();
+
+    let mut end = 0;
+    for sha in &state.pending_commits {
+        if state.unresolved.contains_key(sha) || pending.contains(sha.as_str()) {
+            break;
+        }
+        if !state
+            .excluded
+            .iter()
+            .any(|excluded| excluded.delivery.commits.iter().any(|commit| commit == sha))
+        {
+            break;
+        }
+        end += 1;
+    }
+
+    while end > 0 {
+        let prefix = &state.pending_commits[..end];
+        let split = state.excluded.iter().any(|excluded| {
+            let hits = excluded
+                .delivery
+                .commits
+                .iter()
+                .any(|sha| prefix.contains(sha));
+            let whole = excluded
+                .delivery
+                .commits
+                .iter()
+                .all(|sha| prefix.contains(sha));
+            hits && !whole
+        });
+        let closed = state.excluded.iter().any(|excluded| {
+            prefix.last() == Some(&excluded.delivery.after.commit)
+                && excluded
+                    .delivery
+                    .commits
+                    .iter()
+                    .all(|sha| prefix.contains(sha))
+        });
+        if !split && closed {
+            return Some(end);
+        }
+        end -= 1;
+    }
+
+    None
 }

--- a/crates/orbit-automation/src/delivery/tests/observe.rs
+++ b/crates/orbit-automation/src/delivery/tests/observe.rs
@@ -40,8 +40,10 @@ fn excluded_landings_do_not_count_toward_a_review_threshold() {
     let state = diagnostic.state.unwrap();
     assert_eq!(diagnostic.reason, "not_due");
     assert_eq!(state.pending.len(), 2);
-    assert_eq!(state.excluded.len(), 4);
+    assert_eq!(state.covered, revision(2));
+    assert_eq!(state.excluded.len(), 2);
     assert!(state.active.is_none());
+    assert!(diagnostic.receipts.is_empty());
     assert!(host.actions.lock().unwrap().is_empty());
 
     host.page(6, 7);
@@ -57,11 +59,12 @@ fn excluded_landings_do_not_count_toward_a_review_threshold() {
             .collect::<Vec<_>>(),
         vec![landing(3).key, landing(6).key, landing(7).key]
     );
-    assert_eq!(batch.exclusions.len(), 4);
+    assert_eq!(batch.from_exclusive, revision(2));
+    assert_eq!(batch.exclusions.len(), 2);
     assert_eq!(
         batch.commits.len(),
-        7,
-        "the range keeps excluded commits as context"
+        5,
+        "the range keeps interleaved excluded commits as context"
     );
     let template = evidence_template(state.active.as_ref().unwrap());
     assert_eq!(template.examined_deliveries.len(), 3);
@@ -165,4 +168,86 @@ fn a_pending_landing_is_not_excluded_retroactively() {
         .unwrap();
     assert_eq!(state.pending.len(), 1);
     assert!(state.excluded.is_empty());
+}
+
+fn exclude_range(host: &Host, from: usize, to: usize) {
+    host.page(from, to);
+    let mut page = host.page.lock().unwrap();
+    for n in from + 1..=to {
+        page.exclusions.insert(landing(n).key, exclusion(n));
+    }
+}
+
+/// An excluded-only prefix advances the covered cursor without minting a
+/// receipt or counting toward the review threshold.
+#[test]
+fn excluded_only_prefix_advances_coverage_without_a_receipt() {
+    let (store, host, mut trigger) = review_setup();
+    trigger.threshold = 1;
+    exclude_range(&host, 0, 2);
+
+    let diagnostic = evaluate(store.as_ref(), &host, &trigger, true);
+    let state = diagnostic.state.unwrap();
+    assert_eq!(diagnostic.reason, "not_due");
+    assert_eq!(state.covered, revision(2));
+    assert_eq!(state.observed, revision(2));
+    assert!(state.pending.is_empty());
+    assert!(state.excluded.is_empty());
+    assert!(state.pending_commits.is_empty());
+    assert!(state.active.is_none());
+    assert!(diagnostic.receipts.is_empty());
+    assert!(host.actions.lock().unwrap().is_empty());
+
+    host.page(2, 3);
+    let diagnostic = evaluate(store.as_ref(), &host, &trigger, true);
+    assert_eq!(diagnostic.reason, "threshold_reached");
+    let state = diagnostic.state.unwrap();
+    let batch = &state.active.as_ref().unwrap().batch;
+    assert_eq!(batch.deliveries.len(), 1);
+    assert_eq!(batch.deliveries[0].key, landing(3).key);
+    assert_eq!(batch.from_exclusive, revision(2));
+    assert!(batch.exclusions.is_empty());
+    assert!(diagnostic.receipts.is_empty());
+}
+
+/// A covered-only window larger than the observation cap must keep moving,
+/// then schedule the first later uncovered delivery on the same consumer.
+#[test]
+fn covered_only_prefix_past_five_thousand_still_observes_later_uncovered() {
+    let (store, host, mut trigger) = review_setup();
+    trigger.threshold = 1;
+    const PAGES: usize = 101;
+    const PAGE: usize = 50;
+    let covered = PAGES * PAGE;
+
+    for page in 0..PAGES {
+        let from = page * PAGE;
+        exclude_range(&host, from, from + PAGE);
+        let diagnostic = evaluate(store.as_ref(), &host, &trigger, true);
+        let state = diagnostic.state.unwrap();
+        assert_eq!(diagnostic.reason, "not_due");
+        assert_eq!(state.baseline, revision(0));
+        assert_eq!(state.covered, revision(from + PAGE));
+        assert_eq!(state.observed, revision(from + PAGE));
+        assert!(state.pending.is_empty());
+        assert!(state.excluded.is_empty());
+        assert!(state.pending_commits.len() <= 200);
+        assert!(state.active.is_none());
+        assert!(diagnostic.receipts.is_empty());
+        assert!(host.actions.lock().unwrap().is_empty());
+    }
+
+    host.page(covered, covered + 1);
+    let diagnostic = evaluate(store.as_ref(), &host, &trigger, true);
+    assert_eq!(diagnostic.reason, "threshold_reached");
+    let state = diagnostic.state.unwrap();
+    assert_eq!(state.baseline, revision(0));
+    assert_eq!(state.consumer, "ws/qa");
+    let batch = &state.active.as_ref().unwrap().batch;
+    assert_eq!(batch.deliveries.len(), 1);
+    assert_eq!(batch.deliveries[0].key, landing(covered + 1).key);
+    assert_eq!(batch.from_exclusive, revision(covered));
+    assert!(batch.exclusions.is_empty());
+    assert!(diagnostic.receipts.is_empty());
+    assert_eq!(store.automation_receipts("ws/qa", 20).unwrap().len(), 0);
 }

--- a/crates/orbit-store/src/driver/sqlite/automation/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/mod.rs
@@ -339,11 +339,14 @@ fn validate_transition(
         {
             return Err(invalid());
         }
+    } else if previous.covered != next.covered {
+        // A proven-covered prefix may advance the scheduling cursor without a
+        // consumer examination receipt. Observation remains append-only.
+        validate_excluded_prefix_retirement(previous, next)?;
     } else {
         // Without a receipt the covered cursor stands still: observation may only
         // append commits and retain every delivery already pending.
         if previous.waived != next.waived
-            || previous.covered != next.covered
             || !next.pending_commits.starts_with(&previous.pending_commits)
             || previous
                 .pending
@@ -378,6 +381,103 @@ fn validate_transition(
                 return Err(invalid());
             }
         }
+    }
+
+    Ok(())
+}
+
+fn validate_excluded_prefix_retirement(
+    previous: &AutomationState,
+    next: &AutomationState,
+) -> Result<(), OrbitError> {
+    let invalid = || OrbitError::InvalidInput("invalid automation checkpoint transition".into());
+
+    if previous.active.is_some()
+        || next.active.is_some()
+        || previous.observed != next.observed
+        || previous.pending != next.pending
+        || previous.waived != next.waived
+        || previous.pending_commits.len() <= next.pending_commits.len()
+        || !previous.pending_commits.ends_with(&next.pending_commits)
+    {
+        return Err(invalid());
+    }
+
+    let end = previous.pending_commits.len() - next.pending_commits.len();
+    let prefix = &previous.pending_commits[..end];
+    if prefix.last() != Some(&next.covered.commit) {
+        return Err(invalid());
+    }
+
+    let pending: std::collections::HashSet<&str> = previous
+        .pending
+        .iter()
+        .flat_map(|delivery| delivery.commits.iter().map(String::as_str))
+        .collect();
+    if prefix
+        .iter()
+        .any(|sha| previous.unresolved.contains_key(sha) || pending.contains(sha.as_str()))
+    {
+        return Err(invalid());
+    }
+
+    let closed = previous.excluded.iter().any(|excluded| {
+        excluded.delivery.after == next.covered
+            && excluded
+                .delivery
+                .commits
+                .iter()
+                .all(|sha| prefix.contains(sha))
+    });
+    if !closed {
+        return Err(invalid());
+    }
+
+    if previous.excluded.iter().any(|excluded| {
+        let hits = excluded
+            .delivery
+            .commits
+            .iter()
+            .any(|sha| prefix.contains(sha));
+        let whole = excluded
+            .delivery
+            .commits
+            .iter()
+            .all(|sha| prefix.contains(sha));
+        hits && !whole
+    }) || prefix.iter().any(|sha| {
+        !previous
+            .excluded
+            .iter()
+            .any(|excluded| excluded.delivery.commits.iter().any(|commit| commit == sha))
+    }) {
+        return Err(invalid());
+    }
+
+    let retained = previous
+        .excluded
+        .iter()
+        .filter(|excluded| {
+            !excluded
+                .delivery
+                .commits
+                .iter()
+                .all(|sha| prefix.contains(sha))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if next.excluded != retained {
+        return Err(invalid());
+    }
+
+    let mut unresolved = previous.unresolved.clone();
+    let mut associations = previous.associations.clone();
+    for sha in prefix {
+        unresolved.remove(sha);
+        associations.remove(sha);
+    }
+    if next.unresolved != unresolved || next.associations != associations {
+        return Err(invalid());
     }
 
     Ok(())

--- a/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
+++ b/crates/orbit-store/src/driver/sqlite/automation/tests/checkpoints.rs
@@ -1,4 +1,5 @@
 use crate::{Store, compose};
+use chrono::{TimeZone, Utc};
 use orbit_types::workflow::automation::*;
 
 fn state() -> AutomationState {
@@ -60,4 +61,94 @@ fn observation_cannot_advance_coverage() {
     next.covered.commit = "forged".into();
     assert!(store.automation_commit(&old, &next, None).is_err());
     assert_eq!(store.automation_state(&old.consumer).unwrap(), Some(old));
+}
+
+fn excluded_landing(commit: &str, tree: &str) -> ExcludedDelivery {
+    let revision = SourceRevision {
+        commit: commit.into(),
+        tree: tree.into(),
+    };
+    ExcludedDelivery {
+        delivery: Delivery {
+            key: format!("pr:{commit}"),
+            repository: "repo".into(),
+            branch: "agent-main".into(),
+            before: SourceRevision {
+                commit: "a".into(),
+                tree: "tree-a".into(),
+            },
+            after: revision.clone(),
+            commits: vec![commit.into()],
+            task_ids: vec!["task".into()],
+            evidence_reference: "https://example.test/pr".into(),
+            evidence_digest: "digest".into(),
+            landed_at: Utc.with_ymd_and_hms(2026, 9, 6, 0, 0, 0).unwrap(),
+        },
+        exclusion: DeliveryExclusion {
+            attempt_id: "rvw-1".into(),
+            assurance: "independent_review".into(),
+            task_meaning_digest: "meaning".into(),
+            final_candidate_tree: tree.into(),
+        },
+        decided_at: Utc.with_ymd_and_hms(2026, 9, 6, 0, 0, 0).unwrap(),
+    }
+}
+
+fn observed_excluded(previous: &AutomationState) -> AutomationState {
+    let mut next = previous.clone();
+    next.generation = previous.generation + 1;
+    next.observed = SourceRevision {
+        commit: "b".into(),
+        tree: "tree-b".into(),
+    };
+    next.pending_commits.push("b".into());
+    next.excluded.push(excluded_landing("b", "tree-b"));
+    next
+}
+
+#[test]
+fn excluded_prefix_may_advance_coverage_without_a_receipt() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let old = state();
+    store.automation_initialize(&old).unwrap();
+    let observed = observed_excluded(&old);
+    assert!(store.automation_commit(&old, &observed, None).unwrap());
+
+    let mut retired = observed.clone();
+    retired.generation = observed.generation + 1;
+    retired.covered = observed.observed.clone();
+    retired.pending_commits.clear();
+    retired.excluded.clear();
+    assert!(store.automation_commit(&observed, &retired, None).unwrap());
+    assert_eq!(
+        store.automation_state(&old.consumer).unwrap(),
+        Some(retired)
+    );
+    assert!(
+        store
+            .automation_receipts(&old.consumer, 20)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn excluded_prefix_cannot_drop_pending_debt() {
+    let store = compose::automation_store(Store::open_in_memory().unwrap()).unwrap();
+    let old = state();
+    store.automation_initialize(&old).unwrap();
+    let mut observed = observed_excluded(&old);
+    observed.pending.push(observed.excluded[0].delivery.clone());
+    assert!(store.automation_commit(&old, &observed, None).unwrap());
+
+    let mut retired = observed.clone();
+    retired.generation = observed.generation + 1;
+    retired.covered = observed.observed.clone();
+    retired.pending_commits.clear();
+    retired.excluded.clear();
+    assert!(store.automation_commit(&observed, &retired, None).is_err());
+    assert_eq!(
+        store.automation_state(&old.consumer).unwrap(),
+        Some(observed)
+    );
 }

--- a/crates/orbit-types/src/workflow/automation/mod.rs
+++ b/crates/orbit-types/src/workflow/automation/mod.rs
@@ -188,8 +188,10 @@ pub struct AutomationState {
     pub pending: Vec<Delivery>,
     #[serde(default)]
     pub waived: Vec<Delivery>,
-    /// Deliveries proven covered before landing; retired with the range that
-    /// contains them and never counted toward a threshold.
+    /// Deliveries proven covered before landing. They never count toward a
+    /// threshold. An exclusively excluded prefix may retire without a consumer
+    /// examination receipt; interleaved exclusions retire with the examined
+    /// range that contains them.
     #[serde(default)]
     pub excluded: Vec<ExcludedDelivery>,
     pub unresolved: BTreeMap<String, String>,

--- a/docs/design/automation-triggers/2_design.md
+++ b/docs/design/automation-triggers/2_design.md
@@ -173,8 +173,11 @@ Three separate checkpoints are essential:
   retained as pending/unresolved. Advancing `O` never means successful work.
 - **Dispatched (`D`)**: immutable batch has an acknowledged job run or minted task
   identity. This measures action creation, not the executor's success.
-- **Covered (`C`)**: accepted member receipts and, for code ranges, the highest
-  contiguous successfully examined boundary. Never jump over a coverage hole.
+- **Covered (`C`)**: the highest contiguous boundary that is no longer a
+  scheduling obligation — accepted examination receipts, or a proven
+  before-PR-excluded prefix that advanced without a consumer receipt. Never
+  jump over a coverage hole. Excluded-only progress is not an examination
+  receipt and does not count toward a review threshold.
 
 Use member sets, not one timestamp, for pilot tasks and incidents. For deliveries,
 range boundaries are Git revisions while observation continuations are source

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -220,9 +220,10 @@ not mint an examination receipt. An exclusively excluded prefix advances the
 covered cursor and leaves the pending window so later uncovered landings can
 still be observed. Interleaved exclusions travel with the next frozen batch
 as readable context (`exclusions`) and retire with that examined range.
-`integrated_qa_v1` consumers ignore exclusions entirely. A different base tree, any later edit, an unreviewed conflict
-repair, task drift, missing objects, or an external landing race keeps the
-landing an ordinary obligation. Inspection surfaces and the dashboard list
+`integrated_qa_v1` consumers ignore exclusions entirely. A different base
+tree, any later edit, an unreviewed conflict repair, task drift, missing
+objects, or an external landing race keeps the landing an ordinary
+obligation. Inspection surfaces and the dashboard list
 excluded landings with their certificate and assurance label.
 
 ## State preparation and failure triage [ORB-11331]

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -215,10 +215,12 @@ objects still exist and every task still has the reviewed meaning, and asks
 `orbit_automation::review::exclusion` for the decision: same base tree, same
 final tree, no contradicting managed landing record. A `landed_code_review_v1`
 consumer moves an accepted landing into its `excluded` list; it does not
-count toward the threshold, travels with the frozen batch as readable context
-(`exclusions`), is absent from `examined_deliveries`, and retires with the
-range that contains it. `integrated_qa_v1` consumers ignore exclusions
-entirely. A different base tree, any later edit, an unreviewed conflict
+count toward the threshold, is absent from `examined_deliveries`, and does
+not mint an examination receipt. An exclusively excluded prefix advances the
+covered cursor and leaves the pending window so later uncovered landings can
+still be observed. Interleaved exclusions travel with the next frozen batch
+as readable context (`exclusions`) and retire with that examined range.
+`integrated_qa_v1` consumers ignore exclusions entirely. A different base tree, any later edit, an unreviewed conflict
 repair, task drift, missing objects, or an external landing race keeps the
 landing an ordinary obligation. Inspection surfaces and the dashboard list
 excluded landings with their certificate and assurance label.

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -310,9 +310,10 @@ every task still has the reviewed meaning, and lets
 tree, no contradicting managed landing. Only a `landed_code_review_v1`
 consumer excludes; QA counts every landing. Excluded landings leave
 `pending`, live in the consumer's `excluded` list, do not count toward the
-threshold, travel with the frozen batch as readable context (`exclusions`),
-are absent from `examined_deliveries`, and retire with the range that
-contains them. Later edits, task drift, a different base, an unreviewed
+threshold, and are absent from `examined_deliveries`. An exclusively excluded
+prefix advances the covered cursor without an examination receipt so
+observation cannot stall; interleaved exclusions travel with the next frozen
+batch as readable context (`exclusions`) and retire with that examined range. Later edits, task drift, a different base, an unreviewed
 conflict repair, missing objects, or an external landing race keep the
 landing an ordinary obligation. Exclusions apply when a landing is first
 observed; a certificate that arrives later does not rewrite pending debt.

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -313,9 +313,10 @@ consumer excludes; QA counts every landing. Excluded landings leave
 threshold, and are absent from `examined_deliveries`. An exclusively excluded
 prefix advances the covered cursor without an examination receipt so
 observation cannot stall; interleaved exclusions travel with the next frozen
-batch as readable context (`exclusions`) and retire with that examined range. Later edits, task drift, a different base, an unreviewed
-conflict repair, missing objects, or an external landing race keep the
-landing an ordinary obligation. Exclusions apply when a landing is first
+batch as readable context (`exclusions`) and retire with that examined
+range. Later edits, task drift, a different base, an unreviewed conflict
+repair, missing objects, or an external landing race keep the landing an
+ordinary obligation. Exclusions apply when a landing is first
 observed; a certificate that arrives later does not rewrite pending debt.
 
 ### Surfaces


### PR DESCRIPTION
## Task

[ORB-11524](https://orbit-cli.com/tasks/ORB-11524) — [code-review] Covered-only delivery prefixes eventually stall observation permanently

### Description

## Problem
A review consumer receiving only before-PR-covered deliveries eventually stops observing the integration branch, so a later uncovered delivery is never reviewed.

## Live evidence and reproduction
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24:
- crates/orbit-automation/src/delivery/observe.rs:35-39 retains every observed commit in pending_commits; :118-126 moves covered deliveries to excluded instead of pending.
- crates/orbit-automation/src/delivery/mod.rs:175 stops calling observe once pending_commits exceeds 4800. Due/age checks at :194-209 consider only pending deliveries, so an entirely excluded prefix returns not_due forever.
- Excluded commits are retired only with an accepted later batch (:410-416), and the Store transition contract also requires an accepted batch for that retirement. No pending obligation exists to create such a batch.
- A focused harness reused the repository's DeliveryHost fixture and called the actual compiled delivery::evaluate and SQLite backend: after 97 valid pages of 50 excluded deliveries, pending_commits=4850, pending=[], active=None. Supplying uncovered commit c4851 and evaluating three more times left observed=c4850 and reason=not_due each time. Source is attached to ORB-11451 as review-repros.rs.

Provide bounded progress for proven-covered prefixes while preserving a truthful audit/cursor contract. Do not fabricate examination receipts, review debt, or QA coverage to clear the queue.

### Acceptance Criteria

- A deterministic evaluator test processes more than 5000 exclusively covered commits, then observes and schedules a subsequent uncovered delivery without resetting the consumer.
- Retained state remains bounded and excluded-only progress does not fabricate an examination receipt or count covered deliveries toward the review threshold.
- QA still counts every landing, failed batches preserve genuine debt, and make ci-fast/make ci-lint plus focused automation/store tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Review consumers now retire an exclusively excluded `pending_commits` prefix as a receipt-less checkpoint: `covered` advances to the last excluded `after` revision, and those commits/exclusions/associations leave the pending window.
- `evaluate` compacts before the observation backpressure gate (so an already-stalled consumer recovers) and again after each observed page. Observation itself stays append-only.
- Store `validate_transition` allows that covered advance only when the dropped prefix is fully accounted for by excluded deliveries, pending/unresolved are untouched, and no examination receipt is written. Forged covered advances still fail.
- Mixed windows still keep interleaved exclusions as batch context; QA still ignores exclusions; failed/exhausted batches keep `active` and therefore block compaction.
- Current automation-trigger and operation-mode docs now describe excluded-only cursor progress.
Assessment: The stall is closed at the evaluator/store boundary with a truthful cursor: proven-covered prefixes progress without fabricating receipts or review debt. Existing mixed-exclusion, QA, and failed-batch contracts remain intact.
Strategic decisions: Compaction is a distinct checkpoint from observation so the store can validate each transition. Compact only when `active` is absent so genuine failed debt cannot be erased.
Design weaknesses / risks:
- Severity: low. A mixed window with pending debt at the front still cannot compact later exclusions, so a huge excluded suffix after one pending landing can still hit backpressure. Mitigation: out of scope for this exclusively-covered stall; interleaved exclusions remain batch context.
Deviations from original plan: none.
Criteria:
- >5000 exclusively covered commits then a later uncovered delivery is observed and scheduled without resetting the consumer: `covered_only_prefix_past_five_thousand_still_observes_later_uncovered` processes 5050 excluded landings, keeps `baseline` at revision 0, then admits landing 5051 with `threshold_reached`.
- Bounded state, no fabricated receipt, excluded landings do not count toward the review threshold: after each excluded-only page, `pending_commits` stays <= 200 and receipts stay empty; mixed-exclusion test still requires three uncovered landings to reach threshold 3.
- QA counts every landing; failed batches preserve debt: existing `qa_consumers_ignore_before_pr_exclusions` and `failed_sweeps_retain_exclusions_and_do_not_advance_coverage` pass.
Validation:
- `cargo test -p orbit-automation --lib delivery` — passed (17 tests).
- `cargo test -p orbit-store --lib driver::sqlite::automation::tests` — passed (4 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11524-6a9f0fbe`
- Behind base: 0
- Ahead of base: 2