### PR TITLE
[code-review] Managed PR merge does not atomically pin the reviewed head

### DIFF
--- a/crates/orbit-core/src/application/review/landing.rs
+++ b/crates/orbit-core/src/application/review/landing.rs
@@ -40,6 +40,18 @@ pub(crate) fn record_review_landing(
     let store = runtime.review_store()?;
     let branch = request.base.trim_start_matches("origin/").to_string();
     let landing = match request.landed_commit.as_deref() {
+        // A merge this completion did not perform conditionally landed
+        // content the gate never authorized, whatever tree it produced.
+        Some(landed_commit) if !request.managed_merge => uncovered(
+            &certificate,
+            request,
+            &branch,
+            SourceRevision {
+                commit: landed_commit.to_string(),
+                tree: String::new(),
+            },
+            ReviewInvalidation::ExternalLandingRace,
+        ),
         Some(landed_commit) => classify(request, &certificate, landed_commit, &branch),
         None => uncovered(
             &certificate,
@@ -67,6 +79,7 @@ pub(crate) fn record_review_landing(
             "attempt_id": certificate.attempt_id,
             "pr_number": request.pr_number,
             "landed_commit": landing.landed.commit,
+            "managed_merge": request.managed_merge,
             "transformation": landing.transformation,
             "covered": landing.covered,
             "reason": landing.reason,

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -814,3 +814,64 @@ fn a_landing_on_a_moved_base_or_with_later_edits_stays_uncovered() {
     exclusions(&edited.fixture.runtime, &source, &state, &mut page).expect("exclusions");
     assert!(page.exclusions.is_empty(), "later edits are uncovered");
 }
+
+#[test]
+fn externally_completed_merge_is_audited_and_keeps_review_coverage_open() {
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+    write_report(
+        &gated.fixture.runtime,
+        &gated.task_id,
+        &report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false),
+    );
+    gated.settle(&admission).expect("pass");
+    let runtime = &gated.fixture.runtime;
+    let source = Source::new(&gated.fixture.repo);
+    let repository = source.repository().expect("repository");
+    let delivery = land_squash(&gated, &repository);
+
+    crate::application::review::record_review_landing(
+        runtime,
+        &orbit_engine::ReviewLandingRequest {
+            run_id: gated.run_id.clone(),
+            task_ids: vec![gated.task_id.clone()],
+            workspace_path: gated.fixture.repo.clone(),
+            pr_number: "42".into(),
+            base: "main".into(),
+            reviewed_head_sha: gated.implementation_sha.clone(),
+            managed_merge: false,
+            landed_commit: Some(delivery.after.commit.clone()),
+        },
+    )
+    .expect("record observed external landing");
+    let landings = runtime
+        .review_store()
+        .expect("review store")
+        .review_landings(attempt_id)
+        .expect("landings");
+    assert_eq!(landings.len(), 1);
+    assert!(!landings[0].covered);
+    assert_eq!(landings[0].reason.as_deref(), Some("external_landing_race"));
+    assert_eq!(landings[0].landed.commit, delivery.after.commit);
+
+    let (state, mut page) = page_for(&delivery);
+    exclusions(runtime, &source, &state, &mut page).expect("coverage");
+    assert!(
+        page.exclusions.is_empty(),
+        "even the same tree stays uncovered after an external merge"
+    );
+    let audits = runtime
+        .list_audit_events(None, None, None, None, 100)
+        .expect("audits");
+    assert!(
+        audits
+            .iter()
+            .filter_map(|audit| audit.arguments_json.as_deref())
+            .filter_map(|args| serde_json::from_str::<Value>(args).ok())
+            .any(|args| args["phase"] == "landing"
+                && args["managed_merge"] == false
+                && args["reason"] == "external_landing_race"),
+        "external landing audit carries its provenance"
+    );
+}

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -109,6 +109,8 @@ pub struct ReviewLandingRequest {
     pub pr_number: String,
     pub base: String,
     pub reviewed_head_sha: String,
+    /// A conditional synchronous merge returned the same commit later observed.
+    pub managed_merge: bool,
     /// The merge commit the provider reported, when it reported one.
     pub landed_commit: Option<String>,
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/operations.rs
@@ -181,6 +181,14 @@ fn pr_merge(input: &Value) -> Result<Value, OrbitError> {
     // required check and branch protection. There is deliberately no
     // administrative bypass (`--admin`) in this surface.
     let auto = input.get("auto").and_then(Value::as_bool).unwrap_or(false);
+    if let Some(reviewed_head) = optional_string(input, "reviewed_head_sha") {
+        if auto {
+            return Err(OrbitError::InvalidInput(
+                "review_gate_stale: deferred auto-merge cannot guarantee the reviewed head; wait for checks and request a synchronous merge".to_string(),
+            ));
+        }
+        return pr_merge_reviewed(selector, workspace_path, strategy, reviewed_head);
+    }
     let mut args = vec![
         "pr".to_string(),
         "merge".to_string(),
@@ -200,6 +208,60 @@ fn pr_merge(input: &Value) -> Result<Value, OrbitError> {
     Ok(json!({
         "stdout": result.stdout,
         "stderr": result.stderr,
+    }))
+}
+
+/// Use the synchronous REST mutation: `sha` is checked by GitHub when it
+/// merges, and this endpoint never enables auto-merge or enters a merge queue.
+/// `gh pr merge --match-head-commit` alone is insufficient because the CLI
+/// can choose deferred semantics for a queue-required branch.
+fn pr_merge_reviewed(
+    selector: &str,
+    workspace_path: &str,
+    strategy: &str,
+    reviewed_head: &str,
+) -> Result<Value, OrbitError> {
+    // Managed completion supplies a number in the current repository. Refuse
+    // other selectors here rather than resolving a URL into a different repo.
+    if selector.is_empty() || !selector.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(OrbitError::InvalidInput(
+            "reviewed PR merge requires a pull request number in the workspace repository".into(),
+        ));
+    }
+    if !valid_expected_remote_sha(Some(reviewed_head)) {
+        return Err(OrbitError::InvalidInput(
+            "reviewed PR merge requires an exact 40- or 64-character reviewed_head_sha".into(),
+        ));
+    }
+    let result = execute(
+        "gh",
+        vec![
+            "api".to_string(),
+            format!("repos/{{owner}}/{{repo}}/pulls/{selector}/merge"),
+            "--method".to_string(),
+            "PUT".to_string(),
+            "-f".to_string(),
+            format!("sha={reviewed_head}"),
+            "-f".to_string(),
+            format!("merge_method={strategy}"),
+        ],
+        Some(Path::new(workspace_path)),
+        SLOW_TIMEOUT_MS,
+        "reviewed PR merge",
+    )?;
+    let response: Value = serde_json::from_str(&result.stdout).map_err(|error| {
+        OrbitError::Execution(format!("reviewed PR merge returned invalid JSON: {error}"))
+    })?;
+    if response.get("merged").and_then(Value::as_bool) != Some(true) {
+        return Err(OrbitError::Execution(
+            "reviewed PR merge did not confirm a synchronous merge; deferred merges are unsupported".into(),
+        ));
+    }
+    let landed_commit = required_string(&response, "sha")?;
+    Ok(json!({
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "landed_commit": landed_commit,
     }))
 }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
@@ -13,8 +13,8 @@
 //! with the tasks still in `review`.
 //!
 //! Branch protection is respected by construction. The merge request is an
-//! ordinary `gh pr merge` (optionally `--auto`); no administrative bypass is
-//! reachable from this path, so a PR that GitHub reports as `BLOCKED` fails the
+//! ordinary provider merge (ungated runs may use `--auto`); no administrative
+//! bypass is reachable, so a PR that GitHub reports as `BLOCKED` fails the
 //! run rather than being forced through.
 //!
 //! A `DIRTY` PR is narrower than those policy refusals. With the pipeline's
@@ -86,6 +86,7 @@ pub(in crate::executor::automation) fn pr_complete<H: RuntimeHost + ?Sized>(
                 pr_number: pr_number.clone(),
                 base: input_string_field(input, "base").unwrap_or_default(),
                 reviewed_head_sha,
+                managed_merge: outcome["managed_merge"].as_bool().unwrap_or(false),
                 landed_commit: outcome
                     .get("landed_commit")
                     .and_then(Value::as_str)
@@ -121,6 +122,7 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
     let mut waited_seconds = 0_u64;
     let mut auto_merge_requested = false;
     let mut merge_requested = false;
+    let mut requested_landed_commit: Option<String> = None;
     let mut conflict_refresh_attempted = false;
     let mut merge_capabilities: Option<MergeCapabilities> = None;
 
@@ -130,13 +132,18 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
         let status = read_pr_status(host, workspace_path, pr_number)?;
         match classify(&status) {
             PrMergeState::Merged => {
+                let landed_commit = status.pointer("/mergeCommit/oid").and_then(Value::as_str);
+                let managed_merge = requested_landed_commit
+                    .as_deref()
+                    .is_some_and(|requested| Some(requested) == landed_commit);
                 return Ok(json!({
                     "merged": true,
                     "pr_number": pr_number,
                     "strategy": merge_capabilities.map(|capabilities| capabilities.strategy.as_str()),
                     "auto_merge_requested": auto_merge_requested,
                     "waited_seconds": waited_seconds,
-                    "landed_commit": status.pointer("/mergeCommit/oid").and_then(Value::as_str),
+                    "landed_commit": landed_commit,
+                    "managed_merge": managed_merge,
                     "reviewed_head_sha": reviewed_head_sha,
                 }));
             }
@@ -182,12 +189,13 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                         pr_number,
                         &mut merge_capabilities,
                     )?;
-                    request_merge(
+                    requested_landed_commit = request_merge(
                         host,
                         workspace_path,
                         pr_number,
                         capabilities.strategy,
                         false,
+                        reviewed_head_sha.as_deref(),
                     )
                     .map_err(|error| {
                         OrbitError::Execution(format!(
@@ -203,7 +211,11 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
             }
             PrMergeState::Pending => {
                 ensure_pr_head_is_reviewed(&status, pr_number, reviewed_head_sha.as_deref())?;
-                if !auto_merge_requested {
+                // The CLI auto-merge path cannot retain the review condition.
+                // Gated runs wait locally and use the conditional synchronous
+                // mutation once checks settle, including on queue-only branches
+                // where that mutation will refuse the unsupported merge.
+                if reviewed_head_sha.is_none() && !auto_merge_requested {
                     // Required checks are still running. Hand the merge to
                     // GitHub's auto-merge when this repository allows it, then
                     // keep polling: enabling it is not success. Repositories
@@ -217,14 +229,21 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                         &mut merge_capabilities,
                     )?;
                     if capabilities.auto_merge_allowed {
-                        request_merge(host, workspace_path, pr_number, capabilities.strategy, true)
-                            .map_err(|error| {
-                                OrbitError::Execution(format!(
-                                    "pr_complete: could not enable auto-merge using {} on pull request \
+                        request_merge(
+                            host,
+                            workspace_path,
+                            pr_number,
+                            capabilities.strategy,
+                            true,
+                            None,
+                        )
+                        .map_err(|error| {
+                            OrbitError::Execution(format!(
+                                "pr_complete: could not enable auto-merge using {} on pull request \
                                      #{pr_number}: {error}; the task stays in review",
-                                    capabilities.strategy.as_str()
-                                ))
-                            })?;
+                                capabilities.strategy.as_str()
+                            ))
+                        })?;
                         auto_merge_requested = true;
                     }
                 }
@@ -303,8 +322,8 @@ fn reviewed_head_sha(input: &Value) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-/// Managed completion pins the reviewed head against what the provider
-/// reports as the PR head. A moved head is unreviewed content.
+/// Early diagnostic for an already moved head. The provider mutation must
+/// also enforce the reviewed SHA atomically; this read cannot prevent a race.
 fn ensure_pr_head_is_reviewed(
     status: &Value,
     pr_number: &str,
@@ -456,17 +475,24 @@ fn request_merge<H: RuntimeHost + ?Sized>(
     pr_number: &str,
     strategy: MergeStrategy,
     auto: bool,
-) -> Result<(), OrbitError> {
+    reviewed_head_sha: Option<&str>,
+) -> Result<Option<String>, OrbitError> {
     host.run_private_vcs_operation(
         operations::PR_MERGE,
         json!({
             "pr": pr_number,
             "strategy": strategy.as_str(),
             "auto": auto,
+            "reviewed_head_sha": reviewed_head_sha,
             "workspace_path": workspace_path,
         }),
     )
-    .map(|_| ())
+    .map(|result| {
+        result
+            .get("landed_commit")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    })
 }
 
 fn resolved_capabilities<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
@@ -131,6 +131,12 @@ fn managed_completion_pins_the_reviewed_head_and_records_the_landing() {
         merged(reviewed, "3333333333333333333333333333333333333333"),
     ]);
     host.queue_merge_capabilities(true, true, true, false);
+    host.queue_vcs_result(
+        PR_MERGE_OPERATION,
+        json!({
+            "landed_commit": "3333333333333333333333333333333333333333"
+        }),
+    );
     let output = pr_complete(&host, &complete_input(&workspace.repo, reviewed))
         .expect("reviewed head merges");
     assert_eq!(output["merge"]["merged"], true);
@@ -141,10 +147,147 @@ fn managed_completion_pins_the_reviewed_head_and_records_the_landing() {
     let landings = host.review_landings();
     assert_eq!(landings.len(), 1);
     assert_eq!(landings[0].reviewed_head_sha, reviewed);
+    assert!(landings[0].managed_merge);
+    let merge_call = host
+        .vcs_calls()
+        .into_iter()
+        .find(|call| call.operation == PR_MERGE_OPERATION)
+        .expect("merge call");
+    assert_eq!(merge_call.input["reviewed_head_sha"], reviewed);
+    assert_eq!(merge_call.input["auto"], false);
     assert_eq!(
         landings[0].landed_commit.as_deref(),
         Some("3333333333333333333333333333333333333333")
     );
     assert_eq!(landings[0].pr_number, "42");
     assert_eq!(host.task_status("T1"), TaskStatus::Done);
+}
+
+#[test]
+fn gated_pending_checks_wait_locally_without_enabling_auto_merge() {
+    let workspace = pr_workspace();
+    let reviewed = "1111111111111111111111111111111111111111";
+    let host = PrOpenTestHost::new(
+        vec![review_batch_task("T1", None, None)],
+        workspace.repo.clone(),
+    );
+    host.queue_pr_status([
+        status("PENDING", reviewed),
+        status("CLEAN", reviewed),
+        merged(reviewed, "landed"),
+    ]);
+    host.queue_vcs_result(PR_MERGE_OPERATION, json!({"landed_commit": "landed"}));
+    let mut input = complete_input(&workspace.repo, reviewed);
+    input["max_wait_seconds"] = json!(2);
+    let output = pr_complete(&host, &input).expect("wait then merge reviewed candidate");
+    assert_eq!(output["merge"]["auto_merge_requested"], false);
+    let merges: Vec<_> = host
+        .vcs_calls()
+        .into_iter()
+        .filter(|call| call.operation == PR_MERGE_OPERATION)
+        .collect();
+    assert_eq!(merges.len(), 1);
+    assert_eq!(merges[0].input["auto"], false);
+    assert_eq!(merges[0].input["reviewed_head_sha"], reviewed);
+}
+
+#[test]
+fn gated_pending_timeout_leaves_no_deferred_merge_and_external_landing_is_distinct() {
+    let workspace = pr_workspace();
+    let reviewed = "1111111111111111111111111111111111111111";
+    let host = PrOpenTestHost::new(
+        vec![review_batch_task("T1", None, None)],
+        workspace.repo.clone(),
+    );
+    host.queue_pr_status([status("PENDING", reviewed)]);
+    let error = pr_complete(&host, &complete_input(&workspace.repo, reviewed))
+        .expect_err("pending timeout");
+    assert!(error.to_string().contains("timed out"));
+    assert!(
+        host.vcs_calls()
+            .iter()
+            .all(|call| call.operation != PR_MERGE_OPERATION)
+    );
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
+
+    host.queue_pr_status([merged("external-head", "external-merge")]);
+    let output = pr_complete(&host, &complete_input(&workspace.repo, reviewed))
+        .expect("observe external merge");
+    assert_eq!(output["merge"]["managed_merge"], false);
+    let landings = host.review_landings();
+    assert!(!landings[0].managed_merge);
+    assert_eq!(landings[0].landed_commit.as_deref(), Some("external-merge"));
+    assert!(
+        host.vcs_calls()
+            .iter()
+            .all(|call| call.operation != PR_MERGE_OPERATION)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn managed_completion_rejects_a_push_between_status_and_provider_mutation() {
+    use super::super::super::tests::with_fake_gh;
+
+    // The provider returns A in the first status response, then advances its
+    // own head to B before accepting any merge mutation. An unconditioned
+    // command really merges B, so this test fails against the original code.
+    let script = r#"#!/bin/sh
+set -eu
+printf '%s\n' "$@" >> provider-args
+if [ "$1 $2" = "pr view" ]; then
+    if [ -f provider-merged ]; then
+        printf '%s\n' '{"state":"MERGED","headRefOid":"2222222222222222222222222222222222222222","mergeCommit":{"oid":"unreviewed-merge"}}'
+    else
+        printf '%s\n' '{"state":"OPEN","mergeStateStatus":"CLEAN","headRefOid":"1111111111111111111111111111111111111111"}'
+        printf '%s' '1111111111111111111111111111111111111111' > provider-head
+    fi
+    exit 0
+fi
+# This command only starts after Orbit has inspected the status response.
+printf '%s' '2222222222222222222222222222222222222222' > provider-head
+if [ "$1" = "api" ]; then
+    for arg in "$@"; do
+        case "$arg" in
+            sha=*) if [ "${arg#sha=}" != "$(cat provider-head)" ]; then
+                echo 'HTTP 409: Head branch was modified' >&2
+                exit 1
+            fi ;;
+        esac
+    done
+fi
+printf '%s' 'merged' > provider-merged
+printf '%s\n' '{"merged":true,"sha":"unreviewed-merge"}'
+"#;
+    if !with_fake_gh(
+        module_path!(),
+        "managed_completion_rejects_a_push_between_status_and_provider_mutation",
+        script,
+    ) {
+        return;
+    }
+    let workspace = pr_workspace();
+    let host = PrOpenTestHost::new(
+        vec![review_batch_task("T1", None, None)],
+        workspace.repo.clone(),
+    )
+    .with_provider_completion();
+    let reviewed = "1111111111111111111111111111111111111111";
+    let error = pr_complete(&host, &complete_input(&workspace.repo, reviewed))
+        .expect_err("provider must reject changed head");
+    assert!(error.to_string().contains("HTTP 409"), "{error}");
+    assert_eq!(
+        std::fs::read_to_string(workspace.repo.join("provider-head"))
+            .expect("advanced provider head"),
+        "2222222222222222222222222222222222222222"
+    );
+    assert!(!workspace.repo.join("provider-merged").exists());
+    assert_eq!(host.task_status("T1"), TaskStatus::Review);
+    assert!(host.review_landings().is_empty());
+    let args = std::fs::read_to_string(workspace.repo.join("provider-args"))
+        .expect("actual provider args");
+    let expected_mutation = format!(
+        "api\nrepos/{{owner}}/{{repo}}/pulls/42/merge\n--method\nPUT\n-f\nsha={reviewed}\n-f\nmerge_method=squash\n"
+    );
+    assert!(args.contains(&expected_mutation), "{args}");
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -52,6 +52,7 @@ pub struct PrOpenTestHost {
     vcs_errors: Mutex<HashMap<String, String>>,
     queued_vcs_results: Mutex<HashMap<String, VecDeque<Result<Value, String>>>>,
     pr_exists: Mutex<bool>,
+    provider_completion: bool,
     activity_updates: Mutex<Vec<(String, TaskActivityUpdate)>>,
     review_landings: Mutex<Vec<ReviewLandingRequest>>,
 }
@@ -73,9 +74,16 @@ impl PrOpenTestHost {
             vcs_errors: Mutex::new(HashMap::new()),
             queued_vcs_results: Mutex::new(HashMap::new()),
             pr_exists: Mutex::new(false),
+            provider_completion: false,
             activity_updates: Mutex::new(Vec::new()),
             review_landings: Mutex::new(Vec::new()),
         }
+    }
+
+    #[cfg(unix)]
+    pub fn with_provider_completion(mut self) -> Self {
+        self.provider_completion = true;
+        self
     }
 
     pub fn review_landings(&self) -> Vec<ReviewLandingRequest> {
@@ -451,6 +459,12 @@ impl RuntimeHost for PrOpenTestHost {
                 operation: operation.to_string(),
                 input: input.clone(),
             });
+
+        if self.provider_completion
+            && matches!(operation, operations::PR_STATUS | operations::PR_MERGE)
+        {
+            return operations::run(operation, &input);
+        }
 
         if let Some(message) = self
             .vcs_errors

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
@@ -3,3 +3,41 @@
 mod base_obsolescence;
 mod git;
 mod operations;
+
+/// Isolate PATH in a child test process so real private VCS operations can run
+/// a fake provider without changing the environment of concurrent Rust tests.
+#[cfg(unix)]
+pub(super) fn with_fake_gh(module: &str, test: &str, script: &str) -> bool {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let module = module
+        .strip_prefix(concat!(env!("CARGO_CRATE_NAME"), "::"))
+        .unwrap_or(module);
+    let exact_test = format!("{module}::{test}");
+    if std::env::var("ORBIT_TEST_GH_CHILD").ok().as_deref() == Some(&exact_test) {
+        return true;
+    }
+    let bin = tempfile::tempdir().expect("fake gh directory");
+    let gh = bin.path().join("gh");
+    fs::write(&gh, script).expect("write fake provider");
+    fs::set_permissions(&gh, fs::Permissions::from_mode(0o755)).expect("executable provider");
+    let mut paths = vec![bin.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .args(["--exact", &exact_test, "--nocapture"])
+        .env("ORBIT_TEST_GH_CHILD", &exact_test)
+        .env("PATH", std::env::join_paths(paths).expect("provider PATH"))
+        .output()
+        .expect("isolated provider test");
+    assert!(
+        output.status.success(),
+        "provider test failed:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    false
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/operations.rs
@@ -84,3 +84,91 @@ fn private_vcs_boundary_does_not_guess_when_base_policy_data_is_missing() {
 
     assert!(error.to_string().contains("baseRef policy data"));
 }
+
+#[cfg(unix)]
+#[test]
+fn private_merge_executes_conditional_provider_args_and_preserves_ungated_modes() {
+    use std::fs;
+
+    use super::super::operations::{PR_MERGE, run};
+    use super::with_fake_gh;
+
+    let script = r#"#!/bin/sh
+set -eu
+printf '%s\n' "$@" > provider-args
+if [ -f provider-response ]; then
+    cat provider-response
+else
+    printf '%s\n' '{"merged":true,"sha":"landed"}'
+fi
+"#;
+    if !with_fake_gh(
+        module_path!(),
+        "private_merge_executes_conditional_provider_args_and_preserves_ungated_modes",
+        script,
+    ) {
+        return;
+    }
+    let workspace = tempfile::tempdir().expect("workspace");
+    let reviewed = "1111111111111111111111111111111111111111";
+    for strategy in ["squash", "merge", "rebase"] {
+        let input = json!({
+            "workspace_path": workspace.path(),
+            "pr": "42",
+            "strategy": strategy,
+            "reviewed_head_sha": reviewed,
+        });
+        let result = run(PR_MERGE, &input).expect("synchronous conditional merge");
+        assert_eq!(result["landed_commit"], "landed");
+        assert_eq!(
+            fs::read_to_string(workspace.path().join("provider-args")).expect("argv"),
+            format!(
+                "api\nrepos/{{owner}}/{{repo}}/pulls/42/merge\n--method\nPUT\n-f\nsha={reviewed}\n-f\nmerge_method={strategy}\n"
+            )
+        );
+
+        for auto in [false, true] {
+            let input = json!({
+                "workspace_path": workspace.path(),
+                "pr": "42",
+                "strategy": strategy,
+                "auto": auto,
+            });
+            let result = run(PR_MERGE, &input).expect("ungated merge");
+            assert!(result.get("landed_commit").is_none());
+            let auto_flag = if auto { "--auto\n" } else { "" };
+            assert_eq!(
+                fs::read_to_string(workspace.path().join("provider-args")).expect("argv"),
+                format!("pr\nmerge\n42\n--{strategy}\n{auto_flag}")
+            );
+        }
+    }
+
+    fs::remove_file(workspace.path().join("provider-args")).expect("clear invocation log");
+    let input = json!({
+        "workspace_path": workspace.path(),
+        "pr": "42",
+        "auto": true,
+        "reviewed_head_sha": reviewed,
+    });
+    let error = run(PR_MERGE, &input).expect_err("gated deferred request refused");
+    assert!(error.to_string().contains("deferred auto-merge"));
+    assert!(
+        !workspace.path().join("provider-args").exists(),
+        "refused before provider mutation"
+    );
+
+    for response in [
+        r#"{"merged":false}"#,
+        r#"{"status":"queued"}"#,
+        r#"{"merged":true}"#,
+        "invalid json",
+    ] {
+        fs::write(workspace.path().join("provider-response"), response).expect("provider response");
+        run(
+            PR_MERGE,
+            &json!({"workspace_path": workspace.path(), "pr": "42", "reviewed_head_sha": reviewed}),
+        )
+        .expect_err("only confirmed synchronous merges are accepted");
+    }
+}

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -297,13 +297,25 @@ stays unknown.
 ### Managed completion and landing
 
 `pr_complete` under a gate pins the provider-reported PR head against the
-reviewed head before merging (`review_gate_stale` on a moved head), refuses
-to repair a conflicting reviewed PR (a conflict repair is unreviewed content),
-and after the verified merge reads the merge commit, fetches it, and records
-a landing: `fast_forward`, `squash`, `merge_commit`, or `rebase` when the
-landing started from the reviewed base tree and produced the reviewed final
-tree, otherwise uncovered with `base_changed`, `candidate_changed`,
-`objects_missing`, or `mapping_unknown`. A landing is never fabricated.
+reviewed head before merging (`review_gate_stale` on a moved head), then sends
+that SHA as the `sha` precondition on GitHub's synchronous REST merge mutation.
+A push between inspection and mutation is rejected by the provider. Gated runs
+wait locally for pending checks; they never enable auto-merge or enter a merge
+queue. Queue-only branches and other unsupported synchronous merges fail closed,
+leaving the task in review. Ungated runs retain ordinary `gh pr merge` and
+repository-enabled auto-merge. See the
+[provider merge contract](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request).
+
+Completion refuses to repair a conflicting reviewed PR (a conflict repair is
+unreviewed content), and after the verified merge reads the merge commit,
+fetches it, and records a landing: `fast_forward`, `squash`, `merge_commit`,
+or `rebase` when the landing started from the reviewed base tree and produced
+the reviewed final tree, otherwise uncovered with `base_changed`,
+`candidate_changed`, `objects_missing`, or `mapping_unknown`. An externally
+completed merge (including one observed while polling) is recorded as uncovered
+with `external_landing_race`; the landing audit includes `managed_merge`, which
+requires a conditional mutation response matching the subsequently observed
+merge commit. A landing is never fabricated.
 
 ### Delivery coverage
 


### PR DESCRIPTION
## Task

[ORB-11525](https://orbit-cli.com/tasks/ORB-11525) — [code-review] Managed PR merge does not atomically pin the reviewed head

### Description

## Problem
The before-PR head check is a read followed by an unpinned merge request. A push between those operations can make Orbit merge a different, unreviewed candidate even though the new gate reports that managed completion pins the reviewed head.

## Live evidence
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24:
- crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs:177 checks the status response's headRefOid against reviewed_head_sha, then resolves capabilities and requests the merge at :185.
- request_merge at :453-467 sends only PR number, strategy, auto and workspace_path. It never sends the reviewed SHA.
- crates/orbit-engine/src/executor/automation/vcs/operations.rs:183-199 constructs gh pr merge <number> <strategy> [--auto] without a head precondition. There is no downstream atomic comparison with the SHA the reviewer examined.
- The Pending/auto-merge path has the same omission. A later poll or uncovered landing record occurs after the merge mutation and cannot prevent it.

Concrete interleaving: PR status reports reviewed A; another actor pushes B; Orbit's unconditioned merge request reads/merges B. Existing tests cover a mismatched head already present in the status response, not a change between status read and merge mutation. Enforce the reviewed head at the provider mutation boundary for supported merge modes, and fail closed when a deferred merge cannot guarantee that condition. Preserve existing behavior for ungated runs and distinguish externally completed merges in audit records.

Recovery under Daniel's gate-disable instruction: preserved pushed final candidate2977ad88d3be57e9ee14a86d59d36466902c7d9f on orbit/ORB-11525-6a9f0f13 includes original repair plus reviewer fixes to landing.rs Option matching and doc formatting. Run jrun-20260907-1922-3 failed only deterministic validation bookkeeping: reviewer confirmed all criteria, core review16 and engine VCS203 tests plus ci-fast/ci-lint passed, full make ci intentionally left to CI. Reuse this exact repaired candidate in a fresh ungated run, inspect current-base compatibility and revalidate affected checks. Preserve the reviewer fixes and truthful provenance; pipeline owns commit and PR. No gate re-enable or release actions.

### Acceptance Criteria

- A deterministic race test changes the provider head after status inspection and proves that managed completion cannot merge the unreviewed revision.
- Gated immediate and deferred/auto merge requests preserve a provider-enforced reviewed-head condition or refuse unsupported semantics; ordinary ungated completion remains compatible.
- Tests assert the actual private VCS/provider command arguments rather than only the preceding status check; required repository checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Recovered the exact scoped delta from preserved final candidate 2977ad88d3be57e9ee14a86d59d36466902c7d9f (base 7dbd5d0481e7b7995a342d540ff2fedf27155667) onto starting HEAD 1f7ce659d89a313ea26618eb5f94f25e78dd2bae in recovery run jrun-20260907-1953-7. Applied with git apply after its check passed, without committing.
- Preserved both reviewer repairs from 2977ad88: landing.rs matches Some(landed_commit) before external-landing classification, keeping missing commits classified mapping_unknown; current managed-completion documentation retains corrected wrapping.
- Gated completion carries reviewed_head_sha to the private provider boundary, which issues gh api repos/{owner}/{repo}/pulls/<number>/merge --method PUT -f sha=<reviewed> -f merge_method=<strategy>. Pending gated completion polls locally; explicit gated auto requests and unconfirmed synchronous responses are refused. Ungated gh pr merge strategy and auto arguments remain unchanged.
- Conditional mutation response and subsequent observed merge commit must agree for managed_merge=true. External merges retain an uncovered external_landing_race landing and audit record.
- Reused all ten existing context selectors. No scope additions, persisted artifact formats, dependency edges, CHANGELOG edits, configuration changes, or release operations.

Acceptance criteria:
1. PASS: engine VCS suite includes managed_completion_rejects_a_push_between_status_and_provider_mutation. Its isolated fake gh reports reviewed A during status inspection and advances to B at merge-command entry; assertions require provider HTTP 409, no merged marker, task still Review, no landing, and the actual conditional provider argv.
2. PASS: private provider tests cover SHA-pinned squash/merge/rebase, refusal of gated auto before invoking gh, malformed/unconfirmed responses, and unchanged ungated immediate/auto argv. Completion tests cover local pending polling and timeout without deferred mutation.
3. PASS: actual subprocess arguments and private metadata are tested, with durable external-landing audit and exclusion behavior tested in core. Required repository checks passed.

Current-run validation:
- PASSED: cargo test -p orbit-engine --lib executor::automation::vcs:: — 203 passed, 0 failed.
- PASSED: cargo test -p orbit-core --lib application::review::tests:: — 22 passed, 0 failed; includes current-base symbol-selector and epic-admission tests.
- PASSED: make ci-fast, including cargo fmt --all -- --check and all guardrails. The existing Cursor smoke check reports headless execution unavailable and validates the local symlink/manifest contract; this is not a claim that Cursor execution passed.
- PASSED: make ci-lint — cargo clippy --workspace --all-targets -- -D warnings.
- PASSED: git apply --check; Python per-file comparison of added/removed lines between the preserved candidate delta and recovered HEAD delta — exact match for all ten files.
- PASSED: git diff --check and final git status --short; precisely ten scoped modified files, 482 insertions/23 deletions, no untracked or staged changes. HEAD remains the starting commit.
- NOT RUN: full make ci, explicitly reserved for PR CI by AGENTS.md. No required local check was deferred or weakened.

Prior evidence and provenance:
- The original implementation run recorded an expected regression failure (exit 101) when running the race test with complete.rs and operations.rs restored from f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24: unconditioned code merged unreviewed B and completed the task. That destructive-to-fixture comparison was not repeated in this recovery; the recovered race test passed in the current suite.
- Original implementation candidate: 6794c2021b2e0622ed92a39e0883af04e742bd70. Reviewer repair candidate: 2977ad88d3be57e9ee14a86d59d36466902c7d9f, authored by claude-reviewer for attempt rvw-0e3094e68514-1. The prior gate verdict remains incomplete due to validation bookkeeping; this recovery does not claim a passed independent review or rewrite that evidence.
- Recovery follows the latest authorized gate-disable instruction. No gate configuration was changed.

Assessment:
Complete diff reviewed for provider enforcement, error handling, audit classification, documentation, and scope. Recovery retains newer integration-base symbol-selector tests and delivery-coverage documentation rather than overwriting files with older snapshots. Both envelope roots, canonical pwd, and Git root match. Changes remain uncommitted and task remains in-progress for pipeline-owned commit, push, PR, and lifecycle transitions.

Risks/limits:
- Tests exercise Linux subprocess/private-VCS behavior using a fake provider; no live GitHub merge or other external PR mutation was performed. GitHub's synchronous sha precondition and mismatch HTTP 409 were rechecked against [GitHub REST merge documentation](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request).
- Gated deferred/queue semantics remain intentionally unsupported. Provider-refused synchronous merges fail closed. Already-merged retry observations without a matching conditional response, or a mismatch between REST and later observed merge commits, conservatively remain uncovered.
- Friction checkpoint completed: no new qualifying incident, contradicted assumption, recurring failure, or over-ten-minute gotcha in this recovery; no friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11525-6a9f1647`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra