### PR TITLE
[auto-task] Doc duties — validate the least-recently-validated docs

### DIFF
--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -1,3 +1,10 @@
+---
+type: design
+summary: "Delivery automation operations [ORB-11330]"
+tags: [automation-triggers]
+last_validated: 2026-09-07
+---
+
 # Delivery automation operations [ORB-11330]
 
 Delivery triggers are opt-in. The existing sweep clock evaluates routines; the

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -4,12 +4,12 @@ type: design
 title: "Host Registry — Design"
 owner: codex
 last_updated: 2026-08-15
-last_validated: 2026-08-15
+last_validated: 2026-09-07
 status: Accepted
 feature: host-registry
 doc_role: design
 tags: [host-registry, machine-identity, workspace-catalog, runtime-composition]
-paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/init.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/lib.rs", "crates/orbit-web/src/state.rs", "crates/orbit-mcp/src/remote/identity.rs", "crates/orbit-mcp/src/remote/discovery.rs"]
+paths: ["crates/orbit-types/src/identity/host.rs", "crates/orbit-types/src/workspace/registry.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/init/**", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/lib.rs", "crates/orbit-web/src/state.rs", "crates/orbit-mcp/src/remote/identity.rs", "crates/orbit-mcp/src/remote/discovery.rs"]
 related_features: [host-registry, mcp-session-context, remote-access]
 related_artifacts: []
 ---

--- a/docs/design/host-registry/3_vision.md
+++ b/docs/design/host-registry/3_vision.md
@@ -4,12 +4,12 @@ type: design
 title: "Host Registry — Vision"
 owner: codex
 last_updated: 2026-08-23
-last_validated: 2026-08-15
+last_validated: 2026-09-07
 status: Accepted
 feature: host-registry
 doc_role: vision
 tags: [host-registry, machine-identity, workspace-catalog]
-paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
+paths: ["crates/orbit-types/src/identity/host.rs", "crates/orbit-types/src/workspace/registry.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs"]
 related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
 related_artifacts: [ORB-11008, ORB-11009]
 ---

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -4,12 +4,12 @@ type: design
 title: "Host Registry — Decisions"
 owner: codex
 last_updated: 2026-08-23
-last_validated: 2026-08-15
+last_validated: 2026-09-07
 status: Accepted
 feature: host-registry
 doc_role: decisions
 tags: [host-registry, machine-identity, workspace-catalog, runtime-composition]
-paths: ["crates/orbit-common/src/types/host.rs", "crates/orbit-common/src/types/workspace.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/**"]
+paths: ["crates/orbit-types/src/identity/host.rs", "crates/orbit-types/src/workspace/registry.rs", "crates/orbit-registry/src/host_identity.rs", "crates/orbit-registry/src/workspace_registry/**", "crates/orbit-cmd/src/registry_runtime.rs", "crates/orbit-cli/src/command/host/**", "crates/orbit-cli/src/command/workspace/**", "crates/orbit-cli/src/command/mcp/**", "crates/orbit-web/src/**"]
 related_features: [host-registry, mcp-session-context, remote-access, federated-mcp]
 related_artifacts: [ORB-11008, ORB-11009]
 ---

--- a/docs/design/project-learnings/4_decisions.md
+++ b/docs/design/project-learnings/4_decisions.md
@@ -4,7 +4,7 @@ type: design
 title: "Project Learnings — Decisions"
 owner: claude
 last_updated: 2026-08-13
-last_validated: 2026-08-13
+last_validated: 2026-09-07
 status: Superseded
 feature: project-learnings
 doc_role: decisions
@@ -58,7 +58,7 @@ Storage choice. Three plausible shapes:
 2. **Native primitive in `orbit-store`.** YAML on disk + SQLite index, mirroring tasks. Structured fields (`scope`, `evidence`, `status`), atomic mutations via `orbit.learning.*` tools, indexable for sub-10ms lookups. Implementation cost is real but reuses the existing layered store pattern.
 3. **Hybrid: markdown bodies + YAML metadata.** Markdown for content, YAML frontmatter for structure. Familiar to many tools. Splits concerns awkwardly when programmatic mutations write to one half and humans edit the other.
 
-The injection layers ([2_design.md §4](./2_design.md)) are the forcing function. Layer 1 has to query "which learnings match this task's context_files" before agent spawn; layer 2 has to do the same per MCP call. Both are hot paths. Grepping markdown frontmatter on every spawn or every tool call is the wrong shape — it makes every layer pay a full filesystem walk for what should be an indexed lookup.
+The injection layers (the retired `2_design.md §4`) are the forcing function. Layer 1 has to query "which learnings match this task's context_files" before agent spawn; layer 2 has to do the same per MCP call. Both are hot paths. Grepping markdown frontmatter on every spawn or every tool call is the wrong shape — it makes every layer pay a full filesystem walk for what should be an indexed lookup.
 
 A flat-markdown approach can be retrofitted with an index, but at that point it's a native primitive with extra steps and a less convenient on-disk format.
 
@@ -87,7 +87,7 @@ Where do learning records live on disk?
 
 Per the Scoping Rules table in [CLAUDE.md](../../../CLAUDE.md), tasks are `WorkspaceOnly` and live in `.orbit/tasks/` checked in. Job runs are also `WorkspaceOnly` but under `.orbit/state/`, gitignored, because they're execution artifacts. Learnings sit closer to tasks in shape — durable project artifacts authored over time — so the task locality is the right precedent.
 
-The cross-workspace case ([3_vision.md §1.4](./3_vision.md)) is real but secondary: most learnings are repo-specific, and the cross-cutting ones are best handled by tag-driven promotion later, not by making the default storage location global.
+The cross-workspace case (the retired `3_vision.md §1.4`) is real but secondary: most learnings are repo-specific, and the cross-cutting ones are best handled by tag-driven promotion later, not by making the default storage location global.
 
 ### Decision
 Phase 1 stores learnings at `.orbit/learnings/<id>.yaml`, scoped `WorkspaceOnly` per the Scoping Rules table, checked into git. The SQLite index lives under `.orbit/state/` and is rebuildable from the YAML; it does not need to be checked in.
@@ -126,13 +126,13 @@ Phase 1's binding constraint is: ship before semantic-search reaches Accepted ([
 ### Decision
 Phase 1 supports two scope axes, evaluated as logical OR: path globs (matched via the `orbit-policy` glob engine) and tags (matched as exact strings). Ranking is `updated_at` desc with optional `priority` tagging as a tie-breaker. The schema reserves `scope.symbols` and `scope.semantic_seed` fields for phase 2 forward compatibility, but neither is read in phase 1.
 
-Phase 2 ([3_vision.md §1.1](./3_vision.md), [§1.2](./3_vision.md)) layers symbol-aware scope and semantic ranking once semantic-search ships.
+Phase 2 (the retired `3_vision.md §1.1` and `§1.2`) layers symbol-aware scope and semantic ranking once semantic-search ships.
 
 ### Consequences
 - Phase 1 is implementable in parallel with semantic-search work, not gated on it.
 - Path globs cover the common case (most learnings are file-area-scoped) and tags cover the cross-cutting case.
 - The schema is forward-compatible; phase 2 is additive, not a migration.
-- Cost: recency-only ranking has known failure modes ([3_vision.md §1.2](./3_vision.md)) — old-but-important learnings get out-ranked by recent-but-marginal ones. Path globs are brittle to renames; the documented mitigation is "run `orbit learning prune --stale-only` after refactors that move files," which is operational discipline, not automation. Both costs are accepted as the price of shipping phase 1 ahead of semantic-search.
+- Cost: recency-only ranking has known failure modes (the retired `3_vision.md §1.2`) — old-but-important learnings get out-ranked by recent-but-marginal ones. Path globs are brittle to renames; the documented mitigation is "run `orbit learning prune --stale-only` after refactors that move files," which is operational discipline, not automation. Both costs are accepted as the price of shipping phase 1 ahead of semantic-search.
 
 ---
 
@@ -142,7 +142,7 @@ Phase 2 ([3_vision.md §1.1](./3_vision.md), [§1.2](./3_vision.md)) layers symb
 **Recorded:** 2026-08-13 · [T20260510-11], [ORB-10736]
 
 ### Context
-The push-injection layer ([2_design.md §4](./2_design.md)) has multiple natural placements, each with different coverage:
+The push-injection layer (the retired `2_design.md §4`) has multiple natural placements, each with different coverage:
 
 - **Engine pre-prompt only.** Inject when `orbit-engine` spawns an agent for a task. Universal across agents. Coarse: fires once at task start, before the agent has read its way to the relevant code, so narrow learnings (file-path-scoped) may not surface for the file the agent edits ten tool calls in.
 - **MCP-sidecar only.** Attach `learnings` to MCP tool responses that reference paths. Cross-agent. Misses Claude Code's built-in `Edit | Write | Read`, which agents use far more than they call MCP file tools.
@@ -157,7 +157,7 @@ Phase 1 ships all three layers active simultaneously. Each layer consults a per-
 ### Consequences
 - Coverage is robust: even if one layer misfires or a vendor lacks hook support, the others provide a baseline.
 - Agents see relevant learnings at multiple natural moments — task start, MCP tool call, individual edit — without being drowned in repeats (dedup set).
-- The architecture admits a future "layer 4" (Orbit-side proxy for agents without hooks) without restructuring, but doesn't require it ([3_vision.md §1.5](./3_vision.md)).
+- The architecture admits a future "layer 4" (Orbit-side proxy for agents without hooks) without restructuring, but doesn't require it (the retired `3_vision.md §1.5`).
 - Cost: three injection sites means three places to maintain. A schema change to learning records (new field surfaced at injection time) requires touching `orbit-engine`, `orbit-mcp`, and the Claude Code hook script. The dedup set is agent-local; if context is compressed mid-session, the set may reset and the same learning may inject twice. Both costs are accepted as the price of robust coverage; collapsing to a single layer would mean choosing one failure mode (vendor lock-in, coarse scope, or missing built-in tools) and living with it.
 
 ---

--- a/docs/runbooks/executor-onboarding.md
+++ b/docs/runbooks/executor-onboarding.md
@@ -1,6 +1,7 @@
 ---
 type: runbook
 summary: Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state.
+last_validated: 2026-09-07
 tags: [contributors, executors, providers, testing]
 paths: ["crates/orbit-agent/**", "crates/orbit-core/assets/executors/**", "crates/orbit-core/src/application/executor.rs", "crates/orbit-core/src/adapter/engine_host/v2_host/cli_executor.rs", "crates/orbit-engine/src/activity_job/**"]
 related_features: [activity-job, policy-sandbox]


### PR DESCRIPTION
## Task

[ORB-11501](https://orbit-cli.com/tasks/ORB-11501) — [auto-task] Doc duties — validate the least-recently-validated docs

### Description

Rolling upkeep of this repo's documentation. Each run takes a small batch of
the docs that have gone longest without being checked, verifies them against
the code, fixes what is wrong, and records that they were checked. Over
successive runs the whole corpus cycles.

## Selecting this run's batch

The `last_validated` frontmatter key records when a doc's claims were last
checked against reality. It is NOT `last_updated`: editing a doc changes
`last_updated`, confirming a doc is still true changes `last_validated`.

1. List every in-scope doc together with its `last_validated` value. A
   document with no frontmatter block has no `last_validated` value and is
   treated as never validated.
2. Order them: docs with **no** `last_validated` key first (never validated),
   then oldest date first. Break ties by path so the order is stable.
3. Take the **6 oldest**. That is this run's batch. Do not take more — a
   bounded batch that is done properly beats a broad pass that is not.

Documents with no frontmatter block are eligible for the rotation. When
one is selected, determine whether Orbit Docs' existing tolerant inference
contract supports a confident classification: `type` must be one of the
existing allowed values and `summary` must follow the existing document
heading/content rule. If classification and verification are successful,
you may prepend a schema-compatible frontmatter block, then add
`last_validated` only after the selected document has actually been
checked. Do not invent metadata fields, sidecars, or validation markers.
If classification is uncertain or claims cannot be verified, leave the
document unchanged and report the skip.

## What to do with each doc in the batch

Three passes, in this order:

1. **Staleness — the one that matters.** Check the doc's factual claims
   against the current code: file and module paths, type/trait/function
   names, CLI commands and flags, config keys, crate names, version claims,
   described behavior. Verify each with a command (`ls`, `grep`, `--help`,
   reading the source). Correct what has drifted.
2. **Spelling.** Fix genuine misspellings. Do not impose style preferences —
   hyphenation, dialect, and voice are the author's, not yours.
3. **Formatting.** Fix broken markdown: malformed tables, unclosed code
   fences, broken relative links, inconsistent heading levels. Do not reflow
   prose, rewrap lines, or restructure a document that renders correctly.

Then set `last_validated: <today, YYYY-MM-DD>` in that doc's frontmatter —
adding the key if absent, updating it if present.

## The rule that makes this scheme worth anything

**Only stamp a doc you actually validated.** A `last_validated` date you did
not earn is worse than no date at all: it removes the doc from the rotation
while leaving it wrong, and nobody will look at it again. If you could not
verify a doc's claims — the ground truth is not observable from this repo,
or the doc is too large for the remaining budget — leave it unstamped, say
so in the execution summary, and move on. Reporting five validated docs and
one skipped is a good run. Six stamps and one lie is a bad one.

Likewise: where you cannot verify a specific claim inside an otherwise
checkable doc, leave that claim alone rather than rewriting it on belief,
and note it. A plausible wrong fact is harder to catch than an obviously
old one.

## Scope

In scope: `docs/design/**` (excluding `docs/design/_archive/**`),
`docs/runbooks/**`, and the other prose under `docs/`.

Never modify: `.orbit/adrs/**`, `CHANGELOG.md`, and `docs/changelogs/**`
(historical records — a citation that was accurate when written is
provenance, not staleness), `docs/design/_archive/**`, `.orbit/tasks/`,
`.orbit/graph/`, and any other generated or stored state. Do not author
new documents or new sections; if you find a real documentation gap,
report it rather than filling it.

Do not add project-specific identifiers (person names, task/ADR/friction
ids) to anything under `crates/*/assets/**` — those assets seed every
workspace and must stay project-agnostic.

## Reporting

Your execution summary is the artifact a human reads. State: which docs were
in the batch and why they were selected, what you changed in each with the
verification command behind it, which docs or claims you left unvalidated
and why, and for each selected frontmatter-less doc whether frontmatter was
migrated, the derived `type` and `summary`, and the verification evidence.
Report selected docs left unchanged because their classification or claims
could not be verified confidently.


### Acceptance Criteria

- Exactly the batch of least-recently-validated in-scope docs was worked, selected by missing-then-oldest `last_validated`.
- Every doc stamped with today's `last_validated` was actually verified against the code, with the verification named in the execution summary.
- Docs or individual claims that could not be verified were left unstamped and unmodified, and are listed in the execution summary.
- No file under .orbit/adrs/, CHANGELOG.md, docs/changelogs/, docs/design/_archive/, or generated state was modified.
- Frontmatter-less in-scope docs are eligible for the batch as never validated, and sort before dated docs with the stable path tie-break.
- Frontmatter is created only for a selected doc when `type` and `summary` can be derived under Orbit Docs' existing inference/schema contract; migrated metadata and verification evidence are reported.
- A selected doc with uncertain classification or unverifiable claims is left unchanged and reported; `last_validated` is added only after verification.
- No new metadata field, sidecar, or validation-marker system is introduced.
- No new document or new section was authored.
- Formatting changes are limited to genuinely broken markdown; no prose reflowing or rewrapping appears in the diff.
- make ci-fast passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Batch selection:
- The six selected documents were exactly the two never-validated files and the four oldest dated files from the pre-edit HEAD inventory (stable path tie-break): docs/design/automation-triggers/5_operations.md (no frontmatter), docs/runbooks/executor-onboarding.md (no last_validated key), docs/design/project-learnings/4_decisions.md (2026-08-13), and docs/design/host-registry/{2_design,3_vision,4_decisions}.md (2026-08-15).
- Evidence: git ls-tree -r --name-only HEAD docs plus per-file first-line/frontmatter extraction, sorted with never-validated entries first.

Changes and verification:
- docs/design/automation-triggers/5_operations.md: migrated schema-compatible frontmatter only after verifying its path-derived classification as type design and its first heading-derived summary, added the inferred automation-triggers tag and last_validated: 2026-09-07. Verified delivery/ state trigger types, limits, evidence fields, exclusions, retry/waiver behavior, and source-budget claims against crates/orbit-types/src/workflow/automation/**, crates/orbit-automation/src/**, related Core application code, and the 65 passing orbit-automation tests. CLI help also confirmed --deliveries-landed, --waive-batch, --waiver-reason, --preview, and --json.
- docs/runbooks/executor-onboarding.md: added last_validated: 2026-09-07. Verified the executor family boundary, shipped assets, provider transports, local-shell behavior, fake-fixture paths, and lifecycle/sandbox claims against the referenced source, docs/CONFIG.md, docs/design/executors/specs/local-shell.md, and the installed CLI help.
- docs/design/host-registry/2_design.md, 3_vision.md, 4_decisions.md: updated last_validated to 2026-09-07. Corrected stale paths in their existing paths metadata from deleted orbit-common/src/types files and init.rs to current orbit-types identity/workspace modules and the init directory. Verified the registry, identity, runtime-composition, CLI/Web/MCP, and fail-closed claims against current source and orbit-registry tests (45 unit tests plus 1 dependency-boundary test passed).
- docs/design/project-learnings/4_decisions.md: updated last_validated to 2026-09-07. The current retirement decision was verified against the retired-learning search/migration code and tests. Superseded entries remain historical and were not reinterpreted or rewritten. Removed only links whose relative targets were deleted; all remaining relative links now resolve.

Validation:
- Passed: make ci-fast.
- Passed: cargo test -p orbit-automation (65 passed).
- Passed: cargo test -p orbit-registry (46 passed total).
- Passed: cargo test -p orbit-core docs (24 relevant tests passed).
- Passed: installed CLI help checks for auto-task, executor, and workspace-init surfaces.
- Passed: relative-link target check, referenced-path check, forbidden/generated-path check, git diff --check, and final git status/diff review.
- Not run: make ci-lint; not required by the task acceptance criteria.
- Not usable as evidence: orbit docs show --root .orbit failed because the installed CLI attempted to create .orbit/orbit.db and the managed filesystem denied it with Read-only file system (os error 30). The source-level frontmatter tests and make ci-fast doc-index check passed; no generated state was modified.

Acceptance assessment:
- Exactly six selected docs were handled; all six received today's validation stamp after source verification.
- No selected current claim was left unvalidated. No new document, section, metadata system, sidecar, generated state, forbidden-path file, or prose reflow was introduced.
- Remaining risk is limited to live authenticated provider smoke tests, which the executor runbook makes optional and which were not authorized or needed for this documentation-only update.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11501-6a9f1647`
- Behind base: 0
- Ahead of base: 1