### PR TITLE
Migrate existing task registries before delivery automation reserves task action keys

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
@@ -16,9 +16,9 @@ mod store;
 mod util;
 mod workspace_id;
 
-// Auxiliary action-key tables do not change the v5 task/allocator format.
-// Keep it readable by rollback binaries, which safely ignore those tables.
-const REGISTRY_SCHEMA_VERSION: u32 = 5;
+// Required action-key storage must advance the version so existing v5
+// registries run schema setup before admission. Older binaries fail closed.
+const REGISTRY_SCHEMA_VERSION: u32 = 6;
 
 pub fn task_registry_path(global_root: &Path) -> PathBuf {
     global_root.join("tasks").join("index.sqlite")

--- a/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
@@ -7,13 +7,19 @@ use super::util::now_string;
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     migrate_path_coupled_workspace_bindings(conn)?;
     migrate_allocator_state_v5(conn)?;
-    // Additive v6: permanent action-to-task reservations survive bundle recovery.
+    // Schema v6: permanent action-to-task reservations survive bundle recovery.
+    // Some fresh v5 registries already contain this table. Keep their mappings
+    // intact, and allow replay if opening stopped before user_version was set.
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS task_action_keys (
-      workspace_id TEXT NOT NULL, action_key TEXT NOT NULL, task_id TEXT NOT NULL UNIQUE,
-      input_digest TEXT NOT NULL, PRIMARY KEY(workspace_id,action_key));",
+            workspace_id TEXT NOT NULL,
+            action_key TEXT NOT NULL,
+            task_id TEXT NOT NULL UNIQUE,
+            input_digest TEXT NOT NULL,
+            PRIMARY KEY(workspace_id, action_key)
+        );",
     )
-    .map_err(|e| OrbitError::Store(e.to_string()))?;
+    .map_err(|e| OrbitError::Store(format!("migrate task action keys to registry v6: {e}")))?;
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS allocator_state (

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1,4 +1,7 @@
 // Content moved from tests.rs per ORB-00231
+
+mod schema;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/prior_v5.sql
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/prior_v5.sql
@@ -1,0 +1,90 @@
+-- Frozen prior-v5 schema from 2c143e01b^:crates/orbit-store/src/driver/sqlite/task_registry/schema.rs.
+-- Keep independent of current schema setup: this database never had task_action_keys.
+CREATE TABLE IF NOT EXISTS allocator_state (
+    authority TEXT PRIMARY KEY,
+    next_number INTEGER NOT NULL CHECK(next_number >= 0),
+    task_prefix TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspace_bindings (
+    workspace_id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL,
+    repo_fingerprint TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspace_checkout_bindings (
+    workspace_id TEXT PRIMARY KEY,
+    repo_root TEXT NOT NULL,
+    workspace_path TEXT NOT NULL,
+    orbit_dir TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_workspace_checkout_bindings_paths
+    ON workspace_checkout_bindings(repo_root, workspace_path, orbit_dir);
+
+CREATE TABLE IF NOT EXISTS task_bundle_bindings (
+    task_id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    canonical_path TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_bindings_workspace
+    ON task_bundle_bindings(workspace_id, task_id);
+
+CREATE TABLE IF NOT EXISTS task_bundle_index (
+    task_id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    priority TEXT NOT NULL,
+    job_run_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    terminal_month TEXT,
+    complexity TEXT,
+    FOREIGN KEY(task_id) REFERENCES task_bundle_bindings(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_created
+    ON task_bundle_index(workspace_id, created_at DESC, task_id ASC);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_status
+    ON task_bundle_index(workspace_id, status, created_at DESC, task_id ASC);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_priority
+    ON task_bundle_index(workspace_id, priority, created_at DESC, task_id ASC);
+
+CREATE TABLE IF NOT EXISTS task_bundle_tags (
+    task_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    PRIMARY KEY(task_id, tag),
+    FOREIGN KEY(task_id) REFERENCES task_bundle_bindings(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_tags_workspace_tag
+    ON task_bundle_tags(workspace_id, tag, task_id);
+
+CREATE TABLE IF NOT EXISTS task_bundle_relations (
+    source_task_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    relation_type TEXT NOT NULL,
+    target_task_id TEXT NOT NULL,
+    PRIMARY KEY(source_task_id, relation_type, target_task_id),
+    FOREIGN KEY(source_task_id) REFERENCES task_bundle_bindings(task_id) ON DELETE CASCADE,
+    FOREIGN KEY(workspace_id) REFERENCES workspace_bindings(workspace_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_relations_workspace_type_target
+    ON task_bundle_relations(workspace_id, relation_type, target_task_id, source_task_id);
+
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_job_run
+            ON task_bundle_index(workspace_id, job_run_id, created_at DESC, task_id ASC);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_terminal
+            ON task_bundle_index(workspace_id, terminal_month, task_id);
+CREATE INDEX IF NOT EXISTS idx_task_bundle_index_workspace_complexity
+            ON task_bundle_index(workspace_id, complexity, status);
+PRAGMA user_version = 5;

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
@@ -1,0 +1,298 @@
+//! Upgrade coverage uses the schema shipped before action-key admission existed.
+
+use std::fs;
+use std::path::PathBuf;
+
+use orbit_common::OrbitError;
+use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use rusqlite::{Connection, params, types::Value};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+use super::super::schema::registry_user_version;
+use super::super::{REGISTRY_SCHEMA_VERSION, TaskRegistryStore};
+use super::{registry_path, table_columns};
+use crate::contracts::TaskCreateParams;
+use crate::repository::task::TaskV2Store;
+
+const WORKSPACE: &str = "ws_prior";
+
+fn prior_v5(temp: &TempDir) -> PathBuf {
+    let path = registry_path(temp);
+    fs::create_dir_all(path.parent().expect("registry parent")).expect("create parent");
+    let conn = Connection::open(&path).expect("create prior registry");
+    conn.execute_batch(include_str!("prior_v5.sql"))
+        .expect("create historical schema");
+    conn.execute_batch(
+        "INSERT INTO allocator_state VALUES ('local', 100005, 'DE', '2026-09-01T00:00:00Z');
+         INSERT INTO workspace_bindings VALUES
+             ('ws_prior', 'prior', 'repo-fingerprint', '2026-09-01T00:00:00Z', '2026-09-01T00:00:00Z');
+         INSERT INTO task_bundle_bindings VALUES
+             ('DE-100004', 'ws_prior', '/retained/bundle', '2026-09-01T00:00:00Z', '2026-09-01T00:00:00Z');
+         INSERT INTO task_bundle_index VALUES
+             ('DE-100004', 'ws_prior', 'done', 'high', 'prior-run', '2026-09-01T00:00:00Z',
+              '2026-09-01T00:00:00Z', '2026-09', 'hard');
+         INSERT INTO task_bundle_tags VALUES ('DE-100004', 'ws_prior', 'retained');
+         INSERT INTO task_bundle_relations VALUES ('DE-100004', 'ws_prior', 'produces', 'external-result');",
+    )
+    .expect("seed historical records");
+    let root = temp.path().join("repo");
+    conn.execute(
+        "INSERT INTO workspace_checkout_bindings VALUES
+             ('ws_prior', ?1, ?1, ?2, '2026-09-01T00:00:00Z', '2026-09-01T00:00:00Z')",
+        params![root.to_str(), root.join(".orbit").to_str()],
+    )
+    .expect("seed checkout");
+    assert_eq!(registry_user_version(&conn).expect("version"), 5);
+    assert!(table_columns(&conn, "task_action_keys").is_empty());
+    path
+}
+
+fn retained_rows(conn: &Connection) -> Vec<Vec<Vec<Value>>> {
+    [
+        "allocator_state",
+        "workspace_bindings",
+        "workspace_checkout_bindings",
+        "task_bundle_bindings",
+        "task_bundle_index",
+        "task_bundle_tags",
+        "task_bundle_relations",
+    ]
+    .iter()
+    .map(|table| {
+        let mut statement = conn
+            .prepare(&format!("SELECT * FROM {table} ORDER BY 1, 2"))
+            .expect("prepare retained rows");
+        let columns = statement.column_count();
+        statement
+            .query_map([], |row| {
+                (0..columns).map(|column| row.get(column)).collect()
+            })
+            .expect("query retained rows")
+            .collect::<Result<_, _>>()
+            .expect("read retained rows")
+    })
+    .collect()
+}
+
+#[test]
+fn prior_v5_upgrade_preserves_records_and_enables_action_reservations() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+    let before = retained_rows(&Connection::open(&path).expect("read old registry"));
+
+    let registry = TaskRegistryStore::open(&path).expect("upgrade v5 registry");
+    assert_eq!(
+        retained_rows(&Connection::open(&path).expect("read upgraded registry")),
+        before
+    );
+    assert_eq!(
+        registry
+            .reserve_task_action(WORKSPACE, "delivery-batch", "digest")
+            .expect("reserve after upgrade"),
+        "DE-100005"
+    );
+    let conn = Connection::open(&path).expect("read upgraded registry");
+    assert_eq!(registry_user_version(&conn).expect("version"), 6);
+    assert_eq!(
+        table_columns(&conn, "task_action_keys"),
+        ["workspace_id", "action_key", "task_id", "input_digest"]
+    );
+    assert!(
+        conn.prepare("PRAGMA foreign_key_check")
+            .expect("prepare integrity check")
+            .query([])
+            .expect("query integrity check")
+            .next()
+            .expect("integrity row")
+            .is_none()
+    );
+}
+
+fn admission_params() -> TaskCreateParams {
+    TaskCreateParams {
+        actor: "codex".into(),
+        parent_id: None,
+        title: "Review retained delivery".into(),
+        description: "Examine the retained batch".into(),
+        acceptance_criteria: vec!["Record examination evidence".into()],
+        dependencies: vec![],
+        relations: vec![],
+        tags: vec![],
+        required_tools: vec![],
+        plan: String::new(),
+        execution_summary: String::new(),
+        context_files: vec![],
+        workspace_path: None,
+        repo_root: None,
+        created_by: Some("codex".into()),
+        planned_by: None,
+        implemented_by: None,
+        status: TaskStatus::Backlog,
+        priority: TaskPriority::High,
+        complexity: None,
+        task_type: TaskType::Chore,
+        external_refs: vec![],
+        source_task_id: None,
+        crew: None,
+        orchestrator: None,
+        comments: vec![],
+    }
+}
+
+#[test]
+fn upgraded_registry_replays_admission_after_reservation_and_bundle_creation() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+    let params = admission_params();
+    let digest = format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(&params).expect("serialize input"))
+    );
+    let key = "automation:retained-batch:1";
+
+    // Simulate process exit after reservation, before any bundle is official.
+    let registry = TaskRegistryStore::open(&path).expect("upgrade registry");
+    let reserved = registry
+        .reserve_task_action(WORKSPACE, key, &digest)
+        .expect("reserve action");
+    assert!(
+        registry
+            .find_task_binding(&reserved)
+            .expect("binding")
+            .is_none()
+    );
+    drop(registry);
+
+    let registry = TaskRegistryStore::open(&path).expect("reopen for admission");
+    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    let created = tasks
+        .create_task_with_key(params.clone(), Some(key))
+        .expect("recover reserved action");
+    assert_eq!(created.id, reserved);
+    drop(tasks);
+    drop(registry);
+
+    // Simulate lost acknowledgement after bundle creation. Reopen and admit
+    // repeatedly without allocating another ID or rewriting creation evidence.
+    for _ in 0..2 {
+        let registry = TaskRegistryStore::open(&path).expect("reopen after admission");
+        let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+        let replay = tasks
+            .create_task_with_key(params.clone(), Some(key))
+            .expect("replay action");
+        assert_eq!(replay.id, reserved);
+        assert_eq!(replay.created_at, created.created_at);
+        assert_eq!(replay.status, TaskStatus::Backlog);
+        assert_eq!(registry.allocator_next_number().expect("allocator"), 100006);
+
+        let mut changed = params.clone();
+        changed.title = "Different input".into();
+        assert!(matches!(
+            tasks.create_task_with_key(changed, Some(key)),
+            Err(OrbitError::InvalidInput(message)) if message.contains("action key input changed")
+        ));
+    }
+    let conn = Connection::open(&path).expect("inspect admission");
+    let mappings: i64 = conn
+        .query_row("SELECT COUNT(*) FROM task_action_keys", [], |r| r.get(0))
+        .expect("mapping count");
+    let tasks: i64 = conn
+        .query_row("SELECT COUNT(*) FROM task_bundle_bindings", [], |r| {
+            r.get(0)
+        })
+        .expect("task count");
+    assert_eq!(mappings, 1);
+    assert_eq!(tasks, 2, "one retained task plus one admitted task");
+}
+
+#[test]
+fn v5_with_existing_action_mapping_keeps_reserved_identity() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+    // The defective release also created fresh v5 registries WITH this table.
+    // Preserve their mappings when upgrading, even before bundle registration.
+    let conn = Connection::open(&path).expect("open fresh-v5 fixture");
+    conn.execute_batch(
+        "CREATE TABLE task_action_keys (
+            workspace_id TEXT NOT NULL, action_key TEXT NOT NULL, task_id TEXT NOT NULL UNIQUE,
+            input_digest TEXT NOT NULL, PRIMARY KEY(workspace_id, action_key));
+         INSERT INTO task_action_keys VALUES ('ws_prior', 'retained', 'DE-100005', 'digest');
+         UPDATE allocator_state SET next_number = 100006 WHERE authority = 'local';",
+    )
+    .expect("seed defective fresh-v5 reservation");
+    let before = retained_rows(&conn);
+    drop(conn);
+    let registry = TaskRegistryStore::open(&path).expect("upgrade fresh-v5 fixture");
+    assert_eq!(
+        registry
+            .reserve_task_action(WORKSPACE, "retained", "digest")
+            .expect("replay mapping"),
+        "DE-100005"
+    );
+    let conn = Connection::open(&path).expect("read upgraded fixture");
+    assert_eq!(retained_rows(&conn), before);
+    assert_eq!(registry_user_version(&conn).expect("version"), 6);
+}
+
+#[cfg(unix)]
+#[test]
+fn readonly_prior_v5_requires_upgrade_and_current_registry_remains_readable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+    let before = fs::read(&path).expect("snapshot prior database");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("make read-only");
+    let error = match TaskRegistryStore::open(&path) {
+        Ok(_) => panic!("read-only v5 registry needs migration"),
+        Err(error) => error,
+    };
+    assert!(error.is_readonly_or_access_failure(), "{error}");
+    assert_eq!(fs::read(&path).expect("read failed upgrade"), before);
+    assert!(!path.parent().expect("parent").join("workspaces").exists());
+
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).expect("allow upgrade");
+    drop(TaskRegistryStore::open(&path).expect("retry supported upgrade"));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400))
+        .expect("make upgraded registry read-only");
+    let registry = TaskRegistryStore::open(&path).expect("read current registry");
+    assert_eq!(
+        registry.allocator_next_number().expect("read allocator"),
+        100005
+    );
+    assert!(
+        registry
+            .find_task_binding("DE-100004")
+            .expect("read retained task")
+            .is_some()
+    );
+    let error = registry
+        .reserve_task_action(WORKSPACE, "new", "digest")
+        .expect_err("readonly cannot admit");
+    assert!(error.is_readonly_or_access_failure(), "{error}");
+}
+
+#[test]
+fn newer_registry_is_rejected_without_migrating_retained_records() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = prior_v5(&temp);
+    let conn = Connection::open(&path).expect("open fixture");
+    let newer = REGISTRY_SCHEMA_VERSION + 1;
+    conn.pragma_update(None, "user_version", newer)
+        .expect("set future version");
+    let before = retained_rows(&conn);
+    drop(conn);
+
+    let error = match TaskRegistryStore::open(&path) {
+        Ok(_) => panic!("opened unsupported registry"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains(&format!(
+        "schema version {newer} is newer than supported version {REGISTRY_SCHEMA_VERSION}"
+    )));
+    let conn = Connection::open(&path).expect("inspect rejected fixture");
+    assert_eq!(retained_rows(&conn), before);
+    assert_eq!(registry_user_version(&conn).expect("version"), newer);
+    assert!(table_columns(&conn, "task_action_keys").is_empty());
+}


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11529`
- Run: `jrun-20260907-1958-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `1f7ce659d89a313ea26618eb5f94f25e78dd2bae`
- Target base: `96e6a50dd5b7010f3dfe63049ce5d5fd2eafd2cb`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=post_merge_validation_required; error.message=Acceptance requires an installed same-authority scheduler retry after merge. This managed activity cannot merge or dispatch that retry; operational validation remains incomplete.
```