### PR TITLE
Recognize manually authored covering repairs in CI sweep deduplication

### DIFF
--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -23,12 +23,17 @@ spec:
     task-pilot validation and explicit CI-sweep admission. Filing itself never
     promotes or dispatches implementation. It is deduped
     against still-open tasks first by a commit-independent failure key carried
-    as a `ci-failure:<key>` tag, then by a shared high-confidence material
-    coverage assessment over untagged tasks. A repeated sweep over a run that
-    is still red, or a root cause already owned by a manual task, therefore
-    does not file the same work twice. Skips name the covering task and bounded
-    match evidence; closed historical tasks and superficial similarities do
-    not suppress a current failure. The three endings stay distinct
+    as a `ci-failure:<key>` tag, then by rejected exact-key tasks whose comments
+    name one still-open covering owner, then by a shared high-confidence
+    material coverage assessment over untagged tasks. Coverage matches a
+    generated workflow/job/step brief or a specific error together with the
+    failing command or the same run and job identity; generic npx/cargo
+    wrappers, a shared workflow or file, or a closed historical task do not
+    suppress a current failure. A repeated sweep over a run that is still red,
+    or a root cause already owned by a manual task, therefore does not file
+    the same work twice. Filing never mutates the covering task's tags or
+    prose. Skips name the covering task and bounded match evidence. The three
+    endings stay distinct
     and none of them is a CI pass: a snapshot with `collected: false` reports
     `capability_unavailable` and files nothing, a snapshot with no current
     failure reports `no_current_failure` and files nothing, and anything else
@@ -152,7 +157,7 @@ spec:
               type: string
             match_kind:
               type: string
-              enum: [exact_key, material_coverage]
+              enum: [exact_key, material_coverage, confirmed_duplicate]
             match_evidence:
               type: object
       skipped_over_cap:

--- a/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/automation.md
@@ -189,11 +189,16 @@ Secret values must not be copied into task prose or logs.
 
 A missing GitHub client, authentication, or API permission is a capability gap,
 not evidence of a clean repository. Read the collect/file step outcomes. CI
-failure-key dedupe and security alert identity suppress already-covered work;
-they do not promise general semantic duplicate detection. Discovery and filing
-errors must remain visible and retryable. A previous done repair is evidence to
-inspect, not blanket dedupe: an old failed release already fixed on the current
-integration branch stays proposed as already-landed, while a distinct defect
-that still reproduces at the current revision remains eligible. Choose these
-routines independently of `ship-sweep`; admission to backlog does not authorize
-implementation or completion.
+filing first reuses a still-open `ci-failure:<key>` owner, then a rejected
+exact-key task whose comment names one still-open covering owner, then a
+high-confidence material match (generated workflow/job/step labels, or a
+specific error together with the failing command or the same run and job).
+That is not fuzzy title similarity: a shared workflow, generic npx/cargo
+exit, or the same affected file is not enough, and a closed historical task
+does not suppress a later recurrence. Discovery, filing, and dedupe-lookup
+errors must remain visible and retryable. A previous done repair is evidence
+to inspect, not blanket dedupe: an old failed release already fixed on the
+current integration branch stays proposed as already-landed, while a distinct
+defect that still reproduces at the current revision remains eligible. Choose
+these routines independently of `ship-sweep`; admission to backlog does not
+authorize implementation or completion.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -803,7 +803,7 @@ struct FailureCluster {
 impl FailureCluster {
     fn duplicate_candidate(&self) -> DuplicateCandidate {
         let exact_tag = format!("{CI_FAILURE_KEY_TAG_PREFIX}{}", self.failure_key);
-        let fingerprints = if self.signature_is_step_fallback {
+        let mut fingerprints = if self.signature_is_step_fallback {
             // A step-name fallback contains no diagnostic. It is sufficient
             // for exact-key idempotency but too weak for broader free-text
             // coverage, where it could suppress an unrelated failure of the
@@ -823,6 +823,25 @@ impl FailureCluster {
                 ],
             )]
         };
+        if !self.signature_is_step_fallback {
+            if let Some(command) = specific_command_from_log(&self.log_excerpt) {
+                for diagnostic in specific_error_anchors(&self.log_excerpt, &self.signature)
+                    .into_iter()
+                    .take(3)
+                {
+                    fingerprints.push(CoverageFingerprint::new(
+                        "ci_failure_error_and_command",
+                        vec![
+                            CoverageAnchor::new("specific_error", diagnostic),
+                            CoverageAnchor::new("command", command.clone()),
+                        ],
+                    ));
+                }
+            }
+            if let Some(fingerprint) = source_identity_fingerprint(&self.runs) {
+                fingerprints.push(fingerprint);
+            }
+        }
         DuplicateCandidate::new(exact_tag, fingerprints)
     }
 
@@ -1262,6 +1281,231 @@ fn tested_commit(failure: &Value) -> String {
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
         .unwrap_or_default()
+}
+
+fn source_identity_fingerprint(runs: &[Value]) -> Option<CoverageFingerprint> {
+    let run = runs.first()?;
+    let run_id = value_string(run, "run_id");
+    let job_id = value_string(run, "job_id");
+    if run_id.is_empty() || job_id.is_empty() {
+        return None;
+    }
+    Some(CoverageFingerprint::new(
+        "ci_failure_source_identity",
+        vec![
+            CoverageAnchor::new("run_id", run_id),
+            CoverageAnchor::new("job_id", job_id),
+        ],
+    ))
+}
+
+/// Distinctive diagnostic lines a manual repair brief can quote without
+/// generated `workflow` / `failing job` / `failing step` labels.
+fn specific_error_anchors(log: &str, signature: &str) -> Vec<String> {
+    let mut anchors: Vec<String> = Vec::new();
+    let mut push = |value: &str| {
+        let Some(normalized) = specific_error_text(value) else {
+            return;
+        };
+        if !anchors
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(&normalized))
+        {
+            anchors.push(normalized);
+        }
+    };
+    push(signature);
+    for (kind, line) in classify_log_lines(log) {
+        if !matches!(
+            kind,
+            LineKind::ConcreteDiagnostic
+                | LineKind::ErrorAnnotated
+                | LineKind::Marker
+                | LineKind::Content
+        ) {
+            continue;
+        }
+        push(&strip_ansi_sequences(log_payload(line)));
+    }
+    anchors
+}
+
+fn specific_error_text(value: &str) -> Option<String> {
+    let trimmed = value
+        .trim()
+        .trim_start_matches(|character: char| {
+            character == '-' || character == '*' || character.is_whitespace()
+        })
+        .trim();
+    if trimmed.chars().count() < 16 || trimmed.chars().count() > 180 {
+        return None;
+    }
+    let lowered = trimmed.to_ascii_lowercase();
+    if is_generic_trailer(&lowered)
+        || is_run_command_payload(&lowered)
+        || lowered.starts_with("[command]")
+        || (lowered.contains("added ") && lowered.contains("packages"))
+        || lowered.contains("looking for funding")
+        || lowered.contains("found 0 vulnerabilities")
+        || lowered.contains("wrangler installed")
+        || lowered.contains("logs were written")
+    {
+        return None;
+    }
+    let diagnostic = ERROR_MARKERS.iter().any(|marker| lowered.contains(marker))
+        || lowered.contains("missing")
+        || lowered.contains("not found")
+        || lowered.contains("cannot")
+        || lowered.contains("invalid")
+        || lowered.contains("expected")
+        || lowered.contains("required");
+    diagnostic.then(|| trimmed.to_string())
+}
+
+fn specific_command_from_log(log: &str) -> Option<String> {
+    let mut best = None;
+    for (kind, line) in classify_log_lines(log) {
+        let payload = log_payload(line);
+        let raw = if kind == LineKind::RunCommand {
+            run_command_body(payload)
+        } else {
+            bracket_command_body(payload)
+        };
+        let Some(raw) = raw else {
+            continue;
+        };
+        if let Some(stable) = stabilize_command(raw) {
+            best = Some(stable);
+        }
+    }
+    best
+}
+
+fn run_command_body(payload: &str) -> Option<&str> {
+    let trimmed = payload.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    const PREFIX: &str = "##[group]run ";
+    lower
+        .starts_with(PREFIX)
+        .then(|| trimmed.get(PREFIX.len()..).unwrap_or_default().trim())
+        .filter(|body| !body.is_empty())
+}
+
+fn bracket_command_body(payload: &str) -> Option<&str> {
+    let trimmed = payload.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    const PREFIX: &str = "[command]";
+    lower
+        .starts_with(PREFIX)
+        .then(|| trimmed.get(PREFIX.len()..).unwrap_or_default().trim())
+        .filter(|body| !body.is_empty())
+}
+
+fn stabilize_command(raw: &str) -> Option<String> {
+    let mut tokens = raw.split_whitespace().collect::<Vec<_>>();
+    if tokens
+        .first()
+        .is_some_and(|token| token.eq_ignore_ascii_case("[command]"))
+    {
+        tokens.remove(0);
+    }
+    while tokens
+        .first()
+        .is_some_and(|token| is_javascript_runtime_token(token))
+    {
+        tokens.remove(0);
+        if tokens.first().is_some_and(|token| {
+            matches!(*token, "--no-install" | "--yes" | "-y" | "--prefer-offline")
+        }) {
+            tokens.remove(0);
+        }
+    }
+    if tokens.is_empty() || is_install_invocation(&tokens) {
+        return None;
+    }
+    let mut kept = Vec::new();
+    let mut skip_value = false;
+    for token in tokens {
+        if skip_value {
+            skip_value = false;
+            continue;
+        }
+        if is_volatile_command_flag(token) {
+            if !token.contains('=') {
+                skip_value = true;
+            }
+            continue;
+        }
+        kept.push(token);
+    }
+    if is_generic_command(&kept) {
+        return None;
+    }
+    Some(kept.join(" "))
+}
+
+fn is_javascript_runtime_token(token: &str) -> bool {
+    let base = token
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(token)
+        .to_ascii_lowercase();
+    matches!(base.as_str(), "npx" | "npm" | "node" | "yarn" | "pnpm")
+}
+
+fn is_install_invocation(tokens: &[&str]) -> bool {
+    matches!(
+        tokens
+            .first()
+            .map(|token| token.to_ascii_lowercase())
+            .as_deref(),
+        Some("i" | "install" | "add" | "ci")
+    )
+}
+
+fn is_volatile_command_flag(token: &str) -> bool {
+    let name = token
+        .trim_start_matches('-')
+        .split_once('=')
+        .map(|(name, _)| name)
+        .unwrap_or_else(|| token.trim_start_matches('-'));
+    matches!(
+        name,
+        "commit-hash" | "commit-message" | "commit" | "sha" | "hash"
+    )
+}
+
+fn is_generic_command(tokens: &[&str]) -> bool {
+    if tokens.is_empty() {
+        return true;
+    }
+    let joined = tokens.join(" ").to_ascii_lowercase();
+    if matches!(
+        joined.as_str(),
+        "cargo test"
+            | "cargo build"
+            | "cargo check"
+            | "cargo clippy"
+            | "cargo nextest run"
+            | "cargo llvm-cov"
+            | "npm test"
+            | "npm run build"
+            | "yarn test"
+            | "pnpm test"
+            | "npx"
+            | "node"
+            | "wrangler --version"
+            | "wrangler version"
+    ) {
+        return true;
+    }
+    let distinctive = tokens.iter().any(|token| {
+        token.contains('/')
+            || token.contains('\\')
+            || (token.starts_with("--") && token.contains('='))
+            || token.contains('@')
+    });
+    tokens.len() < 3 && !distinctive
 }
 
 /// Lines a runner emits when something breaks.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/duplicate_tasks.rs
@@ -1,22 +1,37 @@
 //! Shared deterministic duplicate-task assessment for finding sweep actions.
 //!
 //! Exact generated-key tags remain the authoritative fast path. When that
-//! path misses, a candidate is compared with every still-open task using
-//! caller-supplied, high-confidence fingerprints. A fingerprint must match in
-//! full; individual keywords never carry a duplicate decision.
+//! path misses, rejected exact-key tasks may name one still-open covering
+//! owner in a duplicate comment. Otherwise a candidate is compared with
+//! every still-open task using caller-supplied, high-confidence fingerprints.
+//! A fingerprint must match in full; individual keywords never carry a
+//! duplicate decision.
 
-use orbit_common::OrbitError;
 use orbit_common::security::redaction::redact_all;
-use orbit_types::task::{Task, TaskStatus};
+use orbit_common::{NotFoundKind, OrbitError};
+use orbit_types::task::{Task, TaskComment, TaskStatus, is_valid_orb_task_id};
 use serde_json::{Value, json};
 
 const MAX_EVIDENCE_FIELDS: usize = 6;
 const MAX_EVIDENCE_CHARS: usize = 160;
 
+const COVERING_OWNER_MARKERS: &[&str] = &[
+    "duplicate of",
+    "covering implementation",
+    "covering task",
+    "covering repair",
+    "covering work",
+    "covered by",
+];
+
 pub(in crate::adapter::engine_host::v2_host) trait DuplicateTaskLookup {
     fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError>;
 
     fn list_tasks(&self) -> Result<Vec<Task>, OrbitError>;
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError>;
+
+    fn get_task_comments(&self, task_id: &str) -> Result<Vec<TaskComment>, OrbitError>;
 }
 
 impl DuplicateTaskLookup for crate::OrbitRuntime {
@@ -26,6 +41,14 @@ impl DuplicateTaskLookup for crate::OrbitRuntime {
 
     fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         crate::OrbitRuntime::list_tasks(self)
+    }
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        crate::OrbitRuntime::get_task(self, task_id)
+    }
+
+    fn get_task_comments(&self, task_id: &str) -> Result<Vec<TaskComment>, OrbitError> {
+        crate::OrbitRuntime::get_task_comments(self, task_id)
     }
 }
 
@@ -91,7 +114,9 @@ pub(in crate::adapter::engine_host::v2_host) struct DuplicateTaskMatch {
 ///
 /// The tag query deliberately happens before the broader task listing. An
 /// exact generated key is deterministic and sufficient by itself, so a broad
-/// lookup is neither needed nor allowed to override it.
+/// lookup is neither needed nor allowed to override it. Rejected exact-key
+/// tasks are not coverage on their own; they may point at one still-open
+/// owner through an explicit duplicate comment.
 pub(in crate::adapter::engine_host::v2_host) fn find_covering_task<L>(
     lookup: &L,
     candidate: &DuplicateCandidate,
@@ -100,18 +125,19 @@ where
     L: DuplicateTaskLookup + ?Sized,
 {
     let exact_tasks = lookup.list_tasks_by_tags(std::slice::from_ref(&candidate.exact_tag))?;
-    if let Some(task) = exact_tasks
-        .into_iter()
-        .find(|task| is_open_status(task.status))
-    {
+    if let Some(task) = exact_tasks.iter().find(|task| is_open_status(task.status)) {
         return Ok(Some(DuplicateTaskMatch {
-            task_id: task.id,
+            task_id: task.id.clone(),
             match_kind: "exact_key",
             evidence: bounded_evidence(
                 "generated_key",
                 &[CoverageAnchor::new("dedupe_tag", &candidate.exact_tag)],
             ),
         }));
+    }
+
+    if let Some(confirmed) = confirmed_duplicate_match(lookup, candidate, &exact_tasks)? {
+        return Ok(Some(confirmed));
     }
 
     validate_candidate(candidate)?;
@@ -138,6 +164,108 @@ where
     }
 
     Ok(None)
+}
+
+fn confirmed_duplicate_match<L>(
+    lookup: &L,
+    candidate: &DuplicateCandidate,
+    exact_tasks: &[Task],
+) -> Result<Option<DuplicateTaskMatch>, OrbitError>
+where
+    L: DuplicateTaskLookup + ?Sized,
+{
+    let mut rejected = exact_tasks
+        .iter()
+        .filter(|task| task.status == TaskStatus::Rejected)
+        .collect::<Vec<_>>();
+    if rejected.is_empty() {
+        return Ok(None);
+    }
+    rejected.sort_by(|left, right| left.id.cmp(&right.id));
+
+    for task in rejected {
+        let comments = lookup.get_task_comments(&task.id)?;
+        let Some(owner_id) = covering_owner_from_comments(&task.id, &comments) else {
+            continue;
+        };
+        match lookup.get_task(&owner_id) {
+            Ok(owner) if is_open_status(owner.status) => {
+                return Ok(Some(DuplicateTaskMatch {
+                    task_id: owner.id.clone(),
+                    match_kind: "confirmed_duplicate",
+                    evidence: bounded_evidence(
+                        "rejected_duplicate_comment",
+                        &[
+                            CoverageAnchor::new("rejected_task_id", task.id.as_str()),
+                            CoverageAnchor::new("covering_task_id", owner.id.as_str()),
+                            CoverageAnchor::new("dedupe_tag", &candidate.exact_tag),
+                        ],
+                    ),
+                }));
+            }
+            Ok(_) => continue,
+            Err(error) if is_task_not_found(&error) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(None)
+}
+
+fn covering_owner_from_comments(rejected_id: &str, comments: &[TaskComment]) -> Option<String> {
+    let mut owner = None;
+    for comment in comments {
+        if let Some(found) = covering_owner_from_message(rejected_id, &comment.message) {
+            owner = Some(found);
+        }
+    }
+    owner
+}
+
+fn covering_owner_from_message(rejected_id: &str, message: &str) -> Option<String> {
+    let lowered = message.to_ascii_lowercase();
+    let mut owner = None;
+    for marker in COVERING_OWNER_MARKERS {
+        let mut from = 0;
+        while let Some(pos) = lowered[from..].find(marker) {
+            let after = from + pos + marker.len();
+            if let Some(id) = first_task_id_in(&message[after..])
+                && id != rejected_id
+            {
+                owner = Some(id);
+            }
+            from = after;
+        }
+    }
+    owner
+}
+
+fn first_task_id_in(text: &str) -> Option<String> {
+    let mut current = String::new();
+    for character in text.chars() {
+        if character.is_ascii_alphanumeric() || character == '-' {
+            current.push(character);
+            continue;
+        }
+        if let Some(id) = take_task_id(&mut current) {
+            return Some(id);
+        }
+    }
+    take_task_id(&mut current)
+}
+
+fn take_task_id(current: &mut String) -> Option<String> {
+    let candidate = std::mem::take(current);
+    is_valid_orb_task_id(&candidate).then_some(candidate)
+}
+
+fn is_task_not_found(error: &OrbitError) -> bool {
+    matches!(
+        error,
+        OrbitError::NotFound {
+            kind: NotFoundKind::Task,
+            ..
+        }
+    )
 }
 
 fn validate_candidate(candidate: &DuplicateCandidate) -> Result<(), OrbitError> {
@@ -235,12 +363,40 @@ pub(in crate::adapter::engine_host::v2_host) fn is_open_status(status: TaskStatu
 
 #[cfg(test)]
 mod tests {
-    use super::canonical_text;
+    use super::{canonical_text, covering_owner_from_message};
 
     #[test]
     fn canonical_text_preserves_token_boundaries() {
         let searchable = canonical_text("Update runtime in Cargo.lock");
         assert!(!searchable.contains(&canonical_text("time")));
         assert!(searchable.contains(&canonical_text("runtime")));
+    }
+
+    #[test]
+    fn covering_owner_parses_duplicate_and_covering_phrases() {
+        assert_eq!(
+            covering_owner_from_message(
+                "ORB-11513",
+                "Duplicate of active ORB-11511: both cite Wrangler 4.129.0.",
+            )
+            .as_deref(),
+            Some("ORB-11511")
+        );
+        assert_eq!(
+            covering_owner_from_message(
+                "ORB-11526",
+                "Covering implementation is active ORB-11511 (same Wrangler missing-name error).",
+            )
+            .as_deref(),
+            Some("ORB-11511")
+        );
+        assert_eq!(
+            covering_owner_from_message("ORB-11513", "Won't fix; infrastructure flake."),
+            None
+        );
+        assert_eq!(
+            covering_owner_from_message("ORB-11513", "Duplicate of active ORB-11513 itself."),
+            None
+        );
     }
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -1432,7 +1432,7 @@ fn orb_11498_style_golden_log(failing: &str) -> String {
 
 /// ORB-11513: Wrangler colored `[ERROR]` plus the missing-field diagnostic,
 /// then GitHub's generic `The process 'npx' failed with exit code`.
-fn orb_11513_style_wrangler_log(title: &str, detail: &str) -> String {
+pub(super) fn orb_11513_style_wrangler_log(title: &str, detail: &str) -> String {
     let job = "Publish to Cloudflare Pages";
     let step = "Deploy static site";
     let prefix = |payload: &str| github_line(job, step, payload);
@@ -1443,10 +1443,15 @@ fn orb_11513_style_wrangler_log(title: &str, detail: &str) -> String {
     out.push_str(&prefix(
         "##[group]Run cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0",
     ));
+    out.push_str(&prefix("[command]/usr/local/bin/npm i wrangler@4.129.0"));
+    out.push_str(&prefix(
+        "[command]/usr/local/bin/npx --no-install wrangler --version",
+    ));
+    out.push_str(&prefix(
+        "[command]/usr/local/bin/npx wrangler pages deploy dist --project-name=orbit-website --branch=main --commit-hash=a93caa13890764380e184d996fa709b1bcbe278c",
+    ));
     out.push_str(&prefix(&wrangler_error));
-    out.push_str(&prefix(&format!(
-        "    - Missing top-level field \"name\" in configuration file. {detail}"
-    )));
+    out.push_str(&prefix(&format!("    - {detail}")));
     out.push_str(&prefix(
         "##[error]The process '/usr/local/bin/npx' failed with exit code 1",
     ));
@@ -1695,7 +1700,7 @@ fn wrangler_error_outranks_generic_npx_process_failed() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let missing_name = orb_11513_style_wrangler_log(
         "Running configuration file validation for Pages",
-        "Pages requires the name of your project.",
+        "Missing top-level field \"name\" in configuration file.",
     );
     let missing_pages = orb_11513_style_wrangler_log(
         "Failed to publish your Function",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/sweep_duplicate_tasks.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 use orbit_common::OrbitError;
 use orbit_engine::RuntimeHost;
 use orbit_tools::ToolContext;
-use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use orbit_types::task::{Task, TaskComment, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
@@ -13,9 +13,11 @@ use crate::adapter::engine_host::v2_host::ci_failure_tasks::file_ci_failure_task
 use crate::adapter::engine_host::v2_host::dependabot_alert_tasks::file_dependabot_alert_tasks_with_lookup;
 use crate::adapter::engine_host::v2_host::duplicate_tasks::DuplicateTaskLookup;
 use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
-use crate::application::task::TaskAddParams;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
 
-use super::ci_failure_tasks::{failure, filed_task_ids, snapshot as ci_snapshot};
+use super::ci_failure_tasks::{
+    failure, filed_task_ids, orb_11513_style_wrangler_log, snapshot as ci_snapshot,
+};
 use super::dependabot_alert_tasks::{
     alert, code_alert, expanded_snapshot, file as file_security, snapshot as security_snapshot,
 };
@@ -89,6 +91,14 @@ impl DuplicateTaskLookup for FailingBroadLookup<'_> {
     fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         Err(injected_lookup_error())
     }
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.runtime.get_task(task_id)
+    }
+
+    fn get_task_comments(&self, task_id: &str) -> Result<Vec<TaskComment>, OrbitError> {
+        self.runtime.get_task_comments(task_id)
+    }
 }
 
 struct FailingSecondBroadLookup<'a> {
@@ -109,6 +119,36 @@ impl DuplicateTaskLookup for FailingSecondBroadLookup<'_> {
         } else {
             Err(injected_lookup_error())
         }
+    }
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.runtime.get_task(task_id)
+    }
+
+    fn get_task_comments(&self, task_id: &str) -> Result<Vec<TaskComment>, OrbitError> {
+        self.runtime.get_task_comments(task_id)
+    }
+}
+
+struct FailingCommentsLookup<'a> {
+    runtime: &'a OrbitRuntime,
+}
+
+impl DuplicateTaskLookup for FailingCommentsLookup<'_> {
+    fn list_tasks_by_tags(&self, tags: &[String]) -> Result<Vec<Task>, OrbitError> {
+        self.runtime.list_tasks_by_tags(tags)
+    }
+
+    fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
+        self.runtime.list_tasks()
+    }
+
+    fn get_task(&self, task_id: &str) -> Result<Task, OrbitError> {
+        self.runtime.get_task(task_id)
+    }
+
+    fn get_task_comments(&self, _task_id: &str) -> Result<Vec<TaskComment>, OrbitError> {
+        Err(injected_lookup_error())
     }
 }
 
@@ -461,4 +501,240 @@ fn manual_repairs_dedupe_complete_findings_while_gaps_stay_visible() {
         json!(33_900_000_001_u64),
         "the starved candidate is still owed: {output}"
     );
+}
+
+/// Natural prose from the live ORB-11511 brief: specific Wrangler diagnostic,
+/// deploy command, commit, and config path, without generated CI labels.
+fn orb_11511_manual_brief() -> &'static str {
+    "The user reports website publication failing on 2026-09-07 for commit \
+     a93caa13890764380e184d996fa709b1bcbe278c. \
+     cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 installs \
+     Wrangler 4.129.0 and runs `wrangler pages deploy dist \
+     --project-name=orbit-website --branch=main \
+     --commit-hash=a93caa13890764380e184d996fa709b1bcbe278c`. It exits 1 during \
+     Pages configuration validation: `Missing top-level field \"name\" in \
+     configuration file.` No CI run URL was supplied. Local source inspection \
+     confirms website/wrangler.toml contains only compatibility_date and \
+     pages_build_output_dir."
+}
+
+fn website_wrangler_log() -> String {
+    orb_11513_style_wrangler_log(
+        "Running configuration file validation for Pages",
+        "Missing top-level field \"name\" in configuration file.",
+    )
+}
+
+fn website_wrangler_evidence() -> Value {
+    ci_snapshot(vec![failure(
+        10,
+        "Website",
+        "Publish to Cloudflare Pages",
+        "Deploy static site",
+        &website_wrangler_log(),
+        "a93caa13890764380e184d996fa709b1bcbe278c",
+    )])
+}
+
+#[test]
+fn manual_wrangler_brief_covers_the_same_incident_without_generated_labels_or_tag_mutation() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let task_id = seed_manual_task(
+        &runtime,
+        "Fix website Pages deployment failing on missing Wrangler project name",
+        orb_11511_manual_brief(),
+        TaskStatus::InProgress,
+    );
+    let before = runtime.get_task(&task_id).expect("covering task");
+    assert!(
+        !before
+            .description
+            .to_ascii_lowercase()
+            .contains("failing job")
+            && !before
+                .description
+                .to_ascii_lowercase()
+                .contains("failing step"),
+        "fixture must stay natural prose"
+    );
+    assert!(before.tags.is_empty(), "covering task must stay untagged");
+
+    let output = file_ci(&runtime, website_wrangler_evidence());
+
+    assert_eq!(output["filed_count"], json!(0), "{output}");
+    assert_eq!(output["skipped_existing"][0]["task_id"], task_id);
+    assert_eq!(
+        output["skipped_existing"][0]["match_kind"],
+        "material_coverage"
+    );
+    assert_eq!(
+        output["skipped_existing"][0]["match_evidence"]["fingerprint"],
+        "ci_failure_error_and_command"
+    );
+    let after = runtime
+        .get_task(&task_id)
+        .expect("covering task after sweep");
+    assert_eq!(after.tags, before.tags);
+    assert_eq!(after.description, before.description);
+    assert_eq!(after.title, before.title);
+}
+
+#[test]
+fn shared_workflow_generic_npx_or_same_file_do_not_suppress_unrelated_failures() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    seed_manual_task(
+        &runtime,
+        "Website workflow failed because npx exited 1",
+        "The Website workflow's Publish job failed when npx exited 1. \
+         website/wrangler.toml is the Pages config and should be inspected, \
+         but this brief does not quote a missing name field or the deploy command.",
+        TaskStatus::Backlog,
+    );
+
+    let output = file_ci(&runtime, website_wrangler_evidence());
+
+    assert_eq!(output["filed_count"], json!(1), "{output}");
+    assert_eq!(output["skipped_existing"], json!([]));
+}
+
+#[test]
+fn a_done_manual_repair_does_not_hide_a_later_recurrence() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    seed_manual_task(
+        &runtime,
+        "Fix website Pages deployment failing on missing Wrangler project name",
+        orb_11511_manual_brief(),
+        TaskStatus::Done,
+    );
+
+    let output = file_ci(&runtime, website_wrangler_evidence());
+
+    assert_eq!(output["filed_count"], json!(1), "{output}");
+    assert_eq!(output["skipped_existing"], json!([]));
+}
+
+#[test]
+fn rejected_exact_key_comment_reuses_one_open_covering_owner() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let owner_id = seed_manual_task(
+        &runtime,
+        "Fix website Pages deployment failing on missing Wrangler project name",
+        "Repair the Pages project name. This brief deliberately omits the \
+         Wrangler diagnostic and deploy command so coverage must come from \
+         the rejected duplicate comment.",
+        TaskStatus::InProgress,
+    );
+    let first = file_ci(&runtime, website_wrangler_evidence());
+    assert_eq!(first["filed_count"], json!(1), "{first}");
+    let filed_id = filed_task_ids(&first).remove(0);
+    runtime
+        .update_task(
+            &filed_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Rejected),
+                comment: Some(format!(
+                    "Duplicate of active {owner_id}: both cite the same Website Pages failure."
+                )),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("reject as duplicate");
+
+    let output = file_ci(&runtime, website_wrangler_evidence());
+
+    assert_eq!(output["filed_count"], json!(0), "{output}");
+    assert_eq!(output["skipped_existing"][0]["task_id"], owner_id);
+    assert_eq!(
+        output["skipped_existing"][0]["match_kind"],
+        "confirmed_duplicate"
+    );
+    assert_eq!(
+        output["skipped_existing"][0]["match_evidence"]["fingerprint"],
+        "rejected_duplicate_comment"
+    );
+    let owner = runtime.get_task(&owner_id).expect("covering owner");
+    assert!(
+        owner.tags.is_empty(),
+        "confirmed duplicate must not tag the owner"
+    );
+}
+
+#[test]
+fn rejected_exact_key_without_covering_owner_or_with_done_owner_stays_visible() {
+    for (comment, owner_status) in [
+        (
+            Some("Won't fix; this is an infrastructure flake.".to_string()),
+            None,
+        ),
+        (
+            Some("Duplicate of active {owner}: preserve the rejected evidence.".to_string()),
+            Some(TaskStatus::Done),
+        ),
+    ] {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let comment = match owner_status {
+            Some(status) => {
+                let owner_id = seed_manual_task(
+                    &runtime,
+                    "Fix website Pages deployment failing on missing Wrangler project name",
+                    "Repair the Pages project name without quoting the diagnostic.",
+                    status,
+                );
+                comment.map(|template| template.replace("{owner}", &owner_id))
+            }
+            None => comment,
+        };
+        let first = file_ci(&runtime, website_wrangler_evidence());
+        assert_eq!(first["filed_count"], json!(1), "{first}");
+        let filed_id = filed_task_ids(&first).remove(0);
+        runtime
+            .update_task(
+                &filed_id,
+                TaskUpdateParams {
+                    status: Some(TaskStatus::Rejected),
+                    comment,
+                    ..TaskUpdateParams::default()
+                },
+            )
+            .expect("reject filed task");
+
+        let output = file_ci(&runtime, website_wrangler_evidence());
+        assert_eq!(
+            output["filed_count"],
+            json!(1),
+            "closed or unlinked rejected history must not suppress: {output}"
+        );
+    }
+}
+
+#[test]
+fn confirmed_duplicate_comment_lookup_failure_is_redacted_retryable_and_writes_nothing() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let first = file_ci(&runtime, website_wrangler_evidence());
+    let filed_id = filed_task_ids(&first).remove(0);
+    runtime
+        .update_task(
+            &filed_id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::Rejected),
+                comment: Some(
+                    "Duplicate of active ORB-11511: retain provenance until lookup works."
+                        .to_string(),
+                ),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("reject filed task");
+    let before = runtime.list_tasks().expect("list tasks").len();
+
+    let error = file_ci_failure_tasks_with_lookup(
+        &runtime,
+        &json!({"ci_evidence": website_wrangler_evidence()}),
+        &FailingCommentsLookup { runtime: &runtime },
+    )
+    .expect_err("comment lookup failure must fail closed")
+    .to_string();
+
+    assert_retryable_redacted_lookup_error(&error);
+    assert_eq!(runtime.list_tasks().expect("list tasks").len(), before);
 }

--- a/plugin/skills/orbit/references/setup/automation.md
+++ b/plugin/skills/orbit/references/setup/automation.md
@@ -189,11 +189,16 @@ Secret values must not be copied into task prose or logs.
 
 A missing GitHub client, authentication, or API permission is a capability gap,
 not evidence of a clean repository. Read the collect/file step outcomes. CI
-failure-key dedupe and security alert identity suppress already-covered work;
-they do not promise general semantic duplicate detection. Discovery and filing
-errors must remain visible and retryable. A previous done repair is evidence to
-inspect, not blanket dedupe: an old failed release already fixed on the current
-integration branch stays proposed as already-landed, while a distinct defect
-that still reproduces at the current revision remains eligible. Choose these
-routines independently of `ship-sweep`; admission to backlog does not authorize
-implementation or completion.
+filing first reuses a still-open `ci-failure:<key>` owner, then a rejected
+exact-key task whose comment names one still-open covering owner, then a
+high-confidence material match (generated workflow/job/step labels, or a
+specific error together with the failing command or the same run and job).
+That is not fuzzy title similarity: a shared workflow, generic npx/cargo
+exit, or the same affected file is not enough, and a closed historical task
+does not suppress a later recurrence. Discovery, filing, and dedupe-lookup
+errors must remain visible and retryable. A previous done repair is evidence
+to inspect, not blanket dedupe: an old failed release already fixed on the
+current integration branch stays proposed as already-landed, while a distinct
+defect that still reproduces at the current revision remains eligible. Choose
+these routines independently of `ship-sweep`; admission to backlog does not
+authorize implementation or completion.


### PR DESCRIPTION
## Task

[ORB-11527](https://orbit-cli.com/tasks/ORB-11527) — Recognize manually authored covering repairs in CI sweep deduplication

### Description

Live recurrence: ORB-11511 manually describes Wrangler 4.129.0 Missing top-level field name, exact deploy command, a93caa1389 commit and website/wrangler.toml. It is actively executing/reviewing. ORB-11513 was the same failure (run 34081972666/job101830137831), rejected with covering-task evidence; the 19:08 sweep immediately created ORB-11526 with the identical ci-failure:7e4317f4fb8ff0f9 tag. ORB-11526 is held blocked as one open evidence owner. Current FailureCluster::duplicate_candidate requires literal anchors 'workflow Website', 'failing job Publish to Cloudflare Pages', 'failing step Deploy static site', plus the generic signature; manual briefs do not use those labels. find_covering_task ignores rejected history and reads no duplicate comment linkage. Prior ORB-11189 is done but this supported manual-task case remains missed.

Repair the existing CI coverage seam with conservative, concrete matching evidence for manually authored repairs, and a supported durable way to retain confirmed duplicate ownership where necessary. Avoid fuzzy title similarity or suppressing future recurrences merely because a closed task once shared a generic key. Prove matching via specific error/affected target/command or source identity, report why a match holds, and keep unrelated failures separate. Never mutate a running task's meaning to force a match (review digests pin it). Coordinate after ORB-11519 to avoid filer edits colliding. Keep the smallest complete implementation, no second dedupe store or scheduler. Grok medium for bounded existing matching owner and incident fixtures; trace exact introducing history before assigning regression provenance.

### Acceptance Criteria

- Fixture reflecting ORB-11511's natural prose and same CI incident reuses covering work rather than creating ORB-11526, without requiring generated prose labels or tag mutation of the active task.
- Unrelated failures sharing workflow, generic npx exit, or same affected file do not get suppressed; real recurrence after a prior fix remains visible.
- Repeated evidence/confirmed duplicate handling retains explicit provenance and one actionable owner; lookup errors remain retryable.
- Existing duplicate/sweep tests, focused incident tests, make ci-fast and make ci-lint pass; docs match supported workflow.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Extended `find_covering_task` so an exact `ci-failure:<key>` miss can reuse one still-open owner named by a rejected exact-key duplicate/covering comment (`confirmed_duplicate`), with lookup errors remaining retryable and closed owners not suppressing recurrences.
- Added conservative CI material fingerprints: specific diagnostic + stabilized failing command, and run+job source identity. Generated workflow/job/step fingerprints remain. Generic npx/cargo wrappers, step-name fallbacks, and file/workflow-only matches are not coverage.
- Fixtures: ORB-11511 natural prose covers the Wrangler missing-name incident without generated labels or tag mutation; unrelated shared workflow/npx/file still files; done repairs and unlinked rejected history stay visible.
- Updated `file_ci_failure_tasks` contract and automation skill; synced plugin skill mirror. Regression provenance: ORB-11189.

Assessment: Smallest complete repair on the existing duplicate-task owner. Covering tasks are never rewritten.

Acceptance criteria:
- Manual ORB-11511-style prose + same Wrangler incident reuses the covering task (`material_coverage` / `ci_failure_error_and_command`); tags and prose unchanged. Passed.
- Shared workflow, generic npx exit, or same `website/wrangler.toml` without the diagnostic/command still files; a done covering task does not hide a later recurrence. Passed.
- Rejected exact-key comment names one open owner (`confirmed_duplicate` with rejected/covering/tag evidence); unlinked or done-owner history files again; comment lookup failure is redacted retryable and writes nothing. Passed.
- Existing duplicate/sweep and focused CI incident tests, `make ci-fast`, and `make ci-lint` passed; activity YAML and automation docs match the supported workflow.

Validation:
- `cargo test -p orbit-core --lib sweep_duplicate_tasks -- --test-threads=1`: passed (18 tests, including new incident/confirmed-duplicate cases).
- `cargo test -p orbit-core --lib ci_failure_tasks -- --test-threads=1`: passed (42 tests, including wrangler vs generic npx).
- `cargo test -p orbit-core --lib covering_owner_parses -- --test-threads=1`: passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.

Strategic decisions: Comment linkage stays on existing task comments (no second store). Command matching strips npx wrappers and `--commit-hash` so a manual brief can match without generated labels or volatile SHAs.
Remaining risks: Comment parsing is phrase-based (`duplicate of` / `covering …`); a covering note that never names a task ID still files. Live ORB-11526 disposition is operational, not part of this patch.
Deviations from original plan: none.
Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11527-6a9f15cd`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra