### PR TITLE
[code-review] Operation explain omits the active grant policy snapshot

### DIFF
--- a/crates/orbit-core/src/application/operation/explain.rs
+++ b/crates/orbit-core/src/application/operation/explain.rs
@@ -1,10 +1,13 @@
-//! The effective-policy explanation: every resolved field with its winning
-//! source, the authority actually in force, and each cap or limiting reason
-//! that reduces requested behavior [ORB-11332].
+//! The effective-policy explanation: current or preview preferences, the
+//! authority actually in force, and each cap or limiting reason that reduces
+//! requested behavior [ORB-11332].
 //!
-//! This is a read-only projection over configuration, the grant store, the
-//! live drain, and the workspace's routine definitions. It never schedules,
-//! promotes, or authorizes anything.
+//! Preferences (`[operation]`, plus an optional run-layer preview) describe
+//! what a *future* grant would capture. When an active grant exists, live
+//! delivery, preparation, recovery, review, caps, and limiting reasons are
+//! projected from that grant's captured policy, not from the current file.
+//! This is a read-only projection; it never schedules, promotes, or
+//! authorizes anything.
 
 use chrono::Utc;
 use orbit_automation::routines::loader::{RoutineSource, collect_routines};
@@ -14,30 +17,34 @@ use orbit_types::workflow::OperationAdmission;
 use orbit_types::workflow::automation::members::StateTriggerKind;
 use serde_json::{Value, json};
 
-use super::NO_GRANT_REASON;
+use super::{NO_GRANT_REASON, captured_policy};
 use crate::OrbitRuntime;
 
 impl OrbitRuntime {
-    /// Explain the effective operation policy, optionally with run-layer
-    /// overrides applied as a preview.
+    /// Explain operation preferences and live authority, optionally with
+    /// run-layer overrides applied as a preview of a future grant.
     pub fn explain_operation(
         &self,
         run_layer: Option<&OperationLayer>,
     ) -> Result<Value, OrbitError> {
-        let policy = match run_layer {
+        let preferences = match run_layer {
             Some(layer) => self.operation_policy().with_run_layer(layer),
             None => self.operation_policy().clone(),
         };
         let now = Utc::now();
         let hard_limit = self.leaf_run_hard_limit()?;
         let grant = self.active_operation_grant()?;
+        let active_policy = match &grant {
+            Some(grant) => captured_policy(grant)?,
+            None => preferences.clone(),
+        };
         let mut limiting_reasons = Vec::new();
 
-        let (effective_completion, cap_reason) = policy.capped_completion();
+        let (effective_completion, cap_reason) = active_policy.capped_completion();
         if let Some(reason) = cap_reason {
             limiting_reasons.push(reason.to_string());
         }
-        let leaf_cap = (policy.leaf_ceiling.value > hard_limit).then_some("job_hard_limit");
+        let leaf_cap = (active_policy.leaf_ceiling.value > hard_limit).then_some("job_hard_limit");
         if let Some(reason) = leaf_cap {
             limiting_reasons.push(reason.to_string());
         }
@@ -56,6 +63,7 @@ impl OrbitRuntime {
                     "revision": grant.revision,
                     "limits": grant.limits,
                     "policy_version": grant.policy_version,
+                    "policy": active_policy.explain(),
                     "actor": grant.actor,
                     "created_at": grant.created_at.to_rfc3339(),
                 })
@@ -77,7 +85,8 @@ impl OrbitRuntime {
             .filter(|(kind, _, _)| *kind == StateTriggerKind::ExecutionFailed)
             .map(|(_, name, enabled)| json!({ "routine": name, "enabled": enabled }))
             .collect::<Vec<_>>();
-        let preparation_reason = if policy.preparation.value == PreparationPreference::Automatic
+        let preparation_reason = if active_policy.preparation.value
+            == PreparationPreference::Automatic
             && !preparation_owners
                 .iter()
                 .any(|owner| owner["enabled"] == true)
@@ -87,7 +96,7 @@ impl OrbitRuntime {
         } else {
             None
         };
-        let recovery_reason = if policy.recovery.value == RecoveryPreference::Scheduled
+        let recovery_reason = if active_policy.recovery.value == RecoveryPreference::Scheduled
             && !triage_owners.iter().any(|owner| owner["enabled"] == true)
         {
             limiting_reasons.push("no_enabled_triage_routine".to_string());
@@ -97,8 +106,8 @@ impl OrbitRuntime {
         };
         // [ORB-11333] A before-PR gate needs an explicitly configured
         // reviewer crew; without one every gated delivery escalates.
-        let review_reason = (policy.review_policy.value == ReviewPolicy::BeforePr
-            && policy.review_crew.value.is_none())
+        let review_reason = (active_policy.review_policy.value == ReviewPolicy::BeforePr
+            && active_policy.review_crew.value.is_none())
         .then(|| {
             limiting_reasons.push("review_crew_unconfigured".to_string());
             "review_crew_unconfigured"
@@ -107,45 +116,46 @@ impl OrbitRuntime {
         let drain = self.explain_live_drain()?;
 
         Ok(json!({
-            "policy": policy.explain(),
+            "preview": run_layer.is_some(),
+            "policy": preferences.explain(),
             "authority": authority,
             "limits": {
                 "leaf_ceiling": {
-                    "preference": policy.leaf_ceiling.value,
+                    "preference": active_policy.leaf_ceiling.value,
                     "hard_limit": hard_limit,
-                    "effective": policy.leaf_ceiling.value.min(hard_limit),
+                    "effective": active_policy.leaf_ceiling.value.min(hard_limit),
                     "cap": leaf_cap,
                 },
                 "window_max_seconds": orbit_types::workflow::MAX_GRANT_WINDOW_SECONDS,
                 "scope_max_tasks": orbit_types::workflow::MAX_GRANT_SCOPE_TASKS,
             },
             "delivery": {
-                "completion_preference": policy.completion.value,
-                "delivery_cap": policy.delivery_cap.value,
+                "completion_preference": active_policy.completion.value,
+                "delivery_cap": active_policy.delivery_cap.value,
                 "effective_completion": effective_completion,
                 "cap": cap_reason,
                 "grant_complete_right": grant.as_ref().map(|grant| grant.rights.complete),
             },
             "preparation": {
-                "preference": policy.preparation.value,
-                "due_seconds": policy.preparation_due_seconds.value,
+                "preference": active_policy.preparation.value,
+                "due_seconds": active_policy.preparation_due_seconds.value,
                 "cadence_owners": preparation_owners,
                 "reason": preparation_reason,
             },
             "recovery": {
-                "preference": policy.recovery.value,
-                "episodes_per_task": policy.recovery_episodes_per_task.value,
-                "minutes_per_task": policy.recovery_minutes_per_task.value,
+                "preference": active_policy.recovery.value,
+                "episodes_per_task": active_policy.recovery_episodes_per_task.value,
+                "minutes_per_task": active_policy.recovery_minutes_per_task.value,
                 "triage_owners": triage_owners,
                 "reason": recovery_reason,
             },
             "review": {
-                "policy": policy.review_policy.value,
-                "policy_source": policy.review_policy.source.label(),
-                "gates_pr": policy.review_policy.value == ReviewPolicy::BeforePr,
-                "crew": policy.review_crew.value,
-                "crew_source": policy.review_crew.source.label(),
-                "budget": policy.review_budget(),
+                "policy": active_policy.review_policy.value,
+                "policy_source": active_policy.review_policy.source.label(),
+                "gates_pr": active_policy.review_policy.value == ReviewPolicy::BeforePr,
+                "crew": active_policy.review_crew.value,
+                "crew_source": active_policy.review_crew.source.label(),
+                "budget": active_policy.review_budget(),
                 "contract_version": orbit_types::workflow::REVIEW_CONTRACT_VERSION,
                 "reason": review_reason,
             },

--- a/crates/orbit-core/src/application/operation/tests/grant.rs
+++ b/crates/orbit-core/src/application/operation/tests/grant.rs
@@ -331,6 +331,7 @@ fn explanation_names_sources_authority_caps_and_limiting_reasons() {
     .expect("write routine");
 
     let explanation = runtime.explain_operation(None).expect("explain");
+    assert_eq!(explanation["preview"], false);
     assert_eq!(explanation["policy"]["preset"]["value"], "autonomous");
     assert_eq!(explanation["policy"]["preset"]["source"], "workspace");
     assert_eq!(
@@ -384,6 +385,7 @@ fn explanation_names_sources_authority_caps_and_limiting_reasons() {
             ..OperationLayer::default()
         }))
         .expect("preview");
+    assert_eq!(preview["preview"], true);
     assert_eq!(preview["policy"]["preset"]["source"], "run");
     assert_eq!(preview["policy"]["leaf_ceiling"]["value"], 5);
     assert_eq!(preview["policy"]["review_policy"]["value"], "before-pr");
@@ -403,9 +405,16 @@ fn explanation_names_sources_authority_caps_and_limiting_reasons() {
         ))
         .expect("enable");
     let explained = runtime.explain_operation(None).expect("explain with grant");
+    assert_eq!(explained["preview"], false);
     assert_eq!(explained["authority"]["grant_id"], grant.id);
     assert_eq!(explained["authority"]["admission"], "open");
     assert_eq!(explained["delivery"]["grant_complete_right"], false);
+    assert_eq!(
+        explained["authority"]["policy"]["review_policy"]["value"],
+        "none"
+    );
+    assert_eq!(explained["review"]["policy"], "none");
+    assert_eq!(explained["policy"]["review_policy"]["value"], "before-pr");
     assert!(
         !explained["limiting_reasons"]
             .as_array()
@@ -413,6 +422,114 @@ fn explanation_names_sources_authority_caps_and_limiting_reasons() {
             .iter()
             .any(|reason| reason == "scoped_authorization_required")
     );
+}
+
+/// [ORB-11507] Retuning `[operation]` after enablement must not rewrite the
+/// live grant projection; current preferences remain visible as future-grant
+/// defaults, including under a run-layer preview.
+#[test]
+fn explanation_keeps_captured_grant_policy_after_preference_retune() {
+    let fixture = fixture(AUTONOMOUS_DONE);
+    let runtime = &fixture.runtime;
+    let task = seed_task(runtime, "retuned", TaskStatus::Backlog);
+    let grant = runtime
+        .enable_operation_grant(enable(
+            std::slice::from_ref(&task.id),
+            3600,
+            rights(true, true, true),
+            OperationLayer::default(),
+        ))
+        .expect("enable");
+
+    std::fs::write(
+        runtime.shared_root().join("config.toml"),
+        "[operation]\npreset = \"supervised\"\nreview_policy = \"before-pr\"\nreview_crew = \"reviewers\"\n",
+    )
+    .expect("retune workspace operation preferences");
+    let retuned = crate::OrbitRuntime::from_roots(&runtime.global_root(), &runtime.shared_root())
+        .expect("reopen runtime on retuned config")
+        .with_automation_machine_identity(Some(super::MACHINE.to_string()));
+
+    let explained = retuned
+        .explain_operation(None)
+        .expect("explain after retune");
+    assert_eq!(explained["preview"], false);
+    assert_eq!(explained["authority"]["grant_id"], grant.id);
+    assert_eq!(explained["authority"]["admission"], "open");
+
+    assert_eq!(
+        explained["authority"]["policy"]["preset"]["value"],
+        "autonomous"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["completion"]["value"],
+        "done"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["delivery_cap"]["value"],
+        "done"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["preparation"]["value"],
+        "automatic"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["recovery"]["value"],
+        "scheduled"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["review_policy"]["value"],
+        "none"
+    );
+    assert_eq!(
+        explained["authority"]["policy"]["leaf_ceiling"]["value"],
+        10
+    );
+
+    assert_eq!(explained["delivery"]["completion_preference"], "done");
+    assert_eq!(explained["delivery"]["delivery_cap"], "done");
+    assert_eq!(explained["delivery"]["effective_completion"], "done");
+    assert_eq!(explained["delivery"]["cap"], serde_json::Value::Null);
+    assert_eq!(explained["delivery"]["grant_complete_right"], true);
+    assert_eq!(explained["preparation"]["preference"], "automatic");
+    assert_eq!(explained["recovery"]["preference"], "scheduled");
+    assert_eq!(explained["review"]["policy"], "none");
+    assert_eq!(explained["review"]["reason"], serde_json::Value::Null);
+    assert_eq!(explained["limits"]["leaf_ceiling"]["preference"], 10);
+    assert_eq!(
+        explained["preparation"]["reason"],
+        "no_enabled_preparation_routine"
+    );
+    assert_eq!(explained["recovery"]["reason"], "no_enabled_triage_routine");
+
+    assert_eq!(explained["policy"]["preset"]["value"], "supervised");
+    assert_eq!(explained["policy"]["completion"]["value"], "review");
+    assert_eq!(explained["policy"]["preparation"]["value"], "manual");
+    assert_eq!(explained["policy"]["recovery"]["value"], "existing");
+    assert_eq!(explained["policy"]["leaf_ceiling"]["value"], 5);
+    assert_eq!(explained["policy"]["review_policy"]["value"], "before-pr");
+    assert_eq!(explained["policy"]["review_crew"]["value"], "reviewers");
+    assert_eq!(explained["policy"]["delivery_cap"]["value"], "review");
+
+    let preview = retuned
+        .explain_operation(Some(&OperationLayer {
+            leaf_ceiling: Some(1),
+            review_policy: Some(ReviewPolicy::AfterLanding),
+            ..OperationLayer::default()
+        }))
+        .expect("preview must not rewrite live grant behavior");
+    assert_eq!(preview["preview"], true);
+    assert_eq!(preview["policy"]["leaf_ceiling"]["value"], 1);
+    assert_eq!(preview["policy"]["review_policy"]["value"], "after-landing");
+    assert_eq!(preview["authority"]["policy"]["leaf_ceiling"]["value"], 10);
+    assert_eq!(
+        preview["authority"]["policy"]["review_policy"]["value"],
+        "none"
+    );
+    assert_eq!(preview["limits"]["leaf_ceiling"]["preference"], 10);
+    assert_eq!(preview["review"]["policy"], "none");
+    assert_eq!(preview["delivery"]["effective_completion"], "done");
+    assert_eq!(preview["delivery"]["completion_preference"], "done");
 }
 
 /// [ORB-11333] `before-pr` is an ordinary captured review timing: enablement

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -579,10 +579,11 @@ function fetchAndRenderAutoDrain() {
 }
 
 // ORB-11332: operation mode. The panel projects `orbit operation explain`
-// (every resolved field with its winning source, the active grant, caps, and
-// limiting reasons) and offers the two governed grant controls. Enablement is
-// deliberately not a dashboard action: a grant names a finite task set and
-// explicit rights, which is an operator decision made from the CLI or MCP.
+// (current preferences, the captured grant policy when one is active, caps,
+// and limiting reasons) and offers the two governed grant controls.
+// Enablement is deliberately not a dashboard action: a grant names a finite
+// task set and explicit rights, which is an operator decision made from the
+// CLI or MCP.
 const OPERATION_MODE_CONTROLS = {
   stop: {
     label: "Stop grant",
@@ -601,6 +602,23 @@ function policyField(policy, name, label) {
   const value = entry.value ?? "—";
   const source = entry.source ? ` [${entry.source}]` : "";
   return field(label, `${value}${source}`);
+}
+
+function policyGrid(policy) {
+  return el("div", { class: "operation-grid" }, [
+    policyField(policy, "preset", "Preset"),
+    policyField(policy, "preparation", "Preparation"),
+    policyField(policy, "promotion", "Promotion"),
+    policyField(policy, "completion", "Completion"),
+    policyField(policy, "recovery", "Recovery"),
+    policyField(policy, "leaf_ceiling", "Leaf ceiling"),
+    policyField(policy, "review_policy", "Review policy"),
+    policyField(policy, "review_crew", "Review crew"),
+    policyField(policy, "review_reviewer_starts", "Reviewer starts / lineage"),
+    policyField(policy, "review_repair_cycles", "Repair cycles / lineage"),
+    policyField(policy, "review_minutes", "Review minutes / lineage"),
+    policyField(policy, "delivery_cap", "Delivery cap"),
+  ]);
 }
 
 function operationControlButton(payload, kind) {
@@ -656,30 +674,31 @@ function renderOperationMode(payload) {
   const policy = payload.policy || {};
   const authority = payload.authority || {};
   const delivery = payload.delivery || {};
-  body.append(
-    el("div", { class: "operation-grid" }, [
-      policyField(policy, "preset", "Preset"),
-      policyField(policy, "preparation", "Preparation"),
-      policyField(policy, "promotion", "Promotion"),
-      policyField(policy, "completion", "Completion"),
-      policyField(policy, "recovery", "Recovery"),
-      policyField(policy, "leaf_ceiling", "Leaf ceiling"),
-      policyField(policy, "review_policy", "Review policy"),
-      policyField(policy, "review_crew", "Review crew"),
-      policyField(policy, "review_reviewer_starts", "Reviewer starts / lineage"),
-      policyField(policy, "review_repair_cycles", "Repair cycles / lineage"),
-      policyField(policy, "review_minutes", "Review minutes / lineage"),
-      policyField(policy, "delivery_cap", "Delivery cap"),
-    ]),
-    el("div", { class: "operation-grid" }, [
-      field("Effective completion", `${delivery.effective_completion ?? "—"}${delivery.cap ? ` (cap: ${delivery.cap})` : ""}`),
-      field("Grant", authority.grant_id ?? "none"),
-      field("Admission", authority.admission ?? "none"),
-      field("Rights", Array.isArray(authority.rights) && authority.rights.length ? authority.rights.join(", ") : "—"),
-      field("Scope", Array.isArray(authority.task_ids) ? `${authority.task_ids.length} task(s)` : "—"),
-      field("Expires", authority.expires_at ? time(authority.expires_at) : "—"),
-    ]),
-  );
+  const grantPolicy = authority.policy;
+  if (grantPolicy) {
+    body.append(
+      el("p", {
+        class: "operation-control-note",
+        text: "Active grant policy (captured at enablement; retuning preferences does not change it).",
+      }),
+      policyGrid(grantPolicy),
+      el("p", {
+        class: "operation-control-note",
+        text: "Current preferences (apply to a future grant only).",
+      }),
+      policyGrid(policy),
+    );
+  } else {
+    body.appendChild(policyGrid(policy));
+  }
+  body.appendChild(el("div", { class: "operation-grid" }, [
+    field("Effective completion", `${delivery.effective_completion ?? "—"}${delivery.cap ? ` (cap: ${delivery.cap})` : ""}`),
+    field("Grant", authority.grant_id ?? "none"),
+    field("Admission", authority.admission ?? "none"),
+    field("Rights", Array.isArray(authority.rights) && authority.rights.length ? authority.rights.join(", ") : "—"),
+    field("Scope", Array.isArray(authority.task_ids) ? `${authority.task_ids.length} task(s)` : "—"),
+    field("Expires", authority.expires_at ? time(authority.expires_at) : "—"),
+  ]));
   const reasons = Array.isArray(payload.limiting_reasons) ? payload.limiting_reasons : [];
   body.appendChild(el("p", {
     class: "operation-control-note",

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2255,6 +2255,12 @@ fn dashboard_operation_mode_panel_is_explained_governed_and_guarded() {
         "the panel must state that preferences activate nothing and merge is never granted"
     );
     assert!(
+        operations.contains("Active grant policy (captured at enablement")
+            && operations.contains("Current preferences (apply to a future grant only).")
+            && operations.contains("const grantPolicy = authority.policy"),
+        "an active grant must show the captured policy separately from current preferences"
+    );
+    assert!(
         !operations.contains("/api/operation/enable"),
         "enablement stays a CLI/MCP operator decision"
     );
@@ -2290,8 +2296,8 @@ let confirmed = false;
 globalThis.window = { confirm: () => { confirmed = true; return true; }, location: new URL("http://dashboard.test/"), addEventListener: () => {}, localStorage: { getItem: () => null, setItem: () => {} } };
 const requests = [];
 const explanation = {
-  policy: { preset: { value: "autonomous", source: "workspace" }, leaf_ceiling: { value: 10, source: "preset:autonomous@workspace" }, preparation: { value: "automatic", source: "preset:autonomous@workspace" }, promotion: { value: "automatic", source: "preset:autonomous@workspace" }, completion: { value: "done", source: "preset:autonomous@workspace" }, recovery: { value: "scheduled", source: "preset:autonomous@workspace" }, review_policy: { value: "before-pr", source: "workspace" }, review_crew: { value: "reviewers", source: "workspace" }, review_reviewer_starts: { value: 2, source: "built-in" }, review_repair_cycles: { value: 2, source: "built-in" }, review_minutes: { value: 30, source: "built-in" }, delivery_cap: { value: "review", source: "built-in" } },
-  authority: { grant_id: "ogrant-1", status: "active", admission: "open", rights: ["prepare", "promote"], task_ids: ["ORB-1", "ORB-2"], expires_at: "2026-09-07T12:00:00Z", revision: 3 },
+  policy: { preset: { value: "supervised", source: "workspace" }, leaf_ceiling: { value: 5, source: "preset:supervised@workspace" }, preparation: { value: "manual", source: "preset:supervised@workspace" }, promotion: { value: "separate_approval", source: "preset:supervised@workspace" }, completion: { value: "review", source: "preset:supervised@workspace" }, recovery: { value: "existing", source: "preset:supervised@workspace" }, review_policy: { value: "after-landing", source: "workspace" }, review_crew: { value: "reviewers", source: "workspace" }, review_reviewer_starts: { value: 2, source: "built-in" }, review_repair_cycles: { value: 2, source: "built-in" }, review_minutes: { value: 30, source: "built-in" }, delivery_cap: { value: "done", source: "workspace" } },
+  authority: { grant_id: "ogrant-1", status: "active", admission: "open", rights: ["prepare", "promote"], task_ids: ["ORB-1", "ORB-2"], expires_at: "2026-09-07T12:00:00Z", revision: 3, policy: { preset: { value: "autonomous", source: "workspace" }, leaf_ceiling: { value: 10, source: "preset:autonomous@workspace" }, preparation: { value: "automatic", source: "preset:autonomous@workspace" }, promotion: { value: "automatic", source: "preset:autonomous@workspace" }, completion: { value: "done", source: "preset:autonomous@workspace" }, recovery: { value: "scheduled", source: "preset:autonomous@workspace" }, review_policy: { value: "before-pr", source: "workspace" }, review_crew: { value: "reviewers", source: "workspace" }, review_reviewer_starts: { value: 2, source: "built-in" }, review_repair_cycles: { value: 2, source: "built-in" }, review_minutes: { value: 30, source: "built-in" }, delivery_cap: { value: "review", source: "built-in" } } },
   delivery: { effective_completion: "review", cap: "delivery_cap_review" },
   limiting_reasons: ["delivery_cap_review"],
   controls_authorized: true,
@@ -2311,7 +2317,7 @@ initOperations({ getWorkspaces: () => [{ id: "one", name: "one", status: "active
 await fetchAndRenderOperationMode();
 const body = get("operation-mode-body");
 const text = body.textContent;
-for (const expected of ["autonomous [workspace]", "10 [preset:autonomous@workspace]", "before-pr [workspace]", "reviewers [workspace]", "Reviewer starts / lineage", "2 [built-in]", "30 [built-in]", "review (cap: delivery_cap_review)", "ogrant-1", "Limiting reasons: delivery_cap_review", "prepare, promote", "2 task(s)"]) {
+for (const expected of ["Active grant policy (captured at enablement", "Current preferences (apply to a future grant only).", "autonomous [workspace]", "10 [preset:autonomous@workspace]", "before-pr [workspace]", "supervised [workspace]", "5 [preset:supervised@workspace]", "after-landing [workspace]", "reviewers [workspace]", "Reviewer starts / lineage", "2 [built-in]", "30 [built-in]", "review (cap: delivery_cap_review)", "ogrant-1", "Limiting reasons: delivery_cap_review", "prepare, promote", "2 task(s)"]) {
   if (!text.includes(expected)) throw new Error(`panel is missing ${JSON.stringify(expected)} in: ${text}`);
 }
 if (!get("operation-mode-count").textContent.includes("open")) throw new Error("count must show the grant admission");

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -53,7 +53,11 @@ keys and out-of-range values fail config load.
 provenance; a preset-managed key reset by a workspace preset shows `null`
 with a `built-in` source because no explicit value survived. The *effective*
 values and their winning source (`workspace`, `global`, `preset:autonomous@workspace`,
-`run`) come from `orbit operation explain`.
+`run`) come from `orbit operation explain`. That explanation keeps current
+(or preview) preferences distinct from an active grant's captured policy:
+delivery, preparation, recovery, review, caps, and limiting reasons that
+describe live authority are projected from the grant snapshot. Preference
+edits and `--preset` previews apply to a future grant only.
 
 `before-pr` holds PR creation for a fresh reviewer (§10, [ORB-11333]); it
 needs an explicit `review_crew`, and the explanation reports
@@ -185,8 +189,9 @@ a preference has no owner to act through.
   reasons (`outside_grant_scope`, `grant_*`) reflect a live grant-bound drain.
 - Dashboard: the Operations → Auto-drain view has an **Operation Mode** panel
   showing every field with its source, the grant, caps, limiting reasons,
-  and governed Stop/Revoke controls with compare-and-set. Enablement is
-  deliberately CLI/MCP only.
+  and governed Stop/Revoke controls with compare-and-set. When a grant is
+  active the panel shows the captured grant policy separately from current
+  preferences (future grants). Enablement is deliberately CLI/MCP only.
 - Audit: `operation.grant` (enabled/stopped/revoked/rejected),
   `operation.promotion`, `operation.recovery`, `operation.completion`,
   plus the existing `pipeline.invoke` and admissions-stop rows. Run inputs
@@ -339,7 +344,9 @@ observed; a certificate that arrives later does not rewrite pending debt.
 
 `orbit operation explain` and the dashboard operation panel show the review
 policy, crew, and budgets with their sources and report
-`review_crew_unconfigured`. `orbit task show --json`, the task API, and the
+`review_crew_unconfigured`. With an active grant those live fields come from
+the captured snapshot; current or preview preferences remain visible as the
+next grant's defaults. `orbit task show --json`, the task API, and the
 task detail view carry a `review` block: verdict, assurance, reviewer
 (including `same_model_as_implementer`), base/reviewed/final candidate,
 implementation and repair commits, findings, validation, consumed and


### PR DESCRIPTION
## Task

[ORB-11507](https://orbit-cli.com/tasks/ORB-11507) — [code-review] Operation explain omits the active grant policy snapshot

### Description

## Problem

`orbit operation explain` combines the workspace current preferences with an active grant, but it never projects the versioned policy that the grant captured at enablement. After an operator retunes `[operation]`, the explanation and dashboard report the new completion, preparation, recovery, review, caps, and limiting reasons beside the old active grant even though runtime enforcement continues using the grant snapshot. That makes the effective-policy diagnostic misleading exactly when operators need to understand what an existing drain can do.

## Live-code evidence

- `crates/orbit-core/src/application/operation/explain.rs:27` resolves `policy` exclusively from current configuration (plus an optional preview layer).
- `crates/orbit-core/src/application/operation/explain.rs:45` renders grant identity, rights, limits, and version, but omits `grant.policy`; lines 105-145 derive all policy sections and limiting reasons from the current/preview policy.
- `crates/orbit-core/src/application/operation/mod.rs:92` establishes that privileged execution must use the captured policy rather than reinterpret current configuration; `crates/orbit-core/src/application/operation/admission.rs:81` does so when starting a drain.
- `crates/orbit-types/src/workflow/operation.rs:186` says the captured per-field provenance is persisted so later diagnostics can explain what applied.
- `docs/design/operation-mode/5_operations.md:114` documents that preference changes affect future grants only.

The active grant remains safely enforced, so this is an observability/control-plane correctness defect rather than an authority bypass.

### Acceptance Criteria

- When an active grant exists, operation explain exposes the grant's captured policy and clearly distinguishes it from current or preview preferences.
- Delivery, preparation, recovery, review, cap, and limiting-reason projections that describe active authority are derived from the captured grant policy; preview-only output cannot be mistaken for live grant behavior.
- A regression test enables a grant, changes the configured operation preferences, and proves the explanation still reports both the live grant behavior and the distinct future-grant preferences accurately.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `explain_operation` now keeps current/preview preferences in `policy` (with `preview: true` when a run layer is supplied) and, when an active grant exists, exposes the captured snapshot as `authority.policy` via `captured_policy` (fail closed on version/shape mismatch).
- Delivery, preparation, recovery, review, preference-derived leaf caps, and policy-based limiting reasons are projected from that captured grant policy; without a grant they still follow current/preview preferences.
- Dashboard Operation Mode panel renders labeled grant-policy vs future-grant preference grids when `authority.policy` is present.
- Ops design doc records that live authority fields come from the grant snapshot.
- Regression: enable a grant, retune `[operation]`, reopen the runtime, and assert live grant behavior plus distinct future-grant/preview preferences.
Assessment: The diagnostic now matches runtime enforcement. Additive JSON (`preview`, `authority.policy`); `policy` remains current/preview preferences.

Acceptance criteria:
1. Grant captured policy exposed and distinct from current/preview preferences — met (`authority.policy` vs `policy`, dashboard labels).
2. Live delivery/preparation/recovery/review/cap/limiting-reason projections use the grant snapshot; preview cannot be mistaken for live grant behavior — met (`preview` flag; live sections ignore run-layer overlay when a grant is active).
3. Regression test enables, retunes config, and checks both projections — met (`explanation_keeps_captured_grant_policy_after_preference_retune`).

Validation:
- `cargo test -p orbit-core --lib application::operation::tests::grant` — passed (7 tests)
- `cargo test -p orbit-web --lib dashboard_operation_mode` — passed (2 tests)
- `cargo test -p orbit-web --lib api::tests::operation` — passed (3 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Remaining risks:
- An unreadable grant snapshot now fails explain instead of silently falling back to current config (same fail-closed rule as privileged execution).
- Browser UI not exercised; dashboard coverage is the existing JS harness plus source-contract tests.

Deviations from original plan: none. Files left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11507-6a9f1797`
- Behind base: 0
- Ahead of base: 1