### PR TITLE
[code-review] Epic review gate looks up the stable worktree ID instead of its admitted run

### DIFF
--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -43,6 +43,10 @@ spec:
       default_input:
         task_ids:
           - "{{ input.epic_task_id }}"
+        # Stable checkout token only. Dispatcher still injects the admitted
+        # job as `job_run_id`; setup stamps tasks and returns that run so
+        # the review gate and later delivery steps look up the captured
+        # policy, not this worktree identity [ORB-11520].
         run_id: "epic-{{ input.epic_task_id }}"
         branch_prefix: epic
         base: "{{ steps.resolve_ship_input.output.base_branch }}"
@@ -164,10 +168,12 @@ spec:
         commits_behind: "{{ steps.prepare_branch.output.commits_behind }}"
         sync_required: "{{ steps.prepare_branch.output.sync_required }}"
 
-    # ORB-11333: the before-PR review gate examines the epic's final combined
-    # diff after base synchronization and before publication. Both gate steps
-    # always run; the local route and no-diff outcomes report `applies: false`
-    # or refuse, and a non-pass verdict stops delivery without a PR.
+    # ORB-11333 / ORB-11520: the before-PR review gate examines the epic's
+    # final combined diff after base synchronization and before publication.
+    # `job_run_id` is the admitted job (setup output), not the epic worktree
+    # token. Both gate steps always run; the local route and no-diff outcomes
+    # report `applies: false` or refuse, and a non-pass verdict stops delivery
+    # without a PR.
     - id: review_gate_admit
       target: activity:review_gate_admit
       default_input:

--- a/crates/orbit-core/assets/activities/worktree_setup.yaml
+++ b/crates/orbit-core/assets/activities/worktree_setup.yaml
@@ -19,6 +19,14 @@ spec:
           type: string
       run_id:
         type: string
+        description: >
+          Worktree identity token. Epic pipelines pin `epic-<task-id>` so the
+          checkout is stable across runs. Distinct from the admitted job.
+      job_run_id:
+        type: string
+        description: >
+          Admitted job that owns task stamps and downstream execution. The
+          dispatcher injects this when `run_id` is already an identity token.
       base:
         type: string
       base_branch:

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -43,6 +43,10 @@ spec:
       default_input:
         task_ids:
           - "{{ input.epic_task_id }}"
+        # Stable checkout token only. Dispatcher still injects the admitted
+        # job as `job_run_id`; setup stamps tasks and returns that run so
+        # the review gate and later delivery steps look up the captured
+        # policy, not this worktree identity [ORB-11520].
         run_id: "epic-{{ input.epic_task_id }}"
         branch_prefix: epic
         base: "{{ steps.resolve_ship_input.output.base_branch }}"
@@ -164,10 +168,12 @@ spec:
         commits_behind: "{{ steps.prepare_branch.output.commits_behind }}"
         sync_required: "{{ steps.prepare_branch.output.sync_required }}"
 
-    # ORB-11333: the before-PR review gate examines the epic's final combined
-    # diff after base synchronization and before publication. Both gate steps
-    # always run; the local route and no-diff outcomes report `applies: false`
-    # or refuse, and a non-pass verdict stops delivery without a PR.
+    # ORB-11333 / ORB-11520: the before-PR review gate examines the epic's
+    # final combined diff after base synchronization and before publication.
+    # `job_run_id` is the admitted job (setup output), not the epic worktree
+    # token. Both gate steps always run; the local route and no-diff outcomes
+    # report `applies: false` or refuse, and a non-pass verdict stops delivery
+    # without a PR.
     - id: review_gate_admit
       target: activity:review_gate_admit
       default_input:

--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 mod completion;
+mod epic_review_gate;
 mod review_gate;
 
 use chrono::Utc;
@@ -919,14 +920,21 @@ impl RuntimeHost for ScriptedEpicHost<'_> {
                 "mode": self.ship_mode,
                 "base_branch": "agent-main",
             })),
-            "worktree_setup" => Ok(json!({
-                "job_run_id": "epic-ORB-EPIC",
-                "batch_id": "epic-ORB-EPIC",
-                "workspace_path": self.runtime.paths().repo_root,
-                "head_ref": "epic/ORB-EPIC",
-                "base_ref": "origin/agent-main",
-                "base_sha": "1111111111111111111111111111111111111111",
-            })),
+            "worktree_setup" => {
+                let job_run_id = input
+                    .get("job_run_id")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("epic-ORB-EPIC");
+                Ok(json!({
+                    "job_run_id": job_run_id,
+                    "batch_id": job_run_id,
+                    "workspace_path": self.runtime.paths().repo_root,
+                    "head_ref": "epic/ORB-EPIC",
+                    "base_ref": "origin/agent-main",
+                    "base_sha": "1111111111111111111111111111111111111111",
+                }))
+            }
             "list_epic_descendants" => {
                 let descendant_ids = self.current_descendants();
                 let empty = descendant_ids.is_empty();

--- a/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
@@ -1,12 +1,11 @@
-//! The real `task_pr_pipeline` with the before-PR review gate [ORB-11333].
+//! The real `epic_pipeline` before-PR review gate [ORB-11520].
 //!
-//! Git mechanics that reach a remote are scripted; the review gate actions,
-//! the failure handoff, and the task/run records are real. The reviewer
-//! agent is replaced by a deterministic stub that persists the same report
-//! artifact the reviewer tool would. Epic-pipeline coverage lives in the
-//! sibling `epic_review_gate` module.
+//! Git mechanics that reach a remote are scripted; the review gate actions
+//! and the task/run records are real. The reviewer agent is replaced by a
+//! deterministic stub that persists the same report artifact the reviewer
+//! tool would.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
@@ -19,6 +18,9 @@ use orbit_types::workflow::{
 };
 use serde_json::{Value, json};
 
+use super::review_gate::{
+    GATED_CONFIG, ReviewerScript, git_stdout, positions, stub_agent_activity,
+};
 use super::{
     git_in, resolved_job, retarget_engine_actions_for_scripted_host, seed_default_catalogs,
     test_runtime_with_workspace_config, try_execute_job,
@@ -27,36 +29,7 @@ use crate::OrbitRuntime;
 use crate::application::review::install_review_admission;
 use crate::application::task::{TaskAddParams, TaskUpdateParams};
 
-pub(super) const GATED_CONFIG: &str = r#"
-[crews.implementer]
-model = "impl-model"
-provider = "codex"
-backend = "cli"
-
-[crews.reviewers]
-model = "review-model"
-provider = "codex"
-backend = "cli"
-
-[workflow]
-default_crew = "implementer"
-
-[operation]
-review_policy = "before-pr"
-review_crew = "reviewers"
-"#;
-
-pub(super) fn stub_agent_activity(global_root: &Path, name: &str, action: &str) {
-    std::fs::write(
-        global_root.join(format!("resources/activities/{name}.yaml")),
-        format!(
-            "schemaVersion: 2\nkind: Activity\nmetadata:\n  name: {name}\nspec:\n  type: deterministic\n  description: Test stub.\n  input_schema_json:\n    type: object\n  output_schema_json:\n    type: object\n  action: {action}\n  config: {{}}\n"
-        ),
-    )
-    .expect("stub agent activity");
-}
-
-struct Pipeline {
+struct EpicPipeline {
     _root: tempfile::TempDir,
     runtime: OrbitRuntime,
     repo: PathBuf,
@@ -65,11 +38,12 @@ struct Pipeline {
     base_sha: String,
 }
 
-fn pipeline(config: &str) -> Pipeline {
+fn epic_pipeline(config: &str) -> EpicPipeline {
     let (root, runtime, repo, global_root) = test_runtime_with_workspace_config(config);
     seed_default_catalogs(&global_root);
     stub_agent_activity(&global_root, "agent_implement", "scripted_agent_implement");
     stub_agent_activity(&global_root, "agent_review_repair", "scripted_review");
+    stub_agent_activity(&global_root, "epic_orchestrator", "scripted_epic_finish");
 
     let remote = root.path().join("remote.git");
     git_in(
@@ -101,10 +75,11 @@ fn pipeline(config: &str) -> Pipeline {
 
     let task = runtime
         .add_task(TaskAddParams {
-            title: "Gated pipeline task".to_string(),
-            description: "Fixture task delivered through the gated PR pipeline.".to_string(),
+            title: "Gated epic".to_string(),
+            description: "Fixture epic delivered through epic_pipeline.".to_string(),
             acceptance_criteria: vec!["src.txt says implemented.".to_string()],
             plan: "Edit src.txt.".to_string(),
+            tags: vec!["epic".to_string()],
             context_files: vec!["file:src.txt".to_string()],
             workspace_path: Some(".".to_string()),
             priority: TaskPriority::Medium,
@@ -112,8 +87,8 @@ fn pipeline(config: &str) -> Pipeline {
             status: Some(TaskStatus::InProgress),
             ..TaskAddParams::default()
         })
-        .expect("seed task");
-    git_in(&repo, &["checkout", "-b", &format!("orbit/{}", task.id)]);
+        .expect("seed epic");
+    git_in(&repo, &["checkout", "-b", &format!("epic/{}", task.id)]);
     std::fs::write(repo.join("src.txt"), "base\nimplemented\n").expect("implement");
     git_in(&repo, &["add", "src.txt"]);
     git_in(
@@ -122,22 +97,14 @@ fn pipeline(config: &str) -> Pipeline {
     );
 
     let mut input = json!({
-        "task_ids": [task.id],
-        "base_branch": "main",
-        "base_sync": "local",
+        "epic_task_id": task.id,
         "allowed_crews": [],
     });
-    install_review_admission(&runtime, "task_pr_pipeline", &mut input, None, false)
+    install_review_admission(&runtime, "epic_pipeline", &mut input, None, false)
         .expect("capture admission");
-    let run = RuntimeHost::insert_job_run(
-        &runtime,
-        "task_pr_pipeline",
-        1,
-        Utc::now(),
-        Some(input),
-        None,
-    )
-    .expect("insert run");
+    let run =
+        RuntimeHost::insert_job_run(&runtime, "epic_pipeline", 1, Utc::now(), Some(input), None)
+            .expect("insert run");
     runtime
         .update_task(
             &task.id,
@@ -149,9 +116,9 @@ fn pipeline(config: &str) -> Pipeline {
                 ..TaskUpdateParams::default()
             },
         )
-        .expect("bind task");
+        .expect("bind epic");
 
-    Pipeline {
+    EpicPipeline {
         _root: root,
         runtime,
         repo,
@@ -161,17 +128,7 @@ fn pipeline(config: &str) -> Pipeline {
     }
 }
 
-pub(super) fn git_stdout(path: &Path, args: &[&str]) -> String {
-    let output = std::process::Command::new("git")
-        .current_dir(path)
-        .args(args)
-        .output()
-        .expect("git");
-    assert!(output.status.success(), "git {args:?} failed");
-    String::from_utf8_lossy(&output.stdout).trim().to_string()
-}
-
-impl Pipeline {
+impl EpicPipeline {
     fn run_input(&self) -> Value {
         self.runtime
             .get_job_run_backend(&self.run_id)
@@ -181,8 +138,8 @@ impl Pipeline {
             .expect("input")
     }
 
-    fn execute(&self, host: &ScriptedReviewHost<'_>) -> Result<(), DispatchError> {
-        let mut job = resolved_job(&self.runtime, "task_pr_pipeline");
+    fn execute(&self, host: &ScriptedEpicReviewHost<'_>) -> Result<(), DispatchError> {
+        let mut job = resolved_job(&self.runtime, "epic_pipeline");
         retarget_engine_actions_for_scripted_host(&mut job);
         try_execute_job(
             &self.runtime,
@@ -200,29 +157,24 @@ impl Pipeline {
     }
 }
 
-/// What the stubbed reviewer does when the pipeline reaches it.
-#[derive(Clone, Copy)]
-pub(super) struct ReviewerScript {
-    pub(super) verdict: ReviewVerdict,
-    pub(super) repair: bool,
-}
-
-struct ScriptedReviewHost<'a> {
-    pipeline: &'a Pipeline,
+struct ScriptedEpicReviewHost<'a> {
+    pipeline: &'a EpicPipeline,
     reviewer: ReviewerScript,
     calls: Mutex<Vec<String>>,
     pr_open_inputs: Mutex<Vec<Value>>,
-    private_ops: Mutex<Vec<String>>,
+    worktree_inputs: Mutex<Vec<Value>>,
+    admit_inputs: Mutex<Vec<Value>>,
 }
 
-impl<'a> ScriptedReviewHost<'a> {
-    fn new(pipeline: &'a Pipeline, reviewer: ReviewerScript) -> Self {
+impl<'a> ScriptedEpicReviewHost<'a> {
+    fn new(pipeline: &'a EpicPipeline, reviewer: ReviewerScript) -> Self {
         Self {
             pipeline,
             reviewer,
             calls: Mutex::new(Vec::new()),
             pr_open_inputs: Mutex::new(Vec::new()),
-            private_ops: Mutex::new(Vec::new()),
+            worktree_inputs: Mutex::new(Vec::new()),
+            admit_inputs: Mutex::new(Vec::new()),
         }
     }
 
@@ -234,8 +186,15 @@ impl<'a> ScriptedReviewHost<'a> {
         self.pr_open_inputs.lock().expect("pr open inputs").clone()
     }
 
-    fn private_ops(&self) -> Vec<String> {
-        self.private_ops.lock().expect("private ops").clone()
+    fn worktree_inputs(&self) -> Vec<Value> {
+        self.worktree_inputs
+            .lock()
+            .expect("worktree inputs")
+            .clone()
+    }
+
+    fn admit_inputs(&self) -> Vec<Value> {
+        self.admit_inputs.lock().expect("admit inputs").clone()
     }
 
     fn write_report(&self, attempt_id: &str) {
@@ -244,7 +203,7 @@ impl<'a> ScriptedReviewHost<'a> {
             schema_version: REVIEW_CONTRACT_VERSION,
             attempt_id: attempt_id.to_string(),
             verdict: self.reviewer.verdict,
-            summary: "Scripted review.".to_string(),
+            summary: "Scripted epic review.".to_string(),
             findings: if repaired || self.reviewer.verdict == ReviewVerdict::ChangesRequired {
                 vec![ReviewFinding {
                     id: "F1".to_string(),
@@ -293,7 +252,7 @@ impl<'a> ScriptedReviewHost<'a> {
     }
 }
 
-impl RuntimeHost for ScriptedReviewHost<'_> {
+impl RuntimeHost for ScriptedEpicReviewHost<'_> {
     fn run_deterministic(
         &self,
         action: &str,
@@ -303,16 +262,33 @@ impl RuntimeHost for ScriptedReviewHost<'_> {
     ) -> Result<Value, DispatchError> {
         self.calls.lock().expect("calls").push(action.to_string());
         let repo = &self.pipeline.repo;
-        let branch = format!("orbit/{}", self.pipeline.task_id);
+        let branch = format!("epic/{}", self.pipeline.task_id);
         let head = self.pipeline.head();
         match action {
-            "scripted_worktree_setup" => Ok(json!({
-                "workspace_path": repo,
-                "job_run_id": self.pipeline.run_id,
-                "base_ref": "main",
-                "base_sha": self.pipeline.base_sha,
+            "resolve_workspace_ship_input" => Ok(json!({
+                "mode": "pr",
+                "base_branch": "main",
             })),
-            "scripted_agent_implement" => Ok(json!({ "summary": "implemented" })),
+            "scripted_worktree_setup" => {
+                self.worktree_inputs
+                    .lock()
+                    .expect("worktree inputs")
+                    .push(input.clone());
+                let job_run_id = input
+                    .get("job_run_id")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(self.pipeline.run_id.as_str());
+                Ok(json!({
+                    "workspace_path": repo,
+                    "job_run_id": job_run_id,
+                    "batch_id": job_run_id,
+                    "head_ref": branch,
+                    "base_ref": "main",
+                    "base_sha": self.pipeline.base_sha,
+                }))
+            }
+            "scripted_epic_finish" => Ok(json!({ "summary": "finished" })),
             "scripted_git_commit" => Ok(json!({
                 "phase": "commit",
                 "decision": "already_committed",
@@ -387,6 +363,19 @@ impl RuntimeHost for ScriptedReviewHost<'_> {
                 "reused_task_ids": [],
                 "pr_number": "42",
             })),
+            "review_gate_admit" => {
+                self.admit_inputs
+                    .lock()
+                    .expect("admit inputs")
+                    .push(input.clone());
+                <OrbitRuntime as RuntimeHost>::run_deterministic(
+                    &self.pipeline.runtime,
+                    action,
+                    config,
+                    input,
+                    tool_context,
+                )
+            }
             _ => <OrbitRuntime as RuntimeHost>::run_deterministic(
                 &self.pipeline.runtime,
                 action,
@@ -399,27 +388,11 @@ impl RuntimeHost for ScriptedReviewHost<'_> {
 
     fn has_deterministic_action(&self, action: &str) -> bool {
         action.starts_with("scripted_")
+            || action == "resolve_workspace_ship_input"
             || <OrbitRuntime as RuntimeHost>::has_deterministic_action(
                 &self.pipeline.runtime,
                 action,
             )
-    }
-
-    fn run_private_vcs_operation(
-        &self,
-        operation: &str,
-        _input: Value,
-    ) -> Result<Value, orbit_common::OrbitError> {
-        self.private_ops
-            .lock()
-            .expect("private ops")
-            .push(operation.to_string());
-        match operation {
-            "push" => Ok(json!({ "stdout": "", "stderr": "" })),
-            other => Err(orbit_common::OrbitError::Execution(format!(
-                "unexpected private VCS operation {other}"
-            ))),
-        }
     }
 
     fn get_task(&self, task_id: &str) -> Result<Task, orbit_common::OrbitError> {
@@ -499,37 +472,24 @@ impl RuntimeHost for ScriptedReviewHost<'_> {
     }
 }
 
-pub(super) fn positions(calls: &[String], names: &[&str]) -> Vec<usize> {
-    names
-        .iter()
-        .map(|name| {
-            calls
-                .iter()
-                .position(|call| call == name)
-                .unwrap_or_else(|| panic!("{name} was not called: {calls:?}"))
-        })
-        .collect()
-}
-
 #[test]
-fn before_pr_pass_with_repairs_publishes_only_the_settled_candidate() {
-    let pipeline = pipeline(GATED_CONFIG);
-    let implementation = pipeline.head();
-    let host = ScriptedReviewHost::new(
+fn epic_before_pr_with_a_combined_diff_invokes_the_reviewer_and_publishes_only_a_pass() {
+    let pipeline = epic_pipeline(GATED_CONFIG);
+    let host = ScriptedEpicReviewHost::new(
         &pipeline,
         ReviewerScript {
-            verdict: ReviewVerdict::PassedWithRepairs,
-            repair: true,
+            verdict: ReviewVerdict::PassedWithoutRepairs,
+            repair: false,
         },
     );
 
-    pipeline.execute(&host).expect("gated pipeline succeeds");
+    pipeline.execute(&host).expect("gated epic succeeds");
 
     let calls = host.calls();
     let order = positions(
         &calls,
         &[
-            "scripted_git_rebase",
+            "scripted_worktree_setup",
             "review_gate_admit",
             "scripted_review",
             "review_gate_settle",
@@ -540,21 +500,35 @@ fn before_pr_pass_with_repairs_publishes_only_the_settled_candidate() {
     );
     assert!(
         order.windows(2).all(|pair| pair[0] < pair[1]),
-        "the gate runs after base sync and before push/PR: {calls:?}"
+        "the epic gate runs after assembly and before push/PR: {calls:?}"
     );
 
-    let final_head = pipeline.head();
-    assert_ne!(
-        final_head, implementation,
-        "the repair is a separate commit"
-    );
+    let worktree = &host.worktree_inputs()[0];
     assert_eq!(
-        git_stdout(&pipeline.repo, &["log", "-1", "--format=%an", "HEAD"]),
-        "codex-reviewer"
+        worktree["run_id"],
+        format!("epic-{}", pipeline.task_id),
+        "the stable epic checkout token is preserved"
     );
+    let admitted = &host.admit_inputs()[0];
+    assert_eq!(
+        admitted["job_run_id"], pipeline.run_id,
+        "the gate looks up the admitted job, not the worktree token"
+    );
+    assert_eq!(admitted["completed_task_ids"], json!([pipeline.task_id]));
+    assert_eq!(
+        pipeline
+            .runtime
+            .get_task(&pipeline.task_id)
+            .expect("epic")
+            .job_run_id
+            .as_deref(),
+        Some(pipeline.run_id.as_str()),
+        "task ownership stays on the admitted job"
+    );
+
     let opened = host.pr_open_inputs();
     assert_eq!(opened.len(), 1);
-    assert_eq!(opened[0]["reviewed_head_sha"], final_head);
+    assert_eq!(opened[0]["reviewed_head_sha"], pipeline.head());
     assert_eq!(opened[0]["reviewed_base_sha"], pipeline.base_sha);
     assert!(
         pipeline
@@ -563,28 +537,12 @@ fn before_pr_pass_with_repairs_publishes_only_the_settled_candidate() {
             .expect("read")
             .is_some()
     );
-    let review = crate::application::review::task_review_projection(
-        &pipeline.runtime,
-        &pipeline.runtime.get_task(&pipeline.task_id).expect("task"),
-        &pipeline
-            .runtime
-            .get_task_artifact_manifest(&pipeline.task_id)
-            .expect("manifest"),
-    )
-    .expect("projection")
-    .expect("present");
-    assert_eq!(review["verdict"], "passed_with_repairs");
-    assert_eq!(
-        review["assurance"],
-        "independent_review_with_self_authored_repairs"
-    );
-    assert_eq!(review["consumed"]["repair_cycles"], 1);
 }
 
 #[test]
-fn before_pr_changes_required_blocks_the_task_without_opening_a_pr() {
-    let pipeline = pipeline(GATED_CONFIG);
-    let host = ScriptedReviewHost::new(
+fn epic_before_pr_changes_required_blocks_without_opening_a_pr() {
+    let pipeline = epic_pipeline(GATED_CONFIG);
+    let host = ScriptedEpicReviewHost::new(
         &pipeline,
         ReviewerScript {
             verdict: ReviewVerdict::ChangesRequired,
@@ -594,60 +552,25 @@ fn before_pr_changes_required_blocks_the_task_without_opening_a_pr() {
 
     let error = pipeline
         .execute(&host)
-        .expect_err("the gate stops delivery");
+        .expect_err("the gate stops epic delivery");
     assert!(error.to_string().contains("review_gate_blocked"), "{error}");
 
     let calls = host.calls();
-    assert!(calls.iter().any(|call| call == "review_gate_settle"));
+    assert!(calls.iter().any(|call| call == "scripted_review"));
     assert!(
         !calls.iter().any(|call| call == "scripted_pr_open"),
-        "no PR is opened for a blocked candidate: {calls:?}"
+        "no PR is opened for a blocked epic candidate: {calls:?}"
     );
-    assert_eq!(
-        host.private_ops(),
-        vec!["push"],
-        "the failure handoff pushes the candidate but creates no PR"
-    );
-    let task = pipeline.runtime.get_task(&pipeline.task_id).expect("task");
-    assert_eq!(task.status, TaskStatus::Blocked);
-    assert!(
-        task.external_refs
-            .iter()
-            .all(|reference| reference.system != "github-pr"),
-        "no PR reference is attached"
-    );
-    let comments = pipeline
-        .runtime
-        .get_task_comments(&pipeline.task_id)
-        .expect("comments");
-    assert!(
-        comments
-            .iter()
-            .any(|comment| comment.message.contains("Review gate escalation")),
-        "the escalation is recorded on the task"
-    );
-    let review = crate::application::review::task_review_projection(
-        &pipeline.runtime,
-        &task,
-        &pipeline
-            .runtime
-            .get_task_artifact_manifest(&pipeline.task_id)
-            .expect("manifest"),
-    )
-    .expect("projection")
-    .expect("present");
-    assert_eq!(review["verdict"], "changes_required");
-    assert_eq!(review["passed"], false);
 }
 
 #[test]
-fn none_and_after_landing_policies_never_start_a_reviewer() {
+fn epic_none_and_after_landing_policies_never_start_a_reviewer() {
     for policy in ["none", "after-landing"] {
         let config = format!(
             "[crews.implementer]\nmodel = \"impl-model\"\nprovider = \"codex\"\nbackend = \"cli\"\n[workflow]\ndefault_crew = \"implementer\"\n[operation]\nreview_policy = \"{policy}\"\n"
         );
-        let pipeline = pipeline(&config);
-        let host = ScriptedReviewHost::new(
+        let pipeline = epic_pipeline(&config);
+        let host = ScriptedEpicReviewHost::new(
             &pipeline,
             ReviewerScript {
                 verdict: ReviewVerdict::PassedWithoutRepairs,
@@ -655,26 +578,18 @@ fn none_and_after_landing_policies_never_start_a_reviewer() {
             },
         );
 
-        pipeline.execute(&host).expect("ungated pipeline succeeds");
+        pipeline.execute(&host).expect("ungated epic succeeds");
         let calls = host.calls();
         assert!(calls.iter().any(|call| call == "review_gate_admit"));
         assert!(
             !calls.iter().any(|call| call == "scripted_review"),
             "{policy}: no reviewer starts: {calls:?}"
         );
-        let opened = host.pr_open_inputs();
-        assert_eq!(opened.len(), 1);
+        assert_eq!(host.pr_open_inputs().len(), 1);
         assert_eq!(
-            opened[0]["reviewed_head_sha"], "",
+            host.pr_open_inputs()[0]["reviewed_head_sha"],
+            "",
             "{policy}: no pinned gate"
-        );
-        assert!(
-            pipeline
-                .runtime
-                .get_task_artifact(&pipeline.task_id, REVIEW_GATE_ARTIFACT)
-                .expect("read")
-                .is_none(),
-            "{policy}: no certificate is issued"
         );
     }
 }

--- a/crates/orbit-core/src/application/review/gate.rs
+++ b/crates/orbit-core/src/application/review/gate.rs
@@ -50,7 +50,10 @@ pub(crate) fn review_gate_admit(
     // A run without a captured review admission predates the policy or was
     // never a delivery submission: it keeps the pre-existing behavior and
     // never loads tasks or Git state for a gate that cannot apply.
-    let run_id = required_string(input, "job_run_id").map_err(|error| failed(error.to_string()))?;
+    // Prefer the dispatcher-injected `run_id` (the admitted job) over
+    // `job_run_id`, which an epic pipeline may still spell as the stable
+    // worktree token that has no run record [ORB-11520].
+    let run_id = admitted_run_id(input).map_err(|error| failed(error.to_string()))?;
     let Some(admission) =
         run_review_admission(runtime, &run_id).map_err(|error| failed(error.to_string()))?
     else {
@@ -231,7 +234,7 @@ struct GateContext {
 
 impl GateContext {
     fn load(runtime: &OrbitRuntime, input: &Value) -> Result<Self, OrbitError> {
-        let run_id = required_string(input, "job_run_id")?;
+        let run_id = admitted_run_id(input)?;
         let task_ids = input
             .get("completed_task_ids")
             .and_then(Value::as_array)
@@ -348,6 +351,21 @@ fn required_string(input: &Value, key: &str) -> Result<String, OrbitError> {
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .ok_or_else(|| OrbitError::InvalidInput(format!("review gate requires input.{key}")))
+}
+
+/// The admitted job that captured review policy and owns the candidate.
+///
+/// Dispatcher injects the executing run as `run_id`. Epic pipelines may pass
+/// the stable worktree token as `job_run_id`; that token is not a run record.
+fn admitted_run_id(input: &Value) -> Result<String, OrbitError> {
+    let job_run_id = required_string(input, "job_run_id")?;
+    let injected = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    Ok(injected.unwrap_or(job_run_id))
 }
 
 fn not_applicable(reason: &str, admission: Option<&ReviewAdmission>) -> Value {

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -651,6 +651,29 @@ fn the_gate_reads_the_captured_snapshot_not_the_live_preference() {
     );
 }
 
+#[test]
+fn epic_worktree_token_does_not_mask_the_admitted_run() {
+    let gated = gated_fixture(GATED_CONFIG);
+    let worktree_token = format!("epic-{}", gated.task_id);
+    let mut input = admit_input(
+        &worktree_token,
+        std::slice::from_ref(&gated.task_id),
+        &gated.fixture.repo,
+    );
+
+    let missing = review_gate_admit(&gated.fixture.runtime, "review_gate_admit", &input)
+        .expect("a worktree token is not a run record");
+    assert_eq!(missing["applies"], false);
+    assert_eq!(missing["reason"], "review_admission_missing");
+
+    input["run_id"] = json!(&gated.run_id);
+    let admission = review_gate_admit(&gated.fixture.runtime, "review_gate_admit", &input)
+        .expect("the injected admitted run still applies");
+    assert_eq!(admission["applies"], true);
+    assert_eq!(admission["decision"], "admitted");
+    assert_eq!(admission["reviewer"]["crew"], "reviewers");
+}
+
 /// Land the checked-out candidate onto `main` the way a squash merge does
 /// and return the delivery the source adapter would observe.
 fn land_squash(gated: &Gated, repository: &str) -> Delivery {

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -344,12 +344,20 @@ fn dispatch_v2_activity_inner(
     result
 }
 
-fn inject_run_id(input: &Value, run_id: &str) -> Value {
+pub(crate) fn inject_run_id(input: &Value, run_id: &str) -> Value {
     let Value::Object(map) = input else {
         return input.clone();
     };
     if map.contains_key("run_id") {
-        return input.clone();
+        // An explicit `run_id` is a worktree identity token (epic pipelines
+        // pin `epic-<task-id>`). The admitted job still owns execution
+        // authority; expose it as `job_run_id` when the caller did not.
+        if map.contains_key("job_run_id") {
+            return input.clone();
+        }
+        let mut augmented = map.clone();
+        augmented.insert("job_run_id".to_string(), Value::String(run_id.to_string()));
+        return Value::Object(augmented);
     }
 
     let mut augmented = map.clone();

--- a/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/tests/dispatcher.rs
@@ -87,3 +87,45 @@ fn dispatch_error_to_orbit_keeps_validation_variant_and_buckets_the_rest() {
                 && details.conflicting_paths == ["src/lib.rs"]
     ));
 }
+
+#[test]
+fn inject_run_id_fills_absent_run_id() {
+    use super::super::dispatcher::inject_run_id;
+    use serde_json::json;
+
+    let injected = inject_run_id(&json!({ "task_ids": ["ORB-1"] }), "jrun-admitted");
+    assert_eq!(injected["run_id"], "jrun-admitted");
+    assert!(injected.get("job_run_id").is_none());
+}
+
+#[test]
+fn inject_run_id_exposes_the_admitted_job_beside_an_explicit_worktree_token() {
+    use super::super::dispatcher::inject_run_id;
+    use serde_json::json;
+
+    let injected = inject_run_id(
+        &json!({
+            "task_ids": ["ORB-EPIC"],
+            "run_id": "epic-ORB-EPIC",
+        }),
+        "jrun-admitted",
+    );
+    assert_eq!(injected["run_id"], "epic-ORB-EPIC");
+    assert_eq!(injected["job_run_id"], "jrun-admitted");
+}
+
+#[test]
+fn inject_run_id_does_not_overwrite_an_explicit_job_run_id() {
+    use super::super::dispatcher::inject_run_id;
+    use serde_json::json;
+
+    let injected = inject_run_id(
+        &json!({
+            "run_id": "epic-ORB-EPIC",
+            "job_run_id": "jrun-already",
+        }),
+        "jrun-admitted",
+    );
+    assert_eq!(injected["run_id"], "epic-ORB-EPIC");
+    assert_eq!(injected["job_run_id"], "jrun-already");
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -34,7 +34,12 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
     // rule (ORB-10427) — never re-spelled per call site.
     let identity = WorktreeIdentity::from_input(input, None)?;
     let task_ids = &identity.task_ids;
-    let run_id = &identity.run_id;
+    // `identity.run_id` names the stable checkout (epic pipelines pin
+    // `epic-<task-id>`). Execution authority stays on the admitted job when
+    // the dispatcher supplied `job_run_id`.
+    let worktree_run_id = &identity.run_id;
+    let job_run_id =
+        input_string_field(input, "job_run_id").unwrap_or_else(|| worktree_run_id.clone());
     let base = input_string_field(input, "base")
         .or_else(|| input_string_field(input, "base_branch"))
         .unwrap_or_else(|| DEFAULT_BASE.to_string());
@@ -120,14 +125,14 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
         host.apply_task_automation_update(
             task_id,
             TaskAutomationUpdate {
-                job_run_id: Some(run_id.clone()),
+                job_run_id: Some(job_run_id.clone()),
                 ..TaskAutomationUpdate::default()
             },
         )?;
     }
 
     Ok(worktree_setup_output(
-        run_id,
+        &job_run_id,
         workspace_path_str,
         branch_name,
         start_point,

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -329,12 +329,48 @@ fn setup_worktree_succeeds_when_landing_mode_is_local_and_base_is_clean() {
     assert_eq!(host.admitted(), vec!["ORB-11373".to_string()]);
 }
 
+#[test]
+fn setup_worktree_keeps_an_explicit_identity_token_and_stamps_the_admitted_job() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+
+    let host = FakeHost::new(&repo, &["ORB-EPIC"]);
+    let worktree_token = "epic-ORB-EPIC";
+    let admitted_run = "jrun-admitted-epic";
+    let input = json!({
+        "task_ids": ["ORB-EPIC"],
+        "run_id": worktree_token,
+        "job_run_id": admitted_run,
+        "branch_prefix": "epic",
+        "base": "agent-main",
+        "base_sync": "local",
+        "dependency_delivery": "ignore",
+    });
+
+    let output = setup_worktree(&host, &input).expect("epic identity split");
+    let worktree_path = resolve_worktree_path_from_prefix(&repo, "epic", worktree_token).unwrap();
+
+    assert!(
+        worktree_path.exists(),
+        "the stable epic token still names the checkout"
+    );
+    assert_eq!(output["job_run_id"], json!(admitted_run));
+    assert_eq!(output["batch_id"], json!(admitted_run));
+    assert_eq!(
+        host.stamped_job_run_id("ORB-EPIC").as_deref(),
+        Some(admitted_run)
+    );
+}
+
 struct FakeHost {
     tasks: BTreeMap<String, Task>,
     repo_root: PathBuf,
     data_root: PathBuf,
     scoreboard_dir: PathBuf,
     admitted: Mutex<Vec<String>>,
+    stamped_job_run_id: Mutex<BTreeMap<String, String>>,
 }
 
 impl FakeHost {
@@ -380,11 +416,20 @@ impl FakeHost {
             data_root: repo_root.join(".orbit-test-data"),
             scoreboard_dir: repo_root.join(".orbit-test-data").join("scoreboard"),
             admitted: Mutex::new(Vec::new()),
+            stamped_job_run_id: Mutex::new(BTreeMap::new()),
         }
     }
 
     fn admitted(&self) -> Vec<String> {
         self.admitted.lock().expect("admitted lock").clone()
+    }
+
+    fn stamped_job_run_id(&self, task_id: &str) -> Option<String> {
+        self.stamped_job_run_id
+            .lock()
+            .expect("stamp lock")
+            .get(task_id)
+            .cloned()
     }
 }
 
@@ -443,9 +488,15 @@ impl RuntimeHost for FakeHost {
 
     fn apply_task_automation_update(
         &self,
-        _task_id: &str,
-        _update: TaskAutomationUpdate,
+        task_id: &str,
+        update: TaskAutomationUpdate,
     ) -> Result<(), OrbitError> {
+        if let Some(job_run_id) = update.job_run_id {
+            self.stamped_job_run_id
+                .lock()
+                .expect("stamp lock")
+                .insert(task_id.to_string(), job_run_id);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Task

[ORB-11520](https://orbit-cli.com/tasks/ORB-11520) — [code-review] Epic review gate looks up the stable worktree ID instead of its admitted run

### Description

## Problem
A before-pr epic with no unfinished descendants can publish its combined candidate without running the reviewer. The new gate reads admission using the stable worktree token, not the job run that captured the policy.

## Live evidence
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24 (introduced in d2cc023ea / ORB-11333):
- crates/orbit-core/assets/jobs/epic_pipeline.yaml:46 explicitly sets worktree run_id to epic-<task-id>; :171 passes steps.worktree.output.job_run_id to review_gate_admit.
- crates/orbit-engine/src/activity_job/dispatcher.rs:351 preserves an explicitly supplied run_id. crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs:150 returns that token as job_run_id.
- crates/orbit-core/src/application/review/gate.rs:52 loads the review admission by that job_run_id. crates/orbit-core/src/application/review/admission.rs:146 returns None when that run record does not exist, so gate.rs:56 reports review_admission_missing and applies=false.
- The admission was stored on the actual jrun record at submission (crates/orbit-core/src/application/job/pipeline.rs:772). The epic token only identifies its persistent worktree; it has no corresponding admitted run record.

## Impact and scope
The epic reviewer is skipped even when the current run captured before-pr. Preserve the stable epic checkout, but keep execution authority and task/candidate ownership linked to the real admitted job. Add an actual epic-pipeline regression with no unfinished descendants and a nonempty final diff; the existing full gate fixtures only exercise task_pr_pipeline. This is distinct from local child admission rejecting epic assembly.

### Acceptance Criteria

- A real epic_pipeline run with captured before-pr, no unfinished descendants, and a nonempty combined diff invokes the configured reviewer and cannot open a PR without a passing settled certificate.
- The gate reads policy from the actual admitted job run while preserving the stable epic worktree and correctly checking task ownership.
- None/after-landing and checked no-diff behavior remain compatible; make ci-fast, make ci-lint, and focused epic integration tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Split epic worktree identity from admitted-job identity. `worktree_setup` still names the stable checkout with the explicit `run_id` (`epic-<task-id>`), but stamps tasks and returns `job_run_id` from the admitted job when the dispatcher supplies it.
- Dispatcher: an explicit `run_id` no longer drops the executing run; it is injected as `job_run_id` so later steps look up a real run record.
- Review gate: admission and ownership use the dispatcher-injected `run_id` when present, else `job_run_id`. A worktree token alone still reports `review_admission_missing`.
- Epic YAML comments document the split. Added a real `epic_pipeline` before-pr fixture (no unfinished descendants, nonempty combined diff).

Assessment: the gate now applies before-pr on an assembled epic and refuses PR publication without a passing settled certificate; none/after-landing/no-diff stay compatible.

Criteria:
- Real epic_pipeline before-pr, no unfinished descendants, nonempty diff invokes the reviewer and cannot open a PR without a passing settled certificate: pass (`epic_before_pr_with_a_combined_diff_invokes_the_reviewer_and_publishes_only_a_pass`, `epic_before_pr_changes_required_blocks_without_opening_a_pr`).
- Gate reads policy from the admitted job while preserving the stable epic worktree and checking task ownership: pass (worktree input still `epic-<id>`; admit `job_run_id` is the jrun; task.job_run_id matches; unit `epic_worktree_token_does_not_mask_the_admitted_run`).
- None/after-landing and checked no-diff remain compatible; make ci-fast, make ci-lint, focused epic tests: pass.

Validation:
- `cargo test -p orbit-engine --lib inject_run_id` / `setup_worktree_keeps_an_explicit_identity_token_and_stamps_the_admitted_job`: passed
- `cargo test -p orbit-core --lib application::review::tests`: passed (22)
- `cargo test -p orbit-core --lib application::job::tests::exec::epic_review_gate`: passed (3)
- `cargo test -p orbit-core --lib application::job::tests::exec::review_gate`: passed (3)
- `cargo test -p orbit-core --lib epic_pipeline_`: passed (11 existing epic fixtures)
- `make ci-fast`: passed
- `make ci-lint`: passed (workspace clippy -D warnings); re-ran `cargo clippy -p orbit-core --all-targets -- -D warnings` after splitting the epic fixture: passed
- `git diff --check`: passed

Deviations: none. Unlisted files added to context_files because they own the identity split or the new epic fixture. No friction filed.

Remaining risk: live epic worktrees created under the old stamp (`epic-<id>` on the task) would fail the ownership check until a fresh admitted run restamps them.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11520-6a9f1554`
- Behind base: 0
- Ahead of base: 1