### PR TITLE
[security-review] Pin and verify the MCP publisher used by npm smoke CI

### DIFF
--- a/.github/workflows/smoke-npm-install.yml
+++ b/.github/workflows/smoke-npm-install.yml
@@ -43,14 +43,67 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Download and verify the pinned MCP publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          publisher_version="v1.8.1"
+          linux_amd64_sha256="a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+          darwin_arm64_sha256="e45e520892460732a4bdf37255576415d4a53ec171f8b913faf15bb1aef7cb77"
+
+          resolve_publisher() {
+            case "$1" in
+              Linux:x86_64)
+                publisher_asset="mcp-publisher_linux_amd64.tar.gz"
+                publisher_sha256="$linux_amd64_sha256"
+                ;;
+              Darwin:arm64)
+                publisher_asset="mcp-publisher_darwin_arm64.tar.gz"
+                publisher_sha256="$darwin_arm64_sha256"
+                ;;
+              *)
+                echo "Unsupported MCP publisher platform: $1" >&2
+                return 1
+                ;;
+            esac
+          }
+
+          verify_sha256() {
+            local archive="$1"
+            local expected_sha256="$2"
+            local actual_sha256
+
+            actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+            [[ "$actual_sha256" == "$expected_sha256" ]]
+          }
+
+          if resolve_publisher "Windows:x86_64"; then
+            echo "unsupported MCP publisher platform unexpectedly resolved" >&2
+            exit 1
+          fi
+
+          test_archive="$(mktemp)"
+          archive="$(mktemp)"
+          trap 'rm -f "$test_archive" "$archive"' EXIT
+          printf '%s\n' 'not the MCP publisher' > "$test_archive"
+          if verify_sha256 "$test_archive" "$linux_amd64_sha256"; then
+            echo "MCP publisher checksum mismatch unexpectedly passed" >&2
+            exit 1
+          fi
+
+          resolve_publisher "$(uname -s):$(uname -m)"
+          publisher_url="https://github.com/modelcontextprotocol/registry/releases/download/${publisher_version}/${publisher_asset}"
+          curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+            "$publisher_url" --output "$archive"
+          verify_sha256 "$archive" "$publisher_sha256"
+          tar xzf "$archive" mcp-publisher
+          chmod 755 mcp-publisher
+
       - name: Validate MCP Registry metadata
         shell: bash
         run: |
           set -euo pipefail
-          archive="$(mktemp)"
-          trap 'rm -f "$archive"' EXIT
-          curl -LsSf "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" -o "$archive"
-          tar xzf "$archive" mcp-publisher
           ./mcp-publisher validate server.json
 
       - name: Run npm install smoke


### PR DESCRIPTION
## Task

[ORB-11515](https://orbit-cli.com/tasks/ORB-11515) — [security-review] Pin and verify the MCP publisher used by npm smoke CI

### Description

## Problem
`.github/workflows/smoke-npm-install.yml` downloads `mcp-publisher` from the mutable `releases/latest/download/...` URL, extracts it, and executes `./mcp-publisher validate server.json` without verifying a digest or signature. This is the one executable-download path in the reviewed workflows that is neither version-pinned nor integrity-checked.

## Reproducible Evidence
Reviewed at commit `95ec7f8f0139a294b0da57bf826cf5e4224409da`.

`rg -n 'releases/latest|mcp-publisher|sha256sum' .github/workflows/smoke-npm-install.yml .github/workflows/publish-mcp-registry.yml` shows:
- `.github/workflows/smoke-npm-install.yml:52-54` fetches the mutable latest archive and immediately extracts it; the file contains no `sha256sum` check.
- `.github/workflows/smoke-npm-install.yml:55` executes the extracted publisher.
- The production publication workflow demonstrates the expected control at `.github/workflows/publish-mcp-registry.yml:119-132`: version `v1.8.1`, HTTPS/TLS constraints, and SHA-256 `a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc` are pinned before extraction.

No current or historical Orbit task matched searches for `mcp-publisher latest download checksum smoke workflow supply chain`.

## Severity and Impact
**Severity: Low.** Compromise of the upstream latest release channel or an unexpected replacement can execute arbitrary code in scheduled, manually dispatched, and tag-triggered GitHub runners. The job has only `contents: read` and no repository secrets, which limits impact, but the process can access the ephemeral workflow token, checked-out source, runner metadata, and network, and can falsify the smoke result.

## Constraints / Notes
Keep the smoke test cross-platform while making the publisher version and per-platform hashes explicit and reviewable. A mutable latest URL must not be the executable trust anchor.

### Acceptance Criteria

- The smoke workflow downloads an explicit MCP publisher version for every supported matrix platform and verifies a reviewed per-platform checksum or signature before extraction and execution.
- The download enforces HTTPS and fails closed on integrity mismatch; no mutable releases/latest executable path remains.
- A workflow-level check or script test demonstrates that unsupported platform mappings and checksum mismatches fail before the publisher runs.
- The existing Linux and macOS npm install smoke behavior remains intact.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Pinned the smoke workflow to MCP publisher v1.8.1 and added explicit SHA-256 digests for the supported matrix platforms: Linux amd64 and macOS arm64.
- Added a closed platform mapping, HTTPS/TLS 1.2 download enforcement, checksum verification before extraction, and executable permission setup.
- Added workflow-level guard checks proving unsupported platform mappings and checksum mismatches fail before publisher download/execution.
- Kept the existing metadata validation and npm install smoke steps intact.

Acceptance criteria:
- Explicit version and reviewed per-platform integrity checks: satisfied for both matrix platforms; v1.8.1 release assets were downloaded and their digests independently confirmed.
- HTTPS, fail-closed integrity handling, and no mutable latest executable path: satisfied; the workflow contains no releases/latest URL.
- Unsupported mapping and checksum mismatch fail before publisher runs: satisfied by the guard assertions executed before the real download/extraction.
- Existing Linux/macOS npm install smoke behavior: preserved; the Run npm install smoke step and script were unchanged. The full published-artifact smoke was not run locally.

Validation:
- PASS: git diff --check.
- PASS: extracted publisher workflow step passed bash -n.
- PASS: extracted publisher step executed in a temporary Linux x86_64 directory; unsupported-platform and checksum-mismatch guards ran, the pinned v1.8.1 asset downloaded, checksum verified, and archive extraction completed.
- PASS: extracted mcp-publisher validate server.json.
- PASS: ./scripts/smoke-npm-install.sh --dry-run-version-assertion.
- NOT RUN: YAML parser/actionlint validation; ruby, actionlint, and yq are unavailable in the workspace.
- NOT RUN: full GitHub macOS runner and published npm install smoke; these require the hosted runner/external published artifacts.

Assessment: The scoped workflow change is complete and limited to .github/workflows/smoke-npm-install.yml. Remaining risk is limited to hosted-runner execution and continued availability of the pinned upstream v1.8.1 assets.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11515-6a9f1aa6`
- Behind base: 0
- Ahead of base: 1