### PR TITLE
Distinguish required candidate validation from expected failures and scope exclusions in review settlement

### DIFF
--- a/.orbit/resources/activities/agent_review_repair.yaml
+++ b/.orbit/resources/activities/agent_review_repair.yaml
@@ -83,18 +83,40 @@ spec:
        and anything you are unsure about stay open findings.
     4. Run the repository's required validation on the final worktree state
        (for this repository at least `make ci-fast` and `make ci-lint`, plus the
-       focused tests for the change). Record every command with outcome
-       `passed`, `failed`, `denied` (the runner refused it), or `not_run`. Never
-       record a skipped or denied command as passed.
+       focused tests for the change). Record every command you ran or could not
+       run with outcome `passed`, `failed`, `denied` (the runner refused it), or
+       `not_run`. Never record a skipped or denied command as passed, and never
+       drop a record to make the set look clean.
+
+       Classify each record with `role`, which says what it is evidence of.
+       Omitting `role` means `required`. Every role other than `required` needs
+       a `note` explaining it, or the gate refuses the record:
+
+       - `required`: the final candidate must pass it. Any other outcome, an
+         unavailable runner included, blocks the pass.
+       - `expected_failure`: a negative control that must fail, such as the
+         superseded assertion or the pre-fix reproduction. Its `failed` outcome
+         is positive evidence; a `passed` outcome contradicts the claim.
+       - `excluded`: an action outside the authorized scope that you
+         deliberately did not perform, such as a live deployment. Record it as
+         `not_run` (or `denied`); it supplies no coverage and creates no
+         requirement. Never perform an unauthorized action to clear a record.
+       - `superseded`: an earlier diagnostic attempt a later required check
+         replaced, such as a run in a misconfigured environment you then
+         corrected. Keep it and record the replacing required check after it.
+
+       At least one `required` record must pass, or the review establishes
+       nothing about the candidate.
     5. Choose the verdict honestly:
-       - `passed_without_repairs`: no defects, every validation passed, you
-         changed nothing.
-       - `passed_with_repairs`: every finding is `repaired`, every validation
-         passed on the repaired tree, and you changed files.
+       - `passed_without_repairs`: no defects, every required check passed,
+         every other record consistent with its role, you changed nothing.
+       - `passed_with_repairs`: every finding is `repaired`, every required
+         check passed on the repaired tree, and you changed files.
        - `changes_required`: findings remain open that you may not or could not
          repair; set `escalation` to the decision needed.
        - `incomplete`: the review could not be completed (missing evidence,
-         denied validation, ambiguous intent, mismatch); set `escalation`.
+         a denied required check, ambiguous intent, mismatch); set
+         `escalation`.
     6. Write the report to a temporary file and attach it with
        `orbit.task.artifact.put` (`id` = `task_id`, `path` = `report_artifact`)
        using exactly this shape:
@@ -105,7 +127,8 @@ spec:
                      "paths":["src/x.rs"],
                      "disposition":{"kind":"open|repaired"}}],
         "validation":[{"command":"make ci-fast","outcome":"passed|failed|denied|not_run",
-                       "note":"optional"}],
+                       "role":"required|expected_failure|excluded|superseded",
+                       "note":"required unless the role is `required`"}],
         "escalation":"<required decision, when not a pass>"}
 
        Attach the report for every task id in `task_ids`.

--- a/crates/orbit-automation/src/review/mod.rs
+++ b/crates/orbit-automation/src/review/mod.rs
@@ -12,15 +12,18 @@ use orbit_types::task::Task;
 use orbit_types::workflow::automation::{Delivery, DeliveryExclusion};
 use orbit_types::workflow::{
     REVIEW_CONTRACT_VERSION, ReviewCertificate, ReviewInvalidation, ReviewLanding,
-    ValidationOutcome,
 };
 use serde_json::json;
 
 use crate::AutomationError;
 use crate::delivery::definition_epoch;
 
+mod validation;
+
 #[cfg(test)]
 mod tests;
+
+pub use validation::{ValidationDefect, validation_evidence, validation_role_counts};
 
 /// Contract label folded into every task-meaning digest.
 pub const TASK_MEANING_CONTRACT: &str = "review_task_meaning_v1";
@@ -65,8 +68,13 @@ pub fn combined_task_meaning_digest(
 }
 
 /// Whether a certificate is acceptable coverage on its own terms: current
-/// contract, a pass verdict, a validation set that all passed on the final
-/// candidate, and a candidate distinct from its base.
+/// contract, a pass verdict, validation records that establish the final
+/// candidate under [`validation_evidence`], and a candidate distinct from
+/// its base.
+///
+/// The validation rules are re-derived here rather than trusting the
+/// `validation_complete` flag alone, so a certificate whose records do not
+/// support the flag is never spent as coverage.
 pub fn certificate_acceptable(certificate: &ReviewCertificate) -> Result<(), ReviewInvalidation> {
     if certificate.schema_version != REVIEW_CONTRACT_VERSION {
         return Err(ReviewInvalidation::MappingUnknown);
@@ -74,13 +82,7 @@ pub fn certificate_acceptable(certificate: &ReviewCertificate) -> Result<(), Rev
     if !certificate.verdict.passed() || certificate.assurance.is_none() {
         return Err(ReviewInvalidation::VerdictNotPassed);
     }
-    if !certificate.validation_complete
-        || certificate.validation.is_empty()
-        || certificate
-            .validation
-            .iter()
-            .any(|record| record.outcome != ValidationOutcome::Passed)
-    {
+    if !certificate.validation_complete || validation_evidence(&certificate.validation).is_err() {
         return Err(ReviewInvalidation::ValidationIncomplete);
     }
     if certificate.final_candidate.tree == certificate.base.tree {

--- a/crates/orbit-automation/src/review/tests/mod.rs
+++ b/crates/orbit-automation/src/review/tests/mod.rs
@@ -1,5 +1,7 @@
 //! Shared review coverage rules [ORB-11333].
 
+mod validation;
+
 use super::*;
 use chrono::{TimeZone, Utc};
 use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
@@ -7,6 +9,7 @@ use orbit_types::workflow::automation::{Delivery, SourceRevision};
 use orbit_types::workflow::{
     LandingTransformation, REVIEW_CONTRACT_VERSION, ReviewAssurance, ReviewBudget,
     ReviewConsumption, ReviewValidation, ReviewVerdict, ReviewerIdentity, ValidationOutcome,
+    ValidationRole,
 };
 
 fn now() -> chrono::DateTime<Utc> {
@@ -68,6 +71,7 @@ fn certificate(verdict: ReviewVerdict) -> ReviewCertificate {
         validation: vec![ReviewValidation {
             command: "make ci-fast".into(),
             outcome: ValidationOutcome::Passed,
+            role: ValidationRole::Required,
             note: None,
         }],
         validation_complete: true,
@@ -170,6 +174,45 @@ fn only_passed_and_fully_validated_certificates_are_acceptable() {
     assert_eq!(
         certificate_acceptable(&stale_contract),
         Err(ReviewInvalidation::MappingUnknown)
+    );
+}
+
+#[test]
+fn coverage_reads_the_same_validation_contract_the_gate_settled_under() {
+    // A certificate the gate passed under the repaired contract stays
+    // acceptable coverage: the negative control and the excluded deployment
+    // do not make it incomplete.
+    let mut classified = certificate(ReviewVerdict::PassedWithoutRepairs);
+    classified.validation.extend([
+        ReviewValidation {
+            command: "grep -q 'Strict-Transport-Security' old-config".into(),
+            outcome: ValidationOutcome::Failed,
+            role: ValidationRole::ExpectedFailure,
+            note: Some("negative control: the superseded assertion must fail".into()),
+        },
+        ReviewValidation {
+            command: "wrangler deploy".into(),
+            outcome: ValidationOutcome::NotRun,
+            role: ValidationRole::Excluded,
+            note: Some("live deployment is outside the authorized scope".into()),
+        },
+    ]);
+    assert!(certificate_acceptable(&classified).is_ok());
+
+    // The flag alone never carries a certificate whose records contradict it.
+    let mut contradicted = classified.clone();
+    contradicted.validation[1].outcome = ValidationOutcome::Passed;
+    assert!(contradicted.validation_complete);
+    assert_eq!(
+        certificate_acceptable(&contradicted),
+        Err(ReviewInvalidation::ValidationIncomplete)
+    );
+
+    let mut unexplained = classified;
+    unexplained.validation[2].note = None;
+    assert_eq!(
+        certificate_acceptable(&unexplained),
+        Err(ReviewInvalidation::ValidationIncomplete)
     );
 }
 

--- a/crates/orbit-automation/src/review/tests/validation.rs
+++ b/crates/orbit-automation/src/review/tests/validation.rs
@@ -1,0 +1,255 @@
+//! What a reviewer's validation records establish [ORB-11528].
+
+use orbit_types::workflow::{ReviewValidation, ValidationOutcome, ValidationRole};
+
+use crate::review::{ValidationDefect, validation_evidence, validation_role_counts};
+
+fn record(
+    command: &str,
+    outcome: ValidationOutcome,
+    role: ValidationRole,
+    note: Option<&str>,
+) -> ReviewValidation {
+    ReviewValidation {
+        command: command.into(),
+        outcome,
+        role,
+        note: note.map(Into::into),
+    }
+}
+
+fn required(command: &str, outcome: ValidationOutcome) -> ReviewValidation {
+    record(command, outcome, ValidationRole::Required, None)
+}
+
+#[test]
+fn a_negative_control_and_a_scope_exclusion_coexist_with_passing_required_checks() {
+    // The shape ORB-11511 recorded: the superseded assertion had to fail,
+    // the deployment was never authorized, and the checks that bind the
+    // candidate passed.
+    let records = vec![
+        required("make ci-fast", ValidationOutcome::Passed),
+        required("make ci-lint", ValidationOutcome::Passed),
+        record(
+            "grep -q 'Strict-Transport-Security' old-config",
+            ValidationOutcome::Failed,
+            ValidationRole::ExpectedFailure,
+            Some("negative control: the superseded assertion must no longer hold"),
+        ),
+        record(
+            "wrangler deploy",
+            ValidationOutcome::NotRun,
+            ValidationRole::Excluded,
+            Some("live deployment is explicitly outside the authorized scope"),
+        ),
+    ];
+    assert_eq!(validation_evidence(&records), Ok(()));
+    assert_eq!(
+        validation_role_counts(&records),
+        vec![
+            (ValidationRole::Required, 2),
+            (ValidationRole::ExpectedFailure, 1),
+            (ValidationRole::Excluded, 1),
+        ]
+    );
+}
+
+#[test]
+fn required_checks_that_did_not_pass_still_block() {
+    for outcome in [
+        ValidationOutcome::Failed,
+        ValidationOutcome::Denied,
+        ValidationOutcome::NotRun,
+    ] {
+        let records = vec![
+            required("cargo test", ValidationOutcome::Passed),
+            required("make ci-lint", outcome),
+        ];
+        assert_eq!(
+            validation_evidence(&records),
+            Err(ValidationDefect::RequiredNotPassed {
+                command: "make ci-lint".into(),
+                outcome,
+            }),
+            "a {} required check must block a pass",
+            outcome.as_str()
+        );
+    }
+
+    // A denied required check keeps its own label: the runner refused, which
+    // says nothing about the candidate.
+    let denied = vec![required("make ci-lint", ValidationOutcome::Denied)];
+    assert!(
+        validation_evidence(&denied)
+            .unwrap_err()
+            .reason()
+            .starts_with("validation_unavailable:"),
+        "a denied runner is unavailable validation, not a defect"
+    );
+}
+
+#[test]
+fn a_set_without_a_passing_required_check_establishes_nothing() {
+    assert_eq!(
+        validation_evidence(&[]),
+        Err(ValidationDefect::NoRequiredCheck)
+    );
+
+    // Controls and exclusions alone are not coverage, however honest.
+    let no_candidate_check = vec![
+        record(
+            "cargo test old_assertion",
+            ValidationOutcome::Failed,
+            ValidationRole::ExpectedFailure,
+            Some("the pre-fix reproduction must fail"),
+        ),
+        record(
+            "wrangler deploy",
+            ValidationOutcome::NotRun,
+            ValidationRole::Excluded,
+            Some("out of scope"),
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&no_candidate_check),
+        Err(ValidationDefect::NoRequiredCheck)
+    );
+}
+
+#[test]
+fn an_outcome_that_contradicts_its_classification_blocks() {
+    let control_passed = vec![
+        required("make ci-fast", ValidationOutcome::Passed),
+        record(
+            "cargo test old_assertion",
+            ValidationOutcome::Passed,
+            ValidationRole::ExpectedFailure,
+            Some("the pre-fix reproduction must fail"),
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&control_passed),
+        Err(ValidationDefect::RoleContradicted {
+            command: "cargo test old_assertion".into(),
+            role: ValidationRole::ExpectedFailure,
+            outcome: ValidationOutcome::Passed,
+        }),
+        "a negative control that passed disproves what it was recorded for"
+    );
+
+    let exclusion_ran = vec![
+        required("make ci-fast", ValidationOutcome::Passed),
+        record(
+            "wrangler deploy",
+            ValidationOutcome::Passed,
+            ValidationRole::Excluded,
+            Some("out of scope"),
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&exclusion_ran),
+        Err(ValidationDefect::RoleContradicted {
+            command: "wrangler deploy".into(),
+            role: ValidationRole::Excluded,
+            outcome: ValidationOutcome::Passed,
+        }),
+        "an excluded action that ran was not excluded"
+    );
+
+    // A runner that refused the excluded action agrees with the exclusion.
+    let exclusion_denied = vec![
+        required("make ci-fast", ValidationOutcome::Passed),
+        record(
+            "wrangler deploy",
+            ValidationOutcome::Denied,
+            ValidationRole::Excluded,
+            Some("out of scope; the runner refuses it too"),
+        ),
+    ];
+    assert_eq!(validation_evidence(&exclusion_denied), Ok(()));
+}
+
+#[test]
+fn a_superseded_attempt_needs_the_later_check_that_replaced_it() {
+    // The shape ORB-11516 recorded: a leaked sandbox allowlist failed the
+    // first attempt, and the corrected environment passed. The failure stays
+    // in the record.
+    let corrected = vec![
+        record(
+            "cargo test --package orbit-core",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("sandbox allowlist leak; rerun below in a corrected environment"),
+        ),
+        required(
+            "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+            ValidationOutcome::Passed,
+        ),
+    ];
+    assert_eq!(validation_evidence(&corrected), Ok(()));
+    assert_eq!(
+        validation_role_counts(&corrected),
+        vec![
+            (ValidationRole::Required, 1),
+            (ValidationRole::Superseded, 1),
+        ],
+        "the failed observation is preserved, not erased"
+    );
+
+    // Nothing after it: the diagnostic never reached a final-candidate check.
+    let unresolved = vec![
+        required("make ci-fast", ValidationOutcome::Passed),
+        record(
+            "cargo test --package orbit-core",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("sandbox allowlist leak"),
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&unresolved),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test --package orbit-core".into(),
+        }),
+        "a check recorded before the attempt cannot resolve it"
+    );
+}
+
+#[test]
+fn an_unexplained_reclassification_is_refused_and_legacy_records_stay_required() {
+    for role in [
+        ValidationRole::ExpectedFailure,
+        ValidationRole::Excluded,
+        ValidationRole::Superseded,
+    ] {
+        let records = vec![
+            required("make ci-fast", ValidationOutcome::Passed),
+            record("cargo test", ValidationOutcome::Failed, role, Some("  ")),
+        ];
+        assert_eq!(
+            validation_evidence(&records),
+            Err(ValidationDefect::ClassificationUnexplained {
+                command: "cargo test".into(),
+                role,
+            }),
+            "{} needs a note that says why",
+            role.as_str()
+        );
+    }
+
+    // Evidence written before the contract carries no role and keeps its
+    // conservative meaning: every recorded command is a required check.
+    let legacy: Vec<ReviewValidation> = serde_json::from_str(
+        r#"[{"command":"make ci-fast","outcome":"passed"},
+            {"command":"deploy","outcome":"not_run"}]"#,
+    )
+    .expect("legacy validation records");
+    assert!(legacy.iter().all(|r| r.role == ValidationRole::Required));
+    assert_eq!(
+        validation_evidence(&legacy),
+        Err(ValidationDefect::RequiredNotPassed {
+            command: "deploy".into(),
+            outcome: ValidationOutcome::NotRun,
+        })
+    );
+}

--- a/crates/orbit-automation/src/review/validation.rs
+++ b/crates/orbit-automation/src/review/validation.rs
@@ -1,0 +1,185 @@
+//! What a reviewer's validation records establish about a candidate
+//! [ORB-11528].
+//!
+//! An honest reviewer records more than the checks that had to pass: the
+//! negative control that proves a regression, the deployment it was never
+//! authorized to perform, the diagnostic attempt a corrected rerun replaced.
+//! Reading every record as a requirement turns that honesty into a refusal,
+//! and reading a bare pass verdict as sufficient throws the evidence away.
+//! This module sits between the two: the reviewer classifies each record and
+//! the rules here decide whether the outcomes support the claim.
+//!
+//! Both the gate that issues a certificate and the coverage rules that spend
+//! one read these rules, so a certificate never means one thing when it is
+//! written and another when it is used.
+
+use orbit_types::workflow::{ReviewValidation, ValidationOutcome, ValidationRole};
+
+/// Why a validation set does not establish a validated candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationDefect {
+    /// Nothing in the set is a required check that passed, so the set says
+    /// nothing about the candidate.
+    NoRequiredCheck,
+    /// A required check did not pass on the final candidate.
+    RequiredNotPassed {
+        command: String,
+        outcome: ValidationOutcome,
+    },
+    /// The outcome contradicts the classification the record was filed
+    /// under: a negative control that passed, an excluded action that ran.
+    RoleContradicted {
+        command: String,
+        role: ValidationRole,
+        outcome: ValidationOutcome,
+    },
+    /// A superseded attempt that no later required check replaced, so the
+    /// diagnostic never reached a final-candidate outcome.
+    SupersededWithoutReplacement { command: String },
+    /// A classification other than `required` with nothing explaining it.
+    ClassificationUnexplained {
+        command: String,
+        role: ValidationRole,
+    },
+}
+
+impl ValidationDefect {
+    /// The escalation reason recorded on the certificate.
+    ///
+    /// A denied required check keeps its own `validation_unavailable` label:
+    /// the runner refused the command, which is neither a defect in the
+    /// candidate nor evidence about it.
+    pub fn reason(&self) -> String {
+        match self {
+            ValidationDefect::NoRequiredCheck => "validation_incomplete: a pass needs at least \
+                 one required candidate check that passed on the final candidate"
+                .to_string(),
+            ValidationDefect::RequiredNotPassed { command, outcome }
+                if *outcome == ValidationOutcome::Denied =>
+            {
+                format!(
+                    "validation_unavailable: the runner denied required check `{command}`; the \
+                     candidate is kept for unrestricted validation"
+                )
+            }
+            ValidationDefect::RequiredNotPassed { command, outcome } => format!(
+                "validation_incomplete: required check `{command}` is {} on the final candidate",
+                outcome.as_str()
+            ),
+            ValidationDefect::RoleContradicted {
+                command,
+                role,
+                outcome,
+            } => format!(
+                "validation_contradicted: `{command}` was recorded as {} but is {}",
+                role.as_str(),
+                outcome.as_str()
+            ),
+            ValidationDefect::SupersededWithoutReplacement { command } => format!(
+                "validation_incomplete: superseded attempt `{command}` is followed by no required \
+                 check that passed on the final candidate"
+            ),
+            ValidationDefect::ClassificationUnexplained { command, role } => format!(
+                "validation_unexplained: `{command}` is recorded as {} with no note explaining it",
+                role.as_str()
+            ),
+        }
+    }
+}
+
+/// Read a reviewer's validation records as evidence about the final
+/// candidate.
+///
+/// Every required check must have passed and at least one must exist; a
+/// declared negative control must have failed; an excluded action must have
+/// stayed unperformed; a superseded attempt must be followed by the required
+/// check that replaced it. Every classification other than `required` must
+/// explain itself, so an unexplained reclassification is refused rather than
+/// trusted. Records carrying no classification are required checks, which
+/// keeps evidence written before this contract conservative.
+pub fn validation_evidence(records: &[ReviewValidation]) -> Result<(), ValidationDefect> {
+    let mut required_passed = false;
+
+    for (index, record) in records.iter().enumerate() {
+        if record.role != ValidationRole::Required && !explained(record) {
+            return Err(ValidationDefect::ClassificationUnexplained {
+                command: record.command.clone(),
+                role: record.role,
+            });
+        }
+        match record.role {
+            ValidationRole::Required => {
+                if record.outcome != ValidationOutcome::Passed {
+                    return Err(ValidationDefect::RequiredNotPassed {
+                        command: record.command.clone(),
+                        outcome: record.outcome,
+                    });
+                }
+                required_passed = true;
+            }
+            ValidationRole::ExpectedFailure if record.outcome != ValidationOutcome::Failed => {
+                return Err(contradiction(record));
+            }
+            ValidationRole::Excluded
+                if !matches!(
+                    record.outcome,
+                    ValidationOutcome::NotRun | ValidationOutcome::Denied
+                ) =>
+            {
+                return Err(contradiction(record));
+            }
+            ValidationRole::Superseded if !replaced_by_required_check(&records[index + 1..]) => {
+                return Err(ValidationDefect::SupersededWithoutReplacement {
+                    command: record.command.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    if required_passed {
+        Ok(())
+    } else {
+        Err(ValidationDefect::NoRequiredCheck)
+    }
+}
+
+/// How many records carry each classification, for readable disclosure.
+pub fn validation_role_counts(records: &[ReviewValidation]) -> Vec<(ValidationRole, usize)> {
+    [
+        ValidationRole::Required,
+        ValidationRole::ExpectedFailure,
+        ValidationRole::Excluded,
+        ValidationRole::Superseded,
+    ]
+    .into_iter()
+    .filter_map(|role| {
+        let count = records.iter().filter(|record| record.role == role).count();
+        (count > 0).then_some((role, count))
+    })
+    .collect()
+}
+
+fn contradiction(record: &ReviewValidation) -> ValidationDefect {
+    ValidationDefect::RoleContradicted {
+        command: record.command.clone(),
+        role: record.role,
+        outcome: record.outcome,
+    }
+}
+
+fn explained(record: &ReviewValidation) -> bool {
+    record
+        .note
+        .as_deref()
+        .is_some_and(|note| !note.trim().is_empty())
+}
+
+/// Whether a later record is the required check the superseded attempt was
+/// replaced by. Order carries the meaning: a supersession must be resolved
+/// after it, never by a check recorded before it.
+fn replaced_by_required_check(later: &[ReviewValidation]) -> bool {
+    later.iter().any(|record| {
+        record.role == ValidationRole::Required && record.outcome == ValidationOutcome::Passed
+    })
+}

--- a/crates/orbit-core/assets/activities/agent_review_repair.yaml
+++ b/crates/orbit-core/assets/activities/agent_review_repair.yaml
@@ -83,18 +83,40 @@ spec:
        and anything you are unsure about stay open findings.
     4. Run the repository's required validation on the final worktree state
        (for this repository at least `make ci-fast` and `make ci-lint`, plus the
-       focused tests for the change). Record every command with outcome
-       `passed`, `failed`, `denied` (the runner refused it), or `not_run`. Never
-       record a skipped or denied command as passed.
+       focused tests for the change). Record every command you ran or could not
+       run with outcome `passed`, `failed`, `denied` (the runner refused it), or
+       `not_run`. Never record a skipped or denied command as passed, and never
+       drop a record to make the set look clean.
+
+       Classify each record with `role`, which says what it is evidence of.
+       Omitting `role` means `required`. Every role other than `required` needs
+       a `note` explaining it, or the gate refuses the record:
+
+       - `required`: the final candidate must pass it. Any other outcome, an
+         unavailable runner included, blocks the pass.
+       - `expected_failure`: a negative control that must fail, such as the
+         superseded assertion or the pre-fix reproduction. Its `failed` outcome
+         is positive evidence; a `passed` outcome contradicts the claim.
+       - `excluded`: an action outside the authorized scope that you
+         deliberately did not perform, such as a live deployment. Record it as
+         `not_run` (or `denied`); it supplies no coverage and creates no
+         requirement. Never perform an unauthorized action to clear a record.
+       - `superseded`: an earlier diagnostic attempt a later required check
+         replaced, such as a run in a misconfigured environment you then
+         corrected. Keep it and record the replacing required check after it.
+
+       At least one `required` record must pass, or the review establishes
+       nothing about the candidate.
     5. Choose the verdict honestly:
-       - `passed_without_repairs`: no defects, every validation passed, you
-         changed nothing.
-       - `passed_with_repairs`: every finding is `repaired`, every validation
-         passed on the repaired tree, and you changed files.
+       - `passed_without_repairs`: no defects, every required check passed,
+         every other record consistent with its role, you changed nothing.
+       - `passed_with_repairs`: every finding is `repaired`, every required
+         check passed on the repaired tree, and you changed files.
        - `changes_required`: findings remain open that you may not or could not
          repair; set `escalation` to the decision needed.
        - `incomplete`: the review could not be completed (missing evidence,
-         denied validation, ambiguous intent, mismatch); set `escalation`.
+         a denied required check, ambiguous intent, mismatch); set
+         `escalation`.
     6. Write the report to a temporary file and attach it with
        `orbit.task.artifact.put` (`id` = `task_id`, `path` = `report_artifact`)
        using exactly this shape:
@@ -105,7 +127,8 @@ spec:
                      "paths":["src/x.rs"],
                      "disposition":{"kind":"open|repaired"}}],
         "validation":[{"command":"make ci-fast","outcome":"passed|failed|denied|not_run",
-                       "note":"optional"}],
+                       "role":"required|expected_failure|excluded|superseded",
+                       "note":"required unless the role is `required`"}],
         "escalation":"<required decision, when not a pass>"}
 
        Attach the report for every task id in `task_ids`.

--- a/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
@@ -15,6 +15,7 @@ use orbit_types::task::{ExternalRef, Task, TaskArtifact, TaskPriority, TaskStatu
 use orbit_types::workflow::{
     FindingDisposition, REVIEW_CONTRACT_VERSION, REVIEW_GATE_ARTIFACT, REVIEW_REPORT_ARTIFACT,
     ReviewFinding, ReviewReport, ReviewValidation, ReviewVerdict, ValidationOutcome,
+    ValidationRole,
 };
 use serde_json::{Value, json};
 
@@ -222,6 +223,7 @@ impl<'a> ScriptedEpicReviewHost<'a> {
             validation: vec![ReviewValidation {
                 command: "make ci-fast".to_string(),
                 outcome: ValidationOutcome::Passed,
+                role: ValidationRole::Required,
                 note: None,
             }],
             escalation: (self.reviewer.verdict == ReviewVerdict::ChangesRequired)

--- a/crates/orbit-core/src/application/job/tests/exec/review_gate.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/review_gate.rs
@@ -16,6 +16,7 @@ use orbit_types::task::{ExternalRef, Task, TaskArtifact, TaskPriority, TaskStatu
 use orbit_types::workflow::{
     FindingDisposition, REVIEW_CONTRACT_VERSION, REVIEW_GATE_ARTIFACT, REVIEW_REPORT_ARTIFACT,
     ReviewFinding, ReviewReport, ReviewValidation, ReviewVerdict, ValidationOutcome,
+    ValidationRole,
 };
 use serde_json::{Value, json};
 
@@ -263,6 +264,7 @@ impl<'a> ScriptedReviewHost<'a> {
             validation: vec![ReviewValidation {
                 command: "make ci-fast".to_string(),
                 outcome: ValidationOutcome::Passed,
+                role: ValidationRole::Required,
                 note: None,
             }],
             escalation: (self.reviewer.verdict == ReviewVerdict::ChangesRequired)

--- a/crates/orbit-core/src/application/review/gate.rs
+++ b/crates/orbit-core/src/application/review/gate.rs
@@ -5,7 +5,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use chrono::Utc;
-use orbit_automation::review::{combined_task_meaning_digest, task_meaning_digest};
+use orbit_automation::review::{
+    combined_task_meaning_digest, task_meaning_digest, validation_evidence, validation_role_counts,
+};
 use orbit_common::OrbitError;
 use orbit_common::fs::selector::overlaps;
 use orbit_engine::DispatchError;
@@ -21,7 +23,7 @@ use orbit_types::workflow::{
     CommitIdentity, FindingDisposition, REVIEW_CONTRACT_VERSION, REVIEW_GATE_ARTIFACT,
     REVIEW_MANIFEST_ARTIFACT, REVIEW_REPORT_ARTIFACT, ReviewAdmission, ReviewAttempt,
     ReviewAttemptState, ReviewCertificate, ReviewLedger, ReviewManifest, ReviewReport,
-    ReviewReservation, ReviewVerdict, ReviewerIdentity, ValidationOutcome,
+    ReviewReservation, ReviewVerdict, ReviewerIdentity,
 };
 use serde_json::{Value, json};
 
@@ -940,28 +942,14 @@ impl Judgement {
             }
             _ => {}
         }
+        // A pass rests on what the records establish, not on their count:
+        // a required check must have passed, while a declared negative
+        // control, an excluded action, and a superseded attempt carry their
+        // own consistency rules. Delivery coverage reads the same function.
         if self.verdict.passed() {
-            let denied = self
-                .validation
-                .iter()
-                .any(|record| record.outcome == ValidationOutcome::Denied);
-            let all_passed = !self.validation.is_empty()
-                && self
-                    .validation
-                    .iter()
-                    .all(|record| record.outcome == ValidationOutcome::Passed);
-            if denied {
-                self.downgrade(
-                    "validation_unavailable: a required validation command was denied by the \
-                     runner; the candidate is kept for unrestricted validation",
-                );
-            } else if !all_passed {
-                self.downgrade(
-                    "validation_incomplete: a pass needs every recorded validation command to \
-                     pass on the final candidate",
-                );
-            } else {
-                self.validation_complete = true;
+            match validation_evidence(&self.validation) {
+                Ok(()) => self.validation_complete = true,
+                Err(defect) => self.downgrade(&defect.reason()),
             }
         }
     }
@@ -1043,7 +1031,7 @@ fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity
          - Final candidate: `{}`\n\
          - Reviewer repair commits: {}\n\
          - Findings: {} ({} open)\n\
-         - Validation on final candidate: {} record(s), complete: {}\n\
+         - Validation on final candidate: {} record(s) [{}], complete: {}\n\
          - Consumed: {} reviewer start(s), {} repair cycle(s), {}s of {} min\n\
          - Escalation: {}\n\n\
          Reviewer repairs were validated but not independently reviewed; this verdict is \
@@ -1071,6 +1059,7 @@ fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity
             .filter(|finding| finding.disposition == FindingDisposition::Open)
             .count(),
         certificate.validation.len(),
+        validation_roles(&certificate.validation),
         certificate.validation_complete,
         certificate.consumed.reviewer_starts,
         certificate.consumed.repair_cycles,
@@ -1078,6 +1067,21 @@ fn verdict_comment(certificate: &ReviewCertificate, reviewed: &CandidateIdentity
         certificate.budget.minutes,
         certificate.escalation.as_deref().unwrap_or("none"),
     )
+}
+
+/// The classification breakdown of a validation set, so a reader sees which
+/// records were required checks and which were controls or exclusions
+/// without opening the certificate.
+fn validation_roles(records: &[orbit_types::workflow::ReviewValidation]) -> String {
+    let counts = validation_role_counts(records);
+    if counts.is_empty() {
+        return "none".to_string();
+    }
+    counts
+        .into_iter()
+        .map(|(role, count)| format!("{count} {}", role.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Write a gate artifact under the executor run's authority.

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -7,14 +7,14 @@ use chrono::Utc;
 use orbit_types::task::TaskStatus;
 use orbit_types::workflow::automation::{AutomationState, Delivery, SourcePage};
 use orbit_types::workflow::{
-    REVIEW_GATE_ARTIFACT, REVIEW_MANIFEST_ARTIFACT, ReviewAttemptState, ReviewCertificate,
-    ReviewVerdict,
+    REVIEW_CONTRACT_VERSION, REVIEW_GATE_ARTIFACT, REVIEW_MANIFEST_ARTIFACT, ReviewAttemptState,
+    ReviewCertificate, ReviewVerdict, ValidationOutcome, ValidationRole,
 };
 use serde_json::{Value, json};
 
 use super::{
     Fixture, GATED_CONFIG, admit_input, admitted_run, fixture, git, implement_candidate, report,
-    seed_task, settle_input, write_report,
+    seed_task, settle_input, validation, write_report,
 };
 use crate::application::automation::source::Source;
 use crate::application::review::{exclusions, review_gate_admit, review_gate_settle};
@@ -437,6 +437,157 @@ fn inconsistent_claims_and_denied_validation_are_downgraded_honestly() {
         "{error}"
     );
     assert_eq!(denied.certificate().verdict, ReviewVerdict::Incomplete);
+}
+
+#[test]
+fn a_negative_control_and_a_scope_exclusion_pass_alongside_required_checks() {
+    // ORB-11511: the reviewer honestly recorded the superseded assertion as
+    // failed (which is what proves the regression) and the unauthorized
+    // deployment as not run. Neither is a required candidate check, so the
+    // pass is correct and the record stays auditable.
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false);
+    claim.validation = vec![
+        validation(
+            "make ci-fast",
+            ValidationOutcome::Passed,
+            ValidationRole::Required,
+            None,
+        ),
+        validation(
+            "make ci-lint",
+            ValidationOutcome::Passed,
+            ValidationRole::Required,
+            None,
+        ),
+        validation(
+            "grep -q 'Strict-Transport-Security' old-config",
+            ValidationOutcome::Failed,
+            ValidationRole::ExpectedFailure,
+            Some("negative control: the superseded assertion must no longer hold"),
+        ),
+        validation(
+            "wrangler deploy",
+            ValidationOutcome::NotRun,
+            ValidationRole::Excluded,
+            Some("live deployment is explicitly outside the authorized scope"),
+        ),
+    ];
+    write_report(&gated.fixture.runtime, &gated.task_id, &claim);
+
+    let settled = gated.settle(&admission).expect("settle");
+    assert_eq!(settled["gate"], "passed");
+    assert_eq!(settled["verdict"], "passed_without_repairs");
+
+    let certificate = gated.certificate();
+    assert!(certificate.validation_complete);
+    assert_eq!(certificate.escalation, None);
+    assert_eq!(
+        certificate.validation, claim.validation,
+        "every raw observation and its classification survive into the certificate"
+    );
+
+    let comments = gated
+        .fixture
+        .runtime
+        .get_task_comments(&gated.task_id)
+        .expect("comments");
+    assert!(
+        comments.last().is_some_and(|comment| comment
+            .message
+            .contains("4 record(s) [2 required, 1 expected_failure, 1 excluded]")),
+        "the classification breakdown is disclosed on the task"
+    );
+
+    // The deterministic consumer reads the same contract: this certificate
+    // is spendable coverage for the landing that reproduces it.
+    let source = Source::new(&gated.fixture.repo);
+    let repository = source.repository().expect("repository");
+    let delivery = land_squash(&gated, &repository);
+    let (state, mut page) = page_for(&delivery);
+    exclusions(&gated.fixture.runtime, &source, &state, &mut page).expect("exclusions");
+    assert!(
+        page.exclusions.contains_key(&delivery.key),
+        "a controlled and scope-excluded validation set still covers its landing"
+    );
+}
+
+#[test]
+fn classifications_that_contradict_their_outcome_or_explain_nothing_are_refused() {
+    // A negative control that passed disproves what it was recorded for.
+    let contradicted = gated_fixture(GATED_CONFIG);
+    let admission = contradicted.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false);
+    claim.validation.push(validation(
+        "cargo test old_assertion",
+        ValidationOutcome::Passed,
+        ValidationRole::ExpectedFailure,
+        Some("the pre-fix reproduction must fail"),
+    ));
+    write_report(&contradicted.fixture.runtime, &contradicted.task_id, &claim);
+    let error = contradicted.settle(&admission).expect_err("contradicted");
+    assert!(
+        error.to_string().contains("validation_contradicted"),
+        "{error}"
+    );
+    assert_eq!(
+        contradicted.certificate().verdict,
+        ReviewVerdict::Incomplete
+    );
+
+    // An exclusion with nothing explaining it is not a scope decision.
+    let unexplained = gated_fixture(GATED_CONFIG);
+    let admission = unexplained.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false);
+    claim.validation.push(validation(
+        "wrangler deploy",
+        ValidationOutcome::NotRun,
+        ValidationRole::Excluded,
+        None,
+    ));
+    write_report(&unexplained.fixture.runtime, &unexplained.task_id, &claim);
+    let error = unexplained.settle(&admission).expect_err("unexplained");
+    assert!(
+        error.to_string().contains("validation_unexplained"),
+        "{error}"
+    );
+}
+
+#[test]
+fn a_legacy_report_without_classifications_keeps_its_conservative_reading() {
+    // Evidence written before the contract names no role, so every command
+    // it lists is still a required check.
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+    let legacy = json!({
+        "schema_version": REVIEW_CONTRACT_VERSION,
+        "attempt_id": attempt_id,
+        "verdict": "passed_without_repairs",
+        "summary": "Checked the change against the criteria.",
+        "findings": [],
+        "validation": [
+            {"command": "make ci-fast", "outcome": "passed"},
+            {"command": "deploy to production", "outcome": "not_run"},
+        ],
+    });
+    write_report(
+        &gated.fixture.runtime,
+        &gated.task_id,
+        &serde_json::from_value(legacy).expect("legacy report"),
+    );
+    let error = gated.settle(&admission).expect_err("conservative");
+    assert!(
+        error
+            .to_string()
+            .contains("required check `deploy to production` is not_run"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/crates/orbit-core/src/application/review/tests/mod.rs
+++ b/crates/orbit-core/src/application/review/tests/mod.rs
@@ -16,7 +16,7 @@ use orbit_engine::RuntimeHost;
 use orbit_types::task::{Task, TaskArtifact, TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::{
     FindingDisposition, JobRun, REVIEW_CONTRACT_VERSION, REVIEW_REPORT_ARTIFACT, ReviewFinding,
-    ReviewReport, ReviewValidation, ReviewVerdict, ValidationOutcome,
+    ReviewReport, ReviewValidation, ReviewVerdict, ValidationOutcome, ValidationRole,
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -206,10 +206,26 @@ pub(super) fn report(attempt_id: &str, verdict: ReviewVerdict, repaired: bool) -
         validation: vec![ReviewValidation {
             command: "make ci-fast".to_string(),
             outcome: ValidationOutcome::Passed,
+            role: ValidationRole::Required,
             note: None,
         }],
         escalation: (verdict == ReviewVerdict::ChangesRequired)
             .then(|| "decide whether the note is required".to_string()),
+    }
+}
+
+/// One classified validation record for a reviewer report.
+pub(super) fn validation(
+    command: &str,
+    outcome: ValidationOutcome,
+    role: ValidationRole,
+    note: Option<&str>,
+) -> ReviewValidation {
+    ReviewValidation {
+        command: command.to_string(),
+        outcome,
+        role,
+        note: note.map(ToString::to_string),
     }
 }
 

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -61,7 +61,7 @@ pub use review::{
     REVIEW_REPORT_ARTIFACT, ReviewAdmission, ReviewAssurance, ReviewAttempt, ReviewAttemptState,
     ReviewBudget, ReviewCertificate, ReviewConsumption, ReviewFinding, ReviewInvalidation,
     ReviewLanding, ReviewLedger, ReviewManifest, ReviewReport, ReviewReservation, ReviewTiming,
-    ReviewValidation, ReviewVerdict, ReviewerIdentity, ValidationOutcome,
+    ReviewValidation, ReviewVerdict, ReviewerIdentity, ValidationOutcome, ValidationRole,
 };
 pub use routine::{
     MissedRunPolicy, OverlapPolicy, ROUTINE_SCHEMA_VERSION, RoutineDefinition, RoutinePolicy,

--- a/crates/orbit-types/src/workflow/review.rs
+++ b/crates/orbit-types/src/workflow/review.rs
@@ -226,11 +226,67 @@ pub enum ValidationOutcome {
     NotRun,
 }
 
+impl ValidationOutcome {
+    /// Stable label for projections and escalation reasons.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ValidationOutcome::Passed => "passed",
+            ValidationOutcome::Failed => "failed",
+            ValidationOutcome::Denied => "denied",
+            ValidationOutcome::NotRun => "not_run",
+        }
+    }
+}
+
+/// What a recorded validation command is evidence of.
+///
+/// An outcome alone cannot say whether a failure was a defect or the point
+/// of the check, and an honest `not_run` entry for an action nobody
+/// authorized must not become a requirement merely by being listed. The
+/// reviewer therefore classifies each record and settlement judges the
+/// outcome against that claim.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationRole {
+    /// A check the final candidate must pass. Records written before this
+    /// classification existed carry no role and are read as required, so
+    /// older evidence keeps its conservative meaning.
+    #[default]
+    Required,
+    /// A negative control that must fail on the candidate: the superseded
+    /// assertion, the pre-fix reproduction, the counterfactual. The failure
+    /// is the positive evidence, and a pass contradicts the claim.
+    ExpectedFailure,
+    /// An action outside the authorized scope, deliberately not performed.
+    /// It supplies no coverage and imposes no requirement.
+    Excluded,
+    /// A superseded attempt kept for history: a diagnostic run that a later
+    /// required check on the final candidate replaced. It never erases the
+    /// observation and never substitutes for that later check.
+    Superseded,
+}
+
+impl ValidationRole {
+    /// Stable label for projections and escalation reasons.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ValidationRole::Required => "required",
+            ValidationRole::ExpectedFailure => "expected_failure",
+            ValidationRole::Excluded => "excluded",
+            ValidationRole::Superseded => "superseded",
+        }
+    }
+}
+
 /// One validation record in the reviewer report or the certificate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReviewValidation {
     pub command: String,
     pub outcome: ValidationOutcome,
+    /// What the record is evidence of; absent in legacy evidence, which is
+    /// then read as a required check.
+    #[serde(default)]
+    pub role: ValidationRole,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
 }

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -11,7 +11,7 @@ summary: Shipped operation-mode contract — typed preferences, scoped grants, g
 tags: [operation-mode, automation, authorization, recovery, operations]
 paths: ["crates/orbit-config/src/operation.rs", "crates/orbit-core/src/application/operation/**", "crates/orbit-core/src/application/review/**", "crates/orbit-store/src/driver/sqlite/operation/**", "crates/orbit-store/src/driver/sqlite/review/**", "crates/orbit-automation/src/members/**", "crates/orbit-automation/src/review/**", "crates/orbit-engine/src/executor/automation/vcs/review_gate.rs"]
 related_features: [automation-triggers, activity-job, routines]
-related_artifacts: [ORB-11333, ORB-11332, ORB-11331, ORB-11330]
+related_artifacts: [ORB-11528, ORB-11333, ORB-11332, ORB-11331, ORB-11330]
 ---
 
 # Operation Mode — Operations [ORB-11332]
@@ -258,8 +258,40 @@ and 30-minute wall clock. It reads the manifest, verifies claims against code,
 repairs only concrete in-scope defects directly in the worktree, runs
 validation, and persists `review-report.json` (schema version 1: verdict,
 findings with dispositions, validation records with `passed` / `failed` /
-`denied` / `not_run`, escalation). It never runs Git writes, changes task
-lifecycle, approves, or merges.
+`denied` / `not_run` and the `role` each is evidence of, escalation). It never
+runs Git writes, changes task lifecycle, approves, or merges.
+
+### What the validation records establish [ORB-11528]
+
+An honest reviewer records more than the checks that had to pass, so each
+validation record also carries a `role` saying what it is evidence of, and
+`orbit_automation::review::validation_evidence` decides what the set
+establishes. Settlement and delivery coverage both read that one function, so
+a certificate cannot mean one thing when it is issued and another when it is
+spent.
+
+| `role` | Meaning | Passing requires |
+| --- | --- | --- |
+| `required` (default) | A check the final candidate must pass | `passed`; `failed`, `denied`, and `not_run` all block |
+| `expected_failure` | A negative control — the superseded assertion, the pre-fix reproduction | `failed`; any other outcome contradicts the claim |
+| `excluded` | An action outside the authorized scope, deliberately not performed | `not_run` or `denied`; actually running it contradicts the exclusion |
+| `superseded` | A diagnostic attempt a later required check replaced | a later record in the list that is `required` and `passed` |
+
+At least one `required` record must have passed, so a set of controls and
+exclusions alone is never coverage. Every role other than `required` must
+carry a `note`; an unexplained reclassification is refused rather than
+trusted. A record written before this contract carries no role and is read as
+a required check, so older evidence keeps its conservative meaning. The
+certificate keeps every raw observation with its classification — a superseded
+failure is preserved, never erased — and the verdict comment discloses the
+breakdown. A denied required check keeps its own `validation_unavailable`
+reason: the runner refused, which is neither a defect in the candidate nor
+evidence about it.
+
+The contract version stays 1: a record carrying no role decides exactly as it
+did before, so no existing certificate is reinterpreted and none has to be
+reissued. Candidates already refused under the old rule recover through a
+fresh run, not by editing stored evidence.
 
 Settlement rechecks the checked-out head against the admitted candidate,
 reads the report with its artifact provenance (missing, predating the
@@ -269,10 +301,10 @@ uncommitted change as one repair commit authored `<family>-reviewer
 `Orbit-Review-Attempt` trailer, and cross-checks the claim: a pass with
 open findings, a claimed repair that changed nothing, a claimed clean pass
 that changed the tree, repairs outside the task selectors, a spent repair
-cycle, a failed or denied validation, or any task-meaning change other than
-selectors added through the task API downgrades the verdict to `incomplete`
-with the reason recorded. Verdicts are `passed_without_repairs`
-(`independent_review`), `passed_with_repairs`
+cycle, validation records that do not establish the candidate (above), or any
+task-meaning change other than selectors added through the task API
+downgrades the verdict to `incomplete` with the reason recorded. Verdicts are
+`passed_without_repairs` (`independent_review`), `passed_with_repairs`
 (`independent_review_with_self_authored_repairs`; the repairs were validated,
 not independently reviewed), `changes_required`, and `incomplete`. The
 certificate (`review-gate.json`, recorded immutably in the host store and


### PR DESCRIPTION
## Task

[ORB-11528](https://orbit-cli.com/tasks/ORB-11528) — Distinguish required candidate validation from expected failures and scope exclusions in review settlement

### Description

Observed on ORB-11511 run jrun-20260907-1914-3, candidate 104a95b8c3bd91424c759efb12e45e2d582bcdf9, reviewer rvw-9b973aa9d6c9-2: reviewer reported passed_without_repairs and zero findings. Deterministic review_gate_settle rejected incomplete because every recorded validation must pass. The reviewer truthfully recorded the old HSTS grep counterfactual as failed (expected, proves regression) and live Cloudflare deployment as not_run (explicitly unauthorized and outside scope). Required candidate checks passed. ORB-11517 run jrun-20260907-1907-5, candidate46a393c0382bd32ed0642c7c83d966af00556bbb, independently repeats validation_incomplete with zero findings; inspect its report to establish exact entries before treating as same cause. Current gate was introduced by ORB-11333; verify actual introducing diff before assigning regression provenance.

Repair the existing structured review validation contract and deterministic settlement so an expected negative control can provide positive validation evidence and explicitly out-of-scope actions do not become requirements merely by being honestly listed. Preserve hard failure for genuinely required candidate checks that fail, are denied, unrun or unsupported. Do not trust bare reviewer pass verdict to bypass contradictory evidence, silently drop entries, fabricate certificates, or require unauthorized deployment. Align reviewer schema/instructions, parser/settlement and tests with one clear minimal contract. Preserve conservative legacy compatibility. Daniel has now selected after-landing with Grok; do not enable the before-PR gate or perform live release/deployment. Opus hard for cross-boundary validation semantics and regression tests. Recovery of current candidates occurs through fresh ungated runs, not database edits or rewriting prior reports.

### Acceptance Criteria

- A regression fixture reproduces ORB-11511: expected failure of the old assertion and an explicitly excluded deployment coexist with passing required candidate checks and produce an auditable correct pass.
- Required failed, denied, missing or unrun candidate checks still prevent passing; unexplained contradictions and legacy ambiguous evidence remain conservative.
- Reviewer output contract and deterministic consumer agree; raw observations and classifications remain inspectable without inventing coverage or publication.
- Focused review tests, make ci-fast and make ci-lint pass. Preserve Daniel's live after-landing review policy with Grok; no release actions.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success — repaired, uncommitted in worktree `orbit-jrun-20260907-2017-5` (branch `orbit/ORB-11528-6a9f1bd6`, HEAD `439992a76`). Pipeline owns commit/PR.

## Root cause and provenance

Verified the introducing diff before assigning blame: `git log -S` puts the
rule in `d2cc023ea` "feat: Implement independent review policy… [ORB-11333]"
(#1499), not a later regression. `Judgement::reconcile_verdict` required
`!validation.is_empty() && validation.iter().all(outcome == Passed)`.
`ValidationOutcome` says what *happened* to a command; nothing said what it was
*for*, so a truthfully recorded negative control (`failed`) and an
unauthorized action (`not_run`) were read as required checks. Filed friction
F2026-09-055 with the three incidents and the general lesson.

## The contract

`ReviewValidation` gains `role: ValidationRole`
(`required` / `expected_failure` / `excluded` / `superseded`), `#[serde(default)]`
to `Required`. `orbit_automation::review::validation_evidence` (new
`crates/orbit-automation/src/review/validation.rs`) is the single decision
function; it returns a typed `ValidationDefect` whose `reason()` is the
escalation text. Rules:

- `required` → must be `passed`; `failed` / `denied` / `not_run` all block, and
  `denied` keeps its distinct `validation_unavailable` label.
- `expected_failure` → must be `failed`; any other outcome is
  `validation_contradicted`.
- `excluded` → must be `not_run` or `denied`; actually running it contradicts
  the exclusion.
- `superseded` → must be followed by a later `required` + `passed` record;
  order carries the meaning, and the failed observation is preserved.
- At least one `required` record must have passed (`NoRequiredCheck`).
- Any role other than `required` must carry a non-blank `note`
  (`validation_unexplained`).

`gate.rs` settlement and `certificate_acceptable` in delivery coverage both
call it, so the gate and the deterministic consumer cannot disagree; coverage
re-derives rather than trusting `validation_complete` alone. Contract version
stays 1 deliberately: a role-less record decides exactly as before, so no
stored certificate is reinterpreted and none must be reissued — bumping would
have invalidated every existing passed certificate via `MappingUnknown`.

Reviewer instructions updated in both `agent_review_repair.yaml` copies (roles,
the note rule, "never perform an unauthorized action to clear a record",
updated report shape). Design doc §10 gains "What the validation records
establish" with the rule table and the version rationale. The verdict comment
now discloses the breakdown (`4 record(s) [2 required, 1 expected_failure,
1 excluded]`).

## Criteria → results

1. **Regression fixture** — met. `a_negative_control_and_a_scope_exclusion_pass_alongside_required_checks`
   (review/tests/gate.rs) drives the real gate over a git checkout with the
   ORB-11511 shape (failed HSTS grep control + not_run deployment + two passing
   required checks) and asserts the pass, `validation_complete`, no escalation,
   that all four raw records survive into the certificate with their roles, the
   disclosed breakdown on the task, and that the certificate is spendable
   coverage for its own landing. The unit-level shape is also covered in
   automation `tests/validation.rs`, including the ORB-11516 superseded case.
2. **Hard failures preserved** — met.
   `required_checks_that_did_not_pass_still_block` covers failed/denied/not_run;
   `a_set_without_a_passing_required_check_establishes_nothing` covers missing;
   `an_outcome_that_contradicts_its_classification_blocks` and
   `classifications_that_contradict_their_outcome_or_explain_nothing_are_refused`
   cover contradictions and unexplained classifications at the gate boundary;
   `a_legacy_report_without_classifications_keeps_its_conservative_reading`
   deserializes a role-less report and confirms the old all-must-pass reading.
   The pre-existing denied-validation test still passes unchanged.
3. **Contract and consumer agree; inspectable** — met.
   `coverage_reads_the_same_validation_contract_the_gate_settled_under` shows a
   classified certificate is acceptable coverage and that a contradicted or
   unexplained one is `ValidationIncomplete` even with `validation_complete =
   true`. No coverage or publication is invented: no verdict is upgraded, no
   record is dropped, and `excluded` supplies no coverage of its own.
4. **Validation** — see below. Before-PR gate untouched and still disabled;
   after-landing/Grok policy unchanged; no release, deploy, or merge action.

## Validation commands

- `make ci-fast` — **passed** (fmt-check, doc-index check, all guardrails
  including `sync-activity-assets.sh --check`, which confirms the two activity
  YAML copies stay mirrored).
- `make ci-lint` — **passed** on the final code (workspace-wide, all-target
  clippy, warnings denied; clean, exit 0).
- `cargo test -p orbit-automation review` — **passed**, 14/14 (6 new).
- `cargo test -p orbit-core --lib application::review` — **passed**, 26/26
  (3 new gate tests).
- `cargo test -p orbit-core --lib review_gate` — **passed**, 6/6 (pipeline-level
  before-PR and epic gate tests).
- `git diff --check` / `git status --short` — clean; every change accounted for.
- Full `make ci` — **not run**, per workspace policy (it is the CI merge gate,
  not a per-task local check).

## Scope

Four selectors appended beyond the original `context_files`, recorded in a task
comment: `workflow/mod.rs` (re-export the new type),
`orbit-automation/src/review/validation.rs` + its sibling
`tests/validation.rs` (the shared contract and its required test layout), and
`job/tests/exec/epic_review_gate.rs` (constructs `ReviewValidation`). No new
cross-crate dependency edge: orbit-core already depended on
`orbit_automation::review`.

## Risks and deviations

- The `superseded` rule is positional (the replacing required check must come
  after it). This is deliberate and stated in the reviewer instruction and the
  doc, but a reviewer that appends a history section at the end of the list
  will be refused rather than passed. Conservative direction.
- The gate cannot re-execute the reviewer's commands, so classifications are
  trusted claims; the contract catches contradiction and missing coverage, not
  deliberate misreporting. That limit is unchanged from before this repair.
- Recovery of the three refused candidates is out of scope here and happens
  through fresh ungated runs, not by editing stored evidence.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11528-6a9f1bd6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra