### PR TITLE
Restore additive task-registry compatibility and automatically recover registries marked v6

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/mod.rs
@@ -16,9 +16,11 @@ mod store;
 mod util;
 mod workspace_id;
 
-// Required action-key storage must advance the version so existing v5
-// registries run schema setup before admission. Older binaries fail closed.
-const REGISTRY_SCHEMA_VERSION: u32 = 6;
+// Reader compatibility floor, not a counter for additive setup. Action keys
+// preserve the v5 task/allocator format and can be ignored by older readers.
+// Version 6 was shipped for that addition alone; schema.rs recovers it. Never
+// reuse 6 for an incompatible format.
+const REGISTRY_SCHEMA_VERSION: u32 = 5;
 
 pub fn task_registry_path(global_root: &Path) -> PathBuf {
     global_root.join("tasks").join("index.sqlite")

--- a/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/schema.rs
@@ -1,5 +1,7 @@
+use std::path::Path;
+
 use orbit_common::OrbitError;
-use rusqlite::Connection;
+use rusqlite::{Connection, TransactionBehavior, types::Value};
 
 use super::REGISTRY_SCHEMA_VERSION;
 use super::util::now_string;
@@ -7,19 +9,6 @@ use super::util::now_string;
 pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     migrate_path_coupled_workspace_bindings(conn)?;
     migrate_allocator_state_v5(conn)?;
-    // Schema v6: permanent action-to-task reservations survive bundle recovery.
-    // Some fresh v5 registries already contain this table. Keep their mappings
-    // intact, and allow replay if opening stopped before user_version was set.
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS task_action_keys (
-            workspace_id TEXT NOT NULL,
-            action_key TEXT NOT NULL,
-            task_id TEXT NOT NULL UNIQUE,
-            input_digest TEXT NOT NULL,
-            PRIMARY KEY(workspace_id, action_key)
-        );",
-    )
-    .map_err(|e| OrbitError::Store(format!("migrate task action keys to registry v6: {e}")))?;
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS allocator_state (
@@ -156,6 +145,150 @@ pub(super) fn apply_schema(conn: &Connection) -> Result<(), OrbitError> {
     Ok(())
 }
 
+// Required additive storage is checked even when user_version is current.
+// A complete registry needs no write transaction, including on read-only media.
+pub(super) fn ensure_compatible_schema(
+    conn: &mut Connection,
+    path: &Path,
+) -> Result<(), OrbitError> {
+    let version = registry_user_version(conn)?;
+    if version == REGISTRY_SCHEMA_VERSION
+        && table_has_column(conn, "task_action_keys", "action_key")?
+    {
+        return Ok(());
+    }
+    if version > 6 {
+        return Err(unsupported_schema(version, path));
+    }
+
+    // Serialize setup/recovery and re-read the version after taking the lock:
+    // another opener may have recovered v6 while this connection was waiting.
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|e| {
+            OrbitError::Store(format!(
+                "task registry '{}' requires writable additive setup/recovery: {e}",
+                path.display()
+            ))
+        })?;
+    let version = registry_user_version(&tx)?;
+    if version > REGISTRY_SCHEMA_VERSION && (version != 6 || !is_known_additive_v6(&tx)?) {
+        return Err(unsupported_schema(version, path));
+    }
+    ensure_action_keys(&tx)?;
+    if version == 6 {
+        tx.pragma_update(None, "user_version", REGISTRY_SCHEMA_VERSION)
+            .map_err(|e| {
+                OrbitError::Store(format!("recover compatible task registry version: {e}"))
+            })?;
+    }
+    tx.commit()
+        .map_err(|e| OrbitError::Store(format!("commit task registry additive setup: {e}")))
+}
+
+fn ensure_action_keys(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS task_action_keys (
+            workspace_id TEXT NOT NULL,
+            action_key TEXT NOT NULL,
+            task_id TEXT NOT NULL UNIQUE,
+            input_digest TEXT NOT NULL,
+            PRIMARY KEY(workspace_id, action_key)
+        );",
+    )
+    .map_err(|e| OrbitError::Store(format!("ensure task action keys: {e}")))
+}
+
+/// PR1509's v6 only added action keys to v5. Match the actual columns, keys,
+/// indexes and schema objects before lowering its compatibility marker. Column
+/// order in older task indexes differs after ALTER TABLE; their readers name
+/// columns explicitly. Action reservations use positional inserts, so retain
+/// their column order. This reference must stay at v5 when a future format ships.
+fn is_known_additive_v6(conn: &Connection) -> Result<bool, OrbitError> {
+    let reference = Connection::open_in_memory().map_err(|e| OrbitError::Store(e.to_string()))?;
+    apply_schema(&reference)?;
+    ensure_action_keys(&reference)?;
+    for query in [
+        "SELECT name, type, wr, strict FROM pragma_table_list
+         WHERE schema = 'main' AND name NOT GLOB 'sqlite_*' ORDER BY name",
+        "SELECT s.type, s.name FROM sqlite_schema s
+         WHERE s.name NOT GLOB 'sqlite_*' ORDER BY s.type, s.name",
+        "SELECT s.name, p.name, p.type, p.[notnull], p.dflt_value, p.pk, p.hidden
+         FROM sqlite_schema s, pragma_table_xinfo(s.name) p
+         WHERE s.type = 'table' AND s.name NOT GLOB 'sqlite_*'
+         ORDER BY s.name, CASE WHEN s.name = 'task_action_keys' THEN p.cid ELSE 0 END, p.name",
+        "SELECT s.name, i.name, i.[unique], i.origin, i.partial, x.seqno, x.name, x.desc, x.coll, x.key
+         FROM sqlite_schema s, pragma_index_list(s.name) i, pragma_index_xinfo(i.name) x
+         WHERE s.type = 'table' AND s.name NOT GLOB 'sqlite_*'
+         ORDER BY s.name, i.name, x.seqno",
+    ] {
+        if schema_rows(conn, query)? != schema_rows(&reference, query)? {
+            return Ok(false);
+        }
+    }
+    // Early registries did not declare all the current foreign keys. Missing
+    // keys are a shipped legacy shape; changed or additional keys are not.
+    let foreign_keys =
+        "SELECT s.name, f.[table], f.[from], f.[to], f.on_update, f.on_delete, f.match
+        FROM sqlite_schema s, pragma_foreign_key_list(s.name) f
+        WHERE s.type = 'table' ORDER BY s.name, f.id, f.seq";
+    let expected_keys = schema_rows(&reference, foreign_keys)?;
+    if schema_rows(conn, foreign_keys)?
+        .iter()
+        .any(|key| !expected_keys.contains(key))
+    {
+        return Ok(false);
+    }
+
+    // These tables carry the allocation/admission constraints. Ignore only
+    // formatting and identifier quotes introduced by SQLite table renames.
+    let definition = "SELECT sql FROM sqlite_schema WHERE name IN ('allocator_state', 'task_action_keys') ORDER BY name";
+    let normalize = |rows: Vec<Vec<Value>>| {
+        rows.into_iter()
+            .flatten()
+            .map(|value| match value {
+                Value::Text(sql) => sql
+                    .chars()
+                    .filter(|c| !c.is_ascii_whitespace() && *c != '"')
+                    .collect::<String>(),
+                _ => String::new(),
+            })
+            .collect::<Vec<_>>()
+    };
+    Ok(
+        normalize(schema_rows(conn, definition)?)
+            == normalize(schema_rows(&reference, definition)?),
+    )
+}
+
+fn schema_rows(conn: &Connection, query: &str) -> Result<Vec<Vec<Value>>, OrbitError> {
+    let mut stmt = conn
+        .prepare(query)
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    let columns = stmt.column_count();
+    stmt.query_map([], |row| {
+        (0..columns).map(|column| row.get(column)).collect()
+    })
+    .map_err(|e| OrbitError::Store(e.to_string()))?
+    .collect::<Result<_, _>>()
+    .map_err(|e| OrbitError::Store(e.to_string()))
+}
+
+fn unsupported_schema(version: u32, path: &Path) -> OrbitError {
+    let executable = std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "unknown executable".into());
+    OrbitError::Store(format!(
+        "task registry schema version {version} is newer than supported version {REGISTRY_SCHEMA_VERSION} \
+         or is not the known compatible additive format; registry '{}', executable '{}'. \
+         Upgrade the selected Orbit executable and restart long-lived processes. \
+         Check `command -v orbit` and `orbit --version` for mixed installations; \
+         do not edit the database version manually",
+        path.display(),
+        executable
+    ))
+}
+
 /// Schema v5 stores the machine's immutable minting prefix alongside its one
 /// monotonic allocator and removes the obsolete five-digit ceiling.
 fn migrate_allocator_state_v5(conn: &Connection) -> Result<(), OrbitError> {
@@ -250,16 +383,6 @@ fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| OrbitError::Store(e.to_string()))?;
     Ok(columns.iter().any(|candidate| candidate == column))
-}
-
-pub(super) fn reject_unsupported_registry_schema(conn: &Connection) -> Result<(), OrbitError> {
-    let version = registry_user_version(conn)?;
-    if version > REGISTRY_SCHEMA_VERSION {
-        return Err(OrbitError::Store(format!(
-            "task registry schema version {version} is newer than supported version {REGISTRY_SCHEMA_VERSION}"
-        )));
-    }
-    Ok(())
 }
 
 fn add_column_if_missing(

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -17,8 +17,7 @@ use super::queries::{
     workspace_checkout_by_paths, write_task_index_rows,
 };
 use super::schema::{
-    apply_schema, assert_registry_user_version, registry_user_version,
-    reject_unsupported_registry_schema,
+    apply_schema, assert_registry_user_version, ensure_compatible_schema, registry_user_version,
 };
 use super::util::{
     normalize_path, now_string, parse_relation_type_name, path_to_string, relation_type_name,
@@ -44,7 +43,7 @@ impl TaskRegistryStore {
             .unwrap_or_else(|| PathBuf::from("."));
         let workspaces_dir = normalize_path(&registry_dir.join("workspaces"));
         let opened = orbit_common::storage::sqlite::open_private(path)?;
-        let conn = opened.connection;
+        let mut conn = opened.connection;
         let read_only = opened.read_only;
         if !read_only {
             orbit_common::storage::sqlite::create_private_dir_all(&workspaces_dir)?;
@@ -70,10 +69,10 @@ impl TaskRegistryStore {
                 return Err(mapped);
             }
         }
-        reject_unsupported_registry_schema(&conn)?;
         if registry_user_version(&conn)? < super::REGISTRY_SCHEMA_VERSION {
             apply_schema(&conn)?;
         }
+        ensure_compatible_schema(&mut conn, path)?;
         assert_registry_user_version(&conn)?;
 
         Ok(Self {

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/schema.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread;
 
 use orbit_common::OrbitError;
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
@@ -93,7 +95,7 @@ fn prior_v5_upgrade_preserves_records_and_enables_action_reservations() {
         "DE-100005"
     );
     let conn = Connection::open(&path).expect("read upgraded registry");
-    assert_eq!(registry_user_version(&conn).expect("version"), 6);
+    assert_eq!(registry_user_version(&conn).expect("version"), 5);
     assert_eq!(
         table_columns(&conn, "task_action_keys"),
         ["workspace_id", "action_key", "task_id", "input_digest"]
@@ -232,7 +234,7 @@ fn v5_with_existing_action_mapping_keeps_reserved_identity() {
     );
     let conn = Connection::open(&path).expect("read upgraded fixture");
     assert_eq!(retained_rows(&conn), before);
-    assert_eq!(registry_user_version(&conn).expect("version"), 6);
+    assert_eq!(registry_user_version(&conn).expect("version"), 5);
 }
 
 #[cfg(unix)]
@@ -278,7 +280,7 @@ fn newer_registry_is_rejected_without_migrating_retained_records() {
     let temp = TempDir::new().expect("tempdir");
     let path = prior_v5(&temp);
     let conn = Connection::open(&path).expect("open fixture");
-    let newer = REGISTRY_SCHEMA_VERSION + 1;
+    let newer = 7;
     conn.pragma_update(None, "user_version", newer)
         .expect("set future version");
     let before = retained_rows(&conn);
@@ -295,4 +297,267 @@ fn newer_registry_is_rejected_without_migrating_retained_records() {
     assert_eq!(retained_rows(&conn), before);
     assert_eq!(registry_user_version(&conn).expect("version"), newer);
     assert!(table_columns(&conn, "task_action_keys").is_empty());
+}
+
+// Frozen DDL added by PR1509. Do not derive the historical v6 fixture from
+// the repaired opener, which must prove it can recover an already migrated DB.
+const V6_ACTION_KEYS: &str = "CREATE TABLE task_action_keys (
+    workspace_id TEXT NOT NULL,
+    action_key TEXT NOT NULL,
+    task_id TEXT NOT NULL UNIQUE,
+    input_digest TEXT NOT NULL,
+    PRIMARY KEY(workspace_id, action_key)
+);";
+
+fn known_v6(temp: &TempDir) -> PathBuf {
+    let path = prior_v5(temp);
+    let conn = Connection::open(&path).expect("open prior registry");
+    conn.execute_batch(V6_ACTION_KEYS)
+        .expect("apply shipped v6 DDL");
+    conn.execute_batch("PRAGMA user_version = 6;")
+        .expect("mark shipped version");
+    path
+}
+
+#[test]
+fn known_v6_recovers_preserving_reservations_and_bundle_replay() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = known_v6(&temp);
+    let params = admission_params();
+    let digest = format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(&params).expect("input"))
+    );
+    let conn = Connection::open(&path).expect("open v6");
+    conn.execute(
+        "INSERT INTO task_action_keys VALUES (?1, 'retained', 'DE-100005', ?2)",
+        params![WORKSPACE, digest],
+    )
+    .expect("seed v6 reservation");
+    conn.execute_batch("UPDATE allocator_state SET next_number = 100006;")
+        .expect("retain allocation");
+    let before = retained_rows(&conn);
+    drop(conn);
+
+    let registry = TaskRegistryStore::open(&path).expect("recover already migrated v6");
+    let conn = Connection::open(&path).expect("inspect recovery");
+    assert_eq!(registry_user_version(&conn).expect("version"), 5);
+    assert_eq!(retained_rows(&conn), before);
+    assert_eq!(
+        registry
+            .reserve_task_action(WORKSPACE, "retained", &digest)
+            .expect("replay"),
+        "DE-100005"
+    );
+    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    let created = tasks
+        .create_task_with_key(params.clone(), Some("retained"))
+        .expect("recover bundle");
+    assert_eq!(created.id, "DE-100005");
+    drop(tasks);
+    drop(registry);
+
+    let registry = TaskRegistryStore::open(&path).expect("repeat recovery");
+    let tasks = TaskV2Store::new_checkoutless(registry.clone(), WORKSPACE.into());
+    assert_eq!(
+        tasks
+            .create_task_with_key(params, Some("retained"))
+            .expect("replay bundle")
+            .created_at,
+        created.created_at
+    );
+    assert_eq!(registry.allocator_next_number().expect("allocator"), 100006);
+    assert!(
+        conn.execute(
+            "INSERT INTO task_action_keys VALUES ('ws_prior', 'different', 'DE-100005', 'digest')",
+            []
+        )
+        .is_err()
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO task_action_keys VALUES ('ws_prior', 'retained', 'DE-100006', 'digest')",
+            []
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn concurrent_additive_setup_and_v6_recovery_reserve_one_identity() {
+    for version in [5, 6] {
+        let temp = TempDir::new().expect("tempdir");
+        let path = if version == 5 {
+            prior_v5(&temp)
+        } else {
+            known_v6(&temp)
+        };
+        // WAL setup is not under test here; synchronize contenders after the
+        // fixture is in the same journal mode as an ordinary existing registry.
+        let conn = Connection::open(&path).expect("open fixture");
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .expect("enable WAL");
+        let barrier = Arc::new(Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let registry = TaskRegistryStore::open(&path).expect("concurrent open");
+                    registry
+                        .reserve_task_action(WORKSPACE, "concurrent", "digest")
+                        .expect("reserve")
+                })
+            })
+            .collect();
+        let ids: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("join"))
+            .collect();
+        assert!(ids.iter().all(|id| id == &ids[0]));
+        assert_eq!(registry_user_version(&conn).expect("version"), 5);
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM task_action_keys", [], |r| r
+                .get::<_, i64>(0))
+                .expect("count"),
+            1
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM task_bundle_bindings", [], |r| r
+                .get::<_, i64>(0))
+                .expect("count"),
+            1
+        );
+        let registry = TaskRegistryStore::open(&path).expect("reopen");
+        let next = registry.allocator_next_number().expect("allocator");
+        assert_eq!(
+            registry
+                .reserve_task_action(WORKSPACE, "concurrent", "digest")
+                .expect("replay"),
+            ids[0]
+        );
+        assert_eq!(registry.allocator_next_number().expect("allocator"), next);
+    }
+}
+
+#[test]
+fn interrupted_additive_setup_and_recovery_can_be_retried() {
+    for version in [5, 6] {
+        let temp = TempDir::new().expect("tempdir");
+        let path = if version == 5 {
+            prior_v5(&temp)
+        } else {
+            known_v6(&temp)
+        };
+        let conn = Connection::open(&path).expect("open fixture");
+        let before = retained_rows(&conn);
+        conn.execute_batch("BEGIN IMMEDIATE;")
+            .expect("begin interrupted setup");
+        if version == 5 {
+            conn.execute_batch(V6_ACTION_KEYS)
+                .expect("uncommitted additive table");
+        } else {
+            conn.execute_batch("PRAGMA user_version = 5;")
+                .expect("uncommitted recovery");
+        }
+        drop(conn); // Connection close rolls back an interrupted transaction.
+        let conn = Connection::open(&path).expect("inspect rollback");
+        assert_eq!(registry_user_version(&conn).expect("version"), version);
+        assert_eq!(retained_rows(&conn), before);
+        drop(TaskRegistryStore::open(&path).expect("retry after interruption"));
+        assert_eq!(registry_user_version(&conn).expect("version"), 5);
+        assert_eq!(retained_rows(&conn), before);
+    }
+}
+
+#[test]
+fn unrecognized_v6_shapes_are_rejected_without_lowering_version() {
+    for mutation in [
+        "DROP TABLE task_action_keys;",
+        "ALTER TABLE task_action_keys ADD COLUMN future TEXT;",
+        "DROP TABLE task_action_keys; CREATE TABLE task_action_keys (workspace_id TEXT NOT NULL, action_key TEXT NOT NULL, task_id TEXT NOT NULL, input_digest TEXT NOT NULL, PRIMARY KEY(workspace_id, action_key));",
+        "CREATE TABLE future_format (payload BLOB);",
+        "CREATE TRIGGER future_trigger AFTER INSERT ON task_action_keys BEGIN DELETE FROM task_action_keys; END;",
+        "ALTER TABLE allocator_state RENAME COLUMN task_prefix TO incompatible_prefix;",
+    ] {
+        let temp = TempDir::new().expect("tempdir");
+        let path = known_v6(&temp);
+        let conn = Connection::open(&path).expect("open v6");
+        conn.execute_batch(mutation).expect("alter fixture format");
+        let before = retained_rows(&conn);
+        let error = match TaskRegistryStore::open(&path) {
+            Ok(_) => panic!("accepted incompatible v6: {mutation}"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("known compatible additive format"),
+            "{error}"
+        );
+        assert!(error.contains(path.to_str().expect("path")), "{error}");
+        assert!(error.contains("command -v orbit"), "{error}");
+        assert_eq!(registry_user_version(&conn).expect("version"), 6);
+        assert_eq!(retained_rows(&conn), before);
+    }
+}
+
+#[test]
+fn known_v6_with_legacy_altered_column_order_recovers() {
+    let temp = TempDir::new().expect("tempdir");
+    let path = known_v6(&temp);
+    let conn = Connection::open(&path).expect("open fixture");
+    // Before job_run_id was added, timestamps preceded it. Reproduce the
+    // shipped ALTER TABLE path, which also lacked the newer foreign keys.
+    conn.execute_batch(
+        "DROP TABLE task_bundle_index;
+        CREATE TABLE task_bundle_index (
+            task_id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL,
+            status TEXT NOT NULL, priority TEXT NOT NULL,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+        ALTER TABLE task_bundle_index ADD COLUMN job_run_id TEXT;
+        ALTER TABLE task_bundle_index ADD COLUMN terminal_month TEXT;
+        ALTER TABLE task_bundle_index ADD COLUMN complexity TEXT;",
+    )
+    .expect("legacy index table");
+    // Restore exactly the indexes shipped on this table, independently of the
+    // repaired production setup.
+    for statement in include_str!("prior_v5.sql").split(';') {
+        if statement.trim_start().starts_with("CREATE INDEX")
+            && statement.contains("ON task_bundle_index(")
+        {
+            conn.execute_batch(statement).expect("historical index");
+        }
+    }
+    let before = retained_rows(&conn);
+    drop(TaskRegistryStore::open(&path).expect("recover legacy v6"));
+    assert_eq!(registry_user_version(&conn).expect("version"), 5);
+    assert_eq!(retained_rows(&conn), before);
+}
+
+#[cfg(unix)]
+#[test]
+fn readonly_known_v6_waits_for_writable_recovery() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("tempdir");
+    let path = known_v6(&temp);
+    let before = fs::read(&path).expect("snapshot");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("read-only");
+    let error = match TaskRegistryStore::open(&path) {
+        Ok(_) => panic!("readonly v6 cannot persist recovery"),
+        Err(error) => error,
+    };
+    assert!(error.is_readonly_or_access_failure(), "{error}");
+    assert!(error.to_string().contains("requires writable"), "{error}");
+    assert_eq!(fs::read(&path).expect("unchanged DB"), before);
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).expect("writable");
+    drop(TaskRegistryStore::open(&path).expect("recover v6"));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400)).expect("read-only again");
+    let registry = TaskRegistryStore::open(&path).expect("read recovered registry");
+    assert!(
+        registry
+            .find_task_binding("DE-100004")
+            .expect("read task")
+            .is_some()
+    );
 }

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -5,7 +5,7 @@ tags: [operations, upgrades, migrations, recovery]
 paths: ["crates/orbit-cmd/src/update/**", "crates/orbit-store/src/workflow/layout/**", "crates/orbit-store/src/driver/sqlite/migration/**"]
 related_features: [orbit-core]
 related_artifacts: [ORB-10014, ORB-11280, ORB-11344]
-last_validated: 2026-09-06
+last_validated: 2026-09-07
 ---
 
 # Upgrade Orbit Safely
@@ -67,8 +67,8 @@ includes that root explicitly, so retrying from a different checkout does not si
 workspace being repaired.
 
 The outgoing executable stays at `<orbit>.previous`. Restore it only if `.orbit/` state was not
-migrated: once a migration has been applied, an older binary refuses to open the workspace by
-design. See [Respect the downgrade guard](#respect-the-downgrade-guard).
+migrated to a format it cannot read: an older binary refuses unsupported compatibility
+versions. Additive storage can remain compatible, as described below. See [Respect the downgrade guard](#respect-the-downgrade-guard).
 
 Without a root override, `orbit update` converges **the workspace you run it from**. `ORBIT_ROOT`
 selects an environment-only override, while an explicit `--root` takes precedence over it. Run
@@ -102,6 +102,71 @@ Two ledgers guard `.orbit/` state and auto-apply on workspace open:
 - **Store schema:** the `schema_meta` ledger table inside `orbit.db`, backed by
   `crates/orbit-store/src/driver/sqlite/migration/`. Each migration and its ledger row commit in one
   transaction.
+
+The host task registry has a separate reader-compatibility marker:
+`PRAGMA user_version` in `~/.orbit/tasks/index.sqlite` (or the configured global
+root). Its v5 task/allocator format also supports the additive `task_action_keys`
+table. The repaired executable ensures that table when opening a writable v5
+registry, without raising the reader-compatibility floor. A complete v5 registry
+can still open read-only; missing additive storage requires a writable open.
+
+### Recover a task registry marked version 6
+
+A previous build marked this additive table as registry v6, causing v5 readers
+to fail even on ordinary workspace/task access. A build containing the repair
+recognizes the shipped compatible v6 columns, keys, indexes, and allocation
+constraints, then restores the v5 marker in a transaction. Existing task data,
+allocator state, and permanent action reservations remain intact. Repeated or
+concurrent recovery is safe. Unknown schema versions or unrecognized v6 shapes
+remain refused; recovery never means discarding tables or task data.
+
+Executable upgrade and database recovery are separate steps. An already-installed
+old executable does not learn a future migration. Install a build containing this
+repair through its owning install channel, then invoke **that exact executable**
+to open the registry. No manual SQL or registry reset is needed. `orbit migrate`
+reports workspace layout and store-schema migrations; its dry-run report is not
+an inventory of task-registry additive setup.
+
+For mixed macOS installations, inspect the paths before rollout:
+
+```sh
+type -a orbit
+command -v orbit
+ls -l /opt/homebrew/bin/orbit
+/opt/homebrew/bin/orbit --version
+~/.cargo/bin/orbit --version
+```
+
+For example, `/opt/homebrew/bin/orbit` may still point to
+`Cellar/orbit/0.19.0` while `~/.cargo/bin/orbit` is a different checkout build.
+Building the latter does not upgrade Homebrew or change shell command selection.
+A version string alone may not distinguish two checkout builds; confirm the
+selected executable was built from a revision containing the repair. Upgrade
+Homebrew through Homebrew when a release containing the fix is available, or use
+an explicitly selected, validated repaired build under the rollout owner's direction.
+
+Quiesce the build that writes v6 and take a consistent backup of the registry
+and canonical bundles using [the state inventory](./state-and-backup.md). Then
+open through the repaired build on that host, for example:
+
+```sh
+/path/to/repaired/orbit workspace list
+/path/to/repaired/orbit tool run orbit.task.show --input '{"id":"<real-task-id>","model":"codex"}'
+```
+
+After this supported open has recovered a compatible v6 registry, a v5 reader
+can again read its existing workspaces and tasks. Before that open, an old v5
+executable still refuses v6. Do not keep the defective v6 writer running: it can
+raise the marker again. Align `PATH`, any explicit `ORBIT_BIN`, MCP/service
+launch paths, and restarted workers with the intended executable. Other host
+store/layout/host-config compatibility guards still apply; registry recovery is
+not a guarantee that every older release can read every other store.
+
+If recovery is refused, use the reported database and executable paths to check
+which installation is running. Upgrade the selected executable or escalate the
+unrecognized format to the rollout owner; never lower `user_version` manually.
+This repair's automated fixtures run on Linux. macOS Homebrew/PATH behavior and
+live host rollout require verification on the affected Mac by the rollout owner.
 
 ## Back up before a major upgrade
 


### PR DESCRIPTION
## Task

[ORB-11544](https://orbit-cli.com/tasks/ORB-11544) — Restore additive task-registry compatibility and automatically recover registries marked v6

### Description

Daniel reports `orbit workspace list` fails with `task registry schema version 6 is newer than supported version 5`. This regression was introduced by ORB-11529, PR1509, merge7f318c5ca (approved by this orchestrator). That repair changed REGISTRY_SCHEMA_VERSION 5->6 solely to trigger creation of additive task_action_keys; the deleted comment explicitly said the auxiliary table does not change v5 task/allocator format and rollback binaries may safely ignore it. Existing open skips apply_schema when version is current, causing original missing-table issue. Solve BOTH problems: ensure required additive tables on existing compatible registries automatically without unnecessarily raising the reader compatibility floor; safely recover already migrated v6 registries through supported opening/migration code with all task/action reservations intact. Do not merely revert the version constant (would strand v6), remove forward-version guards wholesale, reset registry data, or tell operators to run ad-hoc SQL. Distinguish known compatible additive changes from genuinely unsupported future formats. Inspect existing registry schema and migration contract, use minimal coherent current seams, and provide automatic migration/recovery with actionable binary/path diagnostic if a truly incompatible reader cannot proceed. User's Mac PATH selects /opt/homebrew/bin/orbit -> Cellar/orbit/0.19.0, while ~/.cargo/bin/orbit is another newly built binary, so mixed installations are a real operator scenario. Linux authoritative MCP remains operational at filing. Scope source and isolated-fixture verification; orchestrator owns live rollout. Preserve missing-table repair and idempotent delivery action-key admission. No release publishing.

### Acceptance Criteria

- An authentic old v5 registry missing task_action_keys opens with the fixed binary and automatically gains required storage; task creation/replay works with existing task/allocator/mapping data preserved.
- A known v6 registry produced by PR1509 is automatically recovered by supported code without manual SQL, data loss, or duplicate action reservations, and remains usable by a v5-compatible reader where the actual format is compatible.
- Mixed old/new binary regression evidence demonstrates that this additive table change does not gratuitously break ordinary existing registry/workspace/task access, including opening an already-migrated v6 fixture with the repaired binary before using the old reader.
- Unknown genuinely newer/incompatible schemas remain protected; interrupted/repeated/concurrent additive setup and known-v6 recovery are safe and preserve uniqueness/idempotency.
- Provide focused regression tests and required checks, plus precise rollout guidance distinguishing executable upgrade from database migration; never claim an already-installed old executable learns a future migration automatically.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restored the registry reader-compatibility floor to v5 and moved required action-key setup into the ordinary open path, including existing v5 databases whose version is already current.
- Added serialized, transactional recovery for the known additive v6 format. Recovery checks actual table options, schema objects, columns, indexes/uniqueness, foreign keys, and allocation/admission definitions before restoring the v5 marker; task and reservation rows are untouched. Unknown newer versions and unrecognized v6 shapes remain refused with database/executable paths and binary-selection guidance.
- Preserved read-only access for complete v5 registries. Missing additive storage or v6 recovery requires a writable open; interruption rolls back and a later open retries.
- Updated docs/runbooks/upgrades.md with exact-executable selection, Homebrew/cargo/PATH and ORBIT_BIN distinctions, automatic registry recovery, quiescing the defective v6 writer, and rollout limits.

Acceptance criteria:
1. PASS: the independently frozen authentic prior_v5.sql fixture gains task_action_keys automatically without a version bump. Existing allocator, workspace/checkout bindings, task bindings/index/tags/relations are preserved. Canonical task creation and repeated action-key replay preserve reserved identity and creation time.
2. PASS: populated known-v6 fixtures recover without deleting or rewriting task/action data. A compiled probe using PR1509's actual implementation also migrated an isolated old-v5 fixture to v6; the repaired executable recovered that database, after which the historical v5 executable read it successfully. Reservation uniqueness and bundle replay are covered.
3. PASS: compiled probes linked to actual old (7f318c5ca^), faulty (7f318c5ca registry implementation), and repaired orbit-store code exercised workspace, checkout, task-binding, task-status-index, and allocator reads. Old -> repaired -> old succeeds for v5. Untouched v6 correctly fails in the old executable, then repaired -> old -> repaired succeeds. All seeded rows/action mappings and SQLite integrity checks are preserved.
4. PASS: tests cover unsupported v7, six incompatible v6 mutations, historical ALTER TABLE column ordering, read-only v6 refusal followed by writable recovery, interrupted transaction rollback/retry, repeated open/replay, and eight simultaneous connections converging on one action reservation for both v5 and v6. Existing allocator behavior may leave harmless unused numbers under contention; replay consumes no additional number.
5. PASS: focused regressions, required gates, and precise rollout guidance supplied. No claim that an installed old executable learns new recovery logic.

Validation:
- PASSED: cargo fmt --all.
- PASSED: cargo test -p orbit-store driver::sqlite::task_registry::tests -- --test-threads=4 (49 tests, 0 failures).
- PASSED: make ci-fast.
- PASSED: make ci-lint (workspace, all targets, warnings denied).
- PASSED: cargo build --locked -p orbit-store and historical/faulty probe builds; python3 probe_matrix.py mixed-executable matrix, with final repaired binary rebuilt after the final source changes.
- EXPECTED FAILED, demonstrating regression detection: the final schema tests against PR1509's implementation in a disposable source archive (8 failed, 3 passed). Failures include the unwanted v6 marker, absent recovery, and acceptance of malformed v6 storage.
- Initial temporary matrix fixture failed timestamp parsing because it used date-only values; corrected to valid RFC3339 fixture timestamps, then the complete matrix passed.
- PASSED: git diff --check and final git status --short. Read the complete diff; all five changed files are original selectors. Starting HEAD 3395ce248f3b753bd42aea5e1f2e24380b5e245c was clean. No dependency edges, release files, or unlisted source changes.
- NOT RUN: full make ci, per workspace policy (PR merge gate).
- NOT RUN: full CLI/macOS/Homebrew/live-host rollout, intentionally outside this source/isolated-fixture mandate. Registry probes verify the actual persistence boundary on Linux; they do not establish macOS executable selection. ci-fast's existing Cursor smoke check reports headless execution unavailable and validates its local plugin contract.

Evidence: task artifact registry-compatibility-evidence.txt contains probe source, reproduction matrix, executable hashes/provenance, expected regression failures, and required gate logs.

Assessment: both regressions are resolved within the existing registry boundary; allocation and action-key admission code remain unchanged. v6 is reserved as the shipped additive exception and must never be reused for an incompatible format. Future format work must retain the v5 recovery reference.
Risks/rollout: the defective v6 writer can raise the marker again; stop/restart it and align every launch path with the repaired executable. Other store/layout/host-config guards remain independent. Live rollout belongs to the orchestrator.
Friction checkpoint: no separate qualifying friction beyond the already assigned regression; no duplicate record filed.
Deviations: none. Changes remain uncommitted; commit, push, PR, and lifecycle delivery transitions remain with the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11544-6a9f1fc2`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra