### PR TITLE
[code-review] Review wall-time budget loses interrupted work and does not bound the current attempt

### DIFF
--- a/.orbit/resources/activities/agent_review_repair.yaml
+++ b/.orbit/resources/activities/agent_review_repair.yaml
@@ -35,6 +35,12 @@ spec:
       crew:
         type: string
         description: The separately configured review crew resolved by review_gate_admit.
+      remaining_seconds:
+        type: integer
+        description: >
+          Captured leftover wall-time allowance for this lineage attempt, in
+          seconds. The host shortens the activity timeout to this value; it
+          cannot extend the declared ceiling.
   output_schema_json:
     type: object
     properties:
@@ -61,6 +67,11 @@ spec:
       task edit allowed, and only when a repair needs it.
     - Read broadly; write narrowly. Reading unrelated code does not authorize
       editing it.
+    - Honor the remaining wall-time budget in the pinned manifest
+      (`remaining.seconds`, also supplied as `remaining_seconds`). Stop and
+      write an `incomplete` report before that allowance is exhausted. The
+      activity timeout is a ceiling on this leftover, not extra time beyond
+      the captured lineage budget.
 
     Procedure
 
@@ -68,7 +79,8 @@ spec:
        `orbit.task.artifact.get` (`id` = `task_id`, `path` =
        `manifest_artifact`). Confirm `attempt_id` matches the supplied
        `attempt_id`, that `git rev-parse HEAD` equals `candidate.commit`, and
-       that `base.commit` is an ancestor of HEAD. On any mismatch write a
+       that `base.commit` is an ancestor of HEAD. Note `remaining.seconds`
+       and treat it as the wall-time you may spend. On any mismatch write a
        report with verdict `incomplete` and stop.
     2. Review spec compliance first: check every acceptance criterion against
        the actual diff (`git diff <base.commit>..HEAD`), the affected callers,

--- a/.orbit/resources/jobs/epic_pipeline.yaml
+++ b/.orbit/resources/jobs/epic_pipeline.yaml
@@ -199,6 +199,7 @@ spec:
         manifest_artifact: "{{ steps.review_gate_admit.output.manifest_artifact }}"
         report_artifact: "{{ steps.review_gate_admit.output.report_artifact }}"
         crew: "{{ steps.review_gate_admit.output.reviewer.crew }}"
+        remaining_seconds: "{{ steps.review_gate_admit.output.remaining.seconds }}"
 
     - id: review_gate_settle
       target: activity:review_gate_settle

--- a/.orbit/resources/jobs/task_pr_pipeline.yaml
+++ b/.orbit/resources/jobs/task_pr_pipeline.yaml
@@ -142,6 +142,7 @@ spec:
         manifest_artifact: "{{ steps.review_gate_admit.output.manifest_artifact }}"
         report_artifact: "{{ steps.review_gate_admit.output.report_artifact }}"
         crew: "{{ steps.review_gate_admit.output.reviewer.crew }}"
+        remaining_seconds: "{{ steps.review_gate_admit.output.remaining.seconds }}"
 
     - id: review_gate_settle
       target: activity:review_gate_settle

--- a/crates/orbit-core/assets/activities/agent_review_repair.yaml
+++ b/crates/orbit-core/assets/activities/agent_review_repair.yaml
@@ -35,6 +35,12 @@ spec:
       crew:
         type: string
         description: The separately configured review crew resolved by review_gate_admit.
+      remaining_seconds:
+        type: integer
+        description: >
+          Captured leftover wall-time allowance for this lineage attempt, in
+          seconds. The host shortens the activity timeout to this value; it
+          cannot extend the declared ceiling.
   output_schema_json:
     type: object
     properties:
@@ -61,6 +67,11 @@ spec:
       task edit allowed, and only when a repair needs it.
     - Read broadly; write narrowly. Reading unrelated code does not authorize
       editing it.
+    - Honor the remaining wall-time budget in the pinned manifest
+      (`remaining.seconds`, also supplied as `remaining_seconds`). Stop and
+      write an `incomplete` report before that allowance is exhausted. The
+      activity timeout is a ceiling on this leftover, not extra time beyond
+      the captured lineage budget.
 
     Procedure
 
@@ -68,7 +79,8 @@ spec:
        `orbit.task.artifact.get` (`id` = `task_id`, `path` =
        `manifest_artifact`). Confirm `attempt_id` matches the supplied
        `attempt_id`, that `git rev-parse HEAD` equals `candidate.commit`, and
-       that `base.commit` is an ancestor of HEAD. On any mismatch write a
+       that `base.commit` is an ancestor of HEAD. Note `remaining.seconds`
+       and treat it as the wall-time you may spend. On any mismatch write a
        report with verdict `incomplete` and stop.
     2. Review spec compliance first: check every acceptance criterion against
        the actual diff (`git diff <base.commit>..HEAD`), the affected callers,

--- a/crates/orbit-core/assets/jobs/epic_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/epic_pipeline.yaml
@@ -199,6 +199,7 @@ spec:
         manifest_artifact: "{{ steps.review_gate_admit.output.manifest_artifact }}"
         report_artifact: "{{ steps.review_gate_admit.output.report_artifact }}"
         crew: "{{ steps.review_gate_admit.output.reviewer.crew }}"
+        remaining_seconds: "{{ steps.review_gate_admit.output.remaining.seconds }}"
 
     - id: review_gate_settle
       target: activity:review_gate_settle

--- a/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/task_pr_pipeline.yaml
@@ -142,6 +142,7 @@ spec:
         manifest_artifact: "{{ steps.review_gate_admit.output.manifest_artifact }}"
         report_artifact: "{{ steps.review_gate_admit.output.report_artifact }}"
         crew: "{{ steps.review_gate_admit.output.reviewer.crew }}"
+        remaining_seconds: "{{ steps.review_gate_admit.output.remaining.seconds }}"
 
     - id: review_gate_settle
       target: activity:review_gate_settle

--- a/crates/orbit-core/src/application/review/gate.rs
+++ b/crates/orbit-core/src/application/review/gate.rs
@@ -147,11 +147,11 @@ pub(crate) fn review_gate_settle(
     }
     let context =
         GateContext::load(runtime, &settle_input).map_err(|error| failed(error.to_string()))?;
-    let Some(admission) = context.admission.clone() else {
+    if context.admission.is_none() {
         return Err(failed(
             "review_gate_stale: the run no longer carries a review admission".to_string(),
         ));
-    };
+    }
     let attempt_id = admission_output
         .get("attempt_id")
         .and_then(Value::as_str)
@@ -161,14 +161,7 @@ pub(crate) fn review_gate_settle(
     let reviewer = reviewer_identity(runtime, &context, &admission_output)
         .map_err(|error| failed(error.to_string()))?;
 
-    let outcome = settle(
-        runtime,
-        &context,
-        &admission,
-        &attempt_id,
-        reviewer,
-        &admission_output,
-    );
+    let outcome = settle(runtime, &context, &attempt_id, reviewer, &admission_output);
     let (status, decision, error) = match &outcome {
         Ok(Settled::Passed(value)) => (AuditEventStatus::Success, value.clone(), None),
         Ok(Settled::Blocked { certificate }) => (
@@ -418,11 +411,11 @@ fn admit(
                  {}/{}, repair cycles {}/{}, {}s of {}s); a recorded decision must reset or \
                  re-scope this candidate before another review",
                 consumed.reviewer_starts,
-                admission.budget.reviewer_starts,
+                ledger.budget.reviewer_starts,
                 consumed.repair_cycles,
-                admission.budget.repair_cycles,
+                ledger.budget.repair_cycles,
                 consumed.seconds,
-                u64::from(admission.budget.minutes) * 60
+                u64::from(ledger.budget.minutes) * 60
             )));
         }
     };
@@ -446,8 +439,8 @@ fn admit(
         reviewer_crew: crew.name.clone(),
         contract_version: REVIEW_CONTRACT_VERSION,
         policy_version: admission.policy_version,
-        budget: admission.budget,
-        remaining: ledger.remaining(),
+        budget: ledger.budget,
+        remaining: ledger.remaining_at(now),
         issued_at: now,
     };
     let manifest_bytes = serde_json::to_vec_pretty(&manifest)
@@ -486,8 +479,8 @@ fn admit(
         "task_selectors": selectors,
         "manifest_artifact": REVIEW_MANIFEST_ARTIFACT,
         "report_artifact": REVIEW_REPORT_ARTIFACT,
-        "budget": admission.budget,
-        "remaining": ledger.remaining(),
+        "budget": ledger.budget,
+        "remaining": ledger.remaining_at(now),
         "started_at": attempt.started_at.to_rfc3339(),
     }))
 }
@@ -586,7 +579,6 @@ enum Settled {
 fn settle(
     runtime: &OrbitRuntime,
     context: &GateContext,
-    admission: &ReviewAdmission,
     attempt_id: &str,
     reviewer: ReviewerIdentity,
     admission_output: &Value,
@@ -639,6 +631,9 @@ fn settle(
     judgement.check_task_meaning(context, &attempt, &admitted_selectors)?;
     let repair = judgement.commit_repairs(context, &reviewer, &attempt)?;
     judgement.reconcile_verdict(&ledger, repair.as_ref());
+    let now = Utc::now();
+    let elapsed_seconds = attempt.elapsed_at(now);
+    judgement.enforce_wall_time(&ledger, elapsed_seconds);
 
     let final_candidate = match &repair {
         Some(commit) => SourceRevision {
@@ -647,8 +642,6 @@ fn settle(
         },
         None => reviewed.head.clone(),
     };
-    let now = Utc::now();
-    let elapsed_seconds = u64::try_from((now - attempt.started_at).num_seconds()).unwrap_or(0);
     let repair_cycles = u32::from(repair.is_some());
     let ledger = store.review_settle(
         &context.workspace_id,
@@ -681,7 +674,7 @@ fn settle(
         validation_complete: judgement.validation_complete,
         reviewer,
         consumed: ledger.consumed(),
-        budget: admission.budget,
+        budget: ledger.budget,
         escalation: judgement.escalation.clone(),
         issued_at: now,
     };
@@ -951,6 +944,22 @@ impl Judgement {
                 Ok(()) => self.validation_complete = true,
                 Err(defect) => self.downgrade(&defect.reason()),
             }
+        }
+    }
+
+    /// A pass may not spend more wall time than the captured lineage budget,
+    /// including this attempt's elapsed seconds. Non-pass verdicts still
+    /// record the honest elapsed time.
+    fn enforce_wall_time(&mut self, ledger: &ReviewLedger, elapsed_seconds: u64) {
+        if !self.verdict.passed() {
+            return;
+        }
+        let budget_seconds = u64::from(ledger.budget.minutes).saturating_mul(60);
+        if ledger.consumed_seconds.saturating_add(elapsed_seconds) > budget_seconds {
+            self.downgrade(
+                "review_minutes_exhausted: this attempt exceeded the captured lineage \
+                 wall-time allowance",
+            );
         }
     }
 

--- a/crates/orbit-core/src/application/review/projection.rs
+++ b/crates/orbit-core/src/application/review/projection.rs
@@ -4,6 +4,7 @@
 //! gate wrote as a task artifact, the lineage ledger, and any landing
 //! records. A task without a certificate simply has no review projection.
 
+use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_types::task::{ArtifactManifestFileV2, Task};
 use orbit_types::workflow::{REVIEW_GATE_ARTIFACT, ReviewCertificate};
@@ -69,7 +70,7 @@ pub fn task_review_projection(
         "task_meaning_digest": certificate.task_meaning_digest,
         "budget": certificate.budget,
         "consumed": certificate.consumed,
-        "remaining": ledger.as_ref().map(|ledger| ledger.remaining()),
+        "remaining": ledger.as_ref().map(|ledger| ledger.remaining_at(Utc::now())),
         "attempts": ledger.as_ref().map(|ledger| ledger.attempts.len()).unwrap_or(0),
         "landings": landings,
         "stale_reasons": stale_reasons,

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -3,12 +3,15 @@
 use std::collections::BTreeMap;
 use std::fs;
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
+use orbit_automation::review::{combined_task_meaning_digest, task_meaning_digest};
+use orbit_store::contracts::ReviewReserveRequest;
 use orbit_types::task::TaskStatus;
-use orbit_types::workflow::automation::{AutomationState, Delivery, SourcePage};
+use orbit_types::workflow::automation::{AutomationState, Delivery, SourcePage, SourceRevision};
 use orbit_types::workflow::{
     REVIEW_CONTRACT_VERSION, REVIEW_GATE_ARTIFACT, REVIEW_MANIFEST_ARTIFACT, ReviewAttemptState,
-    ReviewCertificate, ReviewVerdict, ValidationOutcome, ValidationRole,
+    ReviewBudget, ReviewCertificate, ReviewReservation, ReviewVerdict, ValidationOutcome,
+    ValidationRole,
 };
 use serde_json::{Value, json};
 
@@ -17,7 +20,7 @@ use super::{
     seed_task, settle_input, validation, write_report,
 };
 use crate::application::automation::source::Source;
-use crate::application::review::{exclusions, review_gate_admit, review_gate_settle};
+use crate::application::review::{exclusions, lineage_key, review_gate_admit, review_gate_settle};
 use crate::application::task::TaskUpdateParams;
 
 /// Fixture with a task, its admitted run, and a checked-out candidate.
@@ -623,6 +626,77 @@ fn budgets_persist_across_attempts_and_interrupted_attempts_resume() {
         error.to_string().contains("review_starts_exhausted"),
         "{error}"
     );
+}
+
+#[test]
+fn an_over_budget_pass_cannot_issue_a_certificate() {
+    let gated = gated_fixture(
+        "[crews.reviewers]\nmodel = \"review-model\"\nprovider = \"codex\"\nbackend = \"cli\"\n[crews.implementer]\nmodel = \"impl-model\"\nprovider = \"codex\"\nbackend = \"cli\"\n[workflow]\ndefault_crew = \"implementer\"\n[operation]\nreview_policy = \"before-pr\"\nreview_crew = \"reviewers\"\nreview_minutes = 1\n",
+    );
+    let task = gated
+        .fixture
+        .runtime
+        .get_task(&gated.task_id)
+        .expect("task");
+    let digest = task_meaning_digest(&task).expect("digest");
+    let combined =
+        combined_task_meaning_digest(&[(task.id.to_string(), digest)]).expect("combined");
+    let workspace_id = gated.fixture.runtime.workspace_id().expect("workspace");
+    let lineage = lineage_key(&workspace_id, std::slice::from_ref(&gated.task_id), "main");
+    let started = Utc::now() - Duration::minutes(2);
+    let candidate = SourceRevision {
+        commit: gated.implementation_sha.clone(),
+        tree: git(&gated.fixture.repo, &["rev-parse", "HEAD^{tree}"]),
+    };
+    let store = gated.fixture.runtime.review_store().expect("store");
+    let ReviewReservation::Reserved { attempt } = store
+        .review_reserve(
+            &workspace_id,
+            &ReviewReserveRequest {
+                lineage_key: &lineage,
+                task_ids: std::slice::from_ref(&gated.task_id),
+                run_id: &gated.run_id,
+                task_meaning_digest: &combined,
+                candidate: &candidate,
+                budget: ReviewBudget {
+                    reviewer_starts: 2,
+                    repair_cycles: 2,
+                    minutes: 1,
+                },
+                now: started,
+            },
+        )
+        .expect("pre-reserve")
+        .0
+    else {
+        panic!("pre-reserve a start two minutes ago");
+    };
+
+    let admission = gated.admit().expect("resume the overdue attempt");
+    assert_eq!(admission["decision"], "resumed");
+    assert_eq!(admission["attempt_id"], attempt.attempt_id);
+    assert_eq!(
+        admission["remaining"]["seconds"].as_u64(),
+        Some(0),
+        "the leftover allowance for this invocation is already spent"
+    );
+    write_report(
+        &gated.fixture.runtime,
+        &gated.task_id,
+        &report(
+            &attempt.attempt_id,
+            ReviewVerdict::PassedWithoutRepairs,
+            false,
+        ),
+    );
+    let error = gated.settle(&admission).expect_err("over budget");
+    let message = error.to_string();
+    assert!(message.contains("review_minutes_exhausted"), "{message}");
+    let certificate = gated.certificate();
+    assert_eq!(certificate.verdict, ReviewVerdict::Incomplete);
+    assert!(!certificate.verdict.passed());
+    assert_eq!(certificate.budget.minutes, 1);
+    assert!(certificate.consumed.seconds >= 120);
 }
 
 #[test]

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -92,6 +92,13 @@ pub fn run_cli_backend(
         Some(requested) => requested.min(declared_timeout_seconds),
         None => declared_timeout_seconds,
     };
+    // A reviewer invocation may carry the captured leftover lineage
+    // allowance. It can only shorten the same ceiling; a zero leftover
+    // still gets one second so the process is not unbounded.
+    let timeout_seconds = match input.get("remaining_seconds").and_then(Value::as_u64) {
+        Some(remaining) => timeout_seconds.min(remaining.max(1)),
+        None => timeout_seconds,
+    };
     let wall_clock_timeout = Duration::from_secs(timeout_seconds);
 
     let task_ids = task_ids_from_input(input);

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/trusted_host.rs
@@ -361,3 +361,44 @@ fn an_ordinary_activity_ignores_a_requested_timeout() {
         .expect("started event");
     assert_eq!(observed, 45_000);
 }
+
+/// Captured leftover review minutes may only shorten the activity ceiling.
+#[test]
+fn remaining_seconds_can_only_shorten_the_declared_bound() {
+    let temp = tempdir().expect("tempdir");
+    let host = TestHost::with_command(echoing_provider(temp.path()));
+    let spec = test_agent_loop_spec(Duration::from_secs(60));
+
+    for (remaining, expected_ms) in [(30_u64, 30_000_u64), (600, 60_000), (0, 1_000)] {
+        let (audit, _sink) = writer("job-review-remaining");
+        run_cli_backend(
+            &host,
+            &spec,
+            "agent_review_repair",
+            "job-review-remaining",
+            audit.clone(),
+            &serde_json::json!({
+                "prompt": "x",
+                "remaining_seconds": remaining
+            }),
+            None,
+        )
+        .expect("run");
+        let observed = audit
+            .events_snapshot()
+            .expect("events snapshot")
+            .iter()
+            .find_map(|event| match &event.kind {
+                V2AuditEventKind::CliInvocationStarted {
+                    wall_clock_timeout_ms,
+                    ..
+                } => Some(*wall_clock_timeout_ms),
+                _ => None,
+            })
+            .expect("started event");
+        assert_eq!(
+            observed, expected_ms,
+            "remaining {remaining}s against a 60s declared bound"
+        );
+    }
+}

--- a/crates/orbit-store/src/contracts/review.rs
+++ b/crates/orbit-store/src/contracts/review.rs
@@ -47,7 +47,9 @@ pub trait ReviewStoreBackend: Send + Sync {
 
     /// Reserve a reviewer start. An open attempt for the same candidate and
     /// task meaning is resumed rather than charged again; a different
-    /// candidate settles the open attempt as incomplete first.
+    /// candidate settles the open attempt as incomplete, charging elapsed
+    /// wall time from `started_at` to `now` once, then applies the captured
+    /// budget to the new start.
     fn review_reserve(
         &self,
         workspace_id: &str,

--- a/crates/orbit-store/src/driver/sqlite/review/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/review/mod.rs
@@ -138,7 +138,8 @@ impl ReviewStoreBackend for Store {
             });
 
             // An interrupted attempt on the same candidate resumes; on a
-            // different candidate it is partial work, settled as incomplete.
+            // different candidate it is partial work, settled as incomplete
+            // with the wall time already spent.
             if let Some(open) = ledger.open_attempt().cloned() {
                 if open.candidate == *request.candidate
                     && open.task_meaning_digest == request.task_meaning_digest
@@ -150,7 +151,7 @@ impl ReviewStoreBackend for Store {
                     &open.attempt_id,
                     ReviewVerdict::Incomplete,
                     0,
-                    0,
+                    open.elapsed_at(request.now),
                 );
                 write_ledger(
                     conn,

--- a/crates/orbit-store/src/driver/sqlite/review/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/review/tests/mod.rs
@@ -25,11 +25,30 @@ fn store() -> std::sync::Arc<dyn ReviewStoreBackend> {
     compose::review_store(Store::open_in_memory().unwrap()).unwrap()
 }
 
+fn budget(minutes: u32) -> ReviewBudget {
+    ReviewBudget {
+        reviewer_starts: 2,
+        repair_cycles: 2,
+        minutes,
+    }
+}
+
 fn reserve(
     store: &dyn ReviewStoreBackend,
     run_id: &str,
     candidate: &str,
     digest: &str,
+) -> ReviewReservation {
+    reserve_at(store, run_id, candidate, digest, budget(30), Utc::now())
+}
+
+fn reserve_at(
+    store: &dyn ReviewStoreBackend,
+    run_id: &str,
+    candidate: &str,
+    digest: &str,
+    budget: ReviewBudget,
+    now: chrono::DateTime<Utc>,
 ) -> ReviewReservation {
     let task_ids = vec!["ORB-1".to_string()];
     store
@@ -41,12 +60,8 @@ fn reserve(
                 run_id,
                 task_meaning_digest: digest,
                 candidate: &revision(candidate),
-                budget: ReviewBudget {
-                    reviewer_starts: 2,
-                    repair_cycles: 2,
-                    minutes: 30,
-                },
-                now: Utc::now(),
+                budget,
+                now,
             },
         )
         .unwrap()
@@ -190,6 +205,85 @@ fn wall_time_exhaustion_refuses_a_further_start() {
         panic!("minutes are spent");
     };
     assert_eq!(reason, "review_minutes_exhausted");
+}
+
+#[test]
+fn interrupted_candidate_invalidation_charges_elapsed_once_and_exhausts_captured_minutes() {
+    let store = store();
+    let t0 = Utc::now();
+    let ReviewReservation::Reserved { attempt } =
+        reserve_at(store.as_ref(), "run-1", "impl", "meaning", budget(1), t0)
+    else {
+        panic!("reserve");
+    };
+
+    let later = t0 + Duration::minutes(5);
+    let ReviewReservation::Exhausted { reason, consumed } = reserve_at(
+        store.as_ref(),
+        "run-2",
+        "impl-2",
+        "meaning",
+        budget(30),
+        later,
+    ) else {
+        panic!("five minutes against a one-minute captured budget must exhaust");
+    };
+    assert_eq!(reason, "review_minutes_exhausted");
+    assert_eq!(consumed.seconds, 5 * 60);
+    assert_eq!(consumed.reviewer_starts, 1);
+
+    let ledger = store.review_ledger(WORKSPACE, LINEAGE).unwrap().unwrap();
+    assert_eq!(
+        ledger.budget.minutes, 1,
+        "a later request cannot expand the captured budget"
+    );
+    assert_eq!(ledger.attempts.len(), 1);
+    assert_eq!(ledger.attempts[0].elapsed_seconds, Some(5 * 60));
+    assert_eq!(
+        ledger.attempts[0].state,
+        ReviewAttemptState::Settled {
+            verdict: ReviewVerdict::Incomplete
+        }
+    );
+
+    // Replaying settlement of the interrupted attempt does not charge again.
+    let replayed = store
+        .review_settle(
+            WORKSPACE,
+            &ReviewSettlement {
+                lineage_key: LINEAGE,
+                attempt_id: &attempt.attempt_id,
+                verdict: ReviewVerdict::PassedWithoutRepairs,
+                repair_cycles: 9,
+                elapsed_seconds: 900,
+                now: later + Duration::minutes(1),
+            },
+        )
+        .unwrap();
+    assert_eq!(replayed.consumed_seconds, 5 * 60);
+    assert_eq!(replayed.attempts[0].elapsed_seconds, Some(5 * 60));
+    assert_eq!(
+        replayed.attempts[0].state,
+        ReviewAttemptState::Settled {
+            verdict: ReviewVerdict::Incomplete
+        }
+    );
+}
+
+#[test]
+fn remaining_at_counts_open_attempt_elapsed_without_settling() {
+    let store = store();
+    let t0 = Utc::now();
+    let ReviewReservation::Reserved { .. } =
+        reserve_at(store.as_ref(), "run-1", "impl", "meaning", budget(1), t0)
+    else {
+        panic!("reserve");
+    };
+    let ledger = store.review_ledger(WORKSPACE, LINEAGE).unwrap().unwrap();
+    assert_eq!(ledger.remaining().seconds, 60);
+    assert_eq!(ledger.remaining_at(t0).seconds, 60);
+    assert_eq!(ledger.remaining_at(t0 + Duration::seconds(40)).seconds, 20);
+    assert_eq!(ledger.remaining_at(t0 + Duration::minutes(2)).seconds, 0);
 }
 
 #[test]

--- a/crates/orbit-types/src/workflow/review.rs
+++ b/crates/orbit-types/src/workflow/review.rs
@@ -507,6 +507,18 @@ pub struct ReviewAttempt {
     pub elapsed_seconds: Option<u64>,
 }
 
+impl ReviewAttempt {
+    /// Recorded elapsed time once settled, or wall time from `started_at` to
+    /// `now` while the attempt is still open. A clock behind `started_at`
+    /// counts as zero rather than wrapping.
+    pub fn elapsed_at(&self, now: DateTime<Utc>) -> u64 {
+        if let Some(elapsed) = self.elapsed_seconds {
+            return elapsed;
+        }
+        u64::try_from(now.signed_duration_since(self.started_at).num_seconds()).unwrap_or(0)
+    }
+}
+
 /// Aggregate review consumption for one delivery candidate lineage. Retry,
 /// interruption, candidate invalidation, and delivery lineage share it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -549,19 +561,31 @@ impl ReviewLedger {
         }
     }
 
-    /// What the lineage may still spend.
+    /// What the lineage may still spend after settled consumption. An open
+    /// attempt's running wall time is not included; use [`Self::remaining_at`]
+    /// for a live leftover.
     pub fn remaining(&self) -> ReviewConsumption {
-        let consumed = self.consumed();
+        Self::remaining_from(self.budget, self.consumed())
+    }
+
+    /// Remaining allowance at `now`, counting an open attempt's elapsed wall
+    /// time so a resumed invocation sees leftover seconds rather than the
+    /// full captured budget.
+    pub fn remaining_at(&self, now: DateTime<Utc>) -> ReviewConsumption {
+        let mut consumed = self.consumed();
+        if let Some(open) = self.open_attempt() {
+            consumed.seconds = consumed.seconds.saturating_add(open.elapsed_at(now));
+        }
+        Self::remaining_from(self.budget, consumed)
+    }
+
+    fn remaining_from(budget: ReviewBudget, consumed: ReviewConsumption) -> ReviewConsumption {
         ReviewConsumption {
-            reviewer_starts: self
-                .budget
+            reviewer_starts: budget
                 .reviewer_starts
                 .saturating_sub(consumed.reviewer_starts),
-            repair_cycles: self
-                .budget
-                .repair_cycles
-                .saturating_sub(consumed.repair_cycles),
-            seconds: u64::from(self.budget.minutes)
+            repair_cycles: budget.repair_cycles.saturating_sub(consumed.repair_cycles),
+            seconds: u64::from(budget.minutes)
                 .saturating_mul(60)
                 .saturating_sub(consumed.seconds),
         }

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -305,7 +305,8 @@ uncommitted change as one repair commit authored `<family>-reviewer
 `Orbit-Review-Attempt` trailer, and cross-checks the claim: a pass with
 open findings, a claimed repair that changed nothing, a claimed clean pass
 that changed the tree, repairs outside the task selectors, a spent repair
-cycle, validation records that do not establish the candidate (above), or any
+cycle, elapsed wall time beyond the captured lineage `review_minutes`
+allowance, validation records that do not establish the candidate (above), or any
 task-meaning change other than selectors added through the task API
 downgrades the verdict to `incomplete` with the reason recorded. Verdicts are
 `passed_without_repairs` (`independent_review`), `passed_with_repairs`
@@ -329,8 +330,13 @@ the handoff.
 
 The ledger is keyed by workspace, sorted task set, and base branch. It spans
 retries, interruptions, candidate invalidations, and delivery lineage; nothing
-resets it. Reviewer starts are reserved before a reviewer launches, repair
-cycles and wall seconds settle with the attempt, and exhaustion escalates
+resets it. The first budget written on a lineage is captured; a later config
+change cannot expand or replace it. Reviewer starts are reserved before a
+reviewer launches. An interrupted open attempt on a changed candidate settles
+as incomplete with the wall time already spent, once. Repair cycles and wall
+seconds settle with the attempt. The reviewer invocation timeout is the
+captured leftover seconds (capped by the activity's declared ceiling), and a
+pass that exceeds the leftover allowance is refused. Exhaustion escalates
 (`review_budget_exhausted: review_starts_exhausted |
 review_minutes_exhausted`). Provider token/cost caps are not enforced; usage
 stays unknown.


### PR DESCRIPTION
## Task

[ORB-11523](https://orbit-cli.com/tasks/ORB-11523) — [code-review] Review wall-time budget loses interrupted work and does not bound the current attempt

### Description

## Problem
operation.review_minutes does not reliably bound review work across an interrupted candidate or the current reviewer invocation.

## Live evidence and reproduction
Verified at f8c156f06ec866fd36b5deaf0d0eae8e67ec6e24:
- crates/orbit-store/src/driver/sqlite/review/mod.rs:147-154 settles an interrupted open attempt for a changed candidate with elapsed_seconds=0; reserve_new_in at :396 checks only the resulting consumed_seconds.
- A reproduction linked against the actual compiled orbit-store API reserved an attempt five minutes ago with a one-minute budget, then invalidated its candidate. The old attempt was recorded with Some(0) elapsed seconds and another reviewer was reserved. Source is attached to sweep ORB-11451 as review-repros.rs.
- crates/orbit-core/assets/activities/agent_review_repair.yaml:170 always grants 1800 seconds. The resolved remaining budget is present in the manifest but never applied to that timeout; the instruction also never asks the reviewer to stop at the remaining time.
- crates/orbit-core/src/application/review/gate.rs:629-642 records elapsed time after reconciling the verdict, without refusing a pass that exceeded the lineage allowance. A successful two-minute first review with review_minutes=1 can therefore pass.

Account interrupted work honestly and enforce the captured remaining wall-time allowance at execution/settlement. Do not count a renewed candidate as zero prior work or silently replace lineage limits with the fixed activity timeout. Preserve documented idempotent replay semantics.

### Acceptance Criteria

- Deterministic clock-based tests show interrupted candidate invalidation charges prior elapsed work once and refuses a further start when the captured allowance is exhausted.
- Reviewer execution and final settlement honor the remaining review_minutes allowance; an over-budget report cannot issue a passing certificate.
- Retries do not double-charge settled work, budgets remain captured across config changes, and required repository checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Interrupted candidate invalidation now settles the open attempt with elapsed wall time from `started_at` to `now` (once). A later start is refused when the captured `review_minutes` allowance is already spent; a later request cannot expand that captured budget.
- `ReviewLedger::remaining_at(now)` counts an open attempt's running time so admit/manifest remaining is leftover seconds, not the full captured budget.
- Settlement refuses a pass when `consumed_seconds + this attempt's elapsed` exceeds the captured lineage minutes; the certificate records the ledger budget. Replay still does not double-charge.
- `agent_review_repair` instructs the reviewer to stop at `remaining.seconds`. PR and epic pipelines pass that value as `remaining_seconds`. The CLI runner shortens the 1800s activity ceiling to that leftover (floor 1s) and cannot extend it.
Assessment: Scoped to the review ledger, gate, reviewer activity, and the two pipelines that launch it. Existing resume and settlement-replay tests still pass.

Criteria:
- Interrupted invalidation charges elapsed once and refuses a further start when captured minutes are exhausted: covered by `interrupted_candidate_invalidation_charges_elapsed_once_and_exhausts_captured_minutes` (clock: t0 reserve with 1 minute, t0+5m new candidate exhausts; replay settle does not add time).
- Reviewer execution and settlement honor remaining `review_minutes`; over-budget report cannot pass: admit remaining uses `remaining_at`; pipelines pass `remaining_seconds`; CLI timeout is `min(declared, remaining.max(1))`; `an_over_budget_pass_cannot_issue_a_certificate` resumes a 2-minute-old 1-minute attempt and refuses a pass.
- Retries do not double-charge; budgets stay captured across config changes; required checks pass: existing replay test plus the invalidation replay assertion; captured `minutes: 1` survives a later `minutes: 30` reserve request.

Validation:
- `cargo test -p orbit-store --lib driver::sqlite::review --offline`: passed (6 tests)
- `cargo test -p orbit-core --lib application::review::tests::gate --offline`: passed (19 tests)
- `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::trusted_host --offline`: passed (8 tests)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

Strategic decisions: remaining timeout is a shorten-only cap on the activity ceiling rather than replacing it, and leftover 0 still gets 1s so the process is not unbounded. Certificate budget is the captured ledger budget.
Design weaknesses / risks: Severity low — `remaining_seconds` in any agent-loop input shortens timeout; only the review pipelines pass that field. A resumed over-budget attempt still launches for 1s then settlement refuses the pass, instead of skipping the agent.
Deviations: none.
Recommended follow-ups: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11523-6a9f1f70`
- Behind base: 0
- Ahead of base: 1