### PR TITLE
Support validated crew effort configuration and include effort in effective config output

### DIFF
--- a/crates/orbit-cli/src/command/config/get.rs
+++ b/crates/orbit-cli/src/command/config/get.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use orbit_config::{CONFIG_KEY_REGISTRY, load_effective_config};
-use orbit_core::{OrbitError, OrbitRuntime};
+use orbit_config::{admit_config_key, load_effective_config};
+use orbit_core::OrbitRuntime;
 use serde_json::json;
 
 use crate::command::{CommandOut, CommandOutput, Execute, Payload};
@@ -20,16 +20,11 @@ pub struct ConfigGetArgs {
 impl Execute for ConfigGetArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
         if self.scope == ConfigScopeArg::Effective {
+            admit_config_key(&self.key)?;
             let effective = load_effective_config(&runtime_config_roots(runtime))?;
-            let value = effective.value_for(&self.key).ok_or_else(|| {
-                OrbitError::invalid_input_with_suggestions(
-                    format!("unknown config key '{}'", self.key),
-                    CONFIG_KEY_REGISTRY
-                        .iter()
-                        .map(|descriptor| descriptor.key.to_string())
-                        .collect(),
-                )
-            })?;
+            let value = effective
+                .value_for(&self.key)
+                .unwrap_or(serde_json::Value::Null);
             if self.json {
                 return Ok(Payload::document(json!({
                     "key": self.key,

--- a/crates/orbit-cli/src/command/config/tests/get.rs
+++ b/crates/orbit-cli/src/command/config/tests/get.rs
@@ -1,0 +1,107 @@
+use std::fs;
+
+use crate::command::{CommandOutput, Execute};
+
+use super::super::get::ConfigGetArgs;
+use super::super::set::ConfigSetArgs;
+use super::super::support::ConfigScopeArg;
+use super::test_runtime;
+
+fn get_args(key: &str, json: bool) -> ConfigGetArgs {
+    ConfigGetArgs {
+        key: key.to_string(),
+        scope: ConfigScopeArg::Effective,
+        json,
+    }
+}
+
+fn set_args(key: &str, value: &str) -> ConfigSetArgs {
+    ConfigSetArgs {
+        key: key.to_string(),
+        value: value.to_string(),
+        global: false,
+        seed_from_global: false,
+        fresh: false,
+    }
+}
+
+fn write_sol_crew(path: &std::path::Path) {
+    fs::write(
+        path,
+        "[workflow]\ndefault_crew = \"sol\"\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\n",
+    )
+    .expect("write sol crew config");
+}
+
+fn json_value(output: CommandOutput) -> serde_json::Value {
+    let CommandOutput::Payload(payload) = output else {
+        panic!("expected JSON payload, got {output:?}");
+    };
+    let (document, _) = payload.into_view();
+    document
+}
+
+#[test]
+fn get_rejects_misspelled_crew_field() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+
+    let error = get_args("crews.sol.effrot", true)
+        .execute(&runtime)
+        .expect_err("misspelled crew field must fail");
+    assert!(error.to_string().contains("effrot"), "{error}");
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|suggestions| suggestions.iter().any(|key| key == "crews.sol.effort")),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn get_omitted_crew_effort_is_null_not_a_fabricated_default() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+
+    let document = json_value(
+        get_args("crews.sol.effort", true)
+            .execute(&runtime)
+            .expect("omitted effort is gettable"),
+    );
+    assert_eq!(document["key"], "crews.sol.effort");
+    assert_eq!(document["value"], serde_json::Value::Null);
+}
+
+#[test]
+fn get_agrees_with_set_for_sol_crew_effort() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+
+    set_args("crews.sol.effort", "high")
+        .execute(&runtime)
+        .expect("set sol effort");
+
+    let document = json_value(
+        get_args("crews.sol.effort", true)
+            .execute(&runtime)
+            .expect("get configured effort"),
+    );
+    assert_eq!(document["value"], "high");
+}
+
+#[test]
+fn get_reads_hand_authored_crew_effort() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    fs::write(
+        workspace_root.join("config.toml"),
+        "[workflow]\ndefault_crew = \"sol\"\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\neffort = \"high\"\n",
+    )
+    .expect("write hand-authored effort");
+
+    let document = json_value(
+        get_args("crews.sol.effort", true)
+            .execute(&runtime)
+            .expect("get hand-authored effort"),
+    );
+    assert_eq!(document["value"], "high");
+}

--- a/crates/orbit-cli/src/command/config/tests/mod.rs
+++ b/crates/orbit-cli/src/command/config/tests/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use orbit_core::OrbitRuntime;
 use tempfile::tempdir;
 
+mod get;
 mod set;
 mod show;
 mod support;

--- a/crates/orbit-cli/src/command/config/tests/set.rs
+++ b/crates/orbit-cli/src/command/config/tests/set.rs
@@ -136,3 +136,107 @@ fn set_rejects_unknown_key() {
         .expect_err("unknown key must be rejected");
     assert!(error.did_you_mean().is_some());
 }
+
+fn write_sol_crew(path: &std::path::Path) {
+    fs::write(
+        path,
+        "[workflow]\ndefault_crew = \"sol\"\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\n# hand-authored comment\n",
+    )
+    .expect("write sol crew config");
+}
+
+#[test]
+fn set_crew_effort_on_existing_sol_crew_round_trips() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+
+    set_args("crews.sol.effort", "high", false, false, false)
+        .execute(&runtime)
+        .expect("set sol effort succeeds");
+
+    let saved =
+        fs::read_to_string(workspace_root.join("config.toml")).expect("read workspace config");
+    assert!(saved.contains("effort = \"high\""), "{saved}");
+    assert!(saved.contains("# hand-authored comment"), "{saved}");
+    assert!(saved.contains("model = \"gpt-5.6-sol\""), "{saved}");
+}
+
+#[test]
+fn set_crew_effort_rejects_invalid_value_without_writing() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+    let original = fs::read(workspace_root.join("config.toml")).expect("read original");
+
+    let error = set_args("crews.sol.effort", "medium-low", false, false, false)
+        .execute(&runtime)
+        .expect_err("invalid effort must be rejected");
+    assert!(error.to_string().contains("expected one of"), "{error}");
+
+    let after = fs::read(workspace_root.join("config.toml")).expect("read after failed set");
+    assert_eq!(after, original);
+}
+
+#[test]
+fn set_crew_effort_rejects_unsupported_provider_without_writing() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    fs::write(
+        workspace_root.join("config.toml"),
+        "[workflow]\ndefault_crew = \"gemini\"\n\n[crews.gemini]\nmodel = \"gemini\"\nprovider = \"gemini\"\n",
+    )
+    .expect("write gemini crew");
+    let original = fs::read(workspace_root.join("config.toml")).expect("read original");
+
+    let error = set_args("crews.gemini.effort", "high", false, false, false)
+        .execute(&runtime)
+        .expect_err("unsupported provider must be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("does not support configured reasoning effort"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read(workspace_root.join("config.toml")).expect("read after failed set"),
+        original
+    );
+}
+
+#[test]
+fn set_rejects_misspelled_crew_field_without_writing() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    write_sol_crew(&workspace_root.join("config.toml"));
+    let original = fs::read(workspace_root.join("config.toml")).expect("read original");
+
+    let error = set_args("crews.sol.effrot", "high", false, false, false)
+        .execute(&runtime)
+        .expect_err("misspelled crew field must be rejected");
+    assert!(error.to_string().contains("effrot"), "{error}");
+    assert!(
+        error
+            .did_you_mean()
+            .is_some_and(|suggestions| suggestions.iter().any(|key| key == "crews.sol.effort")),
+        "{error:?}"
+    );
+    assert_eq!(
+        fs::read(workspace_root.join("config.toml")).expect("read after failed set"),
+        original
+    );
+}
+
+#[test]
+fn set_claude_crew_effort_accepts_supported_value() {
+    let (_root, runtime, _global_root, workspace_root) = test_runtime();
+    fs::write(
+        workspace_root.join("config.toml"),
+        "[workflow]\ndefault_crew = \"opus\"\n\n[crews.opus]\nmodel = \"opus\"\nprovider = \"claude\"\n",
+    )
+    .expect("write opus crew");
+
+    set_args("crews.opus.effort", "max", false, false, false)
+        .execute(&runtime)
+        .expect("set claude effort succeeds");
+
+    let saved =
+        fs::read_to_string(workspace_root.join("config.toml")).expect("read workspace config");
+    assert!(saved.contains("effort = \"max\""), "{saved}");
+}

--- a/crates/orbit-cli/src/command/config/tests/show.rs
+++ b/crates/orbit-cli/src/command/config/tests/show.rs
@@ -44,3 +44,49 @@ sandbox = "danger-full-access"
         global_root.join("config.toml").to_string_lossy().as_ref()
     );
 }
+
+#[test]
+fn effective_json_includes_configured_crew_effort_and_omits_unconfigured() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    fs::write(
+        global_root.join("config.toml"),
+        r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+effort = "medium"
+
+[crews.opus]
+model = "opus"
+provider = "claude"
+"#,
+    )
+    .expect("write global config");
+    fs::write(
+        workspace_root.join("config.toml"),
+        "[crews.sol]\neffort = \"high\"\n",
+    )
+    .expect("write workspace override");
+
+    let effective = load_effective_config(&ConfigRoots::new(&global_root, &workspace_root))
+        .expect("load effective layered config");
+    let json = effective_json(&runtime, effective.values());
+
+    assert_eq!(json["settings"]["crews.sol.effort"], "high");
+    assert_eq!(json["provenance"]["crews.sol.effort"]["scope"], "workspace");
+    assert_eq!(
+        json["provenance"]["crews.sol.effort"]["path"],
+        workspace_root
+            .join("config.toml")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert!(
+        json["settings"].get("crews.opus.effort").is_none(),
+        "omitted effort must not appear in settings: {}",
+        json["settings"]
+    );
+}

--- a/crates/orbit-config/src/layering.rs
+++ b/crates/orbit-config/src/layering.rs
@@ -103,9 +103,29 @@ pub struct EffectiveConfig {
 }
 
 impl EffectiveConfig {
-    /// Resolved value for one registry key.
+    /// Resolved value for one admitted key, including projected crew fields.
+    ///
+    /// Configured crew effort is present only when the assignment set it.
+    /// A live `crews.<name>.effort` key whose crew exists but omitted the
+    /// field returns JSON null rather than inventing a provider default.
     pub fn value_for(&self, key: &str) -> Option<serde_json::Value> {
-        self.snapshot.value_for(key)
+        if let Some(value) = self.snapshot.value_for(key) {
+            return Some(value);
+        }
+        if let Some(entry) = self.values.iter().find(|entry| entry.key == key) {
+            return Some(entry.value.clone());
+        }
+        if let Ok(Some(parsed)) = crate::registry::parse_crew_field_key(key) {
+            let prefix = format!("crews.{}.", parsed.name);
+            if self
+                .values
+                .iter()
+                .any(|entry| entry.key.starts_with(&prefix))
+            {
+                return Some(serde_json::Value::Null);
+            }
+        }
+        None
     }
 
     /// Every resolved value, sorted by key.
@@ -352,12 +372,18 @@ fn effective_values(
     });
 
     for (name, crew) in &resolved.crews {
-        for (field, value) in [
+        let mut fields = vec![
             ("model", serde_json::json!(crew.assignment.model)),
             ("provider", serde_json::json!(crew.assignment.provider)),
             ("description", serde_json::json!(crew.description)),
             ("tags", serde_json::json!(crew.tags)),
-        ] {
+        ];
+        // Configured effort only. An omitted field keeps the provider default
+        // and must not appear as a fabricated effective setting.
+        if let Some(effort) = crew.assignment.effort {
+            fields.push(("effort", serde_json::json!(effort)));
+        }
+        for (field, value) in fields {
             let key = format!("crews.{name}.{field}");
             values.push(EffectiveConfigValue {
                 source: source_for_crew_field(name, field, global, workspace),

--- a/crates/orbit-config/src/lib.rs
+++ b/crates/orbit-config/src/lib.rs
@@ -72,7 +72,8 @@ pub use operation::{
 pub use persistence::PersistenceConfig;
 pub use raw::CrewSeed;
 pub use registry::{
-    CONFIG_KEY_REGISTRY, ConfigKeyDescriptor, ConfigSnapshot, describe as describe_config_key,
+    CONFIG_KEY_REGISTRY, ConfigKeyDescriptor, ConfigSnapshot, admit_config_key,
+    describe as describe_config_key,
 };
 pub use resolved::{CodexExecutionPolicy, ExecutionEnvPolicy, PrSettings, ResolvedConfig};
 pub use roots::ConfigRoots;

--- a/crates/orbit-config/src/registry.rs
+++ b/crates/orbit-config/src/registry.rs
@@ -4,9 +4,10 @@
 //! drives TOML extraction, defaulting/validation, `orbit config keys`
 //! metadata, the resolved snapshot, and JSON lookup used by `get`/`show`.
 //! Runtime consumers read the admitted snapshot instead of re-parsing raw
-//! section structs. Dynamically named tables (`crews.*`) and removed-key
-//! migration guards remain in `raw`/`runtime` because they are not fixed
-//! settings addressable by `orbit config set`.
+//! section structs. Removed-key migration guards remain in `raw`/`runtime`.
+//! Dynamically named crew tables are not fixed registry rows, but live
+//! `crews.<name>.<field>` keys are addressable by `orbit config set`/`get`
+//! through [`admit_config_key`].
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -38,6 +39,20 @@ pub(crate) const DEFAULT_WORKFLOW_SYSTEM_CREW: &str = "system";
 pub(crate) const LEGACY_WORKFLOW_SYSTEM_CREW: &str = "qa";
 const LEGACY_DEFAULT_WORKFLOW_CREW: &str = "claude";
 const CONSTELLATION_DEFAULT_PROVIDER_ENV: &str = "CONSTELLATION_DEFAULT_PROVIDER";
+
+/// Live `[crews.<name>]` fields addressable as `crews.<name>.<field>`.
+///
+/// The crew name is not known at compile time, so these are not registry
+/// rows. `orbit config keys` still lists only the fixed settings.
+pub(crate) const CREW_CONFIG_FIELDS: &[&str] =
+    &["description", "effort", "model", "provider", "tags"];
+
+/// One live field on a named crew, as used by `orbit config get`/`set`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CrewFieldKey<'a> {
+    pub name: &'a str,
+    pub field: &'a str,
+}
 
 /// One settable `config.toml` key, as advertised by `orbit config keys`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -328,6 +343,70 @@ fn default_admission_crews() -> BTreeMap<String, Crew> {
 /// Look up one registry key's metadata.
 pub fn describe(key: &str) -> Option<&'static ConfigKeyDescriptor> {
     CONFIG_KEY_REGISTRY.iter().find(|entry| entry.key == key)
+}
+
+/// Admit a dotted key for `orbit config get`/`set`.
+///
+/// Fixed registry keys and live `crews.<name>.<field>` keys succeed. Unknown
+/// registry keys and misspelled crew fields fail with suggestions before any
+/// document mutation.
+pub fn admit_config_key(key: &str) -> Result<(), OrbitError> {
+    if describe(key).is_some() {
+        return Ok(());
+    }
+    match parse_crew_field_key(key)? {
+        Some(_) => Ok(()),
+        None => Err(OrbitError::invalid_input_with_suggestions(
+            format!("unknown config key '{key}'"),
+            all_key_names(),
+        )),
+    }
+}
+
+/// Parse `crews.<name>.<field>` when `key` is a crew-table path.
+///
+/// `None` means this is not a crew key (including the bare `crews` table).
+/// An ill-formed crew path or unknown field is an error, not a fallthrough
+/// to the fixed-key registry, so `crews.sol.effrot` is not reported as an
+/// unknown registry setting.
+pub(crate) fn parse_crew_field_key(key: &str) -> Result<Option<CrewFieldKey<'_>>, OrbitError> {
+    let mut parts = key.split('.');
+    if parts.next() != Some("crews") {
+        return Ok(None);
+    }
+    let Some(name) = parts.next() else {
+        return Ok(None);
+    };
+    let Some(field) = parts.next() else {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew config keys are crews.<name>.<field>; '{key}' is missing a field"
+        )));
+    };
+    if parts.next().is_some() {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew config keys are crews.<name>.<field>; '{key}' has extra segments"
+        )));
+    }
+    if name.is_empty() {
+        return Err(OrbitError::InvalidInput(
+            "crew config keys require a non-empty crew name".to_string(),
+        ));
+    }
+    if field.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew config keys are crews.<name>.<field>; '{key}' is missing a field"
+        )));
+    }
+    if CREW_CONFIG_FIELDS.contains(&field) {
+        return Ok(Some(CrewFieldKey { name, field }));
+    }
+    Err(OrbitError::invalid_input_with_suggestions(
+        format!("unknown crew field '{field}' in '{key}'"),
+        CREW_CONFIG_FIELDS
+            .iter()
+            .map(|known| format!("crews.{name}.{known}"))
+            .collect(),
+    ))
 }
 
 /// Every settable key name, used for did-you-mean suggestions.

--- a/crates/orbit-config/src/store.rs
+++ b/crates/orbit-config/src/store.rs
@@ -133,21 +133,25 @@ impl ConfigStore {
     /// show` and `orbit config get` so they report identical values for the
     /// same scope.
     pub fn snapshot(&self) -> Result<ConfigSnapshot, OrbitError> {
-        // Persistence paths are derived from the two data roots, not from
-        // the config document, and are irrelevant to key validation here;
-        // this is discarded by every caller of `snapshot()`.
-        let persistence =
-            PersistenceConfig::default_for_data_root(self.path.parent().unwrap_or(&self.path));
-        let raw = self.doc.to_string();
-        let resolved = ResolvedConfig::from_raw_str(&raw, &self.path, persistence)?;
-        Ok(resolved.snapshot)
+        Ok(self.resolved()?.snapshot)
     }
 
-    /// Look up the effective value of a single registry key.
+    fn resolved(&self) -> Result<ResolvedConfig, OrbitError> {
+        // Persistence paths are derived from the two data roots, not from
+        // the config document, and are irrelevant to key validation here.
+        let persistence =
+            PersistenceConfig::default_for_data_root(self.path.parent().unwrap_or(&self.path));
+        ResolvedConfig::from_raw_str(&self.doc.to_string(), &self.path, persistence)
+    }
+
+    /// Look up the effective value of a single admitted key.
     pub fn effective_value(&self, key: &str) -> Result<JsonValue, OrbitError> {
-        require_known_key(key)?;
-        let snapshot = self.snapshot()?;
-        Ok(snapshot.value_for(key).unwrap_or(JsonValue::Null))
+        registry::admit_config_key(key)?;
+        let resolved = self.resolved()?;
+        if let Some(value) = resolved.snapshot.value_for(key) {
+            return Ok(value);
+        }
+        Ok(crew_field_value(&resolved, key)?.unwrap_or(JsonValue::Null))
     }
 
     /// Set `key` to the TOML-literal-or-string parse of `raw_value`,
@@ -155,13 +159,13 @@ impl ConfigStore {
     /// [`Self::validate`] and then [`Self::save`] afterward — `set_value`
     /// never touches disk.
     pub fn set_value(&mut self, key: &str, raw_value: &str) -> Result<(), OrbitError> {
-        require_known_key(key)?;
+        registry::admit_config_key(key)?;
         let value = parse_value_literal(raw_value);
         let segments: Vec<&str> = key.split('.').collect();
-        // `require_known_key` above already rejects `key` unless it matches
-        // a non-empty registry entry, so `split_last` is always `Some` here;
-        // handled as an error rather than `expect()` since this is
-        // reachable from user input, not a purely local invariant.
+        // `admit_config_key` above already rejects `key` unless it is a
+        // dotted registry or crew-field path, so `split_last` is always
+        // `Some` here; handled as an error rather than `expect()` since
+        // this is reachable from user input, not a purely local invariant.
         let (last, ancestors) = segments.split_last().ok_or_else(|| {
             OrbitError::InvalidInput(format!("config key '{key}' must not be empty"))
         })?;
@@ -214,15 +218,21 @@ impl ConfigStore {
     }
 }
 
-fn require_known_key(key: &str) -> Result<(), OrbitError> {
-    if registry::describe(key).is_some() {
-        Ok(())
-    } else {
-        Err(OrbitError::invalid_input_with_suggestions(
-            format!("unknown config key '{key}'"),
-            registry::all_key_names(),
-        ))
-    }
+fn crew_field_value(resolved: &ResolvedConfig, key: &str) -> Result<Option<JsonValue>, OrbitError> {
+    let Some(parsed) = registry::parse_crew_field_key(key)? else {
+        return Ok(None);
+    };
+    let Some(crew) = resolved.crews.get(parsed.name) else {
+        return Ok(Some(JsonValue::Null));
+    };
+    Ok(Some(match parsed.field {
+        "model" => serde_json::json!(crew.assignment.model),
+        "provider" => serde_json::json!(crew.assignment.provider),
+        "effort" => serde_json::json!(crew.assignment.effort),
+        "description" => serde_json::json!(crew.description),
+        "tags" => serde_json::json!(crew.tags),
+        _ => JsonValue::Null,
+    }))
 }
 
 fn read_optional(path: &Path) -> Result<String, OrbitError> {

--- a/crates/orbit-config/src/tests/layering.rs
+++ b/crates/orbit-config/src/tests/layering.rs
@@ -226,6 +226,73 @@ model = "workspace-model"
         values["crews.build.provider"].source.path(),
         Some(global_config_path.as_path())
     );
+    assert!(
+        !values.contains_key("crews.build.effort"),
+        "omitted effort must not appear as a configured value"
+    );
+}
+
+#[test]
+fn effective_config_projects_configured_crew_effort_with_layer_provenance() {
+    let global = tempdir().expect("global tempdir");
+    let workspace = tempdir().expect("workspace tempdir");
+    write_config(
+        global.path(),
+        r#"
+[workflow]
+default_crew = "sol"
+
+[crews.sol]
+model = "gpt-5.6-sol"
+provider = "codex"
+effort = "medium"
+
+[crews.opus]
+model = "opus"
+provider = "claude"
+"#,
+    );
+    write_config(
+        workspace.path(),
+        r#"
+[crews.sol]
+effort = "high"
+"#,
+    );
+
+    let effective = load_effective_config(&roots(global.path(), workspace.path()))
+        .expect("effective config loads");
+    let values = effective
+        .values()
+        .iter()
+        .map(|entry| (entry.key.as_str(), entry))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(values["crews.sol.effort"].value, serde_json::json!("high"));
+    assert_eq!(
+        values["crews.sol.effort"].source.kind(),
+        ConfigValueSourceKind::Workspace
+    );
+    assert_eq!(
+        values["crews.sol.effort"].source.path(),
+        Some(workspace.path().join("config.toml").as_path())
+    );
+    assert_eq!(
+        values["crews.sol.model"].source.kind(),
+        ConfigValueSourceKind::Global
+    );
+    assert!(
+        !values.contains_key("crews.opus.effort"),
+        "omitted Claude effort must not invent a configured value"
+    );
+    assert_eq!(
+        effective.value_for("crews.sol.effort"),
+        Some(serde_json::json!("high"))
+    );
+    assert_eq!(
+        effective.value_for("crews.opus.effort"),
+        Some(serde_json::Value::Null)
+    );
 }
 
 #[test]

--- a/crates/orbit-config/src/tests/store.rs
+++ b/crates/orbit-config/src/tests/store.rs
@@ -413,6 +413,180 @@ fn admission_registry_snapshot_and_lookup_are_complete() {
     );
 }
 
+fn sol_crew_document() -> &'static str {
+    "[workflow]\ndefault_crew = \"sol\"\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\n# keep this comment\n"
+}
+
+#[test]
+fn get_crew_effort_is_null_when_omitted_and_does_not_invent_a_default() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(&path, sol_crew_document()).expect("write config");
+
+    let store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    assert_eq!(
+        store
+            .effective_value("crews.sol.effort")
+            .expect("omitted effort is an admitted key"),
+        serde_json::Value::Null
+    );
+}
+
+#[test]
+fn set_crew_effort_round_trips_and_preserves_unrelated_toml() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(&path, sol_crew_document()).expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    store
+        .set_value("crews.sol.effort", "high")
+        .expect("set crew effort");
+    store.validate().expect("validate");
+    store.save().expect("save");
+
+    let saved = fs::read_to_string(&path).expect("read saved config");
+    assert!(saved.contains("effort = \"high\""), "{saved}");
+    assert!(saved.contains("# keep this comment"), "{saved}");
+    assert!(saved.contains("default_crew = \"sol\""), "{saved}");
+    assert!(saved.contains("model = \"gpt-5.6-sol\""), "{saved}");
+
+    let reopened = ConfigStore::open(ConfigScope::Workspace, &path).expect("reopen store");
+    assert_eq!(
+        reopened
+            .effective_value("crews.sol.effort")
+            .expect("get configured effort"),
+        serde_json::json!("high")
+    );
+}
+
+#[test]
+fn hand_authored_crew_effort_is_readable_without_config_set() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(
+        &path,
+        "[workflow]\ndefault_crew = \"sol\"\n\n[crews.sol]\nmodel = \"gpt-5.6-sol\"\nprovider = \"codex\"\neffort = \"high\"\n",
+    )
+    .expect("write config");
+
+    let store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    assert_eq!(
+        store
+            .effective_value("crews.sol.effort")
+            .expect("hand-authored effort is readable"),
+        serde_json::json!("high")
+    );
+}
+
+#[test]
+fn set_crew_effort_rejects_invalid_value_and_leaves_file_byte_identical() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    let original = sol_crew_document();
+    fs::write(&path, original).expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    store
+        .set_value("crews.sol.effort", "medium-low")
+        .expect("set_value only mutates in-memory");
+    let error = store
+        .validate()
+        .expect_err("invalid effort must fail validation");
+    assert!(
+        error
+            .to_string()
+            .contains("expected one of low, medium, high, xhigh, max"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read(&path).expect("read after failed validate"),
+        original.as_bytes()
+    );
+}
+
+#[test]
+fn set_crew_effort_rejects_unsupported_provider_before_save() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    let original = "[workflow]\ndefault_crew = \"gemini\"\n\n[crews.gemini]\nmodel = \"gemini\"\nprovider = \"gemini\"\n";
+    fs::write(&path, original).expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    store
+        .set_value("crews.gemini.effort", "high")
+        .expect("set_value only mutates in-memory");
+    let error = store
+        .validate()
+        .expect_err("unsupported provider must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("does not support configured reasoning effort"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read(&path).expect("read after failed validate"),
+        original.as_bytes()
+    );
+}
+
+#[test]
+fn set_rejects_unknown_crew_field_before_mutating_document() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    let original = sol_crew_document();
+    fs::write(&path, original).expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    let error = store
+        .set_value("crews.sol.effrot", "high")
+        .expect_err("misspelled crew field must be rejected");
+    match error {
+        OrbitError::InvalidInputDiagnostic {
+            message,
+            did_you_mean,
+        } => {
+            assert!(message.contains("effrot"), "{message}");
+            assert!(
+                did_you_mean.contains(&"crews.sol.effort".to_string()),
+                "{did_you_mean:?}"
+            );
+        }
+        other => panic!("expected InvalidInputDiagnostic, got {other:?}"),
+    }
+    assert_eq!(
+        fs::read(&path).expect("read after rejected set"),
+        original.as_bytes()
+    );
+}
+
+#[test]
+fn grok_crew_effort_round_trips_supported_value() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(
+        &path,
+        "[workflow]\ndefault_crew = \"grok\"\n\n[crews.grok]\nmodel = \"grok-4.6\"\nprovider = \"grok\"\n",
+    )
+    .expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    store
+        .set_value("crews.grok.effort", "xhigh")
+        .expect("set grok effort");
+    store.validate().expect("validate grok effort");
+    store.save().expect("save");
+
+    let reopened = ConfigStore::open(ConfigScope::Workspace, &path).expect("reopen store");
+    assert_eq!(
+        reopened
+            .effective_value("crews.grok.effort")
+            .expect("get grok effort"),
+        serde_json::json!("xhigh")
+    );
+}
+
 #[test]
 fn open_for_workspace_set_fresh_starts_empty() {
     let dir = tempdir().expect("tempdir");

--- a/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/configuration.md
@@ -61,8 +61,12 @@ assuming a value.
 | `scoring.enabled` | Record scoreboard metrics for task runs. |
 | `pr.task_url_template` | URL template linking a task ID in PR descriptions. |
 
-Use `orbit config keys` to distinguish keys supported by `config set` from
-settings authored as TOML. Set workspace ship mode with
+Use `orbit config keys` to distinguish fixed keys supported by `config set`
+from settings authored as TOML. Named crew fields are also settable as
+`crews.<name>.<field>` (for example `orbit config set crews.sol.effort high`)
+even though those keys are not listed by `orbit config keys`. Creating a crew
+still requires a `[crews.<name>]` table with `model` and `provider`. Set
+workspace ship mode with
 `orbit workspace init --ship-mode pr|local`; verify the registered workspace
 with `orbit workspace show`. Base branch and ship mode govern source delivery,
 not task snapshot publication.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,7 +1,7 @@
 ---
 type: context
 summary: Orbit Configuration
-last_validated: 2026-08-17
+last_validated: 2026-09-07
 ---
 
 # Orbit Configuration
@@ -110,6 +110,24 @@ inline baseline in the same way as the rest of that assignment. For the
 standard Codex tiers, use the model-specific crew to choose capability first:
 Terra (`gpt-5.6-terra`) is the medium-low crew; `effort` adjusts the reasoning
 budget inside the chosen Codex model.
+
+Named crew fields are addressable through `orbit config` as
+`crews.<name>.<field>` (`model`, `provider`, `effort`, `description`, `tags`):
+
+```bash
+orbit config set crews.sol.effort high
+orbit config get crews.sol.effort
+orbit config show --json
+```
+
+`get` and `show` report the same configured effort the runtime assignment
+uses. `show` includes `crews.sol.effort` with `workspace` or `global`
+provenance when the field is set; omitting it leaves the provider default and
+does not invent a configured value in effective output. Invalid values,
+unsupported provider/model combinations, and misspelled crew fields are
+refused before the file is written. Creating a crew still requires a
+`[crews.<name>]` table with `model` and `provider` — `config set` will not
+persist an incomplete crew.
 
 Example — the standard Grok crew:
 

--- a/plugin/skills/orbit/references/setup/configuration.md
+++ b/plugin/skills/orbit/references/setup/configuration.md
@@ -61,8 +61,12 @@ assuming a value.
 | `scoring.enabled` | Record scoreboard metrics for task runs. |
 | `pr.task_url_template` | URL template linking a task ID in PR descriptions. |
 
-Use `orbit config keys` to distinguish keys supported by `config set` from
-settings authored as TOML. Set workspace ship mode with
+Use `orbit config keys` to distinguish fixed keys supported by `config set`
+from settings authored as TOML. Named crew fields are also settable as
+`crews.<name>.<field>` (for example `orbit config set crews.sol.effort high`)
+even though those keys are not listed by `orbit config keys`. Creating a crew
+still requires a `[crews.<name>]` table with `model` and `provider`. Set
+workspace ship mode with
 `orbit workspace init --ship-mode pr|local`; verify the registered workspace
 with `orbit workspace show`. Base branch and ship mode govern source delivery,
 not task snapshot publication.

--- a/website/src/content/docs/reference/config.md
+++ b/website/src/content/docs/reference/config.md
@@ -132,7 +132,11 @@ These are the keys `orbit config set` accepts:
 | `runtime.log_max_total_mb` | integer | Total size budget across JSONL log archives; oldest pruned first. |
 | `runtime.log_retention_days` | integer | Delete JSONL log archives older than this. |
 
-Crews are edited in the file rather than through `orbit config set`.
+Named crew fields are also settable as `crews.<name>.<field>` (`model`,
+`provider`, `effort`, `description`, `tags`). Example:
+`orbit config set crews.sol.effort high`. Creating a crew still requires a
+`[crews.<name>]` table with `model` and `provider`; `config keys` lists only
+the fixed settings above.
 
 ## Root override
 


### PR DESCRIPTION
## Task

[ORB-11543](https://orbit-cli.com/tasks/ORB-11543) — Support validated crew effort configuration and include effort in effective config output

### Description

Daniel reports crews must be hand-authored in TOML: `orbit config set crews.sol.effort high` is unsupported and effective config show omits effort despite execution honoring it. Verified on Linux ws_orbit 2026-09-07: installed `orbit config get crews.sol.effort` returns unknown config key; config show --json settings lists crews.sol.model/provider/description/tags but no effort. Current origin/agent-main layering.rs effective_values explicitly enumerates those four fields and omits crew.assignment.effort. Typed effort config parsing/validation already exists in orbit-config resolved.rs crew_effort_from_raw, introduced by ORB-11279 (6d1ce72db, PR1358). Trace exact omission provenance and current command key validation before implementation. Repair the existing config command and projection seams, supporting named crew effort keys with current provider/model validation and correct global/workspace layering/provenance. Do not introduce a separate crew config store, change configured effort defaults, or silently accept unsupported values. Preserve existing hand-authored TOML behavior and execution semantics. Verify in isolated scratch config roots; do not change the live Sol effort as part of tests.

### Acceptance Criteria

- For an existing Codex Sol crew in a scratch root, `orbit config set crews.sol.effort high` succeeds and config get/show agree with the resolved assignment used by execution; the same behavior works for other valid named crews within their supported provider/model effort contract.
- Effective config output includes configured crew effort with accurate source/provenance across global and workspace overrides; omitted effort remains provider-default without inventing a configured value.
- Invalid effort values, unsupported provider/model combinations, and misspelled crew fields fail actionably before persisting a broken config; unrelated TOML content is preserved.
- Focused CLI/config regression tests reproduce the original missing-key and missing-projection failures and validate roundtrip, layering, and validation behavior; required repository checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Admitted live `crews.<name>.<field>` keys (`model`, `provider`, `effort`, `description`, `tags`) through `admit_config_key` so `orbit config set/get crews.sol.effort` is no longer an unknown registry key. Misspelled fields fail with those suggestions before any write.
- Projected configured `assignment.effort` from `effective_values` with existing per-field provenance. Omitted effort is absent from `config show` and `get` returns JSON null rather than inventing a provider default.
- `config set` still writes surgically via toml_edit and validates through `ResolvedConfig` (`crew_effort_from_raw`), so invalid values and unsupported provider/model pairs do not persist. Unrelated TOML/comments are preserved.
- Docs: `docs/CONFIG.md`, website config reference, and the configuration skill now describe named crew field keys. Creating a crew still requires `model` and `provider` in the table.

Assessment: The original missing-key (`require_known_key`/registry-only get) and missing-projection (`effective_values` enumerated four crew fields) failures are covered by scratch-root tests. Execution semantics for omitted effort are unchanged.

Criteria:
- Sol `config set crews.sol.effort high` + get/show agree with resolved assignment: pass (CLI and store tests on scratch roots; Claude `max` and Grok `xhigh` also round-trip).
- Effective output includes configured effort with workspace/global provenance; omitted effort is not invented: pass (layering + show tests).
- Invalid values, unsupported providers, misspelled fields fail before persist; unrelated TOML preserved: pass.
- Focused regression tests + required repo checks: pass.

Validation:
- `cargo test -p orbit-config --lib -- tests::store tests::layering`: passed (33 tests).
- `cargo test -p orbit-cli --bin orbit -- command::config::tests`: passed (21 tests).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- Live Sol effort: not run (scratch roots only, as required).

Risks: `config set` still validates the target file as a standalone document. A workspace file that only overrides one inherited crew field still cannot be incomplete (missing `model`/`provider`); that pre-existed for other crew fields. `orbit config keys` still lists only fixed registry rows.

Uncommitted; pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11543-6a9f212e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra