### PR TITLE
[ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
@@ -271,6 +271,7 @@ fn bound_runtime(
         crate::WorkspaceRuntimeBinding {
             logical_workspace_id: workspace_id.clone(),
             workspace_id,
+            owner_machine_id: None,
             repo_root: repo.clone(),
             ship_mode: orbit_types::workflow::ShipMode::Pr,
             base_branch: branch.map(ToOwned::to_owned),


### PR DESCRIPTION
## Task

[ORB-11551](https://orbit-cli.com/tasks/ORB-11551) — [ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `macOS Platform`
- Failing job: `macOS Sandbox`
- Failing step: `Run orbit-core sandbox tests`
- Commit the runner actually checked out: `a52912235ad92930721afcbda09f2d53aa70ea5f`
- Normalized error signature (the dedupe identity, not a quote): `error[e0063]: missing field `owner_machine_id` in initializer of `workspaceruntimebinding``
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-07T20:54:10.032961175+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34160850084 run `34160850084` (push on `agent-main`) — status `in_progress`, conclusion `unknown`
  - event-reported head SHA: `a52912235ad92930721afcbda09f2d53aa70ea5f`
  - current head of that ref: `a52912235ad92930721afcbda09f2d53aa70ea5f`
  - commit actually checked out: `a52912235ad92930721afcbda09f2d53aa70ea5f`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/opt/homebrew/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/opt/homebrew/bin/git log -1 --format=%H`
  - failed job `macOS Sandbox` (id `101862218110`): https://github.com/constellation-works/orbit/actions/runs/34160850084/job/101862218110
  - failing step(s): `Run orbit-core sandbox tests`

## Failed-step log excerpt

```
macOS Sandbox	Run orbit-core sandbox tests	﻿2026-09-07T20:52:13.0557270Z ##[group]Run cargo test -p orbit-core --locked sandbox
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:13.0558260Z [36;1mcargo test -p orbit-core --locked sandbox[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:13.1010330Z shell: /bin/bash -e {0}
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:14.6910640Z [1m[92m   Compiling[0m orbit-types v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-types)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:27.7847170Z [1m[92m   Compiling[0m orbit-common v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-common)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:30.8844090Z [1m[92m   Compiling[0m orbit-exec v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-exec)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:30.8854810Z [1m[92m   Compiling[0m orbit-policy v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-policy)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:31.1912550Z [1m[92m   Compiling[0m orbit-store v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-store)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:32.9974600Z [1m[92m   Compiling[0m orbit-tools v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-tools)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:36.3672850Z [1m[92m   Compiling[0m orbit-agent v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-agent)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:37.2849910Z [1m[92m   Compiling[0m orbit-config v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-config)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:40.7238160Z [1m[92m   Compiling[0m orbit-search v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-search)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:43.9485840Z [1m[92m   Compiling[0m orbit-automation v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-automation)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:44.8524090Z [1m[92m   Compiling[0m orbit-engine v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-engine)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:52:50.6864670Z [1m[92m   Compiling[0m orbit-core v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-core)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.0667180Z [1m[91merror[E0063][0m[1m: missing field `owner_machine_id` in initializer of `WorkspaceRuntimeBinding`[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.0762560Z    [1m[94m--> [0mcrates/orbit-core/src/application/job/tests/exec/ci_sweep.rs:271:9
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.0865370Z     [1m[94m|[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.0971030Z [1m[94m271[0m [1m[94m|[0m         crate::WorkspaceRuntimeBinding {
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.1072390Z     [1m[94m|[0m         [1m[91m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mmissing `owner_machine_id`[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:07.1172880Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:22.3139720Z [1mFor more information about this error, try `rustc --explain E0063`.[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:22.3544020Z [1m[91merror[0m: could not compile `orbit-core` (lib test) due to 1 previous error
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T20:53:22.4479160Z ##[error]Process completed with exit code 101.
```

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34160617360 — superseded_by_newer_workflow_run: newer relevant run 34160788656 at 2026-09-07T20:48:21Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 3,
  "current_failures_discovered": 7,
  "current_failures_investigated": 2,
  "current_failures_investigation_attempted": 6,
  "investigation_cursor": 496892,
  "job_log_reads": 6,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "branch 'orbit/ORB-11516-6a9f212e' could not be checked against origin (execution failed: git ls-remote --heads origin -- orbit/ORB-11516-6a9f212e failed in '/home/daniel/workspace/constellation/codebases/orbit': process timed out); its failure remains deferred until verified",
    "3 of 9 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11544-6a9f1fc2"
  ],
  "runs_listed": 100,
  "unverified_refs": [
    "orbit/ORB-11516-6a9f212e"
  ]
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `macOS Platform` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `owner_machine_id: None` to the `WorkspaceRuntimeBinding` test fixture in `crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs`. The fixture constructs a standalone test runtime, matching the neighboring binding fixtures and satisfying the field added to the binding type.

Criteria:
- Repository-owned cause fixed without weakening the workflow, assertions, or lint policy: the stale struct initializer now supplies the required field.
- Reproduced the runner command before the edit at the runner checkout (`a52912235ad92930721afcbda09f2d53aa70ea5f`); it failed to compile with E0063 for the missing `owner_machine_id`. After the edit, the identical command passes.
- Documented pre-handoff gates pass.

Validation:
- Passed: `cargo test -p orbit-core --locked sandbox` — 32 selected test executions passed (29 unit plus 3 fake-agent integration tests; zero failures).
- Passed: `make ci-fast` — exit status 0.
- Passed: `make ci-lint` — exit status 0.
- Passed: `git diff --check`.

Assessment: one test-only fixture update; no workflow, assertion, lint, or gate behavior changed.
Risks: the local verification ran on Linux; macOS-specific execution remains for the task PR CI, but the original failure was platform-independent Rust type checking.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11551-6a9f24c6`
- Behind base: 0
- Ahead of base: 1