### PR TITLE
[BLOCKED] Prove live filesystem enforcement for ORB-11514 without breaking recovery tools

### DIFF
--- a/crates/orbit-exec/tests/live_read_probe.py
+++ b/crates/orbit-exec/tests/live_read_probe.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Isolated Linux mechanism evidence, never a production sandbox or CI pass.
+
+Prepare a NEW fixture directory, then run its probes with each backend:
+  python3 live_read_probe.py prepare /tmp/orbit-live-read-UNIQUE
+  python3 live_read_probe.py run /tmp/orbit-live-read-UNIQUE --backend landlock
+  python3 live_read_probe.py run /tmp/orbit-live-read-UNIQUE --backend apparmor
+
+AppArmor only STACKS an already operator-loaded profile. This script never loads
+policy, creates namespaces, changes host configuration, or retries unconfined.
+The baseline backend means no ADDITIONAL confinement; outer admission persists.
+All negative reads use synthetic data. JSON distinguishes failures/unavailability.
+"""
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import json
+import mmap
+import os
+from pathlib import Path
+import platform
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+
+MARKER = "ORBIT_SYNTHETIC_FORBIDDEN_BYTES"
+GENERATED = "ORBIT_GENERATED_ALLOWED"
+READ_EXEC = 13  # Landlock EXECUTE | READ_FILE | READ_DIR.
+REFER = 1 << 13  # ABI 2: otherwise cross-directory link/rename is implicitly denied.
+LIBC = ctypes.CDLL(None, use_errno=True)
+
+
+class Ruleset(ctypes.Structure):
+    _fields_ = [("handled", ctypes.c_uint64)]
+
+
+class Rule(ctypes.Structure):
+    _pack_ = 1
+    _fields_ = [("access", ctypes.c_uint64), ("fd", ctypes.c_int32)]
+
+
+def checked(value):
+    if value < 0:
+        number = ctypes.get_errno()
+        raise OSError(number, os.strerror(number))
+    return value
+
+
+def landlock(grants):
+    if platform.system() != "Linux" or platform.machine() != "x86_64":
+        raise OSError(errno.ENOSYS, "probe supports Linux x86_64 only")
+    abi = checked(LIBC.syscall(444, None, 0, 1))
+    if abi < 2:
+        raise OSError(errno.ENOSYS, "recovery probe requires Landlock ABI 2 REFER")
+    attr = Ruleset(READ_EXEC | REFER)
+    fd = checked(LIBC.syscall(444, ctypes.byref(attr), ctypes.sizeof(attr), 0))
+    try:
+        for grant in grants:
+            anchor = os.open(grant["path"], os.O_PATH | os.O_CLOEXEC)
+            try:
+                rule = Rule(grant.get("access", READ_EXEC if grant["tree"] else 5), anchor)
+                checked(LIBC.syscall(445, fd, 1, ctypes.byref(rule), 0))
+            finally:
+                os.close(anchor)
+        checked(LIBC.prctl(38, 1, 0, 0, 0))
+        checked(LIBC.syscall(446, fd, 0))
+    finally:
+        os.close(fd)
+
+
+def invoke(argv, cwd, env, restrict=None, pass_fds=()):
+    def setup():
+        if restrict:
+            try:
+                restrict()
+            except OSError as error:
+                os.write(2, f"sandbox_setup: errno={error.errno}: {error}\n".encode())
+                os._exit(125)
+
+    started = time.monotonic()
+    record = {"argv": argv}
+    try:
+        child = subprocess.Popen(
+            argv, cwd=cwd, env=env, stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True,
+            preexec_fn=setup if restrict else None, pass_fds=pass_fds,
+        )
+        try:
+            stdout, stderr = child.communicate(timeout=30)
+            record.update(exit_code=child.returncode, stdout=stdout.decode(errors="replace"),
+                          stderr=stderr.decode(errors="replace"))
+        except subprocess.TimeoutExpired:
+            os.killpg(child.pid, signal.SIGKILL)
+            stdout, stderr = child.communicate()
+            record.update(status="unavailable", reason="30 second timeout",
+                          stdout=stdout.decode(errors="replace"),
+                          stderr=stderr.decode(errors="replace"))
+        finally:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    except OSError as error:
+        record.update(status="unavailable", reason=str(error))
+    record["duration_ms"] = round((time.monotonic() - started) * 1000, 3)
+    if record.get("exit_code") == 125 and "sandbox_setup:" in record["stderr"]:
+        record.update(status="unavailable", reason="sandbox setup denied or absent")
+    return record
+
+
+def safe_path(path):
+    path = str(Path(path).resolve())
+    if not re.fullmatch(r"/[A-Za-z0-9_./-]+", path):
+        raise ValueError(f"fixture profile does not support path metacharacters: {path!r}")
+    return path
+
+
+def prepare(root):
+    root.mkdir(mode=0o700)  # Refuse to overwrite or adopt an existing directory.
+    workspace = root / "workspace"
+    workspace.mkdir()
+    (root / "outside.txt").write_text(MARKER)
+    (workspace / "existing.env").write_text(MARKER)
+    (workspace / "allowed.txt").write_text(GENERATED)
+    (workspace / "worker.py").write_bytes(Path(__file__).read_bytes())
+    for name in ["home", "cargo-home", "tmp", "src", "gh-config"]:
+        (workspace / name).mkdir()
+    (workspace / "Cargo.toml").write_text(
+        '[package]\nname = "sandbox-probe"\nversion = "0.1.0"\nedition = "2021"\n'
+    )
+    (workspace / "src/main.rs").write_text('fn main() { println!("probe"); }\n')
+    (workspace / "Makefile").write_text(
+        'all:\n\tprintf ORBIT_GENERATED_ALLOWED > make-output.txt\n\tcat make-output.txt\n'
+    )
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+
+    programs = {name: shutil.which(name) for name in
+                ["git", "rg", "cargo", "rustup", "make", "gh", "cc", "cat", "sh"]}
+    programs["python"] = sys.executable
+    grants = []
+
+    def grant(path, purpose, tree=None, executable=False):
+        candidate = Path(path)
+        if candidate.exists():
+            is_tree = candidate.is_dir() if tree is None else tree
+            if is_tree:
+                access = READ_EXEC
+            elif candidate.is_dir():
+                access = 8  # Directory listing only, no inherited file reads.
+            elif executable:
+                access = 5
+            else:
+                access = 4
+            entry = {"path": safe_path(candidate), "tree": is_tree,
+                     "directory": candidate.is_dir(), "access": access, "purpose": purpose}
+            if not any(item["path"] == entry["path"] for item in grants):
+                grants.append(entry)
+
+    for program in programs.values():
+        if program:
+            grant(program, "exact executable (symlinks resolved)", executable=True)
+    for path in ["/usr/lib/x86_64-linux-gnu", "/usr/lib/python3.12",
+                 "/usr/lib/git-core", "/usr/share/git-core"]:
+        grant(path, "distribution runtime libraries or git helpers/templates")
+    for path in ["/etc/ld.so.cache", "/dev/null", "/dev/urandom"]:
+        grant(path, "loader or exact runtime device")
+    for path in ["/etc/nsswitch.conf", "/etc/hosts", "/etc/resolv.conf",
+                 "/etc/gai.conf", "/etc/ssl/certs/ca-certificates.crt"]:
+        grant(path, "explicit resolver or CA file; canonical target only")
+
+    rustup_home = Path(os.environ.get("RUSTUP_HOME", str(Path.home() / ".rustup")))
+    grant(rustup_home / "settings.toml", "rustup selection (no home tree grant)")
+    grant(rustup_home / "toolchains", "installed toolchain names only", tree=False)
+    if programs["rustup"]:
+        query = subprocess.run([programs["rustup"], "which", "rustc"],
+                               capture_output=True, text=True, timeout=15)
+        if query.returncode == 0:
+            toolchain = Path(query.stdout.strip()).parent.parent
+            grant(toolchain / "bin", "selected installed toolchain executables")
+            grant(toolchain / "lib", "selected installed toolchain libraries/sysroot")
+
+    profile_name = "orbit-live-read-" + hashlib.sha256(str(root).encode()).hexdigest()[:16]
+    env = {"PATH": ":".join(dict.fromkeys(
+               str(Path(p).parent) for p in programs.values() if p)),
+           "HOME": str(workspace / "home"), "CARGO_HOME": str(workspace / "cargo-home"),
+           "RUSTUP_HOME": str(rustup_home), "RUSTUP_NO_UPDATE_CHECK": "1",
+           "TMPDIR": str(workspace / "tmp"), "GH_CONFIG_DIR": str(workspace / "gh-config"),
+           "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0", "LC_ALL": "C",
+           "GIT_SSL_CAINFO": "/etc/ssl/certs/ca-certificates.crt",
+           "PYTHONDONTWRITEBYTECODE": "1"}
+    manifest = {"schemaVersion": 1, "root": str(root), "workspace": str(workspace),
+                "profile": profile_name, "programs": programs, "host_read_grants": grants,
+                "environment": env}
+    (root / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    # A fixed fixture policy, NOT an implementation of Orbit glob evaluation.
+    # No include abstractions: every host read is reviewable in the manifest.
+    lines = [f"profile {profile_name} flags=(mediate_deleted) {{",
+             "  network inet stream,", "  network inet6 stream,",
+             "  network inet dgram,", "  network inet6 dgram,",
+             f'  signal (send, receive) peer={profile_name},',
+             f'  "{workspace}/" rw,', f'  "{workspace}/**" rwklm,',
+             f'  "{workspace}/**" ix,',
+             f'  deny "{workspace}/*.env" rmx,',
+             f'  deny "{workspace}/**/*.env" rmx,',
+             f'  deny "{workspace}/.env" rmx,',
+             f'  deny "{workspace}/**/.env" rmx,']
+    for entry in grants:
+        path = entry["path"]
+        if entry["tree"]:
+            lines += [f'  "{path}/" r,', f'  "{path}/**" rmix,']
+        else:
+            if path == "/dev/null":
+                permission = "rw"
+            elif entry["access"] & 1:
+                permission = "rmix"
+            else:
+                permission = "r"
+            suffix = "/" if entry["directory"] else ""
+            lines.append(f'  "{path}{suffix}" {permission},')
+    lines.append("}")
+    (root / "profile.apparmor").write_text("\n".join(lines) + "\n")
+    return manifest
+
+
+def child_probe(action, root, inherited_fd):
+    workspace = root / "workspace"
+    target = root / "outside.txt"
+    try:
+        if action == "existing_denied":
+            target = workspace / "existing.env"
+        elif action in ["create_denied", "create_allowed"]:
+            target = workspace / (".env" if action == "create_denied" else "generated.txt")
+            target.write_text(MARKER if action == "create_denied" else GENERATED)
+        elif action in ["rename_denied", "rename_open_fd", "rename_mmap"]:
+            source = workspace / "rename-source.txt"
+            source.write_text(MARKER)
+            target = workspace / "renamed.env"
+            if action != "rename_denied":
+                inherited_fd = os.open(source, os.O_RDONLY)
+            if action == "rename_mmap":
+                mapping = mmap.mmap(inherited_fd, 0, access=mmap.ACCESS_READ)
+            source.rename(target)
+        elif action == "symlink_outside":
+            target = workspace / "outside-link.txt"
+            target.symlink_to(root / "outside.txt")
+        elif action == "hardlink_denied":
+            target = workspace / "hardlink-allowed.txt"
+            try:
+                os.link(workspace / "existing.env", target)
+            except OSError as error:
+                return {"operation": "link", "errno": error.errno, "outcome": "denied"}
+        elif action == "descendant_outside":
+            pid = os.fork()
+            if pid:
+                _, status = os.waitpid(pid, 0)
+                return {"outcome": "descendant_complete", "wait_status": status}
+            os.setsid()
+        elif action == "allowed":
+            target = workspace / "allowed.txt"
+    except OSError as error:
+        return {"outcome": "setup_failed", "errno": error.errno, "reason": str(error)}
+
+    try:
+        if action == "rename_mmap":
+            content = mapping[:].decode()
+        elif action in ["inherited_fd", "rename_open_fd"]:
+            content = os.read(inherited_fd, 4096).decode()
+        else:
+            with target.open("rb") as source:
+                content = source.read(4096).decode()
+        result = {"outcome": "read", "content": content}
+    except OSError as error:
+        result = {"outcome": "denied", "operation": "open/read", "errno": error.errno}
+    if action == "descendant_outside":
+        os.write(1, (json.dumps(result) + "\n").encode())
+        os._exit(0)
+    return result
+
+
+def classify(record, expected):
+    if "status" in record:
+        return record
+    if expected == "positive":
+        record["status"] = "pass" if record["exit_code"] == 0 else "fail"
+        return record
+    try:
+        outcomes = [json.loads(line) for line in record["stdout"].splitlines()]
+        outcomes = [item for item in outcomes if item.get("outcome") != "descendant_complete"]
+    except (ValueError, AttributeError):
+        outcomes = []
+    if record["exit_code"] != 0 or not outcomes or any(
+        item.get("outcome") == "setup_failed" for item in outcomes
+    ):
+        record.update(status="unavailable", reason="probe body did not complete")
+    elif expected == "observation":
+        record["status"] = "observed"
+    elif expected == "deny":
+        denied = all(item.get("outcome") == "denied" and item.get("errno") in
+                     [errno.EACCES, errno.EPERM] for item in outcomes)
+        leaked = MARKER in record["stdout"] or MARKER in record["stderr"]
+        record["status"] = "pass" if denied and not leaked else "fail"
+    else:
+        record["status"] = "pass" if all(item.get("content") == GENERATED
+                                         for item in outcomes) else "fail"
+    return record
+
+
+def run(root, backend):
+    manifest = json.loads((root / "manifest.json").read_text())
+    if manifest["root"] != str(root):
+        raise ValueError("fixture was moved; prepare a new profile instead")
+    workspace = Path(manifest["workspace"])
+    env = manifest["environment"]
+    programs = manifest["programs"]
+    if workspace.resolve() != root / "workspace":
+        raise ValueError("workspace must be the prepared fixture child directory")
+    grants = manifest["host_read_grants"] + [
+        {"path": str(workspace), "tree": True, "access": READ_EXEC | REFER}
+    ]
+    restriction = None
+    if backend == "landlock":
+        restriction = lambda: landlock(grants)
+    elif backend == "apparmor":
+        # Explicit stack API preserves every outer profile. No change_profile fallback.
+        apparmor = ctypes.CDLL("libapparmor.so.1", use_errno=True)
+        apparmor.aa_stack_onexec.argtypes = [ctypes.c_char_p]
+
+        def restriction():
+            checked(apparmor.aa_stack_onexec(manifest["profile"].encode()))
+
+    results = {"schemaVersion": 1, "backend": backend, "kernel": platform.release(),
+               "architecture": platform.machine(), "manifest": manifest, "probes": {}}
+    probes = results["probes"]
+    actions = ["outside", "existing_denied", "create_denied", "rename_denied",
+               "symlink_outside", "hardlink_denied", "descendant_outside", "allowed",
+               "create_allowed", "inherited_fd", "rename_open_fd", "rename_mmap"]
+    for action in actions:
+        # Only remove paths this probe itself creates; fixtures are run-owned.
+        for name in [".env", "generated.txt", "rename-source.txt", "renamed.env",
+                     "outside-link.txt", "hardlink-allowed.txt"]:
+            (workspace / name).unlink(missing_ok=True)
+        worker = [programs["python"], str(workspace / "worker.py"), "child", str(root),
+                  "--action", action]
+        fds = ()
+        if action == "inherited_fd":
+            fd = os.open(root / "outside.txt", os.O_RDONLY)
+            fds = (fd,)
+            worker += ["--inherited-fd", str(fd)]
+        argv = [programs["git"], "-c", "alias.orbitsecurityprobe=!" + shlex.join(worker),
+                "orbitsecurityprobe"]
+        try:
+            record = invoke(argv, workspace, env, restriction, fds)
+        finally:
+            for fd in fds:
+                os.close(fd)
+        if action in ["allowed", "create_allowed"]:
+            expected = "allow"
+        elif action in ["inherited_fd", "rename_open_fd", "rename_mmap"]:
+            expected = "observation"
+        else:
+            expected = "deny"
+        probes[action] = classify(record, expected)
+
+    commands = {
+        "git_status": [programs["git"], "status", "--porcelain"],
+        "rg_generated": [programs["rg"], "--no-mmap", GENERATED, "allowed.txt"],
+        "make_generated": [programs["make"], "-s"],
+        "cargo_check_offline": [programs["cargo"], "check", "--offline"],
+        "gh_version": [programs["gh"], "--version"],
+        "gh_public_api_without_credentials": [programs["gh"], "api", "meta"],
+        "git_network_tls": [programs["git"], "ls-remote", "https://github.com/git/git.git", "HEAD"],
+    }
+    for name, argv in commands.items():
+        if not argv[0]:
+            probes[name] = {"status": "unavailable", "reason": "program not installed"}
+        else:
+            probes[name] = classify(invoke(argv, workspace, env, restriction), "positive")
+    counts = {status: sum(item["status"] == status for item in probes.values())
+              for status in ["pass", "fail", "unavailable", "observed"]}
+    results["counts"] = counts
+    results["complete_contract_proven"] = False  # Operator race/platform/credential gates remain.
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=["prepare", "run", "child"])
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--backend", choices=["baseline", "landlock", "apparmor"],
+                        default="apparmor")
+    parser.add_argument("--action")
+    parser.add_argument("--inherited-fd", type=int, default=-1)
+    args = parser.parse_args()
+    root = Path(safe_path(args.root))
+    if args.operation == "prepare":
+        result = prepare(root)
+    elif args.operation == "child":
+        result = child_probe(args.action, root, args.inherited_fd)
+    else:
+        result = run(root, args.backend)
+    print(json.dumps(result, indent=None if args.operation == "child" else 2))
+    if args.operation == "run":
+        # Evidence collection must not look like a green full-contract test.
+        if result["counts"]["fail"]:
+            return 1
+        if result["counts"]["unavailable"]:
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -2,12 +2,12 @@
 type: design
 summary: "Spec: Sandboxed Exec Contract"
 tags: ["policy-sandbox"]
-last_validated: 2026-09-05
+last_validated: 2026-09-07
 ---
 
 # Spec: Sandboxed Exec Contract
 
-`orbit-exec::run_process` is the single primitive every shell-invoking tool spawns through. This spec names the supervision invariants and failure modes that contract must preserve.
+`orbit-exec::run_process` is the common validated-spawn primitive. Platform sandbox wrappers can instead create a child and pass it to `supervise_child`, which shares the supervision implementation. This spec names the invariants and failure modes those paths must preserve.
 
 ## Why This Exists
 
@@ -63,9 +63,248 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 ## Migration Rules
 
 - New `ExecRequest` fields must default to a backwards-compatible behavior; `EnvironmentMode::default()` and `StdinMode::default()` exist precisely so callers can adopt new fields incrementally.
-- A future kernel-level `Sandbox` impl must implement `validate` to either (a) gate at request-time before spawn, or (b) wrap the spawned process inside its isolation primitive. Mid-spawn isolation that races with `process::spawn` is out of scope for this contract.
-- Changes to `TERMINATION_GRACE_PERIOD` or `WAIT_POLL_INTERVAL` require an ADR because both constants are observable in the timeout/cancel behavior of every shell-invoking tool.
+- The current `Sandbox` trait only exposes request validation. Adding live confinement requires an explicit confined-spawn seam or platform wrapper before untrusted code runs; returning successfully from `validate` alone cannot establish that boundary.
+- Changes to `TERMINATION_GRACE_PERIOD` or `WAIT_POLL_INTERVAL` require updated current documentation and behavior tests because both constants are observable in timeout/cancel behavior.
 
 ## Agent Signature
 
-Last revised by claude / claude-opus-4-7 for [T20260426-0622].
+Live-read investigation and spawn-seam clarification revised by codex on 2026-09-07.
+
+## Live read enforcement investigation (2026-09-07)
+
+**Design and isolated prototype only. No production read boundary was added.**
+The activity-scoped `proc.spawn` implementation still checks apparent path
+arguments before ordinary spawn. An admitted git shell alias can read outside
+that argument check. The preserved candidate `2c40c430` is not a complete repair
+and must not be landed as one. The authoritative original task evidence remains
+in ORB-11514's `read-boundary-probe.py`, `read-boundary-probe.json`, and its
+`enforcement_design_blocked` execution summary. This investigation's command
+outputs and grant manifests are attached to ORB-11546.
+
+### Mechanism selection and limits
+
+| Mechanism | Live names / generated files | Availability and maintenance | Decision |
+| --- | --- | --- | --- |
+| Preserved candidate Landlock path-beneath rules | Directory grant admits future denied names; file grants break new allowed files and follow renamed inodes | Unprivileged on supporting Linux kernels; small existing syscall seam | Useful additional host containment, insufficient for `denyRead` |
+| Existing Bubblewrap mounts and post-run guard | Masks existing paths; cannot deny every future matching basename in a writable tree; after-exit checks cannot recover leaked bytes | Requires admitted namespace setup; already owned by orbit-exec | Retain write isolation; not the missing live read layer |
+| AppArmor pathname LSM, stacked before exec | Candidate for checking actual resolved opens and new names; allowed creation remains possible | Requires enabled LSM, operator-loaded enforcing profile, allowed stacking, parser/version support | Smallest next Linux experiment; offline compilation works, live profile unavailable in this runner |
+| Seccomp notification with pathname check then `CONTINUE`; ptrace pathname filter; preload wrapper | Pointer mutation or path rename can invalidate userspace decisions; preload also misses direct syscalls/static binaries | A syscall tracer needs architecture and descendant coverage | Reject as a security boundary in this form |
+| Seccomp broker that performs opens and injects FDs | Can avoid tracee-pointer races by copying arguments and using `ADDFD`; still must bind policy to the actual object and cover mutation, alternate I/O and descriptor acquisition | New broker lifecycle, syscall/ABI compatibility, deadlock and resource budgets | Fallback research only if the LSM contract is rejected; not a small open-hook patch |
+| Filtered filesystem / FUSE | Could own name mutations and use the canonical evaluator; raw backing access must be inaccessible | Requires mount admission and a filesystem service; caching, mmap, hardlink and external-writer semantics need design | Not established as necessary; do not introduce it before testing existing LSM support |
+
+Landlock governs filesystem objects and hierarchies, not a negative basename
+language. Its documented ABI rules also make cross-directory rename/link fail
+without `REFER`; a nominally read-only ruleset is not transparent to builds.
+The prototype explicitly handles ABI 2 `REFER` and grants it only within the
+synthetic workspace. This retains host isolation while permitting cargo's output
+moves. [Linux Landlock contract](https://docs.kernel.org/userspace-api/landlock.html).
+
+AppArmor supplies pathname rules, deny precedence, execution inheritance (`ix`)
+and hardlink permission-subset checks. The prototype emits a fixed fixture
+policy, denies both read and executable mapping/execution for `.env`/`*.env`,
+and uses **`aa_stack_onexec`**, never a replacing profile transition. Stacking
+intersects the existing confinement. It does not authorize policy loading or
+relax the enclosing provider sandbox.
+[AppArmor profile syntax](https://manpages.ubuntu.com/manpages/noble/man5/apparmor.d.5.html),
+[AppArmor stacking API](https://apparmor.net/man/master/aa_stack_profile/).
+
+The seccomp alternative would need to perform the authorized open itself and
+inject its FD, not resume a syscall using a mutable pathname pointer. Even then,
+checking a pathname and later opening it leaves filesystem races. Safe resolution,
+mutation ownership, notification cancellation, and non-open interfaces remain
+part of that design. [Kernel seccomp notification contract](https://docs.kernel.org/userspace-api/seccomp_filter.html).
+FUSE does not automatically make these decisions correct: its I/O modes include
+kernel caching and mmap behavior that a policy filesystem must account for.
+[Kernel FUSE I/O contract](https://www.kernel.org/doc/html/latest/filesystems/fuse/fuse-io.html).
+
+### Reproducible isolated probe
+
+`crates/orbit-exec/tests/live_read_probe.py` extends the original synthetic probe
+approach. It is an explicitly invoked stdlib Python evidence collector, outside
+Cargo's normal test discovery. It does not implement Orbit policy evaluation or
+change sandbox defaults. `prepare` refuses an existing directory and writes only
+its new fixture. All attempted forbidden contents are synthetic. `run` prints
+exact argv, child outputs, outcomes, elapsed milliseconds and the declared grants.
+Exit 1 means at least one probe failed; exit 2 means unavailable probes without
+other failures. Neither a zero collector exit nor offline profile compilation
+certifies the full production contract.
+
+```sh
+python3 crates/orbit-exec/tests/live_read_probe.py prepare /tmp/orbit-live-read-UNIQUE
+apparmor_parser --skip-kernel-load --skip-cache /tmp/orbit-live-read-UNIQUE/profile.apparmor
+python3 crates/orbit-exec/tests/live_read_probe.py run /tmp/orbit-live-read-UNIQUE --backend baseline
+python3 crates/orbit-exec/tests/live_read_probe.py run /tmp/orbit-live-read-UNIQUE --backend landlock
+python3 crates/orbit-exec/tests/live_read_probe.py run /tmp/orbit-live-read-UNIQUE --backend apparmor
+```
+
+`baseline` retains outer confinement, adding no new sandbox. The paired baseline
+must return the synthetic forbidden data so a missing executable, failed setup,
+or empty output cannot masquerade as enforcement. Negative probes require an
+executed worker reporting `EACCES`/`EPERM`; failure to enter the worker is
+**unavailable**, not pass. Creation/rename setup failures are also unavailable.
+Generated-file positives require the exact allowed content. git aliases invoke a
+real child interpreter, and the descendant probe forks and calls `setsid` before
+attempting the outside read. The separate rerun of the original artifact preserves
+the exact `!cat <outside-sentinel>` regression and direct `/etc` CLI control.
+
+The profile is intentionally a fixed `.env`/`*.env` experiment. Its path renderer
+rejects metacharacters rather than guessing AppArmor escaping. It neither accepts
+arbitrary Orbit glob policies nor asserts semantic parity with them. It permits
+writes to new denied-name fixtures to test read denial independently; production
+modify authority must still come from the effective modify profile.
+
+### Narrow host grants and recovery
+
+The manifest separates workspace access from each host grant and explains its
+purpose. There is no blanket `/`, `/etc`, home, `/proc`, `/dev`, Cargo home, or
+provider credential-tree grant. Canonical paths are recorded, so resolver
+symlinks do not require granting their entire target directory.
+
+- Exact resolved git, rg, shell, Python, make, gh, compiler and rustup executable
+  paths; distribution library directories and git helper/template directories.
+  These are runtime dependencies, not permission for arbitrary host user files.
+- Exact loader cache, `/dev/null`, `/dev/urandom`, NSS/hosts/resolver/gai files and
+  the CA bundle. `GIT_SSL_CAINFO` selects that bundle explicitly instead of
+  granting the complete certificate directory. Network rules permit IPv4/IPv6
+  TCP and UDP; endpoint authorization is a separate network-policy concern.
+- Exact rustup `settings.toml`, directory-list permission on `toolchains` (no
+  inherited subtree access), and the selected installed toolchain's `bin` and
+  `lib` trees. Cargo's home, build output, temporary files and git/gh configuration
+  are fixture-owned. The child environment is rebuilt from declared values.
+- No GitHub, SSH, cloud or model-provider credential is read. `gh --version`
+  is a startup check; `gh api meta` without credentials reports its authentication
+  requirement. That failure is preserved, not counted as network recovery success.
+  Authenticated recovery still needs an explicitly authorized GitHub credential
+  capability and a controlled integration test. It cannot inherit unrelated
+  provider write grants as read authority.
+
+Measured on Linux x86_64, kernel `6.8.0-139-generic`, Landlock ABI 4: outside,
+symlink-outside and detached-descendant reads are denied under the host grants;
+existing denied names, dynamic denied creation and rename, and hardlink aliases
+still leak under the deliberately insufficient directory Landlock backend.
+Generated files, git, rg, make, offline cargo check and TLS git are exercised in
+the attached final run. These positives only demonstrate runtime grant viability
+under Landlock, **not** AppArmor or production `proc.spawn` compatibility.
+
+The first recovery run failed opening rustup's toolchain directory and Git's
+certificate directory. File-only directory-list permission and explicit CA-bundle
+selection resolved those failures. Cargo then reached compilation but failed
+moving its `.rmeta` with `EXDEV`; explicit workspace `REFER` addresses that
+independent kernel restriction. Initial failures and a file-syscall trace are
+retained as evidence rather than discarded.
+
+### Races, aliases and the contract decision
+
+The defensible next contract is **authorization at acquisition of new file
+access**, using the resolved kernel path, with controlled descriptor inheritance.
+It is not retroactive erasure of data previously read. This interpretation needs
+an explicit owner decision before production implementation; this task does not
+silently amend the original mandate.
+
+| Case | Required handling / remaining evidence |
+| --- | --- |
+| New denied name or allowed inode renamed to a denied name, then reopened | Kernel pathname check must deny the new open before bytes enter the child; original regression retained. AppArmor live result unavailable here. |
+| Concurrent symlink/rename swaps | No userspace check-then-open boundary. Kernel LSM is the candidate acquisition boundary; require concurrent adversarial open/openat/openat2 and parent-directory rename probes on the actual host. Sequential success cannot prove race freedom. |
+| Symlinks and alternate workspace mounts | Match resolved target as `PolicyEngine::check_resolved` does. Validate both canonical checkout and `/tmp/orbit-workspace` mount views, dangling links and `/proc` magic links. Never add a broad proc grant to accommodate one runtime file. |
+| Hardlinks | Names do not track secret provenance. AppArmor's subset rule can reject a child creating a more permissive alias, but an already existing allowed-name hardlink is a different case. Define resolved-path semantics consistently with the current evaluator, or require an isolated backing tree with no external hardlink writers. Neither is byte-provenance tracking. |
+| File opened while allowed, then renamed; existing mmap | The Landlock probes retain access. Linux 6.8 AppArmor caches granted FD permissions and does not provide general rename-based revocation. A mapping can already expose bytes without another pathname syscall. If revocation after rename is required, neither candidate is a full solution; specify stronger mutation isolation or a narrower acquisition contract explicitly. |
+| Inherited FD, cwd/dirfd, SCM_RIGHTS and pidfd acquisition | Close all nonessential descriptors before untrusted exec; use owned stdin pipes/null rather than arbitrary inherited files. Restrict Unix-socket FD donors, ptrace/process-memory and other access channels. AppArmor transition revalidation is not a substitute for descriptor hygiene. The deliberate inherited-FD probe demonstrates the Landlock hole. |
+| Descendants and detached sessions | Enforce before the first untrusted instruction; use inherited/stacked confinement across fork/exec. `setsid` does not remove Landlock or AppArmor. Termination of processes escaping the original PGID is a separate supervision problem; the probe's detached child exits and is waited for explicitly. |
+| External writers or already known bytes | A denied name cannot undo copies, prior reads or malicious externally supplied hardlinks. Record the trusted-writer/acquisition boundary; do not advertise retroactive secrecy. |
+
+The descriptor limit above is supported by the Linux 6.8 implementation's cached
+permission path and lack of general revocation, not by an assumed property of a
+profile regex. [AppArmor file permission implementation](https://raw.githubusercontent.com/torvalds/linux/v6.8/security/apparmor/file.c).
+
+### Ownership and eventual implementation targets
+
+Keep one semantic evaluator. `orbit-types/src/policy/policy_def.rs` owns ordered
+rule semantics and `policy/glob.rs` owns the grammar; `orbit-policy` owns resolved
+filesystem decisions. A platform compiler must consume that canonical policy and
+prove equivalence with `PolicyDef::check_path`, including zero-segment `**/`,
+literal metacharacters, normalization, profile negations and final global denies.
+AppArmor's deny precedence is not equivalent to arbitrary last-match re-allows.
+Reject unrepresentable policies explicitly until a complete compilation exists;
+that rejection is a compatibility blocker, not completed implementation.
+
+Concrete follow-on targets, **not modified here**:
+
+1. `orbit-types` policy contracts plus the owning Core activity-grant composition:
+   separate immutable, purpose-attributed host read/execute dependencies from
+   workspace rules and provider write grants. Unknown/absent grants fail closed.
+2. `orbit-policy` and shared Types grammar: canonical compilation semantics and
+   differential tests. `orbit-exec` currently depends on Types/Common, not Policy;
+   do not add the backwards edge casually. Pass a shared compiled contract or
+   review an explicit architecture update before adding a dependency.
+3. `orbit-exec/src/sandbox.rs`, `process.rs`, `runner.rs`: add an authoritative
+   confined-spawn seam. The current trait only validates; a wrapper must not spawn
+   in `validate` and then also take the ordinary unconfined spawn path. Keep
+   existing supervision and outer containment; verify attachment before exec.
+4. `orbit-tools/src/builtin/proc/spawn.rs` and `tests/proc_spawn_lockdown.rs`:
+   supply the effective activity authority and use that seam; retain explicit
+   path preflight as a fast diagnostic, exact allowlist, and cleared environment.
+5. Existing platform sandbox modules and Core admission: capability/attachment
+   checks, bounded profile lifecycle, unsupported-platform failure before exec,
+   cleanup and diagnostics. No retry through `NoSandbox` on failure.
+
+### Acceptance mapping and operator handoff
+
+Each original ORB-11514 criterion remains required for the production repair.
+
+| Original criterion | Enforcement point and present evidence / unresolved gate |
+| --- | --- |
+| 1. Indirect host and denied-name containment | Confined spawn plus kernel path checks; original alias still reproduces the open production bug. Landlock host denial works, live name enforcement is not proved. |
+| 2. Sentinel alias and direct `/etc` regression | Original artifact rerun retains both controls; new worker requires actual denied opens. Must port both into scoped `proc.spawn` integration tests after repair. |
+| 3. git/rg, program allowlist and cleared environment | Narrow-grant tool positives plus existing `proc_spawn_lockdown` boundary tests; fixed prototype environment is not a replacement for the production allowlist tests. |
+| 4. Authoritative boundary, focused tests and CI | Runtime seam specified above; no production boundary change. This leaf runs `make ci-fast` and `make ci-lint`, but they cannot certify missing enforcement. |
+| 5. Runtime/config/resolver needs under declared grants | Manifest and actual git/rg/make/cargo/TLS-git results; authenticated gh, package downloads, credential-helper workflows and real recovery activity boundary remain integration gates. |
+| 6. Dynamic names, unsupported platforms and bounded cost | Landlock failures preserved; AppArmor live probes unavailable. Linux-only collector explicitly rejects unsupported Landlock targets. Production macOS/Windows behavior is unchanged and must fail closed in the repair until separately validated. |
+
+On this runner AppArmor is enabled and the outer label is
+`bwrap//&unpriv_bwrap (enforce)`. Offline parsing succeeds, but
+`aa_stack_onexec(<fixture-profile>)` returns `ENOENT`: the generated profile has
+not been loaded into the visible policy namespace. No policy load was attempted.
+All AppArmor child probes are therefore **unavailable**. The original nested
+Bubblewrap probe still reports namespace creation denied. This says nothing
+about whether the operator's host-side launcher can create namespaces.
+
+The next operator-side experiment is concrete:
+
+1. On the intended host, prepare a unique fixture using the commands above,
+   inspect its manifest/profile, and compile it with `--skip-kernel-load`.
+   The profile contains no host write grant except `/dev/null`.
+2. With separately authorized administration, load only that named experimental
+   profile using `apparmor_parser --add --skip-cache <fixture>/profile.apparmor`.
+   Confirm its enforcing mode and that the existing parent label is retained
+   when stacking. The executor must not self-authorize this administration.
+3. Run the AppArmor backend from the actual admitted execution context. Require
+   executed negative and positive bodies, no unavailable rows, the exact original
+   alias sentinel, and the resolved-policy differential/race tests above. An
+   ENOENT/EPERM result is an admission blocker, never permission to leave the
+   provider sandbox or switch to an unconfined backend.
+4. Separately run `/usr/bin/bwrap --die-with-parent --unshare-user --unshare-pid
+   --ro-bind / / --proc /proc -- /usr/bin/true` as the intended host execution
+   identity and through normal activity admission. Record both argv, exit status,
+   stderr, uid/kernel and the current AppArmor label. This tests namespace
+   admission only; it is not a read-confidentiality test.
+5. After every experimental process exits, an authorized operator removes only
+   this profile with `apparmor_parser --remove <fixture>/profile.apparmor` and
+   deletes only the corresponding run-owned fixture. Preserve the JSON evidence.
+
+Performance has two different gates. The prototype emits a bounded number of
+rules from explicit grants, without recursively walking the workspace; the
+Landlock setup performs one open/add per grant. Five offline AppArmor parser runs for the 1,885-byte fixture profile took
+17.098–23.656 ms; per-command wall times are also attached, including
+failed/unavailable runs.
+There is **no measured live AppArmor overhead**. Before selection, measure cold
+profile compilation/load and warm exec, 3,000-file and large-tree git/rg workloads,
+concurrent jobs, parser memory, and policy size limits; compare distributions with
+the admitted baseline. Cache by policy/grant/platform identity, not mutable file
+inventory. Bound compilation time, profile count and cleanup; do not extrapolate
+from a single small fixture or count failure latency as successful throughput.
+
+The pending decisions are therefore: authorize and provision the host-side LSM
+experiment; ratify acquisition-time versus revocation/provenance semantics; define
+an explicit GitHub credential capability for authenticated recovery; and require
+separate supported-platform evidence. Until those gates settle, this is a
+reviewable experiment and design handoff, not proof of a complete production fix.


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11546`
- Run: `jrun-20260907-2045-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `89efc7b0f8746e5b310974a381beaa97c515cb84`
- Target base: `93eb4f8823a677c251523f901e91525d0849ddfb`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=live_enforcement_unavailable; error.message=AppArmor profile unavailable: all 19 live probes blocked by ENOENT. Denied-name enforcement remains unproved; operator provisioning and explicit descriptor/credential contract decisions are required.
```