### PR TITLE
[code-review] Review-gate failure handoff cannot push a rewritten candidate

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -11,7 +11,7 @@ use crate::executor::automation::input::{
 };
 
 use super::commit::commit_failure_candidate;
-use super::freshness::{commit_sha, original_base_sha};
+use super::freshness::{commit_sha, original_base_sha, remote_branch_sha};
 use super::git::{
     base_sync_mode_from_input, git_command_success, git_output, resolve_worktree_start_point,
 };
@@ -283,10 +283,7 @@ fn preserve_review_gate_candidate<H: RuntimeHost + ?Sized>(
     let head_sha = git_output(workspace_path, &["rev-parse", "--verify", "HEAD^{commit}"])?;
     let pushed = push_batch_changes_inner(
         host,
-        &json!({
-            "branch": head,
-            "workspace_path": workspace_path,
-        }),
+        &review_gate_preservation_push_input(input, &head, workspace_path, &head_sha)?,
         workspace_path,
     )?;
 
@@ -343,6 +340,63 @@ fn preserve_review_gate_candidate<H: RuntimeHost + ?Sized>(
         "pr_created": false,
         "task_status": "blocked",
     }))
+}
+
+/// Push input for a review-gate preservation.
+///
+/// First-time (missing origin) and fast-forward pushes ignore the lease
+/// fields. A diverged origin is replaced only when the lease names the exact
+/// remote SHA `git_push` currently observes. `rewrite_performed` is set by
+/// this handoff even when this run's `sync_base` did not rewrite: a previous
+/// preservation (or re-implementation onto the same head) still has to replace
+/// the published candidate.
+fn review_gate_preservation_push_input(
+    input: &Value,
+    branch: &str,
+    workspace_path: &Path,
+    local_sha: &str,
+) -> Result<Value, OrbitError> {
+    let mut push_input = json!({
+        "branch": branch,
+        "workspace_path": workspace_path,
+    });
+    if let Some((head_before, expected_remote_sha)) =
+        review_gate_rewrite_lease(input, branch, workspace_path, local_sha)?
+    {
+        push_input["rewrite_performed"] = json!(true);
+        push_input["rewrite_head_before"] = json!(head_before);
+        push_input["expected_remote_sha"] = json!(expected_remote_sha);
+    }
+    Ok(push_input)
+}
+
+fn review_gate_rewrite_lease(
+    input: &Value,
+    branch: &str,
+    workspace_path: &Path,
+    local_sha: &str,
+) -> Result<Option<(String, String)>, OrbitError> {
+    let checkpointed_remote = pipeline_checkpoint_string(input, "sync_base", "remote_sha_before")
+        .or_else(|| pipeline_checkpoint_string(input, "prepare_branch", "remote_sha"));
+    let expected_remote_sha = match checkpointed_remote {
+        Some(sha) => sha,
+        None => match remote_branch_sha(workspace_path, branch)? {
+            Some(sha) => sha,
+            None => return Ok(None),
+        },
+    };
+
+    let head_before = pipeline_checkpoint_string(input, "sync_base", "head_sha_before")
+        .filter(|sha| sha != local_sha)
+        .or_else(|| (expected_remote_sha != local_sha).then(|| expected_remote_sha.clone()));
+    Ok(head_before.map(|head_before| (head_before, expected_remote_sha)))
+}
+
+fn pipeline_checkpoint_string(input: &Value, step: &str, field: &str) -> Option<String> {
+    input
+        .get("pipeline")
+        .and_then(|pipeline| pipeline.get(step))
+        .and_then(|checkpoint| input_string_field(checkpoint, field))
 }
 
 fn ensure_failure_handoff_ownership<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
@@ -1,14 +1,19 @@
 //! PR steps recheck the reviewed candidate [ORB-11333].
 
+use std::fs;
+use std::path::Path;
+
 use orbit_types::task::TaskStatus;
 use serde_json::{Value, json};
 
 use super::super::complete::pr_complete;
 use super::super::open::pr_open;
 use super::test_support::{
-    PR_CREATE_OPERATION, PR_MERGE_OPERATION, PrOpenTestHost, batch_task, git, pr_open_input,
-    pr_workspace, review_batch_task,
+    PR_CREATE_OPERATION, PR_MERGE_OPERATION, PUSH_OPERATION, PrOpenTestHost, batch_task, git,
+    pr_open_input, pr_workspace, review_batch_task,
 };
+use crate::executor::automation::vcs::failure::pr_failure_handoff;
+use crate::executor::automation::vcs::push::push_batch_changes;
 
 const SUMMARY: &str = "Outcome: success\n\nChanges:\n- Reviewed change.";
 
@@ -290,4 +295,193 @@ printf '%s\n' '{"merged":true,"sha":"unreviewed-merge"}'
         "api\nrepos/{{owner}}/{{repo}}/pulls/42/merge\n--method\nPUT\n-f\nsha={reviewed}\n-f\nmerge_method=squash\n"
     );
     assert!(args.contains(&expected_mutation), "{args}");
+}
+
+/// [ORB-11538] A rewritten candidate whose origin SHA is not an ancestor must
+/// still be preserved: checkpoint-less push stays fail-closed, and the
+/// review-gate handoff supplies the durable rewrite lease so the blocked
+/// escalation can run.
+#[test]
+fn review_gate_handoff_pushes_a_diverged_candidate_with_a_rewrite_lease() {
+    let workspace = pr_workspace();
+    let (head_before, published) = diverge_published_candidate(&workspace.repo);
+    let task_id = "ORB-11538-DIVERGED";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Preserve rewritten review-gate candidate",
+            SUMMARY,
+        )],
+        workspace.repo.clone(),
+    );
+
+    let error = push_batch_changes(
+        &host,
+        &json!({
+            "workspace_path": workspace.repo,
+            "branch": "orbit/test-batch",
+        }),
+    )
+    .expect_err("checkpoint-less push must not replace a diverged origin");
+    assert!(
+        error.to_string().contains("no durable rewrite checkpoint"),
+        "{error}"
+    );
+    assert!(host.vcs_calls().is_empty(), "no push without a lease");
+    assert_eq!(host.task_status(task_id), TaskStatus::InProgress);
+
+    let recovered = pr_failure_handoff(
+        &host,
+        &review_gate_handoff_input(
+            &workspace.repo,
+            task_id,
+            json!({
+                "head": "orbit/test-batch",
+                "rewritten": true,
+                "head_sha_before": head_before,
+                "remote_sha_before": published,
+            }),
+        ),
+    )
+    .expect("lease-checked preservation must reach the blocked update");
+
+    assert_eq!(recovered["decision"], "blocked_review_gate");
+    assert_eq!(recovered["pr_created"], false);
+    assert_eq!(recovered["task_status"], "blocked");
+    assert_eq!(recovered["push"]["decision"], "performed_force_with_lease");
+    assert_eq!(recovered["push"]["force_with_lease"], true);
+    assert_eq!(host.task_status(task_id), TaskStatus::Blocked);
+    let push = host
+        .vcs_calls()
+        .into_iter()
+        .find(|call| call.operation == PUSH_OPERATION)
+        .expect("preservation push");
+    assert_eq!(push.input["force_with_lease"], true);
+    assert_eq!(push.input["expected_remote_sha"], json!(published));
+    assert!(
+        host.vcs_calls()
+            .iter()
+            .all(|call| call.operation != PR_CREATE_OPERATION),
+        "review-gate preservation must not open a PR"
+    );
+    let update = host
+        .automation_updates()
+        .into_iter()
+        .find(|(_, update)| update.status == Some(TaskStatus::Blocked))
+        .expect("blocked review-gate update");
+    assert_eq!(
+        update.1.status_event.as_deref(),
+        Some("review_gate_escalation")
+    );
+}
+
+#[test]
+fn review_gate_handoff_creates_a_missing_origin_branch_and_fast_forwards_without_force() {
+    let missing = pr_workspace();
+    git(
+        &missing.repo,
+        &["push", "origin", "--delete", "orbit/test-batch"],
+    );
+    let missing_id = "ORB-11538-CREATE";
+    let missing_host = PrOpenTestHost::new(
+        vec![batch_task(
+            missing_id,
+            "Create review-gate candidate",
+            SUMMARY,
+        )],
+        missing.repo.clone(),
+    );
+    let created = pr_failure_handoff(
+        &missing_host,
+        &review_gate_handoff_input(
+            &missing.repo,
+            missing_id,
+            json!({
+                "head": "orbit/test-batch",
+                "rewritten": false,
+                "head_sha_before": git(&missing.repo, &["rev-parse", "HEAD"]),
+                "remote_sha_before": Value::Null,
+            }),
+        ),
+    )
+    .expect("first-time preservation creates the branch");
+    assert_eq!(created["decision"], "blocked_review_gate");
+    assert_eq!(created["push"]["decision"], "performed_create");
+    assert_eq!(created["push"]["force_with_lease"], false);
+    assert_eq!(missing_host.vcs_calls()[0].input["force_with_lease"], false);
+    assert_eq!(missing_host.task_status(missing_id), TaskStatus::Blocked);
+
+    let fast_forward = pr_workspace();
+    fs::write(fast_forward.repo.join("fast-forward.txt"), "local\n").expect("write follow-up");
+    git(&fast_forward.repo, &["add", "fast-forward.txt"]);
+    git(&fast_forward.repo, &["commit", "-m", "local follow-up"]);
+    let ff_id = "ORB-11538-FF";
+    let ff_host = PrOpenTestHost::new(
+        vec![batch_task(
+            ff_id,
+            "Fast-forward review-gate candidate",
+            SUMMARY,
+        )],
+        fast_forward.repo.clone(),
+    );
+    let origin_sha = git(
+        &fast_forward.repo,
+        &["rev-parse", "origin/orbit/test-batch"],
+    );
+    let forwarded = pr_failure_handoff(
+        &ff_host,
+        &review_gate_handoff_input(
+            &fast_forward.repo,
+            ff_id,
+            json!({
+                "head": "orbit/test-batch",
+                "rewritten": false,
+                "head_sha_before": git(&fast_forward.repo, &["rev-parse", "HEAD"]),
+                "remote_sha_before": origin_sha,
+            }),
+        ),
+    )
+    .expect("fast-forward preservation must not force-push");
+    assert_eq!(forwarded["decision"], "blocked_review_gate");
+    assert_eq!(forwarded["push"]["decision"], "performed_fast_forward");
+    assert_eq!(forwarded["push"]["force_with_lease"], false);
+    assert_eq!(ff_host.vcs_calls()[0].input["force_with_lease"], false);
+    assert_eq!(ff_host.task_status(ff_id), TaskStatus::Blocked);
+}
+
+fn review_gate_handoff_input(repo: &Path, task_id: &str, sync_base: Value) -> Value {
+    json!({
+        "failed_step_id": "review_gate_settle",
+        "activity_name": "review_gate_settle",
+        "error_code": "review_gate_failed",
+        "error_message": "before-PR review gate did not pass",
+        "run_id": "batch-1",
+        "job_input": {
+            "task_ids": [task_id],
+            "base_branch": "agent-main",
+            "base_sync": "local",
+        },
+        "pipeline": {
+            "worktree": {
+                "workspace_path": repo,
+                "job_run_id": "batch-1",
+                "base_ref": "agent-main",
+            },
+            "sync_base": sync_base,
+        },
+    })
+}
+
+fn diverge_published_candidate(repo: &Path) -> (String, String) {
+    let head_before = git(repo, &["rev-parse", "HEAD"]);
+    fs::write(repo.join("published-side.txt"), "published\n").expect("write published side");
+    git(repo, &["add", "published-side.txt"]);
+    git(repo, &["commit", "-m", "previous preservation candidate"]);
+    git(repo, &["push", "origin", "orbit/test-batch"]);
+    let published = git(repo, &["rev-parse", "HEAD"]);
+    git(repo, &["reset", "--hard", &head_before]);
+    fs::write(repo.join("retry-side.txt"), "retry\n").expect("write retry side");
+    git(repo, &["add", "retry-side.txt"]);
+    git(repo, &["commit", "-m", "rewritten review-gate candidate"]);
+    (head_before, published)
 }


### PR DESCRIPTION
## Task

[ORB-11538](https://orbit-cli.com/tasks/ORB-11538) — [code-review] Review-gate failure handoff cannot push a rewritten candidate

### Description

## Problem

When the before-PR review gate fails, `preserve_review_gate_candidate` is supposed to push the candidate branch so implementation commits, partial reviewer repairs, and review evidence remain recoverable. The push is issued without the rewrite checkpoints `git_push` requires for a diverged remote, so a retry after a previous handoff (or any rewritten history on the same branch) cannot preserve the candidate and never reaches the blocked-task update.

## Live evidence

Verified at `96e6a50dd5b7010f3dfe63049ce5d5fd2eafd2cb` (introduced with the gate in `d2cc023ea` / ORB-11333):

- `crates/orbit-engine/src/executor/automation/vcs/failure.rs:284-291` calls `push_batch_changes_inner` with only `branch` and `workspace_path`. The blocked-task update at `:317-330` runs only after that push succeeds.
- `crates/orbit-engine/src/executor/automation/vcs/push.rs:79-81` treats a diverged remote as authorized only after `validate_rewrite_checkpoint`.
- `crates/orbit-engine/src/executor/automation/vcs/push.rs:164-188` refuses the replace unless `rewrite_performed` is true, `rewrite_head_before` is not the current SHA, and `expected_remote_sha` equals the observed remote SHA. None of those fields are supplied by the review-gate handoff.
- Pipeline order in `crates/orbit-core/assets/jobs/task_pr_pipeline.yaml:116-169` runs `sync_base` (which may rewrite) before the gate and `git_push` after it. The first review-gate failure therefore often creates the remote branch; a later retry that rebases or re-implements onto the same head diverges from that published SHA and the handoff push fails closed with `git_push: branch 'origin/<head>' diverged, but no durable rewrite checkpoint...`.
- No engine test covers `blocked_review_gate` / `preserve_review_gate_candidate` (only `pr/tests/review_gate.rs` covers stale-head merge refusal).

## Impact

This is not a merge bypass: publication is still withheld. The documented preservation path is lost on the second gate failure for a branch that already exists on origin, and the task is not moved to `blocked` with the escalation because the handoff errors first. Distinct from ORB-11525 (managed merge pin) and ORB-11520 (epic worktree vs admitted run).

### Acceptance Criteria

- A review-gate failure on a branch whose origin SHA is not an ancestor of the current candidate still pushes the candidate (lease-checked) and records the blocked review_gate_escalation update.
- A first-time handoff whose branch is missing on origin still creates the branch; Fast-forward preservation still does not force-push.
- A regression test fails against the current checkpoint-less push and passes once the handoff carries a durable rewrite lease; make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- `preserve_review_gate_candidate` now pushes through `review_gate_preservation_push_input`, which attaches a durable rewrite lease (`rewrite_performed`, `rewrite_head_before`, `expected_remote_sha`) so a diverged origin can be replaced with force-with-lease.
- Lease `expected_remote_sha` prefers `pipeline.sync_base.remote_sha_before`, then `pipeline.prepare_branch.remote_sha`, then the live origin SHA. `rewrite_head_before` prefers `sync_base.head_sha_before` when it differs from the current candidate, else the expected remote SHA. `rewrite_performed` is set by this handoff even when this run's `sync_base` did not rewrite.
- Missing origin still creates the branch (no lease). Fast-forward still does not force-push. After a successful push the task is blocked with `review_gate_escalation`; no PR is opened.
- Engine tests in `pr/tests/review_gate.rs` cover diverged lease-checked preservation (checkpoint-less push still fails closed), first-time create, and fast-forward without force.
- Unlisted one-line fix: `ci_sweep.rs` `WorkspaceRuntimeBinding` now sets `owner_machine_id: None` like the other binding tests, unblocking workspace clippy on this checkout (ORB-11516 initializer vs ORB-11530 field).

Assessment: Smallest compatible change — `git_push` remains the rewrite authority; the handoff supplies the lease it already required. Pipeline YAML unchanged because failure activity already receives `sync_base` output.

Criteria:
- Diverged origin SHA not an ancestor: lease-checked force-with-lease push, then `blocked` + `review_gate_escalation`. Covered by `review_gate_handoff_pushes_a_diverged_candidate_with_a_rewrite_lease`.
- Missing origin creates the branch; fast-forward does not force-push. Covered by `review_gate_handoff_creates_a_missing_origin_branch_and_fast_forwards_without_force`.
- Regression: same test first asserts checkpoint-less `git_push` fails with `no durable rewrite checkpoint`, then the handoff with the lease succeeds. `make ci-fast` and `make ci-lint` passed.

Validation:
- `cargo test -p orbit-engine --lib executor::automation::vcs::pr::tests::review_gate -- --test-threads=1`: passed (7 tests, including the two new ones).
- `make ci-fast`: passed.
- `make ci-lint`: passed (after the `ci_sweep.rs` initializer fix; first run failed on that pre-existing missing field, not on the handoff change).
- `git diff --check`: passed. Uncommitted files: `failure.rs`, `review_gate.rs`, `ci_sweep.rs`.

Deviations from original plan:
- Added `file:crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs` so workspace clippy could run. Justification: acceptance requires `make ci-lint`; HEAD did not compile that test after ORB-11530 added `owner_machine_id`.

Design weaknesses / risks:
- Severity: low. The generic (non-review-gate) failure handoff still calls `push_batch_changes_inner` without a lease. Out of scope; same fail-closed symptom is possible for conflict/dirty-candidate retries on a rewritten branch.
- Severity: low. A stale `sync_base.remote_sha_before` that no longer matches live origin still fails closed, which is the durable-lease contract.
- Tests exercise the private VCS push operation through `PrOpenTestHost` (records lease fields, does not actually update the bare remote).

Recommended follow-ups: consider the same lease on the non-review-gate `pr_failure_handoff` push if retries rewrite after a blocked PR was already published.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11538-6a9f23d3`
- Behind base: 0
- Ahead of base: 1