### PR TITLE
[qa-sweep] Fresh orbit init still tells operators before-pr is not yet supported

### DIFF
--- a/crates/orbit-config/assets/default-config.toml
+++ b/crates/orbit-config/assets/default-config.toml
@@ -60,4 +60,4 @@ system_crew = "system"
 # at that layer; review_policy, review_crew and delivery_cap are independent.
 # preset = "supervised"        # or "autonomous"
 # delivery_cap = "review"      # raise to "done" only where managed completion is allowed
-# review_policy = "none"       # or "after-landing"; "before-pr" is not yet supported
+# review_policy = "none"       # or "before-pr", "after-landing"


### PR DESCRIPTION
## Task

[ORB-11537](https://orbit-cli.com/tasks/ORB-11537) — [qa-sweep] Fresh orbit init still tells operators before-pr is not yet supported

### Description

## Problem
After ORB-11333 shipped independent review policy, `operation.review_policy = "before-pr"` is a live, settable value. `orbit config keys` describes it, `orbit operation explain --review-policy before-pr` captures `gates_pr: true`, and `orbit config set operation.review_policy before-pr` succeeds. The operator-facing default config template still comments:

```
# review_policy = "none"       # or "after-landing"; "before-pr" is not yet supported
```

That comment is copied verbatim into a new host's `config.toml` by `orbit init`.

## Why It Matters
Every new host is told the shipped `before-pr` gate does not exist. Operators who follow the commented example will never enable the feature that `orbit config keys` and `orbit operation explain` advertise. The live registry and the onboarding template contradict each other.

## Evidence (HEAD `96e6a50dd`, 2026-09-07, worktree of jrun-20260907-2008-5)
- Source: `crates/orbit-config/assets/default-config.toml` line 63.
- Shipped policy: ORB-11333 / `d2cc023ea` (#1499). Config registry text: "Automatic review timing: none (default), before-pr, or after-landing. ... before-pr holds PR creation for a fresh reviewer on the PR route and is refused for local-only delivery."
- Hands-on: built `target/debug/orbit` (0.19.2) from this checkout.
- `orbit --root /tmp/orb-qa-11533-root init --non-interactive --host-name qa-sweep-host --task-prefix QASW` wrote `/tmp/orb-qa-11533-root/config.toml` with the same "before-pr is not yet supported" comment.
- Scratch `orbit config get operation.review_policy` was `null` (effective `none`); `orbit config set operation.review_policy before-pr` succeeded and `orbit operation explain` then reported `review_policy.value=before-pr` / `gates_pr=true` (plus `review_crew_unconfigured` until a crew was set).
- Live orbit workspace already uses `after-landing` (`orbit config get operation.review_policy` → `after-landing`; `orbit operation explain` → `review.policy=after-landing`, `gates_pr=false`).
- `orbit run job task_local_pipeline` under scratch `before-pr` refused at submission with the documented local-route error, so the feature is not merely advertised — the gate is enforced.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
ROOT=/tmp/orb-qa-11533-repro
rm -rf "$ROOT"
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-repro --task-prefix QASW
grep -n 'review_policy' "$ROOT/config.toml"
# observe: ... "before-pr" is not yet supported
"$BIN" --root "$ROOT" config keys | grep operation.review_policy
# observe: lists before-pr as a supported value
"$BIN" --root "$ROOT" --format json operation explain --review-policy before-pr
# observe: policy.review_policy.value=before-pr, review.gates_pr=true
```

## Scope
Docs/template only. Runtime already accepts and enforces `before-pr`. No production outage. Fix is to align the commented example in `default-config.toml` (and therefore freshly inited `config.toml`) with the live registry.

### Acceptance Criteria

- crates/orbit-config/assets/default-config.toml no longer claims that before-pr is unsupported.
- A fresh `orbit init` writes a commented review_policy example that names none, after-landing, and before-pr as the supported values, matching `orbit config keys`.
- orbit config set operation.review_policy before-pr and orbit operation explain --review-policy before-pr still succeed on a newly inited root.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Acceptance Criteria Results
- crates/orbit-config/assets/default-config.toml no longer claims that before-pr is unsupported: Passed. Updated commented review_policy example from `# review_policy = "none"       # or "after-landing"; "before-pr" is not yet supported` to `# review_policy = "none"       # or "before-pr", "after-landing"`.
- A fresh `orbit init` writes a commented review_policy example that names none, after-landing, and before-pr as the supported values, matching `orbit config keys`: Passed. Verified that a newly initialized host config contains the updated comment matching the registry.
- orbit config set operation.review_policy before-pr and orbit operation explain --review-policy before-pr still succeed on a newly inited root: Passed. Verified that setting operation.review_policy to before-pr succeeds and operation explain reports gates_pr: true with before-pr policy.

### Validation Commands
- `make ci-fast`: Passed (all formatting, shell guardrails, and doc/asset checks clean).
- `cargo test -p orbit-config`: Passed (105 tests passed, 0 failed).
- `cargo clippy -p orbit-config --all-targets -- -D warnings`: Passed (0 warnings).
- Reproduction script (`orbit init`, `orbit config keys`, `orbit config set`, `orbit operation explain`): Passed.
- `git diff --check`: Passed (clean).
- `git status --short`: Passed (only `crates/orbit-config/assets/default-config.toml` modified).
- `make ci-lint`: Failed due to an unrelated pre-existing compile error on integration branch `agent-main` in `crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs:271` (missing field `owner_machine_id` in `WorkspaceRuntimeBinding` struct initialization).

### Risks and Deviations
- None within task scope. Changes are template-only in crates/orbit-config/assets/default-config.toml.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11537-6a9f2481`
- Behind base: 0
- Ahead of base: 1