### PR TITLE
Bind superseded review validation to the check that actually replaces it

### DIFF
--- a/.orbit/resources/activities/agent_review_repair.yaml
+++ b/.orbit/resources/activities/agent_review_repair.yaml
@@ -116,6 +116,11 @@ spec:
        - `superseded`: an earlier diagnostic attempt a later required check
          replaced, such as a run in a misconfigured environment you then
          corrected. Keep it and record the replacing required check after it.
+         The replacement must name the same check: the same `command`, or the
+         same non-empty `check` identity when the command or environment was
+         corrected. An unrelated later pass (for example `cargo fmt --check`
+         after a failed `cargo test`) does not replace it. A missing, empty,
+         or one-sided `check` identity fails closed.
 
        At least one `required` record must pass, or the review establishes
        nothing about the candidate.
@@ -140,6 +145,7 @@ spec:
                      "disposition":{"kind":"open|repaired"}}],
         "validation":[{"command":"make ci-fast","outcome":"passed|failed|denied|not_run",
                        "role":"required|expected_failure|excluded|superseded",
+                       "check":"optional identity shared with the replacing required check",
                        "note":"required unless the role is `required`"}],
         "escalation":"<required decision, when not a pass>"}
 

--- a/crates/orbit-automation/src/review/tests/mod.rs
+++ b/crates/orbit-automation/src/review/tests/mod.rs
@@ -73,6 +73,7 @@ fn certificate(verdict: ReviewVerdict) -> ReviewCertificate {
             outcome: ValidationOutcome::Passed,
             role: ValidationRole::Required,
             note: None,
+            check: None,
         }],
         validation_complete: true,
         reviewer: ReviewerIdentity {
@@ -189,12 +190,14 @@ fn coverage_reads_the_same_validation_contract_the_gate_settled_under() {
             outcome: ValidationOutcome::Failed,
             role: ValidationRole::ExpectedFailure,
             note: Some("negative control: the superseded assertion must fail".into()),
+            check: None,
         },
         ReviewValidation {
             command: "wrangler deploy".into(),
             outcome: ValidationOutcome::NotRun,
             role: ValidationRole::Excluded,
             note: Some("live deployment is outside the authorized scope".into()),
+            check: None,
         },
     ]);
     assert!(certificate_acceptable(&classified).is_ok());
@@ -214,6 +217,62 @@ fn coverage_reads_the_same_validation_contract_the_gate_settled_under() {
         certificate_acceptable(&unexplained),
         Err(ReviewInvalidation::ValidationIncomplete)
     );
+}
+
+#[test]
+fn coverage_refuses_a_superseded_test_replaced_only_by_an_unrelated_formatter() {
+    let mut loophole = certificate(ReviewVerdict::PassedWithoutRepairs);
+    loophole.validation = vec![
+        ReviewValidation {
+            command: "cargo test".into(),
+            outcome: ValidationOutcome::Failed,
+            role: ValidationRole::Superseded,
+            note: Some("rerun after repair".into()),
+            check: None,
+        },
+        ReviewValidation {
+            command: "cargo fmt --check".into(),
+            outcome: ValidationOutcome::Passed,
+            role: ValidationRole::Required,
+            note: None,
+            check: None,
+        },
+    ];
+    assert_eq!(
+        certificate_acceptable(&loophole),
+        Err(ReviewInvalidation::ValidationIncomplete),
+        "an unrelated later formatter cannot certify a superseded test"
+    );
+}
+
+#[test]
+fn coverage_accepts_a_superseded_attempt_replaced_by_a_related_corrected_rerun() {
+    let mut related = certificate(ReviewVerdict::PassedWithoutRepairs);
+    related.validation = vec![
+        ReviewValidation {
+            command: "cargo test --package orbit-core".into(),
+            outcome: ValidationOutcome::Failed,
+            role: ValidationRole::Superseded,
+            note: Some("sandbox allowlist leak; rerun below in a corrected environment".into()),
+            check: Some("orbit-core-tests".into()),
+        },
+        ReviewValidation {
+            command: "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core".into(),
+            outcome: ValidationOutcome::Passed,
+            role: ValidationRole::Required,
+            note: None,
+            check: Some("orbit-core-tests".into()),
+        },
+    ];
+    assert!(
+        certificate_acceptable(&related).is_ok(),
+        "a shared check identity binds a corrected command as the replacement"
+    );
+    assert_eq!(
+        related.validation[0].command, "cargo test --package orbit-core",
+        "the failed observation remains on the certificate"
+    );
+    assert_eq!(related.validation[0].outcome, ValidationOutcome::Failed);
 }
 
 #[test]

--- a/crates/orbit-automation/src/review/tests/validation.rs
+++ b/crates/orbit-automation/src/review/tests/validation.rs
@@ -15,7 +15,13 @@ fn record(
         outcome,
         role,
         note: note.map(Into::into),
+        check: None,
     }
+}
+
+fn with_check(mut record: ReviewValidation, check: &str) -> ReviewValidation {
+    record.check = Some(check.into());
+    record
 }
 
 fn required(command: &str, outcome: ValidationOutcome) -> ReviewValidation {
@@ -171,19 +177,39 @@ fn an_outcome_that_contradicts_its_classification_blocks() {
 
 #[test]
 fn a_superseded_attempt_needs_the_later_check_that_replaced_it() {
-    // The shape ORB-11516 recorded: a leaked sandbox allowlist failed the
-    // first attempt, and the corrected environment passed. The failure stays
-    // in the record.
-    let corrected = vec![
+    // A same-command rerun is an unambiguous replacement without an extra
+    // identity field.
+    let same_command = vec![
         record(
             "cargo test --package orbit-core",
             ValidationOutcome::Failed,
             ValidationRole::Superseded,
-            Some("sandbox allowlist leak; rerun below in a corrected environment"),
+            Some("first attempt; rerun below after the repair"),
         ),
-        required(
-            "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
-            ValidationOutcome::Passed,
+        required("cargo test --package orbit-core", ValidationOutcome::Passed),
+    ];
+    assert_eq!(validation_evidence(&same_command), Ok(()));
+
+    // The shape ORB-11516 recorded: a leaked sandbox allowlist failed the
+    // first attempt, and the corrected environment passed. The commands
+    // differ, so both records name the same check identity. The failure
+    // stays in the record.
+    let corrected = vec![
+        with_check(
+            record(
+                "cargo test --package orbit-core",
+                ValidationOutcome::Failed,
+                ValidationRole::Superseded,
+                Some("sandbox allowlist leak; rerun below in a corrected environment"),
+            ),
+            "orbit-core-tests",
+        ),
+        with_check(
+            required(
+                "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+                ValidationOutcome::Passed,
+            ),
+            "orbit-core-tests",
         ),
     ];
     assert_eq!(validation_evidence(&corrected), Ok(()));
@@ -212,6 +238,150 @@ fn a_superseded_attempt_needs_the_later_check_that_replaced_it() {
             command: "cargo test --package orbit-core".into(),
         }),
         "a check recorded before the attempt cannot resolve it"
+    );
+}
+
+#[test]
+fn an_unrelated_later_required_pass_does_not_replace_a_superseded_test() {
+    // The ORB-11528 gap: a failed test classified superseded, followed only
+    // by an unrelated formatter, was treated as replaced.
+    let unrelated = vec![
+        record(
+            "cargo test",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("rerun after repair"),
+        ),
+        required("cargo fmt --check", ValidationOutcome::Passed),
+    ];
+    assert_eq!(
+        validation_evidence(&unrelated),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test".into(),
+        }),
+        "a later formatter is not the check that replaced the test"
+    );
+}
+
+#[test]
+fn missing_ambiguous_invalid_or_non_passing_replacement_relationships_fail_closed() {
+    let superseded = |check: Option<&str>| {
+        let record = record(
+            "cargo test --package orbit-core",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("sandbox allowlist leak"),
+        );
+        match check {
+            Some(identity) => with_check(record, identity),
+            None => record,
+        }
+    };
+
+    // Corrected command with no shared identity: missing relationship.
+    let missing_identity = vec![
+        superseded(None),
+        required(
+            "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+            ValidationOutcome::Passed,
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&missing_identity),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test --package orbit-core".into(),
+        }),
+        "a different command is not a replacement without a shared check identity"
+    );
+
+    // Identity on only one side does not bind to the other record's command.
+    let one_sided = vec![
+        superseded(Some("orbit-core-tests")),
+        required(
+            "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+            ValidationOutcome::Passed,
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&one_sided),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test --package orbit-core".into(),
+        }),
+        "a one-sided check identity is not an unambiguous replacement"
+    );
+
+    // Empty and whitespace identities match nothing.
+    for invalid in ["", "   "] {
+        let invalid_identity = vec![
+            with_check(
+                record(
+                    "cargo test",
+                    ValidationOutcome::Failed,
+                    ValidationRole::Superseded,
+                    Some("rerun after repair"),
+                ),
+                invalid,
+            ),
+            required("cargo test", ValidationOutcome::Passed),
+        ];
+        assert_eq!(
+            validation_evidence(&invalid_identity),
+            Err(ValidationDefect::SupersededWithoutReplacement {
+                command: "cargo test".into(),
+            }),
+            "an empty or whitespace check identity is invalid: {invalid:?}"
+        );
+    }
+
+    // A related later required check that did not pass is not a replacement.
+    let related_failed = vec![
+        with_check(
+            record(
+                "cargo test --package orbit-core",
+                ValidationOutcome::Failed,
+                ValidationRole::Superseded,
+                Some("sandbox allowlist leak"),
+            ),
+            "orbit-core-tests",
+        ),
+        with_check(
+            required(
+                "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+                ValidationOutcome::Failed,
+            ),
+            "orbit-core-tests",
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&related_failed),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test --package orbit-core".into(),
+        }),
+        "a related required check that failed is not a replacement"
+    );
+
+    // Identity present but pointing at a different check is not a replacement.
+    let mismatched = vec![
+        with_check(
+            record(
+                "cargo test",
+                ValidationOutcome::Failed,
+                ValidationRole::Superseded,
+                Some("rerun after repair"),
+            ),
+            "unit-tests",
+        ),
+        with_check(
+            required("cargo fmt --check", ValidationOutcome::Passed),
+            "formatting",
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&mismatched),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test".into(),
+        }),
+        "distinct check identities are not a replacement relationship"
     );
 }
 
@@ -245,6 +415,10 @@ fn an_unexplained_reclassification_is_refused_and_legacy_records_stay_required()
     )
     .expect("legacy validation records");
     assert!(legacy.iter().all(|r| r.role == ValidationRole::Required));
+    assert!(
+        legacy.iter().all(|r| r.check.is_none()),
+        "role-less evidence does not gain a check identity"
+    );
     assert_eq!(
         validation_evidence(&legacy),
         Err(ValidationDefect::RequiredNotPassed {

--- a/crates/orbit-automation/src/review/validation.rs
+++ b/crates/orbit-automation/src/review/validation.rs
@@ -76,8 +76,8 @@ impl ValidationDefect {
                 outcome.as_str()
             ),
             ValidationDefect::SupersededWithoutReplacement { command } => format!(
-                "validation_incomplete: superseded attempt `{command}` is followed by no required \
-                 check that passed on the final candidate"
+                "validation_incomplete: superseded attempt `{command}` is followed by no related \
+                 required check that passed on the final candidate"
             ),
             ValidationDefect::ClassificationUnexplained { command, role } => format!(
                 "validation_unexplained: `{command}` is recorded as {} with no note explaining it",
@@ -93,10 +93,11 @@ impl ValidationDefect {
 /// Every required check must have passed and at least one must exist; a
 /// declared negative control must have failed; an excluded action must have
 /// stayed unperformed; a superseded attempt must be followed by the required
-/// check that replaced it. Every classification other than `required` must
-/// explain itself, so an unexplained reclassification is refused rather than
-/// trusted. Records carrying no classification are required checks, which
-/// keeps evidence written before this contract conservative.
+/// check that replaced it — the same command, or the same non-empty `check`
+/// identity. Every classification other than `required` must explain itself,
+/// so an unexplained reclassification is refused rather than trusted. Records
+/// carrying no classification are required checks, which keeps evidence
+/// written before this contract conservative.
 pub fn validation_evidence(records: &[ReviewValidation]) -> Result<(), ValidationDefect> {
     let mut required_passed = false;
 
@@ -128,7 +129,9 @@ pub fn validation_evidence(records: &[ReviewValidation]) -> Result<(), Validatio
             {
                 return Err(contradiction(record));
             }
-            ValidationRole::Superseded if !replaced_by_required_check(&records[index + 1..]) => {
+            ValidationRole::Superseded
+                if !replaced_by_required_check(record, &records[index + 1..]) =>
+            {
                 return Err(ValidationDefect::SupersededWithoutReplacement {
                     command: record.command.clone(),
                 });
@@ -177,9 +180,36 @@ fn explained(record: &ReviewValidation) -> bool {
 
 /// Whether a later record is the required check the superseded attempt was
 /// replaced by. Order carries the meaning: a supersession must be resolved
-/// after it, never by a check recorded before it.
-fn replaced_by_required_check(later: &[ReviewValidation]) -> bool {
+/// after it, never by a check recorded before it. The later record must
+/// name the same check: the same command, or the same non-empty `check`
+/// identity when the command or environment was corrected. Any later
+/// required pass is not enough.
+fn replaced_by_required_check(superseded: &ReviewValidation, later: &[ReviewValidation]) -> bool {
+    let Some(identity) = replacement_identity(superseded) else {
+        return false;
+    };
     later.iter().any(|record| {
-        record.role == ValidationRole::Required && record.outcome == ValidationOutcome::Passed
+        record.role == ValidationRole::Required
+            && record.outcome == ValidationOutcome::Passed
+            && replacement_identity(record) == Some(identity)
     })
+}
+
+/// The identity a superseded attempt and its replacement share.
+///
+/// A present `check` is the identity when it is non-empty after trim.
+/// Otherwise the command string is the identity, so a same-command rerun
+/// still binds. An empty or whitespace-only `check` is invalid and matches
+/// nothing.
+fn replacement_identity(record: &ReviewValidation) -> Option<&str> {
+    match record.check.as_deref() {
+        Some(value) => {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        }
+        None => {
+            let command = record.command.as_str();
+            (!command.trim().is_empty()).then_some(command)
+        }
+    }
 }

--- a/crates/orbit-core/assets/activities/agent_review_repair.yaml
+++ b/crates/orbit-core/assets/activities/agent_review_repair.yaml
@@ -116,6 +116,11 @@ spec:
        - `superseded`: an earlier diagnostic attempt a later required check
          replaced, such as a run in a misconfigured environment you then
          corrected. Keep it and record the replacing required check after it.
+         The replacement must name the same check: the same `command`, or the
+         same non-empty `check` identity when the command or environment was
+         corrected. An unrelated later pass (for example `cargo fmt --check`
+         after a failed `cargo test`) does not replace it. A missing, empty,
+         or one-sided `check` identity fails closed.
 
        At least one `required` record must pass, or the review establishes
        nothing about the candidate.
@@ -140,6 +145,7 @@ spec:
                      "disposition":{"kind":"open|repaired"}}],
         "validation":[{"command":"make ci-fast","outcome":"passed|failed|denied|not_run",
                        "role":"required|expected_failure|excluded|superseded",
+                       "check":"optional identity shared with the replacing required check",
                        "note":"required unless the role is `required`"}],
         "escalation":"<required decision, when not a pass>"}
 

--- a/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/epic_review_gate.rs
@@ -225,6 +225,7 @@ impl<'a> ScriptedEpicReviewHost<'a> {
                 outcome: ValidationOutcome::Passed,
                 role: ValidationRole::Required,
                 note: None,
+                check: None,
             }],
             escalation: (self.reviewer.verdict == ReviewVerdict::ChangesRequired)
                 .then(|| "decide on the note".to_string()),

--- a/crates/orbit-core/src/application/job/tests/exec/review_gate.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/review_gate.rs
@@ -266,6 +266,7 @@ impl<'a> ScriptedReviewHost<'a> {
                 outcome: ValidationOutcome::Passed,
                 role: ValidationRole::Required,
                 note: None,
+                check: None,
             }],
             escalation: (self.reviewer.verdict == ReviewVerdict::ChangesRequired)
                 .then(|| "decide on the note".to_string()),

--- a/crates/orbit-core/src/application/review/tests/gate.rs
+++ b/crates/orbit-core/src/application/review/tests/gate.rs
@@ -594,6 +594,93 @@ fn a_legacy_report_without_classifications_keeps_its_conservative_reading() {
 }
 
 #[test]
+fn a_superseded_test_is_not_replaced_by_an_unrelated_formatter() {
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false);
+    claim.validation = vec![
+        validation(
+            "cargo test",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("rerun after repair"),
+        ),
+        validation(
+            "cargo fmt --check",
+            ValidationOutcome::Passed,
+            ValidationRole::Required,
+            None,
+        ),
+    ];
+    write_report(&gated.fixture.runtime, &gated.task_id, &claim);
+
+    let error = gated.settle(&admission).expect_err("unrelated formatter");
+    assert!(
+        error
+            .to_string()
+            .contains("superseded attempt `cargo test` is followed by no related required check"),
+        "{error}"
+    );
+    let certificate = gated.certificate();
+    assert_eq!(certificate.verdict, ReviewVerdict::Incomplete);
+    assert!(!certificate.validation_complete);
+    assert_eq!(
+        certificate.validation, claim.validation,
+        "the failed test observation is preserved on the incomplete certificate"
+    );
+}
+
+#[test]
+fn a_superseded_attempt_is_replaced_by_a_related_corrected_rerun() {
+    let gated = gated_fixture(GATED_CONFIG);
+    let admission = gated.admit().expect("admit");
+    let attempt_id = admission["attempt_id"].as_str().expect("attempt id");
+
+    let mut claim = report(attempt_id, ReviewVerdict::PassedWithoutRepairs, false);
+    claim.validation = vec![
+        validation(
+            "cargo test --package orbit-core",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("sandbox allowlist leak; rerun below in a corrected environment"),
+        ),
+        validation(
+            "ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core",
+            ValidationOutcome::Passed,
+            ValidationRole::Required,
+            None,
+        ),
+    ];
+    claim.validation[0].check = Some("orbit-core-tests".into());
+    claim.validation[1].check = Some("orbit-core-tests".into());
+    write_report(&gated.fixture.runtime, &gated.task_id, &claim);
+
+    let settled = gated.settle(&admission).expect("related rerun settles");
+    assert_eq!(settled["gate"], "passed");
+    assert_eq!(settled["verdict"], "passed_without_repairs");
+
+    let certificate = gated.certificate();
+    assert!(certificate.validation_complete);
+    assert_eq!(certificate.escalation, None);
+    assert_eq!(
+        certificate.validation, claim.validation,
+        "the failed observation and the corrected rerun both survive into the certificate"
+    );
+
+    let source = Source::new(&gated.fixture.repo);
+    let repository = source.repository().expect("repository");
+    let delivery = land_squash(&gated, &repository);
+    let (state, mut page) = page_for(&delivery);
+    exclusions(&gated.fixture.runtime, &source, &state, &mut page).expect("exclusions");
+    assert!(
+        page.exclusions.contains_key(&delivery.key),
+        "a related corrected rerun still covers its landing"
+    );
+}
+
+#[test]
 fn budgets_persist_across_attempts_and_interrupted_attempts_resume() {
     let gated = gated_fixture(
         "[crews.reviewers]\nmodel = \"review-model\"\nprovider = \"codex\"\nbackend = \"cli\"\n[crews.implementer]\nmodel = \"impl-model\"\nprovider = \"codex\"\nbackend = \"cli\"\n[workflow]\ndefault_crew = \"implementer\"\n[operation]\nreview_policy = \"before-pr\"\nreview_crew = \"reviewers\"\nreview_reviewer_starts = 1\n",

--- a/crates/orbit-core/src/application/review/tests/mod.rs
+++ b/crates/orbit-core/src/application/review/tests/mod.rs
@@ -208,6 +208,7 @@ pub(super) fn report(attempt_id: &str, verdict: ReviewVerdict, repaired: bool) -
             outcome: ValidationOutcome::Passed,
             role: ValidationRole::Required,
             note: None,
+            check: None,
         }],
         escalation: (verdict == ReviewVerdict::ChangesRequired)
             .then(|| "decide whether the note is required".to_string()),
@@ -226,6 +227,7 @@ pub(super) fn validation(
         outcome,
         role,
         note: note.map(ToString::to_string),
+        check: None,
     }
 }
 

--- a/crates/orbit-types/src/workflow/review.rs
+++ b/crates/orbit-types/src/workflow/review.rs
@@ -261,8 +261,10 @@ pub enum ValidationRole {
     /// It supplies no coverage and imposes no requirement.
     Excluded,
     /// A superseded attempt kept for history: a diagnostic run that a later
-    /// required check on the final candidate replaced. It never erases the
-    /// observation and never substitutes for that later check.
+    /// required check on the final candidate replaced. Replacement is the
+    /// later record that names the same check, not any later required pass.
+    /// It never erases the observation and never substitutes for that later
+    /// check.
     Superseded,
 }
 
@@ -289,6 +291,14 @@ pub struct ReviewValidation {
     pub role: ValidationRole,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Identity of the logical check this record belongs to. A superseded
+    /// attempt is replaced only by a later required passing record with the
+    /// same identity. When omitted, the command string is the identity, so a
+    /// same-command rerun still binds. An explicit value lets a corrected
+    /// command or environment replace the attempt without quoting the old
+    /// command. Empty or whitespace-only values match nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check: Option<String>,
 }
 
 /// How a finding was closed, if at all.

--- a/docs/design/operation-mode/5_operations.md
+++ b/docs/design/operation-mode/5_operations.md
@@ -11,7 +11,7 @@ summary: Shipped operation-mode contract — typed preferences, scoped grants, g
 tags: [operation-mode, automation, authorization, recovery, operations]
 paths: ["crates/orbit-config/src/operation.rs", "crates/orbit-core/src/application/operation/**", "crates/orbit-core/src/application/review/**", "crates/orbit-store/src/driver/sqlite/operation/**", "crates/orbit-store/src/driver/sqlite/review/**", "crates/orbit-automation/src/members/**", "crates/orbit-automation/src/review/**", "crates/orbit-engine/src/executor/automation/vcs/review_gate.rs"]
 related_features: [automation-triggers, activity-job, routines]
-related_artifacts: [ORB-11528, ORB-11333, ORB-11332, ORB-11331, ORB-11330]
+related_artifacts: [ORB-11545, ORB-11528, ORB-11333, ORB-11332, ORB-11331, ORB-11330]
 ---
 
 # Operation Mode — Operations [ORB-11332]
@@ -262,10 +262,11 @@ and 30-minute wall clock. It reads the manifest, verifies claims against code,
 repairs only concrete in-scope defects directly in the worktree, runs
 validation, and persists `review-report.json` (schema version 1: verdict,
 findings with dispositions, validation records with `passed` / `failed` /
-`denied` / `not_run` and the `role` each is evidence of, escalation). It never
+`denied` / `not_run`, the `role` each is evidence of, and optional `check`
+identity, escalation). It never
 runs Git writes, changes task lifecycle, approves, or merges.
 
-### What the validation records establish [ORB-11528]
+### What the validation records establish [ORB-11528] [ORB-11545]
 
 An honest reviewer records more than the checks that had to pass, so each
 validation record also carries a `role` saying what it is evidence of, and
@@ -279,7 +280,7 @@ spent.
 | `required` (default) | A check the final candidate must pass | `passed`; `failed`, `denied`, and `not_run` all block |
 | `expected_failure` | A negative control — the superseded assertion, the pre-fix reproduction | `failed`; any other outcome contradicts the claim |
 | `excluded` | An action outside the authorized scope, deliberately not performed | `not_run` or `denied`; actually running it contradicts the exclusion |
-| `superseded` | A diagnostic attempt a later required check replaced | a later record in the list that is `required` and `passed` |
+| `superseded` | A diagnostic attempt a later required check replaced | a later record that is `required` and `passed` and names the same check: the same `command`, or the same non-empty `check` identity when the command or environment was corrected. An unrelated later pass, a missing/empty/one-sided identity, or a related check that did not pass is not a replacement |
 
 At least one `required` record must have passed, so a set of controls and
 exclusions alone is never coverage. Every role other than `required` must
@@ -293,9 +294,11 @@ reason: the runner refused, which is neither a defect in the candidate nor
 evidence about it.
 
 The contract version stays 1: a record carrying no role decides exactly as it
-did before, so no existing certificate is reinterpreted and none has to be
-reissued. Candidates already refused under the old rule recover through a
-fresh run, not by editing stored evidence.
+did before, so older role-less evidence is not reinterpreted. A superseded
+attempt now requires the later required pass that names the same check; a
+certificate that treated an unrelated later pass as a replacement becomes
+incomplete when coverage re-reads the records. Candidates already refused
+under the old rule recover through a fresh run, not by editing stored evidence.
 
 Settlement rechecks the checked-out head against the admitted candidate,
 reads the report with its artifact provenance (missing, predating the


### PR DESCRIPTION
## Task

[ORB-11545](https://orbit-cli.com/tasks/ORB-11545) — Bind superseded review validation to the check that actually replaces it

### Description

Verified in merged ORB-11528 PR1514, commit3395ce248, crates/orbit-automation/src/review/validation.rs: replaced_by_required_check(later) accepts any later record with role Required and Passed, without relating it to the superseded command. Example records: cargo test / Failed / Superseded / note='rerun after repair', followed only by cargo fmt --check / Passed / Required; validation_evidence returns Ok even though no test rerun exists. Both gate settlement and coverage use this function, so the gap can certify incomplete evidence. The source docs say 'the required check that replaced it', which the implementation does not enforce. Repair the existing typed evidence contract with a verifiable replacement relationship (allow corrected commands/env reruns, avoid brittle literal command equality if an explicit identity is appropriate). Preserve all raw observations and old role-less conservative behavior. Do not reactivate before-pr in live config. This is a discovered follow-up; keep distinct from critical registry compatibility and CI integration work.

### Acceptance Criteria

- A superseded failed test followed only by an unrelated passing formatter/check is refused by validation_evidence, gate settlement, and coverage acceptance.
- A superseded attempt with an explicitly related later required passing rerun is accepted, including a corrected environment/command when the relationship is represented unambiguously.
- Missing, ambiguous, invalid, or non-passing replacement relationships fail closed; existing role-less evidence retains its prior meaning and raw observations are preserved.
- Focused negative and positive regression tests and required checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added optional `ReviewValidation.check` (serde default, omitted when absent) as the explicit identity of the logical check a record belongs to.
- `replaced_by_required_check` now requires a later `required`+`passed` record with the same identity: trimmed non-empty `check` when present, otherwise the command string. Empty/whitespace `check` matches nothing.
- Same-command reruns still bind without extra fields. Corrected env/command reruns bind when both records share `check`. An unrelated later formatter does not replace a failed test.
- Updated reviewer activity copies and `docs/design/operation-mode/5_operations.md`. REVIEW_CONTRACT_VERSION stays 1. Live `review_policy` was not changed.
- One-line compile unblocker: `ci_sweep.rs` WorkspaceRuntimeBinding fixture now sets `owner_machine_id: None` so orbit-core lib tests compile. Not part of the superseded-check contract.

Acceptance criteria:
1. Satisfied: `cargo test` Failed/Superseded followed only by `cargo fmt --check` Passed/Required is refused by `validation_evidence`, gate settlement (`a_superseded_test_is_not_replaced_by_an_unrelated_formatter`), and `certificate_acceptable`.
2. Satisfied: shared `check: orbit-core-tests` on a failed `cargo test --package orbit-core` and a passing `ORBIT_TEST_ALLOWLIST=1 cargo test --package orbit-core` is accepted by evidence, settlement, and coverage. Same-command rerun is accepted without `check`.
3. Satisfied: missing identity, one-sided identity, empty/whitespace `check`, mismatched identities, and a related required that failed all fail closed. Role-less JSON still deserializes as Required with no `check` and keeps conservative meaning. Raw superseded observations remain on the certificate.
4. Satisfied: focused tests and required checks passed as listed below.

Validation:
- `cargo test -p orbit-automation --lib review::` — passed (15 tests)
- `cargo test -p orbit-core --lib application::review::` — passed (29 tests, including the two new gate tests)
- `cargo test -p orbit-core --lib application::job::tests::exec::review_gate` — passed (3 tests)
- `cargo test -p orbit-core --lib application::job::tests::exec::epic_review_gate` — passed (3 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Assessment: the replacement relationship is now an explicit identity, not any later required pass. Fail-closed on missing/invalid/unrelated/non-passing replacements.

Deviations from original plan:
- Appended `file:crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs` and filled `owner_machine_id: None` so the orbit-core test crate compiles. Pre-existing on this worktree; not a review-policy change.

Design weaknesses / risks:
- Severity: low. Certificates that previously used the loophole (superseded test + unrelated later pass) become incomplete when coverage re-reads them. Intended fail-closed repair. Role-less records stay required.
- Mitigation: contract version stays 1; no live before-pr reactivation.

Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11545-6a9f2358`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra