### PR TITLE
Collect complete diagnostic units from long CI logs without permanent truncation deferral

### DIFF
--- a/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
+++ b/crates/orbit-core/assets/activities/collect_ci_evidence.yaml
@@ -18,12 +18,17 @@ spec:
     a fallback may only supply that same job. The global max_job_log_reads
     budget defaults to 6 (maximum 25), with stable job ordering and a rotating
     overflow slot. Each read retains the existing timeout, excerpt/scan bounds
-    and one-job fallback. Missing or truncated diagnostic evidence and exhausted
-    job/checkout budgets defer that job with job-scoped retryable errors;
+    and one-job fallback. A separate diagnostic_unit keeps a complete runner
+    command from its Run group through nonzero process completion (256 KiB cap),
+    bound to the unique failed step. A truncated head/tail display alone does
+    not defer a job with this complete unit. Missing/ambiguous command boundaries,
+    source truncation and exhausted job/checkout budgets remain retryable;
     complete sibling jobs still progress. Checkout identity is extracted while
     the full runner-log stream is drained, before the human excerpt is truncated;
     extraction scans at most
-    8 MiB per log and records incomplete evidence rather than guessing.
+    8 MiB per log. Process stdout reads stop beyond 8 MiB with at most one
+    4 KiB lookahead chunk and a retryable error; command line buffers are capped
+    at 16 KiB. No additional query or retry is used for command selection.
     Workflow runs are listed repository-wide in one query. `latest_runs`
     records the newest run of each workflow for audit, ordered by creation
     time then run ID. Current failures are selected by relevant identity

--- a/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
+++ b/crates/orbit-core/assets/activities/file_ci_failure_tasks.yaml
@@ -40,8 +40,12 @@ spec:
     reports `current_failures` with what it filed, skipped as already open,
     left unfiled at the `max_tasks` cap, or deferred for incomplete evidence.
     Schema version 2 requires one job per failure row, matching diagnostic
-    and checkout job identities, one known failed step, and complete untruncated
-    diagnostic evidence. Legacy version-1 run-scoped snapshots remain readable
+    and checkout job identities, one known failed step, and complete
+    diagnostic evidence. A complete bounded diagnostic_unit with matching job
+    and step can replace a truncated display for signature calculation. Raw
+    selected evidence remains in the snapshot; descriptions separately cap
+    display at 4000 bytes and disclose collection display truncation. Legacy
+    version-1 run-scoped snapshots remain readable
     for audit but their failures are deferred for recollection; no job ordering
     inference or event/PR head substitution is allowed. Retryable failures are
     separated by blast radius. One that names a job defers only that job.

--- a/crates/orbit-core/assets/skills/orbit/references/workflows.md
+++ b/crates/orbit-core/assets/skills/orbit/references/workflows.md
@@ -93,10 +93,24 @@ or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
 CI evidence schema 2 binds each failure row to one failed job: both log scopes
-select that job, and checkout provenance carries its job ID. Diagnostic excerpts
-that are missing or truncated, unknown/ambiguous failed steps, incomplete
-checkout identity, and exhausted read budgets defer that job; complete siblings
-still file. `max_job_log_reads` caps failed-job reads across the snapshot (default
+select that job, and checkout provenance carries its job ID. A separate
+`diagnostic_unit` retains a complete runner command from its `Run` group through
+its nonzero process completion, up to 256 KiB. Exactly one failing command and
+one known failed step are required; primary log columns must also match that
+job and step. Filing uses this unit for the signature while `log_excerpt`,
+`log_truncated`, and byte counts continue to describe the bounded head/tail
+display. Raw selected evidence (with secrets redacted) stays in the snapshot;
+task descriptions apply their own 4,000-byte diagnostic display cap.
+
+Each process stdout read stops with a retryable error beyond 8 MiB (at most one
+4 KiB lookahead chunk); the existing process timeout still applies. Command
+selection uses at most two 256 KiB unit buffers and a 16 KiB line buffer.
+Overlong/invalid source lines, explicit log truncation notices, missing command
+boundaries, multiple failing commands, unknown/ambiguous failed steps, incomplete
+checkout identity, and exhausted read budgets defer that job. Oversized commands
+are not sliced into apparently complete evidence. No extra queries or retries
+are introduced; complete siblings still file. `max_job_log_reads` caps failed-job
+reads across the snapshot (default
 6, maximum 25); `max_checkout_log_reads` separately caps additional same-job
 checkout reads (default 3, maximum 25). The rotating investigation slot also
 rotates overflow jobs in stable ID order. Legacy schema-1 failures require

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -629,8 +629,17 @@ fn job_evidence_gap(failure: &Value, schema_version: u64) -> Option<&'static str
     {
         return Some("failed step identity is missing or ambiguous within this job");
     }
-    if value_string(failure, "log_excerpt").trim().is_empty()
-        || failure.get("log_truncated").and_then(Value::as_bool) != Some(false)
+    if let Some(text) = complete_diagnostic(failure)
+        && error_signature(text, &value_string(&job["failed_steps"][0], "name")).step_fallback
+    {
+        return Some("complete command contains no concrete diagnostic");
+    }
+    if failure["log_source_complete"] == false {
+        return Some("job log source is incomplete");
+    }
+    if complete_diagnostic(failure).is_none()
+        && (value_string(failure, "log_excerpt").trim().is_empty()
+            || failure.get("log_truncated").and_then(Value::as_bool) != Some(false))
     {
         return Some("job diagnostic evidence is missing or truncated");
     }
@@ -654,6 +663,23 @@ fn job_evidence_gap(failure: &Value, schema_version: u64) -> Option<&'static str
         return Some("checkout identity is not completely observed for this job");
     }
     None
+}
+
+/// Additive schema-2 evidence. Old snapshots remain conservative when their
+/// display was truncated; only a completely captured, correctly bound unit
+/// can replace that display for diagnosis and stable-key calculation.
+fn complete_diagnostic(failure: &Value) -> Option<&str> {
+    let unit = &failure["diagnostic_unit"];
+    let job = failure["failed_jobs"].as_array()?.first()?;
+    let step = job["failed_steps"].as_array()?.first()?["name"].as_str()?;
+    let text = unit["text"].as_str()?;
+    (unit["kind"] == "runner_command"
+        && unit["complete"] == true
+        && unit["job_id"].as_u64()? == failure["job_id"].as_u64()?
+        && unit["step"].as_str()? == step
+        && !text.trim().is_empty()
+        && text.len() <= 262_144)
+        .then_some(text)
 }
 
 /// The deferred entries flattened back into the error list shape, for the
@@ -1018,14 +1044,14 @@ impl FailureCluster {
             }
             if self.log_truncated {
                 out.push_str(
-                    "\n_The excerpt above was truncated at collection. Head and tail are kept; \
-                     the omitted region is marked inline._\n",
+                    "\n_The collection display was truncated. Complete selected command evidence, \
+                     when available, is used for diagnosis; the description has its own display cap._\n",
                 );
             }
             if let Some(job) = &self.log_source_job {
                 out.push_str(&format!(
                     "\n_The run-scoped failed-step log came back empty, so this excerpt is the \
-                     whole log of job {job}, read from the job log API._\n"
+                     evidence from job {job}, read from the job log API._\n"
                 ));
             }
         }
@@ -1217,7 +1243,9 @@ fn cluster_failures(failures: &[Value]) -> Vec<FailureCluster> {
         }
         let workflow = value_string(failure, "workflow");
         let (job, step) = failing_job_and_step(failure);
-        let log_excerpt = value_string(failure, "log_excerpt");
+        let log_excerpt = complete_diagnostic(failure)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| value_string(failure, "log_excerpt"));
         let signature = error_signature(&log_excerpt, &step);
         let tested_commit = tested_commit(failure);
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -418,7 +418,7 @@ fn a_filed_task_is_a_proposed_bug_carrying_usable_evidence() {
 }
 
 #[test]
-fn an_excerpt_recovered_from_a_job_log_is_labelled_as_the_whole_job_log() {
+fn an_excerpt_recovered_from_a_job_log_names_the_supplying_job() {
     let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
     let mut recovered = failure(
         10,
@@ -456,7 +456,7 @@ fn an_excerpt_recovered_from_a_job_log_is_labelled_as_the_whole_job_log() {
         "the recovered diagnostic must reach the filed task:\n{description}"
     );
     assert!(
-        description.contains("whole log of job `docs` (id `101560010340`)")
+        description.contains("evidence from job `docs` (id `101560010340`)")
             && description.contains("job log API"),
         "a whole-job log must not be presented as a failed-step excerpt:\n{description}"
     );
@@ -2154,4 +2154,71 @@ fn legacy_multi_job_snapshot_cannot_label_coverage_log_as_clippy() {
             .expect("tasks")
             .is_empty()
     );
+}
+
+#[test]
+fn complete_units_from_long_logs_file_and_dedupe_without_using_display_noise() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut findings = two_job_findings();
+    for finding in &mut findings {
+        let text = finding["log_excerpt"]
+            .as_str()
+            .expect("diagnostic")
+            .to_string();
+        finding["diagnostic_unit"] = json!({"kind": "runner_command", "complete": true,
+            "job_id": finding["job_id"], "step": finding["failed_jobs"][0]["failed_steps"][0]["name"],
+            "text": text});
+        finding["log_excerpt"] = json!("setup error: unrelated_setup\n[... omitted ...]\ncleanup");
+        finding["log_truncated"] = json!(true);
+        finding["log_source_complete"] = json!(true);
+    }
+    let first = file(&runtime, json!({"ci_evidence": snapshot(findings.clone())}));
+    assert_eq!(first["filed_count"], 2);
+    let ids = filed_task_ids(&first);
+    for (id, expected) in ids.iter().zip(["unused import", "output_goldens"]) {
+        let task = runtime.get_task(id).expect("task");
+        assert!(task.description.contains(expected));
+        assert!(
+            task.description
+                .contains("collection display was truncated")
+        );
+        assert!(!task.description.contains("unrelated_setup"));
+    }
+    findings.reverse();
+    let second = file(&runtime, json!({"ci_evidence": snapshot(findings)}));
+    assert_eq!(second["filed_count"], 0);
+    assert_eq!(
+        second["skipped_existing"]
+            .as_array()
+            .expect("deduped")
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn incomplete_or_foreign_units_cannot_override_truncated_display() {
+    for fault in ["job", "step", "incomplete", "source", "generic", "oversize"] {
+        let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+        let mut findings = two_job_findings();
+        findings.truncate(1);
+        let finding = &mut findings[0];
+        finding["log_truncated"] = json!(true);
+        finding["diagnostic_unit"] = json!({"kind": "runner_command", "complete": true,
+            "job_id": finding["job_id"], "step": finding["failed_jobs"][0]["failed_steps"][0]["name"],
+            "text": "error: concrete diagnostic"});
+        match fault {
+            "job" => finding["diagnostic_unit"]["job_id"] = json!(999),
+            "step" => finding["diagnostic_unit"]["step"] = json!("Other step"),
+            "incomplete" => finding["diagnostic_unit"]["complete"] = json!(false),
+            "source" => finding["log_source_complete"] = json!(false),
+            "generic" => {
+                finding["diagnostic_unit"]["text"] =
+                    json!("##[error]Process completed with exit code 101.")
+            }
+            _ => finding["diagnostic_unit"]["text"] = json!("x".repeat(262_145)),
+        }
+        let error = file_error(&runtime, json!({"ci_evidence": snapshot(findings)}));
+        assert!(error.contains("job_evidence_identity"), "{fault}: {error}");
+    }
 }

--- a/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
@@ -270,6 +270,7 @@ fn bound_runtime(
         &repo.join(".orbit"),
         crate::WorkspaceRuntimeBinding {
             logical_workspace_id: workspace_id.clone(),
+            owner_machine_id: None,
             workspace_id,
             owner_machine_id: None,
             repo_root: repo.clone(),

--- a/crates/orbit-engine/src/executor/automation/ci/investigate.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/investigate.rs
@@ -140,15 +140,18 @@ fn investigate_job<Q: CiQueries + ?Sized>(
                 return;
             }
             failure["log_job_id"] = json!(job_id);
-            if log.truncated {
+            let diagnostic = bound_diagnostic(&log, failure, job_id);
+            if !log.source_complete || (log.truncated && diagnostic.is_none()) {
                 push_retryable_error(
                     retryable_errors,
                     "investigation",
                     "job_log_truncated",
                     failure.get("run_id"),
-                    "job log excerpt is truncated; diagnostic evidence is incomplete",
+                    "job log source or display is incomplete and no complete bound diagnostic unit is available",
                 );
             }
+            failure["log_source_complete"] = json!(log.source_complete);
+            failure["diagnostic_unit"] = diagnostic.unwrap_or(Value::Null);
             failure["log_excerpt"] = json!(log.text);
             failure["log_truncated"] = json!(log.truncated);
             failure["log_total_bytes"] = json!(log.total_bytes);
@@ -325,4 +328,36 @@ fn set_checkout_identity(failure: &mut Value, scope: &str, log: &super::query::R
             "display_truncated": log.checkout_evidence_display_truncated,
         },
     });
+}
+
+/// A unique runner failure unit can only name a unique failed step. Primary
+/// gh output also carries job/step columns; reject conflicting labels rather
+/// than borrowing a different step's command. Raw fallback logs have no columns.
+fn bound_diagnostic(log: &super::query::RunLog, failure: &Value, job_id: u64) -> Option<Value> {
+    let text = log.diagnostic.as_ref()?;
+    let job = failure["failed_jobs"].as_array()?.first()?;
+    let steps = job["failed_steps"].as_array()?;
+    if steps.len() != 1 {
+        return None;
+    }
+    let step = steps[0]["name"]
+        .as_str()
+        .filter(|name| !name.trim().is_empty())?;
+    if log.source == orbit_tools::github_cli::SOURCE_RUN_LOG {
+        let job_name = job["name"].as_str()?;
+        for line in text.lines() {
+            let mut columns = line.splitn(3, '\t');
+            if columns.next()? != job_name || columns.next()? != step || columns.next().is_none() {
+                return None;
+            }
+        }
+    }
+    Some(json!({
+        "kind": "runner_command",
+        "complete": true,
+        "job_id": job_id,
+        "step": step,
+        "text": text,
+        "returned_bytes": text.len(),
+    }))
 }

--- a/crates/orbit-engine/src/executor/automation/ci/query.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/query.rs
@@ -67,6 +67,8 @@ pub(super) struct RunLog {
     /// with no text at all, so the run's evidence gap can name its own cause.
     pub(super) fallback_error: Option<String>,
     pub(super) text: String,
+    pub(super) diagnostic: Option<String>,
+    pub(super) source_complete: bool,
     pub(super) truncated: bool,
     pub(super) total_bytes: usize,
     pub(super) returned_bytes: usize,
@@ -235,6 +237,8 @@ impl CiQueries for HostCiQueries {
             source_jobs: read.source_jobs,
             fallback_error: read.fallback_error,
             text: read.log.text,
+            diagnostic: read.log.diagnostic,
+            source_complete: read.log.source_complete,
             truncated: read.log.truncated,
             total_bytes: read.log.total_bytes,
             returned_bytes: read.log.returned_bytes,
@@ -266,13 +270,18 @@ impl CiQueries for HostCiQueries {
 /// does not retain an unbounded `gh` stdout value.
 #[cfg(test)]
 pub(super) fn bounded_run_log(raw: &str, max_bytes: usize) -> RunLog {
-    let bounded = github_cli::bound_log_text(raw, max_bytes);
-    let evidence = github_cli::scan_checkout_evidence(raw, github_cli::MAX_EVIDENCE_LINES);
+    let mut collector =
+        github_cli::StreamedLogCollector::new(max_bytes, github_cli::MAX_EVIDENCE_LINES);
+    collector.push(raw.as_bytes());
+    let bounded = collector.finish();
+    let evidence = bounded.checkout_evidence;
     RunLog {
         source: github_cli::SOURCE_RUN_LOG.to_string(),
         source_jobs: Vec::new(),
         fallback_error: None,
         text: bounded.text,
+        diagnostic: bounded.diagnostic,
+        source_complete: bounded.source_complete,
         truncated: bounded.truncated,
         total_bytes: bounded.total_bytes,
         returned_bytes: bounded.returned_bytes,

--- a/crates/orbit-engine/src/executor/automation/ci/tests/log_fallback.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/log_fallback.rs
@@ -368,3 +368,108 @@ fn checkout_fallback_is_bound_to_its_job_and_missing_logs_leave_siblings_complet
             .all(|error| error["job_id"] == 201)
     );
 }
+
+#[test]
+fn long_job_logs_select_only_the_bound_complete_command_and_keep_display_metadata() {
+    for reverse in [false, true] {
+        let mut queries = two_job_queries(reverse);
+        for (job, name, diagnostic) in [
+            (201, "Clippy", "error: unused import `wrong_import`"),
+            (
+                202,
+                "Coverage",
+                "error[E0063]: missing field `owner_machine_id`",
+            ),
+        ] {
+            let prefix = format!("{name}\t{name}\t2026-09-07T20:52:05Z ");
+            let unit = format!(
+                "{prefix}##[group]Run cargo test\n{prefix}##[endgroup]\n{prefix}{diagnostic}\n{prefix}  --> src/lib.rs:7:1\n{prefix}##[error]Process completed with exit code 101.\n"
+            );
+            queries.job_logs.insert(
+                ("10".to_string(), job, false),
+                format!(
+                    "HEAD is now at {CHECKOUT}\n{}{}{}",
+                    "unrelated setup error: setup_probe\n".repeat(1000),
+                    unit,
+                    "cleanup output\n".repeat(3000)
+                ),
+            );
+        }
+        let evidence = collect(&queries, &input()).expect("collect");
+        let jobs = evidence["current_failures"].as_array().expect("jobs");
+        assert_eq!(jobs.len(), 2);
+        for (index, expected, excluded) in [
+            (0, "wrong_import", "owner_machine_id"),
+            (1, "owner_machine_id", "wrong_import"),
+        ] {
+            let job = &jobs[index];
+            assert_eq!(job["evidence_state"], "complete");
+            assert_eq!(job["log_truncated"], true);
+            assert_eq!(job["actual_checkout_shas"], json!([CHECKOUT]));
+            assert_eq!(job["diagnostic_unit"]["job_id"], job["job_id"]);
+            let text = job["diagnostic_unit"]["text"]
+                .as_str()
+                .expect("selected evidence");
+            assert!(text.contains(expected));
+            assert!(!text.contains(excluded));
+            assert!(!text.contains("setup_probe"));
+            assert!(!text.contains("cleanup"));
+        }
+        assert_eq!(evidence["retryable_errors"], json!([]));
+    }
+}
+
+#[test]
+fn long_fallback_unit_requires_one_failed_step_and_complete_source() {
+    let raw = format!(
+        "{}\n{}{}{}",
+        job_log()
+            .split("2026-09-06T21:28")
+            .next()
+            .expect("checkout setup"),
+        "setup output\n".repeat(2000),
+        "2026-09-07T20:52:05Z ##[group]Run cargo doc\n\
+         2026-09-07T20:52:05Z ##[endgroup]\n\
+         2026-09-07T20:52:23Z error: private item `reject_root_override`\n\
+         2026-09-07T20:52:31Z ##[error]Process completed with exit code 101.\n",
+        "cleanup output\n".repeat(2000)
+    );
+    for defect in ["none", "steps", "source", "missing_end"] {
+        let mut job = failed_job(101560010340, "docs");
+        if defect == "steps" {
+            job["failed_steps"] = json!([{"name": "A"}, {"name": "B"}]);
+        }
+        let log = match defect {
+            "source" => format!("{raw}##[warning]Log output was truncated\n"),
+            "missing_end" => raw.replace(
+                "##[error]Process completed with exit code 101.",
+                "lost completion",
+            ),
+            _ => raw.clone(),
+        };
+        let queries = FakeQueries::authenticated()
+            .with_head("topic", HEAD)
+            .with_head("main", HEAD)
+            .with_runs(vec![vec![failing_run(10)]])
+            .with_run_view("10", json!({"failed_jobs": [job]}))
+            .with_job_log_fallback("10", false, &log, vec![source_job()]);
+        let evidence = collect(&queries, &input()).expect("collect");
+        let finding = failure_by_id(&evidence, 10).expect("finding");
+        assert_eq!(finding["log_truncated"], true);
+        assert_eq!(
+            finding["investigated"],
+            defect == "none",
+            "{defect}: {finding}"
+        );
+        if defect == "none" {
+            assert_eq!(finding["diagnostic_unit"]["job_id"], 101560010340_u64);
+            assert_eq!(finding["diagnostic_unit"]["step"], "docs");
+            assert!(
+                finding["diagnostic_unit"]["text"]
+                    .as_str()
+                    .expect("unit")
+                    .contains("reject_root_override")
+            );
+        }
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/diagnostic.rs
+++ b/crates/orbit-tools/src/builtin/github/diagnostic.rs
@@ -1,0 +1,101 @@
+//! Complete runner command units, retained separately from head/tail display.
+//!
+//! A unit starts at the runner's `Run` group and ends at its nonzero process
+//! completion. Only a unique such unit is returned. The caller must still
+//! verify the supplying job has exactly one failed step. We do not infer
+//! completeness from an error headline or from EOF alone.
+
+use orbit_common::security::redaction::redact_all;
+
+use super::MAX_CHECKOUT_LOG_SCAN_BYTES;
+
+const MAX_UNIT_BYTES: usize = 262_144;
+const MAX_LINE_BYTES: usize = 16_384;
+
+#[derive(Default)]
+pub(super) struct DiagnosticCollector {
+    scanned: usize,
+    line: Vec<u8>,
+    invalid: bool,
+    candidate: Option<String>,
+    selected: Option<String>,
+    failures: usize,
+}
+
+impl DiagnosticCollector {
+    pub(super) fn push(&mut self, chunk: &[u8]) {
+        self.scanned = self.scanned.saturating_add(chunk.len());
+        if self.scanned > MAX_CHECKOUT_LOG_SCAN_BYTES {
+            self.invalid = true;
+        }
+        if self.invalid {
+            return;
+        }
+        for byte in chunk {
+            self.line.push(*byte);
+            if self.line.len() > MAX_LINE_BYTES {
+                self.invalid = true;
+                return;
+            }
+            if *byte == b'\n' {
+                let bytes = std::mem::take(&mut self.line);
+                let Ok(line) = std::str::from_utf8(&bytes) else {
+                    self.invalid = true;
+                    return;
+                };
+                self.observe(line);
+            }
+        }
+    }
+
+    fn observe(&mut self, line: &str) {
+        // Keep the original columns, timestamps and ANSI bytes as evidence;
+        // only inspect the runner payload to recognize structural boundaries.
+        let payload = line.rsplit('\t').next().unwrap_or(line).trim();
+        let payload = payload
+            .split_once(' ')
+            .filter(|(prefix, _)| prefix.ends_with('Z') && prefix.contains('T'))
+            .map_or(payload, |(_, rest)| rest);
+        let lower = payload.to_ascii_lowercase();
+        let source_notice = payload.starts_with("##[warning]")
+            || payload.starts_with("##[error]")
+            || payload.starts_with("Log output")
+            || payload.starts_with("[...");
+        if source_notice
+            && lower.contains("log")
+            && (lower.contains("truncat") || lower.contains("omitted"))
+        {
+            self.invalid = true;
+        }
+        if payload.starts_with("##[group]Run ") {
+            self.candidate = Some(String::new());
+        }
+        if let Some(candidate) = &mut self.candidate {
+            if candidate.len() + line.len() > MAX_UNIT_BYTES {
+                self.candidate = None;
+            } else {
+                candidate.push_str(line);
+            }
+        }
+        if payload
+            .strip_prefix("##[error]Process completed with exit code ")
+            .and_then(|code| code.strip_suffix('.'))
+            .and_then(|code| code.parse::<i32>().ok())
+            .is_some_and(|code| code != 0)
+        {
+            self.failures += 1;
+            self.selected = self.candidate.take();
+        }
+    }
+
+    pub(super) fn source_complete(&self) -> bool {
+        !self.invalid
+    }
+
+    pub(super) fn finish(self) -> Option<String> {
+        if self.invalid || !self.line.is_empty() || self.failures != 1 {
+            return None;
+        }
+        self.selected.map(|unit| redact_all(&unit))
+    }
+}

--- a/crates/orbit-tools/src/builtin/github/logs.rs
+++ b/crates/orbit-tools/src/builtin/github/logs.rs
@@ -224,9 +224,8 @@ pub fn read_run_log(
     Ok(recover_from_job_logs(requests, bounds, log))
 }
 
-/// Drain one `gh` stdout stream into a bounded excerpt and checkout evidence.
-/// The stream is consumed incrementally, so no complete copy of the log is
-/// ever held.
+/// Read one `gh` stdout stream up to the source cap, retaining only bounded
+/// display, command, and checkout evidence. No unbounded source copy is held.
 fn stream_bounded_log(
     request: &ExecRequest,
     bounds: LogReadBounds,
@@ -248,12 +247,20 @@ fn stream_bounded_log(
             }
         };
         let mut chunk = [0_u8; 4096];
+        let mut source_bytes = 0usize;
         loop {
             let read = stdout.read(&mut chunk).map_err(|error| {
                 OrbitError::Execution(format!("failed reading gh log stream: {error}"))
             })?;
             if read == 0 {
                 return Ok(collector.finish());
+            }
+            source_bytes += read;
+            if source_bytes > super::MAX_CHECKOUT_LOG_SCAN_BYTES {
+                return Err(OrbitError::Execution(
+                    "job log exceeded the 8 MiB source read limit; evidence is incomplete"
+                        .to_string(),
+                ));
             }
             collector.push(&chunk[..read]);
         }

--- a/crates/orbit-tools/src/builtin/github/mod.rs
+++ b/crates/orbit-tools/src/builtin/github/mod.rs
@@ -112,6 +112,7 @@ pub(super) use gh_tool;
 
 pub mod auth;
 pub mod dependabot_alerts;
+mod diagnostic;
 pub mod logs;
 pub mod pr_checkout;
 pub mod pr_checks;
@@ -378,13 +379,18 @@ pub struct CheckoutEvidence {
 }
 
 /// A bounded excerpt and checkout evidence collected while a log is drained.
-/// No complete copy of the source log is retained.
+/// No unbounded copy of the source log is retained.
 pub struct StreamedLog {
     pub text: String,
     pub truncated: bool,
     pub total_bytes: usize,
     pub returned_bytes: usize,
     pub checkout_evidence: CheckoutEvidence,
+    /// Complete runner command evidence, independent of display truncation.
+    pub diagnostic: Option<String>,
+    /// False when a source limit, invalid line, or explicit truncation notice
+    /// prevents complete diagnostic collection; independent of display size.
+    pub source_complete: bool,
 }
 
 /// Incrementally retain the head/tail excerpt and checkout evidence from a
@@ -398,6 +404,7 @@ pub struct StreamedLogCollector {
     tail: Vec<u8>,
     total_bytes: usize,
     evidence: CheckoutEvidenceCollector,
+    diagnostic: diagnostic::DiagnosticCollector,
 }
 
 impl StreamedLogCollector {
@@ -425,6 +432,7 @@ impl StreamedLogCollector {
             head: Vec::with_capacity(head_bytes),
             tail: Vec::with_capacity(max_bytes.saturating_sub(head_bytes)),
             total_bytes: 0,
+            diagnostic: diagnostic::DiagnosticCollector::default(),
             evidence: CheckoutEvidenceCollector::new(
                 max_evidence_lines,
                 MAX_CHECKOUT_LOG_SCAN_BYTES,
@@ -435,6 +443,7 @@ impl StreamedLogCollector {
     pub fn push(&mut self, chunk: &[u8]) {
         self.total_bytes = self.total_bytes.saturating_add(chunk.len());
         self.evidence.push(chunk);
+        self.diagnostic.push(chunk);
 
         let head_limit = self.head_bytes;
         let head_take = head_limit.saturating_sub(self.head.len()).min(chunk.len());
@@ -470,6 +479,8 @@ impl StreamedLogCollector {
             truncated,
             total_bytes: self.total_bytes,
             checkout_evidence: evidence,
+            source_complete: self.diagnostic.source_complete(),
+            diagnostic: self.diagnostic.finish(),
         }
     }
 }

--- a/crates/orbit-tools/src/builtin/github/run_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/run_logs.rs
@@ -18,7 +18,7 @@ impl crate::Tool for GithubRunLogsTool {
     fn schema(&self) -> orbit_types::tool::ToolSchema {
         super::gh_schema(
             "github.run.logs",
-            "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is drained incrementally; checkout extraction stops after 8 MiB and reports incomplete evidence rather than retaining an unbounded log. When the run-scoped read succeeds with no output at all, the excerpt is recovered from the log API of a job the run itself reported failed, and `source` says so.",
+            "Read a bounded excerpt of one GitHub Actions run's logs — failed steps by default, or the full log — plus runner checkout evidence. The source stream is read incrementally with an 8 MiB stdout limit and process timeout. A separate diagnostic_unit retains a unique complete failing runner command up to 256 KiB; display truncation does not imply missing command evidence. Source-limit exhaustion is retryable. When the run-scoped read succeeds with no output at all, the excerpt is recovered from the log API of a job the run itself reported failed, and `source` says so.",
             vec![
                 super::tool_param("run", "Numeric workflow-run ID", "string", true),
                 super::tool_param(
@@ -35,7 +35,7 @@ impl crate::Tool for GithubRunLogsTool {
                 ),
                 super::tool_param(
                     "max_bytes",
-                    "Maximum log bytes to return (default 16384, capped at 262144). The excerpt keeps the head and the tail and marks the omitted gap.",
+                    "Maximum display excerpt bytes (default 16384, capped at 262144), plus an omission marker. The separate complete diagnostic_unit is capped at 262144 bytes.",
                     "integer",
                     false,
                 ),
@@ -62,6 +62,8 @@ impl crate::Tool for GithubRunLogsTool {
             "run_id": input.get("run"),
             "scope": scope.as_str(),
             "log": log.text,
+            "diagnostic_unit": log.diagnostic,
+            "source_complete": log.source_complete,
             "truncated": log.truncated,
             "returned_bytes": log.returned_bytes,
             "total_bytes": log.total_bytes,

--- a/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/bounded_logs.rs
@@ -433,3 +433,76 @@ fn an_abbreviation_with_rival_expansions_is_not_resolved_to_a_guess() {
 
     assert_eq!(evidence.commits, vec![short.to_string()]);
 }
+
+fn command_unit() -> String {
+    "2026-09-07T20:52:05Z ##[group]Run cargo check\n\
+     2026-09-07T20:52:05Z shell: /usr/bin/bash -e {0}\n\
+     2026-09-07T20:52:05Z ##[endgroup]\n\
+     2026-09-07T20:52:23Z error[E0063]: missing field `owner_machine_id`\n\
+     2026-09-07T20:52:23Z   --> crates/orbit-core/src/runtime.rs:92:7\n\
+     2026-09-07T20:52:23Z    | WorkspaceRuntimeBinding {\n\
+     2026-09-07T20:52:23Z    | ^ missing `owner_machine_id`\n\
+     2026-09-07T20:52:31Z ##[error]Process completed with exit code 101.\n"
+        .to_string()
+}
+
+#[test]
+fn long_log_retains_complete_middle_command_independently_of_display() {
+    let unit = command_unit();
+    let raw = format!(
+        "{}{}{}",
+        "setup output\n".repeat(3000),
+        unit,
+        "cleanup output\n".repeat(3000)
+    );
+    for chunk_size in [1, 7, 4096] {
+        let mut collector = StreamedLogCollector::new(16_384, 40);
+        for chunk in raw.as_bytes().chunks(chunk_size) {
+            collector.push(chunk);
+        }
+        let log = collector.finish();
+        assert!(log.truncated);
+        assert!(!log.text.contains("owner_machine_id"));
+        assert_eq!(log.diagnostic.as_deref(), Some(unit.as_str()));
+    }
+}
+
+#[test]
+fn incomplete_ambiguous_and_source_limited_commands_are_not_complete_units() {
+    let unit = command_unit();
+    for raw in [
+        unit.replace("##[group]Run cargo check", "cargo check"),
+        unit.replace("##[error]Process completed with exit code 101.\n", ""),
+        format!("{unit}{unit}"),
+        format!("{unit}##[warning]Log output was truncated\n"),
+        format!("{unit}partial trailing line"),
+        format!("{}\n{unit}", "x".repeat(MAX_CHECKOUT_LOG_SCAN_BYTES)),
+        unit.replace(
+            "shell: /usr/bin/bash -e {0}",
+            &"build output\n".repeat(30_000),
+        ),
+    ] {
+        let mut collector = StreamedLogCollector::new(16_384, 40);
+        collector.push(raw.as_bytes());
+        assert!(collector.finish().diagnostic.is_none());
+    }
+}
+
+#[test]
+fn selected_command_preserves_unicode_and_redacts_secrets_across_chunk_boundaries() {
+    let raw = command_unit().replace(
+        "missing field",
+        &format!("missing café ghp_{} field", "a".repeat(36)),
+    );
+    let mut collector = StreamedLogCollector::new(64, 40);
+    for byte in raw.as_bytes() {
+        collector.push(std::slice::from_ref(byte));
+    }
+    let unit = collector
+        .finish()
+        .diagnostic
+        .expect("complete redacted unit");
+    assert!(unit.contains("café"));
+    assert!(unit.contains("[REDACTED_SECRET]"));
+    assert!(!unit.contains("ghp_"));
+}

--- a/crates/orbit-tools/src/builtin/github/tests/log_fallback.rs
+++ b/crates/orbit-tools/src/builtin/github/tests/log_fallback.rs
@@ -462,3 +462,72 @@ fn a_repository_that_could_traverse_the_endpoint_is_rejected() {
 /// Only a unix host gates execution on the permission bit.
 #[cfg(not(unix))]
 fn set_executable(_path: &Path) {}
+
+#[test]
+fn source_read_limit_defers_without_retrying_or_returning_a_partial_unit() {
+    let log = "bounded line\n".repeat(700_000);
+    let gh = FakeGh::new(&run_view(&run_url(RUN_ID)), &[(FAILED_JOB_ID, &log)]);
+    let read = gh.read(json!({"run": RUN_ID, "job": FAILED_JOB_ID}), 16_384);
+    assert!(read.log.diagnostic.is_none());
+    assert!(read.log.text.is_empty());
+    assert!(
+        read.fallback_error
+            .as_deref()
+            .is_some_and(|error| error.contains("8 MiB source read limit"))
+    );
+    assert_eq!(gh.calls().len(), 3);
+}
+
+#[test]
+#[ignore = "read-only live GitHub verification requires authenticated gh and retained historical logs"]
+fn live_long_job_logs_retain_complete_command_and_checkout() {
+    for job in [101862218002_u64, 101862218165] {
+        let requests = RunLogRequests::from_input(&json!({
+            "run": "34160850121", "job": job, "scope": "failed", "repo": "constellation-works/orbit",
+        })).expect("requests");
+        let read = read_run_log(&requests, LogReadBounds::new(16_384)).expect("live read");
+        match read.source {
+            "job_api_log" => {
+                assert_eq!(read.source_jobs.len(), 1);
+                assert_eq!(read.source_jobs[0]["job_id"], job);
+            }
+            "run_log" => assert!(read.source_jobs.is_empty()),
+            other => panic!("unexpected log source: {other}"),
+        }
+        assert!(read.log.total_bytes > 16_384);
+        assert!(read.log.returned_bytes <= 16_384 + 128);
+        assert!(read.log.truncated);
+        assert!(read.log.source_complete);
+        let checkout = if read.log.checkout_evidence.commits.is_empty() {
+            let requests = RunLogRequests::from_input(&json!({
+                "run": "34160850121", "job": job, "scope": "all", "repo": "constellation-works/orbit",
+            })).expect("checkout requests");
+            read_run_log(&requests, LogReadBounds::new(16_384))
+                .expect("checkout read")
+                .log
+                .checkout_evidence
+        } else {
+            read.log.checkout_evidence
+        };
+        assert!(checkout.complete);
+        assert_eq!(checkout.commits.len(), 1);
+        assert!(checkout.commits[0].starts_with("a52912235"));
+        let unit = read.log.diagnostic.expect("complete unit");
+        assert!(unit.len() <= 262_144);
+        assert!(unit.contains("owner_machine_id"));
+        assert!(unit.contains("error[E0063]"));
+        assert!(unit.contains("Process completed with exit code"));
+        assert!(!unit.contains("##[group]Run df -h"));
+        if read.source == "run_log" {
+            let (job_name, step) = if job == 101862218002 {
+                ("Check / Clippy / Test", "Run CI guardrails")
+            } else {
+                ("Coverage (informational)", "Collect workspace coverage")
+            };
+            assert!(
+                unit.lines()
+                    .all(|line| line.starts_with(&format!("{job_name}\t{step}\t")))
+            );
+        }
+    }
+}

--- a/plugin/skills/orbit/references/workflows.md
+++ b/plugin/skills/orbit/references/workflows.md
@@ -93,10 +93,24 @@ or panic identity over ANSI styling, generic runner/cargo/nextest trailers, and
 assertion payload help text; the raw excerpt stays in the description.
 
 CI evidence schema 2 binds each failure row to one failed job: both log scopes
-select that job, and checkout provenance carries its job ID. Diagnostic excerpts
-that are missing or truncated, unknown/ambiguous failed steps, incomplete
-checkout identity, and exhausted read budgets defer that job; complete siblings
-still file. `max_job_log_reads` caps failed-job reads across the snapshot (default
+select that job, and checkout provenance carries its job ID. A separate
+`diagnostic_unit` retains a complete runner command from its `Run` group through
+its nonzero process completion, up to 256 KiB. Exactly one failing command and
+one known failed step are required; primary log columns must also match that
+job and step. Filing uses this unit for the signature while `log_excerpt`,
+`log_truncated`, and byte counts continue to describe the bounded head/tail
+display. Raw selected evidence (with secrets redacted) stays in the snapshot;
+task descriptions apply their own 4,000-byte diagnostic display cap.
+
+Each process stdout read stops with a retryable error beyond 8 MiB (at most one
+4 KiB lookahead chunk); the existing process timeout still applies. Command
+selection uses at most two 256 KiB unit buffers and a 16 KiB line buffer.
+Overlong/invalid source lines, explicit log truncation notices, missing command
+boundaries, multiple failing commands, unknown/ambiguous failed steps, incomplete
+checkout identity, and exhausted read budgets defer that job. Oversized commands
+are not sliced into apparently complete evidence. No extra queries or retries
+are introduced; complete siblings still file. `max_job_log_reads` caps failed-job
+reads across the snapshot (default
 6, maximum 25); `max_checkout_log_reads` separately caps additional same-job
 checkout reads (default 3, maximum 25). The rotating investigation slot also
 rotates overflow jobs in stable ID order. Legacy schema-1 failures require


### PR DESCRIPTION
## Task

[ORB-11552](https://orbit-cli.com/tasks/ORB-11552) — Collect complete diagnostic units from long CI logs without permanent truncation deferral

### Description

Live upgraded sweep jrun-20260907-2053-2 confirms ORB11519 schema2 per-job binding but exposes a liveness gap. Current integration job101862218002 in run34160850121 has63686 (~63KB; captured log_total_bytes63386) bytes, returned16447 with log_truncated=true, actual checkouta52912235 verified, and is deferred job_log_truncated. Coverage job101862218165 similarly totals49153/returns16447. Earlier run34160788619 repeats same issue. The ordinary16KB display bound therefore defers these job failures indefinitely on identical retries. Only short macOS job log4130 bytes reached complete evidence and filed ORB11551 for error[E0063] missing owner_machine_id; Linux counterparts remain deferred. Preserve correct job identity/checkout and conservative incomplete-evidence semantics, but collect bounded complete diagnostic units or complete failed-step evidence separately from a truncated display excerpt. Use existing GitHub log adapter/investigation seams; distinguish upstream source/capture loss from intentional bounded display, avoid unbounded downloads/retries or simply declaring all truncated logs complete. Complete diagnostic context must remain bound to the actual single failing job/step and checkout. Test with realistic long setup/compiler output and trailing cleanup, including a diagnostic outside a naive tail. Trace exact origin in ORB11519 integration and design before final attribution. No new generic-wrapper tasks or quiet dropping of current failures.

### Acceptance Criteria

- A realistic >16KB CI job log with a concrete diagnostic and trailing cleanup yields a bounded complete diagnostic unit, correct job/step/checkout binding, and an actionable stable-key task rather than infinite job_log_truncated deferral.
- Two failing jobs with different diagnostics in one run remain separately bound; unrelated setup/output cannot supply another job's signature.
- Truly unavailable/upstream-truncated/missing or ambiguous diagnostic/checkout evidence remains retryable and cannot fabricate a complete diagnosis; collection has documented enforceable byte/read limits and fair deferral.
- Repeated bounded observations of the same long-log failure deduplicate to one owner while preserving raw selected evidence and explicit display truncation metadata.
- Focused regressions fail against current behavior and pass with the fix; required checks and a read-only live long-log verification pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a bounded streaming runner-command collector to the existing GitHub log adapter. It preserves a unique Run-group-to-nonzero-process-completion unit separately from the head/tail display, including raw timestamps/columns/ANSI context with secrets redacted.
- Investigation binds the selected unit to the same supplying job and unique failed step; primary log columns must match both labels. Filing uses that unit for diagnostic/signature/owner lookup even when log_truncated is true. Legacy truncated snapshots without a complete unit still defer. Checkout provenance and existing fair job/read-budget rotation remain enforced.
- Added explicit log_source_complete and diagnostic_unit metadata, preserved display byte counts, and documented bounds in both activity assets and both workflow-reference copies. Source stdout reads stop beyond 8 MiB (one 4 KiB lookahead maximum), command evidence is capped at 256 KiB, and lines at 16 KiB. No additional query or retry path was added.
- Included the exact already-delivered ORB-11551 prerequisite, owner_machine_id: None in the CI-sweep test fixture, because starting HEAD otherwise cannot compile core tests or workspace all-target lint.

Criteria:
1. Met: realistic logs with tens of KiB of setup and trailing cleanup preserve the complete middle diagnostic outside both display windows. Collection retains correct job/step/checkout evidence; filing produces actionable stable-key tasks from that evidence.
2. Met: two-job fixtures in both metadata orders retain distinct diagnostics and exclude unrelated setup and sibling signatures. Existing foreign-fallback and checkout binding regressions pass; long raw fallback tests require one failed step.
3. Met: unavailable logs, explicit upstream truncation notices, missing command boundaries, multiple failure units/steps, oversized units, incomplete/ambiguous checkout, and exhausted budgets remain retryable. A process-level source-cap regression proves an over-limit fallback yields no partial evidence and makes exactly three calls (primary, metadata, one job read). Existing budget rotation tests pass.
4. Met: repeated/reversed long-log findings deduplicate to their existing owners. The snapshot retains complete selected evidence and independent display truncation/byte metadata; task descriptions retain their existing bounded diagnostic rendering and disclose collection-display truncation. Unicode and secret redaction work across one-byte stream chunks.
5. Met: focused regressions, required gates, and read-only live verification pass. The new filing regression was run with only the filer restored to starting HEAD and failed with exit 101: both otherwise complete jobs were deferred as missing/truncated. The fixed filer was restored immediately and the suite passes.

Validation:
- PASSED cargo fmt --all; final cargo fmt --all -- --check.
- PASSED cargo test -p orbit-tools --lib builtin::github::tests --quiet: 54 passed; the one live test is ignored by default and was explicitly run separately.
- PASSED cargo test -p orbit-engine --lib executor::automation::ci::tests --quiet: 47 passed.
- PASSED cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure: 49 passed.
- PASSED cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::sweep_duplicate_tasks: 18 passed.
- PASSED cargo test -p orbit-tools --lib live_long_job_logs_retain_complete_command_and_checkout -- --ignored: one live test covering both incident jobs.
- PASSED make ci-fast and make ci-lint (workspace/all targets, warnings denied).
- PASSED final git diff --check and git status --short. Reviewed all changed code, tests, docs and the new module.
- Initial core compilation FAILED with pre-existing E0063 at application/job/tests/exec/ci_sweep.rs:271; resolved with the exact ORB-11551 fixture fix. An old description assertion initially failed because it still required the misleading whole-log wording; updated to assert supplying-job provenance. The initial live probe incorrectly required both jobs to use fallback; actual Coverage evidence uses the primary labelled log, and the corrected test verifies both valid sources and their attribution.
- NOT RUN full make ci: repository policy reserves that gate for PR CI. Linux checks do not claim macOS execution. No live sweep, task filing against live CI, workflow rerun, release, commit, push, PR or merge was performed.

Live evidence and origin:
- Read-only gh run view 34160850121 --repo constellation-works/orbit --json databaseId,jobs confirmed Check / Clippy / Test job 101862218002 / Run CI guardrails and Coverage (informational) job 101862218165 / Collect workspace coverage.
- The production read_run_log test with 16384 display bytes recovered complete owner_machine_id / error[E0063] units for both >16 KiB logs, independent of trailing cleanup, and completely observed checkout a52912235 from each job. Clippy uses job_api_log; Coverage uses the primary labelled failed-step log with an additional same-job checkout read when needed.
- git log -S job_log_truncated traces the blanket completeness guards to c6aecd3cd, ORB-11519 (#1505). That task's summary explicitly documented long-log deferral as intentional. This change preserves its attribution contract while repairing the liveness consequence.
- Friction checkpoint recorded this distinct display/completeness incident as F2026-09-057 and linked resolves.

Scope and risks:
- Starting checkout was clean at 32ca8a5aa7018f3ba9dcae1143ba48f34dca095d; both envelope roots matched pwd -P and git rev-parse --show-toplevel.
- Context was extended before edits for the existing GitHub adapter directory (new cohesive module, response wiring and process-boundary tests) and the one-line delivered test prerequisite. All 15 modified files and one new module are accounted for and uncommitted; no incidental artifacts are in the patch.
- Units without recognizable runner command/completion boundaries, units over 256 KiB, conflicting primary labels or multiple failures deliberately remain deferred. Bounds apply to consumed process stdout; the existing gh process timeout and its internal HTTP/archive handling are unchanged. Old readers safely continue deferring truncated snapshots.
Assessment: one canonical bounded collection path now distinguishes usable complete command evidence from display loss without assigning another job's diagnostic or weakening checkout validation. Pipeline owns commit and delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11552-6a9f2676`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra