### PR TITLE
[friction-curation] Make agent_implement cleanup compatible with Codex denied rm commands

### DIFF
--- a/.orbit/resources/activities/agent_implement.yaml
+++ b/.orbit/resources/activities/agent_implement.yaml
@@ -125,10 +125,12 @@ spec:
     10. Review the complete deliverable and diff before handoff for accuracy,
         clarity, consistency, unintended changes, and stale supporting material.
         Run the checks required by the task and workspace instructions.
-        Keep incidental caches and temporary artifacts out of the patch; remove
-        only verified run-owned temporary artifacts when cleanup is necessary.
-        Preserve pre-existing contents and legitimate task outputs. Run
-        `git diff --check` and `git status --short`; account for every change.
+        Keep incidental caches and temporary artifacts out of the patch. For
+        Cargo outputs, use `cargo clean` or generate them outside the worktree;
+        never use raw `rm -f` or `rm -rf`. If cleanup is denied, do not retry:
+        record the bounded leftover. Independently run `git diff --check` and
+        `git status --short`, even after a cleanup denial; account for every
+        change. Preserve pre-existing contents and legitimate task outputs.
     11. Workflow admission already set `in-progress`: do not call
         `orbit.task.start`, and do not move the task to `review` (the pipeline
         owns that transition). Before returning, REQUIRED: persist a meaningful

--- a/crates/orbit-core/assets/activities/agent_implement.yaml
+++ b/crates/orbit-core/assets/activities/agent_implement.yaml
@@ -125,10 +125,12 @@ spec:
     10. Review the complete deliverable and diff before handoff for accuracy,
         clarity, consistency, unintended changes, and stale supporting material.
         Run the checks required by the task and workspace instructions.
-        Keep incidental caches and temporary artifacts out of the patch; remove
-        only verified run-owned temporary artifacts when cleanup is necessary.
-        Preserve pre-existing contents and legitimate task outputs. Run
-        `git diff --check` and `git status --short`; account for every change.
+        Keep incidental caches and temporary artifacts out of the patch. For
+        Cargo outputs, use `cargo clean` or generate them outside the worktree;
+        never use raw `rm -f` or `rm -rf`. If cleanup is denied, do not retry:
+        record the bounded leftover. Independently run `git diff --check` and
+        `git status --short`, even after a cleanup denial; account for every
+        change. Preserve pre-existing contents and legitimate task outputs.
     11. Workflow admission already set `in-progress`: do not call
         `orbit.task.start`, and do not move the task to `review` (the pipeline
         owns that transition). Before returning, REQUIRED: persist a meaningful


### PR DESCRIPTION
## Task

[ORB-11570](https://orbit-cli.com/tasks/ORB-11570) — [friction-curation] Make agent_implement cleanup compatible with Codex denied rm commands

### Description

## Problem
`crates/orbit-core/assets/activities/agent_implement.yaml` step 10 requires agents to remove run-owned temporary artifacts before handoff (`Keep incidental caches and temporary artifacts out of the patch; remove only verified run-owned temporary artifacts when cleanup is necessary`) and then run `git status --short`. Codex's command policy rejects `rm -f` / `rm -rf` (`rm -f style commands are not permitted`).

The managed Codex error corpus recorded 85 such `exec_command` rejections from 2026-08-02 through 2026-09-06, 78 of them after this cleanup mandate shipped in `7d8b4ee43` (2026-08-30). For 2026-09-04..06: 71 events across 33 `task_pr_pipeline` child runs; at least 34 tried to delete Cargo `target/`; 51 were compound commands, so a denied cleanup also skipped later `git diff` / `git status`. All 33 runs eventually succeeded — this is a recoverable retry loop that pollutes diagnostics, not an implementation failure.

Current yaml still names the cleanup obligation and does not name a policy-compatible mechanism (`cargo clean`, caches outside the worktree, or record a bounded leftover).

## Why It Matters
The activity contract and the provider policy contradict each other. Agents burn turns on denied `rm -rf`, and the dashboard looks like repeated run failures even when the task succeeded.

## Suggested direction
Make the cleanup instruction explicit and policy-compatible: for Rust worktrees use `cargo clean` (or do not generate `target/` inside the worktree); put caches under `/tmp`; forbid raw `rm -f`/`rm -rf` in managed agent commands; split cleanup from subsequent `git status`/`git diff` so a denied cleanup cannot suppress read-only handoff checks. Recording a bounded leftover is preferable to retrying a denied destructive command. A stronger follow-up (out of this task unless cheap) is moving known build-artifact cleanup into a deterministic workflow activity.

No fail-closed sandbox or command-policy guard is widened; this narrows what the activity asks the model to do.

### Acceptance Criteria

- `agent_implement.yaml` names a Codex-policy-compatible cleanup mechanism for Cargo outputs (for example `cargo clean` or generate outside the worktree) and forbids raw `rm -f` / `rm -rf` as the cleanup method.
- Cleanup is separated from the subsequent `git status` / `git diff` handoff checks so a denied cleanup cannot skip those reads.
- The instruction says to record a bounded leftover rather than retry a denied destructive command.
- A reader of the activity can follow the cleanup path without issuing `rm -rf` against `target/` or `/tmp`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated both byte-identical `agent_implement.yaml` copies with a Codex-policy-compatible Cargo cleanup path: use `cargo clean` or generate outputs outside the worktree.
- Explicitly prohibits raw `rm -f` and `rm -rf`, directs agents not to retry a denied cleanup, and requires recording a bounded leftover.
- Made `git diff --check` and `git status --short` independent, required handoff reads that still run after a cleanup denial.

Acceptance criteria:
- Compatible Cargo cleanup and raw-rm prohibition: met in both shipped activity copies.
- Cleanup separated from handoff reads: met by the explicit independent-read instruction.
- Bounded leftover instead of destructive retry: met.
- Safe, followable cleanup path without raw recursive deletion of build or temporary directories: met.

Validation:
- Passed: `cmp -s crates/orbit-core/assets/activities/agent_implement.yaml .orbit/resources/activities/agent_implement.yaml` (copies remain byte-identical).
- Passed: `cargo test -p orbit-agent representative_activity_prompts_fit_budget_and_preserve_contracts` (1 passed).
- Passed: `git diff --check`; `git status --short` shows only the two intended activity files.
- Not completed: `make ci-fast` and `make ci-lint`; the managed command runner ended each attempted invocation at 30 seconds while the fast check was in `scripts/check-cli-imports.sh` and lint had begun `cargo clippy`. Workspace policy requires these before transition to review; this activity leaves that transition to the pipeline.

Assessment: scoped wording-only change; no source behavior or dependency changes.

Risks: full workspace fast/lint gates remain for the pipeline because this managed run could not keep their command invocation alive beyond the runner limit.

Friction checkpoint: no new friction record; this task addresses an already documented recurring policy conflict.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11570-6a9f2a5e`
- Behind base: 0
- Ahead of base: 1