### PR TITLE
[friction-curation] Say when a task-pilot apply applied zero partitions in the stale-skip diagnostic

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs
@@ -463,13 +463,42 @@ pub(in super::super) fn apply(
         .filter(|decision| decision["outcome"] == "skipped_stale")
         .cloned()
         .collect::<Vec<_>>();
+    let applied_partitions = partition_decisions
+        .iter()
+        .filter(|decision| decision["outcome"] == "applied")
+        .count();
     let succeeded = failed_partitions.is_empty() && skipped_stale_partitions.is_empty();
     let status = if succeeded { "succeeded" } else { "failed" };
     let error = (!succeeded).then(|| {
+        let stale_tasks = skipped_stale_partitions
+            .iter()
+            .flat_map(|partition| partition["stale_tasks"].as_array())
+            .flatten()
+            .filter_map(|task| {
+                Some(format!(
+                    "{}: {}",
+                    task["task_id"].as_str()?,
+                    task["reason"].as_str()?
+                ))
+            })
+            .collect::<Vec<_>>();
+        let stale_details = if stale_tasks.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", stale_tasks.join(", "))
+        };
+        let applied_details = if applied_partitions == 0 {
+            String::new()
+        } else {
+            "; valid partitions were applied".to_string()
+        };
         format!(
-            "{} partition(s) failed and {} partition(s) were skipped as stale; valid partitions were applied",
+            "{} partition(s) failed, {} partition(s) were skipped as stale{}, and {} partition(s) applied{}",
             failed_partitions.len(),
-            skipped_stale_partitions.len()
+            skipped_stale_partitions.len(),
+            stale_details,
+            applied_partitions,
+            applied_details
         )
     });
 

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot.rs
@@ -657,6 +657,59 @@ fn stale_partition_does_not_discard_independent_valid_partition() {
 }
 
 #[test]
+fn all_stale_partition_diagnostic_identifies_zero_apply() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    write_workspace_file(&repo_root, "src/new.rs");
+    let task = seed_task(&runtime, "status changed", TaskStatus::Backlog, &[], &[]);
+    let snapshot = prepared(&runtime, &repo_root, std::slice::from_ref(&task.id));
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                status: Some(TaskStatus::InProgress),
+                ..TaskUpdateParams::default()
+            },
+        )
+        .expect("operator advances task status");
+
+    let output = apply(
+        &runtime,
+        "apply_task_pilot_results",
+        &json!({
+            "prepared": snapshot,
+            "results": [partition_result(
+                0,
+                std::slice::from_ref(&task.id),
+                vec![selector_assessment(&task, vec!["file:src/new.rs"])],
+            )],
+            "workspace_path": repo_root,
+        }),
+    )
+    .expect("stale outcome is retained as a durable failed decision");
+
+    let error = output["error"]
+        .as_str()
+        .expect("all-stale apply carries a diagnostic");
+    assert_eq!(output["status"], "failed");
+    assert_eq!(
+        output["skipped_stale_partitions"].as_array().unwrap().len(),
+        1
+    );
+    assert!(error.contains("1 partition(s) were skipped as stale"));
+    assert!(error.contains("status_changed"));
+    assert!(error.contains(&task.id));
+    assert!(
+        !error.contains("valid partitions were applied"),
+        "zero-apply diagnostic must not claim that valid partitions were applied: {error}"
+    );
+    assert_eq!(
+        runtime.get_task(&task.id).unwrap().status,
+        TaskStatus::InProgress
+    );
+    assert!(runtime.get_task(&task.id).unwrap().context_files.is_empty());
+}
+
+#[test]
 fn malformed_partition_does_not_discard_independent_valid_partition() {
     let (_root, runtime, repo_root) = runtime_with_workspace_layout();
     write_workspace_file(&repo_root, "src/new.rs");


### PR DESCRIPTION
## Task

[ORB-11567](https://orbit-cli.com/tasks/ORB-11567) — [friction-curation] Say when a task-pilot apply applied zero partitions in the stale-skip diagnostic

### Description

## Problem
When task-pilot apply skips its only partition as stale (`status_changed` because another actor mutated the task while the pilot ran), the success-guard error still reads:

```
0 partition(s) failed and 1 partition(s) were skipped as stale; valid partitions were applied
```

Current source, unchanged this pass:
`crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/apply.rs:466-473` sets `succeeded = failed.is_empty() && skipped_stale.is_empty()` and always interpolates that sentence, including the clause `valid partitions were applied`, even when this one-partition run applied zero tasks. The competing mutation is attributed as `by: unknown` with no matching task-update audit event in the host window (incident: `jrun-20260906-1709-2` on ORB-11421).

## Why It Matters
The diagnostic claims work was applied that was not. Operators cannot tell a clean apply of a subset from a total skip, and they cannot identify the competing actor.

## Suggested direction
Make the error state the counts that actually applied vs skipped vs failed, and omit `valid partitions were applied` when applied is zero. Include the stale reason (`status_changed`) and the task id. Attribution of `by: unknown` is a separate audit-gap; this task is the apply diagnostic. Do not resume a failed pilot while a later delivery run for the same task is active.

No fail-closed CAS/stale skip is widened: the skip itself is correct.

### Acceptance Criteria

- When every partition is `skipped_stale` and none succeeded, the apply/success-guard message does not claim that valid partitions were applied.
- The message includes the skipped count, the stale reason (`status_changed` or equivalent), and the affected task id.
- A unit test covers a one-partition stale skip and asserts the message.
- The stale/CAS refusal behavior is unchanged: competing mutations are still preserved, not overwritten.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the task-pilot apply diagnostic to count failed, stale-skipped, and applied partitions.
- Included each stale task id and stale reason in the diagnostic.
- Omitted the “valid partitions were applied” claim when zero partitions applied.
- Added a one-partition `status_changed` regression test asserting the message and unchanged task state.

Acceptance criteria:
- Zero-apply all-stale runs no longer claim valid partitions were applied: satisfied by conditional message construction and regression assertion.
- Diagnostic includes skipped count, stale reason, and affected task id: satisfied and asserted for `status_changed`.
- Unit test covers one-partition stale skip: `all_stale_partition_diagnostic_identifies_zero_apply`.
- Stale/CAS refusal behavior remains fail-closed and preserves competing mutations: existing stale partition and status/deletion tests pass unchanged; the new test verifies the mutated task remains `InProgress` with no applied context change.

Validation:
- Passed: `cargo fmt --all`
- Passed: `cargo fmt --all -- --check`
- Passed: `cargo test -p orbit-core all_stale_partition_diagnostic_identifies_zero_apply`
- Passed: `cargo test -p orbit-core adapter::engine_host::v2_host::tests::task_pilot` (31 tests)
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `git diff --check`
- Passed: final `git status --short` and diff review; only the two task-scoped Rust files are modified.

Assessment: The smallest task-scoped change preserves partition decisions and write-boundary CAS behavior while making the failure diagnostic truthful for both total stale skips and mixed outcomes.

Remaining risks: The diagnostic is intentionally partition-count based, matching the existing guard semantics; no cross-platform behavior is involved.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11567-6a9f2a5d`
- Behind base: 0
- Ahead of base: 1