### PR TITLE
[code-review] Host-registry design docs still assign identity DTOs to orbit-common after path retarget

### DIFF
--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -22,12 +22,12 @@ The live implementation has four layers.
 
 | Layer | Owns | Must not own |
 |---|---|---|
-| orbit-common | Host and workspace DTOs, identifier validation, lifecycle enums, schema constants | Files, runtime construction, transport |
+| orbit-types | Host and workspace identity DTOs, identifier validation, lifecycle enums, schema constants | Files, runtime construction, transport |
 | orbit-registry | Machine identity lifecycle; workspace catalog parsing, mutation, validation, health and file I/O | CLI orchestration, MCP framing, Core execution |
 | orbit-cmd | Registry-aware selection and Core runtime construction | Registry schemas or persistence |
 | CLI, Web and MCP server | User/API inputs, presentation, refresh timing and request dispatch | Alternate catalog semantics |
 
-HostIdentity and host.toml I/O live in orbit-registry. Shared primitives such as validate_machine_id, validate_host_id and the machine-ID namespace constants live in orbit-common so identity validation remains persistence-neutral.
+HostIdentity and host.toml I/O live in orbit-registry. Shared primitives such as validate_machine_id, validate_host_id and the machine-ID namespace constants live in orbit-types so identity validation remains persistence-neutral.
 
 ## 2. Machine identity
 
@@ -77,7 +77,7 @@ An identity-bearing machine must use explicit ownership data:
 
 - an owner checkout has no checkout-level owner_machine_id, and the logical owner must equal the local machine_id;
 - a replica checkout names a non-local owner_machine_id, and that value must equal the logical workspace owner;
-- all persisted machine IDs pass the same orbit-common validator;
+- all persisted machine IDs pass the same orbit-types validator;
 - ownership is never inferred from paths, Git remotes, SSH destinations or caller audit labels.
 
 Installations without host identity retain a narrow standalone compatibility path: a missing checkout role may canonicalize to owner. Once host identity exists, missing or contradictory roles and missing logical owners fail closed.

--- a/docs/design/host-registry/4_decisions.md
+++ b/docs/design/host-registry/4_decisions.md
@@ -24,7 +24,7 @@ must not become a replica protocol. The federated MCP contract itself lives in
 
 **Context.** Host and workspace values are shared across Store, Registry, Core and presentation crates, but file lifecycle needs one owner.
 
-**Decision.** orbit-common owns persistence-neutral DTOs and validators. orbit-registry owns host.toml and workspaces.json. orbit-cmd owns the join from selected registry state to Core runtime state. CLI, Web and MCP remain outer callers.
+**Decision.** orbit-types owns persistence-neutral host/workspace identity DTOs and validators. orbit-registry owns host.toml and workspaces.json. orbit-cmd owns the join from selected registry state to Core runtime state. CLI, Web and MCP remain outer callers.
 
 **Consequences.** Dependency direction stays acyclic and lookup semantics are reusable. Cost: adding a registry field may require coordinated DTO, persistence and composition changes.
 


### PR DESCRIPTION
## Task

[ORB-11572](https://orbit-cli.com/tasks/ORB-11572) — [code-review] Host-registry design docs still assign identity DTOs to orbit-common after path retarget

### Description

## Problem

PR#1508 (`96e6a50dd5b7010f3dfe63049ce5d5fd2eafd2cb`, ORB-11501) stamped `last_validated: 2026-09-07` and retargeted host-registry `paths` frontmatter to `crates/orbit-types/src/identity/host.rs` and `crates/orbit-types/src/workspace/registry.rs`, but left the body claiming orbit-common owns those types.

Verified at that SHA:

- `docs/design/host-registry/2_design.md` layer table: "orbit-common | Host and workspace DTOs, identifier validation…"
- Same file: "validate_machine_id, validate_host_id and the machine-ID namespace constants live in orbit-common"
- `docs/design/host-registry/4_decisions.md`: "orbit-common owns persistence-neutral DTOs and validators"
- `crates/orbit-types/src/identity/host.rs` defines `validate_machine_id` at that SHA

The path map and the ownership prose contradict each other. This is a docs accuracy defect from a validation chore, not a runtime bug.

## Suggested fix

Rewrite the layer table and decision text so identity DTOs and validators are owned by orbit-types, matching the frontmatter and the code. Do not move types; the docs are what is wrong.

Found during landed_code_review_v1 batch review ORB-11555. Distinct from later runtime work (ORB-11544/11551).

### Acceptance Criteria

- Host-registry design and decisions docs name orbit-types as the owner of host/workspace identity DTOs and validators.
- Layer table and decision prose match the existing paths frontmatter and crates/orbit-types/src/identity/host.rs.
- last_validated is refreshed only after the ownership text is corrected.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated docs/design/host-registry/2_design.md to assign host/workspace identity DTOs, validators, lifecycle enums, namespace constants, and machine-ID validation to orbit-types, matching the paths frontmatter and crates/orbit-types/src/identity/host.rs.
- Updated docs/design/host-registry/4_decisions.md to name orbit-types as the owner of persistence-neutral host/workspace identity DTOs and validators.
- Corrected the remaining owner/replica prose reference from orbit-common to orbit-types.
- Confirmed last_validated remains 2026-09-07 in both documents after the ownership corrections; no date change was needed because it already matches the current validation date.
Assessment: The documentation now agrees with the current source ownership and path mappings; the change is limited to the two scoped design documents.
Acceptance criteria:
- Host-registry design and decisions docs name orbit-types as the owner: met.
- Layer table and decision prose match the paths frontmatter and crates/orbit-types/src/identity/host.rs: met; targeted source and path checks passed.
- last_validated is current after the ownership correction: met; both documents show 2026-09-07 and were re-read after editing.
Validation:
- PASS: re-read both documents and crates/orbit-types/src/identity/host.rs with sed.
- PASS: targeted rg checks confirmed orbit-types ownership, validators, namespace constant, paths, and last_validated; no orbit-common references remain in the two documents.
- PASS: git diff --check.
- PASS: git status --short and git diff --stat reviewed; only the two scoped documents changed.
- NOT RUN: cargo/test checks; this is a documentation-only correction with no runtime or dependency changes.
Risks or deviations: None identified.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11572-6a9f2c9c`
- Behind base: 0
- Ahead of base: 1