### PR TITLE
Preserve successful rebase recovery provenance through settlement and resume

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -665,6 +665,42 @@ impl RuntimeHost for OrbitRuntime {
             })
     }
 
+    fn checkpoint_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        output: &Value,
+    ) -> Result<(), DispatchError> {
+        self.stores()
+            .jobs()
+            .update_run_state(run_id, &mut |run_state, state| {
+                if run_state != orbit_types::workflow::JobRunState::Running {
+                    return Err(orbit_common::OrbitError::Execution(
+                        "rebase recovery run is no longer running".to_string(),
+                    ));
+                }
+                state
+                    .rebase_recovery_checkpoints
+                    .insert(step_id.to_string(), output.clone());
+                state.updated_at = Utc::now();
+                Ok(())
+            })
+            .and_then(|updated| {
+                if matches!(updated, orbit_types::workflow::RunStateUpdate::Updated) {
+                    Ok(())
+                } else {
+                    Err(orbit_common::OrbitError::Execution(
+                        "rebase recovery has no durable run state".to_string(),
+                    ))
+                }
+            })
+            .map_err(|error| {
+                DispatchError::JobExecution(format!(
+                    "persist rebase recovery checkpoint (run {run_id}, step `{step_id}`): {error}"
+                ))
+            })
+    }
+
     fn tool_context_for_activity(
         &self,
         run_id: Option<&str>,

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -1193,3 +1193,66 @@ fn orbit_workspace_selector_reports_the_logical_catalog_id() {
         "nested tool calls must carry the logical catalog ID, not the checkout identity"
     );
 }
+
+#[test]
+fn recovered_rebase_checkpoint_survives_restart_without_completing_the_step() {
+    use orbit_types::workflow::{JobRunState, PipelineState};
+
+    let (root, runtime) = test_runtime();
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_pr_pipeline", 1, Utc::now(), None, None)
+        .unwrap();
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .unwrap();
+    let mut state = PipelineState::new(
+        run.run_id.clone(),
+        run.job_id.clone(),
+        json!({"task_ids": ["T-recovery"]}),
+    );
+    state.record_step(
+        3,
+        JobRunState::Success,
+        Some(json!({"head_sha": "before"})),
+        None,
+    );
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(&run.run_id, &state)
+        .unwrap();
+    let output = json!({
+        "run_id": run.run_id,
+        "head_sha_before": "before",
+        "head_sha": "after",
+        "base_sha": "target",
+        "remote_sha_before": "remote",
+    });
+    runtime
+        .checkpoint_rebase_recovery(&run.run_id, "sync_base", &output)
+        .unwrap();
+    drop(runtime);
+
+    let reopened = OrbitRuntime::from_roots(
+        &root.path().join("global"),
+        &root.path().join("repo/.orbit"),
+    )
+    .unwrap();
+    let durable = RuntimeHost::read_run_state(&reopened, &run.run_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(durable.rebase_recovery_checkpoints["sync_base"], output);
+    assert_eq!(durable.step_outputs, state.step_outputs);
+    assert_eq!(durable.step_states, state.step_states);
+    assert_eq!(durable.next_step_index, 4);
+    assert!(durable.failure_activity_checkpoint.is_none());
+    assert!(
+        reopened
+            .checkpoint_rebase_recovery("missing-run", "sync_base", &output)
+            .is_err()
+    );
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/rebase_recovery.rs
@@ -75,6 +75,20 @@ printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
                 &["merge-base", "--is-ancestor", &recovery.target, "HEAD"],
             );
             assert_eq!(git_head(&recovery.fixture.primary), recovery.target);
+            assert_eq!(
+                fs::read_to_string(recovery.fixture.assigned.join("candidate.txt")).unwrap(),
+                "nonconflicting candidate\n"
+            );
+            let persisted: serde_json::Value =
+                serde_json::from_slice(&fs::read(script.with_extension("sync_base.json")).unwrap())
+                    .unwrap();
+            assert_eq!(persisted["head_sha"], git_head(&recovery.fixture.assigned));
+            assert_eq!(persisted["head_sha_before"], recovery.original);
+            assert_eq!(persisted["original_base_sha"], recovery.original_base);
+            assert_eq!(persisted["base_sha"], recovery.target);
+            assert_eq!(persisted["task_ids"], serde_json::json!(["T-recovery"]));
+            assert_eq!(persisted["run_id"], "run-rebase-recovery");
+            assert_eq!(persisted["rewritten"], true);
         }
     }
 }
@@ -241,6 +255,39 @@ fn conflict_recovery_reports_additional_conflicts_without_a_second_agent_attempt
     assert!(!git_bytes(&recovery.fixture.assigned, &["ls-files", "-u"]).is_empty());
 }
 
+#[test]
+fn recovery_cannot_report_success_when_completion_checkpoint_cannot_be_persisted() {
+    let recovery = stopped_rebase_fixture(false);
+    let script = recovery.fixture.root().join("codex");
+    write_executable(
+        &script,
+        r##"#!/bin/sh
+set -eu
+cat > /dev/null
+printf 'candidate and target\n' > README.md
+printf '%s\n' '{"schemaVersion":1,"status":"success","result":{},"error":null}'
+"##,
+    );
+    let mut host = TestHost::with_command(script.display().to_string());
+    host.workspace_root = Some(recovery.fixture.primary.clone());
+    host.task_context = Some(serde_json::json!({"checkpoint_denied": true}));
+    let error = run_cli_backend(
+        &host,
+        &test_agent_loop_spec(Duration::from_secs(30)),
+        "pr_conflict_recovery",
+        "run-rebase-recovery",
+        test_audit("run-checkpoint-denied", "codex"),
+        &conflict_recovery_input(&recovery),
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("checkpoint storage unavailable"),
+        "{error}"
+    );
+    assert!(!script.with_extension("sync_base.json").exists());
+}
+
 struct StoppedRebaseFixture {
     fixture: LinkedWorktreeFixture,
     original: String,
@@ -257,7 +304,12 @@ fn stopped_rebase_fixture(additional_candidate_commit: bool) -> StoppedRebaseFix
         .trim()
         .to_string();
     fs::write(fixture.assigned.join("README.md"), "candidate one\n").unwrap();
-    git_ok(&fixture.assigned, &["add", "README.md"]);
+    fs::write(
+        fixture.assigned.join("candidate.txt"),
+        "nonconflicting candidate\n",
+    )
+    .unwrap();
+    git_ok(&fixture.assigned, &["add", "README.md", "candidate.txt"]);
     git_ok(&fixture.assigned, &["commit", "-m", "candidate one"]);
     if additional_candidate_commit {
         fs::write(fixture.assigned.join("README.md"), "candidate two\n").unwrap();

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -261,6 +261,29 @@ impl TestHost {
 }
 
 impl RuntimeHost for TestHost {
+    fn checkpoint_rebase_recovery(
+        &self,
+        _run_id: &str,
+        step_id: &str,
+        output: &Value,
+    ) -> Result<(), DispatchError> {
+        if self
+            .task_context
+            .as_ref()
+            .is_some_and(|context| context["checkpoint_denied"] == true)
+        {
+            return Err(DispatchError::JobExecution(
+                "checkpoint storage unavailable".to_string(),
+            ));
+        }
+        fs::write(
+            Path::new(&self.command).with_extension(format!("{step_id}.json")),
+            serde_json::to_vec(output).unwrap(),
+        )
+        .map_err(|error| DispatchError::JobExecution(error.to_string()))?;
+        Ok(())
+    }
+
     fn run_deterministic(
         &self,
         _action: &str,

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -17,6 +17,11 @@ pub(super) fn recover_or_return_original(
     if attempt_recovery_activity(step, ctx, &recovery, &original_err, attempt, max_attempts) {
         match run_step_body(step, ctx) {
             Ok(outcome) if outcome.success => return Ok(outcome),
+            // Once VCS recovery succeeded, the old conflict is resolved. A
+            // stale base or other new failure must describe the remaining state.
+            result if matches!(original_err, DispatchError::RecoverableVcsConflict { .. }) => {
+                return result;
+            }
             Ok(_) | Err(_) => {}
         }
     }

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -135,6 +135,28 @@ fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
 }
 
 #[test]
+fn successful_vcs_recovery_reports_the_new_failure_instead_of_resolved_conflicts() {
+    let original = recoverable_vcs_conflict();
+    let remaining = retryable_error("flaky", "prepared base moved after recovery");
+    let host = RecoveryHost::new([
+        ("flaky", vec![Err(original), Err(remaining.clone())]),
+        ("recover", vec![Ok(json!({"recovered": true}))]),
+    ]);
+    let job = recovery_job(Some("recover"), None, "flaky", None, 1);
+    let error = execute_job(
+        &job,
+        Value::Null,
+        "run-new-recovery-failure",
+        Arc::new(test_writer("run-new-recovery-failure")),
+        &host,
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), remaining.to_string());
+    assert!(!error.to_string().contains("conflicting paths"));
+    assert_eq!(host.actions(), vec!["flaky", "recover", "flaky"]);
+}
+
+#[test]
 fn recovery_activity_error_returns_original_error_text() {
     let original_error = retryable_error("flaky", "precondition failed");
     let host = RecoveryHost::new([

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -609,18 +609,27 @@ impl WorktreeBoundaryGuard {
         recovery_step_id: Option<&str>,
         task_ids: &[String],
     ) -> Result<(), DispatchError> {
-        if self.rebase_recovery.is_some() && recovery_succeeded {
+        let completion = if self.rebase_recovery.is_some() && recovery_succeeded {
             let step_id = recovery_step_id.ok_or_else(|| {
                 DispatchError::CliInvocationPermanent(
                     "conflict recovery is missing its failed step identity".to_string(),
                 )
             })?;
-            self.complete_rebase_recovery(host, step_id, task_ids)?;
+            Some((
+                step_id,
+                self.complete_rebase_recovery(host, step_id, task_ids)?,
+            ))
+        } else {
+            None
+        };
+        self.verify()?;
+        if let Some((step_id, output)) = completion {
+            host.checkpoint_rebase_recovery(&self.run_id, step_id, &output)?;
         }
-        self.verify()
+        Ok(())
     }
 
-    pub(crate) fn verify(self) -> Result<(), DispatchError> {
+    pub(crate) fn verify(&self) -> Result<(), DispatchError> {
         let assigned_after = git_fingerprint(&self.assigned_root)?;
         let primary_after = git_fingerprint(&self.primary_root)?;
         let assigned_history_changed = assigned_after.head != self.assigned_before.head

--- a/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
@@ -8,8 +8,7 @@ use crate::context::{RuntimeHost, StepRecoveryAdmission};
 
 use super::{
     DispatchError, GitWorktreeFingerprint, WorktreeBoundaryGuard, changed_paths, git_command_error,
-    git_fingerprint, git_output_raw, git_stdout, git_stdout_bytes, nul_paths,
-    primary_dirt_mutations, safe_relative_path,
+    git_fingerprint, git_output_raw, git_stdout, git_stdout_bytes, nul_paths, safe_relative_path,
 };
 
 pub(super) struct RebaseRecoveryCheckpoint {
@@ -19,6 +18,7 @@ pub(super) struct RebaseRecoveryCheckpoint {
     base_ref: String,
     target_base_sha: String,
     conflicting_paths: Vec<String>,
+    remote_sha_before: Option<String>,
 }
 
 impl WorktreeBoundaryGuard {
@@ -114,6 +114,11 @@ impl WorktreeBoundaryGuard {
                 base_ref,
                 target_base_sha: target.to_string(),
                 conflicting_paths,
+                remote_sha_before: prepared
+                    .get("remote_sha")
+                    .or_else(|| prepared.get("published_head_sha"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
             });
             return Ok(());
         }
@@ -158,7 +163,7 @@ impl WorktreeBoundaryGuard {
         host: &dyn RuntimeHost,
         step_id: &str,
         task_ids: &[String],
-    ) -> Result<(), DispatchError> {
+    ) -> Result<Value, DispatchError> {
         let checkpoint = self.rebase_recovery.as_ref().ok_or_else(|| {
             DispatchError::CliInvocationPermanent(
                 "conflict recovery has no authenticated rebase checkpoint".to_string(),
@@ -256,16 +261,34 @@ impl WorktreeBoundaryGuard {
                 "continued rebase did not leave the checkpointed branch on the pinned base with a candidate commit",
             ));
         }
-        let unrelated_mutations = primary_dirt_mutations(&self.assigned_before, &completed)
-            .into_iter()
-            .filter(|path| !checkpoint.conflicting_paths.contains(path))
-            .collect::<Vec<_>>();
-        if !unrelated_mutations.is_empty() {
-            return Err(invalid(&format!(
-                "host continuation changed unrelated paths: {unrelated_mutations:?}"
-            )));
+        // The stopped index includes every nonconflicting candidate change.
+        // Those staged paths become clean when Git commits them; comparing dirty
+        // path maps across that transition incorrectly rejects the candidate.
+        // Provider edits were checked before continuation. Now require Git to
+        // leave no tracked dirt and preserve the pre-existing untracked payload.
+        if !git_output_raw(&self.assigned_root, &["diff", "--quiet", "HEAD", "--"])?
+            .status
+            .success()
+            || completed.untracked_content != self.assigned_before.untracked_content
+        {
+            return Err(invalid(
+                "host continuation left tracked dirt or changed untracked files",
+            ));
         }
-        Ok(())
+        Ok(serde_json::json!({
+            "run_id": self.run_id,
+            "step_id": step_id,
+            "task_ids": task_ids,
+            "workspace_path": self.assigned_root,
+            "head": checkpoint.branch,
+            "head_sha_before": checkpoint.original_head,
+            "original_base_sha": checkpoint.original_base_sha,
+            "base_ref": checkpoint.base_ref,
+            "base_sha": checkpoint.target_base_sha,
+            "remote_sha_before": checkpoint.remote_sha_before,
+            "head_sha": completed.head,
+            "rewritten": true,
+        }))
     }
 
     fn validate_rebase_checkpoint(

--- a/crates/orbit-engine/src/context/hosts.rs
+++ b/crates/orbit-engine/src/context/hosts.rs
@@ -617,6 +617,19 @@ pub trait RuntimeHost: Send + Sync {
         Ok(())
     }
 
+    /// Persist an exact host-validated recovered rebase before reporting recovery
+    /// success. Unlike ordinary step checkpoints, durability failure is fatal.
+    fn checkpoint_rebase_recovery(
+        &self,
+        _run_id: &str,
+        _step_id: &str,
+        _output: &Value,
+    ) -> Result<(), DispatchError> {
+        Err(DispatchError::JobExecution(
+            "host does not support durable rebase recovery checkpoints".to_string(),
+        ))
+    }
+
     fn tool_context_for_activity(
         &self,
         _run_id: Option<&str>,

--- a/crates/orbit-engine/src/executor/automation/vcs/failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/failure.rs
@@ -104,7 +104,7 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
                 .to_string(),
         ));
     }
-    if conflicting_paths.is_empty() {
+    if conflicting_paths.is_empty() && rebase_aborted {
         conflicting_paths = conflicts_from_error(error_message);
     }
 
@@ -221,7 +221,9 @@ pub(in crate::executor::automation) fn pr_failure_handoff<H: RuntimeHost + Sync 
         "failed_step_id": failed_step_id,
         "branch": head,
         "head_sha": head_sha,
-        "original_base_sha": original_base_sha,
+        // Resume authenticates against the immutable worktree base, even when
+        // a recovered rebase moved the candidate's merge base forward.
+        "original_base_sha": input_string_field(worktree, "base_sha").unwrap_or(original_base_sha),
         "target_base_sha": target_base_sha,
         "conflicting_paths": conflicting_paths,
         "committed_files": committed_files,

--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -94,7 +94,7 @@ pub(in crate::executor::automation) fn rebase_pr_branch<H: RuntimeHost + ?Sized>
     input: &Value,
 ) -> Result<Value, OrbitError> {
     let context = load_handoff_context(host, input, "git_rebase")?;
-    match rebase_pr_branch_inner(input, &context) {
+    match rebase_pr_branch_inner(host, input, &context) {
         Ok(output) => Ok(output),
         Err(error) => {
             record_failed_handoff(host, &context, input, FailedHandoffPhase::Rebase, &error)?;
@@ -103,7 +103,11 @@ pub(in crate::executor::automation) fn rebase_pr_branch<H: RuntimeHost + ?Sized>
     }
 }
 
-fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Value, OrbitError> {
+fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+    context: &HandoffContext,
+) -> Result<Value, OrbitError> {
     let head = required_input_string(input, "head")?;
     let head_sha_before = required_input_string(input, "head_sha")?;
     let base = required_input_string(input, "base")?;
@@ -190,6 +194,7 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
             }
             ("skipped_current", false, current_sha)
         } else if sync_required {
+            validate_recovered_rewrite(host, input, context, &current_sha)?;
             ("reused_recovery", true, current_sha)
         } else {
             return Err(OrbitError::Execution(format!(
@@ -244,6 +249,43 @@ fn rebase_pr_branch_inner(input: &Value, context: &HandoffContext) -> Result<Val
         "remote_sha_before": input_string_field(input, "remote_sha"),
         "rewritten": rewritten,
     }))
+}
+
+fn validate_recovered_rewrite<H: RuntimeHost + ?Sized>(
+    host: &H,
+    input: &Value,
+    context: &HandoffContext,
+    current_sha: &str,
+) -> Result<(), OrbitError> {
+    let run_id = input
+        .get("run_id")
+        .and_then(Value::as_str)
+        .unwrap_or(&context.batch_id);
+    let Some(checkpoint) =
+        recovered_head_checkpoint(host, run_id, &context.workspace_path, current_sha)?
+    else {
+        return Err(OrbitError::Execution(
+            "git_rebase: changed HEAD has no exact host-validated recovery checkpoint".to_string(),
+        ));
+    };
+    let task_ids = context
+        .tasks
+        .iter()
+        .map(|task| task.id.as_str())
+        .collect::<Vec<_>>();
+    if checkpoint["head"] != input["head"]
+        || checkpoint["head_sha_before"] != input["head_sha"]
+        || checkpoint["base_sha"] != input["base_sha"]
+        || checkpoint["remote_sha_before"]
+            != input.get("remote_sha").cloned().unwrap_or(Value::Null)
+        || checkpoint["task_ids"] != json!(task_ids)
+    {
+        return Err(OrbitError::Execution(
+            "git_rebase: recovered HEAD provenance does not match the prepared rewrite checkpoint"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn unmerged_paths(repo_root: &Path) -> Result<Vec<String>, OrbitError> {
@@ -382,4 +424,67 @@ fn parse_divergence_count(
             "invalid {label} divergence count '{raw}' while comparing '{head}' to '{base}': {error}"
         ))
     })
+}
+
+/// Read only host-written provenance, authenticating the original durable run
+/// when a resume carries a copy. Advisory activity outputs never authorize HEAD.
+pub(super) fn recovered_head_checkpoint<H: RuntimeHost + ?Sized>(
+    host: &H,
+    run_id: &str,
+    workspace: &Path,
+    head_sha: &str,
+) -> Result<Option<Value>, OrbitError> {
+    let Some(state) = host.read_run_state(run_id)? else {
+        return Ok(None);
+    };
+    for (step_id, checkpoint) in &state.rebase_recovery_checkpoints {
+        if !matches!(step_id.as_str(), "sync_base" | "complete_pr")
+            || checkpoint.get("head_sha").and_then(Value::as_str) != Some(head_sha)
+            || checkpoint.get("workspace_path").and_then(Value::as_str) != workspace.to_str()
+            || checkpoint.get("step_id").and_then(Value::as_str) != Some(step_id)
+            || checkpoint.get("rewritten").and_then(Value::as_bool) != Some(true)
+        {
+            continue;
+        }
+        let source_run_id = required_input_string(checkpoint, "run_id")?;
+        if source_run_id != run_id {
+            let source = host.read_run_state(source_run_id)?.ok_or_else(|| {
+                OrbitError::Execution(
+                    "recovered rebase source run has no durable state".to_string(),
+                )
+            })?;
+            if source.rebase_recovery_checkpoints.get(step_id) != Some(checkpoint) {
+                return Err(OrbitError::Execution(
+                    "recovered rebase differs from its source checkpoint".to_string(),
+                ));
+            }
+            let task_id = checkpoint
+                .get("task_ids")
+                .and_then(Value::as_array)
+                .and_then(|ids| ids.first())
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    OrbitError::Execution("recovered rebase has no task identity".to_string())
+                })?;
+            super::resume::ensure_retry_descends_from(
+                host,
+                "rebase recovery",
+                "recovery run",
+                task_id,
+                run_id,
+                source_run_id,
+            )?;
+        }
+        let target = required_input_string(checkpoint, "base_sha")?;
+        if !git_command_success(
+            workspace,
+            &["merge-base", "--is-ancestor", target, head_sha],
+        )? {
+            return Err(OrbitError::Execution(
+                "recovered candidate does not descend from its pinned base".to_string(),
+            ));
+        }
+        return Ok(Some(checkpoint.clone()));
+    }
+    Ok(None)
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
@@ -428,6 +428,7 @@ fn refresh_conflicting_pr_branch<H: RuntimeHost + ?Sized>(
     }
 
     let rebase_input = json!({
+        "run_id": input.get("run_id").cloned().unwrap_or(Value::Null),
         "job_run_id": input.get("job_run_id").cloned().unwrap_or(Value::Null),
         "completed_task_ids": input.get("completed_task_ids").cloned().unwrap_or(Value::Null),
         "workspace_path": workspace_path,

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
@@ -351,6 +351,28 @@ fn published_pr_conflict_reuses_pinned_rebase_branch_and_pr_on_completion_retry(
         String::from_utf8_lossy(&continued.stderr)
     );
 
+    let run_id = input["job_run_id"].as_str().unwrap();
+    crate::context::RuntimeHost::checkpoint_rebase_recovery(
+        &host,
+        run_id,
+        "complete_pr",
+        &json!({
+            "run_id": run_id,
+            "step_id": "complete_pr",
+            "workspace_path": workspace.repo,
+            "task_ids": ["T1"],
+            "head": input["head"],
+            "head_sha_before": published_head_sha,
+            "original_base_sha": conflict.original_base_sha,
+            "base_ref": "refs/remotes/origin/agent-main",
+            "base_sha": conflict.target_base_sha,
+            "remote_sha_before": published_head_sha,
+            "head_sha": git(&workspace.repo, &["rev-parse", "HEAD"]),
+            "rewritten": true,
+        }),
+    )
+    .unwrap();
+
     host.queue_pr_status([state("DIRTY"), state("CLEAN"), merged_state()]);
     let output = pr_complete(&host, &input).expect("retry merges recovered published PR");
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -198,8 +198,48 @@ fn recovered_rebase_continues_remaining_handoff_phases_without_replay() {
         String::from_utf8_lossy(&output.stderr)
     );
 
+    let error = rebase_pr_branch(&host, &rebase_input)
+        .expect_err("manual continuation lacks host provenance");
+    assert!(
+        error
+            .to_string()
+            .contains("no exact host-validated recovery checkpoint")
+    );
+    let run_id = rebase_input["job_run_id"].as_str().unwrap();
+    crate::context::RuntimeHost::checkpoint_rebase_recovery(
+        &host,
+        run_id,
+        "sync_base",
+        &json!({
+            "run_id": run_id,
+            "step_id": "sync_base",
+            "workspace_path": workspace.repo,
+            "task_ids": rebase_input["completed_task_ids"],
+            "head": rebase_input["head"],
+            "head_sha_before": rebase_input["head_sha"],
+            "base_ref": rebase_input["base_ref"],
+            "base_sha": rebase_input["base_sha"],
+            "remote_sha_before": rebase_input["remote_sha"],
+            "head_sha": git(&workspace.repo, &["rev-parse", "HEAD"]),
+            "rewritten": true,
+        }),
+    )
+    .unwrap();
     let synced = rebase_pr_branch(&host, &rebase_input).expect("reuse recovered rewrite");
     assert_eq!(synced["decision"], json!("reused_recovery"));
+    let recovered_head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    git(
+        &workspace.repo,
+        &["commit", "--allow-empty", "-m", "unattributed replacement"],
+    );
+    let replacement_error = rebase_pr_branch(&host, &rebase_input).unwrap_err();
+    assert!(
+        replacement_error
+            .to_string()
+            .contains("no exact host-validated recovery checkpoint")
+    );
+    git(&workspace.repo, &["reset", "--hard", &recovered_head]);
+
     assert_eq!(synced["rewritten"], json!(true));
     assert_eq!(
         git(

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_failure.rs
@@ -161,6 +161,26 @@ impl RuntimeHost for ResumeFailureHost {
                     workspace_path,
                     &["-c", "core.editor=true", "rebase", "--continue"],
                 );
+                let run_id = input["run_id"].as_str().unwrap();
+                let prepared = &input["failed_step_input"];
+                self.checkpoint_rebase_recovery(
+                    run_id,
+                    "sync_base",
+                    &json!({
+                        "run_id": run_id,
+                        "step_id": "sync_base",
+                        "workspace_path": workspace_path,
+                        "task_ids": [TASK_ID],
+                        "head": prepared["head"],
+                        "head_sha_before": prepared["head_sha"],
+                        "original_base_sha": input["original_base_sha"],
+                        "base_ref": prepared["base_ref"],
+                        "base_sha": prepared["base_sha"],
+                        "remote_sha_before": prepared["remote_sha"],
+                        "head_sha": git(workspace_path, &["rev-parse", "HEAD"]),
+                        "rewritten": true,
+                    }),
+                )?;
                 Ok(json!({"recovered": true}))
             }
             "git_push" => crate::executor::automation::vcs::push_batch_changes(self, input)
@@ -225,6 +245,22 @@ impl RuntimeHost for ResumeFailureHost {
             .ok_or_else(|| DispatchError::JobExecution(format!("missing state for {run_id}")))?;
         state.record_step(step_index, JobRunState::Success, Some(output.clone()), None);
         state.sync_pipeline(pipeline_snapshot.clone());
+        Ok(())
+    }
+
+    fn checkpoint_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        output: &Value,
+    ) -> Result<(), DispatchError> {
+        self.run_states
+            .lock()
+            .unwrap()
+            .get_mut(run_id)
+            .unwrap()
+            .rebase_recovery_checkpoints
+            .insert(step_id.to_string(), output.clone());
         Ok(())
     }
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_preservation.rs
@@ -117,3 +117,70 @@ fn resume_preflight_rejects_unrelated_lineage_and_changed_ownership() {
         );
     }
 }
+
+#[test]
+fn resumed_recovery_requires_the_exact_immutable_source_checkpoint() {
+    use crate::executor::automation::vcs::freshness::recovered_head_checkpoint;
+
+    let workspace = no_diff_pr_workspace();
+    let mut source = completed_worktree_checkpoint(FIRST_RESUME_RUN_ID, &workspace.repo);
+    let base = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    fs::write(
+        workspace.repo.join("candidate.txt"),
+        "recovered candidate\n",
+    )
+    .unwrap();
+    git(&workspace.repo, &["add", "candidate.txt"]);
+    git(&workspace.repo, &["commit", "-m", "recovered candidate"]);
+    let head = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    let checkpoint = json!({
+        "run_id": FIRST_RESUME_RUN_ID,
+        "step_id": "sync_base",
+        "task_ids": [TASK_ID],
+        "workspace_path": workspace.repo,
+        "head": "orbit/test-batch",
+        "head_sha_before": "original-candidate",
+        "original_base_sha": base,
+        "base_sha": base,
+        "head_sha": head,
+        "rewritten": true,
+    });
+    source
+        .rebase_recovery_checkpoints
+        .insert("sync_base".to_string(), checkpoint.clone());
+    let host = ResumeFailureHost::new(
+        PrOpenTestHost::new(
+            vec![task_owned_by(CHECKPOINT_RUN_ID)],
+            workspace.repo.clone(),
+        )
+        .with_job_run(FIRST_RESUME_RUN_ID, None)
+        .with_job_run(SECOND_RESUME_RUN_ID, Some(FIRST_RESUME_RUN_ID)),
+    );
+    host.write_state(source.clone());
+    let mut resumed: PipelineState =
+        serde_json::from_slice(&serde_json::to_vec(&source).unwrap()).unwrap();
+    resumed.run_id = SECOND_RESUME_RUN_ID.to_string();
+    host.write_state(resumed.clone());
+    assert_eq!(
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap(),
+        Some(checkpoint)
+    );
+    assert_eq!(
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &base).unwrap(),
+        None
+    );
+
+    resumed
+        .rebase_recovery_checkpoints
+        .get_mut("sync_base")
+        .unwrap()["head_sha_before"] = json!("substituted-origin");
+    host.write_state(resumed);
+    let error =
+        recovered_head_checkpoint(&host, SECOND_RESUME_RUN_ID, &workspace.repo, &head).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("differs from its source checkpoint"),
+        "{error}"
+    );
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_refresh.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/resume_refresh.rs
@@ -131,7 +131,37 @@ fn stale_checkpoint_delivery_job() -> JobV2 {
 
 #[test]
 fn stale_preserved_checkpoint_refreshes_then_recovers_and_completes_the_same_pr() {
+    preserved_checkpoint_resume(ResumeCheckpoint::StalePreparation);
+}
+
+#[test]
+fn recovered_candidate_survives_restart_and_failure_handoff_before_step_checkpoint() {
+    preserved_checkpoint_resume(ResumeCheckpoint::RecoveredAfterHandoff);
+}
+
+#[test]
+fn recovered_candidate_resumes_after_restart_without_a_failure_handoff_or_step_success() {
+    preserved_checkpoint_resume(ResumeCheckpoint::RecoveredBeforeHandoff);
+}
+
+enum ResumeCheckpoint {
+    StalePreparation,
+    RecoveredAfterHandoff,
+    RecoveredBeforeHandoff,
+}
+
+fn preserved_checkpoint_resume(checkpoint: ResumeCheckpoint) {
+    let recovered_before_handoff = !matches!(checkpoint, ResumeCheckpoint::StalePreparation);
+    let publish_handoff = !matches!(checkpoint, ResumeCheckpoint::RecoveredBeforeHandoff);
     let workspace = pr_workspace();
+    if recovered_before_handoff {
+        // The observed run had no published remote branch before its recovery.
+        // Diverged failure-handoff publication is the separate rewrite-lease task.
+        git(
+            &workspace.repo,
+            &["push", "origin", "--delete", "orbit/test-batch"],
+        );
+    }
     let original_base = git(&workspace.repo, &["rev-parse", "agent-main"]);
     let candidate_before = git(&workspace.repo, &["rev-parse", "orbit/test-batch"]);
     let mut task = batch_task(
@@ -237,27 +267,69 @@ fn stale_preserved_checkpoint_refreshes_then_recovers_and_completes_the_same_pr(
     .expect_err("the original preparation is stale");
     assert!(stale_error.to_string().contains(&advanced_base));
 
-    let handoff = pr_failure_handoff(
-        &host,
-        &json!({
-            "failed_step_id": "sync_base",
-            "activity_name": "git_rebase",
-            "error_code": "pipeline_step_failed",
-            "error_message": stale_error.to_string(),
-            "run_id": FIRST_RESUME_RUN_ID,
-            "job_input": input,
-            "pipeline": source.pipeline,
-        }),
-    )
-    .expect("publish the preserved candidate to a blocked PR");
-    assert_eq!(handoff["decision"], "blocked_failure_pr");
-    assert_eq!(handoff["pr_number"], "42");
-    assert_eq!(handoff["preservation_commit_created"], false);
-    source.record_failure_activity(
-        "pr_failure_handoff".to_string(),
-        "sync_base".to_string(),
-        handoff,
-    );
+    let mut error_message = stale_error.to_string();
+    if recovered_before_handoff {
+        let prepared =
+            crate::executor::automation::vcs::prepare_pr_handoff(&host, &prepare_input).unwrap();
+        source.step_outputs.insert(3, prepared.clone());
+        source.pipeline["prepare_branch"] = prepared.clone();
+        host.write_state(source.clone());
+        let mut rebase_input = prepared;
+        rebase_input["job_run_id"] = json!(CHECKPOINT_RUN_ID);
+        rebase_input["run_id"] = json!(FIRST_RESUME_RUN_ID);
+        rebase_input["completed_task_ids"] = json!([TASK_ID]);
+        rebase_input["workspace_path"] = json!(workspace.repo);
+        let conflict =
+            crate::executor::automation::vcs::rebase_pr_branch(&host, &rebase_input).unwrap_err();
+        error_message = conflict.to_string();
+        host.run_deterministic(
+            "test_resolve_rebase_conflict",
+            &Value::Null,
+            &json!({
+                "run_id": FIRST_RESUME_RUN_ID,
+                "workspace_path": workspace.repo,
+                "original_base_sha": original_base,
+                "failed_step_input": rebase_input,
+            }),
+            Default::default(),
+        )
+        .unwrap();
+        // The host completion is durable, but sync_base never checkpointed:
+        // simulate process restart by reloading only serialized run state.
+        source = serde_json::from_slice(
+            &serde_json::to_vec(&host.read_run_state(FIRST_RESUME_RUN_ID).unwrap().unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(!source.step_states.contains_key(&4));
+        assert!(!source.step_outputs.contains_key(&4));
+    }
+
+    if publish_handoff {
+        let handoff = pr_failure_handoff(
+            &host,
+            &json!({
+                "failed_step_id": "sync_base",
+                "activity_name": "git_rebase",
+                "error_code": "pipeline_step_failed",
+                "error_message": error_message,
+                "run_id": FIRST_RESUME_RUN_ID,
+                "job_input": input,
+                "pipeline": source.pipeline,
+            }),
+        )
+        .expect("publish the preserved candidate to a blocked PR");
+        assert_eq!(handoff["decision"], "blocked_failure_pr");
+        assert_eq!(handoff["conflicting_paths"], json!([]));
+        assert_eq!(handoff["original_base_sha"], original_base);
+        assert_eq!(handoff["pr_number"], "42");
+        assert_eq!(handoff["preservation_commit_created"], false);
+        source.record_failure_activity(
+            "pr_failure_handoff".to_string(),
+            "sync_base".to_string(),
+            handoff,
+        );
+    }
     host.write_state(source.clone());
     let historical_source = source.clone();
 
@@ -310,21 +382,34 @@ fn stale_preserved_checkpoint_refreshes_then_recovers_and_completes_the_same_pr(
         delivered.pipeline["prepare_branch"]["base_sha"],
         advanced_base
     );
-    assert_eq!(
-        delivered.pipeline["prepare_branch"]["resume_refresh"],
-        json!({
-            "kind": "stale_delivery_checkpoint",
-            "source_run_id": FIRST_RESUME_RUN_ID,
-            "previous_base_sha": original_base,
-            "attempt": 1,
-            "max_attempts": 1,
-        })
-    );
+    if publish_handoff {
+        assert_eq!(
+            delivered.pipeline["prepare_branch"]["resume_refresh"],
+            json!({
+                "kind": "stale_delivery_checkpoint",
+                "source_run_id": FIRST_RESUME_RUN_ID,
+                "previous_base_sha": if recovered_before_handoff { &advanced_base } else { &original_base },
+                "attempt": 1,
+                "max_attempts": 1,
+            })
+        );
+    }
     assert_eq!(
         delivered.pipeline["sync_base"]["decision"],
-        "reused_recovery"
+        if recovered_before_handoff && publish_handoff {
+            "skipped_current"
+        } else {
+            "reused_recovery"
+        }
     );
-    assert_eq!(delivered.pipeline["pr_open"]["decision"], "reused");
+    assert_eq!(
+        delivered.pipeline["pr_open"]["decision"],
+        if publish_handoff {
+            "reused"
+        } else {
+            "performed"
+        }
+    );
     assert_eq!(delivered.pipeline["pr_open"]["pr_number"], "42");
     assert_eq!(host.inner.task_status(TASK_ID), TaskStatus::Done);
     assert_eq!(
@@ -353,7 +438,9 @@ fn stale_preserved_checkpoint_refreshes_then_recovers_and_completes_the_same_pr(
         .expect("read active state")
         .expect("active state exists");
     assert_eq!(active.step_outputs[&3]["base_sha"], advanced_base);
-    assert_eq!(active.step_outputs[&3]["resume_refresh"]["attempt"], 1);
+    if publish_handoff {
+        assert_eq!(active.step_outputs[&3]["resume_refresh"]["attempt"], 1);
+    }
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/test_support.rs
@@ -40,6 +40,7 @@ pub struct VcsCall {
 }
 
 pub struct PrOpenTestHost {
+    run_states: Mutex<HashMap<String, orbit_types::workflow::PipelineState>>,
     tasks: Mutex<Vec<Task>>,
     job_runs: Mutex<Vec<JobRun>>,
     comments: Mutex<HashMap<String, Vec<TaskComment>>>,
@@ -62,6 +63,7 @@ impl PrOpenTestHost {
         let data_root = repo_root.join(".orbit-test-data");
         let scoreboard_dir = data_root.join("scoreboard");
         Self {
+            run_states: Mutex::new(HashMap::new()),
             tasks: Mutex::new(tasks),
             job_runs: Mutex::new(Vec::new()),
             comments: Mutex::new(HashMap::new()),
@@ -254,6 +256,33 @@ impl PrOpenTestHost {
 }
 
 impl RuntimeHost for PrOpenTestHost {
+    fn read_run_state(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<orbit_types::workflow::PipelineState>, OrbitError> {
+        Ok(self.run_states.lock().unwrap().get(run_id).cloned())
+    }
+
+    fn checkpoint_rebase_recovery(
+        &self,
+        run_id: &str,
+        step_id: &str,
+        output: &Value,
+    ) -> Result<(), crate::DispatchError> {
+        let mut states = self.run_states.lock().unwrap();
+        let state = states.entry(run_id.to_string()).or_insert_with(|| {
+            orbit_types::workflow::PipelineState::new(
+                run_id.to_string(),
+                "task_pr_pipeline".to_string(),
+                json!({}),
+            )
+        });
+        state
+            .rebase_recovery_checkpoints
+            .insert(step_id.to_string(), output.clone());
+        Ok(())
+    }
+
     fn get_job_run(&self, run_id: &str) -> Result<Option<JobRun>, OrbitError> {
         Ok(self
             .job_runs

--- a/crates/orbit-engine/src/executor/automation/vcs/resume.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/resume.rs
@@ -14,7 +14,7 @@ use crate::executor::automation::input::{
     canonicalize_existing_dir, input_string_field, required_input_string,
 };
 
-use super::freshness::commit_sha;
+use super::freshness::{commit_sha, recovered_head_checkpoint};
 
 const FAILURE_HANDOFF_LINEAGE_MAX_HOPS: usize = 64;
 const RESUME_PREPARATION_REFRESH_MAX_ATTEMPTS: u64 = 1;
@@ -82,7 +82,7 @@ pub(crate) fn reconcile_resumed_failure_handoff(
     resume: &PipelineState,
     pipeline: &HashMap<String, Value>,
 ) -> Result<Option<ResumePreparationRefresh>, DispatchError> {
-    let preparation_refresh = resumed_preparation_refresh(job, resume)?;
+    let mut preparation_refresh = resumed_preparation_refresh(job, resume)?;
     let Some(commit_index) = job
         .steps
         .iter()
@@ -190,9 +190,10 @@ pub(crate) fn reconcile_resumed_failure_handoff(
             "failure handoff evidence belongs to task '{evidence_task_id}', which is not targeted by the resumed run"
         ))));
     }
-    if preparation_refresh.is_some() {
+    if let Some(refresh) = preparation_refresh.as_mut() {
         validate_preparation_refresh_identity(host, pipeline, evidence, &head_sha)
             .map_err(resume_preservation_error)?;
+        refresh.expected_head_sha = head_sha.clone();
     }
     if let Some(refresh) = preparation_refresh.as_ref()
         && refresh.attempt > refresh.max_attempts
@@ -340,10 +341,26 @@ fn validate_preparation_refresh_identity<H: RuntimeHost + ?Sized>(
     let prepared_head_sha = required_input_string(prepared, "head_sha")?;
     let evidence_head = required_input_string(evidence, "branch")?;
     let evidence_head_sha = required_input_string(evidence, "head_sha")?;
-    if prepared_head != evidence_head
-        || prepared_head_sha != evidence_head_sha
-        || evidence_head_sha != head_sha
-    {
+    let worktree = pipeline
+        .get("worktree")
+        .ok_or_else(|| OrbitError::Execution("resume lost worktree checkpoint".to_string()))?;
+    let workspace = canonicalize_existing_dir(
+        required_input_string(worktree, "workspace_path")?,
+        "workspace_path",
+    )?;
+    let recovered = recovered_head_checkpoint(
+        host,
+        required_input_string(evidence, "handoff_run_id")?,
+        &workspace,
+        head_sha,
+    )?;
+    let prepared_origin_matches = prepared_head_sha == evidence_head_sha
+        || recovered.as_ref().is_some_and(|checkpoint| {
+            checkpoint["head_sha_before"] == prepared_head_sha
+                && checkpoint["base_sha"] == prepared["base_sha"]
+                && checkpoint["head"] == prepared_head
+        });
+    if prepared_head != evidence_head || !prepared_origin_matches || evidence_head_sha != head_sha {
         return Err(OrbitError::Execution(format!(
             "resume refresh candidate changed across preparation, failure handoff, and current checkout: prepared {prepared_head}@{prepared_head_sha}, handoff {evidence_head}@{evidence_head_sha}, current HEAD {head_sha}"
         )));
@@ -462,11 +479,19 @@ fn validate_failure_handoff_evidence<'a, H: RuntimeHost + ?Sized>(
         .get("preservation_commit_created")
         .and_then(Value::as_bool)
         == Some(true);
+    let recovered = recovered_head_checkpoint(host, handoff_run_id, workspace_path, head_sha)?;
+    let recovered_head_owned = recovered.as_ref().is_some_and(|recovery| {
+        recovery["task_ids"]
+            .as_array()
+            .is_some_and(|ids| ids.iter().any(|id| id == task_id))
+            && recovery["head"] == evidence["branch"]
+            && recovery["original_base_sha"] == base_sha
+    });
     let workflow_commit_owned = !preservation_commit_created
         && source_state_step_owns_head(host, handoff_run_id, task_id, evidence_head)?;
-    if !preservation_commit_created && !workflow_commit_owned {
+    if !preservation_commit_created && !workflow_commit_owned && !recovered_head_owned {
         return Err(OrbitError::Execution(
-            "failure handoff HEAD is neither its preservation commit nor a successful workflow commit"
+            "failure handoff HEAD has no preservation commit, successful workflow commit, or exact host-validated rebase recovery"
                 .to_string(),
         ));
     }
@@ -491,14 +516,16 @@ fn validate_failure_handoff_evidence<'a, H: RuntimeHost + ?Sized>(
             "failure handoff evidence does not match the immutable state of run '{handoff_run_id}'"
         )));
     }
-    ensure_preservation_parent_owned(
-        host,
-        workspace_path,
-        handoff_run_id,
-        base_sha,
-        head_sha,
-        &source_state,
-    )?;
+    if !recovered_head_owned {
+        ensure_preservation_parent_owned(
+            host,
+            workspace_path,
+            handoff_run_id,
+            base_sha,
+            head_sha,
+            &source_state,
+        )?;
+    }
 
     let task = host.get_task(task_id)?;
     if task.job_run_id.as_deref() != Some(checkpoint_owner) {

--- a/crates/orbit-types/src/workflow/run_state.rs
+++ b/crates/orbit-types/src/workflow/run_state.rs
@@ -131,6 +131,11 @@ pub struct PipelineState {
     /// candidate the failure activity preserved.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_activity_checkpoint: Option<FailureActivityCheckpoint>,
+    /// Host-validated rebase completions keyed by failed step ID. These are
+    /// provenance, not successful step outputs; retries must still run the step.
+    /// Absent in older runs, whose rewritten heads remain unverified.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub rebase_recovery_checkpoints: BTreeMap<String, Value>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -154,6 +159,7 @@ impl PipelineState {
             drain_worker_limit: None,
             drain_admissions_stop: None,
             failure_activity_checkpoint: None,
+            rebase_recovery_checkpoints: BTreeMap::new(),
             updated_at: Utc::now(),
         }
     }

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -233,12 +233,38 @@ candidate/PR evidence. The boundary finally requires the target as an ancestor
 and a remaining candidate commit. Ordinary providers still cannot move HEAD;
 primary-checkout drift checks apply to recovery too.
 
+The stopped index also contains the candidate's nonconflicting changes. Host
+continuation commits those staged paths normally; their disappearance from the
+dirty-path map is not unrelated editing. After continuation, tracked state must
+be clean and pre-existing untracked contents must be unchanged. Only after all
+boundary checks succeed does the host transactionally persist the exact recovered
+HEAD, original HEAD/base, pinned target, branch, task IDs, workspace, run/step and
+pre-rewrite remote lease in `PipelineState.rebase_recovery_checkpoints`. This is
+recovery provenance, not a successful workflow step. Missing run storage or a
+checkpoint write failure prevents recovery success.
+
+The same failed step still executes once after recovery. Reusing a rewritten
+HEAD requires an exact host checkpoint; a fresh-looking manual replacement is
+insufficient. Once recovery succeeds, a subsequent step error describes the new
+failure rather than reviving resolved conflicts. Failure handoff derives conflict
+paths from the live stopped rebase, retains the immutable worktree base in its
+preservation evidence, and does not infer unresolved paths from an old error after
+Git has completed. A resumed run authenticates copied recovery evidence against
+the source run and retry lineage before refreshing preparation for that exact
+preserved candidate. Recovery checkpoints survive ordinary step checkpoints and
+process restart, including interruption before the recovered step completes.
+If execution stops after Git changes HEAD but before the host persists verified
+completion, there is no authenticated completed-head record: resume fails closed
+and requires inspection. It never reconstructs success from the agent's result.
+
 `step.recovery_attempted` retains a bounded, redacted `error_message` and
 `failure_phase` when authorization, input preparation, crew resolution, dispatch,
 or the recovery activity fails. These optional fields are absent from older
-events and successful attempts. They supplement the original step conflict,
-which remains the returned error and terminal handoff evidence. An admitted
-attempt settles its recovery budget even when preparation fails before launch.
+events and successful attempts. Failed attempts supplement the original step
+conflict. Successful recovery supersedes that conflict; any failure of the
+post-recovery step becomes the returned error and terminal handoff evidence. An
+admitted attempt settles its recovery budget even when preparation fails before
+launch.
 
 After [ORB-10382], a recovery activity's structured result is **advisory only**, and its `output_schema_json` declares no `required` fields to keep it that way. A `recovery_activity` is a step attribute rather than a step, so it has no step id and no `{{ steps.<id>.output.* }}` template can consume it; `attempt_recovery_activity` gates the executor's single post-recovery attempt on dispatch success, never on a returned `recovered` field. `pr_conflict_recovery` no longer advertises such a field at all. Its host-side continuation is authorized by the executor-selected activity and authenticated checkpoints, not response JSON. Final success is established when the deterministic `git_rebase` retry verifies a clean index, no stopped rebase, pinned target-base ancestry, and the expected branch rewrite; later push/open/promote/complete checkpoints remain the normal authorities.
 


### PR DESCRIPTION
## Task

[ORB-11547](https://orbit-cli.com/tasks/ORB-11547) — Preserve successful rebase recovery provenance through settlement and resume

### Description

Observed during ORB-11530 delivery, not a hypothetical: task_pr_pipeline jrun-20260907-2004-3 sync_base hit operations.js conflict rebasing from96e6a50dd to3395ce248. Its recovery agent exited0 with status success and resolved_paths, passing focused dashboard tests, ci-fast, ci-lint, syntax and diff-check (orbit run logs --step sync_base). Host completed rebase: clean branch headb418c86f8 parent3395ce248; failure_handoff itself reported that head, original_base=target_base3395ce248 and pushed it as PR1515. Nevertheless run failed with original recoverable_vcs_conflict. Supported resume jrun-20260907-2041 then failed resume_preservation_unverified: failure handoff HEAD is neither its preservation commit nor a successful workflow commit. Independent audit and exact-head authorized manual merge89efc7b0 completed the task; both failed runs remain recorded. Trace the actual introducing code/commit before attributing origin. Repair recovery settlement and durable rewrite/preservation provenance so genuinely successful recovered rebases can continue/resume. Preserve validation against unrelated/manual/unattributed HEAD substitutions, stale leases and denied/incomplete recovery. Distinct from ORB-11538 (failure handoff lacks rewrite lease before push) and ORB-11532 (default enablement): this case already successfully recovered and pushed. Use exact run/log/checkpoint evidence; no unconditional integrity bypass or fabricated step success.

### Acceptance Criteria

- Regression reproduces conflict->successful recovery->host rebase continuation and confirms the original conflict is not propagated after validated recovery succeeds.
- Recovered/rebased candidate and its origin/target/rewrite provenance are durably recorded so a genuine subsequent resume recognizes the exact preserved head, including crash/restart boundaries.
- Unrelated or unverified head replacement, failed/denied/incomplete recovery and stale remote preconditions still fail closed.
- Task/PR failure diagnostics reflect actual unresolved state; no blocked conflict handoff claims unresolved paths after verified completion.
- Focused tests covering the observed run shape and required checks pass; introducing source/task attribution is verified.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Fixed host rebase settlement: nonconflicting candidate paths staged by the stopped rebase are allowed to become committed/clean. Provider edits still must be confined to the authenticated conflict set; completed tracked state must be clean, untracked contents preserved, and normal worktree boundaries valid.
- Added host-written rebase recovery checkpoints to the existing PipelineState, persisted transactionally before recovery reports success. They retain exact recovered/original HEAD, original base, pinned target/ref, branch, task IDs, workspace, run/step and pre-rewrite remote lease without fabricating a successful workflow step. Missing storage, stopped runs and persistence failures fail closed.
- Rebase retries authenticate exact host provenance; resumed copies must match the source run and its retry lineage. Preserved-candidate refresh accepts the verified original-to-recovered transition while retaining immutable worktree ownership/base checks. Completion retry forwards the active run identity.
- Successful VCS recovery no longer hides a subsequent failure behind the original conflict. Failure handoff derives unresolved paths from live stopped-rebase state and preserves the immutable worktree base for resume authentication. Current activity-job documentation describes the contract and crash limit.

Criteria and evidence:
1. Reproduced the observed multi-file stopped rebase by adding a nonconflicting candidate.txt to the CLI boundary fixture. Before the implementation fix, cargo test -p orbit-engine --lib conflict_recovery_host_completes_only_its_checkpointed_rebase -- --nocapture FAILED with the original 'host continuation changed unrelated paths: ["candidate.txt"]'. It passes after the fix; the job recovery regression also verifies new post-recovery failures replace resolved conflicts.
2. Real Git recovery records exact provenance. Restart tests cover both a persisted recovery followed by failure handoff and interruption before any failure handoff or sync_base success; both resume through delivery. A real OrbitRuntime/store reopen test verifies that recovery evidence survives while step outputs/states remain unchanged. Copied source-checkpoint tampering is rejected.
3. Focused/full engine tests cover incomplete/out-of-scope repairs, mismatched checkpoint, revoked ownership/authorization, checkpoint storage failure, additional conflicts, manual continuation without host evidence, unrelated HEAD replacement, stale preparation, lease checks and changed lineage/ownership. Existing conservative remote push rules remain intact.
4. Recovered failure handoff reports blocked_failure_pr with an empty conflicting_paths list, retains the original immutable worktree base, and resumes the preserved PR. Original conflict text does not resurrect resolved paths.
5. Introducing source verified by git log/show/blame: 93d5adcaffcfdec2822c1f0efc99b895afb197c3, ORB-11499 (#1498). source_task_id is explicitly recorded as ORB-11499. Exact evidence: orbit run show/events jrun-20260907-2004-3 --json, event v2evt-jrun-20260907-2004-3-00000023; orbit run logs jrun-20260907-2004-3 --step sync_base --json, stdout blob 0ff3a69c41d47ad9074658e56f159430e06945a89cc9b7ea28fbafba5284aa96. Provider exit 0/success preceded host settlement rejection; Git head b418c86f8cb22a7cd5a15de39cef938a2ba34662 has parent 3395ce248f3b753bd42aea5e1f2e24380b5e245c. orbit run show jrun-20260907-2041 --json confirms the subsequent resume_preservation_unverified refusal. Historical runs were not altered.

Validation:
- PASSED: cargo test -p orbit-engine --lib -- --test-threads=1 (599 passed, 2 pre-existing ignored tests).
- PASSED: cargo test -p orbit-core --lib recovered_rebase_checkpoint_survives_restart_without_completing_the_step -- --nocapture (1 passed, including reopening persisted runtime state).
- PASSED: cargo test -p orbit-types --lib workflow::tests::run_state (15 passed).
- PASSED on final changes: make ci-fast; make ci-lint (workspace/all-target Clippy with warnings denied); cargo fmt --all; git diff --check; final git status --short/diff review.
- Earlier parallel engine run FAILED: an unchanged tracing lifecycle assertion and a completion fixture that needed the newly required host provenance. The fixture was updated, and the final complete serial suite passed, including the tracing assertion; no assertion was weakened.
- NOT RUN: make ci (reserved for the PR merge gate by workspace policy). Two existing bwrap tests remain ignored because nested user namespaces are unavailable in the runner. ci-fast's existing Cursor smoke check validated the local manifest/install contract, not unavailable headless Cursor execution. Git/filesystem behavior was exercised on Linux; no live GitHub merge or native macOS validation was performed.

Assessment: The authorized deliverable is complete, with explicit provenance and conservative failure behavior. Scope selectors were expanded before edits for existing run-state persistence and its host adapter, direct freshness/failure/completion consumers, their test hosts/regressions, and current documentation. No new crate dependency or separate persistence store was added. All 21 changed files are task-scoped; starting/final HEAD is e7f1a08615c2d744649733613f160c1b6c43e720 and the initial checkout was clean. Changes remain uncommitted for pipeline delivery.
Risks/limits: A crash after Git rewrites HEAD but before verified completion is durably checkpointed remains unverified and fails closed; legacy runs lacking that proof are not retroactively blessed. Diverged pre-existing remote failure-handoff publication remains subject to its existing rewrite-lease requirement (separate ORB-11538); the observed missing-remote recovery/preservation shape is covered here.
Friction checkpoint: recorded F2026-09-058 with exact incident/root-cause evidence and linked it through resolves. No additional work was dispatched.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11547-6a9f27b0`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra