### PR TITLE
[friction-curation] Preserve run attribution on dashboard process error rows

### DIFF
--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -66,10 +66,22 @@ function getDiagMetricsColumns(ctx) {
   ];
 }
 
+function errorRunLabel(row) {
+  if (row.job_run) return row.job_run;
+  if (row.affiliation === "unaffiliated") return "unaffiliated";
+  return "-";
+}
+
 function getDiagErrorsColumns(ctx) {
   return [
     { key: "ts", label: "time", num: false, render: (v) => fmtRelativeValue(ctx, v) },
     { key: "source", label: "source", num: false },
+    {
+      key: "job_run",
+      label: "run",
+      num: false,
+      render: (_v, row) => errorRunLabel(row),
+    },
     { key: "provider", label: "provider", num: false, render: (v) => v || "-" },
     { key: "step", label: "step", num: false, render: (v) => v || "-" },
     {
@@ -130,8 +142,11 @@ function renderDiagnosticsTable(rows, columns, ctx) {
       td.textContent = text;
       tr.appendChild(td);
     }
-    tr.dataset.key = `diag-${row.ts || ''}-${row.step || i}-${row.command || row.actor_identity || ''}`;
+    tr.dataset.key = `diag-${row.ts || ''}-${row.job_run || row.affiliation || ''}-${row.step || i}-${row.command || row.actor_identity || ''}`;
     tr.dataset.hash = JSON.stringify(row);
+    if (row.affiliation === "unaffiliated") {
+      tr.classList.add("unaffiliated");
+    }
     if (row.job_run) {
       tr.classList.add("clickable");
       tr.title = "Open owning run";

--- a/crates/orbit-web/src/api/diagnostics.rs
+++ b/crates/orbit-web/src/api/diagnostics.rs
@@ -16,7 +16,10 @@ use super::{
     DiagnosticsQuery, HISTORY_DEFAULT_LIMIT, bounded_limit, current_year_month_utc,
     map_runtime_error, month_bounds_utc, server_error, validate_year_month,
 };
-use crate::log_format::{Filters as LogFilters, read_recent_rendered_events, resolve_log_path};
+use crate::log_format::{
+    Filters as LogFilters, format_message_html, format_source, read_recent_matching_events,
+    resolve_log_path,
+};
 
 pub(super) async fn list_diagnostics_metrics(
     Ws(runtime): Ws,
@@ -344,26 +347,52 @@ pub(super) fn global_error_rows_from_path(
     limit: usize,
 ) -> Result<Vec<Value>, orbit_core::OrbitError> {
     let filters = LogFilters::from_query_parts(None, Some("error".to_string()), None)?;
-    let events = read_recent_rendered_events(path, &filters, limit)
+    // Read the raw JSONL events so run/task/step/provider survive; the
+    // rendered log-tail shape drops those fields.
+    let events = read_recent_matching_events(path, &filters, limit)
         .map_err(|e| orbit_core::OrbitError::Io(format!("read log {}: {e}", path.display())))?;
     Ok(events
         .into_iter()
-        .map(|event| {
-            json!({
-                "ts": event.ts,
-                "source": "process",
-                "message": strip_htmlish(&event.message_html),
-                "event_id": null,
-                "job_run": null,
-                "step": null,
-                "step_index": null,
-                "task_id": null,
-                "provider": null,
-                "blob_ref": null,
-                "target": event.source,
-            })
-        })
+        .map(|event| process_error_row(&event))
         .collect())
+}
+
+fn process_error_row(event: &Value) -> Value {
+    let ts = event.get("timestamp").and_then(Value::as_str).unwrap_or("");
+    let target = event.get("target").and_then(Value::as_str).unwrap_or("-");
+    let empty_fields = Value::Object(Default::default());
+    let fields = event.get("fields").unwrap_or(&empty_fields);
+    let job_run = optional_log_field(fields, &["job_run_id", "run_id"]);
+    let affiliation = if job_run.is_some() {
+        "run"
+    } else {
+        "unaffiliated"
+    };
+
+    json!({
+        "ts": ts,
+        "source": "process",
+        "message": strip_htmlish(&format_message_html(target, fields)),
+        "event_id": null,
+        "job_run": job_run,
+        "step": optional_log_field(fields, &["step_id", "step", "activity_id"]),
+        "step_index": null,
+        "task_id": optional_log_field(fields, &["task_id"]),
+        "provider": optional_log_field(fields, &["provider"]),
+        "blob_ref": null,
+        "target": format_source(target, fields),
+        "affiliation": affiliation,
+    })
+}
+
+fn optional_log_field<'a>(fields: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| {
+        fields
+            .get(*key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    })
 }
 
 fn agent_stderr_error_rows(

--- a/crates/orbit-web/src/api/tests/diagnostics.rs
+++ b/crates/orbit-web/src/api/tests/diagnostics.rs
@@ -223,10 +223,12 @@ async fn diagnostics_errors_include_codex_style_stderr_rows() {
         .filter(|row| row["source"] == "agent-stderr" && row["job_run"] == run_id)
         .collect::<Vec<_>>();
     assert_eq!(agent_rows.len(), 2);
+    assert_eq!(agent_rows[0]["job_run"], run_id);
     assert_eq!(agent_rows[0]["step"], "implement");
     assert_eq!(agent_rows[0]["step_index"], 0);
     assert_eq!(agent_rows[0]["provider"], "codex");
     assert_eq!(agent_rows[0]["blob_ref"], stderr_ref);
+    assert!(agent_rows[0]["affiliation"].is_null());
     assert!(rows.iter().any(|row| {
         row["message"]
             .as_str()
@@ -298,11 +300,96 @@ fn global_error_rows_include_process_log_errors() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["ts"], "2026-05-08T04:01:00Z");
     assert_eq!(rows[0]["source"], "process");
+    assert_eq!(rows[0]["job_run"], serde_json::Value::Null);
+    assert_eq!(rows[0]["step"], serde_json::Value::Null);
+    assert_eq!(rows[0]["task_id"], serde_json::Value::Null);
+    assert_eq!(rows[0]["provider"], serde_json::Value::Null);
+    assert_eq!(rows[0]["affiliation"], "unaffiliated");
     assert!(
         rows[0]["message"]
             .as_str()
             .is_some_and(|message| message.contains("process failed"))
     );
+}
+
+#[test]
+fn global_error_rows_copy_run_attribution_from_process_log() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.log.jsonl");
+    write_lines(
+        &path,
+        &[
+            json!({
+                "timestamp": "2026-05-08T04:02:00Z",
+                "level": "ERROR",
+                "target": "orbit.job.step_finished",
+                "fields": {
+                    "message": "step finished",
+                    "job_run_id": "jrun-20260906-0306-2",
+                    "task_id": "ORB-11398",
+                    "step_id": "require_apply_success",
+                    "provider": "codex",
+                    "outcome": "failed",
+                    "success": false
+                }
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-05-08T04:03:00Z",
+                "level": "ERROR",
+                "target": "orbit.core.job_run",
+                "fields": {
+                    "message": "failed to observe pipeline worker startup",
+                    "run_id": "jrun-20260906-0204-9",
+                    "task_id": "ORB-11331",
+                    "step": "starvation_check"
+                }
+            })
+            .to_string(),
+        ],
+    );
+
+    let rows = global_error_rows_from_path(&path, 10).expect("rows");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["source"], "process");
+    assert_eq!(rows[0]["job_run"], "jrun-20260906-0306-2");
+    assert_eq!(rows[0]["task_id"], "ORB-11398");
+    assert_eq!(rows[0]["step"], "require_apply_success");
+    assert_eq!(rows[0]["provider"], "codex");
+    assert_eq!(rows[0]["affiliation"], "run");
+    assert_eq!(rows[1]["source"], "process");
+    assert_eq!(rows[1]["job_run"], "jrun-20260906-0204-9");
+    assert_eq!(rows[1]["task_id"], "ORB-11331");
+    assert_eq!(rows[1]["step"], "starvation_check");
+    assert_eq!(rows[1]["provider"], serde_json::Value::Null);
+    assert_eq!(rows[1]["affiliation"], "run");
+}
+
+#[test]
+fn global_error_rows_prefer_job_run_id_over_run_id() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.log.jsonl");
+    write_lines(
+        &path,
+        &[json!({
+            "timestamp": "2026-05-08T04:04:00Z",
+            "level": "ERROR",
+            "target": "orbit.test",
+            "fields": {
+                "message": "both run keys present",
+                "job_run_id": "jrun-canonical",
+                "run_id": "jrun-alias"
+            }
+        })
+        .to_string()],
+    );
+
+    let rows = global_error_rows_from_path(&path, 10).expect("rows");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["job_run"], "jrun-canonical");
+    assert_eq!(rows[0]["affiliation"], "run");
 }
 
 #[test]

--- a/crates/orbit-web/src/log_format.rs
+++ b/crates/orbit-web/src/log_format.rs
@@ -142,11 +142,11 @@ pub(crate) fn resolve_log_path(override_path: Option<&Path>) -> Result<PathBuf, 
     })
 }
 
-pub(crate) fn read_recent_rendered_events(
+pub(crate) fn read_recent_matching_events(
     path: &Path,
     filters: &Filters,
     limit: usize,
-) -> io::Result<Vec<RenderedLogEvent>> {
+) -> io::Result<Vec<Value>> {
     let file = match File::open(path) {
         Ok(file) => file,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -157,13 +157,24 @@ pub(crate) fn read_recent_rendered_events(
     for line in reader.lines() {
         let line = line?;
         if let Some(event) = parse_matching_event(&line, filters) {
-            kept.push(render_log_event_for_web(&event));
+            kept.push(event);
             if kept.len() > limit {
                 kept.remove(0);
             }
         }
     }
     Ok(kept)
+}
+
+pub(crate) fn read_recent_rendered_events(
+    path: &Path,
+    filters: &Filters,
+    limit: usize,
+) -> io::Result<Vec<RenderedLogEvent>> {
+    Ok(read_recent_matching_events(path, filters, limit)?
+        .into_iter()
+        .map(|event| render_log_event_for_web(&event))
+        .collect())
 }
 
 pub(crate) fn parse_matching_event(raw: &str, filters: &Filters) -> Option<Value> {


### PR DESCRIPTION
## Task

[ORB-11569](https://orbit-cli.com/tasks/ORB-11569) — [friction-curation] Preserve run attribution on dashboard process error rows

### Description

## Problem
The dashboard recent-errors feed time-sorts agent-stderr rows (which carry `job_run` / `task_id` / `step` / `provider` from v2 audit events) with process rows from `global_error_rows_from_path`. The process mapper still emits those attribution fields as null:

```
crates/orbit-web/src/api/diagnostics.rs:342-375
"job_run": null, "step": null, "task_id": null, "provider": null
```

Re-read this pass (ORB-11554): that null object is unchanged. Adjacent rows from different jobs therefore look like one failing sequence. On 2026-09-06 the feed mixed a successful ORB-11386 / `jrun-20260906-0303-6` Codex implement_one with an unrelated `starvation_check` from ORB-11331 and `require_apply_success` from `jrun-20260906-0306-2`.

## Why It Matters
Incident triage has to reconstruct run identity from timestamps. Recoverable provider retries look like failed workflow guards.

## Suggested direction
When the structured process log includes run/task/step fields, copy them onto the process row the same way `agent_stderr_error_rows` does. When attribution is genuinely absent, visually separate global process errors from run-scoped agent stderr rather than merging them into one apparently causal timeline. Add a regression that a process log line with a run id is not rendered with `job_run: null`.

No fail-closed guard is widened.

### Acceptance Criteria

- Process error rows whose source log line includes a run id populate `job_run` (and task/step/provider when present) instead of null.
- A regression covers a fixture process line with a run id and asserts the feed row is attributed.
- When a process line has no run id, the feed does not imply it belongs to an adjacent agent-stderr run (separate grouping or an explicit unaffiliated marker).
- Existing agent-stderr attribution from v2 audit events is unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Process error rows now copy `job_run` / `task_id` / `step` / `provider` from structured JSONL fields (`job_run_id` then `run_id`; `task_id`; `step_id`/`step`/`activity_id`; `provider`) instead of emitting nulls.
- Process rows with no run id set `affiliation: "unaffiliated"` and `job_run: null`. The errors table shows that label in a new run column rather than `-`, so they cannot be read as part of an adjacent agent-stderr run.
- `agent_stderr_error_rows` is unchanged; the Codex stderr regression still asserts run/step/provider and now also that `affiliation` is absent.
- `read_recent_matching_events` keeps raw log fields; log-tail rendering still maps through `read_recent_rendered_events`.

Context files added during execution (needed for the criteria):
- `file:crates/orbit-web/src/log_format.rs` — raw-event reader so attribution is not dropped.
- `file:crates/orbit-web/assets/dashboard/diagnostics.js` — run column and unaffiliated label.

Assessment: Attribution is copied at the process-row mapper, which is the boundary that previously hardcoded nulls. Unaffiliated process rows are marked in the API and labeled in the dashboard table. Agent-stderr mapping was not touched.

Criteria:
- Process rows with a run id populate `job_run` (and task/step/provider when present): met (`global_error_rows_copy_run_attribution_from_process_log`).
- Regression for a fixture process line with a run id: met (same test, plus `job_run_id` over `run_id` precedence).
- Process line with no run id does not imply an adjacent agent-stderr run: met (`affiliation: "unaffiliated"` on the row; dashboard run cell renders `unaffiliated`, not `-`).
- Existing agent-stderr attribution unchanged: met (`diagnostics_errors_include_codex_style_stderr_rows` still asserts run/step/provider/blob; `affiliation` remains null).

Validation:
- `cargo test -p orbit-web --lib diagnostics`: passed (13 tests, including the new process-attribution cases and existing agent-stderr cases).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- Browser walkthrough of the errors table: not run (no browser tools in this executor). UI contract is the run column + `unaffiliated` label in `diagnostics.js`; live dashboard rendering was not exercised.

Remaining risks:
- Process log lines that mention a run only in free-text `message` (no structured `job_run_id`/`run_id` field) stay unaffiliated by design.
- The combined feed is still time-sorted; identity is now visible rather than grouped into separate lists.
- No fail-closed guard was widened.

Friction checkpoint: none filed. This implements F2026-09-040; no new contradicted assumption or >10m gotcha.

Uncommitted. Pipeline owns commit, PR, and review transition.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11569-6a9f2a5e`
- Behind base: 0
- Ahead of base: 1