### PR TITLE
Fix global task jump reporting an existing task as not found

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -1,7 +1,7 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder, getWindow, persistScopeToUrl, setScopeChangeListener, syncWindowSelectors, payloadHonorsWindow } from './common.js';
+import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder, getWindow, persistScopeToUrl, setScopeChangeListener, syncWindowSelectors, payloadHonorsWindow, withWorkspace } from './common.js';
 import { buildChips, buildTasksHash, applyTasksHashQuery, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, syncTaskControls, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
@@ -750,81 +750,222 @@ function wireFrictionResponsiveDetail() {
   });
 }
 
-/* Global task ID resolver (ORB-00211).
+/* Global task ID resolver (ORB-00211 / ORB-11560).
+   GET /api/tasks/:id is workspace-scoped. A raw fetch without ?workspace=
+   hits the server default (often not the selected workspace) and reports an
+   existing task as not found — the Diagnostics jump failure on ws_orbit.
    - Only fires on exact ^ORB-\d{5}$ (case-insens) after trim/upper.
-   - 250ms debounce to avoid hammering dashboard_status_index full scan.
-   - On success: switch tab, clear per-tab search, freshen lastTasks, openVisible (active status)
-     or setPinnedExternalTask + render (for done/rejected/archived bypassing filter).
-   - Error: inline .error + span msg with ID, cleared on any next input.
-   - Works from any tab because header input + sAT('tasks').
+   - 250ms debounce; Enter looks up immediately.
+   - Lookup uses the selected workspace first; a confirmed miss then probes
+     other active workspaces and adopts the owner.
+   - Stale replies after a workspace change or a newer lookup are ignored.
+   - Not-found is reserved for a confirmed miss; loading / 403 / 5xx / network
+     have distinct copy.
 */
 function wireGlobalTaskResolver() {
   const input = $("global-task-id");
   if (!input) return;
   let debounce = null;
+  let lookupSeq = 0;
   const ID_RE = /^ORB-\d{5}$/i;
 
-  function clearError() {
+  function lookupWrap() {
+    return input.parentNode;
+  }
+
+  function clearLookupStatus() {
     input.classList.remove("error");
-    const wrap = input.parentNode;
-    if (wrap && wrap.classList) wrap.classList.remove("error");
+    const wrap = lookupWrap();
+    if (wrap && wrap.classList) {
+      wrap.classList.remove("error");
+      wrap.classList.remove("pending");
+    }
     const err = $("global-task-id-error");
     if (err) err.textContent = "";
   }
 
-  input.addEventListener("input", () => {
-    clearError();
-    if (debounce) clearTimeout(debounce);
-    const raw = (input.value || "").trim();
-    if (!raw) return;
-    const candidate = raw.toUpperCase();
-    if (!ID_RE.test(candidate)) {
-      // partial input: explicitly do not fetch (per AC and CPU guard)
-      return;
+  function showLookupStatus(kind, msg) {
+    const wrap = lookupWrap();
+    input.classList.toggle("error", kind === "error");
+    if (wrap && wrap.classList) {
+      wrap.classList.toggle("error", kind === "error");
+      wrap.classList.toggle("pending", kind === "pending");
     }
-    // full match: debounce then fetch exactly once
-    debounce = setTimeout(() => {
-      const id = candidate;
-      fetch(`/api/tasks/${encodeURIComponent(id)}`, { headers: { accept: "application/json" } })
-        .then(async (res) => {
-          if (res.ok) {
-            const task = await res.json();
-            sAT("tasks");
-            searchQuery = "";
-            const ts = $("task-search");
-            if (ts) ts.value = "";
-            // freshen cache so open sees latest (incl sidecars)
-            const idx = lastTasks.findIndex((t) => t && t.id === task.id);
-            if (idx >= 0) lastTasks[idx] = task;
-            else lastTasks.push(task);
-            const ctx = taskContext();
-            if (activeStatuses.has(task.status)) {
-              openVisibleTask(task.id, ctx);
-            } else {
-              setPinnedExternalTask(task, ctx);
-              renderTasks(lastTasks, ctx);
-            }
-            // success: clear the jump input for next use
-            input.value = "";
-          } else if (res.status === 404) {
-            showGlobalIdError(id, `${id} not found`);
-          } else {
-            showGlobalIdError(id, `Error ${res.status} resolving ${id}`);
-          }
-        })
-        .catch(() => {
-          showGlobalIdError(id, `Network error resolving ${id}`);
-        });
-    }, 250);
-  });
-
-  function showGlobalIdError(id, msg) {
-    input.classList.add("error");
-    const wrap = input.parentNode;
-    if (wrap && wrap.classList) wrap.classList.add("error");
     const err = $("global-task-id-error");
     if (err) err.textContent = msg;
   }
+
+  function taskDetailPath(id, workspaceId) {
+    const base = `/api/tasks/${encodeURIComponent(id)}`;
+    if (workspaceId) {
+      return `${base}?workspace=${encodeURIComponent(workspaceId)}`;
+    }
+    return withWorkspace(base);
+  }
+
+  async function readJson(res) {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  function classifyLookupFailure(res, body, id) {
+    const status = res && res.status;
+    const errorText = body && body.error ? String(body.error) : "";
+    if (status === 401 || status === 403) {
+      return { kind: "denied", message: `Lookup denied for ${id}` };
+    }
+    if (status >= 500) {
+      return { kind: "server", message: `Server error resolving ${id}` };
+    }
+    if (status === 404 && /unknown workspace/i.test(errorText)) {
+      return { kind: "server", message: `Workspace error resolving ${id}` };
+    }
+    if (status === 404) {
+      return { kind: "missing", message: `${id} not found` };
+    }
+    if (status === 400) {
+      return { kind: "server", message: errorText || `Error ${status} resolving ${id}` };
+    }
+    return { kind: "server", message: `Error ${status} resolving ${id}` };
+  }
+
+  async function fetchTaskInWorkspace(id, workspaceId) {
+    const res = await fetch(taskDetailPath(id, workspaceId), {
+      headers: { accept: "application/json" },
+    });
+    const body = await readJson(res);
+    return { res, body, workspaceId };
+  }
+
+  function adoptWorkspace(workspaceId) {
+    if (!workspaceId || workspaceId === getWorkspace()) return;
+    setWorkspace(workspaceId);
+    persistScopeToUrl();
+    const selector = $("workspace-select");
+    if (selector) selector.value = workspaceId;
+  }
+
+  function openLookedUpTask(task, workspaceId) {
+    adoptWorkspace(workspaceId);
+    sAT("tasks", { refresh: false });
+    searchQuery = "";
+    const ts = $("task-search");
+    if (ts) ts.value = "";
+    const ctx = taskContext();
+    setPinnedExternalTask(task, ctx);
+    const listedAt = lastTasks.findIndex((t) => t && t.id === task.id);
+    if (listedAt >= 0) {
+      lastTasks[listedAt] = task;
+      openVisibleTask(task.id, ctx);
+    } else {
+      renderTasks(lastTasks, ctx);
+    }
+    input.value = "";
+    clearLookupStatus();
+  }
+
+  function otherActiveWorkspaces(exceptId) {
+    return dashboardWorkspaces.filter((ws) => (
+      ws
+      && ws.status === "active"
+      && ws.id
+      && ws.id !== exceptId
+    ));
+  }
+
+  async function lookupTask(id) {
+    const seq = ++lookupSeq;
+    const workspaceAtStart = getWorkspace();
+    const stillCurrent = () => seq === lookupSeq && getWorkspace() === workspaceAtStart;
+    const discardIfStale = () => {
+      if (stillCurrent()) return false;
+      if (seq === lookupSeq) clearLookupStatus();
+      return true;
+    };
+
+    showLookupStatus("pending", `Looking up ${id}\u2026`);
+    let primary;
+    try {
+      primary = await fetchTaskInWorkspace(id, workspaceAtStart);
+    } catch {
+      if (discardIfStale()) return;
+      showLookupStatus("error", `Network error resolving ${id}`);
+      return;
+    }
+    if (discardIfStale()) return;
+    if (primary.res.ok && primary.body && primary.body.id) {
+      openLookedUpTask(primary.body, primary.workspaceId || workspaceAtStart);
+      return;
+    }
+
+    const classified = classifyLookupFailure(primary.res, primary.body, id);
+    if (classified.kind !== "missing") {
+      showLookupStatus("error", classified.message);
+      return;
+    }
+
+    const others = otherActiveWorkspaces(workspaceAtStart);
+    if (others.length === 0) {
+      showLookupStatus("error", `${id} not found`);
+      return;
+    }
+
+    const probed = await Promise.all(others.map(async (ws) => {
+      try {
+        return await fetchTaskInWorkspace(id, ws.id);
+      } catch (error) {
+        return { network: true, workspaceId: ws.id, error };
+      }
+    }));
+    if (discardIfStale()) return;
+
+    const hit = probed.find((result) => result && result.res && result.res.ok && result.body && result.body.id);
+    if (hit) {
+      openLookedUpTask(hit.body, hit.workspaceId);
+      return;
+    }
+    if (probed.some((result) => result && result.network)) {
+      showLookupStatus("error", `Network error resolving ${id}`);
+      return;
+    }
+    const probeFailure = probed
+      .map((result) => result && result.res ? classifyLookupFailure(result.res, result.body, id) : null)
+      .find((result) => result && result.kind !== "missing");
+    if (probeFailure) {
+      showLookupStatus("error", probeFailure.message);
+      return;
+    }
+    showLookupStatus("error", `${id} not found`);
+  }
+
+  function scheduleLookup() {
+    if (debounce) clearTimeout(debounce);
+    const raw = (input.value || "").trim();
+    if (!raw) {
+      lookupSeq += 1;
+      clearLookupStatus();
+      return;
+    }
+    const candidate = raw.toUpperCase();
+    if (!ID_RE.test(candidate)) return;
+    debounce = setTimeout(() => lookupTask(candidate), 250);
+  }
+
+  input.addEventListener("input", () => {
+    clearLookupStatus();
+    scheduleLookup();
+  });
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter") return;
+    const candidate = (input.value || "").trim().toUpperCase();
+    if (!ID_RE.test(candidate)) return;
+    if (event.preventDefault) event.preventDefault();
+    if (debounce) clearTimeout(debounce);
+    lookupTask(candidate);
+  });
 }
 
 function fmtRelative(iso) {

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -418,6 +418,7 @@
       #global-task-id.error { border-color: #f66; }
       .global-id-error { position: absolute; top: 28px; left: 0; font-size: 10px; color: #f66; white-space: nowrap; background: var(--bg-elev); border: 1px solid var(--border); padding: 1px 4px; border-radius: 2px; z-index: 150; display: none; }
       .global-id-wrap.error .global-id-error { display: block; }
+      .global-id-wrap.pending .global-id-error { display: block; color: var(--fg-dim); }
       .pinned-task-wrap { margin-bottom: 6px; border: 1px solid var(--accent); border-radius: 2px; background: var(--bg-elev); }
       .pinned-task-wrap .row.pinned-external { background: var(--bg-elev); }
 

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -305,10 +305,11 @@ export function openVisibleTask(taskId, context) {
   });
 }
 
-/* Global ID resolver support (ORB-00211): allow rendering detail for a task whose status
-   is outside the active chip filter (done/rejected/archived) without adding it to the
-   bulk-loaded list or mutating DASHBOARD_TASK_STATUSES. The pinned detail appears in a
-   highlighted block at top of #tasks-body; auto-clears if user later enables matching chip. */
+/* Global ID resolver support (ORB-00211): allow rendering detail for a task that
+   is outside the filtered list (hidden status, search, or truncated fetch)
+   without mutating DASHBOARD_TASK_STATUSES. The pinned detail appears in a
+   highlighted block at top of #tasks-body; auto-clears once the filtered list
+   actually contains the task. */
 export function setPinnedExternalTask(task, context) {
   if (!task || !task.id) return;
   pinnedExternalTask = { task, id: task.id };
@@ -1245,14 +1246,12 @@ export function renderTasks(tasks, context) {
   // data so no extra plumbing is needed (single-workspace lists lack the field).
   const aggregate = Array.isArray(tasks) && tasks.some((t) => t && t.workspace_name);
 
-  // Auto-clear pinned external (global resolver) if its status+search now makes it
-  // visible in the normal filtered list (user enabled the chip or cleared search).
+  // Auto-clear a pinned jump only when the task is actually in the filtered
+  // list. Matching status/search chips is not enough: a truncated fetch can
+  // omit the jumped task even when its chip is on.
   if (pinnedExternalTask && pinnedExternalTask.task) {
     const p = pinnedExternalTask.task;
-    const q = (searchQueryValue(context) || "").toLowerCase();
-    const act = activeStatusSet(context);
-    const matchesQ = !q || (p.id && p.id.toLowerCase().includes(q)) || (p.title && p.title.toLowerCase().includes(q));
-    if (act.has(p.status) && matchesQ) {
+    if (filterTasks(tasks, context).some((task) => task.id === p.id)) {
       pinnedExternalTask = null;
     }
   }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2383,3 +2383,246 @@ if (!disabled.disabled) throw new Error("controls must be disabled for an unauth
 "#,
     );
 }
+
+/// ORB-11560: Jump to ORB-NNNNN must look up in the selected workspace, not the
+/// server default. The live failure was Diagnostics/Errors on ws_orbit with
+/// `window=24h&run_state=failed`: GET /api/tasks/ORB-11514 (no workspace) 404'd
+/// against polaris while the same id existed as blocked in ws_orbit.
+#[test]
+fn dashboard_global_task_jump_scopes_to_selected_workspace_and_distinguishes_errors() {
+    run_dashboard_javascript_test(
+        r##"
+class Node {
+  constructor(id = "") {
+    this.id = id;
+    this.children = [];
+    this.dataset = {};
+    this.style = { setProperty: () => {}, display: "" };
+    this.listeners = {};
+    this.className = "";
+    this._text = "";
+    this.parentNode = null;
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.offsetWidth = 40;
+    this.offsetLeft = 0;
+  }
+  appendChild(child) {
+    if (child == null) return child;
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+  insertBefore(child, before) {
+    const index = this.children.indexOf(before);
+    if (index < 0) return this.appendChild(child);
+    this.children.splice(index, 0, child);
+    child.parentNode = this;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((candidate) => candidate !== child);
+    child.parentNode = null;
+    return child;
+  }
+  prepend(child) { this.children.unshift(child); child.parentNode = this; return child; }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this._text = String(value); this.children = []; }
+  get innerHTML() { return this.textContent; }
+  get firstChild() { return this.children[0] || null; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+  querySelectorAll() { return []; }
+  querySelector() { return null; }
+  scrollIntoView() {}
+  get classList() {
+    const self = this;
+    const tokens = () => self.className.split(/\s+/).filter(Boolean);
+    const add = (...names) => { self.className = [...new Set([...tokens(), ...names])].join(" "); };
+    const remove = (...names) => {
+      const drop = new Set(names);
+      self.className = tokens().filter((token) => !drop.has(token)).join(" ");
+    };
+    return {
+      add,
+      remove,
+      contains: (name) => tokens().includes(name),
+      toggle: (name, on) => {
+        if (on === undefined) on = !tokens().includes(name);
+        if (on) add(name); else remove(name);
+      },
+    };
+  }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+const tabs = ["tasks", "audit", "diagnostics", "operations", "knowledge"].map((tab) => Object.assign(new Node(), { dataset: { tab } }));
+const panes = [...tabs, Object.assign(new Node(), { dataset: { tab: "run-detail" } })];
+const tabsStrip = new Node("tabs");
+tabsStrip.className = "tabs";
+const wrap = get("global-id-wrap");
+wrap.className = "global-id-wrap";
+wrap.appendChild(get("global-task-id"));
+wrap.appendChild(get("global-task-id-error"));
+globalThis.document = {
+  body: new Node("body"),
+  hidden: false,
+  getElementById: get,
+  createElement: () => new Node(),
+  createElementNS: () => new Node(),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+  querySelectorAll: (selector) => {
+    if (selector === ".tab") return tabs;
+    if (selector === ".tab-pane") return panes;
+    if (selector === "#task-filter .chip") return get("task-filter").children;
+    if (selector === "#tasks-body .row") return get("tasks-body").children.filter((node) => String(node.className).includes("row"));
+    return [];
+  },
+  querySelector: (selector) => {
+    if (selector === ".tabs") return tabsStrip;
+    const tabMatch = /^\.tab\[data-tab="([^"]+)"\]$/.exec(selector || "");
+    if (tabMatch) return tabs.find((tab) => tab.dataset.tab === tabMatch[1]) || null;
+    return new Node();
+  },
+  addEventListener: () => {},
+};
+const location = new URL("http://dashboard.test/?workspace=ws_orbit&window=24h&run_state=failed");
+location.hash = "#diagnostics/errors?window=24h";
+const hashListeners = [];
+globalThis.window = {
+  location,
+  innerHeight: 900,
+  addEventListener: (name, fn) => { if (name === "hashchange") hashListeners.push(fn); },
+  matchMedia: () => ({ addEventListener: () => {}, matches: false }),
+  localStorage: { getItem: () => null, setItem: () => {} },
+};
+Object.defineProperty(globalThis.window, "location", {
+  configurable: true,
+  get: () => location,
+  set: () => {},
+});
+Object.defineProperty(location, "hash", {
+  configurable: true,
+  get() { return this._hash || ""; },
+  set(value) {
+    const next = String(value || "");
+    const normalized = next.startsWith("#") ? next : `#${next}`;
+    if (this._hash === normalized) return;
+    this._hash = normalized;
+    for (const fn of hashListeners) fn();
+  },
+});
+location._hash = "#diagnostics/errors?window=24h";
+globalThis.history = { replaceState: (_, __, url) => { const next = new URL(String(url), location.href); location.search = next.search; location.pathname = next.pathname; } };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.requestAnimationFrame = (fn) => fn();
+globalThis.setInterval = () => 0;
+globalThis.EventSource = class { constructor() {} close() {} };
+
+const existing = { id: "ORB-11514", title: "Enforce proc.spawn filesystem policy against indirect child access", status: "blocked", history: [], artifacts: [], comments: [] };
+let lookupMode = "existing";
+let delayed = null;
+const requests = [];
+function json(payload, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => payload, text: async () => JSON.stringify(payload) };
+}
+globalThis.fetch = async (path) => {
+  const url = new URL(String(path), "http://dashboard.test");
+  requests.push(url.pathname + url.search);
+  if (url.pathname === "/api/workspaces") {
+    return json([
+      { id: "ws_polaris", name: "polaris", status: "active", is_default: true },
+      { id: "ws_orbit", name: "orbit", status: "active", is_default: false },
+    ]);
+  }
+  if (/^\/api\/tasks\/ORB-/.test(url.pathname)) {
+    const id = decodeURIComponent(url.pathname.slice("/api/tasks/".length));
+    const workspace = url.searchParams.get("workspace");
+    if (lookupMode === "network" && id === "ORB-00001") throw new Error("offline");
+    if (lookupMode === "denied" && id === "ORB-00002") return json({ error: "cross-origin requests not allowed" }, 403);
+    if (lookupMode === "server" && id === "ORB-00003") return json({ error: "boom" }, 500);
+    if (lookupMode === "stale" && id === "ORB-11514") {
+      await new Promise((resolve) => { delayed = resolve; });
+      return workspace === "ws_orbit" ? json(existing) : json({ error: `task not found: ${id}` }, 404);
+    }
+    if (id === "ORB-11514" && workspace === "ws_orbit") return json(existing);
+    return json({ error: `task not found: ${id}` }, 404);
+  }
+  if (url.pathname === "/api/tasks" || url.pathname === "/api/tasks/all") {
+    return json({ items: [], total: 0, limit: 50, truncated: false });
+  }
+  return json([]);
+};
+
+const originalSetTimeout = setTimeout;
+globalThis.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, ms === 250 ? 0 : ms, ...args);
+const tick = () => new Promise((resolve) => originalSetTimeout(resolve, 0));
+
+await import("./app.js");
+await tick(); await tick(); await tick();
+
+const { getWorkspace, setWorkspace } = await import("./common.js");
+if (getWorkspace() !== "ws_orbit") throw new Error(`selected workspace should remain ws_orbit, got ${getWorkspace()}`);
+
+const input = get("global-task-id");
+const err = get("global-task-id-error");
+function jump(id) {
+  input.value = id;
+  if (input.listeners.keydown) input.listeners.keydown({ key: "Enter", preventDefault() {} });
+  else input.listeners.input();
+}
+
+requests.length = 0;
+jump("ORB-11514");
+await tick(); await tick(); await tick(); await tick(); await tick();
+const taskGets = requests.filter((url) => url.startsWith("/api/tasks/ORB-11514"));
+if (!taskGets[0] || !taskGets[0].includes("workspace=ws_orbit")) {
+  throw new Error(`existing-task jump must query the selected workspace first; got ${JSON.stringify(taskGets)}`);
+}
+if (err.textContent.includes("not found")) throw new Error(`existing task reported missing: ${err.textContent}`);
+if (wrap.classList.contains("error")) throw new Error("successful jump must not leave the error state");
+if (input.value) throw new Error("successful jump should clear the input");
+if (!String(location.hash).includes("tasks")) throw new Error(`successful jump should open Tasks, hash=${location.hash}`);
+const opened = get("tasks-body").children.some((node) => String(node.textContent).includes("ORB-11514"));
+if (!opened) throw new Error("existing blocked task must render after jump");
+
+lookupMode = "missing";
+requests.length = 0;
+jump("ORB-99999");
+await tick(); await tick(); await tick();
+if (err.textContent !== "ORB-99999 not found") throw new Error(`missing task copy: ${err.textContent}`);
+if (!wrap.classList.contains("error") || wrap.classList.contains("pending")) throw new Error("confirmed miss must use the error state");
+
+lookupMode = "network";
+jump("ORB-00001");
+await tick(); await tick(); await tick();
+if (err.textContent !== "Network error resolving ORB-00001") throw new Error(`transport copy: ${err.textContent}`);
+if (err.textContent.includes("not found")) throw new Error("transport failure must not look like a miss");
+
+lookupMode = "denied";
+jump("ORB-00002");
+await tick(); await tick(); await tick();
+if (err.textContent !== "Lookup denied for ORB-00002") throw new Error(`denied copy: ${err.textContent}`);
+
+lookupMode = "server";
+jump("ORB-00003");
+await tick(); await tick(); await tick();
+if (err.textContent !== "Server error resolving ORB-00003") throw new Error(`server copy: ${err.textContent}`);
+
+lookupMode = "stale";
+const hashBeforeStale = String(location.hash);
+input.value = "ORB-11514";
+jump("ORB-11514");
+await tick();
+setWorkspace("ws_polaris");
+if (typeof delayed === "function") delayed();
+await tick(); await tick(); await tick();
+if (String(location.hash) !== hashBeforeStale) throw new Error(`stale lookup overwrote navigation: ${location.hash}`);
+if (!input.value) throw new Error("stale lookup must not clear the jump input as a success");
+"##,
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11560](https://orbit-cli.com/tasks/ORB-11560) — Fix global task jump reporting an existing task as not found

### Description

## Reproduction
On Diagnostics/Errors in ws_orbit, enter ORB-11514 into Jump to ORB-NNNNN and press Enter. The settled UI reported ORB-11514 not found. Returning to Tasks showed ORB-11514, titled [security-review] Enforce proc.spawn filesystem policy against indirect child access, in blocked status. The URL retained workspace=ws_orbit&window=24h&run_state=failed. A later task-list search eventually reduced to two matching tasks, so search latency must not be confused with permanent list filtering failure.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Trace global lookup routing, response/error handling and navigation against the actual served revision. Fix false not-found and distinguish transport/permission errors. Do not assume root cause is absent workspace routing until verified.

### Acceptance Criteria

- A known task resolves and opens from Tasks, Diagnostics and Operations regardless of current status/text/run filters; hidden done/archived tasks remain addressable where supported.
- Not-found appears only for a confirmed missing task; loading, server failure and denied lookup have distinct feedback.
- Workspace identity is preserved correctly for explicit lookups and cross-workspace results; stale responses cannot overwrite navigation after a workspace change.
- Behavioral regression coverage reproduces the observed existing-task failure with diagnostic query/hash state, plus missing task and transport error cases; validate in a browser.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Verified live routing at localhost:7878: default workspace is polaris; GET /api/tasks/ORB-11514 returns 404; the same id with ?workspace=ws_orbit returns blocked ORB-11514. The Jump control used a raw fetch without withWorkspace, so Diagnostics on ws_orbit reported an existing task as not found. run_state/window were not applied to that request.
- app.js wireGlobalTaskResolver now looks up in the selected workspace, shows Looking up / not found / Lookup denied / Server error / Network error distinctly, ignores stale replies after a workspace change, probes other active workspaces on a confirmed miss and adopts the owner, pins the result so list filters/truncation cannot hide it, and honors Enter as well as the 250ms debounce.
- tasks.js auto-clears a pinned jump only when the task is actually in the filtered list.
- dashboard.css pending (non-error) style for the jump status line.
- Node harness reproduces Diagnostics workspace=ws_orbit&window=24h&run_state=failed plus missing/transport/denied/server/stale cases.

Assessment: scoped frontend fix matching the verified cause. Header jump works from Tasks, Diagnostics, and Operations; done/archived stay on the pin path.

Criteria:
- Known task opens regardless of status/text/run filters: pass (selected-workspace lookup + pin; diagnostic query/hash is not sent on the task GET).
- Not-found only for a confirmed miss; loading/server/denied distinct: pass.
- Workspace identity for explicit lookups and cross-workspace results; stale replies cannot overwrite navigation: pass.
- Behavioral regression + browser: Node harness pass; no Chromium/playwright on this host so a live browser pass against the patched assets was not run. Curl against the still-deployed 7878 binary confirmed the unpatched 404 vs workspace-scoped 200.

Validation:
- cargo test -p orbit-web --lib dashboard_: passed (51 tests, including the new jump harness).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
- git diff --check: passed.
- make ci-lint: not run (full workspace clippy; pipeline merge gate).
- Browser against patched assets: not run (no browser binary; localhost:7878 still serves the unpatched include_str assets).

Remaining risks: the running dashboard will keep false-not-found until this revision is built and served. A confirmed miss probes every other active workspace (N GETs), only after the selected workspace 404s.

Deviations: none from the persisted plan. Did not add a server-side global get-by-id; client routing was sufficient.

Uncommitted files: crates/orbit-web/assets/dashboard/app.js, tasks.js, dashboard.css, src/tests/dashboard_assets.rs.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11560-6a9f2a1f`
- Behind base: 0
- Ahead of base: 1