### PR TITLE
[qa-sweep] auto-task list and dashboard show Debug coverage names that add rejects

### DIFF
--- a/crates/orbit-cli/src/command/auto_task/output.rs
+++ b/crates/orbit-cli/src/command/auto_task/output.rs
@@ -13,7 +13,7 @@ pub(crate) fn schedule_summary(definition: &AutoTaskDefinition) -> String {
         orbit_core::AutoTaskSchedule::Deliveries {
             deliveries_landed: t,
         } => format!(
-            "deliveries={} branch={} coverage={:?}",
+            "deliveries={} branch={} coverage={}",
             t.threshold, t.branch, t.coverage
         ),
         orbit_core::AutoTaskSchedule::Cron { cron } => format!("cron={cron}"),

--- a/crates/orbit-cli/src/command/tests/auto_task.rs
+++ b/crates/orbit-cli/src/command/tests/auto_task.rs
@@ -1,4 +1,9 @@
 use clap::Parser;
+use orbit_core::{
+    AutoTaskAddParams, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, OrbitRuntime,
+};
+use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::automation::{CoverageClass, DeliveryTrigger};
 
 use crate::command::auto_task::AutoTaskSubcommand;
 use crate::command::{Cli, Commands};
@@ -55,4 +60,57 @@ fn auto_task_update_accepts_required_tools() {
         args.required_tools.as_deref(),
         Some("proc.spawn,orbit.task.show")
     );
+}
+
+#[test]
+fn delivery_schedule_summary_uses_coverage_wire_names() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    for (name, coverage, expected) in [
+        (
+            "integrated",
+            CoverageClass::IntegratedQaV1,
+            "integrated_qa_v1",
+        ),
+        (
+            "review",
+            CoverageClass::LandedCodeReviewV1,
+            "landed_code_review_v1",
+        ),
+    ] {
+        let definition = runtime
+            .auto_task_add(AutoTaskAddParams {
+                name: name.to_string(),
+                description: "Delivery coverage fixture.".to_string(),
+                schedule: AutoTaskSchedule::Deliveries {
+                    deliveries_landed: DeliveryTrigger {
+                        owner_machine: None,
+                        branch: "agent-main".to_string(),
+                        threshold: 3,
+                        max_wait_minutes: 60,
+                        coverage,
+                        max_items: 20,
+                        retries: 0,
+                    },
+                },
+                template: AutoTaskTemplate {
+                    title: "Examine deliveries".to_string(),
+                    description: "Inspect delivery coverage.".to_string(),
+                    acceptance_criteria: vec!["Coverage is recorded.".to_string()],
+                    task_type: TaskType::Chore,
+                    tags: vec![],
+                    required_tools: vec![],
+                    priority: TaskPriority::Medium,
+                    crew: None,
+                    status: TaskStatus::Backlog,
+                },
+                dedupe: DedupePolicy::SkipIfOpen,
+            })
+            .expect("add delivery auto-task");
+
+        assert_eq!(
+            super::super::auto_task::output::schedule_summary(&definition),
+            format!("deliveries=3 branch=agent-main coverage={expected}")
+        );
+    }
 }

--- a/crates/orbit-types/src/workflow/automation/mod.rs
+++ b/crates/orbit-types/src/workflow/automation/mod.rs
@@ -14,6 +14,17 @@ pub enum CoverageClass {
     LandedCodeReviewV1,
 }
 
+impl std::fmt::Display for CoverageClass {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let wire_name = match self {
+            Self::IntegratedQaV1 => "integrated_qa_v1",
+            Self::LandedCodeReviewV1 => "landed_code_review_v1",
+        };
+
+        formatter.write_str(wire_name)
+    }
+}
+
 /// Opt-in delivery scheduling configuration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -428,7 +428,7 @@ fn schedule_summary(schedule: &AutoTaskSchedule) -> String {
         AutoTaskSchedule::Deliveries {
             deliveries_landed: t,
         } => format!(
-            "{} deliveries on {} ({:?})",
+            "{} deliveries on {} ({})",
             t.threshold, t.branch, t.coverage
         ),
         AutoTaskSchedule::Cron { cron } => format!("cron {cron}"),

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -8,6 +8,7 @@ use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
 use orbit_core::application::auto_tasks::cursor_state_path;
 use orbit_core::{AutoTaskAddParams, OrbitRuntime};
 use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::workflow::automation::{CoverageClass, DeliveryTrigger};
 use orbit_types::workflow::{AutoTaskSchedule, AutoTaskTemplate, DedupePolicy};
 use tower::ServiceExt;
 
@@ -28,6 +29,36 @@ fn chore_params(name: &str) -> AutoTaskAddParams {
             title: format!("Chore {name}"),
             description: "Recurring chore body.".to_string(),
             acceptance_criteria: vec!["The chore is observable.".to_string()],
+            task_type: TaskType::Chore,
+            tags: vec![],
+            required_tools: Vec::new(),
+            priority: TaskPriority::Medium,
+            crew: None,
+            status: TaskStatus::Backlog,
+        },
+        dedupe: DedupePolicy::SkipIfOpen,
+    }
+}
+
+fn delivery_params(name: &str, coverage: CoverageClass) -> AutoTaskAddParams {
+    AutoTaskAddParams {
+        name: name.to_string(),
+        description: format!("Delivery definition {name}"),
+        schedule: AutoTaskSchedule::Deliveries {
+            deliveries_landed: DeliveryTrigger {
+                owner_machine: None,
+                branch: "agent-main".to_string(),
+                threshold: 3,
+                max_wait_minutes: 60,
+                coverage,
+                max_items: 20,
+                retries: 0,
+            },
+        },
+        template: AutoTaskTemplate {
+            title: format!("Delivery {name}"),
+            description: "Recurring delivery coverage.".to_string(),
+            acceptance_criteria: vec!["Delivery coverage is observable.".to_string()],
             task_type: TaskType::Chore,
             tags: vec![],
             required_tools: Vec::new(),
@@ -192,6 +223,36 @@ async fn list_reports_enabled_and_disabled_definitions() {
     assert!(hourly["next_evaluation"].as_str().is_some(), "{hourly}");
     assert_eq!(hourly["schedule_summary"], "every 60 minutes");
     assert_eq!(nightly["last_evaluation"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn list_uses_delivery_coverage_wire_name_in_schedule_summary() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(delivery_params(
+            "delivery-qa",
+            CoverageClass::IntegratedQaV1,
+        ))
+        .expect("add");
+    let (state, _) = state(runtime);
+
+    let response = send(state, Method::GET, "/auto-tasks?workspace=default", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let definition = json["definitions"]
+        .as_array()
+        .expect("definitions")
+        .first()
+        .expect("delivery definition");
+
+    assert_eq!(
+        definition["schedule_summary"],
+        "3 deliveries on agent-main (integrated_qa_v1)"
+    );
+    assert_eq!(
+        definition["schedule"]["deliveries_landed"]["coverage"],
+        "integrated_qa_v1"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Task

[ORB-11564](https://orbit-cli.com/tasks/ORB-11564) — [qa-sweep] auto-task list and dashboard show Debug coverage names that add rejects

### Description

## Problem
Plain-text `orbit auto-task list` and the dashboard `schedule_summary` print delivery coverage with the Rust Debug variant (`IntegratedQaV1`, `LandedCodeReviewV1`). `orbit auto-task add --deliveries-landed` and JSON records require the serde snake_case wire values (`integrated_qa_v1`, `landed_code_review_v1`). Copying the table/dashboard token into the JSON flag fails.

## Why It Matters
An operator who inspects a shipped delivery auto-task and tries to create another with the same coverage cannot paste the displayed token. The list and the add contract disagree on the same enum.

## Evidence (HEAD `a52912235`, 2026-09-07, worktree of jrun-20260907-2053-6)
- Built `target/debug/orbit` (0.19.2) from this checkout.
- Scratch root `/tmp/orb-qa-11548-root` + git checkout `/tmp/orb-qa-11548-ws`.
- `orbit auto-task list` (table) for seeded `delivery-qa`:
  `deliveries=3 branch=agent-main coverage=IntegratedQaV1`
- JSON list for the same definition: `schedule.deliveries_landed.coverage = "integrated_qa_v1"`.
- Dashboard API `GET /api/auto-tasks?workspace=ws_qa-sweep-11548` `schedule_summary`:
  `3 deliveries on agent-main (IntegratedQaV1)`.
- Add with the displayed token:
```bash
orbit --root /tmp/orb-qa-11548-root auto-task add --name qa-delivery-owner --title "QA delivery owner check" --deliveries-landed '{"branch":"agent-main","threshold":3,"max_wait_minutes":60,"coverage":"IntegratedQaV1"}' --criterion "Owner machine is recorded."
```
  Error: `invalid deliveries-landed JSON: unknown variant \`IntegratedQaV1\`, expected \`integrated_qa_v1\` or \`landed_code_review_v1\``.
- The same payload with `integrated_qa_v1` succeeds; JSON show then stores `coverage: "integrated_qa_v1"`, but a later table list still prints `coverage=IntegratedQaV1`.

## Source
- `crates/orbit-cli/src/command/auto_task/output.rs` line 16: `coverage={:?}`.
- `crates/orbit-web/src/api/auto_tasks.rs` around line 431: `"{} deliveries on {} ({:?})"`.
- Enum: `crates/orbit-types/src/workflow/automation/mod.rs` `CoverageClass` with `#[serde(rename_all = "snake_case")]`.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
ROOT=/tmp/orb-qa-11549-repro
WS=/tmp/orb-qa-11549-ws
rm -rf "$ROOT" "$WS"
mkdir -p "$WS" && git -C "$WS" init && git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/README.md" && git -C "$WS" add README.md && git -C "$WS" commit -m init
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-cov --task-prefix QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace init --name qa-cov --ship-mode local)
"$BIN" --root "$ROOT" auto-task list
# copy coverage=IntegratedQaV1 from delivery-qa
(cd "$WS" && "$BIN" --root "$ROOT" auto-task add --name copy-cov --title t --deliveries-landed '{"branch":"agent-main","threshold":3,"max_wait_minutes":60,"coverage":"IntegratedQaV1"}' --criterion c)
```

## Scope
Display/help only. JSON and persistence already use snake_case. No production outage. Fix by rendering the serde/wire name (or Display) in both summaries, and optionally naming the allowed values in `--deliveries-landed` help.

### Acceptance Criteria

- `orbit auto-task list` prints coverage as `integrated_qa_v1` / `landed_code_review_v1`, matching JSON and `--deliveries-landed` input.
- Dashboard `schedule_summary` uses the same wire names, not Rust Debug variants.
- Copying the listed coverage token into `auto-task add --deliveries-landed` succeeds.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Implemented CoverageClass Display using the established serde snake_case wire tokens.
- Updated CLI and dashboard delivery schedule summaries to use Display instead of Debug.
- Added focused CLI coverage for both wire tokens and dashboard API coverage for its schedule summary and serialized schedule.

Criteria:
- Plain-text auto-task list now renders integrated_qa_v1 and landed_code_review_v1; exercised with the built CLI table output.
- Dashboard schedule_summary renders integrated_qa_v1 and matches the schedule JSON.
- Pasting integrated_qa_v1 into --deliveries-landed successfully created copy-coverage in a temporary initialized workspace.

Validation passed:
- cargo test -p orbit-cli --bin orbit delivery_schedule_summary_uses_coverage_wire_names
- cargo test -p orbit-web --lib list_uses_delivery_coverage_wire_name_in_schedule_summary
- make ci-lint
- make ci-fast
- git diff --check

Validation note: an initial manual list command used unsupported --format plain and was corrected to --format table; the corrected table and JSON output both showed wire tokens.

Assessment: the display contract is centralized on CoverageClass, so both presentation boundaries use the same canonical names. No production compatibility or persistence changes.

Remaining risk: run-owned temporary validation data remains under /tmp because safe cleanup was rejected by the command policy; it is outside the repository and does not affect the patch.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11564-6a9f2a5d`
- Behind base: 0
- Ahead of base: 1