### PR TITLE
[BLOCKED] Keep explicit review check identities distinct from fallback command identities

### DIFF
--- a/crates/orbit-automation/src/review/tests/validation.rs
+++ b/crates/orbit-automation/src/review/tests/validation.rs
@@ -264,6 +264,49 @@ fn an_unrelated_later_required_pass_does_not_replace_a_superseded_test() {
 }
 
 #[test]
+fn one_sided_check_ids_do_not_collide_with_fallback_commands() {
+    let superseded_check = vec![
+        with_check(
+            record(
+                "cargo test",
+                ValidationOutcome::Failed,
+                ValidationRole::Superseded,
+                Some("rerun after repair"),
+            ),
+            "cargo fmt --check",
+        ),
+        required("cargo fmt --check", ValidationOutcome::Passed),
+    ];
+    assert_eq!(
+        validation_evidence(&superseded_check),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo test".into(),
+        }),
+        "an explicit superseded check ID cannot match a required command"
+    );
+
+    let required_check = vec![
+        record(
+            "cargo fmt --check",
+            ValidationOutcome::Failed,
+            ValidationRole::Superseded,
+            Some("rerun after repair"),
+        ),
+        with_check(
+            required("cargo test", ValidationOutcome::Passed),
+            "cargo fmt --check",
+        ),
+    ];
+    assert_eq!(
+        validation_evidence(&required_check),
+        Err(ValidationDefect::SupersededWithoutReplacement {
+            command: "cargo fmt --check".into(),
+        }),
+        "a required check ID cannot match a superseded fallback command"
+    );
+}
+
+#[test]
 fn missing_ambiguous_invalid_or_non_passing_replacement_relationships_fail_closed() {
     let superseded = |check: Option<&str>| {
         let record = record(

--- a/crates/orbit-automation/src/review/validation.rs
+++ b/crates/orbit-automation/src/review/validation.rs
@@ -181,8 +181,10 @@ fn explained(record: &ReviewValidation) -> bool {
 /// Whether a later record is the required check the superseded attempt was
 /// replaced by. Order carries the meaning: a supersession must be resolved
 /// after it, never by a check recorded before it. The later record must
-/// name the same check: the same command, or the same non-empty `check`
-/// identity when the command or environment was corrected. Any later
+/// name the same check: the same command when both records have no `check`,
+/// or the same non-empty `check` identity when both records provide one and
+/// the command or environment was corrected. Check identities and commands
+/// are separate namespaces, so one cannot impersonate the other. Any later
 /// required pass is not enough.
 fn replaced_by_required_check(superseded: &ReviewValidation, later: &[ReviewValidation]) -> bool {
     let Some(identity) = replacement_identity(superseded) else {
@@ -195,21 +197,28 @@ fn replaced_by_required_check(superseded: &ReviewValidation, later: &[ReviewVali
     })
 }
 
-/// The identity a superseded attempt and its replacement share.
+/// The namespaced identity a superseded attempt and its replacement share.
 ///
-/// A present `check` is the identity when it is non-empty after trim.
-/// Otherwise the command string is the identity, so a same-command rerun
-/// still binds. An empty or whitespace-only `check` is invalid and matches
-/// nothing.
-fn replacement_identity(record: &ReviewValidation) -> Option<&str> {
+/// A present `check` is the identity when it is non-empty after trim;
+/// otherwise the command string is the identity, so a same-command rerun
+/// still binds. These forms deliberately remain distinct even when their
+/// strings are equal. An empty or whitespace-only `check` is invalid and
+/// matches nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplacementIdentity<'a> {
+    Check(&'a str),
+    Command(&'a str),
+}
+
+fn replacement_identity(record: &ReviewValidation) -> Option<ReplacementIdentity<'_>> {
     match record.check.as_deref() {
         Some(value) => {
             let trimmed = value.trim();
-            (!trimmed.is_empty()).then_some(trimmed)
+            (!trimmed.is_empty()).then_some(ReplacementIdentity::Check(trimmed))
         }
         None => {
             let command = record.command.as_str();
-            (!command.trim().is_empty()).then_some(command)
+            (!command.trim().is_empty()).then_some(ReplacementIdentity::Command(command))
         }
     }
 }


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11574`
- Run: `jrun-20260907-2121`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `7f3a8f5fabd24030bba30ec9035849ba7d323d2e`
- Target base: `3cb02879027ecbda3a5dab0c6bd26c4fc37b1ae3`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=Required make ci-lint fails on unchanged baseline duplicate owner_machine_id fields in crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs:273 and :275.
```