### PR TITLE
[ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs
@@ -272,7 +272,6 @@ fn bound_runtime(
             logical_workspace_id: workspace_id.clone(),
             owner_machine_id: None,
             workspace_id,
-            owner_machine_id: None,
             repo_root: repo.clone(),
             ship_mode: orbit_types::workflow::ShipMode::Pr,
             base_branch: branch.map(ToOwned::to_owned),


### PR DESCRIPTION
## Task

[ORB-11577](https://orbit-cli.com/tasks/ORB-11577) — [ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-core sandbox tests

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `macOS Platform`
- Failing job: `macOS Sandbox`
- Failing step: `Run orbit-core sandbox tests`
- Commit the runner actually checked out: `7f3a8f5fabd24030bba30ec9035849ba7d323d2e`
- Normalized error signature (the dedupe identity, not a quote): `error[e0062]: field `owner_machine_id` specified more than once`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-07T21:28:17.175185866+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34162787846 run `34162787846` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `7f3a8f5fabd24030bba30ec9035849ba7d323d2e`
  - current head of that ref: `7f3a8f5fabd24030bba30ec9035849ba7d323d2e`
  - commit actually checked out: `7f3a8f5fabd24030bba30ec9035849ba7d323d2e`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/opt/homebrew/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/opt/homebrew/bin/git log -1 --format=%H`
  - failed job `macOS Sandbox` (id `101867855035`): https://github.com/constellation-works/orbit/actions/runs/34162787846/job/101867855035
  - failing step(s): `Run orbit-core sandbox tests`

## Failed-step log excerpt

```
macOS Sandbox	Run orbit-core sandbox tests	﻿2026-09-07T21:25:30.6032460Z ##[group]Run cargo test -p orbit-core --locked sandbox
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:31.4397030Z [1m[92m   Compiling[0m orbit-types v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-types)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:37.2615510Z [1m[92m   Compiling[0m orbit-common v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-common)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:39.6459760Z [1m[92m   Compiling[0m orbit-policy v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-policy)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:39.6461290Z [1m[92m   Compiling[0m orbit-exec v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-exec)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:39.8200650Z [1m[92m   Compiling[0m orbit-store v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-store)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:40.8713060Z [1m[92m   Compiling[0m orbit-tools v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-tools)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:42.5284410Z [1m[92m   Compiling[0m orbit-agent v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-agent)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:42.8231500Z [1m[92m   Compiling[0m orbit-search v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-search)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:45.5487820Z [1m[92m   Compiling[0m orbit-config v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-config)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:46.9392530Z [1m[92m   Compiling[0m orbit-engine v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-engine)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:47.9454320Z [1m[92m   Compiling[0m orbit-automation v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-automation)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:25:52.8121310Z [1m[92m   Compiling[0m orbit-core v0.19.2 (/Users/runner/work/orbit/orbit/crates/orbit-core)
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.7700060Z [1m[91merror[E0062][0m[1m: field `owner_machine_id` specified more than once[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.7813460Z    [1m[94m--> [0mcrates/orbit-core/src/application/job/tests/exec/ci_sweep.rs:275:13
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.7934170Z     [1m[94m|[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.7982550Z [1m[94m273[0m [1m[94m|[0m             owner_machine_id: None,
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.8085400Z     [1m[94m|[0m             [1m[94m----------------------[0m [1m[94mfirst use of `owner_machine_id`[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.8206540Z [1m[94m274[0m [1m[94m|[0m             workspace_id,
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.8309770Z [1m[94m275[0m [1m[94m|[0m             owner_machine_id: None,
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.8414030Z     [1m[94m|[0m             [1m[91m^^^^^^^^^^^^^^^^[0m [1m[91mused more than once[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:04.8512550Z 
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:17.4559710Z [1mFor more information about this error, try `rustc --explain E0062`.[0m
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:17.4833280Z [1m[91merror[0m: could not compile `orbit-core` (lib test) due to 1 previous error
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:17.4835460Z [1m[33mwarning[0m: build failed, waiting for other jobs to finish...
macOS Sandbox	Run orbit-core sandbox tests	2026-09-07T21:26:17.7829170Z ##[error]Process completed with exit code 101.
```

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34161293408 — superseded_by_newer_workflow_run: newer relevant run 34162537567 at 2026-09-07T21:16:30Z is completed with conclusion success
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34160850084 — superseded_by_newer_workflow_run: newer relevant run 34162537567 at 2026-09-07T21:16:30Z is completed with conclusion success
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34160788656 — superseded_by_newer_workflow_run: newer relevant run 34162537567 at 2026-09-07T21:16:30Z is completed with conclusion success
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34160617360 — superseded_by_newer_workflow_run: newer relevant run 34162537567 at 2026-09-07T21:16:30Z is completed with conclusion success

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 2,
  "current_failures_discovered": 3,
  "current_failures_investigated": 3,
  "current_failures_investigation_attempted": 6,
  "investigation_cursor": 496893,
  "job_log_reads": 3,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "2 of 8 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11516-6a9f212e",
    "orbit/ORB-11523-6a9f1f70",
    "orbit/ORB-11543-6a9f212e",
    "orbit/ORB-11544-6a9f1fc2",
    "orbit/ORB-11552-6a9f2676"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `macOS Platform` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the single duplicate `owner_machine_id: None` initializer from `crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs`.
- This is the repository-owned cause identified in the runner log; no workflow, assertion, lint level, or blocking behavior was changed.

Acceptance criteria:
- Root cause fixed: PASS. The binding initializer now contains one `owner_machine_id` field; final search found only the retained initializer.
- Runner failure reproduced and repaired: PASS. `cargo test -p orbit-core --locked sandbox` reproduced E0062 with exit 101 before the edit, then passed after the edit with 29 sandbox tests and all matching filtered integration targets successful.
- Documented pre-handoff gate: PASS. `make ci-fast` and `make ci-lint` both completed successfully; Clippy covered the workspace/all targets with `-D warnings`.
- Infrastructure fallback criterion: not applicable. The failure was reproduced locally, providing direct repository evidence rather than an infrastructure-only non-reproduction.

Validation:
- PASS — `cargo test -p orbit-core --locked sandbox` before edit: expected E0062 duplicate-field failure.
- PASS — `cargo test -p orbit-core --locked sandbox` after edit: exit 0; 29 sandbox unit tests passed and filtered integration targets passed.
- PASS — `make ci-fast`.
- PASS — `make ci-lint`.
- PASS — `git diff --check`.
- PASS — final diff/status review; only the scoped source file is modified.

Assessment: Minimal, scope-preserving repair. The actual macOS runner cannot be exercised in this Linux workspace; the exact Rust compilation failure and its fix were verified locally, and macOS CI remains the final platform-specific confirmation.

Remaining risk: None identified in repository validation; platform-specific macOS execution is deferred to CI.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11577-6a9f2d29`
- Behind base: 0
- Ahead of base: 1