### PR TITLE
[friction-curation] Stop orbit-web unidentified-caller routine toggle from flaking under parallel tests

### DIFF
--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
+use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
 use orbit_core::application::routines::ClockStatus;
 use orbit_core::{OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_registry::{NewHostIdentity, ensure_host_identity};
@@ -160,25 +161,60 @@ async fn routines_endpoint_returns_envelope_for_empty_host() {
     assert_eq!(json["load_errors"], serde_json::json!([]));
 }
 
+/// Pin the process signals `CallerCapabilities::resolve` reads, for the whole
+/// request rather than just its construction.
+///
+/// The guard in `orbit_common::test_env` is process-wide, so it serializes two
+/// tests only when *both* take it. Parallel `as_operator` tests in
+/// `api::tests::auto_tasks`, `api::tests::runs`, and `api::tests::operation`
+/// set `ORBIT_OPERATOR=1` under that lock. This case used to read the variable
+/// without holding it, so a sibling could promote the caller to Operator;
+/// authorization then succeeded and `routine_statuses` on
+/// `DashboardState::single`'s empty global root mapped `InvalidInput` to HTTP
+/// 400 instead of the 403 unidentified-caller denial [ORB-10894].
+#[allow(clippy::await_holding_lock)]
+async fn with_caller_env<'a, T>(
+    vars: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    fut: impl std::future::Future<Output = T>,
+) -> T {
+    let _env = orbit_common::test_env::scoped(vars);
+    fut.await
+}
+
 #[tokio::test]
 async fn routine_mutation_denies_an_unidentified_dashboard_caller() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");
     let state = DashboardState::single(Arc::new(runtime));
-    let response = router()
-        .with_state(state)
-        .oneshot(
-            Request::builder()
-                .method(Method::POST)
-                .uri("/routines/toggle?workspace=default")
-                .header("origin", "http://localhost:7878")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    r#"{"name":"nightly","source":"default","target":"job:nightly","host_id":"host-a","expected_enabled":true,"enabled":false}"#,
-                ))
-                .expect("request"),
-        )
-        .await
-        .expect("response");
+    // Agent envelope is *set* rather than cleared: with nothing declared,
+    // resolution falls through to the interactive-terminal probe, and a TTY
+    // `cargo test` would resolve to Operator for a reason unrelated to the
+    // handler. The empty-grants unidentified branch is covered without process
+    // state in `orbit_common::governance::tests::authorization`.
+    let response = with_caller_env(
+        [
+            (OPERATOR_OVERRIDE_ENV, None),
+            ("ORBIT_AGENT_NAME", Some("orbit-web-test")),
+            ("ORBIT_AGENT_MODEL", Some("orbit-web-test")),
+        ],
+        async {
+            router()
+                .with_state(state)
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/routines/toggle?workspace=default")
+                        .header("origin", "http://localhost:7878")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            r#"{"name":"nightly","source":"default","target":"job:nightly","host_id":"host-a","expected_enabled":true,"enabled":false}"#,
+                        ))
+                        .expect("request"),
+                )
+                .await
+                .expect("response")
+        },
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let json = body_json(response).await;


### PR DESCRIPTION
## Task

[ORB-11571](https://orbit-cli.com/tasks/ORB-11571) — [friction-curation] Stop orbit-web unidentified-caller routine toggle from flaking under parallel tests

### Description

## Problem
`crates/orbit-web/src/api/tests/routines.rs:164` `routine_mutation_denies_an_unidentified_dashboard_caller` expects HTTP 403 (`authorization_denied`) for a POST `/routines/toggle` without caller identity. Under `cargo test -p orbit-web` it intermittently returns 400 instead of 403 (`left: 400, right: 403`). Isolation passes (4/4); full-crate parallel runs failed, failed, then passed on a clean checkout at 151e40fe2 during ORB-11419 (orbit-web sources unmodified).

The test still exists at line 164 with the same 403 assertion. No covering fix task was found (ORB-11419 was an unrelated whitespace sweep). Likely cause: ambient machine/workspace identity mutated by a sibling test, so the handler rejects the body as a bad request before the unidentified-caller 403 path.

## Why It Matters
The flake is mistaken for a regression in unrelated orbit-web edits and costs ~20 minutes to isolate. It is order/parallelism dependent, so CI nextest (process-per-test) may not see it while `cargo test -p orbit-web` does.

## Suggested direction
Make the test's identity/workspace fixture exclusive for the assertion, matching other orbit-web tests that already isolate process-wide state. The 403 unidentified-caller path must remain the behavior under test; do not weaken it to accept 400. Add a comment naming the sibling state that previously leaked.

No fail-closed authorization guard is widened.

### Acceptance Criteria

- `routine_mutation_denies_an_unidentified_dashboard_caller` still asserts 403 `authorization_denied` for an unidentified dashboard caller.
- The test no longer depends on ambient process identity that a parallel sibling can mutate; it fails 400 only when the request is actually malformed.
- `cargo test -p orbit-web` (default parallel) does not flake this test on a clean checkout across several consecutive runs, or the test is serialized with a documented lock if isolation cannot be local.
- A 400 from a truly malformed body remains covered elsewhere and is not conflated with unidentified-caller denial.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Isolated `routine_mutation_denies_an_unidentified_dashboard_caller` behind `orbit_common::test_env::scoped` for the whole request, matching `api::tests::auto_tasks` / `runs` / `operation` [ORB-10894].
- The test now clears `ORBIT_OPERATOR` and declares `ORBIT_AGENT_NAME`/`ORBIT_AGENT_MODEL` so a parallel `as_operator` sibling cannot promote the caller to Operator. Comments name that leaked sibling state.
- Still asserts HTTP 403 `authorization_denied` / `routine.toggle`. Did not widen authorization. Left `operations_mutations_require_an_explicit_workspace` as the separate 400 `workspace_required` coverage.
Assessment: Small, local test-fixture fix. Product handler unchanged. Isolation uses the existing process-wide lock rather than a new serial_test crate.

Criteria:
- 403 `authorization_denied` for a non-operator dashboard caller: met. Same assertion; request now runs under a pinned non-operator envelope.
- No ambient identity a sibling can mutate: met. Holds the shared test_env lock and pins `ORBIT_OPERATOR` plus the agent envelope.
- `cargo test -p orbit-web` default parallel does not flake: met. Four consecutive full-crate runs all passed this test (`ok` on each).
- 400 malformed/missing-workspace not conflated with 403: met. `operations_mutations_require_an_explicit_workspace` still asserts 400 `workspace_required` in the same file. Truly invalid JSON is axum 0.7's Json extractor (422), not this test.

Strategic decisions: Agent envelope is set rather than cleared so resolution does not fall through to the interactive-terminal probe (a TTY `cargo test` would otherwise become Operator). Empty-grants unidentified remains covered by `orbit_common::governance::tests::authorization::an_unidentified_caller_is_denied`.
Deviations from original plan: none.

Validation:
- `cargo test -p orbit-web --lib api::tests::routines -- --test-threads=1`: passed (9/9).
- `cargo test -p orbit-web` default parallel, 4 consecutive runs: passed (317 passed, 1 ignored each run). Target test `ok` on all four.
- `ORBIT_OPERATOR=1 cargo test -p orbit-web --lib api::tests::routines::routine_mutation_denies_an_unidentified_dashboard_caller -- --exact`: passed (proves isolation against the sibling leak).
- `make ci-fast`: passed.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check`: passed. `git status --short`: only `crates/orbit-web/src/api/tests/routines.rs` modified. Uncommitted by design.

Remaining risks: Isolation is local via the existing process-wide lock; it serializes only with siblings that also take that lock (the `as_operator` tests already do). A future test that sets `ORBIT_OPERATOR` without the lock could still race. No new friction filed; this was the known F2026-09-045 flake.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11571-6a9f2a7d`
- Behind base: 0
- Ahead of base: 1