### PR TITLE
[friction-curation] Document git archive and git-show workarounds for a read-only managed .git

### DIFF
--- a/.orbit/auto_tasks/qa-sweep.yaml
+++ b/.orbit/auto_tasks/qa-sweep.yaml
@@ -25,6 +25,21 @@ template:
     does not need that flag and does not prompt non-interactively in
     practice.
 
+    Similarly, in agent-executor sandboxes and linked job-run worktrees, the
+    repository's managed `.git` mount is read-only by design and must not be
+    worked around by chmod or host-side gitdir writes. Commands that write to
+    `.git` fail (such as `git worktree add` or `git checkout --`).
+    Instead:
+    - To build an arbitrary baseline revision without writing `.git` or creating
+      `.git/worktrees/*`, extract an archive to a scratch directory:
+      `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`,
+      then build there with a separate `CARGO_TARGET_DIR`.
+    - To revert a modified tracked file when `git checkout -- <path>` fails
+      because it cannot acquire `index.lock`, restore it from the commit tree:
+      `git show HEAD:<path> > <path>`.
+    - Read-only inspection commands such as `git status --short` succeed with
+      `GIT_OPTIONAL_LOCKS=0`.
+
     Before filing anything, search open Orbit tasks tagged `qa-sweep`. For each
     real issue that is not already filed, create an Orbit task yourself through
     the Orbit MCP tools or the equivalent `orbit tool run orbit.task.add`

--- a/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
+++ b/crates/orbit-core/assets/auto_tasks/qa-sweep.yaml
@@ -18,6 +18,21 @@ template:
     writable temporary location rather than the machine's real home directory
     or the product's live data root.
 
+    In agent-executor sandboxes and linked job-run worktrees, the repository's
+    managed `.git` mount is read-only by design and must not be worked around by
+    chmod or host-side gitdir writes. Because `.git` is read-only, commands that
+    attempt write access to `.git` fail (such as `git worktree add` or `git checkout --`).
+    Instead:
+    - To build an arbitrary baseline revision without writing `.git` or creating
+      `.git/worktrees/*`, extract an archive to a writable scratch directory:
+      `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`,
+      then build there using a dedicated build cache/target directory.
+    - To revert a modified tracked file when `git checkout -- <path>` fails
+      because it cannot acquire `index.lock`, restore it from the commit tree:
+      `git show HEAD:<path> > <path>`.
+    - Read-only inspection commands such as `git status --short` succeed with
+      `GIT_OPTIONAL_LOCKS=0`.
+
     Before reporting anything, search the workspace's configured task or issue surface
     for open work covering the same problem. For each real issue that is not already
     filed, create a durable record on that surface. Give it severity-appropriate

--- a/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
+++ b/crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md
@@ -90,7 +90,12 @@ That is unavailable evidence, not a clean CI result.
 
 - **`qa-sweep`** — hourly. Identifies recent changes, exercises them hands-on
   through their real user-facing paths rather than just re-running the test
-  suite, and files a task for each non-duplicate issue found.
+  suite, and files a task for each non-duplicate issue found. In agent-executor
+  sandboxes and linked job-run worktrees, the managed `.git` mount is read-only
+  by design (must not be worked around by chmod or host-side gitdir writes).
+  Use `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to build a
+  baseline revision without writing `.git`, and `git show HEAD:<path> > <path>`
+  to revert a tracked file when `git checkout --` cannot take `index.lock`.
 - **`friction-curation`** — daily. Deduplicates the open friction corpus against
   task history, verifies each survivor still reproduces, resolves the ones that
   don't, and files fix tasks for the ones that do. → [friction.md](../friction.md)

--- a/crates/orbit-core/assets/skills/orbit/references/task-execution.md
+++ b/crates/orbit-core/assets/skills/orbit/references/task-execution.md
@@ -87,6 +87,18 @@ pop can restore another session's work. Record the worktree's initial
 `git rev-parse HEAD` and compare against that explicit baseline with
 `git diff <baseline-sha> -- <paths>`.
 
+**Managed `.git` mounts are read-only by design.** In agent-executor sandboxes
+and linked job-run worktrees, the repository's `.git` mount is read-only and
+must not be worked around by chmod or host-side gitdir writes. Commands that
+write to `.git` fail:
+- Do not use `git worktree add` to inspect or build other revisions; use
+  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to extract a
+  baseline revision without touching `.git` or creating `.git/worktrees/*`,
+  then build with a separate build cache/target directory.
+- When `git checkout -- <path>` fails because it cannot acquire `index.lock`,
+  revert the tracked file with `git show HEAD:<path> > <path>`.
+- Read-only inspection commands succeed with `GIT_OPTIONAL_LOCKS=0 git status --short`.
+
 ## Step 5 — Summarize and hand off
 
 Persist `execution_summary` via `orbit.task.update` **first**.

--- a/plugin/skills/orbit/references/setup/auto-tasks.md
+++ b/plugin/skills/orbit/references/setup/auto-tasks.md
@@ -90,7 +90,12 @@ That is unavailable evidence, not a clean CI result.
 
 - **`qa-sweep`** — hourly. Identifies recent changes, exercises them hands-on
   through their real user-facing paths rather than just re-running the test
-  suite, and files a task for each non-duplicate issue found.
+  suite, and files a task for each non-duplicate issue found. In agent-executor
+  sandboxes and linked job-run worktrees, the managed `.git` mount is read-only
+  by design (must not be worked around by chmod or host-side gitdir writes).
+  Use `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to build a
+  baseline revision without writing `.git`, and `git show HEAD:<path> > <path>`
+  to revert a tracked file when `git checkout --` cannot take `index.lock`.
 - **`friction-curation`** — daily. Deduplicates the open friction corpus against
   task history, verifies each survivor still reproduces, resolves the ones that
   don't, and files fix tasks for the ones that do. → [friction.md](../friction.md)

--- a/plugin/skills/orbit/references/task-execution.md
+++ b/plugin/skills/orbit/references/task-execution.md
@@ -87,6 +87,18 @@ pop can restore another session's work. Record the worktree's initial
 `git rev-parse HEAD` and compare against that explicit baseline with
 `git diff <baseline-sha> -- <paths>`.
 
+**Managed `.git` mounts are read-only by design.** In agent-executor sandboxes
+and linked job-run worktrees, the repository's `.git` mount is read-only and
+must not be worked around by chmod or host-side gitdir writes. Commands that
+write to `.git` fail:
+- Do not use `git worktree add` to inspect or build other revisions; use
+  `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` to extract a
+  baseline revision without touching `.git` or creating `.git/worktrees/*`,
+  then build with a separate build cache/target directory.
+- When `git checkout -- <path>` fails because it cannot acquire `index.lock`,
+  revert the tracked file with `git show HEAD:<path> > <path>`.
+- Read-only inspection commands succeed with `GIT_OPTIONAL_LOCKS=0 git status --short`.
+
 ## Step 5 — Summarize and hand off
 
 Persist `execution_summary` via `orbit.task.update` **first**.


### PR DESCRIPTION
## Task

[ORB-11566](https://orbit-cli.com/tasks/ORB-11566) — [friction-curation] Document git archive and git-show workarounds for a read-only managed .git

### Description

## Problem
Agent-executor sandboxes mount the repository `.git` read-only. In this linked worktree `.git` is a file (`ls -ld .git` shows a 103-byte gitdir file) and `touch .git/index.lock.probe` fails with `Not a directory` / cannot create `index.lock`. QA therefore cannot:

```
git worktree add --detach /tmp/qa-base <sha>
git checkout -- <path>
```

The working forms, already proven on ORB-11377, are not written in the QA-sweep auto-task or executor skill:

- Build an arbitrary revision without touching `.git`: `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base`, then a separate `CARGO_TARGET_DIR`.
- Revert a tracked file: `git show HEAD:<path> > <path>` instead of `git checkout -- <path>`.
- Status still works with `GIT_OPTIONAL_LOCKS=0`.

## Why It Matters
Every QA sweep that needs a before/after binary comparison rediscovers this, and regenerating a snapshot cannot be undone with the obvious checkout. That costs ~15 minutes and risks handing off a dirty worktree.

## Suggested direction
Add the two write-side workarounds to `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` (and the orbit skill QA/setup note if that is the file agents actually load for QA). Do not relax the read-only `.git` mount. No fail-closed guard is widened.

Reproduction this pass (ORB-11554, worktree orbit-jrun-20260907-2057-7): `.git` is a gitdir file; index.lock cannot be created.

### Acceptance Criteria

- The QA-sweep auto-task (and any mirrored skill text it points agents at) documents `git archive <sha> | tar -x` for building a baseline revision without writing `.git`.
- It documents `git show HEAD:<path> > <path>` as the revert path when `git checkout --` cannot take `index.lock`.
- It states that the managed `.git` mount is read-only by design and must not be worked around by chmod or host-side gitdir writes.
- A reader can follow those commands in a linked job-run worktree without creating `.git/worktrees/*` or `.git/index.lock`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `crates/orbit-core/assets/auto_tasks/qa-sweep.yaml` and `.orbit/auto_tasks/qa-sweep.yaml` to document that managed `.git` mounts in agent-executor sandboxes and linked job-run worktrees are read-only by design and must not be worked around by chmod or host-side gitdir writes. Documented `mkdir -p /tmp/base && git archive <sha> | tar -x -C /tmp/base` for extracting baseline revisions without writing `.git` or creating `.git/worktrees/*`, `git show HEAD:<path> > <path>` to revert tracked files when `git checkout --` cannot acquire `index.lock`, and `GIT_OPTIONAL_LOCKS=0 git status --short` for read-only status inspection.
- Updated `crates/orbit-core/assets/skills/orbit/references/setup/auto-tasks.md` and `crates/orbit-core/assets/skills/orbit/references/task-execution.md` to document the same read-only `.git` constraints and workarounds.
- Synchronized canonical skill assets to `plugin/skills/orbit/` via `scripts/sync-plugin-skills.sh`.

Criteria verification:
- The QA-sweep auto-task (and mirrored skill text) documents `git archive <sha> | tar -x`: passed.
- It documents `git show HEAD:<path> > <path>` as the revert path when `git checkout --` cannot take `index.lock`: passed.
- It states that the managed `.git` mount is read-only by design and must not be worked around by chmod or host-side gitdir writes: passed.
- A reader can follow those commands in a linked job-run worktree without creating `.git/worktrees/*` or `.git/index.lock`: passed (verified `git archive HEAD | tar -x` and `git show HEAD:<path> > <path>` live in this worktree without creating `.git/worktrees/*` or `.git/index.lock`).

Validation commands:
- `make ci-fast`: passed (all 20 checks passed including sync-plugin-skills, portability, formatting, and security checks).
- `git diff --check`: passed (clean).
- `git status --short`: passed (only the 6 target files modified).
- Live command verification: passed (`git archive HEAD | tar -x -C /tmp/test-base` cleanly extracted repository tree to /tmp/test-base; `git show HEAD:<path> > <path>` successfully restored modified file without index.lock; verified `.git` is read-only gitdir file where index.lock cannot be created).
- `make ci-lint`: not run (unrelated pre-existing compilation failure in `ci_sweep.rs:275` duplicate field on `agent-main`, already tracked and resolved by ORB-11577 / ORB-11582; this task touches only documentation/asset files).

Assessment:
Clean, scoped documentation change addressing friction F2026-09-034 across the auto-task templates and reference skills.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11566-6a9f2e03`
- Behind base: 0
- Ahead of base: 1