### PR TITLE
[qa-sweep] workspace init --root still tells operators to commit checkout .orbit files that were not written

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -19,7 +19,10 @@ use crate::command::init::agent_detect::{RealAgentEnvProbe, detect};
 use crate::command::init::config_seed_from_detection;
 
 use super::role::CliCheckoutRole;
-use super::support::{detect_git_remote, dir_name_or_fallback, ensure_orbit_gitignore_entry};
+use super::support::{
+    detect_git_remote, dir_name_or_fallback, ensure_orbit_gitignore_entry,
+    manages_checkout_local_orbit_files,
+};
 use crate::command::{CommandOut, CommandOutput};
 
 #[derive(Args)]
@@ -72,6 +75,18 @@ pub struct WorkspaceInitArgs {
 }
 
 pub(crate) const ONBOARDING_FINALIZE_GUIDANCE: &str = "review and commit generated definitions (.gitignore, .orbit/auto_tasks, .orbit/routines) before local workflows (Orbit does not auto-commit or discard operator changes)";
+const RELOCATED_ROOT_ONBOARDING_GUIDANCE: &str = "review generated Orbit definitions in the configured Orbit root before local workflows (Orbit does not auto-commit or discard operator changes)";
+
+pub(crate) fn onboarding_finalize_guidance(
+    workspace_root: &Path,
+    orbit_dir: &Path,
+) -> &'static str {
+    if manages_checkout_local_orbit_files(workspace_root, orbit_dir) {
+        ONBOARDING_FINALIZE_GUIDANCE
+    } else {
+        RELOCATED_ROOT_ONBOARDING_GUIDANCE
+    }
+}
 
 impl WorkspaceInitArgs {
     pub fn execute_without_runtime(self, root_override: Option<&Path>) -> CommandOut {
@@ -89,7 +104,10 @@ impl WorkspaceInitArgs {
         println!("  id:        {}", init_result.id);
         println!("  root:      {}", init_result.root.display());
         println!("  orbit_dir: {}", init_result.orbit_dir.display());
-        println!("  onboarding: {ONBOARDING_FINALIZE_GUIDANCE}");
+        println!(
+            "  onboarding: {}",
+            onboarding_finalize_guidance(&init_result.root, &init_result.orbit_dir)
+        );
 
         if let Some(start) = task_id_start {
             let outcome =

--- a/crates/orbit-cli/src/command/workspace/support.rs
+++ b/crates/orbit-cli/src/command/workspace/support.rs
@@ -54,6 +54,15 @@ pub(super) fn ensure_orbit_gitignore_entry(
     write_orbit_gitignore_entry(&gitignore_path)
 }
 
+/// Whether workspace initialization manages checkout-local Orbit definitions.
+///
+/// This is the same condition that determines whether initialization writes
+/// the managed `.gitignore` entry, so onboarding guidance can describe only
+/// files that were actually created in the checkout.
+pub(super) fn manages_checkout_local_orbit_files(workspace_root: &Path, orbit_dir: &Path) -> bool {
+    orbit_gitignore_root(workspace_root, orbit_dir).is_some()
+}
+
 fn orbit_gitignore_root<'a>(workspace_root: &'a Path, orbit_dir: &'a Path) -> Option<&'a Path> {
     // Legacy: walking up from a subdir, orbit_dir is `<repo>/.orbit` whose
     // parent is a git repo root.

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -10,7 +10,10 @@ use orbit_types::workspace::{
 
 use crate::tests::env_isolation::EnvGuard;
 
-use super::super::init::{ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id};
+use super::super::init::{
+    ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id,
+    onboarding_finalize_guidance,
+};
 use super::super::list::{format_workspace_list, workspace_list_json};
 use super::super::role::CliCheckoutRole;
 use super::super::show::format_workspace_show;
@@ -1714,6 +1717,20 @@ fn workspace_init_with_root_override_does_not_modify_repo_gitignore() {
         !gitignore.exists(),
         "`--root` outside the workspace must not create <workspace>/.gitignore",
     );
+
+    let guidance = onboarding_finalize_guidance(workspace.path(), &custom_root);
+    assert!(
+        !guidance.contains("review and commit"),
+        "relocated-root guidance must not tell operators to commit checkout files: {guidance}"
+    );
+    assert!(
+        !guidance.contains(".gitignore"),
+        "relocated-root guidance must not name a checkout .gitignore: {guidance}"
+    );
+    assert!(
+        !guidance.contains(".orbit/auto_tasks") && !guidance.contains(".orbit/routines"),
+        "relocated-root guidance must not name checkout-local definitions: {guidance}"
+    );
 }
 
 /// Regression (ORB-10293): a nameless workspace whose default name is derived
@@ -1814,6 +1831,11 @@ fn workspace_init_guidance_and_generated_onboarding_files_lifecycle() {
     assert!(ONBOARDING_FINALIZE_GUIDANCE.contains(".orbit/routines"));
     assert!(ONBOARDING_FINALIZE_GUIDANCE.contains("review and commit"));
     assert!(ONBOARDING_FINALIZE_GUIDANCE.contains("does not auto-commit or discard"));
+    assert_eq!(
+        onboarding_finalize_guidance(workspace.path(), &workspace.path().join(".orbit")),
+        ONBOARDING_FINALIZE_GUIDANCE,
+        "checkout-local initialization must retain the commit guidance"
+    );
 
     let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
     WorkspaceInitArgs {


### PR DESCRIPTION
## Task

[ORB-11563](https://orbit-cli.com/tasks/ORB-11563) — [qa-sweep] workspace init --root still tells operators to commit checkout .orbit files that were not written

### Description

## Problem
`orbit workspace init` always prints:
`onboarding: review and commit generated definitions (.gitignore, .orbit/auto_tasks, .orbit/routines) ...`
When `--root` relocates the Orbit directory outside the git checkout (the documented scratch/sandbox path, and shared-root mode), those checkout-local files are intentionally not created. The message tells the operator to commit files that are not in the repo.

## Why It Matters
The QA/sandbox onboarding path in this task family is exactly:
```
orbit --root /tmp/<scratch> init --non-interactive --host-name <name> --task-prefix <XXXX>
orbit --root /tmp/<scratch> workspace init
```
Operators following the printed next step look for `.gitignore` and `.orbit/auto_tasks` in the checkout and find neither. Auto-task and routine definitions were written into the external root instead.

## Evidence (HEAD `a52912235`, 2026-09-07, worktree of jrun-20260907-2053-6)
- Built `target/debug/orbit` (0.19.2).
- `orbit --root /tmp/orb-qa-11548-root init --non-interactive --host-name qa-sweep-11548 --task-prefix QASW`
- From `/tmp/orb-qa-11548-ws` (a fresh git repo): `orbit --root /tmp/orb-qa-11548-root workspace init --name qa-sweep-11548 --ship-mode local`
- Printed: `orbit_dir: /tmp/orb-qa-11548-root` and the checkout-commit onboarding sentence above.
- `/tmp/orb-qa-11548-ws` contained only `.git` and `README.md`. No `.gitignore`, no `.orbit/`.
- Definitions existed at `/tmp/orb-qa-11548-root/auto_tasks` and `/tmp/orb-qa-11548-root/routines`.
- `git -C /tmp/orb-qa-11548-ws status --short` was empty.
- Source: `ONBOARDING_FINALIZE_GUIDANCE` in `crates/orbit-cli/src/command/workspace/init.rs` is printed unconditionally. `ensure_orbit_gitignore_entry` in `crates/orbit-cli/src/command/workspace/support.rs` returns `Ok(())` without writing when `orbit_dir` is not `<workspace>/.orbit` (comment: skip gitignore for `--root`).

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
ROOT=/tmp/orb-qa-onboard-repro
WS=/tmp/orb-qa-onboard-ws
rm -rf "$ROOT" "$WS"
mkdir -p "$WS" && git -C "$WS" init
git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/README.md" && git -C "$WS" add README.md && git -C "$WS" commit -m init
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-onboard --task-prefix QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace init --name qa-onboard --ship-mode local)
ls -la "$WS"            # no .gitignore, no .orbit
ls "$ROOT/auto_tasks" "$ROOT/routines"
```

## Scope
Messaging only for the relocated-root/shared-root path. Default in-repo `.orbit` init is unaffected. No production outage. Fix: print guidance that matches whether checkout-local files were actually written.

### Acceptance Criteria

- When `orbit workspace init` is run with `--root` pointing outside the checkout, the printed onboarding line does not tell the operator to commit `.gitignore` / `.orbit/auto_tasks` / `.orbit/routines` that were not created in the repo.
- The default in-repo `.orbit` init path still advises committing the generated checkout-local definitions.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Made workspace-init onboarding guidance follow the same predicate that controls checkout-local `.gitignore` management.
- Relocated roots now direct operators to review definitions in the configured Orbit root without naming or asking them to commit checkout files.
- Checkout-local `.orbit` initialization retains the existing commit guidance.
- Added regression assertions for both guidance paths.

Acceptance criteria:
- `--root` outside the checkout: satisfied; the guidance omits `.gitignore`, `.orbit/auto_tasks`, `.orbit/routines`, and commit instructions.
- In-repo `.orbit`: satisfied; the existing checkout-local commit guidance is retained.

Validation:
- Passed: `cargo test -p orbit-cli workspace_init_with_root_override_does_not_modify_repo_gitignore`.
- Passed: `cargo test -p orbit-cli workspace_init_guidance_and_generated_onboarding_files_lifecycle`.
- Passed: built `target/debug/orbit` and exercised relocated-root and in-repo-root initialization; each printed the expected onboarding line and created only the expected files.
- Passed: `make ci-fast`.
- Passed: `cargo clippy -p orbit-cli --all-targets -- -D warnings`.
- Passed: `git diff --check`.
- Failed (unrelated baseline blocker): `make ci-lint` stops in `crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs:275` because `owner_machine_id` is specified twice. The task does not modify that file; targeted orbit-cli clippy passed.

Assessment: messaging change is scoped to the existing checkout-local file-management predicate, with focused and end-to-end coverage.

Risks: workspace-wide lint remains blocked by the pre-existing duplicate field outside this task scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11563-6a9f2d47`
- Behind base: 0
- Ahead of base: 1