### PR TITLE
[friction-curation] Derive frozen MCP surface length assertions from one canonical list

### DIFF
--- a/crates/orbit-mcp/src/federated/tests/capability.rs
+++ b/crates/orbit-mcp/src/federated/tests/capability.rs
@@ -66,7 +66,6 @@ fn the_locked_mapping_covers_exactly_the_advertised_surface() {
         .collect::<std::collections::BTreeSet<_>>();
 
     assert_eq!(advertised, locked);
-    assert_eq!(advertised.len(), 28);
 }
 
 #[test]

--- a/crates/orbit-mcp/src/federated/tests/host.rs
+++ b/crates/orbit-mcp/src/federated/tests/host.rs
@@ -105,7 +105,6 @@ fn the_mux_advertises_the_canonical_surface() {
         names,
         canonical.iter().map(String::as_str).collect::<Vec<_>>()
     );
-    assert_eq!(names.len(), 28, "the frozen production surface changed");
     let listing = definitions
         .iter()
         .find(|definition| definition.schema.name == FEDERATED_WORKSPACE_LIST_TOOL)

--- a/crates/orbit-mcp/src/remote/tests/discovery.rs
+++ b/crates/orbit-mcp/src/remote/tests/discovery.rs
@@ -57,7 +57,6 @@ fn mcp_owns_the_exact_global_discovery_definitions() {
     assert_eq!(crew.schema.parameters[0].name, "workspace");
 
     let canonical = canonical_mcp_tool_definitions().expect("canonical definitions");
-    assert_eq!(canonical.len(), 28, "the frozen production surface changed");
     assert_eq!(
         canonical
             .iter()


### PR DESCRIPTION
## Task

[ORB-11568](https://orbit-cli.com/tasks/ORB-11568) — [friction-curation] Derive frozen MCP surface length assertions from one canonical list

### Description

## Problem
Adding one MCP tool still requires updating independently frozen copies of the advertised surface, including three bare `len()` assertions that restate the same integer:

- `crates/orbit-mcp/src/federated/tests/host.rs:108` — `assert_eq!(names.len(), 28, "the frozen production surface changed")`
- `crates/orbit-mcp/src/federated/tests/capability.rs:69` — `assert_eq!(advertised.len(), 28)`
- `crates/orbit-mcp/src/remote/tests/discovery.rs:60` — `assert_eq!(canonical.len(), 28, "the frozen production surface changed")`

`canonical_builtin_mcp_tool_definitions()` already exists (`crates/orbit-tools/tests/mcp_definitions.rs` uses the ordered name list). The capability map (`mcp_tool_class`) genuinely needs a human decision per tool. The three count assertions do not: they fail with an integer and no tool name, and they drift independently (four of these guards were already red on main when ORB-11365 added `orbit.task.artifact.get`).

Verified this pass (ORB-11554): all three still hardcode `28`.

## Why It Matters
Fail-fast hides every guard after the first. Authors of a one-line tool registration spend a large fraction of the task rediscovering bookkeeping, and the previous add (`orbit.agent.invoke`, ORB-11354) shipped with the counts stale.

## Suggested direction
Drop the three bare `len()` assertions, or make each read `EXPECTED_SURFACE.len()` / `canonical_builtin_mcp_tool_definitions().len()` from the single ordered list already used by `mcp_definitions.rs`. Keep the set-equality / ordered-name assertions, which already name the offending tool. Keep the capability-class match as a deliberate per-tool edit.

No fail-closed production guard is widened; this is test bookkeeping.

### Acceptance Criteria

- The three hardcoded `len() == 28` assertions in orbit-mcp federated host, federated capability, and remote discovery tests are gone or derived from the same canonical definition list.
- Set-equality or ordered-name assertions still fail with the missing or extra tool name.
- `mcp_tool_class` / the locked class table remains an explicit per-tool edit.
- Adding a fixture tool name to only the canonical list (or only one consumer) makes the remaining guards fail in a way that names the tool, not just an integer.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the three redundant literal 28-length assertions from the federated host, federated capability, and remote discovery tests.
- Retained the ordered host-name comparison, the advertised-versus-locked BTreeSet equality, the explicit ADVERTISED_TOOL_CLASSES table, and discovery-name assertions. These comparisons identify a missing or extra tool by name.

Acceptance criteria:
- All three targeted hardcoded length assertions are gone.
- Name/set equality guards remain and report differing tool names.
- The per-tool capability-class table and mcp_tool_class checks are unchanged.
- A change isolated to the canonical surface or a consumer is caught by the retained ordered/set comparisons with the differing name.

Validation:
- Passed: cargo fmt --check.
- Passed: cargo test -p orbit-tools --test mcp_definitions (3 passed).
- Passed: cargo test -p orbit-mcp (175 tests across unit, integration, and doctest targets passed).
- Passed: make ci-fast.
- Passed: make ci-lint (workspace all-target clippy with warnings denied).
- Passed: git diff --check.

Assessment: Minimal test-bookkeeping refactor; only the three scoped test files changed. No remaining risks or deviations.
Friction checkpoint: no qualifying contradicted assumption, recurring failure, or non-obvious gotcha was observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11568-6a9f311b`
- Behind base: 0
- Ahead of base: 1