### PR TITLE
Reconcile failed-run filtering with dashboard failure counts

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -10,7 +10,7 @@ import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
 import { renderDiagnostics } from './diagnostics.js';
 import { renderMarkdown } from './markdown.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
-import { initRuns, getRunFilter, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
+import { initRuns, getRunFilter, setRunFilter, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
 import { fetchAndRenderOperations, initOperations } from './operations.js';
 import {
   renderRunDetailEmpty,
@@ -77,6 +77,7 @@ let lastTasks = [];
 let lastTasksMeta = null;
 let lastRuns = [];
 let lastRunsMeta = null;
+let lastRunsLoading = true;
 let lastRunSourcesUnavailable = [];
 let lastDiagnostics = { metrics: [], errors: [], incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
@@ -209,10 +210,16 @@ function runsContext() {
     getActiveRunId,
     getLastRuns: () => lastRuns,
     getRunsMeta: () => lastRunsMeta,
+    getRunsLoading: () => lastRunsLoading,
+    markRunsLoading,
     getRunSourcesUnavailable: () => lastRunSourcesUnavailable,
     fmtTimestamp,
     fmtDuration,
   };
+}
+
+function markRunsLoading() {
+  lastRunsLoading = true;
 }
 
 function runDetailContext() {
@@ -1151,6 +1158,7 @@ function buildWorkspaceSelector() {
     // also discarded in fetchAndRenderRuns, so it cannot repaint stale rows.
     lastRuns = [];
     lastRunsMeta = null;
+    lastRunsLoading = true;
     lastRunSourcesUnavailable = [];
     renderRuns(lastRuns);
     refreshDashboard();
@@ -1337,6 +1345,7 @@ function fetchAndRenderRuns() {
   const requestedWorkspace = getWorkspace();
   const requestedAggregate = isAggregateView();
   const runFilter = getRunFilter();
+  lastRunsLoading = true;
   const scopeIsCurrent = () =>
     requestedWorkspace === getWorkspace() &&
     requestedAggregate === isAggregateView() &&
@@ -1349,14 +1358,20 @@ function fetchAndRenderRuns() {
         unavailable: Array.isArray(payload && payload.unavailable) ? payload.unavailable : [],
       }))
     : Promise.all([
-        fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}`),
+        fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}&state=${encodeURIComponent(runFilter)}`),
         fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`),
-      ]).then(([runs, frictionRows]) => ({ runs, frictionRows, meta: null, unavailable: [] }));
+      ]).then(([payload, frictionRows]) => ({
+        runs: listItems(payload),
+        frictionRows,
+        meta: payload,
+        unavailable: [],
+      }));
 
   return request.then(({ runs, frictionRows, meta, unavailable }) => {
     if (!scopeIsCurrent()) return;
     lastRuns = mergeRunsWithFriction(runs, frictionRows);
     lastRunsMeta = meta;
+    lastRunsLoading = false;
     lastRunSourcesUnavailable = unavailable;
     renderRuns(lastRuns);
   }).catch((error) => {
@@ -1364,6 +1379,7 @@ function fetchAndRenderRuns() {
       const workspace = dashboardWorkspaces.find((entry) => entry.id === requestedWorkspace);
       lastRuns = [];
       lastRunsMeta = null;
+      lastRunsLoading = false;
       lastRunSourcesUnavailable = [{
         workspace_id: requestedWorkspace,
         workspace_name: requestedAggregate ? "All workspaces" : (workspace && workspace.name) || requestedWorkspace || "workspace",
@@ -1486,8 +1502,20 @@ function renderHealthStrip(data) {
   } else {
     tile.classList.remove("tile-alert");
   }
+  const windowLabel = data.window || getWindow();
   const failed = $("tile-failed");
-  if (failed) failed.classList.toggle("tile-alert", (data.failed_runs || 0) > 0);
+  if (failed) {
+    failed.classList.toggle("tile-alert", (data.failed_runs || 0) > 0);
+    failed.title = `Failed, timeout, and interrupted job runs in the ${windowLabel} window. Distinct from Recent Runs' failed filter (durable Failed state, no window, most recent page) and Errors (step/event failures this month). Click to open failed runs.`;
+    failed.style.cursor = "pointer";
+    if (!failed.dataset.failedNavBound) {
+      failed.dataset.failedNavBound = "1";
+      failed.addEventListener("click", () => {
+        setRunFilter("failed");
+        sAT("diagnostics/runs");
+      });
+    }
+  }
 
   setRailCount("rail-count-audit", data.events);
   setRailCount("rail-count-diagnostics", data.failed_runs, true);

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -1527,6 +1527,18 @@
         font-family: var(--font-mono);
         font-size: 11px;
       }
+      .runs-scope-note,
+      .runs-limit-note {
+        padding: 8px 16px;
+        border-bottom: 1px solid var(--border);
+        color: var(--fg-dim);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.45;
+      }
+      .runs-limit-note {
+        color: var(--accent);
+      }
       
       .runs-row:last-child {
         border-bottom: none;
@@ -1622,7 +1634,9 @@
         .runs-row { min-width: 790px; }
         .runs-row.workspace-attributed { min-width: 900px; }
         .runs-filter,
-        .runs-source-warning {
+        .runs-source-warning,
+        .runs-scope-note,
+        .runs-limit-note {
           min-width: max-content;
           position: sticky;
           left: 0;

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -98,13 +98,13 @@ function getDiagErrorsColumns(ctx) {
   ];
 }
 
-function renderDiagnosticsTable(rows, columns, ctx) {
+function renderDiagnosticsTable(rows, columns, ctx, emptyText) {
   const body = $("diag-body");
   
   if (!rows || rows.length === 0) {
     syncNodes(body, [el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: "No entries this month." })
+      el("div", { class: "text", text: emptyText || "No entries this month." })
     ])]);
     return;
   }
@@ -428,7 +428,14 @@ function renderDiagnostics(ctx = {}) {
   }
 
   const rows = last[sub] || [];
-  $("diag-count").textContent = `${rows.length}`;
+  const count = $("diag-count");
+  if (sub === "errors") {
+    count.textContent = `${rows.length} error events this month`;
+    count.title = `Step and event failures for the current month, capped at the diag URL parameter (default 50). Distinct from header Failed runs (${getWindow()} Failed, Timeout, and Interrupted job runs) and Recent Runs' failed filter (durable Failed job runs, no window).`;
+  } else {
+    count.textContent = `${rows.length} metric entries this month`;
+    count.title = "Invocation metrics for the current month.";
+  }
   const columns =
     sub === "metrics"
       ? getDiagMetricsColumns(ctx)
@@ -437,6 +444,9 @@ function renderDiagnostics(ctx = {}) {
     rows,
     columns,
     ctx,
+    sub === "errors"
+      ? "No error events this month (step/event failures, not job-run states)."
+      : "No metric entries this month.",
   );
 
   renderDiagnosticsSideCard(last, ctx);

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -73,7 +73,7 @@
           <div class="kpis" id="health-strip" aria-label="Audit health summary">
             <span class="kpi" id="tile-events"><span class="k">Events 24h</span><span class="v" id="tile-events-value">-</span></span>
             <span class="kpi" id="tile-denials"><span class="k">Denials</span><span class="v" id="tile-denials-value">-</span></span>
-            <span class="kpi" id="tile-failed"><span class="k">Failed runs</span><span class="v" id="tile-failed-value">-</span></span>
+            <span class="kpi" id="tile-failed" title="Failed, timeout, and interrupted job runs in the selected window. Distinct from Recent Runs' failed filter (durable Failed state, no window) and Errors (step/event failures this month)."><span class="k">Failed runs</span><span class="v" id="tile-failed-value">-</span></span>
             <span class="kpi" id="tile-active"><span class="k">Long</span><span class="v" id="tile-active-value">-</span></span>
             <svg class="kpi-spark" id="tile-events-sparkline" viewBox="0 0 100 22" preserveAspectRatio="none" aria-hidden="true"></svg>
           </div>

--- a/crates/orbit-web/assets/dashboard/runs.js
+++ b/crates/orbit-web/assets/dashboard/runs.js
@@ -414,18 +414,76 @@ function runMatchesFilter(run) {
   return true;
 }
 
-function setRunFilter(value) {
+export function setRunFilter(value) {
   runFilter = RUN_FILTERS.has(value) ? value : "all";
   const url = new URL(window.location.href);
   if (runFilter === "all") url.searchParams.delete("run_state");
   else url.searchParams.set("run_state", runFilter);
   if (url.href !== window.location.href) history.replaceState(null, "", url);
+  if (hasCtx("markRunsLoading")) _runsCtx.markRunsLoading();
   renderRuns(hasCtx("getLastRuns") ? _runsCtx.getLastRuns() : []);
   doFetchAndRenderRuns().catch((error) => console.error(error));
 }
 
 export function getRunFilter() {
   return runFilter;
+}
+
+export function formatRunCount(shown, fetched, meta) {
+  if (meta && Number.isFinite(meta.total)) {
+    const base = shown === fetched
+      ? `${shown} shown`
+      : `${shown} shown (of ${fetched} fetched)`;
+    return meta.truncated
+      ? `${base} · ${meta.total} total · server limit ${meta.limit}`
+      : `${base} · ${meta.total} total`;
+  }
+  if (meta && meta.truncated) {
+    return `${shown} shown · server limit ${meta.limit || fetched} · older matching runs not loaded`;
+  }
+  return shown === fetched
+    ? `${shown} shown`
+    : `${shown} shown of ${fetched} fetched`;
+}
+
+function runsAreLoading(runs, meta) {
+  if (!(hasCtx("getRunsLoading") && _runsCtx.getRunsLoading())) return false;
+  const loadedState = meta && meta.state;
+  return !runs || runs.length === 0 || (loadedState && loadedState !== runFilter);
+}
+
+function runsEmptyText() {
+  if (runFilter === "failed") {
+    return "No failed job runs (durable Failed state, no time window).";
+  }
+  if (runFilter === "active") {
+    return "No pending or running job runs.";
+  }
+  return "No job runs in this workspace.";
+}
+
+function runsScopeNote() {
+  return el("div", {
+    class: "runs-scope-note",
+    text: "Recent Runs lists durable job-run states with no time window (most recent page). Header Failed runs counts Failed, Timeout, and Interrupted job runs in the selected window. Errors lists step/event failures for the current month.",
+  });
+}
+
+function runsLimitNote(meta) {
+  if (!meta || !meta.truncated) return null;
+  const total = Number.isFinite(meta.total) ? ` of ${meta.total}` : "";
+  return el("div", {
+    class: "runs-limit-note",
+    text: `Showing the most recent ${meta.limit} matching runs${total}. Raise the runs URL parameter to load older matches.`,
+  });
+}
+
+function runsLoadingSkeleton() {
+  return el("div", { class: "skeleton-state" }, [
+    el("div", { class: "skeleton skeleton-row" }),
+    el("div", { class: "skeleton skeleton-row", style: { width: "80%" } }),
+    el("div", { class: "skeleton skeleton-row", style: { width: "90%" } }),
+  ]);
 }
 
 function runFilterControls() {
@@ -515,19 +573,28 @@ export function renderRuns(runs) {
   const unavailable = hasCtx("getRunSourcesUnavailable") ? _runsCtx.getRunSourcesUnavailable() : [];
   const meta = hasCtx("getRunsMeta") ? _runsCtx.getRunsMeta() : null;
   const attributed = (runs || []).some((run) => !!run.workspace_id);
-  const sorted = sortedRunsForDisplay((runs || []).filter(runMatchesFilter));
-  const top = sorted.slice(0, 20);
+  const loading = runsAreLoading(runs, meta);
+  const filtered = (runs || []).filter(runMatchesFilter);
+  const sorted = sortedRunsForDisplay(filtered);
+  const top = sorted;
   if ($("diag-count")) {
-    const bounded = meta && meta.truncated ? "+" : "";
-    $("diag-count").textContent = `${top.length}/${sorted.length}${bounded}`;
+    $("diag-count").textContent = loading ? "…" : formatRunCount(top.length, sorted.length, meta);
   }
   frag.appendChild(runFilterControls());
+  frag.appendChild(runsScopeNote());
   const unavailableNode = unavailableSourcesNode(unavailable);
   if (unavailableNode) frag.appendChild(unavailableNode);
+  const limitNote = loading ? null : runsLimitNote(meta);
+  if (limitNote) frag.appendChild(limitNote);
+  if (loading) {
+    frag.appendChild(runsLoadingSkeleton());
+    syncNodes(body, Array.from(frag.children));
+    return;
+  }
   if (top.length === 0) {
     frag.appendChild(el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
-      el("div", { class: "text", text: runFilter === "all" ? "No job runs yet." : `No ${runFilter} job runs.` })
+      el("div", { class: "text", text: runsEmptyText() }),
     ]));
     syncNodes(body, Array.from(frag.children));
     return;

--- a/crates/orbit-web/src/api/jobs.rs
+++ b/crates/orbit-web/src/api/jobs.rs
@@ -5,8 +5,8 @@ use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Utc};
-use orbit_core::JobRunState;
-use orbit_core::application::job::{JobRunListParams, job_run_to_json};
+use orbit_core::application::job::{JobRunListParams, JobRunOrder, job_run_to_json};
+use orbit_core::{JobRun, JobRunState, OrbitRuntime};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -27,18 +27,40 @@ pub(super) struct JobRunListQuery {
     since: Option<DateTime<Utc>>,
 }
 
+#[derive(Clone, Copy)]
 enum JobRunListState {
+    All,
+    Active,
+    Failed,
     Concrete(JobRunState),
     Terminal,
 }
 
 impl JobRunListState {
-    fn parse(value: &str) -> Result<Self, String> {
+    fn parse(value: Option<&str>) -> Result<Self, String> {
         match value {
-            "pending" => Ok(Self::Concrete(JobRunState::Pending)),
-            "running" => Ok(Self::Concrete(JobRunState::Running)),
-            "terminal" => Ok(Self::Terminal),
-            _ => Err("invalid state; expected one of: pending, running, terminal".to_string()),
+            None | Some("all") => Ok(Self::All),
+            Some("active") => Ok(Self::Active),
+            Some("failed") => Ok(Self::Failed),
+            Some("pending") => Ok(Self::Concrete(JobRunState::Pending)),
+            Some("running") => Ok(Self::Concrete(JobRunState::Running)),
+            Some("terminal") => Ok(Self::Terminal),
+            Some(_) => Err(
+                "invalid state; expected one of: all, active, failed, pending, running, terminal"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Active => "active",
+            Self::Failed => "failed",
+            Self::Concrete(JobRunState::Pending) => "pending",
+            Self::Concrete(JobRunState::Running) => "running",
+            Self::Concrete(_) => "concrete",
+            Self::Terminal => "terminal",
         }
     }
 }
@@ -61,28 +83,107 @@ pub(super) async fn list_jobs(Ws(runtime): Ws) -> Response {
 
 pub(super) async fn list_job_runs(Ws(runtime): Ws, Query(q): Query<JobRunListQuery>) -> Response {
     let limit = bounded_limit(q.limit, JOB_RUN_DEFAULT_LIMIT);
-    let state = match q.state.as_deref().map(JobRunListState::parse).transpose() {
+    let state = match JobRunListState::parse(q.state.as_deref()) {
         Ok(state) => state,
         Err(message) => return bad_request(message),
     };
-    let params = JobRunListParams {
-        job_id: q.job_id,
-        state: state.as_ref().and_then(|state| match state {
-            JobRunListState::Concrete(state) => Some(*state),
-            JobRunListState::Terminal => None,
-        }),
-        terminal_only: matches!(state, Some(JobRunListState::Terminal)),
-        since: q.since,
-        limit: Some(limit),
-        ..Default::default()
-    };
-    match runtime.list_job_runs(params) {
-        Ok(runs) => {
-            let values: Vec<Value> = runs.iter().map(|run| job_run_to_json(run, None)).collect();
-            Json(Value::Array(values)).into_response()
-        }
+    match job_runs_page(&runtime, &q, state, limit) {
+        Ok(value) => Json(value).into_response(),
         Err(e) => server_error(e),
     }
+}
+
+fn job_runs_page(
+    runtime: &OrbitRuntime,
+    query: &JobRunListQuery,
+    state: JobRunListState,
+    limit: usize,
+) -> Result<Value, orbit_core::OrbitError> {
+    let runs = list_job_runs_for_state(runtime, query, state, limit)?;
+    let total = count_job_runs_for_state(runtime, query, state)?;
+    let truncated = total > runs.len() as u64;
+    let items: Vec<Value> = runs.iter().map(|run| job_run_to_json(run, None)).collect();
+    Ok(json!({
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "truncated": truncated,
+        "state": state.label(),
+    }))
+}
+
+fn list_job_runs_for_state(
+    runtime: &OrbitRuntime,
+    query: &JobRunListQuery,
+    state: JobRunListState,
+    limit: usize,
+) -> Result<Vec<JobRun>, orbit_core::OrbitError> {
+    let list = |run_state, terminal_only| {
+        runtime.list_job_runs(job_run_list_params(
+            query,
+            run_state,
+            terminal_only,
+            Some(limit),
+        ))
+    };
+    match state {
+        JobRunListState::All => list(None, false),
+        JobRunListState::Failed => list(Some(JobRunState::Failed), false),
+        JobRunListState::Concrete(run_state) => list(Some(run_state), false),
+        JobRunListState::Terminal => list(None, true),
+        JobRunListState::Active => {
+            let mut runs = list(Some(JobRunState::Pending), false)?;
+            runs.extend(list(Some(JobRunState::Running), false)?);
+            runs.sort_by(|left, right| {
+                job_run_timestamp(right)
+                    .cmp(&job_run_timestamp(left))
+                    .then_with(|| left.run_id.cmp(&right.run_id))
+            });
+            runs.truncate(limit);
+            Ok(runs)
+        }
+    }
+}
+
+fn count_job_runs_for_state(
+    runtime: &OrbitRuntime,
+    query: &JobRunListQuery,
+    state: JobRunListState,
+) -> Result<u64, orbit_core::OrbitError> {
+    let count = |run_state, terminal_only| {
+        runtime.count_job_runs(job_run_list_params(query, run_state, terminal_only, None))
+    };
+    match state {
+        JobRunListState::All => count(None, false),
+        JobRunListState::Failed => count(Some(JobRunState::Failed), false),
+        JobRunListState::Concrete(run_state) => count(Some(run_state), false),
+        JobRunListState::Terminal => count(None, true),
+        JobRunListState::Active => {
+            let pending = count(Some(JobRunState::Pending), false)?;
+            let running = count(Some(JobRunState::Running), false)?;
+            Ok(pending.saturating_add(running))
+        }
+    }
+}
+
+fn job_run_list_params(
+    query: &JobRunListQuery,
+    state: Option<JobRunState>,
+    terminal_only: bool,
+    limit: Option<usize>,
+) -> JobRunListParams {
+    JobRunListParams {
+        job_id: query.job_id.clone(),
+        state,
+        terminal_only,
+        since: query.since,
+        limit,
+        order_by: JobRunOrder::Recency,
+    }
+}
+
+fn job_run_timestamp(run: &JobRun) -> DateTime<Utc> {
+    run.finished_at.or(run.started_at).unwrap_or(run.created_at)
 }
 
 /// [ORB-10709] Optional body carrying the workspace claim token, for a resume

--- a/crates/orbit-web/src/api/tests/handlers.rs
+++ b/crates/orbit-web/src/api/tests/handlers.rs
@@ -234,16 +234,19 @@ async fn job_run_filters_apply_before_limit_and_validate_state() {
 
     let response = request_job_runs(runtime.clone(), "state=running&limit=1").await;
     assert_eq!(response.status(), StatusCode::OK);
-    let rows = body_json(response).await;
-    assert_eq!(rows.as_array().expect("runs array").len(), 1);
+    let body = body_json(response).await;
+    assert_eq!(body["state"], json!("running"));
+    assert_eq!(body["limit"], json!(1));
+    let rows = body["items"].as_array().expect("runs items");
+    assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["run_id"], json!(running.run_id));
 
     let response = request_job_runs(runtime.clone(), "state=terminal&limit=10").await;
     assert_eq!(response.status(), StatusCode::OK);
-    let rows = body_json(response).await;
-    let states = rows
+    let body = body_json(response).await;
+    let states = body["items"]
         .as_array()
-        .expect("runs array")
+        .expect("runs items")
         .iter()
         .map(|run| run["state"].as_str().expect("state"))
         .collect::<Vec<_>>();
@@ -258,10 +261,10 @@ async fn job_run_filters_apply_before_limit_and_validate_state() {
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
-    let rows = body_json(response).await;
-    let run_ids = rows
+    let body = body_json(response).await;
+    let run_ids = body["items"]
         .as_array()
-        .expect("runs array")
+        .expect("runs items")
         .iter()
         .map(|run| run["run_id"].as_str().expect("run id"))
         .collect::<Vec<_>>();
@@ -273,8 +276,75 @@ async fn job_run_filters_apply_before_limit_and_validate_state() {
     let error = body_json(response).await;
     assert_eq!(
         error["error"],
-        json!("invalid state; expected one of: pending, running, terminal")
+        json!("invalid state; expected one of: all, active, failed, pending, running, terminal")
     );
+}
+
+/// Dashboard Recent Runs used to fetch the newest N runs and then filter to
+/// `failed` in the browser. A Failed run older than that recent success/active
+/// slice disappeared even though the header still counted it. Filter, then
+/// limit, so that older failure remains discoverable.
+#[tokio::test]
+async fn job_runs_failed_filter_keeps_older_failures_outside_the_recent_success_slice() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let now = Utc::now();
+
+    for index in 0..3 {
+        let mut recent = seed_run(
+            &runtime,
+            &format!("jrun-recent-success-{index}"),
+            "recent_job",
+            JobRunState::Success,
+        );
+        recent.created_at = now - Duration::minutes(index);
+        recent.scheduled_at = recent.created_at;
+        recent.started_at = Some(recent.created_at);
+        recent.finished_at = Some(now - Duration::minutes(index));
+        write_seeded_run(&runtime, &recent);
+    }
+
+    let mut older_failed = seed_run(
+        &runtime,
+        "jrun-older-failed",
+        "recent_job",
+        JobRunState::Failed,
+    );
+    older_failed.created_at = now - Duration::hours(2);
+    older_failed.scheduled_at = older_failed.created_at;
+    older_failed.started_at = Some(older_failed.created_at);
+    older_failed.finished_at = Some(now - Duration::hours(2));
+    write_seeded_run(&runtime, &older_failed);
+
+    let unfiltered = request_job_runs(runtime.clone(), "limit=3").await;
+    assert_eq!(unfiltered.status(), StatusCode::OK);
+    let unfiltered = body_json(unfiltered).await;
+    assert_eq!(unfiltered["state"], json!("all"));
+    assert_eq!(unfiltered["limit"], json!(3));
+    assert_eq!(unfiltered["total"], json!(4));
+    assert_eq!(unfiltered["truncated"], json!(true));
+    let unfiltered_ids = unfiltered["items"]
+        .as_array()
+        .expect("unfiltered items")
+        .iter()
+        .map(|run| run["run_id"].as_str().expect("run id"))
+        .collect::<Vec<_>>();
+    assert_eq!(unfiltered_ids.len(), 3);
+    assert!(
+        !unfiltered_ids.contains(&"jrun-older-failed"),
+        "the unfiltered recent slice must omit the older failure so this fixture still proves filter-after-limit would hide it"
+    );
+
+    let failed = request_job_runs(runtime, "state=failed&limit=3").await;
+    assert_eq!(failed.status(), StatusCode::OK);
+    let failed = body_json(failed).await;
+    assert_eq!(failed["state"], json!("failed"));
+    assert_eq!(failed["limit"], json!(3));
+    assert_eq!(failed["total"], json!(1));
+    assert_eq!(failed["truncated"], json!(false));
+    let failed_items = failed["items"].as_array().expect("failed items");
+    assert_eq!(failed_items.len(), 1);
+    assert_eq!(failed_items[0]["run_id"], json!("jrun-older-failed"));
+    assert_eq!(failed_items[0]["state"], json!("failed"));
 }
 
 #[tokio::test]

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2037,6 +2037,163 @@ if (rows.length !== 1 || !rows[0].textContent.includes("Beta")) throw new Error(
     );
 }
 
+/// ORB-11561: Recent Runs used to limit first, then filter to failed in the
+/// browser, so an older Failed run outside the newest success/active slice
+/// rendered as 0/0. Loading and mismatched-filter paints must not look like
+/// that empty result either.
+#[test]
+fn dashboard_failed_runs_filter_before_limit_and_label_distinct_scopes() {
+    let app = include_str!("../../assets/dashboard/app.js");
+    let runs = include_str!("../../assets/dashboard/runs.js");
+    let diagnostics = include_str!("../../assets/dashboard/diagnostics.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    assert!(
+        app.contains(
+            r#"`/api/job-runs?limit=${JOB_RUN_LIMIT}&state=${encodeURIComponent(runFilter)}`"#
+        ),
+        "single-workspace Recent Runs must send the active state filter to the server"
+    );
+    assert!(
+        !runs.contains("${top.length}/${sorted.length}"),
+        "the old ambiguous N/M run count shorthand must be gone"
+    );
+    assert!(
+        runs.contains("export function formatRunCount(")
+            && runs.contains("shown")
+            && runs.contains("total")
+            && runs.contains("server limit"),
+        "run counts must use explicit shown/total/server-limit language"
+    );
+    assert!(
+        index.contains("Failed, timeout, and interrupted job runs in the selected window"),
+        "the Failed runs header tile must explain its windowed population"
+    );
+    assert!(
+        diagnostics
+            .contains("No error events this month (step/event failures, not job-run states)."),
+        "Errors empty copy must name the month-scoped event population"
+    );
+
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.disabled = false; }
+  appendChild(child) { if (child == null) return child; if (child.parentNode) child.parentNode.removeChild(child); this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { if (child.parentNode) child.parentNode.removeChild(child); const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  remove() { if (this.parentNode) this.parentNode.removeChild(this); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this.textContent = value; }
+  get innerHTML() { return this.textContent; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+  get classList() { const self = this; return { add: (...classes) => { for (const c of classes) if (!self.className.split(/\s+/).includes(c)) self.className = `${self.className} ${c}`.trim(); }, toggle: (c, on) => { if (on) this.addClass(c); } }; }
+  addClass(c) { if (!this.className.split(/\s+/).includes(c)) this.className = `${this.className} ${c}`.trim(); }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+globalThis.document = {
+  getElementById: get,
+  createElement: () => new Node(),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+};
+const location = new URL("http://dashboard.test/?run_state=failed");
+globalThis.window = { location, innerWidth: 1200, confirm: () => true };
+globalThis.history = { replaceState: (_, __, url) => { location.href = String(url); } };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+
+const { initRuns, renderRuns, formatRunCount } = await import("./runs.js");
+const { renderDiagnostics } = await import("./diagnostics.js");
+
+if (formatRunCount(20, 25, { total: 81, limit: 25, truncated: true }) !== "20 shown (of 25 fetched) · 81 total · server limit 25") {
+  throw new Error(`formatRunCount missed shown/total/limit language: ${formatRunCount(20, 25, { total: 81, limit: 25, truncated: true })}`);
+}
+
+let loading = true;
+let lastRuns = [];
+let lastMeta = { state: "all", total: 4, limit: 3, truncated: true };
+let navigated = null;
+initRuns({
+  getLastRuns: () => lastRuns,
+  getRunsMeta: () => lastMeta,
+  getRunsLoading: () => loading,
+  markRunsLoading: () => { loading = true; },
+  getRunSourcesUnavailable: () => [],
+  navigateToRun: (runId, workspaceId) => { navigated = { runId, workspaceId }; },
+  fetchAndRenderRuns: () => Promise.resolve(),
+  getActiveRunId: () => null,
+});
+
+renderRuns(lastRuns);
+const loadingBody = get("runs-body").textContent;
+if (loadingBody.includes("No failed job runs")) throw new Error("loading painted a zero-failure empty state");
+if (get("diag-count").textContent !== "…") throw new Error(`loading count was treated as zero: ${get("diag-count").textContent}`);
+if (!get("runs-body").children.some((node) => node.className.includes("skeleton-state"))) {
+  throw new Error("loading must keep the skeleton, not an empty result");
+}
+
+loading = false;
+lastRuns = [];
+lastMeta = { state: "failed", total: 0, limit: 25, truncated: false };
+renderRuns(lastRuns);
+const emptyText = get("runs-body").textContent;
+if (!emptyText.includes("No failed job runs (durable Failed state, no time window).")) {
+  throw new Error(`empty copy did not name the failed-run scope: ${emptyText}`);
+}
+if (!emptyText.includes("Header Failed runs counts Failed, Timeout, and Interrupted")) {
+  throw new Error("scope note must explain header vs Recent Runs vs Errors");
+}
+if (!get("diag-count").textContent.includes("0 shown") || !get("diag-count").textContent.includes("0 total")) {
+  throw new Error(`empty count must still say shown/total, got ${get("diag-count").textContent}`);
+}
+
+lastRuns = [
+  { run_id: "jrun-older-failed", job_id: "ship", state: "failed", created_at: "2026-09-07T10:00:00Z", finished_at: "2026-09-07T10:01:00Z" },
+];
+lastMeta = { state: "failed", total: 1, limit: 3, truncated: false };
+renderRuns(lastRuns);
+const failedRows = get("runs-body").children.filter((node) => node.className.includes("runs-row") && !node.className.includes("runs-header"));
+if (failedRows.length !== 1 || !failedRows[0].textContent.includes("jrun-older-failed")) {
+  throw new Error("server-filtered failed payload must keep a failure older than the recent success slice");
+}
+failedRows[0].listeners.click();
+if (!navigated || navigated.runId !== "jrun-older-failed") {
+  throw new Error(`failed-run drilldown did not open the older failure: ${JSON.stringify(navigated)}`);
+}
+
+lastRuns = Array.from({ length: 25 }, (_, index) => ({
+  run_id: `jrun-failed-${index}`,
+  job_id: "ship",
+  state: "failed",
+  created_at: "2026-09-07T12:00:00Z",
+}));
+lastMeta = { state: "failed", total: 81, limit: 25, truncated: true };
+renderRuns(lastRuns);
+if (!get("diag-count").textContent.includes("server limit 25") || !get("diag-count").textContent.includes("81 total")) {
+  throw new Error(`truncated count missing shown/total/limit: ${get("diag-count").textContent}`);
+}
+if (!get("runs-body").textContent.includes("Raise the runs URL parameter to load older matches")) {
+  throw new Error("truncated results must explain how to find older failures");
+}
+
+renderDiagnostics({
+  getActiveDiagSubtab: () => "errors",
+  getLastDiagnostics: () => ({ metrics: [], errors: [], incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] }),
+});
+if (!get("diag-body").textContent.includes("No error events this month (step/event failures, not job-run states).")) {
+  throw new Error(`errors empty copy was wrong: ${get("diag-body").textContent}`);
+}
+if (get("diag-count").textContent !== "0 error events this month") {
+  throw new Error(`errors count must name its month-scoped population, got ${get("diag-count").textContent}`);
+}
+"#,
+    );
+}
+
 async fn response_body(response: Response) -> String {
     let bytes = match to_bytes(response.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,


### PR DESCRIPTION
## Task

[ORB-11561](https://orbit-cli.com/tasks/ORB-11561) — Reconcile failed-run filtering with dashboard failure counts

### Description

## Observation
Recent runs in ws_orbit showed 20/25 loaded runs. Selecting failed settled at 0/0 and No failed job runs even after refreshed diagnostics/runs, while the header displayed 81 Failed runs and Errors loaded 50 entries including recent step failures. This establishes contradictory user-facing scopes, not proof that 81 failed job records must exist: summary events, step failures and durable run states may use different windows and populations.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Trace filtering, recent limits, pagination, time windows and metric populations. Correct any filtering-before/after-limit defect and label valid scope differences. Inspect existing completed recent-run selection work before assigning lineage; do not invent regression_from.

### Acceptance Criteria

- A deterministic fixture with failures older than the newest successful/active run slice remains discoverable under failed filtering; filtering and limits are applied in the correct order.
- Header counts and run/error lists use matching scopes or explicitly explain their different populations and windows; empty text describes the actual searched scope.
- Any limited result set has a clear shown/total or limit explanation and a usable way to find relevant older failures.
- Loading is not interpreted as zero failures; browser validation demonstrates a real failed run drilldown and regression tests establish the actual defect or scope correction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- GET /api/job-runs now accepts dashboard states all|active|failed (keeps pending|running|terminal), filters then limits by Recency, and returns `{items,total,limit,truncated,state}`.
- Single-workspace Recent Runs sends `state=` like `/api/job-runs/all`. Older Failed runs outside the newest success/active slice stay discoverable.
- Run counts use shown/total/server-limit language. Loading/filter-mismatch keeps a skeleton and `…`, not 0/0. Empty copy names the searched scope. Header Failed runs, Recent Runs failed filter, and Errors are labeled as distinct populations/windows. Truncated pages explain `?runs=`. The Failed runs tile opens Diagnostics/Runs with failed selected.
- Added a handlers fixture proving filter-then-limit, plus a Node harness for loading-not-zero, scope labels, truncated paging, and failed-row drilldown.

Assessment: scoped to the observed filter-after-limit defect and contradictory labels. Did not invent regression_from. `/api/job-runs` envelope is a breaking JSON shape change; the dashboard already accepts envelopes via listItems.

Criteria:
- Older failures remain discoverable; filter then limit: pass (handlers fixture: unfiltered limit=3 drops jrun-older-failed; state=failed&limit=3 returns it with total=1).
- Header vs run/error scopes labeled; empty text names searched scope: pass.
- Limited sets show shown/total/limit and a way to load older matches (`?runs=`): pass.
- Loading is not zero failures; failed-row drilldown covered by Node harness: pass for tests. Live Chromium against patched assets not run.

Validation:
- cargo test -p orbit-web --lib job_runs_failed: passed.
- cargo test -p orbit-web --lib dashboard_failed_runs: passed.
- cargo test -p orbit-web --lib -- dashboard_ job_run_: passed (56 tests).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
- cargo clippy -p orbit-web --all-targets -- -D warnings: passed.
- git diff --check: passed.
- make ci-lint: failed on pre-existing orbit-core test compile error (`owner_machine_id` duplicated in crates/orbit-core/src/application/job/tests/exec/ci_sweep.rs). Not in this diff; orbit-web clippy was clean.
- Browser against patched assets: not run (no Chromium/playwright). Node harness clicked jrun-older-failed into navigateToRun.
- Live localhost:7878 (unpatched include_str binary): GET /api/job-runs?state=failed&workspace=ws_orbit still 400 `pending, running, terminal`; unfiltered limit=25 is a bare array; summary failed_runs=95 in 24h; Errors returns 50 events. Confirms the served revision still has the defect until this change is built and served.

Remaining risks: GET /api/job-runs no longer returns a bare array. Header Failed runs still counts Failed+Timeout+Interrupted in the window, while the failed filter is durable Failed with no window — labeled, not equalized. Display now shows the full server page instead of an extra 20-row cap.

Deviations: none from the persisted plan. Did not assign regression_from.

Uncommitted files: crates/orbit-web/src/api/jobs.rs, src/api/tests/handlers.rs, src/tests/dashboard_assets.rs, assets/dashboard/{app.js,runs.js,diagnostics.js,index.html,dashboard.css}.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11561-6a9f2f85`
- Behind base: 0
- Ahead of base: 1