### PR TITLE
Make website First Task onboarding a complete executable sequence

### DIFF
--- a/website/src/content/docs/getting-started/first-task.md
+++ b/website/src/content/docs/getting-started/first-task.md
@@ -1,6 +1,6 @@
 ---
 title: First Task
-description: "Create an Orbit task, inspect it, approve it into the backlog, and ship it."
+description: "Create a proposed Orbit task, approve it into the backlog, ship it, and inspect the run and review artifact."
 sidebar:
   order: 3
 ---
@@ -8,7 +8,38 @@ sidebar:
 A task is the durable unit of work. Everything else in Orbit — shipping,
 backlog drains, recurring work, the audit trail — is organized around one.
 
+This page is one sequence in a prepared disposable repository: create a
+`proposed` task, inspect it, approve it into `backlog`, ship it, then inspect
+the run and the review artifact. Later sections cover other shipment shapes.
+
+## Before you start
+
+Complete [Install Orbit](../install/) first. You need all of the following
+before you create work or dispatch a run:
+
+- `orbit` on your `PATH`. Confirm with `orbit --version`.
+- Global and workspace state: [`orbit init`](../install/#initialize-state),
+  then [`orbit workspace init`](../install/#initialize-state) in the
+  repository.
+- An authenticated provider CLI. Dispatch runs through it. `orbit init`
+  probes `PATH` for the executors it supports; see
+  [Prerequisites](../install/#prerequisites) and the
+  [setup explorer](../../concepts/agents/#set-up-an-executor).
+- For the default PR mode, the GitHub CLI (`gh`) authenticated in the same
+  environment. See [Prerequisites](../install/#prerequisites).
+- On Linux, a working Bubblewrap sandbox before the first dispatch. See
+  [Prepare the sandbox](../install/#prepare-the-sandbox).
+
+`orbit doctor` is the workspace health check after that setup.
+
+The commands below assume you are in a disposable git repository that already
+has `orbit workspace init` completed, so they do not touch a real project.
+
 ## Create a task
+
+`orbit task add` prints the new task ID and nothing else. Capture it.
+New tasks enter `proposed` unless you pass another `--status`; the snippet
+sets that status explicitly so the rest of the sequence matches.
 
 ```bash
 TASK_ID=$(orbit task add \
@@ -17,6 +48,7 @@ TASK_ID=$(orbit task add \
   --acceptance-criteria "orbit-hello.txt exists at the repository root." \
   --acceptance-criteria "orbit-hello.txt contains the text 'hello from orbit'." \
   --complexity low \
+  --status proposed \
   --workspace .)
 
 echo "$TASK_ID"
@@ -27,12 +59,8 @@ required too: agents self-evaluate against them to decide when the work is
 actually done, and a task without them has no finish line. Repeat
 `--acceptance-criteria` for each one.
 
-Two options are worth setting early:
-
-- `--context` narrows the work to the files that matter, as `file:`, `dir:`, or
-  `symbol:` selectors. See [Choose Scopes](../../how-to/scoping-rules/).
-- `--status proposed` parks the task for human approval instead of putting it
-  straight into the backlog.
+`--context` narrows the work to the files that matter, as `file:`, `dir:`, or
+`symbol:` selectors. See [Choose Scopes](../../how-to/scoping-rules/).
 
 You can also just ask an agent with Orbit's MCP tools available:
 
@@ -41,6 +69,8 @@ create an orbit task for ...
 ```
 
 ## Inspect it
+
+The task should be `proposed`:
 
 ```bash
 orbit task list
@@ -53,18 +83,19 @@ acceptance criteria before an agent wastes a run on them.
 
 ## Approve it into the backlog
 
-`orbit task add` puts work straight into `backlog` unless you asked for
-`proposed`. A `proposed` task needs an explicit approval before anything will
-run it:
+A `proposed` task needs an explicit approval before anything will run it:
 
 ```bash
 orbit task update "$TASK_ID" --approve --note "Scope reviewed."
 ```
 
-`--approve` takes the task's *next* approval step, chosen from its current
-status: `proposed` becomes `backlog`, and later `review` becomes `done`. Because
-the transition is derived, `--approve` cannot be combined with field edits or an
-explicit `--status`.
+`--approve` takes the task's *next* approval step from its current status:
+`proposed` becomes `backlog`. The same flag later takes `review` to `done`.
+Because the transition is derived, `--approve` cannot be combined with field
+edits or an explicit `--status`. Approving a task that is already `backlog`
+is refused — that is a different status, not a missing approval.
+
+After this command, `orbit task show "$TASK_ID"` reports `backlog`.
 
 ## Ship it
 
@@ -73,30 +104,52 @@ orbit run ship "$TASK_ID"
 ```
 
 This submits the task through the gated shipment pipeline and prints a durable
-run ID immediately — it does not wait for the outcome. The default mode opens a
-pull request. Deliver in place instead with:
+run identifier immediately — it does not wait for the outcome. Copy the
+`Run ID:` value:
 
-```bash
-orbit run ship --mode local "$TASK_ID"
+```text
+Workflow: ship
+Job ID: task_auto_pipeline
+Run ID: jrun-YYYYMMDD-HHMM-N
+State: submitted
+Inspect: orbit run history -j task_auto_pipeline | orbit run show jrun-YYYYMMDD-HHMM-N
 ```
 
-Ship several known tasks in one run, and target a specific base branch:
-
 ```bash
-orbit run ship "$TASK_ID" "$SECOND_TASK_ID" --base main
+RUN_ID=jrun-YYYYMMDD-HHMM-N   # paste the printed identifier
 ```
+
+`orbit run ship "$TASK_ID" --json` prints the same fields as an object. Copy
+`run_id` from that object if you prefer structured output.
+
+The default mode opens a pull request and requires `gh` as in
+[Before you start](#before-you-start).
 
 ## Watch it
 
 ```bash
-orbit run show              # the most recent run
 orbit run show "$RUN_ID"
 orbit run logs "$RUN_ID"
 orbit task show "$TASK_ID"
 ```
 
-A successful run leaves the task in `review`, not `done` — completion is a
-separate, deliberate step. Approve it when you have looked at the result:
+`orbit run show` with no run ID is the most recent run on this machine. Use it
+only when you know nothing else submitted in between.
+
+A successful run leaves the task in `review`, not `done`. Inspect the
+execution summary and the review artifact before you approve the result:
+
+```bash
+orbit task show "$TASK_ID" --fields status,execution_summary,artifacts
+orbit task artifact get "$TASK_ID" review-gate.json
+```
+
+`review-gate.json` is the settled review certificate when the pipeline's
+review gate completed. `orbit task show "$TASK_ID" --json` also includes a
+`review` object built from that artifact.
+
+Approve the result when you have looked at it. The task moves from `review`
+to `done`:
 
 ```bash
 orbit task update "$TASK_ID" --approve
@@ -106,8 +159,27 @@ If you would rather authorize the run itself to finish delivery, pass
 `--complete` when you ship. That is explained in
 [Delivery Workflows](../workflows/#completing-work-with---complete).
 
+## Other shipment shapes
+
+Keep these off the first path. They are the same pipeline with different
+delivery or selection.
+
+Deliver in place instead of opening a pull request:
+
+```bash
+orbit run ship --mode local "$TASK_ID"
+```
+
+Ship several known tasks in one run, and target a specific base branch.
+`$SECOND_TASK_ID` is another identifier you captured the same way as
+`$TASK_ID` — it is not created by the commands above.
+
+```bash
+orbit run ship "$TASK_ID" "$SECOND_TASK_ID" --base main
+```
+
 ## Next
 
 - [Delivery Workflows](../workflows/) — the whole `orbit run` surface.
-- [Run a Task Lifecycle](../../how-to/task-lifecycle/) — the same path in more detail, including artifacts and review.
+- [Run a Task Lifecycle](../../how-to/task-lifecycle/) — the same path in more detail, including attaching artifacts.
 - [Run a Continuous Delivery Window](../../how-to/continuous-delivery/) — drain a whole backlog instead of one task.


### PR DESCRIPTION
## Task

[ORB-11583](https://orbit-cli.com/tasks/ORB-11583) — Make website First Task onboarding a complete executable sequence

### Description

## Problem
website/src/content/docs/getting-started/first-task.md creates a task without --status proposed (the page says backlog is the default), then presents an approval-into-backlog step. The Watch it block uses $RUN_ID without assigning it. A visitor arriving directly from the homepage is not given a concise prerequisite check before creation. These are documentation sequence gaps; no live task creation or dispatch was attempted during the audit.

## Scope
Provide one coherent first-task path with prerequisites, explicit lifecycle states, captured task/run identifiers and expected results. Keep advanced local/multi-task examples clearly separate from the main sequence. Verify CLI examples against the actual supported release surface without mutating real user workspaces.

## Audit evidence and boundaries
Observed 2026-09-07 around 14:27 America/Los_Angeles in a fresh local Astro production build of website/ at revision 7f3a8f5fa, served at http://127.0.0.1:4321/. Desktop 1440x1000 and mobile 390x844 were exercised. This is local-source evidence, not proof of production parity. Build and Astro check passed, 29 generated HTML pages had no broken local links/anchors, and exercised browser flows logged no warnings/errors. Revalidate current sources at pickup and trace introducing changes before asserting regression lineage. Prepare a validated candidate; this task does not authorize deployment or release.

### Acceptance Criteria

- A reader can follow the primary sequence from a prepared disposable repository without undefined shell variables or an approval step inconsistent with the task's current status.
- The guide links required installation, workspace initialization, provider authentication and PR-mode prerequisites before dispatch.
- Examples explicitly capture or instruct copying the returned run identifier and show how to inspect completion and the review artifact.
- Browser-check the guide and its homepage entry link; validate command syntax and lifecycle expectations with the supported CLI using isolated fixtures or a documented bounded walkthrough; npm run check and npm run build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Rewrote `website/src/content/docs/getting-started/first-task.md` into one copy-pasteable sequence: prerequisites (install, `orbit init` / `workspace init`, provider auth, PR-mode `gh`, Linux sandbox), create with captured `TASK_ID` and explicit `--status proposed` (also the CLI default), inspect, `--approve` into `backlog`, ship with instructed `RUN_ID` copy from the printed `Run ID:` / `--json` `run_id`, watch/logs, inspect `execution_summary` and `review-gate.json`, then `--approve` `review` → `done`.
- Corrected the false claim that `orbit task add` defaults to `backlog`. Isolated CLI 0.19.2 and this worktree both enter `proposed`; `--approve` on `backlog` is refused.
- Moved `--mode local` and multi-task `--base` under "Other shipment shapes", naming `$SECOND_TASK_ID` as a second captured identifier.
- Did not change homepage copy; the existing `/getting-started/first-task/` entry links still work.

Assessment: The primary path is now consistent with the supported CLI lifecycle and does not use undefined `$RUN_ID`. Review-artifact inspection is documented via `orbit task show --fields` and `orbit task artifact get`, not the unregistered `orbit task artifacts` command mentioned only in get-help text.

Criteria:
- Primary sequence without undefined vars or inconsistent approval: met. Create is `proposed`; first `--approve` is `proposed` → `backlog`; second is after `review`.
- Prerequisites linked before dispatch: met (`Before you start` → install init, provider, `gh`, sandbox).
- Run identifier capture and review artifact: met (`RUN_ID=jrun-…` copy instruction, `--json` `run_id`, `review-gate.json`).
- Browser + CLI + npm: met (see Validation).

Validation:
- Isolated HOME/repo fixture (did not mutate `~/.orbit/workspaces.json`): `orbit task add --status proposed` → `proposed`; default add without `--status` → `proposed`; `--approve` → `backlog`; second `--approve` refused (`approve requires 'proposed' or 'review'`); `show`/`lint`/`--fields status,execution_summary,artifacts`/`artifact get review-gate.json` syntax OK (get correctly not-found pre-ship). Passed.
- Live `orbit run ship` dispatch: not run (would start an agent against a disposable repo; ship `--help` confirms async `run ID` print, `--json`, `--mode`, `--complete`). Bounded walkthrough only.
- `npm run check`: passed (0 errors/warnings).
- `npm run build`: passed (29 pages, including `/getting-started/first-task/`).
- Playwright Chromium against `astro preview` at http://127.0.0.1:4321/: desktop 1440x1000 and mobile 390x844. Homepage hero "Write your first task" → First Task; content includes `--status proposed`, `RUN_ID=` assignment, `review-gate.json`; Install Orbit link → install page. No console errors, no horizontal overflow. Passed. Local-source evidence, not production parity.
- `git diff --check`: passed. Only `website/src/content/docs/getting-started/first-task.md` changed. Run-owned `website/node_modules` removed; Playwright/Chromium stayed under `/tmp`.

Remaining risks:
- Did not execute a live ship, so `review-gate.json` presence after a successful gated run is from source (`REVIEW_GATE_ARTIFACT`) plus docs, not from a fixture run completing review.
- `orbit task artifact get --help` still refers to `orbit task artifacts --task`, which is not a registered command on 0.19.2 or this worktree; the guide uses `show --fields artifacts` instead.
- This task does not authorize website deployment.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11583-6a9f31c5`
- Behind base: 0
- Ahead of base: 1