### PR TITLE
Persist an explicit sandbox-off operator choice across executor seeding

### DIFF
--- a/crates/orbit-cli/src/command/executor/mod.rs
+++ b/crates/orbit-cli/src/command/executor/mod.rs
@@ -4,3 +4,6 @@ mod show;
 mod support;
 
 pub use command::{ExecutorCommand, ExecutorSubcommand};
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-cli/src/command/executor/show.rs
+++ b/crates/orbit-cli/src/command/executor/show.rs
@@ -23,6 +23,11 @@ impl Execute for ExecutorShowArgs {
         let mut out = String::new();
         let _ = writeln!(out, "Name:      {}", def.name);
         let _ = writeln!(out, "Type:      {}", def.executor_type);
+        let _ = writeln!(
+            out,
+            "Sandbox:   {}",
+            def.sandbox.map_or("unspecified", |kind| kind.as_str())
+        );
         if let Some(ref cmd) = def.command {
             let _ = writeln!(out, "Command:   {cmd}");
         }

--- a/crates/orbit-cli/src/command/executor/support.rs
+++ b/crates/orbit-cli/src/command/executor/support.rs
@@ -9,6 +9,8 @@ pub(super) fn executor_def_json(def: &orbit_core::ExecutorDef) -> Value {
         "stdout_format": def.stdout_format.as_ref().map(ToString::to_string),
         "timeout_seconds": def.timeout_seconds,
         "env": def.env,
+        "sandbox": def.sandbox,
+        "allow_fallback": def.allow_fallback,
         "created_at": def.created_at.to_rfc3339(),
         "updated_at": def.updated_at.to_rfc3339(),
     })

--- a/crates/orbit-cli/src/command/executor/tests/mod.rs
+++ b/crates/orbit-cli/src/command/executor/tests/mod.rs
@@ -1,0 +1,1 @@
+mod show;

--- a/crates/orbit-cli/src/command/executor/tests/show.rs
+++ b/crates/orbit-cli/src/command/executor/tests/show.rs
@@ -1,0 +1,42 @@
+use orbit_core::OrbitRuntime;
+use orbit_types::resource::ExecutorResource;
+use orbit_types::workflow::ExecutorDef;
+
+use super::super::show::ExecutorShowArgs;
+use crate::command::{CommandOutput, Execute};
+use crate::output::payload::{Block, View};
+
+#[test]
+fn executor_show_reports_explicit_off_in_json_and_human_output() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let resource: ExecutorResource = serde_yaml::from_str(
+        "schemaVersion: 2\nkind: Executor\nmetadata:\n  name: codex\nspec:\n  executor_type: direct_agent\n  command: codex\n  sandbox: off\n",
+    ).expect("operator YAML");
+    let def = ExecutorDef::from_resource_spec(
+        resource.metadata.name,
+        resource.spec.clone(),
+        resource.spec.created_at,
+        resource.spec.updated_at,
+    );
+    runtime.upsert_executor_def(&def).expect("store executor");
+
+    let CommandOutput::Payload(payload) = (ExecutorShowArgs {
+        name: "codex".to_string(),
+        json: true,
+    })
+    .execute(&runtime)
+    .expect("show executor") else {
+        panic!("executor show must return a payload");
+    };
+    let (json, view) = payload.into_view();
+    assert_eq!(json["sandbox"], "off");
+    assert_eq!(json["allow_fallback"], false);
+    let View::Blocks(blocks) = view else {
+        panic!("human detail blocks")
+    };
+    assert!(
+        blocks
+            .iter()
+            .any(|block| matches!(block, Block::Text(text) if text.contains("Sandbox:   off")))
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/sandbox.rs
@@ -26,6 +26,19 @@ pub(crate) fn resolve_executor_sandbox(
         return Ok(None);
     };
     match kind {
+        // Carry explicit off through preparation so the runner can suppress
+        // provider-inner sandboxing and audit the choice without probing an OS
+        // wrapper or resolving filesystem grants that will not be enforced.
+        ExecutorSandboxKind::Off => Ok(Some(ResolvedSandbox {
+            kind,
+            fs_profile: ResolvedFsProfile {
+                name: UNRESTRICTED_FS_PROFILE.to_string(),
+                read: Vec::new(),
+                modify: Vec::new(),
+            },
+            allow_fallback: false,
+            managed_worktree: false,
+        })),
         ExecutorSandboxKind::MacosSandboxExec => {
             #[cfg(not(target_os = "macos"))]
             {

--- a/crates/orbit-core/src/application/executor.rs
+++ b/crates/orbit-core/src/application/executor.rs
@@ -138,7 +138,8 @@ pub(super) fn migrated_default_executor_for_platform(
 
     // Linux shipped without an OS wrapper before ORB-10552, so an installed
     // default commonly has `None` rather than a mismatched concrete kind.
-    // Upgrade that old shipped state to Bubblewrap on the next seed.
+    // Upgrade that old shipped state to Bubblewrap on the next seed. Explicit
+    // `off` is a distinct, platform-independent choice and never enters here.
     if existing.sandbox.is_none()
         && seeded.sandbox == Some(ExecutorSandboxKind::LinuxBwrap)
         && target_os == "linux"

--- a/crates/orbit-core/src/application/tests/executor.rs
+++ b/crates/orbit-core/src/application/tests/executor.rs
@@ -300,6 +300,52 @@ fn seed_default_executors_upgrades_old_unsandboxed_linux_default() {
 }
 
 #[test]
+fn explicit_off_survives_repeated_seeding_and_legacy_executor_type_migration() {
+    for platform in [LINUX, MACOS, "windows"] {
+        let store = InMemoryExecutorStore::default();
+        for name in SANDBOXED_SHIPPED {
+            let mut def = base_def(name, ExecutorType::AgentCli);
+            def.sandbox = Some(ExecutorSandboxKind::Off);
+            store
+                .upsert_executor_def(&def)
+                .expect("install explicit off");
+        }
+
+        seed_default_executors_for_platform(&store, false, platform).expect("migrate type");
+        assert_eq!(
+            seed_default_executors_for_platform(&store, false, platform).expect("reseed"),
+            0
+        );
+        for name in SANDBOXED_SHIPPED {
+            let def = store
+                .get_executor_def(name)
+                .expect("load")
+                .expect("present");
+            assert_eq!(
+                def.sandbox,
+                Some(ExecutorSandboxKind::Off),
+                "{name} on {platform}"
+            );
+            assert_eq!(def.executor_type, ExecutorType::DirectAgent);
+        }
+
+        // Explicit overwrite still means replacing operator customizations.
+        seed_default_executors_for_platform(&store, true, platform).expect("overwrite");
+        let expected = parse_default_executor_for_platform("codex", yaml_for("codex"), platform)
+            .expect("shipped choice")
+            .sandbox;
+        assert_eq!(
+            store
+                .get_executor_def("codex")
+                .expect("load")
+                .expect("present")
+                .sandbox,
+            expected
+        );
+    }
+}
+
+#[test]
 fn custom_executor_sandbox_choice_is_not_rewritten_by_seed_migration() {
     let store = InMemoryExecutorStore::default();
     let mut custom = base_def("custom", ExecutorType::DirectAgent);

--- a/crates/orbit-core/tests/sandbox_off.rs
+++ b/crates/orbit-core/tests/sandbox_off.rs
@@ -1,0 +1,215 @@
+#![allow(missing_docs, clippy::expect_used)]
+#![cfg(unix)]
+
+//! Operator opt-out regression through persisted resources and real dispatch.
+//! This tests absence of confinement; it makes no claim about sandbox enforcement.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use orbit_core::OrbitRuntime;
+use orbit_core::application::workspace_sync::reconcile_workspace_managed_artifacts;
+use orbit_core::bootstrap::init::{InitOptions, init_workspace_at_root};
+use orbit_engine::{RuntimeHost, V2AuditWriter, V2DispatchInput, dispatch_v2_activity};
+use orbit_types::resource::ExecutorResource;
+use orbit_types::workflow::activity_job::{
+    ActivityV2Spec, AgentLoopSpec, OnDenial, Provider, V2AuditEventKind,
+};
+
+fn seed_global(global: &Path) {
+    init_workspace_at_root(
+        global,
+        InitOptions {
+            global_only: true,
+            ..Default::default()
+        },
+    )
+    .expect("non-overwrite global seeding");
+}
+
+#[test]
+fn explicit_off_survives_opens_and_sync_then_spawns_bare_without_inner_sandbox() {
+    let dir = tempfile::tempdir().expect("isolated runtime roots");
+    let global = dir.path().join("global");
+    let workspace = dir.path().join("repo/.orbit");
+    std::fs::create_dir_all(&workspace).expect("workspace root");
+    seed_global(&global);
+
+    let program = fake_codex(dir.path());
+    let argv_path = dir.path().join("argv.txt");
+    let parent_path = dir.path().join("parent.txt");
+
+    // Use the documented operator path, including the literal wire choice.
+    let executor_path = global.join("resources/executors/codex.yaml");
+    let mut resource: serde_yaml::Value =
+        serde_yaml::from_str(&std::fs::read_to_string(&executor_path).expect("seeded executor"))
+            .expect("executor YAML");
+    resource["spec"]["sandbox"] = serde_yaml::Value::String("off".to_string());
+    resource["spec"]["command"] = serde_yaml::Value::String(program.display().to_string());
+    std::fs::write(
+        &executor_path,
+        serde_yaml::to_string(&resource).expect("encode operator choice"),
+    )
+    .expect("persist operator choice");
+    let configured = std::fs::read(&executor_path).expect("configured bytes");
+
+    for _ in 0..2 {
+        seed_global(&global);
+        let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("fresh runtime open");
+        assert_eq!(
+            runtime
+                .get_executor_def("codex")
+                .expect("load")
+                .expect("codex")
+                .sandbox
+                .map(|kind| kind.as_str()),
+            Some("off")
+        );
+        reconcile_workspace_managed_artifacts(&global, &workspace, None, None, false)
+            .expect("normal managed resource sync");
+        assert_eq!(
+            std::fs::read(&executor_path).expect("after sync"),
+            configured
+        );
+    }
+
+    let runtime = OrbitRuntime::from_roots(&global, &workspace).expect("dispatch runtime");
+    let resolved = runtime
+        .resolve_executor_sandbox("codex", Some("implementer"), None)
+        .expect("resolve off")
+        .expect("explicit descriptor");
+    assert_eq!(resolved.kind.as_str(), "off");
+    assert!(resolved.fs_profile.modify.is_empty());
+    assert!(!resolved.allow_fallback);
+
+    let audit = dispatch_codex(&runtime, dir.path());
+    assert_eq!(
+        std::fs::read_to_string(parent_path)
+            .expect("actual parent")
+            .trim(),
+        std::process::id().to_string(),
+        "provider must be a direct child, not a Bubblewrap child"
+    );
+    let argv = std::fs::read_to_string(argv_path).expect("actual provider arguments");
+    let args: Vec<_> = argv.lines().collect();
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == ["--sandbox", "danger-full-access"])
+    );
+    assert!(!args.contains(&"workspace-write"));
+
+    assert_effective_off(&audit, &program);
+
+    // The file store's normal serializer preserves the explicit choice too.
+    let def = runtime
+        .get_executor_def("codex")
+        .expect("load")
+        .expect("codex");
+    runtime.upsert_executor_def(&def).expect("store round trip");
+    let persisted: ExecutorResource =
+        serde_yaml::from_str(&std::fs::read_to_string(executor_path).expect("serialized resource"))
+            .expect("resource round trip");
+    assert_eq!(
+        persisted.spec.sandbox.map(|kind| kind.as_str()),
+        Some("off")
+    );
+}
+
+fn fake_codex(dir: &Path) -> PathBuf {
+    let program = dir.join("codex");
+    let argv_path = dir.join("argv.txt");
+    let parent_path = dir.join("parent.txt");
+    std::fs::write(
+        &program,
+        format!(
+            r#"#!/bin/sh
+printf '%s\n' "$@" > '{}'
+printf '%s\n' "$PPID" > '{}'
+cat > /dev/null
+printf '%s\n' '{{"schemaVersion":1,"status":"success","result":{{"bare":true}},"error":null}}'
+"#,
+            argv_path.display(),
+            parent_path.display()
+        ),
+    )
+    .expect("write fake provider");
+    std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755))
+        .expect("executable provider");
+
+    program
+}
+
+fn dispatch_codex(runtime: &OrbitRuntime, dir: &Path) -> Arc<V2AuditWriter> {
+    let audit = V2AuditWriter::with_disk_sinks(
+        &dir.join("audit"),
+        Arc::new(orbit_store::Store::open_in_memory().expect("audit store")),
+        "ws_test",
+        "sandbox-off",
+        "codex:test".to_string(),
+        None,
+    )
+    .expect("audit writer");
+    let spec = ActivityV2Spec::AgentLoop(AgentLoopSpec {
+        instruction: "Return the requested response envelope.".to_string(),
+        tools: Vec::new(),
+        on_denial: OnDenial::Terminate,
+        model: None,
+        reasoning_effort: None,
+        max_iterations: 1,
+        backend: None,
+        provider: Provider::Codex,
+        wall_clock_timeout_seconds: 15,
+        require_response_envelope: true,
+        require_completion_envelope: true,
+        proc_allowed_programs: None,
+        trusted_host_execution: false,
+    });
+    let outcome = dispatch_v2_activity(V2DispatchInput {
+        activity_name: "explicit_sandbox_off",
+        spec: &spec,
+        fs_profile: Some("implementer"),
+        input: serde_json::json!({"prompt": "Return success."}),
+        audit: audit.clone(),
+        run_id: "sandbox-off",
+        host: Some(runtime),
+    })
+    .expect("dispatch explicit off without a wrapper probe");
+    assert!(outcome.success, "{:?}", outcome.message);
+    assert_eq!(outcome.output["bare"], true);
+    audit
+}
+
+fn assert_effective_off(audit: &V2AuditWriter, program: &Path) {
+    let events = audit
+        .events_snapshot()
+        .expect("effective invocation introspection");
+    let started = events
+        .iter()
+        .find(|event| matches!(event.kind, V2AuditEventKind::CliInvocationStarted { .. }))
+        .expect("invocation started");
+    let V2AuditEventKind::CliInvocationStarted {
+        argv_redacted,
+        sandbox_backend,
+        sandbox_trusted_wrapper,
+        sandbox_probe_outcome,
+        sandbox_write_enforcement,
+        sandbox_read_enforcement,
+        ..
+    } = &started.kind
+    else {
+        unreachable!("matched invocation event")
+    };
+    assert_eq!(argv_redacted.first().map(String::as_str), program.to_str());
+    assert_eq!(sandbox_backend.as_deref(), Some("off"));
+    assert_eq!(sandbox_trusted_wrapper, &None);
+    assert_eq!(sandbox_probe_outcome, &None);
+    assert_eq!(
+        sandbox_write_enforcement.as_deref(),
+        Some("write_unrestricted")
+    );
+    assert_eq!(
+        sandbox_read_enforcement.as_deref(),
+        Some("read_unrestricted")
+    );
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -204,7 +204,12 @@ pub fn run_cli_backend(
     //     transparently inside our outer sandbox.
     //   - gemini: drop `-s` / `--sandbox` from the executor's static args.
     //   - claude: nothing to do; claude has no OS-level sandbox flag.
-    if sandbox.is_some() {
+    // An explicit executor opt-out must not silently restore the provider's
+    // inner sandbox when preparation selects a bare process.
+    let explicitly_off = resolved_sandbox
+        .as_ref()
+        .is_some_and(|sandbox| sandbox.kind == ExecutorSandboxKind::Off);
+    if sandbox.is_some() || explicitly_off {
         neutralize_inner_sandbox(&provider, &mut provider_config, &mut cli_executor.args);
     }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/spawn.rs
@@ -81,11 +81,21 @@ impl PreparedSandbox<'_> {
 /// Resolve availability before provider argv construction. This ordering is
 /// security-sensitive: provider-native flags are neutralized only when the
 /// outer wrapper is actually usable, while an explicitly allowed bare
-/// fallback keeps those flags intact.
+/// fallback keeps those flags intact. Explicit off disables both layers.
 pub(crate) fn prepare_sandbox_for_dispatch(
     sandbox: Option<&ResolvedSandbox>,
 ) -> Result<PreparedSandbox<'_>, SpawnError> {
     match sandbox {
+        Some(sandbox) if sandbox.kind == ExecutorSandboxKind::Off => Ok(PreparedSandbox {
+            effective: None,
+            metadata: SandboxDispatchMetadata {
+                backend: Some("off".to_string()),
+                trusted_wrapper: None,
+                probe_outcome: None,
+                write_enforcement: "write_unrestricted".to_string(),
+                read_enforcement: "read_unrestricted".to_string(),
+            },
+        }),
         Some(sandbox) if sandbox.kind == ExecutorSandboxKind::LinuxBwrap => {
             let probe = probe_bwrap();
             prepare_linux_sandbox_for_dispatch_with_probe(sandbox, probe)

--- a/crates/orbit-engine/src/activity_job/dispatcher.rs
+++ b/crates/orbit-engine/src/activity_job/dispatcher.rs
@@ -51,11 +51,11 @@ pub struct ResolvedShellExecutor {
 /// just before spawn (keeping the orbit-exec dependency local to orbit-engine).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedSandbox {
-    /// OS sandbox primitive selected by the executor declaration.
+    /// Executor choice, including explicit off (no wrapper or profile use).
     pub kind: ExecutorSandboxKind,
     /// Workspace-absolute resolved `read` / `modify` rules from the activity's
     /// `FsProfile`. The engine passes this to `orbit_exec::compile_*_profile`
-    /// to produce a kernel-shaped payload.
+    /// to produce a kernel-shaped payload. Unused and empty for explicit off.
     pub fs_profile: ResolvedFsProfile,
     /// Whether to fall back to bare exec if the OS primitive is unavailable.
     pub allow_fallback: bool,

--- a/crates/orbit-types/src/workflow/executor_def.rs
+++ b/crates/orbit-types/src/workflow/executor_def.rs
@@ -47,13 +47,12 @@ impl fmt::Display for ExecutorType {
     }
 }
 
-/// Sandbox primitive applied to a CLI-backend agent invocation. The variant
-/// names a concrete OS primitive; `orbit-exec` selects the implementation.
-///
-/// Each variant names one concrete, platform-specific kernel wrapper.
+/// Executor sandbox choice: a concrete OS wrapper or an explicit opt-out.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExecutorSandboxKind {
+    /// Persist an operator's choice to disable outer and provider-inner sandboxing.
+    Off,
     MacosSandboxExec,
     LinuxBwrap,
 }
@@ -61,6 +60,7 @@ pub enum ExecutorSandboxKind {
 impl ExecutorSandboxKind {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::Off => "off",
             Self::MacosSandboxExec => "macos-sandbox-exec",
             Self::LinuxBwrap => "linux-bwrap",
         }
@@ -69,12 +69,12 @@ impl ExecutorSandboxKind {
     /// OS this sandbox primitive can be applied on, named to match
     /// `std::env::consts::OS` (e.g. `"macos"`, `"linux"`).
     ///
-    /// Every kind is single-OS. The seed-time platform selector in
-    /// `orbit-core` reads this value when installing shipped executors.
-    pub fn target_os(self) -> &'static str {
+    /// Concrete wrappers are single-OS; explicit off has no OS requirement.
+    pub fn target_os(self) -> Option<&'static str> {
         match self {
-            Self::MacosSandboxExec => "macos",
-            Self::LinuxBwrap => "linux",
+            Self::Off => None,
+            Self::MacosSandboxExec => Some("macos"),
+            Self::LinuxBwrap => Some("linux"),
         }
     }
 
@@ -83,7 +83,8 @@ impl ExecutorSandboxKind {
     /// seed-time selection (see `orbit-core`) be tested deterministically on
     /// either OS without a `#[cfg]` split (see [ORB-10112]).
     pub fn is_available_on(self, target_os: &str) -> bool {
-        self.target_os() == target_os
+        self.target_os()
+            .is_none_or(|required| required == target_os)
     }
 }
 
@@ -155,10 +156,10 @@ pub struct ExecutorDef {
     pub timeout_seconds: Option<u64>,
     #[serde(default)]
     pub env: HashMap<String, String>,
-    /// OS sandbox primitive to wrap the CLI invocation in. When `None`, the
-    /// CLI is spawned bare (today's behavior). When `Some`, `orbit-exec`
-    /// translates the activity's `FsProfile` into a sandbox payload and
-    /// wraps the spawn.
+    /// Sandbox choice. `Off` persistently disables outer and provider-inner
+    /// sandboxing. `None` is unspecified: installed Linux defaults migrate to
+    /// Bubblewrap during seeding; other executors retain provider behavior.
+    /// Concrete kinds wrap the invocation using the activity's `FsProfile`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<ExecutorSandboxKind>,
     /// When `sandbox` is set but the platform's trusted sandbox primitive is

--- a/crates/orbit-types/src/workflow/tests/executor_def.rs
+++ b/crates/orbit-types/src/workflow/tests/executor_def.rs
@@ -1,10 +1,59 @@
 mod sandbox_kind_platform {
     use super::super::super::executor_def::ExecutorSandboxKind;
+    use crate::resource::ExecutorResource;
+
+    #[test]
+    fn sandbox_choices_round_trip_and_legacy_absence_remains_unspecified() {
+        let base = "schemaVersion: 2\nkind: Executor\nmetadata:\n  name: codex\nspec:\n  executor_type: direct_agent\n";
+        for (setting, expected) in [
+            ("", None),
+            ("  sandbox: null\n", None),
+            ("  sandbox: off\n", Some(ExecutorSandboxKind::Off)),
+            (
+                "  sandbox: linux-bwrap\n",
+                Some(ExecutorSandboxKind::LinuxBwrap),
+            ),
+            (
+                "  sandbox: macos-sandbox-exec\n",
+                Some(ExecutorSandboxKind::MacosSandboxExec),
+            ),
+        ] {
+            let resource: ExecutorResource = serde_yaml::from_str(&format!("{base}{setting}"))
+                .expect("supported executor resource");
+            assert_eq!(resource.spec.sandbox, expected);
+            let yaml = serde_yaml::to_string(&resource).expect("serialize YAML");
+            let decoded: ExecutorResource = serde_yaml::from_str(&yaml).expect("read YAML");
+            assert_eq!(decoded, resource);
+            let json = serde_json::to_string(&resource).expect("serialize JSON");
+            let decoded: ExecutorResource = serde_json::from_str(&json).expect("read JSON");
+            assert_eq!(decoded, resource);
+            if expected == Some(ExecutorSandboxKind::Off) {
+                assert_eq!(
+                    serde_json::to_value(&resource).expect("JSON")["spec"]["sandbox"],
+                    "off"
+                );
+            }
+        }
+        for malformed in ["false", "disabled", "[]", "{}", "42"] {
+            let error = serde_yaml::from_str::<ExecutorResource>(&format!(
+                "{base}  sandbox: {malformed}\n"
+            ))
+            .expect_err("malformed choice must not turn sandboxing off");
+            assert!(error.to_string().contains("sandbox"), "{error}");
+        }
+    }
 
     #[test]
     fn target_os_matches_std_env_consts_naming() {
-        assert_eq!(ExecutorSandboxKind::MacosSandboxExec.target_os(), "macos");
-        assert_eq!(ExecutorSandboxKind::LinuxBwrap.target_os(), "linux");
+        assert_eq!(
+            ExecutorSandboxKind::MacosSandboxExec.target_os(),
+            Some("macos")
+        );
+        assert_eq!(ExecutorSandboxKind::LinuxBwrap.target_os(), Some("linux"));
+        assert_eq!(ExecutorSandboxKind::Off.target_os(), None);
+        for platform in ["macos", "linux", "windows"] {
+            assert!(ExecutorSandboxKind::Off.is_available_on(platform));
+        }
     }
 
     #[test]

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -133,6 +133,26 @@ Activity-scoped `proc.spawn` supplies a request-time `Sandbox` validator at this
 
 The `Sandbox` trait remains the seam for generic `run_process` callers, but CLI-backed `agent_loop` invocations use a separate executor wrapper when the executor declares `sandbox: macos-sandbox-exec` ([T20260427-51]). The v2 host resolves the activity `fsProfile`; the engine converts workspace-relative rules to absolute roots and compiles SBPL before spawning the provider CLI.
 
+Executor resources also accept `spec.sandbox: off` as a persistent operator
+opt-out. It survives non-overwriting seeding and normal resource sync, unlike
+omitted/null values on legacy Linux defaults, which migrate to `linux-bwrap`.
+The host carries the explicit off descriptor to the runner without resolving
+filesystem grants; preparation chooses no wrapper and performs no capability
+probe. The runner neutralizes supported provider-inner sandbox flags and audits
+`sandbox_backend: off` with unrestricted read/write enforcement. Bare fallback
+and unspecified settings retain their existing provider delegation behavior.
+Orbit tool authorization and policy checks remain active. See the
+[operator instructions](../../runbooks/linux-sandbox.md#explicitly-disable-worker-sandboxing)
+for the resource path and introspection commands.
+
+Compatibility is directional: new readers accept existing schema-version-2
+resources, but old closed-enum readers reject `off`. Updating a binary on disk
+does not replace persistent MCP servers or active drain/workflow runners.
+Shared executor files must keep their prior values until those readers and
+other runtime-opening processes have restarted on the new build; rollback
+must restore the old concrete values before restarting old readers. The
+runbook specifies the staged rollout and authoritative-MCP verification order.
+
 The macOS wrapper resolves `sandbox-exec` from trusted absolute locations only, currently `/usr/bin/sandbox-exec`; it does not consult `PATH` for either availability checks or process spawn. If the trusted binary is missing, the runner fails closed unless the executor declares `allow_fallback: true`, and the error names the trusted location that was probed ([T20260509-30]).
 
 The wrapper also prepares Codex's TLS trust input before a sandboxed spawn. Its

--- a/docs/runbooks/linux-sandbox.md
+++ b/docs/runbooks/linux-sandbox.md
@@ -64,3 +64,83 @@ Other distributions need the same two conditions: an executable `/usr/bin/bwrap`
 permission for an unprivileged user to create user namespaces and mounts. Non-Linux hosts
 are unaffected: macOS uses `sandbox-exec`, and platforms without a shipped OS-level backend
 rely on in-process filesystem guards only.
+
+## Explicitly disable worker sandboxing
+
+An operator can persistently disable sandboxing for an executor by setting
+`spec.sandbox: off` in its host-global resource, normally
+`~/.orbit/resources/executors/codex.yaml` (use the corresponding filename for
+another provider).
+
+Before editing shared executor YAML, complete the mixed-version rollout below.
+Replacing the CLI binary does not update an already-running MCP server or job
+runner. Preserve the rest of the resource when changing the sandbox field:
+
+```yaml
+spec:
+  # Keep the executor's existing command, arguments, and other settings.
+  sandbox: off
+```
+
+This setting applies to future worker launches using that executor across
+workspaces on the host. It survives fresh runtime opens, repeated default
+seeding, and normal `orbit workspace sync`. Explicit default overwrite/reset
+operations can replace it. Existing processes keep their launch configuration.
+
+`off` is distinct from an omitted or `null` sandbox field. Omitted/null values
+on installed Linux defaults are legacy unspecified settings and migrate to
+`linux-bwrap`; deleting the field is therefore not a persistent opt-out.
+Concrete backend names keep their platform validation. Invalid spellings such
+as `disabled` or boolean `false` fail resource parsing.
+
+With `off`, Orbit does not probe or launch Bubblewrap or `sandbox-exec`, and it
+neutralizes the supported provider-inner sandbox flags (including Codex's
+`--sandbox danger-full-access`). The workspace `execution.codex.sandbox` key
+alone controls Codex's inner mode, not Orbit's outer wrapper. Explicit executor
+`off` takes precedence over that inner mode. Tool authorization and policy
+checks still apply to Orbit tool calls; provider subprocess filesystem access
+has no Orbit sandbox confinement.
+
+Inspect the configured choice with `orbit executor show codex --json` (the
+`sandbox` field is `"off"`). The invocation audit reports `sandbox_backend: off`,
+no trusted wrapper or probe, and `write_unrestricted` / `read_unrestricted`.
+This is an operator opt-out, not a fallback after a failed security check, and
+successful bare execution does not establish Bubblewrap or AppArmor enforcement.
+
+### Mixed-version rollout and rollback
+
+Older Orbit readers accept only the concrete backend enum values. They reject
+`off` with `spec.sandbox: unknown variant off`; retaining `schemaVersion: 2`
+does not make this new value readable by those binaries. New Orbit versions
+continue to read existing resources, but backward reading of `off` by an old
+version is unsupported. Executor loading during bootstrap/seeding or dispatch
+can therefore break ordinary operations before they reach their requested tool.
+
+Use this order on every process sharing the host resource directory:
+
+1. Keep the existing executor YAML unchanged while installing the updated
+   executable. Pause new dispatch and let old workers and active drain/job
+   supervisors finish, or stop them through their normal lifecycle. Keep a
+   backup of the pre-change executor files.
+2. Restart persistent `orbit mcp serve` processes and reconnect their clients.
+   Also restart long-lived drain/workflow runners, orchestration processes,
+   and web/dashboard servers that open runtimes or dispatch work. Any still-active
+   sweep process or worker that can load executors or start nested Orbit commands
+   must finish or restart from the updated executable. Check service/timer
+   launch paths and worker `ORBIT_BIN` overrides for older executable copies.
+3. Verify each restarted reader's executable provenance and run an ordinary
+   read-only task/tool call through each authoritative MCP connection while the
+   YAML still uses the old values. A successful new CLI `--version` invocation
+   alone does not verify the executable already loaded by another process.
+4. Only after all readers have been replaced, set `spec.sandbox: off`. Verify
+   `orbit executor show <provider> --json`, repeat an ordinary authoritative
+   MCP read, and inspect the next invocation's effective sandbox audit before
+   resuming normal dispatch. If an older reader must remain active, defer the
+   shared YAML change; deleting the sandbox field is not a compatibility solution.
+
+For rollback to an older binary, pause dispatch and restore the backed-up
+concrete sandbox values **before** starting any old reader. Then restart the
+affected services/connections and verify ordinary reads again. Do not launch
+an old MCP server or drain against shared executor files that still contain
+`off`. These steps change Orbit processes and resources, not host AppArmor
+settings.


### PR DESCRIPTION
## Task

[ORB-11589](https://orbit-cli.com/tasks/ORB-11589) — Persist an explicit sandbox-off operator choice across executor seeding

### Description

Daniel explicitly requested disabling worker sandboxing so blocked validation can run. Operator removed sandbox:linux-bwrap from host executor YAMLs at21:19:37UTC and set ws_orbit execution.codex.sandbox=danger-full-access, but later Orbit opens restored Bubblewrap. Confirmed newly launched ORB-11577 run2131-3 PID2413365 is bwrap, and ~/.orbit/resources/executors/codex.yaml again contains sandbox:linux-bwrap. Current migrated_default_executor_for_platform in application/executor.rs around142 blindly upgrades any None sandbox on a named Linux default to seeded LinuxBwrap on every seed. It cannot distinguish deliberate operator disable from legacy unspecified state. Add a clear supported explicit-off representation and operator config path, preserve it across normal opens and non-overwriting sync, and keep legacy migration behavior intentional. Propagate explicit off through execution resolution without wrapping or restoring the provider's inner sandbox. Do not simply remove legacy migration, rename executors, change host security permissions, weaken confinement tests, or claim experimental AppArmor enforcement proven. Extend selectors before needed edits using current type/resource/config/CLI seams. Read-only inspect actual source and tests first. Worker delivers source fix; orchestrator will rebuild/install and apply the user's already-authorized setting afterward. Original executor backups: ~/.orbit/backups/sandbox-off-20260907T211937Z.

### Acceptance Criteria

- A documented supported operator setting explicitly disables outer worker sandboxing and survives fresh runtime opens, repeated default seeding and normal non-overwrite resource sync.
- Legacy omitted/unmigrated Linux defaults are distinguished from explicit off; default behavior and incompatible-backend validation remain covered.
- A real subprocess integration regression proves explicit off launches without Bubblewrap/OS wrapper; verify effective introspection truthfully shows off and provider inner sandbox does not silently replace it.
- Config/resource serialization round-trips the off choice with backward-compatible handling; malformed settings fail clearly.
- Focused tests and required gates pass. No system AppArmor/profile/sudo changes or security-test success claims from removing the harness sandbox.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the explicit executor resource choice spec.sandbox: off. Off is platform-independent and remains distinct from omitted/null legacy settings; existing Linux default migration and concrete-backend validation remain intact.
- Runtime resolution preserves explicit off through preparation, without resolving grants or probing an OS wrapper. Dispatch runs bare and neutralizes supported provider-inner sandbox flags. Effective invocation audit reports backend off, no wrapper/probe, and write_unrestricted/read_unrestricted.
- Executor show exposes the sandbox choice in JSON and human output. The Linux runbook and current sandbox design document the host-global YAML operator path, scope, migration distinction, and explicit-overwrite semantics.
- Documented the later operator-requested mixed-version rollout constraint: keep shared YAML unchanged until persistent MCP servers/connections, old drain/workflow runners, and other runtime-opening processes have restarted or finished. Check service/timer launch paths and ORBIT_BIN copies; verify authoritative MCP reads before and after applying off. Roll back resource values before restarting old readers.
- Added resource round-trip/malformed-input coverage, cross-platform seeding coverage, CLI introspection coverage, and a real subprocess regression using isolated file-backed runtime roots.

Acceptance criteria:
1. Documented setting: normally ~/.orbit/resources/executors/<provider>.yaml, spec.sandbox: off. The integration test preserves the configured file byte-for-byte through two non-overwriting seed/fresh-open/normal workspace-sync cycles, then round-trips it through the file store.
2. Existing omitted/null Linux defaults still migrate to linux-bwrap. All shipped agent names preserve explicit off during repeated seeding and legacy AgentCli-to-DirectAgent migration on injected Linux/macOS/Windows platforms. Explicit overwrite still restores platform defaults. Existing incompatible-backend rejection passes.
3. Real Linux subprocess dispatch succeeds without a per-invocation OS wrapper: the fake Codex records the test runner as its direct parent and receives --sandbox danger-full-access, not workspace-write. Audit argv starts with the provider executable and explicitly reports off, absent wrapper/probe, and unrestricted enforcement. CLI configured-choice introspection also passes.
4. YAML and JSON round-trip off, both existing backend names, and legacy omitted/null values. Boolean false, disabled, sequence/map, and numeric settings fail with sandbox-specific parse errors. Existing resource schemaVersion 2 is retained. Compatibility is directional: old closed-enum readers reject off; the rollout guide explicitly defers applying off until old readers are replaced.
5. Focused tests and required gates passed. No host executor/config application, AppArmor/profile/sudo changes, or confinement-test weakening occurred. The enclosing worker harness sandbox was not removed.

Validation — passed:
- cargo fmt --all
- cargo test -p orbit-types workflow::tests::executor_def --lib — 9 tests.
- cargo test -p orbit-core --lib application::tests::executor — 18 tests.
- cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::sandbox:: — 22 tests.
- cargo test -p orbit-core --test sandbox_off — 1 real subprocess/persistence regression; passed again after restoring the implementation from the negative control.
- cargo test -p orbit-engine --lib activity_job::cli_runner::tests::spawn:: — 28 tests.
- cargo test -p orbit-engine --lib neutralize_inner_sandbox — 5 tests.
- cargo test -p orbit-cli --bin orbit command::executor::tests — 1 test.
- make ci-fast — passed again after the final mixed-version rollout documentation changes.
- ./scripts/generate-doc-indexes.sh --check — passed.
- make ci-lint (cargo clippy --workspace --all-targets -- -D warnings) — passed.
- git diff --check; git status --short; complete diff/new-file review — passed; every changed file is task-scoped.

Expected negative control: cargo test -p orbit-core --test sandbox_off against the four owning production files from starting HEAD failed with exit 101: spec.sandbox unknown variant off during non-overwrite seeding. The implementation was restored in a finally block before final validation. This is compiled starting-HEAD production-reader evidence, not a claim that the running persistent MCP process was upgraded or tested with off.

Not run / limits: live installation, persistent-server/drain restarts, and shared-YAML application are reserved for the orchestrator. Applying off before replacing old readers can break executor parsing and authoritative operations; a replaced CLI binary alone does not update those readers. Full make ci is reserved for the merge gate by workspace policy. Native macOS execution and AppArmor/Bubblewrap confinement enforcement were not exercised or established by the bare-execution regression. The fast gate's plugin smoke reports Cursor headless execution unavailable and validates its local manifest/symlink contract only.

Assessment: deliverable complete, no new dependency edge or persisted artifact kind. Selector extensions covered direct type/runtime/CLI/test/documentation consumers before edits and were refined to exact files afterward. Initial checkout was clean at 056f5bac7fa57f2df9dc0abc65c7754bdbe9c8cb; HEAD is unchanged, all 16 scoped files remain uncommitted, and no incidental temporary artifacts are in the patch. The orchestrator retains rebuild/install and application of the already-authorized host setting, as requested. Friction checkpoint completed: no new qualifying friction beyond the already-documented task defect.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11589-6a9f309c`
- Behind base: 0
- Ahead of base: 1