### PR TITLE
Select crews randomly from configurable task-complexity pools in auto dispatch

### DIFF
--- a/.orbit/resources/jobs/workspace_auto_pipeline.yaml
+++ b/.orbit/resources/jobs/workspace_auto_pipeline.yaml
@@ -75,6 +75,11 @@ spec:
     # which is the behavior of every caller that does not pass it. Forwarded
     # unchanged so the leaf/epic jobs this run admits inherit the same window.
     allowed_crews: []
+    # Complexity pools are captured by Core at coordinator admission from
+    # workflow configuration and low/medium/hard_complexity_crews run overrides.
+    # Omit defaults here: an omitted override inherits configuration, while []
+    # explicitly disables a pool. Child admission inherits auto_crew_pools and
+    # freezes crew_selection per task; templates must not reroll selections.
 
   steps:
     - id: resolve_ship_input

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ dependencies = [
  "chrono",
  "croner",
  "fs2",
+ "getrandom 0.3.4",
  "libc",
  "orbit-automation",
  "orbit-common",

--- a/crates/orbit-cli/src/command/config/tests/get.rs
+++ b/crates/orbit-cli/src/command/config/tests/get.rs
@@ -105,3 +105,41 @@ fn get_reads_hand_authored_crew_effort() {
     );
     assert_eq!(document["value"], "high");
 }
+
+#[test]
+fn complexity_pools_set_get_show_agree_and_invalid_edits_do_not_write() {
+    let (_root, runtime, global_root, workspace_root) = test_runtime();
+    let path = workspace_root.join("config.toml");
+    fs::write(&path, "[workflow]\ndefault_crew = \"opus\"\n").expect("config");
+    for complexity in ["low", "medium", "hard"] {
+        let key = format!("workflow.{complexity}_complexity_crews");
+        set_args(&key, r#"["terra", "grok", "terra"]"#)
+            .execute(&runtime)
+            .expect("set pool");
+        let value = json_value(get_args(&key, true).execute(&runtime).expect("get pool"));
+        assert_eq!(value["value"], serde_json::json!(["grok", "terra"]));
+        let effective = orbit_config::load_effective_config(&orbit_config::ConfigRoots::new(
+            &global_root,
+            &workspace_root,
+        ))
+        .expect("effective");
+        let shown = super::super::show::effective_json(&runtime, effective.values());
+        assert_eq!(shown["settings"][&key], value["value"]);
+        assert_eq!(shown["provenance"][&key]["scope"], "workspace");
+        let before = fs::read(&path).expect("before");
+        for invalid in [r#"["unknown-pool-crew"]"#, r#"[""]"#] {
+            let error = set_args(&key, invalid)
+                .execute(&runtime)
+                .expect_err("invalid pool");
+            assert!(error.to_string().contains(&key), "{error}");
+            assert_eq!(fs::read(&path).expect("after"), before);
+        }
+        set_args(&key, "[]")
+            .execute(&runtime)
+            .expect("disable pool");
+        assert_eq!(
+            json_value(get_args(&key, true).execute(&runtime).expect("empty pool"))["value"],
+            serde_json::json!([])
+        );
+    }
+}

--- a/crates/orbit-cli/src/command/run/auto.rs
+++ b/crates/orbit-cli/src/command/run/auto.rs
@@ -17,7 +17,7 @@ pub(super) const AUTO_WORKFLOW: &str = "auto";
 #[command(
     about = "Drain the workspace backlog for a window (loose leaves, plus one epic)",
     override_usage = "orbit run auto [OPTIONS]",
-    after_help = "Examples:\n  orbit run auto\n  orbit run auto --for 4h\n  orbit run auto --for 4h --concurrency 8\n  orbit run auto --for 4h --complete\n  orbit run auto --stop\n\n\
+    after_help = "Examples:\n  orbit run auto\n  orbit run auto --medium-complexity-crews grok,terra\n  orbit run auto --for 4h\n  orbit run auto --for 4h --concurrency 8\n  orbit run auto --for 4h --complete\n  orbit run auto --stop\n\n\
                   The drain re-lists the whole backlog every pass and keeps `--concurrency`\n\
                   tasks in flight, starting a replacement as each one finishes rather than\n\
                   waiting for the batch. An epic root runs alongside the leaves, one at a time.\n\n\
@@ -25,6 +25,11 @@ pub(super) const AUTO_WORKFLOW: &str = "auto";
                   admits for the whole window, including work that reaches the backlog after\n\
                   the run starts. The drain is asynchronous, so this prints the durable run ID\n\
                   and returns without knowing the eventual outcome.\n\n\
+                  Complexity pools select only for tasks without an explicit crew.\n\
+                  Each CLI pool replaces its matching workflow pool for this drain.\n\
+                  Empty pools and unset complexity use the existing default crew chain.\n\
+                  Selections are recorded at admission and retained on retries/resume.\n\
+                  Pools do not restrict manual crew choices.\n\n\
                   `--allow-crew` restricts this one run to the named crews, for its window\n\
                   only. It edits no configuration and reassigns nothing: a backlog task whose\n\
                   crew is excluded is simply not started, and `orbit run readiness --allow-crew`\n\
@@ -70,6 +75,18 @@ pub struct AutoCommand {
     /// invocation is already running is cancelled.
     #[arg(long = "allow-crew", value_name = "CREW", value_delimiter = ',')]
     pub allow_crew: Vec<String>,
+    /// Random crew pool for unassigned low-complexity tasks. Overrides the
+    /// matching workflow pool; pass the flag with no names to disable it.
+    #[arg(long, value_name = "CREW", value_delimiter = ',', num_args = 0..)]
+    pub low_complexity_crews: Option<Vec<String>>,
+    /// Random crew pool for unassigned medium-complexity tasks. Overrides the
+    /// matching workflow pool; pass the flag with no names to disable it.
+    #[arg(long, value_name = "CREW", value_delimiter = ',', num_args = 0..)]
+    pub medium_complexity_crews: Option<Vec<String>>,
+    /// Random crew pool for unassigned hard-complexity tasks. Overrides the
+    /// matching workflow pool; pass the flag with no names to disable it.
+    #[arg(long, value_name = "CREW", value_delimiter = ',', num_args = 0..)]
+    pub hard_complexity_crews: Option<Vec<String>>,
     /// Bind this drain to an operation-mode grant (see `orbit operation`).
     /// Completion, scope, and limits come from the grant; `--complete` is
     /// not accepted alongside it.
@@ -87,7 +104,7 @@ pub struct AutoCommand {
     /// start a drain.
     #[arg(
         long,
-        conflicts_with_all = ["for_duration", "concurrency", "complete", "allow_crew", "grant"]
+        conflicts_with_all = ["for_duration", "concurrency", "complete", "allow_crew", "grant", "low_complexity_crews", "medium_complexity_crews", "hard_complexity_crews"]
     )]
     pub stop: bool,
 }
@@ -97,6 +114,11 @@ impl Execute for AutoCommand {
         if self.stop {
             return execute_stop(runtime, self.json, self.claim_token.as_deref());
         }
+        let complexity_crews = orbit_config::ComplexityCrewPools {
+            low: self.low_complexity_crews,
+            medium: self.medium_complexity_crews,
+            hard: self.hard_complexity_crews,
+        };
         let for_seconds = self
             .for_duration
             .as_deref()
@@ -109,6 +131,7 @@ impl Execute for AutoCommand {
                 for_seconds,
                 self.concurrency,
                 &self.allow_crew,
+                &complexity_crews,
                 self.claim_token.as_deref(),
                 self.json,
             );
@@ -123,6 +146,7 @@ impl Execute for AutoCommand {
             self.concurrency,
             completion,
             &self.allow_crew,
+            &complexity_crews,
             None,
             self.claim_token.as_deref(),
         )?;
@@ -145,12 +169,14 @@ impl Execute for AutoCommand {
 }
 
 /// [ORB-11332] A drain whose every admission is bound to a grant.
+#[allow(clippy::too_many_arguments)]
 fn execute_grant_bound(
     runtime: &OrbitRuntime,
     grant_id: &str,
     for_seconds: Option<u64>,
     concurrency: Option<u32>,
     allow_crew: &[String],
+    complexity_crews: &orbit_config::ComplexityCrewPools,
     claim_token: Option<&str>,
     json: bool,
 ) -> CommandOut {
@@ -159,6 +185,7 @@ fn execute_grant_bound(
         for_seconds,
         max_active_leaf_runs: concurrency,
         allowed_crews: allow_crew,
+        complexity_crews,
         actor: None,
         claim_token,
     })?;

--- a/crates/orbit-cli/src/command/run/tests/mod.rs
+++ b/crates/orbit-cli/src/command/run/tests/mod.rs
@@ -168,6 +168,9 @@ fn workspace_auto_stop_conflicts_with_start_flags() {
 fn auto_stop_with_no_coordinator_is_idle() {
     let runtime = OrbitRuntime::in_memory().expect("runtime");
     super::auto::AutoCommand {
+        low_complexity_crews: None,
+        medium_complexity_crews: None,
+        hard_complexity_crews: None,
         for_duration: None,
         concurrency: None,
         complete: false,
@@ -681,5 +684,63 @@ fn test_audit_event(
         body_kind: Some(body_kind),
         timestamp: None,
         step_id: step_id.map(str::to_string),
+    }
+}
+
+#[test]
+fn workspace_auto_complexity_pools_parse_independently_and_allow_explicit_empty() {
+    let command = parse_run(&[
+        "orbit",
+        "run",
+        "auto",
+        "--medium-complexity-crews",
+        "grok,terra",
+        "--low-complexity-crews",
+        "luna",
+        "--hard-complexity-crews",
+    ]);
+    let RunSubcommand::Auto(args) = command.command else {
+        panic!("auto");
+    };
+    assert_eq!(
+        args.medium_complexity_crews,
+        Some(vec!["grok".into(), "terra".into()])
+    );
+    assert_eq!(args.low_complexity_crews, Some(vec!["luna".into()]));
+    assert_eq!(args.hard_complexity_crews, Some(vec![]));
+    assert!(
+        args.allow_crew.is_empty(),
+        "pools must not become an allowlist"
+    );
+    let RunSubcommand::Auto(defaults) = parse_run(&["orbit", "run", "auto"]).command else {
+        panic!("auto");
+    };
+    assert_eq!(defaults.medium_complexity_crews, None);
+    for flag in [
+        "--low-complexity-crews",
+        "--medium-complexity-crews",
+        "--hard-complexity-crews",
+    ] {
+        assert_cli_rejects(
+            &["orbit", "run", "auto", "--stop", flag, "terra"],
+            ErrorKind::ArgumentConflict,
+            "--stop",
+        );
+    }
+}
+
+#[test]
+fn workspace_auto_help_explains_complexity_pools_and_precedence() {
+    let error = Cli::try_parse_from(["orbit", "run", "auto", "--help"])
+        .err()
+        .expect("help");
+    let help = error.to_string();
+    for text in [
+        "--medium-complexity-crews grok,terra",
+        "without an explicit crew",
+        "replaces its matching workflow pool",
+        "retries/resume",
+    ] {
+        assert!(help.contains(text), "missing {text}: {help}");
     }
 }

--- a/crates/orbit-config/src/crew_pools.rs
+++ b/crates/orbit-config/src/crew_pools.rs
@@ -1,0 +1,54 @@
+//! Named crew pools for automatic task admission. Empty pools disable selection.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use orbit_common::OrbitError;
+use orbit_types::identity::{Crew, resolve_crew};
+use orbit_types::task::TaskComplexity;
+use serde::{Deserialize, Serialize};
+
+/// Per-complexity configuration or run overrides. `None` inherits the matching
+/// configured pool; `Some([])` explicitly disables that pool for a run.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ComplexityCrewPools {
+    /// Pool for low-complexity tasks.
+    pub low: Option<Vec<String>>,
+    /// Pool for medium-complexity tasks.
+    pub medium: Option<Vec<String>>,
+    /// Pool for hard-complexity tasks.
+    pub hard: Option<Vec<String>>,
+}
+
+impl ComplexityCrewPools {
+    /// The matching pool; unassessed tasks have no automatic pool.
+    pub fn pool(&self, complexity: TaskComplexity) -> Option<&[String]> {
+        match complexity {
+            TaskComplexity::Low => self.low.as_deref(),
+            TaskComplexity::Medium => self.medium.as_deref(),
+            TaskComplexity::Hard => self.hard.as_deref(),
+            TaskComplexity::Unassessed => None,
+        }
+    }
+}
+
+/// Validate and canonicalize one pool at configuration or run admission.
+/// Duplicate entries have one ticket per canonical crew name.
+pub fn canonical_crew_pool(
+    names: &[String],
+    crews: &BTreeMap<String, Crew>,
+    setting: &str,
+) -> Result<Vec<String>, OrbitError> {
+    let mut canonical = BTreeSet::new();
+    for name in names {
+        if name.trim().is_empty() {
+            return Err(OrbitError::InvalidInput(format!(
+                "{setting} must contain non-empty crew names; use [] to disable the pool"
+            )));
+        }
+        let crew = resolve_crew(name.trim(), crews)
+            .map_err(|error| OrbitError::InvalidInput(format!("{setting}: {error}")))?;
+        canonical.insert(crew.name);
+    }
+    Ok(canonical.into_iter().collect())
+}

--- a/crates/orbit-config/src/lib.rs
+++ b/crates/orbit-config/src/lib.rs
@@ -46,6 +46,7 @@
 //! - `store` — comment-preserving [`ConfigStore`] edits and atomic save.
 //! - `seed` — rendering and writing a fresh default `config.toml`.
 
+mod crew_pools;
 mod layering;
 pub mod operation;
 mod persistence;
@@ -60,6 +61,7 @@ use std::path::PathBuf;
 
 use orbit_common::OrbitError;
 
+pub use crew_pools::{ComplexityCrewPools, canonical_crew_pool};
 pub use layering::{
     ConfigValueSource, ConfigValueSourceKind, EffectiveConfig, EffectiveConfigValue,
     load_effective_config,

--- a/crates/orbit-config/src/registry.rs
+++ b/crates/orbit-config/src/registry.rs
@@ -287,6 +287,21 @@ define_config_settings! {
         description: "Named crew used when a task does not declare `crew` and no CLI override is given.",
         resolve: |raw: Option<String>| resolve_optional_non_empty(raw, "workflow.default_crew"),
     },
+    workflow_hard_complexity_crews: Vec<String> => Vec<String> {
+        key: "workflow.hard_complexity_crews", value_type: "array<string>",
+        description: "Random crew pool for unassigned hard-complexity tasks in auto drains; empty disables the pool.",
+        resolve: |raw: Option<Vec<String>>| Ok::<_, OrbitError>(raw.unwrap_or_default()),
+    },
+    workflow_low_complexity_crews: Vec<String> => Vec<String> {
+        key: "workflow.low_complexity_crews", value_type: "array<string>",
+        description: "Random crew pool for unassigned low-complexity tasks in auto drains; empty disables the pool.",
+        resolve: |raw: Option<Vec<String>>| Ok::<_, OrbitError>(raw.unwrap_or_default()),
+    },
+    workflow_medium_complexity_crews: Vec<String> => Vec<String> {
+        key: "workflow.medium_complexity_crews", value_type: "array<string>",
+        description: "Random crew pool for unassigned medium-complexity tasks in auto drains; empty disables the pool.",
+        resolve: |raw: Option<Vec<String>>| Ok::<_, OrbitError>(raw.unwrap_or_default()),
+    },
     workflow_system_crew: String => String {
         key: "workflow.system_crew", value_type: "string",
         description: "Named crew used by system activities such as step-failure recovery and failed-run triage.",
@@ -304,6 +319,21 @@ impl ConfigSnapshot {
             Some(self.runtime_log_retention_days),
             Some(self.runtime_log_max_total_mb),
             Some(self.runtime_log_max_file_mb),
+        )?;
+        self.workflow_low_complexity_crews = crate::canonical_crew_pool(
+            &self.workflow_low_complexity_crews,
+            crews,
+            "workflow.low_complexity_crews",
+        )?;
+        self.workflow_medium_complexity_crews = crate::canonical_crew_pool(
+            &self.workflow_medium_complexity_crews,
+            crews,
+            "workflow.medium_complexity_crews",
+        )?;
+        self.workflow_hard_complexity_crews = crate::canonical_crew_pool(
+            &self.workflow_hard_complexity_crews,
+            crews,
+            "workflow.hard_complexity_crews",
         )?;
         self.workflow_default_crew =
             resolve_default_crew(self.workflow_default_crew.take(), crews, env_default)?;

--- a/crates/orbit-config/src/resolved.rs
+++ b/crates/orbit-config/src/resolved.rs
@@ -73,6 +73,8 @@ pub struct ResolvedConfig {
     pub crews: BTreeMap<String, Crew>,
     /// Crew used when a task declares none and no override is given.
     pub default_crew: Option<String>,
+    /// Automatic admission pools; explicit task assignments take precedence.
+    pub complexity_crews: crate::ComplexityCrewPools,
     /// Crew used by system activities such as step-failure recovery and
     /// failed-run triage. Resolution of the named crew is deliberately
     /// deferred to dispatch so a bad system crew does not stop unrelated
@@ -107,6 +109,11 @@ impl ResolvedConfig {
             routines_source: snapshot.routines_role.as_deref() == Some("source"),
             crews: default_crews(),
             default_crew: snapshot.workflow_default_crew.clone(),
+            complexity_crews: crate::ComplexityCrewPools {
+                low: Some(snapshot.workflow_low_complexity_crews.clone()),
+                medium: Some(snapshot.workflow_medium_complexity_crews.clone()),
+                hard: Some(snapshot.workflow_hard_complexity_crews.clone()),
+            },
             system_crew: snapshot.workflow_system_crew.clone(),
             operation: OperationPolicy::built_in(),
             tasks_id_start: snapshot.tasks_id_start,
@@ -206,6 +213,11 @@ impl ResolvedConfig {
             routines_source: snapshot.routines_role.as_deref() == Some("source"),
             crews,
             default_crew: snapshot.workflow_default_crew.clone(),
+            complexity_crews: crate::ComplexityCrewPools {
+                low: Some(snapshot.workflow_low_complexity_crews.clone()),
+                medium: Some(snapshot.workflow_medium_complexity_crews.clone()),
+                hard: Some(snapshot.workflow_hard_complexity_crews.clone()),
+            },
             system_crew: snapshot.workflow_system_crew.clone(),
             operation,
             tasks_id_start: snapshot.tasks_id_start,

--- a/crates/orbit-config/src/tests/resolved.rs
+++ b/crates/orbit-config/src/tests/resolved.rs
@@ -872,3 +872,70 @@ fn built_in_defaults_are_reachable_without_any_config_file() {
         ConfigSnapshot::default().execution_env_pass
     );
 }
+
+#[test]
+fn complexity_crew_pools_are_validated_deduplicated_and_projected() {
+    let config = load_config(
+        r#"
+[workflow]
+low_complexity_crews = ["luna"]
+medium_complexity_crews = ["terra", " grok ", "terra"]
+hard_complexity_crews = ["astra"]
+"#,
+    )
+    .expect("valid pools");
+    assert_eq!(
+        config.complexity_crews.medium,
+        Some(vec!["grok".into(), "terra".into()])
+    );
+    for (key, expected) in [
+        ("workflow.low_complexity_crews", serde_json::json!(["luna"])),
+        (
+            "workflow.medium_complexity_crews",
+            serde_json::json!(["grok", "terra"]),
+        ),
+        (
+            "workflow.hard_complexity_crews",
+            serde_json::json!(["astra"]),
+        ),
+    ] {
+        assert_eq!(config.snapshot.value_for(key), Some(expected));
+    }
+    for invalid in [
+        r#"["missing"]"#,
+        r#"[" "]"#,
+        r#"["grok", ""]"#,
+        "[1]",
+        "false",
+    ] {
+        let error = load_config(&format!(
+            "[workflow]\nmedium_complexity_crews = {invalid}\n"
+        ))
+        .expect_err("bad pools must fail config admission");
+        assert!(
+            error.to_string().contains("medium_complexity_crews"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn complexity_crew_pools_layer_by_replacement_and_empty_disables() {
+    let global = tempdir().expect("global");
+    let workspace = tempdir().expect("workspace");
+    write_config(
+        global.path(),
+        "[workflow]\nlow_complexity_crews = [\"luna\"]\nmedium_complexity_crews = [\"grok\"]\nhard_complexity_crews = [\"astra\"]\n",
+    );
+    write_config(
+        workspace.path(),
+        "[workflow]\nmedium_complexity_crews = [\"terra\"]\nhard_complexity_crews = []\n",
+    );
+    let config =
+        ResolvedConfig::load(&roots(global.path(), workspace.path())).expect("layered pools");
+    assert_eq!(config.complexity_crews.low, Some(vec!["luna".into()]));
+    assert_eq!(config.complexity_crews.medium, Some(vec!["terra".into()]));
+    assert_eq!(config.complexity_crews.hard, Some(vec![]));
+    let defaults = load_config("").expect("defaults");
+    assert_eq!(defaults.complexity_crews.medium, Some(vec![]));
+}

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 clap = ["orbit-types/clap"]
 
 [dependencies]
+getrandom.workspace = true
 orbit-automation = { path = "../orbit-automation" }
 base64.workspace = true
 chrono.workspace = true

--- a/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/workspace_auto_pipeline.yaml
@@ -75,6 +75,11 @@ spec:
     # which is the behavior of every caller that does not pass it. Forwarded
     # unchanged so the leaf/epic jobs this run admits inherit the same window.
     allowed_crews: []
+    # Complexity pools are captured by Core at coordinator admission from
+    # workflow configuration and low/medium/hard_complexity_crews run overrides.
+    # Omit defaults here: an omitted override inherits configuration, while []
+    # explicitly disables a pool. Child admission inherits auto_crew_pools and
+    # freezes crew_selection per task; templates must not reroll selections.
 
   steps:
     - id: resolve_ship_input

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/backlog_exclusion.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::OrbitRuntime;
+use crate::application::job::crew_pools::CapturedCrewPools;
 use crate::runtime::engine::crew::CrewAllowlist;
 use crate::runtime::task::locks::lock_context_files_for_task;
 
@@ -136,10 +137,23 @@ pub(super) fn list_backlog_tasks(
         // list into the lookup, then clone only the backlog tasks that survive
         // the filter — tens of clones on a large workspace instead of one per
         // task, and one copy held rather than two.
+        let pools = if input.get("auto_crew_pools").is_some()
+            || action == "classify_workspace_auto_tasks"
+        {
+            runtime.auto_crew_pools_for_input(input).map_err(|error| {
+                DispatchError::DeterministicActionFailed {
+                    action: action.to_string(),
+                    message: error.to_string(),
+                }
+            })?
+        } else {
+            CapturedCrewPools::new()
+        };
         let snapshot = backlog_snapshot(
             runtime,
             action,
             allowlist_from_input(runtime, action, input)?.as_ref(),
+            &pools,
         )?;
         (snapshot.admissible_leaves, Some(snapshot.excluded))
     } else {
@@ -212,6 +226,7 @@ pub(super) fn backlog_snapshot(
     runtime: &OrbitRuntime,
     action: &str,
     allowlist: Option<&CrewAllowlist>,
+    pools: &CapturedCrewPools,
 ) -> Result<BacklogSnapshot, DispatchError> {
     let task_lookup: BTreeMap<String, Task> = runtime
         .stores()
@@ -253,8 +268,8 @@ pub(super) fn backlog_snapshot(
     // go on filling the drain's slots at the usual rate.
     if let Some(allowlist) = allowlist {
         backlog.retain(|task| {
-            match runtime.effective_task_crew(task) {
-                Ok(crew) if allowlist.permits(&crew) => true,
+            match runtime.auto_task_crew_candidates(task, pools, None) {
+                Ok((crews, _)) if crews.iter().any(|crew| allowlist.permits(crew)) => true,
                 // An unresolvable crew fails closed under an explicit
                 // restriction: the drain cannot show it is permitted, and
                 // guessing would spend a budget the operator scoped.
@@ -264,7 +279,11 @@ pub(super) fn backlog_snapshot(
                         reason: BacklogTaskExclusionReason::CrewNotAllowed,
                         conflicts: Vec::new(),
                         crew: Some(match resolution {
-                            Ok(crew) => crew.name,
+                            Ok((crews, _)) => crews
+                                .into_iter()
+                                .map(|crew| crew.name)
+                                .collect::<Vec<_>>()
+                                .join(", "),
                             Err(error) => format!("<unresolved: {error}>"),
                         }),
                     });

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/workspace_auto.rs
@@ -1543,3 +1543,97 @@ fn readiness_parses_numeric_and_string_run_input_ceilings() {
         assert_eq!(classified["worker_limit_source"], "run_input");
     }
 }
+
+#[test]
+fn complexity_pools_drive_allowlist_eligibility_without_reassigning_manual_tasks() {
+    let (_root, runtime, _repo) = runtime_with_workspace_config(Some(
+        "[workflow]\ndefault_crew = \"opus\"\nmedium_complexity_crews = [\"grok\", \"terra\"]\n",
+    ));
+    let unassigned = runtime
+        .add_task(TaskAddParams {
+            title: "Pool-eligible task".into(),
+            description: "Configured pool permits this task despite its excluded default".into(),
+            plan: "Inspect classification".into(),
+            complexity: orbit_types::task::TaskComplexity::Medium,
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("unassigned task");
+    let manual = runtime
+        .add_task(TaskAddParams {
+            title: "Manual crew outside automatic pool".into(),
+            description: "Manual assignments remain selectable".into(),
+            plan: "Inspect classification".into(),
+            complexity: orbit_types::task::TaskComplexity::Medium,
+            crew: Some("astra".into()),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("manual task");
+    let unrestricted = classify(&runtime);
+    let ids = unrestricted["loose_task_ids"].as_array().expect("ids");
+    assert!(ids.contains(&json!(unassigned.id)));
+    assert!(
+        ids.contains(&json!(manual.id)),
+        "a pool must not install an allowlist"
+    );
+    let restricted = classify_with(&runtime, json!({"allowed_crews": ["terra"]}));
+    assert_eq!(restricted["loose_task_ids"], json!([unassigned.id]));
+    let disjoint = classify_with(&runtime, json!({"allowed_crews": ["luna"]}));
+    assert_eq!(disjoint["loose_task_ids"], json!([]));
+    let readiness = runtime
+        .workspace_auto_readiness(
+            std::slice::from_ref(&unassigned.id),
+            None,
+            10,
+            &["luna".into()],
+        )
+        .expect("readiness");
+    let excluded = readiness_task(&readiness, &unassigned.id);
+    assert_eq!(excluded["reason"], "crew_not_allowed");
+    assert_eq!(excluded["crew"], "grok, terra");
+    assert_eq!(
+        runtime
+            .get_task(&manual.id)
+            .expect("manual task")
+            .crew
+            .as_deref(),
+        Some("astra")
+    );
+}
+
+#[test]
+fn classifier_uses_captured_cli_pool_instead_of_current_configuration() {
+    let (_root, runtime, _repo) =
+        runtime_with_workspace_config(Some("[workflow]\nmedium_complexity_crews = [\"grok\"]\n"));
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Captured pool task".into(),
+            description: "CLI override controls eligibility".into(),
+            plan: "Inspect classifier against coordinator input".into(),
+            complexity: orbit_types::task::TaskComplexity::Medium,
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("task");
+    let mut input = json!({"medium_complexity_crews": ["terra"], "allowed_crews": ["terra"]});
+    runtime
+        .install_auto_crew_admission(
+            "workspace_auto_pipeline",
+            &mut input,
+            None,
+            false,
+            &mut || panic!("capture does not draw"),
+        )
+        .expect("capture");
+    let coordinator = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("workspace_auto_pipeline", 1, Utc::now(), Some(input), None)
+        .expect("coordinator");
+    let result = classify_with(
+        &runtime,
+        json!({"run_id": coordinator.run_id, "allowed_crews": ["terra"]}),
+    );
+    assert_eq!(result["loose_task_ids"], json!([task.id]));
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/workspace_auto.rs
@@ -8,6 +8,7 @@ use orbit_types::workflow::{DrainAdmissionsStop, DrainWorkerLimit, OperationAdmi
 use serde_json::{Value, json};
 
 use crate::OrbitRuntime;
+use crate::application::job::crew_pools::CapturedCrewPools;
 use crate::application::operation::{admission_state, live_admission, promote_within_grant};
 
 use crate::runtime::engine::crew::CrewAllowlist;
@@ -137,6 +138,9 @@ pub(super) fn classify_workspace_auto_tasks(
             .saturating_sub(live_leaves.len())
     };
 
+    let pools = runtime
+        .auto_crew_pools_for_input(input)
+        .map_err(|error| action_failed(action, error.to_string()))?;
     let backlog = list_backlog_tasks(runtime, action, input)?;
     // Priority/age order is `list_backlog_tasks`'s, and the truncation to the
     // free slots has to preserve it: the slots are scarce, so they go to the
@@ -177,6 +181,7 @@ pub(super) fn classify_workspace_auto_tasks(
             runtime,
             action,
             allowlist_from_input(runtime, action, input)?.as_ref(),
+            &pools,
         )?
         .filter(|root| {
             operation
@@ -310,11 +315,16 @@ pub fn explain_workspace_auto_readiness(
 
     // Validated here, before any snapshot work, so a typo reads the same way
     // it would on `orbit run auto --allow-crew`.
+    let pool_input = active_drain
+        .as_ref()
+        .map_or_else(|| json!({}), |drain| json!({"run_id": drain.run_id}));
+    let pools = runtime.auto_crew_pools_for_input(&pool_input)?;
     let allowlist = runtime.crew_allowlist(allowed_crews)?;
     let snapshot = backlog_snapshot(
         runtime,
         "explain_workspace_auto_readiness",
         allowlist.as_ref(),
+        &pools,
     )
     .map_err(|error| OrbitError::Execution(format!("read readiness snapshot: {error}")))?;
     let live_leaves = read_live_leaf_runs(runtime)?;
@@ -388,6 +398,7 @@ pub fn explain_workspace_auto_readiness(
             runtime,
             "explain_workspace_auto_readiness",
             allowlist.as_ref(),
+            &pools,
         )
         .map_err(|error| OrbitError::Execution(format!("read epic readiness: {error}")))?
     } else {
@@ -827,6 +838,7 @@ fn next_admissible_epic_root(
     runtime: &OrbitRuntime,
     action: &str,
     allowlist: Option<&CrewAllowlist>,
+    pools: &CapturedCrewPools,
 ) -> Result<Option<String>, DispatchError> {
     let all_tasks = runtime.stores().tasks().list_tasks().map_err(|err| {
         DispatchError::DeterministicActionFailed {
@@ -855,8 +867,8 @@ fn next_admissible_epic_root(
                 && task_dependencies_ready(task, &status_by_id)
                 && allowlist.is_none_or(|allowlist| {
                     runtime
-                        .effective_task_crew(task)
-                        .is_ok_and(|crew| allowlist.permits(&crew))
+                        .auto_task_crew_eligibility(task, pools, allowlist)
+                        .is_ok()
                 })
         })
         .collect::<Vec<_>>();

--- a/crates/orbit-core/src/application/job/crew_pools.rs
+++ b/crates/orbit-core/src/application/job/crew_pools.rs
@@ -1,0 +1,305 @@
+//! Capture auto policy on the coordinator and freeze each task's selection in
+//! its admitted run input. Descendant pipelines inherit the same task choice.
+
+use std::collections::BTreeMap;
+
+use orbit_common::OrbitError;
+use orbit_config::{ComplexityCrewPools, canonical_crew_pool};
+use orbit_types::identity::Crew;
+use orbit_types::task::{Task, TaskComplexity};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::runtime::engine::crew::{CrewAllowlist, enforce_crew_allowlist};
+use crate::runtime::run_input::{non_empty, singular_task_id_from_input};
+
+const POOLS_KEY: &str = "auto_crew_pools";
+const SELECTION_KEY: &str = "crew_selection";
+const COMPLEXITIES: [TaskComplexity; 3] = [
+    TaskComplexity::Low,
+    TaskComplexity::Medium,
+    TaskComplexity::Hard,
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CapturedCrewPool {
+    crews: Vec<String>,
+    source: String,
+}
+
+pub(crate) type CapturedCrewPools = BTreeMap<String, CapturedCrewPool>;
+
+impl OrbitRuntime {
+    /// Transport inputs only; validation and source capture happen at the
+    /// common pipeline admission boundary, including generic job submissions.
+    pub(crate) fn set_auto_crew_overrides(input: &mut Value, overrides: &ComplexityCrewPools) {
+        for complexity in COMPLEXITIES {
+            if let Some(pool) = overrides.pool(complexity) {
+                input[format!("{complexity}_complexity_crews")] = json!(pool);
+            }
+        }
+    }
+
+    fn capture_auto_crew_pools(&self, input: &Value) -> Result<CapturedCrewPools, OrbitError> {
+        COMPLEXITIES
+            .into_iter()
+            .map(|complexity| {
+                let key = format!("{complexity}_complexity_crews");
+                let (names, source) = match input.get(&key) {
+                    Some(raw) => (
+                        serde_json::from_value::<Vec<String>>(raw.clone()).map_err(|error| {
+                            OrbitError::InvalidInput(format!(
+                                "{key} must be an array of crew names: {error}"
+                            ))
+                        })?,
+                        format!("run_input.{key}"),
+                    ),
+                    None => (
+                        self.context
+                            .settings()
+                            .complexity_crews()
+                            .pool(complexity)
+                            .unwrap_or_default()
+                            .to_vec(),
+                        format!("workflow.{key}"),
+                    ),
+                };
+                let crews = canonical_crew_pool(&names, self.context.settings().crews(), &source)?;
+                Ok((complexity.to_string(), CapturedCrewPool { crews, source }))
+            })
+            .collect()
+    }
+
+    /// Classifiers use the coordinator's frozen policy, including CLI overrides.
+    /// A read-only call without a run uses the current configuration.
+    pub(crate) fn auto_crew_pools_for_input(
+        &self,
+        input: &Value,
+    ) -> Result<CapturedCrewPools, OrbitError> {
+        if let Some(run_id) = input
+            .get("run_id")
+            .and_then(Value::as_str)
+            .and_then(non_empty)
+            && let Some(run) = self.get_job_run_backend(run_id)?
+        {
+            return pools_from_input(run.input.as_ref().unwrap_or(&Value::Null));
+        }
+        if input.get(POOLS_KEY).is_some() {
+            pools_from_input(input)
+        } else {
+            self.capture_auto_crew_pools(input)
+        }
+    }
+
+    /// One selection seam for both read-only eligibility and admission. The
+    /// former inspects the candidates without drawing a random ticket.
+    pub(crate) fn auto_task_crew_candidates(
+        &self,
+        task: &Task,
+        pools: &CapturedCrewPools,
+        explicit: Option<&str>,
+    ) -> Result<(Vec<Crew>, String), OrbitError> {
+        if explicit.and_then(non_empty).is_some()
+            || task.crew.as_deref().and_then(non_empty).is_some()
+        {
+            return Ok((
+                vec![self.resolve_crew_for_task(explicit, task.crew.as_deref())?],
+                if explicit.and_then(non_empty).is_some() {
+                    "explicit"
+                } else {
+                    "task.crew"
+                }
+                .to_string(),
+            ));
+        }
+        if let Some(complexity) = task.complexity
+            && let Some(pool) = pools.get(complexity.as_str())
+            && !pool.crews.is_empty()
+        {
+            let names =
+                canonical_crew_pool(&pool.crews, self.context.settings().crews(), &pool.source)?;
+            let crews = names
+                .iter()
+                .map(|name| self.resolve_crew_for_task(Some(name), None))
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok((crews, pool.source.clone()));
+        }
+        Ok((vec![self.effective_task_crew(task)?], "default".to_string()))
+    }
+
+    pub(crate) fn auto_task_crew_eligibility(
+        &self,
+        task: &Task,
+        pools: &CapturedCrewPools,
+        allowlist: &CrewAllowlist,
+    ) -> Result<(), OrbitError> {
+        let (crews, source) = self.auto_task_crew_candidates(task, pools, None)?;
+        permitted_candidates(crews, &source, Some(allowlist)).map(|_| ())
+    }
+
+    /// Called before the existing durable insert. Resume input already contains
+    /// the chosen crew; neither resume nor same-task child admission rerolls it.
+    /// Randomness is injectable at this application boundary for deterministic
+    /// tests of admission, inheritance and rejection sampling.
+    pub(crate) fn install_auto_crew_admission(
+        &self,
+        job_name: &str,
+        input: &mut Value,
+        parent_run_id: Option<&str>,
+        resuming: bool,
+        random: &mut impl FnMut() -> Result<u64, OrbitError>,
+    ) -> Result<(), OrbitError> {
+        if resuming {
+            return Ok(());
+        }
+        // Only auto coordinators and delivery pipelines carry this policy.
+        // System, review and preparation jobs keep their own crew selection.
+        if !matches!(
+            job_name,
+            "workspace_auto_pipeline"
+                | "task_auto_pipeline"
+                | "task_gate_pipeline"
+                | "task_local_pipeline"
+                | "task_pr_pipeline"
+                | "epic_pipeline"
+        ) {
+            return Ok(());
+        }
+        if !input.is_object() {
+            return Err(OrbitError::InvalidInput(
+                "pipeline run input must be a JSON object".to_string(),
+            ));
+        }
+        if job_name == "workspace_auto_pipeline" {
+            input[POOLS_KEY] = json!(self.capture_auto_crew_pools(input)?);
+            return Ok(());
+        }
+        let Some(parent_id) = parent_run_id else {
+            return Ok(());
+        };
+        let Some(parent) = self.get_job_run_backend(parent_id)? else {
+            return Ok(());
+        };
+        let Some(parent_input) = parent.input.as_ref() else {
+            return Ok(());
+        };
+        let Some(pools_value) = parent_input.get(POOLS_KEY) else {
+            return Ok(());
+        };
+        input[POOLS_KEY] = pools_value.clone();
+        // Keep separately explicit constraints authoritative through every child.
+        if let Some(allowed) = parent_input.get("allowed_crews") {
+            input["allowed_crews"] = allowed.clone();
+        }
+        let Some(task_id) = auto_task_id(input).map(ToOwned::to_owned) else {
+            return Ok(());
+        };
+        if let Some(selection) = parent_input.get(SELECTION_KEY)
+            && selection.get("task_id").and_then(Value::as_str) == Some(&task_id)
+        {
+            input["crew"] = selection["crew"].clone();
+            input[SELECTION_KEY] = selection.clone();
+            return Ok(());
+        }
+
+        self.capture_auto_task_selection(input, &task_id, random)
+    }
+
+    fn capture_auto_task_selection(
+        &self,
+        input: &mut Value,
+        task_id: &str,
+        random: &mut impl FnMut() -> Result<u64, OrbitError>,
+    ) -> Result<(), OrbitError> {
+        let pools = pools_from_input(input)?;
+        let task = self.get_task(task_id)?;
+        let explicit = input
+            .get("crew")
+            .and_then(Value::as_str)
+            .and_then(non_empty);
+        let (crews, source) = self.auto_task_crew_candidates(&task, &pools, explicit)?;
+        let allowlist = self.crew_allowlist_from_input(input)?;
+        let candidates = permitted_candidates(crews, &source, allowlist.as_ref())?;
+        let index = random_index(candidates.len(), random)?;
+        let selected = &candidates[index];
+        input[SELECTION_KEY] = json!({
+            "task_id": task.id,
+            "crew": selected.name,
+            "source": source,
+            "complexity": task.complexity,
+            "eligible_pool": candidates.iter().map(|crew| &crew.name).collect::<Vec<_>>(),
+        });
+        input["crew"] = json!(selected.name);
+        Ok(())
+    }
+}
+
+fn pools_from_input(input: &Value) -> Result<CapturedCrewPools, OrbitError> {
+    input
+        .get(POOLS_KEY)
+        .map(|value| {
+            serde_json::from_value(value.clone())
+                .map_err(|error| OrbitError::InvalidInput(format!("invalid {POOLS_KEY}: {error}")))
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
+}
+
+fn auto_task_id(input: &Value) -> Option<&str> {
+    singular_task_id_from_input(input).or_else(|| {
+        input
+            .get("epic_task_id")
+            .and_then(Value::as_str)
+            .and_then(non_empty)
+    })
+}
+
+fn permitted_candidates(
+    crews: Vec<Crew>,
+    source: &str,
+    allowlist: Option<&CrewAllowlist>,
+) -> Result<Vec<Crew>, OrbitError> {
+    if crews.len() == 1 {
+        enforce_crew_allowlist(allowlist, &crews[0], source)?;
+        return Ok(crews);
+    }
+    let names = crews
+        .iter()
+        .map(|crew| crew.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let permitted = crews
+        .into_iter()
+        .filter(|crew| allowlist.is_none_or(|list| list.permits(crew)))
+        .collect::<Vec<_>>();
+    if permitted.is_empty() {
+        return Err(OrbitError::InvalidInput(format!(
+            "crew pool from {source} [{names}] has no member permitted by this run's crew allowlist"
+        )));
+    }
+    Ok(permitted)
+}
+
+fn random_index(
+    len: usize,
+    random: &mut impl FnMut() -> Result<u64, OrbitError>,
+) -> Result<usize, OrbitError> {
+    if len <= 1 {
+        return Ok(0);
+    }
+    let bound = len as u64;
+    // Rejection sampling avoids modulo bias for pools whose size is not a
+    // power of two. No random draw occurs for explicit or singleton choices.
+    let threshold = bound.wrapping_neg() % bound;
+    loop {
+        let ticket = random()?;
+        if ticket >= threshold {
+            return Ok((ticket % bound) as usize);
+        }
+    }
+}
+
+pub(crate) fn random_crew_ticket() -> Result<u64, OrbitError> {
+    getrandom::u64().map_err(|error| OrbitError::Execution(format!("draw automatic crew: {error}")))
+}

--- a/crates/orbit-core/src/application/job/mod.rs
+++ b/crates/orbit-core/src/application/job/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent_invoke;
 pub(crate) mod catalog;
+pub(crate) mod crew_pools;
 mod exec;
 pub(crate) mod pipeline;
 mod resume;

--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -293,12 +293,14 @@ impl OrbitRuntime {
     /// registry names are what gets persisted and forwarded. It gates what the
     /// drain may *start* — it does not touch workspace configuration, reassign
     /// a task's crew, or cancel work another invocation already has in flight.
+    #[allow(clippy::too_many_arguments)]
     pub fn submit_workspace_auto_run(
         &self,
         for_seconds: Option<u64>,
         max_active_leaf_runs: Option<u32>,
         completion: crate::application::workflow::CompletionPolicy,
         allowed_crews: &[String],
+        complexity_crews: &orbit_config::ComplexityCrewPools,
         actor: Option<&str>,
         claim_token: Option<&str>,
     ) -> Result<PipelineInvokeResult, OrbitError> {
@@ -307,12 +309,13 @@ impl OrbitRuntime {
             crate::application::workflow::AUTO_WORKFLOW_ALIAS,
         )
         .ok_or_else(|| OrbitError::InvalidInput("unknown workflow 'auto'".to_string()))?;
-        let input = workspace_auto_run_input(
+        let mut input = workspace_auto_run_input(
             for_seconds,
             max_active_leaf_runs,
             completion,
             &self.canonical_allowed_crews(allowed_crews)?,
         )?;
+        Self::set_auto_crew_overrides(&mut input, complexity_crews);
         self.submit_pipeline_run(workflow.job_id, input, None, actor)
     }
 
@@ -776,6 +779,13 @@ impl OrbitRuntime {
             &mut input,
             admission.map(|admission| admission.parent_run_id.as_str()),
             resume.is_some(),
+        )?;
+        self.install_auto_crew_admission(
+            job_name,
+            &mut input,
+            admission.map(|admission| admission.parent_run_id.as_str()),
+            resume.is_some(),
+            &mut super::crew_pools::random_crew_ticket,
         )?;
         let result = (|| {
             let spec = match &definition {

--- a/crates/orbit-core/src/application/job/tests/crew_pools.rs
+++ b/crates/orbit-core/src/application/job/tests/crew_pools.rs
@@ -1,0 +1,413 @@
+//! Deterministic admission tests over the real task and run stores.
+
+use chrono::Utc;
+use orbit_common::OrbitError;
+use orbit_types::task::{Task, TaskComplexity, TaskStatus};
+use serde_json::{Value, json};
+
+use crate::OrbitRuntime;
+use crate::application::task::TaskAddParams;
+
+use super::exec::test_runtime_with_workspace_config;
+
+fn task(runtime: &OrbitRuntime, complexity: TaskComplexity, crew: Option<&str>) -> Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: "Crew pool admission fixture".into(),
+            description: "Exercise automatic crew selection".into(),
+            plan: "Inspect admission evidence".into(),
+            complexity,
+            crew: crew.map(ToOwned::to_owned),
+            status: Some(TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("task")
+}
+
+fn no_draw() -> Result<u64, OrbitError> {
+    panic!("this admission must not draw a new random ticket")
+}
+
+fn coordinator(runtime: &OrbitRuntime, mut input: Value) -> String {
+    runtime
+        .install_auto_crew_admission(
+            "workspace_auto_pipeline",
+            &mut input,
+            None,
+            false,
+            &mut no_draw,
+        )
+        .expect("capture coordinator policy");
+    persist(runtime, "workspace_auto_pipeline", input)
+}
+
+fn persist(runtime: &OrbitRuntime, job: &str, input: Value) -> String {
+    runtime
+        .stores()
+        .jobs()
+        .insert_job_run(job, 1, Utc::now(), Some(input), None)
+        .expect("persist run input")
+        .run_id
+}
+
+fn admit(runtime: &OrbitRuntime, parent: &str, task: &Task, ticket: u64) -> Value {
+    let mut input = json!({"task_ids": [task.id]});
+    runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(parent),
+            false,
+            &mut || Ok(ticket),
+        )
+        .expect("admit task");
+    input
+}
+
+#[test]
+fn complexity_pools_override_matching_config_and_select_independently_without_weighting() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config(
+        r#"
+[workflow]
+low_complexity_crews = ["luna"]
+medium_complexity_crews = ["astra"]
+hard_complexity_crews = ["sol"]
+"#,
+    );
+    let parent = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["terra", "grok", "terra"]}),
+    );
+    let first = task(&runtime, TaskComplexity::Medium, None);
+    let second = task(&runtime, TaskComplexity::Medium, None);
+    let left = admit(&runtime, &parent, &first, 0);
+    let right = admit(&runtime, &parent, &second, 1);
+    assert_eq!(left["crew"], "grok");
+    assert_eq!(right["crew"], "terra");
+    assert_eq!(
+        left["crew_selection"]["source"],
+        "run_input.medium_complexity_crews"
+    );
+    assert_eq!(
+        left["crew_selection"]["eligible_pool"],
+        json!(["grok", "terra"])
+    );
+    assert!(left.get("allowed_crews").is_none());
+    assert_eq!(
+        runtime.get_task(&first.id).expect("unchanged task").crew,
+        None
+    );
+    for (complexity, crew) in [(TaskComplexity::Low, "luna"), (TaskComplexity::Hard, "sol")] {
+        let selected = admit(&runtime, &parent, &task(&runtime, complexity, None), 0);
+        assert_eq!(selected["crew"], crew);
+        assert_eq!(
+            selected["crew_selection"]["source"],
+            format!("workflow.{complexity}_complexity_crews")
+        );
+    }
+}
+
+#[test]
+fn explicit_task_crews_empty_pools_and_unassessed_tasks_preserve_fallback() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config(
+        "[workflow]\nmedium_complexity_crews = [\"grok\", \"terra\"]\n",
+    );
+    let parent = coordinator(&runtime, json!({}));
+    let assigned = task(&runtime, TaskComplexity::Medium, Some("astra"));
+    let mut input = json!({"task_ids": [assigned.id]});
+    runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(&parent),
+            false,
+            &mut no_draw,
+        )
+        .expect("manual assignment");
+    assert_eq!(input["crew"], "astra");
+    assert_eq!(input["crew_selection"]["source"], "task.crew");
+    let disabled = coordinator(&runtime, json!({"medium_complexity_crews": []}));
+    assert_eq!(
+        admit(
+            &runtime,
+            &disabled,
+            &task(&runtime, TaskComplexity::Medium, None),
+            0
+        )["crew"],
+        "opus"
+    );
+    assert_eq!(
+        admit(
+            &runtime,
+            &parent,
+            &task(&runtime, TaskComplexity::Unassessed, None),
+            0
+        )["crew"],
+        "opus"
+    );
+    let pools = runtime
+        .auto_crew_pools_for_input(&json!({"run_id": parent}))
+        .expect("pools");
+    let mut unset = assigned;
+    unset.crew = None;
+    unset.complexity = None;
+    let (candidates, source) = runtime
+        .auto_task_crew_candidates(&unset, &pools, None)
+        .expect("legacy unset complexity");
+    assert_eq!(candidates[0].name, "opus");
+    assert_eq!(source, "default");
+}
+
+#[test]
+fn pool_constraints_filter_candidates_and_diagnose_disjoint_or_explicit_crews() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config("");
+    let parent = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["grok", "terra"], "allowed_crews": ["terra"]}),
+    );
+    let unassigned = task(&runtime, TaskComplexity::Medium, None);
+    let mut input = json!({"task_ids": [unassigned.id], "allowed_crews": ["grok"]});
+    runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(&parent),
+            false,
+            &mut no_draw,
+        )
+        .expect("only permitted member");
+    assert_eq!(input["crew"], "terra");
+    assert_eq!(input["allowed_crews"], json!(["terra"]));
+    let disjoint = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["grok", "terra"], "allowed_crews": ["astra"]}),
+    );
+    let mut rejected = json!({"task_ids": [unassigned.id]});
+    let error = runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut rejected,
+            Some(&disjoint),
+            false,
+            &mut no_draw,
+        )
+        .expect_err("disjoint pool");
+    assert!(error.to_string().contains("no member permitted"), "{error}");
+    let assigned = task(&runtime, TaskComplexity::Medium, Some("grok"));
+    let mut rejected = json!({"task_ids": [assigned.id]});
+    let error = runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut rejected,
+            Some(&parent),
+            false,
+            &mut no_draw,
+        )
+        .expect_err("manual excluded");
+    assert!(error.to_string().contains("task.crew"), "{error}");
+}
+
+#[test]
+fn selection_survives_persistence_reopen_same_task_children_and_resume_without_reroll() {
+    let (_root, runtime, repo, global) = test_runtime_with_workspace_config("");
+    let parent = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["grok", "terra"]}),
+    );
+    let selected_task = task(&runtime, TaskComplexity::Medium, None);
+    let selected = admit(&runtime, &parent, &selected_task, 1);
+    let child = persist(&runtime, "task_auto_pipeline", selected.clone());
+    drop(runtime);
+    std::fs::write(
+        repo.join(".orbit/config.toml"),
+        "[workflow]\ndefault_crew = \"astra\"\nmedium_complexity_crews = [\"astra\"]\n",
+    )
+    .expect("change configuration");
+    let runtime = OrbitRuntime::from_roots(&global, &repo.join(".orbit")).expect("reopen");
+    let stored = runtime
+        .get_job_run_backend(&child)
+        .expect("read")
+        .expect("child")
+        .input
+        .expect("input");
+    assert_eq!(stored, selected);
+    let mut nested = json!({"task_ids": [selected_task.id]});
+    runtime
+        .install_auto_crew_admission(
+            "task_gate_pipeline",
+            &mut nested,
+            Some(&child),
+            false,
+            &mut no_draw,
+        )
+        .expect("inherit selection");
+    assert_eq!(nested["crew_selection"], stored["crew_selection"]);
+    let mut resumed = stored.clone();
+    runtime
+        .install_auto_crew_admission("task_auto_pipeline", &mut resumed, None, true, &mut no_draw)
+        .expect("resume");
+    assert_eq!(resumed, stored);
+    assert_eq!(
+        runtime
+            .resolve_crew_for_run_input(&resumed)
+            .expect("dispatch crew")
+            .name,
+        "terra"
+    );
+    let independent = task(&runtime, TaskComplexity::Medium, None);
+    assert_eq!(
+        admit(&runtime, &parent, &independent, 0)["crew"],
+        "grok",
+        "old coordinator retains its pool"
+    );
+}
+
+#[test]
+fn unknown_blank_and_wrong_shape_pools_fail_before_admission() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config("");
+    for bad in [
+        json!(["missing"]),
+        json!([""]),
+        json!(["grok", " "]),
+        json!("grok"),
+        json!([1]),
+    ] {
+        let mut input = json!({"medium_complexity_crews": bad});
+        let error = runtime
+            .install_auto_crew_admission(
+                "workspace_auto_pipeline",
+                &mut input,
+                None,
+                false,
+                &mut no_draw,
+            )
+            .expect_err("invalid pool");
+        assert!(
+            error.to_string().contains("medium_complexity_crews"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn random_sampling_rejects_biased_ticket_and_propagates_entropy_failure() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config("");
+    let parent = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["astra", "grok", "terra"]}),
+    );
+    let selected_task = task(&runtime, TaskComplexity::Medium, None);
+    let mut input = json!({"task_ids": [selected_task.id]});
+    let mut tickets = [0, 2].into_iter();
+    runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(&parent),
+            false,
+            &mut || Ok(tickets.next().expect("two tickets")),
+        )
+        .expect("unbiased selection");
+    assert_eq!(input["crew"], "terra");
+    assert_eq!(tickets.next(), None);
+    let mut input = json!({"task_ids": [selected_task.id]});
+    let error = runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(&parent),
+            false,
+            &mut || Err(OrbitError::Execution("entropy unavailable".into())),
+        )
+        .expect_err("entropy error");
+    assert!(error.to_string().contains("entropy unavailable"));
+    assert!(input.get("crew_selection").is_none());
+}
+
+#[test]
+fn epic_descendants_draw_independently_and_system_jobs_keep_their_crew() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config("");
+    let parent = coordinator(
+        &runtime,
+        json!({"medium_complexity_crews": ["grok", "terra"]}),
+    );
+    let root = task(&runtime, TaskComplexity::Medium, None);
+    let mut epic = json!({"epic_task_id": root.id});
+    runtime
+        .install_auto_crew_admission(
+            "epic_pipeline",
+            &mut epic,
+            Some(&parent),
+            false,
+            &mut || Ok(0),
+        )
+        .expect("epic admission");
+    assert_eq!(epic["crew"], "grok");
+    let epic_run = persist(&runtime, "epic_pipeline", epic);
+    let descendant = task(&runtime, TaskComplexity::Medium, None);
+    let mut child = json!({"task_ids": [descendant.id]});
+    runtime
+        .install_auto_crew_admission(
+            "task_local_pipeline",
+            &mut child,
+            Some(&epic_run),
+            false,
+            &mut || Ok(1),
+        )
+        .expect("descendant admission");
+    assert_eq!(child["crew"], "terra");
+    assert_eq!(child["crew_selection"]["task_id"], descendant.id);
+    let mut system = json!({"task_id": root.id, "crew": "astra"});
+    let original = system.clone();
+    runtime
+        .install_auto_crew_admission(
+            "task_triage_pipeline",
+            &mut system,
+            Some(&epic_run),
+            false,
+            &mut no_draw,
+        )
+        .expect("independent system route");
+    assert_eq!(system, original);
+}
+
+#[test]
+fn explicit_run_crew_wins_and_ordinary_ship_admission_has_no_pool_policy() {
+    let (_root, runtime, _, _) = test_runtime_with_workspace_config(
+        "[workflow]\nmedium_complexity_crews = [\"grok\", \"terra\"]\n",
+    );
+    let parent = coordinator(&runtime, json!({}));
+    let assigned = task(&runtime, TaskComplexity::Medium, Some("astra"));
+    let mut input = json!({"task_ids": [assigned.id], "crew": "luna"});
+    runtime
+        .install_auto_crew_admission(
+            "task_auto_pipeline",
+            &mut input,
+            Some(&parent),
+            false,
+            &mut no_draw,
+        )
+        .expect("explicit run assignment");
+    assert_eq!(input["crew"], "luna");
+    assert_eq!(input["crew_selection"]["source"], "explicit");
+    let ship = persist(&runtime, "workspace_ship_pipeline", json!({}));
+    let mut ordinary = json!({"task_ids": [assigned.id]});
+    let original = ordinary.clone();
+    runtime
+        .install_auto_crew_admission(
+            "task_gate_pipeline",
+            &mut ordinary,
+            Some(&ship),
+            false,
+            &mut no_draw,
+        )
+        .expect("manual ship");
+    assert_eq!(ordinary, original);
+    assert_eq!(
+        runtime
+            .resolve_crew_for_run_input(&ordinary)
+            .expect("manual crew")
+            .name,
+        "astra"
+    );
+}

--- a/crates/orbit-core/src/application/job/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/tests/mod.rs
@@ -1,5 +1,6 @@
 mod agent_invoke;
 mod catalog;
+mod crew_pools;
 mod exec;
 mod resume;
 mod task_pilot_pipeline;

--- a/crates/orbit-core/src/application/operation/admission.rs
+++ b/crates/orbit-core/src/application/operation/admission.rs
@@ -36,6 +36,7 @@ pub struct OperationDrainRequest<'a> {
     /// Requested leaf ceiling; may only narrow the grant's captured ceiling.
     pub max_active_leaf_runs: Option<u32>,
     pub allowed_crews: &'a [String],
+    pub complexity_crews: &'a orbit_config::ComplexityCrewPools,
     pub actor: Option<&'a str>,
     pub claim_token: Option<&'a str>,
 }
@@ -106,6 +107,7 @@ impl OrbitRuntime {
             completion,
             &self.canonical_allowed_crews(request.allowed_crews)?,
         )?;
+        Self::set_auto_crew_overrides(&mut input, request.complexity_crews);
         if let Some(object) = input.as_object_mut() {
             object.insert(
                 OPERATION_ADMISSION_KEY.to_string(),

--- a/crates/orbit-core/src/application/operation/tests/pipeline.rs
+++ b/crates/orbit-core/src/application/operation/tests/pipeline.rs
@@ -87,6 +87,7 @@ fn start_drain(runtime: &OrbitRuntime, grant_id: &str) -> (JobRun, OperationAdmi
     let _worker = WorkerOverride::install();
     let result = runtime
         .submit_operation_drain(OperationDrainRequest {
+            complexity_crews: &Default::default(),
             grant_id: Some(grant_id),
             for_seconds: Some(600),
             max_active_leaf_runs: None,
@@ -917,4 +918,68 @@ fn ordinary_expiry_closes_admission_and_promotion_but_keeps_captured_completion(
         .expect("expiry keeps captured completion");
     // And a new window is not implied: the workspace has no active grant.
     assert!(runtime.active_operation_grant().expect("active").is_none());
+}
+
+#[test]
+fn grant_bound_drain_uses_complexity_override_without_widening_authority() {
+    let fixture = fixture("[workflow]\nmedium_complexity_crews = [\"grok\"]\n");
+    let runtime = &fixture.runtime;
+    let task = seed_task(runtime, "Grant crew pool fixture", TaskStatus::Backlog);
+    runtime
+        .update_task(
+            &task.id,
+            crate::application::task::TaskUpdateParams {
+                complexity: Some(orbit_types::task::TaskComplexity::Medium),
+                ..Default::default()
+            },
+        )
+        .expect("assess complexity");
+    let grant = enable(
+        runtime,
+        std::slice::from_ref(&task.id),
+        GrantRights {
+            prepare: true,
+            promote: true,
+            complete: false,
+        },
+        OperationLayer::default(),
+    );
+    let _worker = WorkerOverride::install();
+    let drain = runtime
+        .submit_operation_drain(OperationDrainRequest {
+            grant_id: Some(&grant.id),
+            for_seconds: Some(600),
+            max_active_leaf_runs: Some(1),
+            allowed_crews: &["terra".into()],
+            complexity_crews: &orbit_config::ComplexityCrewPools {
+                medium: Some(vec!["terra".into()]),
+                ..Default::default()
+            },
+            actor: Some("tester"),
+            claim_token: None,
+        })
+        .expect("grant-bound pool override");
+    let ChildSubmission::Submitted(child) = admit_leaf(runtime, &drain.invoke.run_id, &task.id)
+    else {
+        panic!("admitted");
+    };
+    let input = runtime
+        .get_job_run_backend(&child.run_id)
+        .expect("read child")
+        .expect("child")
+        .input
+        .expect("input");
+    assert_eq!(input["crew"], "terra");
+    assert_eq!(
+        input["crew_selection"]["source"],
+        "run_input.medium_complexity_crews"
+    );
+    assert_eq!(input["allowed_crews"], json!(["terra"]));
+    assert_eq!(input[OPERATION_ADMISSION_KEY]["grant_id"], grant.id);
+    assert_eq!(input[OPERATION_ADMISSION_KEY]["limits"]["leaf_ceiling"], 1);
+    stop(runtime, &grant.id);
+    assert_eq!(
+        classify(runtime, &drain.invoke.run_id)["loose_task_ids"],
+        json!([])
+    );
 }

--- a/crates/orbit-core/src/application/tests/job_submission.rs
+++ b/crates/orbit-core/src/application/tests/job_submission.rs
@@ -357,3 +357,137 @@ fn submission_returns_while_its_worker_is_still_running() {
         "submission must not block on the worker it started"
     );
 }
+
+#[test]
+fn auto_complexity_pool_is_captured_at_submission_and_retained_by_real_resume() {
+    use crate::application::job::pipeline::{ChildPipelineAdmission, ChildSubmission};
+    use crate::application::task::TaskAddParams;
+    use orbit_config::ComplexityCrewPools;
+    use orbit_types::task::TaskComplexity;
+    use serde_json::json;
+
+    let (_root, runtime) = test_runtime();
+    for job in [
+        "workspace_auto_pipeline",
+        "task_auto_pipeline",
+        "task_gate_pipeline",
+    ] {
+        write_job_file(
+            &runtime.paths().global_dir.join("resources/jobs"),
+            job,
+            &job_yaml(job, 10),
+        );
+    }
+    let _worker = WorkerOverride::shell("sleep 5");
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Automatic crew persistence".into(),
+            description: "Admission and resume preserve crew evidence".into(),
+            plan: "Validate persisted input".into(),
+            complexity: TaskComplexity::Medium,
+            status: Some(orbit_types::task::TaskStatus::Backlog),
+            ..Default::default()
+        })
+        .expect("task");
+    let parent = runtime
+        .submit_workspace_auto_run(
+            None,
+            None,
+            crate::CompletionPolicy::Review,
+            &[],
+            &ComplexityCrewPools {
+                medium: Some(vec!["grok".into(), "terra".into()]),
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .expect("submit coordinator");
+    let parent_run = runtime
+        .get_job_run_backend(&parent.run_id)
+        .expect("read coordinator")
+        .expect("coordinator");
+    assert_eq!(
+        parent_run.input.as_ref().expect("input")["auto_crew_pools"]["medium"]["source"],
+        "run_input.medium_complexity_crews"
+    );
+    let child = runtime
+        .submit_child_pipeline_run(
+            "task_auto_pipeline",
+            json!({"task_ids": [task.id]}),
+            None,
+            None,
+            &ChildPipelineAdmission {
+                parent_run_id: parent.run_id,
+                parent_step_id: Some("ship_leaves".into()),
+                action: "invoke_detached".into(),
+                blocking: false,
+            },
+        )
+        .expect("admit child");
+    let ChildSubmission::Submitted(child) = child else {
+        panic!("child admitted");
+    };
+    let run = runtime
+        .get_job_run_backend(&child.run_id)
+        .expect("read child")
+        .expect("child");
+    let input = run.input.expect("child input");
+    assert!(["grok", "terra"].contains(&input["crew"].as_str().expect("crew")));
+    assert_eq!(
+        input["crew_selection"]["source"],
+        "run_input.medium_complexity_crews"
+    );
+    assert!(input.get("allowed_crews").is_none());
+    let nested = runtime
+        .submit_child_pipeline_run(
+            "task_gate_pipeline",
+            json!({"task_ids": [task.id]}),
+            None,
+            None,
+            &ChildPipelineAdmission {
+                parent_run_id: child.run_id.clone(),
+                parent_step_id: Some("gate".into()),
+                action: "invoke_and_wait".into(),
+                blocking: true,
+            },
+        )
+        .expect("admit same-task pipeline");
+    let ChildSubmission::Submitted(nested) = nested else {
+        panic!("nested admitted");
+    };
+    let nested_input = runtime
+        .get_job_run_backend(&nested.run_id)
+        .expect("read nested")
+        .expect("nested")
+        .input
+        .expect("input");
+    assert_eq!(nested_input["crew_selection"], input["crew_selection"]);
+    for run_id in [&nested.run_id, &child.run_id] {
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(run_id, Utc::now(), std::process::id())
+            .expect("start fixture before recording failure");
+        runtime
+            .finalize_job_run_with_reservation_cleanup(
+                run_id,
+                JobRunState::Failed,
+                Utc::now(),
+                Some(1),
+                orbit_store::contracts::TaskReservationReleaseReason::RunTerminal,
+            )
+            .expect("finish fixture run");
+    }
+    let resumed = runtime
+        .submit_resume_run(&child.run_id, None, None)
+        .expect("resume child");
+    let resumed_input = runtime
+        .get_job_run_backend(&resumed.run_id)
+        .expect("read resume")
+        .expect("resumed")
+        .input
+        .expect("input");
+    assert_eq!(resumed_input["crew"], input["crew"]);
+    assert_eq!(resumed_input["crew_selection"], input["crew_selection"]);
+}

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -242,6 +242,7 @@ pub(crate) struct OrbitRuntimeSettings {
     routines_source: bool,
     crews: std::collections::BTreeMap<String, Crew>,
     default_crew: Option<String>,
+    complexity_crews: orbit_config::ComplexityCrewPools,
     system_crew: String,
     /// Resolved operation-mode preferences with provenance (`[operation]`).
     /// Preferences only; authority is a separate durable grant [ORB-11332].
@@ -260,6 +261,7 @@ impl OrbitRuntimeSettings {
         routines_source: bool,
         crews: std::collections::BTreeMap<String, Crew>,
         default_crew: Option<String>,
+        complexity_crews: orbit_config::ComplexityCrewPools,
         system_crew: String,
         operation: orbit_config::OperationPolicy,
     ) -> Self {
@@ -273,6 +275,7 @@ impl OrbitRuntimeSettings {
             routines_source,
             crews,
             default_crew,
+            complexity_crews,
             system_crew,
             operation,
         }
@@ -300,6 +303,10 @@ impl OrbitRuntimeSettings {
 
     pub(crate) fn crews(&self) -> &std::collections::BTreeMap<String, Crew> {
         &self.crews
+    }
+
+    pub(crate) fn complexity_crews(&self) -> &orbit_config::ComplexityCrewPools {
+        &self.complexity_crews
     }
 
     pub(crate) fn default_crew(&self) -> Option<&str> {

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -194,6 +194,7 @@ pub(crate) fn build_context_from_roots(
             routines_source,
             crews,
             default_crew,
+            runtime_config.complexity_crews.clone(),
             system_crew,
             operation,
         ),

--- a/crates/orbit-web/src/api/runs.rs
+++ b/crates/orbit-web/src/api/runs.rs
@@ -210,6 +210,7 @@ pub(super) async fn auto_drain_workflow_action(
         // [ORB-11242] The dashboard launch form does not offer a crew
         // restriction, so it submits the unrestricted window it always has.
         &[],
+        &Default::default(),
         Some("dashboard"),
         body.claim_token.as_deref(),
     ) {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -857,6 +857,66 @@ authoritative.
 
 This means you can mix-and-match in a single ship run: route a tricky refactor to `claude` while routing routine cleanups to `codex` — both go through the same `orbit run ship` invocation, each picking its own crew at dispatch time. `orbit run ship` fans singleton child runs, so each task's `crew` is recorded on that child (`orbit run show` → `resolved_crew`) and used by `implement_one`. A single child pipeline whose `task_ids` name more than one distinct crew (or mix set and unset crews) fails closed rather than inheriting `[workflow].default_crew`.
 
+### Automatic crew pools by complexity
+
+Auto drains can randomly select a crew for each task that has no explicit
+`task.crew`:
+
+```sh
+orbit run auto --medium-complexity-crews grok,terra
+```
+
+The equivalent configuration is:
+
+```toml
+[workflow]
+low_complexity_crews = ["luna"]
+medium_complexity_crews = ["grok", "terra"]
+hard_complexity_crews = ["astra"]
+```
+
+Use `--low-complexity-crews`, `--medium-complexity-crews`, and
+`--hard-complexity-crews` for run overrides, including with `--grant`. Each
+provided CLI pool replaces only its matching configuration pool for that
+drain. Configuration arrays replace their corresponding global arrays when
+specified in the workspace file. Set/get/show use the same fields:
+
+```sh
+orbit config set workflow.medium_complexity_crews '["grok", "terra"]'
+orbit config get workflow.medium_complexity_crews
+orbit config show
+```
+
+For automatic task admission the order is an explicit run-input crew, an
+explicit task crew, the matching nonempty complexity pool, then the existing
+default crew resolution chain. Low, medium and hard are the task complexity
+values; unset or `unassessed` complexity uses the default chain. An omitted
+pool inherits configuration; an absent or empty effective pool uses the
+default chain. `medium_complexity_crews = []` disables that configured pool;
+`orbit run auto --medium-complexity-crews` (with no names) disables it for one
+drain. Blank entries such as `""` and unknown crew names fail before dispatch.
+Names are trimmed, resolved against the configured registry and deduplicated,
+so repeated entries never add random weight.
+
+Pools are selection preferences. They do not install a crew allowlist or
+restrict manual assignments, ordinary `run ship`, or explicit activity crews.
+When a separately supplied `--allow-crew` restricts the drain, random selection
+is uniform among the pool's permitted members. A disjoint pool is ineligible
+and `orbit run readiness --allow-crew <crew>` diagnoses `crew_not_allowed`; an explicit task assignment
+outside the allowlist is also excluded. The allowlist still applies to system
+and review activities at dispatch, and operation grants keep their scope and
+admission limits.
+
+The coordinator captures effective pools in run input `auto_crew_pools`.
+Each admitted leaf or epic root records `crew` and `crew_selection`, including
+the task ID, complexity, source (`task.crew`, `run_input.<complexity>_complexity_crews`,
+`workflow.<complexity>_complexity_crews`, `explicit`, or `default`), and eligible
+pool. Inspect these with `orbit run show <RUN_ID>`. Same-task pipeline children
+and retries/resumes retain the admitted selection even if configuration or
+the task assignment changes later. Different tasks, including epic descendants,
+receive independent draws at their own admission. No choice rewrites
+`task.crew`; a newly admitted run outside the retry lineage can select again.
+
 ### Setting `task.crew`
 
 Three equivalent surfaces:


### PR DESCRIPTION
## Task

[ORB-11573](https://orbit-cli.com/tasks/ORB-11573) — Select crews randomly from configurable task-complexity pools in auto dispatch

### Description

Daniel requests automatic crew selection by task complexity. Support e.g. orbit run auto --medium-complexity-crews grok,terra and config.toml [workflow] medium_complexity_crews = ["grok", "terra"]. Randomly select a crew from the effective pool for each applicable task admission. Provide consistent low/medium/hard complexity options, using Orbit's existing hard enum. CLI overrides the corresponding configured pool for that drain. This is a crew selection policy, not a dispatch allowlist; omitted dispatch allowlists must continue to permit any configured crew.

Define and document precedence with explicit task crew assignments and existing defaults. Preserve deliberate user task assignments; apply automatic pools when no explicit assignment takes precedence. Persist the resolved crew and selection provenance at admission so retries/resumes do not silently reroll. Inspect existing selection seams before implementing; avoid a second competing selector. Validate crew names and empty/duplicate values with actionable errors and define omitted/empty pool behavior. Support the normal configuration set/get/show surfaces alongside TOML and CLI help. No release work.

Assigned to Astra explicitly by Daniel: cross-cutting configuration, dispatch precedence, randomness, and durable retry semantics warrant hard complexity. ORB-11514 and ORB-11546 remain blocked and are unrelated prerequisites; do not tie this feature to them.

### Acceptance Criteria

- CLI accepts --medium-complexity-crews grok,terra; [workflow] accepts medium_complexity_crews = ["grok", "terra"]; equivalent low/hard controls use existing complexity values.
- CLI pool overrides the matching configuration pool; explicit task crew precedence, unset complexity, absent/empty pools, and existing fallback behavior are specified and tested.
- Each eligible task admission randomly selects only from its effective validated pool; duplicate entries cannot accidentally weight selection. Use deterministic injectable randomness for meaningful non-flaky tests.
- Resolved selection and its source are visible in run evidence and stable across retries/resume, while independently admitted tasks can choose different pool members.
- Pool selection does not install an implicit dispatch allowlist or restrict manual crew choices; any separately explicit admission constraints remain honored and diagnosed.
- Config validation and set/get/show expose the new fields consistently; unknown/blank crew names fail clearly before dispatch.
- Focused configuration, CLI, dispatch, persistence/resume tests and repository-required checks pass; help/docs include the requested example and precedence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added low/medium/hard complexity crew pools to the fixed configuration registry, resolved runtime settings, and auto CLI (including grant-bound drains). CLI pools override only matching configuration pools; a flag with no names or an empty TOML array disables that pool.
- Configuration and run admission share crew-name validation and canonical deduplication. Unknown, blank and malformed entries fail before dispatch.
- Auto coordinator admission captures effective pools and their configuration/run-input sources. The existing child-admission path records each task's crew and crew_selection evidence in durable run input. Same-task delivery children and retries/resumes retain the choice; epic descendants draw independently. Explicit task assignments and existing default fallback are preserved.
- Selection uses OS randomness with rejection sampling and an injectable ticket source. An explicit allowlist narrows candidate pools; disjoint pools and excluded manual assignments are diagnosed without manufacturing an implicit allowlist. System/review/preparation jobs retain their own crew selection.
- Updated CONFIG.md, CLI help and mirrored workspace-auto YAML comments with the requested example, precedence, empty/unassessed behavior and persistence semantics.

Acceptance assessment:
1. CLI --medium-complexity-crews grok,terra and all three TOML/CLI controls are implemented and tested using TaskComplexity::Low/Medium/Hard.
2. Matching CLI override, explicit run/task precedence, unset/unassessed complexity, absent/empty pools and existing default fallback have deterministic coverage.
3. Independent deterministic draws prove membership and deduplication; rejection sampling and entropy failure are tested without statistical/flaky assertions.
4. SQLite persistence/reopen, same-task descendants and the real submit_resume_run path preserve crew/source evidence. Separate tasks and epic descendants can choose different members.
5. Unrestricted/manual dispatch remains available; classifier/readiness tests cover permitted and disjoint pools. Grant-bound tests confirm captured grant identity, leaf ceiling, allowlist and stop behavior remain authoritative.
6. Config set/get/show round-trip every new field with provenance; invalid edits leave files byte-identical.
7. Focused tests and both required repository gates passed; help/docs include the example and precedence.

Validation — final outcomes:
- PASS: cargo test -p orbit-config --lib (115 tests).
- PASS: cargo test -p orbit-cli --bin orbit command::config::tests (22 tests).
- PASS: cargo test -p orbit-cli --bin orbit command::run::tests (70 tests).
- PASS: cargo test -p orbit-core --lib crew_pools (8 tests).
- PASS: cargo test -p orbit-core --lib workspace_auto (40 tests).
- PASS: cargo test -p orbit-core --lib auto_complexity_pool (1 real submission/child/resume test).
- PASS: cargo test -p orbit-core --lib application::operation::tests::pipeline (8 tests).
- PASS: cargo test -p orbit-core --lib complexity_pools_drive_allowlist (final targeted recheck after strengthening structured readiness assertions).
- PASS: cargo fmt --all; make ci-fast; make ci-lint (workspace/all-target clippy, warnings denied); git diff --check.
- NOT RUN: make ci, per repository policy reserving the full gate for PR CI. Live provider calls were not needed: admission/persistence use real Linux task/run stores, and the submission fixture substitutes finite shell workers rather than launching agents.
- Initial validation failures were corrected: fixed registry row ordering, new fixture setup (catalog authority, lifecycle and grant rights), and a test-only clone lint. Core tests also initially could not compile due to the baseline duplicate owner_machine_id initializer described below. No validation failures remain.

Scope/deviations:
- Extended context selectors before edits for the config pool DTO/export, admission helper/tests, backlog eligibility, grant/dashboard callers, and existing getrandom workspace dependency plus lockfile. These are direct consumers/boundaries required by the criteria; no new Orbit crate dependency edge or persisted artifact format.
- Removed one pre-existing duplicate owner_machine_id initializer from application/job/tests/exec/ci_sweep.rs (E0062, also present at starting HEAD), solely to unblock all core test compilation.
- Starting checkout was clean at 0ddf3a526a2be7a09d75e506d72d4da5242a73b3. HEAD remains unchanged. All 28 changed/new files are accounted for by task context; no commits, push, PR or lifecycle delivery transition performed.

Assessment: Complete, validated and ready for pipeline delivery. Crew selection names/provenance are frozen; configured provider/model definitions continue to resolve through the existing crew registry at execution. No schema migration or task.crew rewrite is introduced.
Friction checkpoint: completed; no recurring or over-ten-minute implementation gotcha requiring a separate friction record. The one-line baseline compilation repair is recorded in task comments and this summary.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11573-6a9f2fca`
- Behind base: 0
- Ahead of base: 1