### PR TITLE
Make Operations mint and toggle controls usable in authorized dashboard sessions

### DIFF
--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -10,8 +10,24 @@ export function getWorkspace() {
   return currentWorkspace;
 }
 
+let workspaceRevision = 0;
+const workspaceListeners = new Set();
+
+export function getWorkspaceRevision() {
+  return workspaceRevision;
+}
+
+export function onWorkspaceChange(listener) {
+  workspaceListeners.add(listener);
+  return () => workspaceListeners.delete(listener);
+}
+
 export function setWorkspace(id) {
-  currentWorkspace = id || null;
+  const next = id || null;
+  if (next === currentWorkspace) return;
+  currentWorkspace = next;
+  workspaceRevision += 1;
+  for (const listener of workspaceListeners) listener();
 }
 
 // ORB-10872: workspace + time window are one dashboard scope. Scoreboard,

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4266,7 +4266,8 @@
       .operation-button:disabled, .operation-cadence:disabled { opacity: .5; cursor: not-allowed; }
       .operation-button.disable { color: var(--state-failed); }
       .operation-button.enable { color: var(--state-success); }
-      .operation-clock-summary { justify-content: flex-start; margin-bottom: 14px; }
+      .operation-clock-summary { justify-content: flex-start; flex-wrap: wrap; margin-bottom: 14px; overflow-wrap: anywhere; }
+      .operation-cadence { min-width: 0; max-width: 100%; }
       .operation-clock-actions { justify-content: flex-start; flex-wrap: wrap; margin-top: 14px; }
 
       @media (max-width: 900px) {

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -331,6 +331,7 @@
       </main>
     </section>
     <section class="tab-pane" data-tab="operations">
+      <p id="operations-session" class="operations-readonly-note" role="status"></p>
       <nav class="subtabs" id="operations-subtabs">
         <button class="subtab active" data-subtab="routines" type="button">Routines</button>
         <button class="subtab" data-subtab="auto-tasks" type="button">Auto-tasks</button>

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,6 +1,6 @@
 // Routine-definition, host sweep-clock, and auto-task operations [ORB-10875, ORB-10876].
 
-import { el, fetchJson, getWorkspace, postJson } from './common.js';
+import { el, fetchJson, getWorkspace, getWorkspaceRevision, onWorkspaceChange, postJson } from './common.js';
 import { navigateToRun } from './router.js';
 import { renderAutomation } from './automation.js';
 
@@ -18,9 +18,18 @@ let autoDrainComplete = false;
 let lastAutoDrainRun = null;
 let lastOperationMode = null;
 let context = null;
+let unsubscribeWorkspace = null;
 
 export function initOperations(nextContext) {
   context = nextContext;
+  unsubscribeWorkspace?.();
+  unsubscribeWorkspace = onWorkspaceChange(() => {
+    lastOperations = lastAutoTasks = lastAutoDrain = lastOperationMode = null;
+    for (const id of ["routines-body", "clock-body", "auto-tasks-body", "auto-drain-body", "operation-mode-body"]) {
+      if ($(id)) $(id).textContent = "Loading selected workspace…";
+    }
+    for (const id of ["routine-operation-feedback", "clock-operation-feedback", "auto-task-operation-feedback", "auto-drain-operation-feedback", "operation-mode-operation-feedback"]) feedback(id, "", "");
+  });
 }
 
 function selectedWorkspace() {
@@ -64,16 +73,78 @@ function field(label, value) {
   ]);
 }
 
-function controlReason(payload, routine) {
-  if (!getWorkspace()) return "Select one workspace before changing routine or clock state.";
-  if (!payload.controls_authorized) return "Controls require an authorized operator session.";
-  if (routine && !routine.pinned_to_host) return `Select pinned host ${payload.host_id} before changing this routine.`;
+function actionReason(payload, action) {
+  const selectionReason = workspaceReadOnlyReason();
+  if (selectionReason) return selectionReason;
+  const capability = payload.capabilities?.[action];
+  if (capability) return capability.authorized === true ? "" : capability.reason || "Action unavailable. See session access above.";
+  return "Action availability is unavailable. Refresh the dashboard server and this page.";
+}
+
+function controlReason(payload, routine, action = "routine_toggle") {
+  const reason = actionReason(payload, action);
+  if (reason) return reason;
+  if (routine && !routine.pinned_to_host) return `This routine is not pinned to host ${payload.host_id}. Select its owning host.`;
   return "";
 }
 
+function explainUnavailable(button, reason) {
+  if (!reason) return button;
+  // The wrapper is focusable because native disabled buttons cannot receive focus.
+  const wrapper = el("span", { class: "operation-action-unavailable" }, [button]);
+  wrapper.tabIndex = 0;
+  wrapper.title = reason;
+  wrapper.setAttribute("aria-label", `${button.textContent}: ${reason}`);
+  return wrapper;
+}
+
+function selectionSnapshot() {
+  const workspace = getWorkspace();
+  const revision = getWorkspaceRevision();
+  return {
+    workspace,
+    revision,
+    current: () => workspace === getWorkspace() && revision === getWorkspaceRevision(),
+  };
+}
+
+// Keep the guard until readback finishes; old results never replace a new selection.
+async function runOperation({ selection, key, feedbackId, pending, failure, render, request, refresh, success }) {
+  if (!selection.current() || pendingOperations.has(key)) return;
+  pendingOperations.add(key);
+  feedback(feedbackId, "pending", pending);
+  render();
+  try {
+    const result = await request();
+    if (!selection.current()) return;
+    feedback(feedbackId, "success", success(result));
+    if (result.task_id) {
+      const link = el("a", { text: ` Open ${result.task_id} →` });
+      link.href = `?workspace=${encodeURIComponent(selection.workspace)}#tasks?status=all&q=${encodeURIComponent(result.task_id)}`;
+      $(feedbackId)?.appendChild(link);
+    }
+    try {
+      await refresh();
+    } catch (error) {
+      if (selection.current()) {
+        $(feedbackId)?.appendChild(el("span", {
+          text: ` Refresh failed: ${error.message}. The action succeeded; refresh before submitting another action.`,
+        }));
+      }
+    }
+  } catch (error) {
+    if (selection.current()) feedback(feedbackId, "error", `${failure}: ${error.message}`);
+  } finally {
+    pendingOperations.delete(key);
+    // Repaint current cached data only; host clock guards span workspaces.
+    render();
+  }
+}
+
 function routineButton(payload, routine) {
+  const selection = selectionSnapshot();
   const nextEnabled = !routine.enabled;
-  const key = `routine:${routine.name}`;
+  const key = `routine:${selection.workspace}:${routine.name}`;
   const reason = controlReason(payload, routine);
   const button = el("button", {
     class: `operation-button ${nextEnabled ? "enable" : "disable"}`,
@@ -82,34 +153,26 @@ function routineButton(payload, routine) {
   });
   button.type = "button";
   button.disabled = Boolean(reason) || pendingOperations.has(key);
-  button.addEventListener("click", async () => {
-    if (pendingOperations.has(key)) return;
-    pendingOperations.add(key);
-    feedback("routine-operation-feedback", "pending", `${nextEnabled ? "Enabling" : "Disabling"} ${routine.name} → ${routine.target}…`);
-    renderOperations(payload);
-    try {
-      const result = await postJson("/api/routines/toggle", {
-        name: routine.name,
-        source: routine.source,
-        target: routine.target,
-        host_id: payload.host_id,
-        expected_enabled: routine.enabled,
-        enabled: nextEnabled,
-      });
-      feedback("routine-operation-feedback", "success", `${result.message}: ${routine.name} → ${routine.target}.`);
-      await fetchAndRenderOperations();
-    } catch (error) {
-      feedback("routine-operation-feedback", "error", `Routine change failed: ${error.message}`);
-    } finally {
-      pendingOperations.delete(key);
-      if (lastOperations) renderOperations(lastOperations);
-    }
+  button.addEventListener("click", () => {
+    if (reason || !selection.current()) return;
+    return runOperation({
+      selection, key, feedbackId: "routine-operation-feedback",
+      pending: `Updating ${routine.name} → ${routine.target}…`, failure: "Routine change failed",
+      render: () => { if (lastOperations) renderOperations(lastOperations); },
+      request: () => postJson("/api/routines/toggle", {
+        name: routine.name, source: routine.source, target: routine.target,
+        host_id: payload.host_id, expected_enabled: routine.enabled, enabled: nextEnabled,
+      }),
+      refresh: fetchAndRenderOperations,
+      success: (result) => `${result.message}: ${routine.name} → ${routine.target}.`,
+    });
   });
-  return button;
+  return explainUnavailable(button, reason);
 }
 
 function renderOperations(payload) {
   lastOperations = payload;
+  if ($("operations-session")) $("operations-session").textContent = payload.session_explanation || "Operations actions require the capabilities granted to this dashboard server. Refresh to load session access details.";
   const workspace = selectedWorkspaceName();
   const routines = workspace
     ? (payload.routines || []).filter((routine) => routine.source === workspace)
@@ -145,8 +208,7 @@ function renderOperations(payload) {
     const automation = renderAutomation(routine.automation);
     if (automation) card.appendChild(automation);
     if (routine.description) card.appendChild(el("p", { class: "operation-description", text: routine.description }));
-    const reason = controlReason(payload, routine);
-    if (reason) card.appendChild(el("p", { class: "operation-control-note", text: reason }));
+
     body.appendChild(card);
   }
   $("routines-count").textContent = workspace ? `${routines.length} · ${workspace}` : "read-only";
@@ -154,43 +216,38 @@ function renderOperations(payload) {
 }
 
 function clockButton(payload, action, label) {
-  const key = "clock:service";
-  const reason = controlReason(payload);
+  const selection = selectionSnapshot();
+  const key = `clock:${payload.host_id}`;
+  const reason = controlReason(payload, null, "clock_service");
   const button = el("button", { class: "operation-button", text: pendingOperations.has(key) ? "Pending…" : label, title: reason });
   button.type = "button";
   button.disabled = Boolean(reason) || pendingOperations.has(key);
-  button.addEventListener("click", async () => {
-    if (pendingOperations.has(key)) return;
+  button.addEventListener("click", () => {
+    if (reason || !selection.current() || pendingOperations.has(key)) return;
     const verb = action === "enable" ? "Start" : "Stop";
     if (!window.confirm(`${verb} the ${payload.clock.provider} sweep clock on ${payload.host_id}? This does not change any routine definition.`)) return;
-    pendingOperations.add(key);
-    feedback("clock-operation-feedback", "pending", `${action === "enable" ? "Starting" : "Stopping"} the host sweep clock…`);
-    renderClock(payload);
-    try {
-      const result = await postJson("/api/routines/clock", {
-        action,
-        host_id: payload.host_id,
-        expected_enabled: payload.clock.enabled,
+    return runOperation({
+      selection, key, feedbackId: "clock-operation-feedback",
+      pending: `${verb} host sweep clock…`, failure: "Clock service change failed",
+      render: () => { if (lastOperations) renderClock(lastOperations); },
+      request: () => postJson("/api/routines/clock", {
+        action, host_id: payload.host_id, expected_enabled: payload.clock.enabled,
         expected_cadence_seconds: payload.clock.configured_cadence_seconds,
-      });
-      feedback("clock-operation-feedback", "success", `${result.message} on ${payload.host_id}.`);
-      await fetchAndRenderOperations();
-    } catch (error) {
-      feedback("clock-operation-feedback", "error", `Clock service change failed: ${error.message}`);
-    } finally {
-      pendingOperations.delete(key);
-      if (lastOperations) renderClock(lastOperations);
-    }
+      }),
+      refresh: fetchAndRenderOperations,
+      success: (result) => `${result.message} on ${payload.host_id}.`,
+    });
   });
-  return button;
+  return explainUnavailable(button, reason);
 }
 
 function renderClock(payload) {
   const clock = payload.clock;
   const body = $("clock-body");
   body.textContent = "";
-  const reason = controlReason(payload);
-  if (reason) body.appendChild(el("div", { class: "operations-readonly-note", text: reason }));
+  const reason = controlReason(payload, null, "clock_cadence");
+  const selection = selectionSnapshot();
+  const key = `clock:${payload.host_id}`;
   body.append(
     el("div", { class: "operation-clock-summary" }, [
       el("span", { class: `operation-state ${clock.health}`, text: clock.health }),
@@ -216,45 +273,28 @@ function renderClock(payload) {
     option.selected = seconds === clock.configured_cadence_seconds;
     cadence.appendChild(option);
   }
-  cadence.disabled = Boolean(reason) || pendingOperations.has("clock:cadence");
-  const apply = el("button", { class: "operation-button secondary", text: pendingOperations.has("clock:cadence") ? "Pending…" : "Apply cadence", title: "Reload cadence without changing whether the clock is enabled" });
+  cadence.disabled = Boolean(reason) || pendingOperations.has(key);
+  const apply = el("button", { class: "operation-button secondary", text: pendingOperations.has(key) ? "Pending…" : "Apply cadence", title: "Reload cadence without changing whether the clock is enabled" });
   apply.type = "button";
-  apply.disabled = Boolean(reason) || pendingOperations.has("clock:cadence") || Number(cadence.value) === clock.configured_cadence_seconds;
-  cadence.addEventListener("change", () => { apply.disabled = Boolean(reason) || Number(cadence.value) === clock.configured_cadence_seconds; });
-  apply.addEventListener("click", async () => {
-    const key = "clock:cadence";
-    if (pendingOperations.has(key)) return;
-    pendingOperations.add(key);
-    feedback("clock-operation-feedback", "pending", `Changing cadence to ${cadence.value}s; clock service state remains separate…`);
-    renderClock(payload);
-    try {
-      const result = await postJson("/api/routines/clock", {
-        action: "set_cadence",
-        host_id: payload.host_id,
-        expected_enabled: clock.enabled,
-        expected_cadence_seconds: clock.configured_cadence_seconds,
-        cadence_seconds: Number(cadence.value),
-      });
-      feedback("clock-operation-feedback", "success", `${result.message}; service is ${result.clock.enabled ? "enabled" : "paused"}.`);
-      await fetchAndRenderOperations();
-    } catch (error) {
-      feedback("clock-operation-feedback", "error", `Cadence change failed: ${error.message}`);
-    } finally {
-      pendingOperations.delete(key);
-      if (lastOperations) renderClock(lastOperations);
-    }
+  apply.disabled = Boolean(reason) || pendingOperations.has(key) || Number(cadence.value) === clock.configured_cadence_seconds;
+  cadence.addEventListener("change", () => { apply.disabled = Boolean(reason) || pendingOperations.has(key) || Number(cadence.value) === clock.configured_cadence_seconds; });
+  apply.addEventListener("click", () => {
+    if (reason || !selection.current()) return;
+    return runOperation({
+      selection, key, feedbackId: "clock-operation-feedback",
+      pending: `Changing cadence to ${cadence.value}s…`, failure: "Cadence change failed",
+      render: () => { if (lastOperations) renderClock(lastOperations); },
+      request: () => postJson("/api/routines/clock", {
+        action: "set_cadence", host_id: payload.host_id, expected_enabled: clock.enabled,
+        expected_cadence_seconds: clock.configured_cadence_seconds, cadence_seconds: Number(cadence.value),
+      }),
+      refresh: fetchAndRenderOperations,
+      success: (result) => `${result.message}; service is ${result.clock.enabled ? "enabled" : "paused"}.`,
+    });
   });
-  actions.append(cadence, apply);
+  actions.append(cadence, explainUnavailable(apply, reason));
   body.appendChild(actions);
   $("clock-host").textContent = payload.host_id || "unknown host";
-}
-
-function autoTaskControlReason(payload) {
-  const workspaceReason = workspaceReadOnlyReason();
-  if (workspaceReason) return workspaceReason;
-  if (payload && payload.read_only_reason) return payload.read_only_reason;
-  if (payload && payload.controls_authorized === false) return "Controls require an authorized operator session.";
-  return "";
 }
 
 function lastEvaluationText(definition) {
@@ -268,46 +308,40 @@ function lastEvaluationText(definition) {
 }
 
 function autoTaskToggleButton(payload, definition) {
+  const selection = selectionSnapshot();
   const nextEnabled = !definition.enabled;
-  const key = `auto-task-toggle:${definition.name}`;
-  const reason = autoTaskControlReason(payload);
+  const key = `auto-task-toggle:${selection.workspace}:${definition.name}`;
+  const reason = actionReason(payload, "auto_task_toggle");
   const verb = nextEnabled ? "Enable" : "Disable";
   const button = el("button", {
     class: `operation-button ${nextEnabled ? "enable" : "disable"}`,
-    text: pendingOperations.has(key) ? "Pending…" : verb,
-    title: reason || `${verb} ${definition.name}`,
+    text: pendingOperations.has(key) ? "Pending…" : verb, title: reason || `${verb} ${definition.name}`,
   });
   button.type = "button";
   button.disabled = Boolean(reason) || pendingOperations.has(key);
-  button.addEventListener("click", async () => {
-    if (pendingOperations.has(key)) return;
+  button.addEventListener("click", () => {
+    if (reason || !selection.current() || pendingOperations.has(key)) return;
     const workspace = selectedWorkspace();
     const summary = definition.template_summary || definition.template?.title || definition.name;
     if (!window.confirm(`${verb} auto-task "${definition.name}" in workspace "${workspace?.name || workspace?.id}"?\n\nTarget: ${summary}\nThis writes the definition's enabled field.`)) return;
-    pendingOperations.add(key);
-    feedback("auto-task-operation-feedback", "pending", `${verb === "Enable" ? "Enabling" : "Disabling"} ${definition.name} (${summary})…`);
-    renderAutoTasks(payload);
-    try {
-      const result = await postJson("/api/auto-tasks/toggle", {
-        name: definition.name,
-        expected_enabled: definition.enabled,
-        enabled: nextEnabled,
-      });
-      feedback("auto-task-operation-feedback", "success", `${result.message}: ${definition.name}.`);
-      await fetchAndRenderAutoTasks();
-    } catch (error) {
-      feedback("auto-task-operation-feedback", "error", `Auto-task change failed: ${error.message}`);
-    } finally {
-      pendingOperations.delete(key);
-      if (lastAutoTasks) renderAutoTasks(lastAutoTasks);
-    }
+    return runOperation({
+      selection, key, feedbackId: "auto-task-operation-feedback",
+      pending: `${verb} ${definition.name}…`, failure: "Auto-task change failed",
+      render: () => { if (lastAutoTasks) renderAutoTasks(lastAutoTasks); },
+      request: () => postJson("/api/auto-tasks/toggle", {
+        name: definition.name, expected_enabled: definition.enabled, enabled: nextEnabled,
+      }),
+      refresh: fetchAndRenderAutoTasks,
+      success: (result) => `${result.message}: ${definition.name}.`,
+    });
   });
-  return button;
+  return explainUnavailable(button, reason);
 }
 
 function autoTaskMintButton(payload, definition) {
-  const key = `auto-task-mint:${definition.name}`;
-  const reason = autoTaskControlReason(payload);
+  const selection = selectionSnapshot();
+  const key = `auto-task-mint:${selection.workspace}:${definition.name}`;
+  const reason = actionReason(payload, "auto_task_mint");
   const button = el("button", {
     class: "operation-button secondary",
     text: pendingOperations.has(key) ? "Pending…" : "Mint now",
@@ -316,7 +350,7 @@ function autoTaskMintButton(payload, definition) {
   button.type = "button";
   button.disabled = Boolean(reason) || pendingOperations.has(key);
   button.addEventListener("click", async () => {
-    if (pendingOperations.has(key)) return;
+    if (reason || !selection.current() || pendingOperations.has(key)) return;
     const workspace = selectedWorkspace();
     const template = definition.template || {};
     const duplicateLine = definition.may_create_open_duplicate
@@ -332,24 +366,18 @@ function autoTaskMintButton(payload, definition) {
       duplicateLine,
     ].join("\n");
     if (!window.confirm(confirmText)) return;
-    pendingOperations.add(key);
-    feedback("auto-task-operation-feedback", "pending", `Minting ${definition.name} now…`);
-    renderAutoTasks(payload);
-    try {
-      const result = await postJson("/api/auto-tasks/mint", {
-        name: definition.name,
-        acknowledge_unconditional: true,
-      });
-      feedback("auto-task-operation-feedback", "success", `${result.message}`);
-      await fetchAndRenderAutoTasks();
-    } catch (error) {
-      feedback("auto-task-operation-feedback", "error", `Manual mint failed: ${error.message}`);
-    } finally {
-      pendingOperations.delete(key);
-      if (lastAutoTasks) renderAutoTasks(lastAutoTasks);
-    }
+    return runOperation({
+      selection, key, feedbackId: "auto-task-operation-feedback",
+      pending: `Minting ${definition.name} now…`, failure: "Manual mint failed",
+      render: () => { if (lastAutoTasks) renderAutoTasks(lastAutoTasks); },
+      request: () => postJson("/api/auto-tasks/mint", {
+        name: definition.name, acknowledge_unconditional: true,
+      }),
+      refresh: fetchAndRenderAutoTasks,
+      success: (result) => `${result.message}. Task created; no delivery was started.`,
+    });
   });
-  return button;
+  return explainUnavailable(button, reason);
 }
 
 function renderAutoTasks(payload) {
@@ -406,8 +434,7 @@ function renderAutoTasks(payload) {
       class: "operation-control-note operation-mint-warning",
       text: payload.unconditional_mint_warning || UNCONDITIONAL_MINT_WARNING,
     }));
-    const controlReason = autoTaskControlReason(payload);
-    if (controlReason) card.appendChild(el("p", { class: "operation-control-note", text: controlReason }));
+
     body.appendChild(card);
   }
   const count = $("auto-tasks-count");
@@ -415,7 +442,10 @@ function renderAutoTasks(payload) {
 }
 
 function fetchAndRenderAutoTasks() {
-  return fetchJson("/api/auto-tasks").then(renderAutoTasks);
+  const selection = selectionSnapshot();
+  return fetchJson("/api/auto-tasks").then((payload) => {
+    if (selection.current()) renderAutoTasks(payload);
+  });
 }
 
 // ORB-11250: bounded backlog auto-drain window ("orbit run auto --for
@@ -569,13 +599,14 @@ function renderAutoDrain(payload) {
 }
 
 function fetchAndRenderAutoDrain() {
+  const selection = selectionSnapshot();
   const workspace = selectedWorkspace();
   if (!workspace) {
     renderAutoDrain({});
     return Promise.resolve();
   }
   const query = autoDrainConcurrency ? `?concurrency=${encodeURIComponent(autoDrainConcurrency)}` : "";
-  return fetchJson(`/api/workflows/auto/readiness${query}`).then(renderAutoDrain);
+  return fetchJson(`/api/workflows/auto/readiness${query}`).then((payload) => { if (selection.current()) renderAutoDrain(payload); });
 }
 
 // ORB-11332: operation mode. The panel projects `orbit operation explain`
@@ -722,24 +753,26 @@ function renderOperationMode(payload) {
 }
 
 export function fetchAndRenderOperationMode() {
+  const selection = selectionSnapshot();
   if (!selectedWorkspace()) {
     renderOperationMode({});
     return Promise.resolve();
   }
-  return fetchJson("/api/operation/explain").then(renderOperationMode);
+  return fetchJson("/api/operation/explain").then((payload) => { if (selection.current()) renderOperationMode(payload); });
 }
 
 export function fetchAndRenderOperations() {
+  const selection = selectionSnapshot();
   return Promise.all([
-    fetchJson("/api/routines").then(renderOperations),
+    fetchJson("/api/routines").then((payload) => { if (selection.current()) renderOperations(payload); }),
     fetchAndRenderAutoTasks().catch((error) => {
-      feedback("auto-task-operation-feedback", "error", `Failed to load auto-tasks: ${error.message}`);
+      if (selection.current()) feedback("auto-task-operation-feedback", "error", `Failed to load auto-tasks: ${error.message}`);
     }),
     fetchAndRenderAutoDrain().catch((error) => {
-      feedback("auto-drain-operation-feedback", "error", `Failed to load auto-delivery readiness: ${error.message}`);
+      if (selection.current()) feedback("auto-drain-operation-feedback", "error", `Failed to load auto-delivery readiness: ${error.message}`);
     }),
     fetchAndRenderOperationMode().catch((error) => {
-      feedback("operation-mode-operation-feedback", "error", `Failed to load operation mode: ${error.message}`);
+      if (selection.current()) feedback("operation-mode-operation-feedback", "error", `Failed to load operation mode: ${error.message}`);
     }),
   ]);
 }

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -8,7 +8,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use chrono::{DateTime, Duration, Local, Utc};
 use orbit_common::governance::authorization::{
-    DASHBOARD_AUTO_TASK_MINT, DASHBOARD_AUTO_TASK_TOGGLE, OPERATOR_OVERRIDE_ENV,
+    DASHBOARD_AUTO_TASK_MINT, DASHBOARD_AUTO_TASK_TOGGLE,
 };
 use orbit_core::OrbitRuntime;
 use orbit_core::application::auto_tasks::{
@@ -24,8 +24,8 @@ use serde_json::{Value, json};
 
 use super::map_runtime_error;
 use super::routines::{
-    OperationsQuery, authorization_denied, authorized_caller, explicit_workspace,
-    named_entity_not_found, record_operation_audit, selection_conflict,
+    OperationsQuery, action_capability, authorization_denied, authorized_caller,
+    explicit_workspace, named_entity_not_found, record_operation_audit, selection_conflict,
 };
 use crate::state::DashboardState;
 
@@ -299,6 +299,10 @@ fn read_only_envelope(generated_at: DateTime<Utc>, workspace: Option<&str>, reas
         "generated_at": generated_at.to_rfc3339(),
         "workspace": workspace,
         "controls_authorized": false,
+        "capabilities": {
+            "auto_task_toggle": {"authorized": false, "reason": reason},
+            "auto_task_mint": {"authorized": false, "reason": reason},
+        },
         "read_only_reason": reason,
         "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
         "definitions": [],
@@ -334,13 +338,11 @@ fn list_json(
         "workspace": workspace,
         "workspace_name": workspace_name,
         "controls_authorized": controls_authorized,
-        "read_only_reason": if controls_authorized {
-            Value::Null
-        } else {
-            Value::String(format!(
-                "Controls require an authorized operator session (set {OPERATOR_OVERRIDE_ENV} or use an interactive operator terminal)."
-            ))
+        "capabilities": {
+            "auto_task_toggle": action_capability(&DASHBOARD_AUTO_TASK_TOGGLE),
+            "auto_task_mint": action_capability(&DASHBOARD_AUTO_TASK_MINT),
         },
+        "read_only_reason": null,
         "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
         "definitions": definitions,
         "load_errors": collection.errors.iter().map(|error| json!({

--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -336,6 +336,16 @@ pub(super) fn report_json(
         "host_id": report.host_id,
         "machine_id": report.machine_id,
         "controls_authorized": authorized_caller(&DASHBOARD_ROUTINE_TOGGLE).is_ok(),
+        "capabilities": {
+            "routine_toggle": action_capability(&DASHBOARD_ROUTINE_TOGGLE),
+            "clock_service": action_capability(&DASHBOARD_CLOCK_SERVICE),
+            "clock_cadence": action_capability(&DASHBOARD_CLOCK_CADENCE),
+        },
+        "session_explanation": if authorized_caller(&DASHBOARD_ROUTINE_TOGGLE).is_ok() {
+            "Session access: this dashboard server has operator authority. Actions also check workspace and host selection. Mint creates a task without starting delivery; bounded-window submission has separate permissions."
+        } else {
+            "Session access comes from the dashboard server. For deliberate operator access, restart it with ORBIT_OPERATOR=1 orbit web serve and its existing options, then reload this page. Opening a terminal does not authorize a running server. Bounded-window submission has separate permissions."
+        },
         "clock": clock_json(clock),
         "routines": report.statuses.iter().map(status_json).collect::<Vec<_>>(),
         "load_errors": report.load_errors.iter().map(|e| json!({
@@ -410,6 +420,17 @@ pub(super) fn authorized_caller(
     ));
     authorize(operation, &caller)?;
     Ok(caller)
+}
+
+/// Project the same authorization decision enforced by the mutation endpoint.
+pub(super) fn action_capability(operation: &'static GovernedOperation) -> Value {
+    match authorized_caller(operation) {
+        Ok(_) => json!({"authorized": true, "reason": null}),
+        Err(denial) => json!({
+            "authorized": false,
+            "reason": denial.to_string(),
+        }),
+    }
 }
 
 pub(super) fn authorization_denied(denial: AuthorizationDenial) -> Response {

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -493,3 +493,66 @@ async fn mint_returns_the_exact_server_error() {
         "{json}"
     );
 }
+
+#[tokio::test]
+async fn list_capabilities_match_toggle_and_mint_authorization() {
+    let (state, _) = state(runtime());
+    for operator in [false, true] {
+        let request = send(
+            state.clone(),
+            Method::GET,
+            "/auto-tasks?workspace=default",
+            None,
+        );
+        let response = if operator {
+            as_operator(request).await
+        } else {
+            as_agent(request).await
+        };
+        let json = body_json(response).await;
+        for action in ["auto_task_toggle", "auto_task_mint"] {
+            assert_eq!(json["capabilities"][action]["authorized"], operator);
+            if operator {
+                assert!(json["capabilities"][action]["reason"].is_null());
+            } else {
+                assert!(
+                    json["capabilities"][action]["reason"]
+                        .as_str()
+                        .expect("denial")
+                        .contains("operator")
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn toggle_both_directions_reads_back_persisted_state() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    let (state, _) = state(runtime);
+    for enabled in [false, true] {
+        let body =
+            serde_json::json!({"name":"nightly", "expected_enabled": !enabled, "enabled": enabled})
+                .to_string();
+        let response = as_operator(send(
+            state.clone(),
+            Method::POST,
+            "/auto-tasks/toggle?workspace=default",
+            Some(&body),
+        ))
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let listed = body_json(
+            send(
+                state.clone(),
+                Method::GET,
+                "/auto-tasks?workspace=default",
+                None,
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(listed["definitions"][0]["enabled"], enabled);
+    }
+}

--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -246,3 +246,167 @@ async fn operations_mutations_require_an_explicit_workspace() {
     let json = body_json(response).await;
     assert_eq!(json["code"], "workspace_required");
 }
+
+#[tokio::test]
+async fn routine_and_clock_capabilities_use_each_canonical_operation() {
+    use super::super::routines::action_capability;
+    use orbit_common::governance::authorization::{
+        DASHBOARD_CLOCK_CADENCE, DASHBOARD_CLOCK_SERVICE, DASHBOARD_ROUTINE_TOGGLE,
+    };
+
+    for operator in [false, true] {
+        with_caller_env(
+            [
+                (OPERATOR_OVERRIDE_ENV, operator.then_some("1")),
+                ("ORBIT_AGENT_NAME", Some("orbit-web-test")),
+            ],
+            async {
+                for operation in [
+                    &DASHBOARD_ROUTINE_TOGGLE,
+                    &DASHBOARD_CLOCK_SERVICE,
+                    &DASHBOARD_CLOCK_CADENCE,
+                ] {
+                    let capability = action_capability(operation);
+                    assert_eq!(capability["authorized"], operator);
+                    if operator {
+                        assert!(capability["reason"].is_null());
+                    } else {
+                        assert!(
+                            capability["reason"]
+                                .as_str()
+                                .expect("denial")
+                                .contains(operation.id)
+                        );
+                    }
+                }
+            },
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn authorized_routine_toggle_reads_back_and_rejects_stale_or_wrong_selection() {
+    use super::workspaces::workspace_entry;
+    use chrono::Utc;
+    use orbit_registry::workspace_registry;
+    use orbit_types::workspace::{
+        Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus,
+    };
+
+    let temp = tempfile::tempdir().expect("fixture");
+    let global = temp.path().join("global");
+    std::fs::create_dir_all(&global).expect("global");
+    ensure_host_identity(&global, || {
+        Ok(NewHostIdentity {
+            host_id: "dashboard-test".to_string(),
+            task_prefix: "DA".to_string(),
+        })
+    })
+    .expect("identity");
+    let repo = temp.path().join("alpha");
+    let orbit_dir = repo.join(".orbit");
+    std::fs::create_dir_all(&orbit_dir).expect("workspace");
+    std::fs::write(
+        orbit_dir.join("config.yaml"),
+        "schema_version: 1\nworkspace_id: ws_alpha\n",
+    )
+    .expect("workspace identity");
+    std::fs::write(
+        orbit_dir.join("config.toml"),
+        "[routines]\nrole = \"source\"\n",
+    )
+    .expect("source role");
+    super::test_support::write_replay_job_under(&orbit_dir, "noop");
+    let routines = orbit_dir.join("routines");
+    std::fs::create_dir_all(&routines).expect("routines");
+    let path = routines.join("fixture.yaml");
+    std::fs::write(&path, "schemaVersion: 1\nname: fixture\nhosts: [dashboard-test]\nenabled: true\ntrigger: {cron: '* * * * *'}\ntarget: job:noop\n").expect("definition");
+    let now = Utc::now();
+    let registry = WorkspaceRegistry {
+        workspaces: vec![Workspace {
+            id: "ws_alpha".to_string(),
+            name: "alpha".to_string(),
+            owner_machine_id: Some(
+                orbit_registry::host_identity::load_host_identity(&global)
+                    .expect("identity")
+                    .machine_id,
+            ),
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: now,
+            updated_at: now,
+        }],
+        checkouts: vec![WorkspaceCheckout::owner(
+            "ws_alpha".to_string(),
+            repo.clone(),
+            orbit_dir.clone(),
+        )],
+        ..WorkspaceRegistry::default()
+    };
+    workspace_registry::save_registry_to(
+        &registry,
+        &workspace_registry::registry_path_for(&global),
+    )
+    .expect("registry");
+    let state = DashboardState::global(
+        global,
+        vec![workspace_entry("alpha", repo, orbit_dir, true)],
+        Some("alpha".to_string()),
+    );
+
+    with_caller_env([(OPERATOR_OVERRIDE_ENV, Some("1"))], async {
+        for enabled in [false, true] {
+            let body = serde_json::json!({"name":"fixture", "source":"alpha", "target":"job:noop", "host_id":"dashboard-test", "expected_enabled": !enabled, "enabled":enabled});
+            let response = routine_request(state.clone(), "/routines/toggle?workspace=alpha", Some(body.clone())).await;
+            assert_eq!(response.status(), StatusCode::OK, "{}", body_json(response).await);
+            let persisted: serde_yaml::Value = serde_yaml::from_str(&std::fs::read_to_string(&path).expect("read file")).expect("yaml");
+            assert_eq!(persisted["enabled"].as_bool(), Some(enabled));
+            let listed = body_json(routine_request(state.clone(), "/routines", None).await).await;
+            assert_eq!(listed["routines"][0]["enabled"], enabled, "{listed}");
+            assert_eq!(listed["capabilities"]["routine_toggle"]["authorized"], true);
+            let stale = routine_request(state.clone(), "/routines/toggle?workspace=alpha", Some(body)).await;
+            assert_eq!(stale.status(), StatusCode::CONFLICT);
+        }
+        let wrong = routine_request(state.clone(), "/routines/toggle?workspace=alpha", Some(serde_json::json!({
+            "name":"fixture", "source":"other", "target":"job:noop", "host_id":"dashboard-test", "expected_enabled":true, "enabled":false
+        }))).await;
+        assert_eq!(wrong.status(), StatusCode::CONFLICT);
+        assert_eq!(body_json(wrong).await["code"], "workspace_mismatch");
+
+        // Enter the canonical clock handler, but reject an invalid cadence before
+        // native service writes. Actual service mutation belongs to Core's fake-runner tests.
+        let listed = body_json(routine_request(state.clone(), "/routines", None).await).await;
+        let invalid_clock = routine_request(state.clone(), "/routines/clock?workspace=alpha", Some(serde_json::json!({
+            "action":"set_cadence", "host_id":"dashboard-test",
+            "expected_enabled": listed["clock"]["enabled"],
+            "expected_cadence_seconds": listed["clock"]["configured_cadence_seconds"], "cadence_seconds":61
+        }))).await;
+        assert_eq!(invalid_clock.status(), StatusCode::BAD_REQUEST);
+        assert!(body_json(invalid_clock).await["error"].as_str().expect("error").contains("whole minute"));
+    }).await;
+}
+
+async fn routine_request(
+    state: DashboardState,
+    uri: &str,
+    body: Option<serde_json::Value>,
+) -> axum::response::Response {
+    let mut request = Request::builder().uri(uri);
+    let body = if let Some(body) = body {
+        request = request
+            .method(Method::POST)
+            .header("origin", "http://localhost:7878")
+            .header("content-type", "application/json");
+        Body::from(body.to_string())
+    } else {
+        Body::empty()
+    };
+    router()
+        .with_state(state)
+        .oneshot(request.body(body).expect("request"))
+        .await
+        .expect("response")
+}

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2783,3 +2783,31 @@ if (!input.value) throw new Error("stale lookup must not clear the jump input as
 "##,
     );
 }
+
+#[test]
+fn operations_actions_preserve_capabilities_feedback_and_workspace_identity() {
+    let dom = r#"
+class Node {
+  constructor() { this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this._text = ""; }
+  appendChild(child) { this.children.push(child); return child; }
+  append(...children) { children.forEach(child => this.appendChild(child)); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get textContent() { return this._text + this.children.map(child => child.textContent).join(""); }
+  setAttribute(name, value) { this[name] = String(value); }
+  getAttribute(name) { return this[name]; }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  click() { if (!this.disabled) return this.listeners.click?.(); }
+  dispatchEvent(event) { return this.listeners[event.type]?.(event); }
+}
+const nodes = new Map();
+globalThis.document = {
+  getElementById: id => { if (!nodes.has(id)) nodes.set(id, new Node()); return nodes.get(id); },
+  createElement: () => new Node(),
+};
+globalThis.window = { location: new URL("http://dashboard.test"), localStorage: { getItem: () => null } };
+"#;
+    run_dashboard_javascript_test(&format!(
+        "{dom}\n{}",
+        include_str!("dashboard_operations.mjs")
+    ));
+}

--- a/crates/orbit-web/src/tests/dashboard_operations.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations.mjs
@@ -1,0 +1,172 @@
+// Runs against shipped modules in both the Node DOM harness and Chromium.
+const { setWorkspace } = await import('./common.js');
+const { initOperations, fetchAndRenderOperations } = await import('./operations.js');
+const get = id => document.getElementById(id);
+const descendants = node => [node, ...Array.from(node.children || []).flatMap(descendants)];
+const button = (id, label) => descendants(get(id)).find(node => node.textContent === label && node.type === 'button');
+const assert = (condition, message) => { if (!condition) throw new Error(message); };
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+const allowed = { authorized: true, reason: null };
+const denied = { authorized: false, reason: 'Test session cannot perform this action. Ask the server operator.' };
+const capabilities = { routine_toggle: allowed, clock_service: allowed, clock_cadence: allowed, auto_task_toggle: allowed, auto_task_mint: allowed };
+const enabled = { one: true, two: true };
+let responseError = null;
+let readbackError = false;
+let releasePost = null;
+let delayPost = false;
+let delayGet = false;
+let releaseGet = null;
+let nextTask = 1;
+const requests = [];
+const confirmations = [];
+window.confirm = message => { confirmations.push(message); return true; };
+const response = (payload, status = 200) => ({ ok: status === 200, status, json: async () => payload, text: async () => JSON.stringify(payload) });
+globalThis.fetch = async (path, options = {}) => {
+  const url = new URL(path, 'http://dashboard.test');
+  const workspace = url.searchParams.get('workspace');
+  const body = options.body ? JSON.parse(options.body) : null;
+  requests.push({ path: url.pathname, workspace, body });
+  if (options.method === 'POST') {
+    if (delayPost) await new Promise(resolve => { releasePost = resolve; });
+    if (responseError) return response({ error: responseError }, 500);
+    if (url.pathname.endsWith('/toggle')) enabled[workspace] = body.enabled;
+    return response(url.pathname.endsWith('/mint')
+      ? { message: `Minted TEST-${nextTask}`, task_id: `TEST-${nextTask++}` }
+      : { message: 'Saved', clock: { enabled: true } });
+  }
+  if (url.pathname === '/api/auto-tasks') {
+    if (readbackError) throw new Error('Fixture readback unavailable');
+    const payload = { workspace, controls_authorized: capabilities.auto_task_toggle.authorized && capabilities.auto_task_mint.authorized, capabilities: { ...capabilities }, definitions: [{ name: `Chore ${workspace}`, enabled: enabled[workspace], template: { title: 'Fixture chore' }, may_create_open_duplicate: true, open_duplicate: true }] };
+    if (delayGet) await new Promise(resolve => { releaseGet = resolve; });
+    return response(payload);
+  }
+  if (url.pathname === '/api/routines') return response({
+    host_id: 'fixture-host', controls_authorized: capabilities.routine_toggle.authorized, capabilities: { ...capabilities }, session_explanation: 'Session access: restart the dashboard server with explicit operator authority.',
+    routines: ['one', 'two'].map(source => ({ name: `Routine ${source}`, source, target: 'job:fixture', enabled: enabled[source], pinned_to_host: source === 'one' })),
+    clock: { enabled: true, configured_cadence_seconds: 60, provider: 'fixture', health: 'healthy' },
+  });
+  return response({});
+};
+setWorkspace('one');
+initOperations({ getWorkspaces: () => ['one', 'two'].map(id => ({ id, name: id, status: 'active' })), formatAbsoluteTime: value => value });
+await fetchAndRenderOperations();
+assert(!button('auto-tasks-body', 'Disable').disabled, 'authorized toggle available');
+assert(!button('auto-tasks-body', 'Mint now').disabled, 'authorized mint available');
+assert(!button('clock-body', 'Pause clock').disabled, 'authorized clock available');
+
+// The old aggregate authorization bit must not suppress an independently allowed action.
+capabilities.auto_task_toggle = denied;
+capabilities.clock_service = denied;
+await fetchAndRenderOperations();
+assert(button('auto-tasks-body', 'Disable').disabled, 'toggle denied independently');
+assert(!button('auto-tasks-body', 'Mint now').disabled, 'partial capability preserves mint');
+assert(button('clock-body', 'Pause clock').disabled, 'clock service denied independently');
+const explanation = descendants(get('auto-tasks-body')).find(node => node.getAttribute?.('aria-label')?.includes(denied.reason));
+assert(explanation?.tabIndex === 0, 'disabled action reason is keyboard accessible');
+assert(!get('auto-tasks-body').textContent.includes('Ask the server operator'), 'no repeated per-card session warning');
+capabilities.auto_task_mint = denied;
+await fetchAndRenderOperations();
+assert(button('auto-tasks-body', 'Mint now').disabled, 'read-only mint denied');
+capabilities.auto_task_toggle = capabilities.auto_task_mint = capabilities.clock_service = allowed;
+await fetchAndRenderOperations();
+
+// Toggle both ways with server readback; a second event on the old button is ignored.
+delayPost = true;
+let action = button('auto-tasks-body', 'Disable');
+action.click(); action.click();
+await tick();
+assert(requests.filter(r => r.path === '/api/auto-tasks/toggle').length === 1, 'toggle double click submits once');
+assert(button('auto-tasks-body', 'Pending…').disabled, 'toggle pending is disabled');
+releasePost(); await tick(); await tick();
+assert(button('auto-tasks-body', 'Enable'), 'toggle readback changes rendered state');
+delayPost = false;
+button('auto-tasks-body', 'Enable').click(); await tick(); await tick();
+assert(button('auto-tasks-body', 'Disable'), 'toggle can be re-enabled');
+
+// Routine uses the same guarded path, including readback in both directions.
+button('routines-body', 'Disable').click(); await tick(); await tick();
+assert(button('routines-body', 'Enable'), 'routine disable reads back');
+button('routines-body', 'Enable').click(); await tick(); await tick();
+assert(button('routines-body', 'Disable'), 'routine enable reads back');
+
+// Host controls post canonical action names and serialize service/cadence changes.
+delayPost = true;
+action = button('clock-body', 'Pause clock'); action.click(); action.click(); await tick();
+assert(requests.filter(r => r.path === '/api/routines/clock').length === 1, 'clock double click submits once');
+assert(requests.find(r => r.path === '/api/routines/clock').body.action === 'disable', 'clock service canonical action');
+releasePost(); await tick(); await tick();
+delayPost = false;
+const cadence = descendants(get('clock-body')).find(node => node.title === 'Clock cadence');
+cadence.value = '300'; cadence.dispatchEvent(new Event('change'));
+button('clock-body', 'Apply cadence').click(); await tick(); await tick();
+assert(requests.some(r => r.body?.action === 'set_cadence' && r.body.cadence_seconds === 300), 'cadence canonical request');
+
+// Mint acknowledgement, duplicate warning, no dispatch, feedback and task link.
+delayPost = true;
+action = button('auto-tasks-body', 'Mint now');
+action.click(); action.click(); await tick();
+assert(requests.filter(r => r.path === '/api/auto-tasks/mint').length === 1, 'mint double click submits once');
+assert(get('auto-task-operation-feedback').textContent.includes('Minting'), 'mint pending feedback');
+assert(confirmations.at(-1).includes('An open instance already exists'), 'duplicate is clearly acknowledged');
+releasePost(); await tick(); await tick();
+const link = descendants(get('auto-task-operation-feedback')).find(node => String(node.href || '').includes('q=TEST-1'));
+assert(link && String(link.href).includes('workspace=one'), 'mint links to task in originating workspace');
+assert(requests.find(r => r.path.endsWith('/mint')).body.acknowledge_unconditional === true, 'mint acknowledges unconditional semantics');
+assert(!requests.some(r => r.path.includes('/ship')), 'mint never dispatches');
+
+// Error persists through a refresh and releases the pending guard.
+delayPost = false; responseError = 'Fixture disk failure';
+button('auto-tasks-body', 'Mint now').click(); await tick(); await tick();
+await fetchAndRenderOperations();
+assert(get('auto-task-operation-feedback').textContent.includes('Fixture disk failure'), 'mint failure stays inline');
+assert(!button('auto-tasks-body', 'Mint now').disabled, 'failure permits intentional retry');
+button('auto-tasks-body', 'Disable').click(); await tick(); await tick();
+assert(get('auto-task-operation-feedback').textContent.includes('Fixture disk failure'), 'toggle failure stays inline');
+button('routines-body', 'Disable').click(); await tick(); await tick();
+assert(get('routine-operation-feedback').textContent.includes('Fixture disk failure'), 'routine error visible');
+responseError = null;
+
+// A successful mint must not be reported as failed when only its GET readback fails.
+readbackError = true;
+button('auto-tasks-body', 'Mint now').click(); await tick(); await tick();
+assert(get('auto-task-operation-feedback').textContent.includes('The action succeeded'), 'readback failure preserves mutation success');
+assert(descendants(get('auto-task-operation-feedback')).some(node => String(node.href || '').includes('#tasks?')), 'readback failure preserves created-task link');
+readbackError = false; await fetchAndRenderOperations();
+
+// Old mutation replies and old DOM controls cannot act on a new selection.
+delayPost = true;
+action = button('auto-tasks-body', 'Mint now');
+action.click(); await tick();
+const posted = requests.filter(r => r.body).length;
+setWorkspace('two');
+action.click();
+assert(requests.filter(r => r.body).length === posted, 'old DOM action cannot mutate new workspace');
+await fetchAndRenderOperations();
+releasePost(); await tick(); await tick();
+assert(get('auto-tasks-body').textContent.includes('Chore two'), 'old mutation cannot replace new workspace');
+assert(!get('auto-task-operation-feedback').textContent.includes('Minted'), 'old success cannot be attributed to new workspace');
+assert(button('routines-body', 'Disable').disabled, 'foreign host routine disabled despite operator authority');
+assert(!button('auto-tasks-body', 'Mint now').disabled, 'workspace switch does not lock another workspace');
+
+// A→B→A does not revive a response from the prior visit.
+setWorkspace('one'); await fetchAndRenderOperations();
+action = button('auto-tasks-body', 'Mint now'); action.click(); await tick();
+setWorkspace('two'); setWorkspace('one'); await fetchAndRenderOperations();
+releasePost(); await tick(); await tick();
+assert(!get('auto-task-operation-feedback').textContent.includes('Minted'), 'A→B→A drops old feedback');
+assert(button('auto-tasks-body', 'Mint now') && !button('auto-tasks-body', 'Mint now').disabled, 'return visit releases pending guard when old request completes');
+delayPost = false;
+await fetchAndRenderOperations();
+
+// A delayed GET is discarded after selection changes.
+delayGet = true;
+const staleLoad = fetchAndRenderOperations(); await tick();
+setWorkspace('two'); delayGet = false; await fetchAndRenderOperations();
+releaseGet(); await staleLoad;
+assert(get('auto-tasks-body').textContent.includes('Chore two'), 'stale GET cannot overwrite selection');
+setWorkspace(null); await fetchAndRenderOperations();
+assert(get('auto-tasks-body').textContent.includes('Select a workspace'), 'all-workspace selection remains read-only');
+
+// Leave a populated fixture for desktop/narrow rendered inspection.
+setWorkspace('one'); await fetchAndRenderOperations();
+globalThis.operationsTestsPassed = true;

--- a/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
@@ -1,0 +1,59 @@
+// Usage: node dashboard_operations_browser.mjs /absolute/path/to/playwright/index.mjs /evidence/directory
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { chromium } = await import(pathToFileURL(path.resolve(process.argv[2])).href);
+const evidence = path.resolve(process.argv[3]);
+fs.mkdirSync(evidence, { recursive: true });
+const assets = fileURLToPath(new URL('../../assets/dashboard/', import.meta.url));
+const test = fileURLToPath(new URL('./dashboard_operations.mjs', import.meta.url));
+const server = http.createServer((req, res) => {
+  const name = new URL(req.url, 'http://fixture').pathname;
+  const file = name === '/test.mjs' ? test : path.join(assets, name === '/' ? 'index.html' : path.basename(name));
+  if (!fs.existsSync(file)) { res.writeHead(404); res.end(); return; }
+  let data = fs.readFileSync(file);
+  if (name === '/') data = data.toString().replace(/<script[^>]*src="[^"]*app.js"[^>]*><\/script>/g, '');
+  res.setHeader('content-type', file.endsWith('.html') ? 'text/html' : file.endsWith('.css') ? 'text/css' : 'text/javascript');
+  res.end(data);
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+let browser;
+try {
+  browser = await chromium.launch({headless:true});
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  // Serve the actual markup/styles with only the Operations module initialized.
+  // All API traffic is fixture data; no live scheduler or dashboard is contacted.
+  page.on('pageerror', error => console.error(error));
+  await page.goto(`http://127.0.0.1:${server.address().port}/`);
+  await page.addScriptTag({ type: 'module', url: '/test.mjs' });
+  await page.waitForFunction(() => globalThis.operationsTestsPassed, undefined, { timeout: 15000 });
+  await page.evaluate(() => {
+    document.querySelectorAll('.tab-pane').forEach(node => node.classList.toggle('active', node.dataset.tab === 'operations'));
+    document.body.classList.add('operations-active');
+  });
+  for (const width of [1440, 390]) {
+    await page.setViewportSize({width, height:1000});
+    for (const tab of ['routines','auto-tasks']) {
+      await page.evaluate(tab => {
+        for (const name of ['routines','auto-tasks','auto-drain']) document.getElementById(`operations-${name}-main`).hidden = name !== tab;
+      }, tab);
+      await page.waitForTimeout(350);
+      await page.screenshot({path:path.join(evidence, `${tab}-${width}.png`),fullPage:true});
+      const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+      if (overflow) throw new Error(`Horizontal overflow at ${width} / ${tab}`);
+      const clipped = await page.evaluate(tab => {
+        const panel = document.getElementById(`operations-${tab}-main`);
+        return Array.from(panel.querySelectorAll('button, select, .operation-clock-summary')).some(node => {
+          const bounds = node.getBoundingClientRect();
+          return bounds.right > window.innerWidth || node.scrollWidth > node.clientWidth + 1;
+        });
+      }, tab);
+      if (clipped) throw new Error(`Clipped Operations control at ${width} / ${tab}`);
+    }
+  }
+  console.log(`PASS: Chromium Operations fixture; desktop 1440 and narrow 390; no horizontal overflow. Screenshots: ${evidence}`);
+} finally {
+  await browser?.close(); server.close();
+}

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -185,6 +185,40 @@ disclosure. All-workspace and inactive/unknown workspace selections stay
 read-only. Refresh and hash navigation only GET — they never replay a toggle
 or mint.
 
+List responses expose separate `capabilities` decisions for auto-task toggle,
+manual mint, routine toggle, clock service, and clock cadence. Each decision
+uses the same governed operation as its POST endpoint; no client-side grant
+is inferred from another action. These five operations currently all require
+operator authority, while bounded-window submission has a separate policy.
+The legacy `controls_authorized` field remains for existing API consumers.
+
+One session-access explanation appears above Operations. Dashboard authority
+comes from the **server process**, not from opening a browser or terminal.
+For deliberate operator access, restart the server with
+`ORBIT_OPERATOR=1 orbit web serve`, preserving its existing root, port, and
+workspace options, then reload the page. No dashboard button grants authority.
+Unavailable actions retain a keyboard-focusable explanation, including host
+and workspace restrictions.
+
+Toggle and mint controls remain pending through server readback. Failures stay
+inline; mint success links to the created task in its originating workspace
+and never dispatches delivery. The confirmation warns when an open duplicate
+exists and preserves unconditional manual-mint semantics. Workspace changes
+invalidate old controls, list responses, and feedback, including switching
+away and back while a request is pending. The in-flight guard survives that
+switch until the request settles; it is a UI duplicate-click guard, not a
+server-side idempotency promise for manual mint. A failed readback preserves
+the successful action result and task link, so a refresh failure does not
+invite another mint.
+
+Validation uses the shipped modules in the existing Node harness
+(`cargo test -p orbit-web --lib operations_actions_preserve`). The same fixture
+runs in Chromium with `node crates/orbit-web/src/tests/dashboard_operations_browser.mjs
+/absolute/path/to/playwright/index.mjs /evidence/directory` (on one shell line).
+The optional runner serves isolated markup, styles and mocked API responses,
+checks behavior, and captures routine/auto-task panels at 1440px and 390px;
+Rust API tests separately exercise the canonical handlers and persisted state.
+
 ## 6. Concerns & Honest Limitations
 
 The seeded `qa-sweep` definition is disabled by default. When enabled, its


### PR DESCRIPTION
## Task

[ORB-11557](https://orbit-cli.com/tasks/ORB-11557) — Make Operations mint and toggle controls usable in authorized dashboard sessions

### Description

## Problem
Daniel wants to mint auto-tasks and toggle definitions/routines directly from Operations. The existing Enable/Disable, Mint now, and host clock controls were disabled by an operator-session warning, while Start bounded window remained available. This is an observed usability/authorization integration gap, not evidence that all actions should share identical permission requirements.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Complete the existing server-owned authorization and action path, including clear per-action capability status and a supported recovery path for an unavailable operator session. Local source inspection found auto_tasks.rs list_json combines toggle and mint authorization into one controls_authorized flag; verify current implementation. Keep domain authorization enforced server-side; do not simply remove disabled attributes or grant blanket authority. Avoid repeating terminal/environment instructions on every card.

Implement actionable mint/toggle feedback as part of this same end-to-end slice. Mint creates a task; it must not silently dispatch it. Preserve documented unconditional manual-mint semantics and distinguish them from scheduler dedupe. No live scheduler enablement, clock changes, grants, or dispatch are authorized by task execution; use isolated fixtures.

### Acceptance Criteria

- An explicitly authorized dashboard session can enable and disable a routine and auto-task definition, mint an auto-task, and use authorized clock controls through existing canonical server paths; read-only or partially authorized sessions expose accurate per-action availability and actionable reasons.
- Toggle changes persist and are read back; pending state prevents repeat submission, failures remain visible inline, and switching workspace cannot misattribute a response or mutate the new selection.
- Mint shows pending and success/error feedback, prevents accidental double-click submission, links to the created task, and clearly warns when an open duplicate exists; no automatic ship is introduced.
- One concise session/capability explanation replaces repeated per-card warnings while unavailable actions retain accessible explanations.
- Behavioral API and browser tests cover authorized, denied, partial-capability, error, double-click and workspace-switch cases; rendered desktop and narrow validation is recorded.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Exposed independent auto_task_toggle, auto_task_mint, routine_toggle, clock_service and clock_cadence capability decisions using the same server authorization checks as the existing POST handlers. Preserved canonical authorization and legacy controls_authorized API compatibility.
- Added one Operations session-access explanation with the supported deliberate recovery path: restart the dashboard server with ORBIT_OPERATOR=1 orbit web serve and its existing options, then reload. Disabled actions have focusable, labeled explanations.
- Unified the five controls' pending, error and readback handling. Workspace revisions invalidate stale controls and responses, including A→B→A. Workspace-specific guards prevent duplicate submissions; host clock service/cadence share a guard. Old completions repaint only current cached data.
- Mint preserves unconditional acknowledgement and open-duplicate warning, links to the created task in its originating workspace, and starts no delivery. A readback failure preserves successful mint feedback and its link.
- Corrected narrow clock-summary/cadence clipping found during rendered inspection. Updated the existing auto-task design documentation.

Acceptance evidence:
1. API fixtures verify operator/denied capabilities and existing mutation paths; routine and auto-task toggles persist both directions. Clock authorization reaches canonical cadence validation; successful native-service behavior is covered by Core's isolated fake-runner tests. Current policy requires Operator for all five governed actions; mixed per-action capability responses are exercised in browser fixtures, without inventing a new partial grant or changing bounded-window permissions.
2. API tests verify readback, stale-state conflict and wrong-workspace rejection. Shared Node/Chromium behavior tests cover pending guards, errors, repeated clicks, stale GETs, detached controls and workspace switching.
3. Node/Chromium tests verify mint pending/success/error, one POST on double click, duplicate acknowledgement, workspace-specific task link, no ship request, and successful mint retained after readback failure.
4. A single shared session explanation replaces per-card session warnings; unavailable controls retain keyboard-focusable accessible reasons.
5. Chromium exercised the shipped Operations modules and real markup/CSS with isolated API fixtures at 1440x1000 and 390x1000. Four screenshots are attached under operations-validation/. Visual inspection confirmed readable controls after fixing clock clipping; automated checks cover both document overflow and control bounds. The existing fixed navigation rail still makes 390px content narrow; no dashboard-shell redesign was attempted.

Validation:
- PASSED: cargo test -p orbit-web --lib — 329 passed, 0 failed, 1 pre-existing ignored generated-corpus response benchmark.
- PASSED after final frontend changes: cargo test -p orbit-web --lib tests::dashboard_assets — 50 passed.
- PASSED: cargo test -p orbit-core --lib application::routines::tests::clock — 16 passed.
- PASSED: make ci-fast; make ci-lint (final workspace/all-target pass); node --check for operations.js and dashboard_operations_browser.mjs; git diff --check.
- PASSED: LD_LIBRARY_PATH=/tmp/orbit-11557-libs/extracted/usr/lib/x86_64-linux-gnu PLAYWRIGHT_BROWSERS_PATH=/tmp/orbit-11557-browsers node crates/orbit-web/src/tests/dashboard_operations_browser.mjs /tmp/orbit-11557-npm/_npx/e41f203b7505f1fb/node_modules/playwright/index.mjs /tmp/orbit-11557-evidence.
- Regression evidence: the new behavior fixture with starting-HEAD operations.js failed specifically at “partial capability preserves mint”; current modules pass.
- Initial fixture construction failures (registry owner identity, prefix allocation and missing job target) were corrected without weakening assertions. Browser setup initially encountered EROFS at the default npm cache and missing libatk; a task-local cache and extracted temporary shared libraries enabled the browser check without global installation.
- NOT RUN: make ci (reserved for PR merge gate), live scheduler/clock mutations, grants, dispatch or production-dashboard changes. Chromium uses fixture API responses; API tests separately exercise Rust handlers. Core clock tests simulate native managers; they do not establish behavior on a live macOS host. No deployed-regression provenance is claimed.
- Full web/dashboard/clock and gate logs, plus desktop/narrow screenshots, are durable task artifacts under operations-validation/.

Assessment: scoped implementation complete with server authorization preserved and observable regression coverage. Initial checkout was clean at 86ad208ad1869104a55355558dc29a76d586c485; both supplied roots matched pwd -P and git top-level. Final diff/status reviewed: 12 task-scoped files, including two new browser fixture files, no incidental artifacts in the patch. Changes remain uncommitted; pipeline owns delivery and review transition.
Scope additions were persisted before edits: common.js for selection revisions, index.html for shared session copy, dashboard.css for observed narrow clipping, dedicated browser fixtures for maintainable/reproducible validation, and current auto-task design documentation.
Friction checkpoint: no qualifying product/tool incident remained; temporary test-environment setup failures were resolved in-scope.
Remaining limits: the UI guard is not server idempotency across tabs or ambiguous transport failures; manual mint remains intentionally unconditional. No policy expansion or live operator enablement was performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11557-6a9f352b`
- Behind base: 0
- Ahead of base: 1