### PR TITLE
[code-review] Neutralize repository Git hooks and stop inheriting the host environment in host-side VCS mutations

### DIFF
--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -1,13 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 
 use serde::Serialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::context::RuntimeHost;
+use crate::executor::automation::vcs::git::git_command;
 
 use super::dispatcher::DispatchError;
 
@@ -1260,18 +1261,12 @@ fn git_stdout_bytes(root: &Path, args: &[&str]) -> Result<Vec<u8>, DispatchError
 }
 
 fn git_output_raw(root: &Path, args: &[&str]) -> Result<Output, DispatchError> {
-    Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(args)
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .output()
-        .map_err(|error| {
-            DispatchError::CliInvocationPermanent(format!(
-                "snapshot Git state in '{}': {error}",
-                root.display()
-            ))
-        })
+    git_command(root, args).output().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "snapshot Git state in '{}': {error}",
+            root.display()
+        ))
+    })
 }
 
 fn git_command_error(root: &Path, args: &[&str], output: &Output) -> DispatchError {

--- a/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
@@ -1,10 +1,11 @@
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 
 use serde_json::Value;
 
 use crate::context::{RuntimeHost, StepRecoveryAdmission};
+use crate::executor::automation::vcs::git::git_command;
 
 use super::{
     DispatchError, GitWorktreeFingerprint, WorktreeBoundaryGuard, changed_paths, git_command_error,
@@ -411,17 +412,11 @@ fn git_mutation(root: &Path, args: &[&str]) -> Result<(), DispatchError> {
 }
 
 fn git_mutation_output(root: &Path, args: &[&str]) -> Result<Output, DispatchError> {
-    Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(args)
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .output()
-        .map_err(|error| {
-            DispatchError::CliInvocationPermanent(format!(
-                "mutate Git state in '{}' with `git {}`: {error}",
-                root.display(),
-                args.join(" ")
-            ))
-        })
+    git_command(root, args).output().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "mutate Git state in '{}' with `git {}`: {error}",
+            root.display(),
+            args.join(" ")
+        ))
+    })
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use orbit_common::OrbitError;
-use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+use orbit_exec::{EnvironmentMode, NoSandbox, run_process};
 
-use super::super::git::{git_output, git_output_paths, git_success};
+use super::super::git::{git_output, git_output_paths, git_request, git_success};
 use super::author::GitAuthor;
 
 pub(super) fn git_commit_with_identity(
@@ -76,31 +76,16 @@ fn git_success_dynamic_with_identity(
         ("GIT_COMMITTER_NAME", committer.name()),
         ("GIT_COMMITTER_EMAIL", committer.email()),
     ];
-    let mut environment = std::env::vars()
-        .filter(|(key, _)| {
-            key != "AGENT_MODEL"
-                && !env_overrides
-                    .iter()
-                    .any(|(override_key, _)| key == override_key)
-        })
-        .collect::<Vec<_>>();
-    environment.extend(
-        env_overrides
-            .iter()
-            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
-    );
-    let result = run_process(
-        &ExecRequest {
-            program: "git".to_string(),
-            args: args.to_vec(),
-            current_dir: Some(current_dir.to_string_lossy().to_string()),
-            timeout_ms: Some(30_000),
-            stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::ClearAndSet(environment),
-            debug: false,
-        },
-        &NoSandbox,
-    )?;
+    let args_ref = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let mut request = git_request(current_dir, &args_ref, 30_000);
+    if let EnvironmentMode::ClearAndSet(environment) = &mut request.environment_mode {
+        environment.extend(
+            env_overrides
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+        );
+    }
+    let result = run_process(&request, &NoSandbox)?;
 
     if !result.success {
         return Err(OrbitError::Execution(format!(

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/git_ops.rs
@@ -1,0 +1,190 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use orbit_common::security::child_env::AGENT_SUBPROCESS_BASELINE_VARS;
+use serde_json::json;
+
+use super::super::commit_batch_changes;
+use super::test_support::{CommitTestHost, initialized_git_repo, task_with_file};
+use crate::executor::automation::vcs::git::{git_output, git_success};
+use crate::executor::automation::vcs::push::push_batch_changes_inner;
+
+fn executable(path: &Path, contents: &str) {
+    fs::write(path, contents).expect("write executable");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("make executable");
+}
+
+fn tracked_hooks(repo: &Path) {
+    fs::create_dir(repo.join(".hooks")).expect("hooks directory");
+    for name in [
+        "pre-commit",
+        "prepare-commit-msg",
+        "post-commit",
+        "pre-push",
+    ] {
+        executable(
+            &repo.join(".hooks").join(name),
+            &format!("#!/bin/sh\nprintf triggered > .git/{name}-marker\n"),
+        );
+    }
+    git_success(repo, &["add", ".hooks"]).expect("stage hooks");
+    git_success(repo, &["commit", "-m", "tracked hooks"]).expect("commit hooks");
+    git_success(repo, &["config", "core.hooksPath", ".hooks"]).expect("configure tracked hooks");
+}
+
+fn commit_candidate(repo: &Path) {
+    fs::write(repo.join("README.md"), "candidate\n").expect("candidate change");
+    let host = CommitTestHost::new(
+        vec![task_with_file("T1", "Candidate", "README.md", "codex")],
+        repo.to_path_buf(),
+    );
+    commit_batch_changes(
+        &host,
+        &json!({"workspace_path": repo, "job_run_id": "batch-1"}),
+    )
+    .expect("commit candidate");
+    assert_eq!(
+        git_output(repo, &["show", "HEAD:README.md"]).unwrap(),
+        "candidate"
+    );
+}
+
+#[test]
+fn commit_batch_disables_tracked_repository_hooks() {
+    let temp = initialized_git_repo();
+    let repo = temp.path();
+    tracked_hooks(repo);
+    commit_candidate(repo);
+    for name in ["pre-commit", "prepare-commit-msg", "post-commit"] {
+        assert!(
+            !repo.join(format!(".git/{name}-marker")).exists(),
+            "{name} ran"
+        );
+    }
+
+    // Positive control: the same executable hook runs under ordinary Git.
+    let control = Command::new("git")
+        .current_dir(repo)
+        .args(["commit", "--allow-empty", "-m", "control"])
+        .output()
+        .expect("control commit");
+    assert!(control.status.success());
+    assert!(repo.join(".git/pre-commit-marker").exists());
+}
+
+#[test]
+fn push_batch_disables_tracked_repository_hooks() {
+    let temp = initialized_git_repo();
+    let repo = temp.path();
+    tracked_hooks(repo);
+    let remote = tempfile::tempdir().expect("remote");
+    git_success(remote.path(), &["init", "--bare"]).expect("bare remote");
+    git_success(
+        repo,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    )
+    .expect("configure remote");
+    let branch = git_output(repo, &["branch", "--show-current"]).unwrap();
+    let host = CommitTestHost::new(Vec::new(), repo.to_path_buf());
+    let result = push_batch_changes_inner(&host, &json!({"branch": branch}), repo)
+        .expect("push candidate through real private operation");
+    assert_eq!(result["decision"], "performed_create");
+    assert_eq!(
+        git_output(
+            remote.path(),
+            &["rev-parse", &format!("refs/heads/{branch}")]
+        )
+        .unwrap(),
+        git_output(repo, &["rev-parse", "HEAD"]).unwrap()
+    );
+    assert!(!repo.join(".git/pre-push-marker").exists());
+
+    let control = Command::new("git")
+        .current_dir(repo)
+        .args(["push", "origin", &branch])
+        .output()
+        .expect("control push");
+    assert!(control.status.success());
+    assert!(repo.join(".git/pre-push-marker").exists());
+}
+
+#[test]
+fn commit_child_environment_excludes_parent_secrets() {
+    let exact_test = concat!(
+        "executor::automation::vcs::commit::tests::git_ops::",
+        "commit_child_environment_excludes_parent_secrets"
+    );
+    if std::env::var("ORBIT_TEST_SECRET").ok().as_deref() == Some(exact_test) {
+        let temp = initialized_git_repo();
+        tracked_hooks(temp.path());
+        commit_candidate(temp.path());
+        return;
+    }
+
+    // Observe Git's entry environment rather than enabling a repository hook.
+    // Isolating PATH and the canary in a child avoids process-global env races.
+    let bin = tempfile::tempdir().expect("observer directory");
+    let observed_path = bin.path().join("observed-env");
+    let real_git = Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("locate Git");
+    assert!(real_git.status.success());
+    let real_git = String::from_utf8(real_git.stdout).expect("Git path UTF-8");
+    let quote = |value: &str| format!("'{}'", value.replace('\'', "'\"'\"'"));
+    executable(
+        &bin.path().join("git"),
+        &format!(
+            "#!/bin/sh\nif [ -n \"$GIT_AUTHOR_NAME\" ]; then env -0 > {}; fi\nexec {} \"$@\"\n",
+            quote(observed_path.to_str().unwrap()),
+            quote(real_git.trim()),
+        ),
+    );
+    let mut paths = vec![bin.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .args(["--exact", exact_test, "--nocapture"])
+        .env("ORBIT_TEST_SECRET", exact_test)
+        .env("PATH", std::env::join_paths(paths).expect("observer PATH"))
+        .output()
+        .expect("isolated environment test");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let observed = fs::read(observed_path).expect("production commit ran the observer");
+    let observed = String::from_utf8(observed).expect("environment UTF-8");
+    assert!(!observed.contains("ORBIT_TEST_SECRET="));
+    assert!(observed.contains("GIT_AUTHOR_NAME="));
+    assert!(observed.contains("GIT_COMMITTER_NAME="));
+    assert!(observed.contains("GIT_OPTIONAL_LOCKS=0"));
+    for entry in observed.split('\0').filter(|entry| !entry.is_empty()) {
+        let name = entry.split_once('=').expect("environment entry").0;
+        // The observer shell adds PWD, SHLVL and _ after process creation.
+        let git_context = matches!(
+            name,
+            "SSH_AUTH_SOCK"
+                | "GIT_OPTIONAL_LOCKS"
+                | "GIT_AUTHOR_NAME"
+                | "GIT_AUTHOR_EMAIL"
+                | "GIT_COMMITTER_NAME"
+                | "GIT_COMMITTER_EMAIL"
+                | "PWD"
+                | "SHLVL"
+                | "_"
+        );
+        assert!(
+            AGENT_SUBPROCESS_BASELINE_VARS.contains(&name) || git_context,
+            "unexpected commit child variable: {name}"
+        );
+    }
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/tests/mod.rs
@@ -3,6 +3,7 @@
 mod author;
 mod base_checkpoint;
 mod delivery_gate;
+mod git_ops;
 mod message;
 mod scope;
 mod summary;

--- a/crates/orbit-engine/src/executor/automation/vcs/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/git.rs
@@ -1,8 +1,77 @@
 use std::path::Path;
+use std::process::Command;
 
 use orbit_common::OrbitError;
+use orbit_common::security::child_env::AGENT_SUBPROCESS_BASELINE_VARS;
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use serde_json::Value;
+
+/// Compose host VCS environments by name. Git needs the SSH agent socket for
+/// authenticated remotes, but never the provider's credentials or ORBIT_* envelope.
+/// GitHub CLI callers explicitly supply their own authentication names.
+pub(super) fn vcs_environment(extras: &[&str]) -> Vec<(String, String)> {
+    AGENT_SUBPROCESS_BASELINE_VARS
+        .iter()
+        .copied()
+        .chain(extras.iter().copied())
+        .filter_map(|name| {
+            std::env::var(name)
+                .ok()
+                .map(|value| (name.to_string(), value))
+        })
+        .collect()
+}
+
+fn git_environment() -> Vec<(String, String)> {
+    let mut environment = vcs_environment(&["SSH_AUTH_SOCK"]);
+    environment.push(("GIT_OPTIONAL_LOCKS".to_string(), "0".to_string()));
+    environment
+}
+
+fn git_args(args: &[&str]) -> Vec<String> {
+    // Command-line configuration wins over tracked hooksPath configuration.
+    // Disable automatic maintenance too: it may launch additional Git children.
+    let mut secured = vec![
+        "-c".to_string(),
+        "core.hooksPath=/dev/null".to_string(),
+        "-c".to_string(),
+        "gc.auto=0".to_string(),
+    ];
+    if let Some((command, rest)) = args.split_first()
+        && matches!(*command, "commit" | "push")
+    {
+        secured.extend([(*command).to_string(), "--no-verify".to_string()]);
+        secured.extend(rest.iter().map(|arg| (*arg).to_string()));
+    } else {
+        secured.extend(args.iter().map(|arg| (*arg).to_string()));
+    }
+    secured
+}
+
+/// The host Git policy shared by deterministic delivery and workspace recovery.
+pub(crate) fn git_request(current_dir: &Path, args: &[&str], timeout_ms: u64) -> ExecRequest {
+    ExecRequest {
+        program: "git".to_string(),
+        args: git_args(args),
+        current_dir: Some(current_dir.to_string_lossy().into_owned()),
+        timeout_ms: Some(timeout_ms),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::ClearAndSet(git_environment()),
+        debug: false,
+    }
+}
+
+/// Byte-preserving adapter for filesystem snapshots and recovery operations.
+pub(crate) fn git_command(current_dir: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(current_dir)
+        .args(git_args(args))
+        .env_clear()
+        .envs(git_environment())
+        .stdin(std::process::Stdio::null());
+    command
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(in crate::executor::automation) enum BaseSyncMode {
@@ -45,18 +114,7 @@ pub(crate) fn git_output(current_dir: &Path, args: &[&str]) -> Result<String, Or
 }
 
 pub(crate) fn git_output_raw(current_dir: &Path, args: &[&str]) -> Result<String, OrbitError> {
-    let result = run_process(
-        &ExecRequest {
-            program: "git".to_string(),
-            args: args.iter().map(|value| (*value).to_string()).collect(),
-            current_dir: Some(current_dir.to_string_lossy().to_string()),
-            timeout_ms: Some(30_000),
-            stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::Inherit,
-            debug: false,
-        },
-        &NoSandbox,
-    )?;
+    let result = run_process(&git_request(current_dir, args, 30_000), &NoSandbox)?;
 
     if !result.success {
         return Err(OrbitError::Execution(format!(
@@ -71,44 +129,11 @@ pub(crate) fn git_output_raw(current_dir: &Path, args: &[&str]) -> Result<String
 }
 
 pub(crate) fn git_success(current_dir: &Path, args: &[&str]) -> Result<(), OrbitError> {
-    let result = run_process(
-        &ExecRequest {
-            program: "git".to_string(),
-            args: args.iter().map(|value| (*value).to_string()).collect(),
-            current_dir: Some(current_dir.to_string_lossy().to_string()),
-            timeout_ms: Some(30_000),
-            stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::Inherit,
-            debug: false,
-        },
-        &NoSandbox,
-    )?;
-
-    if !result.success {
-        return Err(OrbitError::Execution(format!(
-            "git {} failed in '{}': {}",
-            args.join(" "),
-            current_dir.display(),
-            result.stderr.trim()
-        )));
-    }
-
-    Ok(())
+    git_output_raw(current_dir, args).map(|_| ())
 }
 
 pub(crate) fn git_command_success(current_dir: &Path, args: &[&str]) -> Result<bool, OrbitError> {
-    let result = run_process(
-        &ExecRequest {
-            program: "git".to_string(),
-            args: args.iter().map(|value| (*value).to_string()).collect(),
-            current_dir: Some(current_dir.to_string_lossy().to_string()),
-            timeout_ms: Some(30_000),
-            stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::Inherit,
-            debug: false,
-        },
-        &NoSandbox,
-    )?;
+    let result = run_process(&git_request(current_dir, args, 30_000), &NoSandbox)?;
     Ok(result.success)
 }
 
@@ -118,19 +143,15 @@ pub(in crate::executor::automation) fn fetch_remote_base(
 ) -> Result<(), OrbitError> {
     let branch = normalize_base_branch(base)?;
     let result = run_process(
-        &ExecRequest {
-            program: "git".to_string(),
-            args: vec![
-                "fetch".to_string(),
-                "origin".to_string(),
-                format!("+refs/heads/{branch}:refs/remotes/origin/{branch}"),
+        &git_request(
+            repo_root,
+            &[
+                "fetch",
+                "origin",
+                &format!("+refs/heads/{branch}:refs/remotes/origin/{branch}"),
             ],
-            current_dir: Some(repo_root.to_string_lossy().to_string()),
-            timeout_ms: Some(60_000),
-            stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::Inherit,
-            debug: false,
-        },
+            60_000,
+        ),
         &NoSandbox,
     )?;
 

--- a/crates/orbit-engine/src/executor/automation/vcs/operations.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/operations.rs
@@ -53,14 +53,20 @@ fn push(input: &Value) -> Result<Value, OrbitError> {
         ));
     }
 
-    let mut args = vec!["-C".to_string(), repo_root.to_string(), "push".to_string()];
+    let mut args = vec!["push".to_string()];
     if let Some(expected_remote_sha) = force_with_lease.then_some(expected_remote_sha).flatten() {
         args.push(format!(
             "--force-with-lease=refs/heads/{branch}:{expected_remote_sha}"
         ));
     }
     args.extend(["--".to_string(), "origin".to_string(), branch.to_string()]);
-    let result = execute("git", args, None, LONG_TIMEOUT_MS, "push")?;
+    let result = execute(
+        "git",
+        args,
+        Some(Path::new(repo_root)),
+        LONG_TIMEOUT_MS,
+        "push",
+    )?;
     Ok(json!({
         "stdout": result.stdout,
         "stderr": result.stderr,
@@ -460,18 +466,32 @@ fn execute(
     timeout_ms: u64,
     operation: &str,
 ) -> Result<orbit_exec::ExecutionResult, OrbitError> {
-    let result = run_process(
-        &ExecRequest {
+    let request = if program == "git" {
+        let root = current_dir.ok_or_else(|| {
+            OrbitError::InvalidInput("Git operation requires a working directory".to_string())
+        })?;
+        let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+        super::git::git_request(root, &args, timeout_ms)
+    } else {
+        ExecRequest {
             program: program.to_string(),
             args,
             current_dir: current_dir.map(|path| path.to_string_lossy().into_owned()),
             timeout_ms: Some(timeout_ms),
             stdin_mode: StdinMode::Null,
-            environment_mode: EnvironmentMode::Inherit,
+            environment_mode: EnvironmentMode::ClearAndSet(super::git::vcs_environment(&[
+                "GH_TOKEN",
+                "GITHUB_TOKEN",
+                "GH_ENTERPRISE_TOKEN",
+                "GITHUB_ENTERPRISE_TOKEN",
+                "GH_HOST",
+                "GH_CONFIG_DIR",
+                "XDG_CONFIG_HOME",
+            ])),
             debug: false,
-        },
-        &NoSandbox,
-    )?;
+        }
+    };
+    let result = run_process(&request, &NoSandbox)?;
     if !result.success {
         return Err(OrbitError::Execution(format!(
             "private automation VCS {operation} failed: {}",

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/handoff.rs
@@ -323,6 +323,50 @@ fn rebase_retry_distinguishes_wrong_branch_from_stopped_rebase() {
     assert!(!message.contains("rebase remains stopped"), "{message}");
 }
 
+#[cfg(unix)]
+#[test]
+fn rebase_disables_tracked_post_rewrite_hook() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = pr_workspace();
+    git(&workspace.repo, &["checkout", "agent-main"]);
+    fs::create_dir(workspace.repo.join(".hooks")).expect("hooks directory");
+    let hook = workspace.repo.join(".hooks/post-rewrite");
+    fs::write(
+        &hook,
+        "#!/bin/sh\nprintf triggered > .git/post-rewrite-marker\n",
+    )
+    .expect("write rewrite hook");
+    fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).expect("executable hook");
+    git(&workspace.repo, &["add", ".hooks"]);
+    git(
+        &workspace.repo,
+        &["commit", "-m", "advance base with tracked hook"],
+    );
+    git(&workspace.repo, &["checkout", "orbit/test-batch"]);
+    git(&workspace.repo, &["config", "core.hooksPath", ".hooks"]);
+    let host = PrOpenTestHost::new(
+        vec![batch_task("T1", "Rebase candidate", "Outcome: success")],
+        workspace.repo.clone(),
+    );
+    let input = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": ["T1"],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &input).expect("prepare rebase");
+    let synced = rebase_pr_branch(&host, &rebase_input(&input, &prepared)).expect("rebase");
+    assert_eq!(synced["rewritten"], true);
+    assert!(hook.exists(), "rebased tree includes the executable hook");
+    assert!(!workspace.repo.join(".git/post-rewrite-marker").exists());
+
+    // An ordinary amend invokes the exact hook whose rebase execution was suppressed.
+    git(&workspace.repo, &["commit", "--amend", "--no-edit"]);
+    assert!(workspace.repo.join(".git/post-rewrite-marker").exists());
+}
+
 #[test]
 fn base_advance_with_mergeable_changes_rebases_cleanly_and_continues() {
     let workspace = pr_workspace();

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/gc.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
@@ -11,6 +11,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::context::RuntimeHost;
+use crate::executor::automation::vcs::git::git_command;
 
 use super::super::git::git_success;
 use super::cleanup::remove_worktree;
@@ -354,16 +355,17 @@ fn branch_name(worktree: &Path) -> Result<String, OrbitError> {
 /// whose directory has already been removed simply fails to canonicalize and
 /// does not match, which is the same answer the literal comparison gave.
 fn branch_exists(repo_root: &Path, branch: &str) -> bool {
-    Command::new("git")
-        .current_dir(repo_root)
-        .args([
+    git_command(
+        repo_root,
+        &[
             "show-ref",
             "--verify",
             "--quiet",
             &format!("refs/heads/{branch}"),
-        ])
-        .status()
-        .is_ok_and(|status| status.success())
+        ],
+    )
+    .status()
+    .is_ok_and(|status| status.success())
 }
 
 fn directory_bytes(path: &Path) -> Result<u64, OrbitError> {
@@ -409,9 +411,7 @@ fn git(cwd: &Path, args: &[&str]) -> Result<(), OrbitError> {
 }
 
 fn git_raw(cwd: &Path, args: &[&str]) -> Result<Output, OrbitError> {
-    let output = Command::new("git")
-        .current_dir(cwd)
-        .args(args)
+    let output = git_command(cwd, args)
         .output()
         .map_err(|error| OrbitError::Execution(format!("failed to run git: {error}")))?;
     if output.status.success() {


### PR DESCRIPTION
## Task

[ORB-11604](https://orbit-cli.com/tasks/ORB-11604) — [code-review] Neutralize repository Git hooks and stop inheriting the host environment in host-side VCS mutations

### Description

## Problem
Every deterministic VCS action runs `git` on the host, outside the provider sandbox, inside the agent-edited worktree, and none of them disable hooks: `git_success_dynamic_with_identity` builds the child environment from the *entire* `std::env::vars()` of the Orbit process (minus four names) and runs `git commit`; `git_output_raw`/`git_success`/`git_command_success` run `add --all`, `rebase`, `worktree add`, `merge --ff-only`, `clean -fd` with `EnvironmentMode::Inherit`; `operations::execute` runs `git push` with `Inherit`. Git resolves `core.hooksPath` from the shared `.git/config` (husky and `.githooks` layouts set it to a *tracked, worktree-relative* directory) and runs `pre-commit`, `post-rewrite`, `post-checkout`, `pre-push` etc. from the worktree. An agent that edits `.husky/pre-commit` (or any hook under a repo-configured `core.hooksPath`) therefore gets arbitrary code executed by the host process at the `commit`/`sync_base`/`push` step, with the host's full environment (service tokens, `GH_TOKEN`, provider API keys) — exactly what the sandbox and the composed child environment (`CLAUDE.md`: "Child environments are composed, never inherited") exist to prevent. `cli_runner/inspection.rs:230` already passes `-c core.hooksPath=/dev/null -c gc.auto=0` for its own Git calls, so the crate knows the hazard; the shipment path does not apply it.

## Why It Matters
This is a sandbox escape from an untrusted provider subprocess into the Orbit host process with credentials, reachable on every `task_pr_pipeline` run in any workspace whose repo uses tracked hooks.

## Proposed Fix
Route all host-side Git mutations on agent-touched checkouts through one helper that prepends `-c core.hooksPath=/dev/null` (and `--no-verify` for `commit`/`push`), and build the `git commit` environment from `orbit_common::security::child_env` / `host.agent_subprocess_environment` plus the four identity variables instead of `std::env::vars()`. Keep `GIT_OPTIONAL_LOCKS=0` as `workspace.rs` does.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs:79-103`, `crates/orbit-engine/src/executor/automation/vcs/git.rs:47-113`, `crates/orbit-engine/src/executor/automation/vcs/operations.rs:456-474`, `crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs:390-404`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (security). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test in `vcs/commit/tests/` sets `core.hooksPath` to a tracked `.hooks/` dir containing an executable `pre-commit` that writes a marker file; `commit_batch_changes` succeeds and the marker is never written. Same for `pre-push` via `push_batch_changes_inner` and `post-rewrite` via `rebase_pr_branch`.
- A test asserts the `git commit` child environment contains no variable from the parent process that is not in the allowlist (inject a canary `ORBIT_TEST_SECRET` into the test process env and assert it is absent from the hook-observed environment).
- `grep -rn "EnvironmentMode::Inherit\|std::env::vars" crates/orbit-engine/src/executor/automation/vcs` returns no hits outside the single helper.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Centralized host Git argument/environment policy in vcs/git.rs. ExecRequest and byte-preserving Command adapters disable repository hooks with -c core.hooksPath=/dev/null, disable automatic GC, and add --no-verify for commit/push. Git starts from the shared child_env baseline plus SSH_AUTH_SOCK and GIT_OPTIONAL_LOCKS=0; commit explicitly adds its four author/committer fields.
- Routed delivery reads/mutations, remote fetch/push, workspace snapshots/rebase recovery, and worktree GC through this policy. GitHub CLI uses an explicit baseline/authentication allowlist instead of full inheritance.
- Added real-Git tracked executable hook regressions for commit_batch_changes (pre-commit, prepare-commit-msg, post-commit), push_batch_changes_inner (real private push to a local bare remote), and rebase_pr_branch (post-rewrite). Positive controls prove the hooks execute under ordinary Git.
Acceptance criteria:
1. Passed: commit/push/rebase operations succeed without hook markers; push verifies the remote SHA and rebase verifies an actual rewrite with the tracked executable hook present.
2. Passed: isolated child test injects ORBIT_TEST_SECRET and observes the actual production commit entry environment, asserting the canary is absent and all observed names belong to the baseline, explicit Git identity/transport context, or variables generated by the observer shell. Observation uses a Git executable wrapper rather than enabling a forbidden hook. Reusing allowlisted_child_env unchanged would admit ORBIT_* automatically; the Git policy deliberately uses its explicit baseline instead.
3. Passed: grep -rn 'EnvironmentMode::Inherit\|std::env::vars' crates/orbit-engine/src/executor/automation/vcs returned no matches (expected grep exit 1).
Regression evidence:
- Temporarily restored the three original Git runners from starting HEAD, retaining only new adapters required by workspace/GC consumers. cargo test -p orbit-engine --lib commit::tests::git_ops:: -- --test-threads=1 failed all 3 new tests: pre-commit marker, pre-push marker, and inherited ORBIT_TEST_SECRET.
- cargo test -p orbit-engine --lib rebase_disables_tracked_post_rewrite_hook -- --test-threads=1 failed on the post-rewrite marker.
- Restored the fixed sources in a finally block and reran final validation successfully.
Validation:
- PASSED: CARGO_TARGET_DIR=/tmp/orbit-11604-target cargo test -p orbit-engine --lib executor::automation::vcs:: -- --test-threads=4 (213 passed).
- PASSED: /tmp/orbit-11604-target/debug/deps/orbit_engine-395b853c9ebcfc80 activity_job::tests::workspace --test-threads=4 (6 passed).
- PASSED: same test binary activity_job::cli_runner::tests:: --test-threads=4 (161 passed, 2 existing ignored Bubblewrap tests requiring unprivileged user namespaces).
- PASSED: make ci-fast, including final rerun; its existing Cursor smoke check reports headless execution unavailable while validating the local plugin contract.
- PASSED: CARGO_TARGET_DIR=/tmp/orbit-11604-target make ci-lint, including final rerun (all workspace targets, warnings denied).
- PASSED: cargo fmt --all -- --check; independent git diff --check and git status --short.
- NOT RUN: full make ci (reserved for the merge gate by workspace policy); macOS/Windows execution and authenticated network remotes (Linux real Git and local bare remote exercised).
Assessment: All scoped criteria met with behavioral regressions demonstrated against the original runners. Full diff reviewed; no new crate dependencies, persisted formats, or applicable current documentation changes.
Scope/risks:
- Appended workspace/rebase_recovery.rs and vcs/worktree/gc.rs selectors before edits because their direct host Git mutations otherwise bypassed the same security boundary.
- Environment inheritance is intentionally removed: arbitrary Git environment overrides/provider tokens no longer reach Git. SSH_AUTH_SOCK and baseline HOME/PATH remain; GitHub CLI retains explicitly named token/config variables.
- This closes repository-hook execution and ambient-environment inheritance, not every possible external program selected by Git configuration.
- Friction checkpoint completed: no separate recurring tooling failure or time-consuming gotcha to file.
Checkout/handoff:
- Both supplied roots, pwd -P, and git top-level resolved to the assigned checkout. Starting HEAD 1c140f6cd310394f59fc2a8639269d6bc4ca25f1; starting status clean.
- Final status contains only 8 modified scoped files and the new commit/tests/git_ops.rs. Cargo outputs/logs remain outside the worktree under /tmp; no incidental artifacts in the patch.
- Changes are uncommitted. No review/delivery transitions performed; pipeline owns commit, push, and PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11604-6a9f3a93`
- Behind base: 0
- Ahead of base: 1