### PR TITLE
Give website homepage sections a semantic heading hierarchy

### DIFF
--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -67,7 +67,7 @@ next: false
   </figure>
 </section>
 
-<div class="orbit-section-title">Start here</div>
+<h2 class="orbit-section-title">Start here</h2>
 
 <div class="orbit-card-grid orbit-card-grid-3">
   <a class="orbit-card" data-tag="01" href="/getting-started/install/">
@@ -87,7 +87,7 @@ next: false
   </a>
 </div>
 
-<div class="orbit-section-title">Choose a delivery mode</div>
+<h2 class="orbit-section-title">Choose a delivery mode</h2>
 
 <p class="orbit-section-lede">Every <code>orbit run</code> command is asynchronous: it prints a durable run ID and returns without knowing the outcome. Follow up with <code>orbit run show</code>. Pick the shape of delivery you want — the differences are where the run stops and who authorizes the last step.</p>
 
@@ -231,7 +231,7 @@ next: false
   </div>
 </div>
 
-<div class="orbit-section-title">Why Orbit</div>
+<h2 class="orbit-section-title">Why Orbit</h2>
 
 <div class="orbit-card-grid orbit-card-grid-4">
   <div class="orbit-card">
@@ -256,7 +256,7 @@ next: false
   </div>
 </div>
 
-<div class="orbit-section-title">Go further</div>
+<h2 class="orbit-section-title">Go further</h2>
 
 <div class="orbit-card-grid orbit-card-grid-4">
   <a class="orbit-card" href="/how-to/continuous-delivery/">
@@ -281,24 +281,24 @@ next: false
   </a>
 </div>
 
-<div class="orbit-section-title">Explore the docs</div>
+<h2 class="orbit-section-title">Explore the docs</h2>
 
 <div class="orbit-docs-index">
   <div class="orbit-docs-group">
-    <div class="orbit-docs-group-title">Getting Started</div>
+    <h3 class="orbit-docs-group-title">Getting Started</h3>
     <a href="/getting-started/install/">Install Orbit</a>
     <a href="/getting-started/first-task/">First Task</a>
     <a href="/getting-started/workflows/">Delivery Workflows</a>
   </div>
   <div class="orbit-docs-group">
-    <div class="orbit-docs-group-title">Concepts</div>
+    <h3 class="orbit-docs-group-title">Concepts</h3>
     <a href="/concepts/tasks/">Tasks</a>
     <a href="/concepts/activities-jobs/">Activities and Jobs</a>
     <a href="/concepts/policies/">Policies</a>
     <a href="/concepts/agents/">Agents</a>
   </div>
   <div class="orbit-docs-group">
-    <div class="orbit-docs-group-title">How-to Guides</div>
+    <h3 class="orbit-docs-group-title">How-to Guides</h3>
     <a href="/how-to/task-lifecycle/">Run a Task Lifecycle</a>
     <a href="/how-to/continuous-delivery/">Run Continuous Delivery</a>
     <a href="/how-to/recurring-work/">Schedule Recurring Work</a>
@@ -308,7 +308,7 @@ next: false
     <a href="/how-to/mcp-integration/">Set Up MCP</a>
   </div>
   <div class="orbit-docs-group">
-    <div class="orbit-docs-group-title">Reference</div>
+    <h3 class="orbit-docs-group-title">Reference</h3>
     <a href="/reference/cli/">CLI Commands</a>
     <a href="/reference/activity-job-yaml/">Activity and Job YAML</a>
     <a href="/reference/policy-format/">Policy Format</a>
@@ -316,7 +316,7 @@ next: false
     <a href="/reference/scoping/">Scoping Rules</a>
   </div>
   <div class="orbit-docs-group">
-    <div class="orbit-docs-group-title">Contributing</div>
+    <h3 class="orbit-docs-group-title">Contributing</h3>
     <a href="/contributing/local-dev/">Local Development</a>
     <a href="/contributing/crate-layout/">Crate Layout</a>
     <a href="/contributing/pr-workflow/">PR Workflow</a>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -826,6 +826,7 @@ body {
 
 .orbit-landing .orbit-section-title {
   margin: 4.75rem 0 1.25rem;
+  padding-top: 0;
 }
 
 /* A flat index of the sidebar, so the landing page is a way into the corpus
@@ -849,6 +850,7 @@ body {
   font-family: var(--sl-font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.08em;
+  margin: 0;
   padding-bottom: 0.375rem;
   text-transform: uppercase;
 }


### PR DESCRIPTION
## Task

[ORB-11587](https://orbit-cli.com/tasks/ORB-11587) — Give website homepage sections a semantic heading hierarchy

### Description

## Problem
Homepage Start here, Choose a delivery mode, Why Orbit, Go further and Explore the docs are plain div elements. Browser accessibility output jumps from the H1 to H3 card titles, so heading navigation cannot find the major sections.

## Scope
Use semantic section headings and retain the intended visual design. Inspect the resulting outline and interactive delivery section without introducing duplicate visible labels.

## Audit evidence and boundaries
Observed 2026-09-07 around 14:27 America/Los_Angeles in a fresh local Astro production build of website/ at revision 7f3a8f5fa, served at http://127.0.0.1:4321/. Desktop 1440x1000 and mobile 390x844 were exercised. This is local-source evidence, not proof of production parity. Build and Astro check passed, 29 generated HTML pages had no broken local links/anchors, and exercised browser flows logged no warnings/errors. Revalidate current sources at pickup and trace introducing changes before asserting regression lineage. Prepare a validated candidate; this task does not authorize deployment or release.

### Acceptance Criteria

- The rendered homepage has one H1, H2 major sections and appropriately nested card/subsection headings.
- Accessibility-tree heading navigation exposes each major homepage section in reading order.
- Visual appearance, delivery-mode radio behavior and responsive layout remain usable; browser-check the heading tree and npm run check/build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Promoted Start here, Choose a delivery mode, Why Orbit, Go further, and Explore the docs to semantic H2 headings.
- Promoted the five Explore the docs group labels to nested H3 headings.
- Reset semantic heading spacing in custom.css so the existing visual layout is preserved.

Acceptance criteria:
- Rendered hierarchy: passed. Browser observed one visible H1, five H2 major sections, and appropriately nested H3 card and docs-group headings.
- Accessibility navigation: passed. Chromium AX tree exposed one level-1 hero heading, all five level-2 section headings, and the level-3 card/docs headings.
- Usability and validation: passed. Desktop 1440x1000 and mobile 390x844 browser checks found no horizontal overflow or console/page errors; all four delivery-mode radios selected their matching panel exclusively. npm run check and npm run build passed.

Validation:
- Passed: npm run check (0 errors, 0 warnings, 0 hints).
- Passed: npm run build (29 static pages).
- Passed: Playwright Chromium rendered-page check with AX tree, four radio transitions, desktop/mobile overflow checks, and console/page-error capture.
- Passed: generated-page HTML smoke check and git diff --check.
- Passed: git status --short contains only website/src/content/docs/index.md and website/src/styles/custom.css.

Assessment: Small, task-scoped semantic markup change with CSS resets retaining the existing visual treatment. No deployment or release actions taken.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11587-6a9f3a6f`
- Behind base: 0
- Ahead of base: 1