### PR TITLE
[code-review] Refuse to touch index rows in `unregister_task_bundle` when the binding belongs to another workspace

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -564,6 +564,13 @@ impl TaskRegistryStore {
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .map_err(|e| OrbitError::Store(e.to_string()))?;
 
+        let Some(binding) = task_bundle_by_id(&tx, task_id)? else {
+            return Ok(false);
+        };
+        if binding.workspace_id != workspace_id {
+            return Ok(false);
+        }
+
         tx.execute(
             "DELETE FROM task_bundle_relations
              WHERE source_task_id = ?1 OR target_task_id = ?1",

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -1509,6 +1509,120 @@ fn unregister_task_bundle_removes_binding_indexes_and_relation_edges() {
 }
 
 #[test]
+fn unregister_task_bundle_preserves_sibling_workspace_indexes() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let workspace_a_root = temp.path().join("workspace-a");
+    let workspace_b_root = temp.path().join("workspace-b");
+    let bind_workspace = |workspace_id: &str, root: &Path| {
+        let orbit_dir = root.join(".orbit");
+        fs::create_dir_all(&orbit_dir).expect("create orbit dir");
+        store
+            .bind_workspace(BindWorkspaceParams {
+                workspace_id: Some(workspace_id.into()),
+                slug: workspace_id.into(),
+                repo_root: root.to_path_buf(),
+                workspace_path: root.to_path_buf(),
+                orbit_dir,
+                repo_fingerprint: None,
+            })
+            .expect("bind workspace")
+    };
+    let workspace_a = bind_workspace("ws_a", &workspace_a_root);
+    let workspace_b = bind_workspace("ws_b", &workspace_b_root);
+
+    for task_id in ["ORB-1", "ORB-2"] {
+        let bundle_dir = create_canonical_bundle(&store, &workspace_b, task_id);
+        store
+            .register_task_bundle(task_id, &workspace_b.workspace_id, &bundle_dir)
+            .expect("register bundle");
+    }
+    store
+        .replace_task_index(
+            &workspace_b.workspace_id,
+            &envelope(
+                "ORB-1",
+                TaskStatus::Backlog,
+                vec!["sibling".into()],
+                Vec::new(),
+            ),
+        )
+        .expect("index tagged task");
+    store
+        .replace_task_index(
+            &workspace_b.workspace_id,
+            &envelope(
+                "ORB-2",
+                TaskStatus::Backlog,
+                Vec::new(),
+                vec![TaskRelation {
+                    relation_type: TaskRelationType::BlockedBy,
+                    target: "ORB-1".to_string(),
+                }],
+            ),
+        )
+        .expect("index inbound relation");
+
+    let versions_before = store
+        .indexed_task_versions_for_workspace(&workspace_b.workspace_id)
+        .expect("versions before unregister");
+    let tagged_before = store
+        .indexed_task_ids_filtered(
+            &workspace_b.workspace_id,
+            &TaskIndexFilter {
+                status: None,
+                priority: None,
+                job_run_id: None,
+                tags: vec!["sibling".into()],
+            },
+        )
+        .expect("tagged tasks before unregister");
+    let relation_sources_before = store
+        .indexed_relation_sources(
+            &workspace_b.workspace_id,
+            "ORB-1",
+            TaskRelationType::BlockedBy,
+        )
+        .expect("relation sources before unregister");
+
+    assert!(
+        !store
+            .unregister_task_bundle("ORB-1", &workspace_a.workspace_id)
+            .expect("unregister sibling task")
+    );
+    assert_eq!(
+        store
+            .indexed_task_versions_for_workspace(&workspace_b.workspace_id)
+            .expect("versions after unregister"),
+        versions_before
+    );
+    assert_eq!(
+        store
+            .indexed_task_ids_filtered(
+                &workspace_b.workspace_id,
+                &TaskIndexFilter {
+                    status: None,
+                    priority: None,
+                    job_run_id: None,
+                    tags: vec!["sibling".into()],
+                },
+            )
+            .expect("tagged tasks after unregister"),
+        tagged_before
+    );
+    assert_eq!(
+        store
+            .indexed_relation_sources(
+                &workspace_b.workspace_id,
+                "ORB-1",
+                TaskRelationType::BlockedBy,
+            )
+            .expect("relation sources after unregister"),
+        relation_sources_before
+    );
+}
+
+#[test]
 fn projection_rebuild_creates_and_repairs_symlinks() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);


### PR DESCRIPTION
## Task

[ORB-11685](https://orbit-cli.com/tasks/ORB-11685) — [code-review] Refuse to touch index rows in `unregister_task_bundle` when the binding belongs to another workspace

### Description

## Problem
`unregister_task_bundle(task_id, workspace_id)` deletes from `task_bundle_relations` (source *or* target), `task_bundle_tags`, and `task_bundle_index` by `task_id` alone, and only the final `task_bundle_bindings` delete is scoped by `workspace_id`. Calling `delete_task("ORB-123")` from workspace A when ORB-123 is bound to workspace B therefore wipes B's index row, tags, and every relation edge pointing at ORB-123 from any task, then returns `false` ("nothing deleted"). The index self-heals only when B next lists (registered != indexed triggers a rebuild); the relation rows pointing at it from other tasks are rebuilt only if their envelopes are re-indexed.

## Why It Matters
A no-op delete must not have cross-workspace side effects; the coordination registry is shared by every workspace on the machine.

## Proposed Fix
Inside the transaction, read `task_bundle_by_id` first; if it is absent or its `workspace_id` differs, commit nothing and return `Ok(false)`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-store/src/driver/sqlite/task_registry/store.rs:552-590`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: store.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Sibling registry test: register ORB-1 in `ws_b` with tags and an inbound relation from ORB-2; call `unregister_task_bundle("ORB-1", "ws_a")`; assert it returns `false` and `indexed_task_versions_for_workspace("ws_b")`, tag lookup, and `indexed_relation_sources` are unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Guarded unregister_task_bundle with an authoritative binding lookup before deleting relation, tag, index, or binding rows; absent and sibling-workspace bindings return false without mutation.
- Added a sibling-workspace regression that registers ORB-1 in ws_b with a tag and an inbound ORB-2 relation, then verifies a ws_a unregister leaves versions, tag lookup, and inverse relation sources unchanged.

Assessment: The ownership check is contained in the transaction at the store boundary and retains the existing successful-delete path.

Criteria:
- Sibling registry test: passed.

Validation:
- Passed: cargo test -p orbit-store unregister_task_bundle --lib (2 tests).
- Passed: make ci-fast.
- Passed: make ci-lint.
- Passed: git diff --check.

Risks: No remaining known risk. Full make ci was not run per workspace policy.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11685-6a9f3c9f`
- Behind base: 0
- Ahead of base: 1