### PR TITLE
[code-review] Record `approved_from_proposed` from the pre-write status, not the updated task

### DIFF
--- a/crates/orbit-core/src/application/task/tests/add.rs
+++ b/crates/orbit-core/src/application/task/tests/add.rs
@@ -32,6 +32,64 @@ fn task_add_enters_proposed_and_requires_approval_before_backlog() {
 }
 
 #[test]
+fn task_start_event_records_when_start_approves_a_proposal() {
+    let (_root, runtime) = test_runtime();
+
+    let proposed = runtime
+        .add_task(TaskAddParams {
+            title: "Start a proposed task".to_string(),
+            description: "Exercise the approval-start audit event.".to_string(),
+            plan: "Start the task.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create proposed task");
+    runtime
+        .start_task(&proposed.id, None, None)
+        .expect("proposed task starts");
+
+    let backlog = runtime
+        .add_task(TaskAddParams {
+            title: "Start a backlog task".to_string(),
+            description: "Exercise the ordinary start audit event.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("create backlog task");
+    runtime
+        .approve_task(&backlog.id, None, None)
+        .expect("proposed task enters backlog");
+    runtime
+        .start_task(&backlog.id, None, None)
+        .expect("backlog task starts");
+
+    let events = runtime
+        .list_session_events(10)
+        .expect("list session events");
+    let started_from_proposed = events
+        .iter()
+        .find(|event| {
+            event.event_type == "TaskStarted" && event.payload["data"]["id"] == proposed.id
+        })
+        .expect("proposed start event");
+    let started_from_backlog = events
+        .iter()
+        .find(|event| {
+            event.event_type == "TaskStarted" && event.payload["data"]["id"] == backlog.id
+        })
+        .expect("backlog start event");
+
+    assert_eq!(
+        started_from_proposed.payload["data"]["approved_from_proposed"],
+        true
+    );
+    assert_eq!(
+        started_from_backlog.payload["data"]["approved_from_proposed"],
+        false
+    );
+}
+
+#[test]
 fn task_add_does_not_scan_unrelated_corrupt_bundles() {
     let (root, runtime) = test_runtime();
     let task_a = runtime

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -352,7 +352,7 @@ impl OrbitRuntime {
                         OrbitEvent::TaskStarted {
                             id: id.to_string(),
                             started_by: effective_label.clone(),
-                            approved_from_proposed: task.status == TaskStatus::Proposed,
+                            approved_from_proposed: true,
                         },
                     ))
                 })?;


### PR DESCRIPTION
## Task

[ORB-11668](https://orbit-cli.com/tasks/ORB-11668) — [code-review] Record `approved_from_proposed` from the pre-write status, not the updated task

### Description

## Problem
Inside the `Proposed` arm of `start_task_with_actor_label_override`, the closure rebinds `task` to the updated record (`let task = self.stores().task_records().update(...)?;`, line 330) and then emits `OrbitEvent::TaskStarted { approved_from_proposed: task.status == TaskStatus::Proposed }` (line 355). The updated task is always `in-progress` at that point, so the flag is always `false` even though this arm is exactly the proposed-to-started path; the `Backlog | Someday | Blocked` arm hard-codes `false` too, so no `TaskStarted` event ever carries `true`.

## Why It Matters
The event is the session/audit signal that a start doubled as an approval; it is silently wrong on the only path that sets it.

## Proposed Fix
Use `approved_from_proposed: true` in the `Proposed` arm (or compare against the outer pre-write `task.status` captured before the closure).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/task/transitions.rs:326-360`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `application/task/tests/` starts a `proposed` task and asserts `list_session_events` contains `TaskStarted { approved_from_proposed: true }`; starting a `backlog` task yields `false`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- The proposed-task start transition now emits `TaskStarted` with `approved_from_proposed: true` before returning the updated in-progress record.
- Added application-task regression coverage that inspects `list_session_events` for both a proposed start (`true`) and a backlog start (`false`).
Assessment: Small, canonical transition fix with boundary-level audit-event coverage.
Criteria:
- Proposed and backlog start events are asserted with the required boolean values: passed.
Validation:
- `cargo test -p orbit-core --lib task_start_event_records_when_start_approves_a_proposal`: passed (1 test).
- `cargo fmt --check`: passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
Risks: None identified; changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11668-6a9f3d08`
- Behind base: 0
- Ahead of base: 1