### PR TITLE
[code-review] Serialize store schema migrations across processes with an immediate transaction and in-transaction re-check

### DIFF
--- a/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/ledger.rs
@@ -11,6 +11,10 @@
 //!   ledger insert, so an interrupted migration rolls back instead of
 //!   leaving half-applied schema (SQLite ALTER/rename-copy-drop batches
 //!   are wrappable in a transaction).
+//! - Concurrent openers serialize on `BEGIN IMMEDIATE` and re-read the
+//!   ledger inside that transaction, so a waiter neither hits
+//!   `SQLITE_BUSY_SNAPSHOT` nor re-applies a version another process
+//!   just committed.
 //! - A database whose recorded version is newer than
 //!   [`SUPPORTED_SCHEMA_VERSION`] is refused with
 //!   [`OrbitError::Migration`] (downgrade guard).
@@ -20,7 +24,7 @@
 //!   no-op that then records version 1.
 
 use orbit_common::OrbitError;
-use rusqlite::{Connection, ErrorCode, params};
+use rusqlite::{Connection, ErrorCode, Transaction, TransactionBehavior, params};
 
 /// One entry in the migration registry.
 pub(crate) struct Migration {
@@ -189,10 +193,7 @@ pub(crate) fn run_migrations(
     let current = current_schema_version(conn)?;
     let supported = migrations.last().map(|m| m.version).unwrap_or(0);
     if current > supported {
-        return Err(OrbitError::Migration(format!(
-            "store database schema version {current} is newer than the newest version this \
-            orbit binary supports ({supported}); upgrade orbit to open this database"
-        )));
+        return Err(newer_than_supported(current, supported));
     }
     // A current store needs no write transaction. Return before the
     // idempotent CREATE TABLE so read-only mounts remain genuinely readable.
@@ -200,10 +201,11 @@ pub(crate) fn run_migrations(
         return Ok(());
     }
 
-    ensure_schema_meta_table(conn)?;
-
+    // `current` is only a hint for which versions to attempt. `apply_one`
+    // re-reads the ledger under BEGIN IMMEDIATE and skips anything another
+    // opener already committed while this connection waited.
     for migration in migrations.iter().filter(|m| m.version > current) {
-        apply_one(conn, migration)?;
+        apply_one(conn, migration, supported)?;
     }
 
     Ok(())
@@ -254,16 +256,29 @@ pub(crate) fn applied_migrations(conn: &Connection) -> Result<Vec<AppliedMigrati
     Ok(applied)
 }
 
-fn apply_one(conn: &Connection, migration: &Migration) -> Result<(), OrbitError> {
-    // `unchecked_transaction` rolls back on drop, so a failure inside the
-    // migration (or a process crash) leaves neither partial schema nor a
-    // ledger row behind.
-    let tx = conn.unchecked_transaction().map_err(|e| {
+fn apply_one(conn: &Connection, migration: &Migration, supported: u32) -> Result<(), OrbitError> {
+    // BEGIN IMMEDIATE takes the reserved lock before any read so a WAL
+    // snapshot cannot be pinned under DEFERRED while another opener
+    // commits. `new_unchecked` is the `&Connection` form of
+    // `transaction_with_behavior(TransactionBehavior::Immediate)`.
+    // Drop rolls back, so a failure or panic leaves neither partial
+    // schema nor a ledger row behind.
+    let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate).map_err(|e| {
         OrbitError::Migration(format!(
             "failed to begin transaction for migration v{} ({}): {e}",
             migration.version, migration.name
         ))
     })?;
+
+    let current = current_schema_version(&tx)?;
+    if current > supported {
+        return Err(newer_than_supported(current, supported));
+    }
+    if current >= migration.version {
+        return Ok(());
+    }
+
+    ensure_schema_meta_table(&tx)?;
 
     (migration.apply)(&tx).map_err(|error| {
         OrbitError::Migration(format!(
@@ -298,6 +313,13 @@ fn apply_one(conn: &Connection, migration: &Migration) -> Result<(), OrbitError>
         "applied store schema migration",
     );
     Ok(())
+}
+
+fn newer_than_supported(current: u32, supported: u32) -> OrbitError {
+    OrbitError::Migration(format!(
+        "store database schema version {current} is newer than the newest version this \
+        orbit binary supports ({supported}); upgrade orbit to open this database"
+    ))
 }
 
 pub(super) fn commit_migration_error(migration: &Migration, error: rusqlite::Error) -> OrbitError {

--- a/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
+++ b/crates/orbit-store/src/driver/sqlite/migration/tests/ledger.rs
@@ -1,4 +1,9 @@
 // ORB-10003: versioned schema-migration ledger.
+use std::path::Path;
+use std::sync::{Arc, Barrier, Mutex, mpsc};
+use std::thread;
+use std::time::Duration;
+
 use orbit_common::OrbitError;
 use rusqlite::{Connection, Error as SqliteError, ffi};
 
@@ -538,6 +543,192 @@ fn failed_migration_rolls_back_schema_and_ledger() {
     ];
     ledger::run_migrations(&conn, &fixed).expect("resume after fix");
     assert_eq!(current_schema_version(&conn).expect("current version"), 2);
+}
+
+fn seed_pre_ledger_fixture(path: &Path) {
+    let conn = Connection::open(path).expect("seed pre-ledger db");
+    conn.execute_batch(
+        "CREATE TABLE tools (
+            name TEXT PRIMARY KEY,
+            path TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            is_enabled INTEGER NOT NULL DEFAULT 1,
+            is_builtin INTEGER NOT NULL DEFAULT 0
+        );",
+    )
+    .expect("pre-ledger tools table");
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL on fixture");
+}
+
+fn assert_full_unique_ledger(applied: &[AppliedMigration]) {
+    assert_eq!(applied.len(), SUPPORTED_SCHEMA_VERSION as usize);
+    for (index, row) in applied.iter().enumerate() {
+        assert_eq!(row.version, u32::try_from(index).expect("index") + 1);
+    }
+}
+
+#[test]
+fn concurrent_store_open_on_pre_ledger_fixture_applies_each_version_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.db");
+    seed_pre_ledger_fixture(&path);
+
+    let barrier = Arc::new(Barrier::new(2));
+    let handles: Vec<_> = (0..2)
+        .map(|_| {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                crate::Store::open(&path)
+            })
+        })
+        .collect();
+
+    let stores: Vec<_> = handles
+        .into_iter()
+        .map(|handle| {
+            handle
+                .join()
+                .expect("join")
+                .expect("concurrent Store::open")
+        })
+        .collect();
+
+    for store in &stores {
+        let applied = store.applied_migrations().expect("applied migrations");
+        assert_full_unique_ledger(&applied);
+    }
+}
+
+struct PanicMigrationProbe {
+    started: Option<mpsc::Sender<()>>,
+    release: Option<mpsc::Receiver<()>>,
+    waiting: Option<mpsc::Sender<()>>,
+}
+
+static PANIC_PROBE: Mutex<PanicMigrationProbe> = Mutex::new(PanicMigrationProbe {
+    started: None,
+    release: None,
+    waiting: None,
+});
+
+fn take_probe_started() -> Option<mpsc::Sender<()>> {
+    PANIC_PROBE.lock().expect("panic probe").started.take()
+}
+
+fn take_probe_release() -> Option<mpsc::Receiver<()>> {
+    PANIC_PROBE.lock().expect("panic probe").release.take()
+}
+
+fn take_probe_waiting() -> Option<mpsc::Sender<()>> {
+    PANIC_PROBE.lock().expect("panic probe").waiting.take()
+}
+
+fn migration_holds_lock_then_panics(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch("CREATE TABLE ledger_test_panic (x INTEGER)")
+        .map_err(|e| OrbitError::Store(e.to_string()))?;
+    if let Some(started) = take_probe_started() {
+        let _ = started.send(());
+    }
+    if let Some(release) = take_probe_release() {
+        let _ = release.recv();
+    }
+    panic!("intentional migration panic");
+}
+
+fn migration_creates_panic_table(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch("CREATE TABLE ledger_test_panic (x INTEGER)")
+        .map_err(|e| OrbitError::Store(e.to_string()))
+}
+
+fn waiter_busy_handler(_n: i32) -> bool {
+    if let Some(waiting) = take_probe_waiting() {
+        let _ = waiting.send(());
+    }
+    true
+}
+
+#[test]
+fn waiter_applies_after_holder_panics_and_rolls_back() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.db");
+    let seed = Connection::open(&path).expect("seed db");
+    seed.pragma_update(None, "journal_mode", "WAL")
+        .expect("enable WAL");
+    drop(seed);
+
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let (waiting_tx, waiting_rx) = mpsc::channel();
+    {
+        let mut probe = PANIC_PROBE.lock().expect("panic probe");
+        probe.started = Some(started_tx);
+        probe.release = Some(release_rx);
+        probe.waiting = Some(waiting_tx);
+    }
+
+    let panic_registry = [Migration {
+        version: 1,
+        name: "holds-then-panics",
+        apply: migration_holds_lock_then_panics,
+    }];
+    let success_registry = [Migration {
+        version: 1,
+        name: "applies-after-rollback",
+        apply: migration_creates_panic_table,
+    }];
+
+    let holder_path = path.clone();
+    let holder = thread::spawn(move || {
+        let conn = Connection::open(&holder_path).expect("holder open");
+        orbit_common::storage::sqlite::apply_default_pragmas(&conn).expect("holder pragmas");
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ledger::run_migrations(&conn, &panic_registry)
+        }))
+    });
+
+    started_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("holder entered migration body");
+
+    let waiter_path = path.clone();
+    let waiter = thread::spawn(move || {
+        let conn = Connection::open(&waiter_path).expect("waiter open");
+        conn.busy_handler(Some(waiter_busy_handler))
+            .expect("waiter busy handler");
+        ledger::run_migrations(&conn, &success_registry)
+    });
+
+    let waited = waiting_rx.recv_timeout(Duration::from_secs(5));
+    let _ = release_tx.send(());
+    let holder_result = holder.join().expect("holder join");
+    assert!(
+        holder_result.is_err(),
+        "holder thread must unwind from the migration panic"
+    );
+
+    waited.expect("waiter blocked on BEGIN IMMEDIATE while holder held the lock");
+    waiter
+        .join()
+        .expect("waiter join")
+        .expect("waiter applies after holder rollback");
+
+    let conn = Connection::open(&path).expect("inspect");
+    assert!(
+        table_exists(&conn, "ledger_test_panic").expect("panic table"),
+        "rolled-back holder must not leave the table; waiter must create it"
+    );
+    assert_eq!(current_schema_version(&conn).expect("current version"), 1);
+    assert_eq!(ledger_rows(&conn).len(), 1);
+    assert_eq!(
+        ledger_rows(&conn)[0],
+        (
+            "migration.v0001".to_string(),
+            "applies-after-rollback".to_string()
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11650](https://orbit-cli.com/tasks/ORB-11650) — [code-review] Serialize store schema migrations across processes with an immediate transaction and in-transaction re-check

### Description

## Problem
`run_migrations` reads `current_schema_version` outside any transaction, then `apply_one` opens `conn.unchecked_transaction()` (BEGIN DEFERRED) per migration. Every migration body starts with a read (`CREATE TABLE IF NOT EXISTS`, `PRAGMA table_info`, `table_exists`), which pins a WAL read snapshot before the first write. When two Orbit processes open a pre-upgrade `store.sqlite` at the same time (routine sweep + MCP server + CLI after a binary upgrade is the normal shape), the second writer gets `SQLITE_BUSY_SNAPSHOT` ("database is locked") which the busy handler does not retry, so `Store::open` fails at startup; if it instead waits, it re-applies every migration the first process already committed because its pending set was computed before waiting. The sibling code already does this correctly: the task registry's `ensure_compatible_schema` (schema.rs 162-192) and the layout upgrader (`workflow/layout/mod.rs:349-353`) both take an exclusive lock and re-read the version inside it.

## Why It Matters
First start after an upgrade is exactly when several unattended processes race, and a failed `Store::open` takes down the sweep or MCP server until retried.

## Proposed Fix
In `apply_one` use `transaction_with_behavior(TransactionBehavior::Immediate)`, re-read the ledger inside the transaction, and skip the migration if its version is already recorded; compute the pending list lazily from that in-transaction read.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-store/src/driver/sqlite/migration/ledger.rs:184-210`, `crates/orbit-store/src/driver/sqlite/migration/ledger.rs:257-266`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: store.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: two threads each open a fresh `Store` on the same pre-ledger fixture database concurrently (barrier before `Store::open`); both succeed, and `applied_migrations` shows each version recorded exactly once.
- Test: a migration whose body panics/fails in process A while process B waits leaves B able to apply it after A's rollback.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `apply_one` now starts `BEGIN IMMEDIATE` (`Transaction::new_unchecked` + `TransactionBehavior::Immediate`), re-reads the ledger inside that transaction, and skips a version already recorded. Bootstrap of `schema_meta`, the migration body, and the ledger insert share that exclusive transaction; drop still rolls back on failure or panic.
- Concurrent openers therefore wait on the reserved lock instead of pinning a DEFERRED WAL snapshot (`SQLITE_BUSY_SNAPSHOT`), and a waiter does not re-apply work another process already committed.
- Tests: two threads `Store::open` the same pre-ledger WAL fixture after a barrier; both succeed and each version is recorded once. A holder panics in the migration body while a waiter is blocked on BEGIN IMMEDIATE; after rollback the waiter applies the version once.
Assessment: Canonical path stays in `apply_one`. Fast path for already-current databases is unchanged, so read-only mounts still take no write lock. Scope stayed on the two context files.
Strategic decisions: Used `Transaction::new_unchecked(..., Immediate)` rather than `conn.transaction_with_behavior` because `run_migrations` / `apply_schema` take `&Connection` (Store::open and existing tests). The SQL is the same BEGIN IMMEDIATE as the proposed `transaction_with_behavior` call.
Design weaknesses / risks:
- Severity: low. Concurrent tests use threads with separate connections, not OS processes; SQLite serializes on the file lock either way.
- Mitigation: waiter test observes the busy handler before releasing the holder, so it fails if B never blocked.
Deviations from original plan: None beyond the `&Connection` Immediate API noted above.
Recommended follow-ups: `tests/ledger.rs` is now ~970 lines (over the ~800-line warning); split only if more ledger tests land.

Criteria:
- Two threads open a fresh Store on the same pre-ledger fixture (barrier before Store::open); both succeed; each version recorded once — covered by `concurrent_store_open_on_pre_ledger_fixture_applies_each_version_once` (passed).
- Migration body panics in A while B waits; B applies after A's rollback — covered by `waiter_applies_after_holder_panics_and_rolls_back` (passed).

Validation:
- `cargo test -p orbit-store --lib driver::sqlite::migration::tests::ledger -- --test-threads=1` — passed (16 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed (no whitespace errors).
- `GIT_OPTIONAL_LOCKS=0 git status --short` — only the two intended files modified; uncommitted as required.

Remaining risks: none material. No friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11650-6a9f3c92`
- Behind base: 0
- Ahead of base: 1