### PR TITLE
Show truthful paused schedules and time zones in Operations

### DIFF
--- a/crates/orbit-core/src/application/routines/clock.rs
+++ b/crates/orbit-core/src/application/routines/clock.rs
@@ -700,7 +700,10 @@ struct SystemdClockDetails {
     loaded: Option<bool>,
     running: Option<bool>,
     last_tick_at: Option<String>,
+    /// Wall-clock next elapse from `NextElapseUSecRealtime`. Monotonic values
+    /// are durations from boot, not a next-tick timestamp.
     next_tick_at: Option<String>,
+    next_elapse_known: bool,
 }
 
 impl SystemdClockDetails {
@@ -711,17 +714,19 @@ impl SystemdClockDetails {
                 (key == name).then(|| useful_manager_value(value)).flatten()
             })
         };
+        let next_tick_at = property("NextElapseUSecRealtime");
+        let next_elapse_monotonic = property("NextElapseUSecMonotonic");
         Self {
             loaded: property("LoadState").map(|value| value == "loaded"),
             running: property("ActiveState").map(|value| value == "active"),
             last_tick_at: property("LastTriggerUSec"),
-            next_tick_at: property("NextElapseUSecRealtime")
-                .or_else(|| property("NextElapseUSecMonotonic")),
+            next_elapse_known: next_tick_at.is_some() || next_elapse_monotonic.is_some(),
+            next_tick_at,
         }
     }
 
     fn is_schedulable(&self) -> bool {
-        self.loaded == Some(true) && self.running == Some(true) && self.next_tick_at.is_some()
+        self.loaded == Some(true) && self.running == Some(true) && self.next_elapse_known
     }
 }
 

--- a/crates/orbit-core/src/application/routines/mod.rs
+++ b/crates/orbit-core/src/application/routines/mod.rs
@@ -32,8 +32,8 @@ pub use loader::{
     RoutineWorkspaceProvider, collect_routines,
 };
 pub use status::{
-    RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, pause_routine, recent_fires,
-    resume_routine, routine_statuses_with_providers, set_routine_enabled,
+    RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, ScheduleDisplayState, pause_routine,
+    recent_fires, resume_routine, routine_statuses_with_providers, set_routine_enabled,
 };
 pub use sweep::{
     RoutineSweepReport, SweepOptions, SweepOutcome, run_sweep_at_with_providers,

--- a/crates/orbit-core/src/application/routines/status.rs
+++ b/crates/orbit-core/src/application/routines/status.rs
@@ -18,6 +18,42 @@ use super::validation::{
     RoutineRegistryStatus, validate_routine_pins,
 };
 
+/// Operator-facing schedule readiness. Theoretical next-slot math may still be
+/// present; this state says whether that time is armed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduleDisplayState {
+    /// Enabled, eligible, and a next slot is a real scheduled evaluation.
+    Scheduled,
+    /// Definition `enabled` is false. A next slot, if present, is hypothetical.
+    Disabled,
+    /// Host-local pause. A next slot, if present, is hypothetical.
+    Paused,
+    /// Enabled delivery- or state-triggered work is waiting on that trigger.
+    Waiting,
+    /// The scheduler has never recorded a cursor for this definition.
+    NeverObserved,
+    /// Pin, source, or trigger state cannot be shown as a next evaluation.
+    Unavailable,
+}
+
+impl ScheduleDisplayState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Scheduled => "scheduled",
+            Self::Disabled => "disabled",
+            Self::Paused => "paused",
+            Self::Waiting => "waiting",
+            Self::NeverObserved => "never_observed",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    /// Disabled and paused rows may still carry a theoretical next slot.
+    pub fn is_hypothetical(self) -> bool {
+        matches!(self, Self::Disabled | Self::Paused)
+    }
+}
+
 /// Full effective state of one routine on this host.
 #[derive(Debug, Clone)]
 pub struct RoutineStatus {
@@ -46,6 +82,41 @@ impl RoutineStatus {
     pub fn effective(&self) -> bool {
         self.routine.definition.enabled && self.pinned_to_host && self.paused_at.is_none()
     }
+
+    /// How Operations (and other projections) should label the next slot.
+    pub fn schedule_display_state(&self) -> ScheduleDisplayState {
+        if !self.routine.definition.enabled {
+            return ScheduleDisplayState::Disabled;
+        }
+        if self.paused_at.is_some() {
+            return ScheduleDisplayState::Paused;
+        }
+        if !self.pinned_to_host {
+            return ScheduleDisplayState::Unavailable;
+        }
+        if automation_unavailable(self.automation.as_ref()) {
+            return ScheduleDisplayState::Unavailable;
+        }
+        if self.routine.definition.trigger.deliveries_landed.is_some()
+            || self.routine.definition.trigger.state.is_some()
+        {
+            return ScheduleDisplayState::Waiting;
+        }
+        if self.next_due.is_some() {
+            return ScheduleDisplayState::Scheduled;
+        }
+        if self.first_observed_at.is_none() {
+            return ScheduleDisplayState::NeverObserved;
+        }
+        ScheduleDisplayState::Unavailable
+    }
+}
+
+fn automation_unavailable(automation: Option<&serde_json::Value>) -> bool {
+    automation
+        .and_then(|value| value.get("reason"))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|reason| reason == "source_unavailable" || reason == "state_unavailable")
 }
 
 /// Everything `orbit routine list` renders.

--- a/crates/orbit-core/src/application/routines/tests/clock.rs
+++ b/crates/orbit-core/src/application/routines/tests/clock.rs
@@ -550,6 +550,33 @@ fn enabled_systemd_timer_without_a_future_trigger_is_unhealthy() {
 }
 
 #[test]
+fn systemd_monotonic_duration_is_not_a_wall_clock_next_tick() {
+    let root = tempdir().expect("create global root");
+    let runner = MockRunner::with_outputs(
+        vec![Ok(true)],
+        vec![Ok(Some(
+            "LoadState=loaded\nActiveState=active\nNextElapseUSecRealtime=n/a\nNextElapseUSecMonotonic=4h 14min\nLastTriggerUSec=Sun 2026-09-07 21:00:00 UTC"
+                .to_string(),
+        ))],
+    );
+
+    let status = clock_status_with(root.path(), ClockPlatform::Systemd, &runner)
+        .expect("read monotonic-only timer status");
+
+    assert!(status.enabled);
+    assert!(status.schedulable);
+    assert_eq!(status.effective_cadence_seconds, Some(60));
+    assert_eq!(
+        status.last_tick_at.as_deref(),
+        Some("Sun 2026-09-07 21:00:00 UTC")
+    );
+    assert_eq!(
+        status.next_tick_at, None,
+        "NextElapseUSecMonotonic is a duration from boot, not the next wall-clock tick"
+    );
+}
+
+#[test]
 fn disabled_systemd_timer_reports_loaded_state_without_becoming_schedulable() {
     let root = tempdir().expect("create global root");
     let runner = MockRunner::with_outputs(

--- a/crates/orbit-core/src/application/routines/tests/status.rs
+++ b/crates/orbit-core/src/application/routines/tests/status.rs
@@ -1,10 +1,14 @@
 use std::fs;
+use std::path::PathBuf;
 
+use orbit_automation::routines::validation::RoutinePinValidation;
 use orbit_common::protocol::yaml::parse_routine_yaml;
 use tempfile::tempdir;
 
 use super::super::loader::{LoadedRoutine, RoutineOrigin};
-use super::super::status::{RoutineToggleOutcome, set_routine_enabled};
+use super::super::status::{
+    RoutineStatus, RoutineToggleOutcome, ScheduleDisplayState, set_routine_enabled,
+};
 
 fn loaded(path: std::path::PathBuf) -> LoadedRoutine {
     let raw = fs::read_to_string(&path).expect("read fixture");
@@ -92,5 +96,85 @@ fn routine_toggle_reports_an_exact_noop_without_rewriting() {
             .modified()
             .expect("fixture mtime after noop"),
         before
+    );
+}
+
+fn display_status(
+    yaml: &str,
+    pinned: bool,
+    paused: bool,
+    observed: bool,
+    next_due: Option<&str>,
+    automation: Option<serde_json::Value>,
+) -> RoutineStatus {
+    RoutineStatus {
+        routine: LoadedRoutine {
+            definition: parse_routine_yaml(yaml).expect("parse fixture"),
+            origin: RoutineOrigin::Committed,
+            source_workspace: "orbit".to_string(),
+            source_orbit_dir: PathBuf::from("/tmp"),
+            path: PathBuf::from("/tmp/nightly.yaml"),
+        },
+        pinned_to_host: pinned,
+        validation: RoutinePinValidation {
+            eligible: pinned,
+            diagnostics: Vec::new(),
+        },
+        paused_at: paused.then(|| "2026-09-07T21:00:00+00:00".to_string()),
+        first_observed_at: observed.then(|| "2026-09-07T20:00:00+00:00".to_string()),
+        last_evaluated_slot: None,
+        next_due: next_due.map(str::to_string),
+        last_fire: None,
+        automation,
+    }
+}
+
+const CRON_YAML: &str = "schemaVersion: 1\nname: nightly\nenabled: true\nhosts: [host-a]\ntrigger:\n  cron: '0 2 * * *'\ntarget: job:nightly\n";
+const DISABLED_YAML: &str = "schemaVersion: 1\nname: nightly\nenabled: false\nhosts: [host-a]\ntrigger:\n  cron: '0 2 * * *'\ntarget: job:nightly\n";
+const DELIVERY_YAML: &str = "schemaVersion: 1\nname: ship\nenabled: true\nhosts: [host-a]\npolicy:\n  overlap: forbid\ntrigger:\n  deliveries_landed:\n    branch: agent-main\n    threshold: 1\n    max_wait_minutes: 60\n    coverage: integrated_qa_v1\ntarget: job:ship\n";
+
+#[test]
+fn schedule_display_state_distinguishes_paused_disabled_waiting_and_unobserved() {
+    let next = Some("2026-09-07T21:30:00-07:00");
+    assert_eq!(
+        display_status(DISABLED_YAML, true, false, true, next, None).schedule_display_state(),
+        ScheduleDisplayState::Disabled
+    );
+    assert_eq!(
+        display_status(CRON_YAML, true, true, true, next, None).schedule_display_state(),
+        ScheduleDisplayState::Paused
+    );
+    assert_eq!(
+        display_status(CRON_YAML, false, false, true, next, None).schedule_display_state(),
+        ScheduleDisplayState::Unavailable
+    );
+    assert_eq!(
+        display_status(DELIVERY_YAML, true, false, true, None, None).schedule_display_state(),
+        ScheduleDisplayState::Waiting
+    );
+    assert_eq!(
+        display_status(CRON_YAML, true, false, false, None, None).schedule_display_state(),
+        ScheduleDisplayState::NeverObserved
+    );
+    assert_eq!(
+        display_status(CRON_YAML, true, false, true, next, None).schedule_display_state(),
+        ScheduleDisplayState::Scheduled
+    );
+    assert!(
+        display_status(DISABLED_YAML, true, false, true, next, None)
+            .schedule_display_state()
+            .is_hypothetical()
+    );
+    assert_eq!(
+        display_status(
+            DELIVERY_YAML,
+            true,
+            false,
+            true,
+            None,
+            Some(serde_json::json!({"reason": "state_unavailable"})),
+        )
+        .schedule_display_state(),
+        ScheduleDisplayState::Unavailable
     );
 }

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -60,10 +60,78 @@ function feedback(id, kind, message) {
   node.textContent = message || "";
 }
 
+function timezoneName(date) {
+  return new Intl.DateTimeFormat("en-US", { timeZoneName: "short" })
+    .formatToParts(date)
+    .find((part) => part.type === "timeZoneName")?.value || "UTC";
+}
+
+function looksLikeDuration(value) {
+  const text = String(value).trim();
+  return /\d+\s*(?:h|hr|hrs|hour|hours|min|mins|minute|minutes|s|sec|secs|seconds)\b/i.test(text)
+    && Number.isNaN(new Date(text).getTime());
+}
+
 function time(value) {
   if (!value) return "Not observed";
+  if (looksLikeDuration(value)) return `Duration ${value}`;
   const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? String(value) : context.formatAbsoluteTime(value);
+  if (Number.isNaN(parsed.getTime())) return String(value);
+  const formatted = String(context.formatAbsoluteTime(value));
+  const tz = timezoneName(parsed);
+  if (formatted.includes(tz) || /\bUTC\b/.test(formatted) || /[+-]\d{2}:\d{2}$/.test(formatted)) {
+    return formatted;
+  }
+  return `${formatted} ${tz}`;
+}
+
+function cadenceText(seconds) {
+  if (seconds == null || seconds === "") return "Inactive";
+  const n = Number(seconds);
+  if (!Number.isFinite(n)) return String(seconds);
+  if (n % 60 === 0) {
+    const minutes = n / 60;
+    const label = minutes === 1 ? "every 1 minute" : `every ${minutes} minutes`;
+    return `${label} (${n}s)`;
+  }
+  return `every ${n}s`;
+}
+
+function nextEvaluationText(projection, fallbackAt) {
+  const state = projection?.state;
+  const at = projection?.at || (state === "disabled" || state === "paused" ? fallbackAt : null);
+  const when = at ? time(at) : null;
+  if (state === "disabled") return when ? `Disabled · hypothetical next ${when}` : "Disabled";
+  if (state === "paused") return when ? `Paused · hypothetical next ${when}` : "Paused";
+  if (state === "waiting") return "Waiting for deliveries";
+  if (state === "never_observed") return "Never observed";
+  if (state === "unavailable") return "Unavailable";
+  if (state === "scheduled") return when || "Scheduled";
+  return when || "Unavailable";
+}
+
+function lastMintedText(definition) {
+  if (!definition.last_minted_task_id) return "None";
+  const status = definition.last_minted_task_status ? ` · ${definition.last_minted_task_status}` : "";
+  const schedulerId = definition.last_evaluation?.last_task_id;
+  const source = schedulerId && definition.last_minted_task_id !== schedulerId
+    ? " · manual mint"
+    : schedulerId
+      ? " · scheduler"
+      : "";
+  return `${definition.last_minted_task_id}${status}${source}`;
+}
+
+function clockTickText(value, clock) {
+  if (value) {
+    if (looksLikeDuration(value)) {
+      return `Duration from boot ${value} (not a wall-clock tick)`;
+    }
+    return time(value);
+  }
+  if (!clock.enabled) return "Paused";
+  if (clock.schedulable) return "Armed; exact wall-clock time unavailable";
+  return "Not scheduled";
 }
 
 function field(label, value) {
@@ -200,7 +268,7 @@ function renderOperations(payload) {
         field("Schedule", routine.trigger?.deliveries_landed ? `${routine.trigger.deliveries_landed.threshold} verified deliveries on ${routine.trigger.deliveries_landed.branch}` : routine.cron),
         field("Host pin", (routine.hosts || []).join(", ") || "Local host"),
         field("Last evaluation", time(routine.last_evaluated_slot || routine.first_observed_at)),
-        field("Next evaluation", time(routine.next_due)),
+        field("Next evaluation", nextEvaluationText(routine.next_evaluation, routine.next_due)),
         field("Last fire", fire ? time(fire.finished_at || fire.started_at) : "Never"),
         field("Linked run / outcome", fire ? `${fire.run_id || "No run"} · ${fire.state}` : "No fire recorded"),
       ]),
@@ -255,12 +323,12 @@ function renderClock(payload) {
       el("span", { text: clock.enabled ? "service enabled" : "service paused" }),
     ]),
     el("div", { class: "operation-grid" }, [
-      field("Configured cadence", `${clock.configured_cadence_seconds}s`),
-      field("Effective cadence", clock.effective_cadence_seconds ? `${clock.effective_cadence_seconds}s` : "Inactive"),
+      field("Configured cadence", cadenceText(clock.configured_cadence_seconds)),
+      field("Effective cadence", cadenceText(clock.effective_cadence_seconds)),
       field("Loaded", clock.loaded ? "Yes" : "No"),
       field("Running / waiting", clock.running == null ? "Provider does not expose" : clock.running ? "Yes" : "No"),
-      field("Last tick", clock.last_tick_at || "Provider does not expose"),
-      field("Next expected tick", clock.next_tick_at || (clock.schedulable ? "Armed; exact time unavailable" : "Not scheduled")),
+      field("Last tick", clock.last_tick_at ? time(clock.last_tick_at) : "Provider does not expose"),
+      field("Next expected tick", clockTickText(clock.next_tick_at, clock)),
     ]),
   );
   if (clock.health_issue) body.appendChild(el("p", { class: "operation-control-note error", text: clock.health_issue }));
@@ -417,11 +485,9 @@ function renderAutoTasks(payload) {
       el("div", { class: "operation-grid" }, [
         field("Schedule", definition.schedule_summary || "—"),
         field("Dedupe", definition.dedupe === "always" ? "always fire" : "skip if open"),
-        field("Last evaluation / mint", lastEvaluationText(definition)),
-        field("Last minted task", definition.last_minted_task_id
-          ? `${definition.last_minted_task_id}${definition.last_minted_task_status ? ` · ${definition.last_minted_task_status}` : ""}`
-          : "None"),
-        field("Next evaluation", time(definition.next_evaluation)),
+        field("Last scheduler evaluation", lastEvaluationText(definition)),
+        field("Last minted task", lastMintedText(definition)),
+        field("Next evaluation", nextEvaluationText(definition.next_evaluation)),
         field("Open duplicate", definition.open_duplicate ? "Yes — mint will create another" : "No"),
       ]),
     );

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -12,9 +12,9 @@ use orbit_common::governance::authorization::{
 };
 use orbit_core::OrbitRuntime;
 use orbit_core::application::auto_tasks::{
-    collect_auto_tasks, cursor_state_path, load_cursor_state,
+    AutoTaskCursor, collect_auto_tasks, cursor_state_path, load_cursor_state,
 };
-use orbit_core::application::routines::parse_cron;
+use orbit_core::application::routines::{ScheduleDisplayState, parse_cron};
 use orbit_types::task::TaskStatus;
 use orbit_types::workflow::{
     AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate, DedupePolicy, auto_task_tag,
@@ -25,7 +25,8 @@ use serde_json::{Value, json};
 use super::map_runtime_error;
 use super::routines::{
     OperationsQuery, action_capability, authorization_denied, authorized_caller,
-    explicit_workspace, named_entity_not_found, record_operation_audit, selection_conflict,
+    explicit_workspace, named_entity_not_found, next_evaluation_json, record_operation_audit,
+    selection_conflict,
 };
 use crate::state::DashboardState;
 
@@ -404,7 +405,13 @@ fn definition_json(
         })),
         "last_minted_task_id": last_minted_task_id,
         "last_minted_task_status": last_minted_task_status,
-        "next_evaluation": next_evaluation(&definition.schedule, cursor, now),
+        "next_evaluation": next_evaluation_projection(
+            definition.enabled,
+            &definition.schedule,
+            cursor,
+            automation.as_ref(),
+            now,
+        ),
         "open_duplicate": open_duplicate,
         "may_create_open_duplicate": open_duplicate,
     })
@@ -458,12 +465,50 @@ fn template_summary(template: &AutoTaskTemplate) -> String {
     parts.join(" · ")
 }
 
-fn next_evaluation(
+fn next_evaluation_projection(
+    enabled: bool,
     schedule: &AutoTaskSchedule,
-    cursor: Option<&orbit_core::application::auto_tasks::AutoTaskCursor>,
+    cursor: Option<&AutoTaskCursor>,
+    automation: Option<&Value>,
+    now: DateTime<Utc>,
+) -> Value {
+    if !enabled {
+        return next_evaluation_json(
+            ScheduleDisplayState::Disabled,
+            theoretical_next(schedule, cursor, now),
+        );
+    }
+    if automation_unavailable(automation) {
+        return next_evaluation_json(ScheduleDisplayState::Unavailable, None);
+    }
+    match schedule {
+        AutoTaskSchedule::Deliveries { .. } => {
+            next_evaluation_json(ScheduleDisplayState::Waiting, None)
+        }
+        AutoTaskSchedule::Cron { .. } | AutoTaskSchedule::Interval { .. } => {
+            if cursor.is_none() {
+                return next_evaluation_json(ScheduleDisplayState::NeverObserved, None);
+            }
+            match theoretical_next(schedule, cursor, now) {
+                Some(at) => next_evaluation_json(ScheduleDisplayState::Scheduled, Some(at)),
+                None => next_evaluation_json(ScheduleDisplayState::Unavailable, None),
+            }
+        }
+    }
+}
+
+fn automation_unavailable(automation: Option<&Value>) -> bool {
+    automation
+        .and_then(|value| value.get("reason"))
+        .and_then(Value::as_str)
+        .is_some_and(|reason| reason == "source_unavailable" || reason == "state_unavailable")
+}
+
+fn theoretical_next(
+    schedule: &AutoTaskSchedule,
+    cursor: Option<&AutoTaskCursor>,
     now: DateTime<Utc>,
 ) -> Option<String> {
-    let cursor = cursor?;
     match schedule {
         AutoTaskSchedule::Deliveries { .. } => None,
         AutoTaskSchedule::Cron { cron } => {
@@ -472,17 +517,17 @@ fn next_evaluation(
             parsed
                 .find_next_occurrence(&now_local, false)
                 .ok()
-                .map(|slot| slot.with_timezone(&Utc).to_rfc3339())
+                .map(|slot| slot.to_rfc3339())
         }
         AutoTaskSchedule::Interval { every_minutes } => {
-            next_interval(*every_minutes, cursor, now).map(|slot| slot.to_rfc3339())
+            next_interval(*every_minutes, cursor?, now).map(|slot| slot.to_rfc3339())
         }
     }
 }
 
 fn next_interval(
     every_minutes: u64,
-    cursor: &orbit_core::application::auto_tasks::AutoTaskCursor,
+    cursor: &AutoTaskCursor,
     now: DateTime<Utc>,
 ) -> Option<DateTime<Utc>> {
     if every_minutes == 0 {

--- a/crates/orbit-web/src/api/routines.rs
+++ b/crates/orbit-web/src/api/routines.rs
@@ -13,8 +13,8 @@ use orbit_common::governance::authorization::{
 };
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_core::application::routines::{
-    ClockStatus, RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, clock_status,
-    set_clock_cadence, set_clock_enabled, set_routine_enabled,
+    ClockStatus, RoutineStatus, RoutineStatusReport, RoutineToggleOutcome, ScheduleDisplayState,
+    clock_status, set_clock_cadence, set_clock_enabled, set_routine_enabled,
 };
 use orbit_core::{AuditEventInsertParams, OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_types::telemetry::AuditEventStatus;
@@ -374,7 +374,23 @@ fn status_json(status: &RoutineStatus) -> Value {
         "first_observed_at": status.first_observed_at,
         "last_evaluated_slot": status.last_evaluated_slot,
         "next_due": status.next_due,
+        "next_evaluation": next_evaluation_json(
+            status.schedule_display_state(),
+            status.next_due.clone(),
+        ),
         "last_fire": status.last_fire.as_ref().map(fire_json),
+    })
+}
+
+pub(super) fn next_evaluation_json(state: ScheduleDisplayState, at: Option<String>) -> Value {
+    json!({
+        "state": state.as_str(),
+        "at": if state == ScheduleDisplayState::Waiting {
+            None
+        } else {
+            at
+        },
+        "hypothetical": state.is_hypothetical(),
     })
 }
 

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -220,9 +220,152 @@ async fn list_reports_enabled_and_disabled_definitions() {
     assert_eq!(hourly["last_evaluation"]["kind"], "fired");
     assert_eq!(hourly["last_evaluation"]["last_task_id"], "ORB-00001");
     assert_eq!(hourly["last_minted_task_id"], "ORB-00001");
-    assert!(hourly["next_evaluation"].as_str().is_some(), "{hourly}");
+    assert_eq!(hourly["next_evaluation"]["state"], "scheduled");
+    assert_eq!(hourly["next_evaluation"]["hypothetical"], false);
+    assert!(
+        hourly["next_evaluation"]["at"]
+            .as_str()
+            .is_some_and(|at| chrono::DateTime::parse_from_rfc3339(at).is_ok()),
+        "{hourly}"
+    );
     assert_eq!(hourly["schedule_summary"], "every 60 minutes");
     assert_eq!(nightly["last_evaluation"], serde_json::Value::Null);
+    assert_eq!(nightly["next_evaluation"]["state"], "disabled");
+    assert_eq!(nightly["next_evaluation"]["hypothetical"], true);
+    assert!(nightly["next_evaluation"]["at"].is_null(), "{nightly}");
+}
+
+fn write_cursor(runtime: &OrbitRuntime, name: &str, last_task_id: &str) {
+    let path = cursor_state_path(&runtime.paths().state_dir);
+    std::fs::create_dir_all(path.parent().expect("state dir")).expect("mkdir");
+    let existing =
+        std::fs::read_to_string(&path).unwrap_or_else(|_| r#"{"definitions":{}}"#.to_string());
+    let mut doc: serde_json::Value = serde_json::from_str(&existing).expect("parse cursor");
+    doc["definitions"][name] = serde_json::json!({
+        "baseline_at": "2026-01-01T00:00:00+00:00",
+        "last_slot": "2026-01-01T01:00:00+00:00",
+        "last_fired_at": "2026-01-01T01:00:05+00:00",
+        "last_task_id": last_task_id
+    });
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&doc).expect("serialize cursor"),
+    )
+    .expect("write cursor");
+}
+
+#[tokio::test]
+async fn list_labels_disabled_next_evaluation_as_hypothetical() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(chore_params("paused-chore"))
+        .expect("add");
+    runtime
+        .auto_task_toggle("paused-chore", false)
+        .expect("disable");
+    write_cursor(&runtime, "paused-chore", "ORB-00001");
+
+    let (state, _) = state(runtime);
+    let response = send(state, Method::GET, "/auto-tasks?workspace=default", None).await;
+    let json = body_json(response).await;
+    let item = json["definitions"]
+        .as_array()
+        .expect("definitions")
+        .iter()
+        .find(|item| item["name"] == "paused-chore")
+        .expect("paused-chore");
+    assert_eq!(item["enabled"], false);
+    assert_eq!(item["next_evaluation"]["state"], "disabled");
+    assert_eq!(item["next_evaluation"]["hypothetical"], true);
+    assert!(item["next_evaluation"]["at"].as_str().is_some(), "{item}");
+}
+
+#[tokio::test]
+async fn list_reports_never_observed_when_the_cursor_is_missing() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("fresh")).expect("add");
+    let (state, _) = state(runtime);
+    let response = send(state, Method::GET, "/auto-tasks?workspace=default", None).await;
+    let json = body_json(response).await;
+    let item = &json["definitions"].as_array().expect("definitions")[0];
+    assert_eq!(item["enabled"], true);
+    assert_eq!(item["next_evaluation"]["state"], "never_observed");
+    assert_eq!(item["next_evaluation"]["hypothetical"], false);
+    assert!(item["next_evaluation"]["at"].is_null(), "{item}");
+}
+
+#[tokio::test]
+async fn list_reports_disabled_and_unavailable_delivery_definitions() {
+    let runtime = runtime();
+    runtime
+        .auto_task_add(delivery_params(
+            "delivery-qa",
+            CoverageClass::IntegratedQaV1,
+        ))
+        .expect("add");
+    let (state, runtime) = state(runtime);
+    let disabled = body_json(
+        send(
+            state.clone(),
+            Method::GET,
+            "/auto-tasks?workspace=default",
+            None,
+        )
+        .await,
+    )
+    .await;
+    let disabled_item = &disabled["definitions"].as_array().expect("definitions")[0];
+    assert_eq!(disabled_item["next_evaluation"]["state"], "disabled");
+    assert!(
+        disabled_item["next_evaluation"]["at"].is_null(),
+        "{disabled_item}"
+    );
+
+    runtime
+        .auto_task_toggle("delivery-qa", true)
+        .expect("enable delivery definition");
+    let enabled =
+        body_json(send(state, Method::GET, "/auto-tasks?workspace=default", None).await).await;
+    let enabled_item = &enabled["definitions"].as_array().expect("definitions")[0];
+    assert_eq!(
+        enabled_item["next_evaluation"]["state"], "unavailable",
+        "in-memory runtimes have no delivery coverage; inspect failure is unavailable, not waiting: {enabled_item}"
+    );
+    assert!(
+        enabled_item["next_evaluation"]["at"].is_null(),
+        "{enabled_item}"
+    );
+}
+
+#[tokio::test]
+async fn list_separates_manual_mint_from_scheduler_evaluation() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("nightly")).expect("add");
+    write_cursor(&runtime, "nightly", "ORB-00001");
+    let (state, runtime) = state(runtime);
+    let minted = as_operator(send(
+        state.clone(),
+        Method::POST,
+        "/auto-tasks/mint?workspace=default",
+        Some(r#"{"name":"nightly","acknowledge_unconditional":true}"#),
+    ))
+    .await;
+    assert_eq!(minted.status(), StatusCode::OK);
+    let minted_id = body_json(minted).await["task_id"]
+        .as_str()
+        .expect("minted id")
+        .to_string();
+
+    let response = send(state, Method::GET, "/auto-tasks?workspace=default", None).await;
+    let json = body_json(response).await;
+    let item = &json["definitions"].as_array().expect("definitions")[0];
+    assert_eq!(item["last_evaluation"]["last_task_id"], "ORB-00001");
+    assert_eq!(item["last_minted_task_id"], minted_id);
+    assert_ne!(minted_id, "ORB-00001");
+    let cursor = runtime
+        .list_tasks_by_tags(&["auto-task:nightly".into()])
+        .expect("list");
+    assert_eq!(cursor[0].id.to_string(), minted_id);
 }
 
 #[tokio::test]

--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use orbit_common::governance::authorization::OPERATOR_OVERRIDE_ENV;
-use orbit_core::application::routines::ClockStatus;
+use orbit_core::application::routines::{ClockStatus, ScheduleDisplayState};
 use orbit_core::{OrbitRuntime, RoutineFireRecord, RoutineFireState};
 use orbit_registry::{NewHostIdentity, ensure_host_identity};
 use tower::ServiceExt;
 
 use super::super::router;
-use super::super::routines::{clock_json, duration_ms, fire_json, fire_ok};
+use super::super::routines::{clock_json, duration_ms, fire_json, fire_ok, next_evaluation_json};
 use super::test_support::body_json;
 use crate::state::DashboardState;
 
@@ -121,6 +121,22 @@ fn clock_json_keeps_service_state_and_health_distinct() {
     assert_eq!(missed["health"], "missed");
     assert_eq!(missed["enabled"], true, "enabled is not health");
     assert_eq!(missed["running"], false);
+}
+
+#[test]
+fn next_evaluation_json_marks_disabled_times_hypothetical() {
+    let json = next_evaluation_json(
+        ScheduleDisplayState::Disabled,
+        Some("2026-09-07T14:15:00-07:00".to_string()),
+    );
+    assert_eq!(json["state"], "disabled");
+    assert_eq!(json["hypothetical"], true);
+    assert_eq!(json["at"], "2026-09-07T14:15:00-07:00");
+
+    let waiting = next_evaluation_json(ScheduleDisplayState::Waiting, None);
+    assert_eq!(waiting["state"], "waiting");
+    assert!(waiting["at"].is_null());
+    assert_eq!(waiting["hypothetical"], false);
 }
 
 /// End-to-end: the endpoint resolves host-level routine state from the global

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -412,6 +412,10 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(operations.contains("routine.target"));
     assert!(operations.contains("last_evaluated_slot"));
     assert!(operations.contains("next_tick_at"));
+    assert!(operations.contains("Last scheduler evaluation"));
+    assert!(operations.contains("hypothetical next"));
+    assert!(operations.contains("Waiting for deliveries"));
+    assert!(operations.contains("Never observed"));
     assert!(operations.contains("acknowledge_unconditional: true"));
     assert!(operations.contains("UNCONDITIONAL_MINT_WARNING"));
     assert!(operations.contains(
@@ -442,6 +446,99 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(css.contains("body.operations-active"));
     assert!(css.contains(".operation-mint-warning"));
     assert!(router.contains(r#"classList.toggle("operations-active", top === "operations")"#));
+}
+
+/// ORB-11558: disabled/paused rows must not look scheduled; clock cadence is a
+/// duration; timestamps name a timezone, including PST/PDT across DST.
+#[test]
+fn dashboard_operations_label_paused_schedules_timezones_and_clock_units() {
+    run_dashboard_javascript_test(
+        r#"
+process.env.TZ = "America/Los_Angeles";
+const nodes = [];
+class Node {
+  constructor(id = "") { this.id = id; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.hidden = false; this.disabled = false; this.value = ""; nodes.push(this); }
+  appendChild(child) { if (child == null) return child; this.children.push(child); child.parentNode = this; return child; }
+  append(...children) { for (const child of children) this.appendChild(child); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  querySelectorAll() { return []; }
+  querySelector() { return null; }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+for (const id of ["routines-body", "clock-body", "auto-tasks-body", "auto-drain-body", "operation-mode-body", "routines-count", "clock-host", "auto-tasks-count", "auto-drain-count", "operation-mode-count", "operations-session", "routine-operation-feedback", "clock-operation-feedback", "auto-task-operation-feedback", "auto-drain-operation-feedback", "operation-mode-operation-feedback"]) get(id);
+globalThis.document = { getElementById: get, createElement: () => new Node(), createTextNode: (text) => Object.assign(new Node(), { textContent: text }), body: new Node("body") };
+globalThis.window = { confirm: () => true, location: new URL("http://dashboard.test/"), addEventListener: () => {}, localStorage: { getItem: () => null, setItem: () => {} } };
+const pad = (n) => String(n).padStart(2, "0");
+const formatAbsoluteTime = (value) => {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+const routines = {
+  host_id: "host-1",
+  session_explanation: "test",
+  capabilities: {},
+  clock: {
+    health: "healthy", provider: "systemd", enabled: true, loaded: true, running: true, schedulable: true,
+    configured_cadence_seconds: 300, effective_cadence_seconds: 300,
+    last_tick_at: "2026-09-07T21:00:00Z", next_tick_at: "2026-09-07T21:05:00Z",
+  },
+  routines: [
+    { name: "ship-sweep-orbit", source: "one", target: "job:ship", enabled: false, effective: false, cron: "30 14 * * *", hosts: ["host-1"], pinned_to_host: true, next_due: "2026-09-07T21:30:00Z", next_evaluation: { state: "disabled", at: "2026-09-07T21:30:00Z", hypothetical: true }, last_fire: null },
+    { name: "paused-nightly", source: "one", target: "job:nightly", enabled: true, effective: false, paused_at: "2026-09-07T20:00:00Z", cron: "0 2 * * *", hosts: ["host-1"], pinned_to_host: true, next_due: "2026-09-08T09:00:00Z", next_evaluation: { state: "paused", at: "2026-09-08T09:00:00Z", hypothetical: true }, last_fire: null },
+    { name: "delivery-cover", source: "one", target: "job:cover", enabled: true, effective: true, trigger: { deliveries_landed: { threshold: 3, branch: "agent-main" } }, hosts: ["host-1"], pinned_to_host: true, next_evaluation: { state: "waiting", at: null, hypothetical: false }, last_fire: null },
+  ],
+};
+const autoTasks = {
+  unconditional_mint_warning: "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.",
+  capabilities: { auto_task_toggle: { authorized: true }, auto_task_mint: { authorized: true } },
+  definitions: [
+    { name: "ci-failure-remediation", enabled: false, schedule_summary: "every 15 minutes", template_summary: "[auto-task] remediate", next_evaluation: { state: "disabled", at: "2026-09-07T21:15:00Z", hypothetical: true }, last_evaluation: null, last_minted_task_id: null },
+    { name: "hourly", enabled: true, schedule_summary: "every 60 minutes", last_evaluation: { kind: "fired", last_task_id: "ORB-00001", last_fired_at: "2026-09-07T20:00:00Z" }, last_minted_task_id: "ORB-00099", last_minted_task_status: "backlog", next_evaluation: { state: "scheduled", at: "2026-09-07T22:00:00Z", hypothetical: false } },
+    { name: "fresh", enabled: true, schedule_summary: "every 60 minutes", last_evaluation: null, last_minted_task_id: null, next_evaluation: { state: "never_observed", at: null, hypothetical: false } },
+    { name: "broken-cover", enabled: true, schedule_summary: "3 deliveries on agent-main", next_evaluation: { state: "unavailable", at: null, hypothetical: false } },
+  ],
+};
+globalThis.fetch = async (path) => {
+  const url = String(path);
+  const payload = url.startsWith("/api/routines") ? routines
+    : url.startsWith("/api/auto-tasks") ? autoTasks
+    : {};
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+};
+const { setWorkspace } = await import("./common.js");
+const { initOperations, fetchAndRenderOperations } = await import("./operations.js");
+setWorkspace("one");
+initOperations({ getWorkspaces: () => [{ id: "one", name: "one", status: "active" }], formatAbsoluteTime });
+await fetchAndRenderOperations();
+const routineText = get("routines-body").textContent;
+const autoText = get("auto-tasks-body").textContent;
+const clockText = get("clock-body").textContent;
+for (const expected of ["Disabled · hypothetical next", "Paused · hypothetical next", "Waiting for deliveries"]) {
+  if (!routineText.includes(expected)) throw new Error(`routines missing ${JSON.stringify(expected)} in: ${routineText}`);
+}
+if (routineText.includes("Next evaluation2026-09-07") && !routineText.includes("hypothetical")) {
+  throw new Error(`unqualified next evaluation in: ${routineText}`);
+}
+for (const expected of ["Disabled · hypothetical next", "Never observed", "Unavailable", "Last scheduler evaluation", "manual mint"]) {
+  if (!autoText.includes(expected)) throw new Error(`auto-tasks missing ${JSON.stringify(expected)} in: ${autoText}`);
+}
+if (!clockText.includes("every 5 minutes (300s)")) throw new Error(`cadence should be a duration, got: ${clockText}`);
+const tzName = (iso) => new Intl.DateTimeFormat("en-US", { timeZoneName: "short" }).formatToParts(new Date(iso)).find((part) => part.type === "timeZoneName")?.value;
+if (tzName("2026-01-15T20:00:00Z") !== "PST") throw new Error(`expected PST in January, got ${tzName("2026-01-15T20:00:00Z")}`);
+if (tzName("2026-07-15T19:00:00Z") !== "PDT") throw new Error(`expected PDT in July, got ${tzName("2026-07-15T19:00:00Z")}`);
+if (!routineText.includes("14:30 PDT") || !routineText.includes("hypothetical")) {
+  throw new Error(`disabled 14:30 must be labeled PDT and hypothetical: ${routineText}`);
+}
+if (!clockText.includes("14:00 PDT") && !clockText.includes("14:05 PDT")) {
+  throw new Error(`clock last/next tick must be absolute local times with a timezone: ${clockText}`);
+}
+"#,
+    );
 }
 
 /// ORB-11250: the bounded auto-delivery window action. Default completion

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-09-05
-last_validated: 2026-09-05
+last_updated: 2026-09-07
+last_validated: 2026-09-07
 status: Accepted
 feature: auto-tasks
 doc_role: design
@@ -175,8 +175,13 @@ cursor-neutral on every surface.
 The dashboard Operations tab exposes the same CRUD/mint runtime rather than a
 second scheduler. `#operations/auto-tasks` lists the selected workspace's
 definitions (name, enabled, schedule, template summary, dedupe, last
-evaluation/mint, last minted task id, next evaluation when the cursor makes
-that derivable). Enable/disable writes `enabled` through `auto_task_toggle`
+scheduler evaluation, last minted task id, and a structured next-evaluation
+state). Next evaluation is never an unqualified future timestamp: disabled
+rows show `Disabled` (a theoretical slot is labeled hypothetical), delivery
+rows show waiting-for-deliveries, a missing cursor is never observed, and
+inspect failures are unavailable. Last scheduler evaluation is the host-local
+cursor; last minted task is the newest tagged instance and is labeled a
+manual mint when the two ids differ. Enable/disable writes `enabled` through `auto_task_toggle`
 with `expected_enabled` compare-and-swap, operator authorization
 (`auto_task.toggle`), and a dashboard-operations audit row. `Mint now` calls
 `auto_task_mint` after the operator acknowledges the unconditional warning

--- a/docs/design/routines/2_design.md
+++ b/docs/design/routines/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Routines — Design
 owner: claude
-last_updated: 2026-09-05
-last_validated: 2026-09-05
+last_updated: 2026-09-07
+last_validated: 2026-09-07
 status: Accepted
 feature: routines
 doc_role: design
@@ -46,7 +46,13 @@ the supported platforms; there is no resident Orbit daemon ([Host-local sweep cl
 
 The dashboard Operations view projects the same typed status and control functions
 [ORB-10875]. Routine definitions remain workspace-scoped and show their versioned
-`enabled` value; the host clock remains one independent host-scoped card. A routine
+`enabled` value; the host clock remains one independent host-scoped card.
+Next evaluation uses schedule display state (`scheduled`, `disabled`, `paused`,
+`waiting`, `never_observed`, `unavailable`) so a disabled or paused routine
+does not look armed; a theoretical next slot is labeled hypothetical.
+Clock last/next tick are wall-clock times; systemd `NextElapseUSecMonotonic`
+is used only for schedulability, never as a displayed next tick. Cadence is a
+duration. A routine
 toggle resolves its file from a freshly loaded `LoadedRoutine`, validates the displayed
 workspace, host, target, and expected prior state, changes only the top-level `enabled`
 field, reparses the document, and uses an atomic rename. Clock requests are a closed


### PR DESCRIPTION
## Task

[ORB-11558](https://orbit-cli.com/tasks/ORB-11558) — Show truthful paused schedules and time zones in Operations

### Description

## Problem
Disabled auto-task and routine definitions display future Next evaluation timestamps as if scheduled to execute. For example ci-failure-remediation was disabled yet displayed 2026-09-07 14:15; ship-sweep-orbit was disabled yet displayed 14:30. Routine timestamps were local-looking, while clock last tick explicitly used UTC. Host clock also showed a 300s cadence but a Next expected tick value of 4h 14min; investigate that formatting/source inconsistency rather than assume scheduler failure.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Make effective scheduling state distinguish enabled, paused, not observed and unavailable; retain any theoretical schedule time only with an explicit label. Separate last scheduler evaluation from last manual mint when they differ. Preserve scheduling behavior; repair projection/presentation and any demonstrated calculation fault.

### Acceptance Criteria

- Disabled definitions display Paused or Disabled instead of an unqualified future Next evaluation; theoretical occurrences, if shown, are explicitly hypothetical.
- Enabled time-based and delivery-based definitions accurately distinguish scheduled time, waiting for deliveries, unavailable state and never observed.
- Displayed timestamps identify a consistent timezone; clock next tick and configured/effective cadence use correct units and label absolute times versus durations.
- Deterministic tests cover disabled/enabled, missing cursor, manual mint versus scheduler evaluation, timezone/DST and clock output fixtures; browser screenshots confirm clear labels.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Operations next evaluation is a structured projection (`state`, `at`, `hypothetical`) for routines and auto-tasks. Disabled/paused rows show Disabled or Paused; a theoretical slot is labeled hypothetical. Delivery rows show waiting; missing auto-task cursor is never observed; pin/inspect failures are unavailable.
- Last scheduler evaluation is the host-local cursor; last minted task is the newest tagged instance and is labeled manual mint when the ids differ.
- Operations timestamps append a timezone name. systemd `NextElapseUSecMonotonic` is no longer used as `next_tick_at` (schedulability only). Cadence is labeled as a duration; last/next tick are absolute times.
- Design docs for auto-tasks and routines Operations display were updated.
Assessment: Projection/presentation only; scheduler due-math, mint, and toggle behavior are unchanged.

Criteria:
- Disabled/paused vs unqualified next: met (API state + JS "Disabled/Paused · hypothetical next …").
- Scheduled / waiting / unavailable / never observed: met (core display state, auto-task list JSON, JS labels).
- Timezone and clock units: met (timezone short name on Operations times; cadence "every 5 minutes (300s)"; monotonic duration not shown as next tick).
- Deterministic tests: met except live browser screenshots.

Validation:
- `make ci-fast`: passed
- `cargo test -p orbit-core --lib schedule_display_state_distinguishes`: passed
- `cargo test -p orbit-core --lib systemd_monotonic_duration_is_not_a_wall_clock_next_tick`: passed
- `cargo test -p orbit-web --lib` filters for disabled/hypothetical, missing cursor, delivery disabled/unavailable, manual mint vs scheduler, dashboard JS labels/DST/cadence: passed
- `cargo clippy -p orbit-core -p orbit-web --all-targets -- -D warnings`: passed
- `git diff --check`: passed
- `make ci-lint` (full workspace): not run; clippy covered the changed crates only
- Browser screenshots: not run. No Chromium/Firefox in the sandbox. `http://localhost:7878` returns 200 but serves the already-deployed binary/assets, not this worktree.

Remaining risks:
- Live Operations at :7878 will keep the old labels until this change is built and that server is restarted.
- Waiting-for-deliveries on auto-tasks is covered by the JS fixture and routine unit tests; in-memory HTTP tests see inspect failure as unavailable, which is the intended inspect-error path.
- Friction F2026-09-060 records the systemd monotonic/realtime mix-up.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11558-6a9f3a50`
- Behind base: 0
- Ahead of base: 1