### PR TITLE
[code-review] Write the run definition snapshot atomically

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -8,6 +8,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use orbit_common::fs::io::atomic_write_text;
 use orbit_common::observability::audit_id::audit_execution_id;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_store::contracts::{
@@ -914,14 +915,8 @@ impl OrbitRuntime {
     /// Durably pin a submitted run's job definition next to the run record.
     fn write_run_definition_snapshot(&self, run_id: &str, yaml: &str) -> Result<(), OrbitError> {
         let dir = self.paths().job_runs_dir.clone();
-        std::fs::create_dir_all(&dir).map_err(|error| {
-            OrbitError::Io(format!(
-                "create job run definition directory '{}': {error}",
-                dir.display()
-            ))
-        })?;
         let path = run_definition_snapshot_path(&dir, run_id);
-        std::fs::write(&path, yaml).map_err(|error| {
+        atomic_write_text(&path, yaml).map_err(|error| {
             OrbitError::Io(format!(
                 "write job run definition snapshot '{}': {error}",
                 path.display()


### PR DESCRIPTION
## Task

[ORB-11669](https://orbit-cli.com/tasks/ORB-11669) — [code-review] Write the run definition snapshot atomically

### Description

## Problem
`write_run_definition_snapshot` pins a direct-path job YAML next to the run with `std::fs::write` (line 914). A crash or disk-full mid-write leaves a truncated `<run_id>.job.yaml`; `resolve_run_definition` (line 924-939) checks only `is_file()` and then fails `load_job_asset` with a parse error, so the run (and every resume of it) becomes unexecutable while the terminal-state guard still reports it as a pending run. The crate already uses `orbit_common::fs::io::atomic_write_text` for comparable durable writes (`routines/clock.rs:83`, `auto_tasks/crud.rs:251`).

## Why It Matters
The snapshot exists precisely to make the run independent of later filesystem state; a non-atomic write reintroduces a corruption window.

## Proposed Fix
Replace `std::fs::write` with `atomic_write_text` (temp file + rename in `job_runs_dir`).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/job/pipeline.rs:904-920`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `rg 'std::fs::write' crates/orbit-core/src/application/job/pipeline.rs` returns nothing.
- Existing direct-path submission tests in `application/tests/job_submission.rs` pass and the snapshot content is unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the direct-path run-definition snapshot write with `orbit_common::fs::io::atomic_write_text`, which stages the YAML, renames it atomically, and fsyncs the parent directory. The helper creates the snapshot directory, so the redundant direct directory creation was removed.
- Preserved the existing snapshot-path error context and left direct-path submission tests unchanged.
Assessment: Small, scoped durability fix using the repository standard primitive.

Criteria:
- `rg 'std::fs::write' crates/orbit-core/src/application/job/pipeline.rs` produced no matches.
- Existing direct-path submission tests passed with unchanged test content.

Validation:
- Passed: `cargo fmt --all`
- Passed: `cargo test -p orbit-core direct_path_submission` (2 passed).
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Risks/deviations: None. The focused tests verify snapshot contents and later resolution; the shared atomic helper supplies the crash-safe temp-file/rename behavior.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11669-6a9f3edd`
- Behind base: 0
- Ahead of base: 1