### PR TITLE
Show a concrete product walkthrough before advanced website delivery modes

### DIFF
--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Owner:** Orbit contributors
-**Last updated:** 2026-07-26
+**Last updated:** 2026-09-07
 
 ---
 
@@ -97,21 +97,30 @@ The homepage uses an in-content hero in place of Starlight's auto-rendered title
 - **Lede + install bar + primary/secondary CTAs.** Install bar carries a `$` prompt and a Copy action.
 - **Provider strip** — mono uppercase list of the shipped CLI executors, with the
   legacy Gemini executor named in a footnote rather than implied current.
-- **Transcript** — a `figure` of the task → ship → inspect → commit loop, with a
-  `figcaption` naming it illustrative. Real commands, placeholder identifiers.
+- **Dashboard preview** — a `figure` of the operator Tasks view after that
+  default ship: the walkthrough task in `review`, pull request open and
+  unmerged, `approve` available, `ship` absent. `role="img"` plus a
+  `figcaption` mark it as an illustration of current chrome, not a screenshot
+  or a live host. Identifiers are placeholders; no measured counts or
+  durations.
 
 Below the hero, in order:
 
-1. **Start here** — a 3-card grid, each card carrying a mono numbered tag
-   `01`–`03` and the command it runs.
-2. **Choose a delivery mode** — a four-mode explorer over `orbit run ship`,
+1. **One task, one pull request** — a 4-card grid for create → ship → inspect
+   → review. Each card carries a mono numbered tag `01`–`04` and the command
+   it runs. New tasks start in `proposed` until approved into the backlog.
+   The default path stops in `review` with the PR unmerged; approving the
+   task does not merge the pull request. A sentence under the grid points at
+   Install and First Task.
+2. **Other delivery modes** — a four-mode explorer over `orbit run ship`,
    `--mode local`, `orbit run auto` and `orbit run ship-sweep`. Each panel
    states the command, where the run stops, and that `--complete` is a separate
    explicit authorization. Built as a native radio group switched by CSS
    `:has()`, so pointer, keyboard and screen-reader support are the platform's
-   and the selected panel still renders without JavaScript.
+   and the selected panel still renders without JavaScript. This section stays
+   after the walkthrough so the default path is read first.
 3. **Why Orbit** — a 4-card value-prop strip. Each card carries a thin SVG glyph;
-   these and the Start here tags are the only glyphs in content.
+   these and the walkthrough tags are the only glyphs in content.
 4. **Go further** — a 4-card grid routing to continuous delivery, recurring work,
    publication and recovery, and the CLI reference.
 5. **Explore the docs** — a flat index of the sidebar groups.

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -40,56 +40,109 @@ next: false
     <p class="orbit-hero-providers-note">Gemini CLI ships as a legacy executor for enterprise Gemini Code Assist and API-key accounts. <a href="/concepts/agents/">How agents are invoked →</a></p>
   </div>
 
-  <figure class="orbit-terminal">
-    <div class="orbit-terminal-bar">
-      <span>~/repo</span>
-      <span>one task, end to end</span>
+  <figure class="orbit-dash">
+    <div class="orbit-dash-frame" role="img" aria-label="Illustrative operator dashboard. Tasks is selected in the left rail. Placeholder task Document fsProfile resolution is in review, with the pull request open and unmerged. Approve is available; ship is not.">
+      <div class="orbit-dash-rail" aria-hidden="true">
+        <div class="orbit-dash-brand">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <circle cx="12" cy="12" r="8.5" fill="none" stroke="currentColor" stroke-width="1.6"></circle>
+            <circle class="orbit-dash-mark" cx="18.5" cy="6.5" r="2.5"></circle>
+          </svg>
+          <span>orbit</span>
+        </div>
+        <div class="orbit-dash-rail-group">
+          <div class="orbit-dash-rail-label">Work</div>
+          <div class="orbit-dash-rail-item is-active">Tasks</div>
+        </div>
+        <div class="orbit-dash-rail-group">
+          <div class="orbit-dash-rail-label">Observe</div>
+          <div class="orbit-dash-rail-item">Audit</div>
+          <div class="orbit-dash-rail-item">Diagnostics</div>
+        </div>
+        <div class="orbit-dash-rail-group">
+          <div class="orbit-dash-rail-label">Manage</div>
+          <div class="orbit-dash-rail-item">Operations</div>
+          <div class="orbit-dash-rail-item">Knowledge</div>
+        </div>
+        <div class="orbit-dash-rail-foot">example-repo</div>
+      </div>
+      <div class="orbit-dash-main" aria-hidden="true">
+        <div class="orbit-dash-topbar">
+          <span class="orbit-dash-crumb">Tasks</span>
+          <span class="orbit-dash-jump">Jump to [TASK_ID]</span>
+          <span class="orbit-dash-refresh">Refresh</span>
+        </div>
+        <div class="orbit-dash-body">
+          <div class="orbit-dash-panel">
+            <div class="orbit-dash-panel-head">
+              <span>Tasks</span>
+              <span class="orbit-dash-count">1</span>
+            </div>
+            <div class="orbit-dash-filters">
+              <span>All</span>
+              <span class="is-on">Review</span>
+              <span>Backlog</span>
+            </div>
+            <div class="orbit-dash-row is-open">
+              <span class="orbit-dash-id">[TASK_ID]</span>
+              <span class="orbit-dash-title">Document fsProfile resolution</span>
+              <span class="orbit-dash-status">review</span>
+            </div>
+            <div class="orbit-dash-detail">
+              <p>Default ship stopped here. Pull request open, unmerged.</p>
+              <div class="orbit-dash-actions">
+                <span>comment</span>
+                <span class="is-primary">approve</span>
+                <span>reject</span>
+              </div>
+            </div>
+          </div>
+          <div class="orbit-dash-dock">
+            <div class="orbit-dash-dock-head">
+              <span class="is-on">Status</span>
+              <span>Log</span>
+            </div>
+            <p>Locked files · 0 files / 0 tasks</p>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="orbit-terminal-body">
-      <div><span class="orbit-terminal-prompt">$ </span><span class="orbit-terminal-cmd">orbit task add --title "Document fsProfile resolution" \</span></div>
-      <div><span class="orbit-terminal-cmd">    --acceptance-criteria "..." --complexity medium</span></div>
-      <div><span class="orbit-terminal-id">[TASK_ID]</span></div>
-      <div class="orbit-terminal-gap"></div>
-      <div><span class="orbit-terminal-prompt">$ </span><span class="orbit-terminal-cmd">orbit run ship "$TASK_ID"</span></div>
-      <div>submitted · run <span class="orbit-terminal-id">[RUN_ID]</span></div>
-      <div class="orbit-terminal-gap"></div>
-      <div><span class="orbit-terminal-prompt">$ </span><span class="orbit-terminal-cmd">orbit run show</span></div>
-      <div class="orbit-terminal-head">step   scope             status   duration</div>
-      <div>plan   worktree: iso     <span class="orbit-terminal-id">ok</span>       00:12</div>
-      <div>edit   fsProfile: docs   <span class="orbit-terminal-id">ok</span>       01:47</div>
-      <div>test   fsProfile: docs   <span class="orbit-terminal-id">ok</span>       02:03</div>
-      <div>pr     github            <span class="orbit-terminal-id">ok</span>       00:09</div>
-      <div class="orbit-terminal-gap"></div>
-      <div><span class="orbit-terminal-prompt">$ </span><span class="orbit-terminal-cmd">git log -1 --grep "$TASK_ID" --oneline</span></div>
-      <div><span class="orbit-terminal-id">[SHA]</span> docs: document fsProfile resolution</div>
-    </div>
-    <figcaption class="orbit-terminal-caption">Illustrative transcript. The commands are real; identifiers, step rows and durations are placeholders, not measured results.</figcaption>
+    <figcaption class="orbit-dash-caption">Illustration of the operator dashboard (<code>orbit web serve</code>), not a screenshot. Chrome follows the current Tasks view: left rail, task list, Status dock. The selected row is the walkthrough example after a default PR ship. Identifiers are placeholders, not captured from a live host.</figcaption>
   </figure>
 </section>
 
-<h2 class="orbit-section-title">Start here</h2>
+<h2 class="orbit-section-title">One task, one pull request</h2>
 
-<div class="orbit-card-grid orbit-card-grid-3">
-  <a class="orbit-card" data-tag="01" href="/getting-started/install/">
-    <h3>Install</h3>
-    <p>One binary, no Rust toolchain. Then <code>orbit init</code> sets up your global root, and <code>orbit workspace init</code> registers the repository.</p>
-    <div class="orbit-card-cmd">orbit init</div>
+<p class="orbit-section-lede">The default path, with one example. Create the work, run an agent, inspect the result, then review the pull request. The task stops in <code>review</code> with the PR unmerged. Approving the task does not merge the pull request.</p>
+
+<div class="orbit-card-grid orbit-card-grid-4">
+  <a class="orbit-card" data-tag="01" href="/getting-started/first-task/">
+    <h3>Create a task</h3>
+    <p>Acceptance criteria are the finish line — agents self-evaluate against them. A new task starts in <code>proposed</code> until you approve it into the backlog.</p>
+    <div class="orbit-card-cmd">orbit task add --title "Document fsProfile resolution"</div>
   </a>
-  <a class="orbit-card" data-tag="02" href="/getting-started/first-task/">
-    <h3>Write a task</h3>
-    <p>Acceptance criteria are required — agents self-evaluate against them. Context selectors declare the file scope the run may touch.</p>
-    <div class="orbit-card-cmd">orbit task add --title "…"</div>
-  </a>
-  <a class="orbit-card" data-tag="03" href="/how-to/task-lifecycle/">
+  <a class="orbit-card" data-tag="02" href="/how-to/task-lifecycle/">
     <h3>Ship it</h3>
-    <p>The gated pipeline runs the agent, then opens a pull request. The task stops in <code>review</code> for you.</p>
+    <p>Orbit reserves those files, runs an agent in an isolated worktree, and opens a pull request. The command returns a run ID immediately.</p>
     <div class="orbit-card-cmd">orbit run ship "$TASK_ID"</div>
+  </a>
+  <a class="orbit-card" data-tag="03" href="/how-to/dashboard/">
+    <h3>Inspect the result</h3>
+    <p>Follow the run until the steps settle. The same task and run show up in the operator dashboard.</p>
+    <div class="orbit-card-cmd">orbit run show</div>
+  </a>
+  <a class="orbit-card" data-tag="04" href="/how-to/task-lifecycle/">
+    <h3>Review the pull request</h3>
+    <p>Look at the diff, CI, and execution summary. Approving moves the task from <code>review</code> to <code>done</code> — it does not merge the PR by itself.</p>
+    <div class="orbit-card-cmd">orbit task update "$TASK_ID" --approve</div>
   </a>
 </div>
 
-<h2 class="orbit-section-title">Choose a delivery mode</h2>
+<p class="orbit-walk-next">Next: <a href="/getting-started/install/">install Orbit</a>, then <a href="/getting-started/first-task/">write your first task</a>.</p>
 
-<p class="orbit-section-lede">Every <code>orbit run</code> command is asynchronous: it prints a durable run ID and returns without knowing the outcome. Follow up with <code>orbit run show</code>. Pick the shape of delivery you want — the differences are where the run stops and who authorizes the last step.</p>
+<h2 class="orbit-section-title">Other delivery modes</h2>
+
+<p class="orbit-section-lede">The walkthrough above is <code>orbit run ship</code>. These other shapes change where the run stops and who authorizes the last step. Every <code>orbit run</code> command is asynchronous: it prints a durable run ID and returns without knowing the outcome. Follow up with <code>orbit run show</code>.</p>
 
 <div class="orbit-flow">
   <div class="orbit-flow-tabs" role="radiogroup" aria-label="Delivery mode">
@@ -300,6 +353,7 @@ next: false
   <div class="orbit-docs-group">
     <h3 class="orbit-docs-group-title">How-to Guides</h3>
     <a href="/how-to/task-lifecycle/">Run a Task Lifecycle</a>
+    <a href="/how-to/dashboard/">Use the Dashboard</a>
     <a href="/how-to/continuous-delivery/">Run Continuous Delivery</a>
     <a href="/how-to/recurring-work/">Schedule Recurring Work</a>
     <a href="/how-to/task-publication/">Publish and Restore Tasks</a>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -413,8 +413,10 @@ body {
   text-decoration: underline;
 }
 
-/* Hero terminal: a transcript of the task -> ship -> inspect -> commit loop. */
-.orbit-terminal {
+/* Hero dashboard: an illustration of the operator Tasks view after the
+   default ship in the walkthrough. Not a screenshot and not live data. */
+.orbit-dash {
+  --orbit-dash-review: #d946ef;
   background: var(--sl-color-bg-inline-code);
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 8px;
@@ -423,63 +425,288 @@ body {
   overflow: hidden;
 }
 
-.orbit-terminal-bar {
-  align-items: center;
-  border-bottom: 1px solid var(--sl-color-hairline-light);
-  color: var(--sl-color-gray-4);
-  display: flex;
-  font-family: var(--sl-font-mono);
-  font-size: 0.72rem;
-  gap: 1rem;
-  height: 2.125rem;
-  justify-content: space-between;
-  padding: 0 0.875rem;
+.orbit-dash-frame {
+  display: grid;
+  grid-template-columns: 7.25rem minmax(0, 1fr);
+  min-height: 22.5rem;
 }
 
-/* Flex column, not block: with `white-space: pre` the newlines between the
-   line elements would otherwise render as blank lines of their own. */
-.orbit-terminal-body {
+.orbit-dash-rail {
+  background: color-mix(in srgb, var(--sl-color-bg) 70%, var(--sl-color-bg-inline-code));
+  border-right: 1px solid var(--sl-color-hairline-light);
   color: var(--sl-color-gray-3);
   display: flex;
   flex-direction: column;
-  font-family: var(--sl-font-mono);
-  font-size: 0.78rem;
-  line-height: 1.85;
-  overflow-x: auto;
-  padding: 1.125rem 1.25rem;
-  white-space: pre;
+  font-size: 0.72rem;
+  min-width: 0;
+  padding: 0.75rem 0.55rem 0.65rem;
 }
 
-.orbit-terminal-prompt {
-  color: var(--sl-color-gray-4);
-}
-
-.orbit-terminal-cmd {
+.orbit-dash-brand {
+  align-items: center;
   color: var(--sl-color-text);
+  display: flex;
+  font-size: 0.78rem;
+  font-weight: 650;
+  gap: 0.4rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.85rem;
+  padding: 0 0.3rem;
 }
 
-.orbit-terminal-id {
+.orbit-dash-brand svg {
+  flex: 0 0 auto;
+}
+
+.orbit-dash-mark {
+  fill: var(--sl-color-accent);
+}
+
+.orbit-dash-rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-bottom: 0.7rem;
+}
+
+.orbit-dash-rail-label {
+  color: var(--sl-color-gray-4);
+  font-family: var(--sl-font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  padding: 0.15rem 0.35rem 0.25rem;
+  text-transform: uppercase;
+}
+
+.orbit-dash-rail-item {
+  border-radius: 4px;
+  padding: 0.28rem 0.4rem;
+}
+
+.orbit-dash-rail-item.is-active {
+  background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+  color: var(--sl-color-text);
+  font-weight: 600;
+}
+
+.orbit-dash-rail-foot {
+  color: var(--sl-color-gray-4);
+  font-family: var(--sl-font-mono);
+  font-size: 0.62rem;
+  margin-top: auto;
+  overflow: hidden;
+  padding: 0.45rem 0.35rem 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orbit-dash-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.orbit-dash-topbar {
+  align-items: center;
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+  color: var(--sl-color-gray-3);
+  display: flex;
+  font-size: 0.72rem;
+  gap: 0.5rem;
+  min-height: 2.125rem;
+  padding: 0 0.75rem;
+}
+
+.orbit-dash-crumb {
+  color: var(--sl-color-text);
+  font-weight: 600;
+}
+
+.orbit-dash-jump {
+  background: var(--sl-color-bg);
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 4px;
+  color: var(--sl-color-gray-4);
+  flex: 1 1 auto;
+  font-family: var(--sl-font-mono);
+  font-size: 0.62rem;
+  margin-left: auto;
+  max-width: 11rem;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.2rem 0.45rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orbit-dash-refresh {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 4px;
+  flex: 0 0 auto;
+  font-size: 0.62rem;
+  padding: 0.2rem 0.4rem;
+}
+
+.orbit-dash-body {
+  display: grid;
+  flex: 1 1 auto;
+  grid-template-columns: minmax(0, 1fr) 7.5rem;
+  min-height: 0;
+}
+
+.orbit-dash-panel,
+.orbit-dash-dock {
+  min-width: 0;
+}
+
+.orbit-dash-dock {
+  border-left: 1px solid var(--sl-color-hairline-light);
+  color: var(--sl-color-gray-3);
+  display: flex;
+  flex-direction: column;
+  font-size: 0.68rem;
+  line-height: 1.45;
+  padding: 0.7rem 0.65rem;
+}
+
+.orbit-dash-dock p {
+  margin: 0.55rem 0 0;
+}
+
+.orbit-dash-panel-head,
+.orbit-dash-dock-head {
+  align-items: center;
+  color: var(--sl-color-gray-3);
+  display: flex;
+  font-size: 0.72rem;
+  font-weight: 600;
+  gap: 0.45rem;
+  justify-content: space-between;
+}
+
+.orbit-dash-panel-head {
+  padding: 0.7rem 0.75rem 0.35rem;
+}
+
+.orbit-dash-count {
+  color: var(--sl-color-gray-4);
+  font-family: var(--sl-font-mono);
+  font-size: 0.62rem;
+  font-weight: 500;
+}
+
+.orbit-dash-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.2rem 0.75rem 0.55rem;
+}
+
+.orbit-dash-filters span,
+.orbit-dash-dock-head span,
+.orbit-dash-actions span {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 4px;
+  color: var(--sl-color-gray-3);
+  font-family: var(--sl-font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.04em;
+  padding: 0.12rem 0.35rem;
+  text-transform: uppercase;
+}
+
+.orbit-dash-filters .is-on,
+.orbit-dash-dock-head .is-on {
+  background: color-mix(in srgb, var(--orbit-dash-review) 16%, transparent);
+  border-color: color-mix(in srgb, var(--orbit-dash-review) 45%, var(--sl-color-hairline-light));
+  color: var(--orbit-dash-review);
+}
+
+.orbit-dash-row {
+  align-items: center;
+  border-top: 1px solid var(--sl-color-hairline-light);
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding: 0.55rem 0.75rem;
+}
+
+.orbit-dash-row.is-open {
+  background: color-mix(in srgb, var(--sl-color-accent) 8%, transparent);
+}
+
+.orbit-dash-id {
+  color: var(--sl-color-gray-4);
+  font-family: var(--sl-font-mono);
+  font-size: 0.62rem;
+}
+
+.orbit-dash-title {
+  color: var(--sl-color-text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orbit-dash-status {
+  border-left: 2px solid var(--orbit-dash-review);
+  color: var(--orbit-dash-review);
+  font-family: var(--sl-font-mono);
+  font-size: 0.62rem;
+  padding-left: 0.35rem;
+}
+
+.orbit-dash-detail {
+  border-top: 1px solid var(--sl-color-hairline-light);
+  padding: 0.65rem 0.75rem 0.8rem;
+}
+
+.orbit-dash-detail p {
+  color: var(--sl-color-gray-3);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  margin: 0 0 0.55rem;
+}
+
+.orbit-dash-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.orbit-dash-actions .is-primary {
+  background: color-mix(in srgb, var(--sl-color-accent) 16%, transparent);
+  border-color: var(--sl-color-accent);
   color: var(--sl-color-text-accent);
 }
 
-.orbit-terminal-head {
-  color: var(--sl-color-gray-4);
-}
-
-.orbit-terminal-gap {
-  flex: 0 0 auto;
-  height: 1.85em;
-}
-
-/* Names the transcript as illustrative. The commands above are real; the
-   identifiers and durations are placeholders, and saying so is the point. */
-.orbit-terminal-caption {
+.orbit-dash-caption {
   border-top: 1px solid var(--sl-color-hairline-light);
   color: var(--sl-color-gray-3);
   font-size: 0.75rem;
   line-height: 1.5;
   margin: 0;
   padding: 0.75rem 1.25rem;
+}
+
+.orbit-landing .orbit-walk-next {
+  color: var(--sl-color-gray-3);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: -0.5rem 0 0;
+}
+
+.orbit-walk-next a {
+  color: var(--sl-color-text-accent);
+  font-weight: 600;
+}
+
+.orbit-walk-next a:hover,
+.orbit-walk-next a:focus-visible {
+  text-decoration: underline;
 }
 
 .orbit-section-title {
@@ -529,7 +756,17 @@ body {
 .orbit-flow-tabs > *,
 .orbit-flow-panels > *,
 .orbit-flow-panel > *,
-.orbit-flow-facts > * {
+.orbit-flow-facts > *,
+.orbit-dash-frame > *,
+.orbit-dash-rail > *,
+.orbit-dash-main > *,
+.orbit-dash-body > *,
+.orbit-dash-panel > *,
+.orbit-dash-dock > *,
+.orbit-dash-row > *,
+.orbit-dash-detail > *,
+.orbit-dash-filters > *,
+.orbit-dash-actions > * {
   margin-top: 0;
 }
 
@@ -725,6 +962,7 @@ body {
   border-radius: 6px;
   color: var(--sl-color-text);
   display: block;
+  min-width: 0;
   padding: 1.25rem;
   position: relative;
   text-decoration: none;
@@ -793,10 +1031,6 @@ body {
    cell, breaking row alignment. Zero it out for our grid children. */
 .orbit-card-grid > * {
   margin-top: 0;
-}
-
-.orbit-card-grid-3 {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .orbit-card-grid-4 {
@@ -908,6 +1142,15 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .orbit-dash-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .orbit-dash-dock {
+    border-left: 0;
+    border-top: 1px solid var(--sl-color-hairline-light);
+  }
+
   .orbit-docs-index {
     gap: 1.25rem 2rem;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -948,10 +1191,39 @@ body {
   /* The hero has already stacked by here, but a tablet still has room for two
      cards per row; one column this early wastes half the viewport. */
   .orbit-card-grid,
-  .orbit-card-grid-3,
   .orbit-card-grid-4,
   .orbit-docs-index {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .orbit-dash-frame {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .orbit-dash-rail {
+    align-items: center;
+    border-right: 0;
+    border-bottom: 1px solid var(--sl-color-hairline-light);
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.7rem;
+    padding: 0.55rem 0.75rem;
+  }
+
+  .orbit-dash-brand {
+    margin: 0 0.5rem 0 0;
+  }
+
+  .orbit-dash-rail-group {
+    flex-direction: row;
+    gap: 0.35rem;
+    margin: 0;
+  }
+
+  .orbit-dash-rail-label,
+  .orbit-dash-rail-foot {
+    display: none;
   }
 
   .orbit-flow-panel,
@@ -983,7 +1255,6 @@ body {
    step above kept side by side. */
 @media (max-width: 34rem) {
   .orbit-card-grid,
-  .orbit-card-grid-3,
   .orbit-card-grid-4,
   .orbit-docs-index,
   .orbit-flow-tabs {
@@ -992,6 +1263,18 @@ body {
 
   .orbit-flow-tab {
     border-right: 0;
+  }
+
+  .orbit-dash-jump {
+    display: none;
+  }
+
+  .orbit-dash-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .orbit-dash-id {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Task

[ORB-11588](https://orbit-cli.com/tasks/ORB-11588) — Show a concrete product walkthrough before advanced website delivery modes

### Description

## Problem
The landing page introduces four delivery modes and detailed authorization semantics alongside an illustrative terminal transcript, but gives no visual dashboard preview. This is an editorial/product improvement opportunity rather than a proven functional regression.

## Scope
Rework the landing-page narrative around one understandable task-to-PR walkthrough and a representative dashboard preview, then progressively introduce advanced delivery choices. Preserve accurate review/merge/authorization distinctions and existing reference access. Use captured sanitized product evidence or clearly labeled illustrations, never invented measured outcomes or unsupported capability claims.

## Audit evidence and boundaries
Observed 2026-09-07 around 14:27 America/Los_Angeles in a fresh local Astro production build of website/ at revision 7f3a8f5fa, served at http://127.0.0.1:4321/. Desktop 1440x1000 and mobile 390x844 were exercised. This is local-source evidence, not proof of production parity. Build and Astro check passed, 29 generated HTML pages had no broken local links/anchors, and exercised browser flows logged no warnings/errors. Revalidate current sources at pickup and trace introducing changes before asserting regression lineage. Prepare a validated candidate; this task does not authorize deployment or release.

### Acceptance Criteria

- The primary landing-page path explains task creation, agent execution, inspected result and human review with a coherent example and obvious next action.
- A responsive dashboard preview demonstrates a meaningful current user workflow with accessible descriptive text and provenance/illustration labeling as appropriate.
- Advanced delivery modes remain reachable without dominating the introductory path, and their stopping/authorization semantics stay accurate.
- Browser-check desktop/mobile, both themes, links and delivery interactions; image assets are appropriately sized and npm run check/build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Reworked the homepage around one default task-to-PR walkthrough (create → ship → inspect → review) using the fsProfile example, with Install / First Task as the next action.
- Replaced the hero terminal with a labeled HTML/CSS illustration of the current operator Tasks view after that ship: task in `review`, PR open and unmerged, approve available, ship absent. Caption and `role="img"` mark it as an illustration with placeholder identifiers, not a screenshot or live host.
- Moved the four-mode delivery explorer after the walkthrough as "Other delivery modes". Stopping and `--complete` authorization facts are unchanged.
- Added the dashboard guide to the landing docs index. Updated DESIGN.md landing-page order. No new raster assets; the 6.8MB outdated GIF was not copied.
Assessment: Primary path now teaches the default PR loop before advanced delivery. Dashboard preview is theme-aware and responsive. Review vs merge vs `--complete` distinctions stay accurate.

Criteria:
- Walkthrough with coherent example and next action: met (4 cards + Next: install / first task).
- Responsive dashboard preview with accessible description and illustration labeling: met.
- Advanced modes reachable without dominating, semantics accurate: met.
- Browser-check desktop/mobile, both themes, links, delivery interactions; assets sized; npm check/build: met.

Validation:
- `npm run check` — passed (0 errors/warnings).
- `npm run build` — passed (30 pages).
- Playwright Chromium at 1440x1000 and 390x844, dark and light: passed. Walkthrough, illustration caption/ARIA, delivery-mode radio switching (including local merge-already-happened, auto window, sweep `--complete` never available), local landing links, inspect-card navigation to `/how-to/dashboard/`, no page errors. Mobile overflow (nowrap commands expanding grid items) found and fixed with `min-width: 0` on `.orbit-card`; rechecked at 390px.
- `git diff --check` — passed. Status: 3 modified files (`website/DESIGN.md`, `website/src/content/docs/index.md`, `website/src/styles/custom.css`). `website/public` unchanged.
- `make ci-fast` / `make ci-lint` — not run (website content/CSS only; task gate is npm check/build).

Remaining risks:
- Local Astro preview evidence, not production parity. This task does not authorize deploy/release.
- Dashboard chrome is an illustration of current UI and can drift from `crates/orbit-web` without a captured screenshot.
- Theme toggle is not visible in the mobile header; light theme was applied via `document.documentElement.dataset.theme`.
- `website/node_modules` and `website/dist/` were created for validation and are gitignored.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11588-6a9f3d19`
- Behind base: 0
- Ahead of base: 1