### PR TITLE
[code-review] Guard `redact_home_dir` against a root or very short `$HOME`

### DIFF
--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -22,7 +22,11 @@
 // Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
-use std::{borrow::Cow, sync::OnceLock};
+use std::{
+    borrow::Cow,
+    path::{Component, Path},
+    sync::OnceLock,
+};
 
 use regex::Regex;
 use serde_json::Value;
@@ -79,10 +83,31 @@ pub fn redact_sensitive_env_json(value: Value) -> Value {
 /// `rust/cleartext-logging`.
 pub fn redact_home_dir(text: &str) -> String {
     if let Some(home) = home_dir_string() {
-        text.replace(&home, "~")
+        redact_path_prefix(text, &home)
     } else {
         text.to_string()
     }
+}
+
+fn redact_path_prefix(text: &str, prefix: &str) -> String {
+    let mut redacted = String::with_capacity(text.len());
+    let mut remaining = text;
+
+    while let Some(index) = remaining.find(prefix) {
+        let (before_match, match_and_after) = remaining.split_at(index);
+        let after_match = &match_and_after[prefix.len()..];
+
+        redacted.push_str(before_match);
+        if after_match.is_empty() || after_match.starts_with('/') {
+            redacted.push('~');
+        } else {
+            redacted.push_str(prefix);
+        }
+        remaining = after_match;
+    }
+
+    redacted.push_str(remaining);
+    redacted
 }
 
 /// Apply env-value redaction to the message carried by any `OrbitError` variant.
@@ -497,7 +522,13 @@ fn home_dir_string() -> Option<String> {
     std::env::var("HOME")
         .ok()
         .or_else(|| std::env::var("USERPROFILE").ok())
-        .filter(|h| !h.is_empty())
+        .filter(|home| {
+            let path = Path::new(home);
+            path.is_absolute()
+                && path
+                    .components()
+                    .any(|component| matches!(component, Component::Normal(_)))
+        })
 }
 
 fn sensitive_env_values() -> Vec<String> {

--- a/crates/orbit-common/src/security/tests/redaction.rs
+++ b/crates/orbit-common/src/security/tests/redaction.rs
@@ -2,7 +2,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use super::super::redaction::{
     credential_safe_location, is_high_confidence_single_token_credential, is_redactable_value,
-    is_sensitive_env_name, redact_all, redact_sensitive_env_text,
+    is_sensitive_env_name, redact_all, redact_home_dir, redact_sensitive_env_text,
 };
 
 #[test]
@@ -122,6 +122,21 @@ fn redact_all_preserves_knowledge_record_identifiers_and_paths() {
     );
 
     assert_eq!(redact_all(legitimate), legitimate);
+}
+
+#[test]
+fn redact_home_dir_ignores_root_home() {
+    let _home = EnvVarGuard::set("HOME", "/");
+
+    assert_eq!(redact_home_dir("/tmp/x"), "/tmp/x");
+}
+
+#[test]
+fn redact_home_dir_matches_only_path_boundaries() {
+    let _home = EnvVarGuard::set("HOME", "/Users/a");
+
+    assert_eq!(redact_home_dir("/Users/ab/x"), "/Users/ab/x");
+    assert_eq!(redact_home_dir("/Users/a/x"), "~/x");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11677](https://orbit-cli.com/tasks/ORB-11677) — [code-review] Guard `redact_home_dir` against a root or very short `$HOME`

### Description

## Problem
`redact_home_dir` does `text.replace(&home, "~")` where `home_dir_string` only filters the empty string. With `HOME=/` (common for containers running as an unmapped uid, and for some CI runners), every `/` in every config/store path in error messages becomes `~`, e.g. `/workspace/.orbit/config.toml` renders as `~workspace~.orbit~config.toml`. The helper is used in 27 non-test call sites across orbit-config and orbit-common, all of which produce user-facing error text.

## Why It Matters
Error messages that name a file path become unreadable exactly in the environments where users most need them.

## Proposed Fix
Only substitute when `home` is an absolute path with at least one non-root component, and match on a path-boundary (`home` followed by `/` or end of string) rather than a bare substring.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-common/src/security/redaction.rs:80-86`, `crates/orbit-common/src/security/redaction.rs:496-501`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: foundation.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: with `HOME=/`, `redact_home_dir("/tmp/x")` returns `/tmp/x`.
- Test: with `HOME=/Users/a`, `redact_home_dir("/Users/ab/x")` returns `/Users/ab/x` and `redact_home_dir("/Users/a/x")` returns `~/x`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Restricted home-directory redaction to absolute paths containing a normal component, so root HOME values are ignored.
- Replaced substring substitution with boundary-aware matching: only an exact home path or one followed by / is redacted.
- Added regressions for HOME=/ and the /Users/a versus /Users/ab prefix collision.

Criteria:
- HOME=/ preserves /tmp/x: covered by redact_home_dir_ignores_root_home.
- HOME=/Users/a preserves /Users/ab/x and redacts /Users/a/x to ~/x: covered by redact_home_dir_matches_only_path_boundaries.

Validation:
- PASS cargo test -p orbit-common security::tests::redaction (16 tests passed).
- PASS make ci-fast.
- PASS make ci-lint.
- PASS git diff --check.

Assessment: Focused two-file fix with no added dependencies or compatibility layer.
Risks: Path-boundary behavior is validated on the Unix-style paths required by the task; platform-specific Windows path separators were not changed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11677-6a9f4001`
- Behind base: 0
- Ahead of base: 1