### PR TITLE
[code-review] Unlink dangling symlinks in `remove_path_if_exists` as its contract promises

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -237,11 +237,15 @@ pub fn create_dir_symlink(src: &Path, dst: &Path) -> io::Result<()> {
 /// Removes `path` if it exists, tolerating missing paths. Symlinks are
 /// unlinked without following; directories are removed recursively.
 pub fn remove_path_if_exists(path: &Path) -> io::Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-    let metadata = fs::symlink_metadata(path)?;
-    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(path)
+    } else if metadata.is_dir() {
         fs::remove_dir_all(path)
     } else {
         fs::remove_file(path)

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -3,7 +3,7 @@ use std::io;
 use tempfile::TempDir;
 
 use crate::OrbitError;
-use crate::fs::io::with_exclusive_file_lock;
+use crate::fs::io::{remove_path_if_exists, with_exclusive_file_lock};
 
 fn assert_sandbox_write_message(message: &str, path: &str) {
     assert!(
@@ -86,6 +86,40 @@ fn exclusive_lock_open_on_readonly_dir_names_path_and_hints_sandbox() {
         }
         other => panic!("expected Io, got {other}"),
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn remove_path_if_exists_unlinks_a_dangling_symlink() {
+    let temp = TempDir::new().expect("tempdir");
+    let link = temp.path().join("link");
+    std::os::unix::fs::symlink(temp.path().join("missing"), &link).expect("symlink");
+
+    remove_path_if_exists(&link).expect("remove dangling symlink");
+
+    let error = std::fs::symlink_metadata(&link).expect_err("link must be removed");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+}
+
+#[cfg(unix)]
+#[test]
+fn remove_path_if_exists_unlinks_a_directory_symlink_without_removing_its_target() {
+    let temp = TempDir::new().expect("tempdir");
+    let target = temp.path().join("target");
+    std::fs::create_dir(&target).expect("target directory");
+    let target_file = target.join("keep");
+    std::fs::write(&target_file, b"preserved").expect("target file");
+    let link = temp.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    remove_path_if_exists(&link).expect("remove directory symlink");
+
+    let error = std::fs::symlink_metadata(&link).expect_err("link must be removed");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert_eq!(
+        std::fs::read(target_file).expect("target preserved"),
+        b"preserved"
+    );
 }
 
 /// ORB-10988: nesting the same lock path on one thread must re-enter, not


### PR DESCRIPTION
## Task

[ORB-11676](https://orbit-cli.com/tasks/ORB-11676) — [code-review] Unlink dangling symlinks in `remove_path_if_exists` as its contract promises

### Description

## Problem
The doc says "Symlinks are unlinked without following", but the guard `if !path.exists()` (`io.rs:240`) follows symlinks, so a dangling symlink returns `Ok(())` without being removed; `symlink_metadata` is only consulted afterwards. Callers rely on the promised semantics: `orbit-core/src/bootstrap/init.rs:567` and `:580` call it on a non-directory `skills` link path under `--force` and then `fs::create_dir_all(skills_links_dir)`, which fails with EEXIST when the dangling link is still there, so `orbit init --force` cannot repair a workspace whose skills link target was deleted. `init.rs:486` similarly leaves dangling legacy skill links behind, which keeps `remove_empty_dir` from ever removing the legacy directory.

## Why It Matters
The helper is the shared "remove whatever is here" primitive; a silent no-op on the one symlink case that most needs cleanup produces confusing `File exists` failures in recovery paths.

## Proposed Fix
Replace the `exists()` guard with `match fs::symlink_metadata(path) { Err(NotFound) => Ok(()), Err(e) => Err(e), Ok(meta) => ... }` and branch on `meta.file_type().is_symlink()` before `is_dir()`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-common/src/fs/io.rs:237-249`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: foundation.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `fs/tests/io.rs`: create `link -> missing`, call `remove_path_if_exists(link)`, assert `symlink_metadata(link)` is `NotFound`.
- Existing behaviour for a symlink to a directory (unlinked, target untouched) stays covered.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `remove_path_if_exists` now obtains non-following metadata first, treats only `NotFound` as absent, removes symlinks before directory recursion, and continues removing regular files and directories through the existing paths.
- Added Unix regression tests for a dangling symlink and for a directory symlink whose target and contents remain intact.
Assessment: Small, canonical filesystem-boundary fix; no caller changes or new dependencies.
Criteria:
- Dangling `link -> missing` is removed and `symlink_metadata(link)` reports `NotFound`: satisfied by `remove_path_if_exists_unlinks_a_dangling_symlink`.
- Directory-symlink unlinking leaves the target untouched: satisfied by `remove_path_if_exists_unlinks_a_directory_symlink_without_removing_its_target`.
Validation:
- Passed: `cargo fmt --check` initially identified formatting, then `cargo fmt`; final formatting passed via `make ci-fast`.
- Passed: `cargo test -p orbit-common remove_path_if_exists` (2 passed).
- Passed: `make ci-fast`.
- Passed: `make ci-lint` (workspace all-target clippy with warnings denied).
- Passed: `git diff --check`.
- Passed: final `git status --short` shows only the two task-scoped files.
Risks: Symlink behavior tests are Unix-gated because their setup uses Unix symlink creation; the production helper retains its platform-neutral implementation and Windows-specific directory-symlink constructor unchanged.
Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11676-6a9f3f9d`
- Behind base: 0
- Ahead of base: 1