### PR TITLE
[code-review] Stop minute-truncating cron slots through `DateTime<Local>::with_second` (every cron routine errors for the whole DST fall-back hour)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2115,7 @@ name = "orbit-automation"
 version = "0.19.2"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "croner",
  "orbit-common",
  "orbit-store",
@@ -2509,6 +2520,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -3253,6 +3282,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ assert_cmd = "2"
 base64 = "0.22"
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 croner = "3"
 flate2 = "1"

--- a/crates/orbit-automation/Cargo.toml
+++ b/crates/orbit-automation/Cargo.toml
@@ -24,4 +24,5 @@ thiserror.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
+chrono-tz.workspace = true
 tempfile.workspace = true

--- a/crates/orbit-automation/src/routines/due.rs
+++ b/crates/orbit-automation/src/routines/due.rs
@@ -51,11 +51,14 @@ pub enum DueDecision<Tz: TimeZone> {
 /// Pin a scheduled occurrence to its minute (seconds and sub-seconds
 /// zeroed). Slot identity must be stable across sweeps for the idempotency
 /// key to hold.
-pub fn truncate_to_minute<Tz: TimeZone>(value: DateTime<Tz>) -> Result<DateTime<Tz>, OrbitError> {
-    value
-        .with_second(0)
-        .and_then(|value| value.with_nanosecond(0))
-        .ok_or_else(|| OrbitError::InvalidInput("timestamp cannot be minute-aligned".to_string()))
+pub fn truncate_to_minute<Tz: TimeZone>(value: DateTime<Tz>) -> DateTime<Tz> {
+    // DateTime's wall-clock setters re-resolve ambiguous local times and can
+    // fail during a DST fold. Subtracting the sub-minute duration preserves
+    // the instant and its offset, so every scheduled occurrence has a slot.
+    let seconds = i64::from(value.second());
+    let nanoseconds = i64::from(value.nanosecond());
+
+    value - Duration::seconds(seconds) - Duration::nanoseconds(nanoseconds)
 }
 
 /// Parse and validate a routine cron expression (standard 5-field form,
@@ -105,7 +108,7 @@ pub fn due_decision_with_grace<Tz: TimeZone>(
     // returns, which would make the slot different on every sweep within the
     // same minute — breaking the (name, slot) idempotency key. 5-field cron
     // is minute-granular by definition, so pin slots to the minute.
-    let previous = truncate_to_minute(previous)?;
+    let previous = truncate_to_minute(previous);
 
     if previous <= *lower_bound {
         return Ok(DueDecision::NotDue);

--- a/crates/orbit-automation/src/routines/tests/due.rs
+++ b/crates/orbit-automation/src/routines/tests/due.rs
@@ -1,8 +1,9 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use chrono_tz::Europe::Berlin;
 
 use super::super::due::{
     DueDecision, NATURAL_SLOT_GRACE_SECONDS, due_decision, due_decision_with_grace,
-    natural_slot_grace_for_cadence, parse_cron,
+    natural_slot_grace_for_cadence, parse_cron, truncate_to_minute,
 };
 use orbit_types::workflow::MissedRunPolicy;
 
@@ -202,6 +203,51 @@ fn slots_are_minute_aligned_regardless_of_sub_minute_now() {
             is_catch_up: false,
         }
     );
+}
+
+#[test]
+fn dst_fold_slots_are_distinct_and_due_decisions_do_not_error() {
+    let cron = parse_cron("30 2 * * *").expect("cron");
+    let earliest = Berlin
+        .with_ymd_and_hms(2025, 10, 26, 2, 30, 0)
+        .earliest()
+        .expect("DST fold has an earliest occurrence");
+    let latest = Berlin
+        .with_ymd_and_hms(2025, 10, 26, 2, 30, 0)
+        .latest()
+        .expect("DST fold has a latest occurrence");
+
+    let first_decision = due_decision_with_grace(
+        &cron,
+        MissedRunPolicy::Skip,
+        &(earliest - Duration::minutes(1)),
+        &(earliest + Duration::seconds(45)),
+        Duration::seconds(NATURAL_SLOT_GRACE_SECONDS),
+    )
+    .expect("first fold occurrence is due");
+    let second_decision = due_decision_with_grace(
+        &cron,
+        MissedRunPolicy::Skip,
+        &earliest,
+        &(latest + Duration::seconds(45)),
+        Duration::seconds(NATURAL_SLOT_GRACE_SECONDS),
+    )
+    .expect("second fold occurrence is evaluated");
+
+    assert_eq!(
+        first_decision,
+        DueDecision::Fire {
+            slot: earliest,
+            is_catch_up: false,
+        }
+    );
+    assert_eq!(second_decision, DueDecision::NotDue);
+
+    let earliest_slot = truncate_to_minute(earliest + Duration::seconds(45));
+    let latest_slot = truncate_to_minute(latest + Duration::seconds(45));
+    assert_eq!(earliest_slot, earliest);
+    assert_eq!(latest_slot, latest);
+    assert_ne!(earliest_slot, latest_slot);
 }
 
 #[test]

--- a/crates/orbit-core/src/application/routines/status.rs
+++ b/crates/orbit-core/src/application/routines/status.rs
@@ -162,7 +162,7 @@ pub fn routine_statuses_with_providers(
         let next_due = parse_cron(&routine.definition.trigger.cron)
             .ok()
             .and_then(|cron| cron.find_next_occurrence(&now, false).ok())
-            .and_then(|slot| truncate_to_minute(slot).ok())
+            .map(truncate_to_minute)
             .map(|slot| slot.to_rfc3339());
         let last_fire = store.routine_latest_fire(&routine.definition.name)?;
         let cursor = store.routine_cursor(&routine.definition.name)?;


### PR DESCRIPTION
## Task

[ORB-11725](https://orbit-cli.com/tasks/ORB-11725) — [code-review] Stop minute-truncating cron slots through `DateTime<Local>::with_second` (every cron routine errors for the whole DST fall-back hour)

### Description

## Problem
`due_decision_with_grace` computes the previous occurrence in host-local time and then pins it to the minute with `truncate_to_minute`, which calls `DateTime<Tz>::with_second(0)` / `with_nanosecond(0)`. In chrono 0.4.43 those go through `map_local`, which re-resolves the naive local time with `from_local_datetime(..).single()` and returns `None` whenever the local wall time is ambiguous (chrono-0.4.43/src/datetime/mod.rs:1008-1015, 1441). croner itself resolves the fold with `earliest()/latest()`, so during the repeated hour of the autumn DST transition every routine reaches `truncate_to_minute`, gets `None`, and `sweep_routine` returns `Err("timestamp cannot be minute-aligned")`, which `run_sweep_core_with_registry` (sweep.rs:233-242) turns into an `action: "error"` row. The same path is used for cron auto-tasks (`auto_tasks/schedule.rs:81-86`), so every cron auto-task is also `skipped: error:` for that hour. Under `missed_run: skip` (the default) the slots that fell in that hour are then never fired; under `catch_up_once` they collapse into one make-up fire. `docs/design/routines/2_design.md:364` records only "DST folds can skip or double a slot exactly as classic cron does", not a host-wide hour of errors.

## Why It Matters
Once a year, on every host in a DST timezone, all scheduled work silently stops for an hour and the sweep log fills with an unexplained error; `missed_run: skip` routines lose those slots permanently.

## Proposed Fix
Truncate on the instant rather than the local wall clock: `value.clone() - Duration::seconds(value.second() as i64) - Duration::nanoseconds(value.nanosecond() as i64)` (instant arithmetic never fails), or truncate the UTC projection and convert back. Delete the `Option`/error path from `truncate_to_minute` once it is infallible.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-automation/src/routines/due.rs:54-59`, `crates/orbit-automation/src/routines/due.rs:101-108`, `crates/orbit-automation/src/routines/tests/due.rs`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Add a test in `routines/tests/due.rs` using a fixed-offset-aware fold (e.g. `chrono_tz::Europe::Berlin` 2025-10-26 02:30 earliest and latest, or `Local` with `TZ` pinned) proving `due_decision_with_grace` returns `Fire`/`NotDue` (never `Err`) for `now` inside the repeated hour, and that the two occurrences of 02:30 produce distinct slots.
- `truncate_to_minute` has no `None`/`Err` branch left, and the `"timestamp cannot be minute-aligned"` string is gone from the crate.
- `cargo test -p orbit-automation` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Made routine minute truncation infallible by subtracting sub-minute duration from the instant, preserving the resolved offset through DST folds.
- Added a Berlin 2025-10-26 fold regression test that evaluates both occurrences without errors and verifies their minute slots are distinct.
- Added chrono-tz as an automation test dependency and updated the core routine-status projection for truncate_to_minute’s infallible API.

Criteria:
- DST-fold test: satisfied; the fixed-offset-aware test covers earliest and latest 02:30 and observes Fire/NotDue without Err.
- Infallible truncation: satisfied; truncate_to_minute returns DateTime directly and the old timestamp error string is absent.
- Package tests: satisfied.

Validation:
- Passed: CARGO_HOME=/tmp/orb-11725-cargo-home CARGO_TARGET_DIR=/tmp/orb-11725-cargo-target cargo test -p orbit-automation (78 tests).
- Passed: CARGO_HOME=/tmp/orb-11725-cargo-home CARGO_TARGET_DIR=/tmp/orb-11725-cargo-target make ci-fast.
- Passed: CARGO_HOME=/tmp/orb-11725-cargo-home CARGO_TARGET_DIR=/tmp/orb-11725-cargo-target make ci-lint. The first lint run exposed the core status projection still calling .ok() on truncate_to_minute; that direct consumer was added to context and corrected before the passing rerun.
- Passed: git diff --check.

Assessment: Scoped change is complete. No remaining risks or deviations; build artifacts were kept outside the worktree.

Friction checkpoint: no qualifying friction observed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11725-6a9f423a`
- Behind base: 0
- Ahead of base: 1