### PR TITLE
[code-review] Enforce denyModify for exact/subtree paths that do not exist at spawn time (linux-bwrap)

### DIFF
--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -50,10 +50,11 @@ pub struct LinuxBwrapSpawnRequest<'a> {
     pub stderr: Stdio,
 }
 
-/// Snapshot guard for Bubblewrap's one known write-policy gap: a
-/// non-subtree deny glob cannot be represented for a path that does not exist
-/// yet. Managed worktrees are disposable and single-writer, so Orbit records
-/// existing matches before spawn and rejects any new matches after the child.
+/// Snapshot guard for write-policy gaps Bubblewrap cannot represent as a
+/// mount at spawn time: a non-subtree deny glob, and an exact or subtree
+/// deny whose root does not exist yet. Managed worktrees are disposable and
+/// single-writer, so Orbit records existing matches before spawn and rejects
+/// any new matches after the child.
 #[derive(Debug, Clone)]
 pub struct LinuxBwrapPostRunGuard {
     rules: Vec<String>,
@@ -62,7 +63,7 @@ pub struct LinuxBwrapPostRunGuard {
 
 impl LinuxBwrapPostRunGuard {
     pub fn capture(profile: &ResolvedFsProfile) -> Result<Option<Self>, OrbitError> {
-        let rules = non_subtree_denies(profile);
+        let rules = post_run_deny_rules(profile);
         if rules.is_empty() {
             return Ok(None);
         }
@@ -781,14 +782,46 @@ fn overlaps_writable_root(rule: &str, roots: &[PathBuf]) -> bool {
         .any(|root| root.starts_with(&prefix) || prefix.starts_with(root))
 }
 
-fn non_subtree_denies(profile: &ResolvedFsProfile) -> Vec<String> {
+/// Deny rules that have nothing to `--ro-bind` at spawn: non-subtree globs,
+/// and exact/subtree denies whose root is still absent.
+///
+/// An absent exact/subtree deny with a later nested re-allow is omitted.
+/// Grant preparation materializes that re-allow (creating the deny root) so
+/// `--ro-bind` can apply; watching the root would false-positive on that
+/// pre-spawn create. The orchestrator snapshots this guard before spawn
+/// preparation, so the skip is what keeps default `.orbit/**` plus
+/// `.orbit/auto_tasks/**` from failing on a fresh worktree.
+fn post_run_deny_rules(profile: &ResolvedFsProfile) -> Vec<String> {
     profile
         .modify
         .iter()
-        .filter_map(|rule| rule.strip_prefix('!'))
-        .filter(|rule| !is_exact_or_subtree(rule))
-        .map(str::to_string)
+        .enumerate()
+        .filter_map(|(index, rule)| {
+            let denied = rule.strip_prefix('!')?;
+            if is_exact_or_subtree(denied) {
+                let root = denied.strip_suffix("/**").unwrap_or(denied);
+                if Path::new(root).exists() || deny_has_nested_reallow(&profile.modify, index) {
+                    return None;
+                }
+            }
+            Some(denied.to_string())
+        })
         .collect()
+}
+
+fn deny_has_nested_reallow(modify: &[String], deny_index: usize) -> bool {
+    let Some(denied_root) = modify
+        .get(deny_index)
+        .and_then(|rule| rule.strip_prefix('!'))
+        .and_then(exact_or_subtree_root)
+    else {
+        return false;
+    };
+    modify.iter().skip(deny_index + 1).any(|rule| {
+        !rule.starts_with('!')
+            && exact_or_subtree_root(rule)
+                .is_some_and(|root| root != denied_root && root.starts_with(&denied_root))
+    })
 }
 
 /// Every existing path matched by any of `rules`.

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::PathBuf;
 
-use super::{expand_rule, expand_rules, walk_paths};
+use super::{LinuxBwrapPostRunGuard, expand_rule, expand_rules, walk_paths};
+use orbit_common::OrbitError;
+use orbit_types::policy::ResolvedFsProfile;
 
 fn tree() -> tempfile::TempDir {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -77,4 +79,61 @@ fn walk_lists_every_path_once() {
     // 1 root + 4 dirs (a, a/deep, b, target, target/debug = 5) + 6 files.
     assert_eq!(paths.len(), 1 + 5 + 6);
     assert_eq!(paths[0], root);
+}
+
+fn profile(modify: Vec<String>) -> ResolvedFsProfile {
+    ResolvedFsProfile {
+        name: "test".to_string(),
+        read: vec!["/**".to_string()],
+        modify,
+    }
+}
+
+#[test]
+fn capture_watches_absent_exact_and_subtree_denies() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let secrets = workspace.join("secrets");
+    let lock = workspace.join("Cargo.lock");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**", secrets.display()),
+        format!("!{}", lock.display()),
+    ]);
+
+    let guard = LinuxBwrapPostRunGuard::capture(&resolved)
+        .expect("capture")
+        .expect("absent exact/subtree denies must be guarded");
+    fs::create_dir_all(&secrets).expect("create secrets");
+    fs::write(secrets.join("x"), b"k").expect("write secret");
+    fs::write(&lock, b"k").expect("write lock");
+
+    let error = guard
+        .verify()
+        .expect_err("creating an absent deny root must fail closed");
+    assert!(
+        matches!(error, OrbitError::PolicyDenied(_)),
+        "expected PolicyDenied, got {error}"
+    );
+}
+
+#[test]
+fn capture_skips_absent_deny_whose_nested_reallow_will_create_the_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace");
+    let orbit = workspace.join(".orbit");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**", orbit.display()),
+        format!("{}/**", orbit.join("auto_tasks").display()),
+    ]);
+
+    assert!(
+        LinuxBwrapPostRunGuard::capture(&resolved)
+            .expect("capture")
+            .is_none(),
+        "grant preparation will create .orbit, so watching it would false-positive"
+    );
 }

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -5,6 +5,7 @@
 
 use std::process::Stdio;
 
+use orbit_common::OrbitError;
 use orbit_exec::{
     LINUX_STABLE_BUILD_MOUNT, LINUX_STABLE_WORKSPACE_MOUNT, LinuxBwrapPostRunGuard,
     LinuxBwrapSpawnRequest, WriteAnchorKind, bwrap_path, bwrap_program_for_audit,
@@ -655,6 +656,108 @@ fn managed_worktree_guard_rejects_new_forbidden_match() {
     std::fs::write(workspace.join("new.env"), "secret").expect("write forbidden fixture");
     let error = guard.verify().expect_err("new forbidden match rejected");
     assert!(error.to_string().contains("before commit"));
+}
+
+#[test]
+fn absent_subtree_deny_is_enforced_when_child_creates_the_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let created = workspace.join("secrets/x");
+    assert!(!workspace.join("secrets").exists());
+    assert_absent_deny_enforced(
+        &workspace,
+        vec![
+            format!("{}/**", workspace.display()),
+            format!("!{}/secrets/**", workspace.display()),
+        ],
+        "mkdir -p secrets && touch secrets/x",
+        &created,
+    );
+}
+
+#[test]
+fn absent_exact_file_deny_is_enforced_when_child_creates_the_file() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    let created = workspace.join("Cargo.lock");
+    assert!(!created.exists());
+    assert_absent_deny_enforced(
+        &workspace,
+        vec![
+            format!("{}/**", workspace.display()),
+            format!("!{}", created.display()),
+        ],
+        "touch Cargo.lock",
+        &created,
+    );
+}
+
+fn assert_absent_deny_enforced(
+    workspace: &std::path::Path,
+    modify: Vec<String>,
+    script: &str,
+    created: &std::path::Path,
+) {
+    let resolved = profile(modify);
+    let guard = LinuxBwrapPostRunGuard::capture(&resolved).expect("capture");
+
+    let probe = probe_bwrap();
+    if probe.available {
+        let plan = compile_linux_bwrap_argv(
+            &resolved,
+            "/bin/sh",
+            &["-c".to_string(), script.to_string()],
+            Some(workspace),
+            true,
+        )
+        .expect("compile");
+        let mut child = spawn_under_linux_bwrap(LinuxBwrapSpawnRequest {
+            plan: &plan,
+            env: &[],
+            cwd: Some(workspace),
+            stdin: Stdio::null(),
+            stdout: Stdio::null(),
+            stderr: Stdio::null(),
+        })
+        .expect("spawn");
+        let _ = child.wait().expect("wait");
+    } else {
+        println!(
+            "bwrap unavailable ({}); applying the child script on the host",
+            probe.detail
+        );
+        let status = std::process::Command::new("/bin/sh")
+            .args(["-c", script])
+            .current_dir(workspace)
+            .status()
+            .expect("host script");
+        assert!(status.success(), "host script failed: {status}");
+    }
+
+    let write_blocked = !created.exists();
+    match guard {
+        Some(guard) => match guard.verify() {
+            Ok(()) => assert!(
+                write_blocked,
+                "child created {} and the post-run guard accepted it",
+                created.display()
+            ),
+            Err(OrbitError::PolicyDenied(message)) => {
+                assert!(
+                    message.contains("before commit"),
+                    "PolicyDenied must name the post-run check: {message}"
+                );
+            }
+            Err(other) => panic!("expected PolicyDenied, got {other}"),
+        },
+        None => assert!(
+            write_blocked,
+            "no post-run guard and the child created {}",
+            created.display()
+        ),
+    }
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Task

[ORB-11693](https://orbit-cli.com/tasks/ORB-11693) — [code-review] Enforce denyModify for exact/subtree paths that do not exist at spawn time (linux-bwrap)

### Description

## Problem
A negated `modify` rule is materialised as `--ro-bind path path` only when its root exists: `mount_paths_for_rule(denied, false)` returns an empty vector for an exact or `<root>/**` rule whose root is absent (`linux_sandbox.rs:742-744`), so nothing is mounted and the deny is silently dropped. The `LinuxBwrapPostRunGuard` that is supposed to close the "path does not exist yet" gap only captures `non_subtree_denies` (`linux_sandbox.rs:784-792`), i.e. rules containing `*`/`?` before the trailing `/**`, so an absent exact/subtree deny has no post-run check either. Scenario: effective profile `modify = ["<ws>/**", "!<ws>/secrets/**"]` on a fresh worktree where `secrets/` was never created; the confined agent runs `mkdir secrets && echo k > secrets/token` and the write succeeds, and the run commits it. The same applies to an absent exact-file deny such as `!<ws>/Cargo.lock`.

## Why It Matters
`denyModify` is the operator's hard write boundary; the shipped macOS profile denies these paths via SBPL regardless of existence, so Linux is weaker than documented, and the module comment claims the non-subtree case is the "one known write-policy gap".

## Proposed Fix
In `LinuxBwrapPostRunGuard::capture`, also record every exact/subtree deny whose root is absent and fail `verify()` if the root exists afterwards; or, for managed worktrees, materialise the absent deny root (empty dir / empty file) before spawn so the `--ro-bind` can be applied, mirroring `prepare_linux_bwrap_write_grants`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-exec/src/linux_sandbox.rs:577-589`, `crates/orbit-exec/src/linux_sandbox.rs:739-747`, `crates/orbit-exec/src/linux_sandbox.rs:784-792`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (security). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- New test in `crates/orbit-exec/tests/linux_sandbox.rs`: profile with `!<ws>/secrets/**` and no `secrets/` dir; after the child runs `mkdir -p secrets && touch secrets/x`, either the write fails inside the sandbox or `guard.verify()` returns `PolicyDenied`.
- Same for an absent exact-file deny.
- Module doc comment at `linux_sandbox.rs:53-56` updated to describe the actual guarded set.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `LinuxBwrapPostRunGuard::capture` now watches every deny Bubblewrap cannot `--ro-bind` at spawn: existing non-subtree globs plus exact/subtree denies whose root is still absent.
- Absent exact/subtree denies with a later nested re-allow are omitted, because grant preparation creates that root before the child starts and `--ro-bind` then applies. Without the skip, default `.orbit/**` plus `.orbit/auto_tasks/**` would false-positive on a fresh worktree (orchestrator snapshots the guard *before* spawn preparation).
- Did not materialize empty deny roots. That mutates the worktree (empty `Cargo.lock` / `secrets/`) and has already caused a committed zero-byte grant-anchor incident.
- Guard doc comment now describes the actual guarded set (non-subtree globs and absent exact/subtree roots), not "one known" non-subtree gap.
- Integration tests in `crates/orbit-exec/tests/linux_sandbox.rs`: `!<ws>/secrets/**` with child `mkdir -p secrets && touch secrets/x`; absent `!<ws>/Cargo.lock` with child `touch Cargo.lock`. Either the created path is absent or `verify()` returns `PolicyDenied`.
- Unit tests in `crates/orbit-exec/src/tests/linux_sandbox.rs` lock capture of absent exact/subtree denies and the nested-reallow skip.
- Added `file:crates/orbit-exec/tests/linux_sandbox.rs` and `file:crates/orbit-exec/src/tests/linux_sandbox.rs` to context_files because those tests were required or needed to lock the nested-reallow skip.
Assessment: The post-run guard is the existing "path does not exist yet" seam; extending it is one canonical path and matches macOS in outcome (deny holds even when the path is absent at spawn) without leaving empty files in the worktree.
Strategic decisions: Post-run guard over pre-spawn empty-root materialization. Nested-reallow skip rather than moving capture into spawn (that would thread a guard through `SpawnedChild` / supervisor / orchestrator, outside the intended boundary).
Design weaknesses / risks:
- Severity: medium. Mitigation: documented skip. Guard capture still happens before grant preparation; an operator deny of absent `target/**` could false-positive because `compile_linux_bwrap_argv` creates `target/` for stable mounts. Default policy does not deny `target`.
- Severity: low. This runner could not create bwrap user namespaces (`bwrap: No permissions to create new namespace`). Kernel `--ro-bind` of these denies was not exercised. The new tests ran the child script on the host and asserted `PolicyDenied` from `verify()`. Existing kernel tests in the same file skip under the same probe failure.
Deviations from original plan:
- Nested-reallow skip (Justification: otherwise default-profile managed runs fail closed on a missing `.orbit` at capture time).
- Did not split `linux_sandbox.rs` (~960 lines) or the integration test file (~930 lines); both were already over the ~800-line warning, and splitting would be unrelated restructuring. Tests had to land in the AC-named file.
Recommended follow-ups: Capture the guard after grant preparation and argv compile so the nested-reallow skip (and the `target/` edge) are unnecessary.

Criteria:
- `!<ws>/secrets/**` with no `secrets/` dir, child `mkdir -p secrets && touch secrets/x`, write fails or `PolicyDenied`: met (`absent_subtree_deny_is_enforced_when_child_creates_the_root`; this runner: host script + `PolicyDenied`).
- Same for an absent exact-file deny: met (`absent_exact_file_deny_is_enforced_when_child_creates_the_file` using `Cargo.lock`).
- Module doc at the guard updated to the actual guarded set: met.

Validation:
- `cargo test -p orbit-exec --lib linux_sandbox` (CARGO_TARGET_DIR=/tmp/orbit-orb-11693-target): passed (4 tests, including the two new unit tests).
- `cargo test -p orbit-exec --test linux_sandbox`: passed (20 tests). bwrap probe failed (no user namespaces); kernel spawn tests skipped as before; new tests used the host-script fallback and got `PolicyDenied`.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.
- Full `make ci`: not run (workspace policy: merge gate on PR, not per task).

`git status --short`: `crates/orbit-exec/src/linux_sandbox.rs`, `crates/orbit-exec/src/tests/linux_sandbox.rs`, `crates/orbit-exec/tests/linux_sandbox.rs`. Cargo outputs stayed in `/tmp/orbit-orb-11693-target`. Changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11693-6a9f410c`
- Behind base: 0
- Ahead of base: 1