### PR TITLE
Restore navigation and theme access on the mobile website homepage

### DIFF
--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -28,9 +28,10 @@ The Orbit website is a **documentation site**, not a marketing site. It exists t
 1. **Reference-heavy, search-first.** Users land via `⌘K` or Google. Every page must be findable and self-contained.
 2. **Minimalism as a feature.** Restraint is the aesthetic. One accent color, one type family per role, no decorative motion in docs content.
 3. **Legibility over personality.** The orbit metaphor shows up structurally (logo, section glyphs) — never at the cost of reading comfort.
-4. **Static and fast.** Zero JS by default; the homepage's copy controls are the one
-   scripted exception, and every other interaction is CSS. Hundreds of pages should
-   feel identical in performance to ten.
+4. **Static and fast.** Zero JS by default. The homepage's copy controls and its
+   narrow-viewport Menu (Escape and breakpoint close) are the scripted exceptions;
+   every other interaction is CSS. Hundreds of pages should feel identical in
+   performance to ten.
 5. **Dark-default, light-available.** Theme toggle persists per user; neither mode is an afterthought.
 
 ---
@@ -86,7 +87,9 @@ Three-column, fixed:
 - Left nav: collapsible sections. Active page marked with a 2px accent bar on the left edge.
 - Content column: max-width ~720px, measure 65–75ch for prose.
 - Right rail: sticky "On this page" TOC. Muted until the corresponding section is in view.
-- Top bar: logo, search, theme toggle. Nothing else.
+- Top bar: logo, section links (from 50rem), search, theme toggle. Below 50rem the
+  splash header keeps search and exposes section links plus theme through a Menu
+  disclosure; documentation pages keep Starlight's sidebar Menu.
 
 ### 3.5 Landing page
 
@@ -129,9 +132,10 @@ Commands shown on this page must match current CLI behaviour, and illustrative
 output must say that it is illustrative. The page advertises no unlanded feature
 and publishes no live metric.
 
-The only script on the site is a small inline handler for the copy controls.
-Those buttons are served `hidden` and unhidden by that script, so a page without
-JavaScript shows the command text and no dead control; a clipboard that is
+Scripts are limited to the copy controls and the homepage Menu's Escape /
+breakpoint close. Copy buttons are served `hidden` and unhidden by that script,
+so a page without JavaScript shows the command text and no dead control; a
+clipboard that is
 unavailable or refuses the write reports failure rather than a false success.
 
 Other pages keep Starlight's default chrome (auto title, sidebar, TOC) unchanged.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
       },
       customCss: ['./src/styles/custom.css'],
       components: {
+        Header: './src/components/Header.astro',
         SiteTitle: './src/components/SiteTitle.astro',
         ThemeProvider: './src/components/ThemeProvider.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -1,0 +1,10 @@
+---
+import Default from '@astrojs/starlight/components/Header.astro';
+import HomeMenu from './HomeMenu.astro';
+
+const { hasSidebar } = Astro.locals.starlightRoute;
+---
+
+<Default />
+{/* Splash pages omit Starlight's sidebar Menu; this is the homepage replacement. */}
+{!hasSidebar && <HomeMenu />}

--- a/website/src/components/HomeMenu.astro
+++ b/website/src/components/HomeMenu.astro
@@ -1,0 +1,182 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+import ThemeSelect from './ThemeSelect.astro';
+
+const links = [
+  { href: '/getting-started/', label: 'Getting started' },
+  { href: '/concepts/', label: 'Concepts' },
+  { href: '/how-to/', label: 'How-to guides' },
+  { href: '/reference/', label: 'Reference' },
+];
+
+const pathname = Astro.url.pathname;
+const menuLabel = Astro.locals.t('menuButton.accessibleLabel');
+
+// Splash pages have no Starlight sidebar, so they never get MobileMenuToggle.
+// This disclosure is the homepage stand-in: native open/close, no focus trap.
+---
+
+<details class="orbit-home-menu print:hidden">
+  <summary
+    class="orbit-home-menu-toggle"
+    aria-expanded="false"
+    aria-controls="orbit-home-menu-panel"
+    aria-label={menuLabel}
+  >
+    <Icon name="bars" class="open-menu" />
+    <Icon name="close" class="close-menu" />
+  </summary>
+  <div id="orbit-home-menu-panel" class="orbit-home-menu-panel">
+    <nav class="orbit-home-menu-nav" aria-label="Documentation sections">
+      {
+        links.map(({ href, label }) => (
+          <a href={href} aria-current={pathname.startsWith(href) ? 'true' : undefined}>
+            {label}
+          </a>
+        ))
+      }
+    </nav>
+    <div class="orbit-home-menu-theme">
+      <ThemeSelect />
+    </div>
+  </div>
+</details>
+
+<style>
+  .orbit-home-menu-toggle {
+    align-items: center;
+    background-color: var(--sl-color-white);
+    border: 0;
+    border-radius: 50%;
+    box-shadow: var(--sl-shadow-md);
+    color: var(--sl-color-black);
+    cursor: pointer;
+    display: flex;
+    height: var(--sl-menu-button-size);
+    inset-inline-end: var(--sl-nav-pad-x);
+    justify-content: center;
+    list-style: none;
+    padding: 0.5rem;
+    position: fixed;
+    top: calc((var(--sl-nav-height) - var(--sl-menu-button-size)) / 2);
+    width: var(--sl-menu-button-size);
+    z-index: var(--sl-z-index-navbar);
+  }
+
+  .orbit-home-menu-toggle::-webkit-details-marker,
+  .orbit-home-menu-toggle::marker {
+    display: none;
+  }
+
+  .orbit-home-menu-toggle:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+
+  .orbit-home-menu[open] .orbit-home-menu-toggle {
+    background-color: var(--sl-color-gray-2);
+    box-shadow: none;
+  }
+
+  .orbit-home-menu[open] .open-menu,
+  .orbit-home-menu:not([open]) .close-menu {
+    display: none;
+  }
+
+  :global([data-theme='light']) .orbit-home-menu-toggle {
+    background-color: var(--sl-color-black);
+    color: var(--sl-color-white);
+  }
+
+  :global([data-theme='light']) .orbit-home-menu[open] .orbit-home-menu-toggle {
+    background-color: var(--sl-color-gray-5);
+  }
+
+  .orbit-home-menu-panel {
+    background-color: var(--sl-color-bg-nav);
+    border-bottom: 1px solid var(--sl-color-hairline);
+    inset-inline: 0;
+    max-height: calc(100dvh - var(--sl-nav-height));
+    overflow: auto;
+    padding: 0.75rem var(--sl-nav-pad-x) 1rem;
+    position: fixed;
+    top: var(--sl-nav-height);
+    z-index: var(--sl-z-index-menu);
+  }
+
+  .orbit-home-menu-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .orbit-home-menu-nav a {
+    border-radius: 6px;
+    color: var(--sl-color-gray-2);
+    font-size: 0.95rem;
+    min-height: 2.75rem;
+    padding: 0.65rem 0.5rem;
+    text-decoration: none;
+  }
+
+  .orbit-home-menu-nav a:hover,
+  .orbit-home-menu-nav a:focus-visible,
+  .orbit-home-menu-nav a[aria-current='true'] {
+    color: var(--sl-color-text-accent);
+  }
+
+  .orbit-home-menu-nav a:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+
+  .orbit-home-menu-theme {
+    align-items: center;
+    border-top: 1px solid var(--sl-color-hairline);
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+    padding-top: 0.75rem;
+  }
+
+  @media (min-width: 50rem) {
+    .orbit-home-menu {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  const desktopNav = matchMedia('(min-width: 50rem)');
+
+  const closeMenu = (menu: HTMLDetailsElement, restoreFocus: boolean) => {
+    if (!menu.open) return;
+    menu.open = false;
+    if (restoreFocus) {
+      menu.querySelector('summary')?.focus();
+    }
+  };
+
+  const syncExpanded = (menu: HTMLDetailsElement) => {
+    menu.querySelector('summary')?.setAttribute('aria-expanded', String(menu.open));
+  };
+
+  for (const menu of document.querySelectorAll<HTMLDetailsElement>('.orbit-home-menu')) {
+    syncExpanded(menu);
+    menu.addEventListener('toggle', () => syncExpanded(menu));
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') closeMenu(menu, true);
+    });
+
+    document.addEventListener('pointerdown', (event) => {
+      const target = event.target;
+      if (!(target instanceof Node) || menu.contains(target)) return;
+      closeMenu(menu, false);
+    });
+
+    desktopNav.addEventListener('change', () => {
+      if (desktopNav.matches) closeMenu(menu, false);
+    });
+  }
+</script>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -182,7 +182,7 @@ body {
    src/components/SiteTitle.astro. */
 .orbit-topnav {
   align-items: center;
-  display: flex;
+  display: none;
   gap: 1.5rem;
   white-space: nowrap;
 }
@@ -206,9 +206,31 @@ body {
   overflow: visible;
 }
 
-@media (max-width: 72rem) {
+/* Reserve space for the splash Menu button (same inset as Starlight's
+   sidebar toggle). Docs already get this from `[data-has-sidebar]`. */
+html:not([data-has-sidebar]) header.header {
+  overflow: visible;
+  padding-inline-end: calc(
+    var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+  );
+}
+
+/* Match Starlight's `md` breakpoint: below 50rem the splash page uses
+   HomeMenu instead of the inline section links. Documentation pages keep
+   Starlight's sidebar Menu. */
+@media (min-width: 50rem) {
   .orbit-topnav {
-    display: none;
+    display: flex;
+  }
+
+  html:not([data-has-sidebar]) header.header {
+    padding-inline-end: var(--sl-nav-pad-x);
+  }
+}
+
+@media (min-width: 50rem) and (max-width: 72rem) {
+  .orbit-topnav {
+    gap: 1rem;
   }
 }
 


### PR DESCRIPTION
## Task

[ORB-11585](https://orbit-cli.com/tasks/ORB-11585) — Restore navigation and theme access on the mobile website homepage

### Description

## Problem
At 390px the homepage header exposes only Orbit and Search. Desktop documentation-section navigation and the theme control disappear with no menu replacement. Documentation pages do have a working Menu containing navigation and theme switching, creating an inconsistent entry experience.

## Scope
Use the existing website/Starlight navigation seam to provide accessible mobile navigation and theme access on the landing page as well as docs. Preserve search and desktop layout.

## Audit evidence and boundaries
Observed 2026-09-07 around 14:27 America/Los_Angeles in a fresh local Astro production build of website/ at revision 7f3a8f5fa, served at http://127.0.0.1:4321/. Desktop 1440x1000 and mobile 390x844 were exercised. This is local-source evidence, not proof of production parity. Build and Astro check passed, 29 generated HTML pages had no broken local links/anchors, and exercised browser flows logged no warnings/errors. Revalidate current sources at pickup and trace introducing changes before asserting regression lineage. Prepare a validated candidate; this task does not authorize deployment or release.

### Acceptance Criteria

- At 390px and an intermediate narrow width, homepage users can reach Getting Started, Concepts, How-to and Reference and change theme through visible discoverable controls.
- Menu open/close, keyboard activation, Escape and focus behavior are usable; expanded state is exposed accessibly and navigation does not trap focus.
- The homepage and docs remain free of page-wide horizontal overflow and header overlap at 390, 768 and 1440px.
- Browser-check navigation, search and theme persistence across homepage/doc transitions; npm run check and npm run build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added splash-only `HomeMenu.astro` (details/summary Menu) with Getting started, Concepts, How-to guides, Reference, and the existing ThemeSelect. Native open/close, `aria-expanded`/`aria-controls`, Escape closes and restores focus, no focus trap.
- Wrapped Starlight Header so splash pages (`!hasSidebar`) render HomeMenu; docs keep Starlight's sidebar Menu.
- Registered the Header override in `website/astro.config.mjs`.
- CSS: inline `.orbit-topnav` from Starlight's 50rem `md` breakpoint (was 72rem); splash header reserves Menu-button padding below 50rem.
- Updated `website/DESIGN.md` so the top bar and script exceptions match live chrome.
Assessment: Homepage at 390px and 768px now has the same discoverable Menu pattern as docs. Desktop 1440px still shows inline section links, search, and theme. Search is preserved.
Strategic decisions: Did not force `hasSidebar` on splash (that would indent the landing page). Reused the Header wrap-Default seam already used by SiteTitle/Footer. Used a disclosure (`details`) rather than Starlight's inert focus trap so Tab can leave the menu.
Deviations from original plan: Menu is a native `details`/`summary` with `aria-expanded` kept in sync, not a custom element button. Same accessible expanded state, plus open/close without JS.

Criteria:
1. 390px and 768px homepage: Menu visible with the four section links and theme toggle — passed (Playwright).
2. Open/close, keyboard (Enter), Escape + focus restore, `aria-expanded`, Tab leaves the menu — passed (Playwright).
3. No page-wide overflow or header/control overlap at 390, 768, 1440 on `/` and `/getting-started/` — passed (Playwright). Hero stays below the header.
4. Search finds Install Orbit; theme persists homepage → Getting Started; `npm run check` 0 errors; `npm run build` 30 pages — passed.

Validation:
- `npm --prefix website run check` — passed (0 errors, 0 warnings).
- `npm --prefix website run build` — passed (30 pages, Pagefind indexed).
- Playwright Chromium against local `astro preview` at http://127.0.0.1:4321/ — passed at 390×844, 768×844, 1440×1000 (nav, search, theme, overflow, overlap, a11y).
- `git diff --check` — passed.
- Production / orbit-cli.com — not run (task does not authorize deployment).

Remaining risk: Evidence is a local production build of this worktree, not production parity. Without JS the Menu still opens as native `details`; Escape/breakpoint close require the script. `website/node_modules` was created for validation and is gitignored.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11585-6a9f4228`
- Behind base: 0
- Ahead of base: 1