### PR TITLE
[code-review] Add a deadline to companion RPC reads and to `SubprocessEmbedder::drop`

### DIFF
--- a/crates/orbit-search/src/subprocess.rs
+++ b/crates/orbit-search/src/subprocess.rs
@@ -1,22 +1,27 @@
 //! `Embedder` implementation that talks to the installed companion binary
 //! over JSON-Lines stdio. The subprocess is kept alive across requests via
-//! a `Mutex<ChildIo>`; `Drop` sends `Exit` and reaps the child.
+//! a `Mutex<ChildIo>`; a dedicated reader thread feeds stdout into a
+//! channel so each RPC waits with a payload-scaled deadline. `Drop` sends
+//! `Exit`, closes stdin, and reaps the child within a bounded wait
+//! (killing the process group if it ignores `exit`).
 //!
 //! ## Retry hygiene (ORB-10006)
 //!
 //! Transport-level failures — spawn resource exhaustion, a crashed/exited
-//! companion (EOF), broken pipes — are transient: the request is retried a
-//! bounded number of times with exponential backoff + full jitter,
-//! respawning the companion between attempts. Companion-reported RPC errors
-//! and protocol violations are permanent and surface immediately.
+//! companion (EOF), broken pipes, a wedged companion that misses its read
+//! deadline — are transient: the request is retried a bounded number of
+//! times with exponential backoff + full jitter, respawning the companion
+//! between attempts. Companion-reported RPC errors and protocol violations
+//! are permanent and surface immediately.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread;
-use std::time::Duration;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
 use orbit_common::process::jitter::JitterRng;
@@ -26,11 +31,21 @@ use crate::embedder::{DEFAULT_MODEL, Embedder};
 use crate::rpc::{RpcRequest, RpcResponse, RpcResult, rpc_error_to_orbit};
 
 /// Total request attempts (first try + respawn retries).
-const RPC_MAX_ATTEMPTS: u32 = 3;
+pub(crate) const RPC_MAX_ATTEMPTS: u32 = 3;
 /// Base of the exponential backoff bound between attempts.
 const RPC_RETRY_INITIAL_BACKOFF_MS: u64 = 50;
 /// Cap on the backoff bound.
 const RPC_RETRY_BACKOFF_CAP_MS: u64 = 1_000;
+
+/// Default per-request wait for a companion response. Large payloads add
+/// [`RPC_TIMEOUT_PER_KIB`] so a batch embed is not killed while ONNX runs.
+pub(crate) const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const RPC_TIMEOUT_PER_KIB: Duration = Duration::from_millis(25);
+
+/// How long Drop waits for a cooperative `exit` before killing the child.
+pub(crate) const DEFAULT_DROP_TIMEOUT: Duration = Duration::from_secs(2);
+
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompanionStderr {
@@ -65,6 +80,13 @@ pub(crate) fn retry_backoff_bound_ms(attempt: u32) -> u64 {
         .min(RPC_RETRY_BACKOFF_CAP_MS)
 }
 
+/// Per-request stdout wait: `base` plus 25ms for every KiB of the serialized
+/// request so large embed batches keep a proportional ONNX budget.
+pub(crate) fn rpc_read_deadline(base: Duration, request_line: &str) -> Duration {
+    let kib = u32::try_from(request_line.len() / 1024).unwrap_or(u32::MAX);
+    base.saturating_add(RPC_TIMEOUT_PER_KIB.saturating_mul(kib))
+}
+
 pub struct SubprocessEmbedder {
     model_id: String,
     dim: usize,
@@ -76,12 +98,15 @@ pub struct SubprocessEmbedder {
     companion_path: PathBuf,
     model_arg: String,
     stderr_mode: CompanionStderr,
+    rpc_timeout: Duration,
+    drop_timeout: Duration,
 }
 
 struct ChildIo {
     child: Child,
-    stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
+    stdin: Option<ChildStdin>,
+    lines: Receiver<std::io::Result<String>>,
+    reader: Option<JoinHandle<()>>,
 }
 
 impl SubprocessEmbedder {
@@ -106,6 +131,22 @@ impl SubprocessEmbedder {
         model: &str,
         stderr: CompanionStderr,
     ) -> Result<Self, OrbitError> {
+        Self::with_path_model_stderr_and_timeouts(
+            path,
+            model,
+            stderr,
+            DEFAULT_RPC_TIMEOUT,
+            DEFAULT_DROP_TIMEOUT,
+        )
+    }
+
+    pub(crate) fn with_path_model_stderr_and_timeouts(
+        path: PathBuf,
+        model: &str,
+        stderr: CompanionStderr,
+        rpc_timeout: Duration,
+        drop_timeout: Duration,
+    ) -> Result<Self, OrbitError> {
         let io = spawn_companion_with_retry(&path, model, stderr)?;
         let mut embedder = Self {
             model_id: String::new(),
@@ -116,6 +157,8 @@ impl SubprocessEmbedder {
             companion_path: path,
             model_arg: model.to_string(),
             stderr_mode: stderr,
+            rpc_timeout,
+            drop_timeout,
         };
         let info = embedder.request(RpcRequest::Info { id: 0 })?;
         let RpcResult::Info {
@@ -133,6 +176,11 @@ impl SubprocessEmbedder {
         embedder.dim = dim;
         embedder.max_input_tokens = max_input_tokens;
         Ok(embedder)
+    }
+
+    #[cfg(all(test, unix))]
+    pub(crate) fn child_id(&self) -> Option<u32> {
+        self.io.lock().ok().map(|io| io.child.id())
     }
 
     fn request(&self, request: RpcRequest) -> Result<RpcResult, OrbitError> {
@@ -156,6 +204,7 @@ impl SubprocessEmbedder {
         let line = serde_json::to_string(&request)
             .map_err(|error| OrbitError::Execution(error.to_string()))?;
         let id = request.id();
+        let deadline = rpc_read_deadline(self.rpc_timeout, &line);
 
         let mut io = self
             .io
@@ -170,10 +219,7 @@ impl SubprocessEmbedder {
                 match spawn_companion_child(&self.companion_path, &self.model_arg, self.stderr_mode)
                 {
                     Ok(fresh) => {
-                        // Reap the dead/wedged child before dropping its
-                        // handles so it doesn't linger as a zombie.
-                        let _ = io.child.kill();
-                        let _ = io.child.wait();
+                        io.kill_and_reap();
                         *io = fresh;
                     }
                     Err(error) => {
@@ -190,7 +236,7 @@ impl SubprocessEmbedder {
                     }
                 }
             }
-            match request_once(&mut io, &line, id) {
+            match request_once(&mut io, &line, id, deadline) {
                 Ok(result) => return Ok(result),
                 Err(RequestFailure::Permanent(error)) => return Err(error),
                 Err(RequestFailure::Transient(message)) => {
@@ -214,26 +260,53 @@ impl SubprocessEmbedder {
 }
 
 /// One request/response round-trip against the current companion child.
-/// Transport failures (write/read errors, EOF) are transient; malformed or
-/// mismatched responses and companion-reported errors are permanent.
-fn request_once(io: &mut ChildIo, line: &str, id: u64) -> Result<RpcResult, RequestFailure> {
-    io.stdin
+/// Transport failures (write/read errors, EOF, deadline) are transient;
+/// malformed or mismatched responses and companion-reported errors are
+/// permanent.
+fn request_once(
+    io: &mut ChildIo,
+    line: &str,
+    id: u64,
+    deadline: Duration,
+) -> Result<RpcResult, RequestFailure> {
+    let stdin = io
+        .stdin
+        .as_mut()
+        .ok_or_else(|| RequestFailure::Transient("search companion stdin is closed".to_string()))?;
+    stdin
         .write_all(line.as_bytes())
-        .and_then(|_| io.stdin.write_all(b"\n"))
-        .and_then(|_| io.stdin.flush())
+        .and_then(|_| stdin.write_all(b"\n"))
+        .and_then(|_| stdin.flush())
         .map_err(|error| {
             RequestFailure::Transient(format!("failed to write companion RPC: {error}"))
         })?;
 
-    let mut response_line = String::new();
-    let read = io.stdout.read_line(&mut response_line).map_err(|error| {
-        RequestFailure::Transient(format!("failed to read companion RPC: {error}"))
-    })?;
-    if read == 0 {
-        return Err(RequestFailure::Transient(
-            "search companion exited before sending a response".to_string(),
-        ));
-    }
+    let response_line = match io.lines.recv_timeout(deadline) {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            io.kill_and_reap();
+            return Err(RequestFailure::Transient(format!(
+                "failed to read companion RPC: {error}"
+            )));
+        }
+        Err(RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                ?deadline,
+                "search companion RPC timed out; killing companion"
+            );
+            io.kill_and_reap();
+            return Err(RequestFailure::Transient(format!(
+                "search companion RPC timed out after {}ms",
+                deadline.as_millis()
+            )));
+        }
+        Err(RecvTimeoutError::Disconnected) => {
+            io.kill_and_reap();
+            return Err(RequestFailure::Transient(
+                "search companion exited before sending a response".to_string(),
+            ));
+        }
+    };
     let response: RpcResponse = serde_json::from_str(&response_line).map_err(|error| {
         RequestFailure::Permanent(OrbitError::AgentProtocolViolation(error.to_string()))
     })?;
@@ -251,6 +324,68 @@ fn request_once(io: &mut ChildIo, line: &str, id: u64) -> Result<RpcResult, Requ
                 "companion response id mismatch for request {id}: {other:?}"
             )),
         )),
+    }
+}
+
+impl ChildIo {
+    fn kill_and_reap(&mut self) {
+        self.stdin.take();
+        kill_child_tree(&mut self.child);
+        self.join_reader();
+    }
+
+    fn join_reader(&mut self) {
+        if let Some(handle) = self.reader.take() {
+            let _ = handle.join();
+        }
+    }
+
+    fn shutdown_cooperatively(&mut self, drop_timeout: Duration) {
+        if let Some(mut stdin) = self.stdin.take() {
+            if let Ok(line) = serde_json::to_string(&RpcRequest::Exit { id: 9_999_999 }) {
+                let _ = stdin.write_all(line.as_bytes());
+                let _ = stdin.write_all(b"\n");
+                let _ = stdin.flush();
+            }
+            drop(stdin);
+        }
+        if wait_child_until(&mut self.child, drop_timeout) {
+            self.join_reader();
+            return;
+        }
+        self.kill_and_reap();
+    }
+}
+
+fn kill_child_tree(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let pid = child.id();
+        // Safety: `killpg` is async-signal-safe. The child was spawned with
+        // `process_group(0)`, so its PGID equals its PID and the signal stays
+        // inside that group.
+        unsafe {
+            libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn wait_child_until(child: &mut Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(WAIT_POLL_INTERVAL.min(remaining));
+            }
+            Err(_) => return false,
+        }
     }
 }
 
@@ -305,13 +440,19 @@ fn spawn_companion_child(
     model: &str,
     stderr: CompanionStderr,
 ) -> Result<ChildIo, std::io::Error> {
-    let mut child = Command::new(path)
+    let mut command = Command::new(path);
+    command
         .arg("--model")
         .arg(model)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(stderr.stdio())
-        .spawn()?;
+        .stderr(stderr.stdio());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    let mut child = command.spawn()?;
     let stdin = child
         .stdin
         .take()
@@ -320,11 +461,45 @@ fn spawn_companion_child(
         .stdout
         .take()
         .ok_or_else(|| std::io::Error::other("companion stdout unavailable"))?;
-    Ok(ChildIo {
-        child,
-        stdin,
-        stdout: BufReader::new(stdout),
-    })
+    match spawn_stdout_reader(stdout) {
+        Ok((lines, reader)) => Ok(ChildIo {
+            child,
+            stdin: Some(stdin),
+            lines,
+            reader: Some(reader),
+        }),
+        Err(error) => {
+            kill_child_tree(&mut child);
+            Err(error)
+        }
+    }
+}
+
+fn spawn_stdout_reader(
+    stdout: ChildStdout,
+) -> Result<(Receiver<std::io::Result<String>>, JoinHandle<()>), std::io::Error> {
+    let (tx, rx) = mpsc::channel();
+    let handle = thread::Builder::new()
+        .name("orbit-search-companion-stdout".to_string())
+        .spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) => {
+                        if tx.send(Ok(line)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = tx.send(Err(error));
+                        break;
+                    }
+                }
+            }
+        })?;
+    Ok((rx, handle))
 }
 
 impl CompanionStderr {
@@ -378,16 +553,10 @@ impl Embedder for SubprocessEmbedder {
 
 impl Drop for SubprocessEmbedder {
     fn drop(&mut self) {
-        let Ok(mut io) = self.io.lock() else {
-            return;
+        let mut io = match self.io.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
         };
-        if let Ok(line) = serde_json::to_string(&RpcRequest::Exit { id: 9_999_999 }) {
-            let _ = io.stdin.write_all(line.as_bytes());
-            let _ = io.stdin.write_all(b"\n");
-            let _ = io.stdin.flush();
-            let mut response = String::new();
-            let _ = io.stdout.read_line(&mut response);
-        }
-        let _ = io.child.wait();
+        io.shutdown_cooperatively(self.drop_timeout);
     }
 }

--- a/crates/orbit-search/src/tests/subprocess.rs
+++ b/crates/orbit-search/src/tests/subprocess.rs
@@ -1,6 +1,11 @@
-//! Unit tests for `subprocess` retry hygiene (ORB-10006) — sibling layout.
+//! Unit tests for `subprocess` retry hygiene (ORB-10006) and RPC/Drop
+//! deadlines — sibling layout.
 
-use crate::subprocess::{retry_backoff_bound_ms, spawn_error_is_permanent};
+use std::time::Duration;
+
+use crate::subprocess::{
+    DEFAULT_RPC_TIMEOUT, retry_backoff_bound_ms, rpc_read_deadline, spawn_error_is_permanent,
+};
 
 #[test]
 fn spawn_error_classification_table() {
@@ -38,13 +43,29 @@ fn retry_backoff_bound_doubles_and_saturates_at_cap() {
     assert_eq!(previous, retry_backoff_bound_ms(30), "bound must saturate");
 }
 
+#[test]
+fn rpc_read_deadline_scales_with_payload() {
+    let small = rpc_read_deadline(Duration::from_secs(1), "x");
+    let large = rpc_read_deadline(Duration::from_secs(1), &"y".repeat(4096));
+    assert_eq!(small, Duration::from_secs(1));
+    assert!(large > small, "4 KiB payload must add budget: {large:?}");
+    assert_eq!(
+        rpc_read_deadline(DEFAULT_RPC_TIMEOUT, ""),
+        DEFAULT_RPC_TIMEOUT
+    );
+}
+
 #[cfg(unix)]
 mod fake_companion {
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::time::{Duration, Instant};
 
     use crate::embedder::Embedder;
-    use crate::subprocess::SubprocessEmbedder;
+    use crate::subprocess::{
+        CompanionStderr, RPC_MAX_ATTEMPTS, SubprocessEmbedder, retry_backoff_bound_ms,
+    };
 
     /// Shared JSON-Lines dispatcher for the fake companion. `$EMBED_BODY`
     /// is spliced per test to control embed behavior.
@@ -68,9 +89,7 @@ done
 "#
         );
         std::fs::write(&path, script).expect("write fake companion");
-        let mut perms = std::fs::metadata(&path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).expect("chmod fake companion");
+        chmod_executable(&path);
         path
     }
 
@@ -143,5 +162,128 @@ done
             started.elapsed() < std::time::Duration::from_millis(500),
             "ENOENT should fail fast, not retry"
         );
+    }
+
+    #[test]
+    fn hung_embed_times_out_and_reaps_the_child() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let script = write_companion_script(temp.path(), "sleep 3600");
+        let rpc_timeout = Duration::from_millis(300);
+        let drop_timeout = Duration::from_millis(200);
+        let embedder = SubprocessEmbedder::with_path_model_stderr_and_timeouts(
+            script.clone(),
+            "fake",
+            CompanionStderr::Suppress,
+            rpc_timeout,
+            drop_timeout,
+        )
+        .expect("construct embedder");
+        let pid = embedder.child_id().expect("companion pid");
+
+        let started = Instant::now();
+        let err = embedder
+            .embed(&["hello"])
+            .expect_err("wedged companion must surface an error");
+        let elapsed = started.elapsed();
+        let budget = rpc_timeout * RPC_MAX_ATTEMPTS
+            + Duration::from_millis(retry_backoff_bound_ms(1) + retry_backoff_bound_ms(2))
+            + Duration::from_secs(2);
+        assert!(
+            elapsed < budget,
+            "embed hung for {elapsed:?} (budget {budget:?}): {err}"
+        );
+        assert!(
+            err.to_string().contains("timed out"),
+            "error should name the deadline: {err}"
+        );
+        assert_no_companion_processes(&script, pid);
+    }
+
+    #[test]
+    fn drop_reaps_a_child_that_ignores_exit() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let script = write_ignore_exit_companion(temp.path());
+        let rpc_timeout = Duration::from_millis(300);
+        let drop_timeout = Duration::from_millis(200);
+        let embedder = SubprocessEmbedder::with_path_model_stderr_and_timeouts(
+            script.clone(),
+            "fake",
+            CompanionStderr::Suppress,
+            rpc_timeout,
+            drop_timeout,
+        )
+        .expect("construct embedder");
+        let pid = embedder.child_id().expect("companion pid");
+
+        let started = Instant::now();
+        drop(embedder);
+        let elapsed = started.elapsed();
+        let budget = drop_timeout + Duration::from_secs(2);
+        assert!(
+            elapsed < budget,
+            "Drop hung for {elapsed:?} (budget {budget:?})"
+        );
+        assert_no_companion_processes(&script, pid);
+    }
+
+    fn write_ignore_exit_companion(dir: &Path) -> PathBuf {
+        let path = dir.join("fake-companion.sh");
+        let script = r#"#!/bin/sh
+while read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"info"'*)
+      printf '{"id":%s,"result":{"model_id":"fake","dim":2,"max_input_tokens":16,"version":null}}\n' "$id" ;;
+    *'"method":"exit"'*)
+      sleep 3600 ;;
+    *)
+      printf '{"id":%s,"error":{"code":"bad_request","message":"unknown method"}}\n' "$id" ;;
+  esac
+done
+"#;
+        std::fs::write(&path, script).expect("write ignore-exit companion");
+        chmod_executable(&path);
+        path
+    }
+
+    fn chmod_executable(path: &Path) {
+        let mut perms = std::fs::metadata(path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).expect("chmod fake companion");
+    }
+
+    fn assert_no_companion_processes(script: &Path, pgid: u32) {
+        let pgid_arg = pgid.to_string();
+        let group = pgrep_args(&["-g", &pgid_arg]);
+        assert!(
+            group.is_empty(),
+            "process group {pgid} still has pids {group:?}"
+        );
+        let matching = pgrep_full_command(script);
+        assert!(
+            matching.is_empty(),
+            "pgrep -f still sees companion {}: {matching:?}",
+            script.display()
+        );
+    }
+
+    fn pgrep_full_command(script: &Path) -> Vec<u32> {
+        let pattern = script.to_str().expect("utf-8 companion path");
+        pgrep_args(&["-f", pattern])
+            .into_iter()
+            .filter(|&pid| {
+                std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .map(|comm| comm.trim() != "pgrep")
+                    .unwrap_or(true)
+            })
+            .collect()
+    }
+
+    fn pgrep_args(args: &[&str]) -> Vec<u32> {
+        let output = Command::new("pgrep").args(args).output().expect("pgrep");
+        String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .filter_map(|pid| pid.parse().ok())
+            .collect()
     }
 }

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -72,7 +72,7 @@ Lifecycle:
 
 - `SubprocessEmbedder::new()` resolves the companion path under `~/.orbit/embed/bin/orbit-search-companion-<platform>` and starts the subprocess. ~100–300ms cold-start latency for ORT init.
 - The subprocess stays alive for the duration of the parent process or until explicitly dropped. Callers that retain the embedder, including the background indexing worker, reuse the same subprocess.
-- On process exit, the parent sends an `exit` RPC, reads the response, and waits for the child to exit.
+- On process exit, the parent sends an `exit` RPC, closes stdin, and waits a short bounded interval for the companion to leave; a still-running child is killed (its Unix process group) and reaped. Each RPC read waits only up to a payload-scaled deadline; a timeout is a transient transport failure and respawns the companion.
 
 ### 2.3 RPC protocol
 


### PR DESCRIPTION
## Task

[ORB-11696](https://orbit-cli.com/tasks/ORB-11696) — [code-review] Add a deadline to companion RPC reads and to `SubprocessEmbedder::drop`

### Description

## Problem
`request_once` does a blocking `read_line` on the companion's stdout with no timeout, and `Drop` does a blocking `read_line` for the `Exit` reply followed by `child.wait()` while the child's stdin handle is still open. If the companion wedges (ONNX inference stalls, a deadlock inside fastembed, a paused/stopped process), every caller hangs forever: `orbit semantic search`/`reindex` never return, the `EmbedWorker` thread stops draining its queue so later mutations are silently dropped at `try_send` (`Full`), and because `upsert_embeddings` calls `embed` inside an open transaction while holding the `VectorStore` mutex, all other index operations in the process block too. On process exit `Drop` can never finish because the child does not see EOF (stdin is still held) and `wait()` blocks.

## Why It Matters
One hung companion turns semantic search, doctor and the MCP server's indexing into an unbounded hang with no error surfaced.

## Proposed Fix
Read companion responses through a channel fed by a reader thread (or `poll` on the pipe fd) with a per-request deadline scaled to payload size; on timeout kill and reap the child and classify the failure as `Transient` so the existing respawn loop applies. In `Drop`, drop `stdin` after writing `Exit`, wait with a short bounded deadline, then `kill()` + `wait()`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/subprocess.rs:220-236`, `crates/orbit-search/src/subprocess.rs:380-393`, `crates/orbit-search/src/vector/worker.rs:58-67`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test with a fake companion script that answers `info` and then sleeps forever makes `embed` return an `OrbitError` within the configured deadline and leaves no child process (`pgrep` in test).
- Dropping a `SubprocessEmbedder` whose child ignores `exit` returns within the bounded deadline and reaps the child.
- Existing `tests/subprocess.rs` retry tests still pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `SubprocessEmbedder` now reads companion stdout on a dedicated thread and waits with `recv_timeout` (`30s` base + `25ms` per KiB of request). Timeout, EOF, and read errors kill the Unix process group, reap the child, join the reader, and return `RequestFailure::Transient` so the existing respawn loop still applies.
- Spawn uses `process_group(0)` on Unix so a wedged `sleep`/helper cannot outlive the companion shell.
- `Drop` writes `Exit`, drops stdin, `try_wait`s up to `2s`, then `killpg`+`kill`+`wait`. A poisoned mutex is recovered with `into_inner` so Drop still reaps.
- Tests: hung-embed (info then `sleep 3600`) returns an error within the configured retry budget and `pgrep` finds no child; Drop of an exit-ignoring child returns within the drop deadline and reaps. Existing retry tests still pass.
- `docs/design/orbit-search/2_design.md` lifecycle sentence updated to match bounded Drop/RPC reads.
- `vector/worker.rs` was not changed: the hang was in `embed()`, which now errors instead of blocking forever.
Assessment: Bounded, single-path fix at the subprocess boundary. Files stay under 800 lines. No new crate edges.
Strategic decisions:
- Reader thread + `mpsc` rather than `poll(2)` so the wait is portable and stays off the RPC mutex's stdout handle.
- Process-group kill is required for the `pgrep` acceptance check because `/bin/sleep` is a child of the fake shell.
Design weaknesses / risks:
- Severity: low. Default budget is `30s × 3` attempts plus backoff (~90s) before a wedged companion surfaces an error. Mitigation: still bounded vs unbounded; payload scaling for large embeds.
- Severity: low. Windows has no process-group kill; production companion is a single binary. Tests are `#[cfg(unix)]`.
Deviations from original plan: none material. `worker.rs` listed in context but left untouched (reason above).
Recommended follow-ups: none required for this task.
Criteria:
- Hung embed returns `OrbitError` within the configured deadline and leaves no child (`pgrep`): pass (`hung_embed_times_out_and_reaps_the_child`).
- Drop of an exit-ignoring child returns within the bounded deadline and reaps: pass (`drop_reaps_a_child_that_ignores_exit`).
- Existing `tests/subprocess.rs` retry tests still pass: pass (all 8 `subprocess` tests).
Validation:
- `cargo test -p orbit-search --lib subprocess`: passed (8 passed, 1.05s).
- `make ci-fast`: passed.
- `make ci-lint`: passed (after gating `child_id` with `#[cfg(all(test, unix))]`).
- `git diff --check`: passed (no whitespace errors).
- `GIT_OPTIONAL_LOCKS=0 git status --short`: `M` subprocess.rs, tests/subprocess.rs, 2_design.md only.
Remaining risks: a healthy but extremely slow first embed on a starved CPU could hit the 30s budget; cold-start is documented at 100–300ms and info already loaded the model.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11696-6a9f4232`
- Behind base: 0
- Ahead of base: 1