### PR TITLE
[code-review] Make the global "Jump to" resolver work for non-`ORB` prefixes and the selected workspace

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -761,10 +761,11 @@ function wireFrictionResponsiveDetail() {
    GET /api/tasks/:id is workspace-scoped. A raw fetch without ?workspace=
    hits the server default (often not the selected workspace) and reports an
    existing task as not found — the Diagnostics jump failure on ws_orbit.
-   - Only fires on exact ^ORB-\d{5}$ (case-insens) after trim/upper.
+   - Only fires on a task id shaped like ^[A-Z]{2,5}-\d+$ (case-insens)
+     after trim/upper.
    - 250ms debounce; Enter looks up immediately.
-   - Lookup uses the selected workspace first; a confirmed miss then probes
-     other active workspaces and adopts the owner.
+   - Lookup uses the selected workspace first when one is selected; aggregate
+     mode probes active workspaces and adopts the owner.
    - Stale replies after a workspace change or a newer lookup are ignored.
    - Not-found is reserved for a confirmed miss; loading / 403 / 5xx / network
      have distinct copy.
@@ -774,7 +775,7 @@ function wireGlobalTaskResolver() {
   if (!input) return;
   let debounce = null;
   let lookupSeq = 0;
-  const ID_RE = /^ORB-\d{5}$/i;
+  const ID_RE = /^[A-Z]{2,5}-\d+$/i;
 
   function lookupWrap() {
     return input.parentNode;
@@ -894,24 +895,26 @@ function wireGlobalTaskResolver() {
     };
 
     showLookupStatus("pending", `Looking up ${id}\u2026`);
-    let primary;
-    try {
-      primary = await fetchTaskInWorkspace(id, workspaceAtStart);
-    } catch {
+    if (workspaceAtStart) {
+      let primary;
+      try {
+        primary = await fetchTaskInWorkspace(id, workspaceAtStart);
+      } catch {
+        if (discardIfStale()) return;
+        showLookupStatus("error", `Network error resolving ${id}`);
+        return;
+      }
       if (discardIfStale()) return;
-      showLookupStatus("error", `Network error resolving ${id}`);
-      return;
-    }
-    if (discardIfStale()) return;
-    if (primary.res.ok && primary.body && primary.body.id) {
-      openLookedUpTask(primary.body, primary.workspaceId || workspaceAtStart);
-      return;
-    }
+      if (primary.res.ok && primary.body && primary.body.id) {
+        openLookedUpTask(primary.body, primary.workspaceId);
+        return;
+      }
 
-    const classified = classifyLookupFailure(primary.res, primary.body, id);
-    if (classified.kind !== "missing") {
-      showLookupStatus("error", classified.message);
-      return;
+      const classified = classifyLookupFailure(primary.res, primary.body, id);
+      if (classified.kind !== "missing") {
+        showLookupStatus("error", classified.message);
+        return;
+      }
     }
 
     const others = otherActiveWorkspaces(workspaceAtStart);
@@ -957,7 +960,10 @@ function wireGlobalTaskResolver() {
       return;
     }
     const candidate = raw.toUpperCase();
-    if (!ID_RE.test(candidate)) return;
+    if (!ID_RE.test(candidate)) {
+      lookupSeq += 1;
+      return;
+    }
     debounce = setTimeout(() => lookupTask(candidate), 250);
   }
 

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -79,7 +79,7 @@
           </div>
           <span class="topbar-spacer"></span>
           <div class="global-id-wrap">
-            <input type="search" id="global-task-id" placeholder="Jump to ORB-NNNNN" autocomplete="off" spellcheck="false" />
+            <input type="search" id="global-task-id" placeholder="Jump to task id" autocomplete="off" spellcheck="false" />
             <span id="global-task-id-error" class="global-id-error"></span>
           </div>
           <button id="refresh-btn" class="refresh-btn" type="button">Refresh</button>

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -2638,12 +2638,18 @@ if (!disabled.disabled) throw new Error("controls must be disabled for an unauth
     );
 }
 
-/// ORB-11560: Jump to ORB-NNNNN must look up in the selected workspace, not the
-/// server default. The live failure was Diagnostics/Errors on ws_orbit with
+/// ORB-11691: Jump to task ids must accept non-ORB prefixes, look up in the
+/// selected workspace, and probe concrete workspaces from the aggregate view,
+/// not the server default. The live failure was Diagnostics/Errors on ws_orbit with
 /// `window=24h&run_state=failed`: GET /api/tasks/ORB-11514 (no workspace) 404'd
 /// against polaris while the same id existed as blocked in ws_orbit.
 #[test]
 fn dashboard_global_task_jump_scopes_to_selected_workspace_and_distinguishes_errors() {
+    let app = include_str!("../../assets/dashboard/app.js");
+    let index = include_str!("../../assets/dashboard/index.html");
+    assert!(app.contains(r#"const ID_RE = /^[A-Z]{2,5}-\d+$/i;"#));
+    assert!(index.contains(r#"placeholder="Jump to task id"#));
+
     run_dashboard_javascript_test(
         r##"
 class Node {
@@ -2777,7 +2783,7 @@ globalThis.requestAnimationFrame = (fn) => fn();
 globalThis.setInterval = () => 0;
 globalThis.EventSource = class { constructor() {} close() {} };
 
-const existing = { id: "ORB-11514", title: "Enforce proc.spawn filesystem policy against indirect child access", status: "blocked", history: [], artifacts: [], comments: [] };
+const existing = { id: "DANI-00012", title: "Enforce proc.spawn filesystem policy against indirect child access", status: "blocked", history: [], artifacts: [], comments: [] };
 let lookupMode = "existing";
 let delayed = null;
 const requests = [];
@@ -2793,17 +2799,17 @@ globalThis.fetch = async (path) => {
       { id: "ws_orbit", name: "orbit", status: "active", is_default: false },
     ]);
   }
-  if (/^\/api\/tasks\/ORB-/.test(url.pathname)) {
+  if (/^\/api\/tasks\/(?:ORB-|DANI-)/.test(url.pathname)) {
     const id = decodeURIComponent(url.pathname.slice("/api/tasks/".length));
     const workspace = url.searchParams.get("workspace");
     if (lookupMode === "network" && id === "ORB-00001") throw new Error("offline");
     if (lookupMode === "denied" && id === "ORB-00002") return json({ error: "cross-origin requests not allowed" }, 403);
     if (lookupMode === "server" && id === "ORB-00003") return json({ error: "boom" }, 500);
-    if (lookupMode === "stale" && id === "ORB-11514") {
+    if (lookupMode === "stale" && id === "DANI-00012") {
       await new Promise((resolve) => { delayed = resolve; });
       return workspace === "ws_orbit" ? json(existing) : json({ error: `task not found: ${id}` }, 404);
     }
-    if (id === "ORB-11514" && workspace === "ws_orbit") return json(existing);
+    if (id === "DANI-00012" && workspace === "ws_orbit") return json(existing);
     return json({ error: `task not found: ${id}` }, 404);
   }
   if (url.pathname === "/api/tasks" || url.pathname === "/api/tasks/all") {
@@ -2831,9 +2837,9 @@ function jump(id) {
 }
 
 requests.length = 0;
-jump("ORB-11514");
+jump("dani-00012");
 await tick(); await tick(); await tick(); await tick(); await tick();
-const taskGets = requests.filter((url) => url.startsWith("/api/tasks/ORB-11514"));
+const taskGets = requests.filter((url) => url.startsWith("/api/tasks/DANI-00012"));
 if (!taskGets[0] || !taskGets[0].includes("workspace=ws_orbit")) {
   throw new Error(`existing-task jump must query the selected workspace first; got ${JSON.stringify(taskGets)}`);
 }
@@ -2841,8 +2847,19 @@ if (err.textContent.includes("not found")) throw new Error(`existing task report
 if (wrap.classList.contains("error")) throw new Error("successful jump must not leave the error state");
 if (input.value) throw new Error("successful jump should clear the input");
 if (!String(location.hash).includes("tasks")) throw new Error(`successful jump should open Tasks, hash=${location.hash}`);
-const opened = get("tasks-body").children.some((node) => String(node.textContent).includes("ORB-11514"));
+const opened = get("tasks-body").children.some((node) => String(node.textContent).includes("DANI-00012"));
 if (!opened) throw new Error("existing blocked task must render after jump");
+
+setWorkspace("");
+requests.length = 0;
+jump("DANI-00012");
+await tick(); await tick(); await tick(); await tick(); await tick();
+const aggregateGets = requests.filter((url) => url.startsWith("/api/tasks/DANI-00012"));
+if (aggregateGets.length < 2 || !aggregateGets[0].includes("workspace=ws_polaris") || !aggregateGets.some((url) => url.includes("workspace=ws_orbit"))) {
+  throw new Error(`aggregate lookup must probe concrete workspaces; got ${JSON.stringify(aggregateGets)}`);
+}
+if (getWorkspace() !== "ws_orbit") throw new Error(`aggregate lookup should adopt the owner, got ${getWorkspace()}`);
+if (err.textContent.includes("Error 400")) throw new Error(`aggregate lookup must not expose a missing workspace: ${err.textContent}`);
 
 lookupMode = "missing";
 requests.length = 0;
@@ -2869,8 +2886,8 @@ if (err.textContent !== "Server error resolving ORB-00003") throw new Error(`ser
 
 lookupMode = "stale";
 const hashBeforeStale = String(location.hash);
-input.value = "ORB-11514";
-jump("ORB-11514");
+input.value = "DANI-00012";
+jump("DANI-00012");
 await tick();
 setWorkspace("ws_polaris");
 if (typeof delayed === "function") delayed();


### PR DESCRIPTION
## Task

[ORB-11691](https://orbit-cli.com/tasks/ORB-11691) — [code-review] Make the global "Jump to" resolver work for non-`ORB` prefixes and the selected workspace

### Description

## Problem
`wireGlobalTaskResolver` only fires on `/^ORB-\d{5}$/i` and the placeholder says "Jump to ORB-NNNNN". Task ids are `<2-5 uppercase letters>-<digits>` (`orbit-types/src/task/artifacts.rs:30-45`), and other registered workspaces use other prefixes, so typing a valid id from any non-ORB workspace does nothing. When the regex does match, the fetch at `app.js:788` uses a raw `fetch('/api/tasks/<id>')` instead of `fetchJson`/`withWorkspace`, so in multi-workspace mode it resolves against the server's default workspace (not the one selected in the rail) and in the "All workspaces" view the `Ws` extractor answers 400 and the user sees "Error 400 resolving ORB-…".

## Why It Matters
The one cross-tab navigation affordance silently ignores most inputs in a multi-workspace dashboard, which is the only mode `orbit web serve` runs in.

## Proposed Fix
Match `^[A-Z]{2,5}-\d+$` after uppercasing; use `fetchJson` so the selected workspace is applied; in the aggregate view try each active workspace (or `/api/tasks/all` cache) and switch the selector to the owning workspace before opening; update the placeholder to "Jump to task id".

## Constraints / Notes
- ORB-11560 (done) fixed a false not-found on the same control; verify its change first and only address what remains (non-`ORB` prefixes, selected-workspace routing, aggregate view).
- Found in a full code/UX review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/app.js:761-828`, `crates/orbit-web/assets/dashboard/index.html:82`.
- `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Typing a `DANI-00012`-style id in a workspace whose prefix is `DANI` opens that task.
- With workspace B selected, typing a B task id opens it (no request to the default workspace; check the network tab carries `?workspace=B`).
- In "All workspaces" the resolver finds the task and selects its workspace rather than showing "Error 400".

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Generalized the global Jump to resolver from ORB-only five-digit ids to case-insensitive task ids matching 2-5 letters followed by a hyphen and one or more digits.
- In concrete workspace views, retained workspace-qualified task requests; in All workspaces, skipped the unscoped task-detail request, probed active workspaces, and adopted the workspace that returned the task.
- Updated the input placeholder to "Jump to task id" and invalidated stale lookups when input becomes an invalid id.
- Extended the shipped dashboard behavior harness to cover a lowercase DANI-00012 lookup in the selected workspace and aggregate probing/owner adoption.

Acceptance criteria:
- DANI-00012-style ids: verified by the dashboard behavior test; lowercase input is normalized and opens the blocked task.
- Selected workspace routing: verified by the dashboard behavior test; the first task request includes ?workspace=ws_orbit.
- All workspaces routing: verified by the dashboard behavior test; the resolver probes ?workspace=ws_polaris and ?workspace=ws_orbit, adopts ws_orbit, and does not surface Error 400.

Validation:
- PASS: cargo test -p orbit-web tests::dashboard_assets::dashboard_global_task_jump_scopes_to_selected_workspace_and_distinguishes_errors -- --exact
- PASS: cargo test -p orbit-web tests::dashboard_assets::
- PASS: cargo fmt --all -- --check
- PASS: node --check crates/orbit-web/assets/dashboard/app.js
- PASS: make ci-fast
- PASS: make ci-lint
- PASS: git diff --check
- PASS: GIT_OPTIONAL_LOCKS=0 git status --short

Assessment: Task-scoped changes are limited to the dashboard resolver, placeholder, and its existing behavior test. No commits were made; the pipeline owns delivery. Remaining risk is limited to browser/runtime behavior not covered by the Node dashboard harness.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11691-6a9f4337`
- Behind base: 0
- Ahead of base: 1