### PR TITLE
[code-review] Stop serialising every supervised child on the global signal-handler mutex

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/tests/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/parallel.rs
@@ -4,6 +4,9 @@
 //! `StepJoin` event ordering, and audit parent-stack inheritance into branch
 //! threads. See task T20260509-7.
 
+use std::path::PathBuf;
+use std::time::Instant;
+
 use super::*;
 
 #[test]
@@ -185,5 +188,78 @@ fn parallel_inherits_audit_parent_stack_into_each_branch() {
             Some(outer_started_id.as_str()),
             "branch `{branch_id}` did not inherit the parallel step's parent_event_id"
         );
+    }
+}
+
+/// Two `local_shell` branches of `sleep 2` must overlap. Before the
+/// signal-handler mutex was refcounted, each `supervise_child` held it for
+/// the child's lifetime and the block took ~4 s.
+#[cfg(unix)]
+#[test]
+fn parallel_local_shell_sleeps_overlap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let host = LocalShellHost {
+        root: dir.path().to_path_buf(),
+    };
+    let job = job_with_steps(vec![parallel_step(
+        "fan",
+        JoinMode::All,
+        vec![
+            local_shell_sleep_step("br_a", 2),
+            local_shell_sleep_step("br_b", 2),
+        ],
+    )]);
+    let started = Instant::now();
+    let writer = std::sync::Arc::new(test_writer("run-par-shell-sleep"));
+    let outcome = execute_job(&job, Value::Null, "run-par-shell-sleep", writer, &host)
+        .expect("execute_job ok");
+    assert!(outcome.success, "parallel local_shell job failed");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(3_000),
+        "parallel local_shell sleep 2 branches serialized: {elapsed:?}"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(1_500),
+        "sleep 2 branches finished too quickly to have slept: {elapsed:?}"
+    );
+}
+
+#[cfg(unix)]
+struct LocalShellHost {
+    root: PathBuf,
+}
+
+#[cfg(unix)]
+impl RuntimeHost for LocalShellHost {
+    fn repo_root(&self) -> Result<String, orbit_common::OrbitError> {
+        Ok(self.root.to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(unix)]
+fn local_shell_sleep_step(id: &str, seconds: u32) -> JobV2Step {
+    JobV2Step {
+        id: id.to_string(),
+        when: None,
+        retry: None,
+        recovery_activity: None,
+        resolved_recovery_activity: None,
+        body: JobV2StepBody::Target(TargetStep {
+            spec: ActivityV2Spec::Deterministic(DeterministicSpec {
+                action: "local_shell".to_string(),
+                config: json!({
+                    "shell": "/bin/sh",
+                    "script": format!("sleep {seconds}"),
+                    "timeout_ms": 10_000u64,
+                }),
+            }),
+            activity_name: None,
+            input_schema_json: None,
+            fs_profile: None,
+            default_input: None,
+            timeout_seconds: 0,
+            session: None,
+        }),
     }
 }

--- a/crates/orbit-exec/Cargo.toml
+++ b/crates/orbit-exec/Cargo.toml
@@ -25,3 +25,6 @@ libc.workspace = true
 # state the environment they reason about instead of inheriting the shell.
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
 regex.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+libc.workspace = true

--- a/crates/orbit-exec/src/supervision/signal.rs
+++ b/crates/orbit-exec/src/supervision/signal.rs
@@ -1,74 +1,61 @@
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use orbit_common::OrbitError;
 
-static SIGNAL_HANDLER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-static SIGNAL_PIPE_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+/// Slots for live child process groups. The signal handler walks this table
+/// and therefore cannot take a mutex; empty is `0` (never a valid pgid here,
+/// because children are spawned as their own group leaders).
+const MAX_LIVE_PROCESS_GROUPS: usize = 256;
 
+static HANDLER_INSTALL: OnceLock<Mutex<HandlerInstall>> = OnceLock::new();
+static LAST_SIGNAL: AtomicI32 = AtomicI32::new(0);
+static SIGNAL_GEN: AtomicU64 = AtomicU64::new(0);
+static LIVE_PGIDS: [AtomicU32; MAX_LIVE_PROCESS_GROUPS] =
+    [const { AtomicU32::new(0) }; MAX_LIVE_PROCESS_GROUPS];
+
+struct HandlerInstall {
+    refcount: usize,
+    previous: Option<PreviousHandlers>,
+}
+
+struct PreviousHandlers {
+    sigint: libc::sigaction,
+    sigterm: libc::sigaction,
+}
+
+/// Process-wide SIGINT/SIGTERM intercept for the duration of one supervised
+/// wait. Install is refcounted: the first live guard swaps in the handlers,
+/// and the last drop restores the previous dispositions. The install mutex
+/// is held only for that refcount/sigaction critical section — never across
+/// the child's lifetime — so concurrent supervisors overlap.
 pub(super) struct SignalHandlerGuard {
-    previous_sigint: libc::sigaction,
-    previous_sigterm: libc::sigaction,
-    read_fd: i32,
-    write_fd: i32,
-    _lock: MutexGuard<'static, ()>,
+    start_gen: u64,
+    slot: Option<usize>,
 }
 
 impl SignalHandlerGuard {
-    pub(super) fn install() -> Result<Self, OrbitError> {
-        let lock = SIGNAL_HANDLER_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .map_err(|_| OrbitError::Execution("signal handler lock poisoned".to_string()))?;
-
-        let (read_fd, write_fd) = create_signal_pipe()?;
-        SIGNAL_PIPE_WRITE_FD.store(write_fd, Ordering::SeqCst);
-        let previous_sigint = install_signal_handler(libc::SIGINT)?;
-        let previous_sigterm = match install_signal_handler(libc::SIGTERM) {
-            Ok(previous) => previous,
-            Err(err) => {
-                SIGNAL_PIPE_WRITE_FD.store(-1, Ordering::SeqCst);
-                close_fd(read_fd);
-                close_fd(write_fd);
-                restore_signal_handler(libc::SIGINT, &previous_sigint);
-                return Err(err);
-            }
-        };
-
+    pub(super) fn install(pgid: u32) -> Result<Self, OrbitError> {
+        let start_gen = acquire_handlers()?;
         Ok(Self {
-            previous_sigint,
-            previous_sigterm,
-            read_fd,
-            write_fd,
-            _lock: lock,
+            start_gen,
+            slot: register_pgid(pgid),
         })
     }
 
     pub(super) fn take_signal(&self) -> Option<i32> {
-        let mut signal = [0_u8; 1];
-        // Safety: the read end is non-blocking and owned by this guard.
-        let result = unsafe { libc::read(self.read_fd, signal.as_mut_ptr().cast(), signal.len()) };
-        if result > 0 {
-            return Some(signal[0] as i32);
-        }
-        if result == 0 {
+        if SIGNAL_GEN.load(Ordering::SeqCst) == self.start_gen {
             return None;
         }
-
-        match std::io::Error::last_os_error().raw_os_error() {
-            Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK => None,
-            _ => None,
-        }
+        let signal = LAST_SIGNAL.load(Ordering::SeqCst);
+        (signal != 0).then_some(signal)
     }
 }
 
 impl Drop for SignalHandlerGuard {
     fn drop(&mut self) {
-        SIGNAL_PIPE_WRITE_FD.store(-1, Ordering::SeqCst);
-        restore_signal_handler(libc::SIGINT, &self.previous_sigint);
-        restore_signal_handler(libc::SIGTERM, &self.previous_sigterm);
-        close_fd(self.read_fd);
-        close_fd(self.write_fd);
+        unregister_pgid(self.slot);
+        release_handlers();
     }
 }
 
@@ -85,28 +72,106 @@ fn signal_name(signal: i32) -> &'static str {
     }
 }
 
-unsafe extern "C" fn termination_signal_handler(signal: libc::c_int) {
-    let fd = SIGNAL_PIPE_WRITE_FD.load(Ordering::Relaxed);
-    if fd < 0 {
-        return;
+fn acquire_handlers() -> Result<u64, OrbitError> {
+    let mut state = handler_install()
+        .lock()
+        .map_err(|_| OrbitError::Execution("signal handler lock poisoned".to_string()))?;
+
+    // Snapshot before this waiter is live so a signal that arrives during
+    // first-install still looks newer than `start_gen` on the first poll.
+    let start_gen = SIGNAL_GEN.load(Ordering::SeqCst);
+    if state.refcount == 0 {
+        let sigint = install_signal_handler(libc::SIGINT)?;
+        let sigterm = match install_signal_handler(libc::SIGTERM) {
+            Ok(previous) => previous,
+            Err(err) => {
+                restore_signal_handler(libc::SIGINT, &sigint);
+                return Err(err);
+            }
+        };
+        state.previous = Some(PreviousHandlers { sigint, sigterm });
     }
 
-    let byte = signal as u8;
-    // Safety: `write` is async-signal-safe and writes a single byte to the
-    // non-blocking pipe owned by the active guard.
-    unsafe {
-        libc::write(fd, (&byte as *const u8).cast(), 1);
+    state.refcount = state
+        .refcount
+        .checked_add(1)
+        .ok_or_else(|| OrbitError::Execution("signal handler refcount overflow".to_string()))?;
+    Ok(start_gen)
+}
+
+fn release_handlers() {
+    let Ok(mut state) = handler_install().lock() else {
+        return;
+    };
+    if state.refcount == 0 {
+        return;
+    }
+    state.refcount -= 1;
+    if state.refcount > 0 {
+        return;
+    }
+    if let Some(previous) = state.previous.take() {
+        restore_signal_handler(libc::SIGINT, &previous.sigint);
+        restore_signal_handler(libc::SIGTERM, &previous.sigterm);
+    }
+}
+
+fn handler_install() -> &'static Mutex<HandlerInstall> {
+    HANDLER_INSTALL.get_or_init(|| {
+        Mutex::new(HandlerInstall {
+            refcount: 0,
+            previous: None,
+        })
+    })
+}
+
+fn register_pgid(pgid: u32) -> Option<usize> {
+    if pgid == 0 {
+        return None;
+    }
+    for (index, slot) in LIVE_PGIDS.iter().enumerate() {
+        if slot
+            .compare_exchange(0, pgid, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn unregister_pgid(slot: Option<usize>) {
+    if let Some(index) = slot {
+        LIVE_PGIDS[index].store(0, Ordering::SeqCst);
+    }
+}
+
+unsafe extern "C" fn termination_signal_handler(signal: libc::c_int) {
+    LAST_SIGNAL.store(signal, Ordering::SeqCst);
+    SIGNAL_GEN.fetch_add(1, Ordering::SeqCst);
+    for slot in &LIVE_PGIDS {
+        let pgid = slot.load(Ordering::Relaxed);
+        if pgid != 0 {
+            // Safety: `killpg` is async-signal-safe. `pgid` is a live child's
+            // process-group id stored by a supervisor, or a stale id of a
+            // group that already exited (`ESRCH` is ignored).
+            unsafe {
+                libc::killpg(pgid as libc::pid_t, signal);
+            }
+        }
     }
 }
 
 fn install_signal_handler(signal: libc::c_int) -> Result<libc::sigaction, OrbitError> {
-    // Safety: sigaction initializes/installs a process signal handler. The
-    // handler only performs an atomic store, so it is safe for SIGINT/SIGTERM.
+    // Safety: sigaction installs a process signal handler. The handler only
+    // stores atomics and calls `killpg`, both async-signal-safe.
     unsafe {
         let mut new_action: libc::sigaction = std::mem::zeroed();
         new_action.sa_sigaction = termination_signal_handler as *const () as usize;
         new_action.sa_flags = 0;
         libc::sigemptyset(&mut new_action.sa_mask);
+        libc::sigaddset(&mut new_action.sa_mask, libc::SIGINT);
+        libc::sigaddset(&mut new_action.sa_mask, libc::SIGTERM);
 
         let mut old_action: libc::sigaction = std::mem::zeroed();
         if libc::sigaction(signal, &new_action, &mut old_action) != 0 {
@@ -125,55 +190,5 @@ fn restore_signal_handler(signal: libc::c_int, previous: &libc::sigaction) {
     // Safety: restores the exact handler previously returned by sigaction.
     unsafe {
         libc::sigaction(signal, previous, std::ptr::null_mut());
-    }
-}
-
-fn create_signal_pipe() -> Result<(i32, i32), OrbitError> {
-    let mut fds = [0_i32; 2];
-    // Safety: `pipe` initializes the two file descriptors when it returns 0.
-    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
-    if rc != 0 {
-        return Err(OrbitError::Execution(format!(
-            "failed to create signal pipe: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-
-    if let Err(err) = set_nonblocking(fds[0]) {
-        close_fd(fds[0]);
-        close_fd(fds[1]);
-        return Err(err);
-    }
-
-    Ok((fds[0], fds[1]))
-}
-
-fn set_nonblocking(fd: i32) -> Result<(), OrbitError> {
-    // Safety: `fcntl` queries and updates flags for this valid file descriptor.
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
-        if flags < 0 {
-            return Err(OrbitError::Execution(format!(
-                "failed to inspect signal pipe flags: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) != 0 {
-            return Err(OrbitError::Execution(format!(
-                "failed to set signal pipe non-blocking mode: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn close_fd(fd: i32) {
-    if fd >= 0 {
-        // Safety: closing an owned file descriptor is safe; errors are ignored
-        // during cleanup because the process is already tearing the guard down.
-        unsafe {
-            libc::close(fd);
-        }
     }
 }

--- a/crates/orbit-exec/src/supervision/tests/wait.rs
+++ b/crates/orbit-exec/src/supervision/tests/wait.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use orbit_common::process::output_capture::OUTPUT_TRUNCATED_MARKER;
 
-use super::super::wait::wait_with_timeout_and_output_limit;
+use super::super::wait::{WaitResult, wait_with_timeout_and_output_limit};
 use crate::runner::{EnvironmentMode, ExecRequest, StdinMode};
 
 #[cfg(unix)]
@@ -84,4 +84,47 @@ fn capture_limit_kill_names_its_reason_on_stderr() {
         "stderr was {stderr:?}"
     );
     assert!(result.stdout.ends_with(OUTPUT_TRUNCATED_MARKER));
+}
+
+/// Concurrent supervisors must overlap: the process-wide signal-handler
+/// mutex used to be held for each child's entire lifetime, so two `sleep 1`
+/// waits from two threads took ~2 s instead of ~1 s.
+#[cfg(unix)]
+#[test]
+fn concurrent_supervised_sleeps_overlap() {
+    let started = Instant::now();
+    std::thread::scope(|scope| {
+        let first = scope.spawn(|| supervise_sleep("1"));
+        let second = scope.spawn(|| supervise_sleep("1"));
+        let first = first
+            .join()
+            .expect("first supervisor thread")
+            .expect("first wait");
+        let second = second
+            .join()
+            .expect("second supervisor thread")
+            .expect("second wait");
+        assert!(first.exit_success, "first sleep should exit 0");
+        assert!(second.exit_success, "second sleep should exit 0");
+    });
+    assert!(
+        started.elapsed() < Duration::from_millis(1_500),
+        "concurrent sleep 1 children serialized: {:?}",
+        started.elapsed()
+    );
+}
+
+#[cfg(unix)]
+fn supervise_sleep(seconds: &str) -> Result<WaitResult, orbit_common::OrbitError> {
+    let req = ExecRequest {
+        program: "/bin/sleep".to_string(),
+        args: vec![seconds.to_string()],
+        current_dir: None,
+        timeout_ms: Some(5_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::Inherit,
+        debug: false,
+    };
+    let child = crate::process::spawn(&req).expect("spawn child");
+    wait_with_timeout_and_output_limit(child, Some(5_000), false, None, 64)
 }

--- a/crates/orbit-exec/src/supervision/wait.rs
+++ b/crates/orbit-exec/src/supervision/wait.rs
@@ -70,7 +70,7 @@ pub(super) fn wait_with_timeout_and_output_limit(
         .map(|err| spawn_stderr_drain(err, debug, output_limit, output_limit_tx));
 
     #[cfg(unix)]
-    let signal_guard = SignalHandlerGuard::install()?;
+    let signal_guard = SignalHandlerGuard::install(child.id())?;
 
     let deadline = timeout_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
     let mut stdin_write_error = None;

--- a/crates/orbit-exec/tests/signal_fanout.rs
+++ b/crates/orbit-exec/tests/signal_fanout.rs
@@ -1,0 +1,89 @@
+#![allow(missing_docs)]
+#![cfg(unix)]
+// Integration fixtures exercise public behavior and unwrap setup invariants.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+//! Ctrl-C must terminate every live supervised process group, not only the
+//! one that happened to hold the (former) process-wide handler mutex.
+//!
+//! This lives in its own test binary so `raise(SIGINT)` cannot interrupt
+//! other `orbit-exec` unit tests sharing a process.
+
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+
+#[test]
+fn ctrl_c_terminates_every_live_child_process_group() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first_ready = dir.path().join("first.ready");
+    let second_ready = dir.path().join("second.ready");
+
+    let started = Instant::now();
+    thread::scope(|scope| {
+        let first = scope.spawn(|| supervise_sleep_after_ready(&first_ready));
+        let second = scope.spawn(|| supervise_sleep_after_ready(&second_ready));
+        wait_for_marker(&first_ready);
+        wait_for_marker(&second_ready);
+
+        // Safety: `raise` delivers SIGINT to this process. The supervised
+        // wait has replaced the default disposition with Orbit's handler.
+        let raised = unsafe { libc::raise(libc::SIGINT) };
+        assert_eq!(raised, 0, "raise SIGINT");
+
+        let first = first.join().expect("first supervisor thread");
+        let second = second.join().expect("second supervisor thread");
+        assert_interrupted(&first);
+        assert_interrupted(&second);
+    });
+
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "SIGINT should terminate both live children promptly, took {:?}",
+        started.elapsed()
+    );
+}
+
+fn supervise_sleep_after_ready(marker: &Path) -> orbit_exec::ExecutionResult {
+    let script = format!("touch {} && sleep 8", marker.display());
+    let req = ExecRequest {
+        program: "/bin/sh".to_string(),
+        args: vec!["-c".to_string(), script],
+        current_dir: None,
+        timeout_ms: Some(15_000),
+        stdin_mode: StdinMode::Null,
+        environment_mode: EnvironmentMode::Inherit,
+        debug: false,
+    };
+    run_process(&req, &NoSandbox).expect("run_process")
+}
+
+fn wait_for_marker(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!("child did not become ready: {}", path.display());
+}
+
+fn assert_interrupted(result: &orbit_exec::ExecutionResult) {
+    assert!(!result.success, "interrupted child must not succeed");
+    assert_eq!(
+        result.exit_code,
+        Some(128 + libc::SIGINT),
+        "parent-signal exits report 128+SIGINT, got {:?}",
+        result.exit_code
+    );
+    assert!(
+        result
+            .stderr
+            .contains("process interrupted by signal SIGINT"),
+        "stderr was {:?}",
+        result.stderr
+    );
+}

--- a/crates/orbit-store/src/fs/lock/mod.rs
+++ b/crates/orbit-store/src/fs/lock/mod.rs
@@ -71,7 +71,7 @@ impl Default for LockOptions {
 pub(crate) struct FileLockGuard {
     // Held purely for its Drop side effect: closing the file releases the
     // `flock`. Named with a leading underscore so dead-code analysis does not
-    // flag the never-read field (mirrors `SignalHandlerGuard::_lock`).
+    // flag the never-read field.
     _file: File,
 }
 

--- a/docs/design-patterns/raii_guard.md
+++ b/docs/design-patterns/raii_guard.md
@@ -1,7 +1,7 @@
 ---
 type: pattern
 summary: "RAII Guard Pattern"
-last_validated: 2026-08-23
+last_validated: 2026-09-07
 ---
 # RAII Guard Pattern
 
@@ -89,54 +89,37 @@ Patterns to copy:
 
 ## Reference: `SignalHandlerGuard` — restore global state
 
-From `crates/orbit-exec/src/supervision/signal.rs:9`:
+From `crates/orbit-exec/src/supervision/signal.rs`:
 
 ```rust
 pub(super) struct SignalHandlerGuard {
-    previous_sigint: libc::sigaction,
-    previous_sigterm: libc::sigaction,
-    read_fd: i32,
-    write_fd: i32,
-    _lock: MutexGuard<'static, ()>,   // serialize installs across the process
+    start_gen: u64,          // signals observed after this wait started
+    slot: Option<usize>,     // lock-free live-pgid table index
 }
 
 impl SignalHandlerGuard {
-    pub(super) fn install() -> Result<Self, OrbitError> {
-        let lock = SIGNAL_HANDLER_LOCK.get_or_init(|| Mutex::new(())).lock()?;
-        let (read_fd, write_fd) = create_signal_pipe()?;
-        SIGNAL_PIPE_WRITE_FD.store(write_fd, Ordering::SeqCst);
-        let previous_sigint = install_signal_handler(libc::SIGINT)?;
-        let previous_sigterm = match install_signal_handler(libc::SIGTERM) {
-            Ok(prev) => prev,
-            Err(err) => {
-                // hand-rollback: SIGINT installed but SIGTERM failed, and Drop
-                // never runs on a value that never returned from this function
-                SIGNAL_PIPE_WRITE_FD.store(-1, Ordering::SeqCst);
-                close_fd(read_fd); close_fd(write_fd);
-                restore_signal_handler(libc::SIGINT, &previous_sigint);
-                return Err(err);
-            }
-        };
-        Ok(Self { previous_sigint, previous_sigterm, read_fd, write_fd, _lock: lock })
+    pub(super) fn install(pgid: u32) -> Result<Self, OrbitError> {
+        let start_gen = acquire_handlers()?;   // refcount++; first waiter installs
+        Ok(Self { start_gen, slot: register_pgid(pgid) })
     }
 }
 
 impl Drop for SignalHandlerGuard {
     fn drop(&mut self) {
-        SIGNAL_PIPE_WRITE_FD.store(-1, Ordering::SeqCst);
-        restore_signal_handler(libc::SIGINT, &self.previous_sigint);
-        restore_signal_handler(libc::SIGTERM, &self.previous_sigterm);
-        close_fd(self.read_fd);
-        close_fd(self.write_fd);
+        unregister_pgid(self.slot);
+        release_handlers();                    // last waiter restores prior sigaction
     }
 }
 ```
 
+`acquire_handlers` takes a process-wide `Mutex` only for the refcount/`sigaction` critical section. The first waiter snapshots the previous SIGINT/SIGTERM dispositions and installs a handler that stores a generation counter and `killpg`s every registered child; the last drop restores those dispositions. Concurrent waits overlap.
+
 Patterns to copy:
 
-- **Capture prior state in the guard's fields.** `previous_sigint` isn't recomputed in `Drop` — it's snapshotted at install time.
-- **Hold a `'static` mutex as a field.** `_lock: MutexGuard<'static, ()>` makes "one guard at a time, process-wide" structurally impossible to violate.
-- **Hand-rollback on partial install.** `Drop` only runs on values that successfully return; mid-construction failures must unwind their own work before returning `Err`.
+- **Refcount a process-global side effect.** The guard's job is "this wait is live", not "I own the handler exclusively". Last `Drop` restores prior state.
+- **Keep the mutex off the long path.** Holding `MutexGuard` as a field would serialize every supervised child for its entire lifetime.
+- **Hand-rollback on partial first install.** `Drop` only runs on values that successfully return; if SIGINT is installed and SIGTERM fails, restore SIGINT before returning `Err`, and do not bump the refcount.
+- **Capture prior state next to the refcount, not on every guard.** Previous `sigaction` structs live in the shared install record because only the first/last waiter should swap them.
 
 ## Reference: `FileLockGuard` — resource held until `Drop`
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -4,7 +4,7 @@ type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
 last_updated: 2026-09-06
-last_validated: 2026-09-06
+last_validated: 2026-09-07
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -276,7 +276,7 @@ requires no new ADR.
 
 `process_group_is_alive` uses `killpg(pid, 0)`, treats `ESRCH` as "all gone," and treats other errno values as "still alive" so cleanup errs toward SIGKILL.
 
-`SignalHandlerGuard` is RAII: install acquires a global `Mutex`, creates a pipe, swaps in handlers, and stores prior `sigaction` structs; Drop restores handlers, closes the pipe, and releases the mutex. The handler performs only an atomic load plus one-byte `write`, both async-signal-safe.
+`SignalHandlerGuard` is RAII and refcounted: the first live waiter installs SIGINT/SIGTERM handlers and snapshots the previous `sigaction` structs; the last drop restores them. A process-wide mutex covers only that install/drop critical section, so concurrent `run_process` waits overlap. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: it stores the signal, increments the generation, and `killpg`s every registered group. Waiters that miss a slot still observe the generation counter on the next poll and run the ordinary termination path.
 
 Non-Unix builds use a fallback `terminate_process_group` that just calls `child.kill().ok(); child.wait().ok();` — process-group semantics do not apply on Windows, so orphan reaping is best-effort.
 
@@ -348,7 +348,7 @@ asserts 100 collision-free dense IDs per artifact kind ([ORB-10596]).
 10. **Glob syntax is narrow.** Character classes, brace expansion, and POSIX bracket expressions are unsupported.
 11. **Policy result shapes are parallel.** `PolicyDecision` and `FsPolicyEvaluation` have no bridge for future non-fs evaluators.
 12. **Empty rule sets are safe but opaque.** A profile with only deny rules reports `matched_rule = "[]"`, not the matching deny rule.
-13. **Signal handling is process-global.** `SignalHandlerGuard` serializes installs with a global `Mutex`, which constrains future worker-pool exec.
+13. **Signal handling is process-global.** SIGINT/SIGTERM dispositions are shared across concurrent waits (refcounted install, lock-free pgid fan-out). A waiter that cannot claim a pgid slot still terminates from the generation counter within one poll interval.
 14. **Workspace canonicalization errors collapse to denial.** A missing workspace root can surface as `PolicyDenied("path is outside workspace")` rather than a clearer root-missing error.
 
 ---

--- a/docs/design/policy-sandbox/3_vision.md
+++ b/docs/design/policy-sandbox/3_vision.md
@@ -8,7 +8,7 @@ status: Draft
 feature: policy-sandbox
 doc_role: vision
 tags: ["policy-sandbox"]
-last_validated: 2026-08-15
+last_validated: 2026-09-07
 ---
 
 # Policy & Sandboxing — Vision
@@ -29,7 +29,7 @@ This document captures the questions Orbit must answer before policy and sandbox
 8. **Should empty rule lists warn?** `read: []` / `modify: []` safely denies everything, but a load-time warning would catch likely mistakes earlier.
 9. **What is the dry-run / explain story?** A command like `orbit policy explain --profile <name> --op modify --path <path>` would shorten policy authoring loops.
 10. **Should all denials share one audit shape?** Fs denials, task-lock denials, program allowlists, and future exec denials still report through different channels; auditability asks the same question.
-11. **How should concurrent exec handle signals?** `SignalHandlerGuard` serializes installs; worker-pool exec may need sigmasks, cancellation tokens, or a supervisor thread.
+11. **How should concurrent exec handle signals?** Answered: refcounted SIGINT/SIGTERM install with a lock-free live-pgid table. The handler `killpg`s every registered group; each waiter polls a generation counter. The install mutex is not held across the child's lifetime.
 12. **How far should CLI policy coverage go?** macOS `sandbox-exec` narrows writes, but alternatives include trapping CLI fs calls or moving more work to HTTP-backed activities.
 
 ### 1.1 Shipped answer: a `linux-bwrap` CLI backend

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -8,7 +8,7 @@ status: Draft
 feature: policy-sandbox
 doc_role: decisions
 tags: ["policy-sandbox"]
-last_validated: 2026-09-06
+last_validated: 2026-09-07
 ---
 
 # Policy & Sandboxing — Decisions
@@ -147,19 +147,21 @@ A timed-out or interrupted child needs a chance to flush state before being kill
 - Termination is deterministic, and annotated stderr distinguishes timeout, signal, and clean-exit paths.
 - Cost: the 5-second constant is global. Activities that need a longer drain (database flush, large I/O cleanup) cannot extend it without code changes.
 
-## Signal handler installation is process-global and serialized
+## Signal handler installation is process-global and refcounted
 
 **Recorded:** 2026-05-11 02:06:39.403286Z · [T20260417-0558-5]
+**Updated:** 2026-09-07 · [ORB-11692]
 
 ### Context
-Installing parent-side SIGINT/SIGTERM handlers is a process-global operation. Two concurrent `run_process` calls cannot install independent handlers without races, and a panicking call must restore the prior handler so the orbit process itself remains interruptible.
+Installing parent-side SIGINT/SIGTERM handlers is a process-global operation. Two concurrent `run_process` calls cannot install independent handlers without races, and a panicking call must restore the prior handler so the orbit process itself remains interruptible. Holding the install mutex for each child's entire lifetime also silently serialized every supervised subprocess in the daemon (parallel job branches, MCP `proc.spawn`, web-server `gh` calls).
 
 ### Decision
-`SignalHandlerGuard::install` acquires a `Mutex` from a `OnceLock`, creates a non-blocking pipe, calls `libc::sigaction` for SIGINT and SIGTERM, and stores the previous `sigaction` structs. Drop reverses the steps: restore previous handlers, close the pipe, release the mutex. The handler itself is async-signal-safe (atomic load + 1-byte `write`).
+`SignalHandlerGuard::install` refcounts a process-wide handler. The first live waiter installs SIGINT/SIGTERM and snapshots the previous `sigaction` structs; the last drop restores them. The mutex is held only for that install/drop critical section. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: atomic store of the signal and generation, then `killpg` to every registered group. Waiters poll the generation counter and still run `terminate_process_group` so a missed slot or a race with unregister cannot leave a child running.
 
 ### Consequences
-- Concurrent `run_process` calls serialize handler install/drop, and panics still restore prior handlers via Drop.
-- Cost: contention on the global mutex limits exec parallelism in a single process. Named as an open question in [3_vision.md §1.11](./3_vision.md#1-open-questions).
+- Concurrent `run_process` / `supervise_child` waits overlap. Ctrl-C terminates every live child process group, not only the waiter that would have held an exclusive mutex.
+- Panics still restore prior handlers via the last Drop.
+- Cost: at most `MAX_LIVE_PROCESS_GROUPS` children get immediate handler-side `killpg`; additional waiters terminate on the next 100 ms poll instead. The table is not a semaphore.
 
 ## `NoSandbox` is the default `Sandbox` impl; real isolation is deferred
 

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -28,7 +28,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 - **Background drains.** `wait_with_optional_timeout` spawns reader threads for stdout and stderr immediately after spawn. The child must never block on a full pipe buffer because the parent is not reading.
 - **Stdin writer thread.** When `StdinMode::Bytes` is set, a writer thread copies the payload to the child's stdin. A failed write terminates the child via `terminate_process_group` and surfaces as `OrbitError::Execution(<message>)`.
 - **Poll interval.** The wait loop polls with `WAIT_POLL_INTERVAL = 100ms` (or the remaining deadline, whichever is smaller). The interval is global and not per-request configurable.
-- **Signal handler installation (Unix).** A `SignalHandlerGuard` installs SIGINT and SIGTERM handlers for the duration of the wait loop. Installation acquires a process-global `Mutex`; the guard holds it until drop, so concurrent supervised waits are serialized. Drop restores the previous handlers and closes the signal pipe.
+- **Signal handler installation (Unix).** A `SignalHandlerGuard` refcounts process-wide SIGINT and SIGTERM handlers for the duration of the wait loop. The first live waiter installs the handlers and snapshots the previous `sigaction` structs; the last drop restores them. The install mutex is not held across the wait, so concurrent supervised waits overlap. Each waiter registers its child's pgid in a lock-free table; the handler `killpg`s every registered group and bumps a generation counter that waiters poll.
 - **Timeout escalation.** When the deadline expires, `terminate_process_group(child, SIGTERM, poll_interval)` is called. If the group does not exit within `TERMINATION_GRACE_PERIOD = 5 seconds`, `kill_process_group` (SIGKILL) is invoked plus a direct `child.kill()`/`child.wait()`.
 - **Parent-signal escalation.** When the parent receives SIGINT or SIGTERM during the wait, the same termination path runs with the received signal. The result reports `exit_code = Some(128 + signal)` and `success = false`.
 - **Clean-exit reaping.** When the child exits cleanly, the wait loop calls `kill_process_group(child.id())` to reap any orphan subprocesses still holding pipe write ends, then joins the reader threads. Without this, an orphan grandchild can keep the pipes open and block reader-thread completion indefinitely.
@@ -56,7 +56,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 
 ## Concurrency Constraints
 
-- **Single signal-handler install at a time.** The global `Mutex` in `SignalHandlerGuard` serializes the complete guarded wait on Unix. Two concurrent `run_process` calls in the same process take turns from install through drop; their wait loops do not overlap.
+- **Shared signal-handler install, overlapping waits.** On Unix, concurrent `run_process` / `supervise_child` calls share one SIGINT/SIGTERM disposition (refcounted). Their wait loops overlap. Ctrl-C terminates every live registered process group; waiters that could not claim a pgid slot still observe the generation counter and run the ordinary termination path.
 - **No assumption about thread-local state.** Reader threads, writer threads, and the signal handler are spawned with `'static` requirements; callers must not rely on thread-local data from the spawning thread.
 - **No retry inside `run_process`.** The runner does not retry spawn failures, wait errors, or signal-install failures. Retry policy belongs to the caller.
 


### PR DESCRIPTION
## Task

[ORB-11692](https://orbit-cli.com/tasks/ORB-11692) — [code-review] Stop serialising every supervised child on the global signal-handler mutex

### Description

## Problem
`SignalHandlerGuard::install()` takes `SIGNAL_HANDLER_LOCK` (a process-wide `Mutex<()>`) and stores the `MutexGuard` inside the guard (`_lock`), which lives until the end of `wait_with_timeout_and_output_limit` — i.e. for the whole lifetime of the child. Every `run_process` / `supervise_child` / `run_process_streaming_stdout` call therefore blocks until the previously started child in the same process has exited. Concrete scenario: a `parallel` job block (`crates/orbit-engine/src/activity_job/job_executor/parallel.rs:23-45`) spawns one thread per branch and each branch runs a `local_shell` step via `supervise_child` (`crates/orbit-engine/src/executor/automation/shell.rs:135`); the branches execute strictly one after another, and a 10-minute branch stalls the others for 10 minutes. The MCP server (`crates/orbit-mcp/src/adapter/dispatch.rs:177` uses `spawn_blocking`) and the web server have the same problem: any `proc.spawn` or `gh` call blocks all other tool calls that need a subprocess.

## Why It Matters
Silent loss of all subprocess concurrency across the daemon, with no timeout accounting for the time spent waiting on the lock (the deadline starts only after the lock is acquired).

## Proposed Fix
Install the SIGINT/SIGTERM handlers once (reference-counted or `OnceLock`), keep a registry of active child pgids (e.g. a `Mutex<Vec<pid>>`) that the handler byte fans out to, and let each supervisor poll a per-supervision flag; do not hold a mutex across the child's lifetime.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-exec/src/supervision/signal.rs:6-45`, `crates/orbit-exec/src/supervision/wait.rs:72-73`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (performance). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test in `crates/orbit-exec/src/supervision/tests/wait.rs` that supervises two `sleep 1` children from two threads and asserts total wall time < 1.5 s.
- A `parallel` job with two `local_shell` branches of `sleep 2` completes in ~2 s, not ~4 s.
- Ctrl-C during a run still terminates every live child process group.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `SignalHandlerGuard` is refcounted: first live waiter installs SIGINT/SIGTERM, last drop restores prior dispositions. The process-wide mutex is held only for that install/drop critical section, never across the child's wait.
- A lock-free pgid table plus a generation counter let the async-signal-safe handler `killpg` every registered child; each waiter still polls and runs the ordinary termination path if it missed a slot.
- Tests: two-thread `sleep 1` overlap in `supervision/tests/wait.rs` (1.04 s < 1.5 s); parallel job with two `local_shell` `sleep 2` branches (2.03 s, not ~4 s); isolated-process Ctrl-C fan-out (`tests/signal_fanout.rs`).
- Current docs updated so they no longer describe serialized waits (`raii_guard.md`, policy-sandbox design/spec). Stale `_lock` comment removed from `FileLockGuard`.
Assessment: The daemon can supervise concurrent children again. Ctrl-C still terminates every live process group. Handler-side `killpg` covers the first 256 live groups immediately; extras terminate on the next 100 ms poll.

Acceptance criteria:
1. Two-thread `sleep 1` wall time < 1.5 s — met (`concurrent_supervised_sleeps_overlap`, 1.04 s).
2. Parallel job, two `local_shell` `sleep 2` branches ~2 s not ~4 s — met (`parallel_local_shell_sleeps_overlap`, 2.03 s).
3. Ctrl-C terminates every live child process group — met (`ctrl_c_terminates_every_live_child_process_group`).

Validation:
- `cargo test -p orbit-exec --lib concurrent_supervised_sleeps_overlap` — passed (1.04 s).
- `cargo test -p orbit-exec --lib -- supervision::tests` — passed (3 tests).
- `cargo test -p orbit-exec --test signal_fanout` — passed.
- `cargo test -p orbit-engine parallel_local_shell_sleeps_overlap` — passed (2.03 s).
- `make ci-fast` — passed.
- `make ci-lint` — passed (after replacing a `const AtomicU32` array initializer that tripped `declare_interior_mutable_const`).
- `git diff --check` — passed.

Deviations: Ctrl-C coverage is an integration binary so `raise(SIGINT)` cannot interrupt other in-process unit tests. Uncommitted, as required.
Remaining risk: waiters beyond 256 concurrent groups are not in the handler table and rely on the 100 ms poll; that bound is documented. The 1.5 s overlap gate can flake if spawn overhead exceeds 500 ms under extreme load.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11692-6a9f40f4`
- Behind base: 0
- Ahead of base: 1