### PR TITLE
[code-review] Bound `policy.timeout_minutes` / `retries.backoff_minutes` so a large YAML value cannot panic the whole sweep

### DIFF
--- a/crates/orbit-automation/src/routines/sweep.rs
+++ b/crates/orbit-automation/src/routines/sweep.rs
@@ -189,9 +189,11 @@ pub fn run_sweep_core_with_registry(
         .map(|routine| (routine.definition.name.clone(), routine))
         .collect();
 
-    if !options.dry_run {
-        sync_unresolved_fires(store, &routines_by_name, dispatch, now_utc)?;
-    }
+    let sync_errors = if options.dry_run {
+        BTreeMap::new()
+    } else {
+        sync_unresolved_fires(store, &routines_by_name, dispatch, now_utc)?
+    };
 
     let pauses = store.routine_pauses()?;
 
@@ -221,6 +223,10 @@ pub fn run_sweep_core_with_registry(
             reports.push(skipped(routine, &validation, "duplicate_routine_ownership"));
             continue;
         }
+        if let Some(reason) = sync_errors.get(&routine.definition.name) {
+            reports.push(failure_report(routine, &validation, reason.clone()));
+            continue;
+        }
         let report = sweep_routine(
             store,
             routine,
@@ -230,16 +236,7 @@ pub fn run_sweep_core_with_registry(
             options,
             now_utc,
         )
-        .unwrap_or_else(|error| RoutineSweepReport {
-            routine: routine.definition.name.clone(),
-            source: routine.source_workspace.clone(),
-            origin: routine.origin.as_str(),
-            action: "error",
-            reason: Some(error.to_string()),
-            slot: None,
-            run_id: None,
-            validation: validation.clone(),
-        });
+        .unwrap_or_else(|error| failure_report(routine, &validation, error.to_string()));
         reports.push(report);
     }
 
@@ -394,7 +391,8 @@ fn retry_candidate(
         return Ok(None);
     }
     let failed_at = parse_rfc3339(&latest.updated_at)?;
-    if now_utc.signed_duration_since(failed_at) < Duration::minutes(retries.backoff_minutes as i64)
+    if now_utc.signed_duration_since(failed_at)
+        < duration_from_minutes(retries.backoff_minutes, "policy.retries.backoff_minutes")?
     {
         return Ok(None);
     }
@@ -511,7 +509,8 @@ fn sync_unresolved_fires(
     routines_by_name: &BTreeMap<String, &LoadedRoutine>,
     dispatch: &dyn RoutineDispatch,
     now_utc: DateTime<Utc>,
-) -> Result<(), OrbitError> {
+) -> Result<BTreeMap<String, String>, OrbitError> {
+    let mut errors = BTreeMap::new();
     for fire in store.routine_unresolved_fires()? {
         // Eligibility was resolved before this mutation phase. A routine that
         // is no longer assigned to this machine must leave this machine's
@@ -519,13 +518,23 @@ fn sync_unresolved_fires(
         let Some(routine) = routines_by_name.get(&fire.routine_name) else {
             continue;
         };
-        let timeout_minutes = routine.definition.policy.timeout_minutes;
+        let timeout = match duration_from_minutes(
+            routine.definition.policy.timeout_minutes,
+            "policy.timeout_minutes",
+        ) {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                errors
+                    .entry(routine.definition.name.clone())
+                    .or_insert_with(|| error.to_string());
+                continue;
+            }
+        };
         let created_at = match parse_rfc3339(&fire.created_at) {
             Ok(value) => value,
             Err(_) => continue,
         };
-        let expired =
-            now_utc.signed_duration_since(created_at) > Duration::minutes(timeout_minutes as i64);
+        let expired = now_utc.signed_duration_since(created_at) > timeout;
 
         match fire.state {
             // A recorded intent whose sweep died before dispatch: reclaim it
@@ -639,7 +648,17 @@ fn sync_unresolved_fires(
         }
     }
 
-    Ok(())
+    Ok(errors)
+}
+
+fn duration_from_minutes(minutes: u64, field: &str) -> Result<Duration, OrbitError> {
+    let minutes = i64::try_from(minutes).map_err(|_| {
+        OrbitError::InvalidInput(format!("routine {field} is too large for a duration"))
+    })?;
+
+    Duration::try_minutes(minutes).ok_or_else(|| {
+        OrbitError::InvalidInput(format!("routine {field} is too large for a duration"))
+    })
 }
 
 fn skipped(
@@ -653,6 +672,23 @@ fn skipped(
         origin: routine.origin.as_str(),
         action: "skipped",
         reason: Some(reason.to_string()),
+        slot: None,
+        run_id: None,
+        validation: validation.clone(),
+    }
+}
+
+fn failure_report(
+    routine: &LoadedRoutine,
+    validation: &RoutinePinValidation,
+    reason: String,
+) -> RoutineSweepReport {
+    RoutineSweepReport {
+        routine: routine.definition.name.clone(),
+        source: routine.source_workspace.clone(),
+        origin: routine.origin.as_str(),
+        action: "error",
+        reason: Some(reason),
         slot: None,
         run_id: None,
         validation: validation.clone(),

--- a/crates/orbit-automation/src/routines/tests/sweep.rs
+++ b/crates/orbit-automation/src/routines/tests/sweep.rs
@@ -667,6 +667,59 @@ fn sync_reclaims_stale_intent_and_dispatched_past_timeout() {
     );
 }
 
+#[test]
+fn malformed_timeout_in_one_dispatched_fire_reports_only_that_routine() {
+    let store = store();
+    let dispatch = FakeDispatch::default();
+    let mut malformed = routine("malformed", "* * * * *", true, "forbid", 0);
+    malformed.definition.policy.timeout_minutes = 1_000_000_000_000_000;
+    let coll = collection(vec![
+        malformed,
+        routine("healthy", "* * * * *", true, "forbid", 0),
+    ]);
+
+    let slot = ts(2026, 1, 1, 0, 5, 0).to_rfc3339();
+    store
+        .routine_record_fire_intent(&RoutineFireIntentParams {
+            routine_name: "malformed".to_string(),
+            slot: slot.clone(),
+            attempt: 1,
+            source_workspace: "polaris".to_string(),
+        })
+        .unwrap();
+    store
+        .routine_mark_fire_dispatched("malformed", &slot, 1, "malformed-run")
+        .unwrap();
+
+    let reports = run_sweep_core(
+        &store,
+        HOST,
+        &coll,
+        &dispatch,
+        SweepOptions::default(),
+        Utc::now(),
+    )
+    .expect("malformed policy is isolated to its routine");
+
+    let malformed_report = reports
+        .iter()
+        .find(|report| report.routine == "malformed")
+        .expect("malformed routine report");
+    assert_eq!(malformed_report.action, "error");
+    assert!(
+        malformed_report
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("policy.timeout_minutes"))
+    );
+    assert!(
+        reports
+            .iter()
+            .filter(|report| report.routine != "malformed")
+            .all(|report| report.action != "error")
+    );
+}
+
 // ---- dispatch-error retry --------------------------------------------------
 
 #[test]

--- a/crates/orbit-common/src/protocol/tests/yaml.rs
+++ b/crates/orbit-common/src/protocol/tests/yaml.rs
@@ -1,3 +1,4 @@
+use crate::OrbitError;
 use crate::protocol::yaml::{parse_local_routine_yaml, parse_routine_yaml};
 use orbit_types::workflow::{MissedRunPolicy, OverlapPolicy, RoutineTarget};
 
@@ -70,6 +71,32 @@ target: job:docs_reindex
     )
     .expect_err("unknown trigger field must fail");
     assert!(error.to_string().contains("jitter_seconds"), "{error}");
+}
+
+#[test]
+fn rejects_duration_values_above_one_week() {
+    for (field, policy) in [
+        ("timeout_minutes", "timeout_minutes: 1000000000000000"),
+        (
+            "backoff_minutes",
+            "retries: { max: 1, backoff_minutes: 1000000000000000 }",
+        ),
+    ] {
+        let error = parse_routine_yaml(&format!(
+            "schemaVersion: 1\n\
+             name: reindex\n\
+             hosts: [dk-server-1]\n\
+             trigger:\n  cron: \"*/30 * * * *\"\n\
+             target: job:docs_reindex\n\
+             policy:\n  {policy}\n"
+        ))
+        .expect_err("duration above one week must fail");
+
+        assert!(
+            matches!(error, OrbitError::InvalidInput(ref message) if message.contains(field)),
+            "{error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/orbit-types/src/workflow/routine.rs
+++ b/crates/orbit-types/src/workflow/routine.rs
@@ -222,6 +222,10 @@ const fn default_backoff_minutes() -> u64 {
     2
 }
 
+/// Maximum supported timeout or retry backoff. A week is long enough for
+/// unattended maintenance while keeping routine policy mistakes bounded.
+const MAX_DURATION_MINUTES: u64 = 7 * 24 * 60;
+
 impl RoutineDefinition {
     /// Origin-agnostic semantic checks beyond serde shape: name charset, no
     /// blank host entries, non-empty cron, positive timeout. Full cron parsing
@@ -274,9 +278,15 @@ impl RoutineDefinition {
                 self.name
             )));
         }
-        if self.policy.timeout_minutes == 0 {
+        if self.policy.timeout_minutes == 0 || self.policy.timeout_minutes > MAX_DURATION_MINUTES {
             return Err(WorkflowError::Invalid(format!(
-                "routine '{}' policy.timeout_minutes must be at least 1",
+                "routine '{}' policy.timeout_minutes must be between 1 and {MAX_DURATION_MINUTES}",
+                self.name
+            )));
+        }
+        if self.policy.retries.backoff_minutes > MAX_DURATION_MINUTES {
+            return Err(WorkflowError::Invalid(format!(
+                "routine '{}' policy.retries.backoff_minutes must not exceed {MAX_DURATION_MINUTES}",
                 self.name
             )));
         }


### PR DESCRIPTION
## Task

[ORB-11726](https://orbit-cli.com/tasks/ORB-11726) — [code-review] Bound `policy.timeout_minutes` / `retries.backoff_minutes` so a large YAML value cannot panic the whole sweep

### Description

## Problem
`RoutinePolicy.timeout_minutes` and `RoutineRetries.backoff_minutes` are `u64` and `validate_common` only rejects `timeout_minutes == 0`. The sweep turns them into `chrono::Duration::minutes(x as i64)` at sweep.rs:397 and :528. `Duration::minutes` panics ("out of bounds") when the value exceeds ~1.5e14 minutes, and the `as i64` cast of a value above `i64::MAX` produces a negative duration that makes `expired` true for every fire or the backoff check always pass. A committed routine with `timeout_minutes: 1000000000000000` therefore loads cleanly and then panics `sync_unresolved_fires` (called at the top of every pass, before any per-routine isolation), taking down every routine on the host each minute.

## Why It Matters
One bad number in one routine file becomes a host-wide scheduler outage rather than a per-file load error, contrary to the fail-closed-per-file contract of the loader.

## Proposed Fix
In `validate_common` reject `timeout_minutes` and `backoff_minutes` above a sane ceiling (e.g. 7 days / 10080 minutes, or at least `u32::MAX`), and make the two `Duration::minutes` call sites use `Duration::try_minutes` with an `OrbitError::InvalidInput` fallback so a stale definition still cannot panic.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-types/src/workflow/routine.rs:277-282`, `crates/orbit-automation/src/routines/sweep.rs:397`, `crates/orbit-automation/src/routines/sweep.rs:528`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A `parse_routine_yaml` test with `timeout_minutes: 1000000000000000` returns `WorkflowError::Invalid`.
- A sweep test with a `Dispatched` fire and an absurd `timeout_minutes` yields an `error` report row for that routine only, not a panic.
- `cargo test -p orbit-automation -p orbit-types` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Bound `policy.timeout_minutes` (1..=10080) and `policy.retries.backoff_minutes` (<=10080) in `RoutineDefinition::validate_common`, so routine YAML fails closed before scheduler use.
- Replaced unchecked scheduler duration conversion with `Duration::try_minutes` plus `OrbitError::InvalidInput`; outcome sync now turns a stale malformed routine into its own `error` report while continuing other routines.
- Added parser coverage for absurd timeout/backoff values and sweep coverage for an absurd timeout on a dispatched fire alongside a healthy routine.

Criteria:
- Parser rejects `timeout_minutes: 1000000000000000` as invalid input: passed.
- A dispatched fire with that malformed timeout produces an `error` report only for the malformed routine: passed.
- `cargo test -p orbit-automation -p orbit-types` requirement: passed as part of the broader three-package test command.

Validation:
- Passed: `CARGO_HOME=/tmp/orb-11726-cargo-home CARGO_TARGET_DIR=/tmp/orb-11726-target cargo test -p orbit-common -p orbit-automation -p orbit-types` (all tests passed).
- Passed: `make ci-fast`.
- Passed: `CARGO_HOME=/tmp/orb-11726-cargo-home CARGO_TARGET_DIR=/tmp/orb-11726-target make ci-lint`.
- Passed: `git diff --check`.
- Initial `cargo test -p orbit-common -p orbit-automation -p orbit-types` could not write the read-only default Cargo registry cache; rerunning with isolated `/tmp` Cargo home and target completed successfully.

Assessment: The authoritative schema rejects unsafe configuration, while checked duration conversion preserves per-routine isolation for stale or programmatically constructed definitions.

Risks: Existing committed routine definitions with timeouts or retry backoffs above one week now fail closed at load time by design.

Friction checkpoint: considered; no friction record filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11726-6a9f44d0`
- Behind base: 0
- Ahead of base: 1