### PR TITLE
[code-review] Confine `orbit.task.artifact.put` `source_path` to the workspace checkout (arbitrary file read over MCP)

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -949,7 +949,7 @@
         "required": true
       },
       {
-        "description": "Source file to store as a task artifact.",
+        "description": "Source file to store as a task artifact. Resolved against the caller cwd, then confined to the workspace checkout after symlink resolution. Absolute paths and symlinks that escape the workspace are rejected.",
         "name": "source_path",
         "param_type": "string",
         "required": true

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -831,7 +831,7 @@
           "type": "string"
         },
         "source_path": {
-          "description": "Source file to store as a task artifact.",
+          "description": "Source file to store as a task artifact. Resolved against the caller cwd, then confined to the workspace checkout after symlink resolution. Absolute paths and symlinks that escape the workspace are rejected.",
           "type": "string"
         },
         "workspace": {

--- a/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
+++ b/crates/orbit-core/assets/skills/orbit/references/tool-surface.md
@@ -32,7 +32,7 @@ records in a second store merely to get past a connection error.
 |---|---|---|
 | Workspace discovery | `orbit_workspace_list` | `orbit workspace list/show` |
 | Task create/read/update/start/approve | `orbit_task_add/list/show/update/start/approve` | Registered `orbit.task.*` tools preserve agent attribution |
-| Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host |
+| Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host and must resolve inside the workspace checkout |
 | Retrieval | `orbit_search` | `orbit search`; semantic install/index is separate |
 | Friction | `orbit_friction_add/list/update` | Additional show/stats/tags/resolve commands |
 | Submit explicit tasks | `orbit_workflow_ship` (review-only; no completion input) | `orbit run ship`, `run auto` |

--- a/crates/orbit-core/src/adapter/tool_host/host.rs
+++ b/crates/orbit-core/src/adapter/tool_host/host.rs
@@ -1109,18 +1109,17 @@ mod checkoutless_hub_tests {
             )
             .expect("persist verdict fields");
 
-        let source = root.path().join("caller.txt");
-        std::fs::write(&source, "payload").expect("caller artifact");
+        let mut ssh_context = context.clone();
+        ssh_context.transport = Some(orbit_types::tool::McpTransport::SshMcp);
         let with_artifact = executor
             .execute_tool(
                 "orbit.task.artifact.put",
                 json!({
                     "id": id,
-                    "source_path": source,
-                    "path": "reports/result.txt",
+                    "artifacts": [{"path": "reports/result.txt", "content": "payload"}],
                     "model": "codex"
                 }),
-                context.clone(),
+                ssh_context,
             )
             .expect("put artifact bytes");
         assert_eq!(with_artifact["execution_summary"], "Outcome: success");

--- a/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/task_tools.rs
@@ -2798,7 +2798,7 @@ mod artifact_get {
     }
 
     fn attach(runtime: &OrbitRuntime, task_id: &str, path: &str, content: Vec<u8>) {
-        let source = std::env::temp_dir().join(format!(
+        let source = runtime.paths().repo_root.join(format!(
             "orbit-artifact-fixture-{}-{}",
             std::process::id(),
             path.replace('/', "_"),

--- a/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs
@@ -3,6 +3,9 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
+use orbit_common::tracing;
+use orbit_policy::resolve_symlinks;
+use orbit_types::policy::FsOperation;
 use orbit_types::task::{MAX_TASK_ARTIFACT_CONTENT_BYTES, TaskArtifact};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::{Map, Value, json};
@@ -17,7 +20,11 @@ impl Tool for OrbitTaskArtifactPutTool {
         parameters.extend([
             ToolParam {
                 name: "source_path".to_string(),
-                description: "Source file to store as a task artifact.".to_string(),
+                description: "Source file to store as a task artifact. Resolved against the \
+                    caller cwd, then confined to the workspace checkout after symlink \
+                    resolution. Absolute paths and symlinks that escape the workspace are \
+                    rejected."
+                    .to_string(),
                 param_type: "string".to_string(),
                 required: true,
             },
@@ -60,7 +67,7 @@ impl Tool for OrbitTaskArtifactPutTool {
             return super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskUpdate);
         }
 
-        let update_input = prepare_remote_payload(input, ctx.cwd.as_deref().map(Path::new))?;
+        let update_input = prepare_remote_payload(input, ctx)?;
 
         super::super::execute_host_action(ctx, update_input, OrbitBuiltinAction::TaskUpdate)
     }
@@ -69,10 +76,7 @@ impl Tool for OrbitTaskArtifactPutTool {
 /// Read a caller-local task artifact into the bounded, path-free payload used
 /// by the spoke connector. The source path is consumed locally and never
 /// appears in the returned coordination frame.
-pub(crate) fn prepare_remote_payload(
-    input: Value,
-    cwd: Option<&Path>,
-) -> Result<Value, OrbitError> {
+pub(crate) fn prepare_remote_payload(input: Value, ctx: &ToolContext) -> Result<Value, OrbitError> {
     let id = super::super::required_string(&input, &["id"], "id")?;
     let source_path = super::super::required_string(
         &input,
@@ -81,7 +85,10 @@ pub(crate) fn prepare_remote_payload(
     )?;
     let artifact_path =
         super::super::optional_string_alias(&input, &["path", "artifact_path", "artifactPath"])?;
-    let resolved_source_path = resolve_source_path(cwd, &source_path);
+    let resolved_source_path = confine_source_path(
+        ctx,
+        &resolve_source_path(ctx.cwd.as_deref().map(Path::new), &source_path),
+    )?;
     let artifact = read_bounded_artifact(&resolved_source_path, artifact_path.as_deref())?;
 
     let mut update_input = input.as_object().cloned().unwrap_or_else(Map::new);
@@ -160,4 +167,51 @@ fn resolve_source_path(cwd: Option<&Path>, source_path: &str) -> PathBuf {
         return path;
     }
     cwd.map(|cwd| cwd.join(&path)).unwrap_or(path)
+}
+
+/// Symlink-safe workspace containment for a caller-local artifact source.
+///
+/// Absolute paths, relative `..` traversal, and in-workspace symlinks that
+/// resolve outside `ctx.workspace_root` are rejected as `invalid_input` so a
+/// remote `agent` session cannot attach host secrets such as
+/// `~/.orbit/mcp-ssh-acceptance/*.toml`. When a filesystem profile is present,
+/// `check_resolved` additionally applies deny-read rules to the real path.
+fn confine_source_path(ctx: &ToolContext, source_path: &Path) -> Result<PathBuf, OrbitError> {
+    let workspace_root = ctx.workspace_root.as_deref().ok_or_else(|| {
+        OrbitError::InvalidInput("workspace_root is required to attach a source file".to_string())
+    })?;
+    let canonical_workspace = workspace_root.canonicalize().map_err(|error| {
+        OrbitError::InvalidInput(format!(
+            "failed to canonicalize workspace_root '{}': {error}",
+            workspace_root.display()
+        ))
+    })?;
+    let resolved = resolve_symlinks(source_path)?;
+    if !resolved.starts_with(&canonical_workspace) {
+        return Err(OrbitError::InvalidInput(format!(
+            "source_path '{}' is outside workspace_root '{}'",
+            resolved.display(),
+            canonical_workspace.display()
+        )));
+    }
+
+    if let (Some(policy), Some(profile)) = (ctx.policy_engine.as_ref(), ctx.fs_profile.as_deref()) {
+        let evaluation =
+            policy.check_resolved(&canonical_workspace, profile, FsOperation::Read, &resolved)?;
+        if !evaluation.allowed {
+            tracing::warn!(
+                target: "orbit.policy.deny",
+                tool = "orbit.task.artifact.put",
+                path = evaluation.path.as_str(),
+                profile = evaluation.profile.as_str(),
+                matched_rule = evaluation.matched_rule.as_str(),
+            );
+            return Err(OrbitError::PolicyDenied(format!(
+                "orbit.task.artifact.put path '{}' is denied by fsProfile '{}' (matched rule: {})",
+                evaluation.path, evaluation.profile, evaluation.matched_rule
+            )));
+        }
+    }
+
+    Ok(resolved)
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs
@@ -4,13 +4,15 @@
 // to sibling layout under `task/tests/` per ORB-00243 and
 // docs/design-patterns/test_layout.md.
 
+use std::collections::BTreeSet;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use serde_json::{Value, json};
 
 use orbit_common::OrbitError;
 use orbit_types::task::MAX_TASK_ARTIFACT_CONTENT_BYTES;
-use orbit_types::tool::{McpTransport, ToolSessionContext};
+use orbit_types::tool::{McpCapability, McpTransport, RemoteCallerGrant, ToolSessionContext};
 
 use super::super::artifact_put::*;
 use crate::{OrbitBuiltinAction, OrbitTaskScope, OrbitToolHost, Tool, ToolContext};
@@ -51,17 +53,29 @@ impl OrbitToolHost for RecordingHost {
     }
 }
 
+fn context_in(dir: &Path, host: RecordingHost) -> ToolContext {
+    ToolContext {
+        cwd: Some(dir.to_string_lossy().into_owned()),
+        workspace_root: Some(dir.to_path_buf()),
+        orbit_host: Some(Arc::new(host)),
+        ..Default::default()
+    }
+}
+
+fn assert_invalid_input(error: OrbitError) {
+    assert!(
+        matches!(error, OrbitError::InvalidInput(_)),
+        "expected invalid_input, got {error}"
+    );
+}
+
 #[test]
 fn artifact_put_reads_relative_source_and_delegates_to_task_update() {
     let dir = tempfile::tempdir().expect("tempdir");
     let source = dir.path().join("summary.md");
     std::fs::write(&source, "done\n").expect("write source");
     let host = RecordingHost::default();
-    let ctx = ToolContext {
-        cwd: Some(dir.path().to_string_lossy().into_owned()),
-        orbit_host: Some(Arc::new(host.clone())),
-        ..Default::default()
-    };
+    let ctx = context_in(dir.path(), host.clone());
 
     let output = OrbitTaskArtifactPutTool
         .execute(
@@ -108,15 +122,13 @@ fn artifact_put_rejects_agent_identity_field() {
 
 #[test]
 fn artifact_put_read_failure_never_calls_host() {
+    let dir = tempfile::tempdir().expect("tempdir");
     let host = RecordingHost::default();
-    let ctx = ToolContext {
-        orbit_host: Some(Arc::new(host.clone())),
-        ..Default::default()
-    };
+    let ctx = context_in(dir.path(), host.clone());
     let error = OrbitTaskArtifactPutTool
         .execute(
             &ctx,
-            json!({"id": "ORB-00001", "source_path": "/definitely/missing"}),
+            json!({"id": "ORB-00001", "source_path": "definitely-missing"}),
         )
         .expect_err("missing source must fail locally");
 
@@ -134,15 +146,114 @@ fn artifact_put_size_failure_never_calls_host() {
     )
     .expect("write oversized source");
     let host = RecordingHost::default();
-    let ctx = ToolContext {
-        orbit_host: Some(Arc::new(host.clone())),
-        ..Default::default()
-    };
+    let ctx = context_in(dir.path(), host.clone());
     let error = OrbitTaskArtifactPutTool
         .execute(&ctx, json!({"id": "ORB-00001", "source_path": source}))
         .expect_err("oversized source must fail locally");
 
     assert!(error.to_string().contains("content limit"));
+    assert!(host.call.lock().expect("host call").is_none());
+}
+
+#[test]
+fn artifact_put_rejects_source_outside_workspace_root() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let outside = tempfile::tempdir().expect("outside");
+    let source = outside.path().join("secret.txt");
+    std::fs::write(&source, "leaked\n").expect("write outside source");
+    let host = RecordingHost::default();
+    let ctx = context_in(workspace.path(), host.clone());
+    let error = OrbitTaskArtifactPutTool
+        .execute(&ctx, json!({"id": "ORB-00001", "source_path": source}))
+        .expect_err("outside workspace_root must be refused");
+
+    assert_invalid_input(error);
+    assert!(host.call.lock().expect("host call").is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn artifact_put_rejects_symlink_inside_workspace_pointing_outside() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let outside = tempfile::tempdir().expect("outside");
+    let secret = outside.path().join("secret.txt");
+    std::fs::write(&secret, "leaked\n").expect("write outside target");
+    let link = workspace.path().join("link.txt");
+    std::os::unix::fs::symlink(&secret, &link).expect("symlink");
+    let host = RecordingHost::default();
+    let ctx = context_in(workspace.path(), host.clone());
+    let error = OrbitTaskArtifactPutTool
+        .execute(&ctx, json!({"id": "ORB-00001", "source_path": "link.txt"}))
+        .expect_err("escaping symlink must be refused");
+
+    assert_invalid_input(error);
+    assert!(host.call.lock().expect("host call").is_none());
+}
+
+#[test]
+fn artifact_put_accepts_file_inside_workspace_root() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::write(workspace.path().join("notes.md"), "ok\n").expect("write inside source");
+    let host = RecordingHost::default();
+    let ctx = context_in(workspace.path(), host.clone());
+
+    OrbitTaskArtifactPutTool
+        .execute(
+            &ctx,
+            json!({
+                "id": "ORB-00001",
+                "source_path": "notes.md",
+                "model": "codex"
+            }),
+        )
+        .expect("in-workspace source must be accepted");
+
+    let call = host.call.lock().expect("recorded call").take().unwrap();
+    assert_eq!(call.action, OrbitBuiltinAction::TaskUpdate);
+    assert_eq!(call.input["artifacts"][0]["path"], "notes.md");
+}
+
+#[test]
+fn remote_agent_session_cannot_attach_mcp_ssh_acceptance_secret() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let orbit_home = tempfile::tempdir().expect("orbit home");
+    let acceptance_dir = orbit_home.path().join("mcp-ssh-acceptance");
+    std::fs::create_dir_all(&acceptance_dir).expect("acceptance dir");
+    let secret = acceptance_dir.join("hm_caller.toml");
+    std::fs::write(&secret, "capability = \"secret\"\n").expect("write acceptance secret");
+
+    let host = RecordingHost::default();
+    let ctx = ToolContext {
+        cwd: Some(workspace.path().to_string_lossy().into_owned()),
+        workspace_root: Some(workspace.path().to_path_buf()),
+        session_context: ToolSessionContext {
+            transport: Some(McpTransport::SshMcp),
+            effective_capabilities: BTreeSet::from([McpCapability::Agent]),
+            remote_caller_grant: Some(RemoteCallerGrant {
+                caller_machine_id: "hm_caller".to_string(),
+                granted_capabilities: BTreeSet::from([McpCapability::Agent]),
+                source: secret.display().to_string(),
+                ..RemoteCallerGrant::default()
+            }),
+            ..ToolSessionContext::default()
+        },
+        orbit_host: Some(Arc::new(host.clone())),
+        ..ToolContext::default()
+    };
+
+    let error = OrbitTaskArtifactPutTool
+        .execute(
+            &ctx,
+            json!({
+                "id": "ORB-00001",
+                "source_path": secret,
+                "path": "hm_caller.toml",
+                "model": "codex"
+            }),
+        )
+        .expect_err("remote agent must not attach mcp-ssh-acceptance secrets");
+
+    assert_invalid_input(error);
     assert!(host.call.lock().expect("host call").is_none());
 }
 

--- a/crates/orbit-tools/src/lib.rs
+++ b/crates/orbit-tools/src/lib.rs
@@ -72,11 +72,20 @@ pub use registry::{ToolRegistry, canonical_builtin_mcp_tool_definitions};
 
 /// Materialize a task artifact before a spoke sends the coordination request
 /// to its hub. The returned value contains artifact bytes but no source path.
+///
+/// `source_path` is resolved against `cwd` and must land inside
+/// `workspace_root` after symlink resolution. The hub never sees the path.
 pub fn prepare_remote_task_artifact_put(
     input: Value,
     cwd: Option<&std::path::Path>,
+    workspace_root: Option<&std::path::Path>,
 ) -> Result<Value, OrbitError> {
-    builtin::orbit::task::artifact_put::prepare_remote_payload(input, cwd)
+    let ctx = ToolContext {
+        cwd: cwd.map(|path| path.to_string_lossy().into_owned()),
+        workspace_root: workspace_root.map(PathBuf::from),
+        ..ToolContext::default()
+    };
+    builtin::orbit::task::artifact_put::prepare_remote_payload(input, &ctx)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/design/automation-triggers/5_operations.md
+++ b/docs/design/automation-triggers/5_operations.md
@@ -132,7 +132,7 @@ range, including unattributed neighbors. Fill in the actual checks and findings,
 replace the action ID placeholder with the current task ID, and attach:
 
 ```sh
-orbit tool run orbit.task.artifact.put --input '{"id":"<assigned task>","source_path":"/tmp/automation-coverage.json","path":"automation-coverage.json","model":"codex"}'
+orbit tool run orbit.task.artifact.put --input '{"id":"<assigned task>","source_path":"./automation-coverage.json","path":"automation-coverage.json","model":"codex"}'
 ```
 
 The version-1 schema has these required fields:

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -3,8 +3,8 @@ summary: "Task Artifacts — Design"
 type: design
 title: "Task Artifacts — Design"
 owner: codex
-last_updated: 2026-08-09
-last_validated: 2026-08-16
+last_updated: 2026-09-07
+last_validated: 2026-09-07
 status: Draft
 feature: task-artifacts
 doc_role: design
@@ -192,9 +192,9 @@ To avoid spending the payload twice, the JSON text mirror is replaced with a one
 
 ### `source_path` is caller-local, and paths do not travel
 
-`source_path` on `orbit.task.artifact.put` is resolved **on the machine that makes the call**, relative to that caller's cwd. It is consumed locally and never crosses the coordination boundary: the spoke broker reads the bytes first and sends a path-free payload, which the hub accepts only over the authenticated `ssh-mcp` connector.
+`source_path` on `orbit.task.artifact.put` is resolved **on the machine that makes the call**, relative to that caller's cwd, then confined to that machine's workspace checkout after symlink resolution. Absolute paths and in-workspace symlinks that escape the checkout are rejected as `invalid_input`. The path is consumed locally and never crosses the coordination boundary: the spoke broker reads the bytes first and sends a path-free payload, which the hub accepts only over the authenticated `ssh-mcp` connector.
 
-The consequence is the lesson from ORB-11364: **an operator-host path is not a portable worker reference.** An image uploaded from an operator's `/tmp` is stored successfully and confirmed by `task_show`, and a worker on another host still gets `ENOENT` for that `/tmp` path — the worker never had it. A worker should discover and retrieve an authorized artifact by **owning workspace, task ID, and artifact path**, through `orbit.task.artifact.get`, rather than by assuming operator filesystem visibility. That is the whole point of the read surface, and it removes the need for ad hoc `scp` between hosts wherever the configured connector supports the workspace.
+The consequence is the lesson from ORB-11364: **an operator-host path is not a portable worker reference.** An image attached from the operator checkout is stored successfully and confirmed by `task_show`, and a worker on another host still cannot open the original local path — the worker never had it. A worker should discover and retrieve an authorized artifact by **owning workspace, task ID, and artifact path**, through `orbit.task.artifact.get`, rather than by assuming operator filesystem visibility. That is the whole point of the read surface, and it removes the need for ad hoc `scp` between hosts wherever the configured connector supports the workspace.
 
 Retrieval routes to the authoritative workspace explicitly. `orbit.task.artifact.get` classifies as `control_plane`, so a federated call is delivered to the workspace's owning host using the host-qualified selector the caller copied from federated `orbit.workspace.list`. An unknown selector is refused, never guessed; workspace scoping stays fail-closed and no implicit cross-workspace access is introduced.
 

--- a/plugin/skills/orbit/references/tool-surface.md
+++ b/plugin/skills/orbit/references/tool-surface.md
@@ -32,7 +32,7 @@ records in a second store merely to get past a connection error.
 |---|---|---|
 | Workspace discovery | `orbit_workspace_list` | `orbit workspace list/show` |
 | Task create/read/update/start/approve | `orbit_task_add/list/show/update/start/approve` | Registered `orbit.task.*` tools preserve agent attribution |
-| Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host |
+| Task attachments | `orbit_task_artifact_put` | Task artifact commands; source path is on the executing host and must resolve inside the workspace checkout |
 | Retrieval | `orbit_search` | `orbit search`; semantic install/index is separate |
 | Friction | `orbit_friction_add/list/update` | Additional show/stats/tags/resolve commands |
 | Submit explicit tasks | `orbit_workflow_ship` (review-only; no completion input) | `orbit run ship`, `run auto` |


### PR DESCRIPTION
## Task

[ORB-11694](https://orbit-cli.com/tasks/ORB-11694) — [code-review] Confine `orbit.task.artifact.put` `source_path` to the workspace checkout (arbitrary file read over MCP)

### Description

## Problem
`prepare_remote_payload` resolves `source_path` (absolute paths accepted; relative joined onto `ctx.cwd`) and reads up to 1 MiB of it with no containment check against `ctx.workspace_root`, no policy-engine check, and no symlink resolution. The bytes are stored as a task artifact and can be read back with `orbit.task.artifact.get`. Neither tool is a governed operation (`crates/orbit-common/src/governance/authorization.rs` lists neither), so the default `agent` capability suffices. Scenario: a Tier 2 forced-command caller (`no-pty`, key-bound, default `agent` grant — the surface that is explicitly meant to be *smaller* than shell) calls `orbit_task_artifact_put {id: "ORB-1", source_path: "/home/orbit/.ssh/id_ed25519"}` and then `orbit_task_artifact_get {id: "ORB-1", path: "id_ed25519"}`; the same works against `~/.orbit/mcp-ssh-acceptance/*.toml`, `~/.aws/credentials`, or any 1 MiB-bounded file readable by the Orbit account. The `git.*` tools in the same crate already enforce workspace containment (`crates/orbit-tools/src/builtin/git/mod.rs:44-65`), so this tool is the outlier.

## Why It Matters
The forced-command and federated designs sell the MCP surface as a bounded capability set; an ungoverned read-any-file primitive on the destination defeats that boundary and leaks the very acceptance secrets the SSH tier is built on.

## Proposed Fix
Resolve `source_path` with `orbit_policy::resolve_symlinks`, require it to be inside `ctx.workspace_root` (or the task's own artifacts directory), and reject absolute paths outside it with `invalid_input`; when `ctx.policy_engine`/`fs_profile` are present, additionally run `check_resolved(.., FsOperation::Read, ..)`. Alternatively make `artifact.put` with a `source_path` a governed operation for remote-originated sessions.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs:72-104`, `crates/orbit-tools/src/builtin/orbit/task/artifact_put.rs:157-163`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (security). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `crates/orbit-tools/src/builtin/orbit/task/tests/artifact_put.rs`: `source_path` = a temp file outside `workspace_root` returns `invalid_input`; a symlink inside the workspace pointing outside is rejected; a file inside is accepted.
- A remote session with `agent` capability cannot attach `~/.orbit/mcp-ssh-acceptance/<id>.toml`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `orbit.task.artifact.put` now resolves `source_path` with `orbit_policy::resolve_symlinks` and requires the real path to sit inside `ctx.workspace_root`; escapes (absolute paths, `..`, in-workspace symlinks to host files) return `invalid_input`.
- When `policy_engine` and `fs_profile` are both present, `check_resolved(..., FsOperation::Read, ...)` additionally applies deny-read rules (`PolicyDenied`).
- Missing `workspace_root` fails closed, so a checkoutless hub `source_path` cannot read arbitrary host files; ssh-mcp path-free `artifacts` remains the hub attach path.
- Tests cover outside-workspace, escaping symlink, in-workspace accept, and a remote `agent` session attaching `mcp-ssh-acceptance/<id>.toml`.
- Consumers/docs/goldens updated: fixture attach writes under repo_root; checkoutless hub uses ssh-mcp artifacts payload; `/tmp` coverage example is workspace-relative.
Assessment: Containment lives at the tool boundary, matching git tools and the policy engine's symlink contract. Did not govern the tool (agent can still attach in-workspace files). Did not add a task-artifacts-directory exception (not required by the criteria; `~/.orbit/tasks/` is outside the checkout).

## Criteria
- Outside `workspace_root` → `invalid_input`; in-workspace symlink pointing outside rejected; in-workspace file accepted: **met** (`artifact_put_rejects_source_outside_workspace_root`, `artifact_put_rejects_symlink_inside_workspace_pointing_outside`, `artifact_put_accepts_file_inside_workspace_root`).
- Remote session with `agent` cannot attach `~/.orbit/mcp-ssh-acceptance/<id>.toml`: **met** (`remote_agent_session_cannot_attach_mcp_ssh_acceptance_secret`).

## Validation
- `cargo test -p orbit-tools --lib artifact_put`: **passed** (9 tests).
- `cargo test -p orbit-core --lib -- artifact_get checkoutless task_artifact`: **passed** (17 tests, including checkoutless artifact put and raster attach).
- `cargo test -p orbit-core --lib -- qa_and_review_accept_only_assigned_artifact_evidence`: **passed**.
- `make ci-fast`: **passed**.
- `make ci-lint`: **passed**.
- `git diff --check`: **passed**.

## Remaining risks / deviations
- CLI `orbit task artifact put` still reads via `task_artifact_from_source_file` with no workspace check (separate code path; not the MCP tool).
- `prepare_remote_task_artifact_put` now takes `workspace_root`; no in-repo callers. External spokes must pass the checkout or the helper fail-closes.
- Spoke/hub still trusts the authenticated ssh-mcp `artifacts` payload (bytes, not a hub path). That is the designed remote attach path.
- Did not make `artifact.put` a governed operation; workspace containment is the rule.

Friction considered: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11694-6a9f4214`
- Behind base: 0
- Ahead of base: 1