### PR TITLE
Improve contrast and legibility of small website homepage labels

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -290,7 +290,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-hero-install-prompt {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   flex: 0 0 auto;
 }
 
@@ -398,7 +398,7 @@ html:not([data-has-sidebar]) header.header {
 /* The mono strip under the hero CTAs naming the provider CLIs Orbit drives. */
 .orbit-hero-providers {
   align-items: center;
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   display: flex;
   flex-wrap: wrap;
   font-family: var(--sl-font-mono);
@@ -492,7 +492,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-dash-rail-label {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   font-family: var(--sl-font-mono);
   font-size: 0.58rem;
   letter-spacing: 0.1em;
@@ -512,7 +512,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-dash-rail-foot {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   font-family: var(--sl-font-mono);
   font-size: 0.62rem;
   margin-top: auto;
@@ -548,7 +548,7 @@ html:not([data-has-sidebar]) header.header {
   background: var(--sl-color-bg);
   border: 1px solid var(--sl-color-hairline-light);
   border-radius: 4px;
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   flex: 1 1 auto;
   font-family: var(--sl-font-mono);
   font-size: 0.62rem;
@@ -611,7 +611,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-dash-count {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   font-family: var(--sl-font-mono);
   font-size: 0.62rem;
   font-weight: 500;
@@ -658,7 +658,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-dash-id {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   font-family: var(--sl-font-mono);
   font-size: 0.62rem;
 }
@@ -733,7 +733,7 @@ html:not([data-has-sidebar]) header.header {
 
 .orbit-section-title {
   align-items: center;
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   display: flex;
   font-size: 0.78rem;
   font-weight: 600;
@@ -916,7 +916,7 @@ html:not([data-has-sidebar]) header.header {
 }
 
 .orbit-flow-cmd-prompt {
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   flex: 0 0 auto;
 }
 
@@ -1102,7 +1102,7 @@ html:not([data-has-sidebar]) header.header {
 
 .orbit-docs-group-title {
   border-bottom: 1px solid var(--sl-color-hairline-light);
-  color: var(--sl-color-gray-4);
+  color: var(--sl-color-gray-3);
   font-family: var(--sl-font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.08em;


### PR DESCRIPTION
## Task

[ORB-11586](https://orbit-cli.com/tasks/ORB-11586) — Improve contrast and legibility of small website homepage labels

### Description

## Problem
Dark-theme homepage provider names and section labels use rgb(104,104,114) over rgb(10,10,10), measured contrast 3.59:1, at approximately 11.52–12.48px. The terminal column label is similarly muted. Affected styles include .orbit-hero-providers and .orbit-section-title in website/src/styles/custom.css.

## Scope
Improve these small labels' contrast and legibility while keeping the existing visual hierarchy and both themes coherent. This is a focused style change, not a redesign.

## Audit evidence and boundaries
Observed 2026-09-07 around 14:27 America/Los_Angeles in a fresh local Astro production build of website/ at revision 7f3a8f5fa, served at http://127.0.0.1:4321/. Desktop 1440x1000 and mobile 390x844 were exercised. This is local-source evidence, not proof of production parity. Build and Astro check passed, 29 generated HTML pages had no broken local links/anchors, and exercised browser flows logged no warnings/errors. Revalidate current sources at pickup and trace introducing changes before asserting regression lineage. Prepare a validated candidate; this task does not authorize deployment or release.

### Acceptance Criteria

- Informational small text affected by this finding achieves at least 4.5:1 contrast against its actual rendered background in both themes.
- Provider and section labels are readable at desktop/mobile widths without new clipping or overflow; verify computed foreground/background colors and rendered screenshots.
- Primary heading/action hierarchy remains clear and npm run check and npm run build pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the affected small-label colors in website/src/styles/custom.css from theme gray-4 to theme gray-3.
- Covered the provider strip, hero/flow command prompts, section headings, docs group headings, and the current homepage dashboard's small metadata labels. No layout or hierarchy declarations changed.
- The current homepage source has the dashboard labels that replaced the older terminal transcript; those equivalent low-contrast labels were included so the refreshed page remains coherent.

Acceptance criteria:
- Contrast: satisfied. The rendered theme tokens use rgb(155, 155, 163) in dark mode and rgb(95, 96, 107) in light mode. Static contrast calculations against body and inline-code backgrounds are 7.18:1 and 6.48:1 in dark mode, and 6.23:1 and 5.71:1 in light mode.
- Provider and section readability: satisfied. Playwright rendered dark/light desktop (1440x1000) and dark/light mobile (390x844) screenshots. Computed styles matched the expected theme colors; all 92 inspected selector instances had no element overflow, and all four pages had no document/body horizontal overflow. Screenshots and the computed render report are stored as task artifacts under screenshots/ and render-report.json.
- Hierarchy and npm validation: satisfied. The change is color-only, and the rendered screenshots retain the existing heading/action hierarchy. npm run check passed with 0 errors, 0 warnings, and 0 hints; npm run build passed with 30 pages generated.

Validation:
- PASS: npm ci --cache /tmp/orbit-11586-npm-cache --prefer-offline.
- PASS: npm run check.
- PASS: npm run build.
- PASS: source-level contrast calculation for both themes and body/inline-code surfaces.
- PASS: Playwright computed-style, screenshot, and overflow checks at desktop/mobile widths and both themes.
- PASS: git diff --check.
- PASS: git status --short; only website/src/styles/custom.css is modified.

Risks and deviations:
- Browser validation required task-local Playwright/Chromium dependencies and extracted user-space shared libraries because the host image lacked GUI libraries; no system packages or repository files were modified.
- No deployment, release, commit, or PR action was performed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11586-6a9f468d`
- Behind base: 0
- Ahead of base: 1