### PR TITLE
[code-review] Collapse the two staged-write implementations in `fs/io.rs` into one

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -71,47 +71,20 @@ pub(crate) fn append_private_file(path: &Path) -> io::Result<File> {
 /// Atomically write `content` to `path`, then fsync the parent directory so
 /// the rename survives a crash. Creates parent directories as needed.
 pub fn atomic_write_text(path: &Path, content: &str) -> io::Result<()> {
-    let mut staged = StagedTextFile::new_internal(path, content, true)?;
-    staged.commit()
+    atomic_write_bytes(path, content.as_bytes())
 }
 
 /// Atomically write `content` bytes to `path`, then fsync the parent directory
 /// so the rename survives a crash. Creates parent directories as needed.
 pub fn atomic_write_bytes(path: &Path, content: &[u8]) -> io::Result<()> {
-    let parent = path.parent().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("no parent dir for {}", path.display()),
-        )
-    })?;
-    create_private_dir_all(parent)?;
-
-    let temp_path = temp_path_for(path);
-    let mut file = create_new_private_file(&temp_path)?;
-
-    let staged = (|| {
-        if let Ok(metadata) = fs::metadata(path) {
-            fs::set_permissions(&temp_path, metadata.permissions())?;
-        }
-        file.write_all(content)?;
-        file.sync_all()?;
-        drop(file);
-        fs::rename(&temp_path, path)
-    })();
-    if staged.is_err() {
-        // Every temp name is fresh, so a leftover would never be reclaimed:
-        // a failed write (ENOSPC mid-`write_all`, a rename refused) must not
-        // keep consuming the space it was short of.
-        let _ = fs::remove_file(&temp_path);
-    }
-    staged?;
-    sync_parent_dir(path)
+    let mut staged = StagedTextFile::new_internal(path, content, true)?;
+    staged.commit()
 }
 
 /// Atomically write `content` to `path` without fsyncing the parent.
 /// Cheaper than [`atomic_write_text`] but post-crash the rename may be lost.
 pub fn atomic_write_text_volatile(path: &Path, content: &str) -> io::Result<()> {
-    let mut staged = StagedTextFile::new_internal(path, content, false)?;
+    let mut staged = StagedTextFile::new_internal(path, content.as_bytes(), false)?;
     staged.commit()
 }
 
@@ -129,15 +102,15 @@ pub struct StagedTextFile {
 impl StagedTextFile {
     /// Stage a durable write. `commit()` renames and fsyncs the parent dir.
     pub fn new(target_path: &Path, content: &str) -> io::Result<Self> {
-        Self::new_internal(target_path, content, true)
+        Self::new_internal(target_path, content.as_bytes(), true)
     }
 
     /// Stage a volatile write. `commit()` renames without fsyncing.
     pub fn new_volatile(target_path: &Path, content: &str) -> io::Result<Self> {
-        Self::new_internal(target_path, content, false)
+        Self::new_internal(target_path, content.as_bytes(), false)
     }
 
-    fn new_internal(target_path: &Path, content: &str, durable: bool) -> io::Result<Self> {
+    fn new_internal(target_path: &Path, content: &[u8], durable: bool) -> io::Result<Self> {
         let parent = target_path.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -153,7 +126,7 @@ impl StagedTextFile {
             fs::set_permissions(&temp_path, metadata.permissions())?;
         }
 
-        file.write_all(content.as_bytes())?;
+        file.write_all(content)?;
         if durable {
             file.sync_all()?;
         }


### PR DESCRIPTION
## Task

[ORB-11679](https://orbit-cli.com/tasks/ORB-11679) — [code-review] Collapse the two staged-write implementations in `fs/io.rs` into one

### Description

## Problem
`atomic_write_bytes` (`io.rs:80-109`) re-implements the create-temp / copy-permissions / write / fsync / rename / cleanup sequence that `StagedTextFile::new_internal` + `commit` already own (`io.rs:140-177`), with a slightly different cleanup path (closure + explicit `remove_file` vs. `Drop`). The module's own header says it exists to consolidate the historical variants; having two inside the consolidating module invites the next drift (e.g. only one of them honouring a future `O_NOFOLLOW` or mode change).

## Why It Matters
Every persisted artifact in the workspace funnels through this file; one canonical staging path is the house rule stated in AGENTS.md.

## Proposed Fix
Make `StagedTextFile` byte-based (`new_internal(target, &[u8], durable)`), implement `atomic_write_text` as `atomic_write_bytes(path, content.as_bytes())`, and delete the duplicate body.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-common/src/fs/io.rs:78-109`, `crates/orbit-common/src/fs/io.rs:140-168`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (quality). Review area: foundation.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `fs/tests/io.rs` keeps passing for both text and bytes writers, including the "temp file removed on failed rename" case for bytes.
- `grep -c 'create_new_private_file(&temp_path)' crates/orbit-common/src/fs/io.rs` returns 1.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `crates/orbit-common/src/fs/io.rs` now uses one byte-oriented `StagedTextFile::new_internal` path for durable bytes and text writes; `atomic_write_text` delegates to `atomic_write_bytes`, and volatile text callers convert to bytes at the boundary.
- Removed the duplicate byte-write staging/cleanup implementation so failed commits use `StagedTextFile`'s `Drop` cleanup.
Assessment: Acceptance criteria are met. The focused filesystem tests and the full `orbit-common` suite pass, and the final diff is limited to the authorized file.
Validation:
- PASS `cargo test -p orbit-common fs::tests::io` — 10 tests passed, including `atomic_write_bytes_removes_its_temp_file_when_the_rename_fails`.
- PASS `cargo test -p orbit-common` — 244 unit tests and 1 integration test passed.
- PASS `cargo fmt --all -- --check`.
- PASS `make ci-fast`.
- PASS `make ci-lint` with `CARGO_HOME=/tmp/orbit-ci-lint.aDUPAg`; the initial default-cache attempt failed because `~/.cargo/registry` is read-only, then the safe temporary-cache retry passed.
- PASS `grep -c 'create_new_private_file(&temp_path)' crates/orbit-common/src/fs/io.rs` — returned `1`.
- PASS `git diff --check`.
- PASS `git status --short` — only the authorized source file is modified.
Remaining risks: validation ran on Linux only; no platform-specific filesystem environment was exercised. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11679-6a9f476f`
- Behind base: 0
- Ahead of base: 1