### PR TITLE
[code-review] Make `orbit config set` able to descend through inline tables instead of reporting them as non-table values

### DIFF
--- a/crates/orbit-config/src/store.rs
+++ b/crates/orbit-config/src/store.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value as JsonValue;
-use toml_edit::{DocumentMut, Item, Table};
+use toml_edit::{DocumentMut, Item, Table, TableLike};
 
 use orbit_common::OrbitError;
 use orbit_common::fs::io::atomic_write_text;
@@ -170,12 +170,12 @@ impl ConfigStore {
             OrbitError::InvalidInput(format!("config key '{key}' must not be empty"))
         })?;
 
-        let mut table: &mut Table = self.doc.as_table_mut();
+        let mut table: &mut dyn TableLike = self.doc.as_table_mut();
         for segment in ancestors {
             let item = table
                 .entry(segment)
                 .or_insert_with(|| Item::Table(Table::new()));
-            table = item.as_table_mut().ok_or_else(|| {
+            table = item.as_table_like_mut().ok_or_else(|| {
                 OrbitError::InvalidInput(format!(
                     "cannot set '{key}': '{segment}' along its path is already a non-table value \
                      in '{}'",

--- a/crates/orbit-config/src/tests/store.rs
+++ b/crates/orbit-config/src/tests/store.rs
@@ -79,6 +79,43 @@ fn set_parses_toml_literal_types_not_just_strings() {
 }
 
 #[test]
+fn set_descends_through_inline_tables() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(&path, "execution = { env = { pass = [\"A\"] } }\n").expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    store
+        .set_value("execution.env.pass", "[\"A\",\"B\"]")
+        .expect("set value through inline tables");
+    store.validate().expect("validate");
+    store.save().expect("save");
+
+    let saved = fs::read_to_string(&path).expect("read saved config");
+    assert!(saved.contains("A"), "{saved}");
+    assert!(saved.contains("B"), "{saved}");
+}
+
+#[test]
+fn set_rejects_scalar_ancestor_with_existing_message() {
+    let dir = tempdir().expect("tempdir");
+    let path = config_path(dir.path());
+    fs::write(&path, "execution = 1\n").expect("write config");
+
+    let mut store = ConfigStore::open(ConfigScope::Workspace, &path).expect("open store");
+    let error = store
+        .set_value("execution.env.pass", "[\"A\"]")
+        .expect_err("scalar ancestor must be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("'execution' along its path is already a non-table value"),
+        "{error}"
+    );
+}
+
+#[test]
 fn set_falls_back_to_plain_string_for_non_literal_values() {
     let dir = tempdir().expect("tempdir");
     let path = config_path(dir.path());


### PR DESCRIPTION
## Task

[ORB-11680](https://orbit-cli.com/tasks/ORB-11680) — [code-review] Make `orbit config set` able to descend through inline tables instead of reporting them as non-table values

### Description

## Problem
`ConfigStore::set_value` walks ancestors with `item.as_table_mut()` (`store.rs:178`), which only matches `Item::Table`; a TOML inline table (`execution = { env = { pass = ["A"] } }` or `execution.env = { pass = ["A"] }`) is `Item::Value(Value::InlineTable)` and returns `None`, so `orbit config set execution.env.pass '["A","B"]'` fails with "'execution' along its path is already a non-table value" even though the file is valid config that `ResolvedConfig::from_raw_str` loads fine. The message tells the operator their table is not a table.

## Why It Matters
Inline tables are the natural way to hand-write the three security keys on one line, and the failure blocks the documented `orbit config set` path with a misleading diagnostic.

## Proposed Fix
In the ancestor walk, handle `Item::Value(v) if v.is_inline_table()` by descending via `as_inline_table_mut()` (toml_edit exposes `InlineTable::get_mut`/`insert`), or convert the inline table to a standard table in place before descending; keep the error for genuinely scalar ancestors.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-config/src/store.rs:173-185`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: foundation.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `tests/store.rs`: document `execution = { env = { pass = ["A"] } }`, `set_value("execution.env.pass", "[\"A\",\"B\"]")`, `validate()` succeeds and the rendered document contains both names.
- Scalar ancestor (`execution = 1`) still errors with the existing message.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `ConfigStore::set_value` to traverse both standard TOML tables and inline tables through `toml_edit::TableLike`; scalar ancestors still use the existing non-table error.
- Added store regression tests for nested inline-table updates, validation/rendered output, and scalar-ancestor diagnostics.

Acceptance criteria:
- Inline-table document `execution = { env = { pass = ["A"] } }` accepts `execution.env.pass` = `["A","B"]`, validates, saves, and renders both names: satisfied by `set_descends_through_inline_tables`.
- Scalar ancestor `execution = 1` retains the existing diagnostic: satisfied by `set_rejects_scalar_ancestor_with_existing_message`.

Validation:
- PASS: `cargo fmt --all -- --check`.
- PASS: `cargo test -p orbit-config --lib tests::store` (27 passed).
- PASS: `cargo test -p orbit-config --lib` (117 passed).
- PASS: `make ci-fast`.
- Initial `make ci-lint` was blocked by the read-only default Cargo registry cache while trying to download `phf`; PASS on the same target with an isolated writable `CARGO_HOME`: `CARGO_HOME=/tmp/orbit-11680-cargo.Sb4GCd make ci-lint`.
- PASS: `git diff --check`; final status contains only the two task-scoped source/test files.

Assessment: Localized implementation uses toml_edit's canonical table-like abstraction, preserves scalar failure behavior, and has focused regression coverage. No known remaining risks or deviations.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11680-6a9f4772`
- Behind base: 0
- Ahead of base: 1