### PR TITLE
[code-review] Record the post-recovery re-attempt outcome instead of discarding it

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/audit.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/audit.rs
@@ -154,6 +154,36 @@ pub(super) fn emit_job_tracing(job_run_id: &str, task_id: Option<&str>, kind: &V
                 );
             }
         }
+        V2AuditEventKind::StepPostRecoveryAttempt {
+            step_id,
+            recovery_activity,
+            outcome,
+            error_message,
+        } => {
+            if outcome == "success" {
+                tracing::info!(
+                    target: "orbit.job.step_post_recovery_attempt",
+                    job_run_id = job_run_id,
+                    task_id = task_id,
+                    step_id = step_id.as_str(),
+                    recovery_activity = recovery_activity.as_str(),
+                    outcome = outcome.as_str(),
+                    error_message = error_message.as_deref(),
+                    "step post-recovery attempt",
+                );
+            } else {
+                tracing::warn!(
+                    target: "orbit.job.step_post_recovery_attempt",
+                    job_run_id = job_run_id,
+                    task_id = task_id,
+                    step_id = step_id.as_str(),
+                    recovery_activity = recovery_activity.as_str(),
+                    outcome = outcome.as_str(),
+                    error_message = error_message.as_deref(),
+                    "step post-recovery attempt",
+                );
+            }
+        }
         V2AuditEventKind::StepDenied { step_id, reason } => {
             tracing::error!(
                 target: "orbit.job.step_denied",

--- a/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/recovery.rs
@@ -15,18 +15,51 @@ pub(super) fn recover_or_return_original(
     };
 
     if attempt_recovery_activity(step, ctx, &recovery, &original_err, attempt, max_attempts) {
-        match run_step_body(step, ctx) {
-            Ok(outcome) if outcome.success => return Ok(outcome),
-            // Once VCS recovery succeeded, the old conflict is resolved. A
-            // stale base or other new failure must describe the remaining state.
-            result if matches!(original_err, DispatchError::RecoverableVcsConflict { .. }) => {
-                return result;
-            }
-            Ok(_) | Err(_) => {}
-        }
+        return post_recovery_attempt(step, ctx, &recovery, original_err);
     }
 
     Err(original_err)
+}
+
+fn post_recovery_attempt(
+    step: &JobV2Step,
+    ctx: &ExecCtx<'_>,
+    recovery: &ResolvedRecoveryActivity,
+    original_err: DispatchError,
+) -> Result<StepOutcome, DispatchError> {
+    let reattempt = run_step_body(step, ctx);
+    let (outcome, error_message) = match &reattempt {
+        Ok(outcome) if outcome.success => ("success", None),
+        Ok(outcome) => (
+            "failed",
+            Some(
+                outcome
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| "step completed with success=false".to_string()),
+            ),
+        ),
+        Err(error) => ("error", Some(error.to_string())),
+    };
+    let error_message = error_message.map(|message| redacted_recovery_diagnostic(&message));
+    emit_job_event_lossy(
+        &ctx.audit,
+        ctx.task_id(),
+        V2AuditEventKind::StepPostRecoveryAttempt {
+            step_id: step.id.clone(),
+            recovery_activity: recovery.name.clone(),
+            outcome: outcome.to_string(),
+            error_message: error_message.clone(),
+        },
+    );
+
+    match reattempt {
+        Ok(outcome) if outcome.success => Ok(outcome),
+        Ok(_) | Err(_) => Err(DispatchError::JobExecution(format!(
+            "post-recovery attempt {outcome}: {}; original error before recovery: {original_err}",
+            error_message.unwrap_or_else(|| "no diagnostic".to_string()),
+        ))),
+    }
 }
 
 pub(super) fn recovery_activity_for_step(

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/recovery.rs
@@ -103,7 +103,7 @@ fn recovery_success_runs_one_post_recovery_attempt_with_exact_input_and_fs_profi
 }
 
 #[test]
-fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
+fn recovery_success_with_post_recovery_failure_surfaces_re_run_error() {
     let original_error = retryable_error("flaky", "first failure");
     let post_recovery_error = retryable_error("flaky", "post recovery still failing");
     let host = RecoveryHost::new([
@@ -112,7 +112,7 @@ fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
             vec![
                 Err(original_error.clone()),
                 Err(original_error.clone()),
-                Err(post_recovery_error),
+                Err(post_recovery_error.clone()),
             ],
         ),
         ("recover", vec![Ok(json!({"recovered": true}))]),
@@ -127,15 +127,37 @@ fn recovery_success_with_post_recovery_failure_returns_original_error_text() {
         writer.clone(),
         &host,
     )
-    .expect_err("post-recovery failure should surface original error");
+    .expect_err("post-recovery failure should surface the re-run error");
 
-    assert_eq!(err.to_string(), original_error.to_string());
+    assert!(err.to_string().contains(&post_recovery_error.to_string()));
+    assert!(err.to_string().contains(&original_error.to_string()));
     assert_eq!(host.action_count("recover"), 1);
-    assert_eq!(recovery_events(&writer.events_snapshot().unwrap()).len(), 1);
+    let events = writer.events_snapshot().expect("audit snapshot");
+    assert!(matches!(
+        events.iter().find(|event| matches!(
+            event.kind,
+            V2AuditEventKind::StepPostRecoveryAttempt { .. }
+        )).map(|event| &event.kind),
+        Some(V2AuditEventKind::StepPostRecoveryAttempt {
+            outcome,
+            error_message: Some(error_message),
+            ..
+        }) if outcome == "error" && error_message.contains(&post_recovery_error.to_string())
+    ));
+    assert!(matches!(
+        events.iter().find(|event| matches!(
+            event.kind,
+            V2AuditEventKind::StepFinished { .. }
+        )).map(|event| &event.kind),
+        Some(V2AuditEventKind::StepFinished {
+            error_message: Some(error_message),
+            ..
+        }) if error_message.contains(&post_recovery_error.to_string())
+    ));
 }
 
 #[test]
-fn successful_vcs_recovery_reports_the_new_failure_instead_of_resolved_conflicts() {
+fn successful_vcs_recovery_reports_the_new_failure_with_original_context() {
     let original = recoverable_vcs_conflict();
     let remaining = retryable_error("flaky", "prepared base moved after recovery");
     let host = RecoveryHost::new([
@@ -151,8 +173,8 @@ fn successful_vcs_recovery_reports_the_new_failure_instead_of_resolved_conflicts
         &host,
     )
     .unwrap_err();
-    assert_eq!(error.to_string(), remaining.to_string());
-    assert!(!error.to_string().contains("conflicting paths"));
+    assert!(error.to_string().contains(&remaining.to_string()));
+    assert!(error.to_string().contains("conflicting paths"));
     assert_eq!(host.actions(), vec!["flaky", "recover", "flaky"]);
 }
 
@@ -749,14 +771,15 @@ fn worktree_integrity_unsuccessful_recovery_returns_original() {
 }
 
 #[test]
-fn worktree_integrity_post_recovery_failure_returns_original() {
+fn worktree_integrity_post_recovery_failure_surfaces_the_new_error() {
     let integrity_error = worktree_integrity_error("run-integrity-post-failed");
+    let post_recovery_error = retryable_error("flaky", "still unsafe");
     let host = RecoveryHost::new([
         (
             "flaky",
             vec![
                 Err(integrity_error.clone()),
-                Err(retryable_error("flaky", "still unsafe")),
+                Err(post_recovery_error.clone()),
             ],
         ),
         ("recover", vec![Ok(json!({"recovered": true}))]),
@@ -771,9 +794,10 @@ fn worktree_integrity_post_recovery_failure_returns_original() {
         writer.clone(),
         &host,
     )
-    .expect_err("failed post-recovery attempt must preserve the integrity failure");
+    .expect_err("failed post-recovery attempt must surface the remaining failure");
 
-    assert_eq!(err.to_string(), integrity_error.to_string());
+    assert!(err.to_string().contains(&post_recovery_error.to_string()));
+    assert!(err.to_string().contains(&integrity_error.to_string()));
     assert_eq!(host.actions(), vec!["flaky", "recover", "flaky"]);
     assert_eq!(recovery_events(&writer.events_snapshot().unwrap()).len(), 1);
 }

--- a/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
+++ b/crates/orbit-types/src/workflow/activity_job/audit_envelope.rs
@@ -91,6 +91,14 @@ pub enum V2AuditEventKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error_message: Option<String>,
     },
+    /// The failed step's single re-attempt after recovery completed.
+    StepPostRecoveryAttempt {
+        step_id: String,
+        recovery_activity: String,
+        outcome: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_message: Option<String>,
+    },
     StepDenied {
         step_id: String,
         reason: String,
@@ -284,6 +292,7 @@ impl V2AuditEventKind {
             V2AuditEventKind::StepSkipped { .. } => "step.skipped",
             V2AuditEventKind::StepRetry { .. } => "step.retry",
             V2AuditEventKind::StepRecoveryAttempted { .. } => "step.recovery_attempted",
+            V2AuditEventKind::StepPostRecoveryAttempt { .. } => "step.post_recovery_attempt",
             V2AuditEventKind::StepDenied { .. } => V2_EVENT_TYPE_STEP_DENIED,
             V2AuditEventKind::StepJoin { .. } => "step.join",
             V2AuditEventKind::FanoutDispatched { .. } => "fanout.dispatched",


### PR DESCRIPTION
## Task

[ORB-11675](https://orbit-cli.com/tasks/ORB-11675) — [code-review] Record the post-recovery re-attempt outcome instead of discarding it

### Description

## Problem
After a recovery activity succeeds, `recover_or_return_original` re-runs the step body once and, on `Ok(success: false)` or `Err(_)`, returns the *original* error with no audit event and no message from the second attempt. When the re-run fails for a different reason (a new `WorktreeIntegrity` code, a provider timeout, a `RecoverableVcsConflict` on different paths), the run record and the failure handoff (`attempt_failure_activity`, which formats `original_err`) describe a failure that recovery already fixed, and the actual blocker is invisible.

## Why It Matters
Operators triaging a failed run after conflict recovery are pointed at the wrong error.

## Proposed Fix
Emit a `StepRecoveryAttempted`-style event (or a new `StepPostRecoveryAttempt`) carrying the re-attempt's outcome/message, and when the re-attempt produced an error, return that error (with the original attached in the message) instead of the stale one.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/activity_job/job_executor/recovery.rs:6-25`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `job_executor/tests/recovery.rs`: recovery succeeds, the re-run fails with a distinct message; the returned error and the `StepFinished.error_message` contain the re-run's message, and an audit event records the post-recovery attempt.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the persisted `step.post_recovery_attempt` audit event with a structured outcome and redacted diagnostic, plus matching tracing.
- After a successful recovery, record the re-run result. A failed re-run now returns a terminal error that leads with its own diagnostic and retains the original failure for recovery context.
- Updated recovery tests to show the distinct re-run message reaches both the returned error and `StepFinished.error_message`, and that the post-recovery audit event is emitted.

Criteria:
- Recovery succeeds and a distinct re-run failure is surfaced: passed by `recovery_success_with_post_recovery_failure_surfaces_re_run_error`.
- Returned error and `StepFinished.error_message` contain the re-run message: passed by the same focused test.
- An audit event records the post-recovery attempt: passed by the same focused test.

Assessment: The recovery boundary now has one canonical re-attempt path that retains both the current failure and the original recovery context. Audit diagnostics are redacted and bounded before persistence.

Validation:
- Passed: `CARGO_TARGET_DIR=/tmp/orb-11675-target cargo test -p orbit-engine activity_job::job_executor::tests::recovery` (24 passed).
- Passed: `cargo fmt --check`.
- Passed: `make ci-fast`.
- Passed: `CARGO_HOME=/tmp/orb-11675-cargo-home CARGO_TARGET_DIR=/tmp/orb-11675-target make ci-lint`.
- Failed then recovered: initial `make ci-lint` could not cache the missing `siphasher` crate in the read-only default Cargo home; rerunning with a task-scoped writable Cargo home passed.
- Passed: `git diff --check`.
- Passed: `cargo clean` removed this worktree's generated default-target outputs; final `git status --short` contains only the four task-scoped source/test files.

Risks: The returned terminal error is a `JobExecution` wrapper so it can include both the re-run diagnostic and original recovery context; callers that inspect only its concrete enum variant do not retain the re-run's original variant.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11675-6a9f476b`
- Behind base: 0
- Ahead of base: 1