### PR TITLE
Prevent task-pilot source fetch failures when delivery updates the shared remote ref concurrently

### DIFF
--- a/crates/orbit-common/src/fs/git.rs
+++ b/crates/orbit-common/src/fs/git.rs
@@ -1,7 +1,26 @@
-use std::path::Path;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use crate::OrbitError;
+
+use super::io::with_exclusive_file_lock;
+
+/// Lock file inside the git common directory that serializes Orbit-owned
+/// updates of remote-tracking refs.
+///
+/// ORB-11269/ORB-11256 locked only task-pilot (`orbit-task-pilot-fetch`).
+/// Delivery `fetch_remote_base` was a second writer of the same
+/// `refs/remotes/origin/*` refs, so a linked worktree fetch and
+/// `prepare_task_pilot` could CAS-fail each other. One common-dir lock
+/// covers every Orbit fetch; do not add a second pilot-only lock.
+pub const GIT_FETCH_LOCK_NAME: &str = "orbit-git-fetch";
+
+/// Bounded attempts for a single Orbit-owned fetch, including the first try.
+pub const GIT_FETCH_CAS_ATTEMPTS: u32 = 3;
+
+const GIT_FETCH_CAS_RETRY_DELAY: Duration = Duration::from_millis(20);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CurrentBranchStatus {
@@ -116,6 +135,73 @@ fn local_branches(workspace_path: &Path) -> Result<Vec<String>, OrbitError> {
         .filter(|line| !line.is_empty())
         .map(ToOwned::to_owned)
         .collect())
+}
+
+pub fn git_common_dir(workspace_path: &Path) -> Result<PathBuf, OrbitError> {
+    let output = run_git(
+        workspace_path,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    if !output.success {
+        return Err(OrbitError::Execution(format!(
+            "unable to locate shared Git directory in '{}': {}",
+            workspace_path.display(),
+            output.stderr.trim()
+        )));
+    }
+    let raw = output.stdout.trim();
+    if raw.is_empty() {
+        return Err(OrbitError::Execution(format!(
+            "unable to locate shared Git directory in '{}'",
+            workspace_path.display()
+        )));
+    }
+    Ok(PathBuf::from(raw))
+}
+
+pub fn git_fetch_lock_target(git_common_dir: &Path) -> PathBuf {
+    git_common_dir.join(GIT_FETCH_LOCK_NAME)
+}
+
+/// Run `op` while holding the exclusive lock that serializes Orbit-owned
+/// remote-tracking-ref updates across linked checkouts.
+pub fn with_git_fetch_lock<T, E, F>(workspace: &Path, op: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
+    let common = git_common_dir(workspace).map_err(|error| io::Error::other(error.to_string()))?;
+    with_exclusive_file_lock(&git_fetch_lock_target(&common), "git fetch", op)
+}
+
+/// True when git refused a ref update because another process raced the same
+/// remote-tracking ref. Auth and network failures stay false so callers do
+/// not retry them.
+pub fn is_git_ref_update_contention(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    if looks_like_remote_auth_or_network_failure(&text) {
+        return false;
+    }
+    text.contains("cannot lock ref") || text.contains("unable to update local ref")
+}
+
+pub fn should_retry_git_ref_cas(attempt: u32, stderr: &str) -> bool {
+    attempt + 1 < GIT_FETCH_CAS_ATTEMPTS && is_git_ref_update_contention(stderr)
+}
+
+pub fn git_fetch_cas_retry_delay() -> Duration {
+    GIT_FETCH_CAS_RETRY_DELAY
+}
+
+fn looks_like_remote_auth_or_network_failure(stderr_lower: &str) -> bool {
+    stderr_lower.contains("authentication failed")
+        || stderr_lower.contains("could not resolve host")
+        || stderr_lower.contains("unable to access")
+        || stderr_lower.contains("terminal prompts disabled")
+        || stderr_lower.contains("could not read username")
+        || stderr_lower.contains("permission denied (publickey)")
+        || stderr_lower.contains("the requested url returned error: 401")
+        || stderr_lower.contains("the requested url returned error: 403")
 }
 
 pub fn run_git(workspace_path: &Path, args: &[&str]) -> Result<GitCommandOutput, OrbitError> {

--- a/crates/orbit-common/src/fs/tests/git.rs
+++ b/crates/orbit-common/src/fs/tests/git.rs
@@ -1,0 +1,112 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use super::super::git::{
+    GIT_FETCH_CAS_ATTEMPTS, GIT_FETCH_LOCK_NAME, git_common_dir, git_fetch_lock_target,
+    is_git_ref_update_contention, should_retry_git_ref_cas,
+};
+
+#[test]
+fn cas_contention_matches_the_live_packed_refs_race() {
+    let incident = "cannot lock ref 'refs/remotes/origin/agent-main': is at \
+         1c140f6cd310394f59fc2a8639269d6bc4ca25f1 but expected \
+         eb26940c037ce255b6c28c0378c9276ab38cc75e";
+    assert!(is_git_ref_update_contention(incident));
+    assert!(should_retry_git_ref_cas(0, incident));
+    assert!(!should_retry_git_ref_cas(
+        GIT_FETCH_CAS_ATTEMPTS - 1,
+        incident
+    ));
+}
+
+#[test]
+fn lock_file_contention_is_retryable() {
+    let stderr = "cannot lock ref 'refs/remotes/origin/agent-main': \
+         Unable to create '.git/refs/remotes/origin/agent-main.lock': File exists.\n\
+         error: unable to update local ref";
+    assert!(is_git_ref_update_contention(stderr));
+}
+
+#[test]
+fn auth_and_network_failures_are_not_retryable() {
+    for stderr in [
+        "fatal: Authentication failed for 'https://github.com/example/orbit.git/'",
+        "ssh: Could not resolve host github.com\nfatal: Could not read from remote repository.",
+        "fatal: unable to access 'https://github.com/example/orbit.git/': Could not resolve host",
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        "Permission denied (publickey).\nfatal: Could not read from remote repository.",
+        "fatal: unable to access 'https://github.com/example/orbit.git/': The requested URL returned error: 403",
+    ] {
+        assert!(
+            !is_git_ref_update_contention(stderr),
+            "retried a real remote failure: {stderr}"
+        );
+        assert!(!should_retry_git_ref_cas(0, stderr), "{stderr}");
+    }
+}
+
+#[test]
+fn linked_worktrees_share_one_fetch_lock_target() {
+    let fixture = LinkedWorktreeFixture::new();
+    let primary_common = git_common_dir(&fixture.primary).expect("primary common dir");
+    let linked_common = git_common_dir(&fixture.linked).expect("linked common dir");
+    assert_eq!(primary_common, linked_common);
+    assert_eq!(
+        git_fetch_lock_target(&primary_common),
+        primary_common.join(GIT_FETCH_LOCK_NAME)
+    );
+}
+
+struct LinkedWorktreeFixture {
+    _root: TempDir,
+    primary: PathBuf,
+    linked: PathBuf,
+}
+
+impl LinkedWorktreeFixture {
+    fn new() -> Self {
+        let root = TempDir::new().expect("temp dir");
+        let primary = root.path().join("primary");
+        let linked = root.path().join("linked");
+        fs::create_dir_all(&primary).expect("primary dir");
+        git(&primary, &["init"]);
+        git(&primary, &["checkout", "-b", "agent-main"]);
+        git(&primary, &["config", "user.name", "Orbit Test"]);
+        git(
+            &primary,
+            &["config", "user.email", "orbit-test@example.com"],
+        );
+        git(&primary, &["config", "commit.gpgsign", "false"]);
+        fs::write(primary.join("base.txt"), "v1\n").expect("write");
+        git(&primary, &["add", "base.txt"]);
+        git(&primary, &["commit", "-m", "init"]);
+        git(
+            &primary,
+            &["worktree", "add", linked.to_str().unwrap(), "HEAD"],
+        );
+        Self {
+            _root: root,
+            primary,
+            linked,
+        }
+    }
+}
+
+fn git(current_dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/orbit-common/src/fs/tests/mod.rs
+++ b/crates/orbit-common/src/fs/tests/mod.rs
@@ -1,3 +1,4 @@
+mod git;
 mod glob;
 mod io;
 mod selector;

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/task_pilot/source.rs
@@ -9,8 +9,10 @@ use std::io;
 use std::path::Path;
 use std::process::Command;
 
-use orbit_common::fs::git::run_git;
-use orbit_common::fs::io::with_exclusive_file_lock;
+use orbit_common::fs::git::{
+    GIT_FETCH_CAS_ATTEMPTS, git_fetch_cas_retry_delay, run_git, should_retry_git_ref_cas,
+    with_git_fetch_lock,
+};
 use orbit_engine::DispatchError;
 use serde_json::{Value, json};
 
@@ -204,39 +206,25 @@ pub(super) fn resolve_source_snapshot(
     }
     let has_origin = has_origin_remote(action, workspace_root)?;
 
-    // Serialize fetch + resolution across linked checkouts sharing refs. Git's
-    // common directory works for both a primary .git directory and gitfiles.
-    let common = git(
-        action,
-        workspace_root,
-        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    )?;
-    if !common.success {
-        return Err(action_failed(
-            action,
-            "unable to locate shared Git directory",
-        ));
-    }
-    let lock_target = Path::new(common.stdout.trim()).join("orbit-task-pilot-fetch");
-    let (source_ref, source_revision) =
-        with_exclusive_file_lock(&lock_target, "task-pilot source fetch", || {
-            let source_ref = if has_origin {
-                fetch_origin_branch(action, workspace_root, &base_branch)
-                    .map_err(FetchLockError::Dispatch)?;
-                format!("origin/{base_branch}")
-            } else {
-                format!("refs/heads/{base_branch}")
-            };
-            let revision = rev_parse_commit(action, workspace_root, &source_ref)
+    // Shared git-common-dir lock (`orbit-git-fetch`): the same identity
+    // delivery `fetch_remote_base` uses. ORB-11269's pilot-only
+    // `orbit-task-pilot-fetch` lock left that writer uncoordinated.
+    let (source_ref, source_revision) = with_git_fetch_lock(workspace_root, || {
+        let source_ref = if has_origin {
+            fetch_origin_branch(action, workspace_root, &base_branch)
                 .map_err(FetchLockError::Dispatch)?;
-            Ok::<_, FetchLockError>((source_ref, revision))
-        })
-        .map_err(|error| match error {
-            FetchLockError::Dispatch(error) => error,
-            FetchLockError::Io(error) => {
-                action_failed(action, format!("task-pilot fetch lock: {error}"))
-            }
-        })?;
+            format!("origin/{base_branch}")
+        } else {
+            format!("refs/heads/{base_branch}")
+        };
+        let revision = rev_parse_commit(action, workspace_root, &source_ref)
+            .map_err(FetchLockError::Dispatch)?;
+        Ok::<_, FetchLockError>((source_ref, revision))
+    })
+    .map_err(|error| match error {
+        FetchLockError::Dispatch(error) => error,
+        FetchLockError::Io(error) => action_failed(action, format!("git fetch lock: {error}")),
+    })?;
 
     Ok(Some(SourceSnapshot {
         base_branch,
@@ -277,7 +265,7 @@ fn normalize_base_branch(action: &str, base: &str) -> Result<String, DispatchErr
     Ok(branch.to_string())
 }
 
-/// Local-error wrapper so [`with_exclusive_file_lock`] (which requires
+/// Local-error wrapper so [`with_git_fetch_lock`] (which requires
 /// `E: From<io::Error>`) can carry either lock-acquisition failures or the
 /// module's own [`DispatchError`] out of the locked closure.
 enum FetchLockError {
@@ -310,29 +298,42 @@ fn has_origin_remote(action: &str, workspace: &Path) -> Result<bool, DispatchErr
 
 fn fetch_origin_branch(action: &str, workspace: &Path, branch: &str) -> Result<(), DispatchError> {
     let spec = format!("+refs/heads/{branch}:refs/remotes/origin/{branch}");
-    let output = Command::new("git")
-        .args(["fetch", "origin", &spec])
-        .current_dir(workspace)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .output()
-        .map_err(|error| {
-            action_failed(
-                action,
-                format!(
-                    "failed to fetch origin/{branch} in '{}': {error}",
-                    workspace.display()
-                ),
-            )
-        })?;
-    if output.status.success() {
-        return Ok(());
+    let mut last_stderr = String::new();
+    for attempt in 0..GIT_FETCH_CAS_ATTEMPTS {
+        let output = Command::new("git")
+            .args(["fetch", "origin", &spec])
+            .current_dir(workspace)
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .output()
+            .map_err(|error| {
+                action_failed(
+                    action,
+                    format!(
+                        "failed to fetch origin/{branch} in '{}': {error}",
+                        workspace.display()
+                    ),
+                )
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        last_stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if should_retry_git_ref_cas(attempt, &last_stderr) {
+            tracing::warn!(
+                attempt,
+                branch,
+                "retrying origin fetch after git ref update contention"
+            );
+            std::thread::sleep(git_fetch_cas_retry_delay());
+            continue;
+        }
+        break;
     }
     Err(action_failed(
         action,
         format!(
-            "remote failure: could not fetch origin/{branch} in '{}': {}",
+            "remote failure: could not fetch origin/{branch} in '{}': {last_stderr}",
             workspace.display(),
-            String::from_utf8_lossy(&output.stderr).trim()
         ),
     ))
 }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/task_pilot_source.rs
@@ -8,6 +8,8 @@ use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
+use orbit_engine::fetch_remote_base;
+
 use super::super::task_pilot::{apply, prepare};
 use crate::OrbitRuntime;
 use crate::adapter::engine_host::v2_host::test_support::{
@@ -503,6 +505,100 @@ fn concurrent_prepare_calls_against_the_same_primary_both_succeed() {
             .iter()
             .all(|result| result.as_ref().unwrap()["source"]["fast_forwarded"] == false)
     );
+}
+
+/// Pilot prepare and delivery `fetch_remote_base` share one git-common-dir
+/// lock, so concurrent origin fetches pin the same source identity instead
+/// of failing ref-CAS.
+#[test]
+fn concurrent_prepare_and_delivery_fetch_share_the_common_dir_lock() {
+    let fixture = remote_landing_fixture();
+    fs::write(fixture.repo.join("src/existing.rs"), "user dirty bytes\n").unwrap();
+    fs::write(
+        fixture.repo.join("src/user-only.rs"),
+        "untracked user file\n",
+    )
+    .unwrap();
+    let linked = fixture
+        .repo
+        .parent()
+        .expect("fixture parent")
+        .join("linked");
+    git(
+        &fixture.repo,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            linked.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+
+    let (prepares, fetches) = std::thread::scope(|scope| {
+        let prepare_handles: Vec<_> = (0..3)
+            .map(|_| scope.spawn(|| prepare_landing(&fixture)))
+            .collect();
+        let fetch_paths = [&fixture.repo, &linked];
+        let fetch_handles: Vec<_> = fetch_paths
+            .into_iter()
+            .flat_map(|path| {
+                (0..2).map(|_| {
+                    let path = path.clone();
+                    scope
+                        .spawn(move || fetch_remote_base(&path, LANDING).map_err(|e| e.to_string()))
+                })
+            })
+            .collect();
+        let prepares: Vec<_> = prepare_handles
+            .into_iter()
+            .map(|handle| handle.join().expect("prepare thread joined"))
+            .collect();
+        let fetches: Vec<_> = fetch_handles
+            .into_iter()
+            .map(|handle| handle.join().expect("fetch thread joined"))
+            .collect();
+        (prepares, fetches)
+    });
+
+    for (index, result) in prepares.iter().enumerate() {
+        let prepared = result
+            .as_ref()
+            .unwrap_or_else(|error| panic!("concurrent prepare {index} failed: {error}"));
+        assert_eq!(prepared["source"]["source_revision"], fixture.current_sha);
+        assert_eq!(
+            prepared["source"]["source_ref"],
+            format!("origin/{LANDING}")
+        );
+    }
+    for (index, result) in fetches.iter().enumerate() {
+        result
+            .as_ref()
+            .unwrap_or_else(|error| panic!("concurrent delivery fetch {index} failed: {error}"));
+    }
+
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", &format!("origin/{LANDING}")]),
+        fixture.current_sha
+    );
+    assert_eq!(
+        git(&linked, &["rev-parse", &format!("origin/{LANDING}")]),
+        fixture.current_sha
+    );
+    assert_eq!(
+        git(&fixture.repo, &["rev-parse", "HEAD"]),
+        fixture.stale_sha
+    );
+    assert_eq!(git(&linked, &["rev-parse", "HEAD"]), fixture.stale_sha);
+    assert_eq!(
+        fs::read_to_string(fixture.repo.join("src/existing.rs")).unwrap(),
+        "user dirty bytes\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.repo.join("src/user-only.rs")).unwrap(),
+        "untracked user file\n"
+    );
+    assert!(!fixture.repo.join("src/merged.rs").exists());
 }
 
 #[test]

--- a/crates/orbit-engine/src/executor/automation/vcs/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/git.rs
@@ -2,6 +2,10 @@ use std::path::Path;
 use std::process::Command;
 
 use orbit_common::OrbitError;
+use orbit_common::fs::git::{
+    GIT_FETCH_CAS_ATTEMPTS, git_fetch_cas_retry_delay, should_retry_git_ref_cas,
+    with_git_fetch_lock,
+};
 use orbit_common::security::child_env::AGENT_SUBPROCESS_BASELINE_VARS;
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use serde_json::Value;
@@ -137,33 +141,44 @@ pub(crate) fn git_command_success(current_dir: &Path, args: &[&str]) -> Result<b
     Ok(result.success)
 }
 
-pub(in crate::executor::automation) fn fetch_remote_base(
-    repo_root: &Path,
-    base: &str,
-) -> Result<(), OrbitError> {
+/// Fetch `origin/<branch>` into the local remote-tracking ref.
+///
+/// Serializes with other Orbit-owned fetches through the git-common-dir
+/// lock so linked worktrees and task-pilot prepare do not CAS-fail the
+/// same `refs/remotes/origin/*` ref.
+pub fn fetch_remote_base(repo_root: &Path, base: &str) -> Result<(), OrbitError> {
     let branch = normalize_base_branch(base)?;
-    let result = run_process(
-        &git_request(
-            repo_root,
-            &[
-                "fetch",
-                "origin",
-                &format!("+refs/heads/{branch}:refs/remotes/origin/{branch}"),
-            ],
-            60_000,
-        ),
-        &NoSandbox,
-    )?;
+    with_git_fetch_lock(repo_root, || fetch_remote_base_locked(repo_root, &branch))
+}
 
-    if !result.success {
-        return Err(OrbitError::Execution(format!(
-            "failed to fetch remote base 'origin/{branch}' in '{}': {}",
-            repo_root.display(),
-            result.stderr.trim()
-        )));
+fn fetch_remote_base_locked(repo_root: &Path, branch: &str) -> Result<(), OrbitError> {
+    let spec = format!("+refs/heads/{branch}:refs/remotes/origin/{branch}");
+    let mut last_stderr = String::new();
+    for attempt in 0..GIT_FETCH_CAS_ATTEMPTS {
+        let result = run_process(
+            &git_request(repo_root, &["fetch", "origin", &spec], 60_000),
+            &NoSandbox,
+        )?;
+        if result.success {
+            return Ok(());
+        }
+        last_stderr = result.stderr.trim().to_string();
+        if should_retry_git_ref_cas(attempt, &last_stderr) {
+            tracing::warn!(
+                attempt,
+                branch,
+                "retrying origin fetch after git ref update contention"
+            );
+            std::thread::sleep(git_fetch_cas_retry_delay());
+            continue;
+        }
+        break;
     }
 
-    Ok(())
+    Err(OrbitError::Execution(format!(
+        "failed to fetch remote base 'origin/{branch}' in '{}': {last_stderr}",
+        repo_root.display()
+    )))
 }
 
 pub(in crate::executor::automation) fn resolve_worktree_start_point(

--- a/crates/orbit-engine/src/executor/automation/vcs/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/mod.rs
@@ -16,6 +16,7 @@ mod worktree;
 pub(super) use commit::git_commit;
 pub(super) use failure::pr_failure_handoff;
 pub(super) use freshness::{prepare_pr_handoff, rebase_pr_branch};
+pub use git::fetch_remote_base;
 pub(super) use pr::{git_merge, pr_complete, pr_open, pr_promote, ship_done_attribution};
 pub(super) use push::push_batch_changes;
 pub(crate) use resume::reconcile_resumed_failure_handoff;

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-use super::super::git::{BaseSyncMode, resolve_worktree_start_point};
+use super::super::git::{BaseSyncMode, fetch_remote_base, resolve_worktree_start_point};
 
 #[test]
 fn remote_mode_fetches_origin_base_when_local_base_is_stale() {
@@ -46,6 +46,127 @@ fn remote_mode_fetches_origin_base_when_local_base_is_stale() {
     assert_eq!(start_point, "origin/agent-main");
     assert_eq!(git(&local, &["rev-parse", "agent-main"]), local_v1);
     assert_eq!(git(&local, &["rev-parse", "origin/agent-main"]), remote_v2);
+}
+
+#[test]
+fn concurrent_linked_worktree_fetches_pin_the_same_origin_tip() {
+    let temp = tempdir().unwrap();
+    let remote = temp.path().join("remote.git");
+    let seed = temp.path().join("seed");
+    let local = temp.path().join("local");
+    let linked = temp.path().join("linked");
+
+    git(temp.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    init_repo(&seed, "agent-main");
+    let local_v1 = commit_file(&seed, "base.txt", "v1");
+    git(
+        &seed,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&seed, &["push", "-u", "origin", "agent-main"]);
+    git(
+        temp.path(),
+        &[
+            "clone",
+            "--branch",
+            "agent-main",
+            remote.to_str().unwrap(),
+            local.to_str().unwrap(),
+        ],
+    );
+    git(
+        &local,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            linked.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+
+    let remote_v2 = commit_file(&seed, "base.txt", "v2");
+    git(&seed, &["push", "origin", "agent-main"]);
+    fs::write(local.join("user.txt"), "keep local bytes\n").unwrap();
+
+    let results: Vec<Result<String, String>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = [&local, &linked]
+            .into_iter()
+            .flat_map(|path| {
+                (0..3).map(|_| {
+                    let path = path.clone();
+                    scope.spawn(move || {
+                        resolve_worktree_start_point(&path, "agent-main", BaseSyncMode::Remote)
+                            .map_err(|error| error.to_string())
+                    })
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("fetch thread joined"))
+            .collect()
+    });
+
+    for (index, result) in results.iter().enumerate() {
+        let start_point = result
+            .as_ref()
+            .unwrap_or_else(|error| panic!("concurrent fetch {index} failed: {error}"));
+        assert_eq!(start_point, "origin/agent-main");
+    }
+    assert_eq!(git(&local, &["rev-parse", "origin/agent-main"]), remote_v2);
+    assert_eq!(git(&linked, &["rev-parse", "origin/agent-main"]), remote_v2);
+    assert_eq!(git(&local, &["rev-parse", "agent-main"]), local_v1);
+    assert_eq!(git(&local, &["rev-parse", "HEAD"]), local_v1);
+    assert_eq!(
+        fs::read_to_string(local.join("user.txt")).unwrap(),
+        "keep local bytes\n"
+    );
+}
+
+#[test]
+fn remote_fetch_failure_is_observable_and_leaves_local_refs() {
+    let temp = tempdir().unwrap();
+    let remote = temp.path().join("remote.git");
+    let seed = temp.path().join("seed");
+    let local = temp.path().join("local");
+
+    git(temp.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    init_repo(&seed, "agent-main");
+    let local_v1 = commit_file(&seed, "base.txt", "v1");
+    git(
+        &seed,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&seed, &["push", "-u", "origin", "agent-main"]);
+    git(
+        temp.path(),
+        &[
+            "clone",
+            "--branch",
+            "agent-main",
+            remote.to_str().unwrap(),
+            local.to_str().unwrap(),
+        ],
+    );
+    git(
+        &local,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "/no/such/orbit-delivery-remote.git",
+        ],
+    );
+
+    let error = fetch_remote_base(&local, "agent-main").expect_err("broken origin must fail");
+    let message = error.to_string();
+    assert!(
+        message.contains("failed to fetch") || message.contains("could not fetch"),
+        "{message}"
+    );
+    assert_eq!(git(&local, &["rev-parse", "agent-main"]), local_v1);
+    assert_eq!(git(&local, &["rev-parse", "HEAD"]), local_v1);
 }
 
 #[test]

--- a/crates/orbit-engine/src/lib.rs
+++ b/crates/orbit-engine/src/lib.rs
@@ -55,7 +55,9 @@ pub use context::{
     blocked_workflow_failure_update,
 };
 pub use executor::automation::vcs::review_gate;
-pub use executor::automation::vcs::{WorktreeGcOptions, WorktreeGcResult, collect_worktrees};
+pub use executor::automation::vcs::{
+    WorktreeGcOptions, WorktreeGcResult, collect_worktrees, fetch_remote_base,
+};
 pub use executor::automation::{
     StateExecutionContext, execute_action as execute_deterministic_action,
 };


### PR DESCRIPTION
## Task

[ORB-11741](https://orbit-cli.com/tasks/ORB-11741) — Prevent task-pilot source fetch failures when delivery updates the shared remote ref concurrently

### Description

Observed on dk-server-1 ws_orbit after installing eb26940c037ce255b6c28c0378c9276ab38cc75e and starting authorized concurrency-15 drain jrun-20260907-2224. Preparation run jrun-20260907-2226 for ORB-11740 failed before worker launch: prepare_task_pilot / remote failure: could not fetch origin/agent-main; cannot lock ref refs/remotes/origin/agent-main: is at 1c140f6cd310394f59fc2a8639269d6bc4ca25f1 but expected eb26940c037ce255b6c28c0378c9276ab38cc75e. Retry jrun-20260907-2228 successfully prepared and launched a live pilot, with no repository change by the orchestrator between attempts.

ORB-11269 previously serialized pilot fetch/align calls. Current source.rs still wraps fetch_origin_branch in with_exclusive_file_lock (around lines 222-224), so do not reintroduce a second pilot-only lock or assume that fix is absent. Trace current lock identity and other writers of the shared remote ref, including simultaneous delivery fetches through linked worktrees, and identify the regression or uncoordinated seam from current code/history. Preserve real remote errors and source pinning. Prefer shared git mutation coordination or a bounded ref-CAS contention retry with fresh validation; never delete live locks, force refs backwards, or silently swallow authentication/network errors. Relevant prior task ORB-11269 is reference evidence, not proof this incident is solved.

### Acceptance Criteria

- Reproduce concurrent pilot and another production fetch path against the same shared git common directory; both complete with validated source identity rather than spuriously failing ref-CAS contention.
- Real remote/auth failures remain observable and bounded; concurrent user changes are not overwritten.
- Focused regression tests and required ci-fast/ci-lint pass; document the actual writer/lock seam and introducing change where identifiable.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Shared git-common-dir lock `orbit-git-fetch` in orbit-common (`with_git_fetch_lock`) now serializes every Orbit-owned origin fetch. Task-pilot `resolve_source_snapshot` no longer uses the pilot-only `orbit-task-pilot-fetch` lock from ORB-11269/ORB-11256.
- Delivery `fetch_remote_base` (worktree setup, freshness, PR complete, review gate, failure handoff) takes that same lock. Linked worktrees share the identity.
- Bounded retry (3 attempts, 20ms delay) only for git ref-CAS / unable-to-update-local-ref; auth and network stderr stay fail-closed. Source SHA is re-resolved after a successful fetch. HEAD, index, local branches, and worktree bytes are not written.
- Writer/lock seam: uncoordinated second writer was `fetch_remote_base`, present since worktree extraction and never enrolled in the ORB-11269 lock. Incident jrun-20260907-2226: prepare_task_pilot CAS on origin/agent-main (expected eb26940c / ORB-11582, found 1c140f6 / ORB-11557) during concurrency-15 drain delivery fetches.
- Tests: concurrent prepare_task_pilot + fetch_remote_base on a linked worktree; concurrent delivery fetches; CAS detector vs auth/network; broken origin still fails; dirty/untracked user files preserved.

Assessment: Focused, lowest-owner fix. Two fetch implementations remain by design (pilot GIT_TERMINAL_PROMPT=0 vs engine secured git_request).

Criteria:
- Concurrent pilot + delivery fetch pin origin tip without ref-CAS failure: met (`concurrent_prepare_and_delivery_fetch_share_the_common_dir_lock`, `concurrent_linked_worktree_fetches_pin_the_same_origin_tip`).
- Real remote/auth failures observable; user changes not overwritten: met (existing + new remote-failure tests; dirty/untracked/HEAD assertions).
- Focused tests and ci-fast/ci-lint; document seam: met for tests, ci-fast, and comments; workspace `make ci-lint` sandbox-denied (see Validation).

Validation:
- cargo test -p orbit-common --lib fs::tests::git: passed (4)
- cargo test -p orbit-engine --lib executor::automation::vcs::tests::git: passed (4)
- cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::task_pilot_source: passed (16)
- make ci-fast: passed
- cargo clippy -p orbit-common -p orbit-engine -p orbit-core --all-targets -- -D warnings: passed
- make ci-lint: failed — `failed to open ~/.cargo/registry/cache/.../siphasher-1.0.3.crate`: Read-only file system (os error 30). Offline retry could not resolve chrono-tz. Not a code defect; remaining uncertainty is clippy of untouched workspace crates.
- git diff --check: passed

Remaining risks: an external `git fetch` that does not take `orbit-git-fetch` can still race; bounded CAS retry is the backstop. `fetch_remote_base` is now a crate-root re-export so orbit-core tests can call the production delivery path.

Friction: none filed.
Uncommitted. HEAD 1d3b3c564960f2c6c068d8502b6ac75e516c90db.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11741-6a9f4562`
- Behind base: 0
- Ahead of base: 1