### PR TITLE
[qa-sweep] orbit init without --force resets executor sandbox: off

### DIFF
--- a/crates/orbit-cli/src/command/executor/mod.rs
+++ b/crates/orbit-cli/src/command/executor/mod.rs
@@ -6,4 +6,7 @@ mod support;
 pub use command::{ExecutorCommand, ExecutorSubcommand};
 
 #[cfg(test)]
+pub(crate) use show::ExecutorShowArgs;
+
+#[cfg(test)]
 mod tests;

--- a/crates/orbit-cli/src/command/init/command.rs
+++ b/crates/orbit-cli/src/command/init/command.rs
@@ -15,7 +15,8 @@ use crate::command::{CommandOut, CommandOutput, Execute};
 #[derive(Args)]
 #[command(about = "Initialize the global Orbit root (~/.orbit)")]
 pub struct InitCommand {
-    /// Reset the global Orbit root (~/.orbit/) to defaults before initialization
+    /// Reset the global Orbit root (~/.orbit/) to shipped defaults before
+    /// initialization, including executor sandbox settings
     #[arg(long)]
     pub force: bool,
 

--- a/crates/orbit-cli/src/command/tests/init.rs
+++ b/crates/orbit-cli/src/command/tests/init.rs
@@ -3,9 +3,13 @@ use std::path::{Path, PathBuf};
 
 use tempfile::tempdir;
 
-use crate::InitCommand;
-use crate::tests::env_isolation::EnvGuard;
 use orbit_common::fs::io::create_dir_symlink;
+use orbit_core::OrbitRuntime;
+
+use crate::InitCommand;
+use crate::command::executor::ExecutorShowArgs;
+use crate::command::{CommandOutput, Execute};
+use crate::tests::env_isolation::EnvGuard;
 
 fn seed_discovery_sentinel(home: &Path, agent_dir: &str) -> (PathBuf, PathBuf) {
     let target = home.join("live-sentinels").join(agent_dir).join("orbit");
@@ -317,5 +321,108 @@ fn invalid_task_prefixes_fail_closed() {
 
         init_host(&root, Some("dk-mac"), Some(prefix)).expect_err("invalid prefix must fail");
         assert!(!root.join("host.toml").exists(), "prefix {prefix}");
+    }
+}
+
+/// Ordinary CLI `orbit init` (refresh_defaults, no --force) must keep an
+/// operator `spec.sandbox: off`. `--force` may still restore shipped defaults.
+#[test]
+fn non_interactive_init_preserves_explicit_sandbox_off_without_force() {
+    let home = tempdir().expect("home tempdir");
+    let empty_path = tempdir().expect("empty PATH tempdir");
+    let _env = EnvGuard::acquire()
+        .home(home.path())
+        .path(empty_path.path());
+    let root = home.path().join(".orbit");
+
+    init_host(&root, Some("sandbox-off"), Some("SO")).expect("first init");
+    set_executor_sandbox(&root, "grok", Some("off"));
+    assert_eq!(show_executor_sandbox(&root, "grok"), "off");
+
+    init_host(&root, Some("sandbox-off"), Some("SO")).expect("repeat init without --force");
+    assert_eq!(
+        show_executor_sandbox(&root, "grok"),
+        "off",
+        "ordinary orbit init must not restore shipped sandbox over explicit off"
+    );
+
+    InitCommand {
+        force: true,
+        non_interactive: true,
+        host_name: Some("sandbox-off".to_string()),
+        task_prefix: Some("SO".to_string()),
+    }
+    .execute_without_runtime(Some(&root))
+    .expect("forced init");
+    assert_eq!(
+        show_executor_sandbox(&root, "grok"),
+        shipped_sandbox_json(),
+        "orbit init --force may reset executor sandbox to the shipped default"
+    );
+
+    if cfg!(target_os = "linux") {
+        set_executor_sandbox(&root, "grok", None);
+        init_host(&root, Some("sandbox-off"), Some("SO")).expect("init after omitting sandbox");
+        assert_eq!(
+            show_executor_sandbox(&root, "grok"),
+            "linux-bwrap",
+            "omitted/null sandbox on a Linux shipped default still migrates to linux-bwrap"
+        );
+    }
+}
+
+fn set_executor_sandbox(root: &Path, name: &str, sandbox: Option<&str>) {
+    let path = root
+        .join("resources/executors")
+        .join(format!("{name}.yaml"));
+    let mut resource: serde_yaml::Value =
+        serde_yaml::from_str(&fs::read_to_string(&path).expect("read executor YAML"))
+            .expect("parse executor YAML");
+    let spec = resource
+        .get_mut("spec")
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .expect("executor spec mapping");
+    match sandbox {
+        Some(value) => {
+            spec.insert(
+                serde_yaml::Value::String("sandbox".to_string()),
+                serde_yaml::Value::String(value.to_string()),
+            );
+        }
+        None => {
+            spec.remove(serde_yaml::Value::String("sandbox".to_string()));
+        }
+    }
+    fs::write(
+        &path,
+        serde_yaml::to_string(&resource).expect("encode executor YAML"),
+    )
+    .expect("write executor YAML");
+}
+
+fn show_executor_sandbox(global_root: &Path, name: &str) -> serde_json::Value {
+    let workspace = global_root
+        .parent()
+        .expect("global root parent")
+        .join("repo/.orbit");
+    fs::create_dir_all(&workspace).expect("workspace root");
+    let runtime = OrbitRuntime::from_roots(global_root, &workspace).expect("runtime from roots");
+    let CommandOutput::Payload(payload) = ExecutorShowArgs {
+        name: name.to_string(),
+        json: true,
+    }
+    .execute(&runtime)
+    .expect("executor show") else {
+        panic!("executor show must return a payload");
+    };
+    let (json, _) = payload.into_view();
+    json["sandbox"].clone()
+}
+
+fn shipped_sandbox_json() -> serde_json::Value {
+    match std::env::consts::OS {
+        "linux" => serde_json::Value::String("linux-bwrap".to_string()),
+        "macos" => serde_json::Value::String("macos-sandbox-exec".to_string()),
+        _ => serde_json::Value::Null,
     }
 }

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -228,8 +228,12 @@ pub fn init_workspace_at_root(
         None => {
             let executor_store = global_executor_def_store(layout.executors_dir.clone());
             let policy_store = global_policy_def_store(layout.policies_dir.clone());
+            // Skills/activities/jobs refresh on ordinary `orbit init`.
+            // Executors do not: `refresh_defaults` overwrite would restore
+            // shipped sandbox and wipe an operator `spec.sandbox: off`.
+            // `--force` still resets them by deleting the root first.
             let refreshed_default_executors =
-                seed_default_executors(executor_store.as_ref(), overwrite)?;
+                seed_default_executors(executor_store.as_ref(), options.force)?;
             let refreshed_default_policies =
                 seed_default_policies(policy_store.as_ref(), overwrite)?;
             let activity_reconciliation =

--- a/crates/orbit-core/tests/sandbox_off.rs
+++ b/crates/orbit-core/tests/sandbox_off.rs
@@ -22,10 +22,12 @@ fn seed_global(global: &Path) {
         global,
         InitOptions {
             global_only: true,
+            // Match CLI `orbit init`, which always sets refresh_defaults.
+            refresh_defaults: true,
             ..Default::default()
         },
     )
-    .expect("non-overwrite global seeding");
+    .expect("CLI-equivalent global seeding");
 }
 
 #[test]

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -134,8 +134,10 @@ Activity-scoped `proc.spawn` supplies a request-time `Sandbox` validator at this
 The `Sandbox` trait remains the seam for generic `run_process` callers, but CLI-backed `agent_loop` invocations use a separate executor wrapper when the executor declares `sandbox: macos-sandbox-exec` ([T20260427-51]). The v2 host resolves the activity `fsProfile`; the engine converts workspace-relative rules to absolute roots and compiles SBPL before spawning the provider CLI.
 
 Executor resources also accept `spec.sandbox: off` as a persistent operator
-opt-out. It survives non-overwriting seeding and normal resource sync, unlike
-omitted/null values on legacy Linux defaults, which migrate to `linux-bwrap`.
+opt-out. It survives ordinary `orbit init` (without `--force`), non-overwriting
+seeding, and normal resource sync, unlike omitted/null values on legacy Linux
+defaults, which migrate to `linux-bwrap`. `orbit init --force` may still reset
+shipped executor defaults, including sandbox.
 The host carries the explicit off descriptor to the runner without resolving
 filesystem grants; preparation chooses no wrapper and performs no capability
 probe. The runner neutralizes supported provider-inner sandbox flags and audits

--- a/docs/runbooks/linux-sandbox.md
+++ b/docs/runbooks/linux-sandbox.md
@@ -83,9 +83,11 @@ spec:
 ```
 
 This setting applies to future worker launches using that executor across
-workspaces on the host. It survives fresh runtime opens, repeated default
-seeding, and normal `orbit workspace sync`. Explicit default overwrite/reset
-operations can replace it. Existing processes keep their launch configuration.
+workspaces on the host. It survives fresh runtime opens, ordinary `orbit init`
+(without `--force`), repeated default seeding, and normal `orbit workspace
+sync`. `orbit init --force` resets the global root to shipped defaults,
+including executor sandbox, and therefore restores the sandboxed shipped
+value. Existing processes keep their launch configuration.
 
 `off` is distinct from an omitted or `null` sandbox field. Omitted/null values
 on installed Linux defaults are legacy unspecified settings and migrate to


### PR DESCRIPTION
## Task

[ORB-11745](https://orbit-cli.com/tasks/ORB-11745) — [qa-sweep] orbit init without --force resets executor sandbox: off

### Description

## Problem
ORB-11589 added an explicit `spec.sandbox: off` operator opt-out that is supposed to survive repeated default seeding and `orbit workspace sync`. The operator-facing `orbit init` command (no `--force`) still overwrites host executor YAML, restoring `linux-bwrap` and wiping `off`.

CLI `orbit init` always sets `InitOptions.refresh_defaults = true`. Init computes `overwrite = force || refresh_defaults`, so every `orbit init` takes the overwrite branch of `seed_default_executors` and upserts shipped defaults, including sandbox. Activities/jobs report `refreshed=0` when unchanged; executors report `default_executors_refreshed=10` because overwrite counts every upsert.

The regression test in `crates/orbit-core/tests/sandbox_off.rs` calls `init_workspace_at_root` with default options (`refresh_defaults: false`), so it never exercises the CLI init path operators actually run.

## Why It Matters
Operators who set `sandbox: off` per the linux-sandbox runbook lose that choice the next time they run ordinary `orbit init` to refresh skills/jobs/config. That is the same restore-to-bwrap failure ORB-11589 was filed to stop, on the command that “repeated default seeding” means to an operator.

## Evidence (HEAD `eb26940c0`, 2026-09-07, worktree of jrun-20260907-2224-22)
- Built `target/debug/orbit` (0.19.2).
- Scratch root `/tmp/orb-qa-11593-root`.
- `orbit executor show grok --json` after init: `sandbox: "linux-bwrap"`.
- Edited `resources/executors/grok.yaml` `spec.sandbox: off`; show then reported `"off"`.
- Re-ran `orbit --root /tmp/orb-qa-11593-root init --non-interactive --host-name qa-sweep-11593 --task-prefix QASW` (no `--force`). Printed `default_executors_refreshed=10` (activities/jobs 0).
- `orbit executor show grok --json` after that init: `sandbox: "linux-bwrap"` again.
- A later `workspace sync` on a freshly set `off` **did** preserve `off` (runbook claim for sync holds).
- Invalid spelling `disabled` still fails closed as documented.
- Source: `crates/orbit-cli/src/command/init/command.rs` sets `refresh_defaults: true`; `crates/orbit-core/src/bootstrap/init.rs` `overwrite = options.force || options.refresh_defaults`; `seed_default_executors` overwrite branch upserts the shipped def.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
ROOT=/tmp/orb-qa-sandbox-off-repro
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-off --task-prefix QASW
# set spec.sandbox: off in $ROOT/resources/executors/grok.yaml (preserve other fields)
"$BIN" --root "$ROOT" executor show grok --json   # sandbox=off
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-off --task-prefix QASW
"$BIN" --root "$ROOT" executor show grok --json   # sandbox=linux-bwrap
```

## Scope
Operator opt-out persistence vs CLI init overwrite. `workspace sync` and non-overwrite seeding already preserve `off`. Production default remains sandboxed. Fix: treat explicit `off` as a preserved operator field even when `refresh_defaults` overwrites other shipped executor fields, or stop counting ordinary `orbit init` as a full executor overwrite. Do not weaken the fail-closed default for unspecified/null sandbox.

### Acceptance Criteria

- After setting `spec.sandbox: off` on a host executor, `orbit init` without `--force` leaves `orbit executor show <name> --json` reporting `sandbox: "off"`.
- `orbit init --force` may still reset executor defaults, and that is documented.
- Unspecified/null sandbox on Linux shipped defaults still migrates to `linux-bwrap`.
- A regression covers the CLI `orbit init` path, not only `init_workspace_at_root` with `refresh_defaults: false`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `init_workspace_at_root` seeds executors with `options.force` instead of `force || refresh_defaults`, so ordinary CLI `orbit init` uses the migration path that already preserves `spec.sandbox: off` and still upgrades omitted/null Linux sandbox to `linux-bwrap`.
- `--force` still deletes the global root first and reseeds shipped executor defaults (including sandbox). Documented on `orbit init --force` help, `docs/runbooks/linux-sandbox.md`, and `docs/design/policy-sandbox/2_design.md`.
- CLI regression `non_interactive_init_preserves_explicit_sandbox_off_without_force` drives `InitCommand` then `ExecutorShowArgs --json`. Core `sandbox_off` now seeds with `refresh_defaults: true` to match CLI init options.

Assessment: Small, targeted wiring fix at the init overwrite seam. Executor overwrite API still replaces customizations when `overwrite=true`; CLI no longer uses that for ordinary init.

Acceptance criteria:
- Ordinary `orbit init` without `--force` leaves `executor show --json` reporting `sandbox: "off"`: met (CLI test).
- `orbit init --force` may still reset executor defaults, and that is documented: met (CLI test + clap help + runbook + design doc).
- Unspecified/null sandbox on Linux shipped defaults still migrates to `linux-bwrap`: met (CLI Linux phase + existing core seed test).
- Regression covers the CLI `orbit init` path: met (`InitCommand.execute_without_runtime`, not only `init_workspace_at_root` with `refresh_defaults: false`).

Validation:
- `cargo test -p orbit-cli --bin orbit -- non_interactive_init_preserves_explicit_sandbox_off`: passed
- `cargo test -p orbit-core --test sandbox_off`: passed
- `cargo test -p orbit-core --lib explicit_off_survives_repeated_seeding`: passed
- `cargo test -p orbit-core --lib seed_default_executors_upgrades_old_unsandboxed`: passed
- `make ci-fast`: passed
- `cargo clippy -p orbit-cli -p orbit-core --all-targets -- -D warnings`: passed
- `make ci-lint`: not run to completion; `cargo clippy --workspace --all-targets` failed immediately with EROFS writing `~/.cargo/registry/cache/.../phf_shared-0.12.1.crate` (read-only cargo registry). Scoped clippy on the changed packages is the in-scope alternative; remaining risk is an unrelated workspace crate that those two packages do not compile.
- `git diff --check`: passed. Working tree: 7 modified files, uncommitted as required.

Strategic decisions: Stop treating ordinary init as a full executor overwrite rather than special-casing `off` inside `overwrite=true`. Matches activities/jobs and executor-onboarding (do not overwrite customized executor assets merely because a new default exists). Explicit `seed_default_executors(..., true)` still replaces operator customizations, including `off`.

Deviations from original plan: none material. Added `file:crates/orbit-cli/src/command/init/command.rs`, `file:crates/orbit-cli/src/command/executor/mod.rs`, `file:docs/runbooks/linux-sandbox.md`, and `file:docs/design/policy-sandbox/2_design.md` because documentation and the CLI `--force` help are required by the force-reset criterion, and the test needed a `pub(crate)` re-export of `ExecutorShowArgs`.

Design weaknesses / risks:
- Severity: low. Ordinary `orbit init` will no longer rewrite other customized executor fields (command/env) either; only known migrations apply. Mitigation: `--force` still restores the full shipped catalog; this matches the onboarding rule already on the books.
- Full workspace clippy was blocked by a sandbox EROFS on the crates.io cache, not by a lint finding.

Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11745-6a9f4683`
- Behind base: 0
- Ahead of base: 1