### PR TITLE
[qa-sweep] First Task still fails ship on a disposable repo with no origin

### DIFF
--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -70,6 +70,7 @@ fn ship_auto_mode_preserves_local_mode_and_base_override() {
         json!({
             "mode": "local",
             "base_branch": "main",
+            "base_sync": "local",
         })
     );
 }
@@ -107,6 +108,7 @@ fn explicit_ship_preserves_local_mode_and_base_override() {
         json!({
             "mode": "local",
             "base_branch": "main",
+            "base_sync": "local",
             "task_ids": ["T20260425-2010"],
         })
     );
@@ -253,6 +255,7 @@ fn interactive_ship_inherits_the_shared_in_flight_guard() {
         json!({
             "mode": "local",
             "base_branch": "main",
+            "base_sync": "local",
             "task_ids": [task_id],
         })
     );

--- a/crates/orbit-core/src/application/workflow.rs
+++ b/crates/orbit-core/src/application/workflow.rs
@@ -42,6 +42,12 @@ pub const AUTO_WORKFLOW_ALIAS: &str = "auto";
 /// default, so an ordinary submission's persisted input is unchanged and the
 /// presence of the key is itself the durable record that an operator granted
 /// this run completion authority.
+///
+/// [ORB-11746] `base_sync` is only written for `--mode local`. Seeded shipping
+/// jobs default `base_sync: remote` (fetch `origin/<base>`), which is correct
+/// for PR delivery but fails `worktree_setup` on a disposable repo with no
+/// remotes. Local mode opts into the local base so First Task can complete
+/// without origin; PR submissions omit the key and keep the remote default.
 pub fn build_ship_input(
     mode: ShipMode,
     base_branch: &str,
@@ -77,6 +83,9 @@ pub fn build_ship_input(
         "base_branch".to_string(),
         Value::String(base_branch.to_string()),
     );
+    if mode == ShipMode::Local {
+        map.insert("base_sync".to_string(), Value::String("local".to_string()));
+    }
     if !task_ids.is_empty() {
         map.insert(
             "task_ids".to_string(),
@@ -138,6 +147,10 @@ mod ship_input_tests {
         assert_eq!(input["mode"], "pr");
         assert_eq!(input["base_branch"], "main");
         assert!(input.get("task_ids").is_none());
+        assert!(
+            input.get("base_sync").is_none(),
+            "PR mode must omit base_sync so seeded jobs keep fetching origin/<base>"
+        );
     }
 
     #[test]
@@ -153,7 +166,21 @@ mod ship_input_tests {
         .expect("builds");
         assert_eq!(input["mode"], "local");
         assert_eq!(input["base_branch"], "agent-main");
+        assert_eq!(input["base_sync"], "local");
         assert_eq!(input["task_ids"], serde_json::json!(["T1", "T2"]));
+    }
+
+    #[test]
+    fn local_mode_opts_into_local_base_sync_without_origin() {
+        // Disposable First Task repos have no remotes. Local ship must tell
+        // worktree_setup to use the local base instead of fetching origin/<base>.
+        let local = build_ship_input(ShipMode::Local, "main", &[], CompletionPolicy::Review, &[])
+            .expect("local input builds");
+        assert_eq!(local["base_sync"], "local");
+
+        let pr = build_ship_input(ShipMode::Pr, "main", &[], CompletionPolicy::Review, &[])
+            .expect("pr input builds");
+        assert!(pr.get("base_sync").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Task

[ORB-11746](https://orbit-cli.com/tasks/ORB-11746) — [qa-sweep] First Task still fails ship on a disposable repo with no origin

### Description

## Problem
After ORB-11583 rewrote website First Task as a complete executable sequence, following that page on a disposable git repository still fails at `orbit run ship`. `worktree_setup` fetches `origin/<base>` even for `--mode local`, and a disposable repo created for the tutorial has no `origin`.

The page tells operators to use a disposable git repository that already has `orbit workspace init` completed. It lists `gh` as a prerequisite for default PR mode, but never says the repo needs a git remote. `--mode local` is documented as in-place delivery without a pull request, which operators reasonably take as not needing `origin`.

## Why It Matters
The first user-facing path after install cannot complete. Create / inspect / approve all work; ship always dies in `worktree_setup` before any agent runs.

## Evidence (HEAD `eb26940c0`, 2026-09-07, worktree of jrun-20260907-2224-22)
- Built `target/debug/orbit` (0.19.2) from this checkout (`CARGO_TARGET_DIR=/tmp/orbit-qa-11593-target`).
- Scratch root `/tmp/orb-qa-11593-root` + git checkout `/tmp/orb-qa-11593-ws` (local `main` only; no remotes).
- Followed First Task: `orbit task add` → `QASW-00000`, `task list` / `show` / `lint`, `task update --approve` → `backlog`.
- `orbit run ship QASW-00000 --mode local --json` submitted `jrun-20260907-2229` (`workflow=ship`, `job_id=task_auto_pipeline`).
- Run failed in ~10s:
  `worktree_setup` → `failed to fetch remote base 'origin/main' in '/tmp/orb-qa-11593-ws': fatal: 'origin' does not appear to be a git repository`.
- Child jobs: `task_gate_pipeline` (`jrun-20260907-2229-2`) and `task_local_pipeline` (`jrun-20260907-2229-3`), all `failed`.
- Source: `task_local_pipeline.yaml` `default_input.base_sync: remote`; worktree step uses `base_sync: "{{ input.base_sync }}"`. `orbit run ship --mode local` sets `mode=local` but does not override `base_sync`. Merge later hardcodes `base_sync: local`; setup still fetches origin.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
ROOT=/tmp/orb-qa-first-task-repro
WS=/tmp/orb-qa-first-task-ws
mkdir -p "$WS" && git -C "$WS" init
git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/README.md" && git -C "$WS" add README.md && git -C "$WS" commit -m init
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-first --task-prefix QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace init --name qa-first --ship-mode local)
cd "$WS"
TASK_ID=$("$BIN" --root "$ROOT" task add --title "Create orbit-hello.txt" --description d --acceptance-criteria a --complexity low --status proposed --workspace .)
"$BIN" --root "$ROOT" task update "$TASK_ID" --approve --note ok
"$BIN" --root "$ROOT" run ship "$TASK_ID" --mode local --json
"$BIN" --root "$ROOT" run show   # failed: origin/main fetch
```

## Scope
Onboarding / local-ship base sync. Production clones with `origin` are unaffected. Fix either First Task (require a remote, or show a local-only setup) or have `--mode local` pass `base_sync=local` into worktree setup so a disposable repo can complete the sequence.

### Acceptance Criteria

- Following website First Task on a disposable git repo with no remotes, `orbit run ship --mode local` either completes worktree_setup against the local base or the page names the remote prerequisite before Ship it.
- Default PR-mode ship still fetches origin/<base> when a remote is present.
- A regression test or documented command covers the disposable-repo path.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `build_ship_input` now writes `base_sync: local` when `ShipMode::Local`, so `orbit run ship --mode local` forwards that value through task_auto_pipeline → task_gate_pipeline → task_local_pipeline worktree_setup instead of the YAML default `remote` (fetch origin/<base>).
- PR-mode submissions still omit `base_sync`, so seeded jobs keep fetching origin/<base> when a remote is present.
- Regression coverage: `local_mode_opts_into_local_base_sync_without_origin` plus CLI ship-plan JSON snapshots for local mode.
Assessment: Small, single-path fix at the ship-input builder used by CLI, MCP, dashboard, and auto. Existing worktree local-sync tests already prove a disposable repo without remotes can resolve the local base.

Criteria:
- First Task disposable repo + `--mode local` completes worktree_setup against the local base: met at the ship-input contract. `base_sync: local` is what worktree_setup already honors (`local_mode_resolves_local_base_without_origin_remote`). Full live `orbit run ship` on a scratch repo was not executed (would dispatch a real agent pipeline).
- Default PR-mode ship still fetches origin/<base>: met. PR input omits `base_sync`; YAML default remains `remote`.
- Regression test covers the disposable-repo path: met (`local_mode_opts_into_local_base_sync_without_origin` and CLI local-mode JSON assertions).

Validation:
- Passed: `CARGO_TARGET_DIR=/tmp/orbit-11746-target cargo test -p orbit-core --lib -- ship_input local_mode_opts_into_local_base_sync …` — 10 passed.
- Passed: `CARGO_TARGET_DIR=/tmp/orbit-11746-target cargo test -p orbit-cli --bin orbit -- command::run::tests::ship` — 15 passed.
- Passed: `make ci-fast`.
- Passed: `CARGO_TARGET_DIR=/tmp/orbit-11746-target cargo clippy -p orbit-core --lib --tests -- -D warnings` and `cargo clippy -p orbit-cli --bin orbit --tests -- -D warnings`.
- Not run: `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`). Failed immediately: `failed to open ~/.cargo/registry/cache/.../phf-0.12.1.crate: Read-only file system (os error 30)`. Sandbox denial while fetching extra --all-targets crates; not evidence of a code defect. Remaining uncertainty: other workspace crates were not clippy'd.
- Passed: `git diff --check`. Status: only the two planned files modified. No leftover Cargo artifacts in the worktree (`CARGO_TARGET_DIR` was /tmp/orbit-11746-target).

Strategic decisions: Opt local mode into `base_sync=local` at the shared ship-input builder rather than changing YAML defaults or First Task copy, so PR clones keep remote fetch and every ship surface inherits the local-repo path.
Design weaknesses / risks:
- Severity: low. Direct `orbit run job task_local_pipeline` without `base_sync` still defaults to remote. Mitigation: First Task uses `orbit run ship --mode local`.
- Severity: low. Local mode on a clone that has origin will skip fetching origin at worktree_setup (merge already used local sync). Intended for in-place delivery.
Deviations from original plan: none.
Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11746-6a9f46e8`
- Behind base: 0
- Ahead of base: 1