### PR TITLE
[code-review] Validate cron at auto-task load time like the routine loader does

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/loader.rs
+++ b/crates/orbit-automation/src/auto_tasks/loader.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use orbit_common::protocol::yaml::parse_auto_task_yaml;
 use orbit_types::workflow::AutoTaskDefinition;
 
+use super::schedule::validate_schedule;
+
 /// Directory under a workspace's `.orbit/` holding auto-task YAML files.
 pub const AUTO_TASKS_DIR: &str = "auto_tasks";
 
@@ -94,6 +96,7 @@ pub fn collect_auto_tasks(orbit_dir: &Path) -> AutoTaskCollection {
 fn load_definition_file(path: &Path) -> Result<LoadedAutoTask, String> {
     let raw = std::fs::read_to_string(path).map_err(|error| format!("read failed: {error}"))?;
     let definition = parse_auto_task_yaml(&raw).map_err(|error| error.to_string())?;
+    validate_schedule(&definition.schedule).map_err(|error| error.to_string())?;
 
     // The file stem is the definition identity: reject a mismatch so CRUD (which
     // writes `<name>.yaml`) and the provenance tag stay consistent.

--- a/crates/orbit-automation/src/auto_tasks/schedule.rs
+++ b/crates/orbit-automation/src/auto_tasks/schedule.rs
@@ -23,8 +23,8 @@ pub enum AutoTaskDueDecision {
 }
 
 /// Validate a schedule fail-closed: a cron form must parse as a 5-field cron,
-/// an interval must be non-zero. CRUD calls this so a bad schedule is rejected
-/// at write time rather than silently never firing.
+/// an interval must be non-zero. CRUD and the loader call this so a bad
+/// schedule is rejected before it can silently never fire.
 pub fn validate_schedule(schedule: &AutoTaskSchedule) -> Result<(), OrbitError> {
     match schedule {
         AutoTaskSchedule::Deliveries { deliveries_landed } => {

--- a/crates/orbit-automation/src/auto_tasks/tests/loader.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/loader.rs
@@ -1,0 +1,33 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::auto_tasks::loader::{auto_tasks_dir, collect_auto_tasks};
+
+#[test]
+fn rejects_definition_with_invalid_cron_during_collection() {
+    let root = tempdir().expect("temporary definition root");
+    let definitions = auto_tasks_dir(root.path());
+    fs::create_dir_all(&definitions).expect("auto-task definitions directory");
+    fs::write(
+        definitions.join("invalid-cron.yaml"),
+        r#"schemaVersion: 1
+name: invalid-cron
+schedule:
+  cron: "every day"
+template:
+  title: Invalid cron fixture
+"#,
+    )
+    .expect("definition fixture");
+
+    let collection = collect_auto_tasks(root.path());
+
+    assert!(collection.definitions.is_empty());
+    assert_eq!(collection.errors.len(), 1);
+    assert!(
+        collection.errors[0]
+            .message
+            .contains("invalid cron expression 'every day'")
+    );
+}

--- a/crates/orbit-automation/src/auto_tasks/tests/mod.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/mod.rs
@@ -1,1 +1,3 @@
+mod loader;
 mod schedule;
+mod scheduler;

--- a/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use orbit_common::OrbitError;
+use orbit_store::compose::auto_task::cursor_state_path;
+use orbit_types::workflow::AutoTaskDefinition;
+use orbit_types::workflow::automation::AutomationDiagnostic;
+use tempfile::tempdir;
+
+use crate::auto_tasks::loader::auto_tasks_dir;
+use crate::auto_tasks::scheduler::{
+    AutoTaskDispatch, SchedulerOptions, run_auto_task_scheduler_at,
+};
+
+struct TestDispatch {
+    definition_root: PathBuf,
+    state_dir: PathBuf,
+}
+
+impl AutoTaskDispatch for TestDispatch {
+    fn evaluate_delivery(
+        &self,
+        _definition: &AutoTaskDefinition,
+        _dry_run: bool,
+        _now: DateTime<Utc>,
+    ) -> Result<AutomationDiagnostic, OrbitError> {
+        panic!("invalid cron definitions must not be dispatched")
+    }
+
+    fn definition_root(&self) -> PathBuf {
+        self.definition_root.clone()
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.state_dir.clone()
+    }
+
+    fn has_open_instance(&self, _definition: &AutoTaskDefinition) -> Result<bool, OrbitError> {
+        panic!("invalid cron definitions must not be dispatched")
+    }
+
+    fn mint_task(&self, _definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
+        panic!("invalid cron definitions must not be dispatched")
+    }
+}
+
+#[test]
+fn invalid_cron_definition_does_not_create_a_cursor() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    let definitions = auto_tasks_dir(&definition_root);
+    fs::create_dir_all(&definitions).expect("auto-task definitions directory");
+    fs::write(
+        definitions.join("invalid-cron.yaml"),
+        r#"schemaVersion: 1
+name: invalid-cron
+schedule:
+  cron: "every day"
+template:
+  title: Invalid cron fixture
+"#,
+    )
+    .expect("definition fixture");
+
+    let dispatch = TestDispatch {
+        definition_root,
+        state_dir,
+    };
+    let outcome = run_auto_task_scheduler_at(&dispatch, Utc::now(), SchedulerOptions::default())
+        .expect("scheduler pass");
+
+    assert!(outcome.reports.is_empty());
+    assert_eq!(outcome.errors.len(), 1);
+    assert!(
+        outcome.errors[0]
+            .message
+            .contains("invalid cron expression 'every day'")
+    );
+    assert!(!cursor_state_path(&dispatch.state_dir).exists());
+}


### PR DESCRIPTION
## Task

[ORB-11737](https://orbit-cli.com/tasks/ORB-11737) — [code-review] Validate cron at auto-task load time like the routine loader does

### Description

## Problem
The routine loader parses the cron expression at load time (`routines/loader.rs:221-225`) so an unparsable trigger is a load error listed in `errors`. The auto-task loader does not call `validate_schedule`; `AutoTaskDefinition::validate` only checks the cron string is non-empty. A file with `cron: "every day"` therefore loads as a valid definition, gets a baseline cursor written on the first pass (scheduler.rs:136-151, before any cron parsing), and on every later pass appears as `action: skipped, reason: "error: invalid cron expression ..."` in `reports` rather than in `errors`, so `orbit auto-task list` shows it as healthy and the module doc's "fail-closed per file ... mirrors the routine loader" (loader.rs:1-5) is not true for the schedule.

## Why It Matters
The same misconfiguration is a load error for routines and a per-pass skip for auto-tasks, and the cursor file gains an entry for a definition that can never fire.

## Proposed Fix
Call `validate_schedule(&definition.schedule)` in `load_definition_file` and surface the error as an `AutoTaskLoadError`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-automation/src/auto_tasks/loader.rs:94-115`, `crates/orbit-automation/src/auto_tasks/schedule.rs:28-44`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (quality). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: a definition file with `cron: "every day"` appears in `collection.errors` with the cron message and not in `collection.definitions`.
- No cursor entry is created for it after a scheduler pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- The auto-task loader now runs the shared schedule validator after YAML parsing, so invalid cron schedules fail closed during collection.
- Added loader and scheduler regression tests for `cron: "every day"`; they assert a load error containing the cron diagnostic, no loaded definition or scheduler report, and no cursor state file.
- Updated schedule validation documentation and registered sibling test modules.
Assessment: The loader is now the canonical validation boundary for persisted definitions, preventing invalid schedules from reaching cursor initialization.
Criteria:
- Invalid cron collection behavior: passed by `rejects_definition_with_invalid_cron_during_collection`.
- No cursor entry after scheduler pass: passed by `invalid_cron_definition_does_not_create_a_cursor`.
Validation:
- Passed: `cargo fmt --check`; `git diff --check`; untracked-test diff checks.
- Passed: `CARGO_HOME=/tmp/orb11737-cargo-home.iSaroy CARGO_TARGET_DIR=/tmp/orb11737-target.u2kiFs cargo test -p orbit-automation auto_tasks` (8 passed).
- Passed: `make ci-fast`.
- Passed: `CARGO_HOME=/tmp/orb11737-cargo-home.iSaroy CARGO_TARGET_DIR=/tmp/orb11737-target.u2kiFs make ci-lint`.
- The standard Cargo cache was read-only, so test and lint caches were placed under `/tmp`; compiled target output was removed with `cargo clean`.
Risks: None identified; cron validation reuses the existing shared routine parser and preserves the CRUD validation path.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11737-6a9f48ee`
- Behind base: 0
- Ahead of base: 1