### PR TITLE
[code-review] Report (or reject) retired `orbit.task.add` fields instead of silently dropping them

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/task_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/task_tools.rs
@@ -1,7 +1,7 @@
 use orbit_common::OrbitError;
 use orbit_common::protocol::tool_input::{
     optional_csv_or_string_list_alias, optional_raw_string, optional_string, optional_string_alias,
-    optional_string_list_alias, required_string, strip_retired_task_add_input_fields,
+    optional_string_list_alias, required_string,
 };
 use orbit_types::task::{TaskPriority, validate_relative_artifact_path};
 use serde_json::{Value, json};
@@ -21,19 +21,10 @@ use super::json::{
 
 pub(super) fn add(
     runtime: &OrbitRuntime,
-    mut input: Value,
+    input: Value,
     agent: Option<String>,
     model: Option<String>,
 ) -> Result<Value, OrbitError> {
-    let ignored_fields = strip_retired_task_add_input_fields(&mut input);
-    if !ignored_fields.is_empty() {
-        tracing::warn!(
-            target: "orbit.core.task.add",
-            ignored_fields = ?ignored_fields,
-            "ignored retired orbit.task.add fields"
-        );
-    }
-
     let title = required_string(&input, &["title"], "title")?;
     let description = required_string(&input, &["description"], "description")?;
     let workspace = required_string(&input, &["workspace"], "workspace")?;

--- a/crates/orbit-tools/src/builtin/orbit/task/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/add.rs
@@ -1,7 +1,7 @@
 use orbit_common::OrbitError;
 use orbit_common::protocol::tool_input::{required_string, strip_retired_task_add_input_fields};
 use orbit_types::tool::{ToolParam, ToolSchema};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use crate::{OrbitBuiltinAction, Tool, ToolContext};
 
@@ -129,6 +129,17 @@ impl Tool for OrbitTaskAddTool {
             );
         }
 
-        super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)
+        let mut response =
+            super::super::execute_host_action(ctx, input, OrbitBuiltinAction::TaskAdd)?;
+        if !ignored_fields.is_empty() {
+            let response_object = response.as_object_mut().ok_or_else(|| {
+                OrbitError::Execution(
+                    "orbit.task.add host returned a non-object response".to_string(),
+                )
+            })?;
+            response_object.insert("ignored_fields".to_string(), json!(ignored_fields));
+        }
+
+        Ok(response)
     }
 }

--- a/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
+++ b/crates/orbit-tools/src/builtin/orbit/task/tests/add.rs
@@ -227,7 +227,7 @@ fn schema_exposes_only_trimmed_create_task_fields() {
 }
 
 #[test]
-fn add_call_with_retired_fields_warns_once_and_ignores_them() {
+fn add_call_with_retired_fields_reports_and_ignores_them() {
     let host = RecordingHost::default();
     let ctx = mk_ctx(host.clone());
     let tool = OrbitTaskAddTool;
@@ -257,6 +257,7 @@ fn add_call_with_retired_fields_warns_once_and_ignores_them() {
 
     let (res, logs) = capture_warnings(|| tool.execute(&ctx, input).expect("execute succeeds"));
     assert_eq!(res["id"], "ORB-TEST");
+    assert_eq!(res["ignored_fields"], json!(RETIRED_TASK_ADD_INPUT_FIELDS));
     assert_eq!(
         logs.matches("ignored retired orbit.task.add fields")
             .count(),


### PR DESCRIPTION
## Task

[ORB-11698](https://orbit-cli.com/tasks/ORB-11698) — [code-review] Report (or reject) retired `orbit.task.add` fields instead of silently dropping them

### Description

## Problem
`orbit.task.add` removes `dependencies`, `parent_id`, `status`, `plan`, `source_task_id`, `external_refs`, `context`, and `comment` from the input and only emits a server-side `tracing::warn!`. The MCP caller receives a normal success payload with no indication that its fields were ignored, so an agent that passes `dependencies: ["ORB-1"]` believes the edge exists. The same stripping runs twice: once in the tool (`add.rs:123`) and again in Core (`task_tools.rs:28`), so the Core copy can never observe anything and is dead duplication of a validation rule that per AGENTS.md belongs at one boundary. The advertised schema does not list these fields, but `orbit.task.update` advertises `dependencies` and `source_task_id`, which is why agents keep sending them on add.

## Why It Matters
Silent input loss on a task-creation call produces tasks with missing dependency edges that are only discovered when the scheduler dispatches them out of order; the operator memory in this workspace already records this exact trap.

## Proposed Fix
Return the ignored field names in the response (e.g. `"ignored_fields": [...]` beside the task JSON) or reject with `invalid_input` naming the field and the follow-up tool (`orbit.task.update` for `dependencies`); delete the duplicate strip in Core and keep the rule in one place.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-tools/src/builtin/orbit/task/add.rs:123-130`, `crates/orbit-core/src/adapter/tool_host/task_tools.rs:28-35`, `crates/orbit-common/src/protocol/tool_input.rs:5-28`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit.task.add` with `dependencies: ["ORB-1"]` either errors with `invalid_input` mentioning `dependencies` or returns a payload containing `ignored_fields: ["dependencies"]` (test in `crates/orbit-tools/src/builtin/orbit/task/tests/add.rs`).
- `strip_retired_task_add_input_fields` is called from exactly one layer (`rg strip_retired_task_add_input_fields crates` shows one non-test call site).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- The public `orbit.task.add` boundary now returns `ignored_fields` beside a successfully created task whenever it strips retired input fields.
- Removed Core's duplicate retired-field stripping, leaving one non-test call site at the public tool boundary.
- Added regression coverage that asserts the response reports every stripped field, including `dependencies`.
Criteria:
- `dependencies: ["ORB-1"]` is reported through `ignored_fields` by the task-add tool regression test: passed.
- `rg -n strip_retired_task_add_input_fields crates` shows one non-test call site: passed.
Validation:
- Passed: `cargo test -p orbit-tools add_call_with_retired_fields_reports_and_ignores_them`.
- Passed: `cargo test -p orbit-core task_add_tool_ignores_retired_dependencies`.
- Passed: `make ci-fast`.
- Passed: `CARGO_HOME=/tmp/orbit-ci-lint.iSL8oF make ci-lint`. The initial `make ci-lint` could not write the read-only shared Cargo registry cache (`phf-0.12.1.crate`); the isolated temporary Cargo home is the safe in-scope workaround.
- Passed: `git diff --check`; reviewed `git status --short`.
Assessment: The response now makes ignored create-task fields visible to callers while preserving existing create behavior and one authoritative stripping boundary.
Risks: No known functional risk; the temporary Cargo registry cache remains outside the worktree at `/tmp/orbit-ci-lint.iSL8oF` and is not part of the patch.
Friction checkpoint: considered; no record filed because the cache write denial was a one-off sandbox limitation with a successful safe workaround.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11698-6a9f49b6`
- Behind base: 0
- Ahead of base: 1