### PR TITLE
[code-review] Batch the per-path Git subprocesses in the worktree boundary fingerprint

### DIFF
--- a/crates/orbit-engine/src/activity_job/tests/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/tests/workspace.rs
@@ -1,9 +1,18 @@
 #![allow(missing_docs)]
 
-use tempfile::tempdir;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use tempfile::{TempDir, tempdir};
 
 use super::super::dispatcher::DispatchError;
+use super::super::workspace::fingerprint::{git_fingerprint, untracked_file_identity};
 use super::super::workspace::*;
+
+static GIT_SHIM_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn resolve_subprocess_cwd_prefers_input_over_task_over_tool_ctx() {
@@ -165,4 +174,377 @@ fn vanished_untracked_staging_file_is_not_a_snapshot_failure() {
             .expect("vanished staging file is benign"),
         None
     );
+}
+
+#[test]
+fn fingerprint_identities_match_per_path_git_and_stay_stable() {
+    let fixture = linked_worktree_fixture();
+    seed_identity_dirt(&fixture.assigned);
+
+    let first = git_fingerprint(&fixture.assigned).expect("first fingerprint");
+    let second = git_fingerprint(&fixture.assigned).expect("second fingerprint");
+    assert_eq!(
+        first, second,
+        "consecutive snapshots of an unchanged dirty tree must be byte-identical"
+    );
+
+    let value = serde_json::to_value(&first).expect("serialize fingerprint");
+    let spaced = "dir with spaces/a file.txt";
+    let quoted = "weird/foo\"bar.txt";
+    assert_eq!(
+        value["untracked_content"][spaced],
+        untracked_file_identity(&fixture.assigned, spaced)
+            .expect("spaced untracked identity")
+            .expect("spaced file exists")
+    );
+    assert_eq!(
+        value["untracked_content"][quoted],
+        untracked_file_identity(&fixture.assigned, quoted)
+            .expect("quoted untracked identity")
+            .expect("quoted file exists")
+    );
+
+    assert_eq!(
+        value["path_states"]["README.md"]["index_entry_sha256"],
+        expected_optional_identity(
+            "git-index-entry-v1",
+            &git_bytes(
+                &fixture.assigned,
+                &["ls-files", "--stage", "-z", "--", "README.md"]
+            )
+        )
+    );
+    assert_eq!(
+        value["path_states"]["README.md"]["worktree_patch_sha256"],
+        expected_optional_identity(
+            "git-worktree-path-patch-v1",
+            &git_bytes(
+                &fixture.assigned,
+                &[
+                    "diff",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-renames",
+                    "--",
+                    "README.md",
+                ]
+            )
+        )
+    );
+    assert_eq!(
+        value["path_states"]["staged.txt"]["staged_patch_sha256"],
+        expected_optional_identity(
+            "git-staged-path-patch-v1",
+            &git_bytes(
+                &fixture.assigned,
+                &[
+                    "diff",
+                    "--cached",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-renames",
+                    "HEAD",
+                    "--",
+                    "staged.txt",
+                ]
+            )
+        )
+    );
+    assert_eq!(
+        value["tracked_patch_sha256"],
+        expected_identity(
+            "git-tracked-patch-v1",
+            &git_bytes(
+                &fixture.assigned,
+                &[
+                    "diff",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-renames",
+                    "HEAD",
+                    "--",
+                ]
+            )
+        )
+    );
+}
+
+#[test]
+fn capture_of_thousands_of_untracked_files_uses_a_constant_git_budget() {
+    let fixture = linked_worktree_fixture();
+    write_untracked_tree(&fixture.assigned, 25);
+    let pair = declared_pair(&fixture, "ORB-FINGERPRINT-BUDGET", "run-fingerprint-budget");
+    let input = worktree_input(&fixture, "ORB-FINGERPRINT-BUDGET");
+
+    let _guard = lock_git_shim();
+    let shim = GitShim::install();
+
+    let small_before = shim.invocation_count(&[&fixture.assigned, &fixture.primary]);
+    WorktreeBoundaryGuard::capture(
+        &input,
+        None,
+        "run-fingerprint-budget-small",
+        "codex",
+        Some(&fixture.assigned),
+        Some(&fixture.primary),
+        Some(&pair),
+    )
+    .expect("small capture")
+    .expect("small guard enabled");
+    let small_invocations =
+        shim.invocation_count(&[&fixture.assigned, &fixture.primary]) - small_before;
+    assert!(
+        small_invocations > 0,
+        "capture must spawn git through the PATH shim"
+    );
+
+    write_untracked_tree(&fixture.assigned, 2_000);
+    let large_before = shim.invocation_count(&[&fixture.assigned, &fixture.primary]);
+    let started = Instant::now();
+    WorktreeBoundaryGuard::capture(
+        &input,
+        None,
+        "run-fingerprint-budget-large",
+        "codex",
+        Some(&fixture.assigned),
+        Some(&fixture.primary),
+        Some(&pair),
+    )
+    .expect("large capture")
+    .expect("large guard enabled");
+    let elapsed = started.elapsed();
+    let large_invocations =
+        shim.invocation_count(&[&fixture.assigned, &fixture.primary]) - large_before;
+
+    assert_eq!(
+        small_invocations, large_invocations,
+        "git spawns must stay constant as untracked files grow ({small_invocations} vs {large_invocations})"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "2,000 untracked files must fingerprint well under a second, took {elapsed:?}"
+    );
+}
+
+struct LinkedWorktreeFixture {
+    primary: PathBuf,
+    assigned: PathBuf,
+    _temp: TempDir,
+}
+
+fn linked_worktree_fixture() -> LinkedWorktreeFixture {
+    let temp = tempdir().expect("fixture tempdir");
+    let primary = temp.path().join("primary");
+    let assigned = temp.path().join("assigned");
+    fs::create_dir_all(&primary).expect("create primary");
+    git_ok(&primary, &["init"]);
+    git_ok(&primary, &["config", "user.name", "Orbit Test"]);
+    git_ok(
+        &primary,
+        &["config", "user.email", "orbit-test@example.invalid"],
+    );
+    fs::write(primary.join("README.md"), "base\n").expect("write initial file");
+    git_ok(&primary, &["add", "README.md"]);
+    git_ok(&primary, &["commit", "-m", "initial"]);
+    git_ok(
+        &primary,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "orbit-fingerprint-test",
+            assigned.to_str().expect("utf8 assigned path"),
+        ],
+    );
+
+    LinkedWorktreeFixture {
+        primary: primary.canonicalize().expect("canonical primary"),
+        assigned: assigned.canonicalize().expect("canonical assigned"),
+        _temp: temp,
+    }
+}
+
+fn seed_identity_dirt(root: &Path) {
+    fs::write(root.join("README.md"), b"binary\0dirt\n").expect("dirty tracked file");
+    fs::write(root.join("staged.txt"), "staged\n").expect("write staged file");
+    git_ok(root, &["add", "--", "staged.txt"]);
+    fs::create_dir_all(root.join("dir with spaces")).expect("spaced dir");
+    fs::write(root.join("dir with spaces/a file.txt"), "x").expect("spaced untracked");
+    fs::create_dir_all(root.join("weird")).expect("weird dir");
+    fs::write(root.join("weird/foo\"bar.txt"), "q\n").expect("quoted untracked");
+}
+
+fn write_untracked_tree(root: &Path, count: usize) {
+    let dir = root.join("untracked-batch");
+    fs::create_dir_all(&dir).expect("untracked dir");
+    for index in 0..count {
+        fs::write(dir.join(format!("{index}.txt")), index.to_string()).expect("untracked file");
+    }
+}
+
+fn worktree_input(fixture: &LinkedWorktreeFixture, task_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "prompt": "implement",
+        "task_id": task_id,
+        "workspace_path": fixture.assigned,
+        "repo_root": fixture.assigned,
+    })
+}
+
+fn declared_pair(
+    fixture: &LinkedWorktreeFixture,
+    task_id: &str,
+    run_id: &str,
+) -> super::super::workspace::DeclaredWorktreePair {
+    let input = worktree_input(fixture, task_id);
+    validate_declared_worktree_pair(&input, None, run_id, "codex", Some(&fixture.primary))
+        .expect("validate declared pair")
+        .expect("linked worktree pair")
+}
+
+fn git_ok(repo: &Path, args: &[&str]) {
+    let output = git_command(repo, args);
+    assert!(
+        output.status.success(),
+        "git {} in {} failed: {}",
+        args.join(" "),
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_bytes(repo: &Path, args: &[&str]) -> Vec<u8> {
+    let output = git_command(repo, args);
+    assert!(
+        output.status.success(),
+        "git {} in {} failed: {}",
+        args.join(" "),
+        repo.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn git_command(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
+fn expected_identity(domain: &str, bytes: &[u8]) -> serde_json::Value {
+    serde_json::Value::String(domain_sha256(domain, bytes))
+}
+
+fn expected_optional_identity(domain: &str, bytes: &[u8]) -> serde_json::Value {
+    if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        expected_identity(domain, bytes)
+    }
+}
+
+fn domain_sha256(domain: &str, bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    hasher.update([0]);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn lock_git_shim() -> MutexGuard<'static, ()> {
+    GIT_SHIM_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct GitShim {
+    log_path: PathBuf,
+    previous_path: Option<std::ffi::OsString>,
+    _dir: TempDir,
+}
+
+impl GitShim {
+    fn install() -> Self {
+        let dir = tempdir().expect("shim dir");
+        let log_path = dir.path().join("git-invocations.log");
+        fs::write(&log_path, "").expect("create shim log");
+        let real_git = which_git();
+        let script = dir.path().join("git");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf '%s\\t%s\\n' \"$(pwd)\" \"$*\" >> '{}'\nexec '{}' \"$@\"\n",
+                log_path.display(),
+                real_git.display()
+            ),
+        )
+        .expect("write git shim");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&script).expect("shim metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script, permissions).expect("shim permissions");
+        }
+
+        let previous_path = std::env::var_os("PATH");
+        let mut path = dir.path().as_os_str().to_os_string();
+        path.push(":");
+        if let Some(existing) = &previous_path {
+            path.push(existing);
+        }
+        // SAFETY: the matching Drop restores PATH, and GIT_SHIM_LOCK serializes
+        // the only test that mutates it.
+        unsafe { std::env::set_var("PATH", &path) };
+
+        Self {
+            log_path,
+            previous_path,
+            _dir: dir,
+        }
+    }
+
+    fn invocation_count(&self, roots: &[&Path]) -> usize {
+        let log = fs::read_to_string(&self.log_path).expect("read shim log");
+        log.lines()
+            .filter(|line| {
+                roots.iter().any(|root| {
+                    line.split_once('\t')
+                        .is_some_and(|(cwd, _)| Path::new(cwd) == *root)
+                })
+            })
+            .count()
+    }
+}
+
+impl Drop for GitShim {
+    fn drop(&mut self) {
+        // SAFETY: restores the PATH captured in GitShim::install.
+        unsafe {
+            match &self.previous_path {
+                Some(path) => std::env::set_var("PATH", path),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+}
+
+fn which_git() -> PathBuf {
+    let output = Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("locate git");
+    assert!(output.status.success(), "git must be on PATH");
+    PathBuf::from(String::from_utf8_lossy(&output.stdout).trim())
 }

--- a/crates/orbit-engine/src/activity_job/workspace.rs
+++ b/crates/orbit-engine/src/activity_job/workspace.rs
@@ -1,19 +1,21 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use std::process::Output;
 
 use serde::Serialize;
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 
 use crate::context::RuntimeHost;
-use crate::executor::automation::vcs::git::git_command;
 
 use super::dispatcher::DispatchError;
 
+pub(crate) mod fingerprint;
 mod rebase_recovery;
 
+use fingerprint::{
+    GitPathState, GitWorktreeFingerprint, changed_paths, git_fingerprint, git_output_raw,
+    git_stdout_bytes,
+};
 use rebase_recovery::RebaseRecoveryCheckpoint;
 
 pub fn resolve_subprocess_cwd(
@@ -325,33 +327,6 @@ fn worktree_mismatch_error(
         code: "worktree_mismatch",
         diagnostic: diagnostic.to_string(),
     }
-}
-
-/// Exact, read-only identity of the Git state that an agent invocation can
-/// observe or mutate. Large byte streams are represented by domain-separated
-/// SHA-256 identities; untracked files retain one content identity per path so
-/// diagnostics can name the primary-checkout delta without staging it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub(crate) struct GitWorktreeFingerprint {
-    head: String,
-    branch: Option<String>,
-    index_sha256: String,
-    tracked_patch_sha256: String,
-    untracked_content: BTreeMap<String, String>,
-    dirty_paths: Vec<String>,
-    path_states: BTreeMap<String, GitPathState>,
-}
-
-/// Per-path Git identity. Optional identities distinguish an absent index
-/// entry, an empty staged/unstaged delta, a deletion from the worktree, and an
-/// untracked file without reading file contents into the diagnostic.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct GitPathState {
-    index_entry_sha256: Option<String>,
-    staged_patch_sha256: Option<String>,
-    worktree_patch_sha256: Option<String>,
-    worktree_present: bool,
-    untracked_content_sha256: Option<String>,
 }
 
 /// Durable, content-bearing evidence written before a dirty integrity failure
@@ -1042,240 +1017,4 @@ fn git_common_dir(path: &Path) -> Result<Option<PathBuf>, DispatchError> {
         return Ok(None);
     }
     Ok(Some(canonicalize_dir(Path::new(&common))))
-}
-
-fn git_fingerprint(root: &Path) -> Result<GitWorktreeFingerprint, DispatchError> {
-    let head = git_stdout(root, &["rev-parse", "--verify", "HEAD"])?;
-    let branch_output = git_output_raw(root, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
-    let branch = branch_output
-        .status
-        .success()
-        .then(|| {
-            String::from_utf8_lossy(&branch_output.stdout)
-                .trim()
-                .to_string()
-        })
-        .filter(|branch| !branch.is_empty());
-
-    let index = git_stdout_bytes(root, &["ls-files", "--stage", "-z", "--"])?;
-    let tracked_patch = git_stdout_bytes(
-        root,
-        &[
-            "diff",
-            "--binary",
-            "--full-index",
-            "--no-ext-diff",
-            "--no-textconv",
-            "--no-renames",
-            "HEAD",
-            "--",
-        ],
-    )?;
-    let discovered_untracked_paths = nul_paths(&git_stdout_bytes(
-        root,
-        &["ls-files", "--others", "--exclude-standard", "-z", "--"],
-    )?);
-    let mut untracked_paths = Vec::with_capacity(discovered_untracked_paths.len());
-    let mut untracked_content = BTreeMap::new();
-    for path in discovered_untracked_paths {
-        let Some(identity) = untracked_file_identity(root, &path)? else {
-            // ADR-0286: an atomic tracked-file replacement briefly exposes an
-            // untracked sibling temp file. It may disappear between
-            // `ls-files` and `hash-object`; that file was never part of a
-            // stable checkout state, so omit it instead of turning an
-            // unrelated boundary snapshot into a permanent failure.
-            continue;
-        };
-        untracked_content.insert(path.clone(), identity);
-        untracked_paths.push(path);
-    }
-
-    let mut dirty_paths = nul_paths(&git_stdout_bytes(
-        root,
-        &["diff", "--name-only", "-z", "--no-renames", "HEAD", "--"],
-    )?);
-    dirty_paths.extend(untracked_paths);
-    dirty_paths.sort();
-    dirty_paths.dedup();
-
-    let mut path_states = BTreeMap::new();
-    for path in &dirty_paths {
-        let index_entry = git_stdout_bytes(root, &["ls-files", "--stage", "-z", "--", path])?;
-        let staged_patch = git_stdout_bytes(
-            root,
-            &[
-                "diff",
-                "--cached",
-                "--binary",
-                "--full-index",
-                "--no-ext-diff",
-                "--no-textconv",
-                "--no-renames",
-                "HEAD",
-                "--",
-                path,
-            ],
-        )?;
-        let worktree_patch = git_stdout_bytes(
-            root,
-            &[
-                "diff",
-                "--binary",
-                "--full-index",
-                "--no-ext-diff",
-                "--no-textconv",
-                "--no-renames",
-                "--",
-                path,
-            ],
-        )?;
-        path_states.insert(
-            path.clone(),
-            GitPathState {
-                index_entry_sha256: optional_sha256_identity("git-index-entry-v1", &index_entry),
-                staged_patch_sha256: optional_sha256_identity(
-                    "git-staged-path-patch-v1",
-                    &staged_patch,
-                ),
-                worktree_patch_sha256: optional_sha256_identity(
-                    "git-worktree-path-patch-v1",
-                    &worktree_patch,
-                ),
-                worktree_present: fs::symlink_metadata(root.join(path)).is_ok(),
-                untracked_content_sha256: untracked_content.get(path).cloned(),
-            },
-        );
-    }
-
-    Ok(GitWorktreeFingerprint {
-        head,
-        branch,
-        index_sha256: sha256_identity("git-index-v1", &index),
-        tracked_patch_sha256: sha256_identity("git-tracked-patch-v1", &tracked_patch),
-        untracked_content,
-        dirty_paths,
-        path_states,
-    })
-}
-
-pub(crate) fn untracked_file_identity(
-    root: &Path,
-    path: &str,
-) -> Result<Option<String>, DispatchError> {
-    let args = ["hash-object", "--no-filters", "--", path];
-    let output = git_output_raw(root, &args)?;
-    if output.status.success() {
-        let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        return Ok(Some(format!("git-blob:{identity}")));
-    }
-
-    match fs::symlink_metadata(root.join(path)) {
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        _ => Err(git_command_error(root, &args, &output)),
-    }
-}
-
-fn changed_paths(
-    root: &Path,
-    before: &GitWorktreeFingerprint,
-    after: &GitWorktreeFingerprint,
-) -> Vec<String> {
-    let all_state_paths = before
-        .path_states
-        .keys()
-        .chain(after.path_states.keys())
-        .cloned()
-        .collect::<BTreeSet<_>>();
-    let mut paths = BTreeSet::new();
-    for path in all_state_paths {
-        if before.path_states.get(&path) != after.path_states.get(&path) {
-            paths.insert(path);
-        }
-    }
-
-    if before.head != after.head
-        && let Ok(bytes) = git_stdout_bytes(
-            root,
-            &[
-                "diff",
-                "--name-only",
-                "-z",
-                "--no-renames",
-                &before.head,
-                &after.head,
-                "--",
-            ],
-        )
-    {
-        paths.extend(nul_paths(&bytes));
-    }
-    if paths.is_empty() {
-        if before.head != after.head {
-            paths.insert("<head>".to_string());
-        }
-        if before.branch != after.branch {
-            paths.insert("<branch-ref>".to_string());
-        }
-        if before.index_sha256 != after.index_sha256 {
-            paths.insert("<index>".to_string());
-        }
-        if before.tracked_patch_sha256 != after.tracked_patch_sha256 {
-            paths.insert("<tracked-patch>".to_string());
-        }
-    }
-    paths.into_iter().collect()
-}
-
-fn nul_paths(bytes: &[u8]) -> Vec<String> {
-    bytes
-        .split(|byte| *byte == 0)
-        .filter(|path| !path.is_empty())
-        .map(|path| String::from_utf8_lossy(path).into_owned())
-        .collect()
-}
-
-fn sha256_identity(domain: &str, bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(domain.as_bytes());
-    hasher.update([0]);
-    hasher.update((bytes.len() as u64).to_be_bytes());
-    hasher.update(bytes);
-    format!("sha256:{:x}", hasher.finalize())
-}
-
-fn optional_sha256_identity(domain: &str, bytes: &[u8]) -> Option<String> {
-    (!bytes.is_empty()).then(|| sha256_identity(domain, bytes))
-}
-
-fn git_stdout(root: &Path, args: &[&str]) -> Result<String, DispatchError> {
-    let bytes = git_stdout_bytes(root, args)?;
-    Ok(String::from_utf8_lossy(&bytes).trim().to_string())
-}
-
-fn git_stdout_bytes(root: &Path, args: &[&str]) -> Result<Vec<u8>, DispatchError> {
-    let output = git_output_raw(root, args)?;
-    if output.status.success() {
-        return Ok(output.stdout);
-    }
-    Err(git_command_error(root, args, &output))
-}
-
-fn git_output_raw(root: &Path, args: &[&str]) -> Result<Output, DispatchError> {
-    git_command(root, args).output().map_err(|error| {
-        DispatchError::CliInvocationPermanent(format!(
-            "snapshot Git state in '{}': {error}",
-            root.display()
-        ))
-    })
-}
-
-fn git_command_error(root: &Path, args: &[&str], output: &Output) -> DispatchError {
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    DispatchError::CliInvocationPermanent(format!(
-        "snapshot Git state in '{}' with `git {}` failed (status {}): {}",
-        root.display(),
-        args.join(" "),
-        output.status,
-        stderr.trim()
-    ))
 }

--- a/crates/orbit-engine/src/activity_job/workspace/fingerprint.rs
+++ b/crates/orbit-engine/src/activity_job/workspace/fingerprint.rs
@@ -1,0 +1,585 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Output;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::executor::automation::vcs::git::git_command;
+
+use super::super::dispatcher::DispatchError;
+
+/// Exact, read-only identity of the Git state that an agent invocation can
+/// observe or mutate. Large byte streams are represented by domain-separated
+/// SHA-256 identities; untracked files retain one content identity per path so
+/// diagnostics can name the primary-checkout delta without staging it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct GitWorktreeFingerprint {
+    pub(crate) head: String,
+    pub(crate) branch: Option<String>,
+    pub(crate) index_sha256: String,
+    pub(crate) tracked_patch_sha256: String,
+    pub(crate) untracked_content: BTreeMap<String, String>,
+    pub(crate) dirty_paths: Vec<String>,
+    pub(crate) path_states: BTreeMap<String, GitPathState>,
+}
+
+/// Per-path Git identity. Optional identities distinguish an absent index
+/// entry, an empty staged/unstaged delta, a deletion from the worktree, and an
+/// untracked file without reading file contents into the diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct GitPathState {
+    pub(crate) index_entry_sha256: Option<String>,
+    pub(crate) staged_patch_sha256: Option<String>,
+    pub(crate) worktree_patch_sha256: Option<String>,
+    pub(crate) worktree_present: bool,
+    pub(crate) untracked_content_sha256: Option<String>,
+}
+
+const DIFF_IDENTITY_FLAGS: [&str; 5] = [
+    "--binary",
+    "--full-index",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-renames",
+];
+
+pub(crate) fn git_fingerprint(root: &Path) -> Result<GitWorktreeFingerprint, DispatchError> {
+    let head = git_stdout(root, &["rev-parse", "--verify", "HEAD"])?;
+    let branch_output = git_output_raw(root, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
+    let branch = branch_output
+        .status
+        .success()
+        .then(|| {
+            String::from_utf8_lossy(&branch_output.stdout)
+                .trim()
+                .to_string()
+        })
+        .filter(|branch| !branch.is_empty());
+
+    let index = git_stdout_bytes(root, &["ls-files", "--stage", "-z", "--"])?;
+    let tracked_patch = git_diff_bytes(root, &["HEAD"])?;
+    let status = git_stdout_bytes(
+        root,
+        &[
+            "status",
+            "--porcelain=v2",
+            "-z",
+            "--untracked-files=all",
+            "--no-renames",
+            "--",
+        ],
+    )?;
+    let (tracked_dirty_paths, untracked_paths) = parse_porcelain_v2(&status)?;
+    let untracked_content = untracked_content_identities(root, &untracked_paths)?;
+
+    let mut dirty_paths = tracked_dirty_paths;
+    dirty_paths.extend(untracked_content.keys().cloned());
+    dirty_paths.sort();
+    dirty_paths.dedup();
+
+    let index_entries = index_entries_by_path(&index);
+    let has_tracked_dirty = dirty_paths
+        .iter()
+        .any(|path| !untracked_content.contains_key(path));
+    let staged_patches = if has_tracked_dirty {
+        split_combined_diff(&git_diff_bytes(root, &["--cached", "HEAD"])?)
+    } else {
+        BTreeMap::new()
+    };
+    let worktree_patches = if has_tracked_dirty {
+        split_combined_diff(&git_diff_bytes(root, &[])?)
+    } else {
+        BTreeMap::new()
+    };
+
+    let mut path_states = BTreeMap::new();
+    for path in &dirty_paths {
+        let index_entry = index_entries.get(path).map(Vec::as_slice).unwrap_or(&[]);
+        let staged_patch = staged_patches.get(path).map(Vec::as_slice).unwrap_or(&[]);
+        let worktree_patch = worktree_patches.get(path).map(Vec::as_slice).unwrap_or(&[]);
+        path_states.insert(
+            path.clone(),
+            GitPathState {
+                index_entry_sha256: optional_sha256_identity("git-index-entry-v1", index_entry),
+                staged_patch_sha256: optional_sha256_identity(
+                    "git-staged-path-patch-v1",
+                    staged_patch,
+                ),
+                worktree_patch_sha256: optional_sha256_identity(
+                    "git-worktree-path-patch-v1",
+                    worktree_patch,
+                ),
+                worktree_present: fs::symlink_metadata(root.join(path)).is_ok(),
+                untracked_content_sha256: untracked_content.get(path).cloned(),
+            },
+        );
+    }
+
+    Ok(GitWorktreeFingerprint {
+        head,
+        branch,
+        index_sha256: sha256_identity("git-index-v1", &index),
+        tracked_patch_sha256: sha256_identity("git-tracked-patch-v1", &tracked_patch),
+        untracked_content,
+        dirty_paths,
+        path_states,
+    })
+}
+
+pub(crate) fn untracked_file_identity(
+    root: &Path,
+    path: &str,
+) -> Result<Option<String>, DispatchError> {
+    let args = ["hash-object", "--no-filters", "--", path];
+    let output = git_output_raw(root, &args)?;
+    if output.status.success() {
+        let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Ok(Some(format!("git-blob:{identity}")));
+    }
+
+    match fs::symlink_metadata(root.join(path)) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        _ => Err(git_command_error(root, &args, &output)),
+    }
+}
+
+pub(crate) fn changed_paths(
+    root: &Path,
+    before: &GitWorktreeFingerprint,
+    after: &GitWorktreeFingerprint,
+) -> Vec<String> {
+    let all_state_paths = before
+        .path_states
+        .keys()
+        .chain(after.path_states.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut paths = BTreeSet::new();
+    for path in all_state_paths {
+        if before.path_states.get(&path) != after.path_states.get(&path) {
+            paths.insert(path);
+        }
+    }
+
+    if before.head != after.head
+        && let Ok(bytes) = git_stdout_bytes(
+            root,
+            &[
+                "diff",
+                "--name-only",
+                "-z",
+                "--no-renames",
+                &before.head,
+                &after.head,
+                "--",
+            ],
+        )
+    {
+        paths.extend(nul_paths(&bytes));
+    }
+    if paths.is_empty() {
+        if before.head != after.head {
+            paths.insert("<head>".to_string());
+        }
+        if before.branch != after.branch {
+            paths.insert("<branch-ref>".to_string());
+        }
+        if before.index_sha256 != after.index_sha256 {
+            paths.insert("<index>".to_string());
+        }
+        if before.tracked_patch_sha256 != after.tracked_patch_sha256 {
+            paths.insert("<tracked-patch>".to_string());
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn git_diff_bytes(root: &Path, extra: &[&str]) -> Result<Vec<u8>, DispatchError> {
+    let mut args = Vec::with_capacity(8 + extra.len());
+    args.push("diff");
+    args.extend(DIFF_IDENTITY_FLAGS);
+    args.extend(extra.iter().copied());
+    args.push("--");
+    git_stdout_bytes(root, &args)
+}
+
+fn parse_porcelain_v2(bytes: &[u8]) -> Result<(Vec<String>, Vec<String>), DispatchError> {
+    let mut tracked_dirty = Vec::new();
+    let mut untracked = Vec::new();
+    let mut records = bytes
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty());
+    while let Some(record) = records.next() {
+        if record.starts_with(b"#") {
+            continue;
+        }
+        if record.starts_with(b"? ") {
+            untracked.push(lossy_path(&record[2..]));
+            continue;
+        }
+        if record.starts_with(b"! ") {
+            continue;
+        }
+        if record.starts_with(b"1 ") {
+            tracked_dirty.push(porcelain_path(record, 8)?);
+            continue;
+        }
+        if record.starts_with(b"u ") {
+            tracked_dirty.push(porcelain_path(record, 10)?);
+            continue;
+        }
+        if record.starts_with(b"2 ") {
+            tracked_dirty.push(porcelain_path(record, 9)?);
+            // `-z` rename records are followed by the original path.
+            let _orig = records.next();
+            continue;
+        }
+        return Err(DispatchError::CliInvocationPermanent(format!(
+            "unrecognized git status --porcelain=v2 record: {}",
+            String::from_utf8_lossy(record)
+        )));
+    }
+    Ok((tracked_dirty, untracked))
+}
+
+fn porcelain_path(record: &[u8], fields_before_path: usize) -> Result<String, DispatchError> {
+    rest_after_n_spaces(record, fields_before_path)
+        .map(lossy_path)
+        .ok_or_else(|| {
+            DispatchError::CliInvocationPermanent(format!(
+                "git status --porcelain=v2 record missing path: {}",
+                String::from_utf8_lossy(record)
+            ))
+        })
+}
+
+fn rest_after_n_spaces(bytes: &[u8], n: usize) -> Option<&[u8]> {
+    let mut seen = 0;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b' ' {
+            seen += 1;
+            if seen == n {
+                return Some(&bytes[index + 1..]);
+            }
+        }
+    }
+    None
+}
+
+fn lossy_path(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn index_entries_by_path(index: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let mut entries = BTreeMap::new();
+    for record in index
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+    {
+        let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+            continue;
+        };
+        let path = lossy_path(&record[tab + 1..]);
+        let entry: &mut Vec<u8> = entries.entry(path).or_default();
+        entry.extend_from_slice(record);
+        entry.push(0);
+    }
+    entries
+}
+
+fn split_combined_diff(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let mut patches = BTreeMap::new();
+    for chunk in diff_chunks(bytes) {
+        if let Some(path) = path_from_diff_chunk(chunk) {
+            patches.insert(path, chunk.to_vec());
+        }
+    }
+    patches
+}
+
+fn diff_chunks(bytes: &[u8]) -> Vec<&[u8]> {
+    let starts = diff_chunk_starts(bytes);
+    if starts.is_empty() {
+        return Vec::new();
+    }
+    let mut chunks = Vec::with_capacity(starts.len());
+    for (index, start) in starts.iter().enumerate() {
+        let end = starts.get(index + 1).copied().unwrap_or(bytes.len());
+        chunks.push(&bytes[*start..end]);
+    }
+    chunks
+}
+
+fn diff_chunk_starts(bytes: &[u8]) -> Vec<usize> {
+    const MARKERS: [&[u8]; 3] = [b"diff --git ", b"diff --cc ", b"diff --combined "];
+    let mut starts = Vec::new();
+    let mut search_from = 0;
+    while search_from < bytes.len() {
+        let rest = &bytes[search_from..];
+        let next = MARKERS
+            .iter()
+            .filter_map(|marker| {
+                rest.windows(marker.len())
+                    .position(|window| window == *marker)
+            })
+            .min();
+        let Some(relative) = next else {
+            break;
+        };
+        let absolute = search_from + relative;
+        if absolute == 0 || bytes[absolute - 1] == b'\n' {
+            starts.push(absolute);
+        }
+        search_from = absolute + 1;
+    }
+    starts
+}
+
+fn path_from_diff_chunk(chunk: &[u8]) -> Option<String> {
+    let line_end = chunk
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .unwrap_or(chunk.len());
+    let line = String::from_utf8_lossy(&chunk[..line_end]);
+    let line = line.trim_end_matches('\r');
+    if let Some(rest) = line.strip_prefix("diff --git ") {
+        return parse_diff_git_paths(rest);
+    }
+    if let Some(rest) = line.strip_prefix("diff --cc ") {
+        return parse_single_diff_path(rest);
+    }
+    if let Some(rest) = line.strip_prefix("diff --combined ") {
+        return parse_single_diff_path(rest);
+    }
+    None
+}
+
+fn parse_diff_git_paths(rest: &str) -> Option<String> {
+    if rest.starts_with('"') {
+        let (first, rest) = unescape_git_c_quoted(rest)?;
+        let rest = rest.trim_start();
+        let (second, _) = unescape_git_c_quoted(rest)?;
+        return strip_diff_prefix(&second).or_else(|| strip_diff_prefix(&first));
+    }
+
+    let rest = rest.strip_prefix("a/")?;
+    if rest.len() >= 3 && rest.len() % 2 == 1 {
+        let path_len = (rest.len() - 3) / 2;
+        if rest.get(path_len..path_len + 3) == Some(" b/")
+            && rest.get(..path_len) == rest.get(path_len + 3..)
+        {
+            return Some(rest[..path_len].to_string());
+        }
+    }
+    rest.split_once(" b/").map(|(_, right)| right.to_string())
+}
+
+fn parse_single_diff_path(rest: &str) -> Option<String> {
+    let rest = rest.trim();
+    if rest.starts_with('"') {
+        let (quoted, _) = unescape_git_c_quoted(rest)?;
+        return Some(strip_diff_prefix(&quoted).unwrap_or(quoted));
+    }
+    Some(rest.to_string())
+}
+
+fn strip_diff_prefix(path: &str) -> Option<String> {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .map(ToOwned::to_owned)
+}
+
+fn unescape_git_c_quoted(input: &str) -> Option<(String, &str)> {
+    let input = input.strip_prefix('"')?;
+    let mut decoded = String::new();
+    let mut bytes = input.as_bytes();
+    while let Some((head, rest)) = bytes.split_first() {
+        match *head {
+            b'"' => {
+                return Some((decoded, std::str::from_utf8(rest).ok()?));
+            }
+            b'\\' => {
+                let (escaped, remaining) = unescape_git_escape(rest)?;
+                decoded.push(escaped);
+                bytes = remaining;
+            }
+            byte => {
+                decoded.push(char::from(byte));
+                bytes = rest;
+            }
+        }
+    }
+    None
+}
+
+fn unescape_git_escape(bytes: &[u8]) -> Option<(char, &[u8])> {
+    let (head, rest) = bytes.split_first()?;
+    match *head {
+        b'n' => Some(('\n', rest)),
+        b't' => Some(('\t', rest)),
+        b'r' => Some(('\r', rest)),
+        b'a' => Some(('\u{0007}', rest)),
+        b'b' => Some(('\u{0008}', rest)),
+        b'f' => Some(('\u{000c}', rest)),
+        b'v' => Some(('\u{000b}', rest)),
+        b'\\' => Some(('\\', rest)),
+        b'"' => Some(('"', rest)),
+        b'0'..=b'7' => {
+            if bytes.len() < 3 {
+                return None;
+            }
+            let octal = std::str::from_utf8(&bytes[..3]).ok()?;
+            let value = u8::from_str_radix(octal, 8).ok()?;
+            Some((char::from(value), &bytes[3..]))
+        }
+        byte => Some((char::from(byte), rest)),
+    }
+}
+
+fn untracked_content_identities(
+    root: &Path,
+    paths: &[String],
+) -> Result<BTreeMap<String, String>, DispatchError> {
+    let mut identities = BTreeMap::new();
+    let mut batch_paths = Vec::new();
+    for path in paths {
+        if path.contains('\n') {
+            if let Some(identity) = untracked_file_identity(root, path)? {
+                identities.insert(path.clone(), identity);
+            }
+        } else {
+            batch_paths.push(path.clone());
+        }
+    }
+
+    let mut remaining = batch_paths;
+    for _ in 0..3 {
+        if remaining.is_empty() {
+            break;
+        }
+        let args = ["hash-object", "--no-filters", "--stdin-paths"];
+        let stdin = remaining.join("\n");
+        let stdin = format!("{stdin}\n");
+        let output = git_output_with_stdin(root, &args, stdin.as_bytes())?;
+        if output.status.success() {
+            let hashes = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>();
+            if hashes.len() != remaining.len() {
+                return Err(DispatchError::CliInvocationPermanent(format!(
+                    "snapshot Git state in '{}' with `git hash-object --stdin-paths` returned {} hashes for {} paths",
+                    root.display(),
+                    hashes.len(),
+                    remaining.len()
+                )));
+            }
+            for (path, hash) in remaining.iter().zip(hashes) {
+                identities.insert(path.clone(), format!("git-blob:{hash}"));
+            }
+            break;
+        }
+
+        let existed = remaining
+            .iter()
+            .filter(|path| fs::symlink_metadata(root.join(path)).is_ok())
+            .cloned()
+            .collect::<Vec<_>>();
+        // An atomic tracked-file replacement briefly exposes an untracked
+        // sibling temp file. It may disappear between status and hash-object;
+        // omit it instead of turning an unrelated snapshot into a failure.
+        if existed.len() == remaining.len() {
+            return Err(git_command_error(root, &args, &output));
+        }
+        remaining = existed;
+        if remaining.is_empty() {
+            break;
+        }
+    }
+    Ok(identities)
+}
+
+pub(crate) fn nul_paths(bytes: &[u8]) -> Vec<String> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| String::from_utf8_lossy(path).into_owned())
+        .collect()
+}
+
+fn sha256_identity(domain: &str, bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    hasher.update([0]);
+    hasher.update((bytes.len() as u64).to_be_bytes());
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn optional_sha256_identity(domain: &str, bytes: &[u8]) -> Option<String> {
+    (!bytes.is_empty()).then(|| sha256_identity(domain, bytes))
+}
+
+pub(crate) fn git_stdout(root: &Path, args: &[&str]) -> Result<String, DispatchError> {
+    let bytes = git_stdout_bytes(root, args)?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_string())
+}
+
+pub(crate) fn git_stdout_bytes(root: &Path, args: &[&str]) -> Result<Vec<u8>, DispatchError> {
+    let output = git_output_raw(root, args)?;
+    if output.status.success() {
+        return Ok(output.stdout);
+    }
+    Err(git_command_error(root, args, &output))
+}
+
+pub(crate) fn git_output_raw(root: &Path, args: &[&str]) -> Result<Output, DispatchError> {
+    git_command(root, args).output().map_err(|error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "snapshot Git state in '{}': {error}",
+            root.display()
+        ))
+    })
+}
+
+fn git_output_with_stdin(
+    root: &Path,
+    args: &[&str],
+    stdin_bytes: &[u8],
+) -> Result<Output, DispatchError> {
+    let io_error = |error: std::io::Error| {
+        DispatchError::CliInvocationPermanent(format!(
+            "snapshot Git state in '{}': {error}",
+            root.display()
+        ))
+    };
+    // Feed stdin from a file, not a pipe we still own: `hash-object --stdin-paths`
+    // waits for EOF, and `Child::wait_with_output` waits for the child, so a
+    // parent-written pipe deadlocks.
+    let mut temp = tempfile::Builder::new()
+        .prefix("orbit-git-stdin-")
+        .tempfile()
+        .map_err(io_error)?;
+    temp.write_all(stdin_bytes).map_err(io_error)?;
+    temp.flush().map_err(io_error)?;
+    let stdin = fs::File::open(temp.path()).map_err(io_error)?;
+    let mut command = git_command(root, args);
+    command.stdin(stdin);
+    command.output().map_err(io_error)
+}
+
+pub(crate) fn git_command_error(root: &Path, args: &[&str], output: &Output) -> DispatchError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    DispatchError::CliInvocationPermanent(format!(
+        "snapshot Git state in '{}' with `git {}` failed (status {}): {}",
+        root.display(),
+        args.join(" "),
+        output.status,
+        stderr.trim()
+    ))
+}

--- a/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
+++ b/crates/orbit-engine/src/activity_job/workspace/rebase_recovery.rs
@@ -7,10 +7,11 @@ use serde_json::Value;
 use crate::context::{RuntimeHost, StepRecoveryAdmission};
 use crate::executor::automation::vcs::git::git_command;
 
-use super::{
-    DispatchError, GitWorktreeFingerprint, WorktreeBoundaryGuard, changed_paths, git_command_error,
-    git_fingerprint, git_output_raw, git_stdout, git_stdout_bytes, nul_paths, safe_relative_path,
+use super::fingerprint::{
+    GitWorktreeFingerprint, changed_paths, git_command_error, git_fingerprint, git_output_raw,
+    git_stdout, git_stdout_bytes, nul_paths,
 };
+use super::{DispatchError, WorktreeBoundaryGuard, safe_relative_path};
 
 pub(super) struct RebaseRecoveryCheckpoint {
     branch: String,


### PR DESCRIPTION
## Task

[ORB-11640](https://orbit-cli.com/tasks/ORB-11640) — [code-review] Batch the per-path Git subprocesses in the worktree boundary fingerprint

### Description

## Problem
`git_fingerprint` runs `git hash-object` once per untracked file and three more `git` processes (`ls-files --stage`, `diff --cached`, `diff`) per dirty path, and it is called four times per provider invocation (assigned + primary, before + after) plus again inside `integrity_error`/`changed_paths`. A checkout with a non-ignored dependency or build directory (a few thousand untracked files, common in JS/Python workspaces) costs tens of thousands of `fork+exec git` per agent step, each holding the index lock briefly (`GIT_OPTIONAL_LOCKS=0` only helps for optional locks). On the primary checkout this runs while other runs and the operator use the repo.

## Why It Matters
Minutes of pure process spawning before and after every provider launch, scaling linearly with repository dirt, and it contends with concurrent runs on the shared primary checkout.

## Proposed Fix
Compute the same identities with a bounded number of processes: one `git status --porcelain=v2 -z --untracked-files=all` for paths and states, one `git hash-object --stdin-paths` fed the untracked list, one `git diff --cached … -z --` and one `git diff … -z --` for all dirty paths, split per path on the `diff --git` boundaries. Keep the domain-separated SHA-256 identities unchanged so diagnostics stay comparable.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/activity_job/workspace.rs:1037-1149,1151-1166`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test fixture with 2,000 untracked files completes `WorktreeBoundaryGuard::capture` in well under a second and the number of `git` invocations (counted via a `git` shim on `PATH`) is constant, not proportional to the file count.
- Existing `cli_runner/tests/orchestrator.rs` boundary tests (`primary_checkout_drift`, `worktree_content_conflict`, ADR-0286 temp-file case) still pass unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Extracted worktree fingerprinting into `crates/orbit-engine/src/activity_job/workspace/fingerprint.rs`.
- Replaced per-path `git hash-object` / `ls-files --stage` / `diff` spawns with a bounded set: porcelain v2 status, one `hash-object --stdin-paths` (file stdin; Git 2.43 has no `-z`), full index listing sliced per path, and two combined diffs split on `diff --git` / `diff --cc` boundaries. Domain-separated SHA-256 identities are unchanged.
- Vanishing untracked files are still omitted after a failed batch (ADR-0286). Aggregate `tracked_patch_sha256` mismatches are not suppressed (ORB-11595 evidence retained).
Assessment: Acceptance criteria met. Capture of 2,000 untracked files is constant-cost and sub-second; orchestrator boundary tests including primary_checkout_drift, worktree_content_conflict, and the temp-file refresh case still pass.

Criteria:
- 2,000 untracked files, capture well under 1s, git shim count constant: pass (`capture_of_thousands_of_untracked_files_uses_a_constant_git_budget`; workspace tests 8/8 in 0.20s).
- Existing orchestrator boundary tests unchanged: pass (`activity_job::cli_runner::tests::orchestrator` 79 passed, 2 ignored unrelated bwrap cases), including `primary_escape_*` / `assigned_history_divergence_*` / `concurrent_auto_task_refresh_stays_in_assigned_worktree_during_boundary_checks`.

Validation:
- `cargo test -p orbit-engine --lib activity_job::tests::workspace`: passed
- `cargo test -p orbit-engine --lib activity_job::cli_runner::tests::orchestrator`: passed (79/79 runnable)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

Strategic decisions:
- Identities come from slicing the same Git byte streams the old per-path commands produced, not from porcelain XY codes.
- `hash-object --stdin-paths` is fed from a tempfile (Git has no `-z`; a parent-held stdin pipe deadlocks). Filed F2026-09-061.

Design weaknesses / risks:
- Severity: low. Paths containing a newline cannot be batched and fall back to one `hash-object` each. Mitigation: Git rarely stores such paths; the 2,000-file budget is unaffected.
- Severity: low. Combined-diff splitting depends on `--no-renames` and Git C-quoting. Mitigation: identity tests cover binary, spaced, and quoted paths.
- ORB-11595 mixed-snapshot `tracked_patch_sha256` drift is investigation input only; integrity checks remain fail-closed.

Deviations from original plan: none material. `-z` was dropped for `hash-object` because this Git rejects it.

Recommended follow-ups: none for this leaf. Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11640-6a9f4735`
- Behind base: 0
- Ahead of base: 1