### PR TITLE
[ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-exec sandbox tests (real sandbox-exec)

### DIFF
--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -840,16 +840,33 @@ fn expand_rules(rules: &[String]) -> Result<BTreeSet<PathBuf>, OrbitError> {
                 "invalid linux-bwrap filesystem glob `{rule}`: {error}"
             ))
         })?;
-        let root = nearest_existing_ancestor(&static_prefix(rule))?;
-        by_root.entry(root).or_default().push(regex);
+        let prefix = static_prefix(rule);
+        let display_root = existing_ancestor(&prefix)?;
+        let root = canonical_existing(&display_root, "glob search root")?;
+        by_root.entry(root).or_default().push((regex, display_root));
     }
     let mut matches = BTreeSet::new();
-    for (root, regexes) in by_root {
+    for (root, matchers) in by_root {
         let mut candidates = Vec::new();
         walk_paths(&root, &mut candidates)?;
         for candidate in candidates {
             let rendered = candidate.to_string_lossy().replace('\\', "/");
-            if regexes.iter().any(|regex| regex.is_match(&rendered)) {
+            let relative = candidate.strip_prefix(&root).map_err(|error| {
+                OrbitError::Execution(format!(
+                    "glob candidate `{}` must remain beneath search root `{}`: {error}",
+                    candidate.display(),
+                    root.display()
+                ))
+            })?;
+            if matchers.iter().any(|(regex, display_root)| {
+                regex.is_match(&rendered)
+                    || regex.is_match(
+                        &display_root
+                            .join(relative)
+                            .to_string_lossy()
+                            .replace('\\', "/"),
+                    )
+            }) {
                 matches.insert(canonical_existing(&candidate, "denyModify match")?);
             }
         }
@@ -875,7 +892,7 @@ fn static_prefix(rule: &str) -> PathBuf {
     PathBuf::from(prefix)
 }
 
-fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, OrbitError> {
+fn existing_ancestor(path: &Path) -> Result<PathBuf, OrbitError> {
     let mut current = path.to_path_buf();
     while !current.exists() {
         if !current.pop() {
@@ -885,7 +902,7 @@ fn nearest_existing_ancestor(path: &Path) -> Result<PathBuf, OrbitError> {
             )));
         }
     }
-    canonical_existing(&current, "glob search root")
+    Ok(current)
 }
 
 /// `root` itself and everything beneath it, each path once.

--- a/crates/orbit-exec/src/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/src/tests/linux_sandbox.rs
@@ -118,6 +118,44 @@ fn capture_watches_absent_exact_and_subtree_denies() {
     );
 }
 
+/// macOS commonly reaches `/private/var` through the `/var` symlink. The
+/// guard must match rules written through that spelling even though its walk
+/// canonicalizes the search root.
+#[cfg(unix)]
+#[test]
+fn capture_watches_absent_denies_through_a_symlinked_workspace_path() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let real_workspace = temp.path().join("real-workspace");
+    let workspace = temp.path().join("workspace-link");
+    fs::create_dir_all(&real_workspace).expect("real workspace");
+    symlink(&real_workspace, &workspace).expect("workspace symlink");
+
+    let secrets = workspace.join("secrets");
+    let lock = workspace.join("Cargo.lock");
+    let resolved = profile(vec![
+        format!("{}/**", workspace.display()),
+        format!("!{}/**", secrets.display()),
+        format!("!{}", lock.display()),
+    ]);
+
+    let guard = LinuxBwrapPostRunGuard::capture(&resolved)
+        .expect("capture")
+        .expect("absent exact/subtree denies must be guarded");
+    fs::create_dir_all(&secrets).expect("create secrets");
+    fs::write(secrets.join("x"), b"k").expect("write secret");
+    fs::write(&lock, b"k").expect("write lock");
+
+    let error = guard
+        .verify()
+        .expect_err("creating a deny root through a symlink must fail closed");
+    assert!(
+        matches!(error, OrbitError::PolicyDenied(_)),
+        "expected PolicyDenied, got {error}"
+    );
+}
+
 #[test]
 fn capture_skips_absent_deny_whose_nested_reallow_will_create_the_root() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Task

[ORB-11751](https://orbit-cli.com/tasks/ORB-11751) — [ci-failure-sweep] Fix red CI: macOS Platform / macOS Sandbox / Run orbit-exec sandbox tests (real sandbox-exec)

### Description

This task was filed automatically from a host-side sweep of this repository's GitHub Actions runs. Every CI query ran on the host before this task existed, so the evidence below is all of it — the execution lane for this task cannot reach GitHub, and it is not expected to.

## Failure

- Workflow: `macOS Platform`
- Failing job: `macOS Sandbox`
- Failing step: `Run orbit-exec sandbox tests (real sandbox-exec)`
- Commit the runner actually checked out: `da21eb15b02f6d9a06833c835ea42780f5dbcc3b`
- Normalized error signature (the dedupe identity, not a quote): `test linux_sandbox::tests::capture_watches_absent_exact_and_subtree_denies ... failed`
- Repository: `constellation-works/orbit`
- Release branch as GitHub reports it: `main`
- Evidence collected at: 2026-09-08T00:01:17.602682141+00:00

## Runs exhibiting this failure

Three commits are routinely conflated and are kept apart here: the SHA the workflow event reported, the SHA the ref points at now, and the commit the runner actually checked out. A pull-request merge SHA is not a pull-request head SHA.

- https://github.com/constellation-works/orbit/actions/runs/34170997669 run `34170997669` (push on `agent-main`) — status `completed`, conclusion `failure`
  - event-reported head SHA: `740eb4e8065cf3b8ec06c0efde88883961c17378`
  - current head of that ref: `da21eb15b02f6d9a06833c835ea42780f5dbcc3b`
  - commit actually checked out: `da21eb15b02f6d9a06833c835ea42780f5dbcc3b`
  - checkout evidence: `##[group]Checking out the ref`
  - checkout evidence: `[command]/opt/homebrew/bin/git checkout --progress --force -B agent-main refs/remotes/origin/agent-main`
  - checkout evidence: `/opt/homebrew/bin/git log -1 --format=%H`
  - failed job `macOS Sandbox` (id `101891118541`): https://github.com/constellation-works/orbit/actions/runs/34170997669/job/101891118541
  - failing step(s): `Run orbit-exec sandbox tests (real sandbox-exec)`

## Failed-step log excerpt

```
[...]
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5761300Z 
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5832550Z running 71 tests
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5842340Z test linux_sandbox::tests::capture_skips_absent_deny_whose_nested_reallow_will_create_the_root ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5843340Z test linux_sandbox::tests::walk_lists_every_path_once ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5844020Z test macos_sandbox::tests::compile::compile_allows_macos_sandbox_provenance_syscall ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5844640Z test macos_sandbox::tests::compile::compile_default_profile_denies_well_known_credential_reads ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5845510Z test macos_sandbox::tests::compile::compile_emits_deny_default_and_broad_read_with_modify_subpath ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5846140Z test linux_sandbox::tests::capture_watches_absent_exact_and_subtree_denies ... FAILED
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5846710Z test macos_sandbox::tests::compile::compile_for_claude_without_home_emits_no_keychain_reallow ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5847490Z test macos_sandbox::tests::compile::compile_for_claude_reallows_user_keychain_read_after_the_default_deny ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5848260Z test macos_sandbox::tests::compile::compile_grants_write_access_to_global_orbit_log_dir ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5848860Z test macos_sandbox::tests::compile::compile_for_non_claude_providers_keeps_the_user_keychain_denied ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5849520Z test macos_sandbox::tests::compile::compile_with_env_does_not_mutate_process_home ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5850140Z test macos_sandbox::tests::compile::compile_orders_activity_read_denies_after_the_claude_keychain_reallow ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.5916580Z test linux_sandbox::tests::rules_sharing_a_root_expand_from_one_walk_to_the_same_set ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.6234040Z /bin/sh: line 11: /Users/runner/work/orbit/orbit/crates/orbit-exec/.orbit-sandbox-test-7159-orbit-runtime-roots-1/home/.orbit/not-allowed.txt: Operation not permitted
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.6259580Z /bin/sh: line 12: /Users/runner/work/orbit/orbit/crates/orbit-exec/.orbit-sandbox-test-7159-orbit-runtime-roots-1/repo/.orbit/adrs/.locks/should-stay-denied.lock: Operation not permitted
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.6260770Z test macos_sandbox::tests::compile::compiled_profile_allows_nested_orbit_runtime_writes_without_home_orbit_reallow ... ok
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.6309730Z /bin/sh: /Users/runner/work/orbit/orbit/crates/orbit-exec/.orbit-sandbox-test-7159-modify-scope-2/compile-YDgnBN/blocked/nope: Operation not permitted
macOS Sandbox	Run orbit-exec sandbox tests (real sandbox-exec)	2026-09-07T23:55:49.6319700Z test macos_sandbox::tests::compile::compiled_profile_blocks_writes_outside_modify_scope ... ok
```

_The collection display was truncated. Selected evidence is used for diagnosis; its retention limits are independent of that display._

## Stale or superseded runs of this workflow

These are already excluded from the failure above. They are listed so the repair is not attributed to a run that no longer reflects the current head.

- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170970072 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170785778 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170779001 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170777702 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170719896 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure
- `macOS Platform` run https://github.com/constellation-works/orbit/actions/runs/34170406208 — superseded_by_newer_workflow_run: newer relevant run 34170997669 at 2026-09-07T23:43:43Z is completed with conclusion failure

## Collection bounds

Reported so "no more failures" is never mistaken for "we stopped looking".

```json
{
  "checkout_log_reads": 3,
  "current_failures_discovered": 5,
  "current_failures_investigated": 1,
  "current_failures_investigation_attempted": 6,
  "investigation_cursor": 496896,
  "job_log_reads": 5,
  "log_max_bytes": 16384,
  "max_checkout_log_reads": 3,
  "max_job_log_reads": 6,
  "max_pull_requests": 10,
  "max_retired_ref_probes": 20,
  "max_runs": 100,
  "notes": [
    "repository-wide workflow runs were listed at the cap (100); a workflow whose latest run is older than the newest 100 runs in this repository may be absent entirely",
    "18 of 24 current or mixed-state runs were listed but not investigated (max_investigated_runs=6); their run URLs are still present, and the rotating slot reaches a different overflow candidate on the next sweep"
  ],
  "pull_requests_scanned": 3,
  "refs_scanned": 5,
  "retired_refs": [
    "orbit/ORB-11692-6a9f40f4"
  ],
  "runs_listed": 100,
  "unverified_refs": []
}
```

## How to finish

Reproduce the failure at the current repository head using the exact command or the narrowest faithful local equivalent, fix the repository-owned cause, and rerun that command. Do not disable a workflow, weaken an assertion or lint level, add a broad allow rule, or mark a failing gate non-blocking. Then run the repository's documented pre-handoff gate. Verification happens on this task's own pull request: CI runs there normally, and if the failure is still current the next sweep will see it again.


### Acceptance Criteria

- The root cause of the `macOS Platform` failure recorded below is fixed in this repository; the workflow, assertion, or lint level is not disabled, weakened, or made non-blocking to obtain green.
- The exact command or narrowest faithful local equivalent that failed on the runner is reproduced and then passes locally.
- The repository's documented pre-handoff gate passes.
- If the failure turns out to be infrastructure rather than repository-owned, the execution summary cites concrete evidence for that (a same-commit retry that succeeded, or runner/service fault output) rather than a single non-reproduction.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Preserve each deny glob’s lexical existing search-root spelling while walking its canonical root, so post-run snapshots match macOS `/var` paths that canonicalize to `/private/var`.
- Added a Unix symlink regression that reproduces the same lexical-versus-canonical path mismatch on Linux.

Criteria evidence:
1. Fixed the repository-owned glob-matching defect; no workflow, assertion, lint level, or gate was weakened.
2. Narrow faithful reproduction: `cargo test -p orbit-exec --locked symlinked_workspace_path` failed against the restored original expansion logic (`creating a deny root through a symlink must fail closed: ()`) and passes with the fix. The original runner command is `cargo test -p orbit-exec --locked`; the complete local equivalent now passes.
3. Documented pre-handoff gates passed: `make ci-fast`; `make ci-lint`.
4. Repository-owned root cause confirmed by deterministic reproduction; this was not infrastructure.

Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-exec --locked symlinked_workspace_path`.
- Passed: `cargo test -p orbit-exec --locked`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Assessment: focused two-file repair with a regression test. macOS real `sandbox-exec` execution was not available in this Linux worker; the symlink fixture directly models macOS `/var` to `/private/var` canonicalization.

Friction checkpoint: recorded F2026-09-062 for the non-obvious macOS lexical/canonical path alias.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11751-6a9f511d`
- Behind base: 0
- Ahead of base: 1