### PR TITLE
[code-review] Show the run-events scan-budget error instead of "No v2 envelope events"

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -26,6 +26,7 @@ import {
   setActiveRunDetail,
   getActiveRunEvents,
   setActiveRunEvents,
+  setActiveRunEventsError,
   getActiveRunLogs,
   setActiveRunLogs,
   getActiveRunSubtab,
@@ -1421,9 +1422,10 @@ function fetchAndRenderRunEvents() {
     setActiveRunEvents(events);
     renderRunEvents();
     renderRunGantt();
-  }).catch(() => {
-    // Missing v2 events file is non-fatal — run detail still renders.
+  }).catch((error) => {
     setActiveRunEvents([]);
+    if (error.status !== 404) setActiveRunEventsError(error.message);
+    renderRunEvents();
     renderRunGantt();
   });
 }

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -253,8 +253,18 @@ export function stateCell(state) {
 
 export function fetchJson(path) {
   return fetch(withWorkspace(path), { headers: { accept: "application/json" } })
-    .then(res => {
-      if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
+    .then(async (res) => {
+      if (!res.ok) {
+        const text = await res.text();
+        let message = `${path}: HTTP ${res.status}`;
+        try {
+          const body = JSON.parse(text);
+          if (body && body.error) message = body.error;
+        } catch (_) {}
+        const error = new Error(message);
+        error.status = res.status;
+        throw error;
+      }
       return res.json();
     });
 }

--- a/crates/orbit-web/assets/dashboard/run-detail.js
+++ b/crates/orbit-web/assets/dashboard/run-detail.js
@@ -25,6 +25,7 @@ const RUN_EVENTS_LIMIT = positiveIntParam("events", 100);  // re-export for app 
 let activeRunId = null;
 let activeRunDetail = null;
 let activeRunEvents = [];
+let activeRunEventsError = null;
 let activeRunLogs = [];
 let activeRunSubtab = "steps";
 let expandedStepIndices = new Set();
@@ -99,7 +100,12 @@ export function getActiveRunDetail() { return activeRunDetail; }
 export function setActiveRunDetail(v) { activeRunDetail = v; }
 
 export function getActiveRunEvents() { return activeRunEvents; }
-export function setActiveRunEvents(v) { activeRunEvents = v || []; }
+export function setActiveRunEvents(v) {
+  activeRunEvents = v || [];
+  activeRunEventsError = null;
+}
+
+export function setActiveRunEventsError(v) { activeRunEventsError = v || null; }
 
 export function getActiveRunLogs() { return activeRunLogs; }
 export function setActiveRunLogs(v) { activeRunLogs = v || []; }
@@ -572,6 +578,14 @@ const RUN_EVENT_COLUMNS = [
 export function renderRunEvents() {
   const body = $("run-events-body");
   if (!body) return;
+  if (activeRunEventsError) {
+    syncNodes(body, [el("div", { class: "empty-state" }, [
+      el("div", { class: "icon", text: "!" }),
+      el("div", { class: "text", text: activeRunEventsError }),
+      el("div", { class: "text", text: "Try narrowing the kind filter to reduce the scan." }),
+    ])]);
+    return;
+  }
   const events = activeRunEvents || [];
   if (events.length === 0) {
     syncNodes(body, [el("div", { class: "empty-state" }, [
@@ -635,4 +649,3 @@ function summarizeEvent(ev) {
   const text = parts.join(" ");
   return { text: truncate(text, 200), title: text };
 }
-

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -225,6 +225,56 @@ fn dashboard_run_resume_matches_runtime_guard_and_surfaces_lineage_and_errors() 
 }
 
 #[test]
+fn dashboard_run_events_show_scan_errors_but_keep_404_empty() {
+    run_dashboard_javascript_test(
+        r#"
+import assert from "node:assert/strict";
+class Node {
+  constructor() { this.children = []; this.dataset = {}; this.className = ""; this._text = ""; this.parentNode = null; }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { if (child.parentNode) child.parentNode.removeChild(child); const index = this.children.indexOf(before); this.children.splice(index < 0 ? this.children.length : index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; }
+  get textContent() { return this._text + this.children.map((child) => child.textContent).join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this.textContent = value; }
+  get firstChild() { return this.children[0] || null; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+}
+const nodes = new Map();
+const get = (id) => nodes.get(id) || (nodes.set(id, new Node()), nodes.get(id));
+globalThis.document = { getElementById: get, createElement: () => new Node(), createDocumentFragment: () => new Node() };
+globalThis.window = { location: new URL("http://dashboard.test/") };
+let responseStatus = 413;
+globalThis.fetch = async () => ({
+  ok: responseStatus < 400,
+  status: responseStatus,
+  text: async () => JSON.stringify({ error: "run-events audit rows exceed bounded scan budget" }),
+});
+const { fetchJson } = await import("./common.js");
+const { setActiveRunEvents, setActiveRunEventsError, renderRunEvents } = await import("./run-detail.js");
+let scanError;
+try {
+  await fetchJson("/api/runs/jrun-1/events?limit=100");
+} catch (error) {
+  scanError = error;
+}
+assert.equal(scanError.status, 413);
+assert.match(scanError.message, /bounded scan budget/);
+setActiveRunEvents([]);
+setActiveRunEventsError(scanError.message);
+renderRunEvents();
+assert.match(get("run-events-body").textContent, /bounded scan budget/);
+assert.match(get("run-events-body").textContent, /narrowing the kind filter/);
+responseStatus = 404;
+await assert.rejects(fetchJson("/api/runs/jrun-1/events?limit=100"), (error) => error.status === 404);
+setActiveRunEvents([]);
+renderRunEvents();
+assert.match(get("run-events-body").textContent, /No v2 envelope events for this run/);
+"#,
+    );
+}
+
+#[test]
 fn dashboard_renders_complexity_as_its_own_dimension() {
     let diagnostics = include_str!("../../assets/dashboard/diagnostics.js");
     assert!(


### PR DESCRIPTION
## Task

[ORB-11687](https://orbit-cli.com/tasks/ORB-11687) — [code-review] Show the run-events scan-budget error instead of "No v2 envelope events"

### Description

## Problem
`list_run_events` returns `413 {error: "run-events audit rows exceed bounded scan budget…"}` when a run has more than 50 000 rows. `fetchAndRenderRunEvents` catches every error as "Missing v2 events file is non-fatal", sets the events to `[]`, and the Events subtab renders "No v2 envelope events for this run." The largest, most interesting runs are therefore reported as having no events, and the Gantt loses its retry markers without explanation.

## Why It Matters
The message is the opposite of the truth for exactly the runs an operator is most likely to be debugging.

## Proposed Fix
Keep the 404/empty path as-is, but for any other HTTP error render the server's `error` text in the Events body (and a "narrow the kind filter" hint that the API already suggests).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/app.js:1255-1266`, `crates/orbit-web/src/api/runs.rs:493-501`, `crates/orbit-web/assets/dashboard/run-detail.js:572-581`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Mock a 413 from `/api/runs/:id/events`: the Events subtab shows the server message, not the empty state.
- A 404 still renders the empty state.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Preserved JSON API error status and server message in fetchJson.
- Kept 404 run-event responses as the existing empty state; non-404 responses now render the server message plus a kind-filter narrowing hint in Events.
- Added a dashboard behavior regression test that mocks 413 and 404 event responses.
Assessment: Small, localized state and rendering change. Event data remains an array for Gantt retry-marker behavior.

Criteria evidence:
1. Mocked 413 response exposes the bounded-scan server message and the kind-filter hint in the Events body.
2. Mocked 404 response clears the error and renders “No v2 envelope events for this run.”

Validation:
- Passed: CARGO_TARGET_DIR=/tmp/orb11687-target cargo test -p orbit-web dashboard_run_events_show_scan_errors_but_keep_404_empty
- Passed: CARGO_TARGET_DIR=/tmp/orb11687-target cargo test -p orbit-web dashboard_assets (52 tests)
- Passed: cargo fmt --check
- Passed: make ci-fast
- Passed: make ci-lint
- Passed: git diff --check
- Passed: git status --short reviewed; only the four task-scoped files are modified.

Risks: The UI depends on the API returning JSON {error}; malformed or non-JSON error bodies retain the existing HTTP-status fallback.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11687-6a9f5357`
- Behind base: 0
- Ahead of base: 1