### PR TITLE
[code-review] Stop leaking the full process environment to external tools

### DIFF
--- a/crates/orbit-tools/src/builtin/proc/spawn.rs
+++ b/crates/orbit-tools/src/builtin/proc/spawn.rs
@@ -48,29 +48,7 @@ impl Tool for ProcSpawnTool {
             .ok_or_else(|| OrbitError::InvalidInput("missing `program`".to_string()))?
             .to_string();
 
-        // Enforce program allowlist when the call sits inside an activity-scoped
-        // tool context, or when a legacy unrestricted context still has a
-        // non-empty list. An activity-scoped call with an empty list denies
-        // every program (fail-closed).
-        let restricted = ctx.proc_spawn_activity_scoped || !ctx.proc_allowed_programs.is_empty();
-        if restricted && !ctx.proc_allowed_programs.iter().any(|p| p == &program) {
-            let matched_rule = if ctx.proc_allowed_programs.is_empty() {
-                "<no allowed programs>".to_string()
-            } else {
-                ctx.proc_allowed_programs.join(", ")
-            };
-            tracing::warn!(
-                target: "orbit.policy.deny",
-                tool = "proc.spawn",
-                path = program.as_str(),
-                profile = "proc.allowed_programs",
-                matched_rule = matched_rule.as_str(),
-            );
-            return Err(OrbitError::PolicyDenied(format!(
-                "program '{}' is not in the allowed list: [{}]",
-                program, matched_rule
-            )));
-        }
+        enforce_program_allowlist(ctx, "proc.spawn", &program)?;
 
         let args = input
             .get("args")
@@ -108,7 +86,7 @@ impl Tool for ProcSpawnTool {
             environment_mode: EnvironmentMode::ClearAndSet(env_pairs),
             debug: false,
         };
-        let sandbox = ActivityFsSandbox { ctx };
+        let sandbox = ActivityFsSandbox::new(ctx);
         let exec_result = run_process(&request, &sandbox)?;
 
         serde_json::to_value(exec_result)
@@ -122,8 +100,14 @@ impl Tool for ProcSpawnTool {
 /// activity cannot read. Existing path arguments (including `--key=path`)
 /// are resolved symlink-safely by the same policy engine used by filesystem
 /// tools before the child is created.
-struct ActivityFsSandbox<'a> {
+pub(crate) struct ActivityFsSandbox<'a> {
     ctx: &'a ToolContext,
+}
+
+impl<'a> ActivityFsSandbox<'a> {
+    pub(crate) fn new(ctx: &'a ToolContext) -> Self {
+        Self { ctx }
+    }
 }
 
 impl Sandbox for ActivityFsSandbox<'_> {
@@ -197,6 +181,38 @@ fn proc_spawn_timeout_ms(input: &Value) -> u64 {
         .get("timeout_ms")
         .and_then(Value::as_u64)
         .unwrap_or(TIMEOUT_DEFAULT_MS)
+}
+
+pub(crate) fn enforce_program_allowlist(
+    ctx: &ToolContext,
+    tool_name: &str,
+    program: &str,
+) -> Result<(), OrbitError> {
+    // Enforce program allowlist when the call sits inside an activity-scoped
+    // tool context, or when a legacy unrestricted context still has a
+    // non-empty list. An activity-scoped call with an empty list denies every
+    // program (fail-closed).
+    let restricted = ctx.proc_spawn_activity_scoped || !ctx.proc_allowed_programs.is_empty();
+    if restricted && !ctx.proc_allowed_programs.iter().any(|p| p == program) {
+        let matched_rule = if ctx.proc_allowed_programs.is_empty() {
+            "<no allowed programs>".to_string()
+        } else {
+            ctx.proc_allowed_programs.join(", ")
+        };
+        tracing::warn!(
+            target: "orbit.policy.deny",
+            tool = tool_name,
+            path = program,
+            profile = "proc.allowed_programs",
+            matched_rule = matched_rule.as_str(),
+        );
+        return Err(OrbitError::PolicyDenied(format!(
+            "program '{}' is not in the allowed list: [{}]",
+            program, matched_rule
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/orbit-tools/src/external.rs
+++ b/crates/orbit-tools/src/external.rs
@@ -1,10 +1,12 @@
 use std::env;
 
 use orbit_common::OrbitError;
-use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
+use orbit_common::security::child_env::allowlisted_child_env;
+use orbit_exec::{EnvironmentMode, ExecRequest, StdinMode, run_process};
 use orbit_types::tool::{ToolParam, ToolSchema};
 use serde_json::Value;
 
+use crate::builtin::proc::spawn::{ActivityFsSandbox, enforce_program_allowlist};
 use crate::{TIMEOUT_DEFAULT_MS, Tool, ToolContext};
 
 const EXTERNAL_TOOL_TIMEOUT_OVERRIDE_ENV: &str = "ORBIT_EXTERNAL_TOOL_TIMEOUT_MS";
@@ -43,6 +45,7 @@ impl Tool for ExternalTool {
             ))
         })?;
         let timeout_ms = external_tool_timeout_ms()?;
+        enforce_program_allowlist(ctx, "external tool", &self.path)?;
         let environment_mode =
             EnvironmentMode::ClearAndSet(runtime_environment(ctx, &self.name, &cwd));
 
@@ -56,7 +59,7 @@ impl Tool for ExternalTool {
                 environment_mode,
                 debug: false,
             },
-            &NoSandbox,
+            &ActivityFsSandbox::new(ctx),
         )?;
 
         if !output.success {
@@ -106,7 +109,10 @@ fn external_tool_timeout_ms() -> Result<u64, OrbitError> {
 }
 
 fn runtime_environment(ctx: &ToolContext, tool_name: &str, cwd: &str) -> Vec<(String, String)> {
-    let mut env_pairs: Vec<(String, String)> = env::vars().collect();
+    let mut env_pairs = ctx
+        .proc_spawn_environment
+        .clone()
+        .unwrap_or_else(|| allowlisted_child_env(&[], &[]));
     upsert_env(&mut env_pairs, ORBIT_TOOL_NAME_ENV, tool_name.to_string());
     upsert_env(&mut env_pairs, ORBIT_TOOL_CWD_ENV, cwd.to_string());
     if let Some(workspace_root) = ctx.workspace_root.as_ref() {

--- a/crates/orbit-tools/tests/external_tool_lockdown.rs
+++ b/crates/orbit-tools/tests/external_tool_lockdown.rs
@@ -1,0 +1,89 @@
+#![allow(missing_docs)]
+// External-tool fixtures use expect/unwrap for setup; production code remains linted.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+#[cfg(unix)]
+mod unix_tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use orbit_common::OrbitError;
+    use orbit_tools::external::ExternalTool;
+    use orbit_tools::{Tool, ToolContext};
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn external_tool(path: &str) -> ExternalTool {
+        ExternalTool {
+            name: "print_environment".to_string(),
+            path: path.to_string(),
+            description: String::new(),
+            parameters: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn external_tool_drops_ambient_credentials_and_keeps_runtime_context() {
+        let directory = tempdir().expect("temporary directory");
+        let script_path = directory.path().join("print-environment.sh");
+        fs::write(
+            &script_path,
+            r##"#!/bin/sh
+cat >/dev/null
+if [ -n "${GH_TOKEN+x}" ]; then gh_token_present=true; else gh_token_present=false; fi
+if [ -n "${ORBIT_TOOL_NAME+x}" ]; then name_present=true; else name_present=false; fi
+if [ -n "${ORBIT_TOOL_CWD+x}" ]; then cwd_present=true; else cwd_present=false; fi
+if [ -n "${ORBIT_TOOL_WORKSPACE_ROOT+x}" ]; then root_present=true; else root_present=false; fi
+if [ -n "${ORBIT_TOOL_AGENT_NAME+x}" ]; then agent_present=true; else agent_present=false; fi
+if [ -n "${ORBIT_TOOL_MODEL_NAME+x}" ]; then model_present=true; else model_present=false; fi
+if [ -n "${ORBIT_TOOL_ALLOWED_TOOLS+x}" ]; then tools_present=true; else tools_present=false; fi
+if [ -n "${ORBIT_TOOL_PROC_ALLOWED_PROGRAMS+x}" ]; then programs_present=true; else programs_present=false; fi
+printf '{"gh_token_present":%s,"name_present":%s,"cwd_present":%s,"root_present":%s,"agent_present":%s,"model_present":%s,"tools_present":%s,"programs_present":%s}' \
+  "$gh_token_present" "$name_present" "$cwd_present" "$root_present" "$agent_present" "$model_present" "$tools_present" "$programs_present"
+"##,
+        )
+        .expect("write environment script");
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o700))
+            .expect("make environment script executable");
+
+        let program = script_path.to_string_lossy().into_owned();
+        let context = ToolContext {
+            cwd: Some(directory.path().to_string_lossy().into_owned()),
+            workspace_root: Some(directory.path().to_path_buf()),
+            agent_name: Some("test-agent".to_string()),
+            model_name: Some("test-model".to_string()),
+            allowed_tools: vec!["print_environment".to_string()],
+            proc_allowed_programs: vec![program.clone()],
+            ..ToolContext::default()
+        };
+
+        let output = external_tool(&program)
+            .execute(&context, json!({}))
+            .expect("external tool output");
+
+        assert_eq!(output["gh_token_present"], false);
+        assert_eq!(output["name_present"], true);
+        assert_eq!(output["cwd_present"], true);
+        assert_eq!(output["root_present"], true);
+        assert_eq!(output["agent_present"], true);
+        assert_eq!(output["model_present"], true);
+        assert_eq!(output["tools_present"], true);
+        assert_eq!(output["programs_present"], true);
+    }
+
+    #[test]
+    fn activity_scoped_external_tool_must_be_allowlisted() {
+        let directory = tempdir().expect("temporary directory");
+        let context = ToolContext {
+            cwd: Some(directory.path().to_string_lossy().into_owned()),
+            proc_spawn_activity_scoped: true,
+            ..ToolContext::default()
+        };
+
+        let error = external_tool("/bin/sh")
+            .execute(&context, json!({}))
+            .expect_err("unallowlisted external tool must be denied");
+
+        assert!(matches!(error, OrbitError::PolicyDenied(_)));
+    }
+}


### PR DESCRIPTION
## Task

[ORB-11699](https://orbit-cli.com/tasks/ORB-11699) — [code-review] Stop leaking the full process environment to external tools

### Description

## Problem
`ExternalTool::execute` builds `EnvironmentMode::ClearAndSet(runtime_environment(..))` where `runtime_environment` starts from `env::vars().collect()` — the complete parent environment — and merely upserts the `ORBIT_TOOL_*` keys. The `ClearAndSet` mode therefore clears nothing; every credential in the Orbit process (`GH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_*`, the `ORBIT_MCP_SSH_ACCEPTANCE` Bearer [REDACTED_AUTH] a forced command) is handed to a user-registered executable, and the tool also bypasses the `proc_allowed_programs` allowlist and the activity sandbox (`NoSandbox`). `proc.spawn` in the same crate explicitly refuses ambient inheritance and uses `allowlisted_child_env` (`crates/orbit-tools/src/builtin/proc/spawn.rs:88-95`), so the two subprocess boundaries disagree.

## Why It Matters
External tools are registered from workspace configuration (`crates/orbit-core/src/runtime/builder.rs:339`) and can be invoked by an agent inside a run, so a repository-shipped tool manifest becomes a credential exfiltration path.

## Proposed Fix
Build the external-tool environment from `ctx.proc_spawn_environment.clone().unwrap_or_else(|| allowlisted_child_env(&[], &[]))` plus the `ORBIT_TOOL_*` keys, exactly as `proc.spawn` does, and apply the same `ActivityFsSandbox`/allowlist gate when `ctx.proc_spawn_activity_scoped` is set.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-tools/src/external.rs:108-148`, `crates/orbit-tools/src/external.rs:46-60`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (security). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: with `GH_TOKEN=secret` in the parent environment, an external tool that prints its environment does not receive `GH_TOKEN`.
- `ORBIT_TOOL_NAME`, `ORBIT_TOOL_CWD`, and the other `ORBIT_TOOL_*` keys are still present.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- External tools now build their child environment from the resolved proc-spawn environment, or the credential-free allowlisted baseline when no resolved environment is present; ORBIT_TOOL_* context variables are still overlaid.
- External tools now share proc.spawn's program allowlist and activity filesystem sandbox enforcement.
- Added a real Unix executable regression test covering GH_TOKEN removal, ORBIT_TOOL_* preservation, and activity-scoped allowlist denial.

Acceptance criteria:
1. PASS — `GH_TOKEN=secret cargo test -p orbit-tools --test external_tool_lockdown` ran a real external executable; its output confirmed GH_TOKEN was absent.
2. PASS — The same test confirmed ORBIT_TOOL_NAME, ORBIT_TOOL_CWD, ORBIT_TOOL_WORKSPACE_ROOT, ORBIT_TOOL_AGENT_NAME, ORBIT_TOOL_MODEL_NAME, ORBIT_TOOL_ALLOWED_TOOLS, and ORBIT_TOOL_PROC_ALLOWED_PROGRAMS were present.

Validation:
- PASS: `cargo fmt --all -- --check`
- PASS: `make ci-fast`
- PASS: `make ci-lint`
- PASS: `GH_TOKEN=secret cargo test -p orbit-tools --test external_tool_lockdown`
- PASS: `cargo test -p orbit-tools --tests` — 115 unit tests, 2 external-tool tests, 3 MCP-definition tests, 1 policy-tracing test, 9 proc-spawn lockdown tests, and 17 public-surface tests passed; 1 pre-existing live GitHub test ignored.
- PASS: `git diff --check`
- PASS: `git status --short` — only the three task-scoped files are changed/untracked.
- NOT RUN: full `make ci`, per repository guidance not to run it per task.

Assessment: The subprocess boundary now follows the existing sanitized proc-spawn environment and enforcement path, with focused behavioral coverage. An initial package-test attempt exposed a fixture broken-pipe race; the fixture was corrected to consume stdin and the complete package test suite was rerun successfully. Changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11699-6a9f5358`
- Behind base: 0
- Ahead of base: 1