### PR TITLE
[code-review] Reject out-of-range `every_minutes` so an auto-task interval cannot degenerate into "fire on every pass"

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/schedule.rs
+++ b/crates/orbit-automation/src/auto_tasks/schedule.rs
@@ -9,7 +9,7 @@
 
 use chrono::{DateTime, Duration, Local, Utc};
 use orbit_common::OrbitError;
-use orbit_types::workflow::{AutoTaskSchedule, MissedRunPolicy};
+use orbit_types::workflow::{AutoTaskSchedule, MAX_AUTO_TASK_INTERVAL_MINUTES, MissedRunPolicy};
 
 use crate::routines::due::{DueDecision, due_decision, parse_cron};
 
@@ -23,7 +23,7 @@ pub enum AutoTaskDueDecision {
 }
 
 /// Validate a schedule fail-closed: a cron form must parse as a 5-field cron,
-/// an interval must be non-zero. CRUD and the loader call this so a bad
+/// an interval must be within the supported range. CRUD and the loader call this so a bad
 /// schedule is rejected before it can silently never fire.
 pub fn validate_schedule(schedule: &AutoTaskSchedule) -> Result<(), OrbitError> {
     match schedule {
@@ -34,10 +34,12 @@ pub fn validate_schedule(schedule: &AutoTaskSchedule) -> Result<(), OrbitError> 
             parse_cron(cron)?;
             Ok(())
         }
-        AutoTaskSchedule::Interval { every_minutes } if *every_minutes == 0 => {
-            Err(OrbitError::InvalidInput(
-                "auto-task interval every_minutes must be at least 1".to_string(),
-            ))
+        AutoTaskSchedule::Interval { every_minutes }
+            if *every_minutes == 0 || *every_minutes > MAX_AUTO_TASK_INTERVAL_MINUTES =>
+        {
+            Err(OrbitError::InvalidInput(format!(
+                "auto-task interval every_minutes must be between 1 and {MAX_AUTO_TASK_INTERVAL_MINUTES}"
+            )))
         }
         AutoTaskSchedule::Interval { .. } => Ok(()),
     }
@@ -97,6 +99,11 @@ fn decide_interval(
     lower_bound: DateTime<Utc>,
     now: DateTime<Utc>,
 ) -> Result<AutoTaskDueDecision, OrbitError> {
+    let every_minutes = i64::try_from(every_minutes).map_err(|_| {
+        OrbitError::InvalidInput(
+            "auto-task interval every_minutes exceeds the supported signed duration".to_string(),
+        )
+    })?;
     if every_minutes == 0 {
         return Err(OrbitError::InvalidInput(
             "auto-task interval every_minutes must be at least 1".to_string(),
@@ -109,8 +116,8 @@ fn decide_interval(
     // A single fire covers however many boundaries fell in a downtime gap
     // (catch-up collapse), because we jump straight to the latest boundary.
     let elapsed_minutes = now.signed_duration_since(baseline).num_minutes();
-    let periods = elapsed_minutes / every_minutes as i64;
-    let latest_slot = baseline + Duration::minutes(every_minutes as i64 * periods);
+    let periods = elapsed_minutes / every_minutes;
+    let latest_slot = baseline + Duration::minutes(every_minutes * periods);
     if latest_slot > lower_bound {
         Ok(AutoTaskDueDecision::Fire {
             slot: latest_slot.to_rfc3339(),

--- a/crates/orbit-automation/src/auto_tasks/tests/schedule.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/schedule.rs
@@ -99,7 +99,7 @@ fn cron_fires_for_the_latest_slot_after_the_lower_bound() {
 }
 
 #[test]
-fn validate_schedule_rejects_bad_cron_and_zero_interval() {
+fn validate_schedule_rejects_bad_cron_and_out_of_range_intervals() {
     assert!(
         validate_schedule(&AutoTaskSchedule::Cron {
             cron: "not a cron".to_string(),
@@ -107,5 +107,21 @@ fn validate_schedule_rejects_bad_cron_and_zero_interval() {
         .is_err()
     );
     assert!(validate_schedule(&interval(0)).is_err());
+    assert!(validate_schedule(&interval(u64::MAX)).is_err());
     assert!(validate_schedule(&interval(30)).is_ok());
+}
+
+#[test]
+fn interval_decision_rejects_values_outside_signed_duration_range() {
+    let baseline = at(2026, 1, 1, 0, 0);
+
+    assert!(
+        decide_due(
+            &interval(u64::MAX),
+            baseline,
+            None,
+            baseline + Duration::minutes(1),
+        )
+        .is_err()
+    );
 }

--- a/crates/orbit-types/src/workflow/auto_task.rs
+++ b/crates/orbit-types/src/workflow/auto_task.rs
@@ -20,6 +20,11 @@ use crate::task::{TaskPriority, TaskStatus, TaskType};
 /// Auto-task YAML schema version this binary reads and writes.
 pub const AUTO_TASK_SCHEMA_VERSION: u32 = 1;
 
+/// Longest supported auto-task interval: one year in minutes. This keeps an
+/// operator mistake from becoming a practically inert schedule while remaining
+/// well within the scheduler's signed duration representation.
+pub const MAX_AUTO_TASK_INTERVAL_MINUTES: u64 = 365 * 24 * 60;
+
 /// Tag prefix stamped on every task an auto-task definition creates. The
 /// suffix is the definition name, so `skip_if_open` dedupe and provenance
 /// both key off `auto-task:<name>`.
@@ -170,9 +175,11 @@ impl AutoTaskDefinition {
                     self.name
                 )));
             }
-            AutoTaskSchedule::Interval { every_minutes } if *every_minutes == 0 => {
+            AutoTaskSchedule::Interval { every_minutes }
+                if *every_minutes == 0 || *every_minutes > MAX_AUTO_TASK_INTERVAL_MINUTES =>
+            {
                 return Err(WorkflowError::Invalid(format!(
-                    "auto-task '{}' schedule.every_minutes must be at least 1",
+                    "auto-task '{}' schedule.every_minutes must be between 1 and {MAX_AUTO_TASK_INTERVAL_MINUTES}",
                     self.name
                 )));
             }

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -35,7 +35,8 @@ pub use activity_job::{
 };
 pub use auto_task::{
     AUTO_TASK_SCHEMA_VERSION, AUTO_TASK_TAG_PREFIX, AutoTaskDefinition, AutoTaskSchedule,
-    AutoTaskTemplate, DedupePolicy, auto_task_tag, is_valid_auto_task_name,
+    AutoTaskTemplate, DedupePolicy, MAX_AUTO_TASK_INTERVAL_MINUTES, auto_task_tag,
+    is_valid_auto_task_name,
 };
 pub use child_dispatch::{
     ChildCancellation, ChildCancellationPolicy, ChildDispatch, ChildDispatchPhase,

--- a/crates/orbit-types/src/workflow/tests/auto_task.rs
+++ b/crates/orbit-types/src/workflow/tests/auto_task.rs
@@ -1,0 +1,33 @@
+use crate::task::{TaskPriority, TaskStatus, TaskType};
+use crate::workflow::{AutoTaskDefinition, AutoTaskSchedule, AutoTaskTemplate};
+
+fn definition_with_interval(every_minutes: u64) -> AutoTaskDefinition {
+    AutoTaskDefinition {
+        schema_version: 1,
+        name: "weekly-review".to_string(),
+        description: String::new(),
+        enabled: true,
+        schedule: AutoTaskSchedule::Interval { every_minutes },
+        template: AutoTaskTemplate {
+            title: "Review work".to_string(),
+            description: String::new(),
+            acceptance_criteria: Vec::new(),
+            task_type: TaskType::Chore,
+            tags: Vec::new(),
+            required_tools: Vec::new(),
+            priority: TaskPriority::Medium,
+            crew: None,
+            status: TaskStatus::Backlog,
+        },
+        dedupe: Default::default(),
+        created_by: None,
+        created_at: String::new(),
+        updated_by: None,
+        updated_at: String::new(),
+    }
+}
+
+#[test]
+fn validation_rejects_out_of_range_interval() {
+    assert!(definition_with_interval(u64::MAX).validate().is_err());
+}

--- a/crates/orbit-types/src/workflow/tests/mod.rs
+++ b/crates/orbit-types/src/workflow/tests/mod.rs
@@ -1,3 +1,4 @@
+mod auto_task;
 mod executor_def;
 mod job;
 mod run_state;


### PR DESCRIPTION
## Task

[ORB-11734](https://orbit-cli.com/tasks/ORB-11734) — [code-review] Reject out-of-range `every_minutes` so an auto-task interval cannot degenerate into "fire on every pass"

### Description

## Problem
`AutoTaskSchedule::Interval { every_minutes: u64 }` is validated only for `!= 0`. `decide_interval` casts it with `every_minutes as i64` twice (schedule.rs:112-113). For `every_minutes >= 2^63` the cast is negative: with `u64::MAX` it becomes `-1`, `periods = elapsed / -1`, and `latest_slot = baseline + elapsed = now`, which is always `> lower_bound`, so the definition fires (or is `dedupe_open`-skipped) on every scheduler pass instead of never. `validate_schedule` in the same crate accepts the value too.

## Why It Matters
A typo or fuzzed value turns a periodic chore into a task-minting loop bounded only by `skip_if_open`.

## Proposed Fix
Bound `every_minutes` in `AutoTaskDefinition::validate` and `validate_schedule` (e.g. `1..=525_600`), and use `i64::try_from` in `decide_interval` returning `InvalidInput` on failure.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-types/src/workflow/auto_task.rs:173-178`, `crates/orbit-automation/src/auto_tasks/schedule.rs:100-113`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Unit test: `every_minutes: u64::MAX` is rejected by `validate` and by `validate_schedule`.
- Unit test: `decide_interval` with an out-of-range value returns `Err`, never `Fire`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a canonical one-year maximum interval (525,600 minutes) to AutoTaskDefinition validation and scheduler validation, so u64::MAX is rejected before scheduling.
- Made interval due-math convert minutes with i64::try_from, returning InvalidInput rather than allowing a wrapped negative period.
- Added regression coverage for AutoTaskDefinition::validate, validate_schedule, and interval due decisions with u64::MAX.
Assessment: The authoritative type boundary now rejects unsupported intervals, while due math remains defensive for direct callers.
Criteria evidence:
- every_minutes: u64::MAX is rejected by AutoTaskDefinition::validate and validate_schedule; dedicated unit tests cover both boundaries.
- The interval decision path returns Err for u64::MAX through decide_due, which delegates to decide_interval, so it cannot return Fire.
Validation:
- cargo test -p orbit-types workflow::tests::auto_task: passed (1 test).
- cargo test -p orbit-automation auto_tasks::tests::schedule: passed (8 tests).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks / deviations: No remaining known risks; the one-year bound follows the task proposal and is exported so both validation layers share the same value.
Worktree: Only the six task-scoped workflow/schedule source and test files are modified or added; changes are intentionally uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11734-6a9f53ac`
- Behind base: 0
- Ahead of base: 1