### PR TITLE
[code-review] Tell the aggregate task view when the server truncated it

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -71,10 +71,8 @@ const $ = (id) => document.getElementById(id);
 let searchQuery = "";
 let activeStatuses = new Set(DEFAULT_ACTIVE_STATUSES);
 let lastTasks = [];
-// ORB-10874: paging metadata from the single-workspace `/api/tasks` envelope
-// (`{ items, total, limit, truncated }`) so the count can state a shown/total/
-// server-limit fact instead of an ambiguous `N/50`. Null for the aggregate
-// `/api/tasks/all` view, which answers a bare array with no such metadata.
+// ORB-10874: paging metadata from task-list envelopes so the count can state a
+// shown/total/server-limit fact instead of an ambiguous `N/50`.
 let lastTasksMeta = null;
 let lastRuns = [];
 let lastRunsMeta = null;
@@ -1094,11 +1092,10 @@ function fetchAndRenderTasks() {
     fetchJson(path),
     crews,
   ]).then(([payload]) => {
-    // /api/tasks answers `{ items, total, limit, truncated }` (ORB-10400);
-    // /api/tasks/all a bare array with no paging metadata.
+    // Both task-list endpoints answer `{ items, total, limit, truncated }`.
     const tasks = listItems(payload);
     lastTasks = tasks;
-    lastTasksMeta = !aggregate && payload && !Array.isArray(payload)
+    lastTasksMeta = payload && !Array.isArray(payload)
       ? { total: payload.total, limit: payload.limit, truncated: payload.truncated }
       : null;
     renderTasks(tasks, taskContext());

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -269,10 +269,10 @@ export function fetchJson(path) {
     });
 }
 
-// ORB-10400: /api/tasks answers a paginated envelope
+// ORB-10400: task-list endpoints answer a paginated envelope
 // `{ items, total, limit, truncated }` so a client can tell an empty result from
-// a truncated window, while the /api/tasks/all aggregate still answers a bare
-// array. Accept either shape rather than teaching each call site the difference.
+// a truncated window. Accept either shape for compatibility with non-task list
+// call sites that use this helper.
 export function listItems(payload) {
   if (Array.isArray(payload)) return payload;
   if (payload && Array.isArray(payload.items)) return payload.items;

--- a/crates/orbit-web/src/api/tasks.rs
+++ b/crates/orbit-web/src/api/tasks.rs
@@ -327,8 +327,9 @@ where
 /// the window (previously indistinguishable, because the handler answered a bare
 /// truncated array with no metadata).
 ///
-/// The cross-workspace `/api/tasks/all` aggregate still answers a bare array; it
-/// takes no filters and is bounded by the same default limit.
+/// The cross-workspace `/api/tasks/all` aggregate uses the same envelope. It
+/// takes no filters and its `total` sums the untruncated candidate counts from
+/// active workspaces.
 pub(super) async fn list_tasks(Ws(runtime): Ws, RawQuery(query): RawQuery) -> Response {
     let query = match TaskListQuery::parse(query.as_deref()) {
         Ok(query) => query,

--- a/crates/orbit-web/src/api/tests/task_listing.rs
+++ b/crates/orbit-web/src/api/tests/task_listing.rs
@@ -109,7 +109,7 @@ async fn aggregate_selects_global_newest_rows_before_reading_off_page_workspace_
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let values = body_json(response).await;
-    let rows = values.as_array().unwrap();
+    let rows = values["items"].as_array().unwrap();
     assert_eq!(rows.len(), 50);
     assert!(
         rows.iter()

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -120,7 +120,7 @@ async fn tasks_all_in_single_mode_tags_default_workspace() {
         .await
         .expect("response");
     let body = body_json(response).await;
-    let tasks = body.as_array().expect("array");
+    let tasks = body["items"].as_array().expect("items");
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0]["workspace_id"], json!("default"));
     assert_eq!(tasks[0]["workspace_name"], json!("default"));
@@ -155,7 +155,7 @@ async fn tasks_all_aggregates_active_workspaces_and_skips_inactive() {
         .await
         .expect("response");
     let body = body_json(response).await;
-    let tasks = body.as_array().expect("array");
+    let tasks = body["items"].as_array().expect("items");
     assert_eq!(tasks.len(), 2);
     let ws_ids: HashSet<&str> = tasks
         .iter()
@@ -169,6 +169,9 @@ async fn tasks_all_aggregates_active_workspaces_and_skips_inactive() {
             .as_str()
             .is_some_and(|root| root.ends_with(t["workspace_name"].as_str().expect("name")))
     }));
+    assert_eq!(body["total"], json!(2));
+    assert_eq!(body["limit"], json!(orbit_core::DEFAULT_TASK_LIST_LIMIT));
+    assert_eq!(body["truncated"], json!(false));
 
     // Workspace listing: all three, with status + default flag.
     let response = router()
@@ -201,6 +204,48 @@ async fn tasks_all_aggregates_active_workspaces_and_skips_inactive() {
             .as_str()
             .is_some_and(|dir| dir.ends_with(".orbit"))
     );
+}
+
+#[tokio::test]
+async fn tasks_all_reports_aggregate_total_when_global_limit_truncates() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let global_root = tmp.path().join("global");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+
+    let mut entries = Vec::new();
+    for name in ["alpha", "beta", "gamma"] {
+        let (orbit_dir, repo_root) = seed_workspace(&global_root, tmp.path(), name);
+        let runtime = OrbitRuntime::from_roots(&global_root, &orbit_dir)
+            .expect("build runtime")
+            .with_actor(ActorIdentity::human("human"));
+        for index in 1..30 {
+            runtime
+                .add_task(TaskAddParams {
+                    title: format!("{name} task {index}"),
+                    description: "seed".to_string(),
+                    workspace_path: Some(".".to_string()),
+                    status: Some(TaskStatus::InProgress),
+                    ..Default::default()
+                })
+                .expect("add task");
+        }
+        entries.push(workspace_entry(name, repo_root, orbit_dir, true));
+    }
+
+    let response = router()
+        .with_state(DashboardState::global(
+            global_root,
+            entries,
+            Some("alpha".to_string()),
+        ))
+        .oneshot(get("/tasks/all"))
+        .await
+        .expect("response");
+    let body = body_json(response).await;
+
+    assert_eq!(body["total"], json!(90));
+    assert_eq!(body["truncated"], json!(true));
+    assert_eq!(body["items"].as_array().expect("items").len(), 50);
 }
 
 #[tokio::test]
@@ -566,7 +611,8 @@ async fn cross_workspace_dependency_resolves_global_status_not_missing() {
         .expect("aggregate response");
     let body = body_json(aggregate).await;
     let alpha_row = body
-        .as_array()
+        .get("items")
+        .and_then(serde_json::Value::as_array)
         .expect("aggregate rows")
         .iter()
         .find(|row| row["id"] == alpha_task.id)

--- a/crates/orbit-web/src/api/workspaces.rs
+++ b/crates/orbit-web/src/api/workspaces.rs
@@ -60,7 +60,7 @@ pub(super) async fn list_workspaces(State(state): State<DashboardState>) -> Resp
 /// workspace is broken.
 pub(super) async fn list_all_tasks(State(state): State<DashboardState>) -> Response {
     match blocking("aggregate task list", move || Ok(all_tasks_json(&state))).await {
-        Ok(Ok(values)) => Json(values).into_response(),
+        Ok(Ok(value)) => Json(value).into_response(),
         Ok(Err(error)) => server_error(error),
         Err(response) => *response,
     }
@@ -230,15 +230,17 @@ fn run_timestamp(run: &JobRun) -> DateTime<Utc> {
     run.finished_at.or(run.started_at).unwrap_or(run.created_at)
 }
 
-fn all_tasks_json(state: &DashboardState) -> Result<Vec<Value>, orbit_core::OrbitError> {
+fn all_tasks_json(state: &DashboardState) -> Result<Value, orbit_core::OrbitError> {
     let pinned = state.pin();
     let home = home_dir();
     let mut candidates = Vec::new();
+    let mut total = 0;
     for entry in pinned.entries().iter().filter(|entry| entry.active) {
         let Ok(runtime) = pinned.runtime_for(&entry.id) else {
             continue;
         };
         let page = runtime.task_candidates(&TaskListFilter::default(), DEFAULT_TASK_LIST_LIMIT)?;
+        total += page.total;
         for task in page.items {
             candidates.push((task, runtime.clone(), entry));
         }
@@ -272,7 +274,12 @@ fn all_tasks_json(state: &DashboardState) -> Result<Vec<Value>, orbit_core::Orbi
         }
         values.push(value);
     }
-    Ok(values)
+    Ok(json!({
+        "items": values,
+        "total": total,
+        "limit": DEFAULT_TASK_LIST_LIMIT,
+        "truncated": total > values.len(),
+    }))
 }
 
 /// Render a filesystem path for display, collapsing the user's home directory


### PR DESCRIPTION
## Task

[ORB-11688](https://orbit-cli.com/tasks/ORB-11688) — [code-review] Tell the aggregate task view when the server truncated it

### Description

## Problem
`/api/tasks/all` collects up to `DEFAULT_TASK_LIST_LIMIT` candidates per workspace and truncates the merged list to the same limit with no `total`/`truncated` metadata (bare array). `fetchAndRenderTasks` therefore sets `lastTasksMeta = null` and `formatTaskCount` prints "N shown" with no "server limit" note. With three active workspaces most tasks are missing from the "All workspaces" view and nothing says so; the single-workspace endpoint got exactly this envelope in ORB-10400 for the same reason.

## Why It Matters
The aggregate view is the default landing view when the server is launched outside a workspace.

## Proposed Fix
Return `{ items, total, limit, truncated }` from `/api/tasks/all` (sum of per-workspace totals from `task_candidates`), which `listItems` already accepts, and set `lastTasksMeta` for the aggregate path too.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/src/api/workspaces.rs:233-276`, `crates/orbit-web/assets/dashboard/app.js:938-950`, `crates/orbit-web/assets/dashboard/tasks.js:87-99`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `api/tests/workspaces.rs`: three workspaces with 30 tasks each yield `total: 90, truncated: true, items.len() == 50`.
- The Tasks header reads "… · 90 total · server limit 50" in aggregate mode.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `/api/tasks/all` now returns the canonical `{ items, total, limit, truncated }` envelope, with `total` summed from active workspaces before the global 50-item window is applied.
- Aggregate dashboard fetching now preserves this metadata, so the existing count formatter renders `50 shown · 90 total · server limit 50`; stale aggregate-array documentation and response-shape tests were updated.
- Added a three-workspace/30-task-per-workspace regression test that asserts `total: 90`, `truncated: true`, and 50 returned items.
Assessment: The response contract now matches the single-workspace list and reports the server-side aggregate window without adding dependencies or alternate paths.
Criteria evidence:
1. `tasks_all_reports_aggregate_total_when_global_limit_truncates` passed with three seeded workspaces and asserts total 90, truncation true, and 50 items.
2. A Node module check passed: `formatTaskCount(50, 50, { total: 90, limit: 50, truncated: true })` returned `50 shown · 90 total · server limit 50`; aggregate fetch now stores that metadata.
Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-web api::tests::workspaces --lib` (22 tests).
- Passed: `cargo test -p orbit-web api::tests::task_listing::aggregate_selects_global_newest_rows_before_reading_off_page_workspace_bodies --lib`.
- Passed: focused aggregate regression test.
- Passed: Node count-format check.
- Passed: `make ci-fast`.
- Passed: `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`).
- Passed: `git diff --check`.
Risks: aggregate task candidates remain intentionally bounded to 50 per workspace; this task exposes the accurate summed candidate total but does not alter that established per-workspace selection policy.
Scope deviation: added response-shape test and stale contract-comment files because the API change would otherwise leave direct consumers and current documentation inconsistent.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11688-6a9f55ed`
- Behind base: 0
- Ahead of base: 1