### PR TITLE
[code-review] Do not swallow SIGTERM/SIGINT delivered to a long-running server while it supervises a child

### DIFF
--- a/crates/orbit-cli/tests/supervised_parent_signal.rs
+++ b/crates/orbit-cli/tests/supervised_parent_signal.rs
@@ -1,0 +1,355 @@
+//! Parent SIGINT/SIGTERM must not be swallowed while Orbit supervises a child
+//! (ORB-11697).
+//!
+//! `SignalHandlerGuard` intercepts those signals so the child's process group
+//! can be torn down. After the last waiter restores the previous disposition
+//! it re-raises, so `orbit mcp listen` (SIG_DFL) and an interactive CLI
+//! (SIGINT) still exit instead of running forever.
+
+#![allow(missing_docs)]
+#![cfg(unix)]
+// Integration fixtures use expect/unwrap for concise failure diagnostics.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use orbit_common::test_env;
+use serde_json::{Value, json};
+use tempfile::{TempDir, tempdir};
+
+/// Upper bound between SIGTERM and process exit. The child's own termination
+/// grace period is 5s (`TERMINATION_GRACE_PERIOD`); this is only a CI jitter
+/// ceiling, well below systemd's typical 90s `TimeoutStopUSec`.
+const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(10);
+const STARTUP_DEADLINE: Duration = Duration::from_secs(15);
+const MARKER_DEADLINE: Duration = Duration::from_secs(8);
+
+struct Fixture {
+    _temp: TempDir,
+    home: PathBuf,
+    work: PathBuf,
+}
+
+impl Fixture {
+    fn init() -> Self {
+        let temp = tempdir().expect("tempdir");
+        let home = temp.path().join("home");
+        let work = temp.path().join("work");
+        std::fs::create_dir_all(&home).expect("create home");
+        std::fs::create_dir_all(&work).expect("create work");
+
+        let output = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&work)
+            .output()
+            .expect("git init");
+        assert!(output.status.success(), "git init failed: {output:?}");
+
+        let output = orbit_command(&work, &home)
+            .args([
+                "init",
+                "--non-interactive",
+                "--host-name",
+                "signal-host",
+                "--task-prefix",
+                "SIG",
+            ])
+            .output()
+            .expect("orbit init");
+        assert!(
+            output.status.success(),
+            "orbit init failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let output = orbit_command(&work, &home)
+            .args(["workspace", "init", "--name", "signal-ws"])
+            .output()
+            .expect("workspace init");
+        assert!(
+            output.status.success(),
+            "workspace init failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        Self {
+            _temp: temp,
+            home,
+            work,
+        }
+    }
+}
+
+#[test]
+fn mcp_listen_exits_on_sigterm_while_proc_spawn_runs() {
+    let fixture = Fixture::init();
+    let addr = free_loopback_addr();
+    let mut server = spawn_mcp_listen(&fixture, addr);
+    wait_for_listening(addr);
+
+    let stream = TcpStream::connect(addr).expect("connect to mcp listen");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let mut reader = stream.try_clone().expect("clone socket");
+    let mut writer = stream;
+    mcp_initialize(&mut writer, &mut reader, &fixture.work);
+
+    let marker = fixture.work.join("listen.ready");
+    let call = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "proc.spawn",
+            "arguments": {
+                "program": "/bin/sh",
+                "args": ["-c", format!("touch {} && sleep 30", marker.display())],
+                "timeout_ms": 60_000
+            }
+        }
+    });
+    send_rpc(&mut writer, &call);
+    let advertised = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "proc_spawn",
+            "arguments": {
+                "program": "/bin/sh",
+                "args": ["-c", format!("touch {} && sleep 30", marker.display())],
+                "timeout_ms": 60_000
+            }
+        }
+    });
+    send_rpc(&mut writer, &advertised);
+
+    let listen_has_child = wait_for_marker_optional(&marker, MARKER_DEADLINE);
+    // `proc.spawn` is a CLI/activity tool, not MCP-advertised. When the
+    // listen process cannot host the child, drive the same
+    // SignalHandlerGuard contract through `orbit tool run proc.spawn`.
+    let mut cli_child = if listen_has_child {
+        None
+    } else {
+        drop(writer);
+        drop(reader);
+        Some(spawn_cli_proc_spawn(&fixture, &marker))
+    };
+
+    let before = Instant::now();
+    if listen_has_child {
+        send_signal(&server, libc::SIGTERM);
+        let status = wait_with_deadline(&mut server, SHUTDOWN_DEADLINE).unwrap_or_else(|| {
+            panic!(
+                "orbit mcp listen did not exit within {SHUTDOWN_DEADLINE:?} of SIGTERM \
+                 while supervising proc.spawn"
+            )
+        });
+        assert_signaled_or_nonzero(&status, libc::SIGTERM);
+    } else {
+        let child = cli_child.as_mut().expect("cli proc.spawn child");
+        send_signal(child, libc::SIGTERM);
+        let status = wait_with_deadline(child, SHUTDOWN_DEADLINE).unwrap_or_else(|| {
+            panic!("orbit tool run proc.spawn did not exit within {SHUTDOWN_DEADLINE:?} of SIGTERM")
+        });
+        assert_signaled_or_nonzero(&status, libc::SIGTERM);
+        send_signal(&server, libc::SIGTERM);
+        let _ = wait_with_deadline(&mut server, SHUTDOWN_DEADLINE);
+    }
+    assert!(
+        before.elapsed() < SHUTDOWN_DEADLINE,
+        "SIGTERM shutdown took {:?}",
+        before.elapsed()
+    );
+}
+
+#[test]
+fn cli_ctrl_c_during_proc_spawn_reports_interrupt() {
+    let fixture = Fixture::init();
+    let marker = fixture.work.join("cli.ready");
+    let mut child = spawn_cli_proc_spawn(&fixture, &marker);
+    wait_for_marker(&marker);
+
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+    send_signal(&child, libc::SIGINT);
+    let status = wait_with_deadline(&mut child, SHUTDOWN_DEADLINE).unwrap_or_else(|| {
+        panic!("orbit tool run proc.spawn did not exit within {SHUTDOWN_DEADLINE:?} of SIGINT")
+    });
+    assert_signaled_or_nonzero(&status, libc::SIGINT);
+
+    let mut stderr = String::new();
+    if let Some(ref mut pipe) = stderr_pipe {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    let mut stdout = String::new();
+    if let Some(ref mut pipe) = stdout_pipe {
+        let _ = pipe.read_to_string(&mut stdout);
+    }
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("process interrupted by signal SIGINT"),
+        "expected the CLI interrupt message, got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+fn orbit_command(work: &Path, home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_orbit"));
+    test_env::clear_inherited_authority(|name| {
+        command.env_remove(name);
+    });
+    command
+        .current_dir(work)
+        .env("HOME", home)
+        .env("USERPROFILE", home);
+    command
+}
+
+fn spawn_mcp_listen(fixture: &Fixture, addr: SocketAddr) -> Child {
+    orbit_command(&fixture.work, &fixture.home)
+        .args(["mcp", "listen", &addr.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn orbit mcp listen")
+}
+
+fn spawn_cli_proc_spawn(fixture: &Fixture, marker: &Path) -> Child {
+    let input = json!({
+        "program": "/bin/sh",
+        "args": ["-c", format!("touch {} && sleep 30", marker.display())],
+        "timeout_ms": 60_000
+    });
+    let child = orbit_command(&fixture.work, &fixture.home)
+        .args(["tool", "run", "proc.spawn", "--input", &input.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn orbit tool run proc.spawn");
+    wait_for_marker(marker);
+    child
+}
+
+fn free_loopback_addr() -> SocketAddr {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("probe a free loopback port")
+        .local_addr()
+        .expect("probe address")
+}
+
+fn wait_for_listening(addr: SocketAddr) {
+    let deadline = Instant::now() + STARTUP_DEADLINE;
+    loop {
+        if TcpStream::connect(addr).is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("orbit mcp listen did not bind {addr} within {STARTUP_DEADLINE:?}");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn mcp_initialize(writer: &mut TcpStream, reader: &mut TcpStream, workspace: &Path) {
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "orb-11697", "version": "0" },
+            "_meta": { "orbit": { "workspace": workspace.to_str().expect("utf8 workspace") } }
+        }
+    });
+    send_rpc(writer, &initialize);
+    let response = read_rpc_line(reader).expect("initialize response");
+    assert_eq!(
+        response["result"]["protocolVersion"], "2025-06-18",
+        "initialize failed: {response}"
+    );
+    send_rpc(
+        writer,
+        &json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    );
+}
+
+fn send_rpc(writer: &mut TcpStream, message: &Value) {
+    let mut line = serde_json::to_string(message).expect("serialize rpc");
+    line.push('\n');
+    writer.write_all(line.as_bytes()).expect("write rpc");
+    writer.flush().expect("flush rpc");
+}
+
+fn read_rpc_line(reader: &mut TcpStream) -> Option<Value> {
+    let mut line = String::new();
+    BufReader::new(reader).read_line(&mut line).ok()?;
+    if line.trim().is_empty() {
+        return None;
+    }
+    serde_json::from_str(line.trim()).ok()
+}
+
+fn wait_for_marker(path: &Path) {
+    if !wait_for_marker_optional(path, MARKER_DEADLINE) {
+        panic!("child did not become ready: {}", path.display());
+    }
+}
+
+fn wait_for_marker_optional(path: &Path, deadline: Duration) -> bool {
+    let end = Instant::now() + deadline;
+    while Instant::now() < end {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    path.exists()
+}
+
+fn send_signal(child: &Child, signal: i32) {
+    // Safety: `kill` targets this test's already-spawned child with the
+    // signal under test and performs no other side effect.
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, signal) };
+    assert_eq!(
+        rc,
+        0,
+        "failed to send signal {signal}: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Option<std::process::ExitStatus> {
+    let start = Instant::now();
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if start.elapsed() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn assert_signaled_or_nonzero(status: &std::process::ExitStatus, signal: i32) {
+    if status.signal() == Some(signal) {
+        return;
+    }
+    assert!(
+        !status.success(),
+        "expected SIG{signal} or a non-zero exit, got {status:?}"
+    );
+}

--- a/crates/orbit-exec/src/supervision/signal.rs
+++ b/crates/orbit-exec/src/supervision/signal.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 
@@ -11,6 +12,9 @@ const MAX_LIVE_PROCESS_GROUPS: usize = 256;
 static HANDLER_INSTALL: OnceLock<Mutex<HandlerInstall>> = OnceLock::new();
 static LAST_SIGNAL: AtomicI32 = AtomicI32::new(0);
 static SIGNAL_GEN: AtomicU64 = AtomicU64::new(0);
+/// Signal to re-raise after the last waiter restores the previous disposition.
+/// Written only from the async-signal-safe handler; swapped to `0` on last drop.
+static PENDING_FORWARD: AtomicI32 = AtomicI32::new(0);
 static LIVE_PGIDS: [AtomicU32; MAX_LIVE_PROCESS_GROUPS] =
     [const { AtomicU32::new(0) }; MAX_LIVE_PROCESS_GROUPS];
 
@@ -26,9 +30,11 @@ struct PreviousHandlers {
 
 /// Process-wide SIGINT/SIGTERM intercept for the duration of one supervised
 /// wait. Install is refcounted: the first live guard swaps in the handlers,
-/// and the last drop restores the previous dispositions. The install mutex
-/// is held only for that refcount/sigaction critical section — never across
-/// the child's lifetime — so concurrent supervisors overlap.
+/// and the last drop restores the previous dispositions and re-raises the
+/// captured signal so a long-running server's original handler (tokio
+/// `ctrl_c` / SIGTERM, or SIG_DFL) still runs. The install mutex is held
+/// only for that refcount/sigaction critical section — never across the
+/// child's lifetime or across `raise` — so concurrent supervisors overlap.
 pub(super) struct SignalHandlerGuard {
     start_gen: u64,
     slot: Option<usize>,
@@ -100,20 +106,81 @@ fn acquire_handlers() -> Result<u64, OrbitError> {
 }
 
 fn release_handlers() {
-    let Ok(mut state) = handler_install().lock() else {
-        return;
-    };
-    if state.refcount == 0 {
-        return;
-    }
-    state.refcount -= 1;
-    if state.refcount > 0 {
-        return;
-    }
-    if let Some(previous) = state.previous.take() {
+    let pending_raise = {
+        let Ok(mut state) = handler_install().lock() else {
+            return;
+        };
+        if state.refcount == 0 {
+            return;
+        }
+        state.refcount -= 1;
+        if state.refcount > 0 {
+            return;
+        }
+        let Some(previous) = state.previous.take() else {
+            return;
+        };
         restore_signal_handler(libc::SIGINT, &previous.sigint);
         restore_signal_handler(libc::SIGTERM, &previous.sigterm);
+        let pending = PENDING_FORWARD.swap(0, Ordering::SeqCst);
+        pending_forward_action(&previous, pending)
+    };
+
+    // Raise with the install mutex released: the previous handler (tokio's
+    // pipe write, or SIG_DFL terminate) must not re-enter this lock.
+    if let Some((signal, announce)) = pending_raise {
+        if announce {
+            announce_default_termination(signal);
+        }
+        // Safety: previous disposition is restored; `raise` delivers `signal`
+        // to this process so the original handler or default action runs.
+        let _ = unsafe { libc::raise(signal) };
     }
+}
+
+enum PreviousDisposition {
+    Default,
+    Ignore,
+    Custom,
+}
+
+fn previous_disposition(action: &libc::sigaction) -> PreviousDisposition {
+    if action.sa_flags & libc::SA_SIGINFO != 0 {
+        return PreviousDisposition::Custom;
+    }
+    if action.sa_sigaction == libc::SIG_IGN {
+        PreviousDisposition::Ignore
+    } else if action.sa_sigaction == libc::SIG_DFL {
+        PreviousDisposition::Default
+    } else {
+        PreviousDisposition::Custom
+    }
+}
+
+fn pending_forward_action(previous: &PreviousHandlers, pending: i32) -> Option<(i32, bool)> {
+    if pending == 0 {
+        return None;
+    }
+    let action = match pending {
+        libc::SIGINT => &previous.sigint,
+        libc::SIGTERM => &previous.sigterm,
+        _ => return None,
+    };
+    match previous_disposition(action) {
+        PreviousDisposition::Ignore => None,
+        PreviousDisposition::Default => Some((pending, true)),
+        PreviousDisposition::Custom => Some((pending, false)),
+    }
+}
+
+fn announce_default_termination(signal: i32) {
+    // SIG_DFL terminates this process, so the wait-result stderr annotation
+    // never reaches the CLI. Write the same text to the process stderr first.
+    let message = signal_message(signal);
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(message.as_bytes());
+    let _ = stderr.write_all(b"\n");
+    let _ = stderr.flush();
 }
 
 fn handler_install() -> &'static Mutex<HandlerInstall> {
@@ -149,6 +216,7 @@ fn unregister_pgid(slot: Option<usize>) {
 unsafe extern "C" fn termination_signal_handler(signal: libc::c_int) {
     LAST_SIGNAL.store(signal, Ordering::SeqCst);
     SIGNAL_GEN.fetch_add(1, Ordering::SeqCst);
+    PENDING_FORWARD.store(signal, Ordering::SeqCst);
     for slot in &LIVE_PGIDS {
         let pgid = slot.load(Ordering::Relaxed);
         if pgid != 0 {

--- a/crates/orbit-exec/src/supervision/wait.rs
+++ b/crates/orbit-exec/src/supervision/wait.rs
@@ -69,6 +69,8 @@ pub(super) fn wait_with_timeout_and_output_limit(
         .take()
         .map(|err| spawn_stderr_drain(err, debug, output_limit, output_limit_tx));
 
+    // Last drop restores the previous SIGINT/SIGTERM disposition and
+    // re-raises a captured signal so daemons still shut down.
     #[cfg(unix)]
     let signal_guard = SignalHandlerGuard::install(child.id())?;
 

--- a/crates/orbit-exec/tests/signal_fanout.rs
+++ b/crates/orbit-exec/tests/signal_fanout.rs
@@ -9,14 +9,43 @@
 //! This lives in its own test binary so `raise(SIGINT)` cannot interrupt
 //! other `orbit-exec` unit tests sharing a process.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 
+static FORWARDED_SIGNAL: AtomicI32 = AtomicI32::new(0);
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+unsafe extern "C" fn record_previous_handler(signal: libc::c_int) {
+    FORWARDED_SIGNAL.store(signal, Ordering::SeqCst);
+}
+
+/// In-process tests must not restore SIG_DFL: last-drop re-raise would then
+/// terminate the test binary. Install a recorder that stands in for tokio's
+/// previous handler.
+fn install_previous_handler(signal: libc::c_int) {
+    // Safety: test-only `sigaction` for a handler that stores one atomic.
+    unsafe {
+        let mut new_action: libc::sigaction = std::mem::zeroed();
+        new_action.sa_sigaction = record_previous_handler as *const () as usize;
+        new_action.sa_flags = 0;
+        libc::sigemptyset(&mut new_action.sa_mask);
+        let rc = libc::sigaction(signal, &new_action, std::ptr::null_mut());
+        assert_eq!(rc, 0, "install previous handler");
+    }
+}
+
 #[test]
 fn ctrl_c_terminates_every_live_child_process_group() {
+    let _lock = TEST_LOCK.lock().expect("signal test lock");
+    FORWARDED_SIGNAL.store(0, Ordering::SeqCst);
+    install_previous_handler(libc::SIGINT);
+
     let dir = tempfile::tempdir().expect("tempdir");
     let first_ready = dir.path().join("first.ready");
     let second_ready = dir.path().join("second.ready");
@@ -29,20 +58,114 @@ fn ctrl_c_terminates_every_live_child_process_group() {
         wait_for_marker(&second_ready);
 
         // Safety: `raise` delivers SIGINT to this process. The supervised
-        // wait has replaced the default disposition with Orbit's handler.
+        // wait has replaced the previous disposition with Orbit's handler.
         let raised = unsafe { libc::raise(libc::SIGINT) };
         assert_eq!(raised, 0, "raise SIGINT");
 
         let first = first.join().expect("first supervisor thread");
         let second = second.join().expect("second supervisor thread");
-        assert_interrupted(&first);
-        assert_interrupted(&second);
+        assert_interrupted(&first, libc::SIGINT);
+        assert_interrupted(&second, libc::SIGINT);
     });
 
+    assert_eq!(
+        FORWARDED_SIGNAL.load(Ordering::SeqCst),
+        libc::SIGINT,
+        "previous SIGINT handler must run after the child is reaped"
+    );
     assert!(
         started.elapsed() < Duration::from_secs(2),
         "SIGINT should terminate both live children promptly, took {:?}",
         started.elapsed()
+    );
+}
+
+#[test]
+fn sigterm_is_forwarded_to_the_previous_handler() {
+    let _lock = TEST_LOCK.lock().expect("signal test lock");
+    FORWARDED_SIGNAL.store(0, Ordering::SeqCst);
+    install_previous_handler(libc::SIGTERM);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ready = dir.path().join("term.ready");
+
+    thread::scope(|scope| {
+        let waiter = scope.spawn(|| supervise_sleep_after_ready(&ready));
+        wait_for_marker(&ready);
+
+        // Safety: `raise` delivers SIGTERM to this process while Orbit's
+        // supervisor owns the disposition; last drop must restore and
+        // re-raise into the recorder installed above.
+        let raised = unsafe { libc::raise(libc::SIGTERM) };
+        assert_eq!(raised, 0, "raise SIGTERM");
+
+        let result = waiter.join().expect("supervisor thread");
+        assert_interrupted(&result, libc::SIGTERM);
+    });
+
+    assert_eq!(
+        FORWARDED_SIGNAL.load(Ordering::SeqCst),
+        libc::SIGTERM,
+        "previous SIGTERM handler must run after the child is reaped"
+    );
+}
+
+const SIGTERM_HELPER_ENV: &str = "ORBIT_EXEC_SIGTERM_HELPER";
+const SIGTERM_MARKER_ENV: &str = "ORBIT_EXEC_SIGTERM_MARKER";
+
+/// SIGTERM with the default disposition must actually exit the supervisor
+/// process (the `orbit mcp listen` / systemd-stop case).
+#[test]
+fn sigterm_with_default_disposition_exits_the_supervisor() {
+    if std::env::var_os(SIGTERM_HELPER_ENV).is_some() {
+        let marker =
+            PathBuf::from(std::env::var(SIGTERM_MARKER_ENV).expect("marker dir")).join("ready");
+        let _ = supervise_sleep_after_ready(&marker);
+        panic!("supervisor returned instead of dying on SIGTERM");
+    }
+
+    let _lock = TEST_LOCK.lock().expect("signal test lock");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("ready");
+    let exe = std::env::current_exe().expect("current test binary");
+    let mut child = Command::new(&exe)
+        .env(SIGTERM_HELPER_ENV, "1")
+        .env(SIGTERM_MARKER_ENV, dir.path())
+        .args([
+            "--exact",
+            "sigterm_with_default_disposition_exits_the_supervisor",
+            "--nocapture",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn supervisor helper");
+
+    wait_for_marker(&marker);
+    // Safety: SIGTERM targets this test's helper pid — the same signal
+    // systemd sends on stop — and performs no other side effect.
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(rc, 0, "kill helper with SIGTERM");
+
+    let started = Instant::now();
+    let output = wait_child_output(&mut child, Duration::from_secs(8)).unwrap_or_else(|| {
+        panic!("supervisor helper did not exit within the termination grace period")
+    });
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "SIGTERM should exit the supervisor within the child-termination grace period, took {:?}",
+        started.elapsed()
+    );
+    assert!(
+        !output.status.success(),
+        "SIGTERM must exit the supervisor non-zero, got {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("process interrupted by signal SIGTERM"),
+        "stderr was {stderr:?}"
     );
 }
 
@@ -71,19 +194,52 @@ fn wait_for_marker(path: &Path) {
     panic!("child did not become ready: {}", path.display());
 }
 
-fn assert_interrupted(result: &orbit_exec::ExecutionResult) {
+fn assert_interrupted(result: &orbit_exec::ExecutionResult, signal: i32) {
+    let name = match signal {
+        libc::SIGINT => "SIGINT",
+        libc::SIGTERM => "SIGTERM",
+        _ => "UNKNOWN",
+    };
     assert!(!result.success, "interrupted child must not succeed");
     assert_eq!(
         result.exit_code,
-        Some(128 + libc::SIGINT),
-        "parent-signal exits report 128+SIGINT, got {:?}",
+        Some(128 + signal),
+        "parent-signal exits report 128+{name}, got {:?}",
         result.exit_code
     );
+    let expected = format!("process interrupted by signal {name}");
     assert!(
-        result
-            .stderr
-            .contains("process interrupted by signal SIGINT"),
+        result.stderr.contains(&expected),
         "stderr was {:?}",
         result.stderr
     );
+}
+
+fn wait_child_output(
+    child: &mut std::process::Child,
+    deadline: Duration,
+) -> Option<std::process::Output> {
+    let mut stderr_pipe = child.stderr.take().expect("piped stderr");
+    let stderr_thread = thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = std::io::Read::read_to_end(&mut stderr_pipe, &mut buf);
+        buf
+    });
+    let start = Instant::now();
+    let status = loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            break status;
+        }
+        if start.elapsed() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+    Some(std::process::Output {
+        status,
+        stdout: Vec::new(),
+        stderr: stderr_thread.join().unwrap_or_default(),
+    })
 }

--- a/docs/design-patterns/raii_guard.md
+++ b/docs/design-patterns/raii_guard.md
@@ -112,7 +112,7 @@ impl Drop for SignalHandlerGuard {
 }
 ```
 
-`acquire_handlers` takes a process-wide `Mutex` only for the refcount/`sigaction` critical section. The first waiter snapshots the previous SIGINT/SIGTERM dispositions and installs a handler that stores a generation counter and `killpg`s every registered child; the last drop restores those dispositions. Concurrent waits overlap.
+`acquire_handlers` takes a process-wide `Mutex` only for the refcount/`sigaction` critical section. The first waiter snapshots the previous SIGINT/SIGTERM dispositions and installs a handler that stores a generation counter, records a pending forward, and `killpg`s every registered child; the last drop restores those dispositions and re-raises a captured signal (except `SIG_IGN`) with the mutex released. Concurrent waits overlap.
 
 Patterns to copy:
 

--- a/docs/design/policy-sandbox/2_design.md
+++ b/docs/design/policy-sandbox/2_design.md
@@ -3,8 +3,8 @@ summary: "Policy & Sandboxing — Design"
 type: design
 title: "Policy & Sandboxing — Design"
 owner: claude
-last_updated: 2026-09-06
-last_validated: 2026-09-07
+last_updated: 2026-09-08
+last_validated: 2026-09-08
 status: Draft
 feature: policy-sandbox
 doc_role: design
@@ -278,7 +278,7 @@ requires no new ADR.
 
 `process_group_is_alive` uses `killpg(pid, 0)`, treats `ESRCH` as "all gone," and treats other errno values as "still alive" so cleanup errs toward SIGKILL.
 
-`SignalHandlerGuard` is RAII and refcounted: the first live waiter installs SIGINT/SIGTERM handlers and snapshots the previous `sigaction` structs; the last drop restores them. A process-wide mutex covers only that install/drop critical section, so concurrent `run_process` waits overlap. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: it stores the signal, increments the generation, and `killpg`s every registered group. Waiters that miss a slot still observe the generation counter on the next poll and run the ordinary termination path.
+`SignalHandlerGuard` is RAII and refcounted: the first live waiter installs SIGINT/SIGTERM handlers and snapshots the previous `sigaction` structs; the last drop restores them and re-raises a captured signal so a long-running server's original handler (tokio `ctrl_c` / SIGTERM, or SIG_DFL) still runs. `SIG_IGN` is not re-raised. When the previous disposition is SIG_DFL, the process stderr is annotated with `process interrupted by signal SIG…` before `raise`, because the wait result is discarded as the process terminates. A process-wide mutex covers only that install/drop critical section — never `raise` — so concurrent `run_process` waits overlap. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: it stores the signal, increments the generation, records a pending forward, and `killpg`s every registered group. Waiters that miss a slot still observe the generation counter on the next poll and run the ordinary termination path.
 
 Non-Unix builds use a fallback `terminate_process_group` that just calls `child.kill().ok(); child.wait().ok();` — process-group semantics do not apply on Windows, so orphan reaping is best-effort.
 

--- a/docs/design/policy-sandbox/4_decisions.md
+++ b/docs/design/policy-sandbox/4_decisions.md
@@ -3,12 +3,12 @@ summary: "Policy & Sandboxing — Decisions"
 type: design
 title: "Policy & Sandboxing — Decisions"
 owner: claude
-last_updated: 2026-09-06
+last_updated: 2026-09-08
 status: Draft
 feature: policy-sandbox
 doc_role: decisions
 tags: ["policy-sandbox"]
-last_validated: 2026-09-07
+last_validated: 2026-09-08
 ---
 
 # Policy & Sandboxing — Decisions
@@ -150,16 +150,17 @@ A timed-out or interrupted child needs a chance to flush state before being kill
 ## Signal handler installation is process-global and refcounted
 
 **Recorded:** 2026-05-11 02:06:39.403286Z · [T20260417-0558-5]
-**Updated:** 2026-09-07 · [ORB-11692]
+**Updated:** 2026-09-08 · [ORB-11697]
 
 ### Context
 Installing parent-side SIGINT/SIGTERM handlers is a process-global operation. Two concurrent `run_process` calls cannot install independent handlers without races, and a panicking call must restore the prior handler so the orbit process itself remains interruptible. Holding the install mutex for each child's entire lifetime also silently serialized every supervised subprocess in the daemon (parallel job branches, MCP `proc.spawn`, web-server `gh` calls).
 
 ### Decision
-`SignalHandlerGuard::install` refcounts a process-wide handler. The first live waiter installs SIGINT/SIGTERM and snapshots the previous `sigaction` structs; the last drop restores them. The mutex is held only for that install/drop critical section. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: atomic store of the signal and generation, then `killpg` to every registered group. Waiters poll the generation counter and still run `terminate_process_group` so a missed slot or a race with unregister cannot leave a child running.
+`SignalHandlerGuard::install` refcounts a process-wide handler. The first live waiter installs SIGINT/SIGTERM and snapshots the previous `sigaction` structs; the last drop restores them and re-raises a captured signal (except `SIG_IGN`) so daemons still shut down. The mutex is held only for that install/drop critical section, never across `raise`. Each waiter registers its child's pgid in a lock-free table and snapshots a signal generation counter. The handler is async-signal-safe: atomic store of the signal, generation, and pending-forward, then `killpg` to every registered group. Waiters poll the generation counter and still run `terminate_process_group` so a missed slot or a race with unregister cannot leave a child running.
 
 ### Consequences
 - Concurrent `run_process` / `supervise_child` waits overlap. Ctrl-C terminates every live child process group, not only the waiter that would have held an exclusive mutex.
+- The captured SIGINT/SIGTERM is re-raised after restore, so a daemon that installed tokio `ctrl_c` / SIGTERM (or that still has SIG_DFL) actually shuts down instead of swallowing the signal.
 - Panics still restore prior handlers via the last Drop.
 - Cost: at most `MAX_LIVE_PROCESS_GROUPS` children get immediate handler-side `killpg`; additional waiters terminate on the next 100 ms poll instead. The table is not a semaphore.
 

--- a/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
+++ b/docs/design/policy-sandbox/specs/sandbox-exec-contract.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Sandboxed Exec Contract"
 tags: ["policy-sandbox"]
-last_validated: 2026-09-07
+last_validated: 2026-09-08
 ---
 
 # Spec: Sandboxed Exec Contract
@@ -28,7 +28,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 - **Background drains.** `wait_with_optional_timeout` spawns reader threads for stdout and stderr immediately after spawn. The child must never block on a full pipe buffer because the parent is not reading.
 - **Stdin writer thread.** When `StdinMode::Bytes` is set, a writer thread copies the payload to the child's stdin. A failed write terminates the child via `terminate_process_group` and surfaces as `OrbitError::Execution(<message>)`.
 - **Poll interval.** The wait loop polls with `WAIT_POLL_INTERVAL = 100ms` (or the remaining deadline, whichever is smaller). The interval is global and not per-request configurable.
-- **Signal handler installation (Unix).** A `SignalHandlerGuard` refcounts process-wide SIGINT and SIGTERM handlers for the duration of the wait loop. The first live waiter installs the handlers and snapshots the previous `sigaction` structs; the last drop restores them. The install mutex is not held across the wait, so concurrent supervised waits overlap. Each waiter registers its child's pgid in a lock-free table; the handler `killpg`s every registered group and bumps a generation counter that waiters poll.
+- **Signal handler installation (Unix).** A `SignalHandlerGuard` refcounts process-wide SIGINT and SIGTERM handlers for the duration of the wait loop. The first live waiter installs the handlers and snapshots the previous `sigaction` structs; the last drop restores them and re-raises a captured signal so the previous disposition still runs (tokio shutdown, or SIG_DFL terminate). `SIG_IGN` is not re-raised. SIG_DFL additionally writes `process interrupted by signal SIG…` to the process stderr before `raise`. The install mutex is not held across the wait or across `raise`, so concurrent supervised waits overlap. Each waiter registers its child's pgid in a lock-free table; the handler `killpg`s every registered group, records a pending forward, and bumps a generation counter that waiters poll.
 - **Timeout escalation.** When the deadline expires, `terminate_process_group(child, SIGTERM, poll_interval)` is called. If the group does not exit within `TERMINATION_GRACE_PERIOD = 5 seconds`, `kill_process_group` (SIGKILL) is invoked plus a direct `child.kill()`/`child.wait()`.
 - **Parent-signal escalation.** When the parent receives SIGINT or SIGTERM during the wait, the same termination path runs with the received signal. The result reports `exit_code = Some(128 + signal)` and `success = false`.
 - **Clean-exit reaping.** When the child exits cleanly, the wait loop calls `kill_process_group(child.id())` to reap any orphan subprocesses still holding pipe write ends, then joins the reader threads. Without this, an orphan grandchild can keep the pipes open and block reader-thread completion indefinitely.
@@ -56,7 +56,7 @@ Process supervision is full of subtle deadlocks (full pipe buffers, orphan grand
 
 ## Concurrency Constraints
 
-- **Shared signal-handler install, overlapping waits.** On Unix, concurrent `run_process` / `supervise_child` calls share one SIGINT/SIGTERM disposition (refcounted). Their wait loops overlap. Ctrl-C terminates every live registered process group; waiters that could not claim a pgid slot still observe the generation counter and run the ordinary termination path.
+- **Shared signal-handler install, overlapping waits.** On Unix, concurrent `run_process` / `supervise_child` calls share one SIGINT/SIGTERM disposition (refcounted). Their wait loops overlap. Ctrl-C terminates every live registered process group; waiters that could not claim a pgid slot still observe the generation counter and run the ordinary termination path. After the last waiter restores the previous disposition, the captured signal is re-raised so the parent still shuts down.
 - **No assumption about thread-local state.** Reader threads, writer threads, and the signal handler are spawned with `'static` requirements; callers must not rely on thread-local data from the spawning thread.
 - **No retry inside `run_process`.** The runner does not retry spawn failures, wait errors, or signal-install failures. Retry policy belongs to the caller.
 


### PR DESCRIPTION
## Task

[ORB-11697](https://orbit-cli.com/tasks/ORB-11697) — [code-review] Do not swallow SIGTERM/SIGINT delivered to a long-running server while it supervises a child

### Description

## Problem
While a child is supervised, `SignalHandlerGuard` replaces the process's SIGINT and SIGTERM disposition with a handler that only writes a byte to a pipe. The wait loop then terminates the child's process group and returns `Err("process interrupted by signal …")` — but the parent never re-raises or otherwise honours the signal, and the previous handler (tokio's `ctrl_c`/`signal` registration in `mcp serve`, `web serve`, sweep daemons) is only restored afterwards, so the signal is lost. Scenario: `systemctl stop orbit-web` (SIGTERM) while a dashboard request is running a `gh` query via `run_process`: the `gh` child is killed, the HTTP handler returns an error, and the server keeps running; systemd escalates to SIGKILL after its timeout.

## Why It Matters
Daemons ignore graceful-shutdown signals whenever a tool subprocess happens to be running, which is exactly when a graceful stop matters most.

## Proposed Fix
After terminating the child, re-raise the captured signal with the previous disposition restored (`restore_signal_handler` then `libc::raise(signal)`), or make the guard cooperative: only install Orbit's handler when no other handler is installed (`previous.sa_handler == SIG_DFL`), and otherwise leave the existing handler and rely on the caller's cancellation path.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-exec/src/supervision/signal.rs:88-101`, `crates/orbit-exec/src/supervision/wait.rs:109-126`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: mcp-tools.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Integration test: start `orbit mcp listen`, call `proc.spawn sleep 30`, send SIGTERM to the server; the server exits within the grace period.
- The CLI path (`orbit` invoked interactively) still returns "process interrupted by signal SIGINT" and exits non-zero on Ctrl-C.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `SignalHandlerGuard` last drop now restores the previous SIGINT/SIGTERM dispositions and re-raises the captured signal (`SIG_IGN` skipped). Custom previous handlers (tokio) run; SIG_DFL writes `process interrupted by signal SIG…` to process stderr then `raise`s so the supervisor actually dies.
- In-process `signal_fanout` tests install a recorder handler so re-raise does not kill the test binary; a subprocess test covers SIGTERM+SIG_DFL.
- CLI integration tests cover interactive SIGINT during `orbit tool run proc.spawn` and SIGTERM while a supervised child is live.
- Current supervision docs describe restore-and-re-raise.
Assessment: Small, single-path fix at the signal-guard boundary. Files stay well under 800 lines. No new crate edges.

Criteria:
1. SIGTERM while supervising a child exits within the grace period — passed. `orbit-exec` helper (`sigterm_with_default_disposition_exits_the_supervisor`) and `orbit tool run proc.spawn` + SIGTERM exit promptly. `orbit mcp listen` is started in the same integration test; `proc.spawn` is not MCP-advertised, so the listen process cannot host that child (friction F2026-09-065). Coverage is the same `orbit` binary / `SignalHandlerGuard` contract, not an in-listen `tools/call`.
2. CLI Ctrl-C still reports `process interrupted by signal SIGINT` and exits non-zero — passed (`cli_ctrl_c_during_proc_spawn_reports_interrupt`).

Validation:
- `cargo test -p orbit-exec --test signal_fanout -- --nocapture` — passed (3 tests)
- `cargo test -p orbit-exec --lib -- supervision` — passed (3 tests)
- `cargo test -p orbit-cli --test supervised_parent_signal -- --nocapture` — passed (2 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Strategic decisions: Always intercept to kill the child process group, then restore and re-raise. Cooperative-only-if-SIG_DFL would leave mcp listen (no tokio watcher) still installing Orbit's handler and swallowing SIGTERM.
Design weaknesses / risks:
- Severity: low. Mitigation: `proc.spawn` remains off the unauthenticated MCP listen surface; SIGTERM coverage uses CLI `proc.spawn` plus the exec helper.
- Re-raise from Drop after restore: previous handler must not take the install mutex (tokio's does not).
Deviations: listen `tools/call proc.spawn` cannot install the guard; see F2026-09-065.
Remaining risks: none for the SIG_DFL / custom-handler contracts that were tested. Windows is unchanged (`cfg(unix)`).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11697-6a9f5359`
- Behind base: 0
- Ahead of base: 1