### PR TITLE
Detect incompatible semantic-index layouts across installed Orbit runtimes

### DIFF
--- a/crates/orbit-core/src/application/search/hybrid.rs
+++ b/crates/orbit-core/src/application/search/hybrid.rs
@@ -154,6 +154,12 @@ pub(super) fn fallback_reason(error: &OrbitError) -> String {
         OrbitError::CompanionNotInstalled(_) => {
             "optional inference companion unavailable".to_string()
         }
+        OrbitError::Store(message)
+            if message
+                .contains("semantic index layout is incompatible with this Orbit runtime") =>
+        {
+            message.clone()
+        }
         _ => error.to_string(),
     }
 }

--- a/crates/orbit-core/src/application/search/tests/hybrid.rs
+++ b/crates/orbit-core/src/application/search/tests/hybrid.rs
@@ -111,6 +111,56 @@ fn global_search_task_hybrid_falls_back_without_install_remediation() {
 }
 
 #[test]
+fn global_search_task_hybrid_layout_incompatibility_is_lexical_fallback_not_hybrid_success() {
+    let runtime = OrbitRuntime::in_memory().expect("runtime");
+    let id = add_task_with_status(&runtime, "layout mismatch needle", TaskStatus::Backlog);
+
+    let response = with_task_semantic_override(
+        Err(OrbitError::Store(
+            "semantic index layout is incompatible with this Orbit runtime: \
+             corpus_fts is an external-content FTS5 table over chunks and has no \
+             source_kind column. Upgrade and restart every Orbit process that \
+             opens this workspace's .orbit/state/semantic.db, including Homebrew \
+             installs and MCP servers."
+                .to_string(),
+        )),
+        || {
+            runtime
+                .global_search(GlobalSearchParams {
+                    query: Some("layout mismatch needle".to_string()),
+                    hybrid: true,
+                    kind: GlobalSearchKind::Task,
+                    limit: 3,
+                    ..Default::default()
+                })
+                .expect("layout mismatch should keep lexical search")
+        },
+    );
+
+    assert_eq!(
+        response.mode,
+        GlobalSearchMode::Lexical,
+        "layout mismatch is lexical fallback, not hybrid success: notes={:?}",
+        response.notes
+    );
+    assert!(response.notes.iter().any(|note| {
+        note.contains("falling back to lexical task search")
+            && note.contains("semantic index layout is incompatible with this Orbit runtime")
+            && note.contains("Upgrade and restart every Orbit process")
+    }));
+    assert!(
+        response
+            .notes
+            .iter()
+            .all(|note| !note.to_ascii_lowercase().contains("no such column")),
+        "fallback notes must not leak the unexplained SQL-column error: {:?}",
+        response.notes
+    );
+    assert_eq!(response.results[0].source, "lexical");
+    assert_eq!(response.results[0].id.as_deref(), Some(id.as_str()));
+}
+
+#[test]
 fn global_search_doc_hybrid_uses_docs_semantic_weight() {
     let runtime = OrbitRuntime::in_memory().expect("runtime");
     add_doc_with_tags(&runtime, "docs/z-lexical.md", "Literal primary", &["foo"]);

--- a/crates/orbit-search/src/vector/query/bm25.rs
+++ b/crates/orbit-search/src/vector/query/bm25.rs
@@ -29,6 +29,8 @@ pub fn bm25_top_k(
     let conn = conn
         .lock()
         .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
+    let fts_err =
+        |error| crate::vector::store::schema::translate_corpus_fts_sql_error(&conn, error);
     let mut hits = Vec::new();
     if let Some(kind) = kind {
         let mut stmt = conn
@@ -47,10 +49,10 @@ pub fn bm25_top_k(
                     LIMIT ?3
                 "#,
             )
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
+            .map_err(fts_err)?;
         let mut rows = stmt
             .query(params![match_query, kind, limit as i64])
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
+            .map_err(fts_err)?;
         collect_hits(&mut rows, &mut hits)?;
     } else {
         let mut stmt = conn
@@ -69,10 +71,10 @@ pub fn bm25_top_k(
                     LIMIT ?2
                 "#,
             )
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
+            .map_err(fts_err)?;
         let mut rows = stmt
             .query(params![match_query, limit as i64])
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
+            .map_err(fts_err)?;
         collect_hits(&mut rows, &mut hits)?;
     }
     Ok(hits)
@@ -132,7 +134,7 @@ fn snippet_by_rowid(store: &VectorStore, rowid: i64) -> Result<Option<String>, O
     .map(Some)
     .or_else(|error| match error {
         rusqlite::Error::QueryReturnedNoRows => Ok(None),
-        other => Err(OrbitError::Store(other.to_string())),
+        other => Err(crate::vector::store::schema::translate_corpus_fts_sql_error(&conn, other)),
     })
 }
 
@@ -159,7 +161,7 @@ fn snippet_by_chunk_idx(
     .map(Some)
     .or_else(|error| match error {
         rusqlite::Error::QueryReturnedNoRows => Ok(None),
-        other => Err(OrbitError::Store(other.to_string())),
+        other => Err(crate::vector::store::schema::translate_corpus_fts_sql_error(&conn, other)),
     })
 }
 

--- a/crates/orbit-search/src/vector/query/tests/bm25.rs
+++ b/crates/orbit-search/src/vector/query/tests/bm25.rs
@@ -1,8 +1,11 @@
 //! Unit tests for `bm25` — sibling layout under vector/query/tests/.
 
+use rusqlite::Connection;
+
 use super::super::bm25::{bm25_top_k, fts_terms_query, snippet_for_hit};
 
 use crate::NoopEmbedder;
+use crate::vector::store::schema::SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE;
 use crate::vector::{EmbeddingField, VectorStore};
 
 #[test]
@@ -123,4 +126,72 @@ fn snippet_lookup_preserves_chunk_order() {
     let snippet = snippet_for_hit(&store, "task", "T1", "purpose", Some(1), None).unwrap();
 
     assert_eq!(snippet.as_deref(), Some("second chunk"));
+}
+
+/// Opening a pre-[ORB-11695] inline `corpus_fts` through the current runtime
+/// migrates in place; BM25 and snippets then read `chunks`, and the migrated
+/// rows stay put. This is not a dual-read shim for older binaries.
+#[test]
+fn bm25_and_snippets_survive_inline_to_external_content_migration() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("semantic.db");
+    {
+        let conn = Connection::open(&path).expect("seed db");
+        conn.execute_batch(
+            r#"
+                CREATE VIRTUAL TABLE corpus_fts USING fts5(
+                    source_kind UNINDEXED,
+                    source_id UNINDEXED,
+                    field UNINDEXED,
+                    content,
+                    tokenize = 'porter unicode61 remove_diacritics 2'
+                );
+                INSERT INTO corpus_fts(source_kind, source_id, field, content)
+                VALUES
+                    ('task', 'T1', 'purpose', 'gamma neutrino'),
+                    ('doc', 'docs/a.md', 'body', 'unrelated');
+            "#,
+        )
+        .expect("seed inline corpus");
+    }
+
+    let store = VectorStore::open(&path).expect("open migrates layout");
+    let hits = bm25_top_k(&store, "neutrino", Some("task"), 5).expect("current bm25");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].source_kind, "task");
+    assert_eq!(hits[0].source_id, "T1");
+    assert_eq!(hits[0].field, "purpose");
+
+    let snippet = snippet_for_hit(&store, "task", "T1", "purpose", Some(0), None)
+        .expect("snippet")
+        .expect("migrated chunk text");
+    assert_eq!(snippet, "gamma neutrino");
+
+    let conn = store.connection();
+    let conn = conn.lock().expect("lock");
+    let leftover_inline: i64 = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM pragma_table_info('corpus_fts') WHERE name = 'source_kind')",
+            [],
+            |row| row.get(0),
+        )
+        .expect("pragma");
+    assert_eq!(
+        leftover_inline, 0,
+        "migration must not restore inline columns"
+    );
+    let chunks: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
+        .expect("chunk count");
+    assert_eq!(chunks, 2);
+
+    let mismatch =
+        crate::vector::store::schema::evaluate_legacy_inline_reader(&conn, "neutrino", "task")
+            .expect_err("old inline reader against migrated store");
+    let message = mismatch.to_string();
+    assert!(
+        message.contains(SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE),
+        "{message}"
+    );
+    assert!(!message.to_ascii_lowercase().contains("no such column"));
 }

--- a/crates/orbit-search/src/vector/store/mod.rs
+++ b/crates/orbit-search/src/vector/store/mod.rs
@@ -18,7 +18,7 @@
 
 mod docs;
 mod queries;
-mod schema;
+pub(crate) mod schema;
 mod tasks;
 mod upsert;
 

--- a/crates/orbit-search/src/vector/store/schema.rs
+++ b/crates/orbit-search/src/vector/store/schema.rs
@@ -12,6 +12,12 @@
 //! earlier layout stored the chunk text and its metadata inside `corpus_fts`
 //! itself, where every non-`MATCH` access degraded into a full scan
 //! [ORB-11695]; `adopt_inline_corpus_fts` migrates those databases in place.
+//!
+//! The layout is forward-only. Mixed installed binaries during an upgrade are
+//! an operational fact, but they must not share a migrated `semantic.db`:
+//! restoring the old FTS columns would let an older writer desynchronize the
+//! index from `chunks`. Older readers that `SELECT source_kind FROM corpus_fts`
+//! get [`incompatible_semantic_index_layout_error`], not a raw SQL column miss.
 
 use orbit_common::OrbitError;
 use rusqlite::Connection;
@@ -177,6 +183,131 @@ fn migrate_legacy_task_fts(conn: &Connection) -> Result<(), OrbitError> {
     conn.execute(&format!("DROP TABLE {legacy_table}"), [])
         .map_err(store_error)?;
     Ok(())
+}
+
+/// How `corpus_fts` is physically stored. The pre-[ORB-11695] layout kept
+/// `source_kind` / `source_id` / `field` as UNINDEXED columns on the FTS
+/// table; the current layout is an external-content FTS5 index over `chunks`
+/// and those columns no longer exist on `corpus_fts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CorpusFtsLayout {
+    Missing,
+    /// Orbit 0.19.0 and earlier: `SELECT source_kind FROM corpus_fts` works.
+    InlineMetadata,
+    /// Post-[ORB-11695]: BM25 must join `chunks`; inline-column readers cannot.
+    ExternalContent,
+}
+
+/// Exact BM25 projection shipped in Orbit 0.19.0, before `corpus_fts` lost its
+/// inline metadata columns. Current runtimes must not use this SQL against a
+/// migrated index; [`evaluate_legacy_inline_reader`] is the compatibility
+/// boundary that names that mismatch.
+#[cfg(test)]
+pub(crate) const LEGACY_INLINE_BM25_SQL: &str = "SELECT source_kind, source_id, field, rowid, bm25(corpus_fts) FROM corpus_fts WHERE corpus_fts MATCH ?1 AND source_kind=?2";
+
+/// Prefix of the operator-facing diagnostic when a reader hits a `corpus_fts`
+/// layout this binary cannot use. Matched by hybrid fallback notes; do not
+/// include task IDs in the rest of the message either.
+pub(crate) const SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE: &str =
+    "semantic index layout is incompatible with this Orbit runtime";
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LegacyInlineHit {
+    pub source_kind: String,
+    pub source_id: String,
+    pub field: String,
+    pub rowid: i64,
+}
+
+pub(crate) fn corpus_fts_layout(conn: &Connection) -> Result<CorpusFtsLayout, OrbitError> {
+    if !table_exists(conn, "corpus_fts")? {
+        return Ok(CorpusFtsLayout::Missing);
+    }
+    if corpus_fts_has_inline_columns(conn)? {
+        Ok(CorpusFtsLayout::InlineMetadata)
+    } else {
+        Ok(CorpusFtsLayout::ExternalContent)
+    }
+}
+
+/// Run the pre-migration BM25 reader. On the live old-reader/new-layout
+/// mismatch this returns [`incompatible_semantic_index_layout_error`] instead
+/// of leaking `no such column: source_kind`.
+#[cfg(test)]
+pub(crate) fn evaluate_legacy_inline_reader(
+    conn: &Connection,
+    query: &str,
+    kind: &str,
+) -> Result<Vec<LegacyInlineHit>, OrbitError> {
+    let mut stmt = conn
+        .prepare(LEGACY_INLINE_BM25_SQL)
+        .map_err(|error| translate_corpus_fts_sql_error(conn, error))?;
+    let mut rows = stmt
+        .query(rusqlite::params![query, kind])
+        .map_err(|error| translate_corpus_fts_sql_error(conn, error))?;
+    let mut hits = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| translate_corpus_fts_sql_error(conn, error))?
+    {
+        hits.push(LegacyInlineHit {
+            source_kind: row
+                .get(0)
+                .map_err(|error| translate_corpus_fts_sql_error(conn, error))?,
+            source_id: row
+                .get(1)
+                .map_err(|error| translate_corpus_fts_sql_error(conn, error))?,
+            field: row
+                .get(2)
+                .map_err(|error| translate_corpus_fts_sql_error(conn, error))?,
+            rowid: row
+                .get(3)
+                .map_err(|error| translate_corpus_fts_sql_error(conn, error))?,
+        });
+    }
+    Ok(hits)
+}
+
+pub(crate) fn translate_corpus_fts_sql_error(
+    conn: &Connection,
+    error: rusqlite::Error,
+) -> OrbitError {
+    if !is_corpus_fts_layout_sql_error(&error) {
+        return store_error(error);
+    }
+    match corpus_fts_layout(conn) {
+        Ok(layout) => incompatible_semantic_index_layout_error(layout),
+        Err(_) => store_error(error),
+    }
+}
+
+pub(crate) fn incompatible_semantic_index_layout_error(layout: CorpusFtsLayout) -> OrbitError {
+    let detail = match layout {
+        CorpusFtsLayout::ExternalContent => {
+            "corpus_fts is an external-content FTS5 table over chunks and has no source_kind \
+             column. Hybrid BM25 requires a current Orbit binary. Upgrade and restart every \
+             Orbit process that opens this workspace's .orbit/state/semantic.db, including \
+             Homebrew installs and MCP servers; a newer cargo build that already migrated the \
+             index does not upgrade those processes."
+        }
+        CorpusFtsLayout::InlineMetadata | CorpusFtsLayout::Missing => {
+            "corpus_fts still uses inline metadata columns and has no chunks table. This binary \
+             expected the external-content layout. Re-open the workspace with a writable current \
+             Orbit binary so the in-place migration can run."
+        }
+    };
+    OrbitError::Store(format!(
+        "{SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE}: {detail} Lexical (non-hybrid) task and doc \
+         lookup does not use this index and remains valid. Do not delete or downgrade \
+         semantic.db to make an older binary work."
+    ))
+}
+
+fn is_corpus_fts_layout_sql_error(error: &rusqlite::Error) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    (message.contains("no such column") && message.contains("source_kind"))
+        || (message.contains("no such table") && message.contains("chunks"))
 }
 
 /// True when `corpus_fts` still carries the chunk metadata and text itself,

--- a/crates/orbit-search/src/vector/store/tests/schema.rs
+++ b/crates/orbit-search/src/vector/store/tests/schema.rs
@@ -2,7 +2,10 @@
 
 use rusqlite::Connection;
 
-use super::super::schema::{ensure_vector_schema, legacy_task_fts_table, table_exists};
+use super::super::schema::{
+    CorpusFtsLayout, LEGACY_INLINE_BM25_SQL, SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE, corpus_fts_layout,
+    ensure_vector_schema, evaluate_legacy_inline_reader, legacy_task_fts_table, table_exists,
+};
 
 /// The pre-[ORB-11695] layout: chunk text and its metadata lived in the FTS5
 /// table itself, so every non-`MATCH` access was a full scan.
@@ -184,4 +187,119 @@ fn chunk_access_paths_use_indexes_instead_of_scanning_the_corpus() {
             "query must not scan the chunk table: {sql}\nplan: {plan}"
         );
     }
+}
+
+#[test]
+fn unmigrated_inline_corpus_fts_still_answers_the_pre_migration_reader() {
+    let conn = Connection::open_in_memory().expect("open db");
+    conn.execute_batch(&format!(
+        r#"
+            {INLINE_CORPUS_FTS_DDL}
+            INSERT INTO corpus_fts(source_kind, source_id, field, content)
+            VALUES ('task', 'T1', 'purpose', 'gamma neutrino');
+        "#
+    ))
+    .expect("seed inline corpus");
+
+    assert_eq!(
+        corpus_fts_layout(&conn).expect("layout"),
+        CorpusFtsLayout::InlineMetadata
+    );
+    let hits = evaluate_legacy_inline_reader(&conn, "neutrino", "task").expect("legacy reader");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].source_id, "T1");
+    assert_eq!(hits[0].field, "purpose");
+}
+
+/// Forward-only contract: after [ORB-11695] migrates inline `corpus_fts` into
+/// `chunks` + external-content FTS, the Orbit 0.19.0 BM25 projection cannot
+/// read the index. The chosen result is an explicit layout diagnostic, not a
+/// leaked `no such column: source_kind`. Current JOIN/snippet SQL and the
+/// migrated rows stay intact; the index is not downgraded.
+#[test]
+fn migrated_external_content_rejects_pre_migration_inline_reader() {
+    let conn = open_migrated(&format!(
+        r#"
+            {INLINE_CORPUS_FTS_DDL}
+            INSERT INTO corpus_fts(source_kind, source_id, field, content)
+            VALUES
+                ('task', 'T1', 'purpose', 'gamma neutrino'),
+                ('doc', 'docs/a.md', 'body', 'unrelated');
+        "#
+    ));
+
+    assert_eq!(
+        corpus_fts_layout(&conn).expect("layout"),
+        CorpusFtsLayout::ExternalContent
+    );
+    assert_eq!(count(&conn, "SELECT COUNT(*) FROM chunks"), 2);
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM chunks WHERE source_kind = 'task' AND source_id = 'T1'"
+        ),
+        1
+    );
+
+    let raw = conn
+        .prepare(LEGACY_INLINE_BM25_SQL)
+        .expect_err("migrated corpus_fts must not expose source_kind");
+    let raw_message = raw.to_string().to_ascii_lowercase();
+    assert!(
+        raw_message.contains("no such column") && raw_message.contains("source_kind"),
+        "raw sqlite must still be the live 0.19.0 symptom, proving columns were not restored: {raw}"
+    );
+
+    let error = evaluate_legacy_inline_reader(&conn, "neutrino", "task")
+        .expect_err("legacy reader against external-content layout");
+    let message = error.to_string();
+    assert!(
+        message.contains(SEMANTIC_INDEX_LAYOUT_INCOMPATIBLE),
+        "mismatched reader must name the layout contract: {message}"
+    );
+    assert!(
+        message.contains("Upgrade and restart every Orbit process"),
+        "diagnostic must say which processes to restart: {message}"
+    );
+    assert!(
+        message.contains("Lexical (non-hybrid) task and doc"),
+        "diagnostic must keep lexical lookup in scope: {message}"
+    );
+    assert!(
+        !message.to_ascii_lowercase().contains("no such column"),
+        "must not leak the unexplained SQL-column error: {message}"
+    );
+
+    let current: Vec<(String, String)> = conn
+        .prepare(
+            r#"
+                SELECT chunks.source_id, chunks.field
+                FROM corpus_fts
+                JOIN chunks ON chunks.id = corpus_fts.rowid
+                WHERE corpus_fts MATCH 'neutrino' AND chunks.source_kind = 'task'
+            "#,
+        )
+        .expect("prepare current reader")
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .expect("query current reader")
+        .collect::<Result<_, _>>()
+        .expect("collect current reader");
+    assert_eq!(
+        current,
+        vec![("T1".to_string(), "purpose".to_string())],
+        "current JOIN reader must keep working on the migrated index"
+    );
+    assert_eq!(
+        conn.query_row(
+            r#"
+                SELECT content FROM chunks
+                WHERE source_kind = 'task' AND source_id = 'T1'
+                  AND field = 'purpose' AND chunk_idx = 0
+            "#,
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("snippet"),
+        "gamma neutrino"
+    );
 }

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -234,6 +234,8 @@ CREATE VIRTUAL TABLE corpus_fts USING fts5(
 
 The external-content split is what keeps reindexing linear. Everything the writer does outside a `MATCH` — pruning a source, replacing one field, resolving a snippet, asking which fields a source already has indexed — addresses rows by `(source_kind, source_id, field, chunk_idx)` or by rowid. Holding that metadata inside the FTS5 table made each of those a full corpus scan, so a no-op reindex of a few thousand sources cost tens of seconds of pure scanning.
 
+This layout is forward-only. Older Orbit binaries that selected `source_kind` from `corpus_fts` itself cannot read a migrated `semantic.db`. Mixed installed runtimes during an upgrade must restart every process that opens the index onto a current binary; the index is not dual-written for the old reader and is not downgraded. See [Upgrade Orbit Safely](../../runbooks/upgrades.md#mixed-binaries-and-the-workspace-semantic-index).
+
 ### 5.2 Reciprocal Rank Fusion
 
 Both retrievers run in parallel for a query. Each returns a ranked list of `(source_id, field, chunk_idx)` candidates. RRF combines them:

--- a/docs/runbooks/upgrades.md
+++ b/docs/runbooks/upgrades.md
@@ -4,8 +4,8 @@ summary: Install a new Orbit release with `orbit update`, then review, apply, an
 tags: [operations, upgrades, migrations, recovery]
 paths: ["crates/orbit-cmd/src/update/**", "crates/orbit-store/src/workflow/layout/**", "crates/orbit-store/src/driver/sqlite/migration/**"]
 related_features: [orbit-core]
-related_artifacts: [ORB-10014, ORB-11280, ORB-11344]
-last_validated: 2026-09-07
+related_artifacts: [ORB-10014, ORB-11280, ORB-11344, ORB-11695, ORB-11753]
+last_validated: 2026-09-08
 ---
 
 # Upgrade Orbit Safely
@@ -219,6 +219,57 @@ than the newest version this orbit binary supports (1); upgrade orbit to open th
 The schema ledger has the same guard:
 `store database schema version N is newer than the newest version this orbit binary supports`.
 Upgrade the binary. Never hand-edit `layout.version` to force the workspace open.
+
+## Mixed binaries and the workspace semantic index
+
+`.orbit/state/semantic.db` is a **forward-only** layout, independent of the workspace-layout and store-schema ledgers above. A current Orbit binary migrates `corpus_fts` from inline metadata columns (`source_kind`, `source_id`, `field`) to an external-content FTS5 table over `chunks`. The migration is in place: it does not rewrite task or doc source records, and it does not rebuild embeddings.
+
+Older binaries still run the pre-migration BM25 projection:
+
+```sql
+SELECT source_kind, source_id, field, rowid, bm25(corpus_fts)
+FROM corpus_fts
+WHERE corpus_fts MATCH ?1 AND source_kind=?2
+```
+
+Against a migrated index that query fails with `no such column: source_kind`. Hybrid search on that older process then falls back to lexical ranking. Plain lexical task and doc lookup does not use `semantic.db` and is not broken.
+
+This mismatch is not a dual-read contract. Restoring the old FTS columns would let an older writer insert into `corpus_fts` without writing `chunks`, desynchronizing the index. Do not delete `semantic.db` to make the older binary work, and do not downgrade the schema.
+
+### Which process to upgrade or restart
+
+The binary that **already migrated** the file is current. Restart or upgrade every **other** Orbit process that still has the file open — typically a Homebrew or MCP install that is older than the cargo/`~/.orbit/bin` build:
+
+```sh
+type -a orbit
+/opt/homebrew/bin/orbit --version
+~/.cargo/bin/orbit --version
+~/.orbit/bin/orbit --version
+```
+
+On macOS, `lsof` on `.orbit/state/semantic.db` shows which process holds the migrated index. Align `PATH`, any explicit `ORBIT_BIN`, MCP client command paths, and long-lived dashboard/pipeline workers with the current binary, then restart those processes so they reopen the file. Building or running a newer cargo `orbit` does not upgrade Homebrew or change which executable an already-started MCP server is using.
+
+`orbit update` is the install-channel upgrade for Orbit-owned binaries; Homebrew packages upgrade through Homebrew. This runbook does not authorize replacing a global executable, restarting a host service, or rebuilding the live index as part of diagnosing the mismatch.
+
+### Distinguish lexical fallback from full hybrid success
+
+Ask the **same executable** the MCP client or agent is using, not a different `orbit` on `PATH`:
+
+```sh
+/path/to/suspect/orbit tool run orbit.search --input '{"query":"<term>","kind":"task","hybrid":true,"limit":2,"model":"codex"}'
+```
+
+Read `mode` and `notes` together:
+
+| Observation | Meaning |
+| --- | --- |
+| `mode` is `hybrid` and `notes` is empty | Full hybrid success on a current runtime. |
+| `mode` is `lexical` and a note contains `falling back to lexical` plus `semantic index layout is incompatible` | The answering process cannot read this `semantic.db` layout. Upgrade/restart **that** process. Lexical hits are not hybrid ranking. |
+| `mode` is `lexical` and a note contains `no such column` / `source_kind` | Same mismatch, reported by an older binary that does not yet translate the SQL error. Same remedy: upgrade/restart that process. |
+| `mode` is `lexical` with a companion/embeddings fallback note, no layout diagnostic | Hybrid was skipped for an unrelated reason (missing companion, empty embeddings). Layout is fine. |
+| Hybrid unset / `hybrid: false` | Lexical-only by request. Success here does not prove hybrid works. |
+
+A current binary on the same workspace answering `mode: hybrid` with empty notes, while an older MCP process on the same `semantic.db` falls back, is the mixed-runtime case — not a corrupt index.
 
 ## Verify the upgrade
 


### PR DESCRIPTION
## Task

[ORB-11753](https://orbit-cli.com/tasks/ORB-11753) — Detect incompatible semantic-index layouts across installed Orbit runtimes

### Description

Observed live during dsearch orchestration 2026-09-08: Mac has Homebrew /opt/homebrew/bin/orbit 0.19.0 (all current local MCP processes verified with lsof) and /Users/daniel/.cargo/bin/orbit 0.19.2. Both access authoritative ws_dsearch at /Users/daniel/workspace/repos/dsearch. DANI-10312 worker reported orbit.search SQL failure no such column source_kind. Independently reproduced on the host: 0.19.0 registered orbit.search with {workspace:ws_dsearch,query:launcher,kind:task,hybrid:true,all:true,limit:2,model:codex} warns no such column source_kind in SELECT source_kind, source_id, field, rowid, bm25(corpus_fts) FROM corpus_fts WHERE corpus_fts MATCH ?1 AND source_kind=?2 at offset 28, then falls back to lexical. The identical 0.19.2 query succeeds with mode=hybrid and no notes. Plain lexical task lookup succeeds; do not describe all search as broken.

ORB-11695's delivered migration replaces inline corpus_fts metadata columns with chunks plus an external-content FTS table. Its recorded migration explains this old-reader/new-layout mismatch. Mixed installed runtimes remain a supported operational reality during upgrades; determine the intended compatibility/upgrade boundary explicitly. Prevent unexplained SQL failures or silent incompatible index reuse: provide an actionable runtime/schema incompatibility diagnostic and documented safe upgrade/restart procedure, or preserve compatibility if that is the chosen supported contract. Do not blindly delete/rebuild the live index, downgrade its schema, or add an unstated compatibility shim. Newer-runtime search must remain correct and source task/doc records must remain untouched. No global executable replacement, server restart, merge or release is authorized by this task.

Search covered source_kind, mixed runtime and prior migration coverage; ORB-11695 owns the indexing performance migration, not this observed cross-version failure. Trace exact introducing commit in that task before setting regression attribution.

### Acceptance Criteria

- A deterministic old-inline to new-external-content migration fixture exercises mismatched-reader behavior and produces the explicit chosen compatibility result rather than an unexplained SQL-column error.
- Current runtime hybrid search, snippets, task/doc lookup and source records remain correct; no destructive index downgrade or global runtime replacement.
- Operator guidance explains which runtime must be restarted/upgraded, and validation distinguishes lexical fallback from full hybrid success.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Stated a forward-only semantic-index contract: mixed installed binaries are an operational fact during upgrades, but they must not share a migrated `.orbit/state/semantic.db`. Restoring inline `corpus_fts` columns was rejected because an older writer would desync FTS from `chunks`.
- `schema.rs` detects `CorpusFtsLayout` and translates the Orbit 0.19.0 BM25 projection (`SELECT source_kind … FROM corpus_fts`) into an explicit store diagnostic (upgrade/restart every process that opens this workspace's semantic.db, including Homebrew/MCP; lexical non-hybrid lookup remains valid; do not delete or downgrade the index). Raw `no such column: source_kind` is no longer the current-runtime result.
- Current BM25/snippet SQL still joins `chunks`. Layout-mismatch SQL (`no such column`/`source_kind`, `no such table`/`chunks`) is rewritten through the same diagnostic. Hybrid fallback notes keep `mode=lexical` and the diagnostic, distinct from `mode=hybrid` with empty notes.
- Operator runbook section plus a short design-doc note name which process to restart (the older MCP/Homebrew binary, not the cargo build that already migrated) and how to read `mode`/`notes`.
- Regression attribution: `source_task_id=ORB-11695`; introducing commit `9b1a7243f`, merge `7556303c0`.

Assessment: Scoped to the search-index compatibility boundary. No live-index rebuild, schema downgrade, global binary replacement, or dual-write shim.

Strategic decisions: Forward-only layout rather than a compatibility shim. Shipped 0.19.0 will still print the SQL-column miss until those processes are upgraded; current and future binaries diagnose it.

Added context_files: `file:crates/orbit-search/src/vector/query/bm25.rs`, `file:crates/orbit-search/src/vector/query/tests/bm25.rs`, `file:crates/orbit-core/src/application/search/hybrid.rs`, `file:crates/orbit-core/src/application/search/tests/hybrid.rs`, `file:docs/design/orbit-search/2_design.md`, `file:crates/orbit-search/src/vector/store/mod.rs` (schema module made `pub(crate)` for the translator).

Acceptance criteria:
1. Old-inline → new-external-content fixture exercises the 0.19.0 SQL; raw SQLite still reports the column miss (columns were not restored); `evaluate_legacy_inline_reader` returns the layout diagnostic — met (`migrated_external_content_rejects_pre_migration_inline_reader`).
2. Current JOIN BM25, snippets, and migrated chunk rows remain correct; no destructive rebuild — met (`bm25_and_snippets_survive_inline_to_external_content_migration`, existing schema/bm25 tests, 71 orbit-search lib tests).
3. Runbook names the older MCP/Homebrew process to restart and a `mode`/`notes` table distinguishing lexical fallback from hybrid success; hybrid unit test locks `mode=lexical` plus the diagnostic — met.

Validation:
- `CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0025-6-target cargo test -p orbit-search --lib` — passed (71 tests, including the new schema/bm25 fixtures).
- `CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0025-6-target cargo test -p orbit-core --lib application::search::tests::hybrid` — passed (8 tests, including layout-incompatibility → lexical fallback).
- `make ci-fast` — passed.
- `CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0025-6-target make ci-lint` — passed.
- `git diff --check` — passed (no output).
- `GIT_OPTIONAL_LOCKS=0 git status --short` — 9 modified files, uncommitted.
- `make ci` — not run (workspace policy: PR merge gate).
- Live macOS Homebrew 0.19.0 MCP vs cargo 0.19.2 — not re-run here; this Linux worktree cannot prove host PATH/MCP selection. The fixture reproduces the SQL mismatch and the chosen diagnostic.

Remaining risks: already-running 0.19.0 processes keep the unexplained SQL warning until they are restarted onto a current binary. That is the documented operator step, not a current-runtime defect. No friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11753-6a9f55ed`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra