### PR TITLE
[code-review] Give `AutoTaskSchedule` a readable parse error instead of "did not match any variant of untagged enum"

### DIFF
--- a/crates/orbit-common/src/protocol/tests/yaml.rs
+++ b/crates/orbit-common/src/protocol/tests/yaml.rs
@@ -1,5 +1,5 @@
 use crate::OrbitError;
-use crate::protocol::yaml::{parse_local_routine_yaml, parse_routine_yaml};
+use crate::protocol::yaml::{parse_auto_task_yaml, parse_local_routine_yaml, parse_routine_yaml};
 use orbit_types::workflow::{MissedRunPolicy, OverlapPolicy, RoutineTarget};
 
 const VALID_ROUTINE: &str = r#"
@@ -17,6 +17,70 @@ policy:
   retries: { max: 2, backoff_minutes: 2 }
   overlap: forbid
 "#;
+
+const AUTO_TASK_PREFIX: &str = r#"
+schemaVersion: 1
+name: schedule-test
+schedule:
+"#;
+
+const AUTO_TASK_TEMPLATE: &str = r#"
+template:
+  title: Schedule test
+"#;
+
+#[test]
+fn auto_task_schedule_rejects_unknown_keys_with_accepted_forms() {
+    let error = parse_auto_task_yaml(&format!(
+        "{AUTO_TASK_PREFIX}  every_minute: 5\n{AUTO_TASK_TEMPLATE}"
+    ))
+    .expect_err("unknown schedule key must fail");
+    let message = error.to_string();
+
+    for expected in ["every_minute", "cron", "every_minutes", "deliveries_landed"] {
+        assert!(message.contains(expected), "{message}");
+    }
+}
+
+#[test]
+fn auto_task_schedule_rejects_multiple_forms_with_readable_error() {
+    let error = parse_auto_task_yaml(&format!(
+        "{AUTO_TASK_PREFIX}  cron: \"* * * * *\"\n  every_minutes: 5\n{AUTO_TASK_TEMPLATE}"
+    ))
+    .expect_err("multiple schedule forms must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("exactly one of cron, every_minutes, deliveries_landed"),
+        "{error}"
+    );
+}
+
+#[test]
+fn auto_task_schedule_forms_round_trip_through_yaml() {
+    let schedules = [
+        "  cron: \"* * * * *\"\n",
+        "  every_minutes: 5\n",
+        concat!(
+            "  deliveries_landed:\n",
+            "    branch: agent-main\n",
+            "    threshold: 1\n",
+            "    max_wait_minutes: 60\n",
+            "    coverage: landed_code_review_v1\n"
+        ),
+    ];
+
+    for schedule in schedules {
+        let definition =
+            parse_auto_task_yaml(&format!("{AUTO_TASK_PREFIX}{schedule}{AUTO_TASK_TEMPLATE}"))
+                .expect("schedule form must parse");
+        let serialized = serde_yaml::to_string(&definition).expect("serialize schedule form");
+        let reparsed = parse_auto_task_yaml(&serialized).expect("reparse schedule form");
+
+        assert_eq!(reparsed, definition);
+    }
+}
 
 #[test]
 fn parses_the_design_doc_example() {

--- a/crates/orbit-types/src/workflow/auto_task.rs
+++ b/crates/orbit-types/src/workflow/auto_task.rs
@@ -12,7 +12,7 @@
 //! is provider-neutral: the template carries crew / priority / type only —
 //! there are no turn-based budget knobs anywhere in the definition.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::error::WorkflowError;
 use crate::task::{TaskPriority, TaskStatus, TaskType};
@@ -74,8 +74,8 @@ pub struct AutoTaskDefinition {
 
 /// When a definition is due. Exactly one form is present per definition; the
 /// scheduler's due-math (orbit-core) collapses catch-up fires either way.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
 pub enum AutoTaskSchedule {
     /// Verified landings, independent of task completion.
     Deliveries {
@@ -85,6 +85,50 @@ pub enum AutoTaskSchedule {
     Cron { cron: String },
     /// Fire every N minutes, anchored at the definition's first-observed slot.
     Interval { every_minutes: u64 },
+}
+
+/// Wire representation used to preserve field-specific errors while enforcing
+/// the schedule's one-form invariant.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSchedule {
+    cron: Option<String>,
+    every_minutes: Option<u64>,
+    deliveries_landed: Option<super::automation::DeliveryTrigger>,
+}
+
+impl<'de> Deserialize<'de> for AutoTaskSchedule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawSchedule::deserialize(deserializer)?;
+        let mut forms = Vec::new();
+
+        if raw.cron.is_some() {
+            forms.push("cron");
+        }
+        if raw.every_minutes.is_some() {
+            forms.push("every_minutes");
+        }
+        if raw.deliveries_landed.is_some() {
+            forms.push("deliveries_landed");
+        }
+
+        match (raw.cron, raw.every_minutes, raw.deliveries_landed) {
+            (Some(cron), None, None) => Ok(Self::Cron { cron }),
+            (None, Some(every_minutes), None) => Ok(Self::Interval { every_minutes }),
+            (None, None, Some(deliveries_landed)) => Ok(Self::Deliveries { deliveries_landed }),
+            _ => Err(<D::Error as serde::de::Error>::custom(format!(
+                "schedule must have exactly one of cron, every_minutes, deliveries_landed; found: {}",
+                if forms.is_empty() {
+                    "none".to_string()
+                } else {
+                    forms.join(", ")
+                }
+            ))),
+        }
+    }
 }
 
 /// The task template instantiated on each fire. Provider-neutral (ADR-0217):


### PR DESCRIPTION
## Task

[ORB-11736](https://orbit-cli.com/tasks/ORB-11736) — [code-review] Give `AutoTaskSchedule` a readable parse error instead of "did not match any variant of untagged enum"

### Description

## Problem
`AutoTaskSchedule` is `#[serde(untagged, deny_unknown_fields)]`. Any mistake in the `schedule:` block (a typo such as `every_minute: 5`, a negative interval, `cron` plus `every_minutes` together, a missing `branch` inside `deliveries_landed`) surfaces to the operator as `auto-task: data did not match any variant of untagged enum AutoTaskSchedule at line N` via `parse_auto_task_yaml`, because serde discards each variant's specific error. The definition is then fail-closed (correct) but the load-error row and `orbit auto-task validate` give no hint which key was wrong. The interval bound and the deliveries validation errors (auto_task.rs:165-179) are never reached for shape errors.

## Why It Matters
Auto-task YAML is operator-authored; the only error message for the most common editing mistakes names no field.

## Proposed Fix
Replace the untagged derive with a custom `Deserialize` that reads the mapping into a small `RawSchedule { cron: Option<String>, every_minutes: Option<u64>, deliveries_landed: Option<DeliveryTrigger> }` with `deny_unknown_fields`, then errors with a message naming the present/missing keys ("schedule must have exactly one of cron, every_minutes, deliveries_landed; found: ..."). Keep the serialized shape identical.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-types/src/workflow/auto_task.rs:70-83`, `crates/orbit-common/src/protocol/yaml.rs:34-35`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: `schedule: {every_minute: 5}` fails with a message that contains `every_minute` and lists the three accepted keys.
- Test: `schedule: {cron: "* * * * *", every_minutes: 5}` fails with a message saying exactly one form is allowed.
- Existing round-trip tests for the three schedule forms still pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced untagged schedule deserialization with a deny-unknown-fields raw mapping that preserves field-specific serde errors and reports the present forms when the one-form invariant fails.
- Kept untagged serialization and added protocol-boundary coverage for typo diagnostics, mutually exclusive forms, and all three schedule round trips.
Assessment: The schedule shape now fails closed with actionable operator messages while retaining the existing YAML serialization contract.
Criteria:
- `every_minute` is rejected with the typo and all accepted schedule keys in the message.
- `cron` plus `every_minutes` is rejected with the exactly-one-form diagnostic.
- Cron, interval, and deliveries schedules round-trip through YAML.
Validation:
- passed: `cargo test -p orbit-common protocol::tests::yaml --lib` (14 tests).
- passed: `make ci-fast`.
- passed: `make ci-lint`.
- passed: `git diff --check`.
Risks: None identified; changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11736-6a9f5958`
- Behind base: 0
- Ahead of base: 1