### PR TITLE
Expose active provider liveness and v2 step progress through workflow run show

### DIFF
--- a/crates/orbit-cli/src/command/run/show.rs
+++ b/crates/orbit-cli/src/command/run/show.rs
@@ -61,9 +61,11 @@ pub(crate) fn run_show_payload(
     let doc = json!({
         "run": run_projection,
         "pipeline_state": state,
+        // The same projection the registered/MCP run-show surface emits, so
+        // both readers name a live child identically [ORB-11752].
         "provider_processes": provider_processes
             .iter()
-            .map(provider_process_to_json)
+            .map(RunProviderProcess::to_json)
             .collect::<Vec<_>>(),
     });
 
@@ -174,23 +176,6 @@ fn live_provider_process_lines(processes: &[RunProviderProcess]) -> String {
             )
         })
         .collect()
-}
-
-fn provider_process_to_json(process: &RunProviderProcess) -> Value {
-    json!({
-        "event_id": process.event_id,
-        "ts": process.ts.map(|ts| ts.to_rfc3339()),
-        "step_id": process.step_id,
-        "step_index": process.step_index,
-        "provider": process.provider,
-        "pid": process.pid,
-        "pid_start_time": process.pid_start_time,
-        "finished": process.finished,
-        "liveness": process.liveness.as_str(),
-        "exit_code": process.exit_code,
-        "timed_out": process.timed_out,
-        "duration_ms": process.duration_ms,
-    })
 }
 
 pub(crate) fn legacy_logs_summary_payload(

--- a/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
+++ b/crates/orbit-core/assets/skills/orbit/references/run-debugging.md
@@ -53,6 +53,29 @@ workflow failure. A recovery attempt is secondary evidence: `succeeded` does
 not rewrite that original failure, and a failed `authorization`, preparation,
 `dispatch`, or `activity` attempt explains why recovery did not complete.
 
+### Tell a working agent from an abandoned wrapper
+
+For a run that is still `running`, `orbit_workflow_run_show` carries
+`execution_progress`: the activity step that is open and the provider children
+it spawned. Only `show` carries it — `orbit_workflow_run_list` pages many runs
+and does not pay for an audit scan and a liveness probe per row.
+
+Its `state` is `observed` when the run has a v2 audit trail and `unavailable`
+when it has none, so an empty projection never has to be read as "nothing is
+running". `active_step` names the open `step_id` and `step_index`, and each
+`provider_processes.items` entry names the child's `pid`, `provider`, owning
+step, and a `liveness` of `alive`, `exited`, or `unknown`.
+
+`liveness` is judged against the identity token recorded with the PID, so a
+recycled PID reads `exited` rather than a false `alive`, and a PID recorded in
+another PID namespace reads `unknown` rather than a false `exited`. A child with
+`finished: true` carries its `exit_code` instead. `limit` and `truncated` say
+when a long retry history was bounded; open children are never the ones dropped.
+
+A `running` run whose open step has no `alive` child is the signature of an
+abandoned wrapper. `orbit run show <run_id> --json` reports the same
+`provider_processes` for the owning host.
+
 ### Verify model routing before reading logs
 
 `orbit run show <run_id> --json` separates three identities: `requested_crew`

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -2,6 +2,9 @@ use std::collections::BTreeSet;
 
 use chrono::Utc;
 use orbit_common::OrbitError;
+use orbit_common::process::identity::{
+    STABLE_TOKEN_PREFIX, current_pid_namespace, process_start_identity_token,
+};
 use orbit_tools::ToolContext;
 use orbit_types::policy::Role;
 use orbit_types::task::TaskStatus;
@@ -148,6 +151,70 @@ fn seed_recovery_attempt(
             payload_json: event.to_string(),
         })
         .expect("seed recovery attempt audit event");
+}
+
+/// Seed one v2 audit event for `run_id`. `body` supplies the event-specific
+/// fields; the envelope keys every reader needs are filled in here.
+fn seed_v2_event(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    event_id: &str,
+    ts: &str,
+    parent_event_id: Option<&str>,
+    body: Value,
+) {
+    let mut event = json!({
+        "schemaVersion": 1,
+        "event_type": "test.event",
+        "event_id": event_id,
+        "ts": ts,
+        "run_id": run_id,
+        "agent_identity": "codex",
+        "parent_event_id": parent_event_id,
+    });
+    let object = event.as_object_mut().expect("event object");
+    for (key, value) in body.as_object().expect("event body").clone() {
+        object.insert(key, value);
+    }
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: event_id.to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "test.event".to_string(),
+            ts: chrono::DateTime::parse_from_rfc3339(ts)
+                .expect("fixture timestamp")
+                .with_timezone(&Utc),
+            run_id: run_id.to_string(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: parent_event_id.map(str::to_string),
+            workspace_path: None,
+            payload_json: event.to_string(),
+        })
+        .expect("seed v2 audit event");
+}
+
+fn seed_running_run(runtime: &OrbitRuntime) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_auto_pipeline", 1, Utc::now(), None, None)
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), std::process::id())
+        .expect("start run");
+    run.run_id
+}
+
+/// A PID this process can vouch for, with the identity token that proves the
+/// probe is looking at the same process. Deterministically alive: it is the
+/// test itself.
+fn live_pid_and_token() -> (u32, Option<String>) {
+    let pid = std::process::id();
+    (pid, process_start_identity_token(pid))
 }
 
 /// ORB-10540: the in-run denial, driven by the environment rather than by a
@@ -497,4 +564,367 @@ fn mcp_run_observation_carries_an_empty_lineage_for_a_run_without_children() {
     .expect("operator run show");
 
     assert_eq!(shown["child_dispatches"], json!([]));
+}
+
+/// [ORB-11752] The gap this task closes: a `running` run whose registered
+/// projection reported a wrapper PID and nothing about the implementation
+/// child. `execution_progress` names the open step and the live provider
+/// process, so an orchestrator can tell a working agent from an abandoned
+/// wrapper without falling back to an operator command.
+#[test]
+fn mcp_run_show_names_the_active_step_and_its_live_provider_child() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run_id = seed_running_run(&runtime);
+    let (pid, pid_start_time) = live_pid_and_token();
+
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-prepare",
+        "2026-09-08T00:06:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "prepare_worktree"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-prepare-done",
+        "2026-09-08T00:06:10Z",
+        None,
+        json!({"body_kind": "step_finished", "step_id": "prepare_worktree", "outcome": "success"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-implement",
+        "2026-09-08T00:06:20Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-activity",
+        "2026-09-08T00:06:21Z",
+        Some("evt-implement"),
+        json!({"body_kind": "activity_started"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-process",
+        "2026-09-08T00:06:22Z",
+        Some("evt-activity"),
+        json!({
+            "body_kind": "cli_invocation_process",
+            "provider": "codex",
+            "pid": pid,
+            "pid_start_time": pid_start_time,
+        }),
+    );
+
+    let shown = run_tool_as_operator(&runtime, "orbit.workflow.run.show", json!({"id": run_id}))
+        .expect("operator run show");
+
+    let progress = &shown["execution_progress"];
+    assert_eq!(progress["state"], json!("observed"));
+    assert_eq!(progress["active_step"]["step_id"], json!("implement_one"));
+    assert_eq!(progress["active_step"]["step_index"], json!(1));
+    assert_eq!(
+        progress["active_step"]["started_at"],
+        json!("2026-09-08T00:06:20+00:00")
+    );
+
+    let processes = &progress["provider_processes"];
+    assert_eq!(processes["truncated"], json!(false));
+    assert_eq!(processes["items"].as_array().expect("items").len(), 1);
+    let child = &processes["items"][0];
+    assert_eq!(child["pid"], json!(pid));
+    assert_eq!(child["provider"], json!("codex"));
+    assert_eq!(child["step_id"], json!("implement_one"));
+    assert_eq!(child["step_index"], json!(1));
+    assert_eq!(child["finished"], json!(false));
+    assert_eq!(child["liveness"], json!("alive"));
+
+    // The evidence is additive: everything the surface already answered is
+    // still on the same response.
+    assert_eq!(shown["run_id"], json!(run_id));
+    assert_eq!(shown["state"], json!("running"));
+    assert_eq!(shown["child_dispatches"], json!([]));
+    assert_eq!(shown["recovery_attempts"]["state"], json!("not_attempted"));
+    assert_eq!(shown["agent_invocation"], Value::Null);
+
+    // `list` pages up to 200 runs, so it does not pay for an audit scan and a
+    // liveness probe per row.
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+    assert_eq!(listed["items"][0]["execution_progress"], Value::Null);
+}
+
+/// Retries and parallel invocations under one step stay separable: each spawn
+/// keeps its own exit evidence, and only the child that never reported an exit
+/// is probed for liveness.
+#[test]
+fn mcp_run_show_separates_a_finished_child_from_the_open_retry() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run_id = seed_running_run(&runtime);
+    let (pid, pid_start_time) = live_pid_and_token();
+
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-step",
+        "2026-09-08T00:06:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+    for (activity, process, spawned_pid) in [
+        ("evt-first", "evt-first-pid", 424_242_u32),
+        ("evt-second", "evt-second-pid", pid),
+    ] {
+        seed_v2_event(
+            &runtime,
+            &run_id,
+            activity,
+            "2026-09-08T00:06:01Z",
+            Some("evt-step"),
+            json!({"body_kind": "activity_started"}),
+        );
+        seed_v2_event(
+            &runtime,
+            &run_id,
+            process,
+            "2026-09-08T00:06:02Z",
+            Some(activity),
+            json!({
+                "body_kind": "cli_invocation_process",
+                "provider": "codex",
+                "pid": spawned_pid,
+                "pid_start_time": if spawned_pid == pid { json!(pid_start_time) } else { Value::Null },
+            }),
+        );
+    }
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-first-done",
+        "2026-09-08T00:06:30Z",
+        Some("evt-first"),
+        json!({"body_kind": "cli_invocation_finished", "exit_code": 137, "duration_ms": 28_000}),
+    );
+
+    let shown = run_tool_as_operator(&runtime, "orbit.workflow.run.show", json!({"id": run_id}))
+        .expect("operator run show");
+    let items = shown["execution_progress"]["provider_processes"]["items"]
+        .as_array()
+        .expect("items")
+        .clone();
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["pid"], json!(424_242));
+    assert_eq!(items[0]["finished"], json!(true));
+    assert_eq!(items[0]["exit_code"], json!(137));
+    assert_eq!(items[0]["duration_ms"], json!(28_000));
+    // A child that reported its exit is not probed: it is `exited` by record.
+    assert_eq!(items[0]["liveness"], json!("exited"));
+
+    assert_eq!(items[1]["pid"], json!(pid));
+    assert_eq!(items[1]["finished"], json!(false));
+    assert_eq!(items[1]["exit_code"], Value::Null);
+    assert_eq!(items[1]["liveness"], json!("alive"));
+}
+
+/// A recycled PID is not a live agent. The recorded identity token is what
+/// separates "my child is still running" from "some unrelated process now
+/// holds that number", and a PID recorded in a foreign PID namespace is
+/// `unknown` rather than a false `exited`.
+#[test]
+fn mcp_run_show_rejects_a_recycled_pid_and_refuses_to_judge_a_foreign_namespace() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let run_id = seed_running_run(&runtime);
+    let pid = std::process::id();
+
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-step",
+        "2026-09-08T00:06:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &run_id,
+        "evt-recycled",
+        "2026-09-08T00:06:02Z",
+        Some("evt-step"),
+        json!({
+            "body_kind": "cli_invocation_process",
+            "provider": "codex",
+            "pid": pid,
+            // A live PID whose recorded start identity disagrees with the
+            // process holding it now.
+            "pid_start_time": format!(
+                "{}pidns={}:Thu Jan  1 00:00:00 1970",
+                STABLE_TOKEN_PREFIX,
+                current_pid_namespace().unwrap_or("-"),
+            ),
+        }),
+    );
+
+    let shown = run_tool_as_operator(&runtime, "orbit.workflow.run.show", json!({"id": run_id}))
+        .expect("operator run show");
+    assert_eq!(
+        shown["execution_progress"]["provider_processes"]["items"][0]["liveness"],
+        json!("exited")
+    );
+
+    // Only Linux reports a PID namespace, so only there can a reader stand
+    // outside the one a PID was recorded in.
+    #[cfg(target_os = "linux")]
+    {
+        let foreign_run_id = seed_running_run(&runtime);
+        seed_v2_event(
+            &runtime,
+            &foreign_run_id,
+            "evt-foreign-step",
+            "2026-09-08T00:06:00Z",
+            None,
+            json!({"body_kind": "step_started", "step_id": "implement_one"}),
+        );
+        seed_v2_event(
+            &runtime,
+            &foreign_run_id,
+            "evt-foreign",
+            "2026-09-08T00:06:02Z",
+            Some("evt-foreign-step"),
+            json!({
+                "body_kind": "cli_invocation_process",
+                "provider": "codex",
+                "pid": pid,
+                "pid_start_time": format!("{STABLE_TOKEN_PREFIX}pidns=1:Thu Jan  1 00:00:00 1970"),
+            }),
+        );
+
+        let foreign = run_tool_as_operator(
+            &runtime,
+            "orbit.workflow.run.show",
+            json!({"id": foreign_run_id}),
+        )
+        .expect("operator run show");
+        assert_eq!(
+            foreign["execution_progress"]["provider_processes"]["items"][0]["liveness"],
+            json!("unknown")
+        );
+    }
+}
+
+/// A run with no v2 audit trail — a legacy run, or one whose trail was never
+/// written — reports `unavailable`, which is not the same claim as "nothing is
+/// running". A long retry history is bounded, and the open child keeps its
+/// place in the budget.
+#[test]
+fn mcp_run_show_marks_a_missing_trail_unavailable_and_bounds_a_long_history() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let legacy_run_id = seed_running_run(&runtime);
+
+    let legacy = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": legacy_run_id}),
+    )
+    .expect("operator run show");
+    let progress = &legacy["execution_progress"];
+    assert_eq!(progress["state"], json!("unavailable"));
+    assert_eq!(progress["active_step"], Value::Null);
+    assert_eq!(progress["provider_processes"]["items"], json!([]));
+    assert_eq!(progress["provider_processes"]["limit"], json!(8));
+    assert_eq!(progress["provider_processes"]["truncated"], json!(false));
+
+    let busy_run_id = seed_running_run(&runtime);
+    seed_v2_event(
+        &runtime,
+        &busy_run_id,
+        "evt-step",
+        "2026-09-08T00:06:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+    // One open child spawned first, then more finished retries than the budget
+    // carries: the open one must survive the truncation.
+    let (pid, pid_start_time) = live_pid_and_token();
+    seed_v2_event(
+        &runtime,
+        &busy_run_id,
+        "evt-open-activity",
+        "2026-09-08T00:06:01Z",
+        Some("evt-step"),
+        json!({"body_kind": "activity_started"}),
+    );
+    seed_v2_event(
+        &runtime,
+        &busy_run_id,
+        "evt-open-pid",
+        "2026-09-08T00:06:02Z",
+        Some("evt-open-activity"),
+        json!({
+            "body_kind": "cli_invocation_process",
+            "provider": "codex",
+            "pid": pid,
+            "pid_start_time": pid_start_time,
+        }),
+    );
+    for retry in 0..12u32 {
+        let activity = format!("evt-retry-{retry}-activity");
+        seed_v2_event(
+            &runtime,
+            &busy_run_id,
+            &activity,
+            &format!("2026-09-08T00:07:{retry:02}Z"),
+            Some("evt-step"),
+            json!({"body_kind": "activity_started"}),
+        );
+        seed_v2_event(
+            &runtime,
+            &busy_run_id,
+            &format!("evt-retry-{retry}-pid"),
+            &format!("2026-09-08T00:08:{retry:02}Z"),
+            Some(&activity),
+            json!({
+                "body_kind": "cli_invocation_process",
+                "provider": "codex",
+                "pid": 500_000 + retry,
+            }),
+        );
+        seed_v2_event(
+            &runtime,
+            &busy_run_id,
+            &format!("evt-retry-{retry}-done"),
+            &format!("2026-09-08T00:09:{retry:02}Z"),
+            Some(&activity),
+            json!({"body_kind": "cli_invocation_finished", "exit_code": 1}),
+        );
+    }
+
+    let busy = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": busy_run_id}),
+    )
+    .expect("operator run show");
+    let processes = &busy["execution_progress"]["provider_processes"];
+    let items = processes["items"].as_array().expect("items");
+    assert_eq!(processes["truncated"], json!(true));
+    assert_eq!(items.len(), 8);
+    assert_eq!(items[0]["pid"], json!(pid), "the open child must survive");
+    assert_eq!(items[0]["liveness"], json!("alive"));
+    assert_eq!(
+        items
+            .iter()
+            .skip(1)
+            .map(|item| item["pid"].as_u64().expect("pid"))
+            .collect::<Vec<_>>(),
+        (500_005_u64..=500_011).collect::<Vec<_>>(),
+        "the newest finished retries fill the rest of the budget"
+    );
 }

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -8,6 +8,7 @@ use orbit_types::workflow::{JobRun, JobRunState};
 use serde_json::{Value, json};
 
 use crate::application::job::{DrainWorkerLimitRequest, JobRunListParams};
+use crate::runtime::run_audit::{RunExecutionProgress, RunProviderProcess};
 use crate::{OrbitRuntime, ShipMode};
 
 use super::input::{parse_optional_string_array_field, parse_string_array_field};
@@ -61,7 +62,47 @@ pub(super) fn ship(
 
 pub(super) fn show(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {
     let id = orbit_common::protocol::tool_input::required_string(&input, &["id"], "id")?;
-    run_json_with_lineage(runtime, &runtime.show_job_run(&id)?)
+    let run = runtime.show_job_run(&id)?;
+    let mut value = run_json_with_lineage(runtime, &run)?;
+    value["execution_progress"] = execution_progress_json(runtime, &run.run_id);
+    Ok(value)
+}
+
+/// [ORB-11752] What the run is doing right now, for the reader that asked
+/// about exactly one run.
+///
+/// Without it this surface can report a `running` wrapper PID and nothing
+/// else, so a healthy implementation agent and an abandoned wrapper look
+/// identical here and an orchestrator has to fall back to an operator command.
+/// `list` deliberately does not carry it: the evidence costs an audit scan plus
+/// a liveness probe per open child, which is the right price for one deliberate
+/// read and the wrong one for a 200-run page.
+///
+/// The projection is identifiers, timestamps and process facts only — no
+/// provider output — so it stays bounded and carries nothing to redact. An
+/// unreadable audit trail degrades to `unavailable` rather than failing the
+/// durable run read, as every other evidence field here does.
+fn execution_progress_json(runtime: &OrbitRuntime, run_id: &str) -> Value {
+    let progress = runtime
+        .collect_run_execution_progress(run_id)
+        .unwrap_or_else(|_| RunExecutionProgress::unavailable());
+    json!({
+        "state": progress.state,
+        "active_step": progress.active_step.map(|step| json!({
+            "step_id": step.step_id,
+            "step_index": step.step_index,
+            "started_at": step.started_at.map(|value| value.to_rfc3339()),
+        })),
+        "provider_processes": {
+            "limit": progress.limit,
+            "truncated": progress.truncated,
+            "items": progress
+                .provider_processes
+                .iter()
+                .map(RunProviderProcess::to_json)
+                .collect::<Vec<_>>(),
+        },
+    })
 }
 
 pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitError> {

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -118,6 +118,67 @@ pub struct RunProviderProcess {
     pub liveness: ProcessLiveness,
 }
 
+impl RunProviderProcess {
+    /// The operator-facing projection of one provider child.
+    ///
+    /// Shared by the CLI and the registered/MCP run-show surfaces so both
+    /// readers name the same process with the same keys; a child that is alive
+    /// in one and absent from the other is the failure this projection exists
+    /// to prevent. `run_id` is omitted: every caller already knows the run it
+    /// asked about.
+    pub fn to_json(&self) -> Value {
+        serde_json::json!({
+            "event_id": self.event_id,
+            "ts": self.ts.map(|ts| ts.to_rfc3339()),
+            "step_id": self.step_id,
+            "step_index": self.step_index,
+            "provider": self.provider,
+            "pid": self.pid,
+            "pid_start_time": self.pid_start_time,
+            "finished": self.finished,
+            "liveness": self.liveness.as_str(),
+            "exit_code": self.exit_code,
+            "timed_out": self.timed_out,
+            "duration_ms": self.duration_ms,
+        })
+    }
+}
+
+/// [ORB-11752] What a run is doing *right now*: the activity step that is open
+/// and the provider children it spawned, each with a liveness verdict.
+///
+/// This is the evidence that separates a healthy implementation agent from an
+/// abandoned wrapper. `state` is `observed` when the run has a v2 audit trail
+/// and `unavailable` when it has none — a legacy run, or one whose trail was
+/// never written. An `observed` progress with no active step and no open child
+/// is a run between steps, which is a different fact from having no evidence.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunExecutionProgress {
+    pub state: &'static str,
+    pub active_step: Option<RunAuditStep>,
+    pub provider_processes: Vec<RunProviderProcess>,
+    pub limit: usize,
+    pub truncated: bool,
+}
+
+impl RunExecutionProgress {
+    /// The empty projection: no v2 audit trail, or one this reader could not
+    /// open. Never confused with "nothing is running".
+    pub fn unavailable() -> Self {
+        Self {
+            state: "unavailable",
+            active_step: None,
+            provider_processes: Vec::new(),
+            limit: MAX_PROVIDER_PROCESSES,
+            truncated: false,
+        }
+    }
+}
+
+/// Provider children carried on the progress projection. A run spawns a
+/// handful per step; the budget only bites on a long retry history.
+const MAX_PROVIDER_PROCESSES: usize = 8;
+
 impl OrbitRuntime {
     /// Provider subprocesses recorded for a run, oldest first, each with a
     /// liveness verdict for the ones that have not reported an exit.
@@ -145,94 +206,63 @@ impl OrbitRuntime {
         P: Fn(u32, Option<&str>) -> ProcessLiveness,
     {
         let events = self.collect_run_audit_events(run_id)?;
-        let step_index_by_id = self
-            .collect_run_audit_steps(run_id)?
-            .into_iter()
-            .map(|step| (step.step_id, step.step_index))
-            .collect::<HashMap<_, _>>();
-        let mut records: Vec<RunProviderProcess> = Vec::new();
-        // The direct parent of a provider process / completion event is the
-        // invocation that emitted it. Keep that correlation private to this
-        // reconstruction rather than projecting it as a new API field.
-        let mut invocation_parent_by_process_event = HashMap::<String, String>::new();
+        let steps = audit_steps_from_events(&events);
+        Ok(provider_processes_from_events(
+            run_id,
+            events,
+            &step_index_by_id(&steps),
+            probe,
+        ))
+    }
 
-        for event in events {
-            match event.body_kind.as_deref() {
-                Some("cli_invocation_process") => {
-                    let Some(pid) = event
-                        .raw
-                        .get("pid")
-                        .and_then(Value::as_u64)
-                        .and_then(|pid| u32::try_from(pid).ok())
-                    else {
-                        continue;
-                    };
-                    let step_index = event
-                        .step_id
-                        .as_ref()
-                        .and_then(|step_id| step_index_by_id.get(step_id).copied());
-                    if let Some(parent_event_id) = &event.parent_event_id {
-                        invocation_parent_by_process_event
-                            .insert(event.event_id.clone(), parent_event_id.clone());
-                    }
-                    records.push(RunProviderProcess {
-                        run_id: event
-                            .raw
-                            .get("run_id")
-                            .and_then(Value::as_str)
-                            .unwrap_or(run_id)
-                            .to_string(),
-                        event_id: event.event_id,
-                        ts: event.timestamp,
-                        step_index,
-                        step_id: event.step_id,
-                        provider: event
-                            .raw
-                            .get("provider")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        pid,
-                        pid_start_time: event
-                            .raw
-                            .get("pid_start_time")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        finished: false,
-                        exit_code: None,
-                        timed_out: false,
-                        duration_ms: None,
-                        // Overwritten below; only unfinished records are probed.
-                        liveness: ProcessLiveness::Exited,
-                    });
-                }
-                Some("cli_invocation_finished") => {
-                    let Some(record) = matching_provider_process_for_completion(
-                        &mut records,
-                        &invocation_parent_by_process_event,
-                        &event,
-                    ) else {
-                        continue;
-                    };
-                    record.finished = true;
-                    record.exit_code = event.raw.get("exit_code").and_then(Value::as_i64);
-                    record.timed_out = event
-                        .raw
-                        .get("timed_out")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false);
-                    record.duration_ms = event.raw.get("duration_ms").and_then(Value::as_u64);
-                }
-                _ => {}
-            }
+    /// [ORB-11752] The run's live progress: open activity step plus a bounded,
+    /// liveness-probed view of the provider children it spawned.
+    ///
+    /// One audit scan answers both halves, so an observer asking "is my
+    /// implementation agent still there" pays for a single read rather than
+    /// three overlapping ones.
+    pub fn collect_run_execution_progress(
+        &self,
+        run_id: &str,
+    ) -> Result<RunExecutionProgress, OrbitError> {
+        self.collect_run_execution_progress_with(run_id, probe_process_liveness)
+    }
+
+    /// Inner, testable form of [`Self::collect_run_execution_progress`] with the
+    /// liveness probe injected.
+    pub(crate) fn collect_run_execution_progress_with<P>(
+        &self,
+        run_id: &str,
+        probe: P,
+    ) -> Result<RunExecutionProgress, OrbitError>
+    where
+        P: Fn(u32, Option<&str>) -> ProcessLiveness,
+    {
+        let events = self.collect_run_audit_events(run_id)?;
+        if events.is_empty() {
+            return Ok(RunExecutionProgress::unavailable());
         }
 
-        for record in &mut records {
-            if !record.finished {
-                record.liveness = probe(record.pid, record.pid_start_time.as_deref());
-            }
-        }
+        let steps = audit_steps_from_events(&events);
+        // Parallel activities can leave several steps open at once; the newest
+        // one is what "what is it doing now" means to an operator.
+        let active_step = steps
+            .iter()
+            .rev()
+            .find(|step| step.finished_at.is_none())
+            .cloned();
+        let records =
+            provider_processes_from_events(run_id, events, &step_index_by_id(&steps), probe);
+        let (provider_processes, truncated) =
+            bound_provider_processes(records, MAX_PROVIDER_PROCESSES);
 
-        Ok(records)
+        Ok(RunExecutionProgress {
+            state: "observed",
+            active_step,
+            provider_processes,
+            limit: MAX_PROVIDER_PROCESSES,
+            truncated,
+        })
     }
 
     pub fn collect_run_audit_events(&self, run_id: &str) -> Result<Vec<RunAuditEvent>, OrbitError> {
@@ -290,82 +320,9 @@ impl OrbitRuntime {
     }
 
     pub fn collect_run_audit_steps(&self, run_id: &str) -> Result<Vec<RunAuditStep>, OrbitError> {
-        let events = self.collect_run_audit_events(run_id)?;
-        let mut steps = Vec::<RunAuditStep>::new();
-        let mut index_by_id = HashMap::<String, usize>::new();
-
-        for event in events {
-            match event.body_kind.as_deref() {
-                Some("step_started") => {
-                    let Some(step_id) = event.raw.get("step_id").and_then(Value::as_str) else {
-                        continue;
-                    };
-                    if index_by_id.contains_key(step_id) {
-                        continue;
-                    }
-                    let index = steps.len();
-                    index_by_id.insert(step_id.to_string(), index);
-                    steps.push(RunAuditStep {
-                        step_index: index as u32,
-                        step_id: step_id.to_string(),
-                        started_at: event.timestamp,
-                        finished_at: None,
-                        state: None,
-                        outcome: None,
-                        error_message: None,
-                    });
-                }
-                Some("step_finished") | Some("step_skipped") | Some("step_denied") => {
-                    let Some(step_id) = event.raw.get("step_id").and_then(Value::as_str) else {
-                        continue;
-                    };
-                    let Some(index) = index_by_id.get(step_id).copied() else {
-                        continue;
-                    };
-                    let step = &mut steps[index];
-                    step.finished_at = event.timestamp;
-                    match event.body_kind.as_deref() {
-                        Some("step_finished") => {
-                            let outcome = event
-                                .raw
-                                .get("outcome")
-                                .and_then(Value::as_str)
-                                .unwrap_or("finished")
-                                .to_string();
-                            step.state = Some(outcome.clone());
-                            step.outcome = Some(outcome);
-                            step.error_message = event
-                                .raw
-                                .get("error_message")
-                                .and_then(Value::as_str)
-                                .map(str::to_string);
-                        }
-                        Some("step_skipped") => {
-                            step.state = Some("skipped".to_string());
-                            step.outcome = Some("skipped".to_string());
-                            step.error_message = event
-                                .raw
-                                .get("reason")
-                                .and_then(Value::as_str)
-                                .map(str::to_string);
-                        }
-                        Some("step_denied") => {
-                            step.state = Some("failed".to_string());
-                            step.outcome = Some("denied".to_string());
-                            step.error_message = event
-                                .raw
-                                .get("reason")
-                                .and_then(Value::as_str)
-                                .map(str::to_string);
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        Ok(steps)
+        Ok(audit_steps_from_events(
+            &self.collect_run_audit_events(run_id)?,
+        ))
     }
 
     /// Recover the most recent bounded recovery-attempt evidence for a run.
@@ -483,6 +440,230 @@ impl OrbitRuntime {
     fn v2_audit_blob_root(&self) -> PathBuf {
         self.data_root().join("state").join("audit").join("blobs")
     }
+}
+
+/// Reconstruct a run's activity steps from an already-read audit trail, in
+/// first-started order.
+fn audit_steps_from_events(events: &[RunAuditEvent]) -> Vec<RunAuditStep> {
+    let mut steps = Vec::<RunAuditStep>::new();
+    let mut index_by_id = HashMap::<String, usize>::new();
+
+    for event in events {
+        match event.body_kind.as_deref() {
+            Some("step_started") => {
+                let Some(step_id) = event.raw.get("step_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                if index_by_id.contains_key(step_id) {
+                    continue;
+                }
+                let index = steps.len();
+                index_by_id.insert(step_id.to_string(), index);
+                steps.push(RunAuditStep {
+                    step_index: index as u32,
+                    step_id: step_id.to_string(),
+                    started_at: event.timestamp,
+                    finished_at: None,
+                    state: None,
+                    outcome: None,
+                    error_message: None,
+                });
+            }
+            Some("step_finished") | Some("step_skipped") | Some("step_denied") => {
+                let Some(step_id) = event.raw.get("step_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                let Some(index) = index_by_id.get(step_id).copied() else {
+                    continue;
+                };
+                let step = &mut steps[index];
+                step.finished_at = event.timestamp;
+                match event.body_kind.as_deref() {
+                    Some("step_finished") => {
+                        let outcome = event
+                            .raw
+                            .get("outcome")
+                            .and_then(Value::as_str)
+                            .unwrap_or("finished")
+                            .to_string();
+                        step.state = Some(outcome.clone());
+                        step.outcome = Some(outcome);
+                        step.error_message = event
+                            .raw
+                            .get("error_message")
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                    }
+                    Some("step_skipped") => {
+                        step.state = Some("skipped".to_string());
+                        step.outcome = Some("skipped".to_string());
+                        step.error_message = event
+                            .raw
+                            .get("reason")
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                    }
+                    Some("step_denied") => {
+                        step.state = Some("failed".to_string());
+                        step.outcome = Some("denied".to_string());
+                        step.error_message = event
+                            .raw
+                            .get("reason")
+                            .and_then(Value::as_str)
+                            .map(str::to_string);
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    steps
+}
+
+/// Index each activity step by id so a provider process can name its position
+/// in the run as well as its step.
+fn step_index_by_id(steps: &[RunAuditStep]) -> HashMap<String, u32> {
+    steps
+        .iter()
+        .map(|step| (step.step_id.clone(), step.step_index))
+        .collect()
+}
+
+/// Reconstruct the run's provider subprocesses from an already-read audit
+/// trail, pairing each spawn with the completion that closes it and probing the
+/// liveness of whatever is still open.
+fn provider_processes_from_events<P>(
+    run_id: &str,
+    events: Vec<RunAuditEvent>,
+    step_index_by_id: &HashMap<String, u32>,
+    probe: P,
+) -> Vec<RunProviderProcess>
+where
+    P: Fn(u32, Option<&str>) -> ProcessLiveness,
+{
+    let mut records: Vec<RunProviderProcess> = Vec::new();
+    // The direct parent of a provider process / completion event is the
+    // invocation that emitted it. Keep that correlation private to this
+    // reconstruction rather than projecting it as a new API field.
+    let mut invocation_parent_by_process_event = HashMap::<String, String>::new();
+
+    for event in events {
+        match event.body_kind.as_deref() {
+            Some("cli_invocation_process") => {
+                let Some(pid) = event
+                    .raw
+                    .get("pid")
+                    .and_then(Value::as_u64)
+                    .and_then(|pid| u32::try_from(pid).ok())
+                else {
+                    continue;
+                };
+                let step_index = event
+                    .step_id
+                    .as_ref()
+                    .and_then(|step_id| step_index_by_id.get(step_id).copied());
+                if let Some(parent_event_id) = &event.parent_event_id {
+                    invocation_parent_by_process_event
+                        .insert(event.event_id.clone(), parent_event_id.clone());
+                }
+                records.push(RunProviderProcess {
+                    run_id: event
+                        .raw
+                        .get("run_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or(run_id)
+                        .to_string(),
+                    event_id: event.event_id,
+                    ts: event.timestamp,
+                    step_index,
+                    step_id: event.step_id,
+                    provider: event
+                        .raw
+                        .get("provider")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    pid,
+                    pid_start_time: event
+                        .raw
+                        .get("pid_start_time")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    finished: false,
+                    exit_code: None,
+                    timed_out: false,
+                    duration_ms: None,
+                    // Overwritten below; only unfinished records are probed.
+                    liveness: ProcessLiveness::Exited,
+                });
+            }
+            Some("cli_invocation_finished") => {
+                let Some(record) = matching_provider_process_for_completion(
+                    &mut records,
+                    &invocation_parent_by_process_event,
+                    &event,
+                ) else {
+                    continue;
+                };
+                record.finished = true;
+                record.exit_code = event.raw.get("exit_code").and_then(Value::as_i64);
+                record.timed_out = event
+                    .raw
+                    .get("timed_out")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                record.duration_ms = event.raw.get("duration_ms").and_then(Value::as_u64);
+            }
+            _ => {}
+        }
+    }
+
+    for record in &mut records {
+        if !record.finished {
+            record.liveness = probe(record.pid, record.pid_start_time.as_deref());
+        }
+    }
+
+    records
+}
+
+/// Keep the newest `limit` provider children, preferring the ones still open.
+///
+/// A run with a long retry history can spawn more children than the budget
+/// carries. Dropping an open invocation would hide exactly the child this
+/// projection exists to report, so open records claim the budget first and the
+/// newest finished ones fill what is left. Survivors stay in trail order.
+fn bound_provider_processes(
+    records: Vec<RunProviderProcess>,
+    limit: usize,
+) -> (Vec<RunProviderProcess>, bool) {
+    if records.len() <= limit {
+        return (records, false);
+    }
+
+    let mut keep = vec![false; records.len()];
+    let mut budget = limit;
+    for keeping_open in [true, false] {
+        for (index, record) in records.iter().enumerate().rev() {
+            if budget == 0 {
+                break;
+            }
+            if record.finished == keeping_open {
+                continue;
+            }
+            keep[index] = true;
+            budget -= 1;
+        }
+    }
+
+    let kept = records
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(record, keep)| keep.then_some(record))
+        .collect::<Vec<_>>();
+    // Only reachable past the early return above, so something was dropped.
+    (kept, true)
 }
 
 /// Find the open provider process that a completion can honestly close.

--- a/plugin/skills/orbit/references/run-debugging.md
+++ b/plugin/skills/orbit/references/run-debugging.md
@@ -53,6 +53,29 @@ workflow failure. A recovery attempt is secondary evidence: `succeeded` does
 not rewrite that original failure, and a failed `authorization`, preparation,
 `dispatch`, or `activity` attempt explains why recovery did not complete.
 
+### Tell a working agent from an abandoned wrapper
+
+For a run that is still `running`, `orbit_workflow_run_show` carries
+`execution_progress`: the activity step that is open and the provider children
+it spawned. Only `show` carries it — `orbit_workflow_run_list` pages many runs
+and does not pay for an audit scan and a liveness probe per row.
+
+Its `state` is `observed` when the run has a v2 audit trail and `unavailable`
+when it has none, so an empty projection never has to be read as "nothing is
+running". `active_step` names the open `step_id` and `step_index`, and each
+`provider_processes.items` entry names the child's `pid`, `provider`, owning
+step, and a `liveness` of `alive`, `exited`, or `unknown`.
+
+`liveness` is judged against the identity token recorded with the PID, so a
+recycled PID reads `exited` rather than a false `alive`, and a PID recorded in
+another PID namespace reads `unknown` rather than a false `exited`. A child with
+`finished: true` carries its `exit_code` instead. `limit` and `truncated` say
+when a long retry history was bounded; open children are never the ones dropped.
+
+A `running` run whose open step has no `alive` child is the signature of an
+abandoned wrapper. `orbit run show <run_id> --json` reports the same
+`provider_processes` for the owning host.
+
 ### Verify model routing before reading logs
 
 `orbit run show <run_id> --json` separates three identities: `requested_crew`


### PR DESCRIPTION
## Task

[ORB-11752](https://orbit-cli.com/tasks/ORB-11752) — Expose active provider liveness and v2 step progress through workflow run show

### Description

Observed during user-authorized dsearch orchestration on Mac hm_ba054a1a8fbfb914, ws_dsearch, 2026-09-08 00:06-00:07 UTC. DANI-10313 leaf jrun-20260908-0004-6 is running under installed /Users/daniel/.cargo/bin/orbit 0.19.2. The 0.19.2 registered orbit.workflow.run.show returns state=running, steps=[], agent_invocation=null, wrapper pid=91922, and recovery_attempts=not_attempted, but no provider-process or active-step evidence. Same binary's orbit run show --json reports provider_processes with Codex pid=92157, liveness=alive, step_id=implement_one, step_index=2 and pipeline step 0 success. The connected Homebrew 0.19.0 MCP has the same gap (jrun-20260908-0004-3, provider pid 90477). Thus this is not merely a stale MCP binary report.

Impact: the authoritative agent-facing observation surface cannot distinguish a healthy implementation child from an abandoned wrapper or report current v2 progress; orchestration needs operator command fallback. ORB-10496 delivered liveness to CLI/dashboard, not this registered projection. ORB-11495 adds bounded recovery diagnostics, which are present in 0.19.2 but do not cover normal worker progress. Search included both prior tasks and current open/closed liveness/workflow terms; no active coverage found.

Extend the existing run-show projection with bounded active-step and provider liveness evidence using existing persisted audit/runtime readers. Preserve current fields, process identity/PID reuse semantics, unknown liveness, workspace/operator authorization and redaction. Avoid raw provider-log dumps, new storage, or unbounded audit scans. Verify current owning source and trace introducing task/commit before assigning source_task_id; local reference checkout inspected was older and is not deployment provenance. No merge/release authorized.

### Acceptance Criteria

- Registered tool and MCP run-show expose active implementation step and provider PID/liveness for a live v2 run using deterministic fixtures.
- Finished, missing/legacy, unknown-liveness, PID-reuse, retry and parallel-invocation cases remain distinguishable and correctly correlated.
- Response remains bounded/redacted and preserves existing fields, wrong-workspace and operator authorization behavior.
- Verify an installed current run through the actual registered/MCP surface; do not count CLI-only visibility as satisfying the fix.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What changed

`orbit.workflow.run.show` (registered tool = MCP surface) now carries an
`execution_progress` field: the activity step the run has open, plus a bounded,
liveness-probed view of the provider children it spawned.

- **`crates/orbit-core/src/runtime/run_audit.rs`** — added `RunExecutionProgress`
  (`state`, `active_step`, `provider_processes`, `limit`, `truncated`) and
  `collect_run_execution_progress[_with]`. To keep the read bounded, the existing
  step and provider-process reconstruction was split into free functions over an
  already-read event slice (`audit_steps_from_events`,
  `provider_processes_from_events`, `step_index_by_id`); one audit scan now
  answers both halves where `collect_run_provider_processes_with` previously ran
  three overlapping scans. `bound_provider_processes` caps the list at 8 and lets
  open invocations claim the budget before the newest finished retries, so
  truncation can never drop the live child. `RunProviderProcess::to_json` is the
  single operator-facing per-process projection.
- **`crates/orbit-core/src/adapter/tool_host/workflow_tools.rs`** — `show` appends
  `execution_progress`; an unreadable audit trail degrades to `unavailable`
  rather than failing the durable run read. `list` deliberately does not carry it
  (an audit scan + a liveness probe per row across a 200-run page).
- **`crates/orbit-cli/src/command/run/show.rs`** — deleted the private duplicate
  of the per-process JSON and reuses `RunProviderProcess::to_json`, so the CLI and
  the registered surface name a live child identically. CLI output shape unchanged.
- **Docs** — new "Tell a working agent from an abandoned wrapper" section in the
  `orbit` skill's `run-debugging.md`, plugin mirror re-synced with
  `scripts/sync-plugin-skills.sh`.

No new storage, no raw provider-log dump, no unbounded scan. Existing fields
(`run_id`, `state`, `steps`, `child_dispatches`, `drain_worker_limit`,
`agent_invocation`, `recovery_attempts`) are untouched; the change is additive.
The MCP tool schema/description is unchanged, so this is not a breaking MCP
change and does not affect `tests/snapshots/mcp_tools_list.json`.

## Acceptance criteria

1. **Active step + provider PID/liveness on registered/MCP run-show, deterministic
   fixtures** — met. `mcp_run_show_names_the_active_step_and_its_live_provider_child`
   drives `orbit.workflow.run.show` through `run_tool_with_context_and_role` (the
   real registry + capability chokepoint, the same path MCP dispatches through)
   and asserts `state: observed`, `active_step.step_id = implement_one`,
   `step_index = 1`, and a child with `provider`, `pid`, `step_id`, `step_index`,
   `finished: false`, `liveness: alive`. Determinism comes from using the test
   process's own PID plus its real `process_start_identity_token`, probed by the
   production `probe_process_liveness`.
2. **Finished / missing-legacy / unknown / PID-reuse / retry / parallel all
   distinguishable** — met.
   `mcp_run_show_separates_a_finished_child_from_the_open_retry` (two invocations
   under one step: the closed one keeps `exit_code: 137` and `liveness: exited`,
   the open one is probed `alive`);
   `mcp_run_show_rejects_a_recycled_pid_and_refuses_to_judge_a_foreign_namespace`
   (live PID + mismatched identity token → `exited`; PID recorded in a foreign
   PID namespace → `unknown`, Linux-gated because only Linux reports a namespace);
   `mcp_run_show_marks_a_missing_trail_unavailable_and_bounds_a_long_history`
   (no v2 trail → `unavailable`, distinct from an `observed` run with nothing
   open). Existing `runtime::tests::run_audit` coverage of parallel/ancestry-free
   completion pairing still passes unchanged (12/12).
3. **Bounded/redacted, existing fields, workspace + operator authorization
   preserved** — met. Bounding is asserted (13 children → 8 items,
   `truncated: true`, open child retained, newest 7 finished retries fill the
   rest). The projection is identifiers, timestamps and process facts only — no
   provider output — so there is nothing to redact and the redaction guardrail
   (`scripts/check-artifact-redaction-guardrail.sh`, part of `make ci-fast`) is
   satisfied. Field preservation asserted in test 1. Authorization behavior is
   unchanged and still covered by `operator_can_observe_runs_and_agent_denial_is_audited`
   and the two `managed_run_environment_*` tests; the workspace-selector path is
   untouched and covered by `orbit-cli/tests/mcp_roundtrip.rs` (50/50 pass).
4. **Verify an installed current run through the registered/MCP surface** —
   **partially met; see the blocker below.**

## Criterion 4: what was verified and what was blocked

Verified: the registered dispatch path end-to-end in tests (criterion 1-3 above),
and the real live run's underlying evidence on this machine.
`orbit run show jrun-20260908-0024-3 --json`, built from this worktree, reports
through the *shared* `RunProviderProcess::to_json` added here:
`pid=826599, provider=claude, step_id=implement_one, step_index=2,
liveness=unknown, pid_start_time=ps-lstart-utc-v2:pidns=4026531836:...`
(`unknown` is correct: this reader is in a different PID namespace than the
recorded child).

Blocked: calling the *registered tool* against that live run. Attempted:

    $ orbit tool run orbit.workflow.run.show --input '{"id":"jrun-20260908-0024-3"}'
    {"code":"capability_denied", ...requires the `operator` capability...}
    $ ORBIT_OPERATOR=1 orbit tool run orbit.workflow.run.show --input '{...}'
    {"code":"policy_denied","error":"tool 'orbit.workflow.run.show' is not in the activity allowlist"}

This run's envelope grants `orbit.task.*`, `orbit.friction.*`, `orbit.search`,
`proc.spawn`. The allowlist comes from `ORBIT_ACTIVITY_TOOLS`; the only way past
it is to unset the envelope's own env var, which the execution mandate forbids.
I did not do that. Filed as friction **F2026-09-066** with the reproduction and a
proposed authoring-time check. Remaining risk: the JSON-RPC transport layer and
production audit data are not exercised for the new field, only the tool
dispatch + projection. Recommend one `orbit_workflow_run_show` call against a
live run after this lands.

## Validation

| Command | Outcome |
| --- | --- |
| `make ci-fast` | passed (after `cargo fmt --all`) |
| `make ci-lint` | passed |
| `cargo test -p orbit-core --lib adapter::tool_host::tests::workflow_tools` | passed, 12/12 |
| `cargo test -p orbit-core --lib runtime::tests::run_audit` | passed, 12/12 |
| `cargo test -p orbit-cli --bin orbit command::run` | passed, 74/74 |
| `cargo test -p orbit-cli --test output_goldens` | passed, 3/3 (no golden drift) |
| `cargo test -p orbit-cli --test mcp_roundtrip` | passed, 50/50 |
| `git diff --check` / `git status --short` | clean; only the 6 intended files modified |
| full `make ci` | not run (canonical merge gate is CI on the PR, per CLAUDE.md) |

## Scope notes

`context_files` extended beyond the two listed files, with reasons:
`runtime/run_audit.rs` owns the audit projection the tool host must reuse (the
alternative was duplicating the reconstruction inside the adapter);
`orbit-cli/src/command/run/show.rs` held a private copy of the per-process JSON
that would have drifted from the new shared one — the exact CLI/MCP disagreement
this task is about; the two `run-debugging.md` copies document the run-show
response and are same-PR doc obligations.

`source_task_id` set to **ORB-10496**: `git show 5e7857023 --stat` confirms it
introduced `RunProviderProcess`/liveness and wired it into
`crates/orbit-cli/src/command/run/show.rs` and the dashboard API only — the tool
host was never included. This is that task's scope gap, not a later regression.

Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11752-6a9f55d0`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra