### PR TITLE
[code-review] Clean up the child and its readers when `try_wait` fails in the supervisor

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -457,6 +457,7 @@ pub fn run_cli_backend(
         },
         output_capture_limit: None,
         on_spawn: Some(&on_spawn),
+        wait: None,
     });
 
     let (stdout, stderr, exit_code, duration, timed_out) = match spawn_result {

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -4,7 +4,7 @@
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::Child;
+use std::process::{Child, ExitStatus};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -26,6 +26,7 @@ const DEFAULT_CLI_RUNNER_OUTPUT_CAPTURE_LIMIT_BYTES: usize = 1024 * 1024;
 const OUTPUT_LINE_EVENT_LIMIT_BYTES: usize = 64 * 1024;
 
 type SharedOutputCapture = Arc<Mutex<RollingOutputCapture>>;
+type WaitHook<'a> = &'a dyn Fn(&mut Child) -> std::io::Result<Option<ExitStatus>>;
 
 #[derive(Debug)]
 pub(super) struct CapturedOutput {
@@ -159,6 +160,9 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     /// inside this module (process-group cleanup), so a long-running provider
     /// child has no observable identity while it runs.
     pub(super) on_spawn: Option<&'a dyn Fn(u32)>,
+    /// Test seam for exercising wait failures without depending on another
+    /// thread reaping the child between `try_wait` calls.
+    pub(super) wait: Option<WaitHook<'a>>,
 }
 
 struct OutputReaderContext {
@@ -189,6 +193,7 @@ pub(super) fn spawn_with_timeout(
         trace,
         output_capture_limit,
         on_spawn,
+        wait,
     } = request;
 
     let started = Instant::now();
@@ -251,30 +256,36 @@ pub(super) fn spawn_with_timeout(
 
     let mut timed_out = false;
     let deadline = started + timeout;
-    let exit_status;
-    loop {
-        match child.try_wait() {
+    let wait_result = loop {
+        let result = match wait {
+            Some(wait) => wait(&mut child),
+            None => child.try_wait(),
+        };
+        match result {
             Ok(Some(status)) => {
-                cleanup_child_process_group(child.id());
-                exit_status = Some(status);
-                break;
+                break Ok(Some(status));
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    kill_child_process_tree(&mut child);
                     timed_out = true;
-                    exit_status = None;
-                    break;
+                    break Ok(None);
                 }
                 thread::sleep(Duration::from_millis(25));
             }
             Err(err) => {
-                // `wait` failures are host-side and not clearly deterministic
-                // — leave them retryable.
-                return Err(SpawnError::transient(format!("wait {program}: {err}")));
+                break Err(err);
             }
         }
-    }
+    };
+
+    let (exit_status, wait_error) = match wait_result {
+        Ok(exit_status) => (exit_status, None),
+        // `wait` failures are host-side and not clearly deterministic — leave
+        // them retryable after the common cleanup below.
+        Err(err) => (None, Some(err)),
+    };
+
+    kill_child_process_tree(&mut child);
 
     // The join is bounded on every exit path, not only after a timeout. A
     // reader returns when the last writer closes the pipe, and a helper the
@@ -288,6 +299,10 @@ pub(super) fn spawn_with_timeout(
     }
     if let Some(h) = stderr_reader {
         join_output_reader(h, reader_join_deadline);
+    }
+
+    if let Some(err) = wait_error {
+        return Err(SpawnError::transient(format!("wait {program}: {err}")));
     }
 
     let stdout = stdout_buf
@@ -403,14 +418,6 @@ fn kill_child_process_tree(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
 }
-
-#[cfg(unix)]
-fn cleanup_child_process_group(child_id: u32) {
-    let _ = signal_child_process_group(child_id, libc::SIGKILL);
-}
-
-#[cfg(not(unix))]
-fn cleanup_child_process_group(_child_id: u32) {}
 
 #[cfg(unix)]
 fn signal_child_process_group(child_id: u32, signal: libc::c_int) -> std::io::Result<()> {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -29,6 +29,7 @@ fn spawn_test_request<'a>(
         trace,
         output_capture_limit: None,
         on_spawn: None,
+        wait: None,
     }
 }
 
@@ -148,6 +149,42 @@ fn spawn_with_timeout_reports_the_child_pid_while_the_child_is_still_running() {
         Some(true),
         "the pid must be reported while the child is still running"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn spawn_with_timeout_cleans_process_group_when_wait_fails() {
+    use std::cell::Cell;
+    use std::io;
+
+    let args = sh_args("sleep 30");
+    let child_pid = Cell::new(0u32);
+    let on_spawn = |pid: u32| child_pid.set(pid);
+    let wait = |_child: &mut std::process::Child| Err(io::Error::other("injected wait failure"));
+    let mut request = spawn_test_request(
+        "/bin/sh",
+        &args,
+        None,
+        Duration::from_secs(5),
+        SpawnTraceContext {
+            provider: "codex",
+            job_run_id: "job-wait-error",
+            task_id: Some("TWAIT"),
+            cwd: None,
+        },
+    );
+    request.on_spawn = Some(&on_spawn);
+    request.wait = Some(&wait);
+
+    let error = spawn_with_timeout(request).expect_err("injected wait failure");
+    assert!(!error.permanent);
+    assert!(error.message.contains("injected wait failure"));
+
+    let pid = child_pid.get();
+    assert_ne!(pid, 0);
+    let result = unsafe { libc::killpg(pid as libc::pid_t, 0) };
+    assert_eq!(result, -1);
+    assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH));
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11671](https://orbit-cli.com/tasks/ORB-11671) — [code-review] Clean up the child and its readers when `try_wait` fails in the supervisor

### Description

## Problem
The wait loop's `Err(err) => return Err(SpawnError::transient(…))` arm returns before `kill_child_process_tree`, before the bounded reader joins, and before the sandbox profile tempfile is dropped in order. The child process group keeps running unsupervised while the step is classified transient and retried, so a second provider process is launched for the same task while the first still edits the worktree. `try_wait` failing is rare (`ECHILD` when something else in the process reaps children), which is exactly why the leak would go unnoticed.

## Why It Matters
Two providers concurrently mutating one worktree defeats the boundary guard and produces an unattributable candidate.

## Proposed Fix
Make cleanup unconditional: wrap the loop so every exit path runs `kill_child_process_tree` + the bounded reader joins (a small RAII guard around `child`), and only then map the wait error.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs:255-291`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (bug). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Unit test that reaps the child externally (`libc::waitpid(pid, …)` from the test before the loop observes it) or injects a wait error through a test hook, and asserts the returned error *and* that the process group is gone (`killpg(pgid, 0)` → `ESRCH`).
- No `return` inside the wait loop that bypasses the join/kill sequence (inspection).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Refactored supervisor wait handling to capture wait errors, unconditionally kill the child process tree, join bounded output readers, and only then return the transient wait error.
- Added a named wait-hook seam and a Unix regression test that injects a wait error, asserts the returned retryable error, and verifies killpg(pid, 0) returns ESRCH.
- Updated the sole production SpawnWithTimeoutRequest construction and test helper for the new hook field.

Acceptance criteria:
- Criterion 1: met. The new test injects a wait error and asserts both the error and process-group disappearance via killpg(..., 0) == ESRCH.
- Criterion 2: met. The wait loop has no return; wait errors are mapped only after common process-tree cleanup and bounded reader joins.

Validation:
- cargo fmt --all -- --check — passed.
- cargo test -p orbit-engine activity_job::cli_runner::tests::supervisor — passed, 8 tests.
- make ci-fast — passed.
- make ci-lint — passed.
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — passed; only the three task-scoped files are modified.

Assessment: The cleanup ordering is centralized and preserves retry classification. The regression test deterministically covers the previously leaking wait-error path. An earlier focused test run exposed a missing timeout flag assignment during refactoring; that was corrected and the final focused run passed. No friction record was warranted because the issue was resolved locally without a recurring or non-obvious external failure.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11671-6a9f593a`
- Behind base: 0
- Ahead of base: 1