### PR TITLE
[code-review] Treat a panicked fan-out worker as a failed worker instead of silently dropping it

### DIFF
--- a/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/fan_out.rs
@@ -52,7 +52,7 @@ pub(super) fn run_fan_out(
     let results: Mutex<Vec<(u32, Result<StepOutcome, DispatchError>)>> =
         Mutex::new(Vec::with_capacity(items.len()));
 
-    thread::scope(|scope| {
+    let panicked_workers = thread::scope(|scope| {
         let mut handles = Vec::new();
         for (idx, item) in items.iter().enumerate() {
             let idx = idx as u32;
@@ -125,9 +125,31 @@ pub(super) fn run_fan_out(
                     .push((idx, res));
             }));
         }
-        for h in handles {
-            let _ = h.join();
+        let mut panicked_workers = Vec::new();
+        for (idx, h) in handles.into_iter().enumerate() {
+            if let Err(payload) = h.join() {
+                let idx = idx as u32;
+                panicked_workers.push(idx);
+                let message = panic_payload_message(payload.as_ref());
+                emit_job_event_lossy(
+                    &ctx.audit,
+                    ctx.task_id(),
+                    V2AuditEventKind::WorkerState {
+                        step_id: block.worker.id.clone(),
+                        worker_index: idx,
+                        state: "failed".to_string(),
+                    },
+                );
+                results.lock().expect("results poisoned").push((
+                    idx,
+                    Err(DispatchError::JobExecution(format!(
+                        "worker {idx} panicked: {message}"
+                    ))),
+                ));
+            }
         }
+
+        panicked_workers
     });
 
     let mut collected: Vec<Value> = Vec::new();
@@ -135,8 +157,15 @@ pub(super) fn run_fan_out(
     let mut failed_count = 0u32;
     let mut first_error: Option<DispatchError> = None;
     let mut sorted = results.into_inner().expect("results poisoned");
+    if sorted.len() != items.len() {
+        return Err(DispatchError::JobExecution(format!(
+            "fan-out collected {} results for {} items",
+            sorted.len(),
+            items.len()
+        )));
+    }
     sorted.sort_by_key(|(idx, _)| *idx);
-    for (_idx, res) in sorted {
+    for (idx, res) in sorted {
         match res {
             Ok(o) if o.success => {
                 collected_count += 1;
@@ -148,7 +177,7 @@ pub(super) fn run_fan_out(
             }
             Err(e) => {
                 failed_count += 1;
-                if first_error.is_none() {
+                if !panicked_workers.contains(&idx) && first_error.is_none() {
                     first_error = Some(e);
                 }
                 collected.push(Value::Null);

--- a/crates/orbit-engine/src/activity_job/job_executor/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/mod.rs
@@ -44,6 +44,16 @@ use super::dispatcher::{
 };
 use crate::context::RuntimeHost;
 
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
 mod audit;
 mod concurrency;
 mod exec_ctx;

--- a/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/parallel.rs
@@ -26,10 +26,11 @@ pub(super) fn run_parallel(
             .iter()
             .map(|branch| {
                 let branch_id = branch.id.clone();
+                let join_branch_id = branch_id.clone();
                 let ctx_ref = ctx;
                 let audit = ctx.audit.clone();
                 let inherited_parent_stack = inherited_parent_stack.clone();
-                scope.spawn(move || {
+                let handle = scope.spawn(move || {
                     let _parent_guard = match audit.install_parent_stack(inherited_parent_stack) {
                         Ok(guard) => guard,
                         Err(err) => {
@@ -40,12 +41,22 @@ pub(super) fn run_parallel(
                         }
                     };
                     (branch_id, run_step(branch, ctx_ref))
-                })
+                });
+                (join_branch_id, handle)
             })
             .collect();
         handles
             .into_iter()
-            .map(|h| h.join().expect("branch thread panicked"))
+            .map(|(branch_id, handle)| match handle.join() {
+                Ok(result) => result,
+                Err(payload) => (
+                    branch_id,
+                    Err(DispatchError::JobExecution(format!(
+                        "branch thread panicked: {}",
+                        panic_payload_message(payload.as_ref())
+                    ))),
+                ),
+            })
             .collect()
     });
 

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/fanout.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/fanout.rs
@@ -208,6 +208,57 @@ fn fanout_first_error_surfaces_when_join_unsatisfied() {
 }
 
 #[test]
+fn fanout_panic_is_collected_as_a_failed_worker() {
+    let host = ScriptedHost::new([(
+        "w",
+        vec![Action::PanicOnInputIteration {
+            field: "worker_index",
+            iteration: 1,
+        }],
+    )]);
+    let mut worker = target_step("worker", "w");
+    match &mut worker.body {
+        JobV2StepBody::Target(target) => {
+            target.default_input = Some(json!({"worker_index": "{{ input.iteration }}"}));
+        }
+        _ => unreachable!("target_step must build a target body"),
+    }
+    let job = job_with_steps(vec![fanout_step(
+        "scatter",
+        "{{ input.items }}",
+        3,
+        worker,
+        JoinMode::All,
+        None,
+    )]);
+    let writer = std::sync::Arc::new(test_writer("run-fanout-panic"));
+    let outcome = execute_job(
+        &job,
+        json!({"items": [0, 1, 2]}),
+        "run-fanout-panic",
+        writer.clone(),
+        &host,
+    )
+    .expect("a panicked worker becomes a failed fan-out outcome");
+
+    assert!(!outcome.success);
+    let pipeline = outcome.pipeline.as_object().expect("pipeline obj");
+    assert_eq!(
+        pipeline.get("scatter"),
+        Some(&json!([{"action": "w"}, null, {"action": "w"}]))
+    );
+    let events = writer.events_snapshot().expect("audit");
+    assert!(events.iter().any(|event| matches!(
+        &event.kind,
+        V2AuditEventKind::FaninJoined {
+            collected: 2,
+            failed: 1,
+            ..
+        }
+    )));
+}
+
+#[test]
 fn fanout_collect_alias_writes_collected_value_under_collect_key() {
     // Invariant: when `fan_in.collect = "results"`, the collected_value is
     // stored under both `pipeline["results"]` and `pipeline[step.id]`.

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/mod.rs
@@ -195,6 +195,8 @@ pub(super) enum Action {
     EchoInput,
     SleepOk { ms: u64, value: Value },
     SleepInputMsThenEcho { ms_field: &'static str },
+    Panic,
+    PanicOnInputIteration { field: &'static str, iteration: u64 },
 }
 
 pub(super) struct ScriptedHost {
@@ -285,12 +287,18 @@ impl RuntimeHost for ScriptedHost {
             .lock()
             .expect("call log")
             .push(action.to_string());
-        let next = self
-            .responses
-            .lock()
-            .expect("responses")
-            .get_mut(action)
-            .and_then(VecDeque::pop_front);
+        let next = {
+            let mut responses = self.responses.lock().expect("responses");
+            match responses.get_mut(action) {
+                Some(queue)
+                    if matches!(queue.front(), Some(Action::PanicOnInputIteration { .. })) =>
+                {
+                    queue.front().cloned()
+                }
+                Some(queue) => queue.pop_front(),
+                None => None,
+            }
+        };
         let result = match next {
             Some(Action::Ok(value)) => Ok(value),
             Some(Action::Err(err)) => Err(err),
@@ -307,6 +315,13 @@ impl RuntimeHost for ScriptedHost {
                 })?;
                 std::thread::sleep(Duration::from_millis(ms));
                 Ok(input.clone())
+            }
+            Some(Action::Panic) => panic!("scripted deterministic action panicked"),
+            Some(Action::PanicOnInputIteration { field, iteration }) => {
+                if input.get(field).and_then(Value::as_u64) == Some(iteration) {
+                    panic!("scripted deterministic action panicked for iteration {iteration}");
+                }
+                Ok(json!({ "action": action }))
             }
             // Default: succeed with `{ "action": <name> }` so untyped tests
             // don't have to script every call.

--- a/crates/orbit-engine/src/activity_job/job_executor/tests/parallel.rs
+++ b/crates/orbit-engine/src/activity_job/job_executor/tests/parallel.rs
@@ -56,6 +56,37 @@ fn parallel_join_all_fails_when_any_branch_fails() {
 }
 
 #[test]
+fn parallel_panic_is_recorded_as_a_failed_branch() {
+    let host = ScriptedHost::new([
+        ("a", vec![Action::Ok(json!({"a": true}))]),
+        ("b", vec![Action::Panic]),
+    ]);
+    let job = job_with_steps(vec![parallel_step(
+        "fan",
+        JoinMode::All,
+        vec![target_step("br_a", "a"), target_step("br_b", "b")],
+    )]);
+    let writer = std::sync::Arc::new(test_writer("run-par-panic"));
+    let err = execute_job(&job, Value::Null, "run-par-panic", writer.clone(), &host)
+        .expect_err("a panicked branch must fail the block without panicking the job thread");
+
+    assert!(
+        matches!(err, DispatchError::JobExecution(message) if message.contains("branch thread panicked"))
+    );
+    let events = writer.events_snapshot().expect("audit");
+    assert!(events.iter().any(|event| matches!(
+        &event.kind,
+        V2AuditEventKind::StepJoin { branch_outcomes, .. }
+            if branch_outcomes.iter().any(|branch| branch.branch_id == "br_b" && branch.outcome == "error")
+    )));
+    assert!(events.iter().any(|event| matches!(
+        &event.kind,
+        V2AuditEventKind::StepFinished { step_id, outcome, .. }
+            if step_id == "fan" && outcome == "error"
+    )));
+}
+
+#[test]
 fn parallel_join_any_succeeds_with_one_branch_success() {
     let host = ScriptedHost::new([
         (


### PR DESCRIPTION
## Task

[ORB-11605](https://orbit-cli.com/tasks/ORB-11605) — [code-review] Treat a panicked fan-out worker as a failed worker instead of silently dropping it

### Description

## Problem
`run_fan_out` joins each worker with `let _ = h.join();`. A worker that panics (any `expect("… poisoned")` in the executor, a panic inside a deterministic action, a poisoned `pipeline` mutex after an earlier panic) never pushes into `results`, so the join loop simply sees fewer entries: `collected_count` and `failed_count` both exclude it, `JoinMode::All` evaluates `failed_count == 0` → **true**, and the step reports success with a shorter `collected` array. `std::thread::scope` only re-raises panics of threads that were *not* manually joined, so nothing else surfaces it. `run_parallel` has the opposite problem: `h.join().expect("branch thread panicked")` converts a branch panic into a panic of the job thread, which `execute_job_with_resume` (and `orbit-core`'s caller, which has no `catch_unwind`) never finalizes — the run record stays `running`.

## Why It Matters
A fan-out (e.g. per-task pilot/triage workers) can lose a worker's result and still checkpoint the step as successful; downstream steps consume an incomplete `collect` array as if every item ran.

## Proposed Fix
In both `run_fan_out` and `run_parallel`, match on the `JoinHandle::join()` result and record `Err(DispatchError::JobExecution(format!("worker {idx} panicked: {payload}")))` for that index (emit `WorkerState{state:"failed"}` / a `StepJoin` branch outcome `error`), never `expect`. Assert after the join that `results.len() == items.len()` and fail the block otherwise.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/activity_job/job_executor/fan_out.rs:128-130,133-177`, `crates/orbit-engine/src/activity_job/job_executor/parallel.rs:46-49`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- New test in `job_executor/tests/fanout.rs`: a scripted host whose deterministic action panics for item 1 of 3; the fan-out step returns `success: false` under `JoinMode::All`, the `FaninJoined` event reports `failed: 1`, and the collected array has 3 entries with `Null` at index 1.
- Same shape for `parallel:` — the block returns an `Err`/failed outcome, the process does not panic, and `StepFinished` is emitted.
- `grep -n "expect(\"branch thread panicked\")" crates/orbit-engine/src/activity_job/job_executor/parallel.rs` returns nothing.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Fan-out now converts each joined worker panic into an indexed `DispatchError::JobExecution`, emits a failed WorkerState, preserves an index-aligned collected array, and rejects incomplete join result sets. A panic-only fan-out produces the normal `success: false` block outcome while ordinary worker errors still surface structurally.
- Parallel now converts a joined branch panic into a branch error, allowing StepJoin and StepFinished to be emitted instead of panicking the job thread.
- Added deterministic scripted panic coverage for item 1 of a three-item fan-out and for a parallel branch; centralized panic payload rendering in the executor module.
Assessment: all acceptance criteria are covered by executor-boundary tests.
Criteria evidence:
1. `fanout_panic_is_collected_as_a_failed_worker` verifies `success == false`, three ordered entries with Null at index 1, and `FaninJoined { collected: 2, failed: 1 }`.
2. `parallel_panic_is_recorded_as_a_failed_branch` verifies an Err return without job-thread panic, an error branch in StepJoin, and StepFinished outcome error.
3. The required grep returned no matches.
Validation:
- `cargo test -p orbit-engine activity_job::job_executor::tests` — passed (114 tests).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
Risks: panics still emit Rust panic-hook output in test/runtime logs, but they no longer escape the fan-out or parallel executor joins.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11605-6a9f5b8e`
- Behind base: 0
- Ahead of base: 1