### PR TITLE
[code-review] Apply the task write lock / status compare-and-set to approve, start, and reject transitions

### DIFF
--- a/crates/orbit-core/src/application/task/tests/mod.rs
+++ b/crates/orbit-core/src/application/task/tests/mod.rs
@@ -5,6 +5,7 @@ mod contention;
 mod params;
 mod paths;
 mod records;
+mod transitions;
 mod update;
 
 use crate::OrbitRuntime;

--- a/crates/orbit-core/src/application/task/tests/transitions.rs
+++ b/crates/orbit-core/src/application/task/tests/transitions.rs
@@ -1,0 +1,158 @@
+//! Human task transitions retain the status they read when they write.
+
+use chrono::Utc;
+use orbit_store::contracts::FrictionAddParams;
+use orbit_types::record::FrictionStatus;
+use orbit_types::task::{TaskRelation, TaskRelationType, TaskStatus};
+
+use super::super::transitions::{TRANSITION_READ_HOOK_TEST_LOCK, set_transition_read_hook_status};
+use super::test_runtime;
+use crate::application::task::{TaskAddParams, TaskUpdateParams};
+
+fn add_task(runtime: &crate::OrbitRuntime, title: &str) -> orbit_types::task::Task {
+    runtime
+        .add_task(TaskAddParams {
+            title: title.to_string(),
+            description: "Exercise transition compare-and-set behavior.".to_string(),
+            acceptance_criteria: vec![
+                "The transition must not overwrite a newer status.".to_string(),
+            ],
+            plan: "Use the transition lock.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task")
+}
+
+fn set_status(runtime: &crate::OrbitRuntime, id: &str, status: TaskStatus) {
+    runtime
+        .update_task(
+            id,
+            TaskUpdateParams {
+                status: Some(status),
+                ..Default::default()
+            },
+        )
+        .expect("set status through the store");
+}
+
+fn with_changed_status(id: &str, test: impl FnOnce()) {
+    let _serial = TRANSITION_READ_HOOK_TEST_LOCK
+        .lock()
+        .expect("serialize transition read hooks");
+    set_transition_read_hook_status(Some(id), Some(TaskStatus::Rejected));
+    test();
+    set_transition_read_hook_status(None, None);
+}
+
+#[test]
+fn approve_does_not_overwrite_a_status_changed_after_its_read() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task(&runtime, "Approve CAS");
+    set_status(&runtime, &task.id, TaskStatus::Review);
+
+    with_changed_status(&task.id, || {
+        let error = runtime
+            .approve_task(&task.id, None, None)
+            .expect_err("approve must lose to the direct store update");
+        assert!(
+            error.to_string().contains("status changed to 'rejected'"),
+            "{error}"
+        );
+    });
+
+    assert_eq!(
+        runtime.get_task(&task.id).expect("current task").status,
+        TaskStatus::Rejected
+    );
+}
+
+#[test]
+fn rejected_review_approval_does_not_apply_resolves_side_effects() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task(&runtime, "Approve resolves CAS");
+    let frictions = crate::runtime::friction::store_for(&runtime).expect("friction store");
+    let friction = frictions
+        .add(FrictionAddParams {
+            model: "codex".to_string(),
+            title: Some("Approval race".to_string()),
+            body: "The direct status change must win.".to_string(),
+            tags: Vec::new(),
+            during_task: None,
+            created_at: Utc::now(),
+        })
+        .expect("add friction");
+    runtime
+        .update_task(
+            &task.id,
+            TaskUpdateParams {
+                relations: Some(vec![TaskRelation {
+                    relation_type: TaskRelationType::Resolves,
+                    target: friction.record.id.clone(),
+                }]),
+                status: Some(TaskStatus::Review),
+                ..Default::default()
+            },
+        )
+        .expect("prepare review task with resolves relation");
+
+    with_changed_status(&task.id, || {
+        runtime
+            .approve_task(&task.id, None, None)
+            .expect_err("approval must lose to the direct rejection");
+    });
+
+    assert_eq!(
+        frictions
+            .show(&friction.record.id)
+            .expect("show friction")
+            .expect("friction remains")
+            .record
+            .status,
+        FrictionStatus::Open
+    );
+}
+
+#[test]
+fn start_does_not_overwrite_a_status_changed_after_its_read() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task(&runtime, "Start CAS");
+    set_status(&runtime, &task.id, TaskStatus::Backlog);
+
+    with_changed_status(&task.id, || {
+        let error = runtime
+            .start_task(&task.id, None, None)
+            .expect_err("start must lose to the direct store update");
+        assert!(
+            error.to_string().contains("status changed to 'rejected'"),
+            "{error}"
+        );
+    });
+
+    assert_eq!(
+        runtime.get_task(&task.id).expect("current task").status,
+        TaskStatus::Rejected
+    );
+}
+
+#[test]
+fn reject_does_not_overwrite_a_status_changed_after_its_read() {
+    let (_root, runtime) = test_runtime();
+    let task = add_task(&runtime, "Reject CAS");
+    set_status(&runtime, &task.id, TaskStatus::Review);
+
+    with_changed_status(&task.id, || {
+        let error = runtime
+            .reject_task(&task.id, "not ready".to_string(), None)
+            .expect_err("reject must lose to the direct store update");
+        assert!(
+            error.to_string().contains("status changed to 'rejected'"),
+            "{error}"
+        );
+    });
+
+    assert_eq!(
+        runtime.get_task(&task.id).expect("current task").status,
+        TaskStatus::Rejected
+    );
+}

--- a/crates/orbit-core/src/application/task/transitions.rs
+++ b/crates/orbit-core/src/application/task/transitions.rs
@@ -15,11 +15,28 @@ use super::helpers::{
 };
 use super::params::TaskUpdateParams;
 
+#[cfg(test)]
+use std::sync::Mutex;
+
 const UNAUTHORED_TASK_PLAN_PLACEHOLDER: &str = "To be authored by executing agent at start time.";
 const RELATION_RESOLVES: &str = "resolves";
 /// [ORB-10470] Status event recorded when a resumed run restores its own
 /// lineage's coupling to a task (re-admission and/or batch re-claim).
 const RESUME_READMITTED_EVENT: &str = "resume_readmitted";
+
+#[cfg(test)]
+static TRANSITION_READ_HOOK_STATUS: Mutex<Option<(String, TaskStatus)>> = Mutex::new(None);
+
+#[cfg(test)]
+pub(super) static TRANSITION_READ_HOOK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+pub(super) fn set_transition_read_hook_status(id: Option<&str>, status: Option<TaskStatus>) {
+    *TRANSITION_READ_HOOK_STATUS
+        .lock()
+        .expect("transition read hook mutex") =
+        id.zip(status).map(|(id, status)| (id.to_string(), status));
+}
 
 #[derive(Debug, Default)]
 struct StartTaskOptions {
@@ -52,70 +69,81 @@ impl OrbitRuntime {
         self.ensure_coordination_task_write_permitted()?;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
-        let task = self.get_task(id)?;
         let actor = self.actor().clone();
         let effective_label = effective_actor_label(
             &actor.label,
             canonical_agent.as_deref(),
             canonical_model.as_deref(),
         );
-        let implemented_by =
-            implementation_label(&task, effective_label.as_str(), canonical_model.as_deref());
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
-        if task.status == TaskStatus::Review {
-            self.ensure_resolves_are_workspace_local(&task)?;
-        }
+        let mut result = None;
+        self.stores().tasks().with_task_write_lock(id, &mut || {
+            let task = self.get_task(id)?;
+            #[cfg(test)]
+            self.apply_transition_read_hook(id)?;
+            let implemented_by =
+                implementation_label(&task, effective_label.as_str(), canonical_model.as_deref());
+            if task.status == TaskStatus::Review {
+                self.ensure_resolves_are_workspace_local(&task)?;
+            }
 
-        let result = match task.status {
-            TaskStatus::Proposed => self.with_mutation(|| {
-                let task = self.stores().task_records().update(
-                    id,
-                    StoreTaskUpdateParams {
-                        actor: effective_label.clone(),
-                        status_event: Some("proposal_approved".to_string()),
-                        status_note: note.clone(),
-                        append_comments: append_comments.clone(),
-                        ..StoreTaskUpdateParams::from(TaskUpdateParams {
-                            status: Some(TaskStatus::Backlog),
-                            ..Default::default()
-                        })
-                    },
-                )?;
-                Ok((
-                    task.clone(),
-                    OrbitEvent::TaskProposalApproved {
-                        id: id.to_string(),
-                        approved_by: effective_label.clone(),
-                    },
-                ))
-            }),
-            TaskStatus::Review => self.with_mutation(|| {
-                let task = self.stores().task_records().update(
-                    id,
-                    StoreTaskUpdateParams {
-                        actor: effective_label.clone(),
-                        status_event: Some("review_approved".to_string()),
-                        status_note: note.clone(),
-                        implemented_by: implemented_by.clone().map(Some),
-                        append_comments: append_comments.clone(),
-                        ..StoreTaskUpdateParams::from(TaskUpdateParams {
-                            status: Some(TaskStatus::Done),
-                            ..Default::default()
-                        })
-                    },
-                )?;
-                Ok((
-                    task.clone(),
-                    OrbitEvent::TaskReviewApproved {
-                        id: id.to_string(),
-                        approved_by: effective_label.clone(),
-                    },
-                ))
-            }),
-            other => Err(OrbitError::InvalidInput(format!(
-                "task '{id}' is in status '{other}'; approve requires 'proposed' or 'review'"
-            ))),
-        }?;
+            result = Some(match task.status {
+                TaskStatus::Proposed => self.with_mutation(|| {
+                    let task = self.stores().task_records().update(
+                        id,
+                        StoreTaskUpdateParams {
+                            actor: effective_label.clone(),
+                            status_event: Some("proposal_approved".to_string()),
+                            status_note: note.clone(),
+                            append_comments: append_comments.clone(),
+                            expected_status: Some(vec![task.status]),
+                            ..StoreTaskUpdateParams::from(TaskUpdateParams {
+                                status: Some(TaskStatus::Backlog),
+                                ..Default::default()
+                            })
+                        },
+                    )?;
+                    Ok((
+                        task.clone(),
+                        OrbitEvent::TaskProposalApproved {
+                            id: id.to_string(),
+                            approved_by: effective_label.clone(),
+                        },
+                    ))
+                }),
+                TaskStatus::Review => self.with_mutation(|| {
+                    let task = self.stores().task_records().update(
+                        id,
+                        StoreTaskUpdateParams {
+                            actor: effective_label.clone(),
+                            status_event: Some("review_approved".to_string()),
+                            status_note: note.clone(),
+                            implemented_by: implemented_by.clone().map(Some),
+                            append_comments: append_comments.clone(),
+                            expected_status: Some(vec![task.status]),
+                            ..StoreTaskUpdateParams::from(TaskUpdateParams {
+                                status: Some(TaskStatus::Done),
+                                ..Default::default()
+                            })
+                        },
+                    )?;
+                    Ok((
+                        task.clone(),
+                        OrbitEvent::TaskReviewApproved {
+                            id: id.to_string(),
+                            approved_by: effective_label.clone(),
+                        },
+                    ))
+                }),
+                other => Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is in status '{other}'; approve requires 'proposed' or 'review'"
+                ))),
+            }?);
+            Ok(())
+        })?;
+        let result = result.ok_or_else(|| {
+            OrbitError::Execution("task approve body did not run under the task lock".to_string())
+        })?;
 
         if result.status == TaskStatus::Done {
             self.record_resolves_side_effects(&result)?;
@@ -268,36 +296,6 @@ impl OrbitRuntime {
         } = options;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
-        let task = self.get_task(id)?;
-        // Validate status before crew resolution so a misleading
-        // "no crew selected" error can't mask the real problem
-        // (e.g. trying to restart a task that's already in-progress).
-        match task.status {
-            TaskStatus::Proposed
-            | TaskStatus::Backlog
-            | TaskStatus::Someday
-            | TaskStatus::Blocked => {}
-            TaskStatus::InProgress => {
-                return Err(OrbitError::InvalidInput(format!(
-                    "task '{id}' is already in-progress"
-                )));
-            }
-            other => {
-                return Err(OrbitError::InvalidInput(format!(
-                    "task '{id}' is in status '{other}'; start requires 'proposed', 'backlog', 'someday', or 'blocked'"
-                )));
-            }
-        }
-        self.resolve_and_log_crew_for_task_start(
-            id,
-            crew_override.as_deref(),
-            task.crew.as_deref(),
-        )?;
-        let dependency_status_index = self.task_status_index()?;
-        let unmet_dependencies = unmet_task_dependencies(&task, &dependency_status_index);
-        if in_progress_transition_requires_plan(task.status) {
-            ensure_task_has_execution_plan(id, task.plan.as_str())?;
-        }
         let actor = self.actor().clone();
         let effective_label = actor_label_override.unwrap_or_else(|| {
             effective_actor_label(
@@ -307,23 +305,57 @@ impl OrbitRuntime {
             )
         });
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
-        let unmet_dependency_labels: Vec<String> = unmet_dependencies
-            .iter()
-            .map(|dependency| dependency.label())
-            .collect();
-        let warn_unmet_dependencies = || {
-            if !unmet_dependency_labels.is_empty() {
-                orbit_common::tracing::warn!(
-                    target: "orbit.task.dependencies",
-                    task_id = id,
-                    unmet = unmet_dependency_labels.join(",").as_str(),
-                    "task has unmet dependencies",
-                );
+        let mut started = None;
+        self.stores().tasks().with_task_write_lock(id, &mut || {
+            let task = self.get_task(id)?;
+            #[cfg(test)]
+            self.apply_transition_read_hook(id)?;
+            // Validate status before crew resolution so a misleading
+            // "no crew selected" error can't mask the real problem
+            // (e.g. trying to restart a task that's already in-progress).
+            match task.status {
+                TaskStatus::Proposed
+                | TaskStatus::Backlog
+                | TaskStatus::Someday
+                | TaskStatus::Blocked => {}
+                TaskStatus::InProgress => {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "task '{id}' is already in-progress"
+                    )));
+                }
+                other => {
+                    return Err(OrbitError::InvalidInput(format!(
+                        "task '{id}' is in status '{other}'; start requires 'proposed', 'backlog', 'someday', or 'blocked'"
+                    )));
+                }
             }
-        };
+            self.resolve_and_log_crew_for_task_start(
+                id,
+                crew_override.as_deref(),
+                task.crew.as_deref(),
+            )?;
+            let dependency_status_index = self.task_status_index()?;
+            let unmet_dependencies = unmet_task_dependencies(&task, &dependency_status_index);
+            if in_progress_transition_requires_plan(task.status) {
+                ensure_task_has_execution_plan(id, task.plan.as_str())?;
+            }
+            let unmet_dependency_labels: Vec<String> = unmet_dependencies
+                .iter()
+                .map(|dependency| dependency.label())
+                .collect();
+            let warn_unmet_dependencies = || {
+                if !unmet_dependency_labels.is_empty() {
+                    orbit_common::tracing::warn!(
+                        target: "orbit.task.dependencies",
+                        task_id = id,
+                        unmet = unmet_dependency_labels.join(",").as_str(),
+                        "task has unmet dependencies",
+                    );
+                }
+            };
 
-        match task.status {
-            TaskStatus::Proposed => {
+            started = Some(match task.status {
+                TaskStatus::Proposed => {
                 warn_unmet_dependencies();
                 let result = self.with_mutation(|| {
                     let at = chrono::Utc::now();
@@ -341,6 +373,7 @@ impl OrbitRuntime {
                                 to_status: Some(TaskStatus::Backlog),
                             }],
                             append_comments: append_comments.clone(),
+                            expected_status: Some(vec![task.status]),
                             ..StoreTaskUpdateParams::from(TaskUpdateParams {
                                 status: Some(TaskStatus::InProgress),
                                 ..Default::default()
@@ -356,9 +389,9 @@ impl OrbitRuntime {
                         },
                     ))
                 })?;
-                Ok(result)
-            }
-            TaskStatus::Backlog | TaskStatus::Someday | TaskStatus::Blocked => {
+                    Ok(result)
+                }
+                TaskStatus::Backlog | TaskStatus::Someday | TaskStatus::Blocked => {
                 warn_unmet_dependencies();
                 let task = self.with_mutation(|| {
                     let task = self.stores().task_records().update(
@@ -368,6 +401,7 @@ impl OrbitRuntime {
                             status_event: Some("started".to_string()),
                             status_note: note.clone(),
                             append_comments: append_comments.clone(),
+                            expected_status: Some(vec![task.status]),
                             ..StoreTaskUpdateParams::from(TaskUpdateParams {
                                 status: Some(TaskStatus::InProgress),
                                 ..Default::default()
@@ -383,15 +417,20 @@ impl OrbitRuntime {
                         },
                     ))
                 })?;
-                Ok(task)
-            }
-            TaskStatus::InProgress => Err(OrbitError::InvalidInput(format!(
-                "task '{id}' is already in-progress"
-            ))),
-            other => Err(OrbitError::InvalidInput(format!(
-                "task '{id}' is in status '{other}'; start requires 'proposed', 'backlog', 'someday', or 'blocked'"
-            ))),
-        }
+                    Ok(task)
+                }
+                TaskStatus::InProgress => Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is already in-progress"
+                ))),
+                other => Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is in status '{other}'; start requires 'proposed', 'backlog', 'someday', or 'blocked'"
+                ))),
+            }?);
+            Ok(())
+        })?;
+        started.ok_or_else(|| {
+            OrbitError::Execution("task start body did not run under the task lock".to_string())
+        })
     }
 
     /// Lifecycle half of workflow admission: is this task's *status* one a
@@ -582,7 +621,6 @@ impl OrbitRuntime {
         self.ensure_coordination_task_write_permitted()?;
         let (canonical_agent, canonical_model) =
             self.try_canonical_agent_model_identity(agent.as_deref(), model.as_deref())?;
-        let task = self.get_task(id)?;
         let actor = self.actor().clone();
         let effective_label = effective_actor_label(
             &actor.label,
@@ -598,8 +636,13 @@ impl OrbitRuntime {
         let reason = reason.to_string();
         let append_comments = build_task_comments(comment, effective_label.as_str())?;
 
-        let result = match task.status {
-            TaskStatus::Proposed => self.with_mutation(|| {
+        let mut result = None;
+        self.stores().tasks().with_task_write_lock(id, &mut || {
+            let task = self.get_task(id)?;
+            #[cfg(test)]
+            self.apply_transition_read_hook(id)?;
+            result = Some(match task.status {
+                TaskStatus::Proposed => self.with_mutation(|| {
                 let task = self.stores().task_records().update(
                     id,
                     StoreTaskUpdateParams {
@@ -608,6 +651,7 @@ impl OrbitRuntime {
                         status_event: Some("proposal_rejected".to_string()),
                         status_note: Some(reason.clone()),
                         append_comments: append_comments.clone(),
+                        expected_status: Some(vec![task.status]),
                         ..Default::default()
                     },
                 )?;
@@ -618,8 +662,8 @@ impl OrbitRuntime {
                         rejected_by: effective_label.clone(),
                     },
                 ))
-            }),
-            TaskStatus::Review => self.with_mutation(|| {
+                }),
+                TaskStatus::Review => self.with_mutation(|| {
                 let task = self.stores().task_records().update(
                     id,
                     StoreTaskUpdateParams {
@@ -628,6 +672,7 @@ impl OrbitRuntime {
                         status_event: Some("review_rejected".to_string()),
                         status_note: Some(reason.clone()),
                         append_comments: append_comments.clone(),
+                        expected_status: Some(vec![task.status]),
                         ..Default::default()
                     },
                 )?;
@@ -638,8 +683,8 @@ impl OrbitRuntime {
                         rejected_by: effective_label.clone(),
                     },
                 ))
-            }),
-            TaskStatus::Backlog => self.with_mutation(|| {
+                }),
+                TaskStatus::Backlog => self.with_mutation(|| {
                 let task = self.stores().task_records().update(
                     id,
                     StoreTaskUpdateParams {
@@ -648,6 +693,7 @@ impl OrbitRuntime {
                         status_event: Some("backlog_rejected".to_string()),
                         status_note: Some(reason.clone()),
                         append_comments: append_comments.clone(),
+                        expected_status: Some(vec![task.status]),
                         ..Default::default()
                     },
                 )?;
@@ -658,8 +704,8 @@ impl OrbitRuntime {
                         rejected_by: effective_label.clone(),
                     },
                 ))
-            }),
-            TaskStatus::InProgress => self.with_mutation(|| {
+                }),
+                TaskStatus::InProgress => self.with_mutation(|| {
                 let task = self.stores().task_records().update(
                     id,
                     StoreTaskUpdateParams {
@@ -668,6 +714,7 @@ impl OrbitRuntime {
                         status_event: Some("in_progress_rejected".to_string()),
                         status_note: Some(reason.clone()),
                         append_comments: append_comments.clone(),
+                        expected_status: Some(vec![task.status]),
                         ..Default::default()
                     },
                 )?;
@@ -678,11 +725,16 @@ impl OrbitRuntime {
                         rejected_by: effective_label.clone(),
                     },
                 ))
-            }),
-            other => Err(OrbitError::InvalidInput(format!(
-                "task '{id}' is in status '{other}'; reject requires 'proposed', 'review', 'backlog', or 'in-progress'"
-            ))),
-        }?;
+                }),
+                other => Err(OrbitError::InvalidInput(format!(
+                    "task '{id}' is in status '{other}'; reject requires 'proposed', 'review', 'backlog', or 'in-progress'"
+                ))),
+            }?);
+            Ok(())
+        })?;
+        let result = result.ok_or_else(|| {
+            OrbitError::Execution("task reject body did not run under the task lock".to_string())
+        })?;
 
         Ok(result)
     }
@@ -707,6 +759,26 @@ impl OrbitRuntime {
             }
             Ok(((), OrbitEvent::TaskDeleted { id: id.to_string() }))
         })
+    }
+
+    #[cfg(test)]
+    fn apply_transition_read_hook(&self, id: &str) -> Result<(), OrbitError> {
+        if let Some((hook_id, status)) = TRANSITION_READ_HOOK_STATUS
+            .lock()
+            .expect("transition read hook mutex")
+            .clone()
+            && hook_id == id
+        {
+            self.update_task(
+                id,
+                TaskUpdateParams {
+                    status: Some(status),
+                    ..Default::default()
+                },
+            )?;
+        }
+
+        Ok(())
     }
 
     pub fn delete_task_guarded(&self, id: &str, force: bool) -> Result<(), OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11601](https://orbit-cli.com/tasks/ORB-11601) — [code-review] Apply the task write lock / status compare-and-set to approve, start, and reject transitions

### Description

## Problem
ORB-10988 fixed the lost-update race for `update_task` by wrapping the read-modify-write in `with_task_write_lock` (`update.rs:114-143`), and ORB-11305 added a store-level compare-and-set (`expected_status`, `params.rs:100`, enforced in `orbit-store/src/repository/task/v2/updates.rs:196-210`) used by `admit_task_for_workflow_as_system` (`transitions.rs:476`). The three human-facing transitions never got either: `approve_task_with_identity` reads `task.status` at line 55 and writes at 70-114 with no lock and no `expected_status`; `start_task_with_actor_label_override` reads at 271 and writes at 328-385; `reject_task_with_identity` reads at 585 and writes at 601-685. Concrete failures: (a) a task in `review` is approved and rejected concurrently — both read `review`, one writes `rejected`, the other overwrites it with `done` and fires the `resolves` friction auto-resolution side effect (line 120-122) for a task a human just rejected; (b) `orbit task update --status someday` (withdrawal, taken under the lock) races `orbit task start` — start read `backlog`, then writes `in-progress`, silently undoing the withdrawal; (c) two concurrent starts both append a `started` history event.

## Why It Matters
These are the transitions the dashboard, MCP and CLI expose to humans and agents simultaneously; the store already offers the CAS primitive, so the remaining paths are an unforced inconsistency in the "one canonical execution path" rule.

## Proposed Fix
In each of the three writes pass `expected_status: Some(vec![<status the decision was made against>])` in `StoreTaskUpdateParams` (mirroring line 476), and run the read+decision+write inside `self.stores().tasks().with_task_write_lock(id, ...)` exactly as `update_task_with_context` does, keeping `record_resolves_side_effects` outside the lock.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/task/transitions.rs:44-125`, `crates/orbit-core/src/application/task/transitions.rs:255-395`, `crates/orbit-core/src/application/task/transitions.rs:574-688`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- New sibling tests in `application/task/tests/` that pre-change the status between the read and the write (e.g. via the store directly) and assert approve/start/reject return `InvalidInput` naming the changed status rather than overwriting it.
- `approve` of a task that was concurrently `reject`ed never runs `apply_resolves_side_effects`.
- Existing `tests/update.rs` lock tests still pass; `make ci-lint` clean.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Wrapped approve, start, and reject read/validate/write paths in the per-task write lock and supplied the status snapshot as the store compare-and-set expectation.
- Kept review approval resolves processing after the locked transition.
- Added deterministic sibling regression tests that mutate the task directly after each transition reads it; each transition returns InvalidInput naming rejected rather than overwriting it. The review-approval test also proves the linked friction remains open.

Criteria:
- 1: approve/start/reject stale-write tests pass and assert the changed rejected status is named.
- 2: review approval after the injected direct rejection returns an error and leaves the resolves friction Open.
- 3: existing task update tests and workspace lint pass.

Validation:
- cargo test -p orbit-core application::task::tests --lib: passed (51 tests).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.

Risk: the test-only read hook is scoped to a generated task ID and serializes its setup, allowing the regression tests to deterministically exercise the read-to-write window without affecting production behavior.

Assessment: task-scoped, formatted, and ready for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11601-6a9f5b13`
- Behind base: 0
- Ahead of base: 1