### PR TITLE
[code-review] Stop the pipeline worker observer from polling SQLite every 25 ms for the run's whole lifetime

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1441,6 +1441,8 @@ impl OrbitRuntime {
         let child_pid = child.id();
         let mut claimed = false;
         loop {
+            #[cfg(test)]
+            worker_observer_read_counter::record(run_id);
             let run = self
                 .get_job_run_backend(run_id)?
                 .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
@@ -1463,11 +1465,33 @@ impl OrbitRuntime {
                 claimed = true;
             }
 
-            if let Some(status) = child.try_wait().map_err(|error| {
-                OrbitError::Execution(format!(
-                    "observe pipeline worker process for run '{run_id}': {error}"
-                ))
-            })? {
+            // A persisted owner or non-pending state settles the only startup
+            // question this observer owns. Waiting for the child avoids a
+            // full run/step SQLite read every 25ms throughout normal work.
+            let status = if run.pid.is_some() || run.state != JobRunState::Pending {
+                Some(child.wait().map_err(|error| {
+                    OrbitError::Execution(format!(
+                        "wait for pipeline worker process for run '{run_id}': {error}"
+                    ))
+                })?)
+            } else {
+                child.try_wait().map_err(|error| {
+                    OrbitError::Execution(format!(
+                        "observe pipeline worker process for run '{run_id}': {error}"
+                    ))
+                })?
+            };
+
+            if let Some(status) = status {
+                // The worker may have changed the run after the last startup
+                // observation. Exit handling must use fresh state so duplicate
+                // ownership, cancellation, and terminal outcomes stay
+                // authoritative.
+                #[cfg(test)]
+                worker_observer_read_counter::record(run_id);
+                let run = self.get_job_run_backend(run_id)?.ok_or_else(|| {
+                    OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string())
+                })?;
                 let output = read_pipeline_worker_log_tail(worker_log);
                 let output_detail = output
                     .as_deref()
@@ -2114,5 +2138,57 @@ pub(crate) mod worker_command_override {
             .current_dir(workspace)
             .stdin(Stdio::null());
         Some(command)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod worker_observer_read_counter {
+    use std::collections::HashMap;
+    use std::sync::{LazyLock, Mutex};
+
+    static COUNTS: LazyLock<Mutex<HashMap<String, usize>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    pub(crate) struct Counter {
+        run_id: String,
+    }
+
+    pub(crate) fn track(run_id: &str) -> Counter {
+        COUNTS
+            .lock()
+            .expect("test observer counters are not poisoned")
+            .insert(run_id.to_string(), 0);
+        Counter {
+            run_id: run_id.to_string(),
+        }
+    }
+
+    pub(crate) fn record(run_id: &str) {
+        if let Some(count) = COUNTS
+            .lock()
+            .expect("test observer counters are not poisoned")
+            .get_mut(run_id)
+        {
+            *count += 1;
+        }
+    }
+
+    impl Counter {
+        pub(crate) fn reads(&self) -> usize {
+            *COUNTS
+                .lock()
+                .expect("test observer counters are not poisoned")
+                .get(&self.run_id)
+                .expect("tracked observer counter exists")
+        }
+    }
+
+    impl Drop for Counter {
+        fn drop(&mut self) {
+            COUNTS
+                .lock()
+                .expect("test observer counters are not poisoned")
+                .remove(&self.run_id);
+        }
     }
 }

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -18,7 +18,7 @@ use crate::application::job::JobRunListParams;
 use crate::application::job::pipeline::{
     configure_pipeline_worker_command, configure_pipeline_worker_stdio, pipeline_worker_log_path,
     pipeline_worker_profile_file, pipeline_worker_root_override,
-    resolve_pipeline_worker_executable, worker_command_override,
+    resolve_pipeline_worker_executable, worker_command_override, worker_observer_read_counter,
 };
 use crate::application::task::TaskAddParams;
 use crate::application::workflow::{CompletionPolicy, ShipMode};
@@ -317,6 +317,57 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
         .and_then(|step| step.error_message.as_deref())
         .expect("claimed exit diagnostic");
     assert!(message.contains("after claiming"), "{message}");
+    assert_child_reaped(worker_pid);
+}
+
+/// Once a worker has claimed the run, the startup observer waits for its exit
+/// instead of polling the run row for the rest of the worker lifetime.
+#[cfg(unix)]
+#[test]
+fn claimed_sleeping_worker_does_not_keep_polling_the_run_store() {
+    let (_root, runtime) = test_runtime();
+    let _worker = WorkerOverride::shell("sleep 3");
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
+        .expect("insert pending run");
+    let observer_reads = worker_observer_read_counter::track(&run.run_id);
+    let command = worker_command_override::command(&runtime.paths().repo_root, &run.run_id)
+        .expect("build sleeping worker command");
+    let log_path = pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id);
+
+    let worker_pid = runtime
+        .spawn_pipeline_worker_process(&run.run_id, Some("test"), command, log_path)
+        .expect("spawn detached sleeping worker");
+    runtime
+        .stores()
+        .jobs()
+        .claim_pending_job_run_owner(&run.run_id, worker_pid)
+        .expect("claim sleeping worker");
+
+    wait_for_pipeline_audit_event(&runtime, None, "claimed-worker audit", |audit| {
+        audit.tool_name.as_deref() == Some("pipeline.worker.claimed")
+            && audit.target_id.as_deref() == Some(run.run_id.as_str())
+    });
+    let reads_after_claim = observer_reads.reads();
+
+    // The worker remains alive for three seconds. Its terminal diagnostic
+    // proves the observer reaped it, while this ownership interval retains the
+    // old 25ms poll long enough to make a bounded-read regression observable.
+    thread::sleep(Duration::from_millis(250));
+    assert!(
+        observer_reads.reads() <= reads_after_claim + 1,
+        "claimed worker added {} run-store reads after startup ownership settled",
+        observer_reads.reads() - reads_after_claim
+    );
+    let stored = runtime.show_job_run(&run.run_id).expect("show claimed run");
+    assert_eq!(stored.pid, Some(worker_pid));
+    assert_eq!(stored.state, JobRunState::Pending);
+
+    thread::sleep(Duration::from_secs(3));
+    let terminal = wait_for_worker_terminal(&runtime, &run.run_id);
+    assert_eq!(terminal.state, JobRunState::Interrupted);
     assert_child_reaped(worker_pid);
 }
 


### PR DESCRIPTION
## Task

[ORB-11602](https://orbit-cli.com/tasks/ORB-11602) — [code-review] Stop the pipeline worker observer from polling SQLite every 25 ms for the run's whole lifetime

### Description

## Problem
`monitor_pipeline_worker_startup` is named as a *startup* observer, but its loop (`loop { get_job_run_backend(); ... child.try_wait(); ... thread::sleep(25ms) }`, lines 1438-1543) never exits until the child process exits. After the worker has claimed the run (line 1442-1459) the loop keeps issuing `get_job_run_backend` (a SQLite read of the run row plus its steps) 40 times per second until the run terminalizes. The thread lives in the *submitting* process: for `orbit-web` (which holds `Arc<OrbitRuntime>` for the process lifetime) and for a `workspace_auto_pipeline` coordinator submitting leaf children via `submit_child_pipeline_run` (line 629), that is 40 × N reads/sec for N live children over runs that last from minutes to hours, contending on the shared host `orbit.db` with the workers themselves.

## Why It Matters
This is a steady CPU/IO tax on every long-lived Orbit process proportional to concurrent runs, and it competes with the SQLite write path the workers need.

## Proposed Fix
After the `pipeline.worker.claimed` audit (or after the run leaves `pending`), switch to a slow cadence (e.g. 1-2 s) or block on `child.wait()` in the thread and only re-read the run row once on exit; keep the fast 25 ms cadence only for the pre-claim window bounded by a short deadline.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/job/pipeline.rs:1428-1544`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (performance). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test using `worker_command_override` with a worker that sleeps several seconds asserts the observer performs a bounded number of run reads after the claim (instrument via a counting `JobRunStoreBackend` wrapper or by asserting elapsed sleep cadence).
- Startup-failure detection (`finalize_pipeline_worker_exit_failure`) and the SIGTERM/SIGKILL cancellation path still pass `application/job/run/tests/cancellation_race.rs` and `tests/job_pipeline.rs`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Observer now waits on a child once durable ownership or a non-pending state is observed, then re-reads the run after exit for authoritative duplicate, cancellation, terminal, and failure handling.
- Added a three-second claimed-worker regression that counts observer run reads and proves they stop after claim.
Assessment: focused lifecycle change; no production polling remains after startup settles.
Criteria:
- Bounded reads: passed; claimed sleeping worker records no sustained post-claim observer reads.
- Startup failure and cancellation: passed via full job_pipeline and cancellation_race module tests.
Validation:
- cargo test -p orbit-core application::tests::job_pipeline:: --lib: passed (21 tests).
- cargo test -p orbit-core application::job::run::tests::cancellation_race:: --lib: passed (5 tests).
- make ci-fast: passed.
- CARGO_BUILD_JOBS=2 make ci-lint: passed.
- git diff --check: passed.
Risks: child.wait blocks this observer thread after startup settles by design; exit handling refreshes persisted state before making decisions.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11602-6a9f5b32`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol