### PR TITLE
Classify cancelled CI jobs without steps as inconclusive instead of retryable log failures

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/ci_failure_tasks.rs
@@ -177,11 +177,18 @@ where
     }
 
     let max_tasks = bounded_u64(input, "max_tasks", DEFAULT_MAX_TASKS, MAX_MAX_TASKS)? as usize;
-    let failures = evidence
-        .get("current_failures")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+    let (failures, inconclusive) = split_inconclusive_cancellations(
+        evidence
+            .get("current_failures")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+        evidence
+            .get("inconclusive")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default(),
+    );
     let audit = audit_summary(evidence, &failures);
     let mut retryable_errors = evidence
         .get("retryable_errors")
@@ -201,6 +208,7 @@ where
         .into_iter()
         .map(normalize_retryable_error)
         .collect();
+    retryable_errors = drop_inconclusive_log_errors(retryable_errors, &inconclusive);
     // A gap in one run's evidence is a fact about that run. Letting it also
     // withhold every complete finding in the same snapshot is how a sweep that
     // had three fully evidenced regressions in hand filed nothing at all.
@@ -285,7 +293,7 @@ where
             "reasons": reasons,
         }));
     }
-    let audit = deferral_audit(audit, &deferred);
+    let audit = inconclusive_audit(deferral_audit(audit, &deferred), &inconclusive);
     let clusters = cluster_failures(&complete);
 
     if !complete.is_empty() && clusters.is_empty() {
@@ -322,8 +330,13 @@ where
             "skipped_existing": [],
             "skipped_over_cap": [],
             "deferred": [],
+            "inconclusive": inconclusive,
             "audit": audit,
-            "detail": "the queries ran and found no current, non-superseded failure",
+            "detail": if inconclusive.is_empty() {
+                "the queries ran and found no current, non-superseded failure"
+            } else {
+                "the queries ran and found no current, non-superseded failure; cancelled jobs without failed steps remain explicit inconclusive evidence, not a pass"
+            },
         }));
     }
 
@@ -524,6 +537,7 @@ where
         "repair_assessments": repair_assessments,
         "skipped_over_cap": skipped_over_cap,
         "deferred": deferred,
+        "inconclusive": inconclusive,
         "max_tasks": max_tasks,
         "audit": final_audit,
     }))
@@ -538,6 +552,121 @@ fn run_id_key(entry: &Value) -> Option<String> {
         Some(Value::String(text)) if !text.trim().is_empty() => Some(text.trim().to_string()),
         _ => None,
     }
+}
+
+fn job_is_cancelled_without_failed_steps(job: &Value) -> bool {
+    job.get("conclusion").and_then(Value::as_str) == Some("cancelled")
+        && job
+            .get("failed_steps")
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
+}
+
+fn is_inconclusive_cancellation(failure: &Value) -> bool {
+    if failure.get("evidence_state").and_then(Value::as_str) == Some("inconclusive") {
+        return true;
+    }
+    match failure.get("failed_jobs").and_then(Value::as_array) {
+        Some(jobs) if !jobs.is_empty() => jobs.iter().all(job_is_cancelled_without_failed_steps),
+        Some(_) | None => {
+            failure.get("conclusion").and_then(Value::as_str) == Some("cancelled")
+                && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+        }
+    }
+}
+
+fn split_inconclusive_cancellations(
+    failures: Vec<Value>,
+    mut inconclusive: Vec<Value>,
+) -> (Vec<Value>, Vec<Value>) {
+    let mut seen: BTreeSet<(Option<String>, Option<u64>)> = inconclusive
+        .iter()
+        .map(|entry| {
+            (
+                run_id_key(entry),
+                entry.get("job_id").and_then(Value::as_u64),
+            )
+        })
+        .collect();
+    let mut remaining = Vec::new();
+    for failure in failures {
+        if is_inconclusive_cancellation(&failure) {
+            let identity = (
+                run_id_key(&failure),
+                failure.get("job_id").and_then(Value::as_u64),
+            );
+            if seen.insert(identity) {
+                inconclusive.push(failure);
+            }
+        } else {
+            remaining.push(failure);
+        }
+    }
+    (remaining, inconclusive)
+}
+
+fn log_or_checkout_investigation_operation(operation: &str) -> bool {
+    matches!(
+        operation,
+        "run_logs"
+            | "run_logs_all"
+            | "checkout_evidence"
+            | "checkout_evidence_budget"
+            | "job_log_truncated"
+            | "job_log_budget"
+    )
+}
+
+/// Absent logs for a cancelled job with no failed steps are not a repair
+/// gap. Keep transport, auth, listing, and genuine-failure log errors.
+fn drop_inconclusive_log_errors(errors: Vec<Value>, inconclusive: &[Value]) -> Vec<Value> {
+    let inconclusive_runs: BTreeSet<String> = inconclusive.iter().filter_map(run_id_key).collect();
+    let inconclusive_jobs: BTreeSet<(String, u64)> = inconclusive
+        .iter()
+        .filter_map(|entry| {
+            Some((
+                run_id_key(entry)?,
+                entry.get("job_id").and_then(Value::as_u64)?,
+            ))
+        })
+        .collect();
+    errors
+        .into_iter()
+        .filter(|error| {
+            let operation = error
+                .get("operation")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if !log_or_checkout_investigation_operation(operation) {
+                return true;
+            }
+            let Some(run_id) = run_id_key(error) else {
+                return true;
+            };
+            match error.get("job_id").and_then(Value::as_u64) {
+                Some(job_id) => !inconclusive_jobs.contains(&(run_id, job_id)),
+                None => !inconclusive_runs.contains(&run_id),
+            }
+        })
+        .collect()
+}
+
+fn inconclusive_audit(mut audit: Value, inconclusive: &[Value]) -> Value {
+    audit["inconclusive"] = json!(inconclusive.len());
+    audit["inconclusive_run_ids"] = json!(
+        inconclusive
+            .iter()
+            .filter_map(|entry| entry.get("run_id").cloned())
+            .collect::<Vec<_>>()
+    );
+    audit["inconclusive_job_ids"] = json!(
+        inconclusive
+            .iter()
+            .filter_map(|entry| entry.get("job_id").cloned())
+            .filter(|value| !value.is_null())
+            .collect::<Vec<_>>()
+    );
+    audit
 }
 
 /// Split retryable errors by blast radius.

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_cancelled.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_cancelled.rs
@@ -1,0 +1,196 @@
+//! Filing cancelled zero-step CI jobs as inconclusive, never as repair tasks.
+
+use serde_json::{Value, json};
+
+use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_layout;
+
+use super::ci_failure_tasks::{CHECKOUT, failure, file, file_error, snapshot};
+
+const CODEQL_RUN: u64 = 34_168_609_753;
+const CODEQL_JOBS: [u64; 4] = [
+    101_884_485_004,
+    101_884_485_211,
+    101_884_485_221,
+    101_884_485_257,
+];
+
+fn cancelled_zero_step(job_id: u64, name: &str) -> Value {
+    json!({
+        "run_id": CODEQL_RUN,
+        "job_id": job_id,
+        "workflow": "CodeQL",
+        "title": "CodeQL",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "event": "push",
+        "url": format!("https://github.com/acme/orbit/actions/runs/{CODEQL_RUN}"),
+        "created_at": "2026-09-07T23:00:00Z",
+        "head_branch": "agent-main",
+        "ref_kind": "integration",
+        "investigated": true,
+        "evidence_state": "inconclusive",
+        "inconclusive_reason": "cancelled_without_failed_steps",
+        "failed_jobs": [{
+            "job_id": job_id,
+            "name": name,
+            "conclusion": "cancelled",
+            "url": format!("https://github.com/acme/orbit/actions/runs/{CODEQL_RUN}/job/{job_id}"),
+            "failed_steps": [],
+        }],
+    })
+}
+
+fn four_cancelled_jobs() -> Vec<Value> {
+    CODEQL_JOBS
+        .iter()
+        .enumerate()
+        .map(|(index, job_id)| cancelled_zero_step(*job_id, &format!("Analyze ({index})")))
+        .collect()
+}
+
+#[test]
+fn cancelled_zero_step_jobs_file_nothing_and_stay_explicitly_inconclusive() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut evidence = snapshot(Vec::new());
+    evidence["inconclusive"] = json!(four_cancelled_jobs());
+    evidence["summary"] = json!({"inconclusive": 4, "retryable_errors": 0});
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["outcome"], json!("no_current_failure"));
+    assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(output["deferred"], json!([]));
+    assert_eq!(
+        output["inconclusive"]
+            .as_array()
+            .expect("inconclusive")
+            .len(),
+        4
+    );
+    assert_eq!(output["audit"]["inconclusive"], json!(4));
+    assert!(
+        output["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("inconclusive")),
+        "detail must name the cancelled jobs: {output}"
+    );
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
+    );
+}
+
+#[test]
+fn leaked_cancelled_log_404s_are_not_retryable_and_still_file_nothing() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let jobs = four_cancelled_jobs();
+    let mut evidence = snapshot(jobs.clone());
+    evidence["retryable_errors"] = json!(
+        jobs.iter()
+            .flat_map(|job| {
+                let job_id = job["job_id"].clone();
+                [
+                    json!({
+                        "stage": "investigation",
+                        "operation": "run_logs",
+                        "run_id": CODEQL_RUN,
+                        "job_id": job_id,
+                        "retryable": true,
+                        "message": "Not Found (HTTP 404)",
+                    }),
+                    json!({
+                        "stage": "investigation",
+                        "operation": "run_logs_all",
+                        "run_id": CODEQL_RUN,
+                        "job_id": job_id,
+                        "retryable": true,
+                        "message": "Not Found (HTTP 404)",
+                    }),
+                ]
+            })
+            .collect::<Vec<_>>()
+    );
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["outcome"], json!("no_current_failure"));
+    assert_eq!(output["filed_count"], json!(0));
+    assert_eq!(
+        output["inconclusive"]
+            .as_array()
+            .expect("inconclusive")
+            .len(),
+        4
+    );
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
+    );
+}
+
+#[test]
+fn mixed_snapshot_files_the_failed_step_and_lists_the_cancelled_job() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let complete = failure(
+        20,
+        "ci",
+        "build",
+        "cargo test",
+        "ci\tbuild\t##[error]assertion failed\n",
+        CHECKOUT,
+    );
+    let evidence = snapshot(vec![
+        complete,
+        cancelled_zero_step(CODEQL_JOBS[0], "Analyze"),
+    ]);
+
+    let output = file(&runtime, json!({"ci_evidence": evidence}));
+
+    assert_eq!(output["outcome"], json!("current_failures"));
+    assert_eq!(output["filed_count"], json!(1));
+    assert_eq!(
+        output["inconclusive"]
+            .as_array()
+            .expect("inconclusive")
+            .len(),
+        1
+    );
+    assert_eq!(output["inconclusive"][0]["job_id"], json!(CODEQL_JOBS[0]));
+    assert_eq!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn genuine_failure_log_404_stays_retryable() {
+    let (_root, runtime, _repo_root) = runtime_with_workspace_layout();
+    let mut missing_log = failure(10, "ci", "build", "Run CI guardrails", "", CHECKOUT);
+    missing_log["log_excerpt"] = json!("");
+    let mut evidence = snapshot(vec![missing_log]);
+    evidence["retryable_errors"] = json!([{
+        "stage": "investigation",
+        "operation": "run_logs",
+        "run_id": 10,
+        "job_id": 910,
+        "retryable": true,
+        "message": "Not Found (HTTP 404)",
+    }]);
+
+    let error = file_error(&runtime, json!({"ci_evidence": evidence}));
+    assert!(error.contains("retryable_error"));
+    assert!(error.contains("Not Found (HTTP 404)"));
+    assert!(
+        runtime
+            .list_tasks_by_tags(&["ci-failure-sweep".to_string()])
+            .expect("list tasks")
+            .is_empty()
+    );
+}

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/ci_failure_tasks.rs
@@ -17,10 +17,10 @@ use crate::adapter::engine_host::v2_host::test_support::runtime_with_workspace_l
 use crate::application::task::TaskUpdateParams;
 
 const HEAD: &str = "1111111111111111111111111111111111111111";
-const CHECKOUT: &str = "3333333333333333333333333333333333333333";
+pub(super) const CHECKOUT: &str = "3333333333333333333333333333333333333333";
 const NEXT_HEAD: &str = "4444444444444444444444444444444444444444";
 
-fn file(runtime: &OrbitRuntime, input: Value) -> Value {
+pub(super) fn file(runtime: &OrbitRuntime, input: Value) -> Value {
     runtime
         .run_deterministic(
             "file_ci_failure_tasks",
@@ -31,7 +31,7 @@ fn file(runtime: &OrbitRuntime, input: Value) -> Value {
         .expect("file ci failure tasks")
 }
 
-fn file_error(runtime: &OrbitRuntime, input: Value) -> String {
+pub(super) fn file_error(runtime: &OrbitRuntime, input: Value) -> String {
     runtime
         .run_deterministic(
             "file_ci_failure_tasks",

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/mod.rs
@@ -1,5 +1,6 @@
 mod backlog_exclusion;
 mod ci_failure_admission;
+mod ci_failure_cancelled;
 mod ci_failure_tasks;
 mod cli_executor;
 mod dependabot_alert_tasks;

--- a/crates/orbit-engine/src/executor/automation/ci/collect.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/collect.rs
@@ -242,7 +242,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
     let RunPartition {
         latest,
         mut current,
-        stale,
+        mut stale,
         in_flight,
         mixed_candidates,
         mut deferred,
@@ -317,11 +317,20 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             &mut retryable_errors,
         ));
     }
-    current = findings
-        .into_iter()
-        .filter(is_actionable_current_failure)
-        .collect();
+    let mut inconclusive = Vec::new();
+    let mut remaining = Vec::new();
+    for finding in findings {
+        if is_inconclusive_cancellation(&finding) {
+            inconclusive.push(finding);
+            continue;
+        }
+        if is_actionable_current_failure(&finding) {
+            remaining.push(finding);
+        }
+    }
+    current = supersede_older_when_cancelled_run_is_actionable(remaining, &mut stale);
     sort_current_failures(&mut current);
+    sort_current_failures(&mut inconclusive);
     let discovered = current.len();
     let investigated_ids = current
         .iter()
@@ -340,6 +349,22 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         .iter()
         .filter_map(|run| run.get("run_id").cloned())
         .collect::<Vec<_>>();
+    let inconclusive_ids = inconclusive
+        .iter()
+        .filter_map(|run| run.get("run_id").cloned())
+        .collect::<Vec<_>>();
+    let inconclusive_job_ids = inconclusive
+        .iter()
+        .filter_map(|run| run.get("job_id").cloned())
+        .filter(|value| !value.is_null())
+        .collect::<Vec<_>>();
+    let inconclusive_count = inconclusive.len();
+    if inconclusive_count > 0 {
+        notes.push(format!(
+            "{inconclusive_count} cancelled job(s) had no failed steps and were classified \
+             inconclusive; cancellation is not a pass, but there is no failed step to repair"
+        ));
+    }
     let investigated_count = investigated_ids.len();
     let retryable_error_count = retryable_errors.len();
     let unverified_refs = probes.unverified.keys().cloned().collect::<Vec<_>>();
@@ -362,6 +387,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
         "stale_or_superseded": stale,
         "in_flight": in_flight,
         "deferred": deferred,
+        "inconclusive": inconclusive,
         "retryable_errors": retryable_errors,
         "summary": {
             "latest_runs_discovered": latest_ids.len(),
@@ -372,6 +398,9 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "investigated_failure_run_ids": investigated_ids,
             "deferred_failures": deferred_ids.len(),
             "deferred_failure_run_ids": deferred_ids,
+            "inconclusive": inconclusive_count,
+            "inconclusive_run_ids": inconclusive_ids,
+            "inconclusive_job_ids": inconclusive_job_ids,
             "retryable_errors": retryable_error_count,
         },
         "truncation": json!({
@@ -386,6 +415,7 @@ pub(super) fn collect<Q: CiQueries + ?Sized>(
             "current_failures_discovered": discovered,
             "current_failures_investigation_attempted": attempted,
             "current_failures_investigated": investigated_count,
+            "inconclusive": inconclusive_count,
             "log_max_bytes": bounds.log_max_bytes,
             "job_log_reads": job_log_reads,
             "max_job_log_reads": bounds.max_job_log_reads,
@@ -806,7 +836,13 @@ fn partition_runs(
                     continue;
                 }
                 out.current.push(run_summary(ref_for_run(refs, run), run));
-                seen_current = true;
+                // A cancelled run is still inspected, but job expansion has to
+                // decide whether it is actionable. Claiming the current slot
+                // here would hide an older real failure behind a zero-step
+                // cancellation that has nothing to repair.
+                if !run_is_cancelled(run) {
+                    seen_current = true;
+                }
             }
         }
     }
@@ -829,6 +865,34 @@ pub(super) fn run_is_completed(run: &Value) -> bool {
 
 fn run_is_unsuccessful(run: &Value) -> bool {
     unsuccessful_conclusion(run.get("conclusion").and_then(Value::as_str))
+}
+
+fn run_is_cancelled(run: &Value) -> bool {
+    run.get("conclusion").and_then(Value::as_str) == Some("cancelled")
+}
+
+/// A cancelled job with no failed step is not a repair target: GitHub often
+/// reports `steps: []` and 404s the job log. Cancellation is still not a pass.
+pub(super) fn job_is_cancelled_without_failed_steps(job: &Value) -> bool {
+    job.get("conclusion").and_then(Value::as_str) == Some("cancelled")
+        && job
+            .get("failed_steps")
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
+}
+
+pub(super) fn is_inconclusive_cancellation(failure: &Value) -> bool {
+    if failure.get("evidence_state").and_then(Value::as_str) == Some("inconclusive") {
+        return true;
+    }
+    match failure.get("failed_jobs").and_then(Value::as_array) {
+        Some(jobs) if !jobs.is_empty() => jobs.iter().all(job_is_cancelled_without_failed_steps),
+        Some(_) | None => {
+            // An unexpanded cancelled run might still hide failed steps.
+            run_is_cancelled(failure)
+                && failure.get("investigated").and_then(Value::as_bool) == Some(true)
+        }
+    }
 }
 
 fn has_failed_jobs(failure: &Value) -> bool {
@@ -856,6 +920,96 @@ fn retired_ref_entry(refs: &[ScannedRef], run: &Value) -> Value {
          branch's own runs are the current evidence — or abandoned",
         run_branch(run)
     ));
+    entry
+}
+
+/// After job expansion, a cancelled run that *does* have failed steps is the
+/// current evidence for that workflow/ref. Older unresolved findings of the
+/// same identity then become stale — the same rule partition already applies
+/// to ordinary failures, which a zero-step cancellation is not allowed to
+/// trigger on its own.
+fn supersede_older_when_cancelled_run_is_actionable(
+    findings: Vec<Value>,
+    stale: &mut Vec<Value>,
+) -> Vec<Value> {
+    let mut newest_cancelled: std::collections::BTreeMap<(String, String), (String, u64, Value)> =
+        std::collections::BTreeMap::new();
+    for finding in &findings {
+        if !run_is_cancelled(finding) {
+            continue;
+        }
+        let key = workflow_ref_key(finding);
+        let order = run_order(finding);
+        let replace = newest_cancelled
+            .get(&key)
+            .is_none_or(|(existing_time, existing_id, _)| {
+                order > (existing_time.clone(), *existing_id)
+            });
+        if replace {
+            newest_cancelled.insert(key, (order.0, order.1, finding.clone()));
+        }
+    }
+
+    let mut kept = Vec::new();
+    let mut superseded_runs = std::collections::BTreeSet::new();
+    for finding in findings {
+        let key = workflow_ref_key(&finding);
+        let Some((_, _, newer)) = newest_cancelled.get(&key) else {
+            kept.push(finding);
+            continue;
+        };
+        if run_order(&finding) < run_order(newer) {
+            let run_id = finding.get("run_id").and_then(Value::as_u64).unwrap_or(0);
+            if superseded_runs.insert((key.0.clone(), key.1.clone(), run_id)) {
+                stale.push(stale_from_findings(&finding, newer));
+            }
+            continue;
+        }
+        kept.push(finding);
+    }
+    kept
+}
+
+fn workflow_ref_key(failure: &Value) -> (String, String) {
+    (
+        failure
+            .get("workflow")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        run_branch(failure).to_string(),
+    )
+}
+
+fn stale_from_findings(older: &Value, newer: &Value) -> Value {
+    let mut entry = older.clone();
+    entry["reason"] = json!("superseded_by_newer_workflow_run");
+    entry["evidence"] = json!(format!(
+        "newer relevant run {} at {} is {} with conclusion {}",
+        newer
+            .get("run_id")
+            .and_then(Value::as_u64)
+            .map_or_else(|| "unknown".to_string(), |id| id.to_string()),
+        newer
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or("an unknown time"),
+        newer
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("in an unknown state"),
+        newer
+            .get("conclusion")
+            .and_then(Value::as_str)
+            .unwrap_or("not yet completed"),
+    ));
+    entry["superseded_by"] = json!({
+        "run_id": newer.get("run_id"),
+        "url": newer.get("url"),
+        "created_at": newer.get("created_at"),
+        "status": newer.get("status"),
+        "conclusion": newer.get("conclusion"),
+    });
     entry
 }
 

--- a/crates/orbit-engine/src/executor/automation/ci/investigate.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/investigate.rs
@@ -2,7 +2,10 @@
 
 use serde_json::{Value, json};
 
-use super::collect::{Bounds, investigation_slots, push_retryable_error, run_is_completed};
+use super::collect::{
+    Bounds, investigation_slots, job_is_cancelled_without_failed_steps, push_retryable_error,
+    run_is_completed,
+};
 use super::query::{CiQueries, LogScope};
 
 /// Inspect each failed job independently. The row keeps run freshness metadata,
@@ -44,6 +47,11 @@ pub(super) fn investigate<Q: CiQueries + ?Sized>(
         .cloned()
         .unwrap_or_default();
     if jobs.is_empty() {
+        if run_is_completed(failure)
+            && failure.get("conclusion").and_then(Value::as_str) == Some("cancelled")
+        {
+            return vec![inconclusive_cancellation_finding(failure, None)];
+        }
         if run_is_completed(failure) {
             push_retryable_error(
                 retryable_errors,
@@ -56,22 +64,38 @@ pub(super) fn investigate<Q: CiQueries + ?Sized>(
         return vec![failure.clone()];
     }
 
+    // Stable numeric identity makes a provider's job ordering irrelevant to
+    // which findings receive the bounded reads on repeated sweeps.
+    let mut jobs = jobs;
+    jobs.sort_by_key(|job| job.get("job_id").and_then(Value::as_u64));
+    let mut findings = Vec::new();
+    let mut actionable = Vec::new();
+    for job in jobs {
+        if job_is_cancelled_without_failed_steps(&job) {
+            findings.push(inconclusive_cancellation_finding(failure, Some(&job)));
+        } else {
+            actionable.push(job);
+        }
+    }
+    if actionable.is_empty() {
+        return findings;
+    }
+
     let remaining_reads = bounds.max_job_log_reads.saturating_sub(*job_log_reads);
     let selected = if remaining_reads == 1 {
         // Runs reserve a single slot for integration priority. Within a run,
         // equally relevant failed jobs must rotate even with only one read.
         std::collections::BTreeSet::from([
-            (bounds.investigation_cursor % jobs.len() as u64) as usize
+            (bounds.investigation_cursor % actionable.len() as u64) as usize
         ])
     } else {
-        investigation_slots(jobs.len(), remaining_reads, bounds.investigation_cursor)
+        investigation_slots(
+            actionable.len(),
+            remaining_reads,
+            bounds.investigation_cursor,
+        )
     };
-    let mut findings = Vec::new();
-    // Stable numeric identity makes a provider's job ordering irrelevant to
-    // which findings receive the bounded reads on repeated sweeps.
-    let mut jobs = jobs;
-    jobs.sort_by_key(|job| job.get("job_id").and_then(Value::as_u64));
-    for (index, job) in jobs.into_iter().enumerate() {
+    for (index, job) in actionable.into_iter().enumerate() {
         let mut finding = failure.clone();
         finding["job_id"] = job.get("job_id").cloned().unwrap_or(Value::Null);
         finding["failed_jobs"] = json!([job]);
@@ -116,6 +140,18 @@ pub(super) fn investigate<Q: CiQueries + ?Sized>(
         findings.push(finding);
     }
     findings
+}
+
+fn inconclusive_cancellation_finding(failure: &Value, job: Option<&Value>) -> Value {
+    let mut finding = failure.clone();
+    if let Some(job) = job {
+        finding["job_id"] = job.get("job_id").cloned().unwrap_or(Value::Null);
+        finding["failed_jobs"] = json!([job]);
+    }
+    finding["investigated"] = json!(true);
+    finding["evidence_state"] = json!("inconclusive");
+    finding["inconclusive_reason"] = json!("cancelled_without_failed_steps");
+    finding
 }
 
 fn investigate_job<Q: CiQueries + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/ci/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/mod.rs
@@ -50,7 +50,9 @@ pub(super) const OUTCOME_RETRYABLE_ERROR: &str = "retryable_error";
 ///
 /// `cancelled` and `timed_out` are in here deliberately: a run that never
 /// produced a verdict is not a green run, and treating it as one is exactly
-/// how a red pipeline gets reported as clean.
+/// how a red pipeline gets reported as clean. Job expansion later separates
+/// a cancelled job with no failed steps (inconclusive, nothing to repair)
+/// from a cancelled or mixed run that still has failed steps.
 pub(super) fn unsuccessful_conclusion(conclusion: Option<&str>) -> bool {
     matches!(
         conclusion,

--- a/crates/orbit-engine/src/executor/automation/ci/tests/cancelled.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/cancelled.rs
@@ -1,0 +1,363 @@
+//! Cancelled jobs with no failed steps are inconclusive, not log failures.
+
+use serde_json::{Value, json};
+
+use super::super::collect::collect;
+use super::support::{FakeQueries, failed_job, run_on_branch};
+
+const HEAD: &str = "1111111111111111111111111111111111111111";
+const CODEQL_RUN: u64 = 34_168_609_753;
+const CODEQL_JOBS: [u64; 4] = [
+    101_884_485_004,
+    101_884_485_211,
+    101_884_485_221,
+    101_884_485_257,
+];
+
+fn input() -> Value {
+    json!({"integration_branch": "agent-main", "max_checkout_log_reads": 3})
+}
+
+fn current_ids(evidence: &Value) -> Vec<u64> {
+    evidence["current_failures"]
+        .as_array()
+        .expect("current failures")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect()
+}
+
+fn in_flight_ids(evidence: &Value) -> Vec<u64> {
+    evidence["in_flight"]
+        .as_array()
+        .expect("in flight")
+        .iter()
+        .filter_map(|run| run["run_id"].as_u64())
+        .collect()
+}
+
+fn inconclusive_job_ids(evidence: &Value) -> Vec<u64> {
+    evidence["inconclusive"]
+        .as_array()
+        .expect("inconclusive")
+        .iter()
+        .filter_map(|run| run["job_id"].as_u64())
+        .collect()
+}
+
+fn cancelled_job(job_id: u64, name: &str) -> Value {
+    json!({
+        "job_id": job_id,
+        "name": name,
+        "conclusion": "cancelled",
+        "url": format!("https://github.com/acme/orbit/actions/runs/{CODEQL_RUN}/job/{job_id}"),
+        "failed_steps": [],
+    })
+}
+
+fn codeql_run() -> Value {
+    run_on_branch(
+        CODEQL_RUN,
+        "CodeQL",
+        "agent-main",
+        HEAD,
+        "completed",
+        Some("cancelled"),
+        "2026-09-07T23:00:00Z",
+    )
+}
+
+fn authenticated_heads() -> FakeQueries {
+    FakeQueries::authenticated()
+        .with_head("agent-main", HEAD)
+        .with_head("main", HEAD)
+}
+
+fn checkout_log() -> &'static str {
+    "ci\tCheckout\tHEAD is now at 3333333333333333333333333333333333333333\n"
+}
+
+/// jrun-20260907-2316: four cancelled CodeQL jobs, empty steps, 404 logs.
+#[test]
+fn cancelled_zero_step_jobs_are_inconclusive_and_do_not_consume_log_budget() {
+    let jobs: Vec<Value> = CODEQL_JOBS
+        .iter()
+        .enumerate()
+        .map(|(index, job_id)| cancelled_job(*job_id, &format!("Analyze ({index})")))
+        .collect();
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![codeql_run()]])
+        .with_run_view(
+            CODEQL_RUN.to_string().as_str(),
+            json!({"failed_jobs": jobs}),
+        )
+        .with_log_error(
+            CODEQL_RUN.to_string().as_str(),
+            false,
+            "Not Found (HTTP 404)",
+        )
+        .with_log_error(
+            CODEQL_RUN.to_string().as_str(),
+            true,
+            "Not Found (HTTP 404)",
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(current_ids(&evidence), Vec::<u64>::new());
+    assert_eq!(evidence["retryable_errors"], json!([]));
+    assert_eq!(inconclusive_job_ids(&evidence), CODEQL_JOBS.to_vec());
+    assert!(
+        evidence["inconclusive"]
+            .as_array()
+            .expect("inconclusive")
+            .iter()
+            .all(|entry| {
+                entry["evidence_state"] == json!("inconclusive")
+                    && entry["inconclusive_reason"] == json!("cancelled_without_failed_steps")
+                    && entry["conclusion"] == json!("cancelled")
+                    && entry["investigated"] == json!(true)
+            })
+    );
+    assert_eq!(evidence["truncation"]["job_log_reads"], json!(0));
+    assert_eq!(evidence["truncation"]["checkout_log_reads"], json!(0));
+    assert_eq!(evidence["summary"]["inconclusive"], json!(4));
+}
+
+#[test]
+fn mixed_cancelled_run_keeps_the_failed_step_and_skips_zero_step_siblings() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![codeql_run()]])
+        .with_run_view(
+            CODEQL_RUN.to_string().as_str(),
+            json!({"failed_jobs": [
+                cancelled_job(CODEQL_JOBS[0], "Analyze (javascript)"),
+                failed_job(CODEQL_JOBS[1], "Analyze (python)"),
+            ]}),
+        )
+        .with_log(
+            CODEQL_RUN.to_string().as_str(),
+            false,
+            "CodeQL\tAnalyze (python)\t##[error]analysis failed\n",
+        )
+        .with_log(CODEQL_RUN.to_string().as_str(), true, checkout_log());
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(current_ids(&evidence), [CODEQL_RUN]);
+    assert_eq!(inconclusive_job_ids(&evidence), [CODEQL_JOBS[0]]);
+    assert_eq!(
+        evidence["current_failures"][0]["job_id"],
+        json!(CODEQL_JOBS[1])
+    );
+    assert_eq!(evidence["current_failures"][0]["investigated"], json!(true));
+    assert_eq!(evidence["retryable_errors"], json!([]));
+    assert_eq!(evidence["truncation"]["job_log_reads"], json!(1));
+}
+
+#[test]
+fn newer_zero_step_cancellation_does_not_supersede_an_older_failure() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![
+            codeql_run(),
+            run_on_branch(
+                20,
+                "CodeQL",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-09-07T22:00:00Z",
+            ),
+        ]])
+        .with_run_view(
+            CODEQL_RUN.to_string().as_str(),
+            json!({"failed_jobs": [cancelled_job(CODEQL_JOBS[0], "Analyze")]}),
+        )
+        .with_run_view("20", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log("20", false, "ci\tbuild\tassertion failed\n")
+        .with_log("20", true, checkout_log())
+        .with_log_error(
+            CODEQL_RUN.to_string().as_str(),
+            false,
+            "Not Found (HTTP 404)",
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(current_ids(&evidence), [20]);
+    assert_eq!(inconclusive_job_ids(&evidence), [CODEQL_JOBS[0]]);
+    assert_eq!(evidence["stale_or_superseded"], json!([]));
+    assert_eq!(evidence["outcome_hint"], json!("current_failures"));
+    assert_eq!(evidence["retryable_errors"], json!([]));
+}
+
+#[test]
+fn newer_cancelled_run_with_a_failed_step_does_supersede_the_older_failure() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![
+            codeql_run(),
+            run_on_branch(
+                20,
+                "CodeQL",
+                "agent-main",
+                HEAD,
+                "completed",
+                Some("failure"),
+                "2026-09-07T22:00:00Z",
+            ),
+        ]])
+        .with_run_view(
+            CODEQL_RUN.to_string().as_str(),
+            json!({"failed_jobs": [failed_job(CODEQL_JOBS[1], "Analyze (python)")]}),
+        )
+        .with_log(
+            CODEQL_RUN.to_string().as_str(),
+            false,
+            "CodeQL\tAnalyze (python)\t##[error]analysis failed\n",
+        )
+        .with_log(CODEQL_RUN.to_string().as_str(), true, checkout_log())
+        .with_run_view("20", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log("20", false, "ci\tbuild\tassertion failed\n")
+        .with_log("20", true, checkout_log());
+
+    let evidence = collect(
+        &queries,
+        &json!({"integration_branch": "agent-main", "max_checkout_log_reads": 3}),
+    )
+    .expect("collect");
+
+    assert_eq!(current_ids(&evidence), [CODEQL_RUN]);
+    assert_eq!(evidence["stale_or_superseded"][0]["run_id"], json!(20));
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["reason"],
+        json!("superseded_by_newer_workflow_run")
+    );
+    assert_eq!(
+        evidence["stale_or_superseded"][0]["superseded_by"]["run_id"],
+        json!(CODEQL_RUN)
+    );
+}
+
+#[test]
+fn queued_successor_stays_in_flight_beside_a_zero_step_cancellation() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![
+            run_on_branch(
+                40,
+                "CodeQL",
+                "agent-main",
+                HEAD,
+                "queued",
+                None,
+                "2026-09-07T23:10:00Z",
+            ),
+            codeql_run(),
+        ]])
+        .with_run_view(
+            CODEQL_RUN.to_string().as_str(),
+            json!({"failed_jobs": [cancelled_job(CODEQL_JOBS[0], "Analyze")]}),
+        );
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(in_flight_ids(&evidence), [40]);
+    assert_eq!(current_ids(&evidence), Vec::<u64>::new());
+    assert_eq!(inconclusive_job_ids(&evidence), [CODEQL_JOBS[0]]);
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(evidence["retryable_errors"], json!([]));
+}
+
+#[test]
+fn missing_logs_for_a_genuine_failure_stay_retryable() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![run_on_branch(
+            10,
+            "ci",
+            "agent-main",
+            HEAD,
+            "completed",
+            Some("failure"),
+            "2026-09-07T22:00:00Z",
+        )]])
+        .with_run_view("10", json!({"failed_jobs": [failed_job(5, "build")]}))
+        .with_log_error("10", false, "Not Found (HTTP 404)")
+        .with_log_error("10", true, "Not Found (HTTP 404)");
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+    assert_eq!(current_ids(&evidence), [10]);
+    assert!(
+        evidence["retryable_errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .any(|error| {
+                error["operation"] == json!("run_logs")
+                    && error["message"]
+                        .as_str()
+                        .is_some_and(|text| text.contains("Not Found (HTTP 404)"))
+            })
+    );
+}
+
+#[test]
+fn timed_out_jobs_without_steps_are_not_treated_as_inconclusive() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![run_on_branch(
+            11,
+            "ci",
+            "agent-main",
+            HEAD,
+            "completed",
+            Some("timed_out"),
+            "2026-09-07T22:00:00Z",
+        )]])
+        .with_run_view(
+            "11",
+            json!({"failed_jobs": [{
+                "job_id": 9,
+                "name": "build",
+                "conclusion": "timed_out",
+                "failed_steps": [],
+            }]}),
+        )
+        .with_log_error("11", false, "Not Found (HTTP 404)");
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("retryable_error"));
+    assert_eq!(current_ids(&evidence), [11]);
+    assert_eq!(evidence["inconclusive"], json!([]));
+}
+
+#[test]
+fn unauthenticated_host_is_still_capability_unavailable() {
+    let queries = FakeQueries::unauthenticated("gh holds no usable credentials");
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("capability_unavailable"));
+    assert!(evidence.get("current_failures").is_none());
+    assert!(evidence.get("inconclusive").is_none());
+}
+
+#[test]
+fn cancelled_run_with_no_failed_jobs_is_inconclusive_not_retryable() {
+    let queries = authenticated_heads()
+        .with_runs(vec![vec![codeql_run()]])
+        .with_run_view(CODEQL_RUN.to_string().as_str(), json!({"failed_jobs": []}));
+
+    let evidence = collect(&queries, &input()).expect("collect");
+
+    assert_eq!(evidence["outcome_hint"], json!("no_current_failure"));
+    assert_eq!(current_ids(&evidence), Vec::<u64>::new());
+    assert_eq!(evidence["retryable_errors"], json!([]));
+    assert_eq!(
+        evidence["inconclusive"][0]["inconclusive_reason"],
+        json!("cancelled_without_failed_steps")
+    );
+    assert_eq!(evidence["truncation"]["job_log_reads"], json!(0));
+}

--- a/crates/orbit-engine/src/executor/automation/ci/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/ci/tests/mod.rs
@@ -1,3 +1,4 @@
+mod cancelled;
 mod collect;
 mod integration_branch;
 mod log_fallback;


### PR DESCRIPTION
## Task

[ORB-11750](https://orbit-cli.com/tasks/ORB-11750) — Classify cancelled CI jobs without steps as inconclusive instead of retryable log failures

### Description

Live installed sweep jrun-20260907-2316 on source 07c9b0266 failed file_ci_failure_tasks with 8 retryable errors and zero tasks. Its four current failures were cancelled CodeQL jobs from run34168609753:101884485004/5211/5221/5257 (full IDs 101884485004,101884485211,101884485221,101884485257). Authoritative GitHub jobs API shows every job completed/cancelled with steps:[]; per-job log endpoints return404. No failed step exists to investigate. The collector consumed checkout/log budgets and classified missing logs as retryable failure evidence. Newer runs are queued, not successful, so do not silently call this green.

Source at installed revision: executor/automation/ci/mod.rs unsuccessful_conclusion deliberately includes cancelled, introduced by c541ba2dd (ORB-11107). Preserve its valid distinction that cancellation is not a pass, but separate inconclusive cancellation from actionable failure/log acquisition. Trace collection, failed-job expansion, supersession and output aggregation at their existing owners. Keep genuine failed steps within cancelled/mixed runs visible; never globally ignore cancelled runs or suppress failure/timed-out/auth errors. A newer cancelled run must not erase an older actionable failure just by being newer. No scheduler, database, blanket404 suppression or release work. This is distinct from ORB-11740 oversized evidence and ORB-11748 completed-owner reuse; preserve both contracts.

### Acceptance Criteria

- Replay the four cancelled zero-step jobs: explicit inconclusive/cancelled evidence, zero repair tasks, no retryable log/checkout failure caused solely by absent cancelled-job logs, and bounded query use.
- Cancelled or mixed runs containing genuine failed steps remain investigated and actionable; missing logs for genuine failures and actual transport/auth failures remain explicit errors.
- A newer cancellation does not imply success or incorrectly supersede unresolved older failures; queued successors remain in-flight.
- Cover classification, collection and deterministic filing end to end with fixture tests, preserve evidence provenance and repeat-noise behavior, run focused tests and required ci-fast/ci-lint.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Collector classifies cancelled jobs with empty failed_steps (and cancelled runs with no failed jobs) as explicit `inconclusive` evidence instead of retryable log/checkout failures. Those jobs no longer consume job-log or checkout-log budget.
- `unsuccessful_conclusion` still includes `cancelled` (not a pass). Partition no longer lets a cancelled run claim `seen_current` before job expansion, so a newer zero-step cancellation cannot hide an older real failure. After investigation, a cancelled run that does have failed steps supersedes older same-identity findings.
- Filer splits inconclusive cancellations out of `current_failures`, drops log/checkout retryable errors that belong only to them, files zero repair tasks, and returns them in `inconclusive`/audit. Genuine failed steps, genuine 404s, timed_out, and auth/transport errors stay actionable or retryable.
Assessment: Fixture coverage replays the four CodeQL jobs from run 34168609753, mixed cancelled+failed, newer cancellation vs older failure, queued successors, genuine 404, timed_out, and auth. Existing log-fallback provenance and repeat-noise tests still pass.

Criteria:
1. Replay four cancelled zero-step jobs — passed. Collector emits four `inconclusive` findings, `current_failures` empty, `retryable_errors` empty, job_log_reads=0, checkout_log_reads=0. Filer files zero tasks and keeps explicit inconclusive evidence (including leaked old-shaped 404 errors).
2. Mixed/genuine failures stay actionable — passed. Mixed cancelled+failed keeps the failed step, investigates its logs, and files it. Genuine failure 404s, timed_out without steps, and unauthenticated hosts remain retryable/capability_unavailable.
3. Newer cancellation does not supersede unresolved older failures; queued successors stay in-flight — passed. Zero-step newer cancellation leaves the older failure current; cancelled-with-failed-steps does supersede; queued successor remains `in_flight`.
4. End-to-end fixtures, provenance, ci-fast/ci-lint — passed. New `ci/tests/cancelled.rs` and `ci_failure_cancelled.rs`; existing log-fallback tests unchanged and green.

Validation:
- `cargo test -p orbit-engine --lib executor::automation::ci` — passed (58 passed, 1 ignored replay).
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::ci_failure` — passed (59 passed, 1 ignored replay).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.

Remaining risk: live GitHub 404/empty-steps behavior is modeled by fixtures, not a live `gh` call. Uninvestigated cancelled runs (budget skip) stay current/retryable until jobs are expanded, which is intentional.
Deviations: none material. Added sibling test files `ci/tests/cancelled.rs` and `v2_host/tests/ci_failure_cancelled.rs` rather than growing the already-large collect/filer test files; selectors recorded on the task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11750-6a9f5b0a`
- Behind base: 0
- Ahead of base: 1