### PR TITLE
[code-review] Remove the placeholder `orbit-release-key-4` from the trusted release key set until a real key is generated on the signing host

### DIFF
--- a/crates/orbit-common/src/security/release.rs
+++ b/crates/orbit-common/src/security/release.rs
@@ -59,41 +59,16 @@ y4rLO3hkxWhxfgF5KPSR2iftc3LMONRGWELK6jpD5KB7No5vwIvjpVPUc5xA45Xw
 tT/bo0mm4TvrumxYr1xyEHrdum+ej/WYz/0BZQlwDOtXAgMBAAE=
 -----END PUBLIC KEY-----"#;
 
-/// `orbit-release-key-4` is a PLACEHOLDER pre-staged for the next rotation.
-/// The PEM below was generated locally and the matching private key is NOT
-/// held by release infrastructure — no production signature will ever verify
-/// against it. Replace with a real keypair (generated on the signing host)
-/// before rotating off key-3.
-const ORBIT_RELEASE_KEY_4_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
-MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAiEVVbwQYDnbPg86xYrI8
-Ddm6qpkEJ6GSJOW9NfR/eLpqwwaeWb3EPR9H/U39Rrt8ABPAGObLG9vuvSzg8YqU
-Rz6NjtrSKQ4k9xO/up+qQ/zRsHkOyISEx+6MnIrw5hY/IfkrZ+3+jm8IfXJ+VAjS
-VepR+o58u73ycrnLG1eXWIHtjED3SQSPffJjxSvVDEb3ogiJAsWClCMWNLnEjsQc
-IHYrNdS5N0m5tfcIb9LiV2cDVXgdwdRUU41Ks9sWvBQIHrNup721UWyMdJoK1hTI
-rc4PST3WTHQwFcQvVaAqod9MDPkQYlgD7IjiPkSGLHyIs52kNgFXY55E5DlU4O4e
-9QDbyQTGzZI0XlnoqAuCIXbcNXjMZuEn9UjVN35NeObsj6F/yL07YUhvORnxozjL
-41ouRFtFTWFHNenthtZnH9SUV4+O2cKDmtJpPJd68ZJ/NBqJHM4a6cteT72HJzLb
-t6yto3B43nTeXtp9ozRjetznPnPD7gmI6Zq1P2ce8v49AgMBAAE=
------END PUBLIC KEY-----"#;
-
-/// The release signing keys this binary trusts, newest-generation last.
+/// The release signing keys this binary trusts.
 ///
 /// Kept in lockstep with the same list in `install.sh` and
 /// `npm/scripts/install-binary.js`.
-pub const TRUSTED_RELEASE_KEYS: &[TrustedReleaseKey] = &[
-    TrustedReleaseKey {
-        id: "orbit-release-key-3",
-        not_after: "2029-12-31",
-        revoked_at: None,
-        public_key_pem: ORBIT_RELEASE_KEY_3_PEM,
-    },
-    TrustedReleaseKey {
-        id: "orbit-release-key-4",
-        not_after: "2030-12-31",
-        revoked_at: None,
-        public_key_pem: ORBIT_RELEASE_KEY_4_PEM,
-    },
-];
+pub const TRUSTED_RELEASE_KEYS: &[TrustedReleaseKey] = &[TrustedReleaseKey {
+    id: "orbit-release-key-3",
+    not_after: "2029-12-31",
+    revoked_at: None,
+    public_key_pem: ORBIT_RELEASE_KEY_3_PEM,
+}];
 
 /// Lowercase hex SHA-256 of `bytes`.
 pub fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/orbit-common/src/security/tests/release.rs
+++ b/crates/orbit-common/src/security/tests/release.rs
@@ -161,6 +161,9 @@ fn revoked_key_fails_closed_even_before_its_expiry() {
 
 #[test]
 fn signature_from_an_untrusted_key_never_matches_the_shipped_trust_set() {
+    assert_eq!(TRUSTED_RELEASE_KEYS.len(), 1);
+    assert_eq!(TRUSTED_RELEASE_KEYS[0].id, "orbit-release-key-3");
+
     let error = verify_checksum_signature(
         TEST_MANIFEST.as_bytes(),
         &decode_hex(TEST_SIGNATURE_HEX),

--- a/install.sh
+++ b/install.sh
@@ -46,11 +46,6 @@ download() {
 # The numeric suffix is a generation counter, not a date — IDs survive rotation
 # so a key that has been the "successor" for a year is still readable by ID.
 #
-# orbit-release-key-4 is a PLACEHOLDER pre-staged for the next rotation. The
-# PEM below was generated locally and the matching private key is NOT held by
-# release infrastructure — no production signature will ever verify against
-# it. Replace with a real keypair (generated on the signing host) before
-# rotating off key-3.
 write_release_key_orbit_release_key_3() {
   destination="$1"
 
@@ -65,24 +60,6 @@ Orec31AAFCIIX69YAd21D3MBc4S89/LoYZCq3neDscZ09Y+e6Jg2HpoBstvqSnq/
 npMLlbzNaVfFT7p3IPTxsoEI0SB3ZtO7/XhzuOvOpklYcqjW2DGw/yzr2epAqHE/
 y4rLO3hkxWhxfgF5KPSR2iftc3LMONRGWELK6jpD5KB7No5vwIvjpVPUc5xA45Xw
 tT/bo0mm4TvrumxYr1xyEHrdum+ej/WYz/0BZQlwDOtXAgMBAAE=
------END PUBLIC KEY-----
-EOF
-}
-
-write_release_key_orbit_release_key_4() {
-  destination="$1"
-
-  cat > "$destination" <<'EOF'
------BEGIN PUBLIC KEY-----
-MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAiEVVbwQYDnbPg86xYrI8
-Ddm6qpkEJ6GSJOW9NfR/eLpqwwaeWb3EPR9H/U39Rrt8ABPAGObLG9vuvSzg8YqU
-Rz6NjtrSKQ4k9xO/up+qQ/zRsHkOyISEx+6MnIrw5hY/IfkrZ+3+jm8IfXJ+VAjS
-VepR+o58u73ycrnLG1eXWIHtjED3SQSPffJjxSvVDEb3ogiJAsWClCMWNLnEjsQc
-IHYrNdS5N0m5tfcIb9LiV2cDVXgdwdRUU41Ks9sWvBQIHrNup721UWyMdJoK1hTI
-rc4PST3WTHQwFcQvVaAqod9MDPkQYlgD7IjiPkSGLHyIs52kNgFXY55E5DlU4O4e
-9QDbyQTGzZI0XlnoqAuCIXbcNXjMZuEn9UjVN35NeObsj6F/yL07YUhvORnxozjL
-41ouRFtFTWFHNenthtZnH9SUV4+O2cKDmtJpPJd68ZJ/NBqJHM4a6cteT72HJzLb
-t6yto3B43nTeXtp9ozRjetznPnPD7gmI6Zq1P2ce8v49AgMBAAE=
 -----END PUBLIC KEY-----
 EOF
 }
@@ -105,12 +82,9 @@ write_builtin_trusted_key_records() {
   mkdir -p "$key_dir"
 
   current_key_path="${key_dir}/orbit-release-key-3.pub"
-  successor_key_path="${key_dir}/orbit-release-key-4.pub"
   write_release_key_orbit_release_key_3 "$current_key_path"
-  write_release_key_orbit_release_key_4 "$successor_key_path"
 
   printf 'orbit-release-key-3|2029-12-31||%s\n' "$current_key_path"
-  printf 'orbit-release-key-4|2030-12-31||%s\n' "$successor_key_path"
 }
 
 trusted_key_records() {

--- a/npm/scripts/install-binary.js
+++ b/npm/scripts/install-binary.js
@@ -28,11 +28,6 @@ const TRUSTED_PUBLIC_KEY_PATH = PUBLIC_KEY_OVERRIDE
   ? path.resolve(PUBLIC_KEY_OVERRIDE)
   : path.join(PKG_ROOT, 'release-signing.pub');
 const TRUSTED_KEYS_OVERRIDE_PATH = TRUSTED_KEYS_OVERRIDE ? path.resolve(TRUSTED_KEYS_OVERRIDE) : null;
-// orbit-release-key-4 is a PLACEHOLDER pre-staged for the next rotation. The
-// PEM below was generated locally and the matching private key is NOT held by
-// release infrastructure — no production signature will ever verify against
-// it. Replace with a real keypair (generated on the signing host) before
-// rotating off key-3.
 const TRUSTED_RELEASE_KEYS = Object.freeze([
   Object.freeze({
     id: 'orbit-release-key-3',
@@ -48,23 +43,6 @@ Orec31AAFCIIX69YAd21D3MBc4S89/LoYZCq3neDscZ09Y+e6Jg2HpoBstvqSnq/
 npMLlbzNaVfFT7p3IPTxsoEI0SB3ZtO7/XhzuOvOpklYcqjW2DGw/yzr2epAqHE/
 y4rLO3hkxWhxfgF5KPSR2iftc3LMONRGWELK6jpD5KB7No5vwIvjpVPUc5xA45Xw
 tT/bo0mm4TvrumxYr1xyEHrdum+ej/WYz/0BZQlwDOtXAgMBAAE=
------END PUBLIC KEY-----
-`,
-  }),
-  Object.freeze({
-    id: 'orbit-release-key-4',
-    notAfter: '2030-12-31',
-    revokedAt: null,
-    publicKeyPem: `-----BEGIN PUBLIC KEY-----
-MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAiEVVbwQYDnbPg86xYrI8
-Ddm6qpkEJ6GSJOW9NfR/eLpqwwaeWb3EPR9H/U39Rrt8ABPAGObLG9vuvSzg8YqU
-Rz6NjtrSKQ4k9xO/up+qQ/zRsHkOyISEx+6MnIrw5hY/IfkrZ+3+jm8IfXJ+VAjS
-VepR+o58u73ycrnLG1eXWIHtjED3SQSPffJjxSvVDEb3ogiJAsWClCMWNLnEjsQc
-IHYrNdS5N0m5tfcIb9LiV2cDVXgdwdRUU41Ks9sWvBQIHrNup721UWyMdJoK1hTI
-rc4PST3WTHQwFcQvVaAqod9MDPkQYlgD7IjiPkSGLHyIs52kNgFXY55E5DlU4O4e
-9QDbyQTGzZI0XlnoqAuCIXbcNXjMZuEn9UjVN35NeObsj6F/yL07YUhvORnxozjL
-41ouRFtFTWFHNenthtZnH9SUV4+O2cKDmtJpPJd68ZJ/NBqJHM4a6cteT72HJzLb
-t6yto3B43nTeXtp9ozRjetznPnPD7gmI6Zq1P2ce8v49AgMBAAE=
 -----END PUBLIC KEY-----
 `,
   }),

--- a/scripts/check-installer-pubkey.sh
+++ b/scripts/check-installer-pubkey.sh
@@ -110,8 +110,8 @@ ingest_records() {
 
   local count
   count="$(wc -l < "$dest/ids" | tr -d ' ')"
-  if [ "$count" -lt 2 ]; then
-    die "expected at least two trusted keys in $label, found $count"
+  if [ "$count" -lt 1 ]; then
+    die "expected at least one trusted key in $label, found $count"
   fi
 
   local rec_id na rev

--- a/scripts/test-installer-security.sh
+++ b/scripts/test-installer-security.sh
@@ -320,8 +320,12 @@ expectThrow(
   'npm untrusted key rejection'
 );
 installer.verifyChecksumSignature(checksumText, signature, publicKey);
-if (!Array.isArray(installer.TRUSTED_RELEASE_KEYS) || installer.TRUSTED_RELEASE_KEYS.length < 2) {
-  throw new Error('npm installer must expose at least two trusted release signing keys');
+if (
+  !Array.isArray(installer.TRUSTED_RELEASE_KEYS) ||
+  installer.TRUSTED_RELEASE_KEYS.length !== 1 ||
+  installer.TRUSTED_RELEASE_KEYS[0].id !== 'orbit-release-key-3'
+) {
+  throw new Error('npm installer must expose only the current release signing key');
 }
 expectThrow(
   () => installer.verifyArchiveChecksum(asset, goodArchive, `0000000000000000000000000000000000000000000000000000000000000000  ${asset}\n`),


### PR DESCRIPTION
## Task

[ORB-11608](https://orbit-cli.com/tasks/ORB-11608) — [code-review] Remove the placeholder `orbit-release-key-4` from the trusted release key set until a real key is generated on the signing host

### Description

## Problem
The active release trust set includes orbit-release-key-4, explicitly documented as a locally generated placeholder whose private key is not held by release infrastructure. It is unrevoked and accepted by signature verification. This is unjustified production trust; the source does not establish that the private key still exists or that an attacker holds it.

## Required behavior and constraints
Remove the placeholder key from every active release-signature consumer while retaining the legitimate current key. Do not generate or rotate a production key as part of this task. Preserve the existing parity guard: check-installer-pubkey.sh already compares key id, expiry, revocation and PEM across Rust, shell and npm. Align current explanatory comments/docs and add focused trust-boundary coverage without requiring the unavailable placeholder private key. Release tagging, workflows and publishing remain outside scope.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-common/src/security/release.rs:62,90,193`; `scripts/check-installer-pubkey.sh:416,429`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Rust, install.sh and npm active trust sets exclude the placeholder id and PEM, retain the current legitimate key, and pass the existing parity guard.
- Tests using generated fixture keys verify untrusted signatures fail and supported trusted signatures still verify; no test depends on the placeholder private key.
- Existing installer parity negative tests continue to detect missing/divergent trust records; current comments no longer advertise an active placeholder successor.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Removed the unowned placeholder orbit-release-key-4 PEM and trust records from Rust, install.sh, and the npm installer while retaining the byte-identical key-3 record.
- Updated trust-boundary assertions to require only key-3; generated installer fixture keys continue to prove trusted signatures verify and untrusted signatures fail.
- Relaxed the parity guard only from a two-key minimum to a one-key minimum; its missing-record and field/PEM-divergence comparisons remain unchanged.
Assessment: Active trust now contains only the current legitimate signing key, with all three consumers kept in parity.
Criteria evidence:
1. Rust, shell, and npm active sets contain key-3 only; scripts/check-installer-pubkey.sh passed.
2. cargo test -p orbit-common security::tests::release and scripts/test-installer-security.sh passed; generated OpenSSL fixture keys exercise trusted and untrusted paths, with no placeholder private key.
3. scripts/check-installer-pubkey.sh and make ci-fast passed; the guard retains missing/divergent record comparisons and no active placeholder-successor comments remain.
Validation:
- cargo fmt --check: initially failed because the one-element Rust array required formatting; cargo fmt applied, then make ci-fast passed its formatter check.
- cargo test -p orbit-common security::tests::release: passed (9 tests).
- ./scripts/test-installer-security.sh: passed.
- ./scripts/check-installer-pubkey.sh: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks/deviations: None; release key generation and rotation remain out of scope.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11608-6a9f5df2`
- Behind base: 0
- Ahead of base: 1