### PR TITLE
Make Operations compact and usable on narrow dashboard widths

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -109,6 +109,7 @@
         grid-template-columns: 216px minmax(0, 1fr);
         flex: 1 1 auto;
         min-height: 0;
+        min-width: 0;
       }
 
       .rail {
@@ -117,6 +118,7 @@
         display: flex;
         flex-direction: column;
         min-height: 0;
+        min-width: 0;
         overflow-y: auto;
       }
 
@@ -307,6 +309,84 @@
       .refresh-btn:disabled {
         cursor: wait;
         opacity: 0.55;
+      }
+
+      /* ORB-11559: below ~760px the 216px rail steals the content column.
+         Stack the shell, scroll tabs horizontally, and put diagnostics
+         subtabs on a second row so every destination stays reachable.
+         This block follows the base `.topbar` / `.kpi` rules so height and
+         label hiding win the cascade. */
+      @media (max-width: 760px) {
+        .shell {
+          grid-template-columns: minmax(0, 1fr);
+          grid-template-rows: auto minmax(0, 1fr);
+        }
+        .rail {
+          border-right: none;
+          border-bottom: 1px solid var(--border);
+          overflow-x: auto;
+          overflow-y: visible;
+        }
+        .rail-brand { display: none; }
+        .rail .tabs {
+          flex-direction: row;
+          flex-wrap: wrap;
+          overflow-x: auto;
+          min-width: 0;
+          padding: 6px 8px 0;
+          gap: 2px;
+        }
+        .rail-group { display: contents; }
+        .rail-group-label { display: none; }
+        .rail .tab {
+          width: auto;
+          flex: 0 0 auto;
+          white-space: nowrap;
+        }
+        .rail-label { flex: 0 1 auto; }
+        .rail-subtabs {
+          flex: 1 1 100%;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          overflow-x: auto;
+          padding: 2px 0 6px;
+          gap: 2px;
+        }
+        .rail-subtabs .subtab {
+          padding: 5px 8px;
+          white-space: nowrap;
+          flex: 0 0 auto;
+        }
+        .rail-foot {
+          margin-top: 0;
+          flex-direction: row;
+          flex-wrap: wrap;
+          align-items: center;
+          border-top: 1px solid var(--hair);
+          padding: 8px 10px;
+        }
+        .rail-workspace { flex: 1 1 12rem; min-width: 0; }
+        .topbar {
+          height: auto;
+          min-height: 52px;
+          flex-wrap: wrap;
+          row-gap: 8px;
+          padding: 8px 12px;
+        }
+        .kpi .k { display: none; }
+        .kpi-spark { display: none; }
+        .global-id-error {
+          white-space: normal;
+          max-width: min(100vw - 24px, 280px);
+          overflow-wrap: anywhere;
+        }
+        .tab-pane[data-tab="operations"] .subtabs,
+        #operations-subtabs {
+          overflow-x: auto;
+          flex-wrap: nowrap;
+        }
+        .subtab { white-space: nowrap; }
+        .log-statusbar { overflow: hidden; }
       }
 
       /* ORB-00030 multi-workspace: header selector + per-task workspace badge */
@@ -889,7 +969,13 @@
       .chip:focus-visible,
       .mutation-undo:focus-visible,
       .rail .tab:focus-visible,
-      .dock-seg:focus-visible {
+      .rail-subtabs .subtab:focus-visible,
+      .dock-seg:focus-visible,
+      .subtab:focus-visible,
+      .operation-button:focus-visible,
+      .operation-cadence:focus-visible,
+      .operation-details summary:focus-visible,
+      .operation-action-unavailable:focus-visible {
         outline: 2px solid var(--accent-hover);
         outline-offset: 2px;
       }
@@ -4231,7 +4317,7 @@
       .tab-pane[data-tab="operations"] .subtabs { border-bottom: 1px solid var(--border); }
       .operation-feedback {
         min-height: 30px; padding: 7px 14px; border-bottom: 1px solid var(--border);
-        color: var(--fg-dim); font: 11px/1.4 var(--font-mono);
+        color: var(--fg-dim); font: 11px/1.4 var(--font-mono); overflow-wrap: anywhere;
       }
       .operation-feedback:empty { display: none; }
       .operation-feedback.pending { color: var(--priority-medium); }
@@ -4239,16 +4325,40 @@
       .operation-feedback.error { color: var(--state-failed); }
       #routines-body, #clock-body, #auto-tasks-body, #auto-drain-body { padding: 12px; background: var(--bg); }
       .operation-card {
-        padding: 12px; margin-bottom: 10px; border: 1px solid var(--border);
+        padding: 10px 12px; margin-bottom: 6px; border: 1px solid var(--border);
         border-radius: 4px; background: var(--bg-elev);
       }
       .operation-card:last-child { margin-bottom: 0; }
       .operation-card-title, .operation-clock-summary, .operation-clock-actions, .operation-card-actions {
         display: flex; align-items: center; justify-content: space-between; gap: 10px;
       }
-      .operation-card-actions { justify-content: flex-end; flex-wrap: wrap; }
+      .operation-card-actions { justify-content: flex-end; flex-wrap: wrap; min-width: 0; }
       .operation-card-title > div, .operation-clock-summary { display: flex; align-items: center; gap: 8px; min-width: 0; }
-      .operation-card-title strong { overflow-wrap: anywhere; }
+      .operation-card-title strong, .operation-identity strong { overflow-wrap: anywhere; }
+      .operation-row-head {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.4fr) auto;
+        gap: 8px 12px;
+        align-items: start;
+      }
+      .operation-identity {
+        display: flex; align-items: center; gap: 8px; min-width: 0; flex-wrap: wrap;
+      }
+      .operation-row-facts { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+      .operation-fact { display: flex; gap: 8px; min-width: 0; }
+      .operation-fact-label {
+        flex: 0 0 auto; color: var(--fg-dim); font: 9px var(--font-sans);
+        text-transform: uppercase; letter-spacing: .08em;
+      }
+      .operation-fact-value {
+        min-width: 0; color: var(--fg); font: 11px/1.4 var(--font-mono); overflow-wrap: anywhere;
+      }
+      .operation-details { margin-top: 8px; min-width: 0; }
+      .operation-details summary {
+        cursor: pointer; color: var(--fg-dim); font: 11px var(--font-sans);
+      }
+      .operation-details[open] summary { margin-bottom: 8px; }
+      .operation-action-unavailable { display: inline-flex; min-width: 0; }
       .operation-state {
         padding: 2px 6px; border: 1px solid var(--border); border-radius: 999px;
         color: var(--fg-dim); font: 10px var(--font-mono); text-transform: uppercase;
@@ -4291,7 +4401,8 @@
       }
       @media (max-width: 720px) {
         .operation-grid { grid-template-columns: 1fr; }
-        .operation-card-title { align-items: flex-start; flex-wrap: wrap; }
+        .operation-card-title, .operation-row-head { align-items: flex-start; flex-wrap: wrap; }
+        .operation-row-head { grid-template-columns: minmax(0, 1fr); }
         .operation-card-actions { width: 100%; }
         .operation-mint-warning { overflow-wrap: anywhere; }
       }
@@ -4300,7 +4411,7 @@
         .operations-layout .panel { margin-bottom: 8px; }
         .operation-grid { grid-template-columns: 1fr; }
         .operation-card-title { align-items: flex-start; }
-        .operation-card-title > div { align-items: flex-start; flex-direction: column; }
+        .operation-card-title > div, .operation-identity { align-items: flex-start; flex-direction: column; }
         .operation-clock-actions, .operation-card-actions { align-items: stretch; }
         .operation-clock-actions > *, .operation-card-actions > * { flex: 1 1 100%; }
       }

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -19,6 +19,7 @@ let lastAutoDrainRun = null;
 let lastOperationMode = null;
 let context = null;
 let unsubscribeWorkspace = null;
+const expandedOperations = new Set();
 
 export function initOperations(nextContext) {
   context = nextContext;
@@ -141,6 +142,47 @@ function field(label, value) {
   ]);
 }
 
+function lastFireText(fire) {
+  if (!fire) return "Never";
+  const when = time(fire.finished_at || fire.started_at);
+  return fire.state ? `${fire.state} · ${when}` : when;
+}
+
+function routineScheduleText(routine) {
+  if (routine.trigger?.deliveries_landed) {
+    return `${routine.trigger.deliveries_landed.threshold} verified deliveries on ${routine.trigger.deliveries_landed.branch}`;
+  }
+  return routine.cron || "—";
+}
+
+function operationIdentity(name, state) {
+  return el("div", { class: "operation-identity" }, [
+    el("strong", { text: name }),
+    el("span", { class: `operation-state ${state}`, text: state }),
+  ]);
+}
+
+function operationFact(label, value) {
+  return el("div", { class: "operation-fact" }, [
+    el("span", { class: "operation-fact-label", text: label }),
+    el("span", { class: "operation-fact-value", text: value == null || value === "" ? "—" : String(value) }),
+  ]);
+}
+
+function operationDetails(key, children) {
+  const panel = el("details", { class: "operation-details" });
+  panel.open = expandedOperations.has(key);
+  panel.appendChild(el("summary", { text: "Details" }));
+  for (const child of children) {
+    if (child) panel.appendChild(child);
+  }
+  panel.addEventListener("toggle", () => {
+    if (panel.open) expandedOperations.add(key);
+    else expandedOperations.delete(key);
+  });
+  return panel;
+}
+
 function actionReason(payload, action) {
   const selectionReason = workspaceReadOnlyReason();
   if (selectionReason) return selectionReason;
@@ -256,27 +298,33 @@ function renderOperations(payload) {
   for (const routine of routines) {
     const fire = routine.last_fire;
     const state = routine.enabled ? (routine.effective ? "enabled" : "blocked") : "disabled";
+    const schedule = routineScheduleText(routine);
     const card = el("article", { class: "operation-card routine-card" });
     card.append(
-      el("div", { class: "operation-card-title" }, [
-        el("div", {}, [el("strong", { text: routine.name }), el("span", { class: `operation-state ${state}`, text: state })]),
-        routineButton(payload, routine),
+      el("div", { class: "operation-row-head" }, [
+        operationIdentity(routine.name, state),
+        el("div", { class: "operation-row-facts" }, [
+          operationFact("Schedule", schedule),
+          operationFact("Next", nextEvaluationText(routine.next_evaluation, routine.next_due)),
+          operationFact("Last outcome", lastFireText(fire)),
+        ]),
+        el("div", { class: "operation-card-actions" }, [routineButton(payload, routine)]),
       ]),
-      el("div", { class: "operation-target mono", text: routine.target }),
-      el("div", { class: "operation-grid" }, [
-        field("Source workspace", routine.source),
-        field("Schedule", routine.trigger?.deliveries_landed ? `${routine.trigger.deliveries_landed.threshold} verified deliveries on ${routine.trigger.deliveries_landed.branch}` : routine.cron),
-        field("Host pin", (routine.hosts || []).join(", ") || "Local host"),
-        field("Last evaluation", time(routine.last_evaluated_slot || routine.first_observed_at)),
-        field("Next evaluation", nextEvaluationText(routine.next_evaluation, routine.next_due)),
-        field("Last fire", fire ? time(fire.finished_at || fire.started_at) : "Never"),
-        field("Linked run / outcome", fire ? `${fire.run_id || "No run"} · ${fire.state}` : "No fire recorded"),
+      operationDetails(`routine:${routine.name}`, [
+        el("div", { class: "operation-target mono", text: routine.target }),
+        el("div", { class: "operation-grid" }, [
+          field("Source workspace", routine.source),
+          field("Schedule", schedule),
+          field("Host pin", (routine.hosts || []).join(", ") || "Local host"),
+          field("Last evaluation", time(routine.last_evaluated_slot || routine.first_observed_at)),
+          field("Next evaluation", nextEvaluationText(routine.next_evaluation, routine.next_due)),
+          field("Last fire", fire ? time(fire.finished_at || fire.started_at) : "Never"),
+          field("Linked run / outcome", fire ? `${fire.run_id || "No run"} · ${fire.state}` : "No fire recorded"),
+        ]),
+        renderAutomation(routine.automation),
+        routine.description ? el("p", { class: "operation-description", text: routine.description }) : null,
       ]),
     );
-    const automation = renderAutomation(routine.automation);
-    if (automation) card.appendChild(automation);
-    if (routine.description) card.appendChild(el("p", { class: "operation-description", text: routine.description }));
-
     body.appendChild(card);
   }
   $("routines-count").textContent = workspace ? `${routines.length} · ${workspace}` : "read-only";
@@ -322,13 +370,19 @@ function renderClock(payload) {
       el("span", { class: "mono", text: clock.provider }),
       el("span", { text: clock.enabled ? "service enabled" : "service paused" }),
     ]),
-    el("div", { class: "operation-grid" }, [
-      field("Configured cadence", cadenceText(clock.configured_cadence_seconds)),
-      field("Effective cadence", cadenceText(clock.effective_cadence_seconds)),
-      field("Loaded", clock.loaded ? "Yes" : "No"),
-      field("Running / waiting", clock.running == null ? "Provider does not expose" : clock.running ? "Yes" : "No"),
-      field("Last tick", clock.last_tick_at ? time(clock.last_tick_at) : "Provider does not expose"),
-      field("Next expected tick", clockTickText(clock.next_tick_at, clock)),
+    el("div", { class: "operation-row-facts" }, [
+      operationFact("Cadence", cadenceText(clock.configured_cadence_seconds)),
+      operationFact("Next tick", clockTickText(clock.next_tick_at, clock)),
+    ]),
+    operationDetails("clock", [
+      el("div", { class: "operation-grid" }, [
+        field("Configured cadence", cadenceText(clock.configured_cadence_seconds)),
+        field("Effective cadence", cadenceText(clock.effective_cadence_seconds)),
+        field("Loaded", clock.loaded ? "Yes" : "No"),
+        field("Running / waiting", clock.running == null ? "Provider does not expose" : clock.running ? "Yes" : "No"),
+        field("Last tick", clock.last_tick_at ? time(clock.last_tick_at) : "Provider does not expose"),
+        field("Next expected tick", clockTickText(clock.next_tick_at, clock)),
+      ]),
     ]),
   );
   if (clock.health_issue) body.appendChild(el("p", { class: "operation-control-note error", text: clock.health_issue }));
@@ -373,6 +427,11 @@ function lastEvaluationText(definition) {
     return `${time(evaluation.last_fired_at || evaluation.last_slot)}${task}`;
   }
   return `Baselined ${time(evaluation.baseline_at)}; no fire yet`;
+}
+
+function lastOutcomeText(definition) {
+  if (definition.last_minted_task_id) return lastMintedText(definition);
+  return lastEvaluationText(definition);
 }
 
 function autoTaskToggleButton(payload, definition) {
@@ -472,35 +531,36 @@ function renderAutoTasks(payload) {
       autoTaskToggleButton(payload, definition),
       autoTaskMintButton(payload, definition),
     ]);
+    const duplicate = definition.open_duplicate ? "Yes — mint will create another" : "No";
     const card = el("article", { class: "operation-card auto-task-card" });
     card.append(
-      el("div", { class: "operation-card-title" }, [
-        el("div", {}, [
-          el("strong", { text: definition.name }),
-          el("span", { class: `operation-state ${state}`, text: state }),
+      el("div", { class: "operation-row-head" }, [
+        operationIdentity(definition.name, state),
+        el("div", { class: "operation-row-facts" }, [
+          operationFact("Schedule", definition.schedule_summary || "—"),
+          operationFact("Next", nextEvaluationText(definition.next_evaluation)),
+          operationFact("Last outcome", lastOutcomeText(definition)),
         ]),
         actions,
       ]),
-      el("div", { class: "operation-target mono", text: definition.template_summary || definition.template?.title || "" }),
-      el("div", { class: "operation-grid" }, [
-        field("Schedule", definition.schedule_summary || "—"),
-        field("Dedupe", definition.dedupe === "always" ? "always fire" : "skip if open"),
-        field("Last scheduler evaluation", lastEvaluationText(definition)),
-        field("Last minted task", lastMintedText(definition)),
-        field("Next evaluation", nextEvaluationText(definition.next_evaluation)),
-        field("Open duplicate", definition.open_duplicate ? "Yes — mint will create another" : "No"),
+      operationDetails(`auto-task:${definition.name}`, [
+        el("div", { class: "operation-target mono", text: definition.template_summary || definition.template?.title || "" }),
+        el("div", { class: "operation-grid" }, [
+          field("Schedule", definition.schedule_summary || "—"),
+          field("Dedupe", definition.dedupe === "always" ? "always fire" : "skip if open"),
+          field("Last scheduler evaluation", lastEvaluationText(definition)),
+          field("Last minted task", lastMintedText(definition)),
+          field("Next evaluation", nextEvaluationText(definition.next_evaluation)),
+          field("Open duplicate", duplicate),
+        ]),
+        renderAutomation(definition.automation),
+        definition.description ? el("p", { class: "operation-description", text: definition.description }) : null,
+        el("p", {
+          class: "operation-control-note operation-mint-warning",
+          text: payload.unconditional_mint_warning || UNCONDITIONAL_MINT_WARNING,
+        }),
       ]),
     );
-    const automation = renderAutomation(definition.automation);
-    if (automation) card.appendChild(automation);
-    if (definition.description) {
-      card.appendChild(el("p", { class: "operation-description", text: definition.description }));
-    }
-    card.appendChild(el("p", {
-      class: "operation-control-note operation-mint-warning",
-      text: payload.unconditional_mint_warning || UNCONDITIONAL_MINT_WARNING,
-    }));
-
     body.appendChild(card);
   }
   const count = $("auto-tasks-count");
@@ -772,43 +832,53 @@ function renderOperationMode(payload) {
   const authority = payload.authority || {};
   const delivery = payload.delivery || {};
   const grantPolicy = authority.policy;
-  if (grantPolicy) {
-    body.append(
+  body.append(
+    el("div", { class: "operation-row-head" }, [
+      operationIdentity(authority.grant_id || "No grant", authority.admission || "none"),
+      el("div", { class: "operation-row-facts" }, [
+        operationFact("Completion", `${delivery.effective_completion ?? "—"}${delivery.cap ? ` (cap: ${delivery.cap})` : ""}`),
+        operationFact("Expires", authority.expires_at ? time(authority.expires_at) : "—"),
+      ]),
+    ]),
+    operationDetails("operation-mode", [
+      grantPolicy
+        ? el("p", {
+          class: "operation-control-note",
+          text: "Active grant policy (captured at enablement; retuning preferences does not change it).",
+        })
+        : null,
+      grantPolicy ? policyGrid(grantPolicy) : null,
       el("p", {
         class: "operation-control-note",
-        text: "Active grant policy (captured at enablement; retuning preferences does not change it).",
-      }),
-      policyGrid(grantPolicy),
-      el("p", {
-        class: "operation-control-note",
-        text: "Current preferences (apply to a future grant only).",
+        text: grantPolicy
+          ? "Current preferences (apply to a future grant only)."
+          : "Current preferences.",
       }),
       policyGrid(policy),
-    );
-  } else {
-    body.appendChild(policyGrid(policy));
-  }
-  body.appendChild(el("div", { class: "operation-grid" }, [
-    field("Effective completion", `${delivery.effective_completion ?? "—"}${delivery.cap ? ` (cap: ${delivery.cap})` : ""}`),
-    field("Grant", authority.grant_id ?? "none"),
-    field("Admission", authority.admission ?? "none"),
-    field("Rights", Array.isArray(authority.rights) && authority.rights.length ? authority.rights.join(", ") : "—"),
-    field("Scope", Array.isArray(authority.task_ids) ? `${authority.task_ids.length} task(s)` : "—"),
-    field("Expires", authority.expires_at ? time(authority.expires_at) : "—"),
-  ]));
-  const reasons = Array.isArray(payload.limiting_reasons) ? payload.limiting_reasons : [];
-  body.appendChild(el("p", {
-    class: "operation-control-note",
-    text: reasons.length ? `Limiting reasons: ${reasons.join(", ")}` : "No limiting reasons.",
-  }));
-  body.appendChild(el("p", {
-    class: "operation-control-note",
-    text: "Changing a preference activates nothing. Only an explicit grant (orbit operation enable) authorizes scoped automation, and no grant authorizes merge.",
-  }));
-  body.appendChild(el("p", {
-    class: "operation-control-note",
-    text: "Review crew selects the reviewer for before-PR review only. After-landing review runs from its own delivery auto-task, which mints tasks with that definition's template crew.",
-  }));
+      el("div", { class: "operation-grid" }, [
+        field("Effective completion", `${delivery.effective_completion ?? "—"}${delivery.cap ? ` (cap: ${delivery.cap})` : ""}`),
+        field("Grant", authority.grant_id ?? "none"),
+        field("Admission", authority.admission ?? "none"),
+        field("Rights", Array.isArray(authority.rights) && authority.rights.length ? authority.rights.join(", ") : "—"),
+        field("Scope", Array.isArray(authority.task_ids) ? `${authority.task_ids.length} task(s)` : "—"),
+        field("Expires", authority.expires_at ? time(authority.expires_at) : "—"),
+      ]),
+      el("p", {
+        class: "operation-control-note",
+        text: Array.isArray(payload.limiting_reasons) && payload.limiting_reasons.length
+          ? `Limiting reasons: ${payload.limiting_reasons.join(", ")}`
+          : "No limiting reasons.",
+      }),
+      el("p", {
+        class: "operation-control-note",
+        text: "Changing a preference activates nothing. Only an explicit grant (orbit operation enable) authorizes scoped automation, and no grant authorizes merge.",
+      }),
+      el("p", {
+        class: "operation-control-note",
+        text: "Review crew selects the reviewer for before-PR review only. After-landing review runs from its own delivery auto-task, which mints tasks with that definition's template crew.",
+      }),
+    ]),
+  );
   if (authority.grant_id) {
     body.appendChild(el("div", { class: "operation-clock-actions" }, [
       operationControlButton(payload, "stop"),

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -526,7 +526,68 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(css.contains(".operation-grid { grid-template-columns: 1fr; }"));
     assert!(css.contains("body.operations-active"));
     assert!(css.contains(".operation-mint-warning"));
+    assert!(css.contains(".operation-row-head"));
+    assert!(css.contains(".operation-details summary"));
+    assert!(operations.contains("operation-row-head"));
+    assert!(operations.contains(r#"el("details", { class: "operation-details" })"#));
+    assert!(operations.contains("expandedOperations"));
     assert!(router.contains(r#"classList.toggle("operations-active", top === "operations")"#));
+}
+
+/// ORB-11559: below 760px the 216px rail must give up the content column so
+/// Tasks can use the 520px two-row grid at phone widths, and every top-level
+/// tab plus diagnostics subtab stays in the (now horizontal) nav.
+#[test]
+fn dashboard_narrow_shell_collapses_rail_and_task_rows() {
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    let narrow = css
+        .split("@media (max-width: 760px)")
+        .skip(1)
+        .find(|block| {
+            block.contains(".shell {") && block.contains("grid-template-columns: minmax(0, 1fr);")
+        })
+        .expect("760px must collapse .shell to a single column");
+    assert!(
+        narrow.contains(".rail-group { display: contents; }"),
+        "rail groups must unwrap so tabs and diagnostics subtabs can reflow"
+    );
+    assert!(
+        narrow.contains("flex: 1 1 100%"),
+        "diagnostics subtabs must wrap onto a second row"
+    );
+    assert!(
+        narrow.contains(".kpi .k { display: none; }")
+            && narrow.contains(".kpi-spark { display: none; }"),
+        "KPI labels and the sparkline must collapse at the same width as the rail"
+    );
+    assert!(
+        css.contains(
+            "grid-template-areas:\n            \"id title\"\n            \"status crew\";"
+        ),
+        "the 520px task row must keep its two-row areas for phone widths"
+    );
+
+    for tab in ["tasks", "audit", "diagnostics", "operations", "knowledge"] {
+        assert!(
+            index.contains(&format!(r#"class="tab" data-tab="{tab}""#)),
+            "{tab} must remain a top-level tab"
+        );
+    }
+    for subtab in [
+        "runs",
+        "metrics",
+        "errors",
+        "incidents",
+        "reliability",
+        "scoreboard",
+    ] {
+        assert!(
+            index.contains(&format!(r#"data-subtab="{subtab}""#)),
+            "{subtab} must remain a reachable diagnostics subtab"
+        );
+    }
 }
 
 /// ORB-11558: disabled/paused rows must not look scheduled; clock cadence is a

--- a/crates/orbit-web/src/tests/dashboard_operations.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations.mjs
@@ -36,14 +36,26 @@ globalThis.fetch = async (path, options = {}) => {
   }
   if (url.pathname === '/api/auto-tasks') {
     if (readbackError) throw new Error('Fixture readback unavailable');
-    const payload = { workspace, controls_authorized: capabilities.auto_task_toggle.authorized && capabilities.auto_task_mint.authorized, capabilities: { ...capabilities }, definitions: [{ name: `Chore ${workspace}`, enabled: enabled[workspace], template: { title: 'Fixture chore' }, may_create_open_duplicate: true, open_duplicate: true }] };
+    const payload = { workspace, controls_authorized: capabilities.auto_task_toggle.authorized && capabilities.auto_task_mint.authorized, capabilities: { ...capabilities }, unconditional_mint_warning: "Manual mint ignores this definition's schedule, enabled flag, and scheduler dedupe policy.", definitions: [{ name: `Chore ${workspace}`, enabled: enabled[workspace], template: { title: 'Fixture chore' }, template_summary: 'Fixture chore', schedule_summary: 'every 15 minutes', description: 'Remediate CI failures for the selected workspace.', may_create_open_duplicate: true, open_duplicate: true, last_minted_task_id: 'ORB-00099', last_minted_task_status: 'backlog', last_evaluation: { kind: 'fired', last_task_id: 'ORB-00001', last_fired_at: '2026-09-07T20:00:00Z' }, next_evaluation: { state: 'scheduled', at: '2026-09-07T22:00:00Z' }, automation: { reason: 'covered', state: { consumer: `auto-task/${workspace}`, baseline: { commit: 'abc1234', tree: 'def5678' }, observed: { commit: 'abc1234', tree: 'def5678' }, covered: { commit: 'abc1234', tree: 'def5678' }, pending: [], pending_commits: [], waived: [], excluded: [], unresolved: {} } } }] };
     if (delayGet) await new Promise(resolve => { releaseGet = resolve; });
     return response(payload);
   }
   if (url.pathname === '/api/routines') return response({
     host_id: 'fixture-host', controls_authorized: capabilities.routine_toggle.authorized, capabilities: { ...capabilities }, session_explanation: 'Session access: restart the dashboard server with explicit operator authority.',
-    routines: ['one', 'two'].map(source => ({ name: `Routine ${source}`, source, target: 'job:fixture', enabled: enabled[source], pinned_to_host: source === 'one' })),
-    clock: { enabled: true, configured_cadence_seconds: 60, provider: 'fixture', health: 'healthy' },
+    routines: ['one', 'two'].map(source => ({ name: `Routine ${source}`, source, target: 'job:fixture', enabled: enabled[source], pinned_to_host: source === 'one', cron: '30 14 * * *', description: 'Sweep landed deliveries.', next_evaluation: { state: enabled[source] ? 'scheduled' : 'disabled', at: '2026-09-07T21:30:00Z', hypothetical: !enabled[source] } })),
+    clock: { enabled: true, configured_cadence_seconds: 60, provider: 'fixture', health: 'healthy', loaded: true, running: true, schedulable: true, last_tick_at: '2026-09-07T21:00:00Z', next_tick_at: '2026-09-07T21:01:00Z' },
+  });
+  if (url.pathname === '/api/workflows/auto/readiness') return response({
+    controls_authorized: true,
+    capacity: { active_leaf_runs: 1, max_active_leaf_runs: 4, free_slots: 3 },
+    tasks: [{ id: 'ORB-1', eligible: true }, { id: 'ORB-2', eligible: false }],
+  });
+  if (url.pathname === '/api/operation/explain') return response({
+    controls_authorized: true,
+    policy: { preset: { value: 'balanced', source: 'config' } },
+    authority: { grant_id: null, admission: 'none', rights: [], task_ids: [] },
+    delivery: { effective_completion: 'review' },
+    limiting_reasons: [],
   });
   return response({});
 };
@@ -169,4 +181,23 @@ assert(get('auto-tasks-body').textContent.includes('Select a workspace'), 'all-w
 
 // Leave a populated fixture for desktop/narrow rendered inspection.
 setWorkspace('one'); await fetchAndRenderOperations();
+const autoCard = descendants(get('auto-tasks-body')).find(node => String(node.className || '').includes('auto-task-card'));
+const autoKids = Array.from(autoCard?.children || []);
+const autoHead = autoKids.find(node => node.className === 'operation-row-head');
+const autoDetails = autoKids.find(node => node.className === 'operation-details');
+assert(autoHead, 'auto-task collapsed row is present');
+assert(autoDetails, 'auto-task details are present');
+assert(autoHead.textContent.includes('Chore one'), 'collapsed row shows the name');
+assert(autoHead.textContent.includes('Disable') || autoHead.textContent.includes('Enable'), 'collapsed row keeps the primary action');
+assert(!autoHead.textContent.includes('Manual mint ignores'), 'mint warning is not repeated on the collapsed row');
+assert(autoDetails.textContent.includes('Manual mint ignores'), 'mint explanation stays in details');
+assert(autoDetails.textContent.includes('Open duplicate'), 'duplicate explanation stays in details');
+assert(autoDetails.textContent.includes('Last scheduler evaluation'), 'scheduler cursor stays in details');
+assert(autoDetails.textContent.includes('Delivery coverage') || autoDetails.textContent.includes('covered'), 'delivery coverage stays in details');
+autoDetails.open = true;
+if (typeof Event === 'function') autoDetails.dispatchEvent(new Event('toggle'));
+else autoDetails.listeners?.toggle?.();
+await fetchAndRenderOperations();
+const restored = descendants(get('auto-tasks-body')).find(node => node.className === 'operation-details');
+assert(restored?.open, 'details stay open across rerender');
 globalThis.operationsTestsPassed = true;

--- a/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
+++ b/crates/orbit-web/src/tests/dashboard_operations_browser.mjs
@@ -19,41 +19,211 @@ const server = http.createServer((req, res) => {
   res.end(data);
 });
 await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const pageOverflow = () => document.documentElement.scrollWidth > window.innerWidth + 1;
+const assertNoOverflow = async (label) => {
+  const overflow = await page.evaluate(pageOverflow);
+  if (overflow) {
+    const width = await page.evaluate(() => ({ scroll: document.documentElement.scrollWidth, inner: window.innerWidth }));
+    throw new Error(`Horizontal overflow at ${label}: scrollWidth=${width.scroll} innerWidth=${width.inner}`);
+  }
+};
 let browser;
+let page;
 try {
   browser = await chromium.launch({headless:true});
-  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
   // Serve the actual markup/styles with only the Operations module initialized.
   // All API traffic is fixture data; no live scheduler or dashboard is contacted.
   page.on('pageerror', error => console.error(error));
-  await page.goto(`http://127.0.0.1:${server.address().port}/`);
+  await page.goto(`http://127.0.0.1:${server.address().port}/#operations/routines`);
   await page.addScriptTag({ type: 'module', url: '/test.mjs' });
   await page.waitForFunction(() => globalThis.operationsTestsPassed, undefined, { timeout: 15000 });
   await page.evaluate(() => {
-    document.querySelectorAll('.tab-pane').forEach(node => node.classList.toggle('active', node.dataset.tab === 'operations'));
-    document.body.classList.add('operations-active');
+    const workspace = document.getElementById('rail-workspace');
+    if (workspace && !document.getElementById('workspace-select')) {
+      workspace.innerHTML = '<select class="workspace-select" id="workspace-select" aria-label="Workspace"><option selected>ws_orbit</option></select>';
+    }
+    const tasks = document.getElementById('tasks-body');
+    if (tasks) {
+      tasks.innerHTML = `
+        <div class="row"><span class="id">ORB-11559</span><span class="title">Make Operations compact and usable on narrow dashboard widths</span><span class="status-cell"><select class="task-status-select"><option>in-progress</option></select></span><span class="crew-cell"><select class="task-crew-select"><option>grok</option></select></span></div>
+        <div class="row"><span class="id">ORB-00001-with-a-very-long-identifier</span><span class="title">A deliberately long title that must wrap instead of forcing horizontal page scroll</span><span class="status-cell"><select class="task-status-select"><option>blocked</option></select></span><span class="crew-cell"><select class="task-crew-select"><option>claude</option></select></span></div>`;
+    }
   });
-  for (const width of [1440, 390]) {
-    await page.setViewportSize({width, height:1000});
-    for (const tab of ['routines','auto-tasks']) {
-      await page.evaluate(tab => {
-        for (const name of ['routines','auto-tasks','auto-drain']) document.getElementById(`operations-${name}-main`).hidden = name !== tab;
-      }, tab);
-      await page.waitForTimeout(350);
-      await page.screenshot({path:path.join(evidence, `${tab}-${width}.png`),fullPage:true});
-      const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
-      if (overflow) throw new Error(`Horizontal overflow at ${width} / ${tab}`);
-      const clipped = await page.evaluate(tab => {
-        const panel = document.getElementById(`operations-${tab}-main`);
-        return Array.from(panel.querySelectorAll('button, select, .operation-clock-summary')).some(node => {
-          const bounds = node.getBoundingClientRect();
-          return bounds.right > window.innerWidth || node.scrollWidth > node.clientWidth + 1;
+  await page.evaluate(async () => {
+    const { initRouter, initTabs } = await import('/router.js');
+    let tab = 'operations';
+    let diag = 'runs';
+    let operations = 'routines';
+    let knowledge = 'frictions';
+    initRouter({
+      getTab: () => tab, setTab: (value) => { tab = value; },
+      getDiagSubtab: () => diag, setDiagSubtab: (value) => { diag = value; },
+      getOperationsSubtab: () => operations, setOperationsSubtab: (value) => { operations = value; },
+      getKnowledgeSubtab: () => knowledge, setKnowledgeSubtab: (value) => { knowledge = value; },
+      getRunId: () => null, setRunId: () => {}, getRunSubtab: () => 'steps', setRunSubtab: () => {},
+      getRunDetail: () => null, setRunDetail: () => {}, getRunEvents: () => [], setRunEvents: () => {},
+      getRunLogs: () => [], setRunLogs: () => {}, getExpandedSteps: () => new Set(), setExpandedSteps: () => {},
+      getLastRuns: () => [], refreshDashboard: () => {}, renderDiagnostics: () => {},
+      fitLogPanelToViewport: () => {},
+      getActiveAuditSubtab: () => 'events', setAuditSubtab: () => {}, applyAuditHashQuery: () => {},
+      syncAuditControls: () => {}, buildAuditHash: () => '#audit/events',
+      setActiveAuditSubtabFromButton: () => {},
+    });
+    initTabs();
+  });
+  const viewports = [
+    { name: '1440', width: 1440, height: 1000 },
+    { name: '672', width: 672, height: 900 },
+    { name: '390', width: 390, height: 844 },
+    { name: '375x812', width: 375, height: 812 },
+  ];
+  for (const viewport of viewports) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.evaluate(() => {
+      document.querySelectorAll('.operation-details').forEach((node) => { node.open = false; });
+    });
+    for (const tab of ['routines', 'auto-tasks', 'auto-drain']) {
+      await page.click(`#operations-subtabs .subtab[data-subtab="${tab}"]`);
+      await page.waitForTimeout(200);
+      const reachable = await page.evaluate((name) => {
+        const button = document.querySelector(`#operations-subtabs .subtab[data-subtab="${name}"]`);
+        const panel = document.getElementById(`operations-${name}-main`);
+        const workspace = document.getElementById('workspace-select');
+        const bounds = (node) => node.getBoundingClientRect();
+        const onscreen = (node) => {
+          const box = bounds(node);
+          return box.width > 0 && box.height > 0 && box.right > 0 && box.left < window.innerWidth;
+        };
+        const clipped = Array.from(panel.querySelectorAll('button, select, .operation-row-head, .operation-clock-summary')).some((node) => {
+          const box = bounds(node);
+          return box.right > window.innerWidth + 1;
         });
+        return {
+          subtab: onscreen(button),
+          panel: panel && !panel.hidden,
+          workspace: workspace && onscreen(workspace),
+          clipped,
+        };
       }, tab);
-      if (clipped) throw new Error(`Clipped Operations control at ${width} / ${tab}`);
+      if (!reachable.subtab) throw new Error(`${tab} subtab not reachable at ${viewport.name}`);
+      if (!reachable.panel) throw new Error(`${tab} panel hidden at ${viewport.name}`);
+      if (!reachable.workspace) throw new Error(`workspace selector not reachable at ${viewport.name} / ${tab}`);
+      if (reachable.clipped) throw new Error(`Clipped Operations control at ${viewport.name} / ${tab}`);
+      await assertNoOverflow(`${viewport.name} / ${tab}`);
+      await page.screenshot({ path: path.join(evidence, `${tab}-${viewport.name}.png`), fullPage: true });
     }
   }
-  console.log(`PASS: Chromium Operations fixture; desktop 1440 and narrow 390; no horizontal overflow. Screenshots: ${evidence}`);
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.click('.tab[data-tab="tasks"]');
+  await page.waitForTimeout(200);
+  const taskLayout = await page.evaluate(() => {
+    const row = document.querySelector('#tasks-body .row');
+    const list = document.getElementById('tasks-panel');
+    const style = row ? getComputedStyle(row) : null;
+    return {
+      listWidth: list?.getBoundingClientRect().width || 0,
+      inner: window.innerWidth,
+      areas: style?.gridTemplateAreas || '',
+      columns: style?.gridTemplateColumns || '',
+    };
+  });
+  // 216px rail would leave ~159px. Main padding is 20px on each side, so a
+  // full-width list in a 375px viewport is about 335px.
+  if (taskLayout.listWidth < taskLayout.inner - 80) {
+    throw new Error(`task list is not full-width at 375px: ${taskLayout.listWidth} vs ${taskLayout.inner}`);
+  }
+  if (!taskLayout.areas.includes('id title') || !taskLayout.areas.includes('status crew')) {
+    throw new Error(`375px task row must use the 520px two-row areas, got ${JSON.stringify(taskLayout)}`);
+  }
+  await assertNoOverflow('375x812 / tasks');
+  await page.screenshot({ path: path.join(evidence, 'tasks-375x812.png'), fullPage: true });
+
+  const navReachable = await page.evaluate(() => {
+    const unique = [...document.querySelectorAll('.rail .tab')];
+    const subtabs = [...document.querySelectorAll('#diag-subtabs .subtab')];
+    const onscreen = (node) => {
+      node.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+      const box = node.getBoundingClientRect();
+      return box.width > 0 && box.height > 0 && box.bottom > 0 && box.top < window.innerHeight && box.right > 0 && box.left < window.innerWidth + 8;
+    };
+    return {
+      tabs: unique.map((node) => ({ tab: node.dataset.tab, onscreen: onscreen(node) })),
+      subtabs: subtabs.map((node) => ({ subtab: node.dataset.subtab, onscreen: onscreen(node) })),
+    };
+  });
+  for (const tab of navReachable.tabs) {
+    if (!tab.onscreen) throw new Error(`top-level tab ${tab.tab} not reachable at 375px`);
+  }
+  for (const subtab of navReachable.subtabs) {
+    if (!subtab.onscreen) throw new Error(`diagnostics subtab ${subtab.subtab} not reachable at 375px`);
+  }
+
+  await page.click('.tab[data-tab="operations"]');
+  await page.click('#operations-subtabs .subtab[data-subtab="auto-tasks"]');
+  await page.waitForTimeout(150);
+  await page.locator('.auto-task-card .operation-details summary').first().focus();
+  await page.keyboard.press('Enter');
+  const expanded = await page.evaluate(() => document.querySelector('.auto-task-card .operation-details')?.open);
+  if (!expanded) throw new Error('keyboard Enter did not expand auto-task details');
+  await page.screenshot({ path: path.join(evidence, 'auto-tasks-375x812-expanded.png'), fullPage: true });
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.addScriptTag({ type: 'module', url: '/test.mjs' });
+  await page.waitForFunction(() => globalThis.operationsTestsPassed, undefined, { timeout: 15000 });
+  await page.evaluate(async () => {
+    const { initRouter, initTabs } = await import('/router.js');
+    let tab = 'tasks';
+    let diag = 'runs';
+    let operations = 'routines';
+    let knowledge = 'frictions';
+    initRouter({
+      getTab: () => tab, setTab: (value) => { tab = value; },
+      getDiagSubtab: () => diag, setDiagSubtab: (value) => { diag = value; },
+      getOperationsSubtab: () => operations, setOperationsSubtab: (value) => { operations = value; },
+      getKnowledgeSubtab: () => knowledge, setKnowledgeSubtab: (value) => { knowledge = value; },
+      getRunId: () => null, setRunId: () => {}, getRunSubtab: () => 'steps', setRunSubtab: () => {},
+      getRunDetail: () => null, setRunDetail: () => {}, getRunEvents: () => [], setRunEvents: () => {},
+      getRunLogs: () => [], setRunLogs: () => {}, getExpandedSteps: () => new Set(), setExpandedSteps: () => {},
+      getLastRuns: () => [], refreshDashboard: () => {}, renderDiagnostics: () => {},
+      fitLogPanelToViewport: () => {},
+      getActiveAuditSubtab: () => 'events', setAuditSubtab: () => {}, applyAuditHashQuery: () => {},
+      syncAuditControls: () => {}, buildAuditHash: () => '#audit/events',
+      setActiveAuditSubtabFromButton: () => {},
+    });
+    initTabs();
+  });
+  const afterReload = await page.evaluate(() => ({
+    hash: location.hash,
+    autoTasks: !document.getElementById('operations-auto-tasks-main')?.hidden,
+  }));
+  if (!afterReload.hash.includes('operations/auto-tasks') || !afterReload.autoTasks) {
+    throw new Error(`reload did not restore auto-tasks subtab: ${JSON.stringify(afterReload)}`);
+  }
+  await page.click('#operations-subtabs .subtab[data-subtab="routines"]');
+  await page.waitForFunction(() => location.hash.includes('operations/routines'));
+  await page.click('#operations-subtabs .subtab[data-subtab="auto-tasks"]');
+  await page.waitForFunction(() => location.hash.includes('operations/auto-tasks'));
+  await page.goBack();
+  await page.waitForFunction(() => location.hash.includes('operations/routines'));
+  const afterBack = await page.evaluate(() => ({
+    hash: location.hash,
+    routines: !document.getElementById('operations-routines-main')?.hidden,
+  }));
+  if (!afterBack.hash.includes('operations/routines') || !afterBack.routines) {
+    throw new Error(`back did not restore routines: ${JSON.stringify(afterBack)}`);
+  }
+  await page.goForward();
+  await page.waitForFunction(() => location.hash.includes('operations/auto-tasks'));
+  const afterForward = await page.evaluate(() => ({
+    hash: location.hash,
+    autoTasks: !document.getElementById('operations-auto-tasks-main')?.hidden,
+  }));
+  if (!afterForward.hash.includes('operations/auto-tasks') || !afterForward.autoTasks) {
+    throw new Error(`forward did not restore auto-tasks: ${JSON.stringify(afterForward)}`);
+  }
+  console.log(`PASS: Chromium Operations fixture; 1440/672/390/375; subtabs, reload, history. Screenshots: ${evidence}`);
 } finally {
   await browser?.close(); server.close();
 }


### PR DESCRIPTION
## Task

[ORB-11559](https://orbit-cli.com/tasks/ORB-11559) — Make Operations compact and usable on narrow dashboard widths

### Description

## Problem
Operations Auto-tasks renders ten very tall cards with repetitive warnings and extensive details, requiring several screens of scrolling. At a 390px viewport the fixed roughly 215px sidebar consumes over half the width and leaves the content clipped or wrapping almost word by word. Desktop was inspected at 1440px.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Use compact scannable rows or cards showing name, effective state, schedule/next occurrence, last outcome and primary actions, with expandable secondary details. Provide responsive navigation and keep actions reachable. This owns presentation, not new authorization or mint semantics; coordinate with the separate Operations action task. Preserve mutually exclusive Operations subviews, existing detail information and keyboard access.

### Acceptance Criteria

- At 390, 672 and 1440px, navigation and Operations content remain usable without page-level clipping; primary actions and workspace selector are reachable.
- Collapsed items show useful state and primary actions; description, duplicate/mint explanation, cursor and delivery coverage remain available in accessible expandable details.
- Keyboard navigation, focus visibility and expansion semantics work; long names, IDs and errors do not break layout.
- Rendered validation covers Routines, Auto-tasks and Auto-drain plus shared sidebar behavior on Tasks; record screenshots and test subtab switching, reload and back/forward.
- At 375×812 the task list is full-width and the row grid uses the 520 px two-row layout without horizontal page scroll.
- Every top-level tab and diagnostics subtab remains reachable at 375px.
- The dashboard_assets.rs responsive assertions still pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Compacted Operations routines, auto-tasks, clock, and operation-mode into scannable rows (name, state, schedule/next, last outcome, primary actions) with native `<details>` for description, duplicate/mint copy, scheduler cursor, and delivery coverage. Open state survives rerender.
- At max-width 760px, `.shell` is a single column; the 216px rail becomes a horizontal top strip (tabs wrap/scroll; diagnostics subtabs are a second row); KPI labels and the sparkline hide. No index.html change.
- Tests: CSS rail collapse assertions; Node harness for collapsed vs details; Chromium fixture at 1440/672/390/375×812 with overflow, subtab, reload, and back/forward checks. Screenshots attached under `screenshots/`.
Assessment: Presentation-only. Action guards, mint/toggle/clock semantics, and mutually exclusive Operations subviews are unchanged. index.html was not required; CSS `display: contents` on rail groups is enough.

Criteria:
- 390/672/1440 usable, no page-level clip, actions and workspace selector reachable: passed (Chromium fixture + screenshots).
- Collapsed rows show state and primary actions; details hold description, duplicate/mint, cursor, coverage: passed (Node harness + screenshots).
- Keyboard, focus-visible, expansion, long names/IDs/errors: passed (Enter on summary, focus ring, overflow-wrap).
- Routines, Auto-tasks, Auto-drain, Tasks sidebar; subtab/reload/back-forward; screenshots: passed.
- 375×812 task list full-width with 520px two-row grid, no page scroll: passed.
- Every top-level tab and diagnostics subtab reachable at 375px: passed (scrollIntoView).
- dashboard_assets.rs responsive assertions: passed.

Validation:
- `cargo test -p orbit-web --lib -- dashboard_operations operations_actions_preserve dashboard_narrow_shell`: passed (5 tests).
- Chromium `dashboard_operations_browser.mjs` at 1440/672/390/375: passed. Playwright+Chromium staged in `/tmp/orbit-orb-11559.eOaBhy` (outside worktree); isolated fixture, no live dashboard mutations.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed (no whitespace errors).

Strategic decisions: CSS-only rail collapse (horizontal strip, not a drawer) so hash routes and `.tab`/`.subtab` wiring stay intact. Native details for accessible expansion.
Design weaknesses / risks: Severity low — diagnostics subtabs share the rail flex row via `display: contents`; a later rail-group markup change could break the second-row wrap. Mitigation: `dashboard_narrow_shell_collapses_rail_and_task_rows` pins the CSS. Fixture timestamps use the test `formatAbsoluteTime` passthrough (ISO+zone), not the live dashboard formatter.
Deviations from original plan: none material. index.html left unchanged because CSS was sufficient.
Recommended follow-ups: none required for this task.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11559-6a9f5ab2`
- Behind base: 0
- Ahead of base: 1