### PR TITLE
[code-review] Resolve `orbit run ship` mode from the selected root's registry, not `~/.orbit`

### DIFF
--- a/crates/orbit-cli/src/command/run/ship.rs
+++ b/crates/orbit-cli/src/command/run/ship.rs
@@ -128,14 +128,16 @@ impl Execute for ShipCommand {
 /// workspace's registry entry (matched by `orbit_dir`): explicit `ship_mode`,
 /// else the `pr` default. If the current workspace isn't found in the registry,
 /// fall back to `pr` so omitted configuration still uses reviewable delivery.
-fn resolve_ship_mode(
+pub(crate) fn resolve_ship_mode(
     args: &ShipCommand,
     runtime: &OrbitRuntime,
 ) -> Result<orbit_core::ShipMode, OrbitError> {
     if let Some(mode) = args.mode {
         return Ok(mode.to_core());
     }
-    let registry = orbit_registry::workspace_registry::load_registry()?;
+    let registry_path =
+        orbit_registry::workspace_registry::registry_path_for(&runtime.global_root());
+    let registry = orbit_registry::workspace_registry::load_registry_from(&registry_path)?;
     let orbit_dir = runtime.shared_root();
     let mode = registry
         .checkouts
@@ -144,8 +146,16 @@ fn resolve_ship_mode(
         .and_then(|checkout| {
             orbit_registry::workspace_registry::find_workspace(&registry, &checkout.workspace_id)
         })
-        .map(orbit_core::resolved_ship_mode)
-        .unwrap_or(orbit_core::ShipMode::Pr);
+        .map(orbit_core::resolved_ship_mode);
+    let Some(mode) = mode else {
+        tracing::warn!(
+            registry_path = %registry_path.display(),
+            orbit_dir = %orbit_dir.display(),
+            fallback = "pr",
+            "workspace was not found in registry; falling back to PR ship mode"
+        );
+        return Ok(orbit_core::ShipMode::Pr);
+    };
     Ok(mode)
 }
 

--- a/crates/orbit-cli/src/command/run/tests/ship.rs
+++ b/crates/orbit-cli/src/command/run/tests/ship.rs
@@ -1,4 +1,10 @@
+use chrono::Utc;
+use orbit_registry::workspace_registry::{registry_path_for, save_registry_to};
+use orbit_types::workspace::{Workspace, WorkspaceCheckout, WorkspaceRegistry, WorkspaceStatus};
+use tempfile::tempdir;
+
 use crate::command::Execute;
+use crate::tests::env_isolation::EnvGuard;
 use orbit_core::application::task::TaskAddParams;
 use orbit_core::{OrbitError, OrbitRuntime, TaskStatus};
 use serde_json::json;
@@ -36,6 +42,70 @@ fn restricted_ship_args(
         allow_crew: crews.iter().map(|crew| (*crew).to_string()).collect(),
         ..ship_args(task_ids, mode, base)
     }
+}
+
+#[test]
+fn ship_mode_uses_selected_root_registry_when_home_registry_is_empty() {
+    let fixture = tempdir().expect("fixture tempdir");
+    let selected_root = fixture.path().join("selected-root");
+    let workspace_root = fixture.path().join("workspace-orbit");
+    let repo_root = fixture.path().join("repo");
+    let home = fixture.path().join("empty-home");
+    let home_registry_root = home.join(".orbit");
+    for directory in [
+        &selected_root,
+        &workspace_root,
+        &repo_root,
+        &home_registry_root,
+    ] {
+        std::fs::create_dir_all(directory).expect("fixture directory");
+    }
+
+    let runtime = OrbitRuntime::from_roots(&selected_root, &workspace_root)
+        .expect("build selected-root runtime");
+    let workspace = Workspace {
+        id: "ws_ship_mode".to_string(),
+        name: "ship-mode-test".to_string(),
+        owner_machine_id: None,
+        git_remote: None,
+        ship_mode: Some("local".to_string()),
+        base_branch: "agent-main".to_string(),
+        status: WorkspaceStatus::Active,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let checkout =
+        WorkspaceCheckout::owner(workspace.id.clone(), repo_root, workspace_root.clone());
+    let mut registry = WorkspaceRegistry::default();
+    orbit_registry::workspace_registry::register_workspace(&mut registry, workspace)
+        .expect("register workspace");
+    orbit_registry::workspace_registry::register_checkout(&mut registry, checkout)
+        .expect("register checkout");
+    save_registry_to(&registry, &registry_path_for(&selected_root))
+        .expect("save selected-root registry");
+    save_registry_to(
+        &WorkspaceRegistry::default(),
+        &registry_path_for(&home_registry_root),
+    )
+    .expect("save empty home registry");
+
+    let _env = EnvGuard::acquire().home(&home);
+    assert_eq!(
+        resolve_ship_mode(
+            &ShipCommand {
+                task_ids: Vec::new(),
+                mode: None,
+                base: None,
+                complete: false,
+                allow_crew: Vec::new(),
+                json: false,
+                claim_token: None,
+            },
+            &runtime,
+        )
+        .expect("resolve ship mode"),
+        orbit_core::ShipMode::Local
+    );
 }
 
 /// Build a ship plan from test args, threading the args' explicit mode through


### PR DESCRIPTION
## Task

[ORB-11616](https://orbit-cli.com/tasks/ORB-11616) — [code-review] Resolve `orbit run ship` mode from the selected root's registry, not `~/.orbit`

### Description

## Problem
`resolve_ship_mode` calls `orbit_registry::workspace_registry::load_registry()` (`ship.rs:138`), which reads `$HOME/.orbit/workspaces.json` unconditionally, then matches on `runtime.shared_root()` and falls back to `ShipMode::Pr` when no checkout matches. Under `--root <dir>` or `ORBIT_ROOT` the runtime's registry is `<root>/workspaces.json`, so a workspace registered there with `ship_mode: local` is not found in the home registry and the ship silently runs in `pr` mode. `registry_runtime.rs:322-335` documents `global_root_for` as "the single answer to which registry `--root` selects" and cites ORB-11388 fixing the dashboard for this exact class; this call site was missed.

## Why It Matters
Ship mode decides whether the pipeline opens a PR or delivers in place; a silent fallback to `pr` in a rooted environment (tests, sandboxes, hosted runners) changes delivery semantics without any diagnostic.

## Proposed Fix
Replace the call with `load_registry_from(&registry_path_for(&runtime.global_root()))`, and when the workspace is not found emit a `tracing::warn!` naming the registry path and the fallback.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/run/ship.rs:130-150`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test under `crates/orbit-cli/src/command/run/tests/ship.rs` registers a `ship_mode: local` workspace in a temp root and asserts `resolve_ship_mode` returns `Local` when `HOME` points at an empty registry.
- `grep -rn 'load_registry()' crates/orbit-cli/src crates/orbit-cmd/src | grep -v tests` no longer lists `ship.rs`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `resolve_ship_mode` now loads `workspaces.json` from `runtime.global_root()` and reports the selected registry path, workspace root, and PR fallback in a warning when no workspace binding is found.
- Added a regression test that registers a local-ship workspace in a selected temp-root registry while HOME points to an explicitly empty registry, and asserts `ShipMode::Local`.
Assessment: The change is narrow, follows the existing root-selection boundary, and preserves explicit `--mode` behavior and the PR fallback.

Acceptance criteria:
- Passed: `crates/orbit-cli/src/command/run/tests/ship.rs` covers selected-root local mode versus empty HOME registry.
- Passed: the required grep finds zero `load_registry()` references in `crates/orbit-cli/src/command/run/ship.rs`.

Validation:
- Passed: `cargo fmt --all -- --check`.
- Passed: `cargo test -p orbit-cli ship_mode_uses_selected_root_registry_when_home_registry_is_empty -- --exact`.
- Passed: `cargo test -p orbit-cli command::run::tests::ship -- --nocapture` (16 tests).
- Passed: `grep -rn 'load_registry()' crates/orbit-cli/src crates/orbit-cmd/src | grep -v tests` criterion check; four non-ship matches remain elsewhere, zero in `ship.rs`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`; final worktree contains only the two task-scoped source/test files.
- Not run: `make ci`, per workspace guidance that it is the canonical merge gate and should not be run per task.

Remaining risks or deviations: none.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11616-6a9f5e14`
- Behind base: 0
- Ahead of base: 1