### PR TITLE
[code-review] Validate skill ids as path stems before joining them onto the catalog roots

### DIFF
--- a/crates/orbit-store/src/driver/file/skill_store/mod.rs
+++ b/crates/orbit-store/src/driver/file/skill_store/mod.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
+use crate::fs::path_safety::validate_path_stem;
 use crate::fs::yaml::parse_yaml_with;
 
 const PURPOSE_SECTION: &str = "Purpose";
@@ -129,7 +130,7 @@ impl SkillCatalog {
         ids.sort();
         let mut rows = Vec::new();
         for id in ids {
-            let path = self.candidate_path(&id);
+            let path = self.candidate_path(&id)?;
             match self.load(&id) {
                 Ok(_) => rows.push(SkillCatalogDoctorRow {
                     skill_id: id,
@@ -156,11 +157,7 @@ impl SkillCatalog {
     }
 
     pub fn load(&self, skill_id: &str) -> Result<LoadedSkill, OrbitError> {
-        if skill_id.trim().is_empty() {
-            return Err(OrbitError::SkillValidation(
-                "skill id must not be empty".to_string(),
-            ));
-        }
+        validate_skill_id(skill_id)?;
 
         // Skills use MergeByKey semantics: workspace wins for the named key,
         // otherwise fall through to the global default.
@@ -192,14 +189,16 @@ impl SkillCatalog {
         Ok(ids)
     }
 
-    fn candidate_path(&self, skill_id: &str) -> PathBuf {
+    fn candidate_path(&self, skill_id: &str) -> Result<PathBuf, OrbitError> {
+        validate_skill_id(skill_id)?;
         let workspace = self.root.join(skill_id);
         if workspace.exists() {
-            workspace
+            Ok(workspace)
         } else {
-            self.global_root
+            Ok(self
+                .global_root
                 .as_ref()
-                .map_or(workspace, |global| global.join(skill_id))
+                .map_or(workspace, |global| global.join(skill_id)))
         }
     }
 }
@@ -212,6 +211,7 @@ impl ScopedStore<LoadedSkill> for SkillCatalog {
     }
 
     fn get_workspace(&self, key: &str) -> Result<Option<LoadedSkill>, OrbitError> {
+        validate_skill_id(key)?;
         let dir = self.root.join(key);
         if dir.exists() {
             load_skill_from_dir(key, &dir).map(Some)
@@ -221,6 +221,7 @@ impl ScopedStore<LoadedSkill> for SkillCatalog {
     }
 
     fn get_global(&self, key: &str) -> Result<Option<LoadedSkill>, OrbitError> {
+        validate_skill_id(key)?;
         let Some(ref global) = self.global_root else {
             return Ok(None);
         };
@@ -231,6 +232,15 @@ impl ScopedStore<LoadedSkill> for SkillCatalog {
             Ok(None)
         }
     }
+}
+
+fn validate_skill_id(skill_id: &str) -> Result<(), OrbitError> {
+    if skill_id.trim().is_empty() {
+        return Err(OrbitError::SkillValidation(
+            "skill id must not be empty".to_string(),
+        ));
+    }
+    validate_path_stem(skill_id, "skill")
 }
 
 /// Load a skill from a specific directory on disk.

--- a/crates/orbit-store/src/driver/file/skill_store/tests/skill_store.rs
+++ b/crates/orbit-store/src/driver/file/skill_store/tests/skill_store.rs
@@ -99,6 +99,43 @@ fn doctor_reports_skill_directories_without_skill_markdown() {
     );
 }
 
+#[test]
+fn load_rejects_traversal_and_absolute_skill_ids_without_leaving_catalog() {
+    let parent = tempdir().expect("sandbox tempdir");
+    let catalog_root = parent.path().join("catalog");
+    fs::create_dir(&catalog_root).expect("create catalog root");
+    write_skill(parent.path(), "escape", "escaped purpose");
+
+    let catalog = SkillCatalog::new(catalog_root);
+
+    let traversal = catalog
+        .load("../escape")
+        .expect_err("relative traversal must fail");
+    assert!(
+        matches!(traversal, OrbitError::InvalidInput(_)),
+        "expected InvalidInput for ../escape, got {traversal:?}"
+    );
+
+    let absolute = catalog
+        .load("/etc")
+        .expect_err("absolute skill id must fail");
+    assert!(
+        matches!(absolute, OrbitError::InvalidInput(_)),
+        "expected InvalidInput for /etc, got {absolute:?}"
+    );
+
+    let decoy = SkillCatalog::new(parent.path().to_path_buf());
+    assert_eq!(
+        decoy
+            .load("escape")
+            .expect("decoy skill must be loadable from its own root")
+            .sections
+            .purpose,
+        "escaped purpose",
+        "InvalidInput is not a missing-file miss: the sibling decoy is a valid skill"
+    );
+}
+
 fn write_skill(root: &Path, id: &str, purpose: &str) {
     let dir = root.join(id);
     fs::create_dir_all(&dir).expect("create skill dir");


### PR DESCRIPTION
## Task

[ORB-11654](https://orbit-cli.com/tasks/ORB-11654) — [code-review] Validate skill ids as path stems before joining them onto the catalog roots

### Description

## Problem
`SkillCatalog::load(skill_id)` only rejects an empty/blank id, then `get_workspace`/`get_global`/`candidate_path` do `self.root.join(key)` and `global.join(key)` unchecked. A skill id such as `../../some/dir` resolves outside the catalog and `load_skill_from_dir` reads `SKILL.md`/`meta.json` from there; an absolute id replaces the root entirely (`Path::join` semantics). Every other file store in the crate validates its key (`validate_path_stem` in run_state and job_run_store, `validate_resource_name` in executor/policy def stores); the skill catalog is the outlier, and skill ids arrive from CLI/MCP arguments.

## Why It Matters
Path-safety is supposed to be enforced at the store boundary (AGENTS.md "rules at their authoritative boundary"); a transport that forgets to validate should not be able to read arbitrary `SKILL.md` files on the host.

## Proposed Fix
Call `crate::fs::path_safety::validate_path_stem(skill_id, "skill")` at the top of `load` and in `candidate_path`/`get_*` before joining.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-store/src/driver/file/skill_store/mod.rs:158-172`, `crates/orbit-store/src/driver/file/skill_store/mod.rs:195-204`, `crates/orbit-store/src/driver/file/skill_store/mod.rs:213-231`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (security). Review area: store.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Sibling test: `load("../escape")` and `load("/etc")` return `OrbitError::InvalidInput` without touching the filesystem outside the root.
- Existing skill catalog tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added private `validate_skill_id` in `crates/orbit-store/src/driver/file/skill_store/mod.rs`. It keeps the existing blank-id `SkillValidation` rejection (whitespace-only names are a single `Path` component and would pass stem checks) and then calls `validate_path_stem(skill_id, "skill")` so traversal and absolute ids return `OrbitError::InvalidInput`.
- Call that helper before every catalog `Path::join`: `SkillCatalog::load`, `get_workspace`, `get_global`, and `candidate_path`. `candidate_path` now returns `Result<PathBuf, OrbitError>` so `doctor` cannot emit an out-of-root path.
- Sibling test `load_rejects_traversal_and_absolute_skill_ids_without_leaving_catalog` seeds a valid decoy skill at `../escape` under a parent tempdir and asserts `load("../escape")` and `load("/etc")` are `InvalidInput`. The decoy is then loaded from its own root so the rejection cannot be a missing-file miss.
- Appended `file:crates/orbit-store/src/driver/file/skill_store/tests/skill_store.rs` to context_files because the acceptance criteria required a sibling test there.
Assessment: Path-safety now lives at the store join sites using the crate's existing stem helper, matching run_state and job_run_store. Public `load` is covered; `resolve` cannot skip the check because `get_*` also validate. Blank ids stay `SkillValidation` rather than `InvalidInput`.
Strategic decisions: One helper at every join site instead of validating only in `load`, because `ScopedStore::resolve` can call `get_workspace`/`get_global` directly.
Deviations from original plan: None.
Criteria:
- Sibling test: `load("../escape")` and `load("/etc")` return `OrbitError::InvalidInput` without touching the filesystem outside the root. Met: new sibling test seeds a valid outside decoy and asserts InvalidInput; `/etc` is rejected before join. The decoy is only loaded when pointed at as its own catalog root.
- Existing skill catalog tests pass. Met: all three `skill_store` lib tests passed (2 existing + 1 new).
Validation:
- `cargo test -p orbit-store --lib skill_store`: passed (3 tests, 0 failed).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed (no whitespace errors).
Friction: none filed. No contradicted assumption or recurring failure.
Remaining risks: `/etc` coverage is by error-type (InvalidInput vs SkillValidation/Io), not by intercepting syscalls. `collect_candidate_ids` still trusts `file_name` stems from `read_dir`; those names already cannot contain `..` or absolute components. Changes left uncommitted for the pipeline.
Starting HEAD: 94a0d5ca8213b93e261bf2276289c853b2e07cfb. Working tree: two modified files under skill_store.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11654-6a9f5ee5`
- Behind base: 0
- Ahead of base: 1