### PR TITLE
[code-review] Run `apply_task_automation_update` under the task write lock with an expected status

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -234,76 +234,7 @@ impl RuntimeHost for OrbitRuntime {
         task_id: &str,
         update: TaskAutomationUpdate,
     ) -> Result<(), OrbitError> {
-        let existing_task = self.get_task(task_id)?;
-        if update.status == Some(TaskStatus::InProgress)
-            && crate::application::task::in_progress_transition_requires_plan(existing_task.status)
-        {
-            crate::application::task::ensure_task_has_execution_plan(
-                task_id,
-                existing_task.plan.as_str(),
-            )?;
-        }
-        if update.status == Some(TaskStatus::Done) && existing_task.status != TaskStatus::Done {
-            self.ensure_resolves_are_workspace_local(&existing_task)?;
-        }
-        let (agent, model) = self
-            .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
-        let runtime_model_identity = <Self as RuntimeHost>::actor_model_identity(self);
-        let attribution = assemble_task_attribution(
-            &existing_task,
-            TaskAttributionInput {
-                default_actor_label: SYSTEM_ACTOR_LABEL,
-                actor_override: Some(SYSTEM_ACTOR_LABEL),
-                agent: agent.as_deref(),
-                model: model.as_deref(),
-                runtime_model_identity: runtime_model_identity.as_deref(),
-                plan_changed: update.plan.is_some(),
-                target_status: update.status,
-                explicit_planned_by: None,
-                explicit_implemented_by: None,
-            },
-        );
-        let task = self.with_mutation(|| {
-            let external_refs = if update.external_refs.is_empty() {
-                None
-            } else {
-                let mut refs = existing_task.external_refs.clone();
-                for external_ref in update.external_refs.clone() {
-                    push_external_ref_if_missing(&mut refs, external_ref);
-                }
-                Some(refs)
-            };
-            let task = self.stores().task_records().update(
-                task_id,
-                StoreTaskUpdateParams {
-                    actor: attribution.actor.clone(),
-                    planned_by: attribution.planned_by.clone(),
-                    implemented_by: attribution.implemented_by.clone(),
-                    external_refs,
-                    status_event: update.status_event.clone(),
-                    status_note: update.status_note.clone(),
-                    append_comments: update.append_comments.clone(),
-                    ..StoreTaskUpdateParams::from(TaskUpdateParams {
-                        execution_summary: update.execution_summary.clone(),
-                        plan: update.plan.clone(),
-                        context_files: update.context_files.clone(),
-                        status: update.status,
-                        job_run_id: update.job_run_id.clone().map(Some),
-                        ..Default::default()
-                    })
-                },
-            )?;
-            Ok((
-                task.clone(),
-                OrbitEvent::TaskUpdated {
-                    id: task_id.to_string(),
-                },
-            ))
-        })?;
-        if task.status == TaskStatus::Done {
-            self.record_resolves_side_effects(&task)?;
-        }
-        Ok(())
+        apply_locked_task_automation_update(self, task_id, update)
     }
 
     fn agent_provider_config(&self) -> std::collections::HashMap<String, String> {
@@ -892,4 +823,125 @@ impl RuntimeHost for OrbitRuntime {
             ),
         ))
     }
+}
+
+/// Apply an automation update while holding the task write lock across the
+/// whole read-modify-write.
+///
+/// ORB-11623: delivery automation previously read the task, derived
+/// attribution and a replacement `external_refs` vector, then wrote through
+/// `task_records().update` with no lock and `expected_status: None`. The
+/// store locks each write, not the read that decided it, so an operator
+/// transition or another ref writer in that gap was overwritten. The lock
+/// is re-entrant per thread, so the store's own per-write locking still
+/// holds underneath.
+fn apply_locked_task_automation_update(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    update: TaskAutomationUpdate,
+) -> Result<(), OrbitError> {
+    let mut update = Some(update);
+    let mut updated: Option<Task> = None;
+    runtime
+        .stores()
+        .tasks()
+        .with_task_write_lock(task_id, &mut || {
+            let update = update.take().ok_or_else(|| {
+                OrbitError::Execution(
+                    "task automation update body was invoked more than once".to_string(),
+                )
+            })?;
+            updated = Some(apply_task_automation_update_under_lock(
+                runtime, task_id, update,
+            )?);
+            Ok(())
+        })?;
+    let task = updated.ok_or_else(|| {
+        OrbitError::Execution(
+            "task automation update body did not run under the task lock".to_string(),
+        )
+    })?;
+    if task.status == TaskStatus::Done {
+        runtime.record_resolves_side_effects(&task)?;
+    }
+    Ok(())
+}
+
+fn apply_task_automation_update_under_lock(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    update: TaskAutomationUpdate,
+) -> Result<Task, OrbitError> {
+    let existing_task = runtime.get_task(task_id)?;
+    #[cfg(test)]
+    runtime.invoke_after_locked_state_read(&existing_task);
+    if update.status == Some(TaskStatus::InProgress)
+        && crate::application::task::in_progress_transition_requires_plan(existing_task.status)
+    {
+        crate::application::task::ensure_task_has_execution_plan(
+            task_id,
+            existing_task.plan.as_str(),
+        )?;
+    }
+    if update.status == Some(TaskStatus::Done) && existing_task.status != TaskStatus::Done {
+        runtime.ensure_resolves_are_workspace_local(&existing_task)?;
+    }
+    let (agent, model) = runtime
+        .try_canonical_agent_model_identity(update.agent.as_deref(), update.model.as_deref())?;
+    let runtime_model_identity = <OrbitRuntime as RuntimeHost>::actor_model_identity(runtime);
+    let attribution = assemble_task_attribution(
+        &existing_task,
+        TaskAttributionInput {
+            default_actor_label: SYSTEM_ACTOR_LABEL,
+            actor_override: Some(SYSTEM_ACTOR_LABEL),
+            agent: agent.as_deref(),
+            model: model.as_deref(),
+            runtime_model_identity: runtime_model_identity.as_deref(),
+            plan_changed: update.plan.is_some(),
+            target_status: update.status,
+            explicit_planned_by: None,
+            explicit_implemented_by: None,
+        },
+    );
+    runtime.with_mutation(|| {
+        let external_refs = if update.external_refs.is_empty() {
+            None
+        } else {
+            // Merge against the latest locked state. `external_refs` is a
+            // wholesale replacement in the store, so a re-entrant writer that
+            // landed a ref after the decision snapshot would otherwise be lost.
+            let mut refs = runtime.get_task(task_id)?.external_refs;
+            for external_ref in update.external_refs.clone() {
+                push_external_ref_if_missing(&mut refs, external_ref);
+            }
+            Some(refs)
+        };
+        let task = runtime.stores().task_records().update(
+            task_id,
+            StoreTaskUpdateParams {
+                actor: attribution.actor.clone(),
+                planned_by: attribution.planned_by.clone(),
+                implemented_by: attribution.implemented_by.clone(),
+                external_refs,
+                status_event: update.status_event.clone(),
+                status_note: update.status_note.clone(),
+                append_comments: update.append_comments.clone(),
+                expected_status: Some(vec![existing_task.status]),
+                ..StoreTaskUpdateParams::from(TaskUpdateParams {
+                    execution_summary: update.execution_summary.clone(),
+                    plan: update.plan.clone(),
+                    context_files: update.context_files.clone(),
+                    status: update.status,
+                    job_run_id: update.job_run_id.clone().map(Some),
+                    ..Default::default()
+                })
+            },
+        )?;
+        Ok((
+            task.clone(),
+            OrbitEvent::TaskUpdated {
+                id: task_id.to_string(),
+            },
+        ))
+    })
 }

--- a/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs
@@ -11,12 +11,14 @@ use orbit_engine::{
     RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate, V2AuditWriter, V2DispatchInput,
 };
 use orbit_store::maintenance::task_registry::{WorkspaceConfig, write_workspace_config};
-use orbit_types::task::{Task, TaskStatus};
+use orbit_types::task::{ExternalRef, Task, TaskStatus, push_external_ref_if_missing};
 use orbit_types::workflow::activity_job::{ActivityV2Spec, DeterministicSpec};
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
-use crate::application::task::{SYSTEM_ACTOR_LABEL, TaskAddParams, TaskUpdateParams};
+use crate::application::task::{
+    SYSTEM_ACTOR_LABEL, TaskAddParams, TaskRecordUpdateParams, TaskUpdateParams,
+};
 use crate::application::workflow::ShipMode;
 use crate::runtime::WorkspaceRuntimeBinding;
 use crate::{ActorIdentity, OrbitRuntime};
@@ -959,6 +961,141 @@ fn generic_automation_status_update_uses_system_history_and_preserves_implemente
         .expect("review transition history");
     assert_eq!(status_entry.by, SYSTEM_ACTOR_LABEL);
     assert_eq!(updated.implemented_by.as_deref(), Some("gpt-test"));
+}
+
+#[test]
+fn apply_task_automation_update_keeps_external_refs_written_after_locked_read() {
+    let (_root, runtime) = test_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Concurrent refs".to_string(),
+            description: "Exercise automation external_ref merge under the task lock.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+    let concurrent_ref = ExternalRef::github_pr("200").expect("concurrent github-pr ref");
+    let automation_ref = ExternalRef::github_pr("100").expect("automation github-pr ref");
+    runtime.set_after_locked_state_read_hook(Arc::new({
+        let runtime = runtime.clone();
+        let task_id = task.id.clone();
+        let concurrent_ref = concurrent_ref.clone();
+        move |snapshot| {
+            if snapshot.id != task_id {
+                return;
+            }
+            let mut refs = snapshot.external_refs.clone();
+            push_external_ref_if_missing(&mut refs, concurrent_ref.clone());
+            runtime
+                .stores()
+                .task_records()
+                .update(
+                    &task_id,
+                    TaskRecordUpdateParams {
+                        actor: "concurrent-writer".to_string(),
+                        external_refs: Some(refs),
+                        ..Default::default()
+                    },
+                )
+                .expect("write concurrent ref under the re-entrant lock");
+        }
+    }));
+
+    runtime
+        .apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                external_refs: vec![automation_ref.clone()],
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("automation ref write");
+
+    let updated = runtime.get_task(&task.id).expect("reload task");
+    assert!(
+        updated
+            .external_refs
+            .iter()
+            .any(|reference| reference.has_key(&automation_ref.system, &automation_ref.id)),
+        "automation ref must survive: {:?}",
+        updated.external_refs
+    );
+    assert!(
+        updated
+            .external_refs
+            .iter()
+            .any(|reference| reference.has_key(&concurrent_ref.system, &concurrent_ref.id)),
+        "concurrent ref must survive: {:?}",
+        updated.external_refs
+    );
+}
+
+#[test]
+fn apply_task_automation_update_refuses_done_when_status_changes_after_locked_read() {
+    let (_root, runtime) = test_runtime();
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "Operator withdrawal".to_string(),
+            description: "Exercise automation expected_status compare-and-set.".to_string(),
+            workspace_path: Some(".".to_string()),
+            ..Default::default()
+        })
+        .expect("add task");
+    let task = approve_for_execution(&runtime, &task);
+    runtime
+        .start_task(&task.id, Some("start task".to_string()), None)
+        .expect("start task");
+    runtime
+        .apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::Review),
+                execution_summary: Some("Ready for merge.".to_string()),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("move to review");
+
+    runtime.set_after_locked_state_read_hook(Arc::new({
+        let runtime = runtime.clone();
+        let task_id = task.id.clone();
+        move |snapshot| {
+            if snapshot.id != task_id || snapshot.status != TaskStatus::Review {
+                return;
+            }
+            runtime
+                .update_task(
+                    &task_id,
+                    TaskUpdateParams {
+                        status: Some(TaskStatus::Backlog),
+                        ..Default::default()
+                    },
+                )
+                .expect("operator reclassifies to backlog");
+        }
+    }));
+
+    let error = runtime
+        .apply_task_automation_update(
+            &task.id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::Done),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect_err("stale done write must lose to the operator");
+    let message = error.to_string();
+    assert!(
+        message.contains("status changed"),
+        "names the race: {message}"
+    );
+    assert!(
+        message.contains("backlog"),
+        "names the new status: {message}"
+    );
+
+    let current = runtime.get_task(&task.id).expect("reload task");
+    assert_eq!(current.status, TaskStatus::Backlog);
 }
 
 #[test]

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -36,6 +36,8 @@ mod tests;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
 
 use chrono::Utc;
 use orbit_common::OrbitError;
@@ -65,6 +67,9 @@ pub use resolve::{is_global_orbit_root, resolve_global_root, try_resolve_initial
 pub use run_input::managed_workspace_selector_from_env;
 pub(crate) use task::{failed_run_error_context, is_workflow_failure_state};
 
+#[cfg(test)]
+pub(crate) type AfterLockedStateReadHook = Arc<dyn Fn(&orbit_types::task::Task) + Send + Sync>;
+
 #[derive(Clone)]
 pub struct OrbitRuntime {
     pub(crate) context: OrbitContext,
@@ -84,6 +89,12 @@ pub struct OrbitRuntime {
     /// current). Surfaced by `orbit migrate`.
     layout_report: Arc<orbit_store::workflow::layout::LayoutUpgradeReport>,
     _temp_dir: Option<Arc<builder::TempDir>>,
+    /// Test-only seam for `apply_task_automation_update`: fired after the
+    /// authoritative locked `get_task`, before the derived write. The lock is
+    /// re-entrant, so a hook may mutate the same task and observe whether the
+    /// automation write merges or refuses.
+    #[cfg(test)]
+    after_locked_state_read: Arc<Mutex<Option<AfterLockedStateReadHook>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -158,6 +169,8 @@ impl OrbitRuntime {
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(layout_report),
             _temp_dir: None,
+            #[cfg(test)]
+            after_locked_state_read: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -193,6 +206,8 @@ impl OrbitRuntime {
             event_log: event_bus::EventLog::default(),
             layout_report: Arc::new(orbit_store::workflow::layout::LayoutUpgradeReport::default()),
             _temp_dir: Some(Arc::new(temp_dir)),
+            #[cfg(test)]
+            after_locked_state_read: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -205,6 +220,26 @@ impl OrbitRuntime {
     pub fn with_actor(mut self, actor: ActorIdentity) -> Self {
         self.context.set_actor(actor);
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_after_locked_state_read_hook(&self, hook: AfterLockedStateReadHook) {
+        *self
+            .after_locked_state_read
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(hook);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invoke_after_locked_state_read(&self, task: &orbit_types::task::Task) {
+        let hook = self
+            .after_locked_state_read
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(hook) = hook {
+            hook(task);
+        }
     }
 
     /// Registry-owning composition supplies stable machine identity; Core never discovers it.


### PR DESCRIPTION
## Task

[ORB-11623](https://orbit-cli.com/tasks/ORB-11623) — [code-review] Run `apply_task_automation_update` under the task write lock with an expected status

### Description

## Problem
`apply_task_automation_update` reads `existing_task` (line 237), derives the plan gate, the workspace-local `resolves` check, the attribution, and a full replacement `external_refs` vector (lines 267-275: `existing_task.external_refs.clone()` + pushes), and then writes through `task_records().update` with `expected_status` left at `None` and **without** `stores().tasks().with_task_write_lock`. This is exactly the read-modify-write race that `update_task_with_context` (`application/task/update.rs:109-147`, ORB-10988) closed for the ordinary path: the store locks only the write (`repository/task/v2/updates.rs:16`), and `external_refs` is applied as a wholesale replacement (`updates.rs:111-112`). Scenario: `pr/merge.rs:225` writes `status: Done` + the PR ref from a `batch_tasks` snapshot taken at step start; if an operator moved the task out of `review` or another writer added an external ref between the read at line 237 and the write at line 283, the automation write silently overwrites both.

## Why It Matters
Delivery automation is the one writer that runs concurrently with humans and MCP agents on the same task; a lost external ref or an unconditional `Done` over an operator transition is not recoverable from history.

## Proposed Fix
Wrap the body from the `get_task` read through the `task_records().update` call in `self.stores().tasks().with_task_write_lock(task_id, ...)` and pass `expected_status: Some(vec![existing_task.status])` (or route through `update_task_with_context` with a `TaskUpdateContext` that carries `status_event`/`status_note`/`external_refs`).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/adapter/engine_host/runtime_host.rs:232-307`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: core-adapter.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test in `adapter/engine_host/tests/runtime_host.rs` that installs an `after_locked_state_read`-style hook (or a second thread) which mutates the task's `external_refs` between read and write, and asserts the final task carries both refs.
- A test that changes the task status to `backlog` after the automation read and asserts the automation write is refused with the "status changed" error rather than writing `done`.
- `cargo test -p orbit-core engine_host` passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `apply_task_automation_update` now holds `stores().tasks().with_task_write_lock` from `get_task` through `task_records().update`, matching the ORB-10988 ordinary-update path.
- The write passes `expected_status: Some(vec![existing_task.status])` from that locked snapshot so a post-read status mutation is refused by the store CAS (ORB-11305) instead of writing `done`.
- `external_refs` are merged from a fresh locked read after the decision snapshot so a re-entrant writer that lands a ref between read and write is not dropped by the store's wholesale replacement.
- `record_resolves_side_effects` stays outside the lock. Did not route through `update_task_with_context` (different actor/attribution; no merge-`external_refs` / `status_event`).
- Added a `cfg(test)` `after_locked_state_read` hook on `OrbitRuntime` and two tests in `adapter/engine_host/tests/runtime_host.rs`.
- Appended `file:crates/orbit-core/src/adapter/engine_host/tests/runtime_host.rs` and `file:crates/orbit-core/src/runtime/mod.rs` to context_files because the tests and hook live there.
Assessment: scoped fix at the automation writer; lock and CAS reuse existing store primitives.
Criteria:
1. Hook mutates `external_refs` after the locked read; final task carries both the concurrent and automation refs — covered by `apply_task_automation_update_keeps_external_refs_written_after_locked_read` (passed).
2. Hook reclassifies to `backlog` after the locked read; `done` is refused with the store "status changed" error and persisted status stays `backlog` — covered by `apply_task_automation_update_refuses_done_when_status_changes_after_locked_read` (passed).
3. `cargo test -p orbit-core engine_host` — passed (304 passed, 0 failed, 2 ignored).
Validation:
- `cargo test -p orbit-core engine_host` — passed (required).
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
Friction: none filed. Remaining risks: (1) `expected_status` is taken from the locked re-read, so an operator transition that completes *before* the lock is acquired is still overwritten — the larger `batch_tasks` snapshot race in `pr/merge.rs` is unchanged. Closing that would require callers to pass the snapshot status into `TaskAutomationUpdate`. (2) `runtime_host.rs` is 947 lines and its sibling tests file is 1395 (already over the ~800-line warning before this change).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11623-6a9f5e14`
- Behind base: 0
- Ahead of base: 1