### PR TITLE
[code-review] Make blob-store writes atomic so a crash cannot leave a permanently corrupt content-addressed blob

### DIFF
--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -81,6 +81,13 @@ pub fn atomic_write_bytes(path: &Path, content: &[u8]) -> io::Result<()> {
     staged.commit()
 }
 
+/// Atomically write secret-bearing bytes to `path` with private file
+/// permissions, even when replacing an existing file with broader permissions.
+pub(crate) fn atomic_write_private_bytes(path: &Path, content: &[u8]) -> io::Result<()> {
+    let mut staged = StagedTextFile::new_internal_with_permissions(path, content, true, false)?;
+    staged.commit()
+}
+
 /// Atomically write `content` to `path` without fsyncing the parent.
 /// Cheaper than [`atomic_write_text`] but post-crash the rename may be lost.
 pub fn atomic_write_text_volatile(path: &Path, content: &str) -> io::Result<()> {
@@ -111,6 +118,32 @@ impl StagedTextFile {
     }
 
     fn new_internal(target_path: &Path, content: &[u8], durable: bool) -> io::Result<Self> {
+        Self::new_internal_with_permissions(target_path, content, durable, true)
+    }
+
+    fn new_internal_with_permissions(
+        target_path: &Path,
+        content: &[u8],
+        durable: bool,
+        preserve_existing_permissions: bool,
+    ) -> io::Result<Self> {
+        Self::stage_with(
+            target_path,
+            durable,
+            preserve_existing_permissions,
+            |file| file.write_all(content),
+        )
+    }
+
+    fn stage_with<F>(
+        target_path: &Path,
+        durable: bool,
+        preserve_existing_permissions: bool,
+        write: F,
+    ) -> io::Result<Self>
+    where
+        F: FnOnce(&mut File) -> io::Result<()>,
+    {
         let parent = target_path.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -121,16 +154,19 @@ impl StagedTextFile {
 
         let temp_path = temp_path_for(target_path);
         let mut file = create_new_private_file(&temp_path)?;
+        let mut cleanup = TempFileCleanup::new(temp_path.clone());
 
-        if let Ok(metadata) = fs::metadata(target_path) {
+        if preserve_existing_permissions && let Ok(metadata) = fs::metadata(target_path) {
             fs::set_permissions(&temp_path, metadata.permissions())?;
         }
 
-        file.write_all(content)?;
+        write(&mut file)?;
         if durable {
             file.sync_all()?;
         }
         drop(file);
+
+        cleanup.disarm();
 
         Ok(Self {
             target_path: target_path.to_path_buf(),
@@ -140,6 +176,14 @@ impl StagedTextFile {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn stage_with_for_test<F>(target_path: &Path, write: F) -> io::Result<Self>
+    where
+        F: FnOnce(&mut File) -> io::Result<()>,
+    {
+        Self::stage_with(target_path, true, true, write)
+    }
+
     pub fn commit(&mut self) -> io::Result<()> {
         fs::rename(&self.temp_path, &self.target_path)?;
         self.committed = true;
@@ -147,6 +191,31 @@ impl StagedTextFile {
             sync_parent_dir(&self.target_path)?;
         }
         Ok(())
+    }
+}
+
+/// Removes a newly-created staging file if setup or writing fails before the
+/// staged file can take ownership of cleanup.
+struct TempFileCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl TempFileCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TempFileCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 }
 

--- a/crates/orbit-common/src/fs/tests/io.rs
+++ b/crates/orbit-common/src/fs/tests/io.rs
@@ -267,3 +267,38 @@ fn atomic_write_bytes_removes_its_temp_file_when_the_rename_fails() {
         "staging files left behind: {leftovers:?}"
     );
 }
+
+#[test]
+fn staged_write_removes_partial_temp_file_when_writing_fails() {
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("target");
+
+    let error = match super::super::io::StagedTextFile::stage_with_for_test(&target, |file| {
+        file.write_all(b"partial payload")?;
+        Err(io::Error::other("injected write failure"))
+    }) {
+        Ok(_) => panic!("injected write must fail"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert!(!target.exists(), "partial data was published at final path");
+
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "staging files left behind: {leftovers:?}"
+    );
+
+    super::super::io::atomic_write_private_bytes(&target, b"complete payload")
+        .expect("retry write");
+    assert_eq!(
+        std::fs::read(target).expect("read retry"),
+        b"complete payload"
+    );
+}

--- a/crates/orbit-common/src/storage/blob_store.rs
+++ b/crates/orbit-common/src/storage/blob_store.rs
@@ -11,12 +11,12 @@
 //! from those post-redaction bytes.
 
 use std::fs;
-use std::io::{self, Write};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::fs::io::{create_new_private_file, create_private_dir_all};
+use crate::fs::io::{atomic_write_private_bytes, create_private_dir_all};
 use crate::security::redaction::{PatternRedactor, redact_all};
 
 pub struct BlobStore {
@@ -50,16 +50,8 @@ impl BlobStore {
         let dir = self.root.join(&hash[..2]);
         create_private_dir_all(&dir)?;
         let path = dir.join(&hash);
-        if !path.exists() {
-            let mut f = create_new_private_file(&path).or_else(|err| {
-                if err.kind() == io::ErrorKind::AlreadyExists {
-                    fs::OpenOptions::new().write(true).open(&path)
-                } else {
-                    Err(err)
-                }
-            })?;
-            f.write_all(&redacted)?;
-            f.flush()?;
+        if !path_matches_hash(&path, &hash)? {
+            atomic_write_private_bytes(&path, &redacted)?;
         }
         Ok(hash)
     }
@@ -84,6 +76,14 @@ impl BlobStore {
     pub fn read(&self, sha256: &str) -> io::Result<Vec<u8>> {
         let path = self.root.join(&sha256[..2]).join(sha256);
         fs::read(path)
+    }
+}
+
+fn path_matches_hash(path: &Path, expected_hash: &str) -> io::Result<bool> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(sha256_hex(&bytes) == expected_hash),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/orbit-common/src/storage/tests/blob_store.rs
+++ b/crates/orbit-common/src/storage/tests/blob_store.rs
@@ -1,6 +1,8 @@
 #![allow(missing_docs)]
 
 use std::ffi::OsString;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
@@ -126,6 +128,71 @@ fn write_creates_private_blob_file_and_dirs() {
     assert_eq!(mode(&blob_path), 0o600);
     assert_eq!(mode(&root), 0o700);
     assert_eq!(mode(&shard_dir), 0o700);
+}
+
+#[test]
+fn write_repairs_a_corrupt_existing_blob() {
+    let temp = tempdir().expect("tempdir");
+    let store = BlobStore::new(temp.path());
+    let content = b"complete audit payload";
+    let hash = sha256_hex(content);
+    let path = temp.path().join(&hash[..2]).join(&hash);
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("create shard");
+    std::fs::write(&path, b"truncated").expect("seed corrupt blob");
+
+    assert_eq!(store.write(content).expect("repair blob"), hash);
+    let repaired = std::fs::read(path).expect("read repaired blob");
+    assert_eq!(sha256_hex(&repaired), hash);
+    assert_eq!(repaired, content);
+
+    #[cfg(unix)]
+    assert_eq!(mode(&temp.path().join(&hash[..2]).join(&hash)), 0o600);
+}
+
+#[test]
+fn concurrent_writes_never_publish_partial_blob_content() {
+    let temp = tempdir().expect("tempdir");
+    let store = Arc::new(BlobStore::new(temp.path()));
+    let content = Arc::new(vec![b'x'; 4 * 1024 * 1024]);
+    let hash = sha256_hex(&content);
+    let path = temp.path().join(&hash[..2]).join(&hash);
+    let complete = Arc::new(AtomicBool::new(false));
+    let remaining_writers = Arc::new(std::sync::atomic::AtomicUsize::new(2));
+
+    std::thread::scope(|scope| {
+        for _ in 0..2 {
+            let store = Arc::clone(&store);
+            let content = Arc::clone(&content);
+            let complete = Arc::clone(&complete);
+            let remaining_writers = Arc::clone(&remaining_writers);
+            scope.spawn(move || {
+                assert_eq!(
+                    store.write(&content).expect("write blob"),
+                    sha256_hex(&content)
+                );
+                if remaining_writers.fetch_sub(1, Ordering::AcqRel) == 1 {
+                    complete.store(true, Ordering::Release);
+                }
+            });
+        }
+
+        let complete = Arc::clone(&complete);
+        let reader_content = Arc::clone(&content);
+        let reader_path = path.clone();
+        scope.spawn(move || {
+            while !complete.load(Ordering::Acquire) {
+                match std::fs::read(&reader_path) {
+                    Ok(observed) => {
+                        assert_eq!(observed, *reader_content, "partial final blob was visible")
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => panic!("read blob: {error}"),
+                }
+            }
+        });
+    });
+
+    assert_eq!(std::fs::read(path).expect("final blob"), *content);
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {


### PR DESCRIPTION
## Task

[ORB-11642](https://orbit-cli.com/tasks/ORB-11642) — [code-review] Make blob-store writes atomic so a crash cannot leave a permanently corrupt content-addressed blob

### Description

## Problem
BlobStore writes directly to its final hash-named path before all bytes are present. Interrupted writes can leave truncated content, and the exists fast path then treats that corrupt file as successfully stored. Concurrent readers can observe partially published bytes.

## Required behavior and constraints
Publish complete redacted bytes atomically through the existing private durable-write seam. For an existing hash path, verify enough content integrity to avoid accepting a preexisting truncated/corrupt blob as success and atomically repair it when the caller supplies the correct content. Preserve redaction, private permissions and idempotent concurrent same-content writes. Distinguish handled write failure cleanup from temporary files left by an abrupt process kill.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-common/src/storage/blob_store.rs:47,53,61`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Inject a partial temporary-write failure before publication: no partial final hash path becomes visible, retry succeeds, and handled-failure temporary files are cleaned up.
- Seed a truncated/corrupt file at the expected hash path, write the original content, and verify subsequent bytes hash to the returned hash.
- Concurrent writers/readers observe either absence or complete content at the final path; redaction and private-file permission tests continue to pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- BlobStore now hashes any existing target before accepting it, atomically replaces mismatches through the durable private-write seam, and preserves 0600 permissions on repaired blobs.
- Hardened staging cleanup for errors after a temporary file is created; added a private atomic-byte entry point for secret-bearing replacements.
- Added regression coverage for injected partial staging failure plus retry, corrupt-file repair, concurrent writers/readers, and existing redaction/private-permission behavior.
Criteria:
1. Passed: injected partial temporary-write failure leaves no final path or temp files; retry publishes complete bytes.
2. Passed: a seeded truncated hash path is atomically repaired and the repaired bytes rehash to the returned hash.
3. Passed: concurrent writer/reader test observes only absence or exact complete content; existing redaction and Unix private-permission tests pass.
Validation:
- cargo fmt --check: passed.
- cargo test -p orbit-common blob_store: passed (7 tests).
- cargo test -p orbit-common staged_write_removes_partial_temp_file_when_writing_fails: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Assessment: focused four-file change, no pre-existing edits, no remaining known risks beyond filesystem atomic-rename semantics supplied by the existing durable helper.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11642-6a9f5ec3`
- Behind base: 0
- Ahead of base: 1