### PR TITLE
[code-review] Make `update_run_waiting_reasons` a transactional run-state update

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -575,7 +575,11 @@ pub(super) fn waiting_locks_from_reserve_output(output: &Value) -> Vec<String> {
         .collect()
 }
 
-fn update_run_waiting_reasons(
+// `pub(super)` (not private): the sibling `tests/dispatch.rs` unit-tests this
+// writer directly for no-op, error, lock, and lost-update coverage rather
+// than only through a full `reserve_locks` setup — see
+// docs/design-patterns/test_layout.md migration recipe step 6.
+pub(super) fn update_run_waiting_reasons(
     runtime: &OrbitRuntime,
     input: &Value,
     waiting_on_deps: Option<Vec<String>>,
@@ -585,23 +589,23 @@ fn update_run_waiting_reasons(
     let Some(run_id) = input.get("run_id").and_then(Value::as_str) else {
         return Ok(());
     };
-    let Some(mut state) =
-        runtime
-            .read_run_state(run_id)
-            .map_err(|err| DispatchError::DeterministicActionFailed {
-                action: action.to_string(),
-                message: format!("{err}"),
-            })?
-    else {
-        return Ok(());
-    };
-    state.set_waiting_reasons(waiting_on_deps, waiting_on_locks);
-    runtime.write_run_state(run_id, &state).map_err(|err| {
-        DispatchError::DeterministicActionFailed {
+    // Same transactional primitive as checkpoints and child dispatch: a
+    // separate read then whole-document write would discard a concurrent
+    // admissions-stop or worker-limit that landed in between.
+    let mut waiting_on_deps = waiting_on_deps;
+    let mut waiting_on_locks = waiting_on_locks;
+    runtime
+        .stores()
+        .jobs()
+        .update_run_state(run_id, &mut |_, state| {
+            state.set_waiting_reasons(waiting_on_deps.take(), waiting_on_locks.take());
+            Ok(())
+        })
+        .map(|_| ())
+        .map_err(|err| DispatchError::DeterministicActionFailed {
             action: action.to_string(),
             message: format!("{err}"),
-        }
-    })
+        })
 }
 
 fn non_empty(values: Vec<String>) -> Option<Vec<String>> {

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
@@ -618,3 +618,208 @@ fn waiting_locks_from_reserve_output_extracts_unique_conflict_files() {
         ]
     );
 }
+
+fn seed_run_with_state(runtime: &OrbitRuntime) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), Some(json!({})), None)
+        .expect("insert run");
+    runtime
+        .stores()
+        .jobs()
+        .write_run_state(
+            &run.run_id,
+            &PipelineState::new(run.run_id.clone(), run.job_id.clone(), json!({})),
+        )
+        .expect("write state");
+    run.run_id
+}
+
+fn apply_competing_admissions_stop(runtime: &OrbitRuntime, run_id: &str) {
+    runtime
+        .stores()
+        .jobs()
+        .update_run_state(run_id, &mut |_, state| {
+            state.set_drain_admissions_stop(
+                "operator".to_string(),
+                Some("drain closed".to_string()),
+            );
+            Ok(())
+        })
+        .expect("competing admissions stop");
+}
+
+/// Prior waiting-reason writer: read the document, then write it back whole.
+/// `between_read_and_write` is the lost-update window a concurrent control
+/// used to occupy.
+fn update_run_waiting_reasons_read_then_write(
+    runtime: &OrbitRuntime,
+    input: &serde_json::Value,
+    waiting_on_deps: Option<Vec<String>>,
+    waiting_on_locks: Option<Vec<String>>,
+    action: &str,
+    between_read_and_write: impl FnOnce(),
+) -> Result<(), DispatchError> {
+    let Some(run_id) = input.get("run_id").and_then(serde_json::Value::as_str) else {
+        return Ok(());
+    };
+    let Some(mut state) =
+        runtime
+            .read_run_state(run_id)
+            .map_err(|err| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("{err}"),
+            })?
+    else {
+        return Ok(());
+    };
+    between_read_and_write();
+    state.set_waiting_reasons(waiting_on_deps, waiting_on_locks);
+    runtime.write_run_state(run_id, &state).map_err(|err| {
+        DispatchError::DeterministicActionFailed {
+            action: action.to_string(),
+            message: format!("{err}"),
+        }
+    })
+}
+
+#[test]
+fn read_then_write_waiting_reasons_drop_a_competing_admissions_stop() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = seed_run_with_state(&runtime);
+
+    update_run_waiting_reasons_read_then_write(
+        &runtime,
+        &json!({ "run_id": run_id }),
+        Some(vec!["ORB-1".to_string()]),
+        None,
+        "reserve_locks",
+        || apply_competing_admissions_stop(&runtime, &run_id),
+    )
+    .expect("prior writer");
+
+    let state = runtime
+        .read_run_state(&run_id)
+        .expect("read run state")
+        .expect("state exists");
+    assert_eq!(state.waiting_on_deps, Some(vec!["ORB-1".to_string()]));
+    assert!(
+        !state.admissions_stopped(),
+        "the stale whole-document write must drop the stop that landed in between"
+    );
+}
+
+#[test]
+fn update_run_waiting_reasons_preserves_a_competing_admissions_stop() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = seed_run_with_state(&runtime);
+
+    // Same competing control the prior writer lost, applied as its own
+    // transactional update. The repaired writer must merge waiting reasons
+    // onto the current document rather than replacing it.
+    apply_competing_admissions_stop(&runtime, &run_id);
+    update_run_waiting_reasons(
+        &runtime,
+        &json!({ "run_id": run_id }),
+        Some(vec!["ORB-1".to_string()]),
+        Some(vec!["file:src/lib.rs".to_string()]),
+        "reserve_locks",
+    )
+    .expect("transactional writer");
+
+    let state = runtime
+        .read_run_state(&run_id)
+        .expect("read run state")
+        .expect("state exists");
+    assert!(state.admissions_stopped(), "control data must survive");
+    assert_eq!(state.waiting_on_deps, Some(vec!["ORB-1".to_string()]));
+    assert_eq!(
+        state.waiting_on_locks,
+        Some(vec!["file:src/lib.rs".to_string()])
+    );
+}
+
+#[test]
+fn update_run_waiting_reasons_is_a_noop_without_run_id_run_or_state() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    update_run_waiting_reasons(
+        &runtime,
+        &json!({}),
+        Some(vec!["ORB-1".to_string()]),
+        None,
+        "reserve_locks",
+    )
+    .expect("missing run_id is a no-op");
+
+    update_run_waiting_reasons(
+        &runtime,
+        &json!({ "run_id": "jrun-missing" }),
+        Some(vec!["ORB-1".to_string()]),
+        None,
+        "reserve_locks",
+    )
+    .expect("missing run is a no-op");
+
+    let pending = runtime
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), Some(json!({})), None)
+        .expect("insert run without state");
+    update_run_waiting_reasons(
+        &runtime,
+        &json!({ "run_id": pending.run_id }),
+        Some(vec!["ORB-1".to_string()]),
+        None,
+        "reserve_locks",
+    )
+    .expect("missing pipeline state is a no-op");
+    assert!(
+        runtime
+            .read_run_state(&pending.run_id)
+            .expect("read run state")
+            .is_none(),
+        "a stateless run must not grow a document just to record waiting reasons"
+    );
+}
+
+#[test]
+fn reserve_locks_records_waiting_on_locks_in_run_state() {
+    let (_root, runtime, repo_root) = super::super::test_support::runtime_with_workspace_layout();
+    super::super::test_support::write_workspace_file(&repo_root, "src/lib.rs");
+    let holder = crate::adapter::tool_host::test_support::create_context_task(
+        &runtime,
+        &repo_root,
+        TaskStatus::InProgress,
+        &["file:src/lib.rs"],
+    );
+    let waiting = crate::adapter::tool_host::test_support::create_context_task(
+        &runtime,
+        &repo_root,
+        TaskStatus::Backlog,
+        &["file:src/lib.rs"],
+    );
+
+    let (run_id, result) = reserve_locks_for(&runtime, vec![waiting.id.clone()]);
+    let output = result.expect("lock conflict is a wait, not a dispatch error");
+
+    assert_eq!(output["reserved"], json!(false));
+    assert_eq!(
+        output["conflicts"],
+        json!([{
+            "file": "file:src/lib.rs",
+            "held_by": "task",
+            "held_by_id": holder.id,
+        }])
+    );
+    let state = runtime
+        .read_run_state(&run_id)
+        .expect("read run state")
+        .expect("state exists");
+    assert_eq!(
+        state.waiting_on_locks,
+        Some(vec!["file:src/lib.rs".to_string()])
+    );
+    assert_eq!(state.waiting_on_deps, None);
+}


### PR DESCRIPTION
## Task

[ORB-11624](https://orbit-cli.com/tasks/ORB-11624) — [code-review] Make `update_run_waiting_reasons` a transactional run-state update

### Description

## Problem
`update_run_waiting_reasons` reads a run-state document, modifies waiting reasons, then writes the whole document. A concurrent admissions-stop, worker-limit, or other control update between those operations can be overwritten.

## Required behavior
Apply waiting-reason changes through the existing transactional `jobs().update_run_state` primitive so the closure edits the current state while preserving unrelated fields. Preserve current no-op behavior for absent run/state and existing error mapping. Keep this repair scoped to the waiting-reason writer.
A test that only seeds a stop marker before the function runs does not expose the bug: the old read/write path already preserves that marker. Validation must exercise a competing update in the vulnerable interval or an equivalent deterministic store seam, without deadlocking the repaired transaction.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs:578-605`; existing transactional examples in `crates/orbit-core/src/adapter/engine_host/runtime_host.rs` and child dispatch.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- The waiting-reason writer uses the existing transactional state-update primitive and no longer performs a separate read/whole-document write.
- A deterministic concurrency regression reproduces the old lost update by scheduling a competing control update between the old read/write boundaries; the fixed path preserves both control data and new waiting reasons. The fixture must fail against the prior implementation.
- Focused reserve-path tests cover missing run/state no-op behavior, errors, and dependency/lock waiting reasons; existing relevant dispatch and control tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `update_run_waiting_reasons` now persists through `jobs().update_run_state` instead of `read_run_state` + whole-document `write_run_state`, matching checkpoints and child dispatch. Missing `run_id`, missing run (`NotFound`), and missing pipeline state (`NoState`) remain silent no-ops; store errors still map to `DispatchError::DeterministicActionFailed` with `format!("{err}")`.
- Writer is `pub(super)` so sibling tests can call it directly.
- Added a replica of the prior read/write writer that injects a competing admissions-stop between those boundaries and asserts the stop is lost (the fixture that fails against the prior implementation). The repaired writer keeps both the stop marker and new waiting reasons.
- Direct no-op coverage for missing run_id/run/state; lock-conflict reserve path now records `waiting_on_locks`. Existing unsatisfiable-dependency tests remain the error path.

Assessment: Scoped to the waiting-reason writer. The lost-update fixture uses the prior read/write replica rather than pausing inside the repaired transaction, which would deadlock the in-process SQLite mutex.

Criteria:
1. Transactional writer, no separate read/whole-document write — met (`dispatch.rs` uses `update_run_state`; `read_run_state`/`write_run_state` are gone from this function).
2. Deterministic concurrency regression that fails against the prior implementation; fixed path keeps control data and waiting reasons — met (`read_then_write_waiting_reasons_drop_a_competing_admissions_stop` loses the in-window stop; `update_run_waiting_reasons_preserves_a_competing_admissions_stop` keeps stop plus deps/locks).
3. Focused reserve-path tests for missing run/state no-ops, errors, dependency/lock waiting reasons; existing dispatch and control tests pass — met (new no-op and lock tests; archived/rejected/dangling reserve tests cover the error path; dispatch + admissions_stop + worker_limit tests passed).

Validation:
- `cargo test -p orbit-core --lib adapter::engine_host::v2_host::tests::dispatch -- --test-threads=1` — passed (20 tests)
- `cargo test -p orbit-core --lib application::job::run::tests::admissions_stop -- --test-threads=1` — passed (5 tests)
- `cargo test -p orbit-core --lib application::job::run::tests::worker_limit -- --test-threads=1` — passed (9 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Remaining risks:
- The production preservation test applies the competing stop as a completed transactional update before the writer (serialized equivalent of two `update_run_state` calls). The in-window lost update is proven by the prior-implementation replica, not by pausing inside the repaired transaction.
- No isolated store-error injection for the writer; error mapping is the existing `DeterministicActionFailed` `map_err` plus reserve_locks unsatisfiable tests.

Uncommitted files: `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs`, `crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11624-6a9f5e72`
- Behind base: 0
- Ahead of base: 1