### PR TITLE
[code-review] Resume the log SSE stream without gaps and surface disconnects

### DIFF
--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -3161,6 +3161,15 @@
       .log-statusbar .sb-m[data-level="deny"] { color: var(--status-review); }
       .log-statusbar .sb-m[data-level="warn"] { color: var(--status-proposed); }
       .log-statusbar.empty .sb-label { opacity: 0.6; }
+      #side-dock.disconnected .live-dot,
+      .log-statusbar.disconnected .live-dot {
+        background: var(--fg-mute);
+        box-shadow: none;
+        animation: none;
+      }
+      .log-statusbar.disconnected .sb-label {
+        color: var(--status-blocked);
+      }
 
       /* Policy view (Audit sub-tab) */
       .policy-grid {

--- a/crates/orbit-web/assets/dashboard/log-tail.js
+++ b/crates/orbit-web/assets/dashboard/log-tail.js
@@ -17,6 +17,12 @@ let logFollowTail = true;
 let logRows = []; // Keep track to enforce max 200 after 250 limit
 let activeLogFilters = new Set(["all"]);
 let logPanelResizeWired = false;
+const LOG_STREAM_RETRY_MIN_MS = 1000;
+const LOG_STREAM_RETRY_MAX_MS = 15000;
+const LOG_STREAM_UNAVAILABLE = "log stream unavailable, retrying";
+let logStreamOffset = 0;
+let logStreamRetryTimer = null;
+let logStreamRetryMs = LOG_STREAM_RETRY_MIN_MS;
 
 // ORB-10972: the log lives in the Tasks tab's right dock, which has two modes
 // — Status (in-flight runs, locked files, sweep clock) and Log (the tail at
@@ -172,11 +178,20 @@ function renderLogEvent(ev, isFresh) {
 export function initLogTail() {
   wireLogPanelResize();
   fitLogPanelToViewport();
-  fetchJson("/api/log?limit=50").then((events) => {
+  fetchJson("/api/log?limit=50").then((payload) => {
     const inner = $("logInner");
     if (!inner) return;
     inner.innerHTML = "";
     logRows = [];
+    const events = payload && Array.isArray(payload.events) ? payload.events : [];
+    if (
+      payload &&
+      typeof payload.offset === "number" &&
+      Number.isFinite(payload.offset) &&
+      payload.offset >= 0
+    ) {
+      logStreamOffset = payload.offset;
+    }
     events.slice().reverse().forEach(ev => {
       const row = renderLogEvent(ev, false);
       inner.appendChild(row);
@@ -280,10 +295,42 @@ function applyLogFilters() {
   if (cnt) cnt.textContent = `${visibleCount}`;
 }
 
+function rememberStreamOffset(lastEventId) {
+  if (!lastEventId) return;
+  const parsed = Number.parseInt(lastEventId, 10);
+  if (Number.isFinite(parsed) && parsed >= 0) logStreamOffset = parsed;
+}
+
+function setLogStreamConnected(connected) {
+  const bar = $("log-statusbar");
+  const dock = $("side-dock");
+  if (bar) {
+    bar.classList.toggle("disconnected", !connected);
+    const label = bar.querySelector(".sb-label");
+    if (label) label.textContent = connected ? "orbit.log" : LOG_STREAM_UNAVAILABLE;
+    bar.setAttribute("aria-label", connected ? "Latest log line" : LOG_STREAM_UNAVAILABLE);
+  }
+  if (dock) dock.classList.toggle("disconnected", !connected);
+}
+
 function connectLogStream() {
-  if (logStream) logStream.close();
-  logStream = new EventSource("/api/log/stream");
+  if (logStreamRetryTimer !== null) {
+    clearTimeout(logStreamRetryTimer);
+    logStreamRetryTimer = null;
+  }
+  if (logStream) {
+    logStream.close();
+    logStream = null;
+  }
+  logStream = new EventSource(`/api/log/stream?from=${encodeURIComponent(String(logStreamOffset))}`);
+  logStream.onopen = () => {
+    logStreamRetryMs = LOG_STREAM_RETRY_MIN_MS;
+    setLogStreamConnected(true);
+  };
   logStream.onmessage = (e) => {
+    logStreamRetryMs = LOG_STREAM_RETRY_MIN_MS;
+    setLogStreamConnected(true);
+    rememberStreamOffset(e.lastEventId);
     try {
       const ev = JSON.parse(e.data);
       updateLogStatusBar(ev);
@@ -306,5 +353,17 @@ function connectLogStream() {
     } catch (err) {
       console.error("Failed to parse SSE event", err);
     }
+  };
+  logStream.onerror = () => {
+    setLogStreamConnected(false);
+    if (!logStream || logStream.readyState !== EventSource.CLOSED) return;
+    logStream.close();
+    logStream = null;
+    const delay = logStreamRetryMs;
+    logStreamRetryMs = Math.min(logStreamRetryMs * 2, LOG_STREAM_RETRY_MAX_MS);
+    logStreamRetryTimer = setTimeout(() => {
+      logStreamRetryTimer = null;
+      connectLogStream();
+    }, delay);
   };
 }

--- a/crates/orbit-web/src/api/log.rs
+++ b/crates/orbit-web/src/api/log.rs
@@ -13,9 +13,10 @@ use std::time::Duration as StdDuration;
 
 use axum::body::Body;
 use axum::extract::Query;
-use axum::http::{HeaderValue, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Json, Response};
 use futures_core::Stream;
+use serde::Serialize;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc};
 
 use super::{LogQuery, map_runtime_error, non_empty_string, server_error};
@@ -26,6 +27,16 @@ use crate::log_format::{
 
 const LOG_DEFAULT_LIMIT: usize = 50;
 pub(super) const LOG_MAX_LIMIT: usize = 500;
+
+/// Snapshot body for `GET /api/log`. `offset` is the log file length after
+/// the read so `/api/log/stream?from=` can resume without dropping lines
+/// appended between the two requests.
+#[derive(Debug, Serialize)]
+pub(super) struct LogSnapshot {
+    pub events: Vec<RenderedLogEvent>,
+    pub offset: u64,
+}
+
 const LOG_STREAM_CHANNEL_DEPTH: usize = 64;
 const LOG_STREAM_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
 /// Maximum number of concurrent `/api/log/stream` clients. Each accepted
@@ -85,12 +96,12 @@ pub(super) async fn get_log(Query(q): Query<LogQuery>) -> Response {
         Err(e) => return map_runtime_error(e),
     };
     match read_log_snapshot_from_path(&path, &q) {
-        Ok(events) => Json(events).into_response(),
+        Ok(snapshot) => Json(snapshot).into_response(),
         Err(e) => map_runtime_error(e),
     }
 }
 
-pub(super) async fn stream_log(Query(q): Query<LogQuery>) -> Response {
+pub(super) async fn stream_log(Query(q): Query<LogQuery>, headers: HeaderMap) -> Response {
     let permit = match global_log_stream_gate().try_acquire() {
         Some(p) => p,
         None => return log_stream_unavailable(),
@@ -103,8 +114,9 @@ pub(super) async fn stream_log(Query(q): Query<LogQuery>) -> Response {
         Ok(filters) => filters,
         Err(e) => return map_runtime_error(e),
     };
+    let resume = stream_resume_offset(q.from, last_event_id_header(&headers));
     let stream = ReceiverSseStream {
-        rx: spawn_log_sse_frames(path, filters, permit),
+        rx: spawn_log_sse_frames(path, filters, permit, resume),
     };
     match Response::builder()
         .status(StatusCode::OK)
@@ -140,7 +152,7 @@ pub(super) fn log_stream_unavailable() -> Response {
 pub(super) fn read_log_snapshot_from_path(
     path: &std::path::Path,
     query: &LogQuery,
-) -> Result<Vec<RenderedLogEvent>, orbit_core::OrbitError> {
+) -> Result<LogSnapshot, orbit_core::OrbitError> {
     let limit = match query.limit {
         Some(limit) if limit > LOG_MAX_LIMIT => {
             return Err(orbit_core::OrbitError::InvalidInput(format!(
@@ -151,8 +163,26 @@ pub(super) fn read_log_snapshot_from_path(
         None => LOG_DEFAULT_LIMIT,
     };
     let filters = log_filters(query)?;
-    read_recent_rendered_events(path, &filters, limit)
-        .map_err(|e| orbit_core::OrbitError::Io(format!("read log {}: {e}", path.display())))
+    let events = read_recent_rendered_events(path, &filters, limit)
+        .map_err(|e| orbit_core::OrbitError::Io(format!("read log {}: {e}", path.display())))?;
+    // Length after the snapshot read. Lines appended between this return and
+    // stream-open are picked up by `?from=<offset>` / `Last-Event-ID`.
+    let offset = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    Ok(LogSnapshot { events, offset })
+}
+
+/// Prefer SSE `Last-Event-ID` over `?from=` so a browser auto-reconnect does
+/// not replay from the snapshot offset baked into the EventSource URL.
+pub(super) fn stream_resume_offset(from: Option<u64>, last_event_id: Option<&str>) -> Option<u64> {
+    last_event_id
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .or(from)
+}
+
+pub(super) fn last_event_id_header(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("last-event-id")
+        .and_then(|value| value.to_str().ok())
 }
 
 // Widened to pub(super) for api/tests/ access after test layout migration (ORB-00224).
@@ -168,17 +198,19 @@ pub(super) fn log_filters(query: &LogQuery) -> Result<LogFilters, orbit_core::Or
     )
 }
 
-fn spawn_log_sse_frames(
+pub(super) fn spawn_log_sse_frames(
     path: PathBuf,
     filters: LogFilters,
     permit: OwnedSemaphorePermit,
+    resume_offset: Option<u64>,
 ) -> mpsc::Receiver<String> {
     let (tx, rx) = mpsc::channel(LOG_STREAM_CHANNEL_DEPTH);
     thread::spawn(move || {
         // Permit is dropped when this thread exits, which happens within one
         // poll interval of the client disconnecting (tx.is_closed()).
         let _permit = permit;
-        let mut offset = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let mut offset =
+            resume_offset.unwrap_or_else(|| std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0));
         let mut leftover = String::new();
         loop {
             if tx.is_closed() || SHUTTING_DOWN.load(Ordering::Relaxed) {
@@ -186,8 +218,8 @@ fn spawn_log_sse_frames(
             }
             match read_appended_log_events(&path, &filters, &mut offset, &mut leftover) {
                 Ok(events) => {
-                    for event in events {
-                        let frame = match format_sse_frame(&event) {
+                    for (event, event_offset) in events {
+                        let frame = match format_sse_frame(&event, event_offset) {
                             Ok(frame) => frame,
                             Err(_) => continue,
                         };
@@ -211,7 +243,7 @@ pub(super) fn read_appended_log_events(
     filters: &LogFilters,
     offset: &mut u64,
     leftover: &mut String,
-) -> io::Result<Vec<RenderedLogEvent>> {
+) -> io::Result<Vec<(RenderedLogEvent, u64)>> {
     let mut file = File::open(path)?;
     let len = file.metadata()?.len();
     if len < *offset {
@@ -240,7 +272,7 @@ pub(super) fn read_appended_log_events(
         }
         full_line.push_str(buf.trim_end_matches('\n'));
         if let Some(event) = parse_matching_event(&full_line, filters) {
-            events.push(render_log_event_for_web(&event));
+            events.push((render_log_event_for_web(&event), *offset));
         }
     }
 
@@ -248,8 +280,11 @@ pub(super) fn read_appended_log_events(
 }
 
 // Widened to pub(super) for api/tests/ access after test layout migration (ORB-00224).
-pub(super) fn format_sse_frame(event: &RenderedLogEvent) -> Result<String, serde_json::Error> {
-    serde_json::to_string(event).map(|json| format!("data: {json}\n\n"))
+pub(super) fn format_sse_frame(
+    event: &RenderedLogEvent,
+    offset: u64,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string(event).map(|json| format!("id: {offset}\ndata: {json}\n\n"))
 }
 
 struct ReceiverSseStream {

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -149,6 +149,10 @@ pub(super) struct LogQuery {
     pub(super) level: Option<String>,
     #[serde(default)]
     pub(super) since: Option<String>,
+    /// Byte offset to resume `/log/stream` from. Ignored by `/log` snapshot.
+    /// Overridden by `Last-Event-ID` when both are present.
+    #[serde(default)]
+    pub(super) from: Option<u64>,
 }
 
 pub(super) fn current_year_month_utc() -> String {

--- a/crates/orbit-web/src/api/tests/log.rs
+++ b/crates/orbit-web/src/api/tests/log.rs
@@ -1,17 +1,44 @@
 use std::io::Write;
+use std::time::{Duration, Instant};
 
 use serde_json::json;
 use tempfile::tempdir;
 
-use axum::http::{StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 
 use super::super::LogQuery;
 use super::super::log::{
-    LOG_MAX_LIMIT, LogStreamGate, format_sse_frame, log_stream_unavailable,
-    read_appended_log_events, read_log_snapshot_from_path,
+    LOG_MAX_LIMIT, LogStreamGate, format_sse_frame, last_event_id_header, log_stream_unavailable,
+    read_appended_log_events, read_log_snapshot_from_path, spawn_log_sse_frames,
+    stream_resume_offset,
 };
 use super::test_support::{body_json, write_lines};
 use crate::log_format::Filters as LogFilters;
+
+fn log_line(step_id: &str) -> String {
+    json!({
+        "timestamp": "2026-04-27T01:00:05Z",
+        "level": "INFO",
+        "target": "orbit.job.step_started",
+        "fields": {"job_run_id": "run-1", "step_id": step_id}
+    })
+    .to_string()
+}
+
+fn collect_sse_frames(rx: &mut tokio::sync::mpsc::Receiver<String>, n: usize) -> Vec<String> {
+    let mut frames = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while frames.len() < n && Instant::now() < deadline {
+        match rx.try_recv() {
+            Ok(frame) => frames.push(frame),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
+        }
+    }
+    frames
+}
 
 #[test]
 fn log_snapshot_filters_target_level_and_since() {
@@ -44,22 +71,27 @@ fn log_snapshot_filters_target_level_and_since() {
         ],
     );
 
-    let events = read_log_snapshot_from_path(
+    let snapshot = read_log_snapshot_from_path(
         &path,
         &LogQuery {
             limit: Some(10),
             target: Some("orbit.policy".to_string()),
             level: Some("warn".to_string()),
             since: Some("2026-04-27T01:00:02Z".to_string()),
+            from: None,
         },
     )
     .expect("snapshot");
 
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].source, "policy");
-    assert_eq!(events[0].code, "DENY");
-    assert_eq!(events[0].level, "warn");
-    assert!(events[0].message_html.contains("<b>path</b>="));
+    assert_eq!(snapshot.events.len(), 1);
+    assert_eq!(snapshot.events[0].source, "policy");
+    assert_eq!(snapshot.events[0].code, "DENY");
+    assert_eq!(snapshot.events[0].level, "warn");
+    assert!(snapshot.events[0].message_html.contains("<b>path</b>="));
+    assert_eq!(
+        snapshot.offset,
+        std::fs::metadata(&path).expect("metadata").len()
+    );
 }
 
 #[test]
@@ -110,8 +142,13 @@ fn log_stream_framing_emits_one_data_frame_per_appended_line() {
             .expect("read appended");
     assert_eq!(events.len(), 1);
 
-    let frame = format_sse_frame(&events[0]).expect("frame");
-    assert!(frame.starts_with("data: "));
+    let (event, event_offset) = &events[0];
+    let frame = format_sse_frame(event, *event_offset).expect("frame");
+    assert!(
+        frame.starts_with(&format!("id: {event_offset}\n")),
+        "SSE frame must carry the byte offset as last-event-id: {frame}"
+    );
+    assert!(frame.contains("\ndata: "));
     assert!(frame.ends_with("\n\n"));
     assert!(frame.contains("\"source\":\"job\""));
     assert!(frame.contains("build"));
@@ -161,5 +198,138 @@ async fn log_stream_unavailable_returns_503_with_retry_after() {
             .and_then(|v| v.as_str())
             .is_some_and(|s| s.contains("concurrency limit reached")),
         "error message names the concurrency limit: {body}"
+    );
+}
+
+#[test]
+fn last_event_id_wins_over_from_query() {
+    assert_eq!(stream_resume_offset(Some(10), Some("25")), Some(25));
+    assert_eq!(stream_resume_offset(Some(10), Some("nope")), Some(10));
+    assert_eq!(stream_resume_offset(Some(10), Some(" 8 ")), Some(8));
+    assert_eq!(stream_resume_offset(Some(10), None), Some(10));
+    assert_eq!(stream_resume_offset(None, None), None);
+    assert_eq!(stream_resume_offset(None, Some("")), None);
+}
+
+#[test]
+fn last_event_id_header_reads_sse_reconnect_header() {
+    let mut headers = HeaderMap::new();
+    headers.insert("Last-Event-ID", HeaderValue::from_static("42"));
+    assert_eq!(last_event_id_header(&headers), Some("42"));
+}
+
+#[test]
+fn lines_written_between_snapshot_and_stream_open_all_arrive() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    write_lines(&path, &[log_line("seed")]);
+
+    let snapshot = read_log_snapshot_from_path(
+        &path,
+        &LogQuery {
+            limit: Some(50),
+            ..LogQuery::default()
+        },
+    )
+    .expect("snapshot");
+    assert_eq!(snapshot.events.len(), 1);
+    assert_eq!(
+        snapshot.offset,
+        std::fs::metadata(&path).expect("metadata").len()
+    );
+
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("append");
+    const GAP_LINES: usize = 3;
+    for i in 1..=GAP_LINES {
+        writeln!(file, "{}", log_line(&format!("gap-{i}"))).expect("write gap line");
+    }
+    file.flush().expect("flush");
+
+    let gate = LogStreamGate::new(1);
+    let permit = gate.try_acquire().expect("stream permit");
+    let mut rx = spawn_log_sse_frames(
+        path.clone(),
+        LogFilters::default(),
+        permit,
+        Some(snapshot.offset),
+    );
+    let frames = collect_sse_frames(&mut rx, GAP_LINES);
+    drop(rx);
+
+    assert_eq!(
+        frames.len(),
+        GAP_LINES,
+        "every line written between snapshot and stream open must arrive: {frames:?}"
+    );
+    for i in 1..=GAP_LINES {
+        assert!(
+            frames[i - 1].contains(&format!("gap-{i}")),
+            "frame {i} missing gap-{i}: {}",
+            frames[i - 1]
+        );
+        assert!(
+            frames[i - 1].starts_with("id: "),
+            "frame {i} must include an SSE id: {}",
+            frames[i - 1]
+        );
+    }
+    assert!(
+        frames.iter().all(|frame| !frame.contains("seed")),
+        "snapshot-already-read seed line must not be replayed: {frames:?}"
+    );
+}
+
+#[test]
+fn reconnect_with_last_event_id_replays_only_lines_after_offset() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    write_lines(
+        &path,
+        &[log_line("keep-0"), log_line("after-1"), log_line("after-2")],
+    );
+
+    let mut offset = 0;
+    let mut leftover = String::new();
+    let events =
+        read_appended_log_events(&path, &LogFilters::default(), &mut offset, &mut leftover)
+            .expect("read all");
+    assert_eq!(events.len(), 3);
+    let last_event_id = events[0].1.to_string();
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Last-Event-ID",
+        HeaderValue::from_str(&last_event_id).expect("header"),
+    );
+    let resume = stream_resume_offset(Some(0), last_event_id_header(&headers));
+    assert_eq!(resume, Some(events[0].1));
+
+    let gate = LogStreamGate::new(1);
+    let permit = gate.try_acquire().expect("stream permit");
+    let mut rx = spawn_log_sse_frames(path, LogFilters::default(), permit, resume);
+    let frames = collect_sse_frames(&mut rx, 2);
+    drop(rx);
+
+    assert_eq!(
+        frames.len(),
+        2,
+        "expected the two lines after the id: {frames:?}"
+    );
+    assert!(
+        frames[0].contains("after-1"),
+        "first replayed frame should be after-1: {}",
+        frames[0]
+    );
+    assert!(
+        frames[1].contains("after-2"),
+        "second replayed frame should be after-2: {}",
+        frames[1]
+    );
+    assert!(
+        frames.iter().all(|frame| !frame.contains("keep-0")),
+        "Last-Event-ID must not replay the line at that offset: {frames:?}"
     );
 }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -1428,6 +1428,145 @@ fn dashboard_log_dock_has_two_modes_and_an_always_on_status_bar() {
             && css.contains(".col-tasks {\n        min-height: 0;"),
         "the tasks column must be allowed to shrink so #tasks-body can scroll"
     );
+    assert!(
+        css.contains("#side-dock.disconnected .live-dot")
+            && css.contains(".log-statusbar.disconnected .live-dot"),
+        "a failed log stream must restyle the dock and status-bar live dots"
+    );
+}
+
+/// ORB-11660: the tail must resume from the snapshot byte offset, mark the
+/// dock/status bar disconnected when EventSource goes CLOSED (503 / fatal),
+/// show "log stream unavailable, retrying", and recover on the next open.
+#[test]
+fn dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close() {
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(id = "") {
+    this.id = id;
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.listeners = {};
+    this.className = "";
+    this._text = "";
+    this.parentNode = null;
+    this.attributes = {};
+  }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) {
+    const index = this.children.indexOf(before);
+    if (index < 0) return this.appendChild(child);
+    this.children.splice(index, 0, child);
+    child.parentNode = this;
+    return child;
+  }
+  remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter((child) => child !== this); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this._text = String(value); this.children = []; }
+  get innerHTML() { return this.textContent; }
+  get firstChild() { return this.children[0] || null; }
+  querySelector(sel) {
+    if (sel.startsWith(".")) {
+      const cls = sel.slice(1);
+      return this.children.find((child) => (child.className || "").split(/\s+/).includes(cls)) || null;
+    }
+    return null;
+  }
+  querySelectorAll() { return []; }
+  get classList() {
+    const self = this;
+    const tokens = () => self.className.split(/\s+/).filter(Boolean);
+    const write = (next) => { self.className = next.join(" "); };
+    return {
+      add: (...c) => write([...new Set([...tokens(), ...c])]),
+      remove: (...c) => write(tokens().filter((token) => !c.includes(token))),
+      toggle: (c, on) => {
+        const has = tokens().includes(c);
+        const should = on === undefined ? !has : Boolean(on);
+        if (should) write([...new Set([...tokens(), c])]);
+        else write(tokens().filter((token) => token !== c));
+        return should;
+      },
+      contains: (c) => tokens().includes(c),
+    };
+  }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+const bar = get("log-statusbar");
+const label = new Node();
+label.className = "sb-label";
+label.textContent = "orbit.log";
+bar.appendChild(label);
+get("logInner");
+get("side-dock");
+globalThis.document = {
+  body: new Node("body"),
+  getElementById: get,
+  createElement: () => new Node(),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+const location = new URL("http://dashboard.test/");
+globalThis.window = { location, innerHeight: 900, addEventListener: () => {}, localStorage: { getItem: () => null, setItem: () => {} } };
+const retryFns = [];
+const nativeSetTimeout = setTimeout;
+globalThis.setTimeout = (fn, ms = 0) => {
+  if (ms >= 250) { retryFns.push(fn); return retryFns.length; }
+  return nativeSetTimeout(fn, ms);
+};
+globalThis.clearTimeout = () => {};
+const sources = [];
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  constructor(url) {
+    this.url = String(url);
+    this.readyState = MockEventSource.CONNECTING;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    sources.push(this);
+  }
+  close() { this.readyState = MockEventSource.CLOSED; }
+}
+globalThis.EventSource = MockEventSource;
+globalThis.fetch = async (path) => {
+  const payload = { events: [{ ts: "t", source: "job", code: "OK", level: "info", message_html: "hi" }], offset: 42 };
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+};
+const tick = () => new Promise((resolve) => nativeSetTimeout(resolve, 0));
+const { initLogTail } = await import("./log-tail.js");
+initLogTail();
+await tick();
+await tick();
+if (sources.length !== 1) throw new Error(`expected one EventSource, got ${sources.length}`);
+if (!sources[0].url.includes("from=42")) throw new Error(`stream url missing snapshot offset: ${sources[0].url}`);
+sources[0].readyState = EventSource.CLOSED;
+sources[0].onerror();
+if (label.textContent !== "log stream unavailable, retrying") {
+  throw new Error(`disconnected copy missing, label=${label.textContent}`);
+}
+if (!bar.classList.contains("disconnected")) throw new Error("status bar did not mark disconnected");
+if (!get("side-dock").classList.contains("disconnected")) throw new Error("dock did not mark disconnected");
+if (retryFns.length !== 1) throw new Error(`expected one retry timer, got ${retryFns.length}`);
+retryFns[0]();
+if (sources.length !== 2) throw new Error(`retry did not open a new EventSource, got ${sources.length}`);
+if (!sources[1].url.includes("from=42")) throw new Error(`retry lost resume offset: ${sources[1].url}`);
+sources[1].readyState = EventSource.OPEN;
+sources[1].onopen();
+if (label.textContent !== "orbit.log") throw new Error(`did not recover label, got ${label.textContent}`);
+if (bar.classList.contains("disconnected")) throw new Error("status bar stayed disconnected after open");
+if (get("side-dock").classList.contains("disconnected")) throw new Error("dock stayed disconnected after open");
+"#,
+    );
 }
 
 /// ORB-10972: the top-level nav is a left rail, and the vertical chrome above


### PR DESCRIPTION
## Task

[ORB-11660](https://orbit-cli.com/tasks/ORB-11660) — [code-review] Resume the log SSE stream without gaps and surface disconnects

### Description

## Problem
`initLogTail` fetches the `/api/log` snapshot and only then opens `EventSource('/api/log/stream')`; the stream thread starts at the file's *current* length (`log.rs:181`), so any line appended between the two requests is never shown. No `id:` field is emitted and `Last-Event-ID` is ignored, so a browser auto-reconnect after a blip silently drops everything written meanwhile. When the 8-stream cap answers 503 (`log.rs:122-136`), `EventSource` treats a non-200 as a fatal connection error and does not retry, so the ninth tab never gets a live tail — and because `log-tail.js` registers no `onerror`, the "live" dot and status bar keep looking connected in every failure case.

## Why It Matters
The tail is the primary "what is happening right now" surface and it can be quietly stale.

## Proposed Fix
Have `/api/log` return the end byte offset it read to, accept `?from=<offset>` (and `Last-Event-ID`) on `/api/log/stream`, and emit `id: <offset>` with each frame; on the client pass the snapshot offset when opening the stream, add `onerror` that marks the dock/status bar disconnected and, on a 503, retries with backoff.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/src/api/log.rs:93-136,171-206`, `crates/orbit-web/assets/dashboard/log-tail.js:172-188,283-310`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: write N lines between the snapshot call and stream open; all N arrive on the stream.
- Test: reconnect with `Last-Event-ID: <offset>` replays lines after that offset only.
- Manually: open 9 tabs; the ninth shows a "log stream unavailable, retrying" state and recovers when a tab closes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `/api/log` now returns `{ events, offset }` where `offset` is the log file length after the snapshot read.
- `/api/log/stream` accepts `?from=<offset>` and `Last-Event-ID` (header wins) and emits `id: <byte offset after that line>` on each SSE frame so reconnects do not skip or duplicate lines.
- `log-tail.js` opens the stream at the snapshot offset, tracks `lastEventId`, marks the dock and status bar disconnected on error, shows "log stream unavailable, retrying", and retries with backoff when EventSource goes CLOSED (the 503 / ninth-tab case). `onopen` restores the live state.
- CSS rests the live dots and colors the retry label when disconnected.
Assessment: Scoped to the log snapshot/stream path and the dashboard tail. Snapshot JSON is no longer a bare array; the only consumer is the dashboard, which was updated in the same change.

Criteria:
1. Write N lines between snapshot and stream open; all N arrive — passed (`lines_written_between_snapshot_and_stream_open_all_arrive` writes 3 lines after snapshot and collects 3 SSE frames from `spawn_log_sse_frames` at the snapshot offset).
2. Reconnect with `Last-Event-ID: <offset>` replays later lines only — passed (`reconnect_with_last_event_id_replays_only_lines_after_offset` parses the header, resolves resume offset, and asserts only the two later lines stream).
3. Ninth tab shows "log stream unavailable, retrying" and recovers when a tab closes — implemented; JS harness (`dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close`) drives EventSource CLOSED, asserts that copy on the status-bar label plus disconnected dock/bar, then recovers on `onopen`. Nine real browser tabs were not opened in this run.

Validation:
- `cargo test -p orbit-web --lib -- api::tests::log dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close dashboard_log_dock_has_two_modes` — passed (11 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed (clean)

Risks / deviations:
- EventSource does not expose the HTTP status, so 503 is handled as fatal CLOSED plus backoff retry rather than a status-specific branch. Native CONNECTING reconnects are left to the browser (it sends Last-Event-ID).
- Nine-tab recovery against a live 8-stream cap remains a manual check.
- Uncommitted working tree; pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11660-6a9f601d`
- Behind base: 0
- Ahead of base: 1