### PR TITLE
Distinguish dashboard loading and stale data from empty results

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -1,13 +1,13 @@
 // Orbit dashboard — terminal-dark, manually refreshed SPA.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder, getWindow, persistScopeToUrl, setScopeChangeListener, syncWindowSelectors, payloadHonorsWindow, withWorkspace } from './common.js';
+import { requestPanel, resetPanel, onWorkspaceChange, getWorkspaceRevision, el, statusPill, stateCell, fetchJson, listItems, requestJson, postJson, patchJson, syncNodes, positiveIntParam, getWorkspace, setWorkspace, setMultiWorkspace, isAggregateView, renderPanelPlaceholder, getWindow, persistScopeToUrl, setScopeChangeListener, syncWindowSelectors, payloadHonorsWindow, withWorkspace } from './common.js';
 import { buildChips, buildTasksHash, applyTasksHashQuery, cacheCrewPayload, copyTaskIdWithNotice, hasCrewOptions, openVisibleTask, renderTasks, setPinnedExternalTask, syncTaskControls, wireSearch } from './tasks.js';
 import { applyAuditHashQuery, buildAuditChips, buildAuditHash, fetchAndRenderAudit, fetchAndRenderPolicy, getActiveAuditSubtab, navigateToAuditExecution, renderAuditSummary, setActiveAuditSubtabFromButton, setAuditSubtab, syncAuditControls, wireAuditSearch, } from './audit.js';
 import { renderScoreboard } from './scoreboard.js';
 import { fetchAndRenderReliability, wireReliabilityWindowSelector } from './reliability.js';
 import { initLogTail, fitLogPanelToViewport } from './log-tail.js';
-import { renderDiagnostics } from './diagnostics.js';
+import { renderDiagnosticsSideCard, renderDiagnostics } from './diagnostics.js';
 import { renderMarkdown } from './markdown.js';
 import { initRouter, initTabs as iT, navigateToRun as nTR, setActiveTab as sAT, setRunDetailSubtab, } from './router.js';
 import { initRuns, getRunFilter, setRunFilter, mergeRunsWithFriction, renderRuns, runIsCancellable, buildCancelRunButton, buildReplayRunButton } from './runs.js';
@@ -78,13 +78,13 @@ let lastRuns = [];
 let lastRunsMeta = null;
 let lastRunsLoading = true;
 let lastRunSourcesUnavailable = [];
-let lastDiagnostics = { metrics: [], errors: [], incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] };
+let lastDiagnostics = { metrics: null, errors: null, incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] };
 let lastFrictionPayload = { stats: {}, tags: [], items: [] };
 let activeTab = "tasks";
 let activeDiagSubtab = "runs";
 let activeKnowledgeSubtab = "frictions";
 let activeOperationsSubtab = "routines";
-let isRefreshing = false;
+let refreshSequence = 0;
 let activeFrictionId = null;
 let frictionSearchQuery = "";
 let frictionStatusFilter = DEFAULT_FRICTION_STATUS_FILTER;
@@ -1052,12 +1052,6 @@ function resetHealthStrip() {
   renderSparkline([]);
 }
 
-function fetchAndCacheCrews() {
-  return fetchJson("/api/crews").then((payload) => {
-    return cacheCrewPayload(payload);
-  });
-}
-
 // ORB-10874: the single-workspace list endpoint filters server-side, so the
 // active status chips are sent as `?status=a,b` instead of over-fetching every
 // status and filtering client-side. That keeps the `total`/`limit`/`truncated`
@@ -1087,11 +1081,11 @@ function fetchAndRenderTasks() {
   // previously-selected concrete workspace so the fallback is consistent (a
   // stale, still-enabled crew <select> would PATCH with no workspace).
   if (aggregate) cacheCrewPayload({ crews: [] });
-  const crews = aggregate ? Promise.resolve() : fetchAndCacheCrews();
-  return Promise.all([
+  return requestPanel("tasks-body", path, () => Promise.all([
     fetchJson(path),
-    crews,
-  ]).then(([payload]) => {
+    aggregate ? Promise.resolve({ crews: [] }) : fetchJson("/api/crews"),
+  ]), ([payload, crews]) => {
+    cacheCrewPayload(crews);
     // Both task-list endpoints answer `{ items, total, limit, truncated }`.
     const tasks = listItems(payload);
     lastTasks = tasks;
@@ -1099,7 +1093,7 @@ function fetchAndRenderTasks() {
       ? { total: payload.total, limit: payload.limit, truncated: payload.truncated }
       : null;
     renderTasks(tasks, taskContext());
-  });
+  }, "tasks-count");
 }
 
 // ORB-00030: discover servable workspaces and, in global mode, install a
@@ -1158,13 +1152,6 @@ function buildWorkspaceSelector() {
   select.addEventListener("change", () => {
     setWorkspace(select.value);
     persistScopeToUrl();
-    // Clear the prior scope synchronously. A slower request from that scope is
-    // also discarded in fetchAndRenderRuns, so it cannot repaint stale rows.
-    lastRuns = [];
-    lastRunsMeta = null;
-    lastRunsLoading = true;
-    lastRunSourcesUnavailable = [];
-    renderRuns(lastRuns);
     refreshDashboard();
   });
 
@@ -1296,107 +1283,57 @@ function activeRefreshJobs() {
     }
     if (activeDiagSubtab === "runs") {
       jobs.push(fetchAndRenderRuns());
-    } else if (activeDiagSubtab === "metrics") {
-      jobs.push(
-        fetchJson(`/api/diagnostics/metrics?limit=${DIAG_LIMIT}`).then((rows) => {
-          lastDiagnostics.metrics = rows;
-          renderDiagnostics(diagnosticsContext());
-        })
-      );
-    } else if (activeDiagSubtab === "errors") {
-      jobs.push(
-        fetchJson(`/api/diagnostics/errors?limit=${DIAG_LIMIT}`).then((rows) => {
-          lastDiagnostics.errors = rows;
-          renderDiagnostics(diagnosticsContext());
-        })
-      );
-    } else if (activeDiagSubtab === "incidents") {
-      // ORB-10871: grouped failure incidents. Scoped to the shared dashboard
-      // window so the incident count and the raw failed-event count it states
-      // its denominator against are read off the same cutoff.
+    } else {
+      const subtab = activeDiagSubtab;
       const selectedWindow = getWindow();
-      jobs.push(
-        fetchJson(`/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}&limit=${DIAG_LIMIT}`).then((payload) => {
-          lastDiagnostics.incidents = payload;
-          renderDiagnostics(diagnosticsContext());
-        })
-      );
+      const path = subtab === "incidents"
+        ? `/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}&limit=${DIAG_LIMIT}`
+        : `/api/diagnostics/${subtab}?limit=${DIAG_LIMIT}`;
+      jobs.push(requestPanel("diag-body", path, () => fetchJson(path), (payload) => {
+        lastDiagnostics[subtab] = payload;
+        if (activeDiagSubtab === subtab && getWindow() === selectedWindow) renderDiagnostics(diagnosticsContext());
+      }, "diag-count"));
     }
 
     jobs.push(
-      Promise.all([
+      requestPanel("diag-implement-one-body", "implement-one", () => Promise.all([
         fetchJson(`/api/diagnostics/implement_one`),
-        fetchJson(`/api/tasks/completion-by-complexity`).catch((e) => {
-          console.error("Failed to fetch completion-by-complexity", e);
-          return { by_complexity: [] };
-        }),
-      ])
-        .then(([implOne, completion]) => {
-          lastDiagnostics.implement_one = implOne.implement_one_by_actor || [];
-          lastDiagnostics.implement_one_by_complexity = implOne.implement_one_by_complexity || [];
-          lastDiagnostics.completion_by_complexity = completion.by_complexity || [];
-          if ($("diagnostics-side-panel")) {
-            renderDiagnostics(diagnosticsContext());
-          }
-        })
-        .catch(e => console.error("Failed to fetch implement_one metrics", e))
+        fetchJson(`/api/tasks/completion-by-complexity`),
+      ]), ([implOne, completion]) => {
+        lastDiagnostics.implement_one = implOne.implement_one_by_actor || [];
+        lastDiagnostics.implement_one_by_complexity = implOne.implement_one_by_complexity || [];
+        lastDiagnostics.completion_by_complexity = completion.by_complexity || [];
+        renderDiagnosticsSideCard(lastDiagnostics, diagnosticsContext());
+      })
     );
   }
   return jobs;
 }
 
 function fetchAndRenderRuns() {
-  const requestedWorkspace = getWorkspace();
   const requestedAggregate = isAggregateView();
   const runFilter = getRunFilter();
-  lastRunsLoading = true;
-  const scopeIsCurrent = () =>
-    requestedWorkspace === getWorkspace() &&
-    requestedAggregate === isAggregateView() &&
-    runFilter === getRunFilter();
-  const request = requestedAggregate
+  return requestPanel("runs-body", runFilter, () => requestedAggregate
     ? fetchJson(`/api/job-runs/all?limit=${JOB_RUN_LIMIT}&state=${encodeURIComponent(runFilter)}`).then((payload) => ({
-        runs: listItems(payload),
-        frictionRows: [],
-        meta: payload,
+        runs: listItems(payload), frictionRows: [], meta: payload,
         unavailable: Array.isArray(payload && payload.unavailable) ? payload.unavailable : [],
       }))
     : Promise.all([
         fetchJson(`/api/job-runs?limit=${JOB_RUN_LIMIT}&state=${encodeURIComponent(runFilter)}`),
         fetchJson(`/api/diagnostics/friction?limit=${DIAG_LIMIT}`),
       ]).then(([payload, frictionRows]) => ({
-        runs: listItems(payload),
-        frictionRows,
-        meta: payload,
-        unavailable: [],
-      }));
-
-  return request.then(({ runs, frictionRows, meta, unavailable }) => {
-    if (!scopeIsCurrent()) return;
+        runs: listItems(payload), frictionRows, meta: payload, unavailable: [],
+      })), ({ runs, frictionRows, meta, unavailable }) => {
     lastRuns = mergeRunsWithFriction(runs, frictionRows);
     lastRunsMeta = meta;
     lastRunsLoading = false;
     lastRunSourcesUnavailable = unavailable;
     renderRuns(lastRuns);
-  }).catch((error) => {
-    if (scopeIsCurrent()) {
-      const workspace = dashboardWorkspaces.find((entry) => entry.id === requestedWorkspace);
-      lastRuns = [];
-      lastRunsMeta = null;
-      lastRunsLoading = false;
-      lastRunSourcesUnavailable = [{
-        workspace_id: requestedWorkspace,
-        workspace_name: requestedAggregate ? "All workspaces" : (workspace && workspace.name) || requestedWorkspace || "workspace",
-        error: error.message || "run query failed",
-      }];
-      renderRuns(lastRuns);
-    }
-    throw error;
-  });
+  }, "diag-count");
 }
 
 function fetchAndRenderTaskLocks() {
-  return fetchJson("/api/tasks/locks").then(renderLocksPanel);
+  return requestPanel("locks-body", "locks", () => fetchJson("/api/tasks/locks"), renderLocksPanel, "locks-count");
 }
 
 function fetchAndRenderRunDetail() {
@@ -1439,7 +1376,7 @@ function fetchAndRenderRunLogs() {
 }
 
 function fetchAndRenderSummary() {
-  return fetchJson(`/api/audit/summary?since=24h`).then((data) => {
+  return requestPanel("audit-summary-body", "summary", () => fetchJson(`/api/audit/summary?since=24h`), (data) => {
     lastSummary = data;
     renderHealthStrip(data);
     renderAuditSummary(data, auditContext());
@@ -1463,10 +1400,10 @@ function fetchAndRenderFrictions() {
     if (frictionSearchQuery) sp.set("q", frictionSearchQuery);
     return fetchJson(`/api/frictions?${sp.toString()}`);
   });
-  return Promise.all([
+  return requestPanel("frictions-body", `${frictionStatusFilter}:${frictionSearchQuery}`, () => Promise.all([
     Promise.all(listRequests),
     fetchJson("/api/frictions/stats"),
-  ]).then(([payloads, stats]) => {
+  ]), ([payloads, stats]) => {
     const items = payloads
       .flatMap((payload) => Array.isArray(payload && payload.items) ? payload.items : [])
       .sort((a, b) => {
@@ -1571,36 +1508,41 @@ function refreshLabel() {
 
 
 async function refreshDashboard() {
-  if (isRefreshing) return;
-  isRefreshing = true;
-  const now = new Date();
-  $("meta-text").textContent = `fetching...`;
+  const sequence = ++refreshSequence;
+  const revision = getWorkspaceRevision();
+  $("meta-text").textContent = "fetching…";
   $("conn-status").className = "status-dot orange";
-  const btn = $("refresh-btn");
-  if (btn) btn.disabled = true;
-  
-  let hasErrors = false;
-  
-  await Promise.all(
-    activeRefreshJobs().map((job) =>
-      job.catch((e) => {
-        hasErrors = true;
-        console.error(e);
-      }),
-    ),
-  );
-  
-  if (hasErrors) {
-    $("conn-status").className = "status-dot red";
-    $("meta-text").textContent = `offline · ${now.toLocaleTimeString()}`;
-  } else {
-    $("conn-status").className = "status-dot green";
-    $("meta-text").textContent = `refreshed ${refreshLabel()} · ${now.toLocaleTimeString()}`;
-  }
-  if (btn) btn.disabled = false;
-  isRefreshing = false;
+  // Refresh stays available so a slow request never locks navigation or retry.
+  const results = await Promise.allSettled(activeRefreshJobs());
+  if (sequence !== refreshSequence || revision !== getWorkspaceRevision()) return;
+  const errors = results.filter(result => result.status === "rejected").map(result => result.reason);
+  const offline = errors.some(error => error.networkFailure);
+  for (const error of errors) console.error(error);
+  $("conn-status").className = `status-dot ${offline ? "red" : "green"}`;
+  const label = offline ? "offline" : errors.length ? "panel update failed" : `refreshed ${refreshLabel()}`;
+  $("meta-text").textContent = `${label} · ${new Date().toLocaleTimeString()}`;
   if (activeTab === "tasks") fitLogPanelToViewport();
 }
+
+// Invalidate caches at the scope boundary, including programmatic selections.
+// Panel state is reset synchronously by common.js before another frame paints.
+onWorkspaceChange(() => {
+  lastTasks = [];
+  lastTasksMeta = null;
+  cacheCrewPayload({ crews: [] });
+  lastRuns = [];
+  lastRunsMeta = null;
+  lastRunsLoading = true;
+  lastRunSourcesUnavailable = [];
+  lastDiagnostics = { metrics: null, errors: null, incidents: null };
+  for (const id of ["tasks-count", "diag-count", "task-filter-summary"]) {
+    if ($(id)) $(id).textContent = "—";
+  }
+  resetHealthStrip();
+});
+resetPanel("tasks-body", "tasks-count");
+resetPanel("runs-body", "diag-count");
+resetPanel("diag-body", "diag-count");
 
 const tasksContext = taskContext();
 buildChips(tasksContext);

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -199,10 +199,84 @@ export const AGGREGATE_PANEL_PLACEHOLDER = "Select a workspace to view this pane
 export function renderPanelPlaceholder(bodyId) {
   const body = document.getElementById(bodyId);
   if (!body) return;
+  panelRequests.delete(bodyId);
+  body.setAttribute("aria-busy", "false");
   const note = el("div", { class: "panel-placeholder", text: AGGREGATE_PANEL_PLACEHOLDER });
   note.dataset.key = "aggregate-placeholder";
   note.dataset.hash = "aggregate-placeholder";
   syncNodes(body, [note]);
+}
+
+// One state per rendered panel. Revision plus request identity rejects A→B→A
+// responses and overlapping refreshes, even when their URLs happen to match.
+const panelRequests = new Map();
+
+function panelMessage(bodyId, state) {
+  const body = document.getElementById(bodyId);
+  if (!body) return;
+  body.setAttribute("aria-busy", state.pending ? "true" : "false");
+  let note = Array.from(body.children).find(node => node.dataset.panelStatus);
+  if (!note) {
+    note = el("div", { class: "panel-placeholder" });
+    note.dataset.panelStatus = "true";
+    note.setAttribute("role", "status");
+    note.setAttribute("aria-live", "polite");
+    body.insertBefore(note, body.children[0] || null);
+  }
+  note.className = state.error ? "panel-placeholder action-error" : "panel-placeholder";
+  if (state.error) {
+    const label = state.loaded ? "Refresh failed; showing stale data" : "Unable to load";
+    note.textContent = `${label}: ${state.error.message}. Use Refresh to retry.`;
+  } else if (state.pending) {
+    note.textContent = state.loaded ? "Refreshing… showing previous data." : "Loading…";
+  } else {
+    note.textContent = "Updated.";
+  }
+}
+
+export function panelCanRender(bodyId) {
+  const state = panelRequests.get(bodyId);
+  return !state || state.loaded;
+}
+
+export function resetPanel(bodyId, countId) {
+  const state = { loaded: false, pending: true, countId };
+  panelRequests.set(bodyId, state);
+  const body = document.getElementById(bodyId);
+  if (body) body.textContent = "";
+  const count = document.getElementById(countId);
+  if (count) count.textContent = "—";
+  panelMessage(bodyId, state);
+}
+
+onWorkspaceChange(() => {
+  for (const [bodyId, state] of panelRequests) resetPanel(bodyId, state.countId);
+});
+
+export async function requestPanel(bodyId, scope, request, render, countId) {
+  const revision = getWorkspaceRevision();
+  const previous = panelRequests.get(bodyId);
+  if (!previous || previous.scope !== scope) resetPanel(bodyId, countId);
+  const state = { ...panelRequests.get(bodyId), scope, pending: true, error: null };
+  panelRequests.set(bodyId, state);
+  panelMessage(bodyId, state);
+  const current = () => revision === getWorkspaceRevision() && panelRequests.get(bodyId) === state;
+  try {
+    const payload = await request();
+    if (!current()) return;
+    state.loaded = true;
+    state.pending = false;
+    render(payload);
+  } catch (error) {
+    if (!current()) return;
+    state.error = error;
+    throw error;
+  } finally {
+    if (current()) {
+      state.pending = false;
+      panelMessage(bodyId, state);
+    }
+  }
 }
 
 // Append the selected workspace to an API path, unless one is already present
@@ -251,22 +325,32 @@ export function stateCell(state) {
   return node;
 }
 
-export function fetchJson(path) {
-  return fetch(withWorkspace(path), { headers: { accept: "application/json" } })
-    .then(async (res) => {
-      if (!res.ok) {
-        const text = await res.text();
-        let message = `${path}: HTTP ${res.status}`;
-        try {
-          const body = JSON.parse(text);
-          if (body && body.error) message = body.error;
-        } catch (_) {}
-        const error = new Error(message);
-        error.status = res.status;
-        throw error;
-      }
-      return res.json();
-    });
+export async function fetchJson(path) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30000);
+  try {
+    const res = await fetch(withWorkspace(path), { headers: { accept: "application/json" }, signal: controller.signal });
+    if (!res.ok) {
+      const text = await res.text();
+      let message = `${path}: HTTP ${res.status}`;
+      try {
+        const body = JSON.parse(text);
+        if (body && body.error) message = body.error;
+      } catch (_) {}
+      const error = new Error(message);
+      error.status = res.status;
+      throw error;
+    }
+    return await res.json();
+  } catch (error) {
+    if (controller.signal.aborted) throw new Error("Request timed out after 30 seconds");
+    // Fetch and response-body transport failures are TypeErrors; HTTP and JSON
+    // errors describe an available server and must stay local to the panel.
+    error.networkFailure = error instanceof TypeError;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // ORB-10400: task-list endpoints answer a paginated envelope
@@ -308,6 +392,12 @@ export function patchJson(path, body) {
 }
 
 export function syncNodes(container, newNodesArr) {
+  const state = panelRequests.get(container.id);
+  if (state) {
+    panelMessage(container.id, state);
+    const note = Array.from(container.children).find(node => node.dataset.panelStatus);
+    newNodesArr = [note, ...newNodesArr];
+  }
   const oldNodes = Array.from(container.children);
   const oldMap = new Map();
   for (const node of oldNodes) {
@@ -342,4 +432,5 @@ export function syncNodes(container, newNodesArr) {
   while (container.children.length > newNodesArr.length) {
     container.removeChild(container.lastElementChild);
   }
+  if (state) panelMessage(container.id, state);
 }

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -4042,6 +4042,13 @@
         font-size: 12px;
         font-style: italic;
       }
+      [data-panel-status] {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        background: var(--bg);
+        flex-shrink: 0;
+      }
       .lock-task-group {
         padding: 8px 12px 9px;
         border-bottom: 1px solid rgba(255, 255, 255, 0.04);

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -15,10 +15,10 @@
 // (preserving the ?step= query for run-detail pre-expansion) rather than
 // navigateToRun to ensure identical behavior to before the split.
 //
-// No behavior change. All original column shapes, truncation, click wiring,
-// and side-card rendering preserved exactly.
+// Main-table and side-card requests render independently so a side-card
+// completion cannot replace the main panel's loading or failure feedback.
 
-import { el, syncNodes, getWindow } from './common.js';
+import { panelCanRender, resetPanel, el, syncNodes, getWindow } from './common.js';
 import { navigateToDrilldown } from './audit.js';
 
 const $ = (id) => document.getElementById(id);
@@ -416,6 +416,12 @@ function renderDiagnostics(ctx = {}) {
   const sub = ctx.getActiveDiagSubtab ? ctx.getActiveDiagSubtab() : "metrics";
   const last = ctx.getLastDiagnostics ? ctx.getLastDiagnostics() : { metrics: [], errors: [], incidents: null, implement_one: [], implement_one_by_complexity: [], completion_by_complexity: [] };
 
+  if (!panelCanRender("diag-body")) return;
+  if (ctx.getLastDiagnostics && last[sub] == null) {
+    resetPanel("diag-body", "diag-count");
+    return;
+  }
+
   if (sub === "incidents") {
     const payload = last.incidents || {};
     // Both counts in the header: grouped incidents, and the raw failed events
@@ -423,7 +429,6 @@ function renderDiagnostics(ctx = {}) {
     $("diag-count").textContent =
       `${asCount(payload.failure_categories && payload.failure_categories.unexpected && payload.failure_categories.unexpected.incidents)} unexpected / ${asCount(payload.incident_count)} all incidents / ${asCount(payload.raw_failed_events)} failed events`;
     renderIncidents(payload, ctx);
-    renderDiagnosticsSideCard(last, ctx);
     return;
   }
 
@@ -448,11 +453,9 @@ function renderDiagnostics(ctx = {}) {
       ? "No error events this month (step/event failures, not job-run states)."
       : "No metric entries this month.",
   );
-
-  renderDiagnosticsSideCard(last, ctx);
 }
 
-function renderDiagnosticsSideCard(last, ctx) {
+export function renderDiagnosticsSideCard(last, ctx) {
   const container = $("diag-implement-one-body");
   if (!container) return;
   container.innerHTML = "";

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -93,7 +93,7 @@
             </div>
             <div class="filter-summary" id="task-filter-summary" role="status" aria-live="polite"></div>
             <div class="body" id="tasks-body">
-              <div class="skeleton-state">
+              <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
                 <div class="skeleton skeleton-row"></div>
                 <div class="skeleton skeleton-row" style="width: 80%"></div>
                 <div class="skeleton skeleton-row" style="width: 90%"></div>
@@ -154,14 +154,14 @@
               <div id="audit-filter"></div>
             </div>
             <div class="body scoreboard-table-wrap" id="audit-body">
-              <div class="skeleton-state">
+              <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
                 <div class="skeleton skeleton-row"></div>
                 <div class="skeleton skeleton-row" style="width: 80%"></div>
                 <div class="skeleton skeleton-row" style="width: 70%"></div>
               </div>
             </div>
             <div class="body" id="audit-policy-body" style="display: none;">
-              <div class="skeleton-state">
+              <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
                 <div class="skeleton skeleton-row"></div>
                 <div class="skeleton skeleton-row" style="width: 80%"></div>
               </div>
@@ -185,7 +185,7 @@
             <span class="count" id="run-detail-count">-</span>
           </header>
           <div class="body" id="run-detail-meta">
-            <div class="skeleton-state">
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
               <div class="skeleton skeleton-row"></div>
               <div class="skeleton skeleton-row" style="width: 70%"></div>
             </div>
@@ -210,13 +210,13 @@
               <span class="count" id="diag-count">-</span>
             </header>
             <div class="body scoreboard-table-wrap" id="diag-body" style="display: none;">
-              <div class="skeleton-state">
+              <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
                 <div class="skeleton skeleton-row"></div>
                 <div class="skeleton skeleton-row" style="width: 75%"></div>
               </div>
             </div>
             <div class="body" id="runs-body" style="display: none;">
-              <div class="skeleton-state">
+              <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
                 <div class="skeleton skeleton-row"></div>
                 <div class="skeleton skeleton-row" style="width: 80%"></div>
               </div>
@@ -303,7 +303,7 @@
           <div id="scoreboard-agent-strip" class="scoreboard-agent-strip"></div>
           <section id="scoreboard-highlights" class="scoreboard-highlights-host" aria-label="Notable completions"></section>
           <div class="body scoreboard-table-wrap" id="scoreboard-body">
-            <div class="skeleton-state">
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
               <div class="skeleton skeleton-row"></div>
               <div class="skeleton skeleton-row" style="width: 70%"></div>
             </div>
@@ -342,14 +342,14 @@
           </header>
           <div class="operation-feedback" id="routine-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="routines-body">
-            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>
         <section class="panel" id="clock-panel">
           <header><span>Host Sweep Clock</span><span class="count" id="clock-host">-</span></header>
           <div class="operation-feedback" id="clock-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="clock-body">
-            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>
       </main>
@@ -361,7 +361,7 @@
           </header>
           <div class="operation-feedback" id="auto-task-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="auto-tasks-body">
-            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>
       </main>
@@ -373,7 +373,7 @@
           </header>
           <div class="operation-feedback" id="auto-drain-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="auto-drain-body">
-            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>
         <section class="panel" id="operation-mode-panel">
@@ -383,7 +383,7 @@
           </header>
           <div class="operation-feedback" id="operation-mode-operation-feedback" role="status" aria-live="polite"></div>
           <div class="body" id="operation-mode-body">
-            <div class="skeleton-state"><div class="skeleton skeleton-row"></div></div>
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span><div class="skeleton skeleton-row"></div></div>
           </div>
         </section>
       </main>
@@ -426,7 +426,7 @@
             </label>
           </div>
           <div class="body scoreboard-table-wrap" id="frictions-body">
-            <div class="skeleton-state">
+            <div class="skeleton-state" role="status" aria-live="polite"><span>Loading…</span>
               <div class="skeleton skeleton-row"></div>
               <div class="skeleton skeleton-row" style="width: 80%"></div>
               <div class="skeleton skeleton-row" style="width: 70%"></div>

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,6 +1,6 @@
 // Routine-definition, host sweep-clock, and auto-task operations [ORB-10875, ORB-10876].
 
-import { el, fetchJson, getWorkspace, getWorkspaceRevision, onWorkspaceChange, postJson } from './common.js';
+import { requestPanel, el, fetchJson, getWorkspace, getWorkspaceRevision, onWorkspaceChange, postJson } from './common.js';
 import { navigateToRun } from './router.js';
 import { renderAutomation } from './automation.js';
 
@@ -26,9 +26,6 @@ export function initOperations(nextContext) {
   unsubscribeWorkspace?.();
   unsubscribeWorkspace = onWorkspaceChange(() => {
     lastOperations = lastAutoTasks = lastAutoDrain = lastOperationMode = null;
-    for (const id of ["routines-body", "clock-body", "auto-tasks-body", "auto-drain-body", "operation-mode-body"]) {
-      if ($(id)) $(id).textContent = "Loading selected workspace…";
-    }
     for (const id of ["routine-operation-feedback", "clock-operation-feedback", "auto-task-operation-feedback", "auto-drain-operation-feedback", "operation-mode-operation-feedback"]) feedback(id, "", "");
   });
 }
@@ -567,11 +564,16 @@ function renderAutoTasks(payload) {
   if (count) count.textContent = workspace && !workspaceReason ? `${definitions.length} · ${workspace.name}` : "read-only";
 }
 
+function operationCountId(bodyId) {
+  return bodyId === "clock-body" ? "clock-host" : bodyId.replace("-body", "-count");
+}
+
+function loadOperationPanel(bodyId, path, render) {
+  return requestPanel(bodyId, path, () => fetchJson(path), render, operationCountId(bodyId));
+}
+
 function fetchAndRenderAutoTasks() {
-  const selection = selectionSnapshot();
-  return fetchJson("/api/auto-tasks").then((payload) => {
-    if (selection.current()) renderAutoTasks(payload);
-  });
+  return loadOperationPanel("auto-tasks-body", "/api/auto-tasks", renderAutoTasks);
 }
 
 // ORB-11250: bounded backlog auto-drain window ("orbit run auto --for
@@ -725,14 +727,12 @@ function renderAutoDrain(payload) {
 }
 
 function fetchAndRenderAutoDrain() {
-  const selection = selectionSnapshot();
   const workspace = selectedWorkspace();
   if (!workspace) {
-    renderAutoDrain({});
-    return Promise.resolve();
+    return requestPanel("auto-drain-body", "unselected", () => Promise.resolve({}), renderAutoDrain, "auto-drain-count");
   }
   const query = autoDrainConcurrency ? `?concurrency=${encodeURIComponent(autoDrainConcurrency)}` : "";
-  return fetchJson(`/api/workflows/auto/readiness${query}`).then((payload) => { if (selection.current()) renderAutoDrain(payload); });
+  return loadOperationPanel("auto-drain-body", `/api/workflows/auto/readiness${query}`, renderAutoDrain);
 }
 
 // ORB-11332: operation mode. The panel projects `orbit operation explain`
@@ -889,26 +889,22 @@ function renderOperationMode(payload) {
 }
 
 export function fetchAndRenderOperationMode() {
-  const selection = selectionSnapshot();
   if (!selectedWorkspace()) {
-    renderOperationMode({});
-    return Promise.resolve();
+    return requestPanel("operation-mode-body", "unselected", () => Promise.resolve({}), renderOperationMode, "operation-mode-count");
   }
-  return fetchJson("/api/operation/explain").then((payload) => { if (selection.current()) renderOperationMode(payload); });
+  return loadOperationPanel("operation-mode-body", "/api/operation/explain", renderOperationMode);
 }
 
-export function fetchAndRenderOperations() {
-  const selection = selectionSnapshot();
-  return Promise.all([
-    fetchJson("/api/routines").then((payload) => { if (selection.current()) renderOperations(payload); }),
-    fetchAndRenderAutoTasks().catch((error) => {
-      if (selection.current()) feedback("auto-task-operation-feedback", "error", `Failed to load auto-tasks: ${error.message}`);
-    }),
-    fetchAndRenderAutoDrain().catch((error) => {
-      if (selection.current()) feedback("auto-drain-operation-feedback", "error", `Failed to load auto-delivery readiness: ${error.message}`);
-    }),
-    fetchAndRenderOperationMode().catch((error) => {
-      if (selection.current()) feedback("operation-mode-operation-feedback", "error", `Failed to load operation mode: ${error.message}`);
-    }),
+export async function fetchAndRenderOperations() {
+  const routines = fetchJson("/api/routines");
+  const results = await Promise.allSettled([
+    requestPanel("routines-body", "routines", () => routines, renderOperations, "routines-count"),
+    requestPanel("clock-body", "clock", () => routines, renderClock, "clock-host"),
+    fetchAndRenderAutoTasks(),
+    fetchAndRenderAutoDrain(),
+    fetchAndRenderOperationMode(),
   ]);
+  const errors = results.filter(result => result.status === "rejected").map(result => result.reason);
+  // Preserve transport classification even if a different panel also fails.
+  if (errors.length) throw errors.find(error => error.networkFailure) || errors[0];
 }

--- a/crates/orbit-web/assets/dashboard/runs.js
+++ b/crates/orbit-web/assets/dashboard/runs.js
@@ -11,7 +11,7 @@
 // callbacks (fetchAndRender*, navigateToRun) and getters (activeRunId, lastRuns,
 // formatters) that the actions and render depend on. No direct import from app.js.
 
-import { el, stateCell, syncNodes, postJson } from './common.js';
+import { panelCanRender, el, stateCell, syncNodes, postJson } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -568,6 +568,7 @@ function runDurationCell(run) {
 }
 
 export function renderRuns(runs) {
+  if (!panelCanRender("runs-body")) return;
   const body = $("runs-body");
   const frag = document.createDocumentFragment();
   const unavailable = hasCtx("getRunSourcesUnavailable") ? _runsCtx.getRunSourcesUnavailable() : [];

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, statusPill, patchJson, postJson, syncNodes, isAggregateView, withWorkspace } from './common.js';
+import { onWorkspaceChange, panelCanRender, el, statusPill, patchJson, postJson, syncNodes, isAggregateView, withWorkspace } from './common.js';
 import { renderMarkdown, renderMarkdownInline } from './markdown.js';
 
 const $ = (id) => document.getElementById(id);
@@ -18,6 +18,14 @@ let pinnedExternalTask = null;
 let statusFeedback = new Map();
 let crewFeedback = new Map();
 const MUTATION_UNDO_WINDOW_MS = 8000;
+
+onWorkspaceChange(() => {
+  pinnedExternalTask = null;
+  expandedTaskIds.clear();
+  statusFeedback.clear();
+  crewFeedback.clear();
+});
+
 // ORB-10444: task ids whose Ship dispatch this page has already issued. Ship is
 // a write against a live pipeline, so a second click must not launch a second
 // run: the id stays here for the life of the page once a dispatch succeeds (the
@@ -1238,6 +1246,7 @@ function takeTaskActionNotice() {
 }
 
 export function renderTasks(tasks, context) {
+  if (!panelCanRender("tasks-body")) return;
   const body = $("tasks-body");
   if (!body) return;
 

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -508,7 +508,7 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(operations.contains("Minted") || operations.contains("result.message"));
     assert!(operations.contains("Auto-task change failed"));
     assert!(operations.contains("Manual mint failed"));
-    assert!(operations.contains("fetchJson(\"/api/auto-tasks\")"));
+    assert!(operations.contains("\"/api/auto-tasks\""));
     assert!(
         !operations.contains("postJson(\"/api/auto-tasks")
             || operations.contains("addEventListener(\"click\"")
@@ -608,6 +608,7 @@ class Node {
   set textContent(value) { this._text = String(value); this.children = []; }
   querySelectorAll() { return []; }
   querySelector() { return null; }
+  insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); return child; }
 }
 const byId = new Map();
 const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
@@ -719,7 +720,7 @@ fn dashboard_auto_drain_action_is_bounded_governed_and_guarded() {
         "starting the window must submit through the dashboard auto-drain endpoint"
     );
     assert!(
-        operations.contains(r#"fetchJson(`/api/workflows/auto/readiness"#),
+        operations.contains(r#"`/api/workflows/auto/readiness"#),
         "the panel must project the read-only readiness snapshot, not recompute eligibility"
     );
     assert!(
@@ -1775,8 +1776,7 @@ fn dashboard_failure_metrics_are_incident_aware_and_state_their_denominators() {
         "the incidents subtab must be routable"
     );
     assert!(
-        app.contains(r#"if (activeDiagSubtab === "incidents")"#)
-            && app.contains("/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}"),
+        app.contains("/api/audit/incidents?since=${encodeURIComponent(selectedWindow)}"),
         "the incidents fetch must hang off the diagnostics subtab branch and honor the shared window"
     );
 
@@ -2659,7 +2659,7 @@ fn dashboard_operation_mode_panel_is_explained_governed_and_guarded() {
         assert!(index.contains(&format!(r#"id="{id}""#)), "{id}");
     }
     assert!(
-        operations.contains(r#"fetchJson("/api/operation/explain")"#),
+        operations.contains(r#""/api/operation/explain""#),
         "the panel must project the runtime explanation, not recompute policy"
     );
     assert!(
@@ -2709,6 +2709,7 @@ class Node {
   set textContent(value) { this._text = String(value); this.children = []; }
   querySelectorAll() { return []; }
   querySelector() { return null; }
+  insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); return child; }
 }
 const byId = new Map();
 const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
@@ -3038,6 +3039,7 @@ class Node {
   addEventListener(name, fn) { this.listeners[name] = fn; }
   click() { if (!this.disabled) return this.listeners.click?.(); }
   dispatchEvent(event) { return this.listeners[event.type]?.(event); }
+  insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); return child; }
 }
 const nodes = new Map();
 globalThis.document = {
@@ -3049,5 +3051,14 @@ globalThis.window = { location: new URL("http://dashboard.test"), localStorage: 
     run_dashboard_javascript_test(&format!(
         "{dom}\n{}",
         include_str!("dashboard_operations.mjs")
+    ));
+}
+
+#[test]
+fn dashboard_loading_rejects_stale_responses_and_reports_panel_errors() {
+    run_dashboard_javascript_test(&format!(
+        "{}\n{}",
+        include_str!("dashboard_loading_dom.mjs"),
+        include_str!("dashboard_loading.mjs")
     ));
 }

--- a/crates/orbit-web/src/tests/dashboard_loading.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading.mjs
@@ -1,0 +1,152 @@
+// The same full-app scenarios run in the Node harness and a real browser.
+const node = id => document.getElementById(id);
+const check = (condition, message) => { if (!condition) throw new Error(message); };
+const settle = async () => { for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0)); };
+const response = (payload, status = 200) => ({ ok: status === 200, status, json: async () => payload, text: async () => JSON.stringify(payload) });
+let heldPath = '/api/tasks';
+let networkDown = false;
+let metricsError = false;
+let marker = 'first';
+let summaryReads = 0;
+const pendingReads = [];
+const list = items => ({ items, total: items.length, limit: 50, truncated: false });
+function fixture(url) {
+  const workspace = url.searchParams.get('workspace');
+  switch (url.pathname) {
+    case '/api/workspaces': return ['one', 'two'].map(id => ({ id, name: id, status: 'active', is_default: id === 'one' }));
+    case '/api/tasks': return list([{ id: 'TEST-1', title: marker, status: 'in-progress', priority: 'medium' }]);
+    case '/api/job-runs': return list([{ run_id: marker, job_id: 'fixture', state: 'failed' }]);
+    case '/api/diagnostics/errors': return [{ message: marker, source: 'fixture' }];
+    case '/api/routines': return { host_id: marker, routines: [{ name: marker, source: workspace, enabled: true }], clock: {} };
+    case '/api/auto-tasks': return { definitions: [] };
+    case '/api/audit/summary': summaryReads++; return { events: summaryReads };
+    default: return [];
+  }
+}
+globalThis.fetch = async path => {
+  const url = new URL(path, 'http://dashboard.test');
+  if (networkDown) throw new TypeError('Fixture network unavailable');
+  if (metricsError && url.pathname === '/api/diagnostics/metrics') return response({ error: 'Metrics fixture failure' }, 500);
+  const payload = fixture(url);
+  if (url.pathname === heldPath) return new Promise((resolve, reject) => pendingReads.push({ payload, resolve, reject }));
+  return response(payload);
+};
+await import('./app.js');
+await settle();
+const { setWorkspace } = await import('./common.js');
+const { setActiveTab } = await import('./router.js');
+const refresh = () => {
+  const button = node('refresh-btn');
+  if (button.listeners) button.listeners.click(); else button.click();
+};
+const release = (request, payload = request.payload) => request.resolve(response(payload));
+const text = id => node(id).textContent;
+const busy = id => node(id).getAttribute ? node(id).getAttribute('aria-busy') : node(id)['aria-busy'];
+check(text('tasks-body').includes('Loading'), 'cold Tasks must visibly load');
+check(!text('tasks-body').includes('No tasks'), 'cold Tasks cannot claim empty');
+for (const request of pendingReads.splice(0)) release(request, list([]));
+await settle();
+check(text('tasks-body').includes('No tasks'), 'successful empty Tasks produces empty state');
+
+const surfaces = [
+  { route: 'tasks', body: 'tasks-body', path: '/api/tasks', empty: list([]), emptyText: 'No tasks' },
+  { route: 'diagnostics/runs', body: 'runs-body', path: '/api/job-runs', empty: list([]), emptyText: 'No job runs' },
+  { route: 'diagnostics/errors', body: 'diag-body', path: '/api/diagnostics/errors', empty: [], emptyText: 'No error events' },
+  { route: 'operations/routines', body: 'routines-body', path: '/api/routines', empty: { routines: [], clock: {} }, emptyText: 'No routines' },
+];
+for (const surface of surfaces) {
+  heldPath = surface.path;
+  setWorkspace('one');
+  setWorkspace('two');
+  marker = 'current-scope-data';
+  setActiveTab(surface.route);
+  await settle();
+  if (!pendingReads.length) { refresh(); await settle(); }
+  check(text(surface.body).includes('Loading'), `${surface.route}: cold load visible`);
+  check(!text(surface.body).includes(surface.emptyText), `${surface.route}: cold load cannot be empty`);
+  check(busy(surface.body) === 'true', `${surface.route}: loading marked busy`);
+  const status = Array.from(node(surface.body).children).find(child => child.dataset.panelStatus);
+  const attribute = name => status?.getAttribute ? status.getAttribute(name) : status?.[name];
+  check(attribute('role') === 'status' && attribute('aria-live') === 'polite', `${surface.route}: accessible loading feedback`);
+  if (status.getBoundingClientRect) {
+    const box = status.getBoundingClientRect();
+    check(box.width > 0 && box.height > 0 && box.top < window.innerHeight, `${surface.route}: loading feedback visible in browser`);
+  }
+  for (const request of pendingReads.splice(0)) release(request);
+  await settle();
+  check(text(surface.body).includes(marker), `${surface.route}: loaded data visible`);
+  check(text(surface.body).includes('Updated.'), `${surface.route}: success visible`);
+
+  marker = 'late-old-scope';
+  refresh(); await settle();
+  const old = pendingReads.splice(0);
+  check(text(surface.body).includes('Refreshing') && text(surface.body).includes('current-scope-data'), `${surface.route}: refresh retains labeled data`);
+  check(!node('refresh-btn').disabled, `${surface.route}: refresh remains usable`);
+  setWorkspace('one');
+  check(!text(surface.body).includes('current-scope-data'), `${surface.route}: workspace change clears synchronously`);
+  marker = 'new-scope-data';
+  refresh(); await settle();
+  for (const request of pendingReads.splice(0)) release(request);
+  await settle();
+  for (const request of old) release(request);
+  await settle();
+  check(text(surface.body).includes('new-scope-data') && !text(surface.body).includes('late-old-scope'), `${surface.route}: old scope response discarded`);
+
+  marker = 'older-overlap'; refresh(); await settle();
+  const earlier = pendingReads.splice(0);
+  marker = 'newer-overlap'; refresh(); await settle();
+  for (const request of pendingReads.splice(0)) release(request);
+  await settle();
+  for (const request of earlier) release(request);
+  await settle();
+  check(text(surface.body).includes('newer-overlap') && !text(surface.body).includes('older-overlap'), `${surface.route}: latest request wins`);
+
+  marker = 'late-before-roundtrip'; refresh(); await settle();
+  const roundtrip = pendingReads.splice(0);
+  setWorkspace('two'); setWorkspace('one');
+  for (const request of roundtrip) release(request);
+  await settle();
+  check(text(surface.body).includes('Loading') && !text(surface.body).includes('late-before-roundtrip'), `${surface.route}: A→B→A rejects old response`);
+  marker = 'newer-overlap'; refresh(); await settle();
+  for (const request of pendingReads.splice(0)) release(request);
+  await settle();
+  refresh(); await settle();
+  for (const request of pendingReads.splice(0)) request.reject(new TypeError('Fixture refresh failure'));
+  await settle();
+  check(text(surface.body).includes('stale data') && text(surface.body).includes('newer-overlap'), `${surface.route}: refresh failure retains labeled stale data`);
+  check(busy(surface.body) === 'false', `${surface.route}: failure clears busy`);
+  setWorkspace('two'); refresh(); await settle();
+  for (const request of pendingReads.splice(0)) request.reject(new TypeError('Fixture cold failure'));
+  await settle();
+  check(text(surface.body).includes('Unable to load') && !text(surface.body).includes(surface.emptyText), `${surface.route}: cold error differs from empty`);
+  refresh(); await settle();
+  for (const request of pendingReads.splice(0)) release(request, surface.empty);
+  await settle();
+  check(text(surface.body).includes(surface.emptyText) && !text(surface.body).includes('Unable to load'), `${surface.route}: empty success recovers`);
+}
+heldPath = null;
+metricsError = true;
+const priorSummaryReads = summaryReads;
+setActiveTab('diagnostics/metrics');
+await settle();
+check(text('diag-body').includes('Metrics fixture failure'), 'HTTP failure visible in Metrics panel');
+check(node('conn-status').className.includes('green') && !text('meta-text').includes('offline'), 'one HTTP panel error does not imply offline');
+check(summaryReads > priorSummaryReads && text('tile-events-value') === String(summaryReads), 'audit summary renders updated data independently of failed panel');
+networkDown = true;
+refresh(); await settle();
+check(node('conn-status').className.includes('red') && text('meta-text').includes('offline'), 'network outage reports offline');
+networkDown = false;
+metricsError = false;
+refresh(); await settle();
+check(node('conn-status').className.includes('green'), 'connection recovers');
+const realTimeout = globalThis.setTimeout;
+globalThis.setTimeout = (fn, ms, ...args) => realTimeout(fn, ms === 30000 ? 1 : ms, ...args);
+globalThis.fetch = (_path, options) => new Promise((_resolve, reject) => {
+  options.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+});
+refresh(); await settle();
+check(busy('diag-body') === 'false' && text('diag-body').includes('timed out'), 'hung request times out and clears busy state');
+check(!node('refresh-btn').disabled, 'timeout leaves retry available');
+globalThis.setTimeout = realTimeout;
+globalThis.loadingTestsPassed = true;
+console.log('Dashboard loading, ordering, empty, error and recovery scenarios passed.');

--- a/crates/orbit-web/src/tests/dashboard_loading_browser.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading_browser.mjs
@@ -1,0 +1,68 @@
+// Usage: node dashboard_loading_browser.mjs /path/to/playwright/index.mjs /evidence/directory
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const { chromium } = await import(pathToFileURL(path.resolve(process.argv[2])).href);
+const evidence = path.resolve(process.argv[3]);
+fs.mkdirSync(evidence, { recursive: true });
+const assets = fileURLToPath(new URL('../../assets/dashboard/', import.meta.url));
+const scenarios = fileURLToPath(new URL('./dashboard_loading.mjs', import.meta.url));
+const server = http.createServer((req, res) => {
+  const name = new URL(req.url, 'http://fixture').pathname;
+  const file = name === '/test.mjs' ? scenarios : path.join(assets, name === '/' ? 'index.html' : path.basename(name));
+  if (!fs.existsSync(file)) { res.writeHead(404); res.end(); return; }
+  let data = fs.readFileSync(file);
+  if (name === '/') data = data.toString().replace(/<script[^>]*src="[^"]*app.js"[^>]*><\/script>/g, '');
+  res.setHeader('content-type', file.endsWith('.html') ? 'text/html' : file.endsWith('.css') ? 'text/css' : 'text/javascript');
+  res.end(data);
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+let browser;
+try {
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const failures = [];
+  page.on('pageerror', error => failures.push(error.message));
+  await page.goto(`http://127.0.0.1:${server.address().port}/?workspace=one#tasks`);
+  await page.evaluate(() => {
+    globalThis.nativeFetch = globalThis.fetch;
+    globalThis.setInterval = () => 0;
+    globalThis.EventSource = class { close() {} };
+  });
+  await page.addScriptTag({ type: 'module', url: '/test.mjs' });
+  await page.waitForFunction(() => globalThis.loadingTestsPassed, undefined, { timeout: 15000 }).catch(error => {
+    throw new Error(`${error.message}\nPage errors: ${failures.join('\n')}`);
+  });
+  if (failures.length) throw new Error(failures.join('\n'));
+  // Hold a real visible panel in refresh, then inspect its rendered accessible
+  // feedback and retry affordance at desktop and narrow widths.
+  await page.evaluate(() => {
+    globalThis.fetch = (_path, options) => new Promise((_resolve, reject) => {
+      options?.signal?.addEventListener('abort', () => reject(new DOMException('Timed out', 'AbortError')));
+    });
+    document.getElementById('refresh-btn').click();
+  });
+  for (const width of [1280, 390]) {
+    await page.setViewportSize({ width, height: 900 });
+    const feedback = page.locator('#diag-body [role="status"]');
+    if (!(await feedback.isVisible())) throw new Error(`Refresh feedback invisible at ${width}px`);
+    if (!(await feedback.textContent()).includes('Refreshing')) throw new Error('Missing retained-data feedback');
+    if (await feedback.getAttribute('aria-live') !== 'polite') throw new Error('Missing accessible live feedback');
+    if (!(await page.locator('#refresh-btn').isEnabled())) throw new Error('Retry disabled');
+    await page.screenshot({ path: path.join(evidence, `refresh-${width}.png`) });
+  }
+  await new Promise(resolve => server.close(resolve));
+  await page.evaluate(() => {
+    globalThis.fetch = globalThis.nativeFetch;
+    document.getElementById('refresh-btn').click();
+  });
+  await page.waitForFunction(() => document.getElementById('meta-text').textContent.includes('offline'));
+  if (!(await page.locator('#conn-status').getAttribute('class')).includes('red')) throw new Error('Stopped server must show red connection status');
+  fs.writeFileSync(path.join(evidence, 'result.json'), JSON.stringify({ passed: true, scenarios: 'Tasks, Recent runs, Errors, Operations: cold, stale refresh, scope changes, reordered responses, empty success, network error; Metrics HTTP failure isolation and network offline/recovery; visible live feedback at 1280px and 390px' }, null, 2));
+  console.log('Chromium dashboard lifecycle and accessible visible feedback passed.');
+} finally {
+  await browser?.close();
+  if (server.listening) await new Promise(resolve => server.close(resolve));
+}

--- a/crates/orbit-web/src/tests/dashboard_loading_dom.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading_dom.mjs
@@ -1,0 +1,135 @@
+// DOM adapter for the existing shipped-module Node harness.
+class Node {
+  constructor(id = "") {
+    this.id = id;
+    this.children = [];
+    this.dataset = {};
+    this.style = { setProperty: () => {}, display: "" };
+    this.listeners = {};
+    this.className = "";
+    this._text = "";
+    this.parentNode = null;
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.offsetWidth = 40;
+    this.offsetLeft = 0;
+  }
+  appendChild(child) {
+    if (child == null) return child;
+    if (child.parentNode) child.parentNode.removeChild(child);
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+  append(...children) { for (const child of children) this.appendChild(child); }
+  insertBefore(child, before) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const index = this.children.indexOf(before);
+    if (index < 0) return this.appendChild(child);
+    this.children.splice(index, 0, child);
+    child.parentNode = this;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((candidate) => candidate !== child);
+    child.parentNode = null;
+    return child;
+  }
+  prepend(child) { this.children.unshift(child); child.parentNode = this; return child; }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this._text = String(value); this.children = []; }
+  get innerHTML() { return this.textContent; }
+  get firstChild() { return this.children[0] || null; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+  querySelectorAll() { return []; }
+  querySelector() { return null; }
+  scrollIntoView() {}
+  get classList() {
+    const self = this;
+    const tokens = () => self.className.split(/\s+/).filter(Boolean);
+    const add = (...names) => { self.className = [...new Set([...tokens(), ...names])].join(" "); };
+    const remove = (...names) => {
+      const drop = new Set(names);
+      self.className = tokens().filter((token) => !drop.has(token)).join(" ");
+    };
+    return {
+      add,
+      remove,
+      contains: (name) => tokens().includes(name),
+      toggle: (name, on) => {
+        if (on === undefined) on = !tokens().includes(name);
+        if (on) add(name); else remove(name);
+      },
+    };
+  }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+const tabs = ["tasks", "audit", "diagnostics", "operations", "knowledge"].map((tab) => Object.assign(new Node(), { dataset: { tab } }));
+const panes = [...tabs, Object.assign(new Node(), { dataset: { tab: "run-detail" } })];
+const tabsStrip = new Node("tabs");
+tabsStrip.className = "tabs";
+const wrap = get("global-id-wrap");
+wrap.className = "global-id-wrap";
+wrap.appendChild(get("global-task-id"));
+wrap.appendChild(get("global-task-id-error"));
+globalThis.document = {
+  body: new Node("body"),
+  hidden: false,
+  getElementById: get,
+  createElement: () => new Node(),
+  createElementNS: () => new Node(),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+  createDocumentFragment: () => new Node(),
+  querySelectorAll: (selector) => {
+    if (selector === ".tab") return tabs;
+    if (selector === ".tab-pane") return panes;
+    if (selector === "#task-filter .chip") return get("task-filter").children;
+    if (selector === "#tasks-body .row") return get("tasks-body").children.filter((node) => String(node.className).includes("row"));
+    return [];
+  },
+  querySelector: (selector) => {
+    if (selector === ".tabs") return tabsStrip;
+    const tabMatch = /^\.tab\[data-tab="([^"]+)"\]$/.exec(selector || "");
+    if (tabMatch) return tabs.find((tab) => tab.dataset.tab === tabMatch[1]) || null;
+    return new Node();
+  },
+  addEventListener: () => {},
+};
+const location = new URL("http://dashboard.test/?workspace=one");
+location.hash = "#tasks";
+const hashListeners = [];
+globalThis.window = {
+  location,
+  innerHeight: 900,
+  addEventListener: (name, fn) => { if (name === "hashchange") hashListeners.push(fn); },
+  matchMedia: () => ({ addEventListener: () => {}, matches: false }),
+  localStorage: { getItem: () => null, setItem: () => {} },
+};
+Object.defineProperty(globalThis.window, "location", {
+  configurable: true,
+  get: () => location,
+  set: () => {},
+});
+Object.defineProperty(location, "hash", {
+  configurable: true,
+  get() { return this._hash || ""; },
+  set(value) {
+    const next = String(value || "");
+    const normalized = next.startsWith("#") ? next : `#${next}`;
+    if (this._hash === normalized) return;
+    this._hash = normalized;
+    for (const fn of hashListeners) fn();
+  },
+});
+location._hash = "#tasks";
+globalThis.history = { replaceState: (_, __, url) => { const next = new URL(String(url), location.href); location.search = next.search; location.pathname = next.pathname; } };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.requestAnimationFrame = (fn) => fn();
+globalThis.setInterval = () => 0;
+globalThis.EventSource = class { constructor() {} close() {} };
+


### PR DESCRIPTION
## Task

[ORB-11562](https://orbit-cli.com/tasks/ORB-11562) — Distinguish dashboard loading and stale data from empty results

### Description

## Problem
Navigating to Recent runs first rendered No job runs yet and 0/0 before live runs loaded. Errors first rendered No entries this month before filling 50 entries. Switching workspace briefly displayed the previous workspace's task list/counts under the newly selected workspace. The sidebar fetching indicator did not make these content states unambiguous.

Observed in a read-only browser audit on 2026-09-07 around 14:00 America/Los_Angeles at http://localhost:7878 with workspace=ws_orbit (Linux host hm_9ca6004473492f06). Deployed revision was not established; revalidate the served binary/assets and trace introducing code before assigning regression provenance. No production mutations were exercised.

## Scope
Give affected panels explicit loading/refresh/error/empty states and prevent old workspace results from appearing current. Keep prior data during same-scope refresh only with clear stale/refresh status. This task owns shared loading semantics; separate tasks own lookup and failed-filter correctness.

### Acceptance Criteria

- Cold navigation displays loading rather than no-data claims; only a completed successful empty response produces an empty state.
- Workspace changes do not show old data as belonging to the new selection, and late responses cannot overwrite newer scope selections.
- Refresh distinguishes retained stale data, successful update and failure without disabling the UI indefinitely.
- Delayed and reordered response tests cover Tasks, Recent runs, Errors and Operations, including empty success and network error; browser validation confirms accessible visible feedback.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a shared panel request lifecycle with visible, sticky live-status feedback for loading, retained-data refresh, update success, and cold/refresh failures. Read requests time out after 30 seconds; Refresh stays usable.
- Tasks, Recent Runs, diagnostics (Errors/Metrics/Incidents and their independently rendered summary), Operations panels, audit summary, frictions and task locks use guarded panel requests. Workspace revisions and request identity reject late responses, including A→B→A and overlapping requests. Workspace changes clear caches, counts and pinned task details synchronously.
- HTTP/JSON errors remain panel failures; transport failures mark the rail offline. One Metrics HTTP 500 leaves the connection green and the audit summary updates.
- Added shared full-app scenarios in dashboard_loading.mjs, a DOM adapter for the existing Rust/Node harness, and a Chromium runner using the actual checkout markup/styles/modules. Updated affected source-shape assertions to tolerate the shared request helper while retaining endpoint contracts and behavioral coverage.
Acceptance evidence:
1. All four primary surfaces display Loading with busy/live status before response; only successful empty responses display empty states. Tests cover cold errors and retry recovery.
2. Tests cover synchronous workspace clearing, late old-scope responses, same-scope overlapping requests and A→B→A invalidation for Tasks, Runs, Errors and Operations.
3. Tests cover retained prior content labeled Refreshing, stale-data failure, Updated success, accessible retry, and abort-driven timeout recovery.
4. All scenarios passed in Node and Linux Chromium. Browser checks verify visible role=status/aria-live feedback for each primary surface, desktop/narrow feedback at 1280px and 390px, Metrics-only HTTP 500 isolation with an updated rendered summary value, and red/offline after stopping the actual fixture HTTP server.

Validation:
- PASSED: CARGO_TARGET_DIR=/tmp/orbit-build/jrun-20260908-0109-3 cargo test -p orbit-web --lib dashboard — 58 passed, 0 failed.
- PASSED: make ci-fast — formatting and repository guardrails.
- PASSED: CARGO_TARGET_DIR=/tmp/orbit-build/jrun-20260908-0109-3 make ci-lint — workspace/all-target clippy with warnings denied.
- PASSED: LD_LIBRARY_PATH=/tmp/orb-11562-libs/usr/lib/x86_64-linux-gnu PLAYWRIGHT_BROWSERS_PATH=/tmp/orb-11562-browsers node crates/orbit-web/src/tests/dashboard_loading_browser.mjs /tmp/orb-11562-browser/node_modules/playwright/index.mjs /tmp/orb-11562-browser-evidence
- EXPECTED FAILURE: the new Node scenarios against starting HEAD 89a760e9b11ea672aff62022591f012945230b22 fail at “cold Tasks must visibly load”, demonstrating regression detection.
- PASSED: git diff --check and final git status --short. Whole patch reviewed; nine modified tracked files and three new scoped test files, no incidental build/cache files.
- NOT RUN: make ci, per workspace policy reserving that full gate for PR CI. ci-fast reports Cursor headless unavailable while validating the supported local plugin contract; that optional check is not represented as browser validation.

Assessment: Deliverable complete and uncommitted. Starting checkout was clean and pwd/git top-level matched both supplied roots; HEAD remains unchanged. Added tasks.js to context for cache-render/pinned-detail guards and the existing sibling tests directory for reusable behavioral/browser fixtures. No dependency edges, persisted application artifacts, CHANGELOG edits or delivery transitions.
Environment/limits: Initial npm installation failed with EROFS on ~/.npm/_cacache/CACHEDIR.TAG; retried using an isolated /tmp npm cache successfully. Initial Chromium launch failed for missing libatk and related libraries; downloaded/extracted runtime packages under /tmp and the browser checks then passed. No global packages or production mutations. Browser fixtures serve this checkout's exact assets, not the previously audited deployed binary; regression provenance is not assigned. Live-region attributes/visibility were checked in Chromium, not with a physical screen reader. Build outputs and test logs/screenshots remain outside the patch under /tmp.
Friction checkpoint: considered; no qualifying recurring failure or non-obvious gotcha exceeded the filing threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11562-6a9f603e`
- Behind base: 0
- Ahead of base: 1