### PR TITLE
[code-review] Do not run companion inference inside the SQLite write transaction / store mutex

### DIFF
--- a/crates/orbit-search/src/vector/store/tests/upsert.rs
+++ b/crates/orbit-search/src/vector/store/tests/upsert.rs
@@ -1,7 +1,17 @@
 //! Unit tests for `upsert` — sibling layout under store/tests/.
 
-use crate::NoopEmbedder;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Barrier, mpsc};
+use std::thread;
+use std::time::Duration;
+
+use orbit_common::OrbitError;
+
+use crate::vector::query::cosine_top_k;
 use crate::vector::{EmbeddingField, VectorStore};
+use crate::{Embedder, NoopEmbedder};
+
+const UNBLOCKED_WAIT: Duration = Duration::from_secs(5);
 
 #[test]
 fn upsert_embeddings_skips_unchanged_content_hashes() {
@@ -19,4 +29,399 @@ fn upsert_embeddings_skips_unchanged_content_hashes() {
     assert_eq!(first.embedded_chunks, 1);
     assert_eq!(second.embedded_chunks, 0);
     assert_eq!(second.skipped_fields, 1);
+}
+
+#[test]
+fn upsert_drops_fields_absent_from_the_complete_set_without_reembedding() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let embedder = NoopEmbedder::small();
+    store
+        .upsert_embeddings(
+            "task",
+            "T1",
+            &[
+                EmbeddingField::new("title", "keep me"),
+                EmbeddingField::new("extra", "drop me"),
+            ],
+            &embedder,
+            false,
+        )
+        .unwrap();
+
+    let report = store
+        .upsert_embeddings(
+            "task",
+            "T1",
+            &[EmbeddingField::new("title", "keep me")],
+            &embedder,
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(report.embedded_chunks, 0);
+    assert_eq!(report.skipped_fields, 1);
+    assert_eq!(
+        field_contents(&store, "T1"),
+        BTreeMap::from([("title".to_string(), "keep me".to_string())])
+    );
+}
+
+#[test]
+fn failed_embedding_leaves_previously_committed_source_including_fields_scheduled_for_removal() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let embedder = NoopEmbedder::small();
+    store
+        .upsert_embeddings(
+            "task",
+            "T1",
+            &[
+                EmbeddingField::new("title", "original title"),
+                EmbeddingField::new("extra", "must survive"),
+            ],
+            &embedder,
+            false,
+        )
+        .unwrap();
+
+    let error = store
+        .upsert_embeddings(
+            "task",
+            "T1",
+            &[EmbeddingField::new("title", "replacement that will fail")],
+            &FailingEmbedder {
+                inner: NoopEmbedder::small(),
+            },
+            false,
+        )
+        .expect_err("embed failure should abort before any write");
+
+    assert!(
+        error.to_string().contains("forced embed failure"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        field_contents(&store, "T1"),
+        BTreeMap::from([
+            ("title".to_string(), "original title".to_string()),
+            ("extra".to_string(), "must survive".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn inference_does_not_hold_store_mutex_or_sqlite_write_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("semantic.db");
+    let store = VectorStore::open(&path).unwrap();
+    let noop = NoopEmbedder::small();
+    store
+        .upsert_embeddings(
+            "task",
+            "VISIBLE",
+            &[EmbeddingField::new("purpose", "beta")],
+            &noop,
+            false,
+        )
+        .unwrap();
+    store
+        .upsert_embeddings(
+            "task",
+            "SLOW",
+            &[EmbeddingField::new("purpose", "old slow")],
+            &noop,
+            false,
+        )
+        .unwrap();
+
+    let started = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let embedder = BarrierEmbedder {
+        inner: noop.clone(),
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    };
+
+    let store_for_upsert = store.clone();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = store_for_upsert.upsert_embeddings(
+            "task",
+            "SLOW",
+            &[EmbeddingField::new("purpose", "new slow")],
+            &embedder,
+            false,
+        );
+        done_tx
+            .send(result.map(|report| report.embedded_chunks))
+            .unwrap();
+    });
+    wait_until_inference_started(&started);
+
+    let query = noop.embed(&["beta"]).unwrap().remove(0);
+    let store_for_query = store.clone();
+    let hits = run_unblocked("query on shared store", move || {
+        cosine_top_k(&store_for_query, &query, noop.model_id(), 3, Some("task"))
+    });
+    assert!(
+        hits.iter().any(|hit| hit.source_id == "VISIBLE"),
+        "shared-store query should see the already-committed source: {hits:?}"
+    );
+
+    let path_for_second = path.clone();
+    run_unblocked("unrelated write on second connection", move || {
+        let second = VectorStore::open(&path_for_second).unwrap();
+        second.upsert_embeddings(
+            "task",
+            "OTHER",
+            &[EmbeddingField::new("purpose", "unrelated")],
+            &NoopEmbedder::small(),
+            false,
+        )
+    });
+
+    release.wait();
+    let embedded = done_rx
+        .recv_timeout(UNBLOCKED_WAIT)
+        .expect("paused upsert should finish after release")
+        .expect("paused upsert should commit");
+    assert_eq!(embedded, 1);
+    assert_eq!(
+        field_contents(&store, "OTHER"),
+        BTreeMap::from([("purpose".to_string(), "unrelated".to_string())])
+    );
+}
+
+#[test]
+fn concurrent_same_source_replacement_keeps_the_first_committed_complete_set() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let noop = NoopEmbedder::small();
+    store
+        .upsert_embeddings(
+            "task",
+            "S1",
+            &[
+                EmbeddingField::new("title", "keep"),
+                EmbeddingField::new("body", "old"),
+                EmbeddingField::new("extra", "remove-me"),
+            ],
+            &noop,
+            false,
+        )
+        .unwrap();
+
+    let started = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let embedder = BarrierEmbedder {
+        inner: noop.clone(),
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    };
+
+    let store_for_stale = store.clone();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = store_for_stale.upsert_embeddings(
+            "task",
+            "S1",
+            &[
+                EmbeddingField::new("title", "keep"),
+                EmbeddingField::new("body", "stale replacement"),
+            ],
+            &embedder,
+            false,
+        );
+        done_tx
+            .send(result.err().map(|error| error.to_string()))
+            .unwrap();
+    });
+    wait_until_inference_started(&started);
+
+    store
+        .upsert_embeddings(
+            "task",
+            "S1",
+            &[
+                EmbeddingField::new("title", "newer"),
+                EmbeddingField::new("body", "old"),
+            ],
+            &noop,
+            false,
+        )
+        .unwrap();
+
+    release.wait();
+    let error = done_rx
+        .recv_timeout(UNBLOCKED_WAIT)
+        .expect("stale upsert should finish after release")
+        .expect("stale upsert should abort");
+    assert!(
+        error.contains("changed during embedding"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        field_contents(&store, "S1"),
+        BTreeMap::from([
+            ("title".to_string(), "newer".to_string()),
+            ("body".to_string(), "old".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn concurrent_same_source_delete_is_not_resurrected_by_in_flight_upsert() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let noop = NoopEmbedder::small();
+    store
+        .upsert_embeddings(
+            "task",
+            "S1",
+            &[EmbeddingField::new("purpose", "doomed")],
+            &noop,
+            false,
+        )
+        .unwrap();
+
+    let started = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let embedder = BarrierEmbedder {
+        inner: noop,
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    };
+
+    let store_for_stale = store.clone();
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let result = store_for_stale.upsert_embeddings(
+            "task",
+            "S1",
+            &[EmbeddingField::new("purpose", "should not resurrect")],
+            &embedder,
+            false,
+        );
+        done_tx
+            .send(result.err().map(|error| error.to_string()))
+            .unwrap();
+    });
+    wait_until_inference_started(&started);
+
+    store.delete_source("task", "S1").unwrap();
+
+    release.wait();
+    let error = done_rx
+        .recv_timeout(UNBLOCKED_WAIT)
+        .expect("stale upsert should finish after release")
+        .expect("stale upsert should abort");
+    assert!(
+        error.contains("changed during embedding"),
+        "unexpected error: {error}"
+    );
+    assert!(field_contents(&store, "S1").is_empty());
+}
+
+fn field_contents(store: &VectorStore, source_id: &str) -> BTreeMap<String, String> {
+    let conn = store.connection();
+    let conn = conn.lock().unwrap();
+    let mut stmt = conn
+        .prepare(
+            r#"
+                SELECT field, content
+                FROM chunks
+                WHERE source_kind = 'task' AND source_id = ?1
+                ORDER BY field, chunk_idx
+            "#,
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([source_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap();
+    let mut fields = BTreeMap::new();
+    for row in rows {
+        let (field, content) = row.unwrap();
+        fields.insert(field, content);
+    }
+    fields
+}
+
+fn wait_until_inference_started(started: &Arc<Barrier>) {
+    let started = Arc::clone(started);
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        started.wait();
+        tx.send(()).unwrap();
+    });
+    rx.recv_timeout(UNBLOCKED_WAIT)
+        .expect("inference should start without holding the store mutex");
+}
+
+fn run_unblocked<T, F>(label: &str, work: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, OrbitError> + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(work()).unwrap();
+    });
+    rx.recv_timeout(UNBLOCKED_WAIT)
+        .unwrap_or_else(|_| panic!("{label} blocked while inference was paused"))
+        .unwrap_or_else(|error| panic!("{label} failed: {error}"))
+}
+
+struct BarrierEmbedder {
+    inner: NoopEmbedder,
+    started: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl Embedder for BarrierEmbedder {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    fn max_input_tokens(&self) -> usize {
+        self.inner.max_input_tokens()
+    }
+
+    fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+        self.started.wait();
+        self.release.wait();
+        self.inner.embed(texts)
+    }
+
+    fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+        self.inner.token_count(text)
+    }
+}
+
+struct FailingEmbedder {
+    inner: NoopEmbedder,
+}
+
+impl Embedder for FailingEmbedder {
+    fn model_id(&self) -> &str {
+        self.inner.model_id()
+    }
+
+    fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    fn max_input_tokens(&self) -> usize {
+        self.inner.max_input_tokens()
+    }
+
+    fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+        Err(OrbitError::Execution("forced embed failure".into()))
+    }
+
+    fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+        self.inner.token_count(text)
+    }
 }

--- a/crates/orbit-search/src/vector/store/upsert.rs
+++ b/crates/orbit-search/src/vector/store/upsert.rs
@@ -1,16 +1,17 @@
 //! BLAKE3-deduped per-field write path.
 //!
-//! `upsert_embeddings` is the canonical entry: it transactionally chunks each
-//! field's text, embeds the chunks, and writes the resulting rows into both
-//! `embeddings` (vector storage) and `chunks` (the FTS5 content table, which
-//! its triggers mirror into `corpus_fts`). Unchanged fields short-circuit via
-//! `content_hash`.
+//! `upsert_embeddings` is the canonical entry: it snapshots the stored source,
+//! chunks and embeds changed fields with no store lock held, then writes the
+//! complete field set in one short transaction. Unchanged fields short-circuit
+//! via `content_hash`. Concurrent same-source writers follow the conflict
+//! policy documented on [`VectorStore::upsert_embeddings`].
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use chrono::Utc;
 use orbit_common::OrbitError;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, TransactionBehavior, params};
 
 use super::VectorStore;
 use crate::Embedder;
@@ -25,6 +26,21 @@ impl VectorStore {
     ///
     /// `fields` is the complete current field set, not a partial patch; rows
     /// for previously indexed fields absent from this slice are removed.
+    ///
+    /// Chunking and companion inference run **without** the connection mutex
+    /// or a SQLite write transaction. Only the snapshot and the final commit
+    /// take the mutex; the commit uses `BEGIN IMMEDIATE` so a second
+    /// connection cannot interleave mid-write.
+    ///
+    /// # Concurrency
+    ///
+    /// The first complete same-source write (another `upsert_embeddings` or
+    /// `delete_source`) that commits after this call's snapshot wins. Commit
+    /// reloads the source's field names and active-model content hashes and
+    /// aborts with [`OrbitError::Store`] unless that fingerprint is unchanged.
+    /// The abort does not write, so it cannot mix field revisions, overwrite a
+    /// later accepted source, or resurrect a deleted source. A hash recheck of
+    /// only the fields this call prepared is not the commit gate.
     pub fn upsert_embeddings(
         &self,
         source_kind: &str,
@@ -33,50 +49,73 @@ impl VectorStore {
         embedder: &dyn Embedder,
         force: bool,
     ) -> Result<UpsertReport, OrbitError> {
-        let mut report = UpsertReport::default();
-        let conn = self.connection();
-        let mut conn = conn
-            .lock()
-            .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
-        let tx = conn
-            .transaction()
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let snapshot = {
+            let conn = self.connection();
+            let conn = lock_connection(&conn)?;
+            StoredSource::load(&conn, source_kind, source_id, embedder.model_id())?
+        };
 
-        let stored = StoredSource::load(&tx, source_kind, source_id, embedder.model_id())?;
         let expected_fields = fields
             .iter()
             .map(|field| field.field.as_str())
             .collect::<BTreeSet<_>>();
-        for field in stored.fields_outside(&expected_fields) {
-            delete_field_rows(&tx, source_kind, source_id, field, None)?;
-        }
+        let stale_fields = snapshot
+            .fields_outside(&expected_fields)
+            .map(str::to_string)
+            .collect::<Vec<_>>();
 
+        let mut report = UpsertReport::default();
+        let mut empty_fields = Vec::new();
+        let mut prepared = Vec::new();
         for field in fields {
             if field.text.trim().is_empty() {
-                delete_field_rows(
-                    &tx,
-                    source_kind,
-                    source_id,
-                    &field.field,
-                    Some(embedder.model_id()),
-                )?;
+                empty_fields.push(field.field.as_str());
                 continue;
             }
             let field_hash = content_hash(&field.text);
-            if !force && stored.content_hash_matches(&field.field, &field_hash) {
+            if !force && snapshot.content_hash_matches(&field.field, &field_hash) {
                 report.skipped_fields += 1;
                 continue;
             }
+            prepared.push(prepare_field_chunks(field, &field_hash, embedder)?);
+        }
 
+        if prepared.is_empty() && empty_fields.is_empty() && stale_fields.is_empty() {
+            return Ok(report);
+        }
+
+        let conn = self.connection();
+        let mut conn = lock_connection(&conn)?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        let current = StoredSource::load(&tx, source_kind, source_id, embedder.model_id())?;
+        if current != snapshot {
+            return Err(source_changed_during_embed(source_kind, source_id));
+        }
+
+        for field in &stale_fields {
+            delete_field_rows(&tx, source_kind, source_id, field, None)?;
+        }
+        for field in empty_fields {
             delete_field_rows(
                 &tx,
                 source_kind,
                 source_id,
-                &field.field,
+                field,
+                Some(embedder.model_id()),
+            )?;
+        }
+        for field in &prepared {
+            delete_field_rows(
+                &tx,
+                source_kind,
+                source_id,
+                &field.name,
                 Some(embedder.model_id()),
             )?;
             report.embedded_chunks +=
-                write_field_chunks(&tx, source_kind, source_id, field, &field_hash, embedder)?;
+                insert_field_chunks(&tx, source_kind, source_id, field, embedder)?;
         }
 
         tx.commit()
@@ -85,16 +124,25 @@ impl VectorStore {
     }
 }
 
-/// Chunk, embed and store one field's text, returning the number of chunks
-/// written. The caller has already removed the field's previous rows.
-fn write_field_chunks(
-    conn: &Connection,
-    source_kind: &str,
-    source_id: &str,
+fn lock_connection(
+    conn: &Arc<Mutex<Connection>>,
+) -> Result<MutexGuard<'_, Connection>, OrbitError> {
+    conn.lock()
+        .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))
+}
+
+fn source_changed_during_embed(source_kind: &str, source_id: &str) -> OrbitError {
+    OrbitError::Store(format!(
+        "source {source_kind}:{source_id} changed during embedding; upsert aborted"
+    ))
+}
+
+/// Chunk and embed one field's text with no store access.
+fn prepare_field_chunks(
     field: &EmbeddingField,
     field_hash: &str,
     embedder: &dyn Embedder,
-) -> Result<usize, OrbitError> {
+) -> Result<PreparedField, OrbitError> {
     let chunks = chunk_text(
         &field.text,
         embedder,
@@ -110,8 +158,7 @@ fn write_field_chunks(
             chunks.len()
         )));
     }
-
-    for (idx, (chunk, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
+    for vector in &vectors {
         if vector.len() != embedder.dim() {
             return Err(OrbitError::Execution(format!(
                 "embedder returned dim {} but advertised {}",
@@ -119,6 +166,32 @@ fn write_field_chunks(
                 embedder.dim()
             )));
         }
+    }
+    Ok(PreparedField {
+        name: field.field.clone(),
+        hash: field_hash.to_string(),
+        chunks,
+        vectors,
+    })
+}
+
+struct PreparedField {
+    name: String,
+    hash: String,
+    chunks: Vec<String>,
+    vectors: Vec<Vec<f32>>,
+}
+
+/// Store one already-embedded field. The caller has already removed the
+/// field's previous rows.
+fn insert_field_chunks(
+    conn: &Connection,
+    source_kind: &str,
+    source_id: &str,
+    field: &PreparedField,
+    embedder: &dyn Embedder,
+) -> Result<usize, OrbitError> {
+    for (idx, (chunk, vector)) in field.chunks.iter().zip(field.vectors.iter()).enumerate() {
         conn.prepare_cached(
             r#"
                 INSERT INTO embeddings(
@@ -138,9 +211,9 @@ fn write_field_chunks(
         .execute(params![
             source_kind,
             source_id,
-            field.field,
+            field.name,
             idx as i64,
-            field_hash,
+            field.hash,
             embedder.model_id(),
             embedder.dim() as i64,
             encode_f32_blob(vector),
@@ -159,13 +232,13 @@ fn write_field_chunks(
         .execute(params![
             source_kind,
             source_id,
-            field.field,
+            field.name,
             idx as i64,
             chunk
         ])
         .map_err(|error| OrbitError::Store(error.to_string()))?;
     }
-    Ok(chunks.len())
+    Ok(field.chunks.len())
 }
 
 /// What one source already has indexed, read once per `upsert_embeddings`.
@@ -175,6 +248,7 @@ fn write_field_chunks(
 /// nothing changed — asks these questions for every source; the
 /// pre-[ORB-11695] layout answered them with a scan of the whole corpus, which
 /// made a reindex quadratic in corpus size.
+#[derive(PartialEq, Eq)]
 struct StoredSource {
     /// Fields with rows in `embeddings` (under any model) or in `chunks`. The
     /// two can differ: the legacy FTS migration backfills chunk text for
@@ -232,6 +306,9 @@ impl StoredSource {
                     .push(content_hash);
             }
             stored.fields.insert(field);
+        }
+        for hashes in stored.hashes.values_mut() {
+            hashes.sort();
         }
         Ok(stored)
     }

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -164,13 +164,17 @@ At 30k vectors × 384d, the full scan is ~50ms in pure Rust on a modern laptop a
 
 ### 3.3 Write path
 
-A single `upsert_embeddings` API takes `(source_kind, source_id, fields: Vec<(field, text)>)`. For each field:
+A single `upsert_embeddings` API takes `(source_kind, source_id, fields)` as the **complete** current field set (not a partial patch). Previously indexed fields absent from that set are removed.
 
-1. Compute `content_hash = BLAKE3(text)`.
-2. If a row already exists with the same `(source_kind, source_id, field, chunk_idx, model_id)` and matching `content_hash`, skip.
-3. Otherwise embed and upsert.
+The write is split so companion inference does not hold the store mutex or a SQLite write transaction:
+
+1. Brief mutex read: snapshot the source's field names and active-model `content_hash` values. Unchanged fields (`BLAKE3(text)` still matches) skip inference; empty fields are scheduled for deletion.
+2. Chunk and embed the remaining fields with no store lock held. A failed embed returns here, so the previously committed source is unchanged — including fields that would have been removed.
+3. Brief mutex + `BEGIN IMMEDIATE`: reload the source. If the snapshot fingerprint changed, abort with a store error and write nothing. Otherwise delete stale/empty fields and insert the prepared rows in that one transaction.
 
 This makes "reindex everything" idempotent and cheap when nothing has changed. Re-embedding only happens on real text changes or model changes.
+
+**Same-source concurrency.** The first complete write (`upsert_embeddings` or `delete_source`) that commits after a snapshot wins. An in-flight upsert whose snapshot no longer matches does not write: it cannot mix field revisions, overwrite a later accepted source, or resurrect a deleted source. A hash recheck of only the fields this call prepared is not the commit gate. Unrelated sources and readers are not blocked during inference (mutex released; WAL).
 
 ---
 


### PR DESCRIPTION
## Task

[ORB-11702](https://orbit-cli.com/tasks/ORB-11702) — [code-review] Do not run companion inference inside the SQLite write transaction / store mutex

### Description

## Problem
`upsert_embeddings` holds the shared connection mutex and transaction while chunking and invoking the companion. Deletes occur before inference, extending SQLite write-lock time and blocking in-process queries for inference duration.

## Required behavior and constraints
Prepare embeddings without holding the connection mutex or a SQLite write transaction, then commit the complete source field set atomically in a short transaction. Preserve unchanged-content skipping, field removal and error rollback. Define how concurrent same-source updates/deletes are ordered; a hash recheck alone must not silently overwrite a later accepted source state or resurrect a deleted source. Avoid per-field commits that expose mixed revisions.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-search/src/vector/store/upsert.rs:37,41,71,98,105`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Use a barrier-controlled embedder to pause inference and prove a query on the shared store and an unrelated write through a second connection can complete before inference is released.
- A failed embedding leaves the previously committed complete source unchanged, including fields scheduled for removal.
- Concurrent same-source replacement and deletion tests verify the documented ordering/conflict policy and no partial field set; existing upsert, dedup, docs and task tests pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `upsert_embeddings` snapshots the source under a brief mutex read, chunks/embeds with no store lock, then commits the complete field set in a short `BEGIN IMMEDIATE` transaction.
- Failed inference now returns before any delete/write, so the previously committed source (including fields scheduled for removal) is unchanged.
- Same-source concurrency: first complete write or `delete_source` after the snapshot wins; a stale in-flight upsert aborts with `OrbitError::Store` and does not mix revisions, overwrite a later accepted source, or resurrect a deleted source.
- Tests cover barrier-paused inference (shared-store query + second-connection unrelated write), failed-embed rollback, concurrent replacement, and concurrent delete.
- `docs/design/orbit-search/2_design.md` §3.3 updated to match the write path and conflict policy.
- Context files appended: `file:crates/orbit-search/src/vector/store/tests/upsert.rs`, `file:docs/design/orbit-search/2_design.md`.
Assessment: Scoped to the vector-store write path; skip/dedup and field-removal behavior preserved. Conflict policy is first-committer-wins at the store, which can drop a slower later job until the next reindex/mutation; EmbedWorker already logs upsert errors.

Criteria:
1. Barrier-controlled embedder: `inference_does_not_hold_store_mutex_or_sqlite_write_lock` pauses in `embed()`, then a cosine query on the shared store and an unrelated upsert through a second `VectorStore::open` on the same WAL file both finish before release. Passed.
2. Failed embedding leaves the committed source unchanged, including fields scheduled for removal: `failed_embedding_leaves_previously_committed_source_including_fields_scheduled_for_removal`. Passed.
3. Concurrent same-source replacement/deletion match the documented policy with no partial field set; existing upsert, dedup, docs, and task tests pass. Passed (`concurrent_same_source_replacement_keeps_the_first_committed_complete_set`, `concurrent_same_source_delete_is_not_resurrected_by_in_flight_upsert`, plus store docs/tasks/queries/upsert tests).

Validation:
- `cargo test -p orbit-search --lib vector::store::tests -- --test-threads=1`: passed (20 tests, including new upsert cases and docs/tasks/queries/dedup).
- `cargo test -p orbit-search --lib vector::query::tests -- --test-threads=1`: passed (10 tests).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.

Remaining risks: an in-flight upsert of newer application text that loses the race aborts rather than overwriting; recovery is the next index job. Uncommitted local changes only; pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11702-6a9f614d`
- Behind base: 0
- Ahead of base: 1