### PR TITLE
[code-review] Reduce repeated tokenizer RPCs during long-paragraph chunking

### DIFF
--- a/crates/orbit-search/src/bin/orbit-search-companion.rs
+++ b/crates/orbit-search/src/bin/orbit-search-companion.rs
@@ -94,6 +94,21 @@ impl FastembedServer {
                 },
                 Err(error) => error_response(id, "token_count_failed", error.to_string()),
             },
+            RpcRequest::TokenBoundaries { text, .. } => {
+                match self.model.tokenizer.encode(text, true) {
+                    Ok(encoding) => RpcResponse::Result {
+                        id,
+                        result: RpcResult::TokenBoundaries {
+                            ends: encoding
+                                .get_offsets()
+                                .iter()
+                                .filter_map(|(start, end)| (end > start).then_some(*end))
+                                .collect(),
+                        },
+                    },
+                    Err(error) => error_response(id, "token_boundaries_failed", error.to_string()),
+                }
+            }
             RpcRequest::Exit { .. } => RpcResponse::Result {
                 id,
                 result: RpcResult::Exit { ok: true },

--- a/crates/orbit-search/src/commands/tests/doc_search.rs
+++ b/crates/orbit-search/src/commands/tests/doc_search.rs
@@ -37,6 +37,14 @@ impl Embedder for KeywordEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         Ok(text.split_whitespace().count().max(1))
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(text
+            .match_indices(char::is_whitespace)
+            .map(|(index, _)| index)
+            .chain(std::iter::once(text.len()))
+            .collect())
+    }
 }
 
 fn doc(path: &str, body: &str) -> DocEmbeddingSource {

--- a/crates/orbit-search/src/commands/tests/related.rs
+++ b/crates/orbit-search/src/commands/tests/related.rs
@@ -32,6 +32,14 @@ impl Embedder for KeywordEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         Ok(text.split_whitespace().count().max(1))
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(text
+            .match_indices(char::is_whitespace)
+            .map(|(index, _)| index)
+            .chain(std::iter::once(text.len()))
+            .collect())
+    }
 }
 
 fn vector_for(text: &str) -> Vec<f32> {

--- a/crates/orbit-search/src/commands/tests/search.rs
+++ b/crates/orbit-search/src/commands/tests/search.rs
@@ -32,6 +32,14 @@ impl Embedder for KeywordEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         Ok(text.split_whitespace().count().max(1))
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(text
+            .match_indices(char::is_whitespace)
+            .map(|(index, _)| index)
+            .chain(std::iter::once(text.len()))
+            .collect())
+    }
 }
 
 fn vector_for(text: &str) -> Vec<f32> {

--- a/crates/orbit-search/src/embedder.rs
+++ b/crates/orbit-search/src/embedder.rs
@@ -18,6 +18,14 @@ pub trait Embedder: Send + Sync {
     fn max_input_tokens(&self) -> usize;
     fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError>;
     fn token_count(&self, text: &str) -> Result<usize, OrbitError>;
+
+    /// Byte positions immediately after each model token in `text`.
+    ///
+    /// Chunking uses these positions to select likely boundaries without
+    /// treating independent token counts as additive. Callers still validate
+    /// every emitted chunk with `token_count` because model tokenization may
+    /// depend on the text surrounding a boundary.
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/orbit-search/src/noop.rs
+++ b/crates/orbit-search/src/noop.rs
@@ -56,6 +56,30 @@ impl Embedder for NoopEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         Ok(text.split_whitespace().count().max(1))
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(word_ends(text))
+    }
+}
+
+fn word_ends(text: &str) -> Vec<usize> {
+    let mut ends = Vec::new();
+    let mut in_word = false;
+
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            if in_word {
+                ends.push(index);
+                in_word = false;
+            }
+        } else {
+            in_word = true;
+        }
+    }
+    if in_word {
+        ends.push(text.len());
+    }
+    ends
 }
 
 fn noop_vector(text: &str, dim: usize) -> Vec<f32> {

--- a/crates/orbit-search/src/rpc.rs
+++ b/crates/orbit-search/src/rpc.rs
@@ -1,6 +1,7 @@
 //! JSON-Lines RPC envelope shared between the orbit binary and the
 //! `orbit-search-companion` subprocess. The protocol is deliberately small:
-//! `info`, `embed`, `token_count`, `exit`. Both sides serialize via serde.
+//! `info`, `embed`, `token_count`, `token_boundaries`, `exit`. Both sides
+//! serialize via serde.
 
 use orbit_common::OrbitError;
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,7 @@ pub enum RpcRequest {
     Info { id: u64 },
     Embed { id: u64, texts: Vec<String> },
     TokenCount { id: u64, text: String },
+    TokenBoundaries { id: u64, text: String },
     Exit { id: u64 },
 }
 
@@ -20,6 +22,7 @@ impl RpcRequest {
             Self::Info { id }
             | Self::Embed { id, .. }
             | Self::TokenCount { id, .. }
+            | Self::TokenBoundaries { id, .. }
             | Self::Exit { id } => *id,
         }
     }
@@ -46,6 +49,9 @@ pub enum RpcResult {
     },
     TokenCount {
         tokens: usize,
+    },
+    TokenBoundaries {
+        ends: Vec<usize>,
     },
     Exit {
         ok: bool,

--- a/crates/orbit-search/src/subprocess.rs
+++ b/crates/orbit-search/src/subprocess.rs
@@ -197,6 +197,10 @@ impl SubprocessEmbedder {
                 id: self.next_request_id(),
                 text,
             },
+            RpcRequest::TokenBoundaries { text, .. } => RpcRequest::TokenBoundaries {
+                id: self.next_request_id(),
+                text,
+            },
             RpcRequest::Exit { .. } => RpcRequest::Exit {
                 id: self.next_request_id(),
             },
@@ -546,6 +550,19 @@ impl Embedder for SubprocessEmbedder {
             RpcResult::TokenCount { tokens } => Ok(tokens),
             _ => Err(OrbitError::AgentProtocolViolation(
                 "companion returned non-token_count response".to_string(),
+            )),
+        }
+    }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        let result = self.request(RpcRequest::TokenBoundaries {
+            id: 0,
+            text: text.to_string(),
+        })?;
+        match result {
+            RpcResult::TokenBoundaries { ends } => Ok(ends),
+            _ => Err(OrbitError::AgentProtocolViolation(
+                "companion returned non-token_boundaries response".to_string(),
             )),
         }
     }

--- a/crates/orbit-search/src/vector/chunker.rs
+++ b/crates/orbit-search/src/vector/chunker.rs
@@ -113,32 +113,99 @@ fn split_long_paragraph(
     target_tokens: usize,
     overlap_tokens: usize,
 ) -> Result<Vec<String>, OrbitError> {
-    let words = paragraph.split_whitespace().collect::<Vec<_>>();
+    let word_ends = word_ends(paragraph);
+    let token_ends = embedder.token_boundaries(paragraph)?;
     let mut chunks = Vec::new();
     let mut start = 0;
-    while start < words.len() {
-        let mut end = start + 1;
-        while end <= words.len() {
-            let candidate = words[start..end].join(" ");
-            if embedder.token_count(&candidate)? > target_tokens {
+    while start < word_ends.len() {
+        let mut end = preferred_chunk_end(start, &word_ends, &token_ends, target_tokens);
+
+        // Token offsets come from the full paragraph, while the model counts
+        // emitted chunks independently. Validate each candidate instead of
+        // assuming those counts are additive or monotone across word ranges.
+        while embedder.token_count(word_range(paragraph, start, end, &word_ends))? > target_tokens {
+            if end == start + 1 {
+                // A word that alone exceeds the limit is an unbreakable unit:
+                // emit it intact rather than lose text or stall forever.
                 break;
             }
-            end += 1;
+            end -= 1;
         }
-        let chunk_end = (end - 1).max(start + 1).min(words.len());
-        chunks.push(words[start..chunk_end].join(" "));
-        if chunk_end == words.len() {
+
+        let chunk = word_range(paragraph, start, end, &word_ends).to_string();
+        chunks.push(chunk);
+        if end == word_ends.len() {
             break;
         }
-        let mut overlap_start = chunk_end;
-        while overlap_start > start {
-            let candidate = words[overlap_start - 1..chunk_end].join(" ");
-            if embedder.token_count(&candidate)? > overlap_tokens {
-                break;
-            }
-            overlap_start -= 1;
-        }
-        start = overlap_start.max(start + 1);
+        start = overlap_start(paragraph, start, end, &word_ends, embedder, overlap_tokens)?;
     }
     Ok(chunks)
+}
+
+fn word_ends(text: &str) -> Vec<usize> {
+    let mut ends = Vec::new();
+    let mut in_word = false;
+
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            if in_word {
+                ends.push(index);
+                in_word = false;
+            }
+        } else {
+            in_word = true;
+        }
+    }
+    if in_word {
+        ends.push(text.len());
+    }
+    ends
+}
+
+fn preferred_chunk_end(
+    start: usize,
+    word_ends: &[usize],
+    token_ends: &[usize],
+    target_tokens: usize,
+) -> usize {
+    let start_byte = if start == 0 { 0 } else { word_ends[start - 1] };
+    let token_start = token_ends.partition_point(|end| *end <= start_byte);
+    let token_end = token_ends
+        .get(token_start.saturating_add(target_tokens).saturating_sub(1))
+        .copied()
+        .unwrap_or(usize::MAX);
+    let end = word_ends.partition_point(|end| *end <= token_end);
+
+    end.clamp(start + 1, word_ends.len())
+}
+
+fn overlap_start(
+    paragraph: &str,
+    start: usize,
+    end: usize,
+    word_ends: &[usize],
+    embedder: &dyn Embedder,
+    overlap_tokens: usize,
+) -> Result<usize, OrbitError> {
+    if overlap_tokens == 0 {
+        return Ok(end);
+    }
+
+    let mut overlap_start = end;
+    while overlap_start > start + 1 {
+        let candidate_start = overlap_start - 1;
+        if embedder.token_count(word_range(paragraph, candidate_start, end, word_ends))?
+            > overlap_tokens
+        {
+            break;
+        }
+        overlap_start = candidate_start;
+    }
+
+    Ok(overlap_start.max(start + 1))
+}
+
+fn word_range<'a>(paragraph: &'a str, start: usize, end: usize, word_ends: &[usize]) -> &'a str {
+    let start_byte = if start == 0 { 0 } else { word_ends[start - 1] };
+    paragraph[start_byte..word_ends[end - 1]].trim()
 }

--- a/crates/orbit-search/src/vector/tests/chunker.rs
+++ b/crates/orbit-search/src/vector/tests/chunker.rs
@@ -1,7 +1,105 @@
 //! Unit tests for `chunker` — sibling layout under vector/tests/.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use orbit_common::OrbitError;
+
 use super::super::chunker::chunk_text;
+use crate::Embedder;
 use crate::NoopEmbedder;
+
+#[derive(Default)]
+struct CountingEmbedder {
+    calls: AtomicUsize,
+}
+
+impl CountingEmbedder {
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
+impl Embedder for CountingEmbedder {
+    fn model_id(&self) -> &str {
+        "counting"
+    }
+
+    fn dim(&self) -> usize {
+        1
+    }
+
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+
+    fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(text.split_whitespace().count().max(1))
+    }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(word_ends(text))
+    }
+}
+
+struct ContextSensitiveEmbedder;
+
+impl Embedder for ContextSensitiveEmbedder {
+    fn model_id(&self) -> &str {
+        "context-sensitive"
+    }
+
+    fn dim(&self) -> usize {
+        1
+    }
+
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+
+    fn embed(&self, _texts: &[&str]) -> Result<Vec<Vec<f32>>, OrbitError> {
+        Ok(Vec::new())
+    }
+
+    fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
+        // The three words together have an extra context-dependent token.
+        // Their individual counts are not safely additive.
+        Ok(
+            if text.contains("supercalifragilisticexpialidocious") || text == "alpha beta gamma" {
+                4
+            } else {
+                text.split_whitespace().count().max(1)
+            },
+        )
+    }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        Ok(word_ends(text))
+    }
+}
+
+fn word_ends(text: &str) -> Vec<usize> {
+    let mut ends = Vec::new();
+    let mut in_word = false;
+    for (index, character) in text.char_indices() {
+        if character.is_whitespace() {
+            if in_word {
+                ends.push(index);
+                in_word = false;
+            }
+        } else {
+            in_word = true;
+        }
+    }
+    if in_word {
+        ends.push(text.len());
+    }
+    ends
+}
 
 #[test]
 fn paragraph_chunker_overlaps_at_boundaries() {
@@ -36,4 +134,60 @@ fn counter_resets_after_a_long_paragraph_is_split_on_its_own() {
         "short paragraphs after the split one pack together again: {chunks:?}"
     );
     assert_eq!(chunks[0], "a b c d");
+}
+
+#[test]
+fn long_paragraph_uses_at_most_one_hundred_token_count_calls() {
+    let embedder = CountingEmbedder::default();
+    let text = (0..5_000)
+        .map(|index| format!("word{index}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let chunks = chunk_text(&text, &embedder, 100, 0).unwrap();
+
+    // The old expanding-prefix loop made 5,052 token-count calls here:
+    // one whole-text count, one paragraph count, and 101 per 100-word chunk.
+    // Exact token boundaries reduce the measured total to 52; keep 100 as a
+    // generous regression bound for this fixture.
+    assert_eq!(chunks.len(), 50);
+    assert!(embedder.calls() <= 100, "calls: {}", embedder.calls());
+}
+
+#[test]
+fn validates_context_sensitive_chunks_against_the_model_limit() {
+    let embedder = ContextSensitiveEmbedder;
+    let chunks = chunk_text("alpha beta gamma delta epsilon", &embedder, 3, 0).unwrap();
+
+    assert!(
+        chunks
+            .iter()
+            .all(|chunk| embedder.token_count(chunk).unwrap() <= 3)
+    );
+    assert_eq!(
+        chunks
+            .iter()
+            .flat_map(|chunk| chunk.split_whitespace())
+            .collect::<Vec<_>>(),
+        ["alpha", "beta", "gamma", "delta", "epsilon"]
+    );
+}
+
+#[test]
+fn long_paragraph_handles_unicode_empty_text_and_an_oversized_word() {
+    let embedder = NoopEmbedder::new("noop", 3, 64);
+
+    let unicode = "héllo 世界 alpha beta gamma";
+    let chunks = chunk_text(unicode, &embedder, 2, 1).unwrap();
+    assert!(chunks.iter().any(|chunk| chunk.contains("héllo 世界")));
+    assert!(chunks.iter().any(|chunk| chunk.contains("gamma")));
+    assert_eq!(
+        chunk_text("", &embedder, 2, 1).unwrap(),
+        vec![String::new()]
+    );
+
+    let oversized = "supercalifragilisticexpialidocious tail";
+    let chunks = chunk_text(oversized, &ContextSensitiveEmbedder, 0, 0).unwrap();
+    assert_eq!(chunks[0], "supercalifragilisticexpialidocious");
+    assert!(chunks.iter().any(|chunk| chunk.contains("tail")));
 }


### PR DESCRIPTION
## Task

[ORB-11703](https://orbit-cli.com/tasks/ORB-11703) — [code-review] Reduce repeated tokenizer RPCs during long-paragraph chunking

### Description

## Problem
`split_long_paragraph` repeatedly joins growing word prefixes and calls token_count for each step, then repeats counting for overlap. A subprocess embedder makes these individual RPCs; paragraph overlap paths also recount text.

## Required behavior and constraints
Reduce tokenizer RPCs and repeated text work while preserving valid chunk sizes, forward progress, text coverage and overlap semantics. Do not assume token counts are monotone or additive across words: neither is an Embedder contract. Use actual tokenizer boundaries or a conservative validated algorithm; justify any RPC extension at the owning protocol. With fixed chunk size, avoid describing total work as quadratic in corpus length.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-search/src/vector/chunker.rs:79,104,110,122,135`; token-count RPC in `crates/orbit-search/src/subprocess.rs`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A counting embedder fixture over a 5000-word paragraph demonstrates a substantial measured reduction from the current thousands of tokenizer calls; record the chosen bound and baseline.
- Existing fixtures retain expected chunks; add context-sensitive tokenization coverage so an unsupported monotonicity/additivity assumption cannot silently violate the model limit.
- Test overlap, forward progress, Unicode, empty text and a single oversized word; define and test oversized-unit behavior while preserving text coverage.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added exact token-boundary retrieval to the Embedder protocol and search-companion RPC, then use those boundaries to select long-paragraph candidates with one tokenizer-boundary RPC rather than growing-prefix token-count RPCs.
- Validate every emitted candidate with the model token counter; the only permitted over-limit output is a single unbreakable word, emitted intact for text coverage and forward progress.
- Added regression coverage for existing paragraph overlap behavior, 5,000-word call counts, context-sensitive counts, Unicode, empty input, and oversized words. The 5,000-word/100-token fixture records the former 5,052-call baseline and enforces <=100 calls (current measured result: 52).

Criteria evidence:
1. Counting fixture verifies 50 chunks and <=100 token_count calls against the documented 5,052 baseline (measured 52).
2. Existing overlap fixtures pass; a context-sensitive embedder makes a three-word candidate count as four and verifies all emitted normal chunks are independently within limit.
3. Tests cover overlap, forward progress, Unicode, empty text, and an oversized word; oversized words are intentionally emitted as one intact over-limit chunk.

Validation:
- cargo test -p orbit-search: passed (74 unit tests, 2 integration tests).
- cargo check -p orbit-search --features companion --bin orbit-search-companion: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.

Assessment: The protocol owns tokenizer offsets, avoiding unsound additivity assumptions; per-chunk validation retains model-limit safety.

Remaining risk: Existing external Embedder implementers must implement the new token_boundaries trait method; this repository's implementations and fixtures have been updated.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11703-6a9f629b`
- Behind base: 0
- Ahead of base: 1