### PR TITLE
[code-review] Promote `--workspace` to a global flag and rename `task add --workspace`

### DIFF
--- a/crates/orbit-cli/src/command/mod.rs
+++ b/crates/orbit-cli/src/command/mod.rs
@@ -128,7 +128,7 @@ pub struct Cli {
     /// Select a workspace by registered name, logical ID (`ws_*`), or absolute
     /// checkout path. Distinct from `--root`, which overrides the Orbit data
     /// directory.
-    #[arg(long, value_name = "SELECTOR")]
+    #[arg(long, global = true, value_name = "SELECTOR")]
     pub workspace: Option<String>,
 
     #[command(subcommand)]

--- a/crates/orbit-cli/src/command/task/add.rs
+++ b/crates/orbit-cli/src/command/task/add.rs
@@ -46,9 +46,9 @@ pub struct TaskAddArgs {
     /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
     #[arg(long, action = ArgAction::Append, value_delimiter = ',')]
     pub context: Vec<String>,
-    /// Workspace path for the task
-    #[arg(long)]
-    pub workspace: Option<String>,
+    /// Workspace path for the task, relative to the selected workspace
+    #[arg(long = "workspace-path")]
+    pub workspace_path: Option<String>,
     /// Priority level
     #[arg(long, value_enum, default_value_t = TaskPriority::Medium)]
     pub priority: TaskPriority,
@@ -100,7 +100,7 @@ impl Execute for TaskAddArgs {
                 plan: self.plan,
                 comment: None,
                 context_files: self.context,
-                workspace_path: self.workspace,
+                workspace_path: self.workspace_path,
                 priority: self.priority,
                 complexity: self.complexity,
                 task_type: self.task_type,

--- a/crates/orbit-cli/src/command/task/command.rs
+++ b/crates/orbit-cli/src/command/task/command.rs
@@ -93,8 +93,8 @@ pub enum TaskSubcommand {
     Archive(TaskArchiveArgs),
     /// List tasks with optional filters
     List(TaskListArgs),
-    /// Show detailed information about a task, found by ID in any registered
-    /// workspace unless `--workspace` narrows the search
+    /// Show detailed information about a task, found by ID with an optional
+    /// workspace filter
     Show(TaskShowArgs),
     /// Manage task artifact files
     Artifact(TaskArtifactCommand),

--- a/crates/orbit-cli/src/command/task/tests/add.rs
+++ b/crates/orbit-cli/src/command/task/tests/add.rs
@@ -120,6 +120,34 @@ fn task_add_acceptance_criteria_does_not_split_on_commas() {
 }
 
 #[test]
+fn task_add_separates_global_workspace_selector_from_task_workspace_path() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "task",
+        "add",
+        "--title",
+        "Workspace-scoped task",
+        "--complexity",
+        "low",
+        "--workspace",
+        "ws_nebula",
+        "--workspace-path",
+        "packages/orbit",
+    ]);
+
+    assert_eq!(cli.workspace.as_deref(), Some("ws_nebula"));
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Add(args) = task.command else {
+        panic!("expected task add command");
+    };
+
+    assert_eq!(args.workspace_path.as_deref(), Some("packages/orbit"));
+}
+
+#[test]
 fn task_add_status_only_advertises_creation_legal_values() {
     assert!(
         Cli::try_parse_from([

--- a/crates/orbit-cli/tests/workspace_selector.rs
+++ b/crates/orbit-cli/tests/workspace_selector.rs
@@ -84,6 +84,24 @@ fn global_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout() {
         "name selector from a foreign cwd must list orbit tasks: {by_name}"
     );
 
+    let post_subcommand = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+            "--workspace",
+            "orbit",
+        ],
+    );
+    assert_eq!(
+        post_subcommand, by_name,
+        "a post-subcommand --workspace selector must match the top-level form"
+    );
+
     let by_id = run_orbit_json(
         &elsewhere,
         &home,
@@ -128,6 +146,43 @@ fn global_workspace_flag_selects_by_name_and_id_from_a_foreign_checkout() {
     assert!(
         !task_ids(&other_cwd).contains(&orbit_task_id),
         "cwd discovery without --workspace must keep binding the other checkout: {other_cwd}"
+    );
+
+    let selected_by_post_subcommand = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "task",
+            "add",
+            "--title",
+            "Selected workspace task",
+            "--complexity",
+            "low",
+            "--workspace",
+            "orbit",
+            "--json",
+        ],
+    );
+    let selected_task_id = selected_by_post_subcommand["id"]
+        .as_str()
+        .expect("selected task id")
+        .to_string();
+    let selected_from_workspace = run_orbit_json(
+        &elsewhere,
+        &home,
+        &[
+            "task",
+            "list",
+            "--limit",
+            "10",
+            "--json",
+            "--workspace",
+            "orbit",
+        ],
+    );
+    assert!(
+        task_ids(&selected_from_workspace).contains(&selected_task_id),
+        "post-subcommand --workspace on task add must select the workspace: {selected_from_workspace}"
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11598](https://orbit-cli.com/tasks/ORB-11598) — [code-review] Promote `--workspace` to a global flag and rename `task add --workspace`

### Description

## Problem
`--root` is `global = true` (`mod.rs:125`) and `--format` is grafted onto every subcommand (`main.rs:91-106`), but `--workspace` is a plain root arg (`mod.rs:131`). Verified with binary: `orbit task list --workspace ws_nebula` fails with `error: unexpected argument '--workspace' found` while `orbit --workspace ws_nebula task list` works. Meanwhile `orbit task add --workspace <path>` is accepted and means something different ("Workspace path for the task", `add.rs:49-51`), so the same flag spelled after `task add` is a task attribute and after `task list` is a usage error. `task show`'s own help text tells users to use `--workspace` to narrow the search (`task/command.rs:96-97`) without saying it must precede `task`.

## Why It Matters
This is the flag every multi-workspace agent invocation needs, and the two selector flags that sit next to it in `--help` behave differently; the `task add` collision means an agent copying `--workspace ws_x` onto `task add` silently stores a bogus workspace path instead of selecting a workspace.

## Proposed Fix
Mark `Cli::workspace` `global = true` (values are `Option<String>` at every level, so the id-propagation problem that blocked `--format` does not apply) and rename `TaskAddArgs::workspace` to `--workspace-path` (keep a hidden alias only if a persisted script contract needs it). Update the `task show` help to drop the position caveat.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/mod.rs:124-132`, `crates/orbit-cli/src/command/task/add.rs:49-51`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (ux). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit task list --workspace ws_nebula` and `orbit --workspace ws_nebula task list` produce identical output.
- `orbit task add --title x --complexity low --workspace ws_nebula` selects the workspace rather than storing a path; `--workspace-path` is the task attribute.
- `crates/orbit-cli/tests/workspace_selector.rs` gains a post-subcommand `--workspace` case.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Promoted the top-level `--workspace` selector to a global Clap argument so it is accepted after subcommands.
- Renamed the task metadata option to `--workspace-path` and updated the task-add parameter mapping.
- Clarified `task show` help and added parser/integration coverage for post-subcommand selectors and task-add workspace routing.

Acceptance criteria:
- Passed: `workspace_selector` integration coverage proves `task list --workspace orbit` produces identical JSON to the top-level selector form.
- Passed: parser coverage proves `task add ... --workspace ws_nebula` populates the global selector while `--workspace-path packages/orbit` populates task metadata; integration coverage confirms the created task lands in the selected workspace.
- Passed: `crates/orbit-cli/tests/workspace_selector.rs` now includes post-subcommand `--workspace` cases.

Validation:
- Passed: `cargo test -p orbit-cli --test workspace_selector -- --nocapture` (4 tests).
- Passed: `cargo test -p orbit-cli --bin orbit task_add_separates_global_workspace_selector_from_task_workspace_path`.
- Passed: `cargo fmt --all -- --check`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check` and final `git status --short`.
- Not applicable: `cargo test -p orbit-cli --lib ...` was attempted, but `orbit-cli` has no library target; the equivalent binary test passed.

Assessment: The change keeps workspace selection and task workspace-path metadata as distinct fields at the CLI boundary, with focused behavioral coverage. No remaining risks or deviations; the full `make ci` gate was not run per repository guidance.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11598-6a9f638c`
- Behind base: 0
- Ahead of base: 1