### PR TITLE
[code-review] Bound response-envelope discovery work without losing supported envelopes

### DIFF
--- a/crates/orbit-agent/src/types/response/envelope.rs
+++ b/crates/orbit-agent/src/types/response/envelope.rs
@@ -2,7 +2,6 @@ use orbit_common::OrbitError;
 use orbit_types::telemetry::InvocationTrace;
 use orbit_types::tool::ExecutionResult;
 use orbit_types::workflow::{AgentResponseEnvelope, AgentRunError};
-use serde::Deserialize;
 use serde_json::{Deserializer, Value};
 
 use super::protocol_schema::{RESPONSE_ENVELOPE_SCHEMA_VERSION, RESPONSE_ENVELOPE_STATUSES};
@@ -18,6 +17,7 @@ pub struct DeclaredResponseFailure {
 pub fn parse_and_validate_response(exec_result: &ExecutionResult) -> ResponseParseResult {
     match parse_json_envelope(exec_result) {
         Ok(parsed) => Ok(parsed),
+        Err(err) if is_discovery_limit_error(&err) => Err(err),
         Err(err) => synthesize_response(exec_result).ok_or(err),
     }
 }
@@ -35,16 +35,19 @@ pub fn is_timeout(exec_result: &ExecutionResult) -> bool {
 /// returns `Err` in that case because exit alignment fails, which threw away
 /// the signal the dispatcher needs to classify the outcome.
 ///
-/// Returns `None` when stdout cannot be parsed or carries no recognizable
-/// envelope, so callers can fall through to other classification rather than
-/// regressing legacy provider shapes.
+/// Returns `None` when stdout cannot be parsed, carries no recognizable
+/// envelope, or discovery exhausts its work bound. Validating APIs fail that
+/// last case closed instead of treating it as absent.
 pub fn peek_response_status(stdout: &str) -> Option<String> {
     let documents = parse_json_documents(stdout).ok()?;
-    let envelope = documents
-        .iter()
-        .rev()
-        .find_map(find_agent_response_envelope)?;
-    Some(envelope.status)
+    match discover_in_values(
+        documents.iter().rev(),
+        &mut Budget::production(),
+        deserialize_envelope,
+    ) {
+        Ok(Some(envelope)) => Some(envelope.status),
+        Ok(None) | Err(_) => None,
+    }
 }
 
 /// Best-effort lookup of a terminal failure declaration in provider stdout.
@@ -56,10 +59,12 @@ pub fn peek_response_status(stdout: &str) -> Option<String> {
 /// non-empty strings.
 pub fn peek_declared_response_failure(stdout: &str) -> Option<DeclaredResponseFailure> {
     let documents = parse_json_documents(stdout).ok()?;
-    documents
-        .iter()
-        .rev()
-        .find_map(find_declared_response_failure)
+    discover_in_values(
+        documents.iter().rev(),
+        &mut Budget::production(),
+        declared_response_failure,
+    )
+    .unwrap_or_default()
 }
 
 /// Content-blind check that a provider's stdout *terminated with* a well-formed
@@ -88,11 +93,12 @@ pub fn response_envelope_protocol_check(stdout: &str) -> Result<(), OrbitError> 
     // a completed step over stray stdout would be a worse defect than the one
     // this check exists to catch.
     let envelope = match parse_json_documents(stdout) {
-        Ok(documents) => documents
-            .iter()
-            .rev()
-            .find_map(find_agent_response_envelope),
-        Err(_) => find_agent_response_envelope_in_string(stdout),
+        Ok(documents) => discover_in_values(
+            documents.iter().rev(),
+            &mut Budget::production(),
+            deserialize_envelope,
+        )?,
+        Err(_) => discover_in_string(stdout, &mut Budget::production(), deserialize_envelope)?,
     };
     let envelope = envelope
         .ok_or_else(|| OrbitError::AgentProtocolViolation(missing_envelope_message(stdout)))?;
@@ -182,13 +188,14 @@ fn validate_exit_alignment(
 
 fn parse_json_envelope(exec_result: &ExecutionResult) -> ResponseParseResult {
     let documents = parse_json_documents(&exec_result.stdout)?;
-    let envelope = documents
-        .iter()
-        .rev()
-        .find_map(find_agent_response_envelope)
-        .ok_or_else(|| {
-            OrbitError::AgentProtocolViolation(missing_envelope_message(&exec_result.stdout))
-        })?;
+    let envelope = discover_in_values(
+        documents.iter().rev(),
+        &mut Budget::production(),
+        deserialize_envelope,
+    )?
+    .ok_or_else(|| {
+        OrbitError::AgentProtocolViolation(missing_envelope_message(&exec_result.stdout))
+    })?;
     let trace = extract_invocation_trace(&documents, exec_result.duration_ms);
 
     if envelope.schema_version != RESPONSE_ENVELOPE_SCHEMA_VERSION {
@@ -309,11 +316,13 @@ fn exit_zero_terminal_failure(exec_result: &ExecutionResult) -> Option<String> {
         return None;
     }
     let documents = parse_json_documents(&exec_result.stdout).ok()?;
-    if documents
-        .iter()
-        .any(|document| find_agent_response_envelope(document).is_some())
-    {
-        return None;
+    match discover_in_values(
+        documents.iter(),
+        &mut Budget::production(),
+        deserialize_envelope,
+    ) {
+        Ok(None) => {}
+        Ok(Some(_)) | Err(_) => return None,
     }
     wrapper_signals(&documents).terminal_ending_diagnostic()
 }
@@ -347,87 +356,267 @@ fn synthetic_error_message(exec_result: &ExecutionResult) -> String {
     "agent execution failed".to_string()
 }
 
-fn find_agent_response_envelope(value: &Value) -> Option<AgentResponseEnvelope> {
-    if let Some(envelope) = deserialize_envelope(value) {
-        return Some(envelope);
+/// Suffix JSON parses allowed while searching: the whole-string attempt plus
+/// each `{` candidate that is actually deserialized.
+pub(in crate::types) const ENVELOPE_DISCOVERY_MAX_PARSE_ATTEMPTS: u32 = 4_096;
+
+/// JSON nodes visited while searching for an envelope or declared failure.
+pub(in crate::types) const ENVELOPE_DISCOVERY_MAX_NODES: u32 = 65_536;
+
+const DISCOVERY_LIMIT_PREFIX: &str = "response envelope discovery exceeded a work limit";
+
+// [ORB-10746] `structured_output` first: with `--json-schema` in play it is
+// the schema-validated object the provider committed to, and Claude duplicates
+// it into `result` only as a JSON-encoded string. `result` is null on several
+// terminal paths where `structured_output` still holds the envelope, so probing
+// it first is the difference between reading the authoritative field and
+// parsing a copy by luck.
+const PREFERRED_OBJECT_KEYS: [&str; 9] = [
+    "structured_output",
+    "result",
+    "response",
+    "message",
+    "messages",
+    "content",
+    "final",
+    "final_message",
+    "output",
+];
+
+/// Caps for one envelope or declared-failure search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::types) struct EnvelopeDiscoveryBudget {
+    pub max_parse_attempts: u32,
+    pub max_nodes: u32,
+}
+
+impl EnvelopeDiscoveryBudget {
+    pub const fn production() -> Self {
+        Self {
+            max_parse_attempts: ENVELOPE_DISCOVERY_MAX_PARSE_ATTEMPTS,
+            max_nodes: ENVELOPE_DISCOVERY_MAX_NODES,
+        }
     }
 
-    match value {
-        Value::String(raw) => find_agent_response_envelope_in_string(raw),
-        Value::Array(items) => items.iter().rev().find_map(find_agent_response_envelope),
-        Value::Object(map) => {
-            for key in [
-                // [ORB-10746] `structured_output` first: with `--json-schema`
-                // in play it is the schema-validated object the provider
-                // committed to, and Claude duplicates it into `result` only as
-                // a JSON-encoded string. `result` is null on several terminal
-                // paths where `structured_output` still holds the envelope, so
-                // probing it first is the difference between reading the
-                // authoritative field and parsing a copy by luck.
-                "structured_output",
-                "result",
-                "response",
-                "message",
-                "messages",
-                "content",
-                "final",
-                "final_message",
-                "output",
-            ] {
-                if let Some(found) = map.get(key).and_then(find_agent_response_envelope) {
-                    return Some(found);
-                }
-            }
-
-            map.values().find_map(find_agent_response_envelope)
+    #[cfg(test)]
+    pub const fn new(max_parse_attempts: u32, max_nodes: u32) -> Self {
+        Self {
+            max_parse_attempts,
+            max_nodes,
         }
-        _ => None,
     }
 }
 
-fn find_declared_response_failure(value: &Value) -> Option<DeclaredResponseFailure> {
-    if let Some(failure) = declared_response_failure(value) {
-        return Some(failure);
+/// Parse/traversal accounting for one search. Sibling tests use this to pin
+/// the documented work bound and the skip-already-visited preferred-key rule.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(in crate::types) struct EnvelopeDiscoveryStats {
+    pub parse_attempts: u32,
+    pub nodes_visited: u32,
+}
+
+struct Budget {
+    max_parse_attempts: u32,
+    max_nodes: u32,
+    stats: EnvelopeDiscoveryStats,
+}
+
+impl Budget {
+    fn new(limits: EnvelopeDiscoveryBudget) -> Self {
+        Self {
+            max_parse_attempts: limits.max_parse_attempts,
+            max_nodes: limits.max_nodes,
+            stats: EnvelopeDiscoveryStats::default(),
+        }
     }
 
-    match value {
-        Value::String(raw) => find_declared_response_failure_in_string(raw),
-        Value::Array(items) => items.iter().rev().find_map(find_declared_response_failure),
-        Value::Object(map) => {
-            for key in [
-                "structured_output",
-                "result",
-                "response",
-                "message",
-                "messages",
-                "content",
-                "final",
-                "final_message",
-                "output",
-            ] {
-                if let Some(found) = map.get(key).and_then(find_declared_response_failure) {
-                    return Some(found);
-                }
-            }
+    fn production() -> Self {
+        Self::new(EnvelopeDiscoveryBudget::production())
+    }
 
-            map.values().find_map(find_declared_response_failure)
+    fn visit(&mut self) -> Result<(), OrbitError> {
+        self.stats.nodes_visited = self.stats.nodes_visited.saturating_add(1);
+        if self.stats.nodes_visited > self.max_nodes {
+            Err(discovery_limit_error(
+                "traversed nodes",
+                self.stats.nodes_visited,
+                self.max_nodes,
+            ))
+        } else {
+            Ok(())
         }
-        _ => None,
+    }
+
+    fn parse(&mut self) -> Result<(), OrbitError> {
+        self.stats.parse_attempts = self.stats.parse_attempts.saturating_add(1);
+        if self.stats.parse_attempts > self.max_parse_attempts {
+            Err(discovery_limit_error(
+                "parse attempts",
+                self.stats.parse_attempts,
+                self.max_parse_attempts,
+            ))
+        } else {
+            Ok(())
+        }
     }
 }
 
-fn find_declared_response_failure_in_string(raw: &str) -> Option<DeclaredResponseFailure> {
-    if let Ok(nested) = serde_json::from_str::<Value>(raw)
-        && let Some(failure) = find_declared_response_failure(&nested)
-    {
-        return Some(failure);
+fn discovery_limit_error(what: &str, actual: u32, max: u32) -> OrbitError {
+    OrbitError::AgentProtocolViolation(format!(
+        "{DISCOVERY_LIMIT_PREFIX}: {what} {actual} > max {max}"
+    ))
+}
+
+fn is_discovery_limit_error(err: &OrbitError) -> bool {
+    match err {
+        OrbitError::AgentProtocolViolation(message) => message.starts_with(DISCOVERY_LIMIT_PREFIX),
+        _ => false,
+    }
+}
+
+/// Protocol-check search: JSON documents when the stream parses, otherwise a
+/// bounded suffix scan of mixed stdout. Visible to sibling tests.
+#[cfg(test)]
+pub(in crate::types) fn discover_agent_response_envelope_with_stats(
+    stdout: &str,
+    budget: EnvelopeDiscoveryBudget,
+) -> Result<(Option<AgentResponseEnvelope>, EnvelopeDiscoveryStats), OrbitError> {
+    let mut budget = Budget::new(budget);
+    let found = match parse_json_documents(stdout) {
+        Ok(documents) => {
+            discover_in_values(documents.iter().rev(), &mut budget, deserialize_envelope)?
+        }
+        Err(_) => discover_in_string(stdout, &mut budget, deserialize_envelope)?,
+    };
+    Ok((found, budget.stats))
+}
+
+/// Declared-failure search with the same walk and bounds as envelope
+/// discovery, including the mixed-stdout suffix scan used inside string
+/// fields. Visible to sibling tests.
+#[cfg(test)]
+pub(in crate::types) fn discover_declared_response_failure_with_stats(
+    stdout: &str,
+    budget: EnvelopeDiscoveryBudget,
+) -> Result<(Option<DeclaredResponseFailure>, EnvelopeDiscoveryStats), OrbitError> {
+    let mut budget = Budget::new(budget);
+    let found = match parse_json_documents(stdout) {
+        Ok(documents) => discover_in_values(
+            documents.iter().rev(),
+            &mut budget,
+            declared_response_failure,
+        )?,
+        Err(_) => discover_in_string(stdout, &mut budget, declared_response_failure)?,
+    };
+    Ok((found, budget.stats))
+}
+
+fn discover_in_values<'a, T, I, F>(
+    values: I,
+    budget: &mut Budget,
+    inspect: F,
+) -> Result<Option<T>, OrbitError>
+where
+    I: IntoIterator<Item = &'a Value>,
+    F: Fn(&Value) -> Option<T>,
+{
+    for value in values {
+        if let Some(found) = walk(value, budget, &inspect)? {
+            return Ok(Some(found));
+        }
+    }
+    Ok(None)
+}
+
+fn discover_in_string<T, F>(
+    raw: &str,
+    budget: &mut Budget,
+    inspect: F,
+) -> Result<Option<T>, OrbitError>
+where
+    F: Fn(&Value) -> Option<T>,
+{
+    walk_string(raw, budget, &inspect)
+}
+
+fn walk<T, F>(value: &Value, budget: &mut Budget, inspect: &F) -> Result<Option<T>, OrbitError>
+where
+    F: Fn(&Value) -> Option<T>,
+{
+    budget.visit()?;
+    if let Some(found) = inspect(value) {
+        return Ok(Some(found));
+    }
+    match value {
+        Value::String(raw) => walk_string(raw, budget, inspect),
+        Value::Array(items) => {
+            for item in items.iter().rev() {
+                if let Some(found) = walk(item, budget, inspect)? {
+                    return Ok(Some(found));
+                }
+            }
+            Ok(None)
+        }
+        Value::Object(map) => walk_object(map, budget, inspect),
+        _ => Ok(None),
+    }
+}
+
+fn walk_object<T, F>(
+    map: &serde_json::Map<String, Value>,
+    budget: &mut Budget,
+    inspect: &F,
+) -> Result<Option<T>, OrbitError>
+where
+    F: Fn(&Value) -> Option<T>,
+{
+    for key in PREFERRED_OBJECT_KEYS {
+        if let Some(child) = map.get(key)
+            && let Some(found) = walk(child, budget, inspect)?
+        {
+            return Ok(Some(found));
+        }
     }
 
-    raw.match_indices('{').find_map(|(start, _)| {
-        let mut deserializer = Deserializer::from_str(&raw[start..]);
-        let nested = Value::deserialize(&mut deserializer).ok()?;
-        find_declared_response_failure(&nested)
-    })
+    for (key, child) in map {
+        if PREFERRED_OBJECT_KEYS.contains(&key.as_str()) {
+            continue;
+        }
+        if let Some(found) = walk(child, budget, inspect)? {
+            return Ok(Some(found));
+        }
+    }
+    Ok(None)
+}
+
+fn walk_string<T, F>(raw: &str, budget: &mut Budget, inspect: &F) -> Result<Option<T>, OrbitError>
+where
+    F: Fn(&Value) -> Option<T>,
+{
+    budget.parse()?;
+    if let Ok(nested) = serde_json::from_str::<Value>(raw) {
+        return walk(&nested, budget, inspect);
+    }
+
+    let mut search_from = 0;
+    while let Some(rel) = raw[search_from..].find('{') {
+        let start = search_from + rel;
+        budget.parse()?;
+        let mut stream = Deserializer::from_str(&raw[start..]).into_iter::<Value>();
+        match stream.next() {
+            Some(Ok(nested)) => {
+                let consumed = stream.byte_offset().max(1);
+                if let Some(found) = walk(&nested, budget, inspect)? {
+                    return Ok(Some(found));
+                }
+                search_from = start + consumed;
+            }
+            Some(Err(_)) | None => {
+                search_from = start + 1;
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn declared_response_failure(value: &Value) -> Option<DeclaredResponseFailure> {
@@ -458,20 +647,6 @@ fn declared_response_failure(value: &Value) -> Option<DeclaredResponseFailure> {
     Some(DeclaredResponseFailure {
         status: status.to_string(),
         error,
-    })
-}
-
-fn find_agent_response_envelope_in_string(raw: &str) -> Option<AgentResponseEnvelope> {
-    if let Ok(nested) = serde_json::from_str::<Value>(raw)
-        && let Some(envelope) = find_agent_response_envelope(&nested)
-    {
-        return Some(envelope);
-    }
-
-    raw.match_indices('{').find_map(|(start, _)| {
-        let mut deserializer = Deserializer::from_str(&raw[start..]);
-        let nested = Value::deserialize(&mut deserializer).ok()?;
-        find_agent_response_envelope(&nested)
     })
 }
 

--- a/crates/orbit-agent/src/types/tests/envelope.rs
+++ b/crates/orbit-agent/src/types/tests/envelope.rs
@@ -1,0 +1,330 @@
+#![allow(missing_docs)]
+
+use orbit_types::tool::ExecutionResult;
+use serde_json::{Value, json};
+
+use super::super::response::AgentResponseStatus;
+use super::super::response::envelope::*;
+
+fn exec(stdout: &str, exit_code: Option<i32>) -> ExecutionResult {
+    ExecutionResult {
+        success: exit_code == Some(0),
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+        exit_code,
+        duration_ms: 12,
+        output: None,
+    }
+}
+
+fn success_envelope() -> Value {
+    json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": {"ok": true},
+        "error": null
+    })
+}
+
+fn failed_envelope() -> Value {
+    json!({
+        "schemaVersion": 1,
+        "status": "failed",
+        "result": {},
+        "error": {"code": "E", "message": "failed", "details": null}
+    })
+}
+
+fn timeout_envelope() -> Value {
+    json!({
+        "schemaVersion": 1,
+        "status": "timeout",
+        "result": {},
+        "error": {"code": "deadline", "message": "timed out", "details": null}
+    })
+}
+
+fn production_budget() -> EnvelopeDiscoveryBudget {
+    EnvelopeDiscoveryBudget::production()
+}
+
+fn assert_limit_error(error: &orbit_common::OrbitError) {
+    let message = error.to_string();
+    assert!(
+        message.contains("response envelope discovery exceeded a work limit"),
+        "expected an explicit discovery-limit failure, got {message}"
+    );
+}
+
+fn dummy_object(width: usize) -> Value {
+    let mut map = serde_json::Map::new();
+    for index in 0..width {
+        map.insert(format!("k{index}"), json!(index));
+    }
+    Value::Object(map)
+}
+
+#[test]
+fn banner_wrapped_json_finds_the_envelope_without_rescanning_nested_braces() {
+    let nested_result = json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": {"inner": {"a": {"b": {"c": 1}}}},
+        "error": null
+    });
+    let stdout = format!("tool banner: still running\n{nested_result}");
+
+    response_envelope_protocol_check(&stdout).expect("banner-wrapped envelope is a frame");
+
+    let (found, stats) = discover_agent_response_envelope_with_stats(&stdout, production_budget())
+        .expect("discover");
+    let envelope = found.expect("envelope after banner");
+    assert_eq!(envelope.status, "success");
+    assert!(
+        stats.parse_attempts <= 3,
+        "whole-string miss plus one object parse, not one parse per nested brace: {stats:?}"
+    );
+    assert!(
+        stats.nodes_visited < ENVELOPE_DISCOVERY_MAX_NODES,
+        "{stats:?}"
+    );
+}
+
+#[test]
+fn truncated_large_payload_fails_closed_instead_of_succeeding() {
+    let mut stdout = String::from('{');
+    for index in 0..5_000 {
+        stdout.push_str(&format!("\"k{index}\":{{"));
+    }
+
+    let error = response_envelope_protocol_check(&stdout)
+        .expect_err("truncated payload is not a completed envelope");
+    assert_limit_error(&error);
+    assert!(
+        parse_and_validate_response(&exec(&stdout, Some(0))).is_err(),
+        "must not parse a truncated payload as success"
+    );
+    assert_eq!(peek_response_status(&stdout), None);
+    assert_eq!(peek_declared_response_failure(&stdout), None);
+}
+
+#[test]
+fn brace_dense_text_hits_the_documented_parse_bound() {
+    let raw = "{".repeat(10_000);
+    let wrapped = json!({ "result": raw }).to_string();
+
+    let error = discover_agent_response_envelope_with_stats(&raw, production_budget())
+        .expect_err("brace-dense text must exhaust the parse bound");
+    assert_limit_error(&error);
+    assert!(error.to_string().contains("parse attempts"));
+
+    let error = discover_declared_response_failure_with_stats(&wrapped, production_budget())
+        .expect_err("declared-failure discovery shares the parse bound");
+    assert_limit_error(&error);
+    assert_eq!(peek_declared_response_failure(&wrapped), None);
+    let error = response_envelope_protocol_check(&wrapped)
+        .expect_err("string-field brace density is a limit failure, not a missing envelope");
+    assert_limit_error(&error);
+}
+
+#[test]
+fn deeply_nested_preferred_fields_still_find_the_envelope_and_declared_failure() {
+    let mut envelope = success_envelope();
+    let mut failure = failed_envelope();
+    for key in [
+        "output",
+        "final_message",
+        "final",
+        "content",
+        "messages",
+        "message",
+        "response",
+        "result",
+        "structured_output",
+        "output",
+        "result",
+        "structured_output",
+    ] {
+        envelope = json!({ key: envelope });
+        failure = json!({ key: failure });
+    }
+
+    let stdout = envelope.to_string();
+    let (parsed, status, _) =
+        parse_and_validate_response(&exec(&stdout, Some(0))).expect("nested preferred keys");
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(parsed.result.expect("result")["ok"], true);
+
+    let failure_stdout = failure.to_string();
+    let declared =
+        peek_declared_response_failure(&failure_stdout).expect("nested declared failure");
+    assert_eq!(declared.status, "failed");
+    assert_eq!(declared.error.expect("error").code, "E");
+}
+
+#[test]
+fn large_valid_envelope_is_found_when_its_opening_brace_is_not_among_the_last_few() {
+    let mut nested = json!({"leaf": true});
+    for index in 0..80 {
+        nested = json!({ format!("n{index}"): nested });
+    }
+    let envelope = json!({
+        "schemaVersion": 1,
+        "status": "success",
+        "result": nested,
+        "error": null
+    });
+    let mut tail = Vec::new();
+    for _ in 0..2_000 {
+        tail.push(json!({}));
+    }
+    let wrapper = json!({
+        "payload": envelope,
+        "z_tail": tail
+    });
+    let stdout = format!("note: decoy objects follow the envelope\n{wrapper}");
+
+    let (found, stats) = discover_agent_response_envelope_with_stats(&stdout, production_budget())
+        .expect("discover");
+    assert_eq!(found.expect("early envelope").status, "success");
+    assert!(
+        stats.parse_attempts <= 3,
+        "suffix scan must consume the wrapper once, not the last few nested braces: {stats:?}"
+    );
+    response_envelope_protocol_check(&stdout).expect("frame still holds");
+}
+
+#[test]
+fn preferred_named_children_are_not_walked_twice_for_envelope_or_declared_failure() {
+    let width = 100;
+    let envelope_payload = json!({
+        "structured_output": dummy_object(width),
+        "zz_other": success_envelope()
+    });
+    let failure_payload = json!({
+        "structured_output": dummy_object(width),
+        "zz_other": failed_envelope()
+    });
+    // root + preferred object + `width` leaves + sibling envelope.
+    let expected_nodes = 1 + 1 + width as u32 + 1;
+
+    let (found, stats) = discover_agent_response_envelope_with_stats(
+        &envelope_payload.to_string(),
+        production_budget(),
+    )
+    .expect("envelope search");
+    assert_eq!(found.expect("sibling envelope").status, "success");
+    assert_eq!(
+        stats.nodes_visited,
+        expected_nodes,
+        "re-walking structured_output would add another {} nodes: {stats:?}",
+        1 + width
+    );
+
+    let (found, stats) = discover_declared_response_failure_with_stats(
+        &failure_payload.to_string(),
+        production_budget(),
+    )
+    .expect("declared-failure search");
+    assert_eq!(found.expect("sibling failure").status, "failed");
+    assert_eq!(stats.nodes_visited, expected_nodes);
+
+    let tight = EnvelopeDiscoveryBudget::new(ENVELOPE_DISCOVERY_MAX_PARSE_ATTEMPTS, expected_nodes);
+    discover_agent_response_envelope_with_stats(&envelope_payload.to_string(), tight)
+        .expect("one-pass budget is enough")
+        .0
+        .expect("found");
+
+    let too_tight = EnvelopeDiscoveryBudget::new(
+        ENVELOPE_DISCOVERY_MAX_PARSE_ATTEMPTS,
+        expected_nodes.saturating_sub(width as u32),
+    );
+    let error =
+        discover_agent_response_envelope_with_stats(&envelope_payload.to_string(), too_tight)
+            .expect_err("a one-pass-minus-the-sibling budget must not invent a hit");
+    assert_limit_error(&error);
+    let (_, status, _) = parse_and_validate_response(&exec(&envelope_payload.to_string(), Some(0)))
+        .expect("production bound still finds it");
+    assert_eq!(status, AgentResponseStatus::Success);
+}
+
+#[test]
+fn structured_output_still_outranks_result_for_envelopes_and_declared_failures() {
+    let stdout = json!({
+        "result": failed_envelope(),
+        "structured_output": success_envelope()
+    })
+    .to_string();
+    let (envelope, status, _) =
+        parse_and_validate_response(&exec(&stdout, Some(0))).expect("preferred key wins");
+    assert_eq!(status, AgentResponseStatus::Success);
+    assert_eq!(envelope.result.expect("result")["ok"], true);
+
+    let stdout = json!({
+        "result": failed_envelope(),
+        "structured_output": timeout_envelope()
+    })
+    .to_string();
+    let declared = peek_declared_response_failure(&stdout).expect("preferred failure");
+    assert_eq!(declared.status, "timeout");
+    assert_eq!(declared.error.expect("error").code, "deadline");
+}
+
+#[test]
+fn array_documents_keep_last_to_first_envelope_precedence() {
+    let stdout = json!([failed_envelope(), success_envelope()]).to_string();
+    assert_eq!(peek_response_status(&stdout).as_deref(), Some("success"));
+
+    let stdout = json!([success_envelope(), failed_envelope()]).to_string();
+    assert_eq!(peek_response_status(&stdout).as_deref(), Some("failed"));
+    let declared = peek_declared_response_failure(&stdout).expect("last failed item");
+    assert_eq!(declared.status, "failed");
+}
+
+#[test]
+fn exhausted_limits_do_not_synthesize_success() {
+    let stdout = json!({
+        "is_error": true,
+        "subtype": "error_max_turns",
+        "terminal_reason": "max_turns",
+        "structured_output": dummy_object(70_000)
+    })
+    .to_string();
+    let error = parse_and_validate_response(&exec(&stdout, Some(0)))
+        .expect_err("limit exhaustion is a parse failure");
+    assert_limit_error(&error);
+    assert!(
+        synthesize_response(&exec(&stdout, Some(0))).is_none(),
+        "a limit error must not be rewritten into a synthesized terminal failure"
+    );
+}
+
+#[test]
+fn production_node_bound_fails_closed_on_a_huge_decoy_array() {
+    let mut stdout = String::from('[');
+    for index in 0..70_000 {
+        if index > 0 {
+            stdout.push(',');
+        }
+        stdout.push('0');
+    }
+    stdout.push(']');
+
+    let error = response_envelope_protocol_check(&stdout)
+        .expect_err("70k decoy nodes exceed the documented node bound");
+    assert_limit_error(&error);
+    assert!(error.to_string().contains("traversed nodes"));
+    assert!(
+        parse_and_validate_response(&exec(&stdout, Some(0))).is_err(),
+        "must not classify an unexamined decoy array as success"
+    );
+}
+
+#[test]
+fn declared_failure_inside_a_string_field_still_parses() {
+    let result = format!("could not continue\n{}", failed_envelope());
+    let stdout = json!({ "result": result }).to_string();
+    let declared = peek_declared_response_failure(&stdout).expect("string-embedded failure");
+    assert_eq!(declared.status, "failed");
+    assert_eq!(peek_response_status(&stdout).as_deref(), Some("failed"));
+}

--- a/crates/orbit-agent/src/types/tests/mod.rs
+++ b/crates/orbit-agent/src/types/tests/mod.rs
@@ -1,1 +1,2 @@
+mod envelope;
 mod response;


### PR DESCRIPTION
## Task

[ORB-11700](https://orbit-cli.com/tasks/ORB-11700) — [code-review] Bound response-envelope discovery work without losing supported envelopes

### Description

## Problem
Fallback envelope discovery reparses JSON suffixes starting at each opening brace. Recursive object traversal probes named fields and then visits those fields again through all values; declared-failure discovery repeats this structure. Some malformed/wrapped payloads therefore cause repeated parsing and traversal. Actual duration depends on payload shape and serde recursion limits; minutes/hours were not measured.

## Required behavior and constraints
Bound parsing/traversal work across both envelope and declared-failure discovery, avoiding duplicate child visits. Preserve supported wrapped/string/array forms and authoritative field precedence. A last-few-braces heuristic alone is insufficient because valid envelopes may contain many nested objects. Any explicit input/work limit must fail diagnostically rather than misclassify an unexamined failure as success. Keep the change at response parsing boundaries.

## Evidence and validation
Source validation against agent-main 09dec5183 (original review 7f3a8f5fa); re-locate symbols on the implementation revision. crates/orbit-agent/src/types/response/envelope.rs:350,386,419,464; existing response tests.
These are source-level findings, not measured performance or executed fault-injection results. Use focused deterministic regression tests at the owning boundary. Follow AGENTS.md and pass make ci-fast and make ci-lint before review; no release work is included.

### Acceptance Criteria

- Regression corpus covers banner-wrapped JSON, truncated large payloads, brace-dense text, deeply nested named fields and large valid envelopes whose opening brace is not among the last few candidates.
- Instrumented parse/traversal accounting or a bounded parser contract demonstrates a documented work bound and no repeated traversal of the same named child; exercise both normal and declared-failure discovery.
- Supported valid envelopes and declared failures retain current precedence/status semantics; exhausted limits produce explicit parse/limit failure and never fabricated success.
- Existing response tests pass; any timing benchmark states hardware/input and reports observations rather than asserting a universal 100ms threshold.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the two recursive envelope/declared-failure finders in `crates/orbit-agent/src/types/response/envelope.rs` with one bounded walk.
- Preferred object keys (`structured_output` first) are visited once; remaining keys skip those already walked. Arrays and document streams keep last-to-first precedence.
- Suffix scan parses from each `{` then skips the consumed object; a successful whole-string parse is not re-scanned.
- Documented work bound: 4096 suffix parse attempts and 65536 nodes. Exhausted limits return `AgentProtocolViolation` naming the limit. `parse_and_validate_response` does not synthesize over a limit error. Peek APIs stay `Option` and treat a limit as absent.
- Added sibling regression tests in `crates/orbit-agent/src/types/tests/envelope.rs`.

Assessment: Scoped to the response-parsing boundary. Precedence tests and existing `types::tests::response` coverage still pass. Pathological inputs fail closed rather than hanging or succeeding.

Criteria:
- Banner-wrapped JSON, truncated large payloads, brace-dense text, deeply nested preferred keys, and a large valid envelope whose opening `{` is not among the last few candidates: covered in `types::tests::envelope`.
- Instrumented stats show parse/node counts under the documented bound and exact one-pass node counts for a preferred-key subtree plus sibling (duplicate named-child visits would double that). Same walk for declared-failure discovery.
- `structured_output` still outranks `result`; array last-to-first status is unchanged. Limit exhaustion is an explicit parse/limit failure and does not synthesize success.
- Existing response tests passed. No wall-clock 100ms assertion; brace-dense and 70k-node decoys complete under the work bound (full `types::tests` ~1s).

Validation:
- `cargo test -p orbit-agent --lib types::tests` (CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0110-3-target): passed (52 tests).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed (no whitespace errors).

Remaining risks:
- Peek APIs still return `None` on a work-limit (best-effort). Validating APIs fail closed, so an unexamined payload cannot become success.
- `parse_and_validate_response` still requires a valid JSON document stream; banner-wrapped envelopes remain a protocol-check/suffix-scan path, matching prior behavior.
- No timing benchmark was added; duration was not measured beyond tests completing quickly on this host.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11700-6a9f607b`
- Behind base: 0
- Ahead of base: 1