### PR TITLE
[code-review] Keep `orbit doctor --fix-* --format json` stdout parseable

### DIFF
--- a/crates/orbit-cli/src/command/doctor.rs
+++ b/crates/orbit-cli/src/command/doctor.rs
@@ -37,47 +37,71 @@ pub struct DoctorCommand {
 
 impl Execute for DoctorCommand {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
+        let mut results = Vec::new();
         if self.fix_stale_locks {
             let removed = runtime.remove_stale_lock_files()?;
-            if !self.json {
-                println!("Removed {removed} stale lock file(s).");
-            }
+            eprintln!("Removed {removed} stale lock file(s).");
+            results.push(WorkspaceDoctorResult {
+                check_name: "fix-stale-locks".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!("Removed {removed} stale lock file(s)."),
+                remediation: None,
+            });
         }
         if self.fix_stale_task_locks {
             let released = runtime.clear_stale_task_reservations()?;
-            if !self.json {
-                println!("Released {released} stale task reservation(s).");
-            }
+            eprintln!("Released {released} stale task reservation(s).");
+            results.push(WorkspaceDoctorResult {
+                check_name: "fix-stale-task-locks".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!("Released {released} stale task reservation(s)."),
+                remediation: None,
+            });
         }
         if self.remove_graph {
             let removed = runtime.remove_retired_graph_state()?;
-            if !self.json {
-                println!("Removed {removed} retired graph location(s).");
-            }
+            eprintln!("Removed {removed} retired graph location(s).");
+            results.push(WorkspaceDoctorResult {
+                check_name: "remove-graph".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!("Removed {removed} retired graph location(s)."),
+                remediation: None,
+            });
         }
         if self.fix_stale_artifacts {
             let removed = runtime.remove_stale_definition_artifacts()?;
-            if !self.json {
-                println!("Retired {removed} deprecated definition artifact(s).");
-            }
+            eprintln!("Retired {removed} deprecated definition artifact(s).");
+            results.push(WorkspaceDoctorResult {
+                check_name: "fix-stale-artifacts".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!("Retired {removed} deprecated definition artifact(s)."),
+                remediation: None,
+            });
         }
         if self.fix_retired_activity_backends {
             let report = runtime.repair_retired_activity_backends()?;
-            if !self.json {
-                println!(
+            eprintln!(
+                "Removed retired spec.backend from {} activity file(s).",
+                report.repaired.len()
+            );
+            for skipped in &report.skipped {
+                eprintln!(
+                    "Left untouched {}: {}",
+                    skipped.path.display(),
+                    skipped.reason
+                );
+            }
+            results.push(WorkspaceDoctorResult {
+                check_name: "fix-retired-activity-backends".to_string(),
+                status: WorkspaceDoctorStatus::Ok,
+                message: format!(
                     "Removed retired spec.backend from {} activity file(s).",
                     report.repaired.len()
-                );
-                for skipped in &report.skipped {
-                    println!(
-                        "Left untouched {}: {}",
-                        skipped.path.display(),
-                        skipped.reason
-                    );
-                }
-            }
+                ),
+                remediation: None,
+            });
         }
-        let mut results = runtime.doctor_workspace()?;
+        results.extend(runtime.doctor_workspace()?);
         // Machine-global rows, composed here rather than in `doctor_workspace`:
         // `orbit-cmd` does not know about MCP and must not learn, and this is
         // the one crate that already assembles both [ORB-11053].

--- a/crates/orbit-cli/src/command/tests/doctor.rs
+++ b/crates/orbit-cli/src/command/tests/doctor.rs
@@ -110,3 +110,45 @@ fn warning_only_workspace_keeps_zero_exit_and_structured_rows() {
         "warning"
     );
 }
+
+#[test]
+fn fix_stale_locks_records_repair_count_in_payload_doc() {
+    let runtime = OrbitRuntime::in_memory().expect("build in-memory runtime");
+    let lock_path = runtime.paths().state_dir.join("doctor-test.lock");
+    std::fs::write(
+        lock_path,
+        r#"{"pid":0,"acquired_at":"2026-08-15T23:00:00Z","label":"test"}"#,
+    )
+    .expect("write stale lock metadata");
+
+    let output = super::super::doctor::DoctorCommand {
+        json: false,
+        fix_stale_locks: true,
+        fix_stale_task_locks: false,
+        remove_graph: false,
+        fix_stale_artifacts: false,
+        fix_retired_activity_backends: false,
+    }
+    .execute(&runtime)
+    .expect("doctor should run repairs and render report");
+
+    let CommandOutput::Payload(payload) = output else {
+        panic!("doctor should return its report payload");
+    };
+    assert_eq!(payload.exit_code(), 0);
+    let (document, _) = payload.into_view();
+    let rows = document.as_array().expect("doctor rows");
+    let fix_row = rows
+        .iter()
+        .find(|row| row["check"] == "fix-stale-locks")
+        .expect("fix-stale-locks row");
+    assert_eq!(fix_row["status"], "ok");
+    assert!(
+        fix_row["message"]
+            .as_str()
+            .expect("message")
+            .contains("Removed 1 stale lock file(s)."),
+        "expected repair count in fix-stale-locks row message, got: {:?}",
+        fix_row["message"]
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11597](https://orbit-cli.com/tasks/ORB-11597) — [code-review] Keep `orbit doctor --fix-* --format json` stdout parseable

### Description

## Problem
The five `--fix-*` branches print their result with `println!` gated only on `!self.json`. The global `--format json` sets the sink mode without touching `self.json`, so the prose lands on stdout ahead of the JSON array. Verified with binary: `orbit doctor --fix-stale-locks --format json | head -1` printed `Removed 1 stale lock file(s).` before `[{"check":"config",…`. The fix results are also absent from the JSON document, so a `--json` caller cannot learn what was repaired at all.

## Why It Matters
`doctor` is the command the brief singles out for unattended use (cron/CI, nonzero exit on failure); a JSON consumer gets a parse error exactly when a repair happened.

## Proposed Fix
Collect the fix outcomes into a `fixes` object, print them via `eprintln!` (spec §5: counts go to stderr in every mode), and either fold them into the payload (`{"checks":[…],"fixes":{…}}`) or add them as `WorkspaceDoctorResult` rows with check names like `fix-stale-locks` so the array shape is unchanged.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/doctor.rs:40-79`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit doctor --fix-stale-locks --format json | python3 -m json.tool` succeeds; the repair count appears in the document.
- `orbit doctor --fix-stale-locks` on a TTY still tells the operator what was removed.
- A test in `crates/orbit-cli/src/command/tests/` asserts the `--fix-*` path returns a `Payload` whose doc carries the fix count.

## Execution Summary

<details>
<summary>Click to expand</summary>

### Scope and Changes
- Routed `--fix-*` outcomes in `crates/orbit-cli/src/command/doctor.rs` to stderr via `eprintln!` in every mode (aligning with spec §5: counts and diagnostics to stderr).
- Added fix outcomes as `WorkspaceDoctorResult` rows (`fix-stale-locks`, `fix-stale-task-locks`, `remove-graph`, `fix-stale-artifacts`, `fix-retired-activity-backends`) with status `Ok` so that stdout contains only clean JSON in `--format json` mode, while the repair count is preserved in the JSON document and the array shape remains unchanged.
- Added unit test `fix_stale_locks_records_repair_count_in_payload_doc` in `crates/orbit-cli/src/command/tests/doctor.rs` asserting that `--fix-*` populates the payload document with the fix result row and repair count.
- `context_files` was appended with `file:crates/orbit-cli/src/command/tests/doctor.rs` to fulfill acceptance criterion 3.

### Acceptance Criteria Mapping
1. `orbit doctor --fix-stale-locks --format json | python3 -m json.tool` succeeds; the repair count appears in the document: Passed.
   - Verified with `./target/debug/orbit doctor --fix-stale-locks --format json | python3 -m json.tool`. Output on stdout parsed as valid JSON without prose interference; `fix-stale-locks` check is present in the document with repair message.
2. `orbit doctor --fix-stale-locks` on a TTY still tells the operator what was removed: Passed.
   - Verified with `./target/debug/orbit doctor --fix-stale-locks`. Output to terminal displays the stderr notice and the `fix-stale-locks` row in the human table.
3. A test in `crates/orbit-cli/src/command/tests/` asserts the `--fix-*` path returns a `Payload` whose doc carries the fix count: Passed.
   - Test `fix_stale_locks_records_repair_count_in_payload_doc` in `crates/orbit-cli/src/command/tests/doctor.rs` executes the command with `fix_stale_locks: true` and verifies the payload document contains `fix-stale-locks` with the expected repair count.

### Validation Commands
- `cargo test -p orbit-cli --bin orbit`: passed (466 passed).
- `cargo test -p orbit-cli --test worktree_resolution`: passed (6 passed).
- `./target/debug/orbit doctor --fix-stale-locks --format json | python3 -m json.tool`: passed (exited 0, valid JSON with repair row).
- `./target/debug/orbit doctor --fix-stale-locks`: passed (exited 0, displays repair count on stderr and in table).
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed (no whitespace or format issues).

### Remaining Risks or Deviations
None.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11597-6a9f6363`
- Behind base: 0
- Ahead of base: 1