### PR TITLE
[code-review] Make task deletion coordinate with writers and recover safely after interruption

### DIFF
--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/commit.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/commit.rs
@@ -162,7 +162,7 @@ impl Drop for PendingWriteGuard {
 /// Recover a leftover pending write under the bundle lock, then read.
 pub(crate) fn recover_pending_bundle_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
     with_exclusive_file_lock(
-        &bundle_dir.join(TASK_ENVELOPE_FILE_NAME),
+        &crate::driver::file::task_bundle::bundle_lock_target(bundle_dir),
         "task artifact v2",
         || {
             recover_pending_write(bundle_dir)?;

--- a/crates/orbit-store/src/driver/file/task_bundle/lock.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/lock.rs
@@ -1,25 +1,9 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
-use orbit_common::OrbitError;
-
-pub(crate) fn task_bundle_lock_sentinel_path(bundle_dir: &Path) -> Result<PathBuf, OrbitError> {
-    let file_name = bundle_dir
-        .file_name()
-        .and_then(|value| value.to_str())
-        .ok_or_else(|| {
-            OrbitError::Store(format!(
-                "task bundle path {} has no file name",
-                bundle_dir.display()
-            ))
-        })?;
-    Ok(bundle_dir.with_file_name(format!(".{file_name}.lock")))
-}
-
-pub(crate) fn remove_task_bundle_lock_sentinel(lock_path: &Path) -> Result<(), OrbitError> {
-    match fs::remove_file(lock_path) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(OrbitError::Io(err.to_string())),
-    }
+/// Stable identity outside the removable bundle. Never unlink these lock files:
+/// queued flock callers must acquire the same inode after a deletion. Keeping
+/// the lock in the existing parent also lets a first reader coordinate with a
+/// first writer before any auxiliary directories have been created.
+pub(crate) fn bundle_lock_target(bundle_dir: &Path) -> PathBuf {
+    bundle_dir.with_extension("bundle")
 }

--- a/crates/orbit-store/src/driver/file/task_bundle/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/mod.rs
@@ -1,5 +1,5 @@
 //! Pure task-bundle file persistence: codecs, atomic publication, and bundle
-//! lock-sentinel mechanics. Registry and checkout projection coordination live
+//! stable lock identity. Registry and checkout projection coordination live
 //! in the task repository.
 
 pub(crate) mod bundle_io;
@@ -15,5 +15,5 @@ pub(crate) use bundle_io::{
 
 #[cfg(test)]
 pub(crate) use bundle_io::{PENDING_WRITE_FILE_NAME, inject_bundle_write_faults};
-pub(crate) use lock::{remove_task_bundle_lock_sentinel, task_bundle_lock_sentinel_path};
+pub(crate) use lock::bundle_lock_target;
 pub(crate) use types::{TaskBundleV2, TaskDocumentV2};

--- a/crates/orbit-store/src/repository/task/tests/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/tests/v2_bundle.rs
@@ -23,7 +23,7 @@ enum CreateOutcome {
 }
 
 #[test]
-fn create_bundle_removes_lock_sentinel_after_success() {
+fn create_bundle_retains_the_stable_lock_after_success() {
     let temp = TempDir::new().expect("tempdir");
     let store = bundle_store(&temp);
     let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
@@ -37,7 +37,7 @@ fn create_bundle_removes_lock_sentinel_after_success() {
     assert!(bundle_dir.is_dir());
     assert_eq!(
         lock_entries_for_task(tasks_dir, "ORB-00000"),
-        Vec::<String>::new()
+        vec![".ORB-00000.bundle.lock".to_string()]
     );
     assert!(!task_lock_path(&bundle_dir).exists());
     assert!(!legacy_double_dot_lock_path(&bundle_dir, "ORB-00000").exists());
@@ -97,7 +97,7 @@ fn create_bundle_serializes_concurrent_duplicate_creators() {
     assert!(bundle_dir.is_dir());
     assert_eq!(
         lock_entries_for_task(&tasks_dir, "ORB-00000"),
-        Vec::<String>::new()
+        vec![".ORB-00000.bundle.lock".to_string()]
     );
 }
 
@@ -258,7 +258,7 @@ fn rewrite_document_and_append_logs_are_durable() {
 }
 
 #[test]
-fn create_bundle_cleans_partial_directory_and_lock_on_validation_error() {
+fn create_bundle_cleans_partial_directory_but_retains_lock_on_validation_error() {
     let temp = TempDir::new().expect("tempdir");
     let store = bundle_store(&temp);
     let mut bundle = sample_bundle("ORB-00000");
@@ -270,7 +270,7 @@ fn create_bundle_cleans_partial_directory_and_lock_on_validation_error() {
     assert!(!bundle_path.exists());
     assert_eq!(
         lock_entries_for_task(&tasks_dir, "ORB-00000"),
-        Vec::<String>::new()
+        vec![".ORB-00000.bundle.lock".to_string()]
     );
     assert!(!task_lock_path(&bundle_path).exists());
     assert!(!legacy_double_dot_lock_path(&bundle_path, "ORB-00000").exists());
@@ -303,5 +303,194 @@ fn create_bundle_treats_projection_error_as_degraded_success() {
             .map(|bundle| bundle.envelope.id)
             .collect::<Vec<_>>(),
         vec!["ORB-00000"]
+    );
+}
+
+#[test]
+fn deletion_failures_recover_without_registering_partial_tombstones() {
+    use crate::workflow::task::reindex_workspace;
+
+    for fault in [
+        DeletionFault::Publication,
+        DeletionFault::PublicationSync,
+        DeletionFault::Registry,
+        DeletionFault::Cleanup,
+    ] {
+        for recover_by_reindex in [false, true] {
+            let temp = TempDir::new().unwrap();
+            let store = bundle_store(&temp);
+            store.create_bundle(&sample_bundle("ORB-00000")).unwrap();
+            store.create_bundle(&sample_bundle("ORB-00001")).unwrap();
+            let dir = store.bundle_path("ORB-00000").unwrap();
+            let tombstone = deletion_path(&dir);
+            inject_deletion_fault(fault);
+            assert!(store.delete_bundle("ORB-00000").is_err());
+            assert_eq!(dir.exists(), fault == DeletionFault::Publication);
+            assert_eq!(tombstone.exists(), fault != DeletionFault::Publication);
+            let registered = store
+                .registry
+                .tasks_for_workspace(&store.workspace_id)
+                .unwrap();
+            assert_eq!(
+                registered.len(),
+                if fault == DeletionFault::Cleanup {
+                    1
+                } else {
+                    2
+                }
+            );
+            if fault == DeletionFault::Registry {
+                // No destructive operation has run before registry removal.
+                assert_eq!(
+                    fs::read_to_string(tombstone.join("description.md")).unwrap(),
+                    "Description body"
+                );
+                assert!(store.create_bundle(&sample_bundle("ORB-00000")).is_err());
+            }
+            if fault == DeletionFault::Cleanup {
+                // Model a process dying partway through recursive removal.
+                fs::remove_file(tombstone.join("description.md")).unwrap();
+            }
+            if recover_by_reindex {
+                if fault != DeletionFault::Publication {
+                    // If the same boundary remains unavailable, report failure
+                    // while still indexing the healthy neighbor and retaining data.
+                    inject_deletion_fault(fault);
+                    let error = reindex_workspace(&store.registry, &store.workspace_id)
+                        .unwrap_err()
+                        .to_string();
+                    assert!(error.contains("indexed 1 healthy tasks"), "{error}");
+                    assert!(error.contains("ORB-00000"), "{error}");
+                    assert!(tombstone.exists());
+                    assert_eq!(
+                        store
+                            .registry
+                            .indexed_task_count_for_workspace(&store.workspace_id)
+                            .unwrap(),
+                        1
+                    );
+                }
+                let result = reindex_workspace(&store.registry, &store.workspace_id).unwrap();
+                assert_eq!(
+                    result.indexed,
+                    if fault == DeletionFault::Publication {
+                        2
+                    } else {
+                        1
+                    }
+                );
+                assert!(reindex_workspace(&store.registry, &store.workspace_id).is_ok());
+            } else {
+                assert!(store.delete_bundle("ORB-00000").unwrap());
+                assert!(!store.delete_bundle("ORB-00000").unwrap());
+                assert!(!dir.exists());
+            }
+            assert!(!tombstone.exists());
+            assert!(store.read_bundle("ORB-00001").is_ok());
+        }
+    }
+}
+
+#[test]
+fn reindex_retains_unresolved_data_and_repairs_healthy_neighbors() {
+    use crate::workflow::task::reindex_workspace;
+
+    let temp = TempDir::new().unwrap();
+    let store = bundle_store(&temp);
+    for id in ["ORB-00000", "ORB-00001", "ORB-00002"] {
+        let bundle = sample_bundle(id);
+        store.create_bundle(&bundle).unwrap();
+        store
+            .registry
+            .replace_task_index(&store.workspace_id, &bundle.envelope)
+            .unwrap();
+    }
+    let partial = store.bundle_path("ORB-00000").unwrap();
+    fs::remove_file(partial.join("description.md")).unwrap();
+    let conflict = store.bundle_path("ORB-00001").unwrap();
+    fs::create_dir(deletion_path(&conflict)).unwrap();
+    fs::write(deletion_path(&conflict).join("evidence"), "retain me").unwrap();
+    let orphan = store.bundle_path("ORB-00003").unwrap();
+    fs::create_dir(&orphan).unwrap();
+    fs::write(orphan.join("evidence"), "partial create").unwrap();
+    store
+        .registry
+        .unregister_task_bundle("ORB-00002", &store.workspace_id)
+        .unwrap();
+
+    for _ in 0..2 {
+        let error = reindex_workspace(&store.registry, &store.workspace_id)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("indexed 1 healthy tasks"), "{error}");
+        for id in ["ORB-00000", "ORB-00001", "ORB-00003"] {
+            assert!(error.contains(id), "{error}");
+        }
+        assert_eq!(
+            store
+                .registry
+                .tasks_for_workspace(&store.workspace_id)
+                .unwrap()
+                .len(),
+            3
+        );
+        assert!(
+            store.list_bundles().is_err(),
+            "registered corruption must still fail listing"
+        );
+        assert_eq!(
+            store
+                .registry
+                .indexed_task_count_for_workspace(&store.workspace_id)
+                .unwrap(),
+            3,
+            "keep unresolved registered index rows while repairing the healthy row"
+        );
+        assert!(partial.join("task.yaml").exists());
+        assert!(conflict.join("task.yaml").exists());
+        assert_eq!(
+            fs::read_to_string(deletion_path(&conflict).join("evidence")).unwrap(),
+            "retain me"
+        );
+        assert_eq!(
+            fs::read_to_string(orphan.join("evidence")).unwrap(),
+            "partial create"
+        );
+        assert!(store.registry.allocator_next_number().unwrap() >= 4);
+    }
+}
+
+#[test]
+fn reindex_registers_forward_relation_targets_before_indexing() {
+    use crate::workflow::task::reindex_workspace;
+    use orbit_types::task::{TaskRelation, TaskRelationType};
+
+    let temp = TempDir::new().unwrap();
+    let store = bundle_store(&temp);
+    let mut child = sample_bundle("ORB-00000");
+    child.envelope.relations.push(TaskRelation {
+        relation_type: TaskRelationType::ChildOf,
+        target: "ORB-00001".into(),
+    });
+    store.create_bundle(&child).unwrap();
+    store.create_bundle(&sample_bundle("ORB-00001")).unwrap();
+    for id in ["ORB-00000", "ORB-00001"] {
+        store
+            .registry
+            .unregister_task_bundle(id, &store.workspace_id)
+            .unwrap();
+    }
+    assert_eq!(
+        reindex_workspace(&store.registry, &store.workspace_id)
+            .unwrap()
+            .indexed,
+        2
+    );
+    assert_eq!(
+        store
+            .registry
+            .indexed_task_count_for_workspace(&store.workspace_id)
+            .unwrap(),
+        2
     );
 }

--- a/crates/orbit-store/src/repository/task/v2/crud.rs
+++ b/crates/orbit-store/src/repository/task/v2/crud.rs
@@ -235,9 +235,6 @@ impl TaskV2Store {
 
     pub(crate) fn delete_task(&self, id: &str) -> Result<bool, OrbitError> {
         orbit_types::task::validate_orb_task_id(id)?;
-        let lock_target = self.bundle_store.bundle_path(id)?;
-        with_exclusive_file_lock(&lock_target, "task artifact v2 delete", || {
-            self.bundle_store.delete_bundle(id)
-        })
+        self.bundle_store.delete_bundle(id)
     }
 }

--- a/crates/orbit-store/src/repository/task/v2/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/mod.rs
@@ -15,7 +15,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
-use orbit_common::fs::io::{atomic_write_bytes, with_exclusive_file_lock};
+use orbit_common::fs::io::atomic_write_bytes;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_types::identity::OrbitId;
 use orbit_types::task::{

--- a/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
@@ -11,7 +11,6 @@ use std::sync::{Arc, Barrier};
 use std::time::Duration;
 
 use super::*;
-use crate::driver::file::task_bundle::task_bundle_lock_sentinel_path;
 
 fn create_tasks(store: &TaskV2Store, count: usize) -> Vec<String> {
     (0..count)
@@ -67,29 +66,20 @@ fn listing_survives_a_bundle_removed_under_a_live_registry_binding() {
     );
 }
 
-/// An incomplete bundle whose create/delete lock sentinel is present is a
-/// writer's work in progress, not damage: skip it and serve every other task.
+/// A stale sentinel from the retired lock protocol cannot hide corruption.
 #[test]
-fn listing_skips_an_incomplete_bundle_held_by_the_lock_sentinel() {
+fn listing_reports_an_incomplete_bundle_despite_a_stale_lock_sentinel() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);
     let ids = create_tasks(&store, 2);
-
-    let in_flight = store
-        .bundle_store
-        .bundle_path(&ids[0])
-        .expect("bundle path");
-    let sentinel = task_bundle_lock_sentinel_path(&in_flight).expect("sentinel path");
-    std::fs::write(&sentinel, b"").expect("hold the sentinel");
-    std::fs::remove_file(in_flight.join("description.md")).expect("truncate publication");
-
-    let listed: Vec<String> = store
-        .list_tasks()
-        .expect("an in-flight bundle must not fail the listing")
-        .into_iter()
-        .map(|task| task.id)
-        .collect();
-    assert_eq!(listed, vec![ids[1].clone()]);
+    let path = store.bundle_store.bundle_path(&ids[0]).unwrap();
+    let sentinel = path.with_file_name(format!(".{}.lock", ids[0]));
+    std::fs::write(sentinel, b"").unwrap();
+    std::fs::remove_file(path.join("description.md")).unwrap();
+    assert!(matches!(
+        store.list_tasks(),
+        Err(OrbitError::TaskBundleCorrupt { .. })
+    ));
 }
 
 /// The tolerance is narrow on purpose: a bundle that is neither held by a
@@ -473,4 +463,125 @@ where
         let _ = sender.send(op());
     });
     receiver.recv_timeout(budget).ok()
+}
+
+#[test]
+fn deletion_waits_for_a_transition_and_leaves_no_partial_bundle() {
+    let temp = TempDir::new().unwrap();
+    let store = store(&temp);
+    let id = create_tasks(&store, 1).remove(0);
+    let holding = Barrier::new(2);
+    let release = Barrier::new(2);
+    let (sent, received) = std::sync::mpsc::sync_channel(1);
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .with_task_lock(&id, || {
+                    holding.wait();
+                    release.wait();
+                    store.update_task_history(
+                        &id,
+                        &TaskHistoryUpdateParams {
+                            actor: "codex".into(),
+                            status: Some(TaskStatus::InProgress),
+                            ..Default::default()
+                        },
+                    )?;
+                    Ok(())
+                })
+                .unwrap()
+        });
+        holding.wait();
+        scope.spawn(|| {
+            sent.send(store.delete_task(&id)).unwrap();
+        });
+        let early = received.recv_timeout(Duration::from_millis(100));
+        release.wait();
+        assert!(early.is_err(), "deletion must wait for the transition");
+        assert!(
+            received
+                .recv_timeout(Duration::from_secs(10))
+                .unwrap()
+                .unwrap()
+        );
+    });
+    assert!(!store.bundle_store.bundle_path(&id).unwrap().exists());
+    assert!(store.get_task(&id).unwrap().is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn a_writer_opened_before_deletion_keeps_the_same_lock_inode() {
+    use crate::driver::file::task_bundle::bundle_lock_target;
+    use fs2::FileExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let temp = TempDir::new().unwrap();
+    let store = store(&temp);
+    for _ in 0..20 {
+        let id = create_tasks(&store, 1).remove(0);
+        let dir = store.bundle_store.bundle_path(&id).unwrap();
+        let target = bundle_lock_target(&dir);
+        let lock_path = target.with_file_name(format!(".{id}.bundle.lock"));
+        let holding = Barrier::new(2);
+        let opened = Barrier::new(2);
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                store
+                    .with_task_lock(&id, || {
+                        holding.wait();
+                        opened.wait();
+                        store.delete_task(&id)?;
+                        Ok(())
+                    })
+                    .unwrap()
+            });
+            holding.wait();
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .unwrap();
+            let before = file.metadata().unwrap().ino();
+            // Descriptor opened before deletion, acquisition after deletion:
+            // this is the obsolete-inode window, without scheduler assumptions.
+            opened.wait();
+            file.lock_exclusive().unwrap();
+            assert_eq!(before, std::fs::metadata(&lock_path).unwrap().ino());
+            FileExt::unlock(&file).unwrap();
+        });
+        let error = store
+            .update_task_document(&id, &document_update("codex", "late write"))
+            .unwrap_err();
+        assert!(matches!(error, OrbitError::NotFound { .. }), "{error}");
+        assert!(!dir.exists());
+    }
+}
+
+#[test]
+fn queued_document_updates_cannot_recreate_deleted_bundles() {
+    let temp = TempDir::new().unwrap();
+    let store = store(&temp);
+    for _ in 0..20 {
+        let id = create_tasks(&store, 1).remove(0);
+        let queued = Barrier::new(2);
+        std::thread::scope(|scope| {
+            let writer = store
+                .with_task_lock(&id, || {
+                    let writer = scope.spawn(|| {
+                        queued.wait();
+                        store.update_task_document(&id, &document_update("codex", "queued"))
+                    });
+                    queued.wait();
+                    assert!(store.delete_task(&id)?);
+                    Ok(writer)
+                })
+                .unwrap();
+            assert!(matches!(
+                writer.join().unwrap(),
+                Err(OrbitError::NotFound { .. })
+            ));
+        });
+        assert!(!store.bundle_store.bundle_path(&id).unwrap().exists());
+    }
 }

--- a/crates/orbit-store/src/repository/task/v2/tests/crud.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/crud.rs
@@ -217,7 +217,7 @@ fn create_task_on_readonly_parent_dir_names_lock_path_and_hints_sandbox() {
         .bundle_path("ORB-00001")
         .expect("next bundle path");
     let parent = next_bundle.parent().expect("tasks dir").to_path_buf();
-    let lock_path = parent.join(".ORB-00001.lock");
+    let lock_path = parent.join(".ORB-00001.bundle.lock");
     let _restore = make_readonly(&parent);
 
     let err = store

--- a/crates/orbit-store/src/repository/task/v2/tests/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing.rs
@@ -189,14 +189,12 @@ fn selected_corruption_is_not_replaced_and_in_flight_deletion_is_tolerated() {
             .query_task_rows(&TaskListFilter::default(), 1, None)
             .is_err()
     );
-    let sentinel = crate::driver::file::task_bundle::task_bundle_lock_sentinel_path(&path).unwrap();
+    let sentinel = path.with_file_name(format!(".{}.lock", selected.id));
     fs::write(sentinel, "").unwrap();
     assert!(
         store
             .query_task_rows(&TaskListFilter::default(), 1, None)
-            .unwrap()
-            .items
-            .is_empty()
+            .is_err()
     );
     fs::remove_dir_all(path).unwrap();
     assert_eq!(

--- a/crates/orbit-store/src/repository/task/v2/tests/update.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/update.rs
@@ -290,7 +290,7 @@ fn artifact_update_writes_manifest_and_sorted_text_artifacts() {
 
 #[cfg(unix)]
 #[test]
-fn document_update_on_readonly_bundle_dir_names_lock_path_and_hints_sandbox() {
+fn document_update_on_readonly_bundle_dir_names_path_and_hints_sandbox() {
     let temp = TempDir::new().expect("tempdir");
     let store = store(&temp);
     store
@@ -300,7 +300,6 @@ fn document_update_on_readonly_bundle_dir_names_lock_path_and_hints_sandbox() {
         .bundle_store
         .bundle_path("ORB-00000")
         .expect("bundle path");
-    let lock_path = bundle_dir.join(".task.yaml.lock");
     let _restore = make_readonly(&bundle_dir);
 
     let err = store
@@ -313,7 +312,7 @@ fn document_update_on_readonly_bundle_dir_names_lock_path_and_hints_sandbox() {
             },
         )
         .expect_err("update must fail on a read-only bundle dir");
-    assert_sandbox_write_io(&err, &lock_path.display().to_string());
+    assert_sandbox_write_io(&err, &bundle_dir.display().to_string());
 }
 
 /// [ORB-11305] `expected_status` is a compare-and-set: the write is applied

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -1,7 +1,6 @@
-//! Task bundle v2 persistence is split into focused submodules while this root keeps store orchestration and re-exports.
-//! The `task_bundle_types` submodule owns bundle value types and document filename mapping.
-//! The `bundle_io` submodule owns bundle assembly, validation, JSONL repair, artifact manifest checks, and partial-bundle cleanup.
-//! The `lock` submodule owns bundle create/delete lock ordering, sentinel cleanup, and projection-entry crash recovery checks.
+//! Task bundle orchestration joins file durability, registry bindings and
+//! checkout projections. Full-bundle reads and mutations share a persistent
+//! external lock; deletion publishes a recoverable rename before cleanup.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -16,13 +15,11 @@ use orbit_types::task::{
     TaskEnvelopeV2, TaskEventRowV2,
 };
 
+use crate::driver::file::task_bundle::bundle_lock_target;
 pub(crate) use crate::driver::file::task_bundle::{TaskBundleV2, TaskDocumentV2};
 use crate::driver::file::task_bundle::{
     append_jsonl_row, cleanup_partial_bundle_best_effort, publish_envelope, read_bundle_at,
     read_envelope_at, write_bundle_at,
-};
-use crate::driver::file::task_bundle::{
-    remove_task_bundle_lock_sentinel, task_bundle_lock_sentinel_path,
 };
 use crate::driver::sqlite::task_registry::{
     ProjectionRebuildResult, TaskBundleBinding, TaskRegistryStore,
@@ -100,7 +97,12 @@ impl TaskBundleStoreV2 {
         with_exclusive_file_lock(
             &bundle_lock_target(&self.bundle_path(task_id)?),
             "task artifact v2",
-            op,
+            || {
+                // A queued writer may resume after deletion. Check under the
+                // stable lock before any helper can create parent directories.
+                read_envelope_at(&self.bundle_path(task_id)?)?;
+                op()
+            },
         )
     }
 
@@ -113,11 +115,8 @@ impl TaskBundleStoreV2 {
     ) -> Result<TaskBundleV2, OrbitError> {
         let id = &proposed.envelope.id;
         let path = self.bundle_path(id)?;
-        with_exclusive_file_lock(&path, "task action admission", || {
-            // Under the *creation* lock, which does not exclude a lifecycle
-            // write to an already-recovered bundle — so read this the same
-            // coordinated way, or a replay racing a transition would declare a
-            // perfectly good bundle unreadable.
+        with_exclusive_file_lock(&bundle_lock_target(&path), "task action admission", || {
+            // Re-entrant read under the same lock as lifecycle writes.
             if let Ok(existing) = read_bundle_consistently(&path) {
                 self.registry
                     .register_task_bundle(id, &self.workspace_id, &path)?;
@@ -130,7 +129,6 @@ impl TaskBundleStoreV2 {
                 {
                     orbit_common::tracing::warn!(task_id=id,error=%error,"recovered action task; checkout projection remains degraded");
                 }
-                remove_task_bundle_lock_sentinel(&task_bundle_lock_sentinel_path(&path)?)?;
                 return Ok(existing);
             }
             if path.exists() {
@@ -140,7 +138,6 @@ impl TaskBundleStoreV2 {
                 ));
             }
             self.create_bundle_locked(id, &path, proposed)?;
-            remove_task_bundle_lock_sentinel(&task_bundle_lock_sentinel_path(&path)?)?;
             Ok(proposed.clone())
         })
     }
@@ -151,29 +148,11 @@ impl TaskBundleStoreV2 {
     ) -> Result<TaskBundleCreateResult, OrbitError> {
         let task_id = bundle.envelope.id.clone();
         let bundle_dir = self.bundle_path(&task_id)?;
-        let lock_sentinel_path = task_bundle_lock_sentinel_path(&bundle_dir)?;
-        with_exclusive_file_lock(&bundle_dir, "task bundle create", || {
-            let result = self.create_bundle_locked(&task_id, &bundle_dir, bundle);
-            match (
-                result,
-                remove_task_bundle_lock_sentinel(&lock_sentinel_path),
-            ) {
-                (Ok(created), Ok(())) => Ok(created),
-                (Err(err), Ok(())) => Err(err),
-                (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
-                (Err(err), Err(cleanup_err)) => {
-                    orbit_common::tracing::warn!(
-                        target: "orbit.store.task_bundle_v2",
-                        task_id,
-                        lock_path = %lock_sentinel_path.display(),
-                        original_error = %err,
-                        cleanup_error = %cleanup_err,
-                        "failed to clean up task bundle lock sentinel",
-                    );
-                    Err(err)
-                }
-            }
-        })
+        with_exclusive_file_lock(
+            &bundle_lock_target(&bundle_dir),
+            "task bundle create",
+            || self.create_bundle_locked(&task_id, &bundle_dir, bundle),
+        )
     }
 
     fn create_bundle_locked(
@@ -182,6 +161,11 @@ impl TaskBundleStoreV2 {
         bundle_dir: &Path,
         bundle: &TaskBundleV2,
     ) -> Result<TaskBundleCreateResult, OrbitError> {
+        if deletion_path(bundle_dir).try_exists()? {
+            return Err(OrbitError::Store(
+                "task deletion is pending; rerun deletion or reindex before creation".into(),
+            ));
+        }
         if bundle_dir.exists() {
             return Err(OrbitError::Store(format!(
                 "task bundle already exists at {}",
@@ -267,23 +251,70 @@ impl TaskBundleStoreV2 {
     pub(crate) fn delete_bundle(&self, task_id: &str) -> Result<bool, OrbitError> {
         orbit_types::task::validate_orb_task_id(task_id)?;
         let bundle_dir = self.bundle_path(task_id)?;
+        with_exclusive_file_lock(
+            &bundle_lock_target(&bundle_dir),
+            "task bundle delete",
+            || self.delete_bundle_locked(task_id, &bundle_dir),
+        )
+    }
 
+    /// Reindex resumes only published deletions, never deletes a live bundle.
+    pub(crate) fn recover_deletion(&self, task_id: &str) -> Result<bool, OrbitError> {
+        let bundle_dir = self.bundle_path(task_id)?;
+        with_exclusive_file_lock(
+            &bundle_lock_target(&bundle_dir),
+            "task deletion recovery",
+            || {
+                if !deletion_path(&bundle_dir).try_exists()? {
+                    return Ok(false);
+                }
+                self.delete_bundle_locked(task_id, &bundle_dir)
+            },
+        )
+    }
+
+    fn delete_bundle_locked(&self, task_id: &str, bundle_dir: &Path) -> Result<bool, OrbitError> {
+        let tombstone = deletion_path(bundle_dir);
+        let published = tombstone.try_exists()?;
+        let exists = bundle_dir.try_exists()?;
+        if published && exists {
+            return Err(OrbitError::Store(format!(
+                "task {task_id} has both a canonical bundle and a deletion tombstone; retained both for repair"
+            )));
+        }
         if let Some(workspace_orbit_dir) = self.workspace_orbit_dir.as_deref() {
             ensure_projection_entry_removable(workspace_orbit_dir, task_id)?;
         }
+
+        // Rename publishes deletion before any destructive cleanup. The whole
+        // bundle survives registry failure, and a cleanup failure stays outside
+        // the canonical namespace. Retry always rolls a published deletion forward.
+        deletion_fault(DeletionFault::Publication)?;
+        if exists {
+            fs::rename(bundle_dir, &tombstone)
+                .map_err(|err| OrbitError::from_write_io(bundle_dir, err))?;
+        }
+        if exists || published {
+            deletion_fault(DeletionFault::PublicationSync)?;
+            sync_parent_dir(&tombstone)
+                .map_err(|err| OrbitError::from_write_io(&tombstone, err))?;
+        }
+        deletion_fault(DeletionFault::Registry)?;
         let unregistered = self
             .registry
             .unregister_task_bundle(task_id, &self.workspace_id)?;
-        let removed_bundle = match fs::remove_dir_all(&bundle_dir) {
-            Ok(()) => true,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
-            Err(err) => return Err(OrbitError::from_write_io(&bundle_dir, err)),
-        };
         let removed_projection = match self.workspace_orbit_dir.as_deref() {
             Some(workspace_orbit_dir) => remove_projection_entry(workspace_orbit_dir, task_id)?,
             None => false,
         };
-        Ok(unregistered || removed_bundle || removed_projection)
+        deletion_fault(DeletionFault::Cleanup)?;
+        if exists || published {
+            fs::remove_dir_all(&tombstone)
+                .map_err(|err| OrbitError::from_write_io(&tombstone, err))?;
+            sync_parent_dir(&tombstone)
+                .map_err(|err| OrbitError::from_write_io(&tombstone, err))?;
+        }
+        Ok(unregistered || exists || published || removed_projection)
     }
 
     /// List bundles registered to this workspace.
@@ -408,13 +439,39 @@ impl TaskBundleStoreV2 {
     }
 }
 
-/// The lock file coordinating one bundle's readers and writers.
-///
-/// Deliberately *not* the create/delete sentinel, which keys on the bundle
-/// directory itself: a reader must not block a task's creation or removal, and
-/// those transient states stay governed by [`skip_if_in_flight`].
-fn bundle_lock_target(bundle_dir: &Path) -> PathBuf {
-    bundle_dir.join(TASK_ENVELOPE_FILE_NAME)
+/// A published deletion is retained here until registry/projection removal and
+/// cleanup finish. Canonical and tombstone coexistence is ambiguous and retained.
+pub(crate) fn deletion_path(bundle_dir: &Path) -> PathBuf {
+    bundle_dir.with_extension("deleted")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeletionFault {
+    Publication,
+    PublicationSync,
+    Registry,
+    Cleanup,
+}
+
+#[cfg(test)]
+thread_local! {
+    static DELETION_FAULT: std::cell::Cell<Option<DeletionFault>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn inject_deletion_fault(fault: DeletionFault) {
+    DELETION_FAULT.set(Some(fault));
+}
+
+fn deletion_fault(_fault: DeletionFault) -> Result<(), OrbitError> {
+    #[cfg(test)]
+    if DELETION_FAULT.get() == Some(_fault) {
+        DELETION_FAULT.set(None);
+        return Err(OrbitError::Store(format!(
+            "injected deletion failure at {_fault:?}"
+        )));
+    }
+    Ok(())
 }
 
 /// Assemble a whole bundle under this task's shared read lock.
@@ -444,16 +501,11 @@ fn read_bundle_tolerating_in_flight(bundle_dir: &Path) -> Result<Option<TaskBund
 /// Convert a failed bundle read into `Ok(None)` when the bundle is provably
 /// mid-flight rather than damaged, and re-raise it otherwise.
 ///
-/// Both discriminators are re-checked *after* the read failed, so a bundle
-/// that read cleanly is never suppressed:
-///
-/// - the create/delete lock sentinel is present, meaning another writer holds
-///   the bundle directory right now (or left the sentinel behind by deleting
-///   the task, in which case there is no bundle to read anyway); or
-/// - the bundle directory is gone, meaning the delete completed between the
-///   registry snapshot and the read.
+/// The directory is rechecked after the failed read: a concurrent deletion
+/// can remove it between the registry snapshot and lock acquisition. An old
+/// sentinel file alone is never evidence that a damaged bundle is in flight.
 fn skip_if_in_flight<T>(bundle_dir: &Path, err: OrbitError) -> Result<Option<T>, OrbitError> {
-    if !bundle_read_failure_is_in_flight(bundle_dir) {
+    if bundle_dir.try_exists().unwrap_or(true) {
         return Err(err);
     }
     orbit_common::tracing::debug!(
@@ -463,11 +515,4 @@ fn skip_if_in_flight<T>(bundle_dir: &Path, err: OrbitError) -> Result<Option<T>,
         "skipped a task bundle held by a concurrent writer",
     );
     Ok(None)
-}
-
-fn bundle_read_failure_is_in_flight(bundle_dir: &Path) -> bool {
-    if task_bundle_lock_sentinel_path(bundle_dir).is_ok_and(|path| path.exists()) {
-        return true;
-    }
-    !bundle_dir.is_dir()
 }

--- a/crates/orbit-store/src/workflow/task/reindex.rs
+++ b/crates/orbit-store/src/workflow/task/reindex.rs
@@ -6,12 +6,14 @@
 use std::collections::BTreeSet;
 
 use orbit_common::OrbitError;
+use orbit_common::fs::io::with_exclusive_file_lock;
 use orbit_types::task::is_valid_orb_task_id;
 
-use crate::driver::file::task_bundle::recover_pending_bundle_at;
+use crate::driver::file::task_bundle::{bundle_lock_target, recover_pending_bundle_at};
 use crate::driver::sqlite::task_registry::{
     ProjectionRebuildResult, TaskRegistryStore, parse_orb_task_number,
 };
+use crate::repository::task::v2_bundle::TaskBundleStoreV2;
 
 /// Result of [`reindex_workspace`].
 #[derive(Debug, Clone)]
@@ -41,44 +43,79 @@ pub fn reindex_workspace(
         })?;
     let workspace_id = binding.workspace_id.clone();
 
-    // Enumerate the bundles physically present on disk.
     let workspace_dir = registry.workspaces_dir().join(&workspace_id);
-    let on_disk = on_disk_task_ids(&workspace_dir)?;
-
-    // Drop registry bindings whose bundle directory is gone — bundle dirs are the
-    // source of truth, and replace_workspace_task_indexes requires the registered
-    // set to equal the envelope set.
-    let mut removed_stale = 0usize;
+    let mut candidates = on_disk_task_ids(&workspace_dir)?;
+    let max_number = candidates
+        .iter()
+        .filter_map(|id| parse_orb_task_number(id))
+        .max();
     for existing in registry.tasks_for_workspace(&workspace_id)? {
-        if !on_disk.contains(&existing.task_id)
-            && registry.unregister_task_bundle(&existing.task_id, &workspace_id)?
-        {
-            removed_stale += 1;
-        }
+        candidates.insert(existing.task_id);
     }
-
-    // Register every on-disk bundle (idempotent upsert) and collect envelopes.
-    // An incomplete multi-file write is aborted or finalized from its pending record.
-    let mut envelopes = Vec::with_capacity(on_disk.len());
-    let mut max_number: Option<u32> = None;
-    for task_id in &on_disk {
+    let checkout = registry.find_workspace_checkout(&workspace_id)?;
+    let store = match &checkout {
+        Some(checkout) => TaskBundleStoreV2::new(
+            registry.clone(),
+            workspace_id.clone(),
+            checkout.orbit_dir.clone(),
+        ),
+        None => TaskBundleStoreV2::new_checkoutless(registry.clone(), workspace_id.clone()),
+    };
+    let mut removed_stale = 0;
+    let mut indexed = 0;
+    let mut readable = Vec::new();
+    let mut failures = Vec::new();
+    for task_id in &candidates {
         let dir = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
-        let bundle = recover_pending_bundle_at(&dir)?;
-        registry.register_task_bundle(task_id, &workspace_id, &dir)?;
-        if let Some(number) = parse_orb_task_number(task_id) {
-            max_number = Some(max_number.map_or(number, |current| current.max(number)));
+        let result = with_exclusive_file_lock(&bundle_lock_target(&dir), "task reindex", || {
+            if store.recover_deletion(task_id)? {
+                removed_stale += 1;
+                return Ok(());
+            }
+            if !dir.try_exists()? {
+                if registry.unregister_task_bundle(task_id, &workspace_id)? {
+                    removed_stale += 1;
+                }
+                return Ok(());
+            }
+            recover_pending_bundle_at(&dir)?;
+            registry.register_task_bundle(task_id, &workspace_id, &dir)?;
+            readable.push(task_id);
+            Ok::<(), OrbitError>(())
+        });
+        if let Err(error) = result {
+            // Keep unresolved bytes AND any authoritative binding/index. A
+            // healthy neighbor still gets repaired, but this run cannot succeed.
+            failures.push(format!("{task_id}: {error}"));
         }
-        envelopes.push(bundle.envelope);
     }
 
-    registry.replace_workspace_task_indexes(&workspace_id, &envelopes)?;
+    // Register the readable set before validating relations: imported tasks
+    // may refer to another bundle later in directory order. Re-read under the
+    // lock so an intervening update/deletion cannot publish a stale index.
+    for task_id in readable {
+        let dir = registry.canonical_task_bundle_path(&workspace_id, task_id)?;
+        let result = with_exclusive_file_lock(&bundle_lock_target(&dir), "task reindex", || {
+            if store.recover_deletion(task_id)? || !dir.try_exists()? {
+                return Ok(());
+            }
+            let bundle = recover_pending_bundle_at(&dir)?;
+            registry.replace_task_index(&workspace_id, &bundle.envelope)?;
+            indexed += 1;
+            Ok::<(), OrbitError>(())
+        });
+        if let Err(error) = result {
+            failures.push(format!("{task_id}: {error}"));
+        }
+    }
 
-    // Never let the allocator hand out an id that already exists on disk.
+    // Include unresolved IDs so allocator recovery cannot collide with data
+    // retained for repair. Never replace the entire index with a partial set.
     if let Some(max) = max_number {
-        registry.bump_allocator_to_at_least(max + 1)?;
+        registry.bump_allocator_to_at_least(max.saturating_add(1))?;
     }
 
-    let projection = if let Some(checkout) = registry.find_workspace_checkout(&workspace_id)? {
+    let projection = if let Some(checkout) = checkout {
         crate::repository::checkout_projection::rebuild_projection(
             registry,
             &checkout.orbit_dir,
@@ -92,15 +129,23 @@ pub fn reindex_workspace(
         }
     };
 
+    if !failures.is_empty() {
+        return Err(OrbitError::Store(format!(
+            "reindex incomplete: indexed {indexed} healthy tasks; unresolved bundles retained: {}",
+            failures.join("; ")
+        )));
+    }
+
     Ok(ReindexOutcome {
         workspace_id,
-        indexed: on_disk.len(),
+        indexed,
         removed_stale,
         projection,
     })
 }
 
-/// Canonical task ids that have a bundle directory on disk under `workspace_dir`.
+/// Candidate IDs include tombstones and malformed non-directory entries, so
+/// reindex reports unresolved data rather than treating it as an absent bundle.
 fn on_disk_task_ids(workspace_dir: &std::path::Path) -> Result<BTreeSet<String>, OrbitError> {
     let mut ids = BTreeSet::new();
     let entries = match std::fs::read_dir(workspace_dir) {
@@ -110,17 +155,11 @@ fn on_disk_task_ids(workspace_dir: &std::path::Path) -> Result<BTreeSet<String>,
     };
     for entry in entries {
         let entry = entry.map_err(|e| OrbitError::Io(e.to_string()))?;
-        if !entry
-            .file_type()
-            .map_err(|e| OrbitError::Io(e.to_string()))?
-            .is_dir()
-        {
-            continue;
-        }
-        if let Some(name) = entry.file_name().to_str()
-            && is_valid_orb_task_id(name)
-        {
-            ids.insert(name.to_string());
+        if let Some(name) = entry.file_name().to_str() {
+            let id = name.strip_suffix(".deleted").unwrap_or(name);
+            if is_valid_orb_task_id(id) {
+                ids.insert(id.to_string());
+            }
         }
     }
     Ok(ids)

--- a/docs/design/task-migration/1_overview.md
+++ b/docs/design/task-migration/1_overview.md
@@ -129,7 +129,26 @@ Reindex treats the on-disk bundles as the source of truth: it registers any
 bundle missing from the index, drops stale bindings whose directory is gone,
 rebuilds the index/tag/relation rows, bumps the allocator past the highest
 on-disk id, and reprojects the symlinks. `allocator_state` is otherwise
-preserved.
+preserved. Unreadable or partial bundles retain their bytes and any registered
+binding/index; healthy neighbors are indexed, and reindex returns an error listing
+the unresolved task IDs rather than reporting full success.
+
+Full-bundle readers, writers, creation, deletion, and reindex coordinate through
+persistent `.<task-id>.bundle.lock` files beside the canonical bundles.
+These lock files must not be removed while Orbit processes run. Writers recheck
+the envelope after acquiring the lock, so a queued update cannot recreate a
+deleted bundle. Upgrades changing this lock location require restarting all
+writers together; older processes use the former in-bundle lock.
+
+Deletion atomically renames `<task-id>/` to `<task-id>.deleted/` and syncs its
+parent before removing registry and projection entries, then removes the
+tombstone and syncs again. A crash before rename leaves the live task intact.
+After rename, deletion retry or reindex rolls forward, including when registry
+removal has already succeeded or cleanup left partial contents. A registry
+failure retains the entire renamed bundle; a cleanup failure retains its
+remaining contents. If both canonical and tombstone paths exist, recovery
+reports a conflict and retains both for explicit repair. Tombstones are never
+registered as live tasks.
 
 ## Task References
 


### PR DESCRIPTION
## Task

[ORB-11649](https://orbit-cli.com/tasks/ORB-11649) — [code-review] Make task deletion coordinate with writers and recover safely after interruption

### Description

## Problem
delete_task holds the create/delete sentinel but not the bundle write lock. delete_bundle unregisters the task before removing its directory. A transition can race deletion and recreate a partial directory; interrupted directory removal can leave an unregistered partial bundle that aborts reindex.

## Required behavior and constraints
Coordinate deletion with writers using a stable lock identity and consistent lock order. Recheck task existence after acquisition so blocked writers cannot recreate a deleted bundle after an in-directory lock is renamed or unlinked. Make publication of deletion and cleanup recoverable; if using tombstones, define crash recovery before and after registry removal and retain unresolved data. Reindex should report partial/unreadable bundles while processing healthy tasks, without silently dropping corrupt registered tasks from authoritative state or reporting full success.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-store/src/repository/task/v2/crud.rs:236`; `crates/orbit-store/src/repository/task/v2_bundle.rs:267`; `crates/orbit-store/src/workflow/task/reindex.rs:63`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Barrier-controlled concurrent transition and deletion serialize correctly; after deletion no canonical partial directory remains.
- A writer queued before deletion cannot acquire an obsolete lock inode and recreate the deleted bundle; test repeated delete/update races.
- Inject failures at deletion publication, registry removal and cleanup boundaries; rerun/reindex gives a deterministic recovery/reporting outcome while preserving unresolved data and indexing healthy tasks.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Unified task creation, full-bundle reads, lifecycle writes, deletion and pending-write recovery on persistent sibling .<task-id>.bundle.lock files. Writers recheck the envelope after lock acquisition; retired sentinel files no longer suppress settled corruption.
- Deletion publishes and fsyncs a <task-id>.deleted directory before unregistering/removing the projection and cleaning up. Retry/reindex rolls published deletions forward. Canonical/tombstone conflicts retain both paths and report an error.
- Reindex retains unresolved bundles and their registered binding/index rows, indexes healthy neighbors, and returns an incomplete-run error with task IDs. Registration precedes per-task index repair to support forward relations.
- Updated current recovery/upgrade documentation. No new dependencies or commits.

Criteria evidence:
1. Barrier-controlled lifecycle transition/deletion test proves deletion waits for the writer and leaves no canonical partial directory. Restoring the original delete_bundle method from starting HEAD made this regression fail with “deletion must wait for the transition”; restored fix passes.
2. Twenty pre-opened-descriptor/delete iterations verify the same lock inode survives deletion. Twenty queued document-update/delete iterations return task-not-found and never recreate the canonical directory.
3. Fault matrix covers before rename, after rename/before parent fsync, registry removal, and cleanup; retries and reindex recover deterministically. Partial cleanup is simulated by removing a tombstone sidecar. Repeated unavailable boundaries report failure while indexing the healthy neighbor. Separate tests preserve registered corrupt indexes, unregistered partial data, conflicting tombstones, and forward relation targets.

Validation:
- PASSED: cargo test -p orbit-store --lib — 451 passed, 0 failed, 5 default ignored benchmark/helper entries. The two subprocess helpers are exercised by their parent tests.
- PASSED: make ci-fast.
- PASSED: make ci-lint (cargo clippy --workspace --all-targets -- -D warnings).
- PASSED: cargo fmt --all; git diff --check; final git status --short (13 scoped modified files, no incidental outputs).
- PASSED: cargo clean — removed 5841 files / 3.5 GiB.
- EXPECTED FAILURE: exact transition/deletion regression with original deletion implementation restored, exit 101; final implementation restored before final validation.
- Earlier iteration failures: two permission assertions referenced the previous lock boundary; corrected without removing error-classification coverage. A ci-fast attempt overlapped formatting; final rerun passed.
- NOT RUN: full make ci, reserved for the PR merge gate by workspace policy; macOS execution and physical power-loss testing.
- Captured final command output, tested HEAD/diff hash and baseline regression output are attached as validation.json.

Assessment: All acceptance criteria are covered by observable repository/filesystem tests. Complete diff reviewed for failure ordering, retained data, obsolete lock paths and documentation consistency.
Risks: Validation ran on Linux using real filesystem/flock operations plus fault injection, not physical crash testing. All writer processes must restart together when upgrading across the lock-path change; mixed old/new writers do not share the new lock. Persistent lock files must not be unlinked while processes run.
Scope: Expanded selectors before edits for the common bundle lock/recovery caller, obsolete CRUD import, existing sibling regression/permission/listing tests, and affected documentation. Recovery tests fit the bundle-store test module, so the initially considered workflow test root was not changed.
Checkout: Both requested roots resolved to the current checkout; starting and final HEAD are 522313e7a259e034a39742a6f3f667359208a31b. Starting status was clean. Changes remain uncommitted; pipeline owns delivery and the review transition.
Friction checkpoint: No new qualifying friction beyond the scoped defect; no friction filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11649-6a9f62e2`
- Behind base: 0
- Ahead of base: 1