### PR TITLE
[code-review] Limit detached incremental indexing to long-lived runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Cloning gives you a framework to mold to your team's conventions; everything und
 
 ```bash
 orbit semantic install    # one-time: companion + default model (bge-small)
-orbit semantic index      # backfill existing tasks; later task writes embed automatically
+orbit semantic index      # backfill tasks; CLI mutations do not auto-index — re-run after edits
 orbit docs index          # backfill docs for --kind doc --hybrid
 orbit search "race in the scheduler when locks overlap" --hybrid --kind task
 ```

--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -15,7 +15,7 @@ use orbit_common::protocol::tool_input::required_string;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_core::OrbitRuntime;
 use orbit_core::adapter::command::{ToolEntryPoint, execute_global_in_process_tool_dispatch};
-use orbit_core::runtime::resolve_global_root;
+use orbit_core::runtime::{HostLifetime, resolve_global_root};
 use orbit_mcp::federated;
 use orbit_mcp::{
     ListenerExposure, McpHost, McpListener, McpSessionAuthority, SessionCapabilityPolicy,
@@ -324,10 +324,11 @@ impl ServerMcpHost {
         context: &ToolSessionContext,
     ) -> Result<(OrbitRuntime, ResolvedWorkspaceSelection), OrbitError> {
         let selected = self.workspace_selection(name, input, context)?;
-        let runtime = RegisteredRuntimeFactory::open_registered_checkout(
+        let runtime = RegisteredRuntimeFactory::open_registered_checkout_for(
             &self.global_root,
             &selected.workspace,
             &selected.checkout,
+            HostLifetime::LongLived,
         )?;
         Ok((runtime, selected))
     }

--- a/crates/orbit-cli/src/command/semantic.rs
+++ b/crates/orbit-cli/src/command/semantic.rs
@@ -24,6 +24,9 @@ pub enum SemanticSubcommand {
     /// Show orbit-search index and companion status
     Stats(SemanticStatsArgs),
     /// Rebuild semantic embeddings
+    ///
+    /// CLI task mutations do not index in the background; run this after
+    /// installs or bulk edits.
     Index(SemanticIndexArgs),
 }
 

--- a/crates/orbit-cli/tests/semantic_companion.rs
+++ b/crates/orbit-cli/tests/semantic_companion.rs
@@ -13,54 +13,58 @@ use tempfile::{TempDir, tempdir};
 
 #[test]
 #[cfg(unix)]
-fn tool_run_task_update_with_noisy_background_companion_has_clean_stderr() {
+fn cli_task_mutation_does_not_launch_background_companion() {
     let workspace = TestWorkspace::new();
-    workspace.write_noisy_companion();
+    workspace.write_instrumented_companion();
     let task = workspace.add_task_without_companion();
     let task_id = task["id"].as_str().expect("task id");
 
-    let mut saw_companion_invocation = false;
-    for attempt in 0..8 {
-        let input = json!({
-            "id": task_id,
-            "comment": format!("background semantic indexing attempt {attempt}"),
-            "model": "gpt-5"
-        })
-        .to_string();
-        let output = workspace.run_with_companion(
-            &[
-                "tool",
-                "run",
-                "orbit.task.update",
-                "--input",
-                &input,
-                "--full",
-            ],
-            "tool run task update",
-        );
-        assert_stderr_lacks_broken_pipe(&output);
-
-        if workspace.companion_invoked() {
-            saw_companion_invocation = true;
-            break;
-        }
-    }
-
+    let input = json!({
+        "id": task_id,
+        "comment": "cli mutation must not spawn a detached companion",
+        "model": "gpt-5"
+    })
+    .to_string();
+    let output = workspace.run_with_companion(
+        &[
+            "tool",
+            "run",
+            "orbit.task.update",
+            "--input",
+            &input,
+            "--full",
+        ],
+        "tool run task update",
+    );
+    assert_stderr_lacks_broken_pipe(&output);
     assert!(
-        saw_companion_invocation,
-        "mock companion was not invoked by background task indexing"
+        !workspace.companion_invoked(),
+        "CLI task mutation launched a background companion; launch log should stay empty"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn explicit_semantic_index_launches_companion() {
+    let workspace = TestWorkspace::new();
+    workspace.write_instrumented_companion();
+    workspace.add_task_without_companion();
+
+    workspace.run_with_companion(&["semantic", "index", "--json"], "semantic index");
+    assert!(
+        workspace.companion_invoked(),
+        "explicit `orbit semantic index` must launch the companion; launch log was empty"
     );
 }
 
 /// Foreground search runs the companion with inherited stderr, so a broken
 /// companion's diagnostics reach the operator. Contrast with
-/// [`tool_run_task_update_with_noisy_background_companion_has_clean_stderr`],
-/// where background indexing suppresses companion stderr.
+/// [`cli_task_mutation_does_not_launch_background_companion`],
+/// where short-lived CLI mutations do not start a background companion.
 ///
-/// ADR-0244 (ORB-10304) made the task branch degrade to lexical instead of
-/// failing the command when hybrid infrastructure is unavailable, so the
-/// command now exits 0. The degradation must stay *visible*: the companion's
-/// own stderr plus an explicit fallback note (ORB-10350).
+/// Hybrid search degrades to lexical instead of failing when infrastructure
+/// is unavailable (ORB-10304). The degradation must stay visible: companion
+/// stderr plus an explicit fallback note (ORB-10350).
 #[test]
 #[cfg(unix)]
 fn direct_search_semantic_command_surfaces_companion_stderr() {
@@ -197,7 +201,7 @@ impl TestWorkspace {
     }
 
     #[cfg(unix)]
-    fn write_noisy_companion(&self) {
+    fn write_instrumented_companion(&self) {
         let script = format!(
             r#"#!/bin/sh
 printf '%s\n' 'execution failed: Broken pipe (os error 32)' >&2

--- a/crates/orbit-cmd/src/registry_runtime.rs
+++ b/crates/orbit-cmd/src/registry_runtime.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use orbit_common::OrbitError;
 use orbit_core::OrbitRuntime;
 use orbit_core::runtime::{
-    OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint, WorkspaceRuntimeBinding,
-    managed_workspace_selector_from_env,
+    HostLifetime, OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint,
+    WorkspaceRuntimeBinding, managed_workspace_selector_from_env,
 };
 use orbit_store::maintenance::task_registry::{TaskRegistryStore, task_registry_path};
 use orbit_types::workspace::{
@@ -231,16 +231,34 @@ impl RegisteredRuntimeFactory {
         workspace: &Workspace,
         checkout: &WorkspaceCheckout,
     ) -> Result<OrbitRuntime, OrbitError> {
+        Self::open_registered_checkout_for(
+            global_root,
+            workspace,
+            checkout,
+            HostLifetime::ShortLived,
+        )
+    }
+
+    pub fn open_registered_checkout_for(
+        global_root: &Path,
+        workspace: &Workspace,
+        checkout: &WorkspaceCheckout,
+        host_lifetime: HostLifetime,
+    ) -> Result<OrbitRuntime, OrbitError> {
         sync_task_prefix(global_root)?;
         let binding = workspace_runtime_binding(workspace, checkout)?;
-        OrbitRuntime::from_roots_with_binding(global_root, &checkout.orbit_dir, binding).map(
-            |runtime| {
-                attach_registry_context(
-                    runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
-                    global_root,
-                )
-            },
+        OrbitRuntime::from_roots_with_binding_for(
+            global_root,
+            &checkout.orbit_dir,
+            binding,
+            host_lifetime,
         )
+        .map(|runtime| {
+            attach_registry_context(
+                runtime.with_coordination_write_owner(replica_owner_for_checkout(checkout)),
+                global_root,
+            )
+        })
     }
 
     fn open_registered_checkout_read_only(
@@ -270,12 +288,29 @@ impl RegisteredRuntimeFactory {
         local_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<OrbitRuntime, OrbitError> {
-        sync_task_prefix(global_root)?;
-        OrbitRuntime::from_resolved_roots_with_binding(
+        Self::open_resolved_checkout_for(
             global_root,
             shared_root,
             local_root,
             binding,
+            HostLifetime::ShortLived,
+        )
+    }
+
+    pub fn open_resolved_checkout_for(
+        global_root: &Path,
+        shared_root: &Path,
+        local_root: &Path,
+        binding: WorkspaceRuntimeBinding,
+        host_lifetime: HostLifetime,
+    ) -> Result<OrbitRuntime, OrbitError> {
+        sync_task_prefix(global_root)?;
+        OrbitRuntime::from_resolved_roots_with_binding_for(
+            global_root,
+            shared_root,
+            local_root,
+            binding,
+            host_lifetime,
         )
         .map(|runtime| attach_registry_context(runtime, global_root))
     }

--- a/crates/orbit-core/assets/skills/orbit/references/docs-corpus.md
+++ b/crates/orbit-core/assets/skills/orbit/references/docs-corpus.md
@@ -42,6 +42,6 @@ Agents retrieve through `orbit.search`; these are human and admin workflows.
 |---------|------|
 | Install / remove | `orbit semantic install [--model M] [--force]` / `orbit semantic uninstall [--model M] [--all]` |
 | Status | `orbit semantic stats` |
-| Rebuild embeddings | `orbit semantic index --kind tasks\|docs\|all [--model M] [--force]` |
+| Rebuild embeddings | `orbit semantic index --kind tasks\|docs\|all [--model M] [--force]` — the CLI refresh path; task add/update does not background-index |
 
 Supported on macOS arm64 and Linux x86_64/aarch64 with glibc ≥ 2.38. There is no x86_64-apple-darwin asset. Don't install without operator consent.

--- a/crates/orbit-core/assets/skills/orbit/references/search.md
+++ b/crates/orbit-core/assets/skills/orbit/references/search.md
@@ -31,10 +31,13 @@ tokens are rejected because statuses collide across corpora.
 
 **Index coverage:** lexical covers all three corpora. Vector search covers task
 fields and docs once `orbit semantic index --kind <kind>` has run; frictions are
-never embedded, so they stay lexical even under `--hybrid`. Missing vectors under
-`--hybrid` fall back to lexical with a note rather than failing — and if the
-companion isn't installed at all, fall back to lexical and continue. Never run
-`orbit semantic install` without operator consent.
+never embedded, so they stay lexical even under `--hybrid`. CLI task add/update
+does not spawn a background embedder — re-run `orbit semantic index` after CLI
+mutations. Long-lived hosts (MCP serve, the dashboard) still index mutations
+incrementally. Missing vectors under `--hybrid` fall back to lexical with a note
+rather than failing — and if the companion isn't installed at all, fall back to
+lexical and continue. A missing install does not start or retry a companion.
+Never run `orbit semantic install` without operator consent.
 
 ## Two different dedupe checks
 

--- a/crates/orbit-core/src/composition.rs
+++ b/crates/orbit-core/src/composition.rs
@@ -11,7 +11,7 @@ use crate::bootstrap::policy::seed_default_policies;
 use crate::bootstrap::task_migration::apply_configured_id_start;
 use crate::runtime::run_input::managed_run_context_from_env;
 use crate::runtime::{
-    OrbitRuntime, OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint,
+    HostLifetime, OrbitRuntime, OrbitRuntimeRoots, ResolvedOrbitRoots, WorkspaceRootHint,
     WorkspaceRuntimeBinding, resolve_bootstrap_roots, resolve_bootstrap_roots_with_hint,
     resolve_global_root, resolve_initialize_roots, resolve_initialize_roots_with_hint,
 };
@@ -38,6 +38,7 @@ impl OrbitRuntime {
             &roots.local_root,
             binding,
             true,
+            HostLifetime::ShortLived,
         )
     }
 
@@ -53,6 +54,7 @@ impl OrbitRuntime {
             &roots.local_root,
             binding,
             false,
+            HostLifetime::ShortLived,
         )
     }
 
@@ -107,7 +109,27 @@ impl OrbitRuntime {
         workspace_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<Self, OrbitError> {
-        Self::from_resolved_roots_with_binding(global_root, workspace_root, workspace_root, binding)
+        Self::from_roots_with_binding_for(
+            global_root,
+            workspace_root,
+            binding,
+            HostLifetime::ShortLived,
+        )
+    }
+
+    pub fn from_roots_with_binding_for(
+        global_root: &Path,
+        workspace_root: &Path,
+        binding: WorkspaceRuntimeBinding,
+        host_lifetime: HostLifetime,
+    ) -> Result<Self, OrbitError> {
+        Self::from_resolved_roots_with_binding_for(
+            global_root,
+            workspace_root,
+            workspace_root,
+            binding,
+            host_lifetime,
+        )
     }
 
     pub fn from_resolved_roots(
@@ -115,7 +137,14 @@ impl OrbitRuntime {
         shared_root: &Path,
         local_root: &Path,
     ) -> Result<Self, OrbitError> {
-        build_runtime(global_root, shared_root, local_root, None, true)
+        build_runtime(
+            global_root,
+            shared_root,
+            local_root,
+            None,
+            true,
+            HostLifetime::ShortLived,
+        )
     }
 
     pub fn from_resolved_roots_with_binding(
@@ -124,7 +153,31 @@ impl OrbitRuntime {
         local_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<Self, OrbitError> {
-        build_runtime(global_root, shared_root, local_root, Some(binding), true)
+        Self::from_resolved_roots_with_binding_for(
+            global_root,
+            shared_root,
+            local_root,
+            binding,
+            HostLifetime::ShortLived,
+        )
+    }
+
+    /// Open a runtime whose embed worker matches the constructing host's lifetime.
+    pub fn from_resolved_roots_with_binding_for(
+        global_root: &Path,
+        shared_root: &Path,
+        local_root: &Path,
+        binding: WorkspaceRuntimeBinding,
+        host_lifetime: HostLifetime,
+    ) -> Result<Self, OrbitError> {
+        build_runtime(
+            global_root,
+            shared_root,
+            local_root,
+            Some(binding),
+            true,
+            host_lifetime,
+        )
     }
 
     pub fn from_resolved_roots_read_only_with_binding(
@@ -133,7 +186,14 @@ impl OrbitRuntime {
         local_root: &Path,
         binding: WorkspaceRuntimeBinding,
     ) -> Result<Self, OrbitError> {
-        build_runtime(global_root, shared_root, local_root, Some(binding), false)
+        build_runtime(
+            global_root,
+            shared_root,
+            local_root,
+            Some(binding),
+            false,
+            HostLifetime::ShortLived,
+        )
     }
 
     pub fn in_memory() -> Result<Self, OrbitError> {
@@ -153,6 +213,7 @@ fn build_runtime(
     local_root: &Path,
     binding: Option<WorkspaceRuntimeBinding>,
     reconcile_stale_runs: bool,
+    host_lifetime: HostLifetime,
 ) -> Result<OrbitRuntime, OrbitError> {
     let layout_report = match orbit_store::workflow::layout::upgrade_workspace_layout(shared_root) {
         Ok(report) => report,
@@ -175,6 +236,7 @@ fn build_runtime(
         binding,
         &runtime_config,
         layout_report,
+        host_lifetime,
     )?;
     if reconcile_stale_runs && !managed_run_context_from_env() {
         runtime.reconcile_stale_job_runs_on_open();

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -27,7 +27,7 @@ use crate::context::OrbitContext;
 use crate::context::{
     ActorIdentity, OrbitExecutionAssets, OrbitPolicyContext, OrbitRuntimeSettings, OrbitStores,
 };
-use crate::runtime::WorkspaceRuntimeBinding;
+use crate::runtime::{HostLifetime, WorkspaceRuntimeBinding};
 use crate::skill_catalog::SkillCatalog;
 
 /// Job-run partition used when an explicit `--root` data directory is opened
@@ -44,6 +44,7 @@ pub(crate) fn build_context_from_roots(
     local_root: &Path,
     binding: Option<&WorkspaceRuntimeBinding>,
     runtime_config: &ResolvedConfig,
+    host_lifetime: HostLifetime,
 ) -> Result<OrbitContext, OrbitError> {
     let persistence = &runtime_config.persistence;
 
@@ -105,7 +106,10 @@ pub(crate) fn build_context_from_roots(
         );
     }
     let semantic_vector_store = Arc::new(VectorStore::open(&persistence.semantic_db)?);
-    let semantic_worker = Arc::new(EmbedWorker::start((*semantic_vector_store).clone()));
+    let semantic_worker = match host_lifetime {
+        HostLifetime::LongLived => Arc::new(EmbedWorker::start((*semantic_vector_store).clone())),
+        HostLifetime::ShortLived => Arc::new(EmbedWorker::disabled()),
+    };
     let job_run_store = workspace_job_run_store(store.clone(), workspace_id);
 
     // Executors and policies are global-only. Jobs always persist run state

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -104,6 +104,18 @@ pub struct OrbitRuntimeRoots {
     pub local_root: PathBuf,
 }
 
+/// Whether the constructing process retains this runtime past a single command.
+///
+/// Short-lived CLI mutations must not spawn a detached embed worker: process
+/// exit can interrupt queued indexing, and a missing companion must not add
+/// startup or retry work. Long-lived hosts (MCP serve, the dashboard) keep
+/// incremental indexing on [`orbit_search::EmbedWorker`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostLifetime {
+    ShortLived,
+    LongLived,
+}
+
 /// Registry-neutral metadata supplied by a higher-level workspace catalog.
 ///
 /// `orbit-core` can construct a runtime without this binding for standalone
@@ -152,6 +164,7 @@ impl OrbitRuntime {
         binding: Option<WorkspaceRuntimeBinding>,
         runtime_config: &orbit_config::ResolvedConfig,
         layout_report: orbit_store::workflow::layout::LayoutUpgradeReport,
+        host_lifetime: HostLifetime,
     ) -> Result<Self, OrbitError> {
         let context = builder::build_context_from_roots(
             global_root,
@@ -159,6 +172,7 @@ impl OrbitRuntime {
             local_root,
             binding.as_ref(),
             runtime_config,
+            host_lifetime,
         )?;
         Ok(Self {
             context,
@@ -196,6 +210,7 @@ impl OrbitRuntime {
             data_root,
             Some(&binding),
             runtime_config,
+            HostLifetime::ShortLived,
         )?;
         Ok(Self {
             context,

--- a/crates/orbit-search/src/vector/mod.rs
+++ b/crates/orbit-search/src/vector/mod.rs
@@ -5,8 +5,9 @@
 //! - [`store`] — [`VectorStore`], the SQLite-backed index. Entry point.
 //! - [`chunker`] — paragraph-boundary chunker for fields exceeding the
 //!   model's context window.
-//! - [`worker`] — background indexer that drains task-mutation events into
-//!   the store via a `SubprocessEmbedder`.
+//! - [`worker`] — optional background indexer for long-lived hosts. Short-lived
+//!   CLI runtimes leave it disabled; mutations refresh through
+//!   `orbit semantic index`.
 //! - [`query`] — brute-force cosine, FTS5 BM25, RRF, and task-result rollup.
 //! - [`task_fields`] — extracts the per-field rows that get embedded for a
 //!   `Task`.

--- a/crates/orbit-search/src/vector/tests/mod.rs
+++ b/crates/orbit-search/src/vector/tests/mod.rs
@@ -1,6 +1,7 @@
 mod chunker;
 mod doc_fields;
 mod task_fields;
+mod worker;
 
 #[test]
 fn cosine_similarity_unit_and_orthogonal() {

--- a/crates/orbit-search/src/vector/tests/worker.rs
+++ b/crates/orbit-search/src/vector/tests/worker.rs
@@ -1,0 +1,79 @@
+//! Unit tests for the long-lived `EmbedWorker` path.
+
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+
+use crate::NoopEmbedder;
+use crate::vector::{EmbedWorker, SOURCE_KIND_TASK, VectorStore};
+
+fn task(id: &str, title: &str, description: &str) -> Task {
+    Task {
+        id: id.to_string(),
+        title: title.to_string(),
+        description: description.to_string(),
+        acceptance_criteria: vec!["Indexed after mutation".to_string()],
+        required_tools: Vec::new(),
+        plan: "Plan body".to_string(),
+        execution_summary: String::new(),
+        context_files: Vec::new(),
+        created_by: None,
+        planned_by: None,
+        implemented_by: None,
+        status: TaskStatus::Backlog,
+        priority: TaskPriority::Medium,
+        complexity: None,
+        task_type: TaskType::Chore,
+        pr_status: None,
+        external_refs: Vec::new(),
+        relations: Vec::new(),
+        job_run_id: None,
+        crew: None,
+        orchestrator: None,
+        tags: Vec::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn wait_until(timeout: Duration, mut ready: impl FnMut() -> bool) {
+    let started = Instant::now();
+    while started.elapsed() < timeout {
+        if ready() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("timed out after {timeout:?} waiting for worker indexing");
+}
+
+#[test]
+fn long_lived_worker_indexes_enqueued_task_into_vector_store() {
+    let store = VectorStore::open_in_memory().expect("open in-memory vector store");
+    let worker = EmbedWorker::start_with_embedder(store.clone(), Box::new(NoopEmbedder::small()));
+    let task = task(
+        "T-worker-1",
+        "Index this mutation",
+        "Observed through the vector store",
+    );
+
+    worker.enqueue(task.clone());
+
+    wait_until(Duration::from_secs(2), || {
+        store
+            .source_ids(SOURCE_KIND_TASK)
+            .expect("read source ids")
+            .contains(&task.id)
+    });
+
+    let stats = store.stats(std::slice::from_ref(&task.id)).expect("stats");
+    assert_eq!(stats.stale_rows, 0);
+    assert!(
+        stats
+            .counts
+            .iter()
+            .any(|count| count.source_kind == SOURCE_KIND_TASK && count.model_id == "noop"),
+        "expected noop embeddings for the enqueued task, got {stats:?}"
+    );
+}

--- a/crates/orbit-search/src/vector/worker.rs
+++ b/crates/orbit-search/src/vector/worker.rs
@@ -1,8 +1,9 @@
 //! Background worker that drains an mpsc channel of `EmbedJob`s and feeds
-//! them into a long-lived `SubprocessEmbedder`. Used by `orbit-core`'s task
-//! lifecycle hooks (create / update / delete) so that mutations enqueue
-//! best-effort indexing without blocking the caller. Failures log at debug
-//! and never propagate.
+//! them into a long-lived embedder. Long-lived hosts (MCP, dashboard) start
+//! this worker so task mutations enqueue best-effort indexing without
+//! blocking the caller. Short-lived CLI runtimes use [`EmbedWorker::disabled`]
+//! instead: process exit can interrupt a detached companion, so CLI refresh
+//! is `orbit semantic index`. Failures log at debug and never propagate.
 
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::thread;
@@ -10,6 +11,7 @@ use std::thread;
 use orbit_types::task::Task;
 
 use crate::SubprocessEmbedder;
+use crate::embedder::Embedder;
 
 use super::store::VectorStore;
 
@@ -23,14 +25,34 @@ pub struct EmbedJob {
 
 #[derive(Clone)]
 pub struct EmbedWorker {
-    sender: SyncSender<EmbedJob>,
+    sender: Option<SyncSender<EmbedJob>>,
 }
 
 impl EmbedWorker {
+    /// Incremental indexer for a process that retains this runtime.
+    ///
+    /// The companion is created lazily on the first job so a missing install
+    /// fails before spawn retry, matching [`SubprocessEmbedder::quiet_with_model`].
     pub fn start(store: VectorStore) -> Self {
+        Self::spawn(store, None)
+    }
+
+    /// No background thread and no companion. `enqueue` is a silent no-op.
+    pub fn disabled() -> Self {
+        Self { sender: None }
+    }
+
+    /// Incremental indexer with a caller-supplied embedder. Used by tests so
+    /// indexing is observed through the vector store without a real companion.
+    #[cfg(test)]
+    pub(crate) fn start_with_embedder(store: VectorStore, embedder: Box<dyn Embedder>) -> Self {
+        Self::spawn(store, Some(embedder))
+    }
+
+    fn spawn(store: VectorStore, seeded_embedder: Option<Box<dyn Embedder>>) -> Self {
         let (sender, receiver) = mpsc::sync_channel::<EmbedJob>(128);
         thread::spawn(move || {
-            let mut embedder: Option<SubprocessEmbedder> = None;
+            let mut embedder = seeded_embedder;
             while let Ok(first) = receiver.recv() {
                 let mut batch = vec![first];
                 while batch.len() < EMBED_BATCH_SIZE {
@@ -41,7 +63,7 @@ impl EmbedWorker {
                 }
                 if embedder.is_none() {
                     match SubprocessEmbedder::quiet_with_model(crate::DEFAULT_MODEL) {
-                        Ok(value) => embedder = Some(value),
+                        Ok(value) => embedder = Some(Box::new(value)),
                         Err(error) => {
                             orbit_common::tracing::debug!(
                                 target: "orbit.search.indexer",
@@ -56,7 +78,9 @@ impl EmbedWorker {
                     continue;
                 };
                 for job in &batch {
-                    if let Err(error) = store.index_task(&job.task, active_embedder, job.force) {
+                    if let Err(error) =
+                        store.index_task(&job.task, active_embedder.as_ref(), job.force)
+                    {
                         orbit_common::tracing::debug!(
                             target: "orbit.search.indexer",
                             task_id = job.task.id.as_str(),
@@ -67,11 +91,16 @@ impl EmbedWorker {
                 }
             }
         });
-        Self { sender }
+        Self {
+            sender: Some(sender),
+        }
     }
 
     pub fn enqueue(&self, task: Task) {
-        match self.sender.try_send(EmbedJob { task, force: false }) {
+        let Some(sender) = self.sender.as_ref() else {
+            return;
+        };
+        match sender.try_send(EmbedJob { task, force: false }) {
             Ok(()) => {}
             Err(TrySendError::Full(job)) => {
                 orbit_common::tracing::debug!(

--- a/crates/orbit-web/src/state.rs
+++ b/crates/orbit-web/src/state.rs
@@ -39,7 +39,7 @@ use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Json, Response};
 use orbit_cmd::registry_runtime::{RegisteredRuntimeFactory, workspace_runtime_binding};
-use orbit_core::runtime::WorkspaceRuntimeBinding;
+use orbit_core::runtime::{HostLifetime, WorkspaceRuntimeBinding};
 use orbit_core::{OrbitError, OrbitRuntime, ShipMode};
 use orbit_registry::workspace_registry;
 use orbit_types::workspace::WorkspaceStatus;
@@ -315,11 +315,12 @@ impl StateInner {
         }
 
         // Build outside the lock (no lock held across construction).
-        let runtime = RegisteredRuntimeFactory::open_resolved_checkout(
+        let runtime = RegisteredRuntimeFactory::open_resolved_checkout_for(
             &self.global_root,
             &orbit_dir,
             &orbit_dir,
             binding.clone(),
+            HostLifetime::LongLived,
         )
         .map_err(|e| WsRejection::build_failed(id, &e))?;
         let runtime = Arc::new(runtime);

--- a/plugin/skills/orbit/references/docs-corpus.md
+++ b/plugin/skills/orbit/references/docs-corpus.md
@@ -42,6 +42,6 @@ Agents retrieve through `orbit.search`; these are human and admin workflows.
 |---------|------|
 | Install / remove | `orbit semantic install [--model M] [--force]` / `orbit semantic uninstall [--model M] [--all]` |
 | Status | `orbit semantic stats` |
-| Rebuild embeddings | `orbit semantic index --kind tasks\|docs\|all [--model M] [--force]` |
+| Rebuild embeddings | `orbit semantic index --kind tasks\|docs\|all [--model M] [--force]` — the CLI refresh path; task add/update does not background-index |
 
 Supported on macOS arm64 and Linux x86_64/aarch64 with glibc ≥ 2.38. There is no x86_64-apple-darwin asset. Don't install without operator consent.

--- a/plugin/skills/orbit/references/search.md
+++ b/plugin/skills/orbit/references/search.md
@@ -31,10 +31,13 @@ tokens are rejected because statuses collide across corpora.
 
 **Index coverage:** lexical covers all three corpora. Vector search covers task
 fields and docs once `orbit semantic index --kind <kind>` has run; frictions are
-never embedded, so they stay lexical even under `--hybrid`. Missing vectors under
-`--hybrid` fall back to lexical with a note rather than failing — and if the
-companion isn't installed at all, fall back to lexical and continue. Never run
-`orbit semantic install` without operator consent.
+never embedded, so they stay lexical even under `--hybrid`. CLI task add/update
+does not spawn a background embedder — re-run `orbit semantic index` after CLI
+mutations. Long-lived hosts (MCP serve, the dashboard) still index mutations
+incrementally. Missing vectors under `--hybrid` fall back to lexical with a note
+rather than failing — and if the companion isn't installed at all, fall back to
+lexical and continue. A missing install does not start or retry a companion.
+Never run `orbit semantic install` without operator consent.
 
 ## Two different dedupe checks
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -29,7 +29,7 @@ Global options go **before** the subcommand: `orbit --workspace ws_x task list`.
 | `orbit workspace remove` \| `teardown` | Deregister a workspace, or remove Orbit artifacts from it. |
 | `orbit host show` \| `rename` | Inspect or rename this machine's local host identity. |
 | `orbit config show` \| `get` \| `set` \| `keys` \| `path` | Read and write configuration. See [Configuration](../config/). |
-| `orbit semantic install` \| `uninstall` \| `stats` \| `index` | Manage the local embedding companion used for semantic search. |
+| `orbit semantic install` \| `uninstall` \| `stats` \| `index` | Manage the local embedding companion. CLI task mutations do not auto-index; run `orbit semantic index` to refresh. |
 | `orbit migrate` | Inspect pending `.orbit` layout and store migrations; `--confirm` applies them. |
 | `orbit update` | Install a published release and converge to it. `--check`, `--version`, `--allow-downgrade`. |
 


### PR DESCRIPTION
## Task

[ORB-11704](https://orbit-cli.com/tasks/ORB-11704) — [code-review] Limit detached incremental indexing to long-lived runtimes

### Description

## Problem
The runtime builder starts a detached EmbedWorker thread without a shutdown drain contract. Child startup is lazy after an indexing job, but CLI exit can interrupt queued indexing, so completion of CLI mutations does not establish completion of incremental indexing. Missing companion discovery already fails before subprocess retry.

## Required behavior and constraints
Make host lifetime explicit: do not schedule detached background indexing for short-lived CLI mutations; retain incremental indexing for long-lived hosts. Document and test the CLI-only refresh path through explicit semantic reindex. Avoid adding durable dirty markers or a second indexing queue unless a concrete requirement makes them necessary. Do not claim every invocation spawns a companion or every mutation necessarily loses its update.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-core/src/runtime/builder.rs:108`; `crates/orbit-search/src/vector/worker.rs:30,34,43,69`; `crates/orbit-search/src/subprocess.rs:125`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A CLI mutation test with an instrumented companion launcher proves no detached background companion is launched; test launch events rather than a timing-sensitive pgrep snapshot.
- The long-lived host worker still indexes task mutations, observed through the vector store using a controlled embedder/companion.
- CLI-only indexing behavior and the explicit reindex command are documented; missing installations do not introduce new startup/retry work.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `EmbedWorker` now has `disabled()` (enqueue no-op, no thread) and keeps `start()` for incremental indexing. Companion spawn stays lazy via `SubprocessEmbedder::quiet_with_model`; missing installs still fail before retry. Test-only `start_with_embedder` injects `NoopEmbedder`.
- Runtime construction takes `HostLifetime`. Default constructors and CLI factory opens are `ShortLived` (disabled worker). MCP `ServerMcpHost` and the dashboard runtime cache open as `LongLived`.
- CLI mutation test records companion launch events and asserts none fire; `orbit semantic index` still launches. Worker unit test observes embeddings in `VectorStore`.
- Documented CLI-only refresh (`orbit semantic index`) in README, search/docs-corpus skills, CLI help, and website CLI reference. Plugin skills synced from assets.

Criteria:
1. CLI mutation does not launch a detached companion — passed. `cli_task_mutation_does_not_launch_background_companion` uses the instrumented launch log, not pgrep.
2. Long-lived worker still indexes mutations — passed. `long_lived_worker_indexes_enqueued_task_into_vector_store` uses `NoopEmbedder` and asserts vector-store rows.
3. CLI refresh documented; no new missing-install startup/retry — passed. Docs/help updated; worker still uses existing lazy locate/fail-before-retry. No dirty markers or second queue.

Validation:
- `cargo test -p orbit-search --lib vector::tests::worker` — passed (1 test)
- `cargo test -p orbit-cli --test semantic_companion` — passed (4 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Assessment: Host lifetime is explicit at the runtime seam; CLI no longer schedules a detached indexer. MCP still opens a per-call runtime but the process is long-lived so queued jobs can drain; caching those runtimes was out of scope.

Strategic decisions: Default short-lived to match CLI; opt in long-lived at MCP and dashboard opens rather than inferring from env. No shutdown drain for CLI because the worker is not started.

Design weaknesses / risks:
- Severity: low. MCP per-call runtime still starts a worker thread per tool call. Mitigation: process stays alive so the channel can drain; a later cache would amortize companion startup.
- Severity: low. CLI mutations after `orbit semantic index` stay stale until the operator reindexes. Mitigation: documented as the intended refresh path.

Deviations from original plan: none material. Added `explicit_semantic_index_launches_companion` so an empty launch log cannot be a false pass from a broken launcher.

Remaining risks: uncommitted worktree includes the new `crates/orbit-search/src/vector/tests/worker.rs`. Pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11704-6a9f630a`
- Behind base: 0
- Ahead of base: 1