### PR TITLE
[code-review] Serialise `ensure_host_identity` under the registry lock (check-then-write race creates two machine ids)

### DIFF
--- a/crates/orbit-registry/src/host_identity.rs
+++ b/crates/orbit-registry/src/host_identity.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use orbit_common::OrbitError;
-use orbit_common::fs::io::atomic_write_text;
+use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
 use orbit_common::protocol::toml::escape_basic_string;
 use orbit_types::identity::{MACHINE_ID_PREFIX, validate_machine_id};
 use serde::Deserialize;
@@ -328,51 +328,58 @@ pub fn load_host_identity(global_root: &Path) -> Result<HostIdentity, OrbitError
 ///
 /// Idempotent: a present identity is returned `Unchanged` with no write. A
 /// malformed or future-schema file is never overwritten — the error propagates.
+///
+/// Concurrent callers on the same root are serialised with an exclusive lock
+/// on `host.toml`. Inspect runs after the lock is held, so a racing second
+/// create observes `Present` and returns `Unchanged` instead of minting a
+/// second `machine_id`.
 pub fn ensure_host_identity(
     global_root: &Path,
     new: impl FnOnce() -> Result<NewHostIdentity, OrbitError>,
 ) -> Result<HostIdentityOutcome, OrbitError> {
-    match inspect_host_identity(global_root)? {
-        HostIdentityState::Present(identity) => Ok(HostIdentityOutcome::Unchanged(identity)),
-        HostIdentityState::Legacy {
-            host_id,
-            machine_id,
-        } => {
-            // Migrate atomically: preserve an existing schema-v1 machine id,
-            // generate one only for the oldest host-id-only format, and retain
-            // the historical ORB namespace. Rollback leaves the last valid
-            // file readable.
-            let identity = HostIdentity {
-                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
-                machine_id: machine_id.unwrap_or_else(generate_machine_id),
+    with_exclusive_file_lock(&host_toml_path(global_root), "host identity", move || {
+        match inspect_host_identity(global_root)? {
+            HostIdentityState::Present(identity) => Ok(HostIdentityOutcome::Unchanged(identity)),
+            HostIdentityState::Legacy {
                 host_id,
-                task_prefix: LEGACY_TASK_PREFIX.to_string(),
-            };
-            write_host_identity(global_root, &identity)?;
-            Ok(HostIdentityOutcome::Migrated(identity))
-        }
-        HostIdentityState::Absent => {
-            let NewHostIdentity {
-                host_id,
-                task_prefix,
-            } = new()?;
-            let host_id = host_id.trim().to_string();
-            if host_id.is_empty() {
-                return Err(OrbitError::InvalidInput(
-                    "host name must not be empty".to_string(),
-                ));
+                machine_id,
+            } => {
+                // Migrate atomically: preserve an existing schema-v1 machine id,
+                // generate one only for the oldest host-id-only format, and retain
+                // the historical ORB namespace. Rollback leaves the last valid
+                // file readable.
+                let identity = HostIdentity {
+                    schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                    machine_id: machine_id.unwrap_or_else(generate_machine_id),
+                    host_id,
+                    task_prefix: LEGACY_TASK_PREFIX.to_string(),
+                };
+                write_host_identity(global_root, &identity)?;
+                Ok(HostIdentityOutcome::Migrated(identity))
             }
-            let task_prefix = validate_new_task_prefix(&task_prefix)?;
-            let identity = HostIdentity {
-                schema_version: HOST_IDENTITY_SCHEMA_VERSION,
-                machine_id: generate_machine_id(),
-                host_id,
-                task_prefix,
-            };
-            write_host_identity(global_root, &identity)?;
-            Ok(HostIdentityOutcome::Created(identity))
+            HostIdentityState::Absent => {
+                let NewHostIdentity {
+                    host_id,
+                    task_prefix,
+                } = new()?;
+                let host_id = host_id.trim().to_string();
+                if host_id.is_empty() {
+                    return Err(OrbitError::InvalidInput(
+                        "host name must not be empty".to_string(),
+                    ));
+                }
+                let task_prefix = validate_new_task_prefix(&task_prefix)?;
+                let identity = HostIdentity {
+                    schema_version: HOST_IDENTITY_SCHEMA_VERSION,
+                    machine_id: generate_machine_id(),
+                    host_id,
+                    task_prefix,
+                };
+                write_host_identity(global_root, &identity)?;
+                Ok(HostIdentityOutcome::Created(identity))
+            }
         }
-    }
+    })
 }
 
 /// Atomically (re)write `host.toml`. The staged-rename write never leaves a

--- a/crates/orbit-registry/src/tests/host_identity.rs
+++ b/crates/orbit-registry/src/tests/host_identity.rs
@@ -1,3 +1,6 @@
+use std::sync::Barrier;
+use std::thread;
+
 use crate::HOST_IDENTITY_SCHEMA_VERSION;
 
 use crate::host_identity::{
@@ -47,6 +50,58 @@ fn create_persists_current_schema_identity() {
 
     let loaded = load_host_identity(dir.path()).expect("load");
     assert_eq!(&loaded, identity);
+}
+
+#[test]
+fn concurrent_ensure_on_absent_root_creates_one_identity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let workers = 8;
+    let barrier = Barrier::new(workers);
+
+    let outcomes: Vec<HostIdentityOutcome> = thread::scope(|scope| {
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    ensure_host_identity(root, requested("dk-server-1", "DE")).expect("ensure")
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("worker joined"))
+            .collect()
+    });
+
+    let created = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, HostIdentityOutcome::Created(_)))
+        .count();
+    assert_eq!(created, 1, "exactly one thread must create the identity");
+    assert!(
+        outcomes.iter().all(|outcome| matches!(
+            outcome,
+            HostIdentityOutcome::Created(_) | HostIdentityOutcome::Unchanged(_)
+        )),
+        "losers must observe Unchanged, not a second create: {outcomes:?}"
+    );
+
+    let machine_id = outcomes[0].identity().machine_id.clone();
+    assert!(
+        outcomes
+            .iter()
+            .all(|outcome| outcome.identity().machine_id == machine_id),
+        "all threads must observe the same machine_id"
+    );
+
+    let loaded = load_host_identity(root).expect("load");
+    assert_eq!(loaded.machine_id, machine_id);
+    assert_eq!(loaded.host_id, "dk-server-1");
+    assert_eq!(loaded.task_prefix, "DE");
+    for outcome in &outcomes {
+        assert_eq!(outcome.identity(), &loaded);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11708](https://orbit-cli.com/tasks/ORB-11708) — [code-review] Serialise `ensure_host_identity` under the registry lock (check-then-write race creates two machine ids)

### Description

## Problem
`ensure_host_identity` inspects `host.toml` and, if `Absent`/`Legacy`, generates a `machine_id` and writes the file with a plain atomic rename; no lock is taken (the CLI caller in `orbit-cli/src/command/init/command.rs:111` does not wrap it either). Two processes racing through `orbit init` (or an init racing a test/MCP proxy bootstrap on the same `~/.orbit`) both observe `Absent`, both generate distinct `hm_*` ids (`generate_machine_id` mixes time, pid and a process-local counter), and both "succeed"; the last rename wins. The loser may already have registered a workspace with `owner_machine_id = <its id>`; `validate_workspace_registry` then fails every subsequent load with `declares local owner role, but logical owner is machine 'A' instead of local machine 'B'`, and nothing repairs it. `machine_id` is documented as "generated once and never reused", which this path cannot guarantee.

## Why It Matters
The failure mode is a permanently invalid registry on that machine; the fix is a one-line lock around an existing helper.

## Proposed Fix
Wrap inspect+write in `orbit_common::fs::io::with_exclusive_file_lock(&host_toml_path, "host identity", ...)` (the same helper `with_registry_lock` uses) and re-run `inspect_host_identity` after acquiring the lock before deciding to create/migrate.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-registry/src/host_identity.rs:332-376`, `crates/orbit-registry/src/host_identity.rs:381-393`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: N threads call `ensure_host_identity` on the same absent root concurrently; exactly one returns `Created` and all returned identities have the same `machine_id`; the file matches.
- `orbit init` behaviour is unchanged for the single-process case (existing tests in `tests/host_identity.rs` pass).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Wrapped `ensure_host_identity` inspect+create/migrate in `orbit_common::fs::io::with_exclusive_file_lock` on `host.toml` (sibling `.host.toml.lock`, label `host identity`). Inspect runs only after the lock is held, so racing callers on an absent root serialise: exactly one `Created`, the rest `Unchanged` with the same `machine_id`.
- Added `concurrent_ensure_on_absent_root_creates_one_identity` in `crates/orbit-registry/src/tests/host_identity.rs` (8 threads, barrier start, one `Created`, shared `machine_id`, on-disk identity matches every return).

Assessment: Smallest compatible fix at the owning seam. Single canonical path (no unlocked fast-path). Same lock target as host rename, so init and rename exclude each other. Existing single-process tests unchanged in behaviour.

Criteria:
1. Concurrent Absent-root create — met. `concurrent_ensure_on_absent_root_creates_one_identity` passed (8 threads; exactly one `Created`; all identities and `load_host_identity` share one `machine_id`).
2. Single-process `orbit init` behaviour — met. All 16 existing `tests/host_identity.rs` cases plus the new concurrent test passed (17/17).

Validation:
- `cargo fmt --all` — passed
- `CARGO_TARGET_DIR=/tmp/orbit-build cargo test -p orbit-registry host_identity` — passed (17 tests)
- `make ci-fast` — passed
- `CARGO_TARGET_DIR=/tmp/orbit-build make ci-lint` — passed
- `git diff --check` — passed
- `cargo clean` (worktree `target/`) — failed: Device or resource busy (os error 16) removing `target/`. Not retried. Contents were removed; empty `target/` directory remains (also present at session start). Ignored by git.

Strategic decisions: Always lock, including `Unchanged`. A pre-lock Present fast-path would still require a second inspect under the lock for Absent/Legacy; one locked inspect is the simpler canonical path.

Design weaknesses / risks:
- Severity: low. The concurrent test is in-process threads sharing one pid; cross-process racing uses the same flock and is not separately spawned. Mitigation: flock is process-wide exclusive on the sibling lock file.
- Severity: low. The lock is held across `new()` on a true first-time create, so a second `orbit init` blocks for the duration of any interactive prompt. That is the intended serialisation.

Deviations from original plan: none.

Friction: none filed. No contradicted assumption, recurring failure, incident root cause, or non-obvious gotcha over 10 minutes.

Uncommitted files (pipeline owns commit):
- crates/orbit-registry/src/host_identity.rs
- crates/orbit-registry/src/tests/host_identity.rs

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11708-6a9f6593`
- Behind base: 0
- Ahead of base: 1