### PR TITLE
Bound Orbit repository build concurrency independently of agent concurrency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches compiler-cache-status compiler-cache-setup compiler-cache-bench
+.PHONY: help build release run check test fmt fmt-check clippy clean install uninstall dev watch audit tree ci ci-fast ci-lint stability release-check docs-index cleanup-branches build-budget-test build-budget-bench compiler-cache-status compiler-cache-setup compiler-cache-bench
 
 # ------------------------------------------------------------
 # Config
 # ------------------------------------------------------------
 CARGO ?= cargo
+BUILD_BUDGET ?= ./scripts/build-budget.py
 BINARY := orbit
 BIN_CRATE := orbit-cli
 # Crate sources live under orbit/ (see root Cargo.toml workspace members).
@@ -57,6 +58,8 @@ help:
 	@echo "  make uninstall    Remove installed binary"
 	@echo "  make clean        Clean build artifacts"
 	@echo "  make cleanup-branches  Force-remove worktrees and branches except main/agent-main (DESTRUCTIVE)"
+	@echo "  make build-budget-test   Test cross-worktree build admission without compiling"
+	@echo "  make build-budget-bench  Compare current and budgeted concurrent Cargo checks"
 	@echo "  make compiler-cache-status  Show whether the opt-in rustc cache would enable"
 	@echo "  make compiler-cache-setup   Create ~/.orbit/cache/compiler (SETUP_FLAGS=--install to fetch sccache)"
 	@echo "  make compiler-cache-bench   Two-worktree cold/warm/concurrent compiler-cache timings"
@@ -66,16 +69,16 @@ help:
 # Build
 # ------------------------------------------------------------
 build:
-	$(CARGO) build $(WORKSPACE) $(CARGO_PROFILE)
+	$(BUILD_BUDGET) -- $(CARGO) build $(WORKSPACE) $(CARGO_PROFILE)
 
 release:
-	$(CARGO) build -p $(BIN_CRATE) --bin $(BINARY) --release
+	$(BUILD_BUDGET) -- $(CARGO) build -p $(BIN_CRATE) --bin $(BINARY) --release
 
 # ------------------------------------------------------------
 # Run
 # ------------------------------------------------------------
 run:
-	$(CARGO) run -p $(BIN_CRATE) --bin $(BINARY) -- $(ARGS)
+	$(BUILD_BUDGET) -- $(CARGO) run -p $(BIN_CRATE) --bin $(BINARY) -- $(ARGS)
 
 # Direct execution (after build)
 dev: build
@@ -85,10 +88,10 @@ dev: build
 # Quality
 # ------------------------------------------------------------
 check:
-	$(CARGO) check $(WORKSPACE)
+	$(BUILD_BUDGET) -- $(CARGO) check $(WORKSPACE)
 
 test:
-	$(CARGO) test $(WORKSPACE)
+	$(BUILD_BUDGET) -- $(CARGO) test $(WORKSPACE)
 
 fmt:
 	$(CARGO) fmt --all
@@ -97,7 +100,7 @@ fmt-check:
 	$(CARGO) fmt --all -- --check
 
 clippy:
-	$(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
+	$(BUILD_BUDGET) -- $(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
 
 # Supply-chain audit: advisories + license allow-list via cargo-deny (deny.toml).
 # Canonical command; CI runs the same check via scripts/ci-guardrails.sh.
@@ -111,7 +114,7 @@ tree:
 
 # Full CI pass
 ci:
-	./scripts/ci-guardrails.sh
+	$(BUILD_BUDGET) -- ./scripts/ci-guardrails.sh
 
 # Pre-handoff gate for agents: fast checks, no compile. Full make ci runs on PRs.
 ci-fast:
@@ -137,12 +140,13 @@ ci-fast:
 	./scripts/test-validate-agent-plugin.sh
 	./scripts/test-cursor-marketplace-followup.sh
 	./scripts/smoke-plugin-install.sh
+	./scripts/test-build-budget.sh
 	./scripts/test-compiler-cache.sh
 
 # Compile-time pre-handoff gate for agents. Keep this invocation aligned with
 # the default workspace clippy pass in scripts/ci-guardrails.sh.
 ci-lint:
-	$(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
+	$(BUILD_BUDGET) -- $(CARGO) clippy $(WORKSPACE) --all-targets -- -D warnings
 
 # Verify every workspace crate declares its stability tier
 stability:
@@ -160,7 +164,7 @@ docs-index:
 # Install
 # ------------------------------------------------------------
 install:
-	$(CARGO) build -p $(BIN_CRATE) $(INSTALL_CARGO_PROFILE)
+	$(BUILD_BUDGET) -- $(CARGO) build -p $(BIN_CRATE) $(INSTALL_CARGO_PROFILE)
 	install -d $(INSTALL_BIN_DIR)
 	install -m 755 $(INSTALL_TARGET_DIR)/$(BINARY) $(INSTALL_BIN_DIR)/$(BINARY)
 
@@ -178,6 +182,13 @@ clean:
 cleanup-branches:
 	./scripts/cleanup-branches.sh
 
+# Cooperative host-wide build admission. See docs/runbooks/build-budget.md.
+build-budget-test:
+	./scripts/test-build-budget.sh
+
+build-budget-bench:
+	./scripts/bench-build-budget.sh
+
 # Opt-in host compiler cache shared across worktrees (sccache). Falls back to
 # ordinary rustc when the cache is missing or unwritable. See
 # docs/runbooks/compiler-cache.md. [ORB-11259]
@@ -194,4 +205,4 @@ compiler-cache-bench:
 # Dev Loop
 # ------------------------------------------------------------
 watch:
-	$(CARGO) watch -x "check" -x "test"
+	$(BUILD_BUDGET) -- $(CARGO) watch -x "check" -x "test"

--- a/docs/runbooks/build-budget.md
+++ b/docs/runbooks/build-budget.md
@@ -1,0 +1,118 @@
+---
+type: runbook
+summary: Run Cargo builds within Orbit's host-wide cross-worktree admission and compiler-job budget.
+tags: [operations, performance, rust]
+paths: ["Makefile", "scripts/build-budget.py"]
+related_artifacts: [ORB-11754]
+last_validated: 2026-09-08
+---
+
+# Bound Concurrent Orbit Repository Builds
+
+Use the build budget when several Orbit worktrees validate on the same host. It limits
+heavy build phases independently of agent concurrency while keeping each worktree's
+private Cargo target directory.
+
+## Supported entry points
+
+The repository's heavy Make targets enter the budget automatically: `build`, `release`,
+`run`, `check`, `test`, `clippy`, `ci`, `ci-lint`, `install`, and `watch`. `make ci` holds
+one slot around the complete CI script; its nested Cargo commands inherit that admission
+instead of reacquiring a slot. `dev` is covered through its `build` prerequisite.
+
+Formatting, dependency inspection, supply-chain inspection, cleaning, release utilities,
+and individual guardrail scripts do not enter a build slot. CI workflow commands and
+arbitrary provider shell commands that invoke Cargo directly are also not intercepted.
+
+For a direct Cargo command that should participate, run:
+
+```bash
+scripts/build-budget.py -- cargo test -p orbit-core command::job
+```
+
+An ordinary `cargo ...` remains the explicit escape path when admission is inappropriate.
+For a Make target, `ORBIT_BUILD_BUDGET=0 make check` bypasses only slot admission and still
+sets the resolved Cargo job count.
+
+## Configuration
+
+Defaults are two simultaneous build slots and four Cargo jobs per admitted command:
+
+```bash
+ORBIT_BUILD_SLOTS=2 ORBIT_CARGO_JOBS=4 make ci-lint
+```
+
+`ORBIT_CARGO_JOBS` takes precedence over a caller's `CARGO_BUILD_JOBS`; if the Orbit-specific
+setting is absent, `CARGO_BUILD_JOBS` overrides the four-job default. These overrides are
+deliberate capacity decisions and may exceed the defaults. Slot values must be decimal
+integers from 1 through 128, Cargo job values from 1 through 1024, and
+`ORBIT_BUILD_BUDGET` must be `0` or `1`. Invalid values exit with status 64 before running
+the command.
+
+The default lock directory is `$HOME/.orbit/cache/build-budget`, which is shared by the
+same user across Orbit worktrees. Tests and isolated operators may set
+`ORBIT_BUILD_BUDGET_DIR`. Do not point separate workers at different directories if they
+are intended to share one budget.
+
+Each slot is a kernel `flock`. The wrapper replaces itself with the admitted command while
+retaining the lock descriptor, so normal completion, command failure, cancellation, and
+process termination release the slot. An inherited internal marker prevents nested Make
+or wrapper entry points from reacquiring a slot and deadlocking.
+
+## Verification
+
+Run the deterministic process test without compiling the workspace:
+
+```bash
+scripts/test-build-budget.sh
+```
+
+It exercises separate worktree paths, a two-slot concurrency ceiling, progress after
+success, failure, and termination, nested admission, job-count precedence, bypass, and
+invalid settings.
+
+Run a bounded comparison with private targets outside the checkout:
+
+```bash
+scripts/bench-build-budget.sh
+```
+
+The default workload starts four cold `cargo check -p orbit-types --offline` commands.
+Both arms are capped at two Cargo jobs for safe measurement; the current arm admits all
+four at once, while the budgeted arm admits two. The output records wall time, summed user
+and system CPU from GNU `time`, and aggregate resident memory sampled every 50 ms from the
+arm's process group. The RSS number is a sampled peak, not an instantaneous kernel
+high-water mark. Results depend on host load, filesystem cache, toolchain, and package
+graph; they characterize this workload rather than predict full-workspace Clippy.
+
+### Representative dk-server-1 result
+
+Measured at `8b26169e91ca9dcf523bbae4d71308a2c82c4075` on 2026-09-08 with Linux
+6.8.0 x86-64, 14 logical CPUs, rustc 1.96.0, and Cargo 1.96.0. The host had
+26 GiB RAM; immediately before the run, 19 GiB was available, 3.7 of 4.0 GiB swap was
+occupied from earlier activity, and load averages were 14.45/23.13/23.01. No active Cargo
+or rustc process was visible inside the measurement sandbox.
+
+| Arm | Wall (s) | User CPU (s) | System CPU (s) | Sampled peak RSS (KiB) |
+|---|---:|---:|---:|---:|
+| Current: four admitted at once, two jobs each | 39.726 | 163.79 | 25.03 | 2,199,416 |
+| Budgeted: two slots, two jobs each | 48.762 | 124.07 | 20.11 | 1,197,452 |
+
+For this small cold workload, two-slot admission reduced sampled peak RSS by 45.6% and
+summed CPU time by 23.6%, at a 22.7% wall-time cost. Post-run available memory was 18 GiB;
+the 1-minute load average was 25.02, showing why the result should not be treated as an
+idle-host throughput benchmark. The two-slot default is retained because it materially
+reduces concurrent memory pressure. Four Cargo jobs per slot is the operational default:
+at full admission it caps compiler parallelism at eight workers on this 14-CPU host and
+leaves capacity for eight agents' non-build work. The task benchmark intentionally used
+two jobs per slot to cap added validation load, so the four-job default is bounded by the
+deterministic environment test and host-capacity arithmetic rather than a second load run.
+
+## Limitations
+
+Admission is cooperative and per user: it covers the documented Make targets and explicit
+wrapper calls, not arbitrary direct Cargo commands. Slot selection is work-conserving but
+does not promise strict FIFO order. Changing `ORBIT_BUILD_SLOTS` while commands are active
+changes which lock files new callers scan and should therefore be done only when the queue
+is idle. The lock directory must be on a filesystem that implements advisory `flock`
+consistently; the default local host cache satisfies that requirement.

--- a/scripts/bench-build-budget.sh
+++ b/scripts/bench-build-budget.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Bounded, private-target comparison of concurrent Cargo build admission [ORB-11754].
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF="$ROOT/scripts/bench-build-budget.sh"
+WRAPPER="$ROOT/scripts/build-budget.py"
+PACKAGE="${ORBIT_BUILD_BUDGET_BENCH_PACKAGE:-orbit-types}"
+PROCESSES="${ORBIT_BUILD_BUDGET_BENCH_PROCESSES:-4}"
+SLOTS="${ORBIT_BUILD_BUDGET_BENCH_SLOTS:-2}"
+JOBS="${ORBIT_BUILD_BUDGET_BENCH_JOBS:-2}"
+WORKDIR="${ORBIT_BUILD_BUDGET_BENCH_DIR:-/tmp/orbit-build-budget-bench-$$}"
+RESULT="${ORBIT_BUILD_BUDGET_BENCH_RESULT:-$WORKDIR/results.tsv}"
+HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD)"
+
+cleanup() {
+  rm -rf "$WORKDIR/trees" "$WORKDIR/targets" "$WORKDIR/locks"
+}
+
+if [[ "${1:-}" == "__arm" ]]; then
+  arm="$2"
+  pids=()
+  for index in $(seq 1 "$PROCESSES"); do
+    tree="$WORKDIR/trees/$index"
+    target="$WORKDIR/targets/$arm-$index"
+    if [[ "$arm" == "current" ]]; then
+      (
+        cd "$tree"
+        CARGO_BUILD_JOBS="$JOBS" CARGO_TARGET_DIR="$target" CARGO_INCREMENTAL=0 \
+          cargo check -p "$PACKAGE" --offline
+      ) &
+    else
+      (
+        cd "$tree"
+        ORBIT_BUILD_BUDGET_DIR="$WORKDIR/locks" ORBIT_BUILD_SLOTS="$SLOTS" \
+          ORBIT_CARGO_JOBS="$JOBS" CARGO_TARGET_DIR="$target" CARGO_INCREMENTAL=0 \
+          "$WRAPPER" -- cargo check -p "$PACKAGE" --offline
+      ) &
+    fi
+    pids+=("$!")
+  done
+  status=0
+  for pid in "${pids[@]}"; do
+    wait "$pid" || status=1
+  done
+  exit "$status"
+fi
+
+trap cleanup EXIT
+
+mkdir -p "$WORKDIR/trees" "$WORKDIR/targets" "$WORKDIR/locks"
+for index in $(seq 1 "$PROCESSES"); do
+  mkdir -p "$WORKDIR/trees/$index"
+  git -C "$ROOT" archive "$HEAD_SHA" | tar -x -C "$WORKDIR/trees/$index"
+done
+
+measure() {
+  local arm="$1"
+  local timing="$WORKDIR/$arm.time" output="$WORKDIR/$arm.log"
+  local start end wall peak current
+  start="$(date +%s.%N)"
+  setsid /usr/bin/time -f '%U\t%S' -o "$timing" \
+    env ORBIT_BUILD_BUDGET_BENCH_PACKAGE="$PACKAGE" \
+    ORBIT_BUILD_BUDGET_BENCH_PROCESSES="$PROCESSES" \
+    ORBIT_BUILD_BUDGET_BENCH_SLOTS="$SLOTS" \
+    ORBIT_BUILD_BUDGET_BENCH_JOBS="$JOBS" \
+    ORBIT_BUILD_BUDGET_BENCH_DIR="$WORKDIR" \
+    "$SELF" __arm "$arm" >"$output" 2>&1 &
+  local group_pid=$!
+  peak=0
+  while kill -0 "$group_pid" 2>/dev/null; do
+    current="$(ps -eo pgid=,rss= | awk -v pgid="$group_pid" '$1 == pgid { total += $2 } END { print total + 0 }')"
+    (( current > peak )) && peak="$current"
+    sleep 0.05
+  done
+  wait "$group_pid"
+  end="$(date +%s.%N)"
+  wall="$(awk -v start="$start" -v end="$end" 'BEGIN { printf "%.3f", end - start }')"
+  read -r user system <"$timing"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$arm" "$wall" "$user" "$system" "$peak" | tee -a "$RESULT"
+}
+
+{
+  printf 'build-budget benchmark\n'
+  printf 'head=%s\n' "$HEAD_SHA"
+  printf 'rustc=%s\n' "$(rustc --version)"
+  printf 'cargo=%s\n' "$(cargo --version)"
+  printf 'workload=%s concurrent private targets; cargo check -p %s --offline; CARGO_INCREMENTAL=0\n' "$PROCESSES" "$PACKAGE"
+  printf 'budget=%s slots x %s Cargo jobs; current arm has no admission but is safety-capped at %s Cargo jobs\n' "$SLOTS" "$JOBS" "$JOBS"
+  printf 'arm\twall_s\tuser_cpu_s\tsystem_cpu_s\tpeak_sampled_rss_kib\n'
+} | tee "$RESULT"
+
+measure current
+measure budgeted
+printf 'results=%s\n' "$RESULT"

--- a/scripts/build-budget.py
+++ b/scripts/build-budget.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Admit repository build commands to a host-wide, cross-worktree budget."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+import sys
+import time
+from typing import NoReturn
+
+
+DEFAULT_BUILD_SLOTS = 2
+DEFAULT_CARGO_JOBS = 4
+MAX_BUILD_SLOTS = 128
+MAX_CARGO_JOBS = 1024
+
+
+def fail(message: str, status: int = 64) -> NoReturn:
+    print(f"build-budget: {message}", file=sys.stderr)
+    raise SystemExit(status)
+
+
+def positive_integer(name: str, value: str, maximum: int) -> int:
+    if not value.isascii() or not value.isdecimal() or value.startswith("0"):
+        fail(f"{name} must be a decimal integer from 1 through {maximum}; got {value!r}")
+
+    parsed = int(value)
+    if parsed > maximum:
+        fail(f"{name} must be a decimal integer from 1 through {maximum}; got {value!r}")
+
+    return parsed
+
+
+def command_arguments(arguments: list[str]) -> list[str]:
+    if arguments == ["--help"] or arguments == ["-h"]:
+        print(
+            "usage: scripts/build-budget.py -- COMMAND [ARG ...]\n"
+            "\n"
+            "Environment: ORBIT_BUILD_SLOTS (default 2), ORBIT_CARGO_JOBS "
+            "(default CARGO_BUILD_JOBS or 4), ORBIT_BUILD_BUDGET_DIR, and "
+            "ORBIT_BUILD_BUDGET=0 to bypass admission."
+        )
+        raise SystemExit(0)
+
+    if not arguments or arguments[0] != "--" or len(arguments) == 1:
+        fail("expected -- followed by a command")
+
+    return arguments[1:]
+
+
+def configured_budget() -> tuple[int, int, bool]:
+    slots = positive_integer(
+        "ORBIT_BUILD_SLOTS",
+        os.environ.get("ORBIT_BUILD_SLOTS", str(DEFAULT_BUILD_SLOTS)),
+        MAX_BUILD_SLOTS,
+    )
+    jobs_source = (
+        os.environ["ORBIT_CARGO_JOBS"]
+        if "ORBIT_CARGO_JOBS" in os.environ
+        else os.environ.get("CARGO_BUILD_JOBS", str(DEFAULT_CARGO_JOBS))
+    )
+    jobs = positive_integer("ORBIT_CARGO_JOBS/CARGO_BUILD_JOBS", jobs_source, MAX_CARGO_JOBS)
+
+    enabled = os.environ.get("ORBIT_BUILD_BUDGET", "1")
+    if enabled not in {"0", "1"}:
+        fail(f"ORBIT_BUILD_BUDGET must be 0 or 1; got {enabled!r}")
+
+    return slots, jobs, enabled == "1"
+
+
+def lock_directory() -> Path:
+    configured = os.environ.get("ORBIT_BUILD_BUDGET_DIR")
+    if configured:
+        directory = Path(configured).expanduser()
+    else:
+        directory = Path.home() / ".orbit" / "cache" / "build-budget"
+
+    if directory.is_symlink():
+        fail(f"lock directory must not be a symbolic link: {directory}")
+
+    try:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as error:
+        fail(f"cannot create lock directory {directory}: {error}", 73)
+
+    return directory
+
+
+def acquire_slot(directory: Path, slots: int) -> tuple[int, int]:
+    descriptors: list[tuple[int, int]] = []
+    try:
+        for slot in range(1, slots + 1):
+            path = directory / f"slot-{slot:03d}.lock"
+            descriptor = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+            descriptors.append((slot, descriptor))
+
+        while True:
+            for slot, descriptor in descriptors:
+                try:
+                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    continue
+
+                for other_slot, other_descriptor in descriptors:
+                    if other_slot != slot:
+                        os.close(other_descriptor)
+                return slot, descriptor
+
+            time.sleep(0.05)
+    except BaseException:
+        for _, descriptor in descriptors:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        raise
+
+
+def main() -> None:
+    command = command_arguments(sys.argv[1:])
+    slots, cargo_jobs, enabled = configured_budget()
+
+    environment = os.environ.copy()
+    environment["CARGO_BUILD_JOBS"] = str(cargo_jobs)
+
+    already_admitted = environment.get("ORBIT_BUILD_BUDGET_HELD") == "1"
+    if not enabled or already_admitted:
+        os.execvpe(command[0], command, environment)
+
+    slot, descriptor = acquire_slot(lock_directory(), slots)
+    os.set_inheritable(descriptor, True)
+    environment["ORBIT_BUILD_BUDGET_HELD"] = "1"
+    environment["ORBIT_BUILD_BUDGET_SLOT"] = str(slot)
+
+    try:
+        os.execvpe(command[0], command, environment)
+    except FileNotFoundError:
+        fail(f"command not found: {command[0]}", 127)
+    except OSError as error:
+        fail(f"could not execute {command[0]}: {error}", 126)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-build-budget.sh
+++ b/scripts/test-build-budget.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Deterministic process tests for the cross-worktree build budget [ORB-11754].
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$ROOT/scripts/build-budget.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  printf 'test-build-budget: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+wait_for() {
+  local path="$1"
+  local attempts=0
+  while [[ ! -e "$path" ]]; do
+    attempts=$((attempts + 1))
+    [[ "$attempts" -lt 200 ]] || fail "timed out waiting for $path"
+    sleep 0.02
+  done
+}
+
+mkdir -p "$TMP/state" "$TMP/worktrees/a" "$TMP/worktrees/b" \
+  "$TMP/worktrees/c" "$TMP/worktrees/d"
+
+cat >"$TMP/helper.py" <<'PY'
+#!/usr/bin/env python3
+import fcntl
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+state = Path(sys.argv[1])
+label = sys.argv[2]
+mode = sys.argv[3]
+duration = float(sys.argv[4]) if len(sys.argv) > 4 else 0.0
+active = state / "active"
+active.mkdir(parents=True, exist_ok=True)
+lock_file = (state / "state.lock").open("a+")
+
+
+def update(event):
+    fcntl.flock(lock_file, fcntl.LOCK_EX)
+    try:
+        if event == "start":
+            (active / label).touch()
+            current = len(list(active.iterdir()))
+            maximum_path = state / "max"
+            previous = int(maximum_path.read_text()) if maximum_path.exists() else 0
+            maximum_path.write_text(f"{max(previous, current)}\n")
+            (state / f"started-{label}").touch()
+        else:
+            (active / label).unlink(missing_ok=True)
+        with (state / "events").open("a") as events:
+            events.write(
+                f"{event} {label} cwd={Path.cwd()} jobs={os.environ.get('CARGO_BUILD_JOBS')} "
+                f"slot={os.environ.get('ORBIT_BUILD_BUDGET_SLOT')} "
+                f"target={os.environ.get('CARGO_TARGET_DIR')}\n"
+            )
+    finally:
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def terminate(_signal, _frame):
+    raise SystemExit(143)
+
+
+signal.signal(signal.SIGTERM, terminate)
+update("start")
+try:
+    if mode == "sleep":
+        time.sleep(duration)
+    elif mode == "block":
+        while True:
+            time.sleep(1)
+    elif mode == "fail":
+        time.sleep(duration)
+        raise SystemExit(23)
+finally:
+    update("end")
+PY
+chmod +x "$TMP/helper.py"
+
+# Different worktree paths share two slots, and enough overlapping work reaches both.
+pids=()
+for label in a b c d; do
+  (
+    cd "$TMP/worktrees/$label"
+    CARGO_TARGET_DIR="$TMP/targets/$label" ORBIT_BUILD_BUDGET_DIR="$TMP/locks-cross" \
+      ORBIT_BUILD_SLOTS=2 ORBIT_CARGO_JOBS=3 \
+      "$WRAPPER" -- "$TMP/helper.py" "$TMP/state" "$label" sleep 0.25
+  ) &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+[[ "$(cat "$TMP/state/max")" == "2" ]] || fail "cross-worktree concurrency was not exactly two"
+[[ "$(grep -c '^start ' "$TMP/state/events")" == "4" ]] || fail "not all cross-worktree commands ran"
+[[ "$(grep -c '^start .* jobs=3 ' "$TMP/state/events")" == "4" ]] || fail "Cargo job limit was not exported"
+for label in a b c d; do
+  grep -Fq "target=$TMP/targets/$label" "$TMP/state/events" || fail "$label lost its private target directory"
+done
+
+run_queue_case() {
+  local case_name="$1" first_mode="$2"
+  local case_state="$TMP/$case_name"
+  local owner_status
+  mkdir -p "$case_state"
+  ORBIT_BUILD_BUDGET_DIR="$TMP/locks-$case_name" ORBIT_BUILD_SLOTS=1 \
+    "$WRAPPER" -- "$TMP/helper.py" "$case_state" owner "$first_mode" 0.25 &
+  local owner_pid=$!
+  wait_for "$case_state/started-owner"
+  ORBIT_BUILD_BUDGET_DIR="$TMP/locks-$case_name" ORBIT_BUILD_SLOTS=1 \
+    "$WRAPPER" -- "$TMP/helper.py" "$case_state" queued sleep 0.01 &
+  local queued_pid=$!
+  sleep 0.08
+  [[ ! -e "$case_state/started-queued" ]] || fail "$case_name queue started before the owner released its slot"
+
+  if [[ "$first_mode" == "block" ]]; then
+    kill -TERM "$owner_pid"
+  fi
+  set +e
+  wait "$owner_pid" 2>/dev/null
+  owner_status=$?
+  set -e
+  case "$first_mode" in
+    sleep) [[ "$owner_status" == "0" ]] || fail "$case_name owner returned $owner_status" ;;
+    fail) [[ "$owner_status" == "23" ]] || fail "$case_name did not preserve failure status" ;;
+    block) [[ "$owner_status" == "143" ]] || fail "$case_name terminated owner returned $owner_status" ;;
+  esac
+  wait "$queued_pid"
+  [[ -e "$case_state/started-queued" ]] || fail "$case_name queue did not proceed"
+}
+
+run_queue_case after-success sleep
+run_queue_case after-failure fail
+run_queue_case after-termination block
+
+# A nested admitted entry point must not try to acquire a second slot.
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-nested" ORBIT_BUILD_SLOTS=1 ORBIT_CARGO_JOBS=5 \
+  timeout 5 "$WRAPPER" -- "$WRAPPER" -- "$TMP/helper.py" "$TMP/nested" nested sleep 0.01
+grep -Fq 'jobs=5' "$TMP/nested/events" || fail "nested command lost Cargo job limit"
+
+# Exercise a real Make entry point inside an existing admission. The inner
+# wrapper inherits the marker and must not wait on the only slot.
+cat >"$TMP/fake-cargo" <<'SH'
+#!/usr/bin/env bash
+printf 'jobs=%s\n' "${CARGO_BUILD_JOBS:-}" >"${FAKE_CARGO_LOG}"
+printf '%s\n' "$@" >>"${FAKE_CARGO_LOG}"
+SH
+chmod +x "$TMP/fake-cargo"
+FAKE_CARGO_LOG="$TMP/make.log" ORBIT_BUILD_BUDGET_DIR="$TMP/locks-make" \
+  ORBIT_BUILD_SLOTS=1 ORBIT_CARGO_JOBS=9 timeout 5 "$WRAPPER" -- \
+  make -s -C "$ROOT" check CARGO="$TMP/fake-cargo" BUILD_BUDGET="$WRAPPER"
+grep -Fxq 'jobs=9' "$TMP/make.log" || fail "nested Make entry lost Cargo job limit"
+grep -Fxq 'check' "$TMP/make.log" || fail "nested Make entry did not invoke cargo check"
+grep -Fxq -- '--workspace' "$TMP/make.log" || fail "nested Make entry lost workspace arguments"
+
+# CARGO_BUILD_JOBS is a supported caller override; ORBIT_CARGO_JOBS is more specific.
+CARGO_BUILD_JOBS=6 ORBIT_BUILD_BUDGET_DIR="$TMP/locks-override" \
+  "$WRAPPER" -- "$TMP/helper.py" "$TMP/override" cargo-override sleep 0.01
+grep -Fq 'jobs=6' "$TMP/override/events" || fail "CARGO_BUILD_JOBS override was not honored"
+CARGO_BUILD_JOBS=6 ORBIT_CARGO_JOBS=7 ORBIT_BUILD_BUDGET_DIR="$TMP/locks-override" \
+  "$WRAPPER" -- "$TMP/helper.py" "$TMP/override" orbit-override sleep 0.01
+grep -Fq 'jobs=7' "$TMP/override/events" || fail "ORBIT_CARGO_JOBS did not take precedence"
+
+for setting in 'ORBIT_BUILD_SLOTS=0' 'ORBIT_BUILD_SLOTS=banana' \
+  'ORBIT_CARGO_JOBS=0' 'ORBIT_CARGO_JOBS=4.5' 'ORBIT_BUILD_BUDGET=maybe'; do
+  set +e
+  env "$setting" "$WRAPPER" -- true >/dev/null 2>"$TMP/invalid.err"
+  status=$?
+  set -e
+  [[ "$status" == "64" ]] || fail "$setting returned $status instead of 64"
+  grep -Fq 'build-budget:' "$TMP/invalid.err" || fail "$setting did not explain the invalid value"
+done
+
+# Explicit bypass avoids admission but retains the resolved Cargo job setting.
+ORBIT_BUILD_BUDGET=0 ORBIT_CARGO_JOBS=8 \
+  "$WRAPPER" -- "$TMP/helper.py" "$TMP/bypass" bypass sleep 0.01
+grep -Fq 'jobs=8' "$TMP/bypass/events" || fail "bypass lost Cargo job setting"
+grep -Fq 'slot=None' "$TMP/bypass/events" || fail "bypass unexpectedly acquired a slot"
+
+printf 'test-build-budget: ok\n'


### PR DESCRIPTION
## Task

[ORB-11754](https://orbit-cli.com/tasks/ORB-11754) — Bound Orbit repository build concurrency independently of agent concurrency

### Description

## Problem
At eight concurrent jobs on dk-server-1 (14 CPUs), host inspection on 2026-09-08 found six concurrent Cargo test/check commands, 96-99% busy intervals, 16-20 runnable processes, and almost-full swap with active swap-ins. Active builds have no CARGO_BUILD_JOBS override. Every task pays workspace-wide Clippy and separate worktrees compile independently.
## Scope
Implement a small repository-owned build admission/budget mechanism for supported make validation/build entry points, with a documented direct-Cargo escape/entry point. Keep language-specific policy in repository scripts/config, not generic Orbit scheduler internals. Bound simultaneous heavy build phases across worktrees on the same host and compiler jobs within each admitted build; preserve eight agents' non-build work. Start evaluation at two build slots and four Cargo jobs per slot, then choose defaults from evidence. Preserve private target directories. Use kernel-owned locking where appropriate, release on failure/cancellation, avoid nested admission deadlocks, and make overrides explicit. Document actual coverage and limitations rather than claiming arbitrary provider shell commands are globally enforced.
## Constraints
Validated candidate only; no release, merge, or global configuration edits. Do not alter other live jobs. Benchmark small representative workloads first and cap added build load. Follow existing scripts/Makefile patterns. Coordinate files with compiler-cache validation work; no shared Cargo target directory.

### Acceptance Criteria

- Deterministic multi-process test shows no more than configured build slots execute concurrently across different worktree paths, and queued work proceeds after success, failure, and terminated owner.
- Admitted Cargo invocations receive the configured parallelism bound; caller overrides and invalid values have tested documented behavior, and nested make/build entry points do not deadlock.
- Representative bounded comparison records wall time, CPU consumption and peak memory for current versus budgeted concurrent builds; state machine/toolchain/workload and limitations.
- make ci-fast and make ci-lint pass; preserve all required validation checks and document direct Cargo coverage.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Makefile: routed heavy repository build and validation targets through the cooperative budget, added test/benchmark targets, and kept ci-fast coverage.
- scripts/build-budget.py: added a two-slot host-wide kernel-lock admission wrapper with a four-job Cargo default, explicit overrides/bypass, nested-admission handling, and exec-based lock lifetime.
- scripts/test-build-budget.sh: added deterministic multi-process coverage across distinct worktree paths for the concurrency ceiling, queue progress after success/failure/termination, exact exit codes, private targets, Cargo job precedence and invalid values, bypass, and nested wrapper/Make behavior.
- scripts/bench-build-budget.sh: added a capped four-process current-versus-budgeted Cargo check harness with private target directories and wall/CPU/sampled aggregate RSS measurements.
- docs/runbooks/build-budget.md: documented supported and uncovered entry points, direct-Cargo admission and escape paths, configuration, failure behavior, limitations, and the representative host measurement.
- Exact changed paths: Makefile; scripts/build-budget.py; scripts/test-build-budget.sh; scripts/bench-build-budget.sh; docs/runbooks/build-budget.md. No compiler-cache file changed.

Acceptance criteria:
1. Passed: the deterministic process test observed exactly two concurrent commands across four distinct worktree paths and proved queued work continued after a successful owner, exit 23 failure, and SIGTERM owner exit 143.
2. Passed: admitted and nested Make commands received CARGO_BUILD_JOBS; CARGO_BUILD_JOBS and higher-precedence ORBIT_CARGO_JOBS overrides, invalid values, bypass, and one-slot nested Make behavior are tested and documented.
3. Passed: the bounded Linux x86-64/rustc 1.96.0/Cargo 1.96.0 comparison is recorded in the runbook. Current was 39.726 s wall, 188.82 s summed CPU, and 2,199,416 KiB sampled peak RSS; two-slot budgeted was 48.762 s, 144.18 s, and 1,197,452 KiB. Host state, workload, private targets, safety cap, sampling method, and limitations are documented.
4. Passed: make ci-fast and make ci-lint both pass. The runbook explicitly names direct Cargo coverage and limitations.

Validation:
- scripts/test-build-budget.sh — passed repeatedly, including in final make ci-fast.
- ORBIT_BUILD_BUDGET_BENCH_JOBS=2 scripts/bench-build-budget.sh — passed; result persisted in docs/runbooks/build-budget.md.
- CARGO_BUILD_JOBS=2 make ci-fast — passed at final code state.
- CARGO_BUILD_JOBS=2 make ci-lint — passed; workspace all-target Clippy finished in 3m20s with warnings denied.
- bash -n scripts/test-build-budget.sh scripts/bench-build-budget.sh — passed.
- python3 -m py_compile scripts/build-budget.py — passed; generated cache removed.
- scripts/generate-doc-indexes.sh --check — passed; docs/INDEX.md remained unchanged.
- git diff --check plus untracked-file whitespace checks — passed.
- git status --short — only the five task-scoped paths above are modified/untracked.

Assessment: Small, repository-owned implementation with one canonical admission entry point and no scheduler, global configuration, shared Cargo target, dependency-edge, release, commit, or compiler-cache changes.

Deviations from original plan:
- The benchmark used two Cargo jobs in both arms rather than the initial four-job evaluation to honor the task plan cap on added validation load. The four-job operational default is justified by the two-slot ceiling on a 14-CPU host and tested environment propagation, but was not load-benchmarked in this run.
- No PR was created because the managed pipeline owns commit, push, PR creation, and review transition.

Design weaknesses / risks:
- Severity low: admission is cooperative and per user; arbitrary direct Cargo or separate lock directories are not globally enforced. Mitigation: coverage and the admitted direct-Cargo entry point are explicit in the runbook.
- Severity low: the measurement ran under elevated host load and sampled RSS at 50 ms, so it demonstrates bounded resource behavior for the stated workload rather than general full-workspace throughput.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11754-6a9f6355`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol