### PR TITLE
[code-review] Enforce checkout `repo_root` / `path_overrides` uniqueness at the persistence boundary

### DIFF
--- a/crates/orbit-registry/src/tests/workspace_registry.rs
+++ b/crates/orbit-registry/src/tests/workspace_registry.rs
@@ -13,7 +13,8 @@ use tempfile::tempdir;
 use crate::workspace_registry::{
     assign_checkout_role, find_checkout_by_path, find_workspace, find_workspace_by_path,
     load_registry_from, load_registry_from_with_writer, register_checkout,
-    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, validate_workspaces,
+    rename_local_owner_host_id, resolve_logical_workspace, save_registry_to, set_path_override,
+    validate_workspaces,
 };
 
 fn timestamp() -> chrono::DateTime<Utc> {
@@ -394,6 +395,87 @@ fn checkout_registration_allows_distinct_repos_to_share_an_orbit_root() {
     .expect("shared Orbit root is not checkout identity");
 
     assert_eq!(registry.checkouts.len(), 2);
+}
+
+#[test]
+fn save_rejects_two_checkouts_sharing_a_repo_root() {
+    let root = tempdir().expect("tempdir");
+    let path = root.path().join("workspaces.json");
+    let shared = PathBuf::from("/repos/shared");
+    let registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_alpha", None),
+            logical_workspace("ws_beta", None),
+        ],
+        checkouts: vec![
+            WorkspaceCheckout::owner(
+                "ws_alpha".to_string(),
+                shared.clone(),
+                PathBuf::from("/repos/shared/.orbit-alpha"),
+            ),
+            WorkspaceCheckout::owner(
+                "ws_beta".to_string(),
+                shared,
+                PathBuf::from("/repos/shared/.orbit-beta"),
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let error = save_registry_to(&registry, &path)
+        .expect_err("duplicate repo_root must fail at the persistence boundary")
+        .to_string();
+    assert!(error.contains("invalid registry:"), "{error}");
+    assert!(error.contains("ws_alpha"), "{error}");
+    assert!(error.contains("ws_beta"), "{error}");
+    assert!(!path.exists(), "rejected save must not write the registry");
+}
+
+#[test]
+fn set_path_override_rejects_a_path_claimed_by_another_checkout() {
+    let mut registry = WorkspaceRegistry {
+        workspaces: vec![
+            logical_workspace("ws_alpha", None),
+            logical_workspace("ws_beta", None),
+        ],
+        checkouts: vec![
+            WorkspaceCheckout::owner(
+                "ws_alpha".to_string(),
+                PathBuf::from("/repos/alpha"),
+                PathBuf::from("/repos/alpha/.orbit"),
+            ),
+            {
+                let mut beta = WorkspaceCheckout::owner(
+                    "ws_beta".to_string(),
+                    PathBuf::from("/repos/beta"),
+                    PathBuf::from("/repos/beta/.orbit"),
+                );
+                beta.path_overrides = vec![PathBuf::from("/overrides/beta")];
+                beta
+            },
+        ],
+        ..Default::default()
+    };
+    let before = registry.clone();
+
+    let claimed_root = set_path_override(&mut registry, PathBuf::from("/repos/alpha"), "ws_beta")
+        .expect_err("override equal to another repo_root must fail")
+        .to_string();
+    assert!(
+        claimed_root.contains("already registered to workspace 'ws_alpha'"),
+        "{claimed_root}"
+    );
+    assert_eq!(registry, before);
+
+    let claimed_override =
+        set_path_override(&mut registry, PathBuf::from("/overrides/beta"), "ws_alpha")
+            .expect_err("override equal to another override must fail")
+            .to_string();
+    assert!(
+        claimed_override.contains("already registered to workspace 'ws_beta'"),
+        "{claimed_override}"
+    );
+    assert_eq!(registry, before);
 }
 
 #[test]

--- a/crates/orbit-registry/src/workspace_registry/catalog.rs
+++ b/crates/orbit-registry/src/workspace_registry/catalog.rs
@@ -1,6 +1,6 @@
 //! Versioned logical workspace catalog and machine-local checkout bindings.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -443,20 +443,45 @@ pub fn find_workspace_by_path<'a>(
 }
 
 /// Sets a path override binding a directory to a workspace.
+///
+/// The path must not already be another checkout's `repo_root` or override.
+/// Persistence repeats this uniqueness rule so a hand-edited or CLI-rewritten
+/// registry cannot save a collision that would make `find_checkout_by_path`
+/// order-dependent.
 pub fn set_path_override(
     registry: &mut WorkspaceRegistry,
     path: PathBuf,
     workspace_id: &str,
 ) -> Result<(), OrbitError> {
-    let checkout = registry
+    let checkout_index = registry
         .checkouts
-        .iter_mut()
-        .find(|checkout| checkout.workspace_id == workspace_id)
+        .iter()
+        .position(|checkout| checkout.workspace_id == workspace_id)
         .ok_or_else(|| {
             OrbitError::WorkspaceError(format!(
                 "workspace '{workspace_id}' has no local checkout binding"
             ))
         })?;
+    if let Some(existing) = registry
+        .checkouts
+        .iter()
+        .enumerate()
+        .find(|(index, checkout)| {
+            *index != checkout_index
+                && (checkout.repo_root == path
+                    || checkout
+                        .path_overrides
+                        .iter()
+                        .any(|claimed| claimed == &path))
+        })
+        .map(|(_, checkout)| checkout.workspace_id.as_str())
+    {
+        return Err(OrbitError::WorkspaceError(format!(
+            "checkout path '{}' is already registered to workspace '{existing}'",
+            path.display()
+        )));
+    }
+    let checkout = &mut registry.checkouts[checkout_index];
     if !checkout.path_overrides.contains(&path) {
         checkout.path_overrides.push(path);
         checkout.path_overrides.sort();
@@ -741,6 +766,23 @@ pub fn validate_workspace_registry(
         checkout.path_overrides.dedup();
         changed |= checkout.path_overrides.len() != before;
     }
+
+    // A path may belong to only one checkout. `register_checkout` and
+    // `set_path_override` refuse the same collision early; this check is the
+    // persistence rule so a rewritten `repo_root` or hand-edited override
+    // cannot save and then resolve by JSON order.
+    let mut claimed_paths: HashMap<&Path, &str> = HashMap::new();
+    for checkout in &registry.checkouts {
+        claim_checkout_path(
+            &mut claimed_paths,
+            &checkout.repo_root,
+            &checkout.workspace_id,
+        )?;
+        for override_path in &checkout.path_overrides {
+            claim_checkout_path(&mut claimed_paths, override_path, &checkout.workspace_id)?;
+        }
+    }
+
     if context.machine_id.is_some() {
         for workspace in &registry.workspaces {
             if workspace.owner_machine_id.is_none() {
@@ -858,6 +900,31 @@ pub fn rename_local_owner_host_id(
             .insert(machine_id.to_string(), new_host_id.to_string());
     }
     Ok(affected)
+}
+
+fn claim_checkout_path<'a>(
+    claimed: &mut HashMap<&'a Path, &'a str>,
+    path: &'a Path,
+    workspace_id: &'a str,
+) -> Result<(), OrbitError> {
+    match claimed.get(path) {
+        Some(existing) if *existing != workspace_id => {
+            let (first, second) = if *existing <= workspace_id {
+                (*existing, workspace_id)
+            } else {
+                (workspace_id, *existing)
+            };
+            Err(invalid_registry(format!(
+                "checkout path '{}' is claimed by both '{first}' and '{second}'",
+                path.display()
+            )))
+        }
+        Some(_) => Ok(()),
+        None => {
+            claimed.insert(path, workspace_id);
+            Ok(())
+        }
+    }
 }
 
 fn invalid_registry(message: String) -> OrbitError {

--- a/docs/design/host-registry/2_design.md
+++ b/docs/design/host-registry/2_design.md
@@ -3,7 +3,7 @@ summary: "Host Registry — Design"
 type: design
 title: "Host Registry — Design"
 owner: codex
-last_updated: 2026-08-15
+last_updated: 2026-09-08
 last_validated: 2026-09-07
 status: Accepted
 feature: host-registry
@@ -69,7 +69,7 @@ RegisteredRuntimeFactory projects task_prefix into the global task allocator bef
 - checkouts are machine-local bindings: workspace ID, repo_root, orbit_dir, role, optional replica owner and path overrides;
 - owner_host_ids maps owner machine IDs referenced by local workspace records to display names. It is a local presentation projection, not a fleet inventory.
 
-A logical workspace may exist without a local checkout. Runtime callers require both. The catalog allows at most one local checkout per logical workspace and rejects duplicate workspace IDs or names. Mutation helpers also reject reusing a registered repo_root or orbit_dir.
+A logical workspace may exist without a local checkout. Runtime callers require both. The catalog allows at most one local checkout per logical workspace and rejects duplicate workspace IDs or names. Load and save reject a `repo_root` or `path_override` claimed by more than one checkout. `register_checkout` refuses a reused `repo_root`; `set_path_override` refuses a path already claimed as another checkout's `repo_root` or override. Distinct checkouts may share an `orbit_dir`.
 
 ### Owner and replica roles
 


### PR DESCRIPTION
## Task

[ORB-11709](https://orbit-cli.com/tasks/ORB-11709) — [code-review] Enforce checkout `repo_root` / `path_overrides` uniqueness at the persistence boundary

### Description

## Problem
`register_checkout` refuses a `repo_root` already bound to another workspace (lines 63-73), but `validate_workspace_registry` — the rule that every `save_registry_to`/`load_registry_from` runs — only checks one-checkout-per-workspace (lines 637-655), and `set_path_override` accepts any path without checking whether another checkout already claims it as `repo_root` or override. A registry with two checkouts sharing a `repo_root` (produced today by the CLI's direct `checkout.repo_root = cwd` reassignment in `orbit-cli/src/command/workspace/init.rs:310`, by hand edits, or by an override equal to another checkout's root) validates and saves cleanly, and `find_checkout_by_path` then resolves the path to whichever checkout appears first in the JSON — silently choosing the wrong workspace for every command run from that directory.

## Why It Matters
AGENTS.md puts rules at their authoritative boundary; the uniqueness rule lives only on one mutation helper, so persisted state can violate it and path resolution becomes order-dependent.

## Proposed Fix
In `validate_workspace_registry`, collect every `repo_root` and every `path_override` across checkouts into a set and fail on duplicates (an override may not equal another checkout's `repo_root`); in `set_path_override`, reject a path already claimed by a different checkout. Keep the `register_checkout` check as the early user-facing error.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-registry/src/workspace_registry/catalog.rs:569-756`, `crates/orbit-registry/src/workspace_registry/catalog.rs:446-465`, `crates/orbit-registry/src/workspace_registry/catalog.rs:411-430`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (design). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: saving a registry where two checkouts share `repo_root` fails with an `invalid registry: ...` message naming both workspace ids.
- Test: `set_path_override` for a path equal to another checkout's `repo_root` or override returns an error.
- Existing `tests/workspace_registry.rs` cases pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `validate_workspace_registry` now claims every checkout `repo_root` and `path_override` and fails when a second workspace claims the same path, with an `invalid registry: checkout path '...' is claimed by both '<id>' and '<id>'` message. Same-checkout override equal to that checkout's own root is allowed.
- `set_path_override` refuses a path already used as another checkout's `repo_root` or override, matching `register_checkout`'s existing user-facing collision wording. `register_checkout`'s `repo_root` check is unchanged.
- Tests cover save of two checkouts sharing a `repo_root` and `set_path_override` against another root or override. Existing `tests/workspace_registry.rs` cases still pass.
- `docs/design/host-registry/2_design.md` now states the persistence-boundary uniqueness rule and that distinct checkouts may share an `orbit_dir`.
Assessment: The uniqueness rule now lives on the load/save validator, which is the authoritative boundary for persisted state. Mutation helpers still fail early. Path comparison remains exact `PathBuf` equality, same as `register_checkout`.
Strategic decisions: Collect claimed paths after per-checkout override sort/dedup so intra-checkout duplicates canonicalize before the cross-checkout check. Sort workspace ids in the persist error for a stable message.
Design weaknesses / risks:
- Severity: low. `register_checkout` still only compares `repo_root` to other `repo_root`s; a new checkout whose root equals another checkout's override still fails at save rather than at register. Mitigation: persist validation is the gate that load and save both run.
- Severity: medium (pre-existing, out of scope). `make ci-lint` fails on HEAD `a4c9f657b` because ORB-11703 added `Embedder::token_boundaries` without updating `BarrierEmbedder` and `FailingEmbedder` in `crates/orbit-search/src/vector/store/tests/upsert.rs`. Not caused by this change; crate-local clippy for `orbit-registry` passed.
Deviations from original plan: None in scoped files. Workspace-wide clippy was not green on this checkout before the change.

Criteria:
1. Saving two checkouts that share `repo_root` fails with `invalid registry: ...` naming both workspace ids — covered by `save_rejects_two_checkouts_sharing_a_repo_root` (passed).
2. `set_path_override` for a path equal to another checkout's `repo_root` or override returns an error — covered by `set_path_override_rejects_a_path_claimed_by_another_checkout` (passed).
3. Existing `tests/workspace_registry.rs` cases pass — 20 tests passed, including the 18 pre-existing cases.

Validation:
- `cargo test -p orbit-registry --lib -- workspace_registry` — passed (20 passed, 0 failed).
- `cargo clippy -p orbit-registry --all-targets -- -D warnings` — passed.
- `make ci-fast` — passed.
- `make ci-lint` — failed (pre-existing: orbit-search test Embedder stubs missing `token_boundaries` on HEAD `a4c9f657baa65d6b845b8572bdef1575f3a525c0`; error `E0046` in `crates/orbit-search/src/vector/store/tests/upsert.rs`). Not run as a green gate.
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — three modified files, uncommitted: `catalog.rs`, `tests/workspace_registry.rs`, `docs/design/host-registry/2_design.md`.

Remaining risks: hand-edited registries that already contain colliding paths will now fail load/save instead of silently resolving by JSON order; operators must delete or rewrite one binding. `orbit workspace init`'s direct `checkout.repo_root = cwd` reassignment is unchanged and will now surface at save.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11709-6a9f65d3`
- Behind base: 0
- Ahead of base: 1