### PR TITLE
[code-review] Companion download: remove the implicit 30 s total timeout and stream to disk

### DIFF
--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -16,12 +16,13 @@ use std::io::{Read, Seek, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use orbit_common::OrbitError;
 use orbit_common::security::release::{
     RELEASE_CHECKSUMS_FILENAME, RELEASE_CHECKSUMS_SIGNATURE_FILENAME, TRUSTED_RELEASE_KEYS,
 };
-use reqwest::Url;
+use reqwest::{Url, blocking::Client};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -35,6 +36,8 @@ use crate::{CompanionPaths, platform_companion_filename};
 
 const COMPANION_URL_ENV: &str = "ORBIT_SEARCH_COMPANION_URL";
 const COMPANION_SHA256_ENV: &str = "ORBIT_SEARCH_COMPANION_SHA256";
+const COMPANION_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const CHECKSUM_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct SemanticInstallParams {
@@ -121,15 +124,15 @@ fn install_companion(destination: &Path) -> Result<(), OrbitError> {
     install_result
 }
 
-fn install_companion_to_temp(temp_path: &Path) -> Result<String, OrbitError> {
+pub(crate) fn install_companion_to_temp(temp_path: &Path) -> Result<String, OrbitError> {
     if let Some(local_path) = env_var_non_empty(COMPANION_OVERRIDE_ENV) {
         return install_local_companion(Path::new(&local_path), temp_path);
     }
 
     let source = resolve_download_source()?;
-    let bytes = download_bytes(&source.url)?;
-    let checksum = verify_download_integrity(&bytes, &source.integrity)?;
-    fs::write(temp_path, bytes).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let client = companion_download_client()?;
+    let checksum = download_companion_to_temp(&client, &source.url, temp_path)?;
+    verify_download_integrity(&checksum, &source.integrity, &client)?;
     make_executable(temp_path)?;
     Ok(checksum)
 }
@@ -235,20 +238,55 @@ fn validate_download_url(url: &str) -> Result<(), OrbitError> {
     Ok(())
 }
 
-fn download_bytes(url: &str) -> Result<Vec<u8>, OrbitError> {
-    Ok(reqwest::blocking::get(url)
-        .map_err(|error| OrbitError::Execution(format!("failed to download companion: {error}")))?
-        .error_for_status()
-        .map_err(|error| OrbitError::Execution(format!("failed to download companion: {error}")))?
-        .bytes()
+fn companion_download_client() -> Result<Client, OrbitError> {
+    Client::builder()
+        // Companion assets are large enough that a whole-request deadline
+        // rejects healthy slow links. A bounded connection phase still avoids
+        // waiting indefinitely for an unreachable server.
+        .timeout(None)
+        .connect_timeout(COMPANION_CONNECT_TIMEOUT)
+        .build()
         .map_err(|error| {
-            OrbitError::Execution(format!("failed to read companion download: {error}"))
-        })?
-        .to_vec())
+            OrbitError::Execution(format!("failed to configure companion download: {error}"))
+        })
 }
 
-fn download_checksum_manifest(url: &str) -> Result<Vec<u8>, OrbitError> {
-    Ok(reqwest::blocking::get(url)
+fn download_companion_to_temp(
+    client: &Client,
+    url: &str,
+    temp_path: &Path,
+) -> Result<String, OrbitError> {
+    let mut response = client
+        .get(url)
+        .send()
+        .map_err(|error| OrbitError::Execution(format!("failed to download companion: {error}")))?
+        .error_for_status()
+        .map_err(|error| OrbitError::Execution(format!("failed to download companion: {error}")))?;
+    let mut file =
+        fs::File::create(temp_path).map_err(|error| OrbitError::Io(error.to_string()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+
+    loop {
+        let count = response.read(&mut buffer).map_err(|error| {
+            OrbitError::Execution(format!("failed to read companion download: {error}"))
+        })?;
+        if count == 0 {
+            break;
+        }
+        file.write_all(&buffer[..count])
+            .map_err(|error| OrbitError::Io(error.to_string()))?;
+        hasher.update(&buffer[..count]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn download_checksum_manifest(client: &Client, url: &str) -> Result<Vec<u8>, OrbitError> {
+    Ok(client
+        .get(url)
+        .timeout(CHECKSUM_METADATA_TIMEOUT)
+        .send()
         .map_err(|error| {
             OrbitError::Execution(format!(
                 "failed to download companion checksum manifest: {error}"
@@ -269,8 +307,11 @@ fn download_checksum_manifest(url: &str) -> Result<Vec<u8>, OrbitError> {
         .to_vec())
 }
 
-fn download_checksum_signature(url: &str) -> Result<Vec<u8>, OrbitError> {
-    Ok(reqwest::blocking::get(url)
+fn download_checksum_signature(client: &Client, url: &str) -> Result<Vec<u8>, OrbitError> {
+    Ok(client
+        .get(url)
+        .timeout(CHECKSUM_METADATA_TIMEOUT)
+        .send()
         .map_err(|error| {
             OrbitError::Execution(format!(
                 "failed to download companion checksum signature: {error}"
@@ -292,29 +333,29 @@ fn download_checksum_signature(url: &str) -> Result<Vec<u8>, OrbitError> {
 }
 
 fn verify_download_integrity(
-    bytes: &[u8],
+    checksum: &str,
     integrity: &CompanionIntegrity,
+    client: &Client,
 ) -> Result<String, OrbitError> {
-    let checksum = sha256_hex(bytes);
     match integrity {
         CompanionIntegrity::ReleaseSignedChecksum {
             checksums_url,
             signature_url,
             asset_name,
         } => {
-            let manifest = download_checksum_manifest(checksums_url)?;
-            let signature = download_checksum_signature(signature_url)?;
+            let manifest = download_checksum_manifest(client, checksums_url)?;
+            let signature = download_checksum_signature(client, signature_url)?;
             verify_release_checksum_signature(&manifest, &signature)?;
             let manifest = std::str::from_utf8(&manifest).map_err(|error| {
                 OrbitError::Execution(format!("companion checksum manifest is not UTF-8: {error}"))
             })?;
             let expected = checksum_from_manifest(manifest, asset_name)?;
-            verify_sha256_digest(&checksum, &expected)?;
+            verify_sha256_digest(checksum, &expected)?;
         }
-        CompanionIntegrity::Sha256(expected) => verify_sha256_digest(&checksum, expected)?,
+        CompanionIntegrity::Sha256(expected) => verify_sha256_digest(checksum, expected)?,
         CompanionIntegrity::UnsafeDeveloperOverride => {}
     }
-    Ok(checksum)
+    Ok(checksum.to_string())
 }
 
 fn verify_release_checksum_signature(manifest: &[u8], signature: &[u8]) -> Result<(), OrbitError> {

--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -9,8 +9,8 @@
 use super::super::install::path_execution_fallback_rationale;
 use super::super::install::{
     CompanionIntegrity, CompanionLaunchMode, ManagedCompanion, SemanticInstallParams,
-    checksum_from_manifest, companion_launch_mode, default_release_download_source, run,
-    sha256_hex,
+    checksum_from_manifest, companion_launch_mode, default_release_download_source,
+    install_companion_to_temp, run, sha256_hex,
 };
 
 use orbit_common::security::release::verify_checksum_signature_with_key;
@@ -19,10 +19,98 @@ use crate::companion::{
     ensure_semantic_search_supported_for_platform, unsafe_companion_overrides_enabled,
 };
 use crate::{CompanionPaths, locate_companion, platform_companion_filename};
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use tempfile::{TempDir, tempdir};
+
+#[test]
+fn companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout() {
+    let _guard = EnvGuard::new();
+    let fixture = InstallFixture::new();
+    let body = vec![b'x'; 1024 * 1024];
+    let checksum = sha256_hex(&body);
+    let url = serve_throttled_response(body, Duration::from_millis(2_400));
+    let temp_path = fixture.paths.bin_dir.join("downloaded-companion");
+
+    remove_env("ORBIT_SEARCH_COMPANION");
+    set_env("NO_PROXY", "127.0.0.1,localhost");
+    set_env("no_proxy", "127.0.0.1,localhost");
+    set_env("ORBIT_SEARCH_COMPANION_URL", &url);
+    set_env("ORBIT_SEARCH_COMPANION_SHA256", &checksum);
+    set_env("ORBIT_SEARCH_COMPANION_ALLOW_UNSAFE", "1");
+
+    let started = Instant::now();
+    let actual_checksum = install_companion_to_temp(&temp_path)
+        .expect("a healthy response taking more than 35 seconds should install");
+
+    assert!(
+        started.elapsed() > Duration::from_secs(35),
+        "the fixture must exceed reqwest's former 30-second whole-request timeout"
+    );
+    assert_eq!(actual_checksum, checksum);
+    assert_eq!(
+        std::fs::metadata(temp_path)
+            .expect("download metadata")
+            .len(),
+        1024 * 1024
+    );
+}
+
+#[test]
+fn companion_install_reports_a_dead_connection() {
+    let _guard = EnvGuard::new();
+    let fixture = InstallFixture::new();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve local port");
+    let address = listener.local_addr().expect("listener address");
+    drop(listener);
+    let temp_path = fixture.paths.bin_dir.join("downloaded-companion");
+
+    remove_env("ORBIT_SEARCH_COMPANION");
+    set_env(
+        "ORBIT_SEARCH_COMPANION_URL",
+        &format!("https://{address}/companion"),
+    );
+    set_env("ORBIT_SEARCH_COMPANION_SHA256", &"0".repeat(64));
+
+    let error = install_companion_to_temp(&temp_path)
+        .expect_err("a closed local port should fail the connection");
+
+    assert!(
+        error.to_string().contains("failed to download companion"),
+        "{error}"
+    );
+}
+
+fn serve_throttled_response(body: Vec<u8>, delay_between_chunks: Duration) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind throttled HTTP server");
+    let address = listener.local_addr().expect("throttled server address");
+
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept companion download");
+        std::io::Write::write_all(
+            &mut stream,
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .as_bytes(),
+        )
+        .expect("write response headers");
+
+        for (index, chunk) in body.chunks(64 * 1024).enumerate() {
+            if index != 0 {
+                thread::sleep(delay_between_chunks);
+            }
+            std::io::Write::write_all(&mut stream, chunk).expect("write throttled response chunk");
+        }
+    });
+
+    format!("http://{address}/companion")
+}
 
 #[test]
 #[cfg(unix)]
@@ -525,6 +613,8 @@ impl EnvGuard {
             "ORBIT_SEARCH_COMPANION_URL",
             "ORBIT_SEARCH_COMPANION_SHA256",
             "ORBIT_SEARCH_COMPANION_ALLOW_UNSAFE",
+            "NO_PROXY",
+            "no_proxy",
         ];
         let vars = names
             .into_iter()


### PR DESCRIPTION
## Task

[ORB-11707](https://orbit-cli.com/tasks/ORB-11707) — [code-review] Companion download: remove the implicit 30 s total timeout and stream to disk

### Description

## Problem
`download_bytes` uses `reqwest::blocking::get`, which builds a default blocking `Client` whose `Timeout::default()` is 30 s for the whole request (reqwest 0.12.28 `blocking/client.rs:1500`). The companion asset is ~32 MB (installed binary on this Mac is 32 MB), so on any link slower than ~1.1 MB/s `orbit semantic install` deterministically fails with `failed to download companion: operation timed out`, and retrying cannot help. The whole body is also buffered in memory (`.bytes().to_vec()`) before being hashed and written to the temp file.

## Why It Matters
First-run install fails on ordinary home/CI links with an error that does not say the fix is a faster connection, and there is no `--timeout`/env override.

## Proposed Fix
Build one `reqwest::blocking::Client` with `timeout(None)` plus a `connect_timeout`, stream the response into the temp file while feeding the SHA-256 hasher, and reuse the client for the checksum manifest/signature downloads (which can keep a short timeout).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/commands/install.rs:238-248`, `crates/orbit-search/src/commands/install.rs:250-292`, `crates/orbit-search/src/commands/install.rs:124-135`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Unit test with a local HTTP server that serves 1 MB over >35 s (throttled chunks) succeeds through `install_companion_to_temp`.
- `orbit semantic install` on a throttled link (e.g. `--limit-rate`-style proxy) completes; the error message for a genuinely dead connection still surfaces.
- Peak RSS of the install command no longer grows by the asset size (inspection).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Configured the companion blocking client with no whole-request timeout and a bounded 10-second connect timeout.
- Streamed the companion response directly to the temporary file while computing SHA-256, then reused the client for checksum metadata requests with 30-second per-request limits.
- Added local HTTP regression coverage for a 1 MiB response delivered over more than 35 seconds, including an elapsed-time assertion, plus a closed-port error regression.
Assessment: The asset path now has constant-size (8 KiB) transfer buffering rather than buffering the full asset in memory; checksum validation and temp-file cleanup remain on the canonical install path.
Criteria evidence:
1. The throttled local-server test downloads 1 MiB in 64 KiB chunks spaced 2.4 seconds apart, succeeds through install_companion_to_temp, and asserts elapsed time exceeds 35 seconds.
2. The closed-port regression confirms the failed-to-download error prefix remains visible; the slow-server test exercises the same install_companion_to_temp path used by semantic install.
3. Inspection confirms hashing and writing use an 8 KiB stack buffer with no response-body Vec allocation.
Validation:
- cargo fmt --check: passed.
- cargo test -p orbit-search commands::tests::install::companion_install_reports_a_dead_connection -- --exact: passed.
- cargo test -p orbit-search commands::tests::install::companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout -- --exact: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
- git status --short: only the two task-scoped source and sibling test files are modified.
Remaining risk: the slow-link regression intentionally adds roughly 36 seconds to the focused test runtime, as required to exceed the old total timeout.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11707-6a9f64c8`
- Behind base: 0
- Ahead of base: 1