### PR TITLE
[code-review] Stop the 30 s refresh from clobbering in-progress operator state

### DIFF
--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -354,7 +354,16 @@ function renderFailuresByToolCard(rateRows, failuresRows, onCardClick, window = 
 function renderAuditSummary(data, ctx) {
   const container = $("audit-summary-body");
   if (!container) return;
-  container.innerHTML = "";
+
+  // ORB-11655: keyed cards, so the 30 s refresh replaces only the cards whose
+  // data moved. Emptying the container instead collapsed this scroll box and
+  // dropped the operator's scroll position on every tick.
+  const cards = [];
+  const addCard = (key, card, source) => {
+    card.dataset.key = key;
+    card.dataset.hash = JSON.stringify(source);
+    cards.push(card);
+  };
 
   const createCard = (title, renderBody) => {
     const card = el("div", { class: "audit-summary-card" });
@@ -405,12 +414,12 @@ function renderAuditSummary(data, ctx) {
   const namedRates = (data.failure_rate_by_tool || []).filter((row) => isNamedTool(row.tool));
   const namedFailures = (data.failures_by_tool || []).filter((row) => isNamedTool(row.tool));
   if (namedRates.length) {
-    container.appendChild(renderFailuresByToolCard(
+    addCard("failures-by-tool", renderFailuresByToolCard(
       namedRates,
       namedFailures,
       filterByTool,
       data.window || "24h",
-    ));
+    ), [namedRates, namedFailures, data.window || "24h"]);
   }
 
   const categoryOrder = ["unexpected", "expected", "denied", "diagnostic"];
@@ -423,7 +432,7 @@ function renderAuditSummary(data, ctx) {
     affected_runs: Number(categories[key] && categories[key].affected_runs) || 0,
   }));
   if (categoryRows.some((row) => row.incidents || row.raw_events)) {
-    container.appendChild(createCard(
+    addCard("failure-categories", createCard(
       `Failure categories · window ${data.window || "24h"}`,
       renderTable(categoryRows, [
         { key: "label", label: "classification" },
@@ -431,7 +440,7 @@ function renderAuditSummary(data, ctx) {
         { key: "raw_events", label: "raw events", num: true },
         { key: "affected_runs", label: "affected runs", num: true },
       ]),
-    ));
+    ), [categoryRows, data.window || "24h"]);
   }
 
   const lifecycleFailures = Number(data.lifecycle_diagnostic_events) || 0;
@@ -451,11 +460,17 @@ function renderAuditSummary(data, ctx) {
       text: `Failure-only diagnostic surfaces; excluded from callable-tool denominators and rates · window ${window}`,
     }));
     lifecycleCard.appendChild(body);
-    container.appendChild(lifecycleCard);
+    addCard("lifecycle-diagnostics", lifecycleCard, [
+      label,
+      window,
+      lifecycleIncidents,
+      lifecycleFailures,
+      Number(data.lifecycle_diagnostic_affected_run_count) || 0,
+    ]);
   }
 
   if (data.duration_by_tool) {
-    container.appendChild(createCard("Top duration (avg)", renderTable(
+    addCard("duration-by-tool", createCard("Top duration (avg)", renderTable(
       data.duration_by_tool,
       [
         { key: "tool", label: "tool" },
@@ -464,7 +479,7 @@ function renderAuditSummary(data, ctx) {
         { key: "p95", label: "p95", num: true, format: (v) => fmtDurationValue(ctx, v) }
       ],
       filterByTool
-    )));
+    )), data.duration_by_tool);
   }
 
   if (data.denials_by_tool || data.denials_by_reason) {
@@ -491,11 +506,11 @@ function renderAuditSummary(data, ctx) {
       null
     )(body);
     card.appendChild(body);
-    container.appendChild(card);
+    addCard("denials", card, [toolRows, reasonRows]);
   }
 
   if (data.role_split) {
-    container.appendChild(createCard("Role split", renderTable(
+    addCard("role-split", createCard("Role split", renderTable(
       data.role_split,
       [
         { key: "label", label: "role" },
@@ -510,16 +525,18 @@ function renderAuditSummary(data, ctx) {
         syncAuditControls();
         window.location.hash = buildAuditHash();
       }
-    )));
+    )), data.role_split);
   }
 
   if (data.mcp_vs_cli_split) {
-    container.appendChild(createCard("MCP vs CLI", renderTable(
+    addCard("mcp-vs-cli", createCard("MCP vs CLI", renderTable(
       data.mcp_vs_cli_split,
       [{ key: "label", label: "surface" }, { key: "count", label: "count", num: true }],
       null
-    )));
+    )), data.mcp_vs_cli_split);
   }
+
+  syncNodes(container, cards);
 }
 
 function fetchAndRenderPolicy(ctx) {

--- a/crates/orbit-web/assets/dashboard/automation.js
+++ b/crates/orbit-web/assets/dashboard/automation.js
@@ -1,5 +1,5 @@
 // Persisted delivery observations and accepted coverage, shared by both consumers.
-import { el, withWorkspace } from './common.js';
+import { detailsPanel, el, withWorkspace } from './common.js';
 
 const field = (label, value) => el('div', { class: 'operation-field' }, [
   el('span', { class: 'operation-field-label', text: label }),
@@ -22,9 +22,11 @@ const ownershipBlocker = ownership => {
   }
 };
 
-export function renderAutomation(diagnostic) {
+// `key` identifies this diagnostic's disclosure across refreshes; the caller
+// owns it because the same consumer can be shown under different cards.
+export function renderAutomation(diagnostic, key) {
   if (!diagnostic) return null;
-  const panel = el('details', { class: 'automation-diagnostic' });
+  const panel = detailsPanel(key, { class: 'automation-diagnostic' });
   panel.appendChild(el('summary', { text: `${diagnostic.state?.members ? 'State automation' : 'Delivery coverage'} · ${diagnostic.reason || 'unknown'}` }));
   if (diagnostic.error) panel.appendChild(el('p', { text: diagnostic.error }));
   const blocker = ownershipBlocker(diagnostic.ownership);

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -305,6 +305,22 @@ export function el(tag, opts = {}, children = []) {
   return node;
 }
 
+// ORB-11655: a panel refresh rebuilds its nodes every 30 s, but disclosure is
+// operator state, not payload state — a <details> the operator opened has to
+// come back open. Keyed in one store so every rebuilt panel restores the same
+// way; `key` must identify the disclosure across renders, not the node.
+const expandedDetails = new Set();
+
+export function detailsPanel(key, opts = {}) {
+  const panel = el("details", opts);
+  panel.open = expandedDetails.has(key);
+  panel.addEventListener("toggle", () => {
+    if (panel.open) expandedDetails.add(key);
+    else expandedDetails.delete(key);
+  });
+  return panel;
+}
+
 export function statusPill(status) {
   const color = `var(--status-${status}, var(--fg))`;
   const pill = el("span", { class: "pill mono", text: status });

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -455,20 +455,25 @@ function renderDiagnostics(ctx = {}) {
   );
 }
 
+// ORB-11655: keyed cards, so the 30 s refresh replaces only what moved.
+// Emptying this scroll box instead dropped the operator's scroll position on
+// every tick.
 export function renderDiagnosticsSideCard(last, ctx) {
   const container = $("diag-implement-one-body");
   if (!container) return;
-  container.innerHTML = "";
-  renderCompletionByComplexityCard(container, last.completion_by_complexity || [], ctx);
-  renderImplementOneCard(
-    container,
-    last.implement_one_by_complexity || [],
-    last.implement_one || [],
-    ctx,
-  );
+  syncNodes(container, [
+    completionByComplexityCard(last.completion_by_complexity || []),
+    ...implementOneCards(last.implement_one_by_complexity || [], last.implement_one || [], ctx),
+  ]);
 }
 
-function renderMetricsCard(container, title, rows, cols) {
+function keyed(node, key, source) {
+  node.dataset.key = key;
+  node.dataset.hash = JSON.stringify(source);
+  return node;
+}
+
+function metricsCard(title, rows, cols) {
   const card = el("div", { class: "audit-summary-card" });
   card.appendChild(el("div", { class: "card-title", text: title }));
   const body = el("div", { class: "card-body" });
@@ -492,7 +497,7 @@ function renderMetricsCard(container, title, rows, cols) {
   table.appendChild(tbody);
   body.appendChild(table);
   card.appendChild(body);
-  container.appendChild(card);
+  return card;
 }
 
 function formatCountRate(count, total) {
@@ -506,15 +511,14 @@ function complexityLabel(value) {
   return value === "unset" ? "unset (unlabeled)" : (value || "unset (unlabeled)");
 }
 
-function renderCompletionByComplexityCard(container, rows, _ctx = {}) {
+function completionByComplexityCard(rows) {
   if (!rows.length) {
     const card = el("div", { class: "audit-summary-card" });
     card.appendChild(el("div", { class: "card-title", text: "Task completion by complexity" }));
     const body = el("div", { class: "card-body" });
     body.appendChild(el("div", { class: "empty", text: "No tasks." }));
     card.appendChild(body);
-    container.appendChild(card);
-    return;
+    return keyed(card, "completion-by-complexity", []);
   }
   const statusCols = [
     { key: "complexity", label: "complexity" },
@@ -538,10 +542,14 @@ function renderCompletionByComplexityCard(container, rows, _ctx = {}) {
       archived: cell("archived"),
     };
   });
-  renderMetricsCard(container, "Task completion by complexity", tableRows, statusCols);
+  return keyed(
+    metricsCard("Task completion by complexity", tableRows, statusCols),
+    "completion-by-complexity",
+    tableRows,
+  );
 }
 
-function renderImplementOneCard(container, byComplexity, fallbackRows, ctx = {}) {
+function implementOneCards(byComplexity, fallbackRows, ctx = {}) {
   const durCols = [
     { key: "actor", label: "actor" },
     { key: "n", label: "n", num: true },
@@ -551,25 +559,28 @@ function renderImplementOneCard(container, byComplexity, fallbackRows, ctx = {})
   ];
   const bands = Array.isArray(byComplexity) ? byComplexity.filter((band) => (band.actors || []).length) : [];
   if (bands.length) {
-    for (const band of bands) {
+    return bands.map((band) => {
       const label = complexityLabel(band.complexity);
-      renderMetricsCard(
-        container,
-        `Average implement_one duration by actor (30d) · ${label} · n=${band.n || 0}`,
-        band.actors,
-        durCols,
+      return keyed(
+        metricsCard(
+          `Average implement_one duration by actor (30d) · ${label} · n=${band.n || 0}`,
+          band.actors,
+          durCols,
+        ),
+        `implement-one:${band.complexity}`,
+        [band.n || 0, band.actors],
       );
-    }
-    return;
+    });
   }
   if (!fallbackRows.length) {
-    container.appendChild(el("div", { class: "empty", text: "No implement_one runs in last 30d." }));
-    return;
+    const empty = el("div", { class: "empty", text: "No implement_one runs in last 30d." });
+    return [keyed(empty, "implement-one", [])];
   }
-  renderMetricsCard(container, "Average implement_one duration by actor (30d)", fallbackRows, durCols);
+  return [keyed(
+    metricsCard("Average implement_one duration by actor (30d)", fallbackRows, durCols),
+    "implement-one",
+    fallbackRows,
+  )];
 }
 
-export {
-  renderDiagnostics,
-  renderImplementOneCard,
-};
+export { renderDiagnostics };

--- a/crates/orbit-web/assets/dashboard/operations.js
+++ b/crates/orbit-web/assets/dashboard/operations.js
@@ -1,6 +1,6 @@
 // Routine-definition, host sweep-clock, and auto-task operations [ORB-10875, ORB-10876].
 
-import { requestPanel, el, fetchJson, getWorkspace, getWorkspaceRevision, onWorkspaceChange, postJson } from './common.js';
+import { requestPanel, detailsPanel, el, fetchJson, getWorkspace, getWorkspaceRevision, onWorkspaceChange, postJson } from './common.js';
 import { navigateToRun } from './router.js';
 import { renderAutomation } from './automation.js';
 
@@ -19,7 +19,9 @@ let lastAutoDrainRun = null;
 let lastOperationMode = null;
 let context = null;
 let unsubscribeWorkspace = null;
-const expandedOperations = new Set();
+// The operator's unapplied cadence choice, held outside the rebuilt <select>
+// so a background refresh cannot revert it. Host-scoped, like the clock itself.
+let pendingCadenceSeconds = null;
 
 export function initOperations(nextContext) {
   context = nextContext;
@@ -167,16 +169,11 @@ function operationFact(label, value) {
 }
 
 function operationDetails(key, children) {
-  const panel = el("details", { class: "operation-details" });
-  panel.open = expandedOperations.has(key);
+  const panel = detailsPanel(key, { class: "operation-details" });
   panel.appendChild(el("summary", { text: "Details" }));
   for (const child of children) {
     if (child) panel.appendChild(child);
   }
-  panel.addEventListener("toggle", () => {
-    if (panel.open) expandedOperations.add(key);
-    else expandedOperations.delete(key);
-  });
   return panel;
 }
 
@@ -296,6 +293,7 @@ function renderOperations(payload) {
     const fire = routine.last_fire;
     const state = routine.enabled ? (routine.effective ? "enabled" : "blocked") : "disabled";
     const schedule = routineScheduleText(routine);
+    const detailsKey = `routine:${routine.name}`;
     const card = el("article", { class: "operation-card routine-card" });
     card.append(
       el("div", { class: "operation-row-head" }, [
@@ -307,7 +305,7 @@ function renderOperations(payload) {
         ]),
         el("div", { class: "operation-card-actions" }, [routineButton(payload, routine)]),
       ]),
-      operationDetails(`routine:${routine.name}`, [
+      operationDetails(detailsKey, [
         el("div", { class: "operation-target mono", text: routine.target }),
         el("div", { class: "operation-grid" }, [
           field("Source workspace", routine.source),
@@ -318,7 +316,7 @@ function renderOperations(payload) {
           field("Last fire", fire ? time(fire.finished_at || fire.started_at) : "Never"),
           field("Linked run / outcome", fire ? `${fire.run_id || "No run"} · ${fire.state}` : "No fire recorded"),
         ]),
-        renderAutomation(routine.automation),
+        renderAutomation(routine.automation, `${detailsKey}:automation`),
         routine.description ? el("p", { class: "operation-description", text: routine.description }) : null,
       ]),
     );
@@ -385,18 +383,28 @@ function renderClock(payload) {
   if (clock.health_issue) body.appendChild(el("p", { class: "operation-control-note error", text: clock.health_issue }));
   const actions = el("div", { class: "operation-clock-actions" });
   actions.appendChild(clockButton(payload, clock.enabled ? "disable" : "enable", clock.enabled ? "Pause clock" : "Enable clock"));
+  // A cadence the operator picked but has not applied yet outlives this render;
+  // it clears once the host reports that value as configured, whoever applied it.
+  if (pendingCadenceSeconds === clock.configured_cadence_seconds) pendingCadenceSeconds = null;
+  const selectedCadence = pendingCadenceSeconds ?? clock.configured_cadence_seconds;
   const cadence = el("select", { class: "operation-cadence", title: "Clock cadence" });
   for (const seconds of [60, 300, 900, 1800, 3600]) {
     const option = el("option", { text: seconds === 60 ? "Every minute" : `Every ${seconds / 60} minutes` });
     option.value = String(seconds);
-    option.selected = seconds === clock.configured_cadence_seconds;
+    option.selected = seconds === selectedCadence;
     cadence.appendChild(option);
   }
   cadence.disabled = Boolean(reason) || pendingOperations.has(key);
   const apply = el("button", { class: "operation-button secondary", text: pendingOperations.has(key) ? "Pending…" : "Apply cadence", title: "Reload cadence without changing whether the clock is enabled" });
   apply.type = "button";
-  apply.disabled = Boolean(reason) || pendingOperations.has(key) || Number(cadence.value) === clock.configured_cadence_seconds;
-  cadence.addEventListener("change", () => { apply.disabled = Boolean(reason) || pendingOperations.has(key) || Number(cadence.value) === clock.configured_cadence_seconds; });
+  const syncApplyState = (chosen) => {
+    apply.disabled = Boolean(reason) || pendingOperations.has(key) || chosen === clock.configured_cadence_seconds;
+  };
+  syncApplyState(selectedCadence);
+  cadence.addEventListener("change", () => {
+    pendingCadenceSeconds = Number(cadence.value);
+    syncApplyState(pendingCadenceSeconds);
+  });
   apply.addEventListener("click", () => {
     if (reason || !selection.current()) return;
     return runOperation({
@@ -524,6 +532,7 @@ function renderAutoTasks(payload) {
   }
   for (const definition of definitions) {
     const state = definition.enabled ? "enabled" : "disabled";
+    const detailsKey = `auto-task:${definition.name}`;
     const actions = el("div", { class: "operation-card-actions" }, [
       autoTaskToggleButton(payload, definition),
       autoTaskMintButton(payload, definition),
@@ -540,7 +549,7 @@ function renderAutoTasks(payload) {
         ]),
         actions,
       ]),
-      operationDetails(`auto-task:${definition.name}`, [
+      operationDetails(detailsKey, [
         el("div", { class: "operation-target mono", text: definition.template_summary || definition.template?.title || "" }),
         el("div", { class: "operation-grid" }, [
           field("Schedule", definition.schedule_summary || "—"),
@@ -550,7 +559,7 @@ function renderAutoTasks(payload) {
           field("Next evaluation", nextEvaluationText(definition.next_evaluation)),
           field("Open duplicate", duplicate),
         ]),
-        renderAutomation(definition.automation),
+        renderAutomation(definition.automation, `${detailsKey}:automation`),
         definition.description ? el("p", { class: "operation-description", text: definition.description }) : null,
         el("p", {
           class: "operation-control-note operation-mint-warning",

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1124,6 +1124,7 @@ async function shipTask(task, detail, btnNode, context) {
 function showCommentForm(task, detail, actions, context) {
   const form = el("div", { class: "comment-form" });
   form.addEventListener("click", (e) => e.stopPropagation());
+  detail.dataset.draft = "comment";
   const ta = el("textarea");
   ta.placeholder = "comment";
   const buttons = el("div", { class: "actions" });
@@ -1142,6 +1143,9 @@ function showCommentForm(task, detail, actions, context) {
     cancel.disabled = true;
     try {
       await postJson(`/api/tasks/${encodeURIComponent(task.id)}/comments`, { message });
+      // The draft is spent: let the next render rebuild the detail so the
+      // posted comment appears.
+      delete detail.dataset.draft;
       await refreshTasks(context);
     } catch (error) {
       submit.disabled = false;
@@ -1156,6 +1160,7 @@ function showCommentForm(task, detail, actions, context) {
   });
   cancel.addEventListener("click", (e) => {
     e.stopPropagation();
+    delete detail.dataset.draft;
     form.replaceWith(actions);
   });
   buttons.appendChild(submit);
@@ -1169,6 +1174,7 @@ function showCommentForm(task, detail, actions, context) {
 function showRejectForm(task, detail, actions, context) {
   const form = el("div", { class: "reject-form" });
   form.addEventListener("click", (e) => e.stopPropagation());
+  detail.dataset.draft = "reject";
   const ta = el("textarea");
   ta.placeholder = "reason for rejection";
   const buttons = el("div", { class: "actions" });
@@ -1185,6 +1191,7 @@ function showRejectForm(task, detail, actions, context) {
   });
   cancel.addEventListener("click", (e) => {
     e.stopPropagation();
+    delete detail.dataset.draft;
     form.replaceWith(actions);
   });
   buttons.appendChild(submit);
@@ -1245,6 +1252,59 @@ function takeTaskActionNotice() {
   return notice;
 }
 
+// The pinned global-resolver result: a task outside the active filter, shown
+// above the list with its own dismiss control.
+function buildPinnedTask(ptask, context) {
+  const row = el("div", {
+    class: "row pinned-external",
+    title: `${ptask.title} (global resolver; status ${ptask.status})`
+  }, [
+    el("span", { class: "id mono", text: ptask.id }),
+    el("span", { class: "title", text: ptask.title }),
+    buildStatusUpdateControl(ptask, context),
+    buildCrewUpdateControl(ptask, context),
+  ]);
+  row.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
+  });
+  row.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, ptask.id)}-${feedbackSignature(crewFeedback, ptask.id)}`;
+
+  const detail = buildTaskDetail(ptask, context);
+  const dismiss = el("button", { class: "action", text: "Close" });
+  dismiss.title = "Dismiss global task detail";
+  dismiss.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    pinnedExternalTask = null;
+    renderTasks(taskList(context), context);
+  });
+  let actions = detail.querySelector(".actions");
+  if (!actions) {
+    actions = el("div", { class: "actions" });
+    detail.appendChild(actions);
+  }
+  actions.appendChild(dismiss);
+
+  const wrap = el("div", { class: "pinned-task-wrap" }, [row, detail]);
+  wrap.dataset.key = `pinned-${ptask.id}`;
+  wrap.dataset.hash = `${row.dataset.hash}-${JSON.stringify(ptask)}`;
+  return wrap;
+}
+
+/* ORB-11655: a comment or reject form holds text the operator is still typing,
+   so the 30 s refresh must not rebuild the detail node that contains it — not
+   even when the task itself changed. Collect the live top-level nodes holding
+   an open form, keyed the way syncNodes keys them, and reuse them verbatim.
+   The detail resumes tracking task data as soon as the form is closed. */
+function openDraftNodes(body) {
+  const drafts = new Map();
+  for (const node of Array.from(body.children)) {
+    if (!node.dataset.key) continue;
+    if (node.dataset.draft || node.querySelector?.("[data-draft]")) drafts.set(node.dataset.key, node);
+  }
+  return drafts;
+}
+
 export function renderTasks(tasks, context) {
   if (!panelCanRender("tasks-body")) return;
   const body = $("tasks-body");
@@ -1265,45 +1325,18 @@ export function renderTasks(tasks, context) {
     }
   }
 
-  const frag = document.createDocumentFragment();
+  // Collected as a plain array rather than a document fragment: a fragment
+  // would detach every reused node from the panel, and moving a node is what
+  // costs an open draft its caret. syncNodes leaves a node it already holds in
+  // place.
+  const nodes = [];
+  const drafts = openDraftNodes(body);
   const notice = takeTaskActionNotice();
 
   // Render pinned external task detail (for statuses outside active filter) at top.
   if (pinnedExternalTask && pinnedExternalTask.task) {
     const ptask = pinnedExternalTask.task;
-    const pRow = el("div", {
-      class: "row pinned-external",
-      title: `${ptask.title} (global resolver; status ${ptask.status})`
-    }, [
-      el("span", { class: "id mono", text: ptask.id }),
-      el("span", { class: "title", text: ptask.title }),
-      buildStatusUpdateControl(ptask, context),
-      buildCrewUpdateControl(ptask, context),
-    ]);
-    pRow.addEventListener("click", (e) => {
-      e.stopPropagation();
-      if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
-    });
-    pRow.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, ptask.id)}-${feedbackSignature(crewFeedback, ptask.id)}`;
-    const pDetail = buildTaskDetail(ptask, context);
-    // Dismiss button to close the global detail without affecting chips
-    const dismiss = el("button", { class: "action", text: "Close" });
-    dismiss.title = "Dismiss global task detail";
-    dismiss.addEventListener("click", (ev) => {
-      ev.stopPropagation();
-      pinnedExternalTask = null;
-      renderTasks(taskList(context), context);
-    });
-    let acts = pDetail.querySelector(".actions");
-    if (!acts) {
-      acts = el("div", { class: "actions" });
-      pDetail.appendChild(acts);
-    }
-    acts.appendChild(dismiss);
-    const pWrap = el("div", { class: "pinned-task-wrap" }, [pRow, pDetail]);
-    pWrap.dataset.key = `pinned-${ptask.id}`;
-    pWrap.dataset.hash = `${pRow.dataset.hash}-${JSON.stringify(ptask)}`;
-    frag.appendChild(pWrap);
+    nodes.push(drafts.get(`pinned-${ptask.id}`) || buildPinnedTask(ptask, context));
   }
 
   const filtered = filterTasks(tasks, context);
@@ -1313,7 +1346,7 @@ export function renderTasks(tasks, context) {
   const railCount = document.getElementById("rail-count-tasks");
   if (railCount) railCount.textContent = String(filtered.length);
   renderFilterSummary(context);
-  if (filtered.length === 0 && frag.children.length === 0) {
+  if (filtered.length === 0 && nodes.length === 0) {
     const defaultText = tasks.length === 0 ? "No tasks available." : "No tasks match filter.";
     const emptyState = el("div", { class: "empty-state" }, [
       el("div", { class: "icon", text: "✧" }),
@@ -1323,7 +1356,7 @@ export function renderTasks(tasks, context) {
     return;
   }
   const groups = new Map();
-  if (notice) frag.appendChild(notice);
+  if (notice) nodes.push(notice);
 
   // Column header strip (once, before first group-header). Uses .row.header so grid
   // (and all @media overrides) are identical to data rows; labels sit over ID/Title/Status/Crew.
@@ -1334,7 +1367,7 @@ export function renderTasks(tasks, context) {
     el("span", { class: "crew-cell", text: "Crew" }),
   ]);
   colHeader.dataset.key = "task-col-header";
-  frag.appendChild(colHeader);
+  nodes.push(colHeader);
 
   for (const t of filtered) {
     if (!groups.has(t.status)) groups.set(t.status, []);
@@ -1352,7 +1385,7 @@ export function renderTasks(tasks, context) {
     ]);
     header.dataset.key = `header-${status}`;
     header.dataset.hash = `${status}-${group.length}`;
-    frag.appendChild(header);
+    nodes.push(header);
     for (const t of group) {
       const idSpan = el("span", { class: "id mono", text: t.id, title: "Click to copy ID" });
       idSpan.addEventListener("click", (e) => {
@@ -1397,15 +1430,21 @@ export function renderTasks(tasks, context) {
         }
       });
       if (expandedTaskIds.has(t.id)) row.classList.add("expanded");
-      frag.appendChild(row);
+      nodes.push(row);
       if (expandedTaskIds.has(t.id)) {
-        const detail = buildTaskDetail(t, context);
-        detail.dataset.key = `detail-${t.id}`;
-        // Diff by full task object stringified
-        detail.dataset.hash = JSON.stringify(t);
-        frag.appendChild(detail);
+        const key = `detail-${t.id}`;
+        const draft = drafts.get(key);
+        if (draft) {
+          nodes.push(draft);
+        } else {
+          const detail = buildTaskDetail(t, context);
+          detail.dataset.key = key;
+          // Diff by full task object stringified
+          detail.dataset.hash = JSON.stringify(t);
+          nodes.push(detail);
+        }
       }
     }
   }
-  syncNodes(body, Array.from(frag.children));
+  syncNodes(body, nodes);
 }

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -529,8 +529,7 @@ fn dashboard_operations_are_typed_guarded_and_responsive() {
     assert!(css.contains(".operation-row-head"));
     assert!(css.contains(".operation-details summary"));
     assert!(operations.contains("operation-row-head"));
-    assert!(operations.contains(r#"el("details", { class: "operation-details" })"#));
-    assert!(operations.contains("expandedOperations"));
+    assert!(operations.contains(r#"{ class: "operation-details" }"#));
     assert!(router.contains(r#"classList.toggle("operations-active", top === "operations")"#));
 }
 
@@ -1345,6 +1344,160 @@ if (!select) throw new Error("status select did not render");
 const values = select.children.map((option) => option.value).filter(Boolean);
 const expected = statuses.filter((status) => status !== "done");
 if (JSON.stringify(values) !== JSON.stringify(expected)) throw new Error(`status options ${JSON.stringify(values)} != ${JSON.stringify(expected)}`);
+"#,
+    );
+}
+
+/// ORB-11655: the Tasks detail node is diffed on the whole task object, so any
+/// field change (an agent bumping `updated_at`) rebuilt it — discarding a
+/// comment the operator was still typing inside it.
+#[test]
+fn dashboard_task_refresh_keeps_a_half_written_comment() {
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(tag = "") { this.tag = tag; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.disabled = false; }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { const old = child.parentNode; if (old) old.children = old.children.filter((candidate) => candidate !== child); const index = this.children.indexOf(before); this.children.splice(index < 0 ? this.children.length : index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  replaceWith(next) { const parent = this.parentNode; if (!parent) return; parent.children = parent.children.map((candidate) => candidate === this ? next : candidate); next.parentNode = parent; this.parentNode = null; }
+  addEventListener(name, callback) { this.listeners[name] = callback; }
+  setAttribute(name, value) { this[name] = String(value); }
+  focus() {}
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get lastElementChild() { return this.children[this.children.length - 1]; }
+  get classList() { return { add: (...names) => { this.className = `${this.className} ${names.join(" ")}`.trim(); } }; }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node()), byId.get(id));
+globalThis.document = {
+  getElementById: get,
+  createElement: (tag) => new Node(tag),
+  createTextNode: (text) => Object.assign(new Node(), { textContent: text }),
+};
+globalThis.window = { location: new URL("http://dashboard.test/#tasks"), addEventListener: () => {}, confirm: () => false };
+Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText: () => Promise.resolve() } }, configurable: true });
+globalThis.setTimeout = () => 0;
+
+const statuses = ["in-progress", "review", "blocked", "proposed", "backlog", "someday", "done", "rejected", "archived"];
+const task = { id: "ORB-1", title: "Reviewable", status: "review", updated_at: "2026-09-08T01:00:00Z", history: [], artifacts: [] };
+const context = {
+  getTasks: () => [task], getTasksMeta: () => null, getSearchQuery: () => "",
+  getActiveStatuses: () => new Set(["review"]), statusOrder: statuses,
+  statusUpdateTargets: statuses, fmtAbsTime: (value) => value,
+  refreshDashboard: () => Promise.resolve(),
+};
+const { renderTasks } = await import("./tasks.js");
+
+function find(node, predicate) {
+  if (predicate(node)) return node;
+  for (const child of node.children || []) { const match = find(child, predicate); if (match) return match; }
+  return null;
+}
+const body = get("tasks-body");
+const detail = () => find(body, (node) => node.dataset.key === "detail-ORB-1");
+const tick = () => { task.updated_at = `${task.updated_at}+`; renderTasks([task], context); };
+
+renderTasks([task], context);
+find(body, (node) => node.dataset.key === "task-ORB-1").listeners.click();
+
+// Control: with no draft open, a task field change does rebuild the detail.
+const before = detail();
+if (!before) throw new Error("expanding the task did not render its detail");
+tick();
+if (detail() === before) throw new Error("a changed task must still rebuild its detail");
+
+const held = detail();
+find(held, (node) => node.className === "action comment").listeners.click({ stopPropagation: () => {} });
+const textarea = find(held, (node) => node.tag === "textarea");
+if (!textarea) throw new Error("the comment form did not render a textarea");
+textarea.value = "half written";
+
+tick();
+if (detail() !== held) throw new Error("the refresh replaced a detail holding an open comment form");
+const live = find(body, (node) => node.tag === "textarea");
+if (live !== textarea) throw new Error("the refresh replaced the textarea the operator was typing in");
+if (live.value !== "half written") throw new Error(`the draft text was lost: ${JSON.stringify(live.value)}`);
+
+// Closing the form hands the detail back to the data: the next tick rebuilds it.
+find(held, (node) => node.className === "action cancel").listeners.click({ stopPropagation: () => {} });
+tick();
+if (detail() === held) throw new Error("the detail stayed frozen after the draft was cancelled");
+if (find(body, (node) => node.tag === "textarea")) throw new Error("the cancelled comment form is still rendered");
+"#,
+    );
+}
+
+/// ORB-11655: the Audit summary and the Diagnostics side card are their own
+/// scroll boxes. Emptying them on the 30 s tick collapsed their height and
+/// dropped the operator's scroll position, so they diff by keyed card instead.
+#[test]
+fn dashboard_summary_scroll_boxes_replace_only_the_cards_whose_data_moved() {
+    run_dashboard_javascript_test(
+        r#"
+class Node {
+  constructor(tag = "") { this.tag = tag; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; }
+  appendChild(child) { this.children.push(child); child.parentNode = this; return child; }
+  insertBefore(child, before) { const old = child.parentNode; if (old) old.children = old.children.filter((candidate) => candidate !== child); const index = this.children.indexOf(before); this.children.splice(index < 0 ? this.children.length : index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); child.parentNode = null; return child; }
+  addEventListener(name, callback) { this.listeners[name] = callback; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get lastElementChild() { return this.children[this.children.length - 1]; }
+  get classList() { return { add: () => {} }; }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node()), byId.get(id));
+globalThis.document = { getElementById: get, createElement: (tag) => new Node(tag), createTextNode: (text) => Object.assign(new Node(), { textContent: text }) };
+globalThis.window = { location: new URL("http://dashboard.test/#audit"), addEventListener: () => {} };
+
+const ctx = { fmtDuration: (value) => String(value) };
+const { renderAuditSummary } = await import("./audit.js");
+const { renderDiagnosticsSideCard } = await import("./diagnostics.js");
+
+const cardsIn = (container) => new Map(container.children.filter((node) => node.dataset.key).map((node) => [node.dataset.key, node]));
+function expectStable(label, container, before, changedKey) {
+  const after = cardsIn(container);
+  if (after.size !== before.size) throw new Error(`${label}: card set changed (${before.size} -> ${after.size})`);
+  for (const [key, node] of before) {
+    const reused = after.get(key) === node;
+    if (key === changedKey && reused) throw new Error(`${label}: the ${key} card was not rebuilt after its data moved`);
+    if (key !== changedKey && !reused) throw new Error(`${label}: the ${key} card was rebuilt with unchanged data`);
+  }
+}
+
+const summary = {
+  window: "24h",
+  duration_by_tool: [{ tool: "orbit.task.show", count: 3, avg: 10, p95: 20 }],
+  role_split: [{ label: "human", count: 1, mcp: 1, cli: 0, other: 0, no_subcommand: 0 }],
+  mcp_vs_cli_split: [{ label: "mcp", count: 1 }],
+};
+const auditBody = get("audit-summary-body");
+renderAuditSummary(summary, ctx);
+const auditCards = cardsIn(auditBody);
+if (auditCards.size !== 3) throw new Error(`expected three keyed audit cards, got ${auditCards.size}`);
+renderAuditSummary(summary, ctx);
+expectStable("audit summary", auditBody, auditCards, null);
+summary.role_split[0].count = 2;
+renderAuditSummary(summary, ctx);
+expectStable("audit summary", auditBody, auditCards, "role-split");
+
+const diagnostics = {
+  completion_by_complexity: [{ complexity: "low", total: 2, statuses: [{ status: "done", count: 1 }] }],
+  implement_one_by_complexity: [],
+  implement_one: [{ actor: "claude", n: 2, avg: 5, p50: 4, p95: 9 }],
+};
+const diagBody = get("diag-implement-one-body");
+renderDiagnosticsSideCard(diagnostics, ctx);
+const diagCards = cardsIn(diagBody);
+if (diagCards.size !== 2) throw new Error(`expected two keyed diagnostics cards, got ${diagCards.size}`);
+renderDiagnosticsSideCard(diagnostics, ctx);
+expectStable("diagnostics side card", diagBody, diagCards, null);
+diagnostics.implement_one[0].n = 3;
+renderDiagnosticsSideCard(diagnostics, ctx);
+expectStable("diagnostics side card", diagBody, diagCards, "implement-one");
 "#,
     );
 }
@@ -2584,7 +2737,7 @@ const {renderAutomation} = await import('./automation.js');
 const panel = renderAutomation({reason:'fresh_unready',state:{consumer:'host/ws/routine/pilot',members:{
   pending:{}, assessed:{task:{ready:false,resulting_fingerprint:'f'}},withheld:{other:'human_block'},failed:{},
   active:{member:{key:'task'},attempt:2,max_attempts:2,deadline:'2026-09-06T12:00:00Z',action_id:'run'}
-},unresolved:{}},receipts:[],waivers:[]});
+},unresolved:{}},receipts:[],waivers:[]}, 'routine:pilot:automation');
 function text(node) { return [node.textContent,...(node.children||[]).map(text)].join(' '); }
 const rendered=text(panel);
 assert.match(rendered,/State automation/);
@@ -2594,6 +2747,109 @@ assert.match(rendered,/2026-09-06T12:00:00Z/);
 assert.match(rendered,/Unknown/);
 assert.match(rendered,/does not authorize promotion/);
 assert.doesNotMatch(rendered,/Examined through/);
+"#,
+    );
+}
+
+/// ORB-11655: `refreshDashboard` rebuilds every Operations panel on a 30 s
+/// timer the operator did not trigger. Disclosure state and an unapplied
+/// cadence choice are operator state, not payload state, and must survive it.
+#[test]
+fn dashboard_operations_refresh_keeps_open_details_and_an_unapplied_cadence() {
+    run_dashboard_javascript_test(
+        r#"
+const created = [];
+class Node {
+  constructor(id = "", tag = "") { this.id = id; this.tag = tag; this.children = []; this.dataset = {}; this.style = {}; this.listeners = {}; this.className = ""; this._text = ""; this.parentNode = null; this.disabled = false; this.open = false; created.push(this); }
+  appendChild(child) { if (child == null) return child; this.children.push(child); child.parentNode = this; return child; }
+  append(...children) { for (const child of children) this.appendChild(child); }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  setAttribute(name, value) { this[name] = String(value); }
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  get lastElementChild() { return this.children[this.children.length - 1]; }
+  get classList() { return { add: () => {}, toggle: () => {} }; }
+  querySelectorAll() { return []; }
+  querySelector() { return null; }
+  insertBefore(child, before) { const index = this.children.indexOf(before); if (index < 0) return this.appendChild(child); this.children.splice(index, 0, child); child.parentNode = this; return child; }
+  removeChild(child) { this.children = this.children.filter((candidate) => candidate !== child); return child; }
+}
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, new Node(id)), byId.get(id));
+globalThis.document = { getElementById: get, createElement: (tag) => new Node("", tag), createTextNode: (text) => Object.assign(new Node(), { textContent: text }), body: new Node("body") };
+globalThis.window = { confirm: () => true, location: new URL("http://dashboard.test/"), addEventListener: () => {} };
+
+const routines = {
+  host_id: "hm_local",
+  session_explanation: "session access",
+  capabilities: { routine_toggle: { authorized: true }, clock_service: { authorized: true }, clock_cadence: { authorized: true } },
+  routines: [{
+    name: "pilot", source: "one", target: "orbit.workflow.auto", enabled: true, effective: true,
+    pinned_to_host: true, cron: "*/5 * * * *", hosts: ["hm_local"], description: "pilot routine",
+    next_evaluation: { state: "scheduled", at: "2026-09-08T01:00:00Z" }, last_fire: null,
+    automation: {
+      reason: "not_due", ownership: { owned_here: true }, receipts: [], waivers: [],
+      state: { consumer: "hm_local/one/routine/pilot", baseline: null, observed: null, covered: null, pending: [], pending_commits: [], unresolved: {} },
+    },
+  }],
+  clock: { provider: "systemd", enabled: true, health: "healthy", schedulable: true, loaded: true, running: true, configured_cadence_seconds: 60, effective_cadence_seconds: 60, next_tick_at: "2026-09-08T01:00:00Z", last_tick_at: null },
+};
+const payloads = {
+  "/api/routines": routines,
+  "/api/auto-tasks": { definitions: [], capabilities: {} },
+  "/api/workflows/auto/readiness": { tasks: [], capacity: {}, controls_authorized: true },
+  "/api/operation/explain": { policy: {}, authority: {}, delivery: {}, limiting_reasons: [], controls_authorized: true },
+};
+globalThis.fetch = async (path) => {
+  const url = String(path).split("?")[0];
+  const payload = payloads[url] || {};
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+};
+
+const { setWorkspace } = await import("./common.js");
+const { initOperations, fetchAndRenderOperations } = await import("./operations.js");
+setWorkspace("one");
+initOperations({ getWorkspaces: () => [{ id: "one", name: "one", status: "active" }], formatAbsoluteTime: (value) => value });
+
+const latest = (predicate) => created.filter(predicate).pop();
+const automationPanel = () => latest((node) => node.className === "automation-diagnostic");
+const routineDetails = () => latest((node) => node.className === "operation-details" && node.textContent.includes("pilot routine"));
+const cadenceSelect = () => latest((node) => node.tag === "select" && node.title === "Clock cadence");
+const applyButton = () => latest((node) => node.textContent === "Apply cadence");
+const chosenCadence = (select) => select.children.filter((option) => option.selected).map((option) => option.value);
+
+await fetchAndRenderOperations();
+if (automationPanel().open) throw new Error("an automation diagnostic must start closed");
+
+// The operator opens both disclosures and picks a cadence without applying it.
+for (const panel of [routineDetails(), automationPanel()]) {
+  if (typeof panel.listeners.toggle !== "function") throw new Error("a disclosure must record its open state on toggle");
+  panel.open = true;
+  panel.listeners.toggle();
+}
+const select = cadenceSelect();
+select.value = "300";
+select.listeners.change();
+if (applyButton().disabled) throw new Error("a changed cadence must enable Apply");
+
+// The 30 s tick: same payload, every panel rebuilt.
+await fetchAndRenderOperations();
+
+if (!routineDetails().open) throw new Error("the routine details snapped shut on refresh");
+if (!automationPanel().open) throw new Error("the automation diagnostic snapped shut on refresh");
+const rechosen = chosenCadence(cadenceSelect());
+if (JSON.stringify(rechosen) !== JSON.stringify(["300"])) throw new Error(`refresh reverted the cadence choice to ${JSON.stringify(rechosen)}`);
+if (applyButton().disabled) throw new Error("refresh disabled Apply for a still-unapplied cadence");
+
+// Once the host reports the chosen cadence as configured, the select follows
+// the payload again rather than pinning the stale choice forever.
+routines.clock.configured_cadence_seconds = 300;
+await fetchAndRenderOperations();
+if (!applyButton().disabled) throw new Error("Apply must be disabled once the chosen cadence is the configured one");
+routines.clock.configured_cadence_seconds = 900;
+await fetchAndRenderOperations();
+const configured = chosenCadence(cadenceSelect());
+if (JSON.stringify(configured) !== JSON.stringify(["900"])) throw new Error(`the select must track the configured cadence again, got ${JSON.stringify(configured)}`);
 "#,
     );
 }
@@ -2617,23 +2873,23 @@ const {renderAutomation} = await import('./automation.js');
 function text(node) { return [node.textContent,...(node.children||[]).map(text)].join(' '); }
 
 const unresolved = text(renderAutomation({reason:'ownership_unresolved',state:null,receipts:[],waivers:[],
-  ownership:{authority:'missing',owned_here:false}}));
+  ownership:{authority:'missing',owned_here:false}}, 'a:automation'));
 assert.match(unresolved,/ownership_unresolved/);
 assert.match(unresolved,/No owner machine is registered/);
 assert.match(unresolved,/set owner_machine on the definition/);
 
 const elsewhere = text(renderAutomation({reason:'owned_elsewhere',state:null,receipts:[],waivers:[],
-  ownership:{owner_machine:'hm_other',authority:'workspace',owned_here:false}}));
+  ownership:{owner_machine:'hm_other',authority:'workspace',owned_here:false}}, 'b:automation'));
 assert.match(elsewhere,/Owned by machine hm_other/);
 
 const conflicting = text(renderAutomation({reason:'ownership_unresolved',state:null,receipts:[],waivers:[],
-  ownership:{authority:'conflicting',owned_here:false}}));
+  ownership:{authority:'conflicting',owned_here:false}}, 'c:automation'));
 assert.match(conflicting,/contradictory/);
 
 const owned = text(renderAutomation({reason:'not_due',receipts:[],waivers:[],
   ownership:{owner_machine:'hm_local',authority:'workspace',owned_here:true},
   state:{consumer:'hm_local/ws/auto-task/delivery-qa',baseline:{commit:'a',tree:'b'},
-    observed:{commit:'a',tree:'b'},covered:{commit:'a',tree:'b'},pending:[],pending_commits:[],unresolved:{}}}));
+    observed:{commit:'a',tree:'b'},covered:{commit:'a',tree:'b'},pending:[],pending_commits:[],unresolved:{}}}, 'd:automation'));
 assert.doesNotMatch(owned,/Owned by machine/);
 "#,
     );


### PR DESCRIPTION
## Task

[ORB-11655](https://orbit-cli.com/tasks/ORB-11655) — [code-review] Stop the 30 s refresh from clobbering in-progress operator state

### Description

## Problem
`refreshDashboard` runs every 30 s (`router.js:359`) and on the Operations tab `fetchAndRenderOperations` rebuilds every panel with `body.textContent = ""` and fresh nodes. Concretely: every `<details class="automation-diagnostic">` an operator opened (`automation.js:26`) snaps shut every 30 s; the sweep-clock cadence `<select>` is rebuilt with `selected = configured` (`operations.js:212-217`), so a cadence picked but not yet applied reverts under the cursor; the audit summary and diagnostics side card do `innerHTML = ""` and lose scroll position. On the Tasks tab a comment/reject textarea (`showCommentForm`) lives inside the detail node whose sync hash is `JSON.stringify(t)` (`tasks.js:1397`); any field change on that task (e.g. an agent bumping `updated_at`) replaces the detail node and discards the half-written comment.

## Why It Matters
Operators lose typed input and expanded state on a timer they did not trigger; on Operations this happens on every tick, not only on data change.

## Proposed Fix
Give the Operations/audit-summary/diagnostics panels keyed `syncNodes` rendering (stable `dataset.key` per card, hash from payload) as the other panels have; keep `details` open-state and pending select values by reading them from the existing node before replacing (or key the form nodes so `syncNodes` preserves them); exclude the comment/reject form from the detail hash or skip re-rendering a detail that contains a focused input.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/operations.js:111-154,188-250,355-415`, `crates/orbit-web/assets/dashboard/automation.js:24-27`, `crates/orbit-web/assets/dashboard/audit.js:354-357`, `crates/orbit-web/assets/dashboard/diagnostics.js:430-434`, `crates/orbit-web/assets/dashboard/tasks.js:1115-1158,1393-1398`, `crates/orbit-web/assets/dashboard/router.js:359`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Open an automation `<details>` on Operations, wait 35 s: it stays open.
- Change the cadence select without clicking Apply, wait 35 s: the chosen value and the enabled Apply button persist.
- Start typing a comment on a task, PATCH that task from the CLI, wait for the next tick: the textarea and its text survive.

## Execution Summary

<details>
<summary>Click to expand</summary>

Operator state (disclosure, unapplied form values, in-progress text, scroll position) is now held outside — or protected from — the nodes the 30 s `refreshDashboard` rebuilds. Each rule sits at the boundary that owns it.

## Changes

- **`common.js`** — new `detailsPanel(key, opts)`: one keyed store of `<details>` open state, restored on every rebuild. Replaces the per-module set that only Operations had.
- **`automation.js`** — `renderAutomation(diagnostic, key)` builds its `<details class="automation-diagnostic">` through `detailsPanel`. It was a plain anonymous `<details>`, so it snapped shut on every tick.
- **`operations.js`** — `operationDetails` delegates to `detailsPanel` (local `expandedOperations` deleted); routine/auto-task cards pass `${cardKey}:automation` for the nested diagnostic. New module-level `pendingCadenceSeconds` holds an unapplied cadence choice and drives both `option.selected` and the Apply button's enabled state; it self-clears once the host reports that value as `configured_cadence_seconds` (so an externally applied change is still followed). This is the idiom the auto-drain duration/concurrency/complete controls already use.
- **`tasks.js`** — a detail node holding an open comment or reject form is marked `data-draft`; `openDraftNodes` collects those live nodes and `renderTasks` reuses them verbatim instead of rebuilding, so a task-data change cannot discard half-written text. The marker is cleared on cancel and after a successful comment post, at which point the detail tracks task data again. `renderTasks` now collects into a plain array rather than a `DocumentFragment`: a fragment detaches every node it receives, and moving a node is what costs the caret. The pinned global-resolver wrapper was extracted to `buildPinnedTask` so it takes the same reuse path (and to shorten `renderTasks`).
- **`audit.js` / `diagnostics.js`** — `renderAuditSummary` and `renderDiagnosticsSideCard` render keyed `syncNodes` cards (stable `dataset.key`, hash from the payload slice) instead of `innerHTML = ""`. Both containers carry `overflow-y: auto` in `index.html`, so emptying them collapsed their height and reset `scrollTop` on every tick. `renderMetricsCard`/`renderCompletionByComplexityCard`/`renderImplementOneCard` became node-returning `metricsCard`/`completionByComplexityCard`/`implementOneCards`; the now-unused `renderImplementOneCard` export was dropped (no consumers).

## Acceptance criteria

1. **Automation `<details>` stays open across a 35 s tick** — met. `dashboard_operations_refresh_keeps_open_details_and_an_unapplied_cadence` opens both the routine `operation-details` and the nested `automation-diagnostic`, re-runs `fetchAndRenderOperations()` (the tick), and asserts both come back open. Verified to fail when `renderAutomation` is reverted to an anonymous `<details>`.
2. **Unapplied cadence and its enabled Apply button persist** — met. The same test changes the cadence select without applying, ticks, and asserts the `300` option is still selected and Apply still enabled; it then asserts the select follows the payload again once the host reports 300 (Apply disabled) and later 900 (selection follows). Verified to fail when the select is rebuilt from `clock.configured_cadence_seconds` (reverts to `["60"]`).
3. **Comment textarea and its text survive a task PATCH plus a tick** — met. `dashboard_task_refresh_keeps_a_half_written_comment` first proves the control (a task field change does rebuild a detail with no draft), then opens the comment form, types, mutates the task, re-renders, and asserts the same detail node, the same textarea object, and the same text. It also asserts cancelling releases the freeze. Verified to fail when the reuse branch is removed.

The scroll-position half of the reported Problem (audit summary / diagnostics side card) is covered by `dashboard_summary_scroll_boxes_replace_only_the_cards_whose_data_moved`, which asserts identical card node objects on an unchanged payload and rebuild of only the card whose data moved.

## Validation

| Command | Outcome |
| --- | --- |
| `make ci-fast` | passed |
| `make ci-lint` | passed (workspace-wide clippy, warnings denied) |
| `cargo test -p orbit-web` | 347 passed, 1 failed — the failure is pre-existing, see below |
| `cargo test -p orbit-web --lib dashboard` | 61 passed, same 1 pre-existing failure |
| `node --check` on all six modified modules | passed |

**Pre-existing failure, not caused by this change:** `tests::dashboard_assets::dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close` fails with `expected one retry timer, got 2`, deterministically (3/3 runs). Its Node harness loads only `log-tail.js` (which imports `common.js`); restoring both to `HEAD` content reproduces the identical failure, and `git diff HEAD` shows neither `log-tail.js` nor that test was touched here. Most likely from `9e281b512` (ORB-11660, log SSE resume/retry). Filed as friction `F2026-09-070`; it needs its own repair task.

## Deviations and remaining risk

- `context_files` gained `file:crates/orbit-web/assets/dashboard/common.js` (the shared leaf that now owns keyed disclosure state) and `file:crates/orbit-web/src/tests/dashboard_assets.rs` (where the three behavior tests live). `router.js` was read but not changed — the 30 s interval is correct; the panels were the defect.
- Two source-text shape assertions in `dashboard_assets.rs` were retired: `el("details", { class: "operation-details" })` was narrowed to the `operation-details` class contract (which the CSS pairs with), and the `expandedOperations` name check was deleted. Both were implementation-shape checks of the kind that file's own header says to replace once behavior is covered; the new behavior test covers them. The five existing `renderAutomation(...)` test call sites now pass a disclosure key.
- The Operations routines/auto-tasks/clock/auto-drain/operation-mode panels still rebuild their nodes wholesale each tick. Converting them to keyed `syncNodes` was considered and deliberately not done: their cards embed in-flight action state (`pendingOperations`, capability reasons) in button closures, so a payload-derived hash would silently freeze a "Pending…" button. The state-store approach satisfies every criterion without that hazard. If flicker on those panels is later judged a problem, the hash must include the pending/authorization signature.
- Behavioral tradeoff, documented in the code: while a comment or reject form is open, that task's detail does not reflect incoming task changes. The freeze is bounded by an explicit operator action (cancel, or a successful post) and is the point of the fix.
- All checks ran on Linux under Node 24 with a hand-rolled DOM stub, matching the existing `run_dashboard_javascript_test` harness. That harness models `children`/`dataset`/listeners faithfully enough for node identity and reuse, but it is not a browser: it does not prove real caret/focus retention or actual `scrollTop` preservation. Those follow from not detaching or replacing the node, which the tests do assert directly.
- Working tree is clean apart from the seven intended files; `git diff --check` reports nothing. Changes left uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11655-6a9f64c9`
- Behind base: 0
- Ahead of base: 1