### PR TITLE
[code-review] Make `task update` accept the same list-flag shapes as `task add`

### DIFF
--- a/crates/orbit-cli/src/command/task/tests/update.rs
+++ b/crates/orbit-cli/src/command/task/tests/update.rs
@@ -43,11 +43,63 @@ fn task_update_accepts_context_files_alias() {
     };
 
     assert_eq!(args.id, "ORB-00001");
-    assert_eq!(
-        args.context_files.as_deref(),
-        Some("file:src/lib.rs,dir:tests")
-    );
+    assert_eq!(args.context_files, ["file:src/lib.rs", "dir:tests"]);
     assert!(args.json);
+}
+
+#[test]
+fn task_update_parses_repeat_and_comma_delimited_lists() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "task",
+        "update",
+        "ORB-00001",
+        "--dependencies",
+        "ORB-00002,ORB-00003",
+        "--dependency",
+        "ORB-00004",
+        "--context",
+        "file:src/lib.rs,dir:tests",
+        "--context-files",
+        "symbol:Task",
+    ]);
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Update(args) = task.command else {
+        panic!("expected task update command");
+    };
+
+    assert_eq!(args.dependencies, ["ORB-00002", "ORB-00003", "ORB-00004"]);
+    assert_eq!(
+        args.context_files,
+        ["file:src/lib.rs", "dir:tests", "symbol:Task"]
+    );
+}
+
+#[test]
+fn task_update_preserves_explicit_empty_list_values_for_clearing() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "task",
+        "update",
+        "ORB-00001",
+        "--dependencies",
+        "",
+        "--context",
+        "",
+    ]);
+
+    let Commands::Task(task) = cli.command else {
+        panic!("expected task command");
+    };
+    let TaskSubcommand::Update(args) = task.command else {
+        panic!("expected task update command");
+    };
+
+    assert_eq!(args.dependencies, [""]);
+    assert_eq!(args.context_files, [""]);
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/task/update.rs
+++ b/crates/orbit-cli/src/command/task/update.rs
@@ -17,12 +17,12 @@ pub struct TaskUpdateArgs {
     /// New description (empty string clears)
     #[arg(long)]
     pub description: Option<String>,
-    /// Acceptance criteria. Repeat the flag for multiple criteria.
+    /// Replacement acceptance criteria. Repeat the flag for multiple criteria.
     #[arg(long = "acceptance-criteria")]
     pub acceptance_criteria: Vec<String>,
-    /// Comma-separated dependency task IDs (empty string clears)
-    #[arg(long, alias = "dependency")]
-    pub dependencies: Option<String>,
+    /// Replacement dependency task IDs. Repeat or comma-separate for multiple dependencies (empty string clears).
+    #[arg(long, alias = "dependency", action = ArgAction::Append, value_delimiter = ',')]
+    pub dependencies: Vec<String>,
     /// Replacement task tags. Repeat or comma-separate for multiple tags.
     #[arg(long = "tag", action = ArgAction::Append, value_delimiter = ',')]
     pub tags: Vec<String>,
@@ -62,10 +62,10 @@ pub struct TaskUpdateArgs {
     /// Named crew responsible for orchestration attribution (empty string clears)
     #[arg(long)]
     pub orchestrator: Option<String>,
-    /// Comma-separated task context selectors (empty string clears). Prefer
-    /// `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
-    #[arg(long = "context", alias = "context-files")]
-    pub context_files: Option<String>,
+    /// Replacement task context selectors. Repeat or comma-separate for multiple selectors (empty string clears).
+    /// Prefer `file:`, `dir:`, or `symbol:` forms; legacy raw paths are accepted and upgraded.
+    #[arg(long = "context", alias = "context-files", action = ArgAction::Append, value_delimiter = ',')]
+    pub context_files: Vec<String>,
     /// Task artifact write in `path=content` form. Repeat for multiple artifacts.
     #[arg(long = "artifact")]
     pub artifacts: Vec<String>,
@@ -194,7 +194,7 @@ impl Execute for TaskUpdateArgs {
             }
         });
         let acceptance_criteria = (!acceptance_criteria.is_empty()).then_some(acceptance_criteria);
-        let dependencies = dependencies.map(|value| crate::parse::csv_to_vec(&value));
+        let dependencies = parse_replacement_list(dependencies);
         let tags = (!tags.is_empty()).then_some(tags);
         let upsert_artifacts = parse_artifact_args(&artifacts)?;
         let (agent, model) = super::mutation_identity(model);
@@ -219,7 +219,7 @@ impl Execute for TaskUpdateArgs {
                 job_run_id,
                 crew,
                 orchestrator,
-                context_files: context_files.map(|c| crate::parse::csv_to_vec(&c)),
+                context_files: parse_replacement_list(context_files),
                 upsert_artifacts,
                 ..Default::default()
             },
@@ -233,6 +233,15 @@ impl Execute for TaskUpdateArgs {
         )
         .into())
     }
+}
+
+fn parse_replacement_list(values: Vec<String>) -> Option<Vec<String>> {
+    (!values.is_empty()).then(|| {
+        values
+            .into_iter()
+            .flat_map(|value| crate::parse::csv_to_vec(&value))
+            .collect()
+    })
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]

--- a/crates/orbit-cli/tests/task_trimmed_surface.rs
+++ b/crates/orbit-cli/tests/task_trimmed_surface.rs
@@ -80,6 +80,38 @@ fn task_update_complexity_roundtrips_through_a_real_task_record() {
 }
 
 #[test]
+fn task_update_repeats_dependencies_and_clears_context() {
+    let workspace = TestWorkspace::new();
+    let dependency_a = workspace.add_task("First dependency");
+    let dependency_b = workspace.add_task("Second dependency");
+    let id = workspace.add_task("List update");
+
+    workspace.run(
+        &[
+            "task",
+            "update",
+            &id,
+            "--dependencies",
+            &dependency_a,
+            "--dependencies",
+            &dependency_b,
+            "--context",
+            "file:one.rs",
+        ],
+        "update repeated dependencies and context",
+    );
+
+    let dependencies =
+        workspace.task_json(&["task", "show", &id, "--fields", "dependencies", "--json"]);
+    assert_eq!(dependencies, json!([dependency_a, dependency_b]));
+
+    workspace.run(&["task", "update", &id, "--context", ""], "clear context");
+    let context =
+        workspace.task_json(&["task", "show", &id, "--fields", "context_files", "--json"]);
+    assert_eq!(context, json!([]));
+}
+
+#[test]
 fn locks_list_projects_files_held_by_active_tasks() {
     let workspace = TestWorkspace::new();
     fs::write(workspace.work.join("held.rs"), "// held\n").expect("write held file");


### PR DESCRIPTION
## Task

[ORB-11661](https://orbit-cli.com/tasks/ORB-11661) — [code-review] Make `task update` accept the same list-flag shapes as `task add`

### Description

## Problem
On `task add`, `--dependencies`/`--dependency` and `--context` are `Vec<String>` with `ArgAction::Append` and `value_delimiter = ','` (`add.rs:26-27,47-48`), so both `--dependencies A --dependencies B` and `--dependencies A,B` work. On `task update` the same flags are `Option<String>` (`update.rs:23-25,65-68`), so repeating the flag is a clap error and only the comma form is accepted, while `--tag` on `update` *is* the repeatable form (`update.rs:26-28`). The `--acceptance-criteria` help on update does not say the list replaces the existing one.

## Why It Matters
Agents learn the flag shape from `task add` and then fail on `task update` with a usage error that does not mention the comma form.

## Proposed Fix
Change `update`'s `dependencies` and `context_files` to `Vec<String>` with the same `Append + value_delimiter` attributes, keeping "empty string clears" via an explicit `--clear-dependencies`/`--clear-context` or by treating a single empty value as clear; say "replaces" in the `--acceptance-criteria` and `--tag` help.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/task/update.rs:23-25,65-68`, `crates/orbit-cli/src/command/task/add.rs:25-27,45-48`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (ux). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit task update <id> --dependencies A --dependencies B` succeeds and `task show --fields dependencies` lists both.
- `orbit task update <id> --context ""` still clears.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Changed `task update --dependencies`/`--dependency` and `--context`/`--context-files` to accept repeated and comma-delimited values, while preserving an explicit empty value as a clear replacement.
- Updated replacement-oriented help text and added parser plus binary-level regression coverage.
Acceptance criteria:
- Repeated dependencies: passed. The integration test updates a task with two repeated dependency flags and verifies both through `task show --fields dependencies --json`; comma-delimited parsing is covered by the focused parser test.
- Empty context clears: passed. The integration test sets context, runs `task update --context ""`, and verifies `task show --fields context_files --json` returns `[]`.
Validation:
- Passed: `cargo test -p orbit-cli task_update_` (11 tests).
- Passed: `cargo test -p orbit-cli --test task_trimmed_surface task_update_repeats_dependencies_and_clears_context` (1 test).
- Passed: `make ci-fast`.
- Passed: `cargo clippy -p orbit-cli --all-targets -- -D warnings`.
- Passed: `git diff --check`.
- Failed: `make ci-lint`; unrelated workspace test compilation fails in `crates/orbit-search/src/vector/store/tests/upsert.rs` because two `Embedder` test implementations lack the existing `token_boundaries` trait method. The affected `orbit-cli` package clippy check passed.
- Not run: full `make ci`, per workspace guidance to use CI as the canonical merge gate rather than running it per task.
Assessment: Scoped CLI change is formatted, tested at parser and binary behavior boundaries, and leaves the worktree uncommitted for pipeline delivery. Remaining risk is the pre-existing workspace-wide clippy blocker in orbit-search.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11661-6a9f676a`
- Behind base: 0
- Ahead of base: 1