### PR TITLE
[code-review] Make `ActorIdentity` serde round-trip losslessly (a persisted `Human { label }` reads back as an agent model)

### DIFF
--- a/crates/orbit-types/src/identity/actor.rs
+++ b/crates/orbit-types/src/identity/actor.rs
@@ -205,20 +205,63 @@ pub fn normalize_optional_attribution_label(
         .filter(|value| !value.is_empty())
 }
 
-/// Custom serialization: emits the flat display label string.
+/// Custom serialization: emits the flat display label when that label reads
+/// back as the same variant, and the tagged map form otherwise.
 ///
 /// - `System` → `"system"`
-/// - `Agent { model }` → `"model"`
-/// - `Human { label }` → `"label"`
+/// - `Agent { model }` → `"model"`, or `{"agent": {"model": "..."}}` when the
+///   bare label would be re-read as another variant (see
+///   [`agent_label_round_trips`])
+/// - `Human { label }` → `{"human": "label"}`, because a bare string only ever
+///   reads back as `Human` for the literal `"human"`
+///
+/// orbit-types is a stable tier, so the flat forms every earlier writer
+/// emitted — including bare-string agent labels — stay readable; only the
+/// variants that the flat form cannot represent move to the tagged shape.
 impl Serialize for ActorIdentity {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.label())
+        use serde::ser::SerializeMap;
+
+        match self {
+            Self::System => serializer.serialize_str("system"),
+            Self::Agent { model } if agent_label_round_trips(model) => {
+                serializer.serialize_str(model)
+            }
+            Self::Agent { model } => {
+                let fields = AgentFields {
+                    name: String::new(),
+                    model: model.clone(),
+                };
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("agent", &fields)?;
+                map.end()
+            }
+            Self::Human { label } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("human", label)?;
+                map.end()
+            }
+        }
     }
 }
 
+/// Whether an agent model survives being written as a bare label string.
+///
+/// `visit_str` claims `"system"` and `"human"` for their own variants and
+/// keeps only the right-hand side of the legacy `"<family> / <model>"` form,
+/// so a model matching any of those must be written as a tagged map instead.
+fn agent_label_round_trips(model: &str) -> bool {
+    model != "system" && model != "human" && !model.contains(" / ")
+}
+
+/// Payload of the tagged `{"agent": {...}}` form.
+///
+/// `name` carried the agent family for writers that predate the model-only
+/// convention. It is still read as a fallback when `model` is absent, but it
+/// is no longer written, since the family is derived from the model.
 #[derive(Serialize, Deserialize)]
 struct AgentFields {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     name: String,
     #[serde(default)]
     model: String,

--- a/crates/orbit-types/src/identity/tests/actor.rs
+++ b/crates/orbit-types/src/identity/tests/actor.rs
@@ -31,3 +31,77 @@ mod mapping {
         assert_eq!(provider_from_model("unknown-model"), None);
     }
 }
+
+mod serde_round_trip {
+    use super::super::super::actor::ActorIdentity;
+
+    fn round_trip(actor: &ActorIdentity) -> ActorIdentity {
+        let encoded = serde_json::to_string(actor).expect("serialize actor");
+        serde_json::from_str(&encoded).expect("deserialize actor")
+    }
+
+    #[test]
+    fn every_variant_survives_a_round_trip() {
+        for actor in [
+            ActorIdentity::human("daniel"),
+            ActorIdentity::agent("claude / opus"),
+            ActorIdentity::agent("gpt-5"),
+            ActorIdentity::System,
+        ] {
+            assert_eq!(round_trip(&actor), actor, "round trip changed {actor:?}");
+        }
+    }
+
+    #[test]
+    fn unambiguous_agent_models_stay_flat_strings() {
+        let encoded = serde_json::to_string(&ActorIdentity::agent("gpt-5")).expect("serialize");
+        assert_eq!(encoded, r#""gpt-5""#);
+        assert_eq!(
+            serde_json::to_string(&ActorIdentity::System).expect("serialize"),
+            r#""system""#
+        );
+    }
+
+    #[test]
+    fn variants_the_flat_label_cannot_represent_use_the_tagged_form() {
+        assert_eq!(
+            serde_json::to_string(&ActorIdentity::human("daniel")).expect("serialize"),
+            r#"{"human":"daniel"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ActorIdentity::agent("claude / opus")).expect("serialize"),
+            r#"{"agent":{"model":"claude / opus"}}"#
+        );
+        // A model that collides with a reserved flat label must not read back
+        // as `System` or `Human`.
+        for model in ["system", "human"] {
+            assert_eq!(
+                round_trip(&ActorIdentity::agent(model)),
+                ActorIdentity::agent(model)
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_encodings_still_deserialize() {
+        let cases = [
+            (r#""system""#, ActorIdentity::System),
+            (r#""gpt-5""#, ActorIdentity::agent("gpt-5")),
+            (r#""claude / opus""#, ActorIdentity::agent("opus")),
+            (r#""human""#, ActorIdentity::human("human")),
+            (
+                r#"{"agent":{"name":"claude","model":"opus"}}"#,
+                ActorIdentity::agent("opus"),
+            ),
+            (
+                r#"{"agent":{"name":"claude"}}"#,
+                ActorIdentity::agent("claude"),
+            ),
+            (r#"{"human":"daniel"}"#, ActorIdentity::human("daniel")),
+        ];
+        for (encoded, expected) in cases {
+            let decoded: ActorIdentity = serde_json::from_str(encoded).expect("deserialize legacy");
+            assert_eq!(decoded, expected, "decoding {encoded}");
+        }
+    }
+}

--- a/crates/orbit-types/src/telemetry/tests/metrics.rs
+++ b/crates/orbit-types/src/telemetry/tests/metrics.rs
@@ -1,0 +1,77 @@
+//! `MetricsEntry` is persisted as day-partitioned JSONL, so its actor
+//! attribution has to survive a write/read cycle unchanged and keep reading
+//! the lines earlier writers produced.
+
+use chrono::{TimeZone, Utc};
+
+use crate::identity::ActorIdentity;
+use crate::telemetry::MetricsEntry;
+
+fn entry(actor: ActorIdentity) -> MetricsEntry {
+    MetricsEntry {
+        ts: Utc
+            .with_ymd_and_hms(2026, 9, 7, 12, 0, 0)
+            .single()
+            .expect("unambiguous fixture timestamp"),
+        job_run: "jrun-20260907-0001".to_string(),
+        step: "implement".to_string(),
+        task_id: Some("ORB-11731".to_string()),
+        actor_identity: actor,
+        tool_invocations: 3,
+        token_usage: Some(1_024),
+        step_duration_ms: Some(4_200),
+        retry_count: 1,
+    }
+}
+
+#[test]
+fn human_attribution_survives_a_jsonl_round_trip() {
+    let written = entry(ActorIdentity::human("daniel"));
+
+    let line = serde_json::to_string(&written).expect("serialize metrics entry");
+    let read_back: MetricsEntry = serde_json::from_str(&line).expect("deserialize metrics entry");
+
+    assert_eq!(read_back, written);
+    assert_eq!(
+        read_back.actor_identity,
+        ActorIdentity::human("daniel"),
+        "a human step must not be re-read as an agent model"
+    );
+}
+
+#[test]
+fn agent_attribution_survives_a_jsonl_round_trip() {
+    for model in ["gpt-5", "claude / opus"] {
+        let written = entry(ActorIdentity::agent(model));
+
+        let line = serde_json::to_string(&written).expect("serialize metrics entry");
+        let read_back: MetricsEntry =
+            serde_json::from_str(&line).expect("deserialize metrics entry");
+
+        assert_eq!(read_back, written, "round trip changed the {model} entry");
+    }
+}
+
+#[test]
+fn legacy_jsonl_lines_with_bare_string_actors_still_parse() {
+    let cases = [
+        (r#""gpt-5.5""#, ActorIdentity::agent("gpt-5.5")),
+        (r#""codex / gpt-5.5""#, ActorIdentity::agent("gpt-5.5")),
+        (r#""system""#, ActorIdentity::System),
+        (
+            r#"{"agent":{"name":"claude","model":"claude-opus-5"}}"#,
+            ActorIdentity::agent("claude-opus-5"),
+        ),
+    ];
+
+    for (actor_json, expected) in cases {
+        let line = format!(
+            r#"{{"ts":"2026-09-07T12:00:00Z","job_run":"jrun-legacy","step":"implement","actor_identity":{actor_json},"tool_invocations":1,"token_usage":10,"step_duration_ms":50,"retry_count":0}}"#
+        );
+
+        let parsed: MetricsEntry = serde_json::from_str(&line).expect("parse legacy metrics line");
+
+        assert_eq!(parsed.actor_identity, expected, "parsing {actor_json}");
+        assert_eq!(parsed.job_run, "jrun-legacy");
+    }
+}

--- a/crates/orbit-types/src/telemetry/tests/mod.rs
+++ b/crates/orbit-types/src/telemetry/tests/mod.rs
@@ -1,3 +1,4 @@
 mod audit_actor;
 mod audit_event;
+mod metrics;
 mod self_reported_actor;

--- a/crates/orbit-web/assets/dashboard/diagnostics.js
+++ b/crates/orbit-web/assets/dashboard/diagnostics.js
@@ -44,11 +44,27 @@ function truncateValue(ctx, s, n = 220) {
   return hasCtx(ctx, "truncate") ? ctx.truncate(s, n) : String(s || "").slice(0, n);
 }
 
+// `actor_identity` is the persisted ActorIdentity enum: a flat label string,
+// or the tagged `{"human": "..."}` / `{"agent": {"model": "..."}}` shape used
+// for the labels a flat string cannot represent. Both render as one label.
+function actorIdentityLabel(v) {
+  if (v == null) return "";
+  if (typeof v !== "object") return String(v);
+  if (typeof v.human === "string") return v.human;
+  const agent = v.agent || {};
+  return agent.model || agent.name || "";
+}
+
 function getDiagMetricsColumns(ctx) {
   return [
     { key: "ts", label: "time", num: false, render: (v) => fmtRelativeValue(ctx, v) },
     { key: "step", label: "step", num: false },
-    { key: "actor_identity", label: "actor", num: false, render: (v) => v || "-" },
+    {
+      key: "actor_identity",
+      label: "actor",
+      num: false,
+      render: (v) => actorIdentityLabel(v) || "-",
+    },
     {
       key: "token_usage",
       label: "tokens",
@@ -142,7 +158,7 @@ function renderDiagnosticsTable(rows, columns, ctx, emptyText) {
       td.textContent = text;
       tr.appendChild(td);
     }
-    tr.dataset.key = `diag-${row.ts || ''}-${row.job_run || row.affiliation || ''}-${row.step || i}-${row.command || row.actor_identity || ''}`;
+    tr.dataset.key = `diag-${row.ts || ''}-${row.job_run || row.affiliation || ''}-${row.step || i}-${row.command || actorIdentityLabel(row.actor_identity) || ''}`;
     tr.dataset.hash = JSON.stringify(row);
     if (row.affiliation === "unaffiliated") {
       tr.classList.add("unaffiliated");

--- a/scripts/orbit_metrics.py
+++ b/scripts/orbit_metrics.py
@@ -51,13 +51,20 @@ STEP_COLORS = {
 # ── Parsing ───────────────────────────────────────────────────────────────────
 
 def parse_actor(raw) -> str:
+    """Render an ActorIdentity: a flat label string, or the tagged
+    ``{"human": ...}`` / ``{"agent": {...}}`` shape used for the labels a flat
+    string cannot represent."""
     if isinstance(raw, str):
         return raw
     if isinstance(raw, dict):
+        if isinstance(raw.get("human"), str):
+            return raw["human"] or "unknown"
         agent = raw.get("agent", {})
-        name = agent.get("name", "unknown")
+        name = agent.get("name", "")
         model = agent.get("model", "")
-        return f"{name} / {model}" if model else name
+        if name and model:
+            return f"{name} / {model}"
+        return model or name or "unknown"
     return "unknown"
 
 


### PR DESCRIPTION
## Task

[ORB-11731](https://orbit-cli.com/tasks/ORB-11731) — [code-review] Make `ActorIdentity` serde round-trip losslessly (a persisted `Human { label }` reads back as an agent model)

### Description

## Problem
`impl Serialize for ActorIdentity` writes only `self.label()` (actor.rs:213-217): `Human { label: "daniel" }` becomes the bare string `"daniel"`. The custom `Deserialize::visit_str` (actor.rs:242-261) maps a bare string to `System` only for `"system"`, to `Human` only for the literal `"human"`, and to `Agent { model }` for everything else; a string containing `" / "` is split and only the right half kept. So `Human { label: "daniel" }` round-trips as `Agent { model: "daniel" }`, and `Agent { model: "claude / opus" }` round-trips as `Agent { model: "opus" }`. `MetricsEntry.actor_identity` (metrics.rs:18) persists this enum in the day-partitioned metrics JSONL, and `compute_metrics_extras` (scoreboard.rs:294-297) groups on the decoded variant, so any human-attributed step is re-read and reported as an agent model. The doc comment on the impl describes the flattening but not the resulting misclassification, and no test in `identity/tests/actor.rs` covers serde at all.

## Why It Matters
The dashboard's per-actor metrics silently reclassify humans as agents after the first write/read cycle; the persisted contract is not the in-memory contract.

## Proposed Fix
Serialize the `Human` variant in the map form the deserializer already accepts (`{"human": "<label>"}`) and `Agent` as `{"agent": {"model": ...}}` when the model contains `" / "` (or always), keeping `"system"` and the legacy bare-string reads. Since orbit-types is tier stable, add a note that bare-string agent labels remain readable.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-types/src/identity/actor.rs:208-217`, `crates/orbit-types/src/identity/actor.rs:242-261`, `crates/orbit-types/src/telemetry/metrics.rs:17-18`, `crates/orbit-types/src/record/friction.rs:105-106`, `crates/orbit-web/src/api/scoreboard.rs:294-297`, `crates/orbit-types/src/identity/tests/actor.rs`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: automation-types.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Round-trip tests in `identity/tests/actor.rs`: `Human{"daniel"}`, `Agent{"claude / opus"}`, `Agent{"gpt-5"}`, `System` each serialize and deserialize to the same value through `serde_json`.
- A `MetricsEntry` with a human actor written and read back still reports `ActorIdentity::Human`.
- Existing metrics JSONL fixtures with bare-string agents still parse.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What changed

`ActorIdentity`'s `Serialize` impl (`crates/orbit-types/src/identity/actor.rs`) now emits the flat display label only when that label reads back as the same variant, and the tagged map form when it cannot:

- `System` → `"system"` (unchanged)
- `Agent { model }` → `"model"` when `agent_label_round_trips(model)` holds, otherwise `{"agent": {"model": "..."}}`
- `Human { label }` → `{"human": "label"}` always, because a bare string only ever reads back as `Human` for the literal `"human"`

`agent_label_round_trips` is a small named predicate stating exactly what `visit_str` claims for itself: the reserved labels `"system"` and `"human"`, and anything containing the legacy `" / "` family separator (which `visit_str` splits, keeping only the right half). `AgentFields.name` gained `skip_serializing_if = "String::is_empty"` so the tagged agent form writes `{"model": ...}` only — the family is derived from the model, and `name` stays a read-only legacy fallback. The `Deserialize` impl is untouched, so every shape any earlier writer produced (bare agent strings, `"codex / gpt-5.5"`, `{"agent": {"name", "model"}}`, `{"human": ...}`) still parses; that stable-tier constraint is stated in the doc comment on the impl.

Two directly affected display consumers were updated to render the tagged shape, since `MetricsEntry` is handed to them verbatim:

- `crates/orbit-web/assets/dashboard/diagnostics.js` — new `actorIdentityLabel()` helper used by the metrics table's `actor` column and by the row dedup key. Without it a human-attributed row rendered `[object Object]`. The endpoint's invocation-fallback path still emits a flat string, and the helper handles both.
- `scripts/orbit_metrics.py` — `parse_actor` gained the `{"human": ...}` branch and no longer prints a literal `unknown / <model>` when the tagged agent form omits `name`. Output for the old `{"agent": {"name", "model"}}` shape is unchanged (`"name / model"`).

`crates/orbit-web/src/api/scoreboard.rs` needed no change: `compute_metrics_extras` already matches on `ActorIdentity::Human`, which is now actually reachable after a read.

## Criteria → results

1. **Round-trip tests in `identity/tests/actor.rs` for `Human{"daniel"}`, `Agent{"claude / opus"}`, `Agent{"gpt-5"}`, `System`** — met. New `serde_round_trip` module: `every_variant_survives_a_round_trip` asserts equality through `serde_json` for exactly those four values; `unambiguous_agent_models_stay_flat_strings` and `variants_the_flat_label_cannot_represent_use_the_tagged_form` pin the wire shapes and additionally cover the reserved-label collisions `Agent{"system"}` / `Agent{"human"}`; `legacy_encodings_still_deserialize` pins all seven accepted input shapes.
2. **A `MetricsEntry` with a human actor written and read back still reports `ActorIdentity::Human`** — met. New `crates/orbit-types/src/telemetry/tests/metrics.rs` (registered in `telemetry/tests/mod.rs`, sibling test layout): `human_attribution_survives_a_jsonl_round_trip` asserts full entry equality plus the explicit `ActorIdentity::human("daniel")` check; `agent_attribution_survives_a_jsonl_round_trip` does the same for `gpt-5` and `claude / opus`.
3. **Existing metrics JSONL fixtures with bare-string agents still parse** — met. `legacy_jsonl_lines_with_bare_string_actors_still_parse` parses hand-written JSONL lines with `"gpt-5.5"`, `"codex / gpt-5.5"`, `"system"`, and `{"agent": {"name", "model"}}` into `MetricsEntry` and asserts the decoded variants and a sibling field.

## Validation

| Command | Outcome |
| --- | --- |
| `cargo test -p orbit-types --lib` | **passed** — 206 passed, 0 failed; all 10 new tests named in the output |
| `make ci-fast` | **passed** (after `cargo fmt --all`) |
| `cargo clippy -p orbit-types -p orbit-web -p orbit-cmd --all-targets --all-features -- -D warnings` | **passed**, clean |
| `git diff --check`, `git status --short` | **passed**; only the 5 modified files + the new test file, no stray artifacts |
| `node` harness over the extracted `actorIdentityLabel` | **passed** — `'gpt-5'→gpt-5`, `{human:'daniel'}→daniel`, `{agent:{model:'claude / opus'}}→claude / opus`, `{agent:{name:'claude'}}→claude`, `null`/`undefined`/`''`→`-` |
| `python3` harness over the extracted `parse_actor` | **passed** — `'gpt-5'→gpt-5`, `{human:'daniel'}→daniel`, `{agent:{model:'claude / opus'}}→claude / opus`, `{agent:{name:'claude',model:'opus'}}→claude / opus`, `{agent:{name:'claude'}}→claude`, `None→unknown` |
| `make ci-lint` | **failed — pre-existing, outside this task's scope.** See below. |
| `cargo test -p orbit-web --lib` | **failed on 1 of 345 — pre-existing, outside this task's scope.** See below. |

## Pre-existing failures on the base commit (not introduced here)

Base commit is `c1cb64371`; this task changes no file in either failing area.

- **`make ci-lint`** — `crates/orbit-search/src/vector/store/tests/upsert.rs:379,407` (`BarrierEmbedder`, `FailingEmbedder`) do not implement `token_boundaries`, required by `crates/orbit-search/src/embedder.rs:28` (E0046 ×2). Proof: `git show HEAD:crates/orbit-search/src/vector/store/tests/upsert.rs | grep -c token_boundaries` → `0` at the unmodified base; the trait method landed in `a4c9f657b` (ORB-11703). Filed as friction **F2026-09-069**. Compensated with the scoped `--all-targets --all-features -D warnings` clippy run over the three crates this task touches, which is clean.
- **`cargo test -p orbit-web --lib`** — `tests::dashboard_assets::dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close` fails with `expected one retry timer, got 2`. Proof: restoring the base `diagnostics.js` via `git show HEAD:... > ...` and re-running the single test reproduces it identically; the harness imports only `log-tail.js` (which imports only `common.js`) and never loads `diagnostics.js`. Filed as friction **F2026-09-071**. The other 344 orbit-web tests, including the diagnostics and scoreboard suites that consume `MetricsEntry`, pass.

## Scope note

`context_files` was extended from the two listed files to also cover `crates/orbit-types/src/telemetry/tests/metrics.rs` and `telemetry/tests/mod.rs` (acceptance criteria 2 and 3 are `MetricsEntry`-level and belong beside `metrics.rs` under the sibling test-layout convention), and `crates/orbit-web/assets/dashboard/diagnostics.js` plus `scripts/orbit_metrics.py` (the two consumers that read `actor_identity` straight off the persisted/serialized record and would otherwise mis-render the new tagged shape).

## Remaining risk

The wire form is now conditional rather than uniform, so a reader that assumed `actor_identity` is always a string sees an object for human actors and for agent models containing `" / "`. Both in-repo readers are updated and the shape is documented on the `Serialize` impl; any out-of-repo consumer of the metrics/friction JSONL would need the same one-line accommodation. The alternative — always emitting the tagged form — would have changed every persisted line's shape instead, which the task description left open and which is strictly more disruptive. Neither dashboard change was exercised in a live browser; both helpers were verified by direct execution of the extracted function under `node` and `python3`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11731-6a9f6681`
- Behind base: 0
- Ahead of base: 1