### PR TITLE
[BLOCKED] [code-review] Fix silent input handling in friction add and run-list limit

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/friction_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/friction_tools.rs
@@ -52,8 +52,8 @@ fn add(runtime: &OrbitRuntime, input: Value, model: Option<String>) -> Result<Va
         .map(|raw| normalize_title(&raw))
         .transpose()?;
     let tags = optional_csv_or_string_list_alias(&input, &["tags", "tag"])?.unwrap_or_default();
-    let during_task = optional_string(&input, "during_task")?
-        .or_else(|| optional_string(&input, "task_id").ok().flatten());
+    let during_task =
+        optional_string(&input, "during_task")?.or(optional_string(&input, "task_id")?);
     let model = model
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())

--- a/crates/orbit-core/src/adapter/tool_host/tests/friction_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/friction_tools.rs
@@ -47,6 +47,17 @@ fn add_without_a_title_falls_back_to_the_bodys_subject() {
 }
 
 #[test]
+fn add_refuses_a_non_string_task_id() {
+    let message = invalid_input_message(add(json!({
+        "body": SECTIONED_BODY,
+        "task_id": 123,
+        "model": TEST_CODEX_MODEL,
+    })));
+
+    assert!(message.contains("`task_id`"), "{message}");
+}
+
+#[test]
 fn add_refuses_a_title_too_long_to_read_in_a_list() {
     let message = invalid_input_message(add(json!({
         "body": SECTIONED_BODY,

--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -349,6 +349,19 @@ fn ship_tool_parses_and_rejects_an_unknown_crew_allowlist_before_dispatch() {
     );
 }
 
+#[test]
+fn run_list_refuses_a_limit_above_200() {
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let error = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({ "limit": 500 }))
+        .expect_err("run.list must reject an oversized limit");
+
+    let OrbitError::InvalidInput(message) = error else {
+        panic!("expected invalid input");
+    };
+    assert!(message.contains("200"), "{message}");
+}
+
 /// ORB-10540: the guard is narrow. Inside the same managed envelope that
 /// refuses ship and resume, the read-only verbs still answer — a blanket
 /// in-run denial would break run observation for every agent.

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -229,8 +229,12 @@ fn parse_limit(input: &Value) -> Result<usize, OrbitError> {
             "`limit` must be at least 1".to_string(),
         ));
     }
-    usize::try_from(limit.min(MAX_RUN_LIST_LIMIT as u64))
-        .map_err(|_| OrbitError::InvalidInput("`limit` is too large".to_string()))
+    if limit > MAX_RUN_LIST_LIMIT as u64 {
+        return Err(OrbitError::InvalidInput(format!(
+            "`limit` must be at most {MAX_RUN_LIST_LIMIT}"
+        )));
+    }
+    usize::try_from(limit).map_err(|_| OrbitError::InvalidInput("`limit` is too large".to_string()))
 }
 
 fn run_json(run: &JobRun) -> Result<Value, OrbitError> {

--- a/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
+++ b/crates/orbit-tools/src/builtin/orbit/workflow/mod.rs
@@ -120,7 +120,9 @@ impl Tool for OrbitWorkflowRunListTool {
             parameters: vec![
                 ToolParam {
                     name: "limit".to_string(),
-                    description: "Maximum runs to return (default 25, maximum 200).".to_string(),
+                    description:
+                        "Maximum runs to return (default 25; values above 200 are rejected)."
+                            .to_string(),
                     param_type: "integer".to_string(),
                     required: false,
                 },


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11666`
- Run: `jrun-20260908-0144-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `10d3a4c1ef792dd9d9222f7a8756bd2baeb83430`
- Target base: `5c7451ed9c26d6578443942038b78685b045d36e`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=Scoped implementation and focused tests passed, but required make ci-lint fails on unrelated missing Embedder::token_boundaries test implementations in crates/orbit-search.
```