### PR TITLE
[BLOCKED] [code-review] Show relations and artifacts in the human `task show` view

### DIFF
--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use orbit_cmd::task_owner::{WorkspaceIdentity, bound_workspace_identity};
 use orbit_core::{OrbitError, OrbitRuntime, TaskRelatedDoc};
-use orbit_types::task::is_task_show_projection_field;
+use orbit_types::task::{TaskRelationType, is_task_show_projection_field};
 use serde_json::{Value, json};
 
 use crate::command::{Block, CommandOut, Execute, Payload};
@@ -117,6 +117,36 @@ impl Execute for TaskShowArgs {
                     let _ = writeln!(out, "  - {}", dependency.label());
                 }
             }
+            let relations = orbit_core::resolve_task_relations(&task, &status_by_id);
+            if !relations.is_empty() {
+                let _ = writeln!(out, "{}", bold("Relations:"));
+                for relation in relations {
+                    let status = relation
+                        .verification
+                        .or_else(|| status_by_id.get(&relation.target).map(ToString::to_string))
+                        .unwrap_or_else(|| "missing".to_string());
+                    let _ = writeln!(
+                        out,
+                        "  - {}: {} [{}]",
+                        relation_type_label(relation.relation_type),
+                        relation.target,
+                        status
+                    );
+                }
+            }
+            let artifacts = runtime.get_task_artifacts(&task.id)?;
+            if !artifacts.is_empty() {
+                let _ = writeln!(out, "{}", bold("Artifacts:"));
+                for artifact in artifacts {
+                    let _ = writeln!(
+                        out,
+                        "  - {} ({}, {} bytes)",
+                        artifact.path,
+                        artifact.media_type,
+                        artifact.content.len()
+                    );
+                }
+            }
             if !task.tags.is_empty() {
                 let _ = writeln!(out, "{} {}", bold("Tags:"), task.tags.join(", "));
             }
@@ -224,6 +254,9 @@ impl Execute for TaskShowArgs {
             if let Some(ref pr_status) = task.pr_status {
                 let _ = writeln!(out, "{} {}", bold("PR Status:"), pr_status);
             }
+            if let Some(review) = doc.get("review") {
+                let _ = writeln!(out, "{} {}", bold("Review:"), review);
+            }
             if let Some(source_task_id) = task.source_task_id() {
                 let _ = writeln!(out, "{} {}", bold("Source Task:"), source_task_id);
             }
@@ -242,6 +275,19 @@ impl Execute for TaskShowArgs {
             blocks.push(Block::text(out));
             Ok(Payload::blocks(doc, blocks).into())
         }
+    }
+}
+
+fn relation_type_label(relation_type: TaskRelationType) -> &'static str {
+    match relation_type {
+        TaskRelationType::BlockedBy => "blocked_by",
+        TaskRelationType::ChildOf => "child_of",
+        TaskRelationType::SpawnedFrom => "spawned_from",
+        TaskRelationType::RegressionFrom => "regression_from",
+        TaskRelationType::Supersedes => "supersedes",
+        TaskRelationType::RelatedTo => "related_to",
+        TaskRelationType::Produces => "produces",
+        TaskRelationType::Resolves => "resolves",
     }
 }
 

--- a/crates/orbit-cli/tests/output_goldens.rs
+++ b/crates/orbit-cli/tests/output_goldens.rs
@@ -353,6 +353,45 @@ fn plain_and_json_forms_match_their_goldens() {
     }
 }
 
+#[test]
+fn task_show_relations_and_artifacts_match_golden() {
+    let fixture = Fixture::new();
+    let listed = parse_json_stdout(&fixture.run(&["task", "list", "--json"], &[]), "task list");
+    let task_id = listed[0]["id"].as_str().expect("task id");
+    let blocker_id = listed[1]["id"].as_str().expect("blocker id");
+    let update = serde_json::to_string(&json!({
+        "id": task_id,
+        "relations": [{"type": "blocked_by", "target": blocker_id}],
+    }))
+    .expect("serialize task update");
+
+    fixture.run(
+        &["tool", "run", "orbit.task.update", "--input", &update],
+        &[],
+    );
+    let artifact_source = fixture.work.join("evidence.txt");
+    std::fs::write(&artifact_source, "relation evidence").expect("write artifact source");
+    let artifact_source = artifact_source
+        .to_str()
+        .expect("artifact source path is UTF-8");
+    fixture.run(
+        &[
+            "task",
+            "artifact",
+            "put",
+            task_id,
+            artifact_source,
+            "--path",
+            "evidence.txt",
+        ],
+        &[],
+    );
+
+    let shown = fixture.run(&["task", "show", task_id], &[]);
+    let shown_stdout = fixture.redact(&String::from_utf8_lossy(&shown.stdout));
+    assert_golden("task_show_relations_artifacts.plain.txt", &shown_stdout);
+}
+
 /// table-rendering.md §4: "truncation never applies to json ... or the
 /// plain piped form." color-and-styling.md §4: json/ndjson/plain carry no
 /// escape sequences under any flag. Since this harness never gives the

--- a/crates/orbit-cli/tests/output_goldens/task_show_relations_artifacts.plain.txt
+++ b/crates/orbit-cli/tests/output_goldens/task_show_relations_artifacts.plain.txt
@@ -1,0 +1,19 @@
+ID: ORB-00002
+Workspace: output-goldens (ws_output-goldens)
+Title: Add pagination to the audit export command
+Status: proposed
+Priority: low
+Complexity: medium
+Type: feature
+Description: orbit audit export currently loads the entire event log into memory.
+Dependencies:
+  - ORB-00001 [proposed]
+Relations:
+  - blocked_by: ORB-00001 [proposed]
+Artifacts:
+  - evidence.txt (text/plain, 17 bytes)
+Created By: claude
+History:
+  [<TIMESTAMP>] claude: created
+Created: <TIMESTAMP>
+Updated: <TIMESTAMP>


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11662`
- Run: `jrun-20260908-0142-6`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `10d3a4c1ef792dd9d9222f7a8756bd2baeb83430`
- Target base: `9c9a3ead185aa0c075f6bedebab9f0272e2da0d3`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=make ci-lint cannot complete بسبب unrelated pre-existing orbit-search test errors.
```