### PR TITLE
[BLOCKED] [code-review] Decouple token-scoreboard regeneration from every invocation trace

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/runtime_host.rs
@@ -12,7 +12,6 @@ use orbit_store::contracts::{
     InvocationInsertParams, InvocationQuery, InvocationRecord, JobRunStepParams,
     TaskReservationReleaseReason,
 };
-use orbit_store::token_scoreboard;
 use orbit_tools::{FsAuditLogger, ReservationOwnerContext, ToolContext};
 use orbit_types::identity::AgentModelPair;
 use orbit_types::policy::{Role, UNRESTRICTED_FS_PROFILE};
@@ -708,32 +707,17 @@ impl RuntimeHost for OrbitRuntime {
             job_run_id,
             activity_id,
         );
-        let store = orbit_store::compose::invocation_store(&self.context.persistence().audit_db)
-            .map_err(|error| {
-                DispatchError::JobExecution(format!("open invocation store: {error}"))
-            })?;
-        store
-            .insert_invocation_trace_record(&InvocationInsertParams {
-                job_run_id: job_run_id.to_string(),
-                activity_id: activity_id.to_string(),
-                agent: agent.unwrap_or_else(|| provider.to_ascii_lowercase()),
-                model,
-                task_ids: task_context::associated_task_ids(input),
-                trace: trace.clone(),
-            })
-            .map_err(|error| {
-                DispatchError::JobExecution(format!("persist invocation trace: {error}"))
-            })?;
-
-        if let Err(error) =
-            token_scoreboard::write_token_scoreboard(&self.paths().scoreboard_dir, store.as_ref())
-        {
-            tracing::warn!(
-                target: "orbit.core.scoreboard",
-                error = %error,
-                "failed to refresh tokens scoreboard",
-            );
-        }
+        self.insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: job_run_id.to_string(),
+            activity_id: activity_id.to_string(),
+            agent: agent.unwrap_or_else(|| provider.to_ascii_lowercase()),
+            model,
+            task_ids: task_context::associated_task_ids(input),
+            trace: trace.clone(),
+        })
+        .map_err(|error| {
+            DispatchError::JobExecution(format!("persist invocation trace: {error}"))
+        })?;
 
         let existing = self
             .get_job_run_backend(job_run_id)

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/v2_host.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/v2_host.rs
@@ -154,6 +154,30 @@ fn persist_invocation_trace_prefers_provider_model_over_requested_alias() {
     assert_eq!(records[0].model.as_deref(), Some("claude-fable-5"));
 }
 
+#[test]
+fn persist_invocation_trace_defers_token_scoreboard_refresh_to_the_sweep() {
+    let (_root, runtime, repo_root) = runtime_with_workspace_layout();
+    let run_id = seed_running_job_run(&runtime, "deferred_scoreboard_job");
+
+    RuntimeHost::persist_invocation_trace(
+        &runtime,
+        &run_id,
+        "implement_one",
+        "codex",
+        Some("gpt-test"),
+        &serde_json::json!({}),
+        &InvocationTrace::default(),
+    )
+    .expect("persist invocation trace");
+
+    assert!(
+        !repo_root
+            .join(".orbit/state/scoreboard/tokens.json")
+            .exists(),
+        "trace persistence must not synchronously refresh the scoreboard"
+    );
+}
+
 fn persist_test_trace(runtime: &OrbitRuntime, run_id: &str, trace: &InvocationTrace) {
     RuntimeHost::persist_invocation_trace(
         runtime,

--- a/crates/orbit-core/src/application/routines/sweep.rs
+++ b/crates/orbit-core/src/application/routines/sweep.rs
@@ -21,11 +21,27 @@ pub use orbit_automation::routines::sweep::{
 use orbit_common::OrbitError;
 use orbit_common::observability::log_rotation::{self, LogRotationConfig};
 use orbit_types::workflow::JobRunState;
+use orbit_types::workspace::Workspace;
 use serde_json::json;
 
 /// Production dispatch over the per-workspace runtimes discovered this pass.
 pub(crate) struct RuntimeDispatch<'a> {
     runtimes: BTreeMap<PathBuf, &'a OrbitRuntime>,
+}
+
+/// Refresh each discovered workspace's read-side token projection once per
+/// successful sweep. A stale projection must not stop routine evaluation.
+pub(crate) fn refresh_discovered_token_scoreboards(workspaces: &[(Workspace, OrbitRuntime)]) {
+    for (workspace, runtime) in workspaces {
+        if let Err(error) = runtime.refresh_token_scoreboard() {
+            tracing::warn!(
+                target: "orbit.core.scoreboard",
+                workspace = %workspace.name,
+                error = %error,
+                "failed to refresh tokens scoreboard during routine sweep",
+            );
+        }
+    }
 }
 
 impl RoutineDispatch for RuntimeDispatch<'_> {
@@ -146,6 +162,7 @@ pub fn run_sweep_at_with_providers(
 
     // One runtime per active workspace; discovery and dispatch share them.
     let discovered = workspace_provider.discover_workspaces(global_root)?;
+    refresh_discovered_token_scoreboards(&discovered.entries);
     let mut load_errors: Vec<RoutineLoadError> = discovered.errors.clone();
 
     let mut collection = collect_routines(&discovered.entries, &local_host.host_id);

--- a/crates/orbit-core/src/application/routines/tests/sweep.rs
+++ b/crates/orbit-core/src/application/routines/tests/sweep.rs
@@ -1,12 +1,17 @@
 use crate::application::routines::clock::{ClockSettings, save_clock_settings};
 use crate::application::routines::loader::{DiscoveredWorkspaces, RoutineWorkspaceProvider};
 use crate::application::routines::sweep::{
-    SweepOptions, configured_sweep_options, run_sweep_at_with_providers,
+    SweepOptions, configured_sweep_options, refresh_discovered_token_scoreboards,
+    run_sweep_at_with_providers,
 };
 use crate::application::routines::validation::{
     RoutineHostIdentity, RoutinePlacementProjection, RoutinePlacementProvider,
 };
+use chrono::Utc;
 use orbit_common::OrbitError;
+use orbit_store::InvocationInsertParams;
+use orbit_types::telemetry::{InvocationTrace, TokenUsage};
+use orbit_types::workspace::{Workspace, WorkspaceStatus};
 use std::path::Path;
 struct MustNotLoad;
 
@@ -66,4 +71,50 @@ fn production_sweep_options_follow_the_host_clock_cadence() {
     let configured_options = configured_sweep_options(root.path(), SweepOptions::default())
         .expect("configured clock settings");
     assert_eq!(configured_options.sweep_cadence_seconds, 300);
+}
+
+#[test]
+fn sweep_refreshes_token_scoreboard_for_each_discovered_workspace() {
+    let root = tempfile::tempdir().expect("root");
+    let global = root.path().join("global");
+    let workspace_root = root.path().join("repo/.orbit");
+    std::fs::create_dir_all(&global).expect("global root");
+    std::fs::create_dir_all(&workspace_root).expect("workspace root");
+    let runtime = crate::OrbitRuntime::from_roots(&global, &workspace_root).expect("runtime");
+
+    runtime
+        .insert_invocation_trace_record(&InvocationInsertParams {
+            job_run_id: "jrun-scoreboard".to_string(),
+            activity_id: "implement".to_string(),
+            agent: "codex".to_string(),
+            model: Some("gpt-test".to_string()),
+            task_ids: Vec::new(),
+            trace: InvocationTrace {
+                usage: TokenUsage {
+                    input: 10,
+                    ..TokenUsage::default()
+                },
+                ..InvocationTrace::default()
+            },
+        })
+        .expect("persist invocation");
+
+    refresh_discovered_token_scoreboards(&[(
+        Workspace {
+            id: "ws-scoreboard".to_string(),
+            name: "scoreboard".to_string(),
+            owner_machine_id: None,
+            git_remote: None,
+            ship_mode: None,
+            base_branch: "agent-main".to_string(),
+            status: WorkspaceStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        },
+        runtime,
+    )]);
+
+    let tokens = std::fs::read_to_string(workspace_root.join("state/scoreboard/tokens.json"))
+        .expect("scoreboard refreshed during sweep");
+    assert!(tokens.contains("codex"), "{tokens}");
 }

--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -265,6 +265,15 @@ impl OrbitRuntime {
         open_invocation_store(self)?.insert_invocation_trace_record(params)
     }
 
+    /// Refreshes the read-side token scoreboard from persisted invocation telemetry.
+    pub(crate) fn refresh_token_scoreboard(&self) -> Result<(), OrbitError> {
+        let store = open_invocation_store(self)?;
+        orbit_store::token_scoreboard::write_token_scoreboard(
+            &self.context.paths().scoreboard_dir,
+            store.as_ref(),
+        )
+    }
+
     /// Aggregates managed invocation telemetry by canonical task orchestrator.
     ///
     /// The effective window is half-open (`since <= ts < until`). Missing


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11664`
- Run: `jrun-20260908-0142-5`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `10d3a4c1ef792dd9d9222f7a8756bd2baeb83430`
- Target base: `9c9a3ead185aa0c075f6bedebab9f0272e2da0d3`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=make ci-lint fails outside task scope: orbit-search test embedders lack Embedder::token_boundaries.
```