### PR TITLE
Repair orbit-search test embedders missing token_boundaries after ORB-11703

### DIFF
--- a/crates/orbit-search/src/vector/store/tests/upsert.rs
+++ b/crates/orbit-search/src/vector/store/tests/upsert.rs
@@ -398,6 +398,10 @@ impl Embedder for BarrierEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         self.inner.token_count(text)
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        self.inner.token_boundaries(text)
+    }
 }
 
 struct FailingEmbedder {
@@ -423,5 +427,9 @@ impl Embedder for FailingEmbedder {
 
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         self.inner.token_count(text)
+    }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        self.inner.token_boundaries(text)
     }
 }


### PR DESCRIPTION
## Task

[ORB-11759](https://orbit-cli.com/tasks/ORB-11759) — Repair orbit-search test embedders missing token_boundaries after ORB-11703

### Description

CI run 34173211839 at ffb995ac23948f37c0d6ec8eb247aeb35f39fec3 fails cargo llvm-cov --workspace --locked --no-report with E0046: BarrierEmbedder (upsert.rs:379) and FailingEmbedder (:407) omit Embedder::token_boundaries. ORB-11731 independently reproduced this in make ci-lint at c1cb64371; it explicitly does not own repair. GitHub API inspection of current agent-main e05fa2fe68be7b351197258162537921993e8e73 confirms both omissions still present. ORB-11703/a4c9f657b added the trait method; ORB-11702 introduced these test doubles. Implement the required delegation to each double's inner embedder, preserving barrier/failure behavior. Audit other Embedder impls for this same integration omission. Keep scope limited to compile restoration and focused validation; do not weaken production trait or tests. Evidence: https://github.com/constellation-works/orbit/actions/runs/34173211839/job/101897422095 . Use low build parallelism on busy host.

### Acceptance Criteria

- All Embedder test doubles satisfy the current trait while preserving their intended barrier/failure behavior.
- cargo test -p orbit-search --lib passes; make ci-fast and make ci-lint pass or independently identify remaining unrelated failures with exact evidence.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `token_boundaries` delegation to `BarrierEmbedder` and `FailingEmbedder` in `crates/orbit-search/src/vector/store/tests/upsert.rs`, so both test doubles now satisfy `Embedder` without changing their barrier or forced-failure behavior.
- Audited all `Embedder` implementations in `crates/orbit-search`; no other implementation is missing `token_boundaries`.

Criteria assessment:
- All Embedder test doubles satisfy the current trait while preserving intended behavior: passed via compilation and the complete 82-test `orbit-search` library suite.
- `cargo test -p orbit-search --lib`: passed (82 passed, 0 failed).
- `make ci-lint`: passed with `CARGO_BUILD_JOBS=2`.
- `make ci-fast`: failed independently before task code validation because `./scripts/generate-doc-indexes.sh --check` reported `docs/INDEX.md is stale`; this checkout began clean and the task changes only `upsert.rs`, so the stale generated documentation is unrelated. Its preceding `cargo fmt --all -- --check` completed successfully.

Validation:
- Passed: `CARGO_BUILD_JOBS=2 cargo test -p orbit-search --lib`.
- Passed: `CARGO_BUILD_JOBS=2 make ci-lint`.
- Failed (unrelated): `CARGO_BUILD_JOBS=2 make ci-fast` due to stale `docs/INDEX.md` from the documentation-index check.
- Passed: `git diff --check`; final status contains only the scoped test file.

Assessment: minimal compile-restoration change; no remaining task-specific risks.

Friction checkpoint: not filed; the stale documentation index was immediately diagnosable and did not exceed the reporting threshold.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11759-6a9f6b5c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra