### PR TITLE
[code-review] Make auto-task slot minting concurrency-safe and preserve corrupt cursor evidence

### DIFF
--- a/crates/orbit-automation/src/auto_tasks/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/scheduler.rs
@@ -4,9 +4,16 @@ use super::loader::{AutoTaskLoadError, collect_auto_tasks};
 use super::schedule::{AutoTaskDueDecision, decide_due};
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
-use orbit_store::compose::auto_task::{cursor_state_path, load_cursor_state, upsert_cursor};
-use orbit_types::workflow::{AutoTaskCursor, AutoTaskDefinition, DedupePolicy};
+use orbit_store::compose::auto_task::{
+    CursorSession, cursor_state_path, load_cursor_state, with_cursor_lock,
+};
+use orbit_types::workflow::{
+    AutoTaskCursor, AutoTaskDefinition, AutoTaskPendingClaim, DedupePolicy,
+};
 use std::path::PathBuf;
+
+#[cfg(test)]
+use std::sync::{Arc, Barrier};
 
 /// Lifecycle adapter. Core retains task creation, authorization and audit.
 pub trait AutoTaskDispatch {
@@ -33,8 +40,8 @@ pub struct AutoTaskFireReport {
     pub name: String,
     /// One of: `fired`, `would_fire`, `baselined`, `would_baseline`, `skipped`.
     pub action: &'static str,
-    /// Why, for `skipped` rows; for `fired` rows, only when the cursor
-    /// checkpoint after minting failed.
+    /// Why, for `skipped` rows; for `fired` rows, when the cursor checkpoint
+    /// after minting failed or a pending mint was reconciled.
     pub reason: Option<String>,
     /// Scheduled slot consumed (RFC 3339, UTC), when a fire was involved.
     pub slot: Option<String>,
@@ -63,31 +70,34 @@ pub struct SchedulerOptions {
 /// explicit `now` (the test seam). Loads definitions from
 /// `<local_orbit_dir>/auto_tasks/`, cursors from
 /// `<shared_orbit_dir>/state/auto-tasks.json`.
+///
+/// Slot admission and cursor writes share a stable sidecar lock. Concurrent
+/// passes serialize there; `max_active_runs` on the job is not this guarantee.
 pub fn run_auto_task_scheduler_at(
     host: &dyn AutoTaskDispatch,
     now: DateTime<Utc>,
     options: SchedulerOptions,
 ) -> Result<AutoTaskSchedulerOutcome, OrbitError> {
-    // ADR-0286: definitions are tracked checkout content, while cursor state
-    // is host-local coordination state shared by linked worktrees.
+    // Definitions are tracked checkout content; cursor state is host-local
+    // coordination state shared by linked worktrees.
     let definition_root = host.definition_root();
     let state_path = cursor_state_path(&host.state_dir());
 
     let collection = collect_auto_tasks(&definition_root);
-    let cursors = load_cursor_state(&state_path);
 
     let mut reports = Vec::new();
     for loaded in &collection.definitions {
         let definition = &loaded.definition;
-        let cursor = cursors.definitions.get(&definition.name);
-        let report = fire_definition(host, definition, cursor, &state_path, now, options)
-            .unwrap_or_else(|error| AutoTaskFireReport {
-                name: definition.name.clone(),
-                action: "skipped",
-                reason: Some(format!("error: {error}")),
-                slot: None,
-                task_id: None,
-                automation: None,
+        let report =
+            fire_definition(host, definition, &state_path, now, options).unwrap_or_else(|error| {
+                AutoTaskFireReport {
+                    name: definition.name.clone(),
+                    action: "skipped",
+                    reason: Some(format!("error: {error}")),
+                    slot: None,
+                    task_id: None,
+                    automation: None,
+                }
             });
         reports.push(report);
     }
@@ -101,7 +111,6 @@ pub fn run_auto_task_scheduler_at(
 fn fire_definition(
     host: &dyn AutoTaskDispatch,
     definition: &AutoTaskDefinition,
-    cursor: Option<&AutoTaskCursor>,
     state_path: &std::path::Path,
     now: DateTime<Utc>,
     options: SchedulerOptions,
@@ -127,26 +136,82 @@ fn fire_definition(
         });
     }
 
+    if options.dry_run {
+        return dry_run_definition(host, definition, state_path, now);
+    }
+
+    #[cfg(test)]
+    wait_for_admission_overlap();
+    with_cursor_lock(state_path, |session| {
+        fire_locked(host, definition, session, now)
+    })
+}
+
+fn dry_run_definition(
+    host: &dyn AutoTaskDispatch,
+    definition: &AutoTaskDefinition,
+    state_path: &std::path::Path,
+    now: DateTime<Utc>,
+) -> Result<AutoTaskFireReport, OrbitError> {
     if !definition.enabled {
         return Ok(skipped(definition, "disabled"));
     }
 
-    // First observation: record the baseline and fire nothing — a definition
-    // never mints tasks for slots that predate its registration on this host.
-    let Some(cursor) = cursor else {
-        if options.dry_run {
-            return Ok(action(definition, "would_baseline"));
+    let state = load_cursor_state(state_path)?;
+    let Some(cursor) = state.definitions.get(&definition.name) else {
+        return Ok(action(definition, "would_baseline"));
+    };
+    if let Some(pending) = &cursor.pending {
+        return Ok(unresolved_pending(definition, pending));
+    }
+
+    let baseline = parse_rfc3339(&cursor.baseline_at)?;
+    let last_slot = cursor.last_slot.as_deref().map(parse_rfc3339).transpose()?;
+    match decide_due(&definition.schedule, baseline, last_slot, now)? {
+        AutoTaskDueDecision::NotDue => Ok(skipped(definition, "not_due")),
+        AutoTaskDueDecision::Fire { slot } => {
+            if definition.dedupe == DedupePolicy::SkipIfOpen
+                && host.has_open_instance(definition)?
+            {
+                return Ok(AutoTaskFireReport {
+                    slot: Some(slot),
+                    ..skipped(definition, "dedupe_open")
+                });
+            }
+            Ok(AutoTaskFireReport {
+                slot: Some(slot),
+                ..action(definition, "would_fire")
+            })
         }
-        upsert_cursor(
-            state_path,
-            &definition.name,
+    }
+}
+
+fn fire_locked(
+    host: &dyn AutoTaskDispatch,
+    definition: &AutoTaskDefinition,
+    session: &mut CursorSession,
+    now: DateTime<Utc>,
+) -> Result<AutoTaskFireReport, OrbitError> {
+    if let Some(report) = recover_pending(definition, session, now)? {
+        return Ok(report);
+    }
+
+    if !definition.enabled {
+        return Ok(skipped(definition, "disabled"));
+    }
+
+    let Some(cursor) = session.state.definitions.get(&definition.name).cloned() else {
+        session.state.definitions.insert(
+            definition.name.clone(),
             AutoTaskCursor {
                 baseline_at: now.to_rfc3339(),
                 last_slot: None,
                 last_fired_at: None,
                 last_task_id: None,
+                pending: None,
             },
-        )?;
+        );
+        session.save()?;
         return Ok(action(definition, "baselined"));
     };
 
@@ -156,10 +221,6 @@ fn fire_definition(
     match decide_due(&definition.schedule, baseline, last_slot, now)? {
         AutoTaskDueDecision::NotDue => Ok(skipped(definition, "not_due")),
         AutoTaskDueDecision::Fire { slot } => {
-            // Dedupe: never fire while a prior instance is still open, so a
-            // stalled backlog cannot accumulate identical tasks. The cursor is
-            // deliberately left unadvanced so the pending occurrence fires
-            // (once, collapsed) as soon as the queue drains.
             if definition.dedupe == DedupePolicy::SkipIfOpen
                 && host.has_open_instance(definition)?
             {
@@ -168,44 +229,183 @@ fn fire_definition(
                     ..skipped(definition, "dedupe_open")
                 });
             }
+            fire_slot(host, definition, session, cursor, slot, now)
+        }
+    }
+}
 
-            if options.dry_run {
-                return Ok(AutoTaskFireReport {
-                    slot: Some(slot),
-                    ..action(definition, "would_fire")
-                });
-            }
+fn recover_pending(
+    definition: &AutoTaskDefinition,
+    session: &mut CursorSession,
+    now: DateTime<Utc>,
+) -> Result<Option<AutoTaskFireReport>, OrbitError> {
+    let Some(cursor) = session.state.definitions.get(&definition.name).cloned() else {
+        return Ok(None);
+    };
+    let Some(pending) = cursor.pending.clone() else {
+        return Ok(None);
+    };
 
-            let task = host.mint_task(definition)?;
-            // The task exists from here on. A cursor that cannot be written
-            // must not turn this into a `skipped` row: the operator would
-            // see no fire while the backlog gained a task, and every later
-            // pass would mint another for the same slot. Report the fire
-            // with the task id and say the checkpoint is missing.
-            let reason = upsert_cursor(
-                state_path,
-                &definition.name,
+    if let Some(task_id) = pending.task_id.clone() {
+        return match checkpoint_consumed(session, definition, &cursor, &pending.slot, &task_id, now)
+        {
+            Ok(()) => Ok(Some(AutoTaskFireReport {
+                name: definition.name.clone(),
+                action: "fired",
+                reason: Some(format!(
+                    "reconciled pending mint for slot {} as {task_id}",
+                    pending.slot
+                )),
+                slot: Some(pending.slot),
+                task_id: Some(task_id),
+                automation: None,
+            })),
+            Err(error) => Ok(Some(AutoTaskFireReport {
+                name: definition.name.clone(),
+                action: "fired",
+                reason: Some(format!(
+                    "cursor not advanced; retry will reconcile from pending mint evidence or report unresolved: {error}"
+                )),
+                slot: Some(pending.slot),
+                task_id: Some(task_id),
+                automation: None,
+            })),
+        };
+    }
+
+    Ok(Some(unresolved_pending(definition, &pending)))
+}
+
+fn fire_slot(
+    host: &dyn AutoTaskDispatch,
+    definition: &AutoTaskDefinition,
+    session: &mut CursorSession,
+    cursor: AutoTaskCursor,
+    slot: String,
+    now: DateTime<Utc>,
+) -> Result<AutoTaskFireReport, OrbitError> {
+    let mut claimed = cursor.clone();
+    claimed.pending = Some(AutoTaskPendingClaim {
+        slot: slot.clone(),
+        task_id: None,
+    });
+    session
+        .state
+        .definitions
+        .insert(definition.name.clone(), claimed);
+    session.save()?;
+    fail_if_injected(SchedulerFault::AfterClaim)?;
+
+    let task = match host.mint_task(definition) {
+        Ok(task) => task,
+        Err(error) => {
+            session.state.definitions.insert(
+                definition.name.clone(),
                 AutoTaskCursor {
-                    baseline_at: cursor.baseline_at.clone(),
-                    last_slot: Some(slot.clone()),
-                    last_fired_at: Some(now.to_rfc3339()),
-                    last_task_id: Some(task.clone()),
+                    pending: None,
+                    ..cursor
                 },
-            )
-            .err()
-            .map(|error| {
-                format!("cursor not advanced; the next pass may fire this slot again: {error}")
+            );
+            session.save()?;
+            return Ok(AutoTaskFireReport {
+                name: definition.name.clone(),
+                action: "skipped",
+                reason: Some(format!("mint failed; slot not consumed: {error}")),
+                slot: Some(slot),
+                task_id: None,
+                automation: None,
             });
+        }
+    };
 
+    session.state.definitions.insert(
+        definition.name.clone(),
+        AutoTaskCursor {
+            pending: Some(AutoTaskPendingClaim {
+                slot: slot.clone(),
+                task_id: Some(task.clone()),
+            }),
+            ..cursor.clone()
+        },
+    );
+    session.save()?;
+    fail_if_injected(SchedulerFault::AfterMintBeforeCheckpoint)?;
+
+    match checkpoint_consumed(session, definition, &cursor, &slot, &task, now) {
+        Ok(()) => Ok(AutoTaskFireReport {
+            name: definition.name.clone(),
+            action: "fired",
+            reason: None,
+            slot: Some(slot),
+            task_id: Some(task),
+            automation: None,
+        }),
+        Err(error) => {
+            session.state.definitions.insert(
+                definition.name.clone(),
+                AutoTaskCursor {
+                    pending: Some(AutoTaskPendingClaim {
+                        slot: slot.clone(),
+                        task_id: Some(task.clone()),
+                    }),
+                    ..cursor
+                },
+            );
+            let evidence = session
+                .save()
+                .err()
+                .map(|save_error| format!("; mint evidence also unpersisted: {save_error}"));
             Ok(AutoTaskFireReport {
                 name: definition.name.clone(),
                 action: "fired",
-                reason,
+                reason: Some(format!(
+                    "cursor not advanced; retry will reconcile from pending mint evidence or report unresolved: {error}{}",
+                    evidence.unwrap_or_default()
+                )),
                 slot: Some(slot),
                 task_id: Some(task),
                 automation: None,
             })
         }
+    }
+}
+
+fn checkpoint_consumed(
+    session: &mut CursorSession,
+    definition: &AutoTaskDefinition,
+    cursor: &AutoTaskCursor,
+    slot: &str,
+    task_id: &str,
+    now: DateTime<Utc>,
+) -> Result<(), OrbitError> {
+    fail_if_injected(SchedulerFault::CheckpointWrite)?;
+    session.state.definitions.insert(
+        definition.name.clone(),
+        AutoTaskCursor {
+            baseline_at: cursor.baseline_at.clone(),
+            last_slot: Some(slot.to_string()),
+            last_fired_at: Some(now.to_rfc3339()),
+            last_task_id: Some(task_id.to_string()),
+            pending: None,
+        },
+    );
+    session.save()
+}
+
+fn unresolved_pending(
+    definition: &AutoTaskDefinition,
+    pending: &AutoTaskPendingClaim,
+) -> AutoTaskFireReport {
+    AutoTaskFireReport {
+        slot: Some(pending.slot.clone()),
+        ..skipped(
+            definition,
+            &format!(
+                "unresolved_pending: slot {} was claimed without mint evidence; inspect {} tagged tasks and auto-tasks.json before retrying — refusing to remint or consume the slot",
+                pending.slot,
+                orbit_types::workflow::auto_task_tag(&definition.name)
+            ),
+        )
     }
 }
 
@@ -235,4 +435,58 @@ fn parse_rfc3339(raw: &str) -> Result<DateTime<Utc>, OrbitError> {
     DateTime::parse_from_rfc3339(raw)
         .map(|value| value.with_timezone(&Utc))
         .map_err(|error| OrbitError::Store(format!("invalid stored timestamp '{raw}': {error}")))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SchedulerFault {
+    AfterClaim,
+    AfterMintBeforeCheckpoint,
+    CheckpointWrite,
+}
+
+#[cfg(test)]
+thread_local! {
+    static INJECTED_FAULT: std::cell::RefCell<Option<SchedulerFault>> =
+        const { std::cell::RefCell::new(None) };
+    static ADMISSION_BARRIER: std::cell::RefCell<Option<Arc<Barrier>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn inject_scheduler_fault(fault: Option<SchedulerFault>) {
+    INJECTED_FAULT.with(|cell| *cell.borrow_mut() = fault);
+}
+
+#[cfg(test)]
+pub(crate) fn set_admission_overlap_barrier(barrier: Option<Arc<Barrier>>) {
+    ADMISSION_BARRIER.with(|cell| *cell.borrow_mut() = barrier);
+}
+
+fn fail_if_injected(_fault: SchedulerFault) -> Result<(), OrbitError> {
+    #[cfg(test)]
+    {
+        let hit = INJECTED_FAULT.with(|cell| {
+            let current = *cell.borrow();
+            if current == Some(_fault) {
+                *cell.borrow_mut() = None;
+                true
+            } else {
+                false
+            }
+        });
+        if hit {
+            return Err(OrbitError::Store(format!(
+                "injected scheduler interruption at {_fault:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn wait_for_admission_overlap() {
+    let barrier = ADMISSION_BARRIER.with(|cell| cell.borrow().clone());
+    if let Some(barrier) = barrier {
+        barrier.wait();
+    }
 }

--- a/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-automation/src/auto_tasks/tests/scheduler.rs
@@ -1,21 +1,44 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use orbit_common::OrbitError;
-use orbit_store::compose::auto_task::cursor_state_path;
-use orbit_types::workflow::AutoTaskDefinition;
+use orbit_store::compose::auto_task::{cursor_state_path, load_cursor_state, upsert_cursor};
 use orbit_types::workflow::automation::AutomationDiagnostic;
+use orbit_types::workflow::{
+    AutoTaskCursor, AutoTaskDefinition, AutoTaskPendingClaim, DedupePolicy,
+};
 use tempfile::tempdir;
 
 use crate::auto_tasks::loader::auto_tasks_dir;
 use crate::auto_tasks::scheduler::{
-    AutoTaskDispatch, SchedulerOptions, run_auto_task_scheduler_at,
+    AutoTaskDispatch, SchedulerFault, SchedulerOptions, inject_scheduler_fault,
+    run_auto_task_scheduler_at, set_admission_overlap_barrier,
 };
 
 struct TestDispatch {
     definition_root: PathBuf,
     state_dir: PathBuf,
+    minted: AtomicUsize,
+    mint_ids: Mutex<Vec<String>>,
+    mint_should_fail: AtomicBool,
+    open_instance: AtomicBool,
+}
+
+impl TestDispatch {
+    fn new(definition_root: PathBuf, state_dir: PathBuf) -> Self {
+        Self {
+            definition_root,
+            state_dir,
+            minted: AtomicUsize::new(0),
+            mint_ids: Mutex::new(Vec::new()),
+            mint_should_fail: AtomicBool::new(false),
+            open_instance: AtomicBool::new(false),
+        }
+    }
 }
 
 impl AutoTaskDispatch for TestDispatch {
@@ -25,7 +48,7 @@ impl AutoTaskDispatch for TestDispatch {
         _dry_run: bool,
         _now: DateTime<Utc>,
     ) -> Result<AutomationDiagnostic, OrbitError> {
-        panic!("invalid cron definitions must not be dispatched")
+        panic!("interval fixtures must not take the delivery path")
     }
 
     fn definition_root(&self) -> PathBuf {
@@ -37,12 +60,69 @@ impl AutoTaskDispatch for TestDispatch {
     }
 
     fn has_open_instance(&self, _definition: &AutoTaskDefinition) -> Result<bool, OrbitError> {
-        panic!("invalid cron definitions must not be dispatched")
+        Ok(self.open_instance.load(Ordering::SeqCst))
     }
 
     fn mint_task(&self, _definition: &AutoTaskDefinition) -> Result<String, OrbitError> {
-        panic!("invalid cron definitions must not be dispatched")
+        if self.mint_should_fail.load(Ordering::SeqCst) {
+            return Err(OrbitError::Execution("injected mint failure".to_string()));
+        }
+        let n = self.minted.fetch_add(1, Ordering::SeqCst) + 1;
+        let id = format!("ORB-{n:05}");
+        self.mint_ids.lock().expect("ids").push(id.clone());
+        Ok(id)
     }
+}
+
+fn at(y: i32, m: u32, d: u32, h: u32, min: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(y, m, d, h, min, 0)
+        .single()
+        .expect("valid ts")
+}
+
+fn write_interval_definition(root: &std::path::Path, name: &str, dedupe: &str) {
+    let definitions = auto_tasks_dir(root);
+    fs::create_dir_all(&definitions).expect("auto-task definitions directory");
+    fs::write(
+        definitions.join(format!("{name}.yaml")),
+        format!(
+            r#"schemaVersion: 1
+name: {name}
+schedule:
+  every_minutes: 60
+dedupe: {dedupe}
+template:
+  title: Fixture {name}
+"#
+        ),
+    )
+    .expect("definition fixture");
+}
+
+fn cursor(baseline: &str, last_slot: Option<&str>) -> AutoTaskCursor {
+    AutoTaskCursor {
+        baseline_at: baseline.to_string(),
+        last_slot: last_slot.map(str::to_string),
+        last_fired_at: last_slot.map(|_| "2026-01-01T01:00:05+00:00".to_string()),
+        last_task_id: last_slot.map(|_| "ORB-00000".to_string()),
+        pending: None,
+    }
+}
+
+fn due_fixture(name: &str) -> (tempfile::TempDir, TestDispatch, DateTime<Utc>) {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, name, "always");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    let t0 = at(2026, 1, 1, 0, 0);
+    upsert_cursor(
+        &cursor_state_path(&dispatch.state_dir),
+        name,
+        cursor(&t0.to_rfc3339(), None),
+    )
+    .expect("baseline cursor");
+    (root, dispatch, t0)
 }
 
 #[test]
@@ -64,10 +144,7 @@ template:
     )
     .expect("definition fixture");
 
-    let dispatch = TestDispatch {
-        definition_root,
-        state_dir,
-    };
+    let dispatch = TestDispatch::new(definition_root, state_dir);
     let outcome = run_auto_task_scheduler_at(&dispatch, Utc::now(), SchedulerOptions::default())
         .expect("scheduler pass");
 
@@ -79,4 +156,384 @@ template:
             .contains("invalid cron expression 'every day'")
     );
     assert!(!cursor_state_path(&dispatch.state_dir).exists());
+}
+
+#[test]
+fn overlapping_due_passes_mint_one_task() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    let dispatch = Arc::new(dispatch);
+    let barrier = Arc::new(Barrier::new(2));
+
+    thread::scope(|scope| {
+        for _ in 0..2 {
+            let dispatch = Arc::clone(&dispatch);
+            let barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                set_admission_overlap_barrier(Some(barrier));
+                let outcome = run_auto_task_scheduler_at(
+                    dispatch.as_ref(),
+                    t0 + Duration::minutes(65),
+                    SchedulerOptions::default(),
+                );
+                set_admission_overlap_barrier(None);
+                outcome.expect("overlapping pass")
+            });
+        }
+    });
+
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 1);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert_eq!(
+        state.definitions["chore"].last_task_id.as_deref(),
+        Some("ORB-00001")
+    );
+    assert!(state.definitions["chore"].pending.is_none());
+}
+
+#[test]
+fn mint_failure_does_not_consume_the_slot_and_retry_can_fire() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    dispatch.mint_should_fail.store(true, Ordering::SeqCst);
+
+    let outcome = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("pass");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert!(
+        outcome.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("mint failed; slot not consumed")),
+        "{:?}",
+        outcome.reports[0]
+    );
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].last_slot.is_none());
+    assert!(state.definitions["chore"].pending.is_none());
+
+    dispatch.mint_should_fail.store(false, Ordering::SeqCst);
+    let retry = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("retry");
+    assert_eq!(retry.reports[0].action, "fired");
+    assert_eq!(retry.reports[0].task_id.as_deref(), Some("ORB-00001"));
+}
+
+#[test]
+fn interruption_after_claim_reports_unresolved_and_does_not_remint() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    inject_scheduler_fault(Some(SchedulerFault::AfterClaim));
+
+    let interrupted = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("interrupted");
+    assert_eq!(interrupted.reports[0].action, "skipped");
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert_eq!(
+        state.definitions["chore"]
+            .pending
+            .as_ref()
+            .map(|pending| pending.task_id.as_deref()),
+        Some(None)
+    );
+
+    let retry = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("retry");
+    assert_eq!(retry.reports[0].action, "skipped");
+    assert!(
+        retry.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("unresolved_pending")),
+        "{:?}",
+        retry.reports[0]
+    );
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].last_slot.is_none());
+}
+
+#[test]
+fn interruption_after_mint_reconciles_on_retry_without_reminting() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    inject_scheduler_fault(Some(SchedulerFault::AfterMintBeforeCheckpoint));
+
+    let interrupted = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("interrupted");
+    assert_eq!(interrupted.reports[0].action, "skipped");
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 1);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert_eq!(
+        state.definitions["chore"]
+            .pending
+            .as_ref()
+            .and_then(|pending| pending.task_id.as_deref()),
+        Some("ORB-00001")
+    );
+    assert!(state.definitions["chore"].last_slot.is_none());
+
+    let retry = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("retry");
+    assert_eq!(retry.reports[0].action, "fired");
+    assert_eq!(retry.reports[0].task_id.as_deref(), Some("ORB-00001"));
+    assert!(
+        retry.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("reconciled pending mint")),
+        "{:?}",
+        retry.reports[0]
+    );
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 1);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].pending.is_none());
+    assert!(state.definitions["chore"].last_slot.is_some());
+}
+
+#[test]
+fn checkpoint_write_failure_records_mint_evidence_and_retry_reconciles() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    inject_scheduler_fault(Some(SchedulerFault::CheckpointWrite));
+
+    let failed = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("checkpoint fail");
+    assert_eq!(failed.reports[0].action, "fired");
+    assert_eq!(failed.reports[0].task_id.as_deref(), Some("ORB-00001"));
+    assert!(
+        failed.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("cursor not advanced")),
+        "{:?}",
+        failed.reports[0]
+    );
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert_eq!(
+        state.definitions["chore"]
+            .pending
+            .as_ref()
+            .and_then(|pending| pending.task_id.as_deref()),
+        Some("ORB-00001")
+    );
+    assert!(state.definitions["chore"].last_slot.is_none());
+
+    let retry = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("retry");
+    assert_eq!(retry.reports[0].action, "fired");
+    assert_eq!(retry.reports[0].task_id.as_deref(), Some("ORB-00001"));
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn dry_run_creates_nothing_and_persists_no_cursor() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, "chore", "skip_if_open");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    let outcome = run_auto_task_scheduler_at(&dispatch, t0, SchedulerOptions { dry_run: true })
+        .expect("dry run");
+    assert_eq!(outcome.reports[0].action, "would_baseline");
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    assert!(!cursor_state_path(&dispatch.state_dir).exists());
+
+    let again = run_auto_task_scheduler_at(&dispatch, t0, SchedulerOptions { dry_run: true })
+        .expect("dry run 2");
+    assert_eq!(again.reports[0].action, "would_baseline");
+}
+
+#[test]
+fn skip_if_open_does_not_claim_or_mint() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, "chore", "skip_if_open");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    dispatch.open_instance.store(true, Ordering::SeqCst);
+    let t0 = at(2026, 1, 1, 0, 0);
+    upsert_cursor(
+        &cursor_state_path(&dispatch.state_dir),
+        "chore",
+        cursor(&t0.to_rfc3339(), None),
+    )
+    .expect("baseline");
+
+    let outcome = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("pass");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert_eq!(outcome.reports[0].reason.as_deref(), Some("dedupe_open"));
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].last_slot.is_none());
+    assert!(state.definitions["chore"].pending.is_none());
+}
+
+#[test]
+fn dry_run_would_fire_without_writing_when_due() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    let outcome = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions { dry_run: true },
+    )
+    .expect("dry run");
+    assert_eq!(outcome.reports[0].action, "would_fire");
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].last_slot.is_none());
+    assert!(state.definitions["chore"].pending.is_none());
+}
+
+#[test]
+fn malformed_cursor_is_not_baselined_or_rewritten() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, "chore", "always");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    let path = cursor_state_path(&dispatch.state_dir);
+    fs::create_dir_all(&dispatch.state_dir).expect("state dir");
+    fs::write(&path, "{not json").expect("corrupt");
+
+    let outcome =
+        run_auto_task_scheduler_at(&dispatch, at(2026, 1, 1, 0, 0), SchedulerOptions::default())
+            .expect("pass");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert!(
+        outcome.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("malformed auto-task cursor state")),
+        "{:?}",
+        outcome.reports[0]
+    );
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    assert_eq!(fs::read_to_string(&path).expect("raw"), "{not json");
+}
+
+#[test]
+fn missing_state_still_baselines_on_first_observation() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, "chore", "always");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    let t0 = at(2026, 1, 1, 0, 0);
+
+    let outcome =
+        run_auto_task_scheduler_at(&dispatch, t0, SchedulerOptions::default()).expect("pass");
+    assert_eq!(outcome.reports[0].action, "baselined");
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+    let state = load_cursor_state(&cursor_state_path(&dispatch.state_dir)).expect("load");
+    assert!(state.definitions["chore"].last_slot.is_none());
+    assert!(state.definitions["chore"].pending.is_none());
+}
+
+#[test]
+fn seeded_pending_without_task_id_is_unresolved() {
+    let (_root, dispatch, t0) = due_fixture("chore");
+    let path = cursor_state_path(&dispatch.state_dir);
+    upsert_cursor(
+        &path,
+        "chore",
+        AutoTaskCursor {
+            pending: Some(AutoTaskPendingClaim {
+                slot: (t0 + Duration::minutes(60)).to_rfc3339(),
+                task_id: None,
+            }),
+            ..cursor(&t0.to_rfc3339(), None)
+        },
+    )
+    .expect("seed pending");
+
+    let outcome = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions::default(),
+    )
+    .expect("pass");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert!(
+        outcome.reports[0]
+            .reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("unresolved_pending")),
+        "{:?}",
+        outcome.reports[0]
+    );
+    assert_eq!(dispatch.minted.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn skip_if_open_dry_run_reports_dedupe_without_writing() {
+    let root = tempdir().expect("temporary root");
+    let definition_root = root.path().join("definitions");
+    let state_dir = root.path().join("state");
+    write_interval_definition(&definition_root, "chore", "skip_if_open");
+    let dispatch = TestDispatch::new(definition_root, state_dir);
+    dispatch.open_instance.store(true, Ordering::SeqCst);
+    let t0 = at(2026, 1, 1, 0, 0);
+    upsert_cursor(
+        &cursor_state_path(&dispatch.state_dir),
+        "chore",
+        cursor(&t0.to_rfc3339(), None),
+    )
+    .expect("baseline");
+    let before = fs::read_to_string(cursor_state_path(&dispatch.state_dir)).expect("before");
+
+    let outcome = run_auto_task_scheduler_at(
+        &dispatch,
+        t0 + Duration::minutes(65),
+        SchedulerOptions { dry_run: true },
+    )
+    .expect("dry run");
+    assert_eq!(outcome.reports[0].action, "skipped");
+    assert_eq!(outcome.reports[0].reason.as_deref(), Some("dedupe_open"));
+    assert_eq!(
+        fs::read_to_string(cursor_state_path(&dispatch.state_dir)).expect("after"),
+        before
+    );
+}
+
+// DedupePolicy is referenced so a rename of the production default fails this file closed.
+#[test]
+fn skip_if_open_is_the_named_default_policy() {
+    assert_eq!(DedupePolicy::default(), DedupePolicy::SkipIfOpen);
 }

--- a/crates/orbit-core/assets/jobs/auto_task_scheduler_pipeline.yaml
+++ b/crates/orbit-core/assets/jobs/auto_task_scheduler_pipeline.yaml
@@ -11,10 +11,21 @@
 #   clean no-op, the same contract as `task_auto_pipeline` on an empty backlog.
 #
 # Overlap safety
-# - `max_active_runs: 1` makes the scheduler single-flight, and the seeded
-#   routine fires it with `policy.overlap: forbid`. The scheduler advances a
-#   per-definition cursor before returning, so even a racing pass cannot
-#   double-mint a slot.
+# - `max_active_runs: 1` and the seeded routine's `policy.overlap: forbid`
+#   reduce overlapping job runs. They are not a storage-level idempotency
+#   guarantee: a manual activity, a racing caller, or a crash between mint
+#   and cursor checkpoint can still overlap the scheduler.
+# - Slot admission is exclusive under `.auto-tasks.json.lock`, a sidecar that
+#   survives atomic replacement of `state/auto-tasks.json`. Two due passes
+#   for the same definition/slot mint one task. Missing cursor state may
+#   baseline; unreadable or malformed existing state fails closed and is
+#   left for investigation.
+# - Recovery: a mint failure rolls back the claim so the slot is not
+#   consumed. A persisted pending claim with a task id is checkpointed on
+#   retry without reminting. A pending claim without mint evidence is
+#   reported unresolved — the scheduler will not silently consume the slot
+#   or remint. An in-memory lock is host exclusion only; it is not
+#   exactly-once across the task store and the cursor file.
 
 schemaVersion: 2
 kind: Job

--- a/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
+++ b/crates/orbit-core/src/application/auto_tasks/tests/scheduler.rs
@@ -77,12 +77,11 @@ fn fires_and_stamps_provenance() {
     );
 }
 
-/// The task is minted before the cursor is advanced. When that checkpoint
-/// cannot be written the pass must still report the fire and the task it
-/// created, not a `skipped` row that hides a task the backlog now carries.
+/// Claim is persisted before mint, so a state directory that cannot accept
+/// atomic replacement must fail closed: no task, baseline cursor left intact.
 #[cfg(unix)]
 #[test]
-fn cursor_write_failure_after_minting_is_reported_as_a_fire() {
+fn unwritable_cursor_directory_does_not_mint_or_rewrite_baseline() {
     use std::os::unix::fs::PermissionsExt;
 
     let runtime = runtime();
@@ -93,11 +92,13 @@ fn cursor_write_failure_after_minting_is_reported_as_a_fire() {
     fire(&runtime, t0); // baseline writes the cursor file
 
     let state_path = cursor_state_path(&runtime.paths().state_dir);
-    let writable = std::fs::metadata(&state_path)
-        .expect("state file")
+    let before = std::fs::read_to_string(&state_path).expect("baseline cursor");
+    let state_dir = runtime.paths().state_dir.clone();
+    let writable = std::fs::metadata(&state_dir)
+        .expect("state dir")
         .permissions();
-    std::fs::set_permissions(&state_path, std::fs::Permissions::from_mode(0o444))
-        .expect("make cursor file read-only");
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o555))
+        .expect("make cursor directory read-only so atomic replace cannot create a temp file");
 
     let outcome = run_auto_task_scheduler_at(
         &runtime,
@@ -105,19 +106,22 @@ fn cursor_write_failure_after_minting_is_reported_as_a_fire() {
         SchedulerOptions::default(),
     )
     .expect("scheduler pass");
-    std::fs::set_permissions(&state_path, writable).expect("restore permissions");
+    std::fs::set_permissions(&state_dir, writable).expect("restore permissions");
 
     assert_eq!(outcome.reports.len(), 1);
     let report = &outcome.reports[0];
-    assert_eq!(report.action, "fired", "{report:?}");
-    let task_id = report.task_id.clone().expect("minted task id");
-    assert!(runtime.get_task(&task_id).is_ok());
+    assert_eq!(report.action, "skipped", "{report:?}");
     assert!(
         report
             .reason
             .as_deref()
-            .is_some_and(|reason| reason.contains("cursor not advanced")),
+            .is_some_and(|reason| reason.contains("error:")),
         "{report:?}"
+    );
+    assert!(runtime.list_tasks().expect("tasks").is_empty());
+    assert_eq!(
+        std::fs::read_to_string(&state_path).expect("cursor after denied write"),
+        before
     );
 }
 

--- a/crates/orbit-search/src/vector/store/tests/upsert.rs
+++ b/crates/orbit-search/src/vector/store/tests/upsert.rs
@@ -398,6 +398,10 @@ impl Embedder for BarrierEmbedder {
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         self.inner.token_count(text)
     }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        self.inner.token_boundaries(text)
+    }
 }
 
 struct FailingEmbedder {
@@ -423,5 +427,9 @@ impl Embedder for FailingEmbedder {
 
     fn token_count(&self, text: &str) -> Result<usize, OrbitError> {
         self.inner.token_count(text)
+    }
+
+    fn token_boundaries(&self, text: &str) -> Result<Vec<usize>, OrbitError> {
+        self.inner.token_boundaries(text)
     }
 }

--- a/crates/orbit-store/src/compose/mod.rs
+++ b/crates/orbit-store/src/compose/mod.rs
@@ -176,7 +176,10 @@ mod tests;
 
 /// Legacy cursor file persistence, retained for rollback compatibility.
 pub mod auto_task {
-    pub use crate::driver::file::auto_task::{cursor_state_path, load_cursor_state, upsert_cursor};
+    pub use crate::driver::file::auto_task::{
+        CursorSession, cursor_lock_path, cursor_state_path, load_cursor_state, upsert_cursor,
+        with_cursor_lock,
+    };
 }
 
 /// Open automation contracts over the already-configured host store.

--- a/crates/orbit-store/src/driver/file/auto_task/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/mod.rs
@@ -5,39 +5,75 @@
 //! gitignored runtime state.
 //! The git-versioned definition YAML is never rewritten by a scheduler fire,
 //! so the store stays churn-free and a definition edit never races the
-//! scheduler. Updates take an exclusive file lock and re-read under the lock,
-//! so a manual run racing the routine merges instead of clobbering.
+//! scheduler.
+//!
+//! Slot admission and persistence share one stable sidecar lock
+//! (`.auto-tasks.json.lock`). The data file is replaced by rename, so the
+//! lock is not the inode being replaced and readers never observe truncated
+//! JSON. Missing state is an empty map (first-observation baseline). An
+//! existing unreadable or malformed file is an explicit error and is left
+//! unchanged for investigation.
 
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::fs;
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
 use orbit_common::OrbitError;
+use orbit_common::fs::io::{atomic_write_text, with_exclusive_file_lock};
 use orbit_types::workflow::{AutoTaskCursor, AutoTaskCursorState};
+
+#[cfg(test)]
+use std::cell::RefCell;
 
 /// Path of the cursor state file under a workspace state dir.
 pub fn cursor_state_path(state_dir: &Path) -> PathBuf {
     state_dir.join("auto-tasks.json")
 }
 
-/// Read the current cursor state (missing or unparsable file → empty state;
-/// every definition is then treated as never-observed, which only re-baselines
-/// it — safe in both directions).
-pub fn load_cursor_state(path: &Path) -> AutoTaskCursorState {
-    fs::read_to_string(path)
-        .ok()
-        .map(|raw| parse_state(&raw))
-        .unwrap_or_default()
+/// Stable sidecar lock for [`cursor_state_path`]. Matches
+/// `orbit_common::fs::io::with_exclusive_file_lock` so atomic replacement of
+/// the data file cannot drop exclusion.
+pub fn cursor_lock_path(state_path: &Path) -> PathBuf {
+    let file_name = state_path.file_name().map_or_else(
+        || "auto-tasks.json".to_string(),
+        |name| name.to_string_lossy().into_owned(),
+    );
+    state_path.with_file_name(format!(".{file_name}.lock"))
 }
 
-pub(crate) fn parse_state(raw: &str) -> AutoTaskCursorState {
-    serde_json::from_str(raw.trim()).unwrap_or_default()
+/// Read the current cursor state.
+///
+/// A missing file is empty state. An existing file that cannot be read or
+/// parsed is an error; callers must not treat that as a baseline or rewrite it.
+pub fn load_cursor_state(path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
+    match fs::read_to_string(path) {
+        Ok(raw) => parse_state(&raw, path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(AutoTaskCursorState::default())
+        }
+        Err(error) => Err(OrbitError::Io(format!(
+            "unreadable auto-task cursor state {}: {error}; file left unchanged for investigation",
+            path.display()
+        ))),
+    }
 }
 
-/// Upsert one definition's cursor under an exclusive file lock,
-/// read-modify-writing the file so other definitions' cursors survive.
-pub fn upsert_cursor(path: &Path, name: &str, cursor: AutoTaskCursor) -> Result<(), OrbitError> {
+fn parse_state(raw: &str, path: &Path) -> Result<AutoTaskCursorState, OrbitError> {
+    serde_json::from_str(raw.trim()).map_err(|error| {
+        OrbitError::Store(format!(
+            "malformed auto-task cursor state {}: {error}; file left unchanged for investigation",
+            path.display()
+        ))
+    })
+}
+
+/// Hold the sidecar lock, load current state, and run `op`.
+///
+/// `op` may [`CursorSession::save`] more than once (claim, then checkpoint).
+/// A successful `op` does not implicitly write; callers persist explicitly.
+pub fn with_cursor_lock<T, F>(path: &Path, op: F) -> Result<T, OrbitError>
+where
+    F: FnOnce(&mut CursorSession) -> Result<T, OrbitError>,
+{
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             OrbitError::Io(format!(
@@ -47,51 +83,75 @@ pub fn upsert_cursor(path: &Path, name: &str, cursor: AutoTaskCursor) -> Result<
         })?;
     }
 
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(path)
-        .map_err(|error| {
-            OrbitError::Io(format!(
-                "open auto-tasks state file {}: {error}",
-                path.display()
-            ))
-        })?;
-    file.lock_exclusive().map_err(|error| {
-        OrbitError::Io(format!(
-            "lock auto-tasks state file {}: {error}",
-            path.display()
-        ))
-    })?;
-
-    let result = write_locked(&mut file, path, name, cursor);
-    let unlock = fs2::FileExt::unlock(&file).map_err(|error| {
-        OrbitError::Io(format!(
-            "unlock auto-tasks state file {}: {error}",
-            path.display()
-        ))
-    });
-    result.and(unlock)
+    with_exclusive_file_lock(path, "auto-task cursor", || {
+        let state = load_cursor_state(path)?;
+        let mut session = CursorSession {
+            path: path.to_path_buf(),
+            state,
+        };
+        op(&mut session)
+    })
 }
 
-fn write_locked(
-    file: &mut File,
-    path: &Path,
-    name: &str,
-    cursor: AutoTaskCursor,
-) -> Result<(), OrbitError> {
-    let mut raw = String::new();
-    file.read_to_string(&mut raw)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
-    let mut state = parse_state(&raw);
-    state.definitions.insert(name.to_string(), cursor);
-
-    let encoded = serde_json::to_string_pretty(&state)
-        .map_err(|error| OrbitError::Io(format!("encode auto-tasks state: {error}")))?;
-    file.seek(SeekFrom::Start(0))
-        .and_then(|_| file.set_len(0))
-        .and_then(|_| file.write_all(encoded.as_bytes()))
-        .map_err(|error| OrbitError::Io(format!("write {}: {error}", path.display())))
+/// Locked cursor file session. Mutations are local until [`Self::save`].
+pub struct CursorSession {
+    path: PathBuf,
+    /// Current in-memory cursor map, including other definitions' rows.
+    pub state: AutoTaskCursorState,
 }
+
+impl CursorSession {
+    /// Atomically replace the state file with `self.state`.
+    ///
+    /// The sidecar lock, not this inode, maintains exclusion. A write failure
+    /// leaves the previous complete JSON in place.
+    pub fn save(&self) -> Result<(), OrbitError> {
+        fail_if_injected_save()?;
+        let encoded = serde_json::to_string_pretty(&self.state)
+            .map_err(|error| OrbitError::Io(format!("encode auto-tasks state: {error}")))?;
+        atomic_write_text(&self.path, &encoded)
+            .map_err(|error| OrbitError::from_write_io(&self.path, error))
+    }
+}
+
+/// Upsert one definition's cursor under the sidecar lock,
+/// read-modify-writing so other definitions' cursors survive.
+pub fn upsert_cursor(path: &Path, name: &str, cursor: AutoTaskCursor) -> Result<(), OrbitError> {
+    with_cursor_lock(path, |session| {
+        session.state.definitions.insert(name.to_string(), cursor);
+        session.save()
+    })
+}
+
+#[cfg(test)]
+thread_local! {
+    static INJECTED_SAVE_FAULTS: RefCell<usize> = const { RefCell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn inject_cursor_save_failures(count: usize) {
+    INJECTED_SAVE_FAULTS.with(|cell| *cell.borrow_mut() = count);
+}
+
+fn fail_if_injected_save() -> Result<(), OrbitError> {
+    #[cfg(test)]
+    {
+        let hit = INJECTED_SAVE_FAULTS.with(|cell| {
+            let mut remaining = cell.borrow_mut();
+            if *remaining == 0 {
+                return false;
+            }
+            *remaining -= 1;
+            true
+        });
+        if hit {
+            return Err(OrbitError::Store(
+                "injected auto-task cursor save failure".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/auto_task/tests/mod.rs
@@ -1,0 +1,278 @@
+//! Cursor-file load, lock, and atomic replace tests.
+
+use std::fs;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+use orbit_types::workflow::AutoTaskCursor;
+use tempfile::tempdir;
+
+use super::{
+    cursor_lock_path, cursor_state_path, inject_cursor_save_failures, load_cursor_state,
+    upsert_cursor, with_cursor_lock,
+};
+
+fn cursor(baseline: &str, last_slot: Option<&str>) -> AutoTaskCursor {
+    AutoTaskCursor {
+        baseline_at: baseline.to_string(),
+        last_slot: last_slot.map(str::to_string),
+        last_fired_at: last_slot.map(|_| "2026-01-01T01:00:05+00:00".to_string()),
+        last_task_id: last_slot.map(|_| "ORB-1".to_string()),
+        pending: None,
+    }
+}
+
+#[test]
+fn missing_state_is_empty_and_first_upsert_baselines() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+
+    let loaded = load_cursor_state(&path).expect("missing is empty");
+    assert!(loaded.definitions.is_empty());
+
+    upsert_cursor(&path, "chore", cursor("2026-01-01T00:00:00+00:00", None)).expect("baseline");
+    let loaded = load_cursor_state(&path).expect("load");
+    assert_eq!(
+        loaded.definitions["chore"].baseline_at,
+        "2026-01-01T00:00:00+00:00"
+    );
+    assert!(path.is_file());
+    assert!(cursor_lock_path(&path).is_file());
+}
+
+#[test]
+fn malformed_existing_state_errors_and_is_left_unchanged() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::write(&path, "{not json").expect("corrupt");
+
+    let error = load_cursor_state(&path).expect_err("malformed");
+    assert!(
+        error
+            .to_string()
+            .contains("malformed auto-task cursor state"),
+        "{error}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("left unchanged for investigation"),
+        "{error}"
+    );
+    assert_eq!(fs::read_to_string(&path).expect("raw"), "{not json");
+
+    let error = upsert_cursor(&path, "chore", cursor("2026-01-01T00:00:00+00:00", None))
+        .expect_err("upsert must not rewrite corrupt state");
+    assert!(error.to_string().contains("malformed"), "{error}");
+    assert_eq!(fs::read_to_string(&path).expect("raw"), "{not json");
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_existing_state_errors_and_is_left_unchanged() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::write(&path, r#"{"definitions":{}}"#).expect("write");
+    let original = fs::metadata(&path).expect("meta").permissions();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("chmod");
+
+    let error = load_cursor_state(&path).expect_err("unreadable");
+    fs::set_permissions(&path, original.clone()).expect("restore");
+    assert!(
+        error
+            .to_string()
+            .contains("unreadable auto-task cursor state"),
+        "{error}"
+    );
+    assert_eq!(
+        fs::read_to_string(&path).expect("raw"),
+        r#"{"definitions":{}}"#
+    );
+
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("chmod");
+    let error = upsert_cursor(&path, "chore", cursor("2026-01-01T00:00:00+00:00", None))
+        .expect_err("upsert must not rewrite unreadable state");
+    fs::set_permissions(&path, original).expect("restore");
+    assert!(error.to_string().contains("unreadable"), "{error}");
+    assert_eq!(
+        fs::read_to_string(&path).expect("raw"),
+        r#"{"definitions":{}}"#
+    );
+}
+
+#[test]
+fn empty_existing_file_is_malformed_not_a_baseline() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    fs::write(&path, "").expect("empty");
+
+    let error = load_cursor_state(&path).expect_err("empty existing file");
+    assert!(error.to_string().contains("malformed"), "{error}");
+    assert_eq!(fs::read_to_string(&path).expect("raw"), "");
+}
+
+#[test]
+fn concurrent_upserts_for_different_definitions_preserve_both_cursors() {
+    let root = tempdir().expect("tempdir");
+    let path = Arc::new(cursor_state_path(root.path()));
+    let barrier = Arc::new(Barrier::new(2));
+
+    thread::scope(|scope| {
+        for name in ["alpha", "beta"] {
+            let path = Arc::clone(&path);
+            let barrier = Arc::clone(&barrier);
+            scope.spawn(move || {
+                barrier.wait();
+                upsert_cursor(
+                    &path,
+                    name,
+                    cursor(
+                        "2026-01-01T00:00:00+00:00",
+                        Some("2026-01-01T01:00:00+00:00"),
+                    ),
+                )
+                .expect("upsert");
+            });
+        }
+    });
+
+    let loaded = load_cursor_state(&path).expect("load");
+    assert!(loaded.definitions.contains_key("alpha"), "{loaded:?}");
+    assert!(loaded.definitions.contains_key("beta"), "{loaded:?}");
+}
+
+#[test]
+fn atomic_replace_keeps_sidecar_lock_and_never_exposes_truncated_json() {
+    let root = tempdir().expect("tempdir");
+    let path = Arc::new(cursor_state_path(root.path()));
+    upsert_cursor(&path, "seed", cursor("2026-01-01T00:00:00+00:00", None)).expect("seed");
+    let lock_path = cursor_lock_path(&path);
+    let lock_ino = fs::metadata(&lock_path).expect("lock").ino_or_zero();
+
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let reader_error = Arc::new(std::sync::Mutex::new(None));
+    thread::scope(|scope| {
+        let path_reader = Arc::clone(&path);
+        let stop_reader = Arc::clone(&stop);
+        let reader_error = Arc::clone(&reader_error);
+        scope.spawn(move || {
+            while !stop_reader.load(std::sync::atomic::Ordering::Relaxed) {
+                match load_cursor_state(&path_reader) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        *reader_error.lock().expect("lock") = Some(error.to_string());
+                        break;
+                    }
+                }
+            }
+        });
+
+        for index in 0..40 {
+            upsert_cursor(
+                &path,
+                "seed",
+                cursor(
+                    "2026-01-01T00:00:00+00:00",
+                    Some(&format!("2026-01-01T01:{index:02}:00+00:00")),
+                ),
+            )
+            .expect("upsert");
+        }
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+
+    assert!(
+        reader_error.lock().expect("lock").is_none(),
+        "reader observed invalid JSON: {:?}",
+        reader_error.lock().expect("lock")
+    );
+    assert_eq!(
+        fs::metadata(&lock_path).expect("lock").ino_or_zero(),
+        lock_ino,
+        "sidecar lock identity must survive data-file replacement"
+    );
+}
+
+#[test]
+fn sidecar_lock_excludes_a_second_writer() {
+    let root = tempdir().expect("tempdir");
+    let path = Arc::new(cursor_state_path(root.path()));
+    upsert_cursor(&path, "seed", cursor("2026-01-01T00:00:00+00:00", None)).expect("seed");
+
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let holder_path = Arc::clone(&path);
+    let holder = thread::spawn(move || {
+        with_cursor_lock(&holder_path, |_session| {
+            entered_tx.send(()).expect("entered");
+            release_rx.recv().expect("release");
+            Ok(())
+        })
+        .expect("hold lock");
+    });
+    entered_rx.recv().expect("holder entered");
+
+    let blocked_path = Arc::clone(&path);
+    let blocked = thread::spawn(move || {
+        upsert_cursor(
+            &blocked_path,
+            "other",
+            cursor("2026-01-01T00:00:00+00:00", None),
+        )
+    });
+    thread::sleep(Duration::from_millis(50));
+    assert!(
+        !blocked.is_finished(),
+        "second writer must wait on the sidecar lock"
+    );
+    release_tx.send(()).expect("release holder");
+    blocked.join().expect("join").expect("upsert after release");
+    holder.join().expect("holder");
+
+    let loaded = load_cursor_state(&path).expect("load");
+    assert!(loaded.definitions.contains_key("seed"));
+    assert!(loaded.definitions.contains_key("other"));
+}
+
+#[test]
+fn injected_save_failure_does_not_consume_or_truncate_state() {
+    let root = tempdir().expect("tempdir");
+    let path = cursor_state_path(root.path());
+    upsert_cursor(&path, "seed", cursor("2026-01-01T00:00:00+00:00", None)).expect("seed");
+    let before = fs::read_to_string(&path).expect("before");
+
+    inject_cursor_save_failures(1);
+    let error = upsert_cursor(
+        &path,
+        "other",
+        cursor(
+            "2026-01-01T00:00:00+00:00",
+            Some("2026-01-01T01:00:00+00:00"),
+        ),
+    )
+    .expect_err("injected save");
+    inject_cursor_save_failures(0);
+    assert!(error.to_string().contains("injected"), "{error}");
+    assert_eq!(fs::read_to_string(&path).expect("after"), before);
+}
+
+trait InoOrZero {
+    fn ino_or_zero(&self) -> u64;
+}
+
+impl InoOrZero for fs::Metadata {
+    fn ino_or_zero(&self) -> u64 {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            self.ino()
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
+    }
+}

--- a/crates/orbit-types/src/workflow/auto_task_cursor.rs
+++ b/crates/orbit-types/src/workflow/auto_task_cursor.rs
@@ -28,4 +28,18 @@ pub struct AutoTaskCursor {
     /// Task id minted by the last fire.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_task_id: Option<String>,
+    /// Durable in-flight slot claim. Present between claim and a successful
+    /// consumed-slot checkpoint so a retry can reconcile or refuse to remint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending: Option<AutoTaskPendingClaim>,
+}
+
+/// In-flight admission evidence for one scheduled slot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutoTaskPendingClaim {
+    /// Slot this host has claimed (RFC 3339, UTC).
+    pub slot: String,
+    /// Task id when mint succeeded but the consumed-slot checkpoint has not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 }

--- a/crates/orbit-types/src/workflow/mod.rs
+++ b/crates/orbit-types/src/workflow/mod.rs
@@ -75,6 +75,6 @@ pub use ship::{CompletionPolicy, ShipMode, resolved_ship_mode};
 pub use skill::Skill;
 
 mod auto_task_cursor;
-pub use auto_task_cursor::{AutoTaskCursor, AutoTaskCursorState};
+pub use auto_task_cursor::{AutoTaskCursor, AutoTaskCursorState, AutoTaskPendingClaim};
 
 pub mod automation;

--- a/crates/orbit-web/src/api/auto_tasks.rs
+++ b/crates/orbit-web/src/api/auto_tasks.rs
@@ -307,6 +307,7 @@ fn read_only_envelope(generated_at: DateTime<Utc>, workspace: Option<&str>, reas
         "read_only_reason": reason,
         "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
         "definitions": [],
+        "cursor_state_error": null,
         "load_errors": [],
     })
 }
@@ -318,7 +319,9 @@ fn list_json(
     generated_at: DateTime<Utc>,
 ) -> Value {
     let collection = collect_auto_tasks(&runtime.paths().local_dir);
-    let cursors = load_cursor_state(&cursor_state_path(&runtime.paths().state_dir));
+    let cursor_load = load_cursor_state(&cursor_state_path(&runtime.paths().state_dir));
+    let cursor_state_error = cursor_load.as_ref().err().map(ToString::to_string);
+    let cursors = cursor_load.as_ref().ok();
     let now = Utc::now();
     let definitions = collection
         .definitions
@@ -327,7 +330,8 @@ fn list_json(
             definition_json(
                 runtime,
                 &loaded.definition,
-                cursors.definitions.get(&loaded.definition.name),
+                cursors.and_then(|state| state.definitions.get(&loaded.definition.name)),
+                cursor_state_error.is_some(),
                 now,
             )
         })
@@ -346,6 +350,7 @@ fn list_json(
         "read_only_reason": null,
         "unconditional_mint_warning": UNCONDITIONAL_MINT_WARNING,
         "definitions": definitions,
+        "cursor_state_error": cursor_state_error,
         "load_errors": collection.errors.iter().map(|error| json!({
             "path": error.path.as_ref().map(|path| path.display().to_string()),
             "message": error.message,
@@ -357,6 +362,7 @@ fn definition_json(
     runtime: &OrbitRuntime,
     definition: &AutoTaskDefinition,
     cursor: Option<&orbit_core::application::auto_tasks::AutoTaskCursor>,
+    cursor_state_unavailable: bool,
     now: DateTime<Utc>,
 ) -> Value {
     let automation = match &definition.schedule {
@@ -402,6 +408,10 @@ fn definition_json(
             "last_slot": cursor.last_slot,
             "last_fired_at": cursor.last_fired_at,
             "last_task_id": cursor.last_task_id,
+            "pending": cursor.pending.as_ref().map(|pending| json!({
+                "slot": pending.slot,
+                "task_id": pending.task_id,
+            })),
         })),
         "last_minted_task_id": last_minted_task_id,
         "last_minted_task_status": last_minted_task_status,
@@ -409,6 +419,7 @@ fn definition_json(
             definition.enabled,
             &definition.schedule,
             cursor,
+            cursor_state_unavailable,
             automation.as_ref(),
             now,
         ),
@@ -469,6 +480,7 @@ fn next_evaluation_projection(
     enabled: bool,
     schedule: &AutoTaskSchedule,
     cursor: Option<&AutoTaskCursor>,
+    cursor_state_unavailable: bool,
     automation: Option<&Value>,
     now: DateTime<Utc>,
 ) -> Value {
@@ -478,7 +490,7 @@ fn next_evaluation_projection(
             theoretical_next(schedule, cursor, now),
         );
     }
-    if automation_unavailable(automation) {
+    if cursor_state_unavailable || automation_unavailable(automation) {
         return next_evaluation_json(ScheduleDisplayState::Unavailable, None);
     }
     match schedule {

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -233,6 +233,47 @@ async fn list_reports_enabled_and_disabled_definitions() {
     assert_eq!(nightly["next_evaluation"]["state"], "disabled");
     assert_eq!(nightly["next_evaluation"]["hypothetical"], true);
     assert!(nightly["next_evaluation"]["at"].is_null(), "{nightly}");
+    assert!(json["cursor_state_error"].is_null(), "{json}");
+}
+
+#[tokio::test]
+async fn list_surfaces_malformed_cursor_state_instead_of_baselining() {
+    let runtime = runtime();
+    runtime.auto_task_add(chore_params("hourly")).expect("add");
+    let path = cursor_state_path(&runtime.paths().state_dir);
+    std::fs::create_dir_all(path.parent().expect("state dir")).expect("mkdir");
+    std::fs::write(&path, "{not json").expect("corrupt cursor");
+
+    let (dashboard, runtime) = state(runtime);
+    let response = send(
+        dashboard,
+        Method::GET,
+        "/auto-tasks?workspace=default",
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert!(
+        json["cursor_state_error"]
+            .as_str()
+            .is_some_and(|error| error.contains("malformed auto-task cursor state")),
+        "{json}"
+    );
+    let hourly = json["definitions"]
+        .as_array()
+        .expect("definitions")
+        .iter()
+        .find(|item| item["name"] == "hourly")
+        .expect("hourly");
+    assert_eq!(hourly["last_evaluation"], serde_json::Value::Null);
+    assert_eq!(hourly["next_evaluation"]["state"], "unavailable");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("raw"),
+        "{not json",
+        "list must not rewrite corrupt cursor evidence"
+    );
+    drop(runtime);
 }
 
 fn write_cursor(runtime: &OrbitRuntime, name: &str, last_task_id: &str) {

--- a/docs/design/auto-tasks/2_design.md
+++ b/docs/design/auto-tasks/2_design.md
@@ -1,8 +1,8 @@
 ---
 title: Auto-tasks — Design
 owner: claude
-last_updated: 2026-09-07
-last_validated: 2026-09-07
+last_updated: 2026-09-08
+last_validated: 2026-09-08
 status: Accepted
 feature: auto-tasks
 doc_role: design
@@ -11,7 +11,7 @@ summary: Current implementation of the auto-task record, due-math, host-local cu
 tags: [auto-tasks]
 paths: ["crates/orbit-core/src/application/auto_tasks/**", "crates/orbit-web/src/api/auto_tasks.rs", "crates/orbit-web/assets/dashboard/operations.js"]
 related_features: [auto-tasks]
-related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876, ORB-11095, ORB-11315]
+related_artifacts: [ORB-10149, ORB-10439, ORB-10441, ORB-10446, ORB-10472, ORB-10583, ORB-10800, ORB-10876, ORB-11095, ORB-11315, ORB-11730]
 ---
 
 # Auto-tasks — Design
@@ -63,29 +63,59 @@ collapses to **one** fire, never one per missed slot.
 
 `state.rs` stores one cursor per definition in
 `<orbit_dir>/state/auto-tasks.json` (`{ baseline_at, last_slot, last_fired_at,
-last_task_id }`), using a file-locked read-modify-write.
-This is workspace-local, gitignored runtime state (the scoreboard precedent,
-L-0041), so a scheduler fire never rewrites the git-versioned definition and a
-definition edit never races the scheduler.
+last_task_id, pending? }`). This is workspace-local, gitignored runtime state
+(the scoreboard precedent, L-0041), so a scheduler fire never rewrites the
+git-versioned definition and a definition edit never races the scheduler.
+
+Admission and persistence share one stable sidecar lock,
+`.auto-tasks.json.lock`. The JSON file is replaced by rename, so exclusion is
+not tied to the inode being replaced and a reader never observes truncated
+JSON. Updates re-read under that lock, so concurrent upserts for different
+definitions keep both cursors.
+
+A missing file is empty state and may baseline on first observation. An
+existing file that cannot be read or parsed is an explicit error; the bytes
+are left unchanged for investigation. The dashboard list surfaces that error
+instead of rendering a silent never-observed baseline.
+
+`pending` is durable in-flight evidence: `{ slot, task_id? }`. It is written
+before mint and cleared only after the consumed-slot checkpoint. It is not a
+cross-store exactly-once token.
 
 ## 4. The scheduler pass
 
-`scheduler::run_auto_task_scheduler_at` loads the workspace's definitions and
-cursors, then per enabled definition: on first sight it records a baseline and
-fires nothing; otherwise it evaluates due-math. On `Fire`, if `dedupe =
-skip_if_open` and a task tagged `auto-task:<name>` is still open, it skips
-**without advancing the cursor** — so the pending occurrence fires (once,
-collapsed) the moment the queue drains. Otherwise it mints a `system_created`
-task from the template (tagged for provenance, complexity `unassessed`)
-and advances the cursor. Every
-minted title is `[auto-task] ` followed by the template title; the prefix is
-applied at the shared template-to-task mapping, so definition YAML titles stay
-clean and an already-prefixed template is not double-prefixed.
+`scheduler::run_auto_task_scheduler_at` loads the workspace's definitions,
+then per enabled definition holds the sidecar lock, re-reads cursors, and
+either baselines, skips, or fires. Dry-run never writes. On first sight it
+records a baseline and fires nothing; otherwise it evaluates due-math. On
+`Fire`, if `dedupe = skip_if_open` and a task tagged `auto-task:<name>` is
+still open, it skips **without claiming or advancing the cursor** — so the
+pending occurrence fires (once, collapsed) the moment the queue drains.
+Otherwise it claims the slot, mints a `system_created` task from the template
+(tagged for provenance, complexity `unassessed`), and checkpoints
+`last_slot` / `last_task_id`. Every minted title is `[auto-task] ` followed
+by the template title; the prefix is applied at the shared template-to-task
+mapping, so definition YAML titles stay clean and an already-prefixed
+template is not double-prefixed.
+
+Recovery on the next locked pass:
+
+- Mint failure rolls the claim back; the slot is not consumed and a later
+  pass may fire it.
+- `pending.task_id` set: checkpoint the already-minted task, do not remint.
+- `pending` without `task_id`: report `unresolved_pending` and leave the
+  file alone. The scheduler will not silently consume an unminted slot or
+  remint an uncertain one. An operator inspects tagged tasks and
+  `auto-tasks.json`.
+- Checkpoint write failure reports `fired` with the task id and best-effort
+  mint evidence; retry reconciles from `pending.task_id` or stays
+  unresolved.
 
 The pass is the deterministic `run_auto_task_scheduler` action
 (`dispatch.rs`), wrapped in `auto_task_scheduler_pipeline` (`max_active_runs:
 1`), fired by the seeded `auto_task_scheduler` routine (`overlap: forbid`,
-minutely). Because it is a routine, its fires flow to `GET /api/routines`.
+minutely). Those job/routine knobs reduce overlap; they are not storage-level
+idempotency. Because it is a routine, its fires flow to `GET /api/routines`.
 
 ## 5. CRUD surfaces
 


### PR DESCRIPTION
## Task

[ORB-11730](https://orbit-cli.com/tasks/ORB-11730) — [code-review] Make auto-task slot minting concurrency-safe and preserve corrupt cursor evidence

### Description

## Problem
run_auto_task_scheduler_at reads cursors before acquiring the write lock, then mints and checkpoints separately. Concurrent due passes can mint the same slot. load_cursor_state and parse_state treat unreadable or malformed existing state as empty; subsequent truncate-in-place writes can silently discard cursor history. Job max_active_runs is not a storage-level idempotency guarantee.

## Required behavior and constraints
Coordinate slot admission and cursor persistence across all scheduler callers using a stable lock identity. If replacing the state file atomically, do not lock the inode being replaced. Missing state may baseline; unreadable/corrupt existing state must produce explicit diagnostics and remain available for investigation. Define recovery when mint fails, a claim succeeds before a crash, or mint succeeds before checkpoint failure: never silently consume an unminted slot or blindly remint an uncertain successful one. Use durable reconciliation/idempotency evidence where needed, without promising exactly-once across unrelated stores from an in-memory lock alone. Preserve dry-run, skip-if-open and other definitions' cursors.

## Evidence and validation
Source validation against agent-main 09dec5183 (original review 7f3a8f5fa); re-locate symbols on the implementation revision. crates/orbit-automation/src/auto_tasks/scheduler.rs:77,181; crates/orbit-store/src/driver/file/auto_task/mod.rs:27,35,79; scheduler job asset and current auto-task design docs.
These are source-level findings, not measured performance or executed fault-injection results. Use focused deterministic regression tests at the owning boundary. Follow AGENTS.md and pass make ci-fast and make ci-lint before review; no release work is included.

### Acceptance Criteria

- Barrier-controlled concurrent scheduler passes observing the same due definition/slot create one task; test actually overlaps admission rather than merely running two passes sequentially.
- Malformed and unreadable existing cursor state produce explicit errors, no silent baselines, and no destructive rewrite; missing state retains intentional first-observation baseline behavior.
- Fault injection covers mint failure, interruption around claim/mint/checkpoint and checkpoint write failure. Retry either safely reconciles to the one task or reports an actionable unresolved state without silent loss/duplicate mint.
- Concurrent updates to different definitions preserve both cursors; atomic replacement maintains exclusion through a stable lock and never exposes truncated JSON.
- Dry-run and skip-if-open tests pass, and scheduler job/current docs describe the guarantees and recovery limitations actually implemented.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Auto-task cursor admission now uses a stable sidecar lock (`.auto-tasks.json.lock`) and atomic rename of `auto-tasks.json`, so exclusion is not the replaced inode and readers never see truncated JSON.
- `load_cursor_state` returns Result: missing file still baselines; existing unreadable/malformed state errors and is left unchanged. `pending` claim evidence (`slot`, optional `task_id`) is persisted before mint and cleared on checkpoint.
- Scheduler holds that lock across claim → mint → checkpoint. Mint failure rolls the claim back. `pending.task_id` reconciles without reminting. Pending without mint evidence reports `unresolved_pending`. Dry-run and skip-if-open do not claim or write.
- Dashboard list surfaces `cursor_state_error` instead of a silent never-observed baseline. Job YAML and `docs/design/auto-tasks/2_design.md` document sidecar exclusion, recovery windows, and that `max_active_runs: 1` is not storage idempotency.
- Unrelated compile fix required for `make ci-lint`: two orbit-search test Embedder stubs now implement `token_boundaries`.
Assessment: Acceptance criteria are covered at the owning store and scheduler boundaries with overlapping-admission, corrupt-state, and fault-injection tests. Remaining uncertainty is crash timing between mint and the mint-evidence write: retry reports unresolved rather than reminting.

Criteria:
1. Overlapping due passes: `overlapping_due_passes_mint_one_task` uses a barrier at admission (before the sidecar lock) so two threads enter together; one mint.
2. Corrupt/unreadable state errors without rewrite; missing state still baselines (store + scheduler tests). Dashboard list no longer pretends never-observed.
3. Fault injection: mint failure rolls back claim; AfterClaim → unresolved, no remint; AfterMintBeforeCheckpoint and CheckpointWrite persist evidence and retry reconciles to one task.
4. Concurrent different-definition upserts keep both cursors; sidecar lock identity survives replace; concurrent reader never parses truncated JSON.
5. Dry-run and skip-if-open tests pass; job asset and design doc match the implemented guarantees and limits.

Validation:
- `cargo test -p orbit-store --lib driver::file::auto_task`: passed (8)
- `cargo test -p orbit-automation --lib auto_tasks::tests::scheduler`: passed (14)
- `cargo test -p orbit-core --lib application::auto_tasks`: passed (36)
- `cargo test -p orbit-web --lib api::tests::auto_tasks`: passed after holding the runtime Arc so the temp cursor file outlives the request (20)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

Risks / deviations:
- Claim is durable before mint; a crash after claim without mint evidence stays unresolved until an operator inspects tagged tasks and `auto-tasks.json`.
- Sidecar lock is host-local exclusion, not exactly-once across the task store.
- Core chmod test now asserts unwritable state dir does not mint or rewrite baseline (claim precedes mint). Post-mint checkpoint failure is covered by scheduler fault injection.
- `file:crates/orbit-search/src/vector/store/tests/upsert.rs` was added only so workspace clippy compiles: BarrierEmbedder/FailingEmbedder were missing `token_boundaries`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11730-6a9f661e`
- Behind base: 0
- Ahead of base: 1