### PR TITLE
[BLOCKED] [code-review] Do not load the whole audit trail to find an orphaned run's last activity timestamp

### DIFF
--- a/crates/orbit-core/src/application/job/run/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/reconcile.rs
@@ -214,11 +214,7 @@ impl OrbitRuntime {
 
     /// Timestamp of the most recent audit event recorded for a run.
     fn last_run_activity_at(&self, run_id: &str) -> Result<Option<DateTime<Utc>>, OrbitError> {
-        Ok(self
-            .collect_run_audit_events(run_id)?
-            .into_iter()
-            .filter_map(|event| event.timestamp)
-            .max())
+        self.latest_run_audit_timestamp(run_id)
     }
 
     pub(super) fn reconcile_job_run_records(&self, runs: &[JobRun]) -> Result<usize, OrbitError> {

--- a/crates/orbit-core/src/application/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/tests/reconcile.rs
@@ -4,7 +4,8 @@ use super::*;
 
 use super::super::JobRunListParams;
 use crate::application::job::TERMINAL_OUTCOME_CONFLICT_CODE;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
+use orbit_store::V2AuditEventInsertParams;
 use orbit_types::workflow::JobRunState;
 
 #[test]
@@ -396,6 +397,68 @@ fn orphaned_run_finished_at_tracks_last_audit_activity_not_detection_time() {
         (295_000..=305_000).contains(&duration_ms),
         "duration must span started_at..last activity, got {duration_ms}ms"
     );
+}
+
+#[test]
+fn orphaned_run_finished_at_falls_back_to_now_for_out_of_range_audit_timestamps() {
+    let (_root, runtime) = test_runtime();
+
+    for (suffix, activity_at) in [
+        ("before-start", Utc::now() - Duration::hours(2)),
+        ("after-now", Utc::now() + Duration::hours(2)),
+    ] {
+        let run = insert_pending_run(&runtime, "qa_orphan_out_of_range_timing");
+        let started_at = Utc::now() - Duration::minutes(30);
+        runtime
+            .stores()
+            .jobs()
+            .mark_job_run_running(&run.run_id, started_at, 999_999)
+            .expect("mark running with impossible pid");
+        write_audit_activity(&runtime, &run.run_id, suffix, activity_at);
+
+        let before_fallback = Utc::now();
+        let shown = runtime
+            .show_job_run(&run.run_id)
+            .expect("show reconciled run");
+        let after_fallback = Utc::now();
+        let finished_at = shown.finished_at.expect("reconciled finished time");
+
+        assert!(
+            finished_at >= before_fallback && finished_at <= after_fallback,
+            "{suffix} activity must fall back to detection time"
+        );
+    }
+}
+
+fn write_audit_activity(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    suffix: &str,
+    activity_at: DateTime<Utc>,
+) {
+    let event = serde_json::json!({
+        "schemaVersion": 1,
+        "event_type": "test.activity",
+        "event_id": format!("evt-{run_id}-{suffix}"),
+        "ts": activity_at.to_rfc3339(),
+        "run_id": run_id,
+        "agent_identity": "system",
+    });
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: event["event_id"].as_str().expect("event id").to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "test.activity".to_string(),
+            ts: activity_at,
+            run_id: run_id.to_string(),
+            agent_identity: "system".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: event.to_string(),
+        })
+        .expect("insert audit activity");
 }
 
 #[cfg(unix)]

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -319,6 +319,25 @@ impl OrbitRuntime {
         Ok(events)
     }
 
+    /// The newest valid timestamp carried by the bounded v2 envelope rows for
+    /// a run. This deliberately reads the envelope payload rather than the
+    /// audit row ordering: imports and delayed writers can persist rows out of
+    /// timestamp order.
+    pub(crate) fn latest_run_audit_timestamp(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<DateTime<Utc>>, OrbitError> {
+        let rows = self.list_v2_audit_events(V2AuditEventFilter {
+            workspace_id: String::new(),
+            run_id: Some(run_id.to_string()),
+            source: Some("v2_envelope".to_string()),
+            limit: Some(50_000),
+            ..Default::default()
+        })?;
+
+        Ok(latest_timestamp_from_envelope_rows(rows))
+    }
+
     pub fn collect_run_audit_steps(&self, run_id: &str) -> Result<Vec<RunAuditStep>, OrbitError> {
         Ok(audit_steps_from_events(
             &self.collect_run_audit_events(run_id)?,
@@ -371,8 +390,7 @@ impl OrbitRuntime {
     ) -> Result<Vec<RunCliInvocationRecord>, OrbitError> {
         let events = self.collect_run_audit_events(run_id)?;
         let blob_store = BlobStore::new(self.v2_audit_blob_root());
-        let step_index_by_id = self
-            .collect_run_audit_steps(run_id)?
+        let step_index_by_id = audit_steps_from_events(&events)
             .into_iter()
             .map(|step| (step.step_id, step.step_index))
             .collect::<HashMap<_, _>>();
@@ -440,6 +458,24 @@ impl OrbitRuntime {
     fn v2_audit_blob_root(&self) -> PathBuf {
         self.data_root().join("state").join("audit").join("blobs")
     }
+}
+
+fn latest_timestamp_from_envelope_rows(
+    rows: impl IntoIterator<Item = orbit_store::V2AuditEventRow>,
+) -> Option<DateTime<Utc>> {
+    rows.into_iter()
+        .filter_map(|row| serde_json::from_str::<Value>(&row.payload_json).ok())
+        // Match the full audit projection's envelope validity boundary without
+        // reconstructing parent links or activity steps just to read `ts`.
+        .filter(|value| value.get("event_id").and_then(Value::as_str).is_some())
+        .filter_map(|value| {
+            value
+                .get("ts")
+                .and_then(Value::as_str)
+                .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+                .map(|value| value.with_timezone(&Utc))
+        })
+        .max()
 }
 
 /// Reconstruct a run's activity steps from an already-read audit trail, in

--- a/crates/orbit-core/src/runtime/tests/run_audit.rs
+++ b/crates/orbit-core/src/runtime/tests/run_audit.rs
@@ -1,6 +1,7 @@
 //! Sibling tests for `run_audit.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
 use crate::{OrbitRuntime, V2AuditEventInsertParams};
+use chrono::{DateTime, Utc};
 use orbit_common::process::identity::ProcessLiveness;
 use orbit_common::storage::blob_store::BlobStore;
 
@@ -66,6 +67,106 @@ fn seed_v2_audit_events(
             })
             .expect("insert v2 audit event");
     }
+}
+
+fn insert_v2_audit_payload(
+    runtime: &OrbitRuntime,
+    run_id: &str,
+    event_id: &str,
+    stored_at: DateTime<Utc>,
+    payload_json: String,
+) {
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: event_id.to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "test.event".to_string(),
+            ts: stored_at,
+            run_id: run_id.to_string(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json,
+        })
+        .expect("insert v2 audit payload");
+}
+
+#[test]
+fn latest_audit_timestamp_uses_valid_envelope_payloads_not_row_order() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run_id = "jrun-timestamp-projection";
+    let earliest = "2026-04-26T07:01:00Z";
+    let latest = "2026-04-26T07:20:00Z";
+
+    // The store orders these rows by its `ts`, but the envelope timestamps are
+    // deliberately reversed. The timestamp projection must retain the old
+    // full-projection behavior and select the latest payload value instead.
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-row-newer",
+        DateTime::parse_from_rfc3339("2026-04-26T07:30:00Z")
+            .expect("parse stored timestamp")
+            .with_timezone(&Utc),
+        json!({"event_id": "evt-row-newer", "ts": earliest}).to_string(),
+    );
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-payload-newer",
+        DateTime::parse_from_rfc3339("2026-04-26T07:02:00Z")
+            .expect("parse stored timestamp")
+            .with_timezone(&Utc),
+        json!({"event_id": "evt-payload-newer", "ts": latest}).to_string(),
+    );
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-malformed",
+        Utc::now(),
+        "not json".to_string(),
+    );
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-missing-ts",
+        Utc::now(),
+        json!({"event_id": "evt-missing-ts"}).to_string(),
+    );
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-missing-event-id",
+        Utc::now(),
+        json!({"ts": "2026-04-26T08:00:00Z"}).to_string(),
+    );
+    insert_v2_audit_payload(
+        &runtime,
+        run_id,
+        "evt-invalid-ts",
+        Utc::now(),
+        json!({"event_id": "evt-invalid-ts", "ts": "not-a-timestamp"}).to_string(),
+    );
+
+    let timestamp = runtime
+        .latest_run_audit_timestamp(run_id)
+        .expect("read timestamp projection");
+    assert_eq!(
+        timestamp,
+        Some(
+            DateTime::parse_from_rfc3339(latest)
+                .expect("parse latest")
+                .with_timezone(&Utc)
+        )
+    );
+    assert_eq!(
+        runtime
+            .latest_run_audit_timestamp("jrun-empty-timestamp-projection")
+            .expect("read empty timestamp projection"),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11667`
- Run: `jrun-20260908-0145-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `bcf007dc882d03b8a6625aa9b019916fd1677427`
- Target base: `ce5c2f5e7c018eeaa9dad13d9d221dfe962ed761`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_gate_failed; error.message=make ci-lint fails on unrelated pre-existing orbit-search test Embedder implementations missing token_boundaries; execution summary persisted to ORB-11667.
```