### PR TITLE
[code-review] Fix the macOS platform job: two of its test steps run zero tests and its path filters point at deleted files

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -22,16 +22,15 @@ on:
       # [ORB-10009] SBPL profiles are compiled from resolved policy rules, so
       # policy-evaluation changes can alter what the macOS sandbox enforces.
       - "crates/orbit-policy/**"
-      - "crates/orbit-common/src/types/policy_def.rs"
-      - "crates/orbit-common/src/utility/glob.rs"
+      - "crates/orbit-common/src/fs/**"
+      - "crates/orbit-types/src/policy/**"
       # [ORB-11067] Managed-child logging must use the registry root authorized
       # by the macOS sandbox rather than the provider-specific HOME.
       - "crates/orbit-common/src/observability/logging.rs"
       - "crates/orbit-common/src/observability/tests/logging.rs"
       # [ORB-10682] Darwin owner/cancellation liveness uses native libproc
       # state so unreaped zombies do not look like surviving work.
-      - "crates/orbit-common/src/utility/process_identity.rs"
-      - "crates/orbit-common/src/utility/tests/process_identity.rs"
+      - "crates/orbit-common/src/process/**"
       - "crates/orbit-core/src/application/job/run/owner.rs"
       - "crates/orbit-core/src/application/job/run/tests/actions.rs"
       - "crates/orbit-core/src/application/job/run/tests/owner.rs"
@@ -88,6 +87,6 @@ jobs:
       # these filters aligned with the owner/liveness path triggers above.
       - name: Run process identity and job-run owner tests
         run: |
-          cargo test -p orbit-common --locked process_identity -- --nocapture
-          cargo test -p orbit-core --locked command::job::run::tests::owner -- --nocapture
-          cargo test -p orbit-core --locked command::job::run::tests::actions -- --nocapture
+          cargo test -p orbit-common --locked process::tests::identity -- --nocapture
+          cargo test -p orbit-core --locked application::job::run::tests::owner -- --nocapture
+          cargo test -p orbit-core --locked application::job::run::tests::actions -- --nocapture

--- a/scripts/check-ci-macos.sh
+++ b/scripts/check-ci-macos.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workflow="${CI_MACOS_WORKFLOW:-$repo_root/.github/workflows/ci-macos.yml}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "check-ci-macos: python3 is required; install it before running" >&2
+  exit 1
+fi
+
+python3 - "$repo_root" "$workflow" <<'PY'
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+repo_root = Path(sys.argv[1]).resolve()
+workflow = Path(sys.argv[2]).resolve()
+
+if not workflow.is_file():
+    print(f"check-ci-macos: workflow does not exist: {workflow}", file=sys.stderr)
+    raise SystemExit(1)
+
+lines = workflow.read_text(encoding="utf-8").splitlines()
+
+
+def indentation(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def pull_request_paths() -> list[str]:
+    entries: list[str] = []
+
+    for index, line in enumerate(lines):
+        if line.strip() != "pull_request:":
+            continue
+
+        event_indent = indentation(line)
+        paths_index = None
+        paths_indent = None
+        cursor = index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor]
+            stripped = candidate.strip()
+            if stripped and indentation(candidate) <= event_indent:
+                break
+            if stripped == "paths:":
+                paths_index = cursor
+                paths_indent = indentation(candidate)
+                break
+            cursor += 1
+
+        if paths_index is None or paths_indent is None:
+            continue
+
+        cursor = paths_index + 1
+        while cursor < len(lines):
+            candidate = lines[cursor]
+            stripped = candidate.strip()
+            if stripped and indentation(candidate) <= paths_indent:
+                break
+            if stripped.startswith("-") and indentation(candidate) > paths_indent:
+                value = stripped[1:].strip()
+                value = re.sub(r"\s+#.*$", "", value).strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                    value = value[1:-1]
+                entries.append(value)
+            cursor += 1
+
+    return entries
+
+
+def filtered_cargo_tests() -> list[tuple[str, str]]:
+    commands: list[tuple[str, str]] = []
+
+    for line in lines:
+        if "cargo test" not in line or line.lstrip().startswith("#"):
+            continue
+
+        try:
+            tokens = shlex.split(line.strip())
+        except ValueError as error:
+            print(f"check-ci-macos: cannot parse workflow command {line!r}: {error}", file=sys.stderr)
+            raise SystemExit(1) from error
+
+        try:
+            cargo_index = tokens.index("cargo")
+        except ValueError:
+            continue
+
+        if cargo_index + 1 >= len(tokens) or tokens[cargo_index + 1] != "test":
+            continue
+
+        try:
+            separator = tokens.index("--", cargo_index + 2)
+        except ValueError:
+            separator = len(tokens)
+
+        cargo_args = tokens[cargo_index + 2:separator]
+        package = None
+        for option in ("-p", "--package"):
+            if option in cargo_args:
+                package_index = cargo_args.index(option)
+                if package_index + 1 < len(cargo_args):
+                    package = cargo_args[package_index + 1]
+                break
+
+        if package is None:
+            continue
+
+        package_index = cargo_args.index(package)
+        positional = [token for token in cargo_args[package_index + 1:] if not token.startswith("-")]
+        if positional:
+            commands.append((package, positional[0]))
+
+    return commands
+
+
+errors: list[str] = []
+
+for path in pull_request_paths():
+    if path.startswith("!") or any(character in path for character in "*?["):
+        continue
+    if not (repo_root / path).exists():
+        errors.append(f"pull_request.paths entry does not exist: {path}")
+
+filtered_tests = filtered_cargo_tests()
+if not filtered_tests:
+    errors.append("no filtered cargo test commands found in the macOS workflow")
+
+for package, test_filter in filtered_tests:
+    command = [
+        "cargo",
+        "test",
+        "-p",
+        package,
+        "--locked",
+        test_filter,
+        "--",
+        "--list",
+    ]
+    result = subprocess.run(command, cwd=repo_root, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        errors.append(
+            f"filtered cargo test failed for {package} {test_filter!r} "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+        continue
+
+    test_count = sum(1 for line in result.stdout.splitlines() if re.search(r": test\s*$", line))
+    if test_count == 0:
+        errors.append(f"filtered cargo test matched zero tests: {package} {test_filter}")
+    else:
+        print(f"check-ci-macos: {package} {test_filter} matched {test_count} tests")
+
+if errors:
+    for error in errors:
+        print(f"check-ci-macos: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print("check-ci-macos: workflow paths and filtered tests passed")
+PY

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -12,6 +12,8 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
+"$repo_root/scripts/check-ci-macos.sh"
+
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 if cargo nextest --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Task

[ORB-11609](https://orbit-cli.com/tasks/ORB-11609) — [code-review] Fix the macOS platform job: two of its test steps run zero tests and its path filters point at deleted files

### Description

## Problem
The "Run process identity and job-run owner tests" step filters on `process_identity` and `command::job::run::tests::{owner,actions}`. The process-identity code now lives at `crates/orbit-common/src/process/identity.rs` with tests in `crates/orbit-common/src/process/tests/identity.rs` (9 `#[test]`s, none containing the substring `process_identity`), and orbit-core has no `command::job` module — the tests are at `application::job::run::tests::{owner,actions}` (`crates/orbit-core/src/application/job/run/tests/mod.rs:5,9`). `cargo test` with a filter that matches nothing prints "running 0 tests" and exits 0, so the ORB-10682 Darwin libproc/zombie regression the job exists to gate has been passing vacuously. Separately, four `pull_request.paths` entries (`crates/orbit-common/src/types/policy_def.rs`, `crates/orbit-common/src/utility/glob.rs`, `crates/orbit-common/src/utility/process_identity.rs`, `.../utility/tests/process_identity.rs`) no longer exist, so a PR that edits `crates/orbit-common/src/process/identity.rs` or the glob/policy code (now under `crates/orbit-common/src/fs/`) does not trigger the macOS leg at all.

## Why It Matters
This is the only CI leg that exercises Darwin-specific liveness and sandbox semantics; today it silently covers neither the liveness tests nor the files that change them.

## Proposed Fix
Change the filters to `process::tests::identity` and `application::job::run::tests::owner` / `...::actions`; update the path list to `crates/orbit-common/src/process/**` and the current fs/glob/policy paths. Add `-- --list` count assertions (fail if 0 tests match) or a small guard script that asserts every non-glob `paths:` entry in the workflows exists and every `cargo test <filter>` resolves to at least one test.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `.github/workflows/ci-macos.yml:25-26`, `.github/workflows/ci-macos.yml:33-34`, `.github/workflows/ci-macos.yml:89-93`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: high (bug). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `cargo test -p orbit-common process::tests::identity -- --list | grep -c ': test'` prints > 0, and likewise for both orbit-core filters.
- Every literal path in `ci-macos.yml` `pull_request.paths` exists in the tree.
- A guard (in `scripts/`, wired into `ci-guardrails.sh`) fails when a workflow test filter matches zero tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated `.github/workflows/ci-macos.yml` to use `process::tests::identity` and `application::job::run::tests::{owner,actions}`.
- Replaced deleted macOS path filters with current `orbit-common/src/fs/**`, `orbit-types/src/policy/**`, and `orbit-common/src/process/**` coverage.
- Added `scripts/check-ci-macos.sh`, wired from `scripts/ci-guardrails.sh`; it rejects missing literal path entries and zero-match or failed filtered Cargo test commands.
Criteria evidence:
- Exact acceptance filters passed with counts 8 (`orbit-common` identity), 18 (owner), and 13 (actions).
- The guard's workflow path check passed for the current macOS path list.
- The guard passed normally, matched the additional `sandbox` filter (37 tests), and failed as expected against a temporary zero-match filter fixture.
Validation:
- `./scripts/check-ci-macos.sh`: passed.
- Exact `cargo test ... -- --list | grep -c ': test'` commands: passed.
- `make ci-lint`: passed.
- `bash -n scripts/check-ci-macos.sh scripts/ci-guardrails.sh`: passed.
- `git diff --check`: passed.
- `make ci-fast`: failed before task-specific checks because the pre-existing `docs/INDEX.md` is stale; no documentation files were changed.
Risks/deviations: macOS-specific runtime behavior was not executable in this Linux worktree; the workflow guard and filters were validated on Linux. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11609-6a9f6cd9`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra