### PR TITLE
Release build admission before application runtime and between watch iterations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,38 @@ release:
 # ------------------------------------------------------------
 # Run
 # ------------------------------------------------------------
+# Resolve the built executable from Cargo JSON artifact messages. `cargo run`
+# is compilation-capable and must not run after the slot is released.
+define CARGO_EXECUTABLE_FROM_JSON
+import json, sys
+path = None
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw.startswith("{"):
+        continue
+    try:
+        message = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+    executable = message.get("executable")
+    if message.get("reason") == "compiler-artifact" and executable:
+        path = executable
+if not path:
+    sys.stderr.write("make run: cargo did not report an executable\n")
+    raise SystemExit(1)
+print(path)
+endef
+export CARGO_EXECUTABLE_FROM_JSON
+
+# Admit compilation only, then launch the resolved binary without a build slot.
 run:
-	$(BUILD_BUDGET) -- $(CARGO) run -p $(BIN_CRATE) --bin $(BINARY) -- $(ARGS)
+	@set -eu; \
+	json="$$(mktemp)"; \
+	trap 'rm -f "$$json"' EXIT; \
+	$(BUILD_BUDGET) -- $(CARGO) build -p $(BIN_CRATE) --bin $(BINARY) --message-format=json-render-diagnostics >"$$json"; \
+	bin="$$(python3 -c "$$CARGO_EXECUTABLE_FROM_JSON" <"$$json")"; \
+	rm -f "$$json"; \
+	"$$bin" $(ARGS)
 
 # Direct execution (after build)
 dev: build
@@ -204,5 +234,6 @@ compiler-cache-bench:
 # ------------------------------------------------------------
 # Dev Loop
 # ------------------------------------------------------------
+# Idle watcher lifetime stays outside the budget; each check/test iteration is admitted.
 watch:
-	$(BUILD_BUDGET) -- $(CARGO) watch -x "check" -x "test"
+	$(CARGO) watch -s "$(BUILD_BUDGET) -- $(CARGO) check" -s "$(BUILD_BUDGET) -- $(CARGO) test"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@ CLI behavior, state layout, or recovery semantics change.
 | Runbook | Purpose |
 | --- | --- |
 | [Inspect the Audit Trail](./runbooks/audit-trail.md) | Query and interpret Orbit invocation, run, step, and activity audit history. |
+| [Bound Concurrent Orbit Repository Builds](./runbooks/build-budget.md) | Run Cargo builds within Orbit's host-wide cross-worktree admission and compiler-job budget. |
 | [Share Rust dependency compilation across worker worktrees](./runbooks/compiler-cache.md) | Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees. |
 | [Recover a Corrupted Database](./runbooks/database-recovery.md) | Recover a corrupted Orbit SQLite database from backup, salvage, or regeneration. |
 | [Onboard an Executor](./runbooks/executor-onboarding.md) | Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state. |

--- a/docs/runbooks/build-budget.md
+++ b/docs/runbooks/build-budget.md
@@ -3,7 +3,7 @@ type: runbook
 summary: Run Cargo builds within Orbit's host-wide cross-worktree admission and compiler-job budget.
 tags: [operations, performance, rust]
 paths: ["Makefile", "scripts/build-budget.py"]
-related_artifacts: [ORB-11754]
+related_artifacts: [ORB-11754, ORB-11760]
 last_validated: 2026-09-08
 ---
 
@@ -19,6 +19,12 @@ The repository's heavy Make targets enter the budget automatically: `build`, `re
 `run`, `check`, `test`, `clippy`, `ci`, `ci-lint`, `install`, and `watch`. `make ci` holds
 one slot around the complete CI script; its nested Cargo commands inherit that admission
 instead of reacquiring a slot. `dev` is covered through its `build` prerequisite.
+
+`make run` admits compilation of the CLI binary, then launches the resolved executable
+without holding a slot and without invoking `cargo run`. `make watch` does not occupy a
+slot while idle; each `check` and `test` iteration is admitted separately. Wrapping a
+whole `cargo run` or `cargo watch` process would starve other worktrees for as long as
+those processes live.
 
 Formatting, dependency inspection, supply-chain inspection, cleaning, release utilities,
 and individual guardrail scripts do not enter a build slot. CI workflow commands and
@@ -68,8 +74,9 @@ scripts/test-build-budget.sh
 ```
 
 It exercises separate worktree paths, a two-slot concurrency ceiling, progress after
-success, failure, and termination, nested admission, job-count precedence, bypass, and
-invalid settings.
+success, failure, and termination, nested admission, job-count precedence, bypass,
+invalid settings, `make run` releasing its slot before application runtime, and
+`make watch` admitting each check/test iteration without retaining a slot while idle.
 
 Run a bounded comparison with private targets outside the checkout:
 

--- a/scripts/test-build-budget.sh
+++ b/scripts/test-build-budget.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
-# Deterministic process tests for the cross-worktree build budget [ORB-11754].
+# Deterministic process tests for the cross-worktree build budget [ORB-11754] [ORB-11760].
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WRAPPER="$ROOT/scripts/build-budget.py"
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+BACKGROUND_PIDS=()
+cleanup() {
+  local pid
+  if ((${#BACKGROUND_PIDS[@]})); then
+    for pid in "${BACKGROUND_PIDS[@]}"; do
+      kill "$pid" 2>/dev/null || true
+    done
+  fi
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
 
 fail() {
   printf 'test-build-budget: FAIL: %s\n' "$*" >&2
   exit 1
+}
+
+forget_pid() {
+  local target="$1"
+  local pid
+  local remaining=()
+  for pid in "${BACKGROUND_PIDS[@]}"; do
+    if [[ "$pid" != "$target" ]]; then
+      remaining+=("$pid")
+    fi
+  done
+  BACKGROUND_PIDS=("${remaining[@]}")
 }
 
 wait_for() {
@@ -184,5 +206,259 @@ ORBIT_BUILD_BUDGET=0 ORBIT_CARGO_JOBS=8 \
   "$WRAPPER" -- "$TMP/helper.py" "$TMP/bypass" bypass sleep 0.01
 grep -Fq 'jobs=8' "$TMP/bypass/events" || fail "bypass lost Cargo job setting"
 grep -Fq 'slot=None' "$TMP/bypass/events" || fail "bypass unexpectedly acquired a slot"
+
+cat >"$TMP/fake-app" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${FAKE_RUN_ARGS}"
+touch "${FAKE_RUN_STARTED}"
+while [[ ! -e "${FAKE_RUN_RELEASE}" ]]; do
+  sleep 0.02
+done
+exit "${FAKE_RUN_EXIT:-0}"
+SH
+chmod +x "$TMP/fake-app"
+
+cat >"$TMP/fake-make-cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+if [[ "$#" -gt 0 ]]; then
+  shift
+fi
+printf 'event=invoke cmd=%s slot=%s held=%s\n' \
+  "$cmd" "${ORBIT_BUILD_BUDGET_SLOT:-}" "${ORBIT_BUILD_BUDGET_HELD:-}" \
+  >>"${FAKE_MAKE_LOG}"
+
+case "$cmd" in
+  build)
+    printf '%s\n' "$@" >>"${FAKE_BUILD_ARGS}"
+    case "${FAKE_ARTIFACT_MODE:-ok}" in
+      ok)
+        python3 -c 'import json, os; print(json.dumps({"reason":"compiler-artifact","executable":os.environ["FAKE_APP"],"target":{"name":"orbit"}}))'
+        ;;
+      none)
+        python3 -c 'import json; print(json.dumps({"reason":"compiler-artifact","executable":None,"target":{"name":"orbit"}}))'
+        ;;
+      malformed)
+        printf 'not-json\n'
+        ;;
+      *)
+        exit 64
+        ;;
+    esac
+    touch "${FAKE_BUILD_STARTED}"
+    exit "${FAKE_BUILD_EXIT:-0}"
+    ;;
+  run)
+    printf 'event=invoke cmd=run-after-release\n' >>"${FAKE_MAKE_LOG}"
+    printf 'fake cargo run must not run after the build slot is released\n' >&2
+    exit 64
+    ;;
+  watch)
+    trap 'exit 143' TERM
+    printf '%s\n' "$$" >"${FAKE_WATCH_PID}"
+    commands=()
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "-s" ]]; then
+        [[ "$#" -ge 2 ]] || exit 2
+        commands+=("$2")
+        shift 2
+      else
+        shift
+      fi
+    done
+    [[ "${#commands[@]}" -gt 0 ]] || exit 2
+    export FAKE_WATCH_ITER=1
+    for shell_cmd in "${commands[@]}"; do
+      sh -c "$shell_cmd"
+    done
+    touch "${FAKE_WATCH_IDLE}"
+    while [[ ! -e "${FAKE_WATCH_AGAIN}" ]]; do
+      sleep 0.02
+    done
+    export FAKE_WATCH_ITER=2
+    for shell_cmd in "${commands[@]}"; do
+      sh -c "$shell_cmd"
+    done
+    touch "${FAKE_WATCH_SECOND}"
+    while true; do
+      sleep 1
+    done
+    ;;
+  check|test)
+    printf 'event=iteration cmd=%s iter=%s slot=%s held=%s\n' \
+      "$cmd" "${FAKE_WATCH_ITER:-}" "${ORBIT_BUILD_BUDGET_SLOT:-}" \
+      "${ORBIT_BUILD_BUDGET_HELD:-}" >>"${FAKE_MAKE_LOG}"
+    touch "${FAKE_WATCH_DIR}/started-${cmd}-${FAKE_WATCH_ITER:-unknown}"
+    if [[ "$cmd" == "check" && "${FAKE_WATCH_ITER:-}" == "1" ]]; then
+      sleep "${FAKE_CHECK_SLEEP:-0}"
+    fi
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+SH
+chmod +x "$TMP/fake-make-cargo"
+
+# make run admits compilation, then launches the resolved binary without cargo run.
+FAKE_APP="$TMP/fake-app"
+FAKE_MAKE_LOG="$TMP/make-run.log"
+FAKE_BUILD_ARGS="$TMP/make-run-build-args"
+FAKE_BUILD_STARTED="$TMP/make-run-build-started"
+FAKE_RUN_ARGS="$TMP/make-run-app-args"
+FAKE_RUN_STARTED="$TMP/make-run-app-started"
+FAKE_RUN_RELEASE="$TMP/make-run-app-release"
+FAKE_RUN_EXIT=0
+FAKE_BUILD_EXIT=0
+FAKE_ARTIFACT_MODE=ok
+FAKE_WATCH_DIR="$TMP/run-unused-watch"
+mkdir -p "$FAKE_WATCH_DIR"
+: >"$FAKE_MAKE_LOG"
+: >"$FAKE_BUILD_ARGS"
+export FAKE_APP FAKE_MAKE_LOG FAKE_BUILD_ARGS FAKE_BUILD_STARTED FAKE_RUN_ARGS \
+  FAKE_RUN_STARTED FAKE_RUN_RELEASE FAKE_RUN_EXIT FAKE_BUILD_EXIT \
+  FAKE_ARTIFACT_MODE FAKE_WATCH_DIR
+
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-run" ORBIT_BUILD_SLOTS=1 \
+  make -s -C "$ROOT" run CARGO="$TMP/fake-make-cargo" BUILD_BUDGET="$WRAPPER" \
+  ARGS='alpha beta' >"$TMP/make-run.out" 2>"$TMP/make-run.err" &
+RUN_PID=$!
+BACKGROUND_PIDS+=("$RUN_PID")
+wait_for "$FAKE_RUN_STARTED"
+grep -Eq '^event=invoke cmd=build slot=1 held=1$' "$FAKE_MAKE_LOG" \
+  || fail "make run build was not admitted"
+[[ "$(grep -c '^event=invoke cmd=build ' "$FAKE_MAKE_LOG")" == "1" ]] \
+  || fail "make run invoked cargo build more than once"
+if grep -Eq '^event=invoke cmd=run' "$FAKE_MAKE_LOG"; then
+  fail "make run invoked a compilation-capable cargo run after slot release"
+fi
+grep -Fxq -- '-p' "$FAKE_BUILD_ARGS" && grep -Fxq -- 'orbit-cli' "$FAKE_BUILD_ARGS" \
+  && grep -Fxq -- '--bin' "$FAKE_BUILD_ARGS" && grep -Fxq -- 'orbit' "$FAKE_BUILD_ARGS" \
+  && grep -Fxq -- '--message-format=json-render-diagnostics' "$FAKE_BUILD_ARGS" \
+  || fail "make run build lost package, binary, or artifact-format arguments"
+printf 'alpha\nbeta\n' >"$TMP/expected-run-args"
+diff -q "$FAKE_RUN_ARGS" "$TMP/expected-run-args" >/dev/null \
+  || fail "make run did not preserve application arguments"
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-run" ORBIT_BUILD_SLOTS=1 \
+  timeout 2 "$WRAPPER" -- true \
+  || fail "make run application runtime retained the build slot"
+touch "$FAKE_RUN_RELEASE"
+set +e
+wait "$RUN_PID"
+run_status=$?
+set -e
+forget_pid "$RUN_PID"
+[[ "$run_status" == "0" ]] || fail "make run lost a successful application exit ($run_status)"
+
+FAKE_RUN_EXIT=42
+export FAKE_RUN_EXIT
+rm -f "$FAKE_RUN_STARTED"
+: >"$FAKE_MAKE_LOG"
+: >"$FAKE_BUILD_ARGS"
+touch "$FAKE_RUN_RELEASE"
+set +e
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-run" ORBIT_BUILD_SLOTS=1 \
+  make -s -C "$ROOT" run CARGO="$TMP/fake-make-cargo" BUILD_BUDGET="$WRAPPER" \
+  ARGS='alpha beta' >"$TMP/make-run-fail.out" 2>"$TMP/make-run-fail.err"
+fail_status=$?
+set -e
+[[ "$fail_status" != "0" ]] || fail "make run succeeded despite application exit 42"
+grep -Fq 'Error 42' "$TMP/make-run-fail.err" \
+  || fail "make run did not report application exit status 42"
+if grep -Eq '^event=invoke cmd=run' "$FAKE_MAKE_LOG"; then
+  fail "failing make run invoked cargo run after slot release"
+fi
+
+assert_make_run_does_not_start_app() {
+  local label="$1"
+  rm -f "$FAKE_RUN_STARTED"
+  : >"$FAKE_MAKE_LOG"
+  : >"$FAKE_BUILD_ARGS"
+  set +e
+  ORBIT_BUILD_BUDGET_DIR="$TMP/locks-run" ORBIT_BUILD_SLOTS=1 \
+    make -s -C "$ROOT" run CARGO="$TMP/fake-make-cargo" BUILD_BUDGET="$WRAPPER" \
+    ARGS='should-not-run' >"$TMP/make-run-$label.out" 2>"$TMP/make-run-$label.err"
+  local status=$?
+  set -e
+  [[ "$status" != "0" ]] || fail "make run $label succeeded"
+  [[ ! -e "$FAKE_RUN_STARTED" ]] || fail "make run $label executed the built artifact"
+  if grep -Eq '^event=invoke cmd=run' "$FAKE_MAKE_LOG"; then
+    fail "make run $label invoked cargo run"
+  fi
+}
+
+FAKE_ARTIFACT_MODE=ok
+FAKE_BUILD_EXIT=23
+export FAKE_ARTIFACT_MODE FAKE_BUILD_EXIT
+assert_make_run_does_not_start_app failed-build
+grep -Fq 'Error 23' "$TMP/make-run-failed-build.err" \
+  || fail "make run did not stop on cargo build failure"
+
+FAKE_ARTIFACT_MODE=malformed
+FAKE_BUILD_EXIT=0
+export FAKE_ARTIFACT_MODE FAKE_BUILD_EXIT
+assert_make_run_does_not_start_app malformed-artifact
+grep -Fq 'make run: cargo did not report an executable' "$TMP/make-run-malformed-artifact.err" \
+  || fail "make run did not reject malformed cargo artifact JSON"
+
+FAKE_ARTIFACT_MODE=none
+export FAKE_ARTIFACT_MODE
+assert_make_run_does_not_start_app missing-executable
+grep -Fq 'make run: cargo did not report an executable' "$TMP/make-run-missing-executable.err" \
+  || fail "make run did not reject a cargo artifact without an executable"
+
+FAKE_ARTIFACT_MODE=ok
+FAKE_BUILD_EXIT=0
+export FAKE_ARTIFACT_MODE FAKE_BUILD_EXIT
+
+# make watch admits each check/test iteration; idle watcher lifetime does not hold a slot.
+FAKE_MAKE_LOG="$TMP/make-watch.log"
+FAKE_WATCH_DIR="$TMP/watch-state"
+FAKE_WATCH_IDLE="$TMP/watch-idle"
+FAKE_WATCH_AGAIN="$TMP/watch-again"
+FAKE_WATCH_SECOND="$TMP/watch-second"
+FAKE_WATCH_PID="$TMP/watch-pid"
+FAKE_CHECK_SLEEP=0.8
+mkdir -p "$FAKE_WATCH_DIR"
+: >"$FAKE_MAKE_LOG"
+export FAKE_MAKE_LOG FAKE_WATCH_DIR FAKE_WATCH_IDLE FAKE_WATCH_AGAIN \
+  FAKE_WATCH_SECOND FAKE_WATCH_PID FAKE_CHECK_SLEEP
+
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-watch" ORBIT_BUILD_SLOTS=1 \
+  make -s -C "$ROOT" watch CARGO="$TMP/fake-make-cargo" BUILD_BUDGET="$WRAPPER" \
+  >"$TMP/make-watch.out" 2>"$TMP/make-watch.err" &
+WATCH_MAKE_PID=$!
+BACKGROUND_PIDS+=("$WATCH_MAKE_PID")
+wait_for "$FAKE_WATCH_DIR/started-check-1"
+set +e
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-watch" ORBIT_BUILD_SLOTS=1 \
+  timeout 0.4 "$WRAPPER" -- true
+during_check=$?
+set -e
+[[ "$during_check" == "124" ]] || fail "watch check iteration did not hold a slot (status $during_check)"
+wait_for "$FAKE_WATCH_IDLE"
+ORBIT_BUILD_BUDGET_DIR="$TMP/locks-watch" ORBIT_BUILD_SLOTS=1 \
+  timeout 2 "$WRAPPER" -- true \
+  || fail "idle watch retained a build slot"
+grep -Eq '^event=invoke cmd=watch slot= held=$' "$FAKE_MAKE_LOG" \
+  || fail "watch driver should not hold a slot"
+grep -Eq '^event=iteration cmd=check iter=1 slot=1 held=1$' "$FAKE_MAKE_LOG" \
+  || fail "first watch check was not admitted"
+grep -Eq '^event=iteration cmd=test iter=1 slot=1 held=1$' "$FAKE_MAKE_LOG" \
+  || fail "first watch test was not admitted"
+touch "$FAKE_WATCH_AGAIN"
+wait_for "$FAKE_WATCH_SECOND"
+grep -Eq '^event=iteration cmd=check iter=2 slot=1 held=1$' "$FAKE_MAKE_LOG" \
+  || fail "second watch check was not admitted"
+grep -Eq '^event=iteration cmd=test iter=2 slot=1 held=1$' "$FAKE_MAKE_LOG" \
+  || fail "second watch test was not admitted"
+if [[ -f "$FAKE_WATCH_PID" ]]; then
+  kill "$(cat "$FAKE_WATCH_PID")" 2>/dev/null || true
+fi
+kill "$WATCH_MAKE_PID" 2>/dev/null || true
+wait "$WATCH_MAKE_PID" 2>/dev/null || true
+forget_pid "$WATCH_MAKE_PID"
 
 printf 'test-build-budget: ok\n'


### PR DESCRIPTION
## Task

[ORB-11760](https://orbit-cli.com/tasks/ORB-11760) — Release build admission before application runtime and between watch iterations

### Description

## Regression
Merged ORB-11754/PR1624 (e05fa2fe68be7b351197258162537921993e8e73) wraps whole cargo run/watch processes. With two long-lived apps or watchers, both build slots remain occupied even with no compilation, starving other worktrees. Orchestrator reproduced with /tmp/orbit-budget-runtime-check.sh: real Makefile make run, fake Cargo at app runtime, one slot, unrelated admitted true times out. See comments on ORB-11754.
## Scope
Keep build admission scoped to compilation/validation phases. Release before application runtime and admit each watch check/test iteration individually rather than whole watcher lifetime. Preserve make run ARGS and exit behavior and watch behavior. Do not disable admission for builds or change defaults to conceal starvation. Keep changes narrowly in Makefile/test/runbook; no global config, merge, release, or cache wrapper changes. Existing exact modification targets are known, so no broad selectors needed.

### Acceptance Criteria

- A deterministic test keeps a simulated make run application alive after build completion and proves another admitted build can start; application arguments and exit status remain correct.
- A fake watch driver proves admission wraps each check/test iteration but idle watcher lifetime does not hold a slot.
- Existing build-budget tests including nested admission, failure and termination still pass; make ci-fast and CARGO_BUILD_JOBS=2 make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Makefile `run`: admitted `cargo build -p orbit-cli --bin orbit --message-format=json-render-diagnostics`, then launches the resolved executable from Cargo JSON artifacts. Recipe uses `set -eu` so a failed build or missing/malformed executable never starts the binary. `cargo run` is not used after slot release.
- Makefile `watch`: idle watcher is outside the budget; each check/test iteration is `$(BUILD_BUDGET) -- $(CARGO) check|test` via cargo-watch `-s`.
- scripts/test-build-budget.sh: live `make run` keeps a fake app alive after admitted build and proves another one-slot command starts; ARGS and success/Error 42 exit reporting are checked; cargo run is never invoked; failed build, malformed JSON, and missing executable do not start the artifact. Fake watch driver proves check/test iterations hold a slot, idle does not, and a second iteration is admitted.
- docs/runbooks/build-budget.md: documented run/watch slot lifetime. docs/INDEX.md: registered the existing build-budget runbook so generate-doc-indexes --check passes.
- crates/orbit-search/src/vector/store/tests/upsert.rs: forwarded `token_boundaries` on BarrierEmbedder and FailingEmbedder. Pre-existing HEAD compile break after ORB-11703; required for `make ci-lint`.

Acceptance criteria:
1. Passed: simulated `make run` holds the app after admitted build; `timeout 2 build-budget.py -- true` succeeds on one slot; arguments `alpha beta` are preserved; successful exit 0 and recipe Error 42 are reported. Failed build (exit 23), malformed artifact JSON, and missing executable never start the app.
2. Passed: fake cargo-watch `-s` driver runs admitted check/test (slot held during first check, timeout 0.4 returns 124); after idle, timeout 2 true succeeds; second iteration check/test are admitted; watch driver itself has no slot.
3. Passed: existing nested/failure/termination budget tests still run in the same harness. `make ci-fast` passed. `CARGO_BUILD_JOBS=2 make ci-lint` passed after the upsert.rs stub fix.

Validation:
- scripts/test-build-budget.sh — passed (including three consecutive reruns).
- make ci-fast — passed (includes generate-doc-indexes --check and test-build-budget.sh).
- CARGO_BUILD_JOBS=2 make ci-lint — passed (10.03s incremental after upsert.rs fix; earlier run failed on pre-existing orbit-search test stubs).
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — Makefile, scripts/test-build-budget.sh, docs/runbooks/build-budget.md, docs/INDEX.md, crates/orbit-search/src/vector/store/tests/upsert.rs. Uncommitted as required.

Assessment: Slot lifetime is now scoped to compilation/validation. Run launches the Cargo-reported binary rather than a second compilation-capable command. Watch admits each iteration only.

Strategic decisions:
- Followed later orchestrator comments: no unadmitted `cargo run`; fail-fast recipe; regressions for nonzero build and bad JSON.
- INDEX.md and upsert.rs were added only because ci-fast/ci-lint required them.

Deviations from original plan:
- Added file:docs/INDEX.md so the already-merged build-budget runbook is indexed (is_versioned skipped it while untracked in ORB-11754).
- Added file:crates/orbit-search/src/vector/store/tests/upsert.rs to unblock the required clippy gate. Justification: acceptance criterion 3; not a budget-behavior change.

Design weaknesses / risks:
- Severity low: `make run` depends on python3 and Cargo JSON artifact messages. Mitigation: python3 is already required by scripts/build-budget.py; tests cover missing/malformed artifacts.
- Severity low: `make watch` uses cargo-watch `-s` instead of `-x` so the budget wrapper can wrap each iteration. Check/test commands are unchanged.

Remaining risks: none for the scoped budget behavior. Defaults, cache wrappers, and concurrency settings were not changed.

Recommended follow-ups: none required for this task. ORB-11703 left the two search test stubs incomplete; this candidate repairs them only far enough for ci-lint.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11760-6a9f6b0a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol