### PR TITLE
Repair task-pilot source inspection interaction with Git metadata protection

### DIFF
--- a/crates/orbit-core/src/runtime/tests/git_sandbox.rs
+++ b/crates/orbit-core/src/runtime/tests/git_sandbox.rs
@@ -92,3 +92,98 @@ fn metadata_aliases_and_invalid_pointers_fail_closed() {
         assert_eq!(fs::read_to_string(outside).unwrap(), "host state");
     }
 }
+
+/// The task-pilot boundary [ORB-11756]. A source-inspection slot holds a
+/// checkout of ordinary tracked content, symlinks included. It lives in Orbit
+/// state beside the repository rather than under authoritative Git metadata,
+/// so protection admits the launch while every metadata leaf stays denied.
+/// Planting the same checkout back inside the metadata tree is still refused.
+#[cfg(target_os = "linux")]
+#[test]
+fn source_inspection_slot_launches_while_git_metadata_leaves_stay_denied() {
+    use std::fs;
+    use std::path::Path;
+
+    use super::append_linux_git_denies;
+    use orbit_common::fs::git::run_git;
+    use orbit_exec::linux_bwrap_write_grant_diagnostic;
+    use orbit_types::policy::ResolvedFsProfile;
+
+    fn git(root: &Path, args: &[&str]) -> String {
+        let output = run_git(root, args).unwrap();
+        assert!(output.success, "git {args:?}: {}", output.stderr);
+        output.stdout.trim().to_string()
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().canonicalize().unwrap().join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "--quiet"]);
+    git(&repo, &["config", "user.name", "Orbit Test"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("CLAUDE.md"), "guide\n").unwrap();
+    std::os::unix::fs::symlink("CLAUDE.md", repo.join("AGENTS.md")).unwrap();
+    git(&repo, &["add", "CLAUDE.md", "AGENTS.md"]);
+    git(&repo, &["commit", "--quiet", "-m", "initial"]);
+    let revision = git(&repo, &["rev-parse", "HEAD"]);
+
+    // The slot layout the CLI runner materializes: a standalone repository in
+    // Orbit state, populated by fetch so no object arrives hard-linked.
+    let checkout = repo.join(".orbit/state/source-inspections-v1/0/checkout");
+    fs::create_dir_all(&checkout).unwrap();
+    git(&checkout, &["init", "--quiet", "--template="]);
+    git(
+        &checkout,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            repo.join(".git").to_str().unwrap(),
+            &revision,
+        ],
+    );
+    git(&checkout, &["checkout", "--quiet", "--detach", &revision]);
+    assert!(
+        fs::symlink_metadata(checkout.join("AGENTS.md"))
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+
+    let mut profile = ResolvedFsProfile {
+        name: "test".to_string(),
+        read: vec!["/**".to_string()],
+        modify: vec![format!("{}/**", repo.display())],
+    };
+    append_linux_git_denies(&repo, &mut profile).unwrap();
+    append_linux_git_denies(&checkout, &mut profile).unwrap();
+
+    for denied in [
+        repo.join(".git/HEAD"),
+        repo.join(".git/refs/heads/protected"),
+        checkout.join(".git/HEAD"),
+    ] {
+        assert!(
+            linux_bwrap_write_grant_diagnostic(&profile, &denied)
+                .unwrap()
+                .is_some(),
+            "{} must stay write-denied",
+            denied.display()
+        );
+    }
+    assert!(
+        linux_bwrap_write_grant_diagnostic(&profile, &checkout.join("AGENTS.md"))
+            .unwrap()
+            .is_none(),
+        "the inspected tracked symlink is not Git metadata"
+    );
+
+    let planted = repo.join(".git/orbit-source-inspections-v1/0/checkout");
+    fs::create_dir_all(&planted).unwrap();
+    std::os::unix::fs::symlink("CLAUDE.md", planted.join("AGENTS.md")).unwrap();
+    let error = append_linux_git_denies(&repo, &mut profile).unwrap_err();
+    assert!(error.to_string().contains("metadata entry"), "{error}");
+}

--- a/crates/orbit-engine/src/activity_job/cli_runner/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/inspection.rs
@@ -1,11 +1,16 @@
 //! Invocation-owned source checkouts for read-only inspection [ORB-11256].
 //!
-//! Slots are private scratch space under the source repository's common Git
-//! directory. A kernel lease lasts through provider exit and RAII cleanup.
-//! After a crash the next holder removes the abandoned checkout before reuse.
-//! The fixed slot count bounds leftovers even when no retry follows a crash.
-//! These are standalone repositories: no shared index, alternates, registered
-//! worktree, branch, or global worktree-prune operation is involved.
+//! Slots are private scratch space in the source repository's Orbit state
+//! directory, beside the managed worktrees. A slot holds ordinary tracked
+//! content, which legitimately includes symlinks, so it stays outside the Git
+//! metadata tree — host protection refuses every symlink and hard link there
+//! [ORB-11756].
+//!
+//! A kernel lease lasts through provider exit and RAII cleanup. After a crash
+//! the next holder removes the abandoned checkout before reuse. The fixed slot
+//! count bounds leftovers even when no retry follows a crash. These are
+//! standalone repositories: no shared index, alternates, registered worktree,
+//! branch, or global worktree-prune operation is involved.
 
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io;
@@ -17,6 +22,8 @@ use serde_json::Value;
 use super::super::dispatcher::DispatchError;
 
 const SLOT_COUNT: usize = 16;
+const POOL_DIR: &str = "source-inspections-v1";
+const LEGACY_POOL_DIR: &str = "orbit-source-inspections-v1";
 const OWNER: &str = "orbit-source-inspection-v1\n";
 
 pub(super) struct SourceInspection {
@@ -78,9 +85,12 @@ impl SourceInspection {
             source,
             &["rev-parse", "--path-format=absolute", "--git-common-dir"],
         )?;
+        let common = common.trim();
         let format = git(source, &["rev-parse", "--show-object-format"])?;
-        let pool = Path::new(common.trim()).join("orbit-source-inspections-v1");
-        directory(&pool).map_err(io_failure)?;
+        if let Err(error) = retire_legacy_pool(Path::new(common)) {
+            tracing::warn!(%error, "retiring the in-metadata inspection pool needs operator attention");
+        }
+        let pool = prepare_pool(Path::new(common))?;
         for index in 0..SLOT_COUNT {
             let slot = pool.join(index.to_string());
             directory(&slot).map_err(io_failure)?;
@@ -137,7 +147,7 @@ impl SourceInspection {
                     "fetch",
                     "--quiet",
                     "--no-tags",
-                    common.trim(),
+                    common,
                     revision,
                 ],
             )?;
@@ -188,6 +198,71 @@ impl Drop for SourceInspection {
             tracing::warn!(path = %self.root.display(), %error, "inspection cleanup deferred to next lease holder");
         }
     }
+}
+
+/// Create or adopt this repository's inspection pool and return its path.
+///
+/// The pool is derived from the common Git directory so that every linked
+/// worktree of a repository leases from one bounded set of slots, but it is
+/// placed next to it rather than inside it: a slot is Orbit scratch holding a
+/// working tree, not authoritative Git metadata. The policy's `.orbit/**`
+/// write deny already covers the pool for any concurrent activity that can
+/// write the repository root.
+fn prepare_pool(common: &Path) -> Result<PathBuf, DispatchError> {
+    let repo_root = common
+        .parent()
+        .ok_or_else(|| failure("source repository has no directory containing its Git metadata"))?;
+    let mut pool = repo_root.to_path_buf();
+    for component in [".orbit", "state", POOL_DIR] {
+        pool.push(component);
+        directory(&pool).map_err(io_failure)?;
+    }
+    Ok(pool)
+}
+
+/// Retire the pool this module used to keep inside the common Git directory.
+///
+/// A checkout abandoned there by a crash is no longer reclaimed by the current
+/// pool, and would sit under authoritative Git metadata forever — where host
+/// protection refuses its tracked symlinks and so blocks every sandboxed
+/// activity in the repository. Only slots still carrying this module's owner
+/// marker are removed; anything else is left for an operator to inspect.
+fn retire_legacy_pool(common: &Path) -> io::Result<()> {
+    let legacy = common.join(LEGACY_POOL_DIR);
+    reject_symlink(&legacy)?;
+    if !legacy.is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(&legacy)? {
+        let slot = entry?.path();
+        reject_symlink(&slot)?;
+        let marker = slot.join("owner");
+        reject_symlink(&marker)?;
+        if fs::read_to_string(&marker).unwrap_or_default() != OWNER {
+            return Err(io::Error::other(format!(
+                "unowned entry in the retired inspection pool: {}",
+                slot.display()
+            )));
+        }
+        // A slot an older build still leases is cleaning up after itself.
+        let lock_path = slot.join("lease");
+        reject_symlink(&lock_path)?;
+        let lease = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        match lease.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => return Ok(()),
+            Err(TryLockError::Error(error)) => return Err(error),
+        }
+
+        remove_checkout(&slot.join("checkout"))?;
+        fs::remove_dir_all(&slot)?;
+    }
+    fs::remove_dir(&legacy)
 }
 
 fn remove_checkout(root: &Path) -> io::Result<()> {

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs
@@ -27,7 +27,10 @@ fn repository() -> (TempDir, String) {
     git(root.path(), &["config", "user.email", "test@example.com"]);
     git(root.path(), &["config", "commit.gpgsign", "false"]);
     fs::write(root.path().join("target.txt"), "pinned\n").unwrap();
-    git(root.path(), &["add", "target.txt"]);
+    // Repositories legitimately track symlinks (Orbit's own per-crate
+    // AGENTS.md files are one), so every slot carries them into its checkout.
+    std::os::unix::fs::symlink("target.txt", root.path().join("linked.txt")).unwrap();
+    git(root.path(), &["add", "target.txt", "linked.txt"]);
     git(root.path(), &["commit", "--quiet", "-m", "initial"]);
     let revision = git(root.path(), &["rev-parse", "HEAD"]);
     (root, revision)
@@ -79,6 +82,71 @@ fn snapshot_stays_pinned_and_live_leases_are_never_reclaimed() {
             .filter(|line| line.starts_with("worktree "))
             .collect::<Vec<_>>()
     );
+}
+
+/// The slot must not sit under authoritative Git metadata: host protection
+/// refuses every symlink there, and a checkout of tracked content has them.
+#[test]
+fn slots_carry_tracked_symlinks_and_stay_outside_the_git_metadata_tree() {
+    let (repo, revision) = repository();
+    let common = git(
+        repo.path(),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    );
+    let snapshot = inspect(repo.path(), &revision);
+
+    let linked = snapshot.root().join("linked.txt");
+    assert!(
+        fs::symlink_metadata(&linked)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(fs::read_to_string(&linked).unwrap(), "pinned\n");
+    snapshot.verify().unwrap();
+
+    assert!(
+        !snapshot.root().starts_with(&common),
+        "{} is inside the common Git directory {common}",
+        snapshot.root().display()
+    );
+    assert!(
+        snapshot
+            .root()
+            .starts_with(repo.path().join(".orbit/state/source-inspections-v1")),
+        "{}",
+        snapshot.root().display()
+    );
+}
+
+/// A crash could abandon a checkout in the pool this module used to keep
+/// inside the common Git directory, where host protection refuses its tracked
+/// symlinks. The current pool never leases that slot again, so creating an
+/// inspection retires the whole legacy pool instead.
+#[test]
+fn creating_an_inspection_retires_an_abandoned_in_metadata_pool() {
+    let (repo, revision) = repository();
+    let common = git(
+        repo.path(),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    );
+    let legacy = Path::new(&common).join("orbit-source-inspections-v1");
+    let abandoned = legacy.join("0/checkout");
+    fs::create_dir_all(&abandoned).unwrap();
+    fs::write(legacy.join("0/owner"), "orbit-source-inspection-v1\n").unwrap();
+    std::os::unix::fs::symlink("target.txt", abandoned.join("linked.txt")).unwrap();
+
+    let snapshot = inspect(repo.path(), &revision);
+    assert!(!legacy.exists());
+    drop(snapshot);
+
+    // An entry this module did not write stays for an operator to inspect.
+    let foreign = legacy.join("0");
+    fs::create_dir_all(&foreign).unwrap();
+    fs::write(foreign.join("owner"), "another tool\n").unwrap();
+    let snapshot = inspect(repo.path(), &revision);
+    assert!(foreign.exists());
+    drop(snapshot);
 }
 
 #[test]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@ CLI behavior, state layout, or recovery semantics change.
 | Runbook | Purpose |
 | --- | --- |
 | [Inspect the Audit Trail](./runbooks/audit-trail.md) | Query and interpret Orbit invocation, run, step, and activity audit history. |
+| [Bound Concurrent Orbit Repository Builds](./runbooks/build-budget.md) | Run Cargo builds within Orbit's host-wide cross-worktree admission and compiler-job budget. |
 | [Share Rust dependency compilation across worker worktrees](./runbooks/compiler-cache.md) | Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees. |
 | [Recover a Corrupted Database](./runbooks/database-recovery.md) | Recover a corrupted Orbit SQLite database from backup, salvage, or regeneration. |
 | [Onboard an Executor](./runbooks/executor-onboarding.md) | Add and validate a CLI-agent or deterministic local-shell executor without changing existing users' routing or state. |


### PR DESCRIPTION
## Task

[ORB-11756](https://orbit-cli.com/tasks/ORB-11756) — Repair task-pilot source inspection interaction with Git metadata protection

### Description

## Observed Failure
Task-pilot jrun-20260908-0127 failed before provider launch on build ada765f77: Git metadata protection rejected .git/orbit-source-inspections-v1/0/checkout/crates/orbit-types/AGENTS.md. See F2026-09-068. ORB-11506 introduced recursive metadata validation; temporary source-inspection checkouts contain legitimate tracked symlinks.
## Scope
Reproduce and repair inspection ownership/location or integration without weakening Git metadata protection or host recovery integrity. Preserve read-only source access. This is a proposed incident follow-up; do not alter live state or roll back security protections.

### Acceptance Criteria

- Linux integration coverage launches the source-inspection/task-pilot boundary with tracked symlinks while denying leaf writes to authoritative Git metadata.
- Existing malicious symlink, hard-link and recovery-poisoning protections pass; concurrent inspection and cleanup remain correct.
- make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Repaired the source-inspection / Git-metadata-protection conflict (F2026-09-068).

ROOT CAUSE
`SourceInspection::create` placed slot checkouts at `<git-common-dir>/orbit-source-inspections-v1/<n>/checkout`, i.e. inside authoritative Git metadata. ORB-11506's `validate_linux_git_tree` recursively walks the whole metadata root and refuses every symlink there, so a checkout of ordinary tracked content (Orbit's own per-crate `AGENTS.md -> CLAUDE.md` symlinks) made `append_linux_git_denies` fail for the source repository. The pilot died before provider launch. This is a concurrency-shaped failure: the refusal happens while another (or the same) invocation holds a live checkout, since `create()` reclaims stale slots before sandbox resolution.

CHANGE
1. crates/orbit-engine/src/activity_job/cli_runner/inspection.rs
   - New `prepare_pool`: the pool moves to `<repo-root>/.orbit/state/source-inspections-v1`, derived from the common Git directory so one bounded 16-slot pool is still shared by every linked worktree. A slot is Orbit scratch holding a working tree, not Git metadata. It stays read-only for the reviewer profile (bwrap's base is `--ro-bind / /`, reviewer grants no modify root), and the policy's `.orbit/**` deny already covers it for any activity that can write the repository root — so read-only inspection is unchanged.
   - New `retire_legacy_pool`: because the new pool never leases the in-metadata slots again, a crash-abandoned checkout there would block every sandboxed activity in the repository forever. Retirement removes only slots carrying this module's `owner` marker, refuses symlinked entries, and acquires each slot's `lease` flock first so a concurrently running older build is never disturbed (WouldBlock leaves the pool alone). Failures warn instead of failing dispatch.
   - Git metadata protection itself is untouched: no exemption, no relaxed validation.

2. crates/orbit-core/src/runtime/tests/git_sandbox.rs — new Linux-gated integration test `source_inspection_slot_launches_while_git_metadata_leaves_stay_denied`, over a real Git repository with a real tracked symlink and a real init+fetch+checkout slot.

3. crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs — fixture repository now tracks a symlink; new `slots_carry_tracked_symlinks_and_stay_outside_the_git_metadata_tree` and `creating_an_inspection_retires_an_abandoned_in_metadata_pool`.

4. docs/INDEX.md — regenerated (one line). Unrelated to this fix; see DEVIATIONS.

CRITERIA
1. "Linux integration coverage ... tracked symlinks ... denying leaf writes to authoritative Git metadata" — MET. The orbit-core test builds the slot layout the runner materializes, checks out a tracked symlink into it, runs `append_linux_git_denies` for both the repository root and the inspection cwd (both now succeed), and asserts `<repo>/.git/HEAD`, `<repo>/.git/refs/heads/**` and `<checkout>/.git/HEAD` remain write-denied under a broad `<repo>/**` modify grant, while the inspected tracked symlink is not treated as metadata. Its final assertion plants the old in-`.git` checkout and confirms protection still refuses it, so the fix is not a weakening. The engine-side test proves the slot is outside the common Git directory and materializes the symlink.
2. "Existing malicious symlink, hard-link and recovery-poisoning protections pass; concurrent inspection and cleanup remain correct" — MET. `git_sandbox` pre-existing tests (linked pointer / real metadata / shared recovery; symlink-entry, hardlink-entry, hardlink-pointer, invalid-pointer fail-closed) pass unchanged. All 10 inspection tests pass, including bounded capacity with 16 concurrent live leases, slot reuse, crash-leftover reclamation alongside a live snapshot, registered-worktree cleanup refusal, and dispatch failure/timeout release. Legacy-pool retirement is lease-gated so it cannot race a live holder.
3. "make ci-fast and make ci-lint pass" — see VALIDATION.

VALIDATION
- cargo test -p orbit-engine --lib activity_job::cli_runner::tests::inspection — PASSED (10 passed).
- cargo test -p orbit-engine --lib activity_job::cli_runner — PASSED (166 passed, 2 ignored).
- cargo test -p orbit-core --lib runtime::git_sandbox — PASSED (3 passed).
- cargo test -p orbit-core --lib -- git_sandbox sandbox — PASSED (33 passed).
- Fault detection: with the pool temporarily restored to the common Git directory, `slots_carry_tracked_symlinks_and_stay_outside_the_git_metadata_tree` FAILS with "<...>/.git/source-inspections-v1/0/checkout is inside the common Git directory". The fix was then restored and re-verified.
- make ci-fast — PASSED (exit 0).
- make ci-lint — PASSED (exit 0), but only after temporarily supplying agent-main's version of crates/orbit-search/src/vector/store/tests/upsert.rs; see DEVIATIONS. The temporary file was restored byte-exact and `git status --short` shows only the four intended files.
- git diff --check — clean. No build artifacts or caches in the patch.

DEVIATIONS / RISKS
- Pre-existing break outside this task's scope: at this branch's base (5c7451ed9) `cargo clippy --all-targets` fails to compile orbit-search test doubles (`BarrierEmbedder`, `FailingEmbedder` missing `token_boundaries`, added to the `Embedder` trait by ORB-11703). This is already repaired on agent-main by ORB-11759 (f6197845c), and this branch's HEAD is an ancestor of agent-main, so I deliberately did NOT duplicate that fix here — doing so would conflict with the integration branch. ci-lint was verified green with that upstream file applied temporarily.
- docs/INDEX.md was stale at this base and on agent-main: ORB-11754 added docs/runbooks/build-budget.md without regenerating the index, which fails ci-fast's generate-doc-indexes.sh --check. Because acceptance criterion 3 requires ci-fast to pass, I ran the generator (one added line, machine-produced) and appended file:docs/INDEX.md to context_files. It is unrelated to the security fix and can be dropped if the pipeline prefers to route it separately.
- Also appended file:crates/orbit-engine/src/activity_job/cli_runner/tests/inspection.rs to context_files: the sibling tests for the changed module needed the symlink fixture and the new location/retirement coverage.
- Location choice: `.orbit/state/` follows the existing engine convention (resolve_worktree_path_from_prefix already anchors managed worktrees at `<repo_root>/.orbit/state/worktrees`). The repository root is taken as the common Git directory's parent; for a bare repository that is the directory containing the bare repo, which is functional but unusual. Source inspection already requires the source to be inside a work tree.
- Untested in this environment: no bwrap child was actually spawned. The denial assertions use `linux_bwrap_write_grant_diagnostic`, the same function the runtime uses to attribute an EROFS, so they prove the compiled profile's decision, not kernel enforcement. Kernel enforcement is unchanged by this task.
- Repositories carrying a legacy in-`.git` pool are retired on the next inspection; a pool containing an entry this module did not write is left in place with a warning rather than removed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11756-6a9f6b3f`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra