### PR TITLE
[code-review] Remove redundant run-owner probes without weakening reconciliation

### DIFF
--- a/crates/orbit-core/src/application/job/run/owner.rs
+++ b/crates/orbit-core/src/application/job/run/owner.rs
@@ -20,6 +20,9 @@ use std::thread;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
+#[cfg(all(test, unix))]
+use std::cell::RefCell;
+
 #[cfg(unix)]
 pub(super) const RUN_OWNER_TERMINATION_GRACE: Duration = Duration::from_secs(2);
 #[cfg(unix)]
@@ -354,6 +357,8 @@ pub(super) enum OwnerIdentity {
 
 #[cfg(unix)]
 pub(super) fn classify_run_owner(run: &JobRun) -> OwnerIdentity {
+    #[cfg(test)]
+    record_classify_owner_snapshot(run);
     classify_run_owner_with_probes(
         run.pid,
         run.pid_start_time.as_deref(),
@@ -525,4 +530,44 @@ pub(super) fn stale_job_run_message(run: &JobRun, _reason: Option<()>) -> String
             .unwrap_or_else(|| "-".to_string()),
         run.pid_start_time.as_deref().unwrap_or("-")
     )
+}
+
+/// One `classify_run_owner` observation, used by list/history counting fixtures
+/// to prove a single list/history call classifies an unchanged owner snapshot
+/// at most once. Stale finalization may classify again after rereading.
+#[cfg(all(test, unix))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ClassifyOwnerSnapshot {
+    pub run_id: String,
+    pub state: JobRunState,
+    pub pid: Option<u32>,
+    pub pid_start_time: Option<String>,
+}
+
+#[cfg(all(test, unix))]
+thread_local! {
+    static CLASSIFY_OWNER_SNAPSHOTS: RefCell<Vec<ClassifyOwnerSnapshot>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+#[cfg(all(test, unix))]
+fn record_classify_owner_snapshot(run: &JobRun) {
+    CLASSIFY_OWNER_SNAPSHOTS.with(|snapshots| {
+        snapshots.borrow_mut().push(ClassifyOwnerSnapshot {
+            run_id: run.run_id.clone(),
+            state: run.state,
+            pid: run.pid,
+            pid_start_time: run.pid_start_time.clone(),
+        });
+    });
+}
+
+#[cfg(all(test, unix))]
+pub(super) fn reset_classify_owner_snapshots() {
+    CLASSIFY_OWNER_SNAPSHOTS.with(|snapshots| snapshots.borrow_mut().clear());
+}
+
+#[cfg(all(test, unix))]
+pub(super) fn classify_owner_snapshots() -> Vec<ClassifyOwnerSnapshot> {
+    CLASSIFY_OWNER_SNAPSHOTS.with(|snapshots| snapshots.borrow().clone())
 }

--- a/crates/orbit-core/src/application/job/run/query.rs
+++ b/crates/orbit-core/src/application/job/run/query.rs
@@ -6,15 +6,17 @@ use orbit_types::workflow::JobRun;
 
 use crate::OrbitRuntime;
 
+use super::reconcile::ReconcilePass;
 use super::types::JobRunListParams;
 
 impl OrbitRuntime {
     pub fn job_history(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
-        self.reconcile_stale_job_runs(Some(job_id))?;
+        let mut pass = ReconcilePass::default();
+        self.reconcile_stale_job_runs_with_pass(Some(job_id), &mut pass)?;
         match self.load_v2_job_asset_by_name(job_id) {
-            Ok(_) => self.list_reconciled_job_history_backend(job_id),
+            Ok(_) => self.list_reconciled_job_history_backend(job_id, &mut pass),
             Err(error) => {
-                let runs = self.list_reconciled_job_history_backend(job_id)?;
+                let runs = self.list_reconciled_job_history_backend(job_id, &mut pass)?;
                 if runs.is_empty() {
                     Err(error)
                 } else {
@@ -25,7 +27,8 @@ impl OrbitRuntime {
     }
 
     pub fn list_job_runs(&self, params: JobRunListParams) -> Result<Vec<JobRun>, OrbitError> {
-        self.reconcile_stale_job_runs(params.job_id.as_deref())?;
+        let mut pass = ReconcilePass::default();
+        self.reconcile_stale_job_runs_with_pass(params.job_id.as_deref(), &mut pass)?;
         if let Some(job_id) = params.job_id.as_deref()
             && let Err(error) = self.load_v2_job_asset_by_name(job_id)
         {
@@ -37,7 +40,7 @@ impl OrbitRuntime {
 
         let query = job_run_query(params);
         let runs = self.list_job_runs_filtered_backend(&query)?;
-        if self.reconcile_job_run_records(&runs)? > 0 {
+        if self.reconcile_job_run_records_with_pass(&runs, &mut pass)? > 0 {
             self.list_job_runs_filtered_backend(&query)
         } else {
             Ok(runs)
@@ -53,9 +56,8 @@ impl OrbitRuntime {
             .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))
     }
 
-    // Note: list_reconciled..., reconcile_job_run_records, list_job_history_backend,
-    // list_job_runs_filtered_backend, get_job_run_backend live in reconcile + here
-    // but to avoid dup, some private backends are here; reconcile has list_reconciled etc.
+    // History/list backends and get_job_run_backend live here; the two-pass
+    // reconcile helpers that share ReconcilePass live in reconcile.rs.
 
     pub(super) fn list_job_history_backend(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
         self.stores().jobs().list_job_runs(job_id)

--- a/crates/orbit-core/src/application/job/run/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/reconcile.rs
@@ -1,5 +1,8 @@
 //! Stale-run reconciliation, terminal timing repair, and audit helpers.
 
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
 use orbit_store::contracts::TaskReservationReleaseReason;
@@ -12,6 +15,53 @@ use super::owner::{
     owner_identity_error_code, pending_run_stale_reason, running_run_owner_is_stale,
     running_run_owner_stale_reason, stale_job_run_message, stale_pending_run_message,
 };
+
+/// Call-scoped reuse of healthy owner classifications.
+///
+/// Keyed by run/owner identity so a later row with a different pid, token, or
+/// state is classified again. Stale verdicts are never stored: orphan
+/// finalization always rereads the durable row. The set lives only for one
+/// list/history call.
+#[derive(Default)]
+pub(super) struct ReconcilePass {
+    healthy: HashSet<OwnerSnapshotKey>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OwnerSnapshotKey {
+    run_id: String,
+    state: JobRunState,
+    pid: Option<u32>,
+    pid_start_time: Option<String>,
+}
+
+impl Hash for OwnerSnapshotKey {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.run_id.hash(hasher);
+        std::mem::discriminant(&self.state).hash(hasher);
+        self.pid.hash(hasher);
+        self.pid_start_time.hash(hasher);
+    }
+}
+
+impl ReconcilePass {
+    fn key(run: &JobRun) -> OwnerSnapshotKey {
+        OwnerSnapshotKey {
+            run_id: run.run_id.clone(),
+            state: run.state,
+            pid: run.pid,
+            pid_start_time: run.pid_start_time.clone(),
+        }
+    }
+
+    fn has_healthy(&self, run: &JobRun) -> bool {
+        self.healthy.contains(&Self::key(run))
+    }
+
+    fn remember_healthy(&mut self, run: &JobRun) {
+        self.healthy.insert(Self::key(run));
+    }
+}
 
 impl OrbitRuntime {
     /// [ORB-10002] Best-effort orphan scan at workspace open. Marks stuck
@@ -73,6 +123,14 @@ impl OrbitRuntime {
         &self,
         job_id: Option<&str>,
     ) -> Result<usize, OrbitError> {
+        self.reconcile_stale_job_runs_with_pass(job_id, &mut ReconcilePass::default())
+    }
+
+    pub(super) fn reconcile_stale_job_runs_with_pass(
+        &self,
+        job_id: Option<&str>,
+        pass: &mut ReconcilePass,
+    ) -> Result<usize, OrbitError> {
         let runs = if let Some(job_id) = job_id {
             self.stores()
                 .jobs()
@@ -83,7 +141,7 @@ impl OrbitRuntime {
 
         let mut reconciled = 0usize;
         for run in runs {
-            if self.reconcile_stale_job_run(&run)? {
+            if self.reconcile_stale_job_run_with_pass(&run, pass)? {
                 reconciled += 1;
             }
         }
@@ -91,12 +149,21 @@ impl OrbitRuntime {
     }
 
     pub(crate) fn reconcile_stale_job_run(&self, run: &JobRun) -> Result<bool, OrbitError> {
-        self.reconcile_stale_job_run_before_revalidation(run, || {})
+        self.reconcile_stale_job_run_with_pass(run, &mut ReconcilePass::default())
+    }
+
+    fn reconcile_stale_job_run_with_pass(
+        &self,
+        run: &JobRun,
+        pass: &mut ReconcilePass,
+    ) -> Result<bool, OrbitError> {
+        self.reconcile_stale_job_run_before_revalidation(run, pass, || {})
     }
 
     fn reconcile_stale_job_run_before_revalidation<F>(
         &self,
         run: &JobRun,
+        pass: &mut ReconcilePass,
         before_revalidation: F,
     ) -> Result<bool, OrbitError>
     where
@@ -105,7 +172,13 @@ impl OrbitRuntime {
         if terminal_run_timing_is_incomplete(run) {
             return self.repair_terminal_job_run_timing(run);
         }
+        if pass.has_healthy(run) {
+            return Ok(false);
+        }
         if stale_job_run_diagnostic(run).is_none() {
+            if !run.state.is_terminal() {
+                pass.remember_healthy(run);
+            }
             return Ok(false);
         }
 
@@ -124,7 +197,11 @@ impl OrbitRuntime {
     where
         F: FnOnce(),
     {
-        self.reconcile_stale_job_run_before_revalidation(run, concurrent_completion)
+        self.reconcile_stale_job_run_before_revalidation(
+            run,
+            &mut ReconcilePass::default(),
+            concurrent_completion,
+        )
     }
 
     /// [ORB-10002] Orphaned runs (owner process conclusively gone) become
@@ -217,10 +294,14 @@ impl OrbitRuntime {
         self.latest_run_audit_timestamp(run_id)
     }
 
-    pub(super) fn reconcile_job_run_records(&self, runs: &[JobRun]) -> Result<usize, OrbitError> {
+    pub(super) fn reconcile_job_run_records_with_pass(
+        &self,
+        runs: &[JobRun],
+        pass: &mut ReconcilePass,
+    ) -> Result<usize, OrbitError> {
         let mut reconciled = 0usize;
         for run in runs {
-            if self.reconcile_stale_job_run(run)? {
+            if self.reconcile_stale_job_run_with_pass(run, pass)? {
                 reconciled += 1;
             }
         }
@@ -230,9 +311,10 @@ impl OrbitRuntime {
     pub(super) fn list_reconciled_job_history_backend(
         &self,
         job_id: &str,
+        pass: &mut ReconcilePass,
     ) -> Result<Vec<JobRun>, OrbitError> {
         let runs = self.list_job_history_backend(job_id)?;
-        if self.reconcile_job_run_records(&runs)? > 0 {
+        if self.reconcile_job_run_records_with_pass(&runs, pass)? > 0 {
             self.list_job_history_backend(job_id)
         } else {
             Ok(runs)
@@ -280,20 +362,17 @@ impl OrbitRuntime {
 fn stale_job_run_diagnostic(run: &JobRun) -> Option<(String, String)> {
     // [ORB-10070] Orphaned queued runs (claimed worker conclusively gone, or
     // never claimed past the grace window) finalize exactly like orphaned
-    // running runs.
+    // running runs. Each diagnostic is built from one classification result.
     if let Some(reason) = pending_run_stale_reason(run) {
         return Some((
             reason.error_code().to_string(),
             stale_pending_run_message(run, reason),
         ));
     }
-    if !running_run_owner_is_stale(run) {
-        return None;
-    }
-    let stale_reason = running_run_owner_stale_reason(run);
+    let stale_reason = running_run_owner_stale_reason(run)?;
     Some((
-        owner_identity_error_code(stale_reason).to_string(),
-        stale_job_run_message(run, stale_reason),
+        owner_identity_error_code(Some(stale_reason)).to_string(),
+        stale_job_run_message(run, Some(stale_reason)),
     ))
 }
 

--- a/crates/orbit-core/src/application/job/run/tests/mod.rs
+++ b/crates/orbit-core/src/application/job/run/tests/mod.rs
@@ -12,7 +12,7 @@ mod reconcile;
 mod worker_limit;
 
 use chrono::{DateTime, Utc};
-use orbit_store::V2AuditEventInsertParams;
+use orbit_store::{TaskReservationReserveParams, V2AuditEventInsertParams};
 use orbit_types::workflow::{JobRun, JobRunState};
 use rusqlite::{Connection, params};
 use tempfile::tempdir;
@@ -85,6 +85,59 @@ pub(crate) fn set_run_pid_start_time(runtime: &OrbitRuntime, run: &JobRun, token
         ],
     )
     .expect("set pid_start_time");
+}
+
+/// Overwrite the recorded owner identity without going through start/claim
+/// guards, so race fixtures can change ownership after a stale snapshot.
+pub(crate) fn set_run_owner(
+    runtime: &OrbitRuntime,
+    run: &JobRun,
+    pid: u32,
+    pid_start_time: Option<&str>,
+) {
+    let conn = Connection::open(runtime.global_root().join("orbit.db")).expect("open orbit db");
+    conn.execute(
+        "UPDATE job_runs SET pid = ?3, pid_start_time = ?4 \
+         WHERE workspace_id = ?1 AND run_id = ?2",
+        params![
+            runtime.workspace_id().expect("workspace id"),
+            run.run_id,
+            pid,
+            pid_start_time,
+        ],
+    )
+    .expect("set run owner");
+}
+
+pub(crate) fn reserve_for_run(runtime: &OrbitRuntime, owner_run_id: &str, file: &str) {
+    runtime
+        .stores()
+        .task_reservations()
+        .reserve_task_reservation(TaskReservationReserveParams {
+            workspace_orbit_dir: runtime.paths().orbit_dir.to_string_lossy().into_owned(),
+            workspace_id: Some(runtime.workspace_id().expect("workspace id")),
+            task_ids: Vec::new(),
+            requested_files: vec![file.to_string()],
+            actor: "test".to_string(),
+            ttl_seconds: 3_600,
+            owner_run_id: Some(owner_run_id.to_string()),
+            owner_metadata_json: None,
+        })
+        .expect("reserve for run");
+}
+
+pub(crate) fn active_reservation_owners(runtime: &OrbitRuntime) -> Vec<String> {
+    let workspace_orbit_dir = runtime.paths().orbit_dir.to_string_lossy().into_owned();
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    runtime
+        .stores()
+        .task_reservations()
+        .list_active_task_reservations(&workspace_orbit_dir, Some(&workspace_id))
+        .expect("list active reservations")
+        .reservations
+        .into_iter()
+        .filter_map(|reservation| reservation.owner_run_id)
+        .collect()
 }
 
 pub(crate) fn write_run_finished_audit(

--- a/crates/orbit-core/src/application/job/run/tests/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/tests/reconcile.rs
@@ -264,6 +264,8 @@ fn concurrent_terminal_outcomes_win_before_stale_interruption_revalidation() {
             .get_job_run_backend(&run.run_id)
             .expect("read stale snapshot")
             .expect("stale run exists");
+        reserve_for_run(&runtime, &run.run_id, "file:src/reconcile-race.rs");
+        reserve_for_run(&runtime, "jrun-unrelated", "file:src/unrelated.rs");
 
         let reconciled = runtime
             .reconcile_stale_job_run_after_classification(&stale_snapshot, || {
@@ -283,6 +285,15 @@ fn concurrent_terminal_outcomes_win_before_stale_interruption_revalidation() {
             step.state != JobRunState::Interrupted
                 && step.error_code.as_deref() != Some(TERMINAL_OUTCOME_CONFLICT_CODE)
         }));
+        let owners = active_reservation_owners(&runtime);
+        assert!(
+            owners.iter().any(|owner| owner == &run.run_id),
+            "{terminal_state} winner must keep its reservation"
+        );
+        assert!(
+            owners.iter().any(|owner| owner == "jrun-unrelated"),
+            "unrelated reservations must stay"
+        );
     }
 }
 
@@ -495,4 +506,190 @@ fn list_job_runs_reconciles_before_state_filtering() {
             .iter()
             .any(|candidate| candidate.run_id == run.run_id)
     );
+}
+
+/// [ORB-11603] A worker may replace the recorded owner after the sweep
+/// classified a stale snapshot. The freshness reread must observe the new
+/// owner and must not interrupt or release reservations.
+#[cfg(unix)]
+#[test]
+fn concurrent_owner_change_after_stale_classification_is_not_interrupted() {
+    use orbit_common::process::identity::process_start_identity_token;
+
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_reconcile_owner_race");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now() - Duration::seconds(3), 999_999)
+        .expect("mark stale running");
+    let stale_snapshot = runtime
+        .get_job_run_backend(&run.run_id)
+        .expect("read stale snapshot")
+        .expect("stale run exists");
+    reserve_for_run(&runtime, &run.run_id, "file:src/owner-race.rs");
+    reserve_for_run(&runtime, "jrun-unrelated", "file:src/unrelated.rs");
+
+    let pid = std::process::id();
+    let Some(token) = process_start_identity_token(pid) else {
+        return;
+    };
+
+    let reconciled = runtime
+        .reconcile_stale_job_run_after_classification(&stale_snapshot, || {
+            set_run_owner(&runtime, &run, pid, Some(token.as_str()));
+        })
+        .expect("reconcile after owner change");
+
+    assert!(
+        !reconciled,
+        "a live replacement owner must prevent interruption"
+    );
+    let stored = runtime
+        .get_job_run_backend(&run.run_id)
+        .expect("read winner")
+        .expect("run exists");
+    assert_eq!(stored.state, JobRunState::Running);
+    assert!(stored.finished_at.is_none());
+    let owners = active_reservation_owners(&runtime);
+    assert!(
+        owners.iter().any(|owner| owner == &run.run_id),
+        "live replacement owner must keep its reservation"
+    );
+    assert!(
+        owners.iter().any(|owner| owner == "jrun-unrelated"),
+        "unrelated reservations must stay"
+    );
+}
+
+/// [ORB-11603] List and history repair incomplete terminal timing on the
+/// second pass without requiring a stale-owner classification.
+#[test]
+fn list_and_history_repair_terminal_run_missing_timing() {
+    let (_root, runtime) = test_runtime();
+    let run = insert_pending_run(&runtime, "qa_list_terminal");
+    let started_at = Utc::now() - Duration::seconds(8);
+    let finished_at = started_at + Duration::seconds(5);
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, started_at, std::process::id())
+        .expect("mark running");
+    runtime
+        .stores()
+        .jobs()
+        .finalize_job_run(&run.run_id, JobRunState::Success, finished_at, Some(5_000))
+        .expect("finalize success");
+    let finalized = runtime
+        .get_job_run_backend(&run.run_id)
+        .expect("read finalized")
+        .expect("run exists");
+    strip_run_timing(&runtime, &finalized);
+    write_run_finished_audit(&runtime, &run.run_id, finished_at);
+
+    let listed = runtime
+        .list_job_runs(JobRunListParams {
+            job_id: Some("qa_list_terminal".to_string()),
+            ..JobRunListParams::default()
+        })
+        .expect("list repaired");
+    let listed_run = listed
+        .iter()
+        .find(|candidate| candidate.run_id == run.run_id)
+        .expect("listed repaired run");
+    assert_eq!(listed_run.state, JobRunState::Success);
+    assert_eq!(listed_run.finished_at, Some(finished_at));
+    assert_eq!(listed_run.duration_ms, Some(5_000));
+
+    strip_run_timing(&runtime, listed_run);
+    let history = runtime
+        .job_history("qa_list_terminal")
+        .expect("history repaired");
+    let history_run = history
+        .iter()
+        .find(|candidate| candidate.run_id == run.run_id)
+        .expect("history repaired run");
+    assert_eq!(history_run.state, JobRunState::Success);
+    assert_eq!(history_run.finished_at, Some(finished_at));
+    assert_eq!(history_run.duration_ms, Some(5_000));
+}
+
+/// [ORB-11603] Unchanged healthy pending/running owners are classified once
+/// per list/history call. A later call classifies again (pass-local reuse
+/// does not cross calls). Stale finalization may probe again after rereading
+/// and is covered separately by the race fixtures.
+#[cfg(unix)]
+#[test]
+fn list_and_history_classify_unchanged_healthy_owners_once() {
+    use super::super::owner::reset_classify_owner_snapshots;
+    use orbit_common::process::identity::process_start_identity_token;
+
+    let pid = std::process::id();
+    if process_start_identity_token(pid).is_none() {
+        return;
+    }
+
+    let (_root, runtime) = test_runtime();
+    let pending = insert_pending_run(&runtime, "qa_probe_pending");
+    assert!(
+        runtime
+            .stores()
+            .jobs()
+            .claim_pending_job_run_owner(&pending.run_id, pid)
+            .expect("claim pending")
+    );
+    let running = insert_pending_run(&runtime, "qa_probe_running");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&running.run_id, Utc::now(), pid)
+        .expect("mark running");
+
+    reset_classify_owner_snapshots();
+    let listed = runtime
+        .list_job_runs(JobRunListParams::default())
+        .expect("list healthy owners");
+    assert!(listed.iter().any(|candidate| {
+        candidate.run_id == pending.run_id && candidate.state == JobRunState::Pending
+    }));
+    assert!(listed.iter().any(|candidate| {
+        candidate.run_id == running.run_id && candidate.state == JobRunState::Running
+    }));
+    assert_one_classification_per_run(&[pending.run_id.as_str(), running.run_id.as_str()]);
+
+    reset_classify_owner_snapshots();
+    let history = runtime
+        .job_history("qa_probe_pending")
+        .expect("history healthy pending");
+    assert!(
+        history
+            .iter()
+            .any(|candidate| candidate.run_id == pending.run_id)
+    );
+    assert_one_classification_per_run(&[pending.run_id.as_str()]);
+
+    reset_classify_owner_snapshots();
+    runtime
+        .list_job_runs(JobRunListParams::default())
+        .expect("list healthy owners again");
+    assert_one_classification_per_run(&[pending.run_id.as_str(), running.run_id.as_str()]);
+}
+
+#[cfg(unix)]
+fn assert_one_classification_per_run(run_ids: &[&str]) {
+    use super::super::owner::classify_owner_snapshots;
+
+    let snapshots = classify_owner_snapshots();
+    for run_id in run_ids {
+        let matches: Vec<_> = snapshots
+            .iter()
+            .filter(|snapshot| snapshot.run_id == *run_id)
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "run {run_id} classified {} times in one list/history operation: {matches:?}; all={snapshots:?}",
+            matches.len()
+        );
+    }
 }


### PR DESCRIPTION
## Task

[ORB-11603](https://orbit-cli.com/tasks/ORB-11603) — [code-review] Remove redundant run-owner probes without weakening reconciliation

### Description

## Problem
Run listing/history first reconcile pending/running rows, then reconcile the returned rows again. Healthy owners can be probed twice, and stale diagnostic construction separately classifies ownership to decide and explain the result. This adds process probes to repeated operator reads. Show/count/duration queries do not all execute the same two full passes.

## Required behavior
Avoid duplicate healthy-owner classification in one list/history operation and derive each diagnostic from one classification result. Preserve the second pass's distinct responsibility to repair incomplete terminal timing. Final orphan terminalization deliberately rereads the durable row and revalidates state/owner; retain that fresh decision rather than serving it from an earlier cache. Any pass-local reuse must distinguish changed run/owner identity and cannot cross calls. Keep reconciliation semantics and reservation cleanup authoritative.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/application/job/run/query.rs:28`, `:40`, `:47`, `:83`; `crates/orbit-core/src/application/job/run/reconcile.rs:103`, `:141`, `:225`, `:284`.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- A counting fixture with unchanged healthy pending/running owners demonstrates at most one owner classification per owner snapshot in a list/history operation; stale finalization freshness checks are explicitly allowed separately.
- Terminal fixtures with missing finish time/duration still receive the existing timing repair during list/history.
- Race tests demonstrate a worker terminalizing or changing ownership after initial stale classification is not incorrectly interrupted and reservations are not incorrectly released.
- Existing pending/running/terminal reconciliation fixtures and query behavior pass; record the bounded probe reduction without asserting unmeasured dashboard-wide spawn totals.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- list_job_runs and job_history now share a call-scoped ReconcilePass keyed by run id, state, pid, and pid_start_time so unchanged healthy pending/running owners are classified once per operation.
- stale_job_run_diagnostic builds the running-run message from a single running_run_owner_stale_reason result instead of classifying twice.
- Pass 2 still repairs incomplete terminal timing. Orphan finalization still rereads the durable row and revalidates; stale verdicts are not cached. A later call gets a fresh pass.
- Tests: counting fixture for list/history; list/history terminal timing repair; terminal-winner race now asserts reservations; new live-owner-change race.

Assessment: Bounded probe reduction at the list/history boundary without changing reconciliation or reservation cleanup semantics.

Criteria:
1. Counting fixture list_and_history_classify_unchanged_healthy_owners_once: live claimed pending + live running owners are classified exactly once per list/history call; a second list classifies again (no cross-call reuse). Stale finalization rereads remain allowed and are covered by race fixtures.
2. list_and_history_repair_terminal_run_missing_timing: Success rows missing finished_at/duration_ms are repaired on list and history.
3. concurrent_terminal_outcomes_win_before_stale_interruption_revalidation (now with reservations) and concurrent_owner_change_after_stale_classification_is_not_interrupted: worker terminalize or live pid rewrite after stale classification does not interrupt and does not release this run or unrelated reservations.
4. Existing pending/running/terminal reconcile fixtures in application::job::run::tests passed (73 tests). Probe reduction is asserted per owner snapshot in the counting fixture, not as dashboard-wide spawn totals.

Validation:
- cargo test -p orbit-core --lib application::job::run::tests: passed (73 tests; CARGO_TARGET_DIR=/tmp/orbit-jrun-20260908-0204-3-target)
- cargo test -p orbit-core --lib application::job::run::tests::reconcile: passed (16 tests, no warnings)
- make ci-lint: passed (clippy --workspace --all-targets -D warnings)
- make ci-fast: not fully green. cargo fmt --check and the remaining ci-fast scripts passed. ./scripts/generate-doc-indexes.sh --check failed on this checkout because committed docs/INDEX.md is missing the already-tracked build-budget runbook row. INDEX.md is unchanged by this task (restored after a probe generate). Pre-existing; not introduced here.
- git diff --check: passed

Strategic decisions: Pass-local HashSet of healthy snapshots rather than skipping all pending/running work in pass 2, so a changed pid/token/state is classified again. Do not cache stale verdicts.

Risks: Pipeline make ci-fast on this worktree HEAD will still fail the docs-index check until INDEX.md is regenerated on the base branch. Show/count/duration keep a fresh empty pass and were not given a second full classify pass before this change.

Context files added: tests/reconcile.rs and tests/mod.rs for the new fixtures and shared reservation/owner-rewrite helpers.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11603-6a9f6d16`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra