### PR TITLE
[code-review] Stop hashing every artifact blob on every bundle read used by listing and search

### DIFF
--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs
@@ -34,6 +34,33 @@ pub(crate) use commit::{PENDING_WRITE_FILE_NAME, inject_bundle_write_faults};
 
 static STAGING_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Whether a bundle read must hash every `artifacts/files/**` payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ArtifactPayloadCheck {
+    /// Canonical full-read: open each blob and verify size plus sha256.
+    Verify,
+    /// Listing/search materialization: parse the manifest, skip payload bytes.
+    Defer,
+}
+
+#[cfg(test)]
+thread_local! {
+    static ARTIFACT_PAYLOAD_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn record_artifact_payload_read() {
+    #[cfg(test)]
+    ARTIFACT_PAYLOAD_READS.with(|count| count.set(count.get() + 1));
+}
+
+/// Number of artifact payload files opened by strict bundle verification on
+/// this thread since the previous take. Listing tests use this to prove the
+/// lightweight path does not touch blob bytes.
+#[cfg(test)]
+pub(crate) fn take_artifact_payload_reads() -> usize {
+    ARTIFACT_PAYLOAD_READS.with(|count| count.replace(0))
+}
+
 /// Write a new v2 bundle at `bundle_dir`.
 ///
 /// The complete bundle is assembled in a unique sibling directory and renamed
@@ -90,7 +117,11 @@ where
             })?;
             copy_artifact_blobs(source, &staging_dir, manifest)?;
         }
-        read_bundle_for_id(&staging_dir, &bundle.envelope.id)?;
+        read_bundle_for_id(
+            &staging_dir,
+            &bundle.envelope.id,
+            ArtifactPayloadCheck::Verify,
+        )?;
         sync_staged_bundle_dirs(&staging_dir)?;
         publish(&staging_dir, bundle_dir).map_err(|err| OrbitError::from_write_io(bundle_dir, err))
     })();
@@ -184,9 +215,32 @@ fn publish_staged_bundle(staging_dir: &Path, bundle_dir: &Path) -> std::io::Resu
     sync_parent_dir(bundle_dir)
 }
 
+/// Canonical full-bundle read: parse every sidecar and hash every artifact blob.
 pub(crate) fn read_bundle_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    read_bundle_at_with(bundle_dir, ArtifactPayloadCheck::Verify)
+}
+
+/// Assemble a task bundle without opening artifact payload bytes.
+///
+/// This is the listing/search materialization primitive. It still reads the
+/// envelope, markdown bodies, events, comments, and `artifacts/manifest.yaml`,
+/// applies the pending-write view, and checks event-log/envelope status
+/// consistency. Callers that need a consistent snapshot must take the same
+/// canonical bundle lock used by [`read_bundle_at`].
+///
+/// Deferred checks, performed by [`read_bundle_at`] and by import, reindex,
+/// publication restore, and artifact retrieval: existence, size, and sha256 of
+/// every `artifacts/files/**` blob named by the manifest.
+pub(crate) fn read_bundle_lightweight_at(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    read_bundle_at_with(bundle_dir, ArtifactPayloadCheck::Defer)
+}
+
+fn read_bundle_at_with(
+    bundle_dir: &Path,
+    payloads: ArtifactPayloadCheck,
+) -> Result<TaskBundleV2, OrbitError> {
     let expected_task_id = task_id_from_bundle_dir(bundle_dir)?;
-    read_bundle_for_id(bundle_dir, &expected_task_id).map_err(|error| match error {
+    read_bundle_for_id(bundle_dir, &expected_task_id, payloads).map_err(|error| match error {
         OrbitError::NotFound {
             kind: NotFoundKind::Task,
             ..
@@ -250,6 +304,7 @@ fn read_envelope_for_id(
 fn read_bundle_for_id(
     bundle_dir: &Path,
     expected_task_id: &str,
+    payloads: ArtifactPayloadCheck,
 ) -> Result<TaskBundleV2, OrbitError> {
     let mut bundle = TaskBundleV2 {
         envelope: read_envelope_for_id(bundle_dir, expected_task_id)?,
@@ -259,7 +314,7 @@ fn read_bundle_for_id(
         execution_summary: read_required_text(&bundle_dir.join(TASK_EXECUTION_SUMMARY_FILE_NAME))?,
         events: read_task_events(&bundle_dir.join(TASK_EVENTS_FILE_NAME))?,
         comments: read_task_comments(&bundle_dir.join(TASK_COMMENTS_FILE_NAME))?,
-        artifact_manifest: read_artifact_manifest(bundle_dir)?,
+        artifact_manifest: read_artifact_manifest(bundle_dir, payloads)?,
     };
     commit::apply_pending_read_view(bundle_dir, &mut bundle)?;
     validate_bundle(&bundle)?;
@@ -499,7 +554,10 @@ fn scan_jsonl_tail(path: &Path, raw: &str) -> Result<JsonlTailScan, OrbitError> 
     })
 }
 
-fn read_artifact_manifest(bundle_dir: &Path) -> Result<Option<ArtifactManifestV2>, OrbitError> {
+fn read_artifact_manifest(
+    bundle_dir: &Path,
+    payloads: ArtifactPayloadCheck,
+) -> Result<Option<ArtifactManifestV2>, OrbitError> {
     let artifact_dir = bundle_dir.join(TASK_ARTIFACTS_DIR_NAME);
     if !artifact_dir.is_dir() {
         return Err(OrbitError::Store(format!(
@@ -518,7 +576,9 @@ fn read_artifact_manifest(bundle_dir: &Path) -> Result<Option<ArtifactManifestV2
                 ))
             })?;
             manifest.validate()?;
-            validate_artifact_manifest_files(&artifact_dir, &manifest)?;
+            if payloads == ArtifactPayloadCheck::Verify {
+                validate_artifact_manifest_files(&artifact_dir, &manifest)?;
+            }
             Ok(Some(manifest))
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -587,6 +647,7 @@ fn validate_artifact_manifest_files(
 ) -> Result<(), OrbitError> {
     for file in &manifest.files {
         let blob_path = artifact_dir.join(&file.blob);
+        record_artifact_payload_read();
         let bytes = fs::read(&blob_path).map_err(|err| {
             if err.kind() == std::io::ErrorKind::NotFound {
                 OrbitError::Store(format!(

--- a/crates/orbit-store/src/driver/file/task_bundle/bundle_io/tests/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/bundle_io/tests/mod.rs
@@ -13,7 +13,10 @@ use orbit_types::task::{
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
-use super::{append_jsonl_row, read_bundle_at, read_task_events, write_bundle_atomically};
+use super::{
+    append_jsonl_row, read_bundle_at, read_bundle_lightweight_at, read_task_events,
+    take_artifact_payload_reads, write_bundle_atomically,
+};
 use crate::repository::task::tests::test_support::{bundle_store, sample_bundle};
 
 #[test]
@@ -354,6 +357,57 @@ fn read_bundle_rejects_manifest_entry_with_missing_artifact_file() {
             ..
         }) if task_id == "ORB-00000" && reason.contains("missing file")
     ));
+}
+
+#[test]
+fn lightweight_read_skips_tampered_artifact_bytes_that_strict_read_rejects() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = bundle_store(&temp);
+    store
+        .create_bundle(&sample_bundle("ORB-00000"))
+        .expect("create bundle");
+    let now = Utc.with_ymd_and_hms(2026, 5, 11, 12, 0, 0).unwrap();
+    let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+    let blob = format!("{TASK_ARTIFACT_FILES_DIR_NAME}/result.txt");
+    let blob_path = bundle_dir.join(TASK_ARTIFACTS_DIR_NAME).join(&blob);
+    atomic_write_text(&blob_path, "hello").expect("write artifact blob");
+    let manifest = ArtifactManifestV2 {
+        schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+        files: vec![ArtifactManifestFileV2 {
+            path: "result.txt".to_string(),
+            blob: blob.clone(),
+            sha256: format!("{:x}", Sha256::digest(b"hello")),
+            media_type: "text/plain".to_string(),
+            size_bytes: 5,
+            created_by: "codex:gpt-5.5".to_string(),
+            created_at: now,
+        }],
+    };
+    store
+        .rewrite_artifact_manifest("ORB-00000", &manifest)
+        .expect("write manifest");
+    atomic_write_text(&blob_path, "wrong").expect("tamper artifact blob");
+    let _ = take_artifact_payload_reads();
+
+    let light = read_bundle_lightweight_at(&bundle_dir).expect("lightweight read");
+    assert_eq!(take_artifact_payload_reads(), 0);
+    assert_eq!(
+        light
+            .artifact_manifest
+            .as_ref()
+            .map(|manifest| manifest.files[0].path.as_str()),
+        Some("result.txt")
+    );
+
+    assert!(matches!(
+        read_bundle_at(&bundle_dir),
+        Err(OrbitError::TaskBundleCorrupt {
+            task_id,
+            reason,
+            ..
+        }) if task_id == "ORB-00000" && reason.contains("sha256 mismatch")
+    ));
+    assert_eq!(take_artifact_payload_reads(), 1);
 }
 
 #[test]

--- a/crates/orbit-store/src/driver/file/task_bundle/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/mod.rs
@@ -9,11 +9,13 @@ mod types;
 
 pub(crate) use bundle_io::{
     BundleWriteFault, PendingWriteGuard, append_jsonl_row, cleanup_partial_bundle_best_effort,
-    fail_if_injected, publish_envelope, read_bundle_at, read_envelope_at,
-    recover_pending_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
+    fail_if_injected, publish_envelope, read_bundle_at, read_bundle_lightweight_at,
+    read_envelope_at, recover_pending_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
 };
 
 #[cfg(test)]
-pub(crate) use bundle_io::{PENDING_WRITE_FILE_NAME, inject_bundle_write_faults};
+pub(crate) use bundle_io::{
+    PENDING_WRITE_FILE_NAME, inject_bundle_write_faults, take_artifact_payload_reads,
+};
 pub(crate) use lock::bundle_lock_target;
 pub(crate) use types::{TaskBundleV2, TaskDocumentV2};

--- a/crates/orbit-store/src/repository/task/v2/crud.rs
+++ b/crates/orbit-store/src/repository/task/v2/crud.rs
@@ -101,6 +101,7 @@ impl TaskV2Store {
         self.task_from_bundle(bundle)
     }
 
+    /// Materialize tasks on the lightweight bundle path: no artifact hashing.
     pub(crate) fn list_tasks(&self) -> Result<Vec<Task>, OrbitError> {
         if let Some(tasks) = self.indexed_tasks(TaskIndexFilter {
             status: None,
@@ -201,6 +202,8 @@ impl TaskV2Store {
         query: &str,
         tags: &[String],
     ) -> Result<Vec<Task>, OrbitError> {
+        // Candidate materialization is lightweight; artifact content search
+        // below may still open matching text blobs on demand.
         let lowered = query.to_lowercase();
         let bundles = self.candidate_bundles_by_tags(tags)?;
         self.search_bundles(bundles, &lowered)

--- a/crates/orbit-store/src/repository/task/v2/index.rs
+++ b/crates/orbit-store/src/repository/task/v2/index.rs
@@ -111,8 +111,11 @@ impl TaskV2Store {
     }
 
     /// Rebuild the generated index from the bundles, degrading to `false` (use
-    /// the bundle scan instead) on any failure. Every caller reaches this from
-    /// a *read*, so a rebuild that cannot run must not fail that read.
+    /// the bundle scan instead) on any failure. Listing-triggered rebuild uses
+    /// the lightweight bundle read (task fields only); explicit
+    /// `reindex_workspace` still hashes artifact payloads. Every caller
+    /// reaches this from a *read*, so a rebuild that cannot run must not fail
+    /// that read.
     fn rebuild_index_best_effort(&self, reason: &str) -> Result<bool, OrbitError> {
         let rebuilt = self.bundle_store.list_bundles().and_then(|bundles| {
             let envelopes = bundles

--- a/crates/orbit-store/src/repository/task/v2/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/listing.rs
@@ -10,8 +10,10 @@ impl TaskV2Store {
         let envelopes = match self.validated_envelopes()? {
             Some(envelopes) => envelopes,
             None => {
-                // Rebuild/fallback deliberately validates every encountered bundle.
-                // Never swallow a content error while repairing a generated index.
+                // Rebuild/fallback validates task fields on every encountered
+                // bundle (envelope, bodies, events, event/envelope status).
+                // Artifact payload hashing is deferred; never swallow a
+                // task-field error while repairing a generated index.
                 let envelopes = self
                     .bundle_store
                     .list_bundles()?

--- a/crates/orbit-store/src/repository/task/v2/query.rs
+++ b/crates/orbit-store/src/repository/task/v2/query.rs
@@ -2,8 +2,9 @@ use super::*;
 
 impl TaskV2Store {
     /// Search over the bundles the candidate listing already read, so a
-    /// query costs one bundle read per task instead of three (each of which
-    /// re-hashed every artifact blob) plus a fourth read of the blobs.
+    /// query costs one lightweight bundle read per task. Materialization does
+    /// not hash artifact payloads; a later on-demand read may open a text
+    /// blob only when in-memory fields and comments did not already match.
     pub(super) fn search_bundles(
         &self,
         bundles: Vec<TaskBundleV2>,

--- a/crates/orbit-store/src/repository/task/v2/tests/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing.rs
@@ -1,7 +1,10 @@
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use super::*;
 use crate::contracts::TaskListFilter;
+use crate::driver::file::task_bundle::take_artifact_payload_reads;
+use crate::workflow::task::reindex_workspace;
 
 pub(super) fn reads(store: &TaskV2Store) -> (usize, usize) {
     (
@@ -60,7 +63,7 @@ fn bounded_queries_load_only_selected_bundles_as_the_corpus_grows() {
 
 #[test]
 fn bounded_integrity_is_selected_only_but_direct_unbounded_and_fallback_reads_are_strict() {
-    for corruption in ["body", "events", "artifact"] {
+    for corruption in ["body", "events"] {
         let temp = TempDir::new().unwrap();
         let store = store(&temp);
         let old = store
@@ -288,5 +291,157 @@ fn metadata_filters_preserve_ties_and_legacy_tag_normalization() {
             .map(|row| &row.task.id)
             .collect::<Vec<_>>(),
         expected[..2].iter().collect::<Vec<_>>()
+    );
+}
+
+fn upsert_proof(store: &TaskV2Store, id: &str, content: &[u8]) {
+    store
+        .upsert_task_artifacts(
+            id,
+            &TaskArtifactUpdateParams {
+                owner_run_id: None,
+                actor: "codex".to_string(),
+                upsert_artifacts: vec![TaskArtifact {
+                    path: "proof.txt".to_string(),
+                    media_type: "text/plain".to_string(),
+                    content: content.to_vec(),
+                    created_by: None,
+                }],
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn listing_and_search_defer_artifact_payload_verification() {
+    let temp = TempDir::new().unwrap();
+    let store = store(&temp);
+    let old = store
+        .create_task(create_params("Old matching", TaskStatus::Backlog))
+        .unwrap();
+    upsert_proof(&store, &old.id, b"proof");
+    let newest = store
+        .create_task(create_params("New task", TaskStatus::Backlog))
+        .unwrap();
+    let path = store.bundle_store.bundle_path(&old.id).unwrap();
+    fs::write(path.join("artifacts/files/proof.txt"), "wrong").unwrap();
+    let _ = take_artifact_payload_reads();
+
+    let listed = store.list_tasks().unwrap();
+    assert_eq!(
+        listed
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![newest.id.as_str(), old.id.as_str()]
+    );
+    let searched = store.search_tasks("old matching").unwrap();
+    assert_eq!(
+        searched
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![old.id.as_str()]
+    );
+    let page = store
+        .query_task_rows(&TaskListFilter::default(), 2, None)
+        .unwrap();
+    assert_eq!(page.total, 2);
+    assert_eq!(page.items[0].task.id, newest.id);
+    assert_eq!(page.items[1].task.id, old.id);
+    assert_eq!(page.items[1].artifacts[0].path, "proof.txt");
+    assert_eq!(take_artifact_payload_reads(), 0);
+
+    assert!(store.get_task(&old.id).is_err());
+    assert!(store.get_task_row(&old.id, false).is_err());
+    assert!(store.get_task_artifact(&old.id, "proof.txt").is_err());
+    assert!(reindex_workspace(&store.registry, &store.workspace_id).is_err());
+    let _ = take_artifact_payload_reads();
+
+    let conn = rusqlite::Connection::open(task_registry_path(temp.path())).unwrap();
+    conn.execute("DELETE FROM task_bundle_index", []).unwrap();
+    let rebuilt = store
+        .query_task_rows(&TaskListFilter::default(), 2, None)
+        .unwrap();
+    assert_eq!(rebuilt.total, 2);
+    assert_eq!(take_artifact_payload_reads(), 0);
+}
+
+#[test]
+#[allow(clippy::print_stdout)]
+fn lightweight_listing_skips_artifact_payload_io() {
+    let temp = TempDir::new().unwrap();
+    let store = store(&temp);
+    const TASKS: usize = 8;
+    const BLOB_BYTES: usize = 512 * 1024;
+    let payload = vec![b'x'; BLOB_BYTES];
+    let mut ids = Vec::with_capacity(TASKS);
+    for index in 0..TASKS {
+        let task = store
+            .create_task(create_params(
+                &format!("Heavy artifact task {index}"),
+                TaskStatus::Backlog,
+            ))
+            .unwrap();
+        upsert_proof(&store, &task.id, &payload);
+        ids.push(task.id);
+    }
+    let _ = take_artifact_payload_reads();
+    let _ = store.list_tasks().unwrap();
+    let _ = store.search_tasks("heavy artifact").unwrap();
+    let _ = store
+        .query_task_rows(&TaskListFilter::default(), TASKS, None)
+        .unwrap();
+    for id in &ids {
+        let _ = store.get_task(id).unwrap();
+    }
+    let _ = take_artifact_payload_reads();
+
+    let list_started = Instant::now();
+    let listed = store.list_tasks().unwrap();
+    let list_ms = list_started.elapsed().as_secs_f64() * 1000.0;
+    let list_payload_opens = take_artifact_payload_reads();
+
+    let search_started = Instant::now();
+    let searched = store.search_tasks("heavy artifact").unwrap();
+    let search_ms = search_started.elapsed().as_secs_f64() * 1000.0;
+    let search_payload_opens = take_artifact_payload_reads();
+
+    let rows_started = Instant::now();
+    let page = store
+        .query_task_rows(&TaskListFilter::default(), TASKS, None)
+        .unwrap();
+    let rows_ms = rows_started.elapsed().as_secs_f64() * 1000.0;
+    let row_payload_opens = take_artifact_payload_reads();
+
+    let strict_started = Instant::now();
+    for id in &ids {
+        store.get_task(id).unwrap().unwrap();
+    }
+    let strict_ms = strict_started.elapsed().as_secs_f64() * 1000.0;
+    let strict_payload_opens = take_artifact_payload_reads();
+
+    assert_eq!(listed.len(), TASKS);
+    assert_eq!(searched.len(), TASKS);
+    assert_eq!(page.items.len(), TASKS);
+    assert_eq!(list_payload_opens, 0);
+    assert_eq!(search_payload_opens, 0);
+    assert_eq!(row_payload_opens, 0);
+    assert_eq!(strict_payload_opens, TASKS);
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "tasks": TASKS,
+            "blob_bytes_per_task": BLOB_BYTES,
+            "lightweight_list_ms": list_ms,
+            "lightweight_search_ms": search_ms,
+            "lightweight_rows_ms": rows_ms,
+            "strict_get_all_ms": strict_ms,
+            "lightweight_list_payload_opens": list_payload_opens,
+            "lightweight_search_payload_opens": search_payload_opens,
+            "lightweight_rows_payload_opens": row_payload_opens,
+            "strict_get_all_payload_opens": strict_payload_opens,
+        })
     );
 }

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -19,7 +19,7 @@ use crate::driver::file::task_bundle::bundle_lock_target;
 pub(crate) use crate::driver::file::task_bundle::{TaskBundleV2, TaskDocumentV2};
 use crate::driver::file::task_bundle::{
     append_jsonl_row, cleanup_partial_bundle_best_effort, publish_envelope, read_bundle_at,
-    read_envelope_at, write_bundle_at,
+    read_bundle_lightweight_at, read_envelope_at, write_bundle_at,
 };
 use crate::driver::sqlite::task_registry::{
     ProjectionRebuildResult, TaskBundleBinding, TaskRegistryStore,
@@ -240,6 +240,7 @@ impl TaskBundleStoreV2 {
         })
     }
 
+    /// Canonical full-bundle read: hashes every artifact payload.
     pub(crate) fn read_bundle(&self, task_id: &str) -> Result<TaskBundleV2, OrbitError> {
         #[cfg(test)]
         self.bundle_reads
@@ -317,17 +318,20 @@ impl TaskBundleStoreV2 {
         Ok(unregistered || exists || published || removed_projection)
     }
 
-    /// List bundles registered to this workspace.
+    /// List bundles registered to this workspace using the lightweight read.
     ///
-    /// Corruption is still fail-fast — one damaged bundle fails the list so
-    /// store damage is never silently hidden. An incomplete multi-file write
-    /// is recognized by `.pending-write.yaml` and recovered rather than
-    /// reported as damage. What is *not* fail-fast is a bundle caught
-    /// mid-publication or mid-removal by a concurrent writer (ORB-10988 /
-    /// F2026-07-119): the binding list is a snapshot, so a create or delete of
-    /// one task would otherwise fail every read of every other task. Those
-    /// bundles are skipped, exactly as they would be had the snapshot been
-    /// taken a moment earlier or later.
+    /// Task-field corruption is still fail-fast — one damaged envelope, body,
+    /// event log, or event/envelope status mismatch fails the list so store
+    /// damage is never silently hidden. Artifact payload existence, size, and
+    /// sha256 are deferred; [`Self::read_bundle`] and explicit reindex, import,
+    /// publication restore, and artifact retrieval still verify those bytes.
+    /// An incomplete multi-file write is recognized by `.pending-write.yaml`
+    /// and recovered rather than reported as damage. What is *not* fail-fast
+    /// is a bundle caught mid-publication or mid-removal by a concurrent
+    /// writer (ORB-10988 / F2026-07-119): the binding list is a snapshot, so a
+    /// create or delete of one task would otherwise fail every read of every
+    /// other task. Those bundles are skipped, exactly as they would be had
+    /// the snapshot been taken a moment earlier or later.
     pub(crate) fn list_bundles(&self) -> Result<Vec<TaskBundleV2>, OrbitError> {
         let bindings = self.registry.tasks_for_workspace(&self.workspace_id)?;
         let mut bundles = Vec::with_capacity(bindings.len());
@@ -342,8 +346,9 @@ impl TaskBundleStoreV2 {
         Ok(bundles)
     }
 
-    /// Read one registered bundle, skipping it when a concurrent writer has it
-    /// in flight. See [`Self::list_bundles`] for the tolerance rule.
+    /// Read one registered bundle on the lightweight listing path, skipping it
+    /// when a concurrent writer has it in flight. See [`Self::list_bundles`]
+    /// for the tolerance rule and the checks this read defers.
     pub(crate) fn read_bundle_if_settled(
         &self,
         task_id: &str,
@@ -491,8 +496,15 @@ fn read_bundle_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitErro
     })
 }
 
+/// Same lock as [`read_bundle_consistently`], without hashing artifact blobs.
+fn read_bundle_lightweight_consistently(bundle_dir: &Path) -> Result<TaskBundleV2, OrbitError> {
+    with_shared_file_lock(&bundle_lock_target(bundle_dir), "task artifact v2", || {
+        read_bundle_lightweight_at(bundle_dir)
+    })
+}
+
 fn read_bundle_tolerating_in_flight(bundle_dir: &Path) -> Result<Option<TaskBundleV2>, OrbitError> {
-    match read_bundle_consistently(bundle_dir) {
+    match read_bundle_lightweight_consistently(bundle_dir) {
         Ok(bundle) => Ok(Some(bundle)),
         Err(err) => skip_if_in_flight(bundle_dir, err),
     }

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -835,6 +835,51 @@ fn round_trip_preserves_artifact_blobs() {
     }
 }
 
+#[test]
+fn import_rejects_tampered_artifact_bytes() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive = src.path().join("tasks.tar.zst");
+    let ws = "ws_art_tamper";
+    let registry = open_registry(src.path());
+    let binding = bind(&registry, src.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        ws,
+        &make_bundle("ORB-00000", "artifact task", Vec::new()),
+    );
+    let entry = seed_artifact_blob(&store, "ORB-00000", "top.txt", b"original", "codex");
+    store
+        .rewrite_artifact_manifest(
+            "ORB-00000",
+            &ArtifactManifestV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                files: vec![entry.clone()],
+            },
+        )
+        .expect("rewrite manifest");
+    fs::write(
+        store
+            .bundle_path("ORB-00000")
+            .unwrap()
+            .join(TASK_ARTIFACTS_DIR_NAME)
+            .join(&entry.blob),
+        b"xxxxxxxx",
+    )
+    .unwrap();
+    export_tasks(&registry, ws, ExportSelection::All, &archive, exported_at()).unwrap();
+
+    let target_registry = open_registry(dst.path());
+    let error = import_tasks(&target_registry, &archive, None, ImportConflictPolicy::Fail)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("ORB-00000"), "{error}");
+    assert!(error.contains("sha256 mismatch"), "{error}");
+    assert!(target_registry.tasks_for_workspace(ws).unwrap().is_empty());
+}
+
 /// Regression for the pre-ORB-10042 "half-imported" state: a canonical bundle
 /// with a manifest but no blob files. The documented backfill flow is to copy
 /// the blob tree back from the retained archive. `copy_artifact_blobs` is the

--- a/crates/orbit-store/src/workflow/task/tests/restore.rs
+++ b/crates/orbit-store/src/workflow/task/tests/restore.rs
@@ -321,6 +321,32 @@ fn restore_preserves_crlf_attachment_bytes_despite_gitattributes() {
 }
 
 #[test]
+fn restore_rejects_tampered_publication_artifact_bytes() {
+    let fixture = fixture(AttachmentPolicyKind::Include);
+    let blob = fixture
+        .remote
+        .join("tasks/ORB-00007/artifacts/files/report.txt");
+    fs::write(&blob, b"tampered-secret-content").unwrap();
+    git(&fixture.remote, &["add", "-A"]);
+    git(&fixture.remote, &["commit", "--amend", "--no-edit"]);
+    let registry = fixture.registry();
+    let error = restore_publication(
+        &registry,
+        fixture.request(PublicationRestoreMode::EmptyDestination),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("ORB-00007"), "{error}");
+    assert!(!error.contains("tampered-secret-content"), "{error}");
+    assert!(
+        registry
+            .tasks_for_workspace(&fixture.task_workspace_id)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn collision_and_identity_mismatch_abort_before_mutation() {
     let collision_fixture = fixture(AttachmentPolicyKind::Include);
     let registry = collision_fixture.registry();

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -251,10 +251,10 @@ The v2 bundle is local and file-backed, so multi-file mutations are not fully tr
 
 - Document updates may write Markdown sidecars before `task.yaml`; readers return the sidecar content and the previous envelope metadata until the next successful mutation.
 - History updates may append `events.jsonl` before `task.yaml`; readers reject bundles when the last status event does not match the envelope status.
-- Artifact updates may write files before `manifest.yaml`; unreferenced files under `artifacts/files/` are ignored, while manifest entries with missing files, size drift, or hash drift are corruption and fail loudly.
+- Artifact updates may write files before `manifest.yaml`; unreferenced files under `artifacts/files/` are ignored. Manifest entries with missing files, size drift, or hash drift are corruption on the canonical full-read used by get, reindex, import, publication restore, and artifact retrieval. Listing and search materialization parse the manifest but defer those payload-byte checks.
 - Generated index writes may fail after the envelope changes; `updated_at` validation detects the stale row and rebuilds from bundles before indexed reads.
 
-Malformed registered bundles produce a typed `task_bundle_corrupt` diagnostic naming the affected task and canonical path. Direct reads and task creation do not scan unrelated bundles, while list and search retain their fail-loud behavior. Diagnosis never deletes, moves, or repairs the malformed directory; operators can inspect or quarantine it explicitly. Legacy `review-threads/` sidecars were retired in [ORB-10332], so either their presence or absence is ignored non-destructively.
+Malformed registered bundles produce a typed `task_bundle_corrupt` diagnostic naming the affected task and canonical path. Direct reads and task creation do not scan unrelated bundles. List and search remain fail-loud for envelope, body, and event-log damage, including a settled event/envelope status mismatch; they do not hash artifact payloads on the lightweight materialization path. Diagnosis never deletes, moves, or repairs the malformed directory; operators can inspect or quarantine it explicitly. Legacy `review-threads/` sidecars were retired in [ORB-10332], so either their presence or absence is ignored non-destructively.
 
 Task lock reservations in v2 mode require `.orbit/config.yaml` to provide the workspace binding. If that file disappears while a runtime is active, lock writes fail instead of silently creating legacy `NULL`-workspace reservations.
 

--- a/docs/design/task-artifacts/specs/task-bundle-v2.md
+++ b/docs/design/task-artifacts/specs/task-bundle-v2.md
@@ -2,7 +2,7 @@
 type: design
 summary: "Spec: Task Bundle V2"
 tags: ["task-artifacts"]
-last_validated: 2026-09-05
+last_validated: 2026-09-08
 ---
 
 # Spec: Task Bundle V2
@@ -330,18 +330,24 @@ Last revised by `claude` on 2026-08-09 for [ORB-10343].
 
 ORB-11205: bounded task queries validate the generated index against every
 registered, settled envelope, then apply metadata predicates and newest-first
-ordering (task ID ascending for ties) before loading full bundles. Exact totals
+ordering (task ID ascending for ties) before loading bundles. Exact totals
 count metadata matches; they do not certify off-page body, event, or artifact
-integrity. A selected corrupt bundle fails the request and is never replaced
-with another row. Direct and unbounded full-bundle reads remain strict.
+integrity. A selected bundle with envelope, body, or event-log damage fails
+the request and is never replaced with another row. Listing and search
+materialization use a locked lightweight bundle read: they still apply the
+canonical bundle lock and event/envelope status consistency, but they do not
+open or hash `artifacts/files/**` payload bytes. Direct `get` reads, explicit
+reindex, import, publication restore, and artifact retrieval remain strict
+full-bundle verification.
 
 Status, type, priority, parent, job run, tags and external-reference predicates
 use metadata. Readiness and context-path predicates currently use an explicit
 residual fallback, hydrating metadata matches before filtering and limiting.
-Missing/stale indexes require a strict bundle scan and best-effort index repair;
-errors encountered reading that scan propagate. An update racing selected-row
-hydration causes one strict rescan with filter-before-limit semantics. In-flight
-creation/deletion retains the existing list-read tolerance.
+Missing/stale indexes require a lightweight bundle scan (task fields only) and
+best-effort index repair; task-field errors encountered reading that scan
+propagate. An update racing selected-row hydration causes one rescan with
+filter-before-limit semantics. In-flight creation/deletion retains the
+existing list-read tolerance.
 
 Dashboard list and detail projections retain comments, history and the sorted
 artifact manifest from each validated bundle. The aggregate selects the global


### PR DESCRIPTION
## Task

[ORB-11612](https://orbit-cli.com/tasks/ORB-11612) — [code-review] Stop hashing every artifact blob on every bundle read used by listing and search

### Description

## Problem
Full task-bundle reads parse the artifact manifest and read/hash every referenced artifact file. Listing and search paths materialize these bundles even when the Task result does not need artifact bytes, making their cost grow with artifact volume.

## Required behavior and constraints
Introduce an explicitly lightweight task/list read path that avoids artifact-byte verification while preserving the canonical bundle lock and the consistency checks required for task fields. Keep strict full-bundle verification for import, reindex, publication restore and artifact access. Do not globally weaken the existing canonical full-read primitive or omit event-log consistency checks merely to reduce file opens. Document which checks lightweight listing defers; measure performance rather than asserting an unmeasured dominant cost.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-store/src/driver/file/task_bundle/bundle_io/mod.rs:240,491,573`; `crates/orbit-store/src/repository/task/v2/index.rs:144`; `crates/orbit-store/src/repository/task/v2/listing.rs:59`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A representative artifact-heavy corpus shows listing/search task materialization opens no artifact payload bytes on its normal lightweight path, with before/after timing and I/O measurements.
- Tampered artifact bytes remain rejected through explicit reindex, import, publication restore and artifact retrieval where those paths verify integrity.
- Concurrent transition and settled envelope/event mismatch tests preserve task consistency behavior; listing output, filtering and ordering remain unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `read_bundle_lightweight_at` beside unchanged `read_bundle_at`. Lightweight reads keep the canonical shared bundle lock, pending-write view, and event/envelope status checks, but do not open or hash `artifacts/files/**` payload bytes. Deferred checks: blob existence, size, sha256.
- Listing/search materialization (`list_bundles`, `read_bundle_if_settled`, indexed list/search, `query_task_rows`) uses the lightweight path. `read_bundle`, action recovery, writes, reindex (`recover_pending_bundle_at`), import, publication restore/inspect, and artifact get stay on the strict full-read.
- Tests cover zero payload opens plus before/after timing on an 8-task × 512KiB corpus; tampered bytes still fail reindex, import, restore, and artifact retrieval; concurrent transition and settled event/envelope mismatch behavior is unchanged.
- Documented the deferred checks in bundle_io rustdoc and live task-artifact design/spec notes.
Assessment: Scoped, measured, and covered at the listing vs strict-read boundary without weakening the canonical full-read primitive.

Criteria:
1. Lightweight listing/search/row materialization opened 0 artifact payloads on 8 tasks × 512KiB (4MiB total). Warm-cache timings: list 3.33ms, search 3.18ms, rows 3.23ms vs strict get-all 60.85ms with 8 payload opens (~18×). Artifact: `lightweight-listing-io.json`.
2. Tampered same-size blobs still fail `reindex_workspace`, `import_tasks`, publication restore/inspect, `get_task` / `get_task_row(false)` / `get_task_artifact`. Listing and title-matching search succeed and keep newest-first ID-tie order.
3. Concurrent half-published transition still waits for the envelope; settled event/envelope mismatch still fails get and list. Filter/order tests unchanged. Body/event corruption still fail-loud on selected and fallback listing.

Validation:
- `cargo test -p orbit-store --lib` — passed (464 passed, 5 ignored). CARGO_TARGET_DIR=/tmp/orbit-orb-11612-target.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed (no whitespace errors).

Deviations:
- `docs/INDEX.md` gained one generated runbook row (`build-budget.md`) required for `make ci-fast` on this checkout; not a listing-path change.
- Search may still open a text artifact on demand after lightweight materialization when in-memory fields do not match. Title-matching search in the corpus opened 0 payloads.

Remaining risk: cold-cache / HDD I/O was not measured; timings are warm tmpfs in this process. Payload-open counts are exact.

Uncommitted on ce5c2f5e7. Pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11612-6a9f6cd8`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*

Orchestrated-By: astra