### PR TITLE
[BLOCKED] [code-review] Compare the CSRF `Origin` check against the request `Host`, and accept `[::1]`

### DIFF
--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -10,6 +10,7 @@
 
 use axum::Router;
 use axum::body::Body;
+use axum::http::uri::Authority;
 use axum::http::{Method, Request, StatusCode, header};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
@@ -17,6 +18,7 @@ use axum::routing::{get, post};
 use chrono::{DateTime, Duration, TimeZone, Timelike, Utc};
 use serde::Deserialize;
 use serde_json::json;
+use std::str::FromStr;
 use url::Url;
 
 mod audit;
@@ -409,10 +411,14 @@ async fn require_localhost_origin(request: Request<Body>, next: Next) -> Respons
     let allowed = origin
         .and_then(|origin| origin.to_str().ok())
         .and_then(|origin| Url::parse(origin).ok())
-        .is_some_and(|origin| {
-            origin.scheme() == "http"
-                && matches!(origin.host_str(), Some("localhost" | "127.0.0.1"))
-        });
+        .zip(
+            request
+                .headers()
+                .get(header::HOST)
+                .and_then(|host| host.to_str().ok())
+                .and_then(|host| Authority::from_str(host).ok()),
+        )
+        .is_some_and(|(origin, host)| localhost_origin_matches_authority(&origin, &host));
     if !allowed && (unsafe_method || origin.is_some()) {
         return (
             StatusCode::FORBIDDEN,
@@ -421,6 +427,25 @@ async fn require_localhost_origin(request: Request<Body>, next: Next) -> Respons
             .into_response();
     }
     next.run(request).await
+}
+
+fn localhost_origin_matches_authority(origin: &Url, authority: &Authority) -> bool {
+    let Some(origin_host) = origin.host_str().map(|host| host.trim_matches(['[', ']'])) else {
+        return false;
+    };
+
+    let authority_host = authority.host().trim_matches(['[', ']']);
+    let same_host = origin_host.eq_ignore_ascii_case(authority_host);
+    let same_port = origin.port_or_known_default() == authority.port_u16().or(Some(80));
+    let valid_origin = origin.scheme() == "http"
+        && origin.path() == "/"
+        && origin.username().is_empty()
+        && origin.password().is_none()
+        && origin.query().is_none()
+        && origin.fragment().is_none();
+    let approved_loopback_host = matches!(origin_host, "localhost" | "127.0.0.1" | "::1");
+
+    valid_origin && approved_loopback_host && same_host && same_port
 }
 
 /// Tell long-lived streaming handlers (currently `/api/log/stream`) to close

--- a/crates/orbit-web/src/api/tests/auto_tasks.rs
+++ b/crates/orbit-web/src/api/tests/auto_tasks.rs
@@ -85,6 +85,7 @@ async fn send(
     if !matches!(method, Method::GET) {
         builder = builder
             .header("origin", "http://localhost:7878")
+            .header("host", "localhost:7878")
             .header("content-type", "application/json");
     }
     router()

--- a/crates/orbit-web/src/api/tests/frictions.rs
+++ b/crates/orbit-web/src/api/tests/frictions.rs
@@ -35,7 +35,9 @@ async fn request(
 ) -> axum::response::Response {
     let mut builder = Request::builder().method(method).uri(uri);
     if let Some(origin) = origin {
-        builder = builder.header(header::ORIGIN, origin);
+        builder = builder
+            .header(header::ORIGIN, origin)
+            .header(header::HOST, "localhost:7878");
     }
     let request = if let Some(body) = body {
         builder

--- a/crates/orbit-web/src/api/tests/handlers.rs
+++ b/crates/orbit-web/src/api/tests/handlers.rs
@@ -11,12 +11,20 @@ use tower::ServiceExt;
 use super::super::*;
 use super::test_support::{body_json, seed_run, write_seeded_run};
 
-async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str>) -> Response {
+async fn request_cancel(
+    runtime: OrbitRuntime,
+    run_id: &str,
+    origin: Option<&str>,
+    host: Option<&str>,
+) -> Response {
     let mut builder = Request::builder()
         .method(Method::POST)
         .uri(format!("/runs/{run_id}/cancel"));
     if let Some(origin) = origin {
         builder = builder.header(header::ORIGIN, origin);
+    }
+    if let Some(host) = host {
+        builder = builder.header(header::HOST, host);
     }
     router()
         .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
@@ -66,6 +74,7 @@ async fn patch_task_body(runtime: OrbitRuntime, task_id: &str, body: String) -> 
                 .uri(format!("/tasks/{task_id}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .body(Body::from(body))
                 .expect("request"),
         )
@@ -421,7 +430,13 @@ async fn require_localhost_origin_rejects_prefix_match() {
             JobRunState::Pending,
         );
 
-        let response = request_cancel(runtime.clone(), &run.run_id, Some(origin)).await;
+        let response = request_cancel(
+            runtime.clone(),
+            &run.run_id,
+            Some(origin),
+            Some("localhost:7878"),
+        )
+        .await;
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN, "{label}");
         let stored = runtime.show_job_run(&run.run_id).expect("show run");
@@ -513,7 +528,13 @@ async fn require_localhost_origin_rejects_https_origin() {
         JobRunState::Pending,
     );
 
-    let response = request_cancel(runtime.clone(), &run.run_id, Some("https://localhost")).await;
+    let response = request_cancel(
+        runtime.clone(),
+        &run.run_id,
+        Some("https://localhost"),
+        Some("localhost:7878"),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let stored = runtime.show_job_run(&run.run_id).expect("show run");
@@ -521,13 +542,16 @@ async fn require_localhost_origin_rejects_https_origin() {
 }
 
 #[tokio::test]
-async fn require_localhost_origin_accepts_localhost_with_port() {
+async fn require_localhost_origin_matches_loopback_authority_and_effective_http_port() {
     let cases = [
-        ("http://localhost:7878", "localhost"),
-        ("http://127.0.0.1:7878", "127-0-0-1"),
+        ("http://localhost:7878", "localhost:7878", "localhost"),
+        ("http://127.0.0.1:7878", "127.0.0.1:7878", "127-0-0-1"),
+        ("http://[::1]:7878", "[::1]:7878", "ipv6-loopback"),
+        ("http://localhost", "localhost", "implicit-http-port"),
+        ("http://localhost:80", "localhost", "explicit-http-port"),
     ];
 
-    for (origin, label) in cases {
+    for (origin, host, label) in cases {
         let runtime = OrbitRuntime::in_memory().expect("build runtime");
         let run = seed_run(
             &runtime,
@@ -536,12 +560,125 @@ async fn require_localhost_origin_accepts_localhost_with_port() {
             JobRunState::Pending,
         );
 
-        let response = request_cancel(runtime.clone(), &run.run_id, Some(origin)).await;
+        let response = request_cancel(runtime.clone(), &run.run_id, Some(origin), Some(host)).await;
 
         assert_eq!(response.status(), StatusCode::OK, "{label}");
         let stored = runtime.show_job_run(&run.run_id).expect("show run");
         assert_eq!(stored.state, JobRunState::Cancelled, "{label}");
     }
+}
+
+#[tokio::test]
+async fn require_localhost_origin_rejects_mismatched_or_malformed_authorities() {
+    let cases = [
+        (
+            Some("http://localhost:3000"),
+            Some("localhost:7878"),
+            "mismatched port",
+        ),
+        (
+            Some("http://localhost:7878"),
+            Some("127.0.0.1:7878"),
+            "mismatched host",
+        ),
+        (Some("http://localhost:7878"), None, "missing host"),
+        (
+            Some("http://localhost:7878"),
+            Some("localhost:not-a-port"),
+            "malformed host",
+        ),
+        (Some("null"), Some("localhost:7878"), "null origin"),
+        (
+            Some("http://localhost:7878/path"),
+            Some("localhost:7878"),
+            "malformed origin",
+        ),
+        (
+            Some("https://localhost:7878"),
+            Some("localhost:7878"),
+            "unsupported scheme",
+        ),
+        (
+            Some("http://example.test:7878"),
+            Some("example.test:7878"),
+            "non-loopback",
+        ),
+    ];
+
+    for (index, (origin, host, label)) in cases.into_iter().enumerate() {
+        let runtime = OrbitRuntime::in_memory().expect("build runtime");
+        let run = seed_run(
+            &runtime,
+            &format!("jrun-web-cancel-rejected-authority-{index}"),
+            "web_cancel_rejected_authority",
+            JobRunState::Pending,
+        );
+
+        let response = request_cancel(runtime.clone(), &run.run_id, origin, host).await;
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{label}");
+        assert_eq!(
+            runtime.show_job_run(&run.run_id).expect("show run").state,
+            JobRunState::Pending,
+            "{label}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn require_localhost_origin_does_not_trust_forwarded_authority_headers() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run = seed_run(
+        &runtime,
+        "jrun-web-cancel-forwarded-authority",
+        "web_cancel_forwarded_authority",
+        JobRunState::Pending,
+    );
+
+    let response = router()
+        .with_state(crate::state::DashboardState::single(Arc::new(
+            runtime.clone(),
+        )))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/runs/{}/cancel", run.run_id))
+                .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "example.test:7878")
+                .header("x-forwarded-host", "localhost:7878")
+                .header("forwarded", "host=localhost:7878")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Pending
+    );
+}
+
+#[tokio::test]
+async fn require_localhost_origin_preserves_missing_origin_behavior() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let run = seed_run(
+        &runtime,
+        "jrun-web-cancel-missing-origin",
+        "web_cancel_missing_origin",
+        JobRunState::Pending,
+    );
+
+    let unsafe_response = request_cancel(runtime.clone(), &run.run_id, None, None).await;
+    assert_eq!(unsafe_response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        runtime.show_job_run(&run.run_id).expect("show run").state,
+        JobRunState::Pending
+    );
+
+    let safe_response = request_tasks(runtime).await;
+    assert_eq!(safe_response.status(), StatusCode::OK);
 }
 
 #[tokio::test]
@@ -555,6 +692,7 @@ async fn require_localhost_origin_blocks_cross_origin_get_with_attacker_origin()
                 .method(Method::GET)
                 .uri("/tasks")
                 .header(header::ORIGIN, "http://localhost.evil.com")
+                .header(header::HOST, "localhost.evil.com")
                 .body(Body::empty())
                 .expect("request"),
         )

--- a/crates/orbit-web/src/api/tests/metrics.rs
+++ b/crates/orbit-web/src/api/tests/metrics.rs
@@ -52,6 +52,7 @@ async fn ingest_metrics(runtime: OrbitRuntime, params: &InvocationInsertParams) 
                 .uri("/api/metrics/invocations")
                 .header("content-type", "application/json")
                 .header("origin", "http://localhost")
+                .header("host", "localhost")
                 .body(Body::from(
                     serde_json::to_vec(params).expect("serialize invocation params"),
                 ))

--- a/crates/orbit-web/src/api/tests/operation.rs
+++ b/crates/orbit-web/src/api/tests/operation.rs
@@ -23,7 +23,8 @@ async fn request(
     let mut builder = Request::builder()
         .method(method)
         .uri(path)
-        .header(header::ORIGIN, "http://localhost:3000");
+        .header(header::ORIGIN, "http://localhost:3000")
+        .header(header::HOST, "localhost:3000");
     let body = match body {
         Some(value) => {
             builder = builder.header(header::CONTENT_TYPE, "application/json");

--- a/crates/orbit-web/src/api/tests/routines.rs
+++ b/crates/orbit-web/src/api/tests/routines.rs
@@ -220,6 +220,7 @@ async fn routine_mutation_denies_an_unidentified_dashboard_caller() {
                         .method(Method::POST)
                         .uri("/routines/toggle?workspace=default")
                         .header("origin", "http://localhost:7878")
+                        .header("host", "localhost:7878")
                         .header("content-type", "application/json")
                         .body(Body::from(
                             r#"{"name":"nightly","source":"default","target":"job:nightly","host_id":"host-a","expected_enabled":true,"enabled":false}"#,
@@ -249,6 +250,7 @@ async fn operations_mutations_require_an_explicit_workspace() {
                 .method(Method::POST)
                 .uri("/routines/clock")
                 .header("origin", "http://localhost:7878")
+                .header("host", "localhost:7878")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     r#"{"action":"disable","host_id":"host-a","expected_enabled":true,"expected_cadence_seconds":60}"#,
@@ -415,6 +417,7 @@ async fn routine_request(
         request = request
             .method(Method::POST)
             .header("origin", "http://localhost:7878")
+            .header("host", "localhost:7878")
             .header("content-type", "application/json");
         Body::from(body.to_string())
     } else {

--- a/crates/orbit-web/src/api/tests/runs.rs
+++ b/crates/orbit-web/src/api/tests/runs.rs
@@ -24,7 +24,9 @@ async fn request_cancel(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
         .method(Method::POST)
         .uri(format!("/runs/{run_id}/cancel"));
     if let Some(origin) = origin {
-        builder = builder.header(header::ORIGIN, origin);
+        builder = builder
+            .header(header::ORIGIN, origin)
+            .header(header::HOST, "localhost:3000");
     }
     router()
         .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
@@ -38,7 +40,9 @@ async fn request_resume(runtime: OrbitRuntime, run_id: &str, origin: Option<&str
         .method(Method::POST)
         .uri(format!("/job-runs/{run_id}/resume"));
     if let Some(origin) = origin {
-        builder = builder.header(header::ORIGIN, origin);
+        builder = builder
+            .header(header::ORIGIN, origin)
+            .header(header::HOST, "localhost:3000");
     }
     router()
         .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
@@ -686,7 +690,8 @@ async fn request_ship(runtime: OrbitRuntime, body: Option<Value>) -> Response {
     let mut builder = Request::builder()
         .method(Method::POST)
         .uri("/workflows/ship")
-        .header(header::ORIGIN, "http://localhost:3000");
+        .header(header::ORIGIN, "http://localhost:3000")
+        .header(header::HOST, "localhost:3000");
     let body = match body {
         Some(json) => {
             builder = builder.header(header::CONTENT_TYPE, "application/json");
@@ -728,6 +733,7 @@ async fn request_ship_global(
                 .method(Method::POST)
                 .uri(uri)
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(body.to_string()))
                 .expect("request"),
@@ -982,7 +988,8 @@ mod auto_drain {
         let mut builder = Request::builder()
             .method(Method::POST)
             .uri("/workflows/auto")
-            .header(header::ORIGIN, "http://localhost:3000");
+            .header(header::ORIGIN, "http://localhost:3000")
+            .header(header::HOST, "localhost:3000");
         let body = match body {
             Some(json) => {
                 builder = builder.header(header::CONTENT_TYPE, "application/json");
@@ -1195,6 +1202,7 @@ mod auto_drain {
                     .method(Method::POST)
                     .uri("/workflows/auto?workspace=ghost")
                     .header(header::ORIGIN, "http://localhost:7878")
+                    .header(header::HOST, "localhost:7878")
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(json!({ "for_duration": "30m" }).to_string()))
                     .expect("request"),

--- a/crates/orbit-web/src/api/tests/tasks.rs
+++ b/crates/orbit-web/src/api/tests/tasks.rs
@@ -22,6 +22,7 @@ fn post_json(uri: &str, body: Value) -> Request<Body> {
         .method(Method::POST)
         .uri(uri)
         .header(header::ORIGIN, "http://localhost:7878")
+        .header(header::HOST, "localhost:7878")
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
         .expect("request")
@@ -32,6 +33,7 @@ fn patch_json(uri: &str, body: Value) -> Request<Body> {
         .method(Method::PATCH)
         .uri(uri)
         .header(header::ORIGIN, "http://localhost:7878")
+        .header(header::HOST, "localhost:7878")
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
         .expect("request")
@@ -691,6 +693,7 @@ async fn patch_api_accepts_in_progress_hyphen_from_dashboard_and_returns_in_prog
                 .uri(format!("/api/tasks/{}", task_id))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .body(Body::from(r#"{"status":"in-progress"}"#))
                 .expect("build patch request"),
         )
@@ -737,6 +740,7 @@ async fn patch_api_persists_pr_status_with_status_and_execution_summary() {
                 .uri(format!("/tasks/{}", task.id))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .body(Body::from(
                     json!({
                         "pr_status": "approved",
@@ -782,6 +786,7 @@ async fn patch_api_persists_complexity_and_omission_preserves_it() {
                 .uri(format!("/tasks/{}", task.id))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .body(Body::from(json!({ "complexity": "medium" }).to_string()))
                 .expect("build complexity patch request"),
         )
@@ -808,6 +813,7 @@ async fn patch_api_persists_complexity_and_omission_preserves_it() {
                 .uri(format!("/tasks/{}", task.id))
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .body(Body::from(
                     json!({ "title": "Retitled without complexity" }).to_string(),
                 ))
@@ -1251,6 +1257,7 @@ async fn create_task_rejects_stray_workspace_body_key() {
                 .method(Method::POST)
                 .uri("/tasks")
                 .header(header::ORIGIN, "http://localhost:7878")
+                .header(header::HOST, "localhost:7878")
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
                     json!({

--- a/crates/orbit-web/src/api/tests/workspaces.rs
+++ b/crates/orbit-web/src/api/tests/workspaces.rs
@@ -655,6 +655,7 @@ fn post_json(uri: &str, body: serde_json::Value) -> Request<Body> {
         .method(Method::POST)
         .uri(uri)
         .header(header::ORIGIN, "http://localhost:7878")
+        .header(header::HOST, "localhost:7878")
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
         .expect("request")


### PR DESCRIPTION
## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11613`
- Run: `jrun-20260908-0208-4`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `0049eafc8d56b1831b412cb859e1aa04d13c50fc`
- Target base: `2d115ec40cdfe5e71781948f7134b689b782a279`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=make ci-fast fails because docs/INDEX.md is stale; make ci-lint final outcome was not capturable.
```