### PR TITLE
Validate compiler-cache effectiveness across managed worktrees and fix measured blockers

### DIFF
--- a/crates/orbit-exec/src/linux_sandbox.rs
+++ b/crates/orbit-exec/src/linux_sandbox.rs
@@ -641,6 +641,9 @@ pub fn compile_linux_bwrap_argv(
         if managed_worktree && cwd_is_writable_root(&cwd, &writable_roots) {
             append_stable_toolchain_mounts(&mut out, &cwd)?;
         }
+        // Keep the provider agent on the real worktree path. rustc cache-key
+        // cwd normalization belongs in scripts/rustc-compiler-cache.sh, which
+        // chdirs onto LINUX_STABLE_WORKSPACE_MOUNT only for compiler invocations.
         out.push("--chdir".to_string());
         out.push(cwd.display().to_string());
     }

--- a/crates/orbit-exec/tests/linux_sandbox.rs
+++ b/crates/orbit-exec/tests/linux_sandbox.rs
@@ -474,6 +474,14 @@ fn managed_worktree_argv_binds_stable_workspace_and_build_mounts() {
         )),
         "missing build bind in {joined}"
     );
+    assert!(
+        joined.contains(&format!("--chdir {}", cwd.display())),
+        "provider agent cwd must stay on the worktree, not the stable alias: {joined}"
+    );
+    assert!(
+        !joined.contains(&format!("--chdir {LINUX_STABLE_WORKSPACE_MOUNT}")),
+        "do not remap provider agent cwd onto the stable workspace mount: {joined}"
+    );
 }
 
 #[test]

--- a/docs/runbooks/compiler-cache.md
+++ b/docs/runbooks/compiler-cache.md
@@ -2,10 +2,10 @@
 type: runbook
 summary: Opt in, measure, and remove the host Rust compiler cache shared across Orbit worker worktrees.
 tags: [operations, rust, cache, worktrees, sandbox, linux]
-paths: ["Makefile", "scripts/rustc-compiler-cache.sh", "scripts/compiler-cache.sh", ".cargo/config.toml"]
+paths: ["scripts/rustc-compiler-cache.sh", "scripts/compiler-cache.sh", "scripts/test-compiler-cache.sh", "scripts/test-compiler-cache-namespaces.sh", "scripts/bench-compiler-cache.sh", ".cargo/config.toml"]
 related_features: [policy-sandbox, executors]
-related_artifacts: [ORB-11259]
-last_validated: 2026-09-05
+related_artifacts: [ORB-11259, ORB-11755]
+last_validated: 2026-09-08
 ---
 
 # Share Rust dependency compilation across worker worktrees
@@ -17,7 +17,9 @@ enabling, checking, or removing the opt-in host compiler cache.
 The cache is **opt-in at the host**: the repository ships a rustc wrapper that
 falls back to ordinary `rustc` whenever sccache is missing or the cache
 directory is not writable. It does **not** share `CARGO_TARGET_DIR`. Per-worktree
-test binaries and dirty-source fingerprints stay private.
+test binaries and dirty-source fingerprints stay private. Do not enable a
+global host cache until `scripts/test-compiler-cache-namespaces.sh` passes on
+a host that can create Linux mount namespaces.
 
 ## Safety
 
@@ -29,6 +31,10 @@ test binaries and dirty-source fingerprints stay private.
 - Do not delete `$HOME/.orbit/cache/compiler` while workers are compiling.
 - Do not change live worker processes; new cargo invocations pick up the
   committed wrapper after the branch is present in their worktree.
+- Do not share one TCP sccache daemon across Linux mount namespaces that bind
+  different sources at `/tmp/orbit-workspace`. That daemon compiles through
+  the first namespace's mounts and the second fails with a missing rlib.
+  The wrapper defaults prevent this (see [Daemon ownership](#daemon-ownership)).
 
 ## Ownership and location
 
@@ -48,6 +54,16 @@ protected-path denies are unchanged. Reviewer and other read-only profiles do
 not receive the cache grant. macOS already allows `$HOME/Library/Caches` and
 also grants `$HOME/.orbit/cache/**` so the same default directory works. The
 stable `/tmp` mounts are Linux Bubblewrap-only.
+
+The provider **agent cwd stays on the real worktree**. Bubblewrap `--chdir` is
+not mapped onto `/tmp/orbit-workspace`. The rustc wrapper, and only the rustc
+wrapper, remaps *compiler* cwd onto the stable source mount so sccache hashes a
+stable cwd (sccache includes rustc cwd in the rustc cache key and embeds it in
+rlibs). A nested suffix is preserved: rustc invoked from
+`<worktree>/crates/orbit-types` lands in `/tmp/orbit-workspace/crates/orbit-types`,
+so relative `src/lib.rs` keeps the same referent. A cwd outside the checkout is
+not moved onto the repo root. Relative compiler args stay relative; they are
+not expanded back to the unique worktree prefix.
 
 Unavailable cache (missing binary, unwritable directory, `ORBIT_COMPILER_CACHE=0`)
 execs `rustc` with the original argv. Compilation stays correct; it is just
@@ -71,10 +87,15 @@ $HOME/.orbit/cache/bin/sccache --show-stats
 ```
 
 A warm second worktree against unchanged source should show compile-request
-hits and a wall-clock drop versus the first worktree's cold fill. Hits with no
-wall-clock improvement are not evidence of a win.
+hits **and** a wall-clock drop versus the first worktree's cold fill. Hits with
+no wall-clock improvement are not evidence of a win. Cache cold fill is often
+*slower* than an uncached baseline because of wrapper/daemon overhead; do not
+advertise a blanket speedup.
 
 ## Setup
+
+Host-side, outside a managed implementer sandbox (those workers must not write
+the live `~/.orbit/cache` from a task):
 
 ```bash
 scripts/compiler-cache.sh setup --install
@@ -85,6 +106,18 @@ sccache `v0.17.0` into `$HOME/.orbit/cache/bin`. No apt packages. The committed
 wrapper looks there before `PATH`. The binary lives beside the cache data, not
 inside `SCCACHE_DIR`.
 
+Confirm the Linux implementer profile can write the cache directory, then run
+the namespace regression on a host that can create user namespaces (not nested
+inside an existing Bubblewrap sandbox):
+
+```bash
+scripts/test-compiler-cache.sh
+ORBIT_COMPILER_CACHE_REQUIRE_NS=1 scripts/test-compiler-cache-namespaces.sh
+```
+
+Only after that regression passes should the orchestrator leave the host cache
+directory writable for workers.
+
 Optional host overrides (passed through `[execution.env].pass` only if you set
 them on the Orbit process):
 
@@ -93,34 +126,104 @@ them on the Orbit process):
 | `SCCACHE_DIR` | `$HOME/.orbit/cache/compiler` |
 | `SCCACHE_CACHE_SIZE` | `5G` (sccache LRU) |
 | `ORBIT_COMPILER_CACHE_BIN` | `$HOME/.orbit/cache/bin/sccache`, else `sccache` on `PATH` |
-| `ORBIT_COMPILER_CACHE=0` | Force ordinary rustc |
-| `SCCACHE_BASEDIRS` | For the pinned sccache `v0.17.0`, inert for rustc; Rust path normalization comes from the wrapper's `STABLE_SRC`/`STABLE_TGT` argv and environment rewrite when Linux Bubblewrap stable mounts alias the checkout and target |
-| `CARGO_INCREMENTAL=0` | Recommended for workers; sccache cannot cache rustc incremental invocations |
+| `ORBIT_COMPILER_CACHE=0` | Force ordinary rustc (practical opt-out) |
+| `SCCACHE_CLIENT_SIDE` | Wrapper default `1`: compile in the rustc client; daemon is cache storage only |
+| `SCCACHE_SERVER_UDS` | Wrapper default `/tmp/orbit-sccache.sock` (private per Linux sandbox `/tmp`) |
+| `SCCACHE_SERVER_PORT` | Unset. Setting it disables the default UDS and uses TCP on the shared net |
+| `SCCACHE_BASEDIRS` | For the pinned sccache `v0.17.0`, inert for rustc; Rust path normalization comes from the wrapper's `STABLE_SRC`/`STABLE_TGT` argv/env rewrite and rustc cwd chdir when Linux Bubblewrap stable mounts alias the checkout |
+| `CARGO_INCREMENTAL=0` | Required for cacheable rustc; sccache `cannot_cache` incremental invocations |
+| `CARGO_BUILD_JOBS` | Bound concurrency; primary mitigation for Clippy, which sccache does not cache |
 
-After upgrading the Orbit binary that contains the Linux cache grant, new
-implementer runs can write the directory. Until then the wrapper sees an
-unwritable path and falls back.
+## Daemon ownership
+
+sccache 0.17.0 defaults to a background daemon on `127.0.0.1:4226`. Managed
+Linux sandboxes use `--share-net`, so two worktrees would otherwise share that
+daemon. The daemon then runs rustc against *its* `/tmp/orbit-workspace` bind.
+A second namespace with different source contents fails with
+`extern location /tmp/orbit-workspace/target/debug/deps/lib…rlib does not exist`.
+
+The wrapper's default ownership model:
+
+1. `SCCACHE_CLIENT_SIDE=1` — rustc runs in the client process (the calling
+   namespace). The daemon is only a disk-cache gateway.
+2. `SCCACHE_SERVER_UDS=/tmp/orbit-sccache.sock` — each sandbox's private `/tmp`
+   tmpfs gets its own daemon. Disk cache (`SCCACHE_DIR`) stays shared.
+
+Honor explicit operator overrides, including `SCCACHE_CLIENT_SIDE=0` plus a
+shared `SCCACHE_SERVER_PORT`, which is how
+`scripts/test-compiler-cache-namespaces.sh` regresses the missing-artifact
+failure. Do not use that combination on workers.
+
+## Custom `CARGO_TARGET_DIR`
+
+Jobs may set a private target directory that is **not** `<worktree>/target`, so
+it is not bind-mounted at `/tmp/orbit-build`. The wrapper used to require
+*both* source and target aliases before rewriting anything; that silently
+left unique worktree prefixes in argv, `CARGO_*` env, and cwd, so sccache
+missed.
+
+The wrapper now rewrites source paths and rustc cwd whenever
+`/tmp/orbit-workspace/Cargo.toml` aliases the checkout, even if the custom
+target is not aliased. `--out-dir` is excluded from sccache's rustc key, so
+reuse still works; outputs stay in each private target. Relative compiler
+inputs are left relative.
+
+If you need `--out-dir` itself to use the stable build mount (debuginfo paths),
+bind that custom target at `/tmp/orbit-build` inside the sandbox. The
+namespace test and bench do this for their private targets. The Linux
+Bubblewrap planner still binds `<cwd>/target` by default and does **not**
+remap the provider agent cwd.
+
+## When sccache is ineffective or slower
+
+| Workload | What sccache 0.17.0 does | What to do |
+| --- | --- | --- |
+| `cargo clippy` analysis (`clippy-driver`) | Tiny-fixture smoke: 0 cacheable compile requests; reasons include `missing output_dir` and `multiple input files`. That is the clippy-driver invocation, not every rustc the phase may spawn. | Do not advertise `cargo check` hits as caching clippy-driver itself. rustc dependency compilations on a representative graph may still reuse the disk cache during a Clippy run. Keep bounded `CARGO_BUILD_JOBS`. Opt out with `ORBIT_COMPILER_CACHE=0` if wrapper overhead is noise. |
+| Incremental (`CARGO_INCREMENTAL=1` / `-C incremental`) | Pinned sccache `0.17.0` **rejects** the invocation (`incremental compilation is prohibited: Unset CARGO_INCREMENTAL to continue`) instead of compiling uncached. | Keep `CARGO_INCREMENTAL=0` on workers. To run incremental rustc, set `ORBIT_COMPILER_CACHE=0`. |
+| Cache cold fill | Extra wrapper/daemon/hash work; measured slower than uncached `ORBIT_COMPILER_CACHE=0` on the same crate | Expected. Judge effectiveness on a *warm* second worktree vs uncached, not vs cold fill. |
+| Tiny crates | Daemon startup can dominate wall time | Hits without a wall-clock drop are not a win. |
+| Crate types other than rlib/staticlib (bins, dylibs, proc-macros) | Non-cacheable `crate-type` | Dependency rlibs can still hit; the final bin still compiles. |
+
+`/usr/bin/time` user/sys on the cargo process tree excludes a detached cache
+daemon's CPU. With the wrapper default `SCCACHE_CLIENT_SIDE=1`, compiler CPU
+stays in the client tree. Do not advertise command-tree CPU as total compiler
+CPU when using server-side mode.
+
+Practical opt-out, no uninstall: `ORBIT_COMPILER_CACHE=0`.
 
 ## Measure
 
 Same toolchain, unchanged `HEAD`, private target directories, equivalent
-command (`cargo check -p orbit-types --offline` by default):
+command (`cargo check -p orbit-types --offline --locked` by default):
 
 ```bash
-scripts/compiler-cache.sh setup --install   # once per host
-make compiler-cache-bench
+# Isolated bench (downloads pinned sccache into the bench workdir if needed;
+# does not write ~/.orbit/cache unless SCCACHE_DIR points there):
+scripts/bench-compiler-cache.sh
+
+# On a host that can create user namespaces, also require the concurrent test:
+ORBIT_COMPILER_CACHE_REQUIRE_NS=1 scripts/bench-compiler-cache.sh
 ```
 
 The harness records sequential no-cache cold builds, a cache cold fill, a cache
-warm second worktree, and a concurrent pair. It never reuses one `CARGO_TARGET_DIR`.
+warm second worktree, Clippy and incremental probes, a real-mount custom-target
+pair when `/tmp/orbit-workspace` aliases the checkout, and concurrent
+different-source namespaces when Bubblewrap can create them. It never reuses
+one `CARGO_TARGET_DIR`. Nested implementer sandboxes cannot create a second
+user namespace; that skip is not a pass. Re-run the namespace script on the
+host.
 
 ## Invalidation
 
-sccache keys on compiler identity, flags, and source inputs. Expected misses:
+sccache keys on compiler identity, flags, hashed sources, `CARGO_*` env
+(with a few exclusions), and **rustc cwd**. Expected misses:
 
 - source edits in the crate being compiled
 - toolchain upgrades (`rustc --version` changes)
 - feature / flag / profile changes (`--release`, extra `--features`, `RUSTFLAGS`)
+- original worktree cwd without the wrapper's stable-source chdir
+- incremental rustc (`-C incremental`)
+- Clippy-driver invocations
 
 The second worktree's private `target/` still rebuilds crates whose fingerprints
 changed; only identical rustc invocations hit.

--- a/scripts/bench-compiler-cache.sh
+++ b/scripts/bench-compiler-cache.sh
@@ -1,23 +1,52 @@
 #!/usr/bin/env bash
-# Two-worktree cold/warm/concurrent compiler-cache benchmark [ORB-11259].
+# Isolated compiler-cache benchmark [ORB-11259] [ORB-11755].
 #
-# Uses equivalent cargo commands against an unchanged HEAD, with a private
-# CARGO_TARGET_DIR per worktree. Does not share a target directory.
+# Records source revision, toolchain, workload, wall/CPU time, and sccache
+# hits/misses/non-cacheable reasons for: no-cache baseline, cache cold fill,
+# a different worktree warm build, Clippy, incremental, and concurrent
+# different-source Linux mount namespaces when Bubblewrap can create them.
+#
+# Uses private CARGO_TARGET_DIR values per tree. The disk cache and UDS live
+# only under the bench workdir; the harness refuses a caller SCCACHE_DIR outside
+# that tree so it cannot reset an operator cache. Does not enable a global host
+# cache.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 PACKAGE="${ORBIT_COMPILER_CACHE_BENCH_PACKAGE:-orbit-types}"
-CARGO_CMD=(cargo check -p "$PACKAGE" --offline)
+CARGO_CMD=(cargo check -p "$PACKAGE" --offline --locked)
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 WORKDIR="${ORBIT_COMPILER_CACHE_BENCH_DIR:-/tmp/orbit-compiler-cache-bench-$$}"
 CACHE_DIR="${SCCACHE_DIR:-$WORKDIR/cache}"
 RESULT="${ORBIT_COMPILER_CACHE_BENCH_RESULT:-$WORKDIR/results-$STAMP.txt}"
+JOBS="${CARGO_BUILD_JOBS:-1}"
+REQUIRE_NS="${ORBIT_COMPILER_CACHE_REQUIRE_NS:-0}"
+SCCACHE_VERSION="v0.17.0"
+BENCH_UDS="$WORKDIR/sccache.sock"
+SCCACHE_BIN=""
 
-HEAD_SHA="$(git rev-parse HEAD)"
+HEAD_SHA="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+case "$CACHE_DIR" in
+  "$WORKDIR" | "$WORKDIR"/*) ;;
+  *)
+    printf 'bench-compiler-cache: refusing SCCACHE_DIR=%s (must be under %s)\n' \
+      "$CACHE_DIR" "$WORKDIR" >&2
+    exit 1
+    ;;
+esac
+
+stop_owned_daemon() {
+  [[ -n "$SCCACHE_BIN" && -x "$SCCACHE_BIN" ]] || return 0
+  SCCACHE_DIR="$CACHE_DIR" SCCACHE_SERVER_UDS="$BENCH_UDS" \
+    "$SCCACHE_BIN" --stop-server >/dev/null 2>&1 || true
+}
+
 cleanup() {
-  rm -rf "$WORKDIR/a" "$WORKDIR/b" "$WORKDIR/a-target" "$WORKDIR/b-target"
+  stop_owned_daemon
+  rm -rf "$WORKDIR/a" "$WORKDIR/b" "$WORKDIR/a-target" "$WORKDIR/b-target" \
+    "$WORKDIR/probe-c" "$WORKDIR/probe-d" "$WORKDIR/probe-c-target" "$WORKDIR/probe-d-target"
 }
 trap cleanup EXIT
 
@@ -37,140 +66,298 @@ now() {
   date +%s.%N
 }
 
+resolve_sccache() {
+  if [[ -n "${ORBIT_COMPILER_CACHE_BIN:-}" && -x "${ORBIT_COMPILER_CACHE_BIN}" ]]; then
+    printf '%s\n' "${ORBIT_COMPILER_CACHE_BIN}"
+    return 0
+  fi
+  if [[ -x "$WORKDIR/bin/sccache" ]]; then
+    printf '%s\n' "$WORKDIR/bin/sccache"
+    return 0
+  fi
+  if [[ -x "${HOME:-}/.orbit/cache/bin/sccache" ]]; then
+    printf '%s\n' "$HOME/.orbit/cache/bin/sccache"
+    return 0
+  fi
+  if command -v sccache >/dev/null 2>&1; then
+    command -v sccache
+    return 0
+  fi
+  return 1
+}
+
+install_isolated_sccache() {
+  local os arch asset url tmp dest
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}/${arch}" in
+    Linux/x86_64 | Linux/amd64)
+      asset="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+      ;;
+    Linux/aarch64 | Linux/arm64)
+      asset="sccache-${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz"
+      ;;
+    Darwin/x86_64 | Darwin/amd64)
+      asset="sccache-${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz"
+      ;;
+    Darwin/arm64 | Darwin/aarch64)
+      asset="sccache-${SCCACHE_VERSION}-aarch64-apple-darwin.tar.gz"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  dest="$WORKDIR/bin/sccache"
+  mkdir -p "$WORKDIR/bin"
+  url="https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${asset}"
+  tmp="$(mktemp -d)"
+  log "downloading isolated $url"
+  if ! curl -fsSL "$url" -o "$tmp/$asset"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+  tar -xzf "$tmp/$asset" -C "$tmp"
+  find "$tmp" -type f -name sccache -exec cp {} "$dest" \;
+  chmod +x "$dest"
+  rm -rf "$tmp"
+  [[ -x "$dest" ]]
+}
+
+time_cmd() {
+  local label="$1"
+  shift
+  local start end elapsed timefile status
+  timefile="$WORKDIR/time-$label"
+  start="$(now)"
+  status=0
+  if [[ -x /usr/bin/time ]]; then
+    /usr/bin/time -f 'wall=%e user=%U sys=%S' -o "$timefile" "$@" || status=$?
+  else
+    "$@" || status=$?
+    printf 'wall=unknown user=unknown sys=unknown (no /usr/bin/time)\n' >"$timefile"
+  fi
+  end="$(now)"
+  elapsed="$(secs "$start" "$end")"
+  log "    wall_s=$elapsed  $(tr '\n' ' ' <"$timefile")"
+  printf '%s\n' "$elapsed" >"$WORKDIR/last-elapsed"
+  return "$status"
+}
+
 run_build() {
   local label="$1" tree="$2" target="$3"
   shift 3
-  local start end elapsed
   mkdir -p "$target"
   rm -rf "${target:?}/"*
-  log "==> $label  (tree=$tree target=$target)"
-  start="$(now)"
+  log "==> $label  (tree=$tree target=$target cwd=$(pwd))"
   (
     cd "$tree"
-    env "$@" CARGO_TARGET_DIR="$target" CARGO_INCREMENTAL=0 \
+    time_cmd "$label" env "$@" \
+      CARGO_TARGET_DIR="$target" \
+      CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}" \
+      CARGO_BUILD_JOBS="$JOBS" \
       "${CARGO_CMD[@]}"
   )
-  end="$(now)"
-  elapsed="$(secs "$start" "$end")"
-  log "    wall_s=$elapsed"
-  printf '%s\n' "$elapsed" >"$WORKDIR/last-elapsed"
 }
 
 sccache_stats() {
-  local bin="${ORBIT_COMPILER_CACHE_BIN:-}"
-  if [[ -z "$bin" ]]; then
-    if [[ -x "${HOME:-}/.orbit/cache/bin/sccache" ]]; then
-      bin="$HOME/.orbit/cache/bin/sccache"
-    elif command -v sccache >/dev/null 2>&1; then
-      bin="$(command -v sccache)"
-    else
-      return 0
-    fi
+  local bin="${SCCACHE_BIN:-}"
+  [[ -n "$bin" && -x "$bin" ]] || return 0
+  log "--- sccache --show-stats (uds=$BENCH_UDS) ---"
+  SCCACHE_DIR="$CACHE_DIR" SCCACHE_SERVER_UDS="$BENCH_UDS" \
+    "$bin" --show-stats 2>&1 | tee -a "$RESULT" || true
+}
+
+can_create_ns() {
+  command -v bwrap >/dev/null 2>&1 || return 1
+  bwrap --die-with-parent --unshare-all --share-net --ro-bind / / --tmpfs /tmp \
+    --dev /dev --proc /proc -- /bin/true >/dev/null 2>"$WORKDIR/bwrap-probe.err"
+}
+
+copy_tree() {
+  local dest="$1"
+  mkdir -p "$dest"
+  if git archive "$HEAD_SHA" >/dev/null 2>&1; then
+    git archive "$HEAD_SHA" | tar -x -C "$dest"
+  else
+    tar -C "$ROOT" --exclude target --exclude .git --exclude tmp -cf - . \
+      | tar -C "$dest" -xf -
   fi
-  log "--- sccache --show-stats ---"
-  SCCACHE_DIR="$CACHE_DIR" "$bin" --show-stats 2>&1 | tee -a "$RESULT" || true
+  mkdir -p "$dest/.cargo" "$dest/scripts"
+  cp "$ROOT/.cargo/config.toml" "$dest/.cargo/config.toml"
+  cp "$ROOT/scripts/rustc-compiler-cache.sh" "$dest/scripts/rustc-compiler-cache.sh"
+  chmod +x "$dest/scripts/rustc-compiler-cache.sh"
 }
 
 log "compiler-cache bench $STAMP"
 log "head=$HEAD_SHA"
+log "rustc=$(rustc --version 2>/dev/null || echo missing)"
+log "cargo=$(cargo --version 2>/dev/null || echo missing)"
+log "host=$(uname -srm)"
 log "package=$PACKAGE"
 log "cmd=${CARGO_CMD[*]}"
+log "jobs=$JOBS"
 log "workdir=$WORKDIR"
 log "cache_dir=$CACHE_DIR"
+log "note=/usr/bin/time user/sys is the cargo process tree; it excludes a detached sccache daemon. Wrapper defaults (SCCACHE_CLIENT_SIDE=1) keep compiler CPU in the client tree."
 
-# Copy two identical trees. `git worktree add` writes the shared git dir, which
-# a managed Linux worktree cannot do; the copies still share one commit and
-# keep private target directories.
 mkdir -p "$WORKDIR/a" "$WORKDIR/b"
-if git archive "$HEAD_SHA" >/dev/null 2>&1; then
-  git archive "$HEAD_SHA" | tar -x -C "$WORKDIR/a"
-  git archive "$HEAD_SHA" | tar -x -C "$WORKDIR/b"
-else
-  tar -C "$ROOT" --exclude target --exclude .git --exclude tmp -cf - . \
-    | tar -C "$WORKDIR/a" -xf -
-  tar -C "$ROOT" --exclude target --exclude .git --exclude tmp -cf - . \
-    | tar -C "$WORKDIR/b" -xf -
-fi
-# Overlay the wrapper and cargo config so both trees exercise the same hook
-# even when those files are still untracked in this worktree.
-mkdir -p "$WORKDIR/a/.cargo" "$WORKDIR/b/.cargo" "$WORKDIR/a/scripts" "$WORKDIR/b/scripts"
-cp "$ROOT/.cargo/config.toml" "$WORKDIR/a/.cargo/config.toml"
-cp "$ROOT/.cargo/config.toml" "$WORKDIR/b/.cargo/config.toml"
-cp "$ROOT/scripts/rustc-compiler-cache.sh" "$WORKDIR/a/scripts/rustc-compiler-cache.sh"
-cp "$ROOT/scripts/rustc-compiler-cache.sh" "$WORKDIR/b/scripts/rustc-compiler-cache.sh"
-chmod +x "$WORKDIR/a/scripts/rustc-compiler-cache.sh" "$WORKDIR/b/scripts/rustc-compiler-cache.sh"
+copy_tree "$WORKDIR/a"
+copy_tree "$WORKDIR/b"
 
-# Baseline: wrapper forced off, two sequential cold worktrees.
 log ""
-log "### baseline (ORBIT_COMPILER_CACHE=0, sequential cold)"
+log "### baseline (ORBIT_COMPILER_CACHE=0, sequential cold, custom CARGO_TARGET_DIR)"
 run_build "baseline-a-cold" "$WORKDIR/a" "$WORKDIR/a-target" ORBIT_COMPILER_CACHE=0
 base_a="$(cat "$WORKDIR/last-elapsed")"
 run_build "baseline-b-cold" "$WORKDIR/b" "$WORKDIR/b-target" ORBIT_COMPILER_CACHE=0
 base_b="$(cat "$WORKDIR/last-elapsed")"
 
-if ! command -v sccache >/dev/null 2>&1 && [[ ! -x "${ORBIT_COMPILER_CACHE_BIN:-}" && ! -x "${HOME:-}/.orbit/cache/bin/sccache" ]]; then
+SCCACHE_BIN=""
+if ! SCCACHE_BIN="$(resolve_sccache)"; then
+  if install_isolated_sccache; then
+    SCCACHE_BIN="$WORKDIR/bin/sccache"
+  fi
+fi
+
+if [[ -z "$SCCACHE_BIN" || ! -x "$SCCACHE_BIN" ]]; then
   log ""
-  log "sccache is not available; cache arms skipped. Run: scripts/compiler-cache.sh setup --install"
+  log "sccache is not available; cache arms skipped."
+  log "Host setup: curl the pinned $SCCACHE_VERSION musl binary into a private dir and set ORBIT_COMPILER_CACHE_BIN. Do not write ~/.orbit/cache from a managed worker."
   log "baseline_a_s=$base_a"
   log "baseline_b_s=$base_b"
   log "results=$RESULT"
   exit 0
 fi
 
+log "sccache_bin=$SCCACHE_BIN"
+log "sccache_version=$("$SCCACHE_BIN" --version 2>/dev/null || echo unknown)"
+log "sccache_uds=$BENCH_UDS"
 CACHE_ENV=(
   SCCACHE_DIR="$CACHE_DIR"
   SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-5G}"
+  ORBIT_COMPILER_CACHE_BIN="$SCCACHE_BIN"
+  SCCACHE_SERVER_UDS="$BENCH_UDS"
+  SCCACHE_CLIENT_SIDE=1
 )
-if [[ -n "${ORBIT_COMPILER_CACHE_BIN:-}" ]]; then
-  CACHE_ENV+=(ORBIT_COMPILER_CACHE_BIN="$ORBIT_COMPILER_CACHE_BIN")
-fi
 
 log ""
-log "### cache sequential (cold then warm, private targets)"
-# Reset cache for a true cold fill. This directory is the bench-private cache,
-# never the live worker cache, unless the caller overrode SCCACHE_DIR.
-if [[ "$CACHE_DIR" == "$WORKDIR/cache" ]]; then
-  rm -rf "$CACHE_DIR"
-  mkdir -p "$CACHE_DIR"
-fi
+log "### unnormalized copy-tree baseline (no stable mounts; unique cwd/paths expected to miss)"
+rm -rf "$CACHE_DIR"
+mkdir -p "$CACHE_DIR"
 sccache_stats
-run_build "cache-a-cold" "$WORKDIR/a" "$WORKDIR/a-target" "${CACHE_ENV[@]}"
+run_build "unnormalized-a-cold" "$WORKDIR/a" "$WORKDIR/a-target" "${CACHE_ENV[@]}"
 cache_a="$(cat "$WORKDIR/last-elapsed")"
 sccache_stats
-run_build "cache-b-warm" "$WORKDIR/b" "$WORKDIR/b-target" "${CACHE_ENV[@]}"
+run_build "unnormalized-b-warm" "$WORKDIR/b" "$WORKDIR/b-target" "${CACHE_ENV[@]}"
 cache_b="$(cat "$WORKDIR/last-elapsed")"
 sccache_stats
+log "unnormalized_note=these copies are not bind-mounted at /tmp/orbit-workspace; treat as a miss-path control, not cross-worktree reuse."
+
+real_custom_cold=""
+real_custom_warm=""
+if [[ -e /tmp/orbit-workspace/Cargo.toml && -e "$ROOT/Cargo.toml" ]] \
+  && [[ "$(stat -L -c '%d:%i' /tmp/orbit-workspace/Cargo.toml 2>/dev/null || stat -L -f '%d:%i' /tmp/orbit-workspace/Cargo.toml)" \
+    == "$(stat -L -c '%d:%i' "$ROOT/Cargo.toml" 2>/dev/null || stat -L -f '%d:%i' "$ROOT/Cargo.toml")" ]]; then
+  log ""
+  log "### real Linux stable source mount + custom CARGO_TARGET_DIR (same checkout, two private targets)"
+  log "Demonstrates cwd normalization and unaliased custom targets. Not a second worktree; cross-worktree reuse is the namespace arm."
+  stop_owned_daemon
+  rm -rf "$CACHE_DIR"
+  mkdir -p "$CACHE_DIR" "$WORKDIR/real-custom-a" "$WORKDIR/real-custom-b"
+  sccache_stats
+  run_build "real-mount-custom-cold" "$ROOT" "$WORKDIR/real-custom-a" "${CACHE_ENV[@]}"
+  real_custom_cold="$(cat "$WORKDIR/last-elapsed")"
+  sccache_stats
+  run_build "real-mount-custom-warm" "$ROOT" "$WORKDIR/real-custom-b" "${CACHE_ENV[@]}"
+  real_custom_warm="$(cat "$WORKDIR/last-elapsed")"
+  sccache_stats
+else
+  log ""
+  log "### real Linux stable mounts: not aliased in this environment"
+fi
 
 log ""
-log "### cache concurrent (two warm-empty-target worktrees)"
-rm -rf "$WORKDIR/a-target" "$WORKDIR/b-target"
-mkdir -p "$WORKDIR/a-target" "$WORKDIR/b-target"
-conc_start="$(now)"
+log "### clippy (tiny probe; sccache 0.17 does not cache clippy-driver itself)"
+mkdir -p "$WORKDIR/probe/src" "$WORKDIR/probe/scripts" "$WORKDIR/probe/.cargo" "$WORKDIR/probe-target"
+cat >"$WORKDIR/probe/Cargo.toml" <<'EOF'
+[package]
+name = "orbit_cache_probe"
+version = "0.1.0"
+edition = "2021"
+EOF
+printf 'pub fn value() -> i32 { 1 }\n' >"$WORKDIR/probe/src/lib.rs"
+cp "$ROOT/scripts/rustc-compiler-cache.sh" "$WORKDIR/probe/scripts/rustc-compiler-cache.sh"
+cp "$ROOT/.cargo/config.toml" "$WORKDIR/probe/.cargo/config.toml"
+chmod +x "$WORKDIR/probe/scripts/rustc-compiler-cache.sh"
+(cd "$WORKDIR/probe" && cargo generate-lockfile >/dev/null)
+rm -rf "$WORKDIR/probe-target/"*
+log "==> clippy-probe"
 (
-  cd "$WORKDIR/a"
-  env "${CACHE_ENV[@]}" CARGO_TARGET_DIR="$WORKDIR/a-target" CARGO_INCREMENTAL=0 \
-    "${CARGO_CMD[@]}"
-) >"$WORKDIR/conc-a.log" 2>&1 &
-pid_a=$!
-(
-  cd "$WORKDIR/b"
-  env "${CACHE_ENV[@]}" CARGO_TARGET_DIR="$WORKDIR/b-target" CARGO_INCREMENTAL=0 \
-    "${CARGO_CMD[@]}"
-) >"$WORKDIR/conc-b.log" 2>&1 &
-pid_b=$!
-status=0
-wait "$pid_a" || status=1
-wait "$pid_b" || status=1
-conc_end="$(now)"
-conc_wall="$(secs "$conc_start" "$conc_end")"
-cat "$WORKDIR/conc-a.log" >>"$RESULT"
-cat "$WORKDIR/conc-b.log" >>"$RESULT"
-[[ "$status" -eq 0 ]] || {
-  log "concurrent builds failed"
-  exit 1
-}
-log "    concurrent_wall_s=$conc_wall"
+  cd "$WORKDIR/probe"
+  time_cmd clippy env "${CACHE_ENV[@]}" \
+    CARGO_TARGET_DIR="$WORKDIR/probe-target" CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS="$JOBS" \
+    cargo clippy --offline --locked --quiet
+) || log "    clippy command failed (recorded, not fatal for the harness)"
+clippy_s="$(cat "$WORKDIR/last-elapsed")"
 sccache_stats
+log "clippy_s=$clippy_s"
+log "clippy_note=clippy-driver analysis invocations are non-cacheable (missing output_dir / multiple input files on the tiny fixture). rustc dependency compilations on a representative graph may still hit. Do not treat clippy-driver misses as proof that Clippy phases cannot reuse cached rlibs. Opt out of the wrapper with ORBIT_COMPILER_CACHE=0; keep bounded CARGO_BUILD_JOBS."
+
+log ""
+log "### incremental (sccache 0.17.0 prohibits CARGO_INCREMENTAL=1; it does not degrade to rustc)"
+rm -rf "$WORKDIR/probe-target/"*
+log "==> incremental-probe"
+incr_status=0
+(
+  cd "$WORKDIR/probe"
+  time_cmd incremental env "${CACHE_ENV[@]}" \
+    CARGO_TARGET_DIR="$WORKDIR/probe-target" CARGO_INCREMENTAL=1 CARGO_BUILD_JOBS="$JOBS" \
+    cargo check --offline --locked --quiet
+) || incr_status=$?
+incr_s="$(cat "$WORKDIR/last-elapsed")"
+sccache_stats
+log "incremental_s=$incr_s"
+log "incremental_exit=$incr_status"
+log "incremental_note=pinned sccache 0.17.0 exits with 'incremental compilation is prohibited: Unset CARGO_INCREMENTAL to continue' rather than falling through to uncached rustc. Keep CARGO_INCREMENTAL=0 on workers. To use incremental, set ORBIT_COMPILER_CACHE=0."
+
+conc_wall="skipped"
+ns_detail="bwrap namespace probe not run"
+if can_create_ns; then
+  ns_detail="bwrap can create mount namespaces"
+  log ""
+  log "### concurrent Linux namespaces (different source, shared disk cache)"
+  mkdir -p "$WORKDIR/probe-c/src" "$WORKDIR/probe-d/src" \
+    "$WORKDIR/probe-c/scripts" "$WORKDIR/probe-d/scripts" \
+    "$WORKDIR/probe-c/.cargo" "$WORKDIR/probe-d/.cargo" \
+    "$WORKDIR/probe-c-target" "$WORKDIR/probe-d-target"
+  cp "$WORKDIR/probe/Cargo.toml" "$WORKDIR/probe-c/Cargo.toml"
+  cp "$WORKDIR/probe/Cargo.toml" "$WORKDIR/probe-d/Cargo.toml"
+  printf 'pub fn value() -> i32 { 1 }\n' >"$WORKDIR/probe-c/src/lib.rs"
+  printf 'pub fn value() -> i32 { 4 }\n' >"$WORKDIR/probe-d/src/lib.rs"
+  printf 'fn main() { print!("{}", orbit_cache_probe::value() + 2); }\n' \
+    >"$WORKDIR/probe-c/src/main.rs"
+  cp "$WORKDIR/probe-c/src/main.rs" "$WORKDIR/probe-d/src/main.rs"
+  cp "$ROOT/scripts/rustc-compiler-cache.sh" "$WORKDIR/probe-c/scripts/"
+  cp "$ROOT/scripts/rustc-compiler-cache.sh" "$WORKDIR/probe-d/scripts/"
+  cp "$ROOT/.cargo/config.toml" "$WORKDIR/probe-c/.cargo/"
+  cp "$ROOT/.cargo/config.toml" "$WORKDIR/probe-d/.cargo/"
+  (cd "$WORKDIR/probe-c" && cargo generate-lockfile >/dev/null)
+  cp "$WORKDIR/probe-c/Cargo.lock" "$WORKDIR/probe-d/Cargo.lock"
+  conc_start="$(now)"
+  PATH="$PATH" ORBIT_COMPILER_CACHE_BIN="$SCCACHE_BIN" \
+    ORBIT_COMPILER_CACHE_REQUIRE_NS="$REQUIRE_NS" \
+    "$ROOT/scripts/test-compiler-cache-namespaces.sh" | tee -a "$RESULT"
+  conc_wall="$(secs "$conc_start" "$(now)")"
+else
+  err="$(tr '\n' ' ' <"$WORKDIR/bwrap-probe.err" 2>/dev/null || true)"
+  ns_detail="cannot create mount namespace: ${err:-bwrap missing}"
+  log ""
+  log "### concurrent Linux namespaces: skipped ($ns_detail)"
+  if [[ "$REQUIRE_NS" == "1" ]]; then
+    log "ORBIT_COMPILER_CACHE_REQUIRE_NS=1: treating skip as failure"
+    exit 1
+  fi
+  log "Run scripts/test-compiler-cache-namespaces.sh on a host that can create user namespaces (not nested inside an implementer sandbox)."
+fi
 
 log ""
 log "### summary"
@@ -178,6 +365,13 @@ log "baseline_a_cold_s=$base_a"
 log "baseline_b_cold_s=$base_b"
 log "cache_a_cold_s=$cache_a"
 log "cache_b_warm_s=$cache_b"
-log "cache_concurrent_wall_s=$conc_wall"
+log "real_mount_custom_cold_s=${real_custom_cold:-skipped}"
+log "real_mount_custom_warm_s=${real_custom_warm:-skipped}"
+log "clippy_s=$clippy_s"
+log "incremental_s=$incr_s"
+log "cache_concurrent=$conc_wall"
+log "namespace_probe=$ns_detail"
 log "results=$RESULT"
+log "opt_out=ORBIT_COMPILER_CACHE=0"
+log "do_not_enable_global_cache=1"
 printf 'compiler-cache bench complete: %s\n' "$RESULT"

--- a/scripts/compiler-cache.sh
+++ b/scripts/compiler-cache.sh
@@ -102,6 +102,9 @@ cmd_status() {
   printf '  SCCACHE_DIR:        %s\n' "${SCCACHE_DIR:-<unset, wrapper default $dir>}"
   printf '  SCCACHE_CACHE_SIZE: %s\n' "${SCCACHE_CACHE_SIZE:-<unset, wrapper default $DEFAULT_SIZE>}"
   printf '  ORBIT_COMPILER_CACHE=%s\n' "${ORBIT_COMPILER_CACHE:-<unset>}"
+  printf '  SCCACHE_CLIENT_SIDE:  %s\n' "${SCCACHE_CLIENT_SIDE:-<unset, wrapper default 1>}"
+  printf '  SCCACHE_SERVER_UDS:   %s\n' "${SCCACHE_SERVER_UDS:-<unset, wrapper default /tmp/orbit-sccache.sock>}"
+  printf '  SCCACHE_SERVER_PORT:  %s\n' "${SCCACHE_SERVER_PORT:-<unset>}"
   if cache_bin="$(resolve_sccache)"; then
     printf '  sccache:            %s\n' "$cache_bin"
     printf '  sccache_version:    %s\n' "$("$cache_bin" --version 2>/dev/null || echo unknown)"

--- a/scripts/rustc-compiler-cache.sh
+++ b/scripts/rustc-compiler-cache.sh
@@ -3,13 +3,18 @@
 #
 # Cargo invokes this as: rustc-compiler-cache.sh <rustc> [args...]
 # It must never write to stdout (that stream is rustc's). Missing or unusable
-# cache degrades to ordinary rustc. [ORB-11259]
+# cache degrades to ordinary rustc. [ORB-11259] [ORB-11755]
 set -euo pipefail
 
 # Tests may override these aliases to avoid sharing host-global /tmp paths.
 # Managed Linux sandboxes use the defaults below.
 STABLE_SRC="${ORBIT_COMPILER_CACHE_STABLE_SRC:-/tmp/orbit-workspace}"
 STABLE_TGT="${ORBIT_COMPILER_CACHE_STABLE_TGT:-/tmp/orbit-build}"
+# Per-namespace daemon socket. Linux Bubblewrap replaces /tmp with a private
+# tmpfs, so concurrent sandboxes that share the host network do not attach to
+# one TCP sccache daemon (that daemon would compile through another
+# namespace's stable mounts).
+DEFAULT_SERVER_UDS="${ORBIT_COMPILER_CACHE_SERVER_UDS:-/tmp/orbit-sccache.sock}"
 
 debug() {
   if [[ "${ORBIT_COMPILER_CACHE_DEBUG:-}" == "1" ]]; then
@@ -69,26 +74,15 @@ fi
 
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
 repo_root="$(cd "$script_dir/.." && pwd -P)"
+orig_cwd="$(pwd)"
 if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
   target_real="${CARGO_TARGET_DIR}"
+  if [[ "$target_real" != /* ]]; then
+    target_real="${orig_cwd}/${target_real}"
+  fi
 else
   target_real="${repo_root}/target"
 fi
-
-# Managed Linux sandboxes bind the worktree and its target/ at stable /tmp
-# paths so sccache keys do not include the jrun worktree prefix.
-rewrite_value() {
-  local s="$1"
-  if [[ -n "$target_real" && ( "$s" == "$target_real" || "$s" == "$target_real/"* ) ]]; then
-    printf '%s%s' "$STABLE_TGT" "${s#"$target_real"}"
-    return
-  fi
-  if [[ "$s" == "$repo_root" || "$s" == "$repo_root/"* ]]; then
-    printf '%s%s' "$STABLE_SRC" "${s#"$repo_root"}"
-    return
-  fi
-  printf '%s' "$s"
-}
 
 file_id() {
   local path="$1"
@@ -105,8 +99,37 @@ same_inode() {
   [[ "$(file_id "$a")" == "$(file_id "$b")" ]]
 }
 
-if same_inode "$STABLE_SRC/Cargo.toml" "$repo_root/Cargo.toml" && same_inode "$STABLE_TGT" "$target_real"; then
-  debug "rewriting paths onto $STABLE_SRC and $STABLE_TGT"
+# Source and target aliasing are independent. A private custom CARGO_TARGET_DIR
+# that is not bind-mounted at STABLE_TGT used to skip *all* rewriting, so
+# worktree prefixes stayed in argv, CARGO_* env, and cwd — silent cache misses.
+# sccache hashes rustc cwd and the input path; --out-dir is excluded from the
+# key, so source/cwd normalization is enough for reuse when outputs stay private.
+source_aliased=0
+target_aliased=0
+if same_inode "$STABLE_SRC/Cargo.toml" "$repo_root/Cargo.toml"; then
+  source_aliased=1
+fi
+if same_inode "$STABLE_TGT" "$target_real"; then
+  target_aliased=1
+fi
+
+# Managed Linux sandboxes bind the worktree and its target/ at stable /tmp
+# paths so sccache keys do not include the jrun worktree prefix.
+rewrite_value() {
+  local s="$1"
+  if [[ "$target_aliased" -eq 1 && -n "$target_real" && ( "$s" == "$target_real" || "$s" == "$target_real/"* ) ]]; then
+    printf '%s%s' "$STABLE_TGT" "${s#"$target_real"}"
+    return
+  fi
+  if [[ "$source_aliased" -eq 1 && ( "$s" == "$repo_root" || "$s" == "$repo_root/"* ) ]]; then
+    printf '%s%s' "$STABLE_SRC" "${s#"$repo_root"}"
+    return
+  fi
+  printf '%s' "$s"
+}
+
+if [[ "$source_aliased" -eq 1 || "$target_aliased" -eq 1 ]]; then
+  debug "rewriting paths onto source=$source_aliased ($STABLE_SRC) target=$target_aliased ($STABLE_TGT)"
   rewritten=()
   for arg in "$@"; do
     rewritten+=("$(rewrite_value "$arg")")
@@ -115,6 +138,9 @@ if same_inode "$STABLE_SRC/Cargo.toml" "$repo_root/Cargo.toml" && same_inode "$S
   # Bash 3.2 lacks array loading, and macOS env does not provide GNU env -0.
   # compgen emits exported names without touching their values, so indirect
   # expansion keeps spaces, equals signs, newlines, and empty values intact.
+  # Relative compiler args are left relative: after a stable-src chdir they
+  # resolve to the same files, and rewriting them to the original worktree
+  # absolute path would re-introduce unique prefixes into sccache's key.
   while IFS= read -r name; do
     value="${!name}"
     [[ -n "$name" ]] || continue
@@ -123,6 +149,37 @@ if same_inode "$STABLE_SRC/Cargo.toml" "$repo_root/Cargo.toml" && same_inode "$S
       export "${name}=${new}"
     fi
   done < <(compgen -e)
+  if [[ "$source_aliased" -eq 1 && "$target_aliased" -eq 0 ]]; then
+    debug "custom CARGO_TARGET_DIR is not aliased to $STABLE_TGT; source/cwd only"
+  fi
+fi
+
+# sccache hashes rustc cwd into the rustc cache key (and embeds it in rlibs).
+# Bubblewrap --chdir stays on the real worktree so the provider agent cwd is
+# unchanged; only this rustc wrapper remaps compiler cwd onto the stable
+# source mount. Preserve a nested suffix (crates/foo) so relative rustc
+# inputs keep their referent. Do not move an unrelated cwd onto the repo root.
+if [[ "$source_aliased" -eq 1 ]]; then
+  dest_cwd=""
+  case "$orig_cwd" in
+    "$STABLE_SRC" | "$STABLE_SRC"/*)
+      dest_cwd="$orig_cwd"
+      ;;
+    "$repo_root")
+      dest_cwd="$STABLE_SRC"
+      ;;
+    "$repo_root"/*)
+      dest_cwd="$STABLE_SRC${orig_cwd#"$repo_root"}"
+      ;;
+  esac
+  if [[ -n "$dest_cwd" && "$orig_cwd" != "$dest_cwd" ]]; then
+    if cd "$dest_cwd"; then
+      export PWD="$dest_cwd"
+      debug "cwd normalized $orig_cwd -> $dest_cwd"
+    else
+      debug "cannot chdir to $dest_cwd; keeping $orig_cwd"
+    fi
+  fi
 fi
 
 export SCCACHE_DIR="$cache_dir"
@@ -131,5 +188,18 @@ export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-5G}"
 # for sccache's non-Rust compatibility. Rust path normalization is performed by
 # the STABLE_SRC/STABLE_TGT rewrite above when the stable mounts are available.
 export SCCACHE_BASEDIRS="${SCCACHE_BASEDIRS:-$STABLE_SRC:$STABLE_TGT:$repo_root:$target_real}"
-debug "enabled bin=$cache_bin dir=$cache_dir"
+
+# Compile in the client process so a daemon in another mount namespace cannot
+# write artifacts through that namespace's /tmp/orbit-workspace bind. Honor an
+# explicit operator override (including SCCACHE_CLIENT_SIDE=0 for reproducing
+# the shared-daemon missing-artifact failure).
+if [[ -z "${SCCACHE_CLIENT_SIDE+x}" ]]; then
+  export SCCACHE_CLIENT_SIDE=1
+fi
+# Private /tmp UDS unless the operator picked a TCP port or socket explicitly.
+if [[ -z "${SCCACHE_SERVER_UDS:-}" && -z "${SCCACHE_SERVER_PORT:-}" ]]; then
+  export SCCACHE_SERVER_UDS="$DEFAULT_SERVER_UDS"
+fi
+
+debug "enabled bin=$cache_bin dir=$cache_dir client_side=${SCCACHE_CLIENT_SIDE-} uds=${SCCACHE_SERVER_UDS-}"
 exec "$cache_bin" "$@"

--- a/scripts/test-compiler-cache-namespaces.sh
+++ b/scripts/test-compiler-cache-namespaces.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# Concurrent Linux mount-namespace regression for the rustc compiler-cache wrapper.
+#
+# A shared TCP sccache daemon (SCCACHE_CLIENT_SIDE=0) compiles through whichever
+# namespace started it, so a second sandbox with different source at the same
+# stable mounts fails with a missing rlib. The wrapper's default client-side
+# compile plus a private /tmp UDS keeps outputs in each namespace's target
+# while still sharing the disk cache. [ORB-11755]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REQUIRE_NS="${ORBIT_COMPILER_CACHE_REQUIRE_NS:-0}"
+
+skip() {
+  printf 'test-compiler-cache-namespaces: skip: %s\n' "$*"
+  if [[ "$REQUIRE_NS" == "1" ]]; then
+    printf 'test-compiler-cache-namespaces: FAIL: namespace test required\n' >&2
+    exit 1
+  fi
+  exit 0
+}
+
+fail() {
+  printf 'test-compiler-cache-namespaces: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+if ! command -v bwrap >/dev/null 2>&1; then
+  skip "bwrap not on PATH"
+fi
+
+probe_err="$(mktemp)"
+if ! bwrap --die-with-parent --unshare-all --share-net --ro-bind / / --tmpfs /tmp --dev /dev --proc /proc -- /bin/true 2>"$probe_err"; then
+  err="$(tr '\n' ' ' <"$probe_err" | sed 's/[[:space:]]*$//')"
+  rm -f "$probe_err"
+  skip "cannot create a mount namespace ($err)"
+fi
+rm -f "$probe_err"
+
+sccache_bin="${ORBIT_COMPILER_CACHE_BIN:-}"
+if [[ -z "$sccache_bin" && -x "${HOME:-}/.orbit/cache/bin/sccache" ]]; then
+  sccache_bin="$HOME/.orbit/cache/bin/sccache"
+fi
+if [[ -z "$sccache_bin" ]] && command -v sccache >/dev/null 2>&1; then
+  sccache_bin="$(command -v sccache)"
+fi
+if [[ -z "$sccache_bin" || ! -x "$sccache_bin" ]]; then
+  skip "sccache not available for live namespace compile"
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  skip "cargo not on PATH"
+fi
+
+alloc_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+WORKDIR="$(mktemp -d)"
+PIDS=()
+cleanup() {
+  local pid
+  for pid in "${PIDS[@]:-}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+  for pid in "${PIDS[@]:-}"; do
+    wait "$pid" >/dev/null 2>&1 || true
+  done
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+write_probe() {
+  local dest="$1" value="$2"
+  mkdir -p "$dest/src" "$dest/scripts" "$dest/.cargo" "$dest/bin"
+  cat >"$dest/Cargo.toml" <<'EOF'
+[package]
+name = "orbit_cache_probe"
+version = "0.1.0"
+edition = "2021"
+EOF
+  printf 'pub fn value() -> i32 { %s }\n' "$value" >"$dest/src/lib.rs"
+  cat >"$dest/src/main.rs" <<'EOF'
+fn main() {
+    print!("{}", orbit_cache_probe::value() + 2);
+}
+EOF
+  cp "$ROOT/scripts/rustc-compiler-cache.sh" "$dest/scripts/rustc-compiler-cache.sh"
+  chmod +x "$dest/scripts/rustc-compiler-cache.sh"
+  cp "$ROOT/.cargo/config.toml" "$dest/.cargo/config.toml"
+  # Copy sccache into the tree so --tmpfs /tmp cannot hide a /tmp-installed binary.
+  cp "$sccache_bin" "$dest/bin/sccache"
+  chmod +x "$dest/bin/sccache"
+  (cd "$dest" && cargo generate-lockfile >/dev/null)
+}
+
+write_probe "$WORKDIR/src-c" 1
+write_probe "$WORKDIR/src-d" 4
+write_probe "$WORKDIR/src-e" 1
+mkdir -p "$WORKDIR/tgt-c" "$WORKDIR/tgt-d" "$WORKDIR/tgt-e" "$WORKDIR/cache" \
+  "$WORKDIR/logs" "$WORKDIR/sync"
+
+# Inside the namespace the tree is also at /tmp/orbit-workspace; prefer that
+# copy so stats and cargo use the same wrapper-visible binary.
+NS_SCCACHE=/tmp/orbit-workspace/bin/sccache
+
+run_ns() {
+  local tree="$1" target="$2" logfile="$3"
+  shift 3
+  local extra_binds=()
+  extra_binds+=(--bind "$tree" "$tree")
+  extra_binds+=(--bind "$target" "$target")
+  extra_binds+=(--bind "$WORKDIR/cache" "$WORKDIR/cache")
+  extra_binds+=(--bind "$WORKDIR/sync" "$WORKDIR/sync")
+  extra_binds+=(--dir /tmp/orbit-workspace --bind "$tree" /tmp/orbit-workspace)
+  extra_binds+=(--dir /tmp/orbit-build --bind "$target" /tmp/orbit-build)
+  extra_binds+=(--ro-bind "$tree/bin/sccache" "$tree/bin/sccache")
+  if [[ -n "${HOME:-}" && -d "$HOME" ]]; then
+    extra_binds+=(--ro-bind "$HOME" "$HOME")
+  fi
+  bwrap \
+    --die-with-parent \
+    --new-session \
+    --unshare-all \
+    --share-net \
+    --ro-bind / / \
+    --dev /dev \
+    --proc /proc \
+    --tmpfs /tmp \
+    "${extra_binds[@]}" \
+    --chdir /tmp/orbit-workspace \
+    --setenv HOME "${HOME:-$WORKDIR}" \
+    --setenv PATH "$PATH" \
+    --setenv CARGO_TARGET_DIR "$target" \
+    --setenv CARGO_INCREMENTAL 0 \
+    --setenv CARGO_BUILD_JOBS 1 \
+    --setenv SCCACHE_DIR "$WORKDIR/cache" \
+    --setenv ORBIT_COMPILER_CACHE_BIN "$NS_SCCACHE" \
+    "$@" \
+    -- \
+    /bin/bash -c '
+      set -euo pipefail
+      cargo run --offline --locked --quiet
+      printf "\n__SCCACHE_STATS__\n"
+      if [[ -n "${SCCACHE_SERVER_PORT:-}" ]]; then
+        SCCACHE_DIR="$SCCACHE_DIR" SCCACHE_SERVER_PORT="$SCCACHE_SERVER_PORT" \
+          "$ORBIT_COMPILER_CACHE_BIN" --show-stats || true
+      else
+        uds="${SCCACHE_SERVER_UDS:-/tmp/orbit-sccache.sock}"
+        SCCACHE_DIR="$SCCACHE_DIR" SCCACHE_SERVER_UDS="$uds" \
+          "$ORBIT_COMPILER_CACHE_BIN" --show-stats || true
+      fi
+    ' >"$logfile" 2>"$logfile.err"
+}
+
+# Owner namespace for the shared-daemon hazard: compile, signal ready, hold
+# until the sibling finishes so the TCP daemon stays in this mount ns.
+run_ns_hold() {
+  local tree="$1" target="$2" logfile="$3" ready="$4" done="$5"
+  shift 5
+  local extra_binds=()
+  extra_binds+=(--bind "$tree" "$tree")
+  extra_binds+=(--bind "$target" "$target")
+  extra_binds+=(--bind "$WORKDIR/cache" "$WORKDIR/cache")
+  extra_binds+=(--bind "$WORKDIR/sync" "$WORKDIR/sync")
+  extra_binds+=(--dir /tmp/orbit-workspace --bind "$tree" /tmp/orbit-workspace)
+  extra_binds+=(--dir /tmp/orbit-build --bind "$target" /tmp/orbit-build)
+  extra_binds+=(--ro-bind "$tree/bin/sccache" "$tree/bin/sccache")
+  if [[ -n "${HOME:-}" && -d "$HOME" ]]; then
+    extra_binds+=(--ro-bind "$HOME" "$HOME")
+  fi
+  bwrap \
+    --die-with-parent \
+    --new-session \
+    --unshare-all \
+    --share-net \
+    --ro-bind / / \
+    --dev /dev \
+    --proc /proc \
+    --tmpfs /tmp \
+    "${extra_binds[@]}" \
+    --chdir /tmp/orbit-workspace \
+    --setenv HOME "${HOME:-$WORKDIR}" \
+    --setenv PATH "$PATH" \
+    --setenv CARGO_TARGET_DIR "$target" \
+    --setenv CARGO_INCREMENTAL 0 \
+    --setenv CARGO_BUILD_JOBS 1 \
+    --setenv SCCACHE_DIR "$WORKDIR/cache" \
+    --setenv ORBIT_COMPILER_CACHE_BIN "$NS_SCCACHE" \
+    --setenv READY_FILE "$ready" \
+    --setenv DONE_FILE "$done" \
+    "$@" \
+    -- \
+    /bin/bash -c '
+      set -euo pipefail
+      cargo run --offline --locked --quiet
+      printf "\n__SCCACHE_STATS__\n"
+      SCCACHE_DIR="$SCCACHE_DIR" SCCACHE_SERVER_PORT="$SCCACHE_SERVER_PORT" \
+        "$ORBIT_COMPILER_CACHE_BIN" --show-stats || true
+      : >"$READY_FILE"
+      while [[ ! -f "$DONE_FILE" ]]; do
+        sleep 0.05
+      done
+      SCCACHE_DIR="$SCCACHE_DIR" SCCACHE_SERVER_PORT="$SCCACHE_SERVER_PORT" \
+        "$ORBIT_COMPILER_CACHE_BIN" --stop-server >/dev/null 2>&1 || true
+    ' >"$logfile" 2>"$logfile.err"
+}
+
+wait_for_file() {
+  local path="$1" attempts=0
+  while [[ ! -f "$path" ]]; do
+    attempts=$((attempts + 1))
+    [[ "$attempts" -lt 400 ]] || fail "timed out waiting for $path"
+    sleep 0.05
+  done
+}
+
+probe_out() {
+  local file="$1"
+  awk 'BEGIN {out=""} /^__SCCACHE_STATS__$/ {exit} {out=$0} END {printf "%s", out}' "$file"
+}
+
+has_rust_hit() {
+  local file="$1"
+  grep -Eq 'Cache hits \(Rust\)[[:space:]]+[1-9][0-9]*' "$file" \
+    || grep -Eq '^Cache hits[[:space:]]+[1-9][0-9]*$' "$file"
+}
+
+# Wrapper defaults: per-namespace daemon + client-side compile. Different
+# sources must each produce the expected binary while sharing SCCACHE_DIR.
+run_ns "$WORKDIR/src-c" "$WORKDIR/tgt-c" "$WORKDIR/logs/ok-c" &
+PIDS+=($!)
+pid_c=$!
+run_ns "$WORKDIR/src-d" "$WORKDIR/tgt-d" "$WORKDIR/logs/ok-d" &
+PIDS+=($!)
+pid_d=$!
+status=0
+wait "$pid_c" || status=1
+wait "$pid_d" || status=1
+PIDS=()
+if [[ "$status" -ne 0 ]]; then
+  cat "$WORKDIR/logs/ok-c.err" "$WORKDIR/logs/ok-d.err" >&2 || true
+  fail "isolated-daemon concurrent namespaces failed"
+fi
+assert_out_c="$(probe_out "$WORKDIR/logs/ok-c")"
+assert_out_d="$(probe_out "$WORKDIR/logs/ok-d")"
+[[ "$assert_out_c" == "3" ]] || fail "namespace C expected 3, got '$assert_out_c'"
+[[ "$assert_out_d" == "6" ]] || fail "namespace D expected 6, got '$assert_out_d'"
+[[ -x "$WORKDIR/tgt-c/debug/orbit_cache_probe" ]] || fail "namespace C missing private binary"
+[[ -x "$WORKDIR/tgt-d/debug/orbit_cache_probe" ]] || fail "namespace D missing private binary"
+if ! compgen -G "$WORKDIR/tgt-c/debug/deps/liborbit_cache_probe-*.rlib" >/dev/null; then
+  fail "namespace C missing private rlib"
+fi
+if compgen -G "$WORKDIR/src-d/target/debug/deps/liborbit_cache_probe-*.rlib" >/dev/null; then
+  fail "namespace D wrote into the sibling source tree"
+fi
+
+# Cross-worktree warm reuse: identical source, private cleaned target, shared disk cache.
+rm -rf "$WORKDIR/tgt-e"
+mkdir -p "$WORKDIR/tgt-e"
+run_ns "$WORKDIR/src-e" "$WORKDIR/tgt-e" "$WORKDIR/logs/ok-e" \
+  || {
+    cat "$WORKDIR/logs/ok-e.err" >&2 || true
+    fail "warm identical-source namespace failed"
+  }
+assert_out_e="$(probe_out "$WORKDIR/logs/ok-e")"
+[[ "$assert_out_e" == "3" ]] || fail "warm namespace E expected 3, got '$assert_out_e'"
+if ! has_rust_hit "$WORKDIR/logs/ok-e"; then
+  cat "$WORKDIR/logs/ok-e" >&2 || true
+  fail "identical second worktree did not report Rust cache hits"
+fi
+
+# Shared TCP daemon + client-side compile: rustc runs in each namespace.
+cs_port="$(alloc_port)"
+rm -rf "$WORKDIR/tgt-c" "$WORKDIR/tgt-d"
+mkdir -p "$WORKDIR/tgt-c" "$WORKDIR/tgt-d"
+run_ns "$WORKDIR/src-c" "$WORKDIR/tgt-c" "$WORKDIR/logs/cs-c" \
+  --setenv SCCACHE_CLIENT_SIDE 1 \
+  --setenv SCCACHE_SERVER_PORT "$cs_port" &
+PIDS+=($!)
+pid_c=$!
+run_ns "$WORKDIR/src-d" "$WORKDIR/tgt-d" "$WORKDIR/logs/cs-d" \
+  --setenv SCCACHE_CLIENT_SIDE 1 \
+  --setenv SCCACHE_SERVER_PORT "$cs_port" &
+PIDS+=($!)
+pid_d=$!
+status=0
+wait "$pid_c" || status=1
+wait "$pid_d" || status=1
+PIDS=()
+if [[ "$status" -ne 0 ]]; then
+  cat "$WORKDIR/logs/cs-c.err" "$WORKDIR/logs/cs-d.err" >&2 || true
+  fail "client-side shared TCP daemon concurrent namespaces failed"
+fi
+[[ "$(probe_out "$WORKDIR/logs/cs-c")" == "3" ]] || fail "client-side namespace C expected 3"
+[[ "$(probe_out "$WORKDIR/logs/cs-d")" == "6" ]] || fail "client-side namespace D expected 6"
+
+# Shared TCP daemon, server-side compile: hold C's namespace (and daemon) until D
+# has finished, reproducing the missing-artifact failure.
+bad_port="$(alloc_port)"
+rm -rf "$WORKDIR/tgt-c" "$WORKDIR/tgt-d" "$WORKDIR/cache" "$WORKDIR/sync"
+mkdir -p "$WORKDIR/tgt-c" "$WORKDIR/tgt-d" "$WORKDIR/cache" "$WORKDIR/sync"
+ready="$WORKDIR/sync/c-ready"
+donef="$WORKDIR/sync/c-done"
+run_ns_hold "$WORKDIR/src-c" "$WORKDIR/tgt-c" "$WORKDIR/logs/bad-c" "$ready" "$donef" \
+  --setenv SCCACHE_CLIENT_SIDE 0 \
+  --setenv SCCACHE_SERVER_PORT "$bad_port" &
+PIDS+=($!)
+pid_c=$!
+wait_for_file "$ready"
+run_ns "$WORKDIR/src-d" "$WORKDIR/tgt-d" "$WORKDIR/logs/bad-d" \
+  --setenv SCCACHE_CLIENT_SIDE 0 \
+  --setenv SCCACHE_SERVER_PORT "$bad_port" &
+PIDS+=($!)
+pid_d=$!
+set +e
+wait "$pid_d"
+d_status=$?
+set -e
+: >"$donef"
+wait "$pid_c" || true
+PIDS=()
+if [[ "$d_status" -eq 0 ]]; then
+  fail "shared TCP daemon should not succeed for a different-source namespace"
+fi
+if ! grep -E -q 'does not exist|extern location|/tmp/orbit-workspace' "$WORKDIR/logs/bad-d.err" \
+  && ! grep -E -q 'does not exist|extern location|/tmp/orbit-workspace' "$WORKDIR/logs/bad-d"; then
+  cat "$WORKDIR/logs/bad-d.err" >&2 || true
+  fail "shared-daemon failure did not look like the missing-artifact mismatch"
+fi
+
+printf 'test-compiler-cache-namespaces: ok\n'

--- a/scripts/test-compiler-cache.sh
+++ b/scripts/test-compiler-cache.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Fallback and enablement tests for scripts/rustc-compiler-cache.sh [ORB-11259].
+# Fallback and enablement tests for scripts/rustc-compiler-cache.sh [ORB-11259] [ORB-11755].
 # No full crate compile: the wrapper is a rustc argv passthrough.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WRAPPER="$ROOT/scripts/rustc-compiler-cache.sh"
+HOST_PATH="$PATH"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -16,6 +17,14 @@ fail() {
 assert_eq() {
   local got="$1" want="$2" msg="$3"
   [[ "$got" == "$want" ]] || fail "$msg: got '$got' want '$want'"
+}
+
+file_id() {
+  if stat -L -c '%d:%i' "$1" >/dev/null 2>&1; then
+    stat -L -c '%d:%i' "$1"
+  else
+    stat -L -f '%d:%i' "$1"
+  fi
 }
 
 mkdir -p "$TMP/bin"
@@ -35,7 +44,11 @@ printf '%s\n' "$@" > "${FAKE_SCCACHE_LOG}"
   printf 'SCCACHE_DIR=%s\n' "${SCCACHE_DIR-}"
   printf 'SCCACHE_BASEDIRS=%s\n' "${SCCACHE_BASEDIRS-}"
   printf 'SCCACHE_CLIENT_SIDE=%s\n' "${SCCACHE_CLIENT_SIDE-}"
+  printf 'SCCACHE_SERVER_UDS=%s\n' "${SCCACHE_SERVER_UDS-}"
+  printf 'SCCACHE_SERVER_PORT=%s\n' "${SCCACHE_SERVER_PORT-}"
+  printf 'CARGO_TARGET_DIR=%s\n' "${CARGO_TARGET_DIR-}"
 } > "${FAKE_SCCACHE_ENV:-/dev/null}"
+pwd > "${FAKE_SCCACHE_CWD:-/dev/null}"
 printf '%s' "${CACHE_ENV_SPACES-}" > "${FAKE_SCCACHE_SPACES:-/dev/null}"
 printf '%s' "${CACHE_ENV_EQUALS-}" > "${FAKE_SCCACHE_EQUALS:-/dev/null}"
 printf '%s' "${CACHE_ENV_MULTILINE-}" > "${FAKE_SCCACHE_MULTILINE:-/dev/null}"
@@ -49,6 +62,9 @@ chmod +x "$TMP/sccache"
 export HOME="$TMP/home"
 mkdir -p "$HOME"
 unset SCCACHE_DIR ORBIT_COMPILER_CACHE_BIN RUSTC_WRAPPER ORBIT_COMPILER_CACHE
+unset SCCACHE_CLIENT_SIDE SCCACHE_SERVER_UDS SCCACHE_SERVER_PORT
+unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
+unset ORBIT_COMPILER_CACHE_SERVER_UDS
 export ORBIT_COMPILER_CACHE_DEBUG=0
 # Isolate PATH so a host sccache cannot leak into fallback cases.
 export PATH="$TMP/bin:/usr/bin:/bin"
@@ -84,22 +100,27 @@ rm -f "$FAKE_SCCACHE_LOG" "$FAKE_RUSTC_LOG"
 [[ ! -f "$FAKE_SCCACHE_LOG" ]] || fail "unwritable cache must not exec sccache"
 chmod u+w "$HOME/.orbit/cache/compiler"
 
-# 4. Writable cache + sccache -> sccache then rustc.
+# 4. Writable cache + sccache -> sccache then rustc, with per-namespace daemon defaults.
 export FAKE_SCCACHE_LOG="$TMP/sccache-hit.log"
 export FAKE_SCCACHE_ENV="$TMP/sccache-hit.env"
+export FAKE_SCCACHE_CWD="$TMP/sccache-hit.cwd"
 export FAKE_RUSTC_LOG="$TMP/rustc-hit.log"
-rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_RUSTC_LOG"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_SCCACHE_CWD" "$FAKE_RUSTC_LOG"
 "$WRAPPER" "$TMP/bin/rustc" --crate-name cached
 [[ -f "$FAKE_SCCACHE_LOG" ]] || fail "writable cache did not exec sccache"
 [[ -f "$FAKE_RUSTC_LOG" ]] || fail "sccache did not exec rustc"
 head -n 1 "$FAKE_SCCACHE_LOG" | grep -Fq "$TMP/bin/rustc" || fail "sccache first arg should be rustc"
 grep -E -q '^SCCACHE_DIR=/.+' "$FAKE_SCCACHE_ENV" || fail "wrapper must export SCCACHE_DIR"
+grep -E -q '^SCCACHE_CLIENT_SIDE=1$' "$FAKE_SCCACHE_ENV" || fail "wrapper must default SCCACHE_CLIENT_SIDE=1"
+grep -E -q '^SCCACHE_SERVER_UDS=/tmp/orbit-sccache.sock$' "$FAKE_SCCACHE_ENV" || fail "wrapper must default a private /tmp UDS"
+grep -E -q '^SCCACHE_SERVER_PORT=$' "$FAKE_SCCACHE_ENV" || fail "wrapper must not invent a TCP port when using UDS"
 
 # 5. Operator surfaces exist and do not require a host sccache.
 "$ROOT/scripts/compiler-cache.sh" --help >/dev/null
 HOME="$HOME" "$ROOT/scripts/compiler-cache.sh" status >/dev/null
 
-# 6. When the Linux stable mounts alias this checkout, argv paths are rewritten.
+# 6. When the Linux stable mounts alias this checkout, argv paths are rewritten
+# and rustc cwd is the stable source mount (provider agent cwd is not changed).
 fake_tgt="$TMP/stable-target"
 stable_src="$TMP/orbit-workspace"
 stable_tgt="$TMP/orbit-build"
@@ -110,12 +131,14 @@ export ORBIT_COMPILER_CACHE_STABLE_SRC="$stable_src"
 export ORBIT_COMPILER_CACHE_STABLE_TGT="$stable_tgt"
 export FAKE_SCCACHE_LOG="$TMP/sccache-rewrite.log"
 export FAKE_SCCACHE_ENV="$TMP/sccache-rewrite.env"
+export FAKE_SCCACHE_CWD="$TMP/sccache-rewrite.cwd"
 export FAKE_RUSTC_LOG="$TMP/rustc-rewrite.log"
 export CARGO_TARGET_DIR="$fake_tgt"
-rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_RUSTC_LOG"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_SCCACHE_CWD" "$FAKE_RUSTC_LOG"
 "$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" "$ROOT/crates/orbit-types/src/lib.rs"
 grep -Fq "$stable_tgt/debug" "$FAKE_SCCACHE_LOG" || fail "out-dir should rewrite onto the stable build mount"
 grep -Fq "$stable_src/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "source path should rewrite onto the stable workspace mount"
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$stable_src" "stable-mount rustc cwd"
 
 # Environment values are read without splitting, and only paths rooted at the
 # checkout or target directory are rewritten. Keep expected files in TMP so
@@ -149,6 +172,87 @@ cmp "$TMP/env-empty.expected" "$FAKE_SCCACHE_EMPTY" || fail "empty environment v
 cmp "$TMP/env-boundary.expected" "$FAKE_SCCACHE_BOUNDARY" || fail "target path-prefix boundary was rewritten unexpectedly"
 cmp "$TMP/env-source-boundary.expected" "$FAKE_SCCACHE_SOURCE_BOUNDARY" || fail "source path-prefix boundary was rewritten unexpectedly"
 
+# Relative compiler inputs stay relative so they resolve after the stable chdir
+# instead of being expanded to a unique worktree prefix.
+export FAKE_SCCACHE_LOG="$TMP/sccache-relative.log"
+export FAKE_SCCACHE_CWD="$TMP/sccache-relative.cwd"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_CWD"
+(
+  cd "$ROOT"
+  "$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" crates/orbit-types/src/lib.rs
+)
+grep -Fq "crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "relative source arg should stay relative"
+grep -Fq "$ROOT/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" && fail "relative source arg must not expand to the original worktree path"
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$stable_src" "relative-arg rustc cwd after stable chdir"
+
+# Nested workspace-member cwd keeps its suffix so relative src/lib.rs does not
+# change referent when the stable source mount aliases the repo root.
+mkdir -p "$stable_src/crates/orbit-types"
+export FAKE_SCCACHE_LOG="$TMP/sccache-nested-cwd.log"
+export FAKE_SCCACHE_CWD="$TMP/sccache-nested-cwd.cwd"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_CWD"
+(
+  cd "$ROOT/crates/orbit-types"
+  "$WRAPPER" "$TMP/bin/rustc" --out-dir "$fake_tgt/debug" src/lib.rs
+)
+grep -Fq "src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "nested-cwd relative src/lib.rs should stay relative"
+grep -Fq "$ROOT/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" && fail "nested-cwd relative input must not expand to the original worktree path"
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$stable_src/crates/orbit-types" "nested member rustc cwd"
+
+# cwd outside the checkout is left alone even when the stable source mount aliases.
+mkdir -p "$TMP/external-cwd"
+export FAKE_SCCACHE_LOG="$TMP/sccache-external-cwd.log"
+export FAKE_SCCACHE_CWD="$TMP/sccache-external-cwd.cwd"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_CWD"
+(
+  cd "$TMP/external-cwd"
+  "$WRAPPER" "$TMP/bin/rustc" --crate-name external src/lib.rs
+)
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$TMP/external-cwd" "external cwd must not move to the repo root"
+
+# 7. Custom CARGO_TARGET_DIR that is not aliased to STABLE_TGT still rewrites
+# source paths and cwd. Silently skipping all rewriting was the measured miss.
+custom_tgt="$TMP/custom-target"
+mkdir -p "$custom_tgt"
+export CARGO_TARGET_DIR="$custom_tgt"
+export FAKE_SCCACHE_LOG="$TMP/sccache-custom-tgt.log"
+export FAKE_SCCACHE_ENV="$TMP/sccache-custom-tgt.env"
+export FAKE_SCCACHE_CWD="$TMP/sccache-custom-tgt.cwd"
+rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_SCCACHE_CWD"
+"$WRAPPER" "$TMP/bin/rustc" --out-dir "$custom_tgt/debug" "$ROOT/crates/orbit-types/src/lib.rs"
+grep -Fq "$stable_src/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "custom target must not prevent source rewrite"
+grep -Fq "$custom_tgt/debug" "$FAKE_SCCACHE_LOG" || fail "custom --out-dir should stay in the private target"
+grep -Fq "$stable_tgt/debug" "$FAKE_SCCACHE_LOG" && fail "unaliased custom target must not rewrite onto STABLE_TGT"
+grep -E -q "^CARGO_TARGET_DIR=${custom_tgt}$" "$FAKE_SCCACHE_ENV" || fail "unaliased CARGO_TARGET_DIR must not be rewritten"
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$stable_src" "custom-target rustc cwd still normalizes"
+
+# 8. Explicit daemon overrides are preserved (shared-daemon regression setup).
+unset CARGO_TARGET_DIR
+export SCCACHE_CLIENT_SIDE=0
+export SCCACHE_SERVER_PORT=45265
+unset SCCACHE_SERVER_UDS
+export FAKE_SCCACHE_ENV="$TMP/sccache-override.env"
+export FAKE_SCCACHE_LOG="$TMP/sccache-override.log"
+rm -f "$FAKE_SCCACHE_ENV" "$FAKE_SCCACHE_LOG"
+"$WRAPPER" "$TMP/bin/rustc" --crate-name override
+grep -E -q '^SCCACHE_CLIENT_SIDE=0$' "$FAKE_SCCACHE_ENV" || fail "explicit SCCACHE_CLIENT_SIDE=0 must be preserved"
+grep -E -q '^SCCACHE_SERVER_PORT=45265$' "$FAKE_SCCACHE_ENV" || fail "explicit SCCACHE_SERVER_PORT must be preserved"
+grep -E -q '^SCCACHE_SERVER_UDS=$' "$FAKE_SCCACHE_ENV" || fail "explicit TCP port must not also set a UDS"
+unset SCCACHE_CLIENT_SIDE SCCACHE_SERVER_PORT
+
+# 9. Without a source alias, rustc cwd stays the caller's directory. Force
+# non-matching aliases so a live /tmp/orbit-workspace mount cannot leak in.
+mkdir -p "$TMP/no-src" "$TMP/no-tgt"
+export ORBIT_COMPILER_CACHE_STABLE_SRC="$TMP/no-src"
+export ORBIT_COMPILER_CACHE_STABLE_TGT="$TMP/no-tgt"
+export FAKE_SCCACHE_CWD="$TMP/sccache-noalias.cwd"
+export FAKE_SCCACHE_LOG="$TMP/sccache-noalias.log"
+rm -f "$FAKE_SCCACHE_CWD" "$FAKE_SCCACHE_LOG"
+noalias_cwd="$(pwd)"
+"$WRAPPER" "$TMP/bin/rustc" --crate-name noalias
+assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "$noalias_cwd" "unaliased wrapper must not chdir"
+unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
+
 # sccache must return the compiler's status unchanged.
 export FAKE_RUSTC_EXIT_STATUS=23
 set +e
@@ -156,7 +260,51 @@ set +e
 status=$?
 set -e
 assert_eq "$status" "23" "compiler exit status"
+unset FAKE_RUSTC_EXIT_STATUS
 unset CARGO_TARGET_DIR
-unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
+
+# 10. Actual Linux stable mounts in this sandbox: source rewrite + cwd, even
+# with a custom target path that is not /tmp/orbit-build.
+if [[ -e /tmp/orbit-workspace/Cargo.toml && -e "$ROOT/Cargo.toml" ]] \
+  && [[ "$(file_id /tmp/orbit-workspace/Cargo.toml)" == "$(file_id "$ROOT/Cargo.toml")" ]]; then
+  real_custom="$TMP/real-custom-target"
+  mkdir -p "$real_custom"
+  unset ORBIT_COMPILER_CACHE_STABLE_SRC ORBIT_COMPILER_CACHE_STABLE_TGT
+  export CARGO_TARGET_DIR="$real_custom"
+  export FAKE_SCCACHE_LOG="$TMP/sccache-real-mount.log"
+  export FAKE_SCCACHE_ENV="$TMP/sccache-real-mount.env"
+  export FAKE_SCCACHE_CWD="$TMP/sccache-real-mount.cwd"
+  rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_ENV" "$FAKE_SCCACHE_CWD"
+  (
+    cd "$ROOT"
+    "$WRAPPER" "$TMP/bin/rustc" --out-dir "$real_custom/debug" "$ROOT/crates/orbit-types/src/lib.rs"
+  )
+  grep -Fq "/tmp/orbit-workspace/crates/orbit-types/src/lib.rs" "$FAKE_SCCACHE_LOG" \
+    || fail "real stable source mount should rewrite the input path"
+  grep -Fq "$real_custom/debug" "$FAKE_SCCACHE_LOG" \
+    || fail "real-mount custom --out-dir should remain private"
+  grep -Fq "/tmp/orbit-build/debug" "$FAKE_SCCACHE_LOG" \
+    && fail "custom target must not silently alias onto /tmp/orbit-build"
+  grep -E -q "^CARGO_TARGET_DIR=${real_custom}$" "$FAKE_SCCACHE_ENV" \
+    || fail "real-mount custom CARGO_TARGET_DIR must stay unaliased"
+  assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "/tmp/orbit-workspace" "real stable-mount rustc cwd"
+  export FAKE_SCCACHE_LOG="$TMP/sccache-real-nested.log"
+  export FAKE_SCCACHE_CWD="$TMP/sccache-real-nested.cwd"
+  rm -f "$FAKE_SCCACHE_LOG" "$FAKE_SCCACHE_CWD"
+  (
+    cd "$ROOT/crates/orbit-types"
+    "$WRAPPER" "$TMP/bin/rustc" --out-dir "$real_custom/debug" src/lib.rs
+  )
+  grep -Fq "src/lib.rs" "$FAKE_SCCACHE_LOG" || fail "real-mount nested relative src/lib.rs should stay relative"
+  assert_eq "$(cat "$FAKE_SCCACHE_CWD")" "/tmp/orbit-workspace/crates/orbit-types" "real-mount nested member rustc cwd"
+  unset CARGO_TARGET_DIR
+fi
+
+# Live mount-namespace regression lives in a sibling script so this file stays
+# a wrapper-argv unit test. Nested sandboxes that cannot create user
+# namespaces skip that script instead of failing ci-fast.
+if [[ -x "$ROOT/scripts/test-compiler-cache-namespaces.sh" ]]; then
+  PATH="$HOST_PATH" "$ROOT/scripts/test-compiler-cache-namespaces.sh"
+fi
 
 printf 'test-compiler-cache: ok\n'


### PR DESCRIPTION
## Task

[ORB-11755](https://orbit-cli.com/tasks/ORB-11755) — Validate compiler-cache effectiveness across managed worktrees and fix measured blockers

### Description

## Problem
Host inspection on 2026-09-08 confirms compiler caching disabled: ~/.orbit/cache/compiler absent and sccache unavailable. Existing ORB-11259 installed wrapper/hooks and stable sandbox mount support, but recorded zero cross-worktree hits before those mounts were deployed. Its claim of cross-worktree benefit remains unverified on the current installed 0.19.2 host. Active jobs also use private custom CARGO_TARGET_DIR values that may prevent stable-target aliasing.
## Scope
Inspect and validate existing compiler-cache harness and wrapper with current Linux sandbox semantics. Produce bounded reproducible cold/no-cache, cold-fill, warm second-worktree and concurrent evidence at identical source revision and toolchain, plus Clippy cacheability and incremental/custom-target limitations. Fix concrete wrapper/harness issues demonstrated by measurements; avoid speculative redesign. The orchestrator will handle user-level host setup outside the managed worker when needed; do not modify live workers or global config from this task.
## Constraints
Use isolated cache/target directories for experiments, low compiler parallelism and a small representative crate first. Retain uncached fallback and private per-worktree targets. No merge or release. Coordinate scripts with separate build-budget task. Do not accept hit counts alone as proof of reduced CPU/wall time.
## Confirmed Host Findings and Ownership
The orchestrator reproduced zero reuse with original worktree cwd, then 46/46 warm cache hits for orbit-types with a stable cwd. A shared long-lived sccache daemon across differently mounted source trees fails artifact resolution; correctness of namespace-specific daemon ownership is required, not just hit-rate improvement. Detailed experiments and scratch paths are in task comments. Existing Makefile cache hooks suffice: do not modify Makefile, which belongs to ORB-11754. Limit edits to the existing cache wrapper/harness/runbook and necessary Linux sandbox boundary; new files are allowed when justified.

### Acceptance Criteria

- A reproducible benchmark records source revision, toolchain, workload, CPU and wall time, cache hits/misses/noncacheable reasons for no-cache baseline, cache cold fill and a different worktree warm build.
- Exercise actual Linux stable source/target mount behavior and a custom target path; identify or fix paths that silently prevent reuse, with deterministic regression coverage for changes.
- Evaluate Clippy and incremental-build behavior explicitly; document workloads where enabling sccache is ineffective or slower and a practical opt-out.
- Any code changes pass make ci-fast and make ci-lint; provide evidence and precise host setup steps needed to obtain the measured result.
- Concurrent Linux mount namespaces with different source contents must produce each expected output in separate private targets while sharing the disk cache; demonstrate correct daemon namespace ownership, cross-worktree warm reuse, and cleanup. Regress the reproduced shared-daemon missing-artifact failure; do not globally enable the cache before this passes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- rustc wrapper now rewrites source and target independently, remaps rustc cwd onto the stable source mount while preserving a nested suffix (crates/foo) and leaving an external cwd alone, defaults SCCACHE_CLIENT_SIDE=1 and a private /tmp UDS, and keeps relative compiler args relative.
- test-compiler-cache.sh covers cwd suffix, external cwd, unaliased custom CARGO_TARGET_DIR, real /tmp/orbit-workspace mounts, and daemon overrides.
- test-compiler-cache-namespaces.sh (invoked from the unit test; Makefile untouched) exercises distinct-source namespaces with copied-in sccache, matching stats endpoints, isolated TCP ports, owner-namespace hold for the shared-daemon missing-rlib failure, and a warm-reuse assertion that requires actual Rust cache hits.
- Bench uses an isolated workdir cache+UDS, refuses SCCACHE_DIR outside that tree, stops only the owned daemon, labels unnormalized copy-tree arms as miss-path controls, and records Clippy-driver vs incremental prohibition.
- Runbook documents daemon ownership, custom targets, Clippy-driver vs dependency reuse, incremental hard-fail, opt-out ORBIT_COMPILER_CACHE=0, and host setup. Bubblewrap --chdir stays on the real worktree.
- docs/INDEX.md regenerated so ci-fast index check passes (also lists the already-landed build-budget runbook row).
Assessment: Wrapper and unit tests match the measured blockers (cwd key, custom target silent skip, nested relative inputs, client-side daemon ownership). Live concurrent namespaces could not be created in this implementer sandbox (bwrap EPERM); the harness is ready for a host that can create user namespaces. Global cache was not enabled.

Criteria:
1. Reproducible benchmark schema (revision, toolchain, workload, wall/CPU via /usr/bin/time, hits/misses/non-cacheable) is in scripts/bench-compiler-cache.sh. Full orbit-types cold/warm not executed in this nested worker. Isolated sccache 0.17.0 tiny-crate smoke: uncached wall 0.08s; cold fill 0.45s 0 hits/1 miss; Clippy added missing output_dir=2 and multiple input files=1. Historical host orbit-types timings in comments are server-side and are not this candidate's CPU evidence.
2. Real Linux stable mounts exercised in this sandbox (same inode /tmp/orbit-workspace). Custom CARGO_TARGET_DIR no longer disables source/cwd rewrite. Deterministic tests cover rewrite, nested cwd, external cwd, and unaliased custom targets. Agent --chdir remains the worktree path.
3. Clippy-driver analysis invocations are non-cacheable on the tiny fixture; rustc dependency compiles on a representative graph may still hit. sccache 0.17.0 hard-fails CARGO_INCREMENTAL=1 ("incremental compilation is prohibited"). Opt-out: ORBIT_COMPILER_CACHE=0. Cold fill can be slower than uncached.
4. make ci-fast: passed. cargo clippy -p orbit-exec --all-targets -- -D warnings: passed. cargo test -p orbit-exec --test linux_sandbox managed_worktree_argv_binds_stable_workspace_and_build_mounts: passed. make ci-lint: failed on pre-existing HEAD orbit-search test mocks missing Embedder::token_boundaries (crates/orbit-search/src/vector/store/tests/upsert.rs); not in this diff. Host setup: scripts/compiler-cache.sh setup --install outside the worker; ORBIT_COMPILER_CACHE_REQUIRE_NS=1 scripts/test-compiler-cache-namespaces.sh on a host that can create user namespaces; do not enable ~/.orbit/cache until that passes.
5. Nested bwrap: skipped (bwrap: No permissions to create new namespace). Host comments already showed SCCACHE_CLIENT_SIDE=1 distinct-source namespaces producing 3 and 6, and CLIENT_SIDE=0 missing rlib. This run did not re-execute those live namespaces. Global cache left disabled (~/.orbit/cache/compiler absent).

Validation:
- ./scripts/test-compiler-cache.sh: passed (namespace script skipped)
- make ci-fast: passed
- cargo clippy -p orbit-exec --all-targets -- -D warnings: passed
- cargo test -p orbit-exec --test linux_sandbox managed_worktree_argv_binds_stable_workspace_and_build_mounts: passed
- make ci-lint: failed (pre-existing orbit-search test Embedder impls on HEAD)
- git diff --check: passed
- Live concurrent namespace compile: not run (EPERM)

Remaining risks: host must run test-compiler-cache-namespaces.sh before enabling the global cache; make ci-lint is red on this branch independently of this change; copy-tree bench arms without bind mounts are miss-path controls, not cross-worktree hits.

Strategic decisions: client-side compile plus private /tmp UDS as default ownership; do not remap provider agent cwd.
Deviations: did not edit Makefile; did not write ~/.orbit/cache.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11755-6a9f6b05`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol