### PR TITLE
[code-review] Remove arbitrary task scans and redundant git probes from tool context resolution

### DIFF
--- a/crates/orbit-core/src/adapter/command/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/dispatch.rs
@@ -279,7 +279,7 @@ impl OrbitRuntime {
                     ..Default::default()
                 };
                 if proc_spawn_activity_scoped {
-                    populate_filesystem_policy_context(self, None, &mut tool_context)?;
+                    populate_filesystem_policy_context(self, &mut tool_context)?;
                 }
                 let capability_enforcement = match entry_point {
                     ToolEntryPoint::Cli => CapabilityEnforcement::Enforce,

--- a/crates/orbit-core/src/runtime/tests/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tests/tool_exec.rs
@@ -1,12 +1,20 @@
 //! Sibling tests for `tool_exec.rs` (migrated per ORB-00246 / docs/design-patterns/test_layout.md).
 
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
 use crate::OrbitRuntime;
+use crate::adapter::tool_host::build_orbit_tool_host;
+use crate::runtime::tool_exec::{
+    ContextResolutionProbes, populate_filesystem_policy_context, resolve_task_id_from_context,
+};
+use orbit_store::contracts::TaskCreateParams;
 use orbit_tools::ToolContext;
 use orbit_types::policy::Role;
-
-use orbit_store::contracts::TaskCreateParams;
-use orbit_types::task::{TaskPriority, TaskStatus, TaskType};
+use orbit_types::task::{Task, TaskPriority, TaskStatus, TaskType};
+use orbit_types::tool::ToolSessionContext;
 use serde_json::json;
+use tempfile::TempDir;
 
 #[test]
 fn run_tool_context_allowlist_honors_task_wildcard() {
@@ -63,4 +71,306 @@ fn run_tool_context_allowlist_honors_task_wildcard() {
         .expect("wildcard activity context should permit orbit.task.show");
 
     assert_eq!(output["id"], task.id);
+}
+
+#[test]
+fn consecutive_registered_calls_from_repo_root_skip_task_scan_and_git_probes() {
+    let fixture = GitRuntimeFixture::new();
+    let first = create_task(&fixture.runtime, &fixture.repo_root, "first");
+    let _second = create_task(&fixture.runtime, &fixture.repo_root, "second");
+    let repo_root = canonical(&fixture.repo_root);
+
+    assert!(
+        resolve_task_id_from_context(&fixture.runtime, &cwd_context(&repo_root, None, None))
+            .expect("resolve task id")
+            .is_none(),
+        "cwd-inside-repo must not select an arbitrary first task"
+    );
+
+    let probes = ContextResolutionProbes::capture();
+    for _ in 0..2 {
+        // fs.read is retired; the registered execution path is the same seam.
+        let output = fixture
+            .runtime
+            .run_tool_with_context_and_role(
+                "orbit.task.show",
+                json!({ "id": first.id.clone() }),
+                Role::Admin,
+                cwd_context(&repo_root, None, None),
+            )
+            .expect("registered show");
+        assert_eq!(output["id"], first.id);
+    }
+
+    assert_eq!(
+        probes.git_checkout_probes(),
+        0,
+        "stable repository-root cwd must not spawn git checkout probes"
+    );
+    assert_eq!(
+        probes.git_common_dir_probes(),
+        0,
+        "stable repository-root cwd must not spawn git common-dir probes"
+    );
+}
+
+#[test]
+fn dry_run_and_registered_resolution_preserve_explicit_host_context() {
+    let fixture = GitRuntimeFixture::new();
+    let first = create_task(&fixture.runtime, &fixture.repo_root, "first");
+    let shown = create_task(&fixture.runtime, &fixture.repo_root, "shown");
+    let repo_root = canonical(&fixture.repo_root);
+    let host = build_orbit_tool_host(
+        &fixture.runtime,
+        Some(first.id.clone()),
+        Some("jrun-keep".to_string()),
+        ToolSessionContext::default(),
+    );
+
+    let dry_run = fixture
+        .runtime
+        .run_tool_dry_run("orbit.task.show", &json!({ "id": shown.id.clone() }))
+        .expect("dry-run");
+    assert!(dry_run.missing_params.is_empty());
+    assert!(
+        resolve_task_id_from_context(&fixture.runtime, &cwd_context(&repo_root, None, None))
+            .expect("resolve")
+            .is_none()
+    );
+
+    let output = fixture
+        .runtime
+        .run_tool_with_context_and_role(
+            "orbit.task.show",
+            json!({ "id": shown.id.clone() }),
+            Role::Admin,
+            cwd_context(&repo_root, Some(host.clone()), None),
+        )
+        .expect("show with explicit host");
+    assert_eq!(output["id"], shown.id);
+    assert_eq!(
+        host.task_scope().task_id.as_deref(),
+        Some(first.id.as_str())
+    );
+    assert_eq!(host.task_scope().run_id.as_deref(), Some("jrun-keep"));
+}
+
+#[test]
+fn task_show_does_not_enumerate_the_table_for_scope_inference() {
+    let fixture = GitRuntimeFixture::new();
+    let mut ids = Vec::new();
+    for index in 0..12 {
+        ids.push(
+            create_task(
+                &fixture.runtime,
+                &fixture.repo_root,
+                &format!("task-{index}"),
+            )
+            .id,
+        );
+    }
+    let requested = ids[7].clone();
+    let repo_root = canonical(&fixture.repo_root);
+
+    // Before: list_tasks() of all 12 + get_task(first) for unused root
+    // inference, then get_task(requested) for the show payload.
+    // After: inference reads 0 rows; show reads the requested bundle only.
+    assert!(
+        resolve_task_id_from_context(&fixture.runtime, &cwd_context(&repo_root, None, None))
+            .expect("resolve")
+            .is_none()
+    );
+
+    let output = fixture
+        .runtime
+        .run_tool_with_context_and_role(
+            "orbit.task.show",
+            json!({ "id": requested.clone(), "fields": ["id", "title"] }),
+            Role::Admin,
+            cwd_context(&repo_root, None, None),
+        )
+        .expect("show requested task");
+    assert_eq!(output["id"], requested);
+    assert_eq!(output["title"], "task-7");
+}
+
+#[test]
+fn root_resolution_keeps_linked_worktrees_and_rejects_unrelated_checkouts() {
+    let fixture = GitRuntimeFixture::new();
+    let repo_root = canonical(&fixture.repo_root);
+    let linked = canonical(&fixture.linked);
+    let unrelated = canonical(&fixture.unrelated);
+
+    let probes = ContextResolutionProbes::capture();
+    let mut linked_context = cwd_context(&linked, None, None);
+    populate_filesystem_policy_context(&fixture.runtime, &mut linked_context)
+        .expect("populate linked worktree");
+    assert_eq!(
+        linked_context.workspace_root.as_deref(),
+        Some(linked.as_path()),
+        "linked worktree cwd must remain that checkout"
+    );
+    assert!(
+        probes.git_checkout_probes() >= 1,
+        "linked worktree is outside the runtime checkout and still probes git"
+    );
+    assert!(probes.git_common_dir_probes() >= 1);
+
+    let probes = ContextResolutionProbes::capture();
+    let mut unrelated_context = cwd_context(&unrelated, None, None);
+    populate_filesystem_policy_context(&fixture.runtime, &mut unrelated_context)
+        .expect("populate unrelated checkout");
+    assert_eq!(
+        unrelated_context.workspace_root.as_deref(),
+        Some(repo_root.as_path()),
+        "unrelated checkout must not become the filesystem policy root"
+    );
+    assert!(
+        probes.git_checkout_probes() >= 1,
+        "unrelated cwd is outside the runtime checkout"
+    );
+
+    let probes = ContextResolutionProbes::capture();
+    let mut supplied = cwd_context(&linked, None, Some(repo_root.clone()));
+    populate_filesystem_policy_context(&fixture.runtime, &mut supplied)
+        .expect("preserve supplied root");
+    assert_eq!(
+        supplied.workspace_root.as_deref(),
+        Some(repo_root.as_path())
+    );
+    assert_eq!(
+        probes.git_checkout_probes() + probes.git_common_dir_probes(),
+        0,
+        "an already-supplied workspace_root must not re-probe git"
+    );
+}
+
+struct GitRuntimeFixture {
+    _root: TempDir,
+    runtime: OrbitRuntime,
+    repo_root: PathBuf,
+    linked: PathBuf,
+    unrelated: PathBuf,
+}
+
+impl GitRuntimeFixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("tempdir");
+        let global_root = root.path().join("global");
+        let repo_root = root.path().join("repo");
+        let linked = root.path().join("linked");
+        let unrelated = root.path().join("unrelated");
+        std::fs::create_dir_all(&global_root).expect("global");
+        std::fs::create_dir_all(repo_root.join(".orbit")).expect("workspace");
+        std::fs::create_dir_all(&unrelated).expect("unrelated");
+
+        git(&repo_root, &["init", "-b", "agent-main"]);
+        git(&repo_root, &["config", "user.name", "Orbit Test"]);
+        git(
+            &repo_root,
+            &["config", "user.email", "orbit-test@example.com"],
+        );
+        git(&repo_root, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(repo_root.join("README.md"), "init\n").expect("write");
+        git(&repo_root, &["add", "README.md"]);
+        git(&repo_root, &["commit", "-m", "init"]);
+        git(
+            &repo_root,
+            &[
+                "worktree",
+                "add",
+                linked.to_str().expect("utf8 linked path"),
+                "HEAD",
+            ],
+        );
+
+        git(&unrelated, &["init", "-b", "other"]);
+        git(&unrelated, &["config", "user.name", "Orbit Test"]);
+        git(
+            &unrelated,
+            &["config", "user.email", "orbit-test@example.com"],
+        );
+        git(&unrelated, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(unrelated.join("other.txt"), "other\n").expect("write unrelated");
+        git(&unrelated, &["add", "other.txt"]);
+        git(&unrelated, &["commit", "-m", "unrelated"]);
+
+        let runtime = OrbitRuntime::from_roots(&global_root, &repo_root.join(".orbit"))
+            .expect("build runtime");
+        Self {
+            _root: root,
+            runtime,
+            repo_root,
+            linked,
+            unrelated,
+        }
+    }
+}
+
+fn create_task(runtime: &OrbitRuntime, workspace_path: &Path, title: &str) -> Task {
+    runtime
+        .stores()
+        .task_records()
+        .create(TaskCreateParams {
+            actor: "test".to_string(),
+            parent_id: None,
+            title: title.to_string(),
+            description: "context-resolution fixture".to_string(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            relations: Vec::new(),
+            tags: Vec::new(),
+            required_tools: Vec::new(),
+            plan: String::new(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: Some(workspace_path.to_string_lossy().into_owned()),
+            repo_root: None,
+            created_by: Some("test".to_string()),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
+            orchestrator: None,
+            comments: Vec::new(),
+        })
+        .expect("create task")
+}
+
+fn cwd_context(
+    cwd: &Path,
+    orbit_host: Option<std::sync::Arc<dyn orbit_tools::OrbitToolHost>>,
+    workspace_root: Option<PathBuf>,
+) -> ToolContext {
+    ToolContext {
+        cwd: Some(cwd.to_string_lossy().into_owned()),
+        orbit_host,
+        workspace_root,
+        ..Default::default()
+    }
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn git(current_dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn git {}: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "git {} failed in {}:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        current_dir.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }

--- a/crates/orbit-core/src/runtime/tool_exec.rs
+++ b/crates/orbit-core/src/runtime/tool_exec.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -36,12 +38,7 @@ impl OrbitRuntime {
                 .map(|cwd| cwd.to_string_lossy().into_owned());
         }
 
-        let resolved_task_id = match tool_context.orbit_host.as_ref() {
-            Some(host) => host.task_scope().task_id,
-            None => resolve_task_id_from_context(self, &tool_context)?,
-        };
-
-        populate_filesystem_policy_context(self, resolved_task_id.as_deref(), &mut tool_context)?;
+        populate_filesystem_policy_context(self, &mut tool_context)?;
 
         self.check_tool_enabled(name)?;
 
@@ -115,9 +112,7 @@ impl OrbitRuntime {
                 .map(|cwd| cwd.to_string_lossy().into_owned()),
             ..Default::default()
         };
-        let task_id = resolve_task_id_from_context(self, &tool_context)?;
-        tool_context.workspace_root =
-            resolve_workspace_root_from_context(self, task_id.as_deref(), &tool_context)?;
+        tool_context.workspace_root = resolve_workspace_root_from_context(self, &tool_context)?;
 
         // Validate required parameters are present
         let mut missing_params = Vec::new();
@@ -164,12 +159,10 @@ impl OrbitRuntime {
 /// handling when the managed envelope omitted `ORBIT_ACTIVITY_FS_PROFILE`.
 pub(crate) fn populate_filesystem_policy_context(
     runtime: &OrbitRuntime,
-    task_id: Option<&str>,
     tool_context: &mut ToolContext,
 ) -> Result<(), OrbitError> {
     if tool_context.workspace_root.is_none() {
-        tool_context.workspace_root =
-            resolve_workspace_root_from_context(runtime, task_id, tool_context)?;
+        tool_context.workspace_root = resolve_workspace_root_from_context(runtime, tool_context)?;
     }
     if tool_context.policy_engine.is_none() {
         tool_context.policy_engine = Some(Arc::new(runtime.policy_engine().clone()));
@@ -180,39 +173,23 @@ pub(crate) fn populate_filesystem_policy_context(
     Ok(())
 }
 
+/// Task scope is supplied by the caller (host or trusted run envelope).
+///
+/// Cwd-inside-repo is not a task selector: scanning the table and returning
+/// the first row was both arbitrary and unused by root resolution.
 pub(crate) fn resolve_task_id_from_context(
-    runtime: &OrbitRuntime,
-    tool_context: &ToolContext,
+    _runtime: &OrbitRuntime,
+    _tool_context: &ToolContext,
 ) -> Result<Option<String>, OrbitError> {
-    let Some(cwd) = tool_context.cwd.as_deref() else {
-        return Ok(None);
-    };
-    let canonical_cwd = match Path::new(cwd).canonicalize() {
-        Ok(path) => path,
-        Err(_) => PathBuf::from(cwd),
-    };
-    let canonical_repo_root = canonical_repo_root(runtime);
-    if !task_workspace_matches(&canonical_repo_root, &canonical_cwd) {
-        return Ok(None);
-    }
-
-    let tasks = runtime.stores().tasks().list_tasks()?;
-    Ok(tasks.into_iter().next().map(|task| task.id))
+    Ok(None)
 }
 
 fn resolve_workspace_root_from_context(
     runtime: &OrbitRuntime,
-    task_id: Option<&str>,
     tool_context: &ToolContext,
 ) -> Result<Option<PathBuf>, OrbitError> {
     let canonical_repo_root = canonical_repo_root(runtime);
     if let Some(workspace_root) = active_git_checkout_root(&canonical_repo_root, tool_context) {
-        return Ok(Some(workspace_root));
-    }
-
-    if let Some(task_id) = task_id
-        && let Some(workspace_root) = resolve_task_workspace_root(runtime, task_id)
-    {
         return Ok(Some(workspace_root));
     }
     Ok(Some(canonical_repo_root))
@@ -227,23 +204,28 @@ fn canonical_repo_root(runtime: &OrbitRuntime) -> PathBuf {
         .unwrap_or_else(|_| runtime.context.paths().repo_root.clone())
 }
 
-fn resolve_task_workspace_root(runtime: &OrbitRuntime, task_id: &str) -> Option<PathBuf> {
-    let repo_root = canonical_repo_root(runtime);
-    runtime.get_task(task_id).ok()?;
-    Some(repo_root)
-}
-
 fn active_git_checkout_root(
     canonical_repo_root: &Path,
     tool_context: &ToolContext,
 ) -> Option<PathBuf> {
     let cwd = tool_context.cwd.as_deref()?;
     let cwd = Path::new(cwd);
+    let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+
+    // Stable checkout fast path: the runtime's own tree does not need git
+    // probes. Linked worktrees and unrelated checkouts fall through.
+    if canonical_cwd.starts_with(canonical_repo_root) {
+        return Some(canonical_repo_root.to_path_buf());
+    }
+
     let checkout_root = git_checkout_root(cwd)?;
     same_git_common_dir(&checkout_root, canonical_repo_root).then_some(checkout_root)
 }
 
 fn git_checkout_root(path: &Path) -> Option<PathBuf> {
+    #[cfg(test)]
+    GIT_CHECKOUT_PROBES.with(|count| count.set(count.get() + 1));
+
     let output = Command::new("git")
         .arg("-C")
         .arg(path)
@@ -270,6 +252,9 @@ fn same_git_common_dir(left: &Path, right: &Path) -> bool {
 }
 
 fn git_common_dir(path: &Path) -> Option<PathBuf> {
+    #[cfg(test)]
+    GIT_COMMON_DIR_PROBES.with(|count| count.set(count.get() + 1));
+
     let output = Command::new("git")
         .arg("-C")
         .arg(path)
@@ -288,8 +273,30 @@ fn git_common_dir(path: &Path) -> Option<PathBuf> {
     Some(path.canonicalize().unwrap_or(path))
 }
 
-fn task_workspace_matches(canonical_workspace: &Path, canonical_cwd: &Path) -> bool {
-    canonical_cwd.starts_with(canonical_workspace)
+#[cfg(test)]
+thread_local! {
+    static GIT_CHECKOUT_PROBES: Cell<usize> = const { Cell::new(0) };
+    static GIT_COMMON_DIR_PROBES: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) struct ContextResolutionProbes;
+
+#[cfg(test)]
+impl ContextResolutionProbes {
+    pub(crate) fn capture() -> Self {
+        GIT_CHECKOUT_PROBES.with(|count| count.set(0));
+        GIT_COMMON_DIR_PROBES.with(|count| count.set(0));
+        Self
+    }
+
+    pub(crate) fn git_checkout_probes(&self) -> usize {
+        GIT_CHECKOUT_PROBES.with(Cell::get)
+    }
+
+    pub(crate) fn git_common_dir_probes(&self) -> usize {
+        GIT_COMMON_DIR_PROBES.with(Cell::get)
+    }
 }
 
 fn read_activity_fs_profile_from_env() -> Option<String> {


### PR DESCRIPTION
## Task

[ORB-11600](https://orbit-cli.com/tasks/ORB-11600) — [code-review] Remove arbitrary task scans and redundant git probes from tool context resolution

### Description

## Problem
When tool context requires inferred task scope and has a cwd inside the repository, `resolve_task_id_from_context` loads the full task list and returns its first task. The filesystem-root consumer then reads that task but returns the repository root regardless. Missing workspace-root context can also trigger repeated git checkout/common-directory probes. These costs are conditional on context; they do not occur on every tool call.

## Required behavior
Remove arbitrary first-task inference and its redundant target read while preserving explicitly supplied host/run context. Resolve filesystem roots without task-table scans. Consolidated scope includes ORB-11635: cover ordinary registered execution and dry-run paths, and avoid redundant canonical-root/common-directory probes for the stable repository-root case.
Preserve linked-worktree and unrelated-checkout isolation. Prefer a bounded stable-root fast path; any cache for other cwd paths needs an explicit lifetime/invalidation rule because checkout topology can change during a long-lived runtime. Do not retain stale negative or authorization-relevant root results indefinitely. A task.show request still legitimately reads its requested task bundle; the target is eliminating unrelated full-table and arbitrary-task reads.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/adapter/tool_execution.rs:50`; `crates/orbit-core/src/runtime/tool_exec.rs:118`, `:183`, `:199`, `:209`, `:230`, `:247`.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- Two consecutive registered fs.read calls from a stable repository-root cwd perform no task-store reads for context inference and avoid repeated git checkout/common-directory probes; use counters at scoped seams rather than global PATH mutation in parallel tests.
- Registered and dry-run context resolution no longer selects an arbitrary task; existing explicit host/run context remains intact.
- Task.show with many unrelated tasks reads only data needed for its requested task and does not enumerate the task table for scope inference; report a bounded before/after measurement.
- Root-resolution tests preserve linked-worktree handling and reject unrelated-checkout scope; any broader cache is tested against its declared topology-change/invalidation behavior.
- Relevant runtime and tool-host state/task tests pass without weakening filesystem policy.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Stopped cwd-based first-task inference. `resolve_task_id_from_context` returns None; explicit `orbit_host` / trusted run env remain the only task/run scope. Registered host attach and dry-run no longer `list_tasks` or `get_task` for unused root resolution.
- Deleted `resolve_task_workspace_root` (it read a task then returned the repo root). Dropped the unused `task_id` argument from `populate_filesystem_policy_context`.
- Fast-path workspace root when canonical cwd is inside the runtime checkout; skip `git rev-parse --show-toplevel` and `--git-common-dir`. Linked worktrees still probe git and keep that checkout as `workspace_root`. Unrelated checkouts do not become the policy root. No cwd→root cache (topology can change; negatives are authorization-relevant).
- Thread-local git-probe counters at the checkout/common-dir seams. Tests use `orbit.task.show` on the registered `run_tool` path because `fs.read` is retired (ORB-10798 / ORB-10828).
- Added `file:crates/orbit-core/src/adapter/command/dispatch.rs` and `file:crates/orbit-core/src/runtime/tests/tool_exec.rs` as directly affected consumers/tests.

Assessment: Scoped change at the context-resolution boundary; filesystem policy still fail-closed for unrelated checkouts and still honors a pre-supplied `workspace_root`.

Criteria:
1. Two consecutive registered calls from repo-root cwd: no task-table scan for inference (`resolve_task_id_from_context` is None with two tasks present); git checkout/common-dir counters stay 0. Passed via `consecutive_registered_calls_from_repo_root_skip_task_scan_and_git_probes`.
2. Dry-run and registered attach no longer pick an arbitrary task; explicit host task_id/run_id survive. Passed via `dry_run_and_registered_resolution_preserve_explicit_host_context`.
3. Task.show of one id among 12 unrelated tasks does not enumerate the table for scope inference. Before: `list_tasks()` of 12 + `get_task(first)` + `get_task(requested)`. After: inference reads 0 rows; show with `fields=[id,title]` reads only the requested envelope. Passed via `task_show_does_not_enumerate_the_table_for_scope_inference`.
4. Linked worktree cwd keeps that checkout; unrelated git repo is rejected as policy root; supplied `workspace_root` skips git. No broader cache. Passed via `root_resolution_keeps_linked_worktrees_and_rejects_unrelated_checkouts`.
5. `runtime::tests::runtime` (14), `runtime::tests::tool_exec` (5), `adapter::tool_host::tests::task_tools` (68, excluding a pre-existing deadlock), `adapter::tool_host::tests::state_tools` (6) passed. `cargo clippy -p orbit-core --all-targets -- -D warnings` passed.

Validation:
- `cargo test -p orbit-core --lib runtime::tests::tool_exec`: passed (5 tests).
- `cargo test -p orbit-core --lib runtime::tests::runtime`: passed (14 tests).
- `cargo test -p orbit-core --lib adapter::tool_host::tests::task_tools -- --skip checkoutless_updates_to_distinct_tasks_remain_independent`: passed (68 tests).
- `cargo test -p orbit-core --lib adapter::tool_host::tests::state_tools`: passed (6 tests).
- `cargo clippy -p orbit-core --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed as the first `make ci-fast` step.
- Remaining `make ci-fast` scripts after docs index: passed.
- `make ci-fast`: failed at pre-existing `docs/INDEX.md is stale` (no docs files in this diff).
- `make ci-lint`: failed in unrelated `orbit-search` test Embedder stubs missing `token_boundaries`; orbit-core clippy passed.
- `git diff --check`: passed.
- `adapter::tool_host::tests::task_tools::checkoutless_updates_to_distinct_tasks_remain_independent`: not run to completion; deadlocks alone on this checkout (HubCoordinationExecutor, not this path).

Risks:
- Workspace `make ci-fast` / `make ci-lint` remain red on this snapshot for reasons outside this diff.
- Fast path treats any cwd under the runtime checkout as that checkout; a nested foreign git worktree inside the tree would not be granted as `workspace_root` (same as the previous fallback when common dirs differ).

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11600-6a9f6bfd`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra