### PR TITLE
[code-review] Print the host's real task prefix in `workspace init --task-id-start` output

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -112,13 +112,12 @@ impl WorkspaceInitArgs {
         if let Some(start) = task_id_start {
             let outcome =
                 orbit_core::bootstrap::task_migration::seed_task_id_start(&global_root, start)?;
+            let rendered_id =
+                render_task_id_start(init_result.task_prefix.as_deref(), outcome.next);
             if outcome.changed {
-                println!("  id_start:  allocator seeded to ORB-{:05}", outcome.next);
+                println!("  id_start:  allocator seeded to {rendered_id}");
             } else {
-                println!(
-                    "  id_start:  allocator already at ORB-{:05} (unchanged)",
-                    outcome.next
-                );
+                println!("  id_start:  allocator already at {rendered_id} (unchanged)");
             }
         }
 
@@ -172,12 +171,15 @@ impl WorkspaceInitArgs {
         if let Some(mode) = self.ship_mode.as_deref() {
             orbit_core::ShipMode::parse(mode)?;
         }
-        let (local_machine_id, local_host_id) = match inspect_host_identity(global_root)? {
-            HostIdentityState::Present(identity) => {
-                (Some(identity.machine_id), Some(identity.host_id))
-            }
-            HostIdentityState::Legacy { .. } | HostIdentityState::Absent => (None, None),
-        };
+        let (local_machine_id, local_host_id, task_prefix) =
+            match inspect_host_identity(global_root)? {
+                HostIdentityState::Present(identity) => (
+                    Some(identity.machine_id),
+                    Some(identity.host_id),
+                    Some(identity.task_prefix),
+                ),
+                HostIdentityState::Legacy { .. } | HostIdentityState::Absent => (None, None, None),
+            };
         let explicit_role = self.role.map(WorkspaceCheckoutRole::from);
         match (explicit_role, self.owner.as_deref()) {
             (None, Some(_)) => {
@@ -412,7 +414,15 @@ impl WorkspaceInitArgs {
             name,
             root: cwd.to_path_buf(),
             orbit_dir: orbit_dir.to_path_buf(),
+            task_prefix,
         })
+    }
+}
+
+pub(super) fn render_task_id_start(task_prefix: Option<&str>, next: u32) -> String {
+    match task_prefix {
+        Some(task_prefix) => format!("{task_prefix}-{next:05}"),
+        None => format!("{next:05}"),
     }
 }
 
@@ -614,4 +624,5 @@ struct WorkspaceInitResult {
     name: String,
     root: PathBuf,
     orbit_dir: PathBuf,
+    task_prefix: Option<String>,
 }

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -12,12 +12,17 @@ use crate::tests::env_isolation::EnvGuard;
 
 use super::super::init::{
     ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id,
-    onboarding_finalize_guidance,
+    onboarding_finalize_guidance, render_task_id_start,
 };
 use super::super::list::{format_workspace_list, workspace_list_json};
 use super::super::role::CliCheckoutRole;
 use super::super::show::format_workspace_show;
 use super::super::support::orbit_gitignore_block;
+
+#[test]
+fn task_id_start_uses_the_host_task_prefix() {
+    assert_eq!(render_task_id_start(Some("DANI"), 20_000), "DANI-20000");
+}
 
 #[test]
 fn workspace_reinit_requires_force_and_force_reconciles_matching_registration() {


### PR DESCRIPTION
## Task

[ORB-11617](https://orbit-cli.com/tasks/ORB-11617) — [code-review] Print the host's real task prefix in `workspace init --task-id-start` output

### Description

## Problem
After seeding the allocator the command prints `allocator seeded to ORB-{:05}` / `allocator already at ORB-{:05}` with a hard-coded `ORB` prefix (`init.rs:98,101`). The task prefix is per-host and chosen at `orbit init` (`validate_new_task_prefix`, `orbit-registry/src/host_identity.rs:36-48`; this machine's `~/.orbit/host.toml` has `task_prefix = "DANI"`), and `sync_task_prefix` (`registry_runtime.rs:549-556`) projects it into the allocator. So on any host that is not `ORB` the confirmation names an id that will never be minted.

## Why It Matters
The line exists to confirm the id range an operator just handed a machine; printing the wrong prefix is a confirmation of the wrong fact during first-run setup.

## Proposed Fix
Use the `HostIdentityState::Present(identity).task_prefix` already read at `init.rs:157-162` (thread it out of `execute_at_path` or re-read it) to format the id, and fall back to the bare number when no identity exists.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/workspace/init.rs:94-105`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- On a host with `task_prefix = "DANI"`, `orbit workspace init --task-id-start 20000 --force` prints `DANI-20000`.
- A sibling test in `crates/orbit-cli/src/command/workspace/tests/init.rs` asserts the rendered line for a non-`ORB` prefix.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Threaded the present host identity task prefix through workspace initialization into the `--task-id-start` confirmation, with a zero-prefix fallback that renders the bare five-digit number.
- Added sibling regression coverage asserting the non-ORB rendering `DANI-20000`.
Assessment: The output now names the allocator namespace selected for the host while preserving existing seeded and unchanged messages.
Acceptance criteria:
- A present `task_prefix = "DANI"` is rendered as `DANI-20000`: satisfied by the shared output path and regression test.
- Sibling test coverage in `crates/orbit-cli/src/command/workspace/tests/init.rs`: satisfied.
Validation:
- `cargo test -p orbit-cli command::workspace::tests::init::task_id_start_uses_the_host_task_prefix`: passed.
- `cargo test -p orbit-cli command::workspace::tests::init`: passed, 29 tests.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short`: passed; only the two task-scoped source files are modified.
Deviations from original plan: none.
Remaining risks: No known risks; direct host-level CLI invocation was not added because the sibling unit test covers the extracted renderer and the command path uses it directly.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11617-6a9f7091`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra