### PR TITLE
[code-review] Remove or implement the dead and misleading flags on `orbit tool run`

### DIFF
--- a/crates/orbit-cli/src/command/operation.rs
+++ b/crates/orbit-cli/src/command/operation.rs
@@ -751,7 +751,7 @@ impl Commands {
                 )
             }
             Commands::Tool(command) => {
-                use super::tool::{OutputFormat, ToolSubcommand};
+                use super::tool::ToolSubcommand;
                 let (subcommand, tool_name, target_type, target_id, role, json_output) =
                     match &command.command {
                         ToolSubcommand::Run(args) => (
@@ -760,7 +760,7 @@ impl Commands {
                             Some("tool".to_string()),
                             Some(args.name.clone()),
                             tool_run_actor_role(args),
-                            matches!(args.output, OutputFormat::Json).then_some(args.pretty),
+                            Some(args.pretty),
                         ),
                         ToolSubcommand::List(_) => {
                             ("list", None, None, None, "admin".to_string(), None)

--- a/crates/orbit-cli/src/command/tests/operation.rs
+++ b/crates/orbit-cli/src/command/tests/operation.rs
@@ -113,18 +113,6 @@ fn json_error_preferences_are_derived_from_operations() {
         Some(true)
     );
     assert_eq!(
-        operation_for(&[
-            "orbit",
-            "tool",
-            "run",
-            "orbit.task.show",
-            "--output",
-            "text",
-        ])
-        .json_error_preference,
-        None
-    );
-    assert_eq!(
         operation_for(&["orbit", "docs", "list", "--json"]).json_error_preference,
         Some(true)
     );

--- a/crates/orbit-cli/src/command/tool/mod.rs
+++ b/crates/orbit-cli/src/command/tool/mod.rs
@@ -12,7 +12,7 @@ mod show;
 mod support;
 
 pub use command::{ToolCommand, ToolSubcommand};
-pub use run::{OutputFormat, ToolRunArgs};
+pub use run::ToolRunArgs;
 
 #[cfg(test)]
 mod tests;

--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -1,4 +1,4 @@
-use clap::{Args, ValueEnum};
+use clap::Args;
 use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
 use orbit_cmd::task_owner::bound_workspace_identity;
 use orbit_common::observability::audit_id::audit_execution_id;
@@ -8,13 +8,6 @@ use orbit_types::tool::{McpTransport, ToolSessionContext};
 use serde_json::{Map, Value};
 
 use crate::command::{CommandOut, Execute, Payload};
-
-#[derive(Clone, ValueEnum, Default)]
-pub enum OutputFormat {
-    #[default]
-    Json,
-    Text,
-}
 
 #[derive(Args)]
 pub struct ToolRunArgs {
@@ -32,9 +25,6 @@ pub struct ToolRunArgs {
     /// Exact agent model for provenance attribution (overrides ORBIT_AGENT_MODEL)
     #[arg(long)]
     pub model: Option<String>,
-    /// Execution timeout (e.g. "30s", "5000ms")
-    #[arg(long)]
-    pub timeout: Option<String>,
     /// Validate without executing
     #[arg(long)]
     pub dry_run: bool,
@@ -44,12 +34,9 @@ pub struct ToolRunArgs {
     /// Return the tool's full unfiltered JSON output
     #[arg(long)]
     pub full: bool,
-    /// Pretty-print JSON output for human debugging
-    #[arg(long)]
+    /// Compatibility alias for pretty-printing JSON error output
+    #[arg(long, hide = true)]
     pub pretty: bool,
-    /// Output format
-    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
-    pub output: OutputFormat,
 }
 
 impl ToolRunArgs {
@@ -138,13 +125,7 @@ impl Execute for ToolRunArgs {
         )?;
         let output = shape_tool_output(&self.name, &input, output, self.full, &self.fields);
 
-        // Local `--output`/`--pretty` stay accepted (ORB-11618 owns removing
-        // them). `--format` still wins: a Text human view is ignored when the
-        // sink is json/ndjson, and Json always hands the document to render.
-        match self.output {
-            OutputFormat::Json => Ok(Payload::document(output).into()),
-            OutputFormat::Text => Ok(Payload::detail(output.clone(), output.to_string()).into()),
-        }
+        Ok(Payload::document(output).into())
     }
 }
 

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -13,12 +13,10 @@ fn task_show_id_is_read_only_from_orbit_task_show_input() {
         input_file: None,
         agent: None,
         model: None,
-        timeout: None,
         dry_run: false,
         fields: Vec::new(),
         full: false,
         pretty: false,
-        output: super::super::run::OutputFormat::Json,
     };
     assert_eq!(show.task_show_id().as_deref(), Some("ORB-10961"));
 

--- a/crates/orbit-cli/tests/output_goldens.rs
+++ b/crates/orbit-cli/tests/output_goldens.rs
@@ -667,7 +667,7 @@ fn log_tail_format_ndjson_emits_three_event_lines() {
 }
 
 #[test]
-fn global_format_outranks_local_json_and_tool_output_flags() {
+fn global_format_controls_tool_run_output() {
     let fixture = Fixture::new();
     let (task_id, title) = first_listed_task(&fixture);
 
@@ -684,22 +684,11 @@ fn global_format_outranks_local_json_and_tool_output_flags() {
     );
     assert!(table_text.contains(&title), "{table_text}");
 
-    let json_over_output_text = parse_json_stdout(
-        &fixture.run(
-            &[
-                "tool",
-                "run",
-                "orbit.task.list",
-                "--output",
-                "text",
-                "--format",
-                "json",
-            ],
-            &[],
-        ),
-        "tool run --output text --format json",
+    let tool_output = parse_json_stdout(
+        &fixture.run(&["tool", "run", "orbit.task.list", "--format", "json"], &[]),
+        "tool run --format json",
     );
-    assert!(json_over_output_text.as_array().is_some());
+    assert!(tool_output.as_array().is_some());
 
     let config = parse_json_stdout(
         &fixture.run(


### PR DESCRIPTION
## Task

[ORB-11618](https://orbit-cli.com/tasks/ORB-11618) — [code-review] Remove or implement the dead and misleading flags on `orbit tool run`

### Description

## Problem
`--timeout` is declared with help text promising "Execution timeout (e.g. "30s", "5000ms")" (`run.rs:35-37`) but `self.timeout` is never read anywhere in the crate (`grep -rn timeout crates/orbit-cli/src/command/tool/` matches only the declaration); verified with binary: `--timeout 1ms` runs to completion. `--output text` (`run.rs:147-150`) does `println!("{}", output)` on a `serde_json::Value`, whose `Display` is compact JSON, so `text` and `json` produce identical bytes (verified). The command therefore carries three overlapping format controls — `--output`, `--pretty`, and the global `--format` — of which one is a no-op and one is a lie.

## Why It Matters
`tool run` is the agent-facing escape hatch; help text that advertises a timeout that does not exist causes callers to rely on protection they do not have.

## Proposed Fix
Delete `--timeout` (or wire it to `execute_tool_command_with_session_context` if the runtime exposes a deadline) and delete `--output`; let `--format` select rendering and keep `--pretty` only as a hidden alias for `--format json` on a TTY. Land this with the payload conversion in the `--format` finding above.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/tool/run.rs:12-17,35-37,47-52,136-151`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit tool run --help` no longer lists `--timeout` or `--output`, or `--timeout 1ms` demonstrably aborts a slow tool.
- `crates/orbit-cli/src/command/tool/tests/run.rs` has no reference to `OutputFormat::Text`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed the unused --timeout and redundant --output/OutputFormat flags from orbit tool run.
- Returned tool results directly as document payloads so the global --format renderer owns output selection.
- Retained --pretty only as a hidden compatibility flag for JSON error formatting.
- Updated operation metadata and CLI tests to match the simplified surface.

Assessment: The scoped CLI behavior is complete and the diff is limited to the implementation, direct consumers, and affected tests.

Acceptance criteria:
- orbit tool run --help omits --timeout and --output: passed; verified against the built binary.
- --timeout 1ms is no longer accepted: passed; the built binary exits 2 with an unexpected-argument error.
- crates/orbit-cli/src/command/tool/tests/run.rs has no OutputFormat::Text reference: passed; scoped search found none.

Validation:
- cargo fmt --all -- --check: passed.
- cargo test -p orbit-cli command::tool::tests::run: passed (4 tests).
- cargo test -p orbit-cli --test output_goldens global_format_controls_tool_run_output: passed.
- cargo test -p orbit-cli --test output_goldens: failed on pre-existing tool_list.json golden drift; all seven other tests passed, including the changed tool-run coverage. The drift is unrelated to this task.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
- Final git status --short: only the six task-scoped files are modified.

Remaining risk: The existing command::tests::operation::json_error_preferences_are_derived_from_operations test also fails while parsing an unrelated duplicate --workspace option in search; no out-of-scope fix was made. Changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11618-6a9f70a4`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra