### PR TITLE
[code-review] Move `/api/log` off the async worker and stop scanning the whole log file

### DIFF
--- a/crates/orbit-web/src/api/log.rs
+++ b/crates/orbit-web/src/api/log.rs
@@ -95,9 +95,14 @@ pub(super) async fn get_log(Query(q): Query<LogQuery>) -> Response {
         Ok(path) => path,
         Err(e) => return map_runtime_error(e),
     };
-    match read_log_snapshot_from_path(&path, &q) {
+    // File scan is blocking IO; run it on the pool, not the request worker.
+    match super::blocking("log snapshot", move || {
+        read_log_snapshot_from_path(&path, &q)
+    })
+    .await
+    {
         Ok(snapshot) => Json(snapshot).into_response(),
-        Err(e) => map_runtime_error(e),
+        Err(response) => *response,
     }
 }
 

--- a/crates/orbit-web/src/api/tests/log.rs
+++ b/crates/orbit-web/src/api/tests/log.rs
@@ -333,3 +333,117 @@ fn reconnect_with_last_event_id_replays_only_lines_after_offset() {
         "Last-Event-ID must not replay the line at that offset: {frames:?}"
     );
 }
+
+#[test]
+fn log_snapshot_skips_malformed_records_and_preserves_order() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    write_lines(
+        &path,
+        &[
+            log_line("keep-1"),
+            "not-json".to_string(),
+            "{".to_string(),
+            log_line("keep-2"),
+        ],
+    );
+
+    let snapshot = read_log_snapshot_from_path(
+        &path,
+        &LogQuery {
+            limit: Some(10),
+            ..LogQuery::default()
+        },
+    )
+    .expect("snapshot");
+
+    assert_eq!(snapshot.events.len(), 2);
+    assert!(snapshot.events[0].message_html.contains("keep-1"));
+    assert!(snapshot.events[1].message_html.contains("keep-2"));
+    assert_eq!(
+        snapshot.offset,
+        std::fs::metadata(&path).expect("metadata").len()
+    );
+}
+
+#[test]
+fn log_snapshot_includes_final_line_without_trailing_newline() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    let body = format!("{}\n{}", log_line("first"), log_line("last"));
+    std::fs::write(&path, body).expect("write");
+
+    let snapshot = read_log_snapshot_from_path(
+        &path,
+        &LogQuery {
+            limit: Some(10),
+            ..LogQuery::default()
+        },
+    )
+    .expect("snapshot");
+
+    assert_eq!(snapshot.events.len(), 2);
+    assert!(snapshot.events[0].message_html.contains("first"));
+    assert!(snapshot.events[1].message_html.contains("last"));
+}
+
+#[test]
+fn log_snapshot_zero_limit_returns_no_events() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    write_lines(&path, &[log_line("seed")]);
+
+    let snapshot = read_log_snapshot_from_path(
+        &path,
+        &LogQuery {
+            limit: Some(0),
+            ..LogQuery::default()
+        },
+    )
+    .expect("snapshot");
+
+    assert!(snapshot.events.is_empty());
+    assert_eq!(
+        snapshot.offset,
+        std::fs::metadata(&path).expect("metadata").len()
+    );
+}
+
+#[test]
+fn log_snapshot_missing_file_returns_empty_events() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("missing.jsonl");
+
+    let snapshot = read_log_snapshot_from_path(
+        &path,
+        &LogQuery {
+            limit: Some(10),
+            ..LogQuery::default()
+        },
+    )
+    .expect("snapshot");
+
+    assert!(snapshot.events.is_empty());
+    assert_eq!(snapshot.offset, 0);
+}
+
+#[tokio::test]
+async fn log_snapshot_scan_runs_through_blocking_boundary() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("orbit.jsonl");
+    write_lines(&path, &[log_line("blocked")]);
+    let query = LogQuery {
+        limit: Some(10),
+        ..LogQuery::default()
+    };
+
+    let snapshot = super::super::blocking("log snapshot", {
+        let path = path.clone();
+        move || read_log_snapshot_from_path(&path, &query)
+    })
+    .await
+    .unwrap_or_else(|_| panic!("blocking snapshot"));
+
+    assert_eq!(snapshot.events.len(), 1);
+    assert!(snapshot.events[0].message_html.contains("blocked"));
+}

--- a/crates/orbit-web/src/log_format.rs
+++ b/crates/orbit-web/src/log_format.rs
@@ -4,7 +4,7 @@
 //! used by /api/log and /api/diagnostics.
 
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -142,6 +142,10 @@ pub(crate) fn resolve_log_path(override_path: Option<&Path>) -> Result<PathBuf, 
     })
 }
 
+/// Block size for reverse JSONL scans. Sparse filters may still walk every
+/// block to offset 0; a dense tail stops once `limit` matches are in hand.
+pub(crate) const TAIL_READ_BLOCK: usize = 64 * 1024;
+
 pub(crate) fn read_recent_matching_events(
     path: &Path,
     filters: &Filters,
@@ -152,18 +156,112 @@ pub(crate) fn read_recent_matching_events(
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
     };
-    let reader = BufReader::new(file);
-    let mut kept = Vec::new();
-    for line in reader.lines() {
-        let line = line?;
-        if let Some(event) = parse_matching_event(&line, filters) {
-            kept.push(event);
-            if kept.len() > limit {
-                kept.remove(0);
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    read_recent_matching_events_from(file, filters, limit, TAIL_READ_BLOCK)
+}
+
+/// Newest matching JSONL events from a seekable reader, scanning backwards.
+///
+/// `block_size` is the read window so tests can force a line to span blocks
+/// without a huge fixture. Production callers use [`TAIL_READ_BLOCK`].
+pub(crate) fn read_recent_matching_events_from<R: Read + Seek>(
+    mut reader: R,
+    filters: &Filters,
+    limit: usize,
+    block_size: usize,
+) -> io::Result<Vec<Value>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let block_size = if block_size == 0 {
+        TAIL_READ_BLOCK
+    } else {
+        block_size
+    };
+
+    let mut pos = reader.seek(SeekFrom::End(0))?;
+    if pos == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut newest_first = Vec::with_capacity(limit);
+    let mut carry = Vec::new();
+    let mut buf = Vec::new();
+
+    while pos > 0 && newest_first.len() < limit {
+        let chunk_len = u64::min(block_size as u64, pos);
+        let start = pos - chunk_len;
+        reader.seek(SeekFrom::Start(start))?;
+        buf.clear();
+        buf.resize(chunk_len as usize, 0);
+        reader.read_exact(&mut buf)?;
+        if !carry.is_empty() {
+            buf.extend_from_slice(&carry);
+        }
+
+        let (next_carry, complete) = split_tail_chunk(&buf, start > 0)?;
+        carry = next_carry;
+        pos = start;
+
+        for line in complete.into_iter().rev() {
+            if let Some(event) = parse_matching_event(&line, filters) {
+                newest_first.push(event);
+                if newest_first.len() == limit {
+                    break;
+                }
             }
         }
     }
-    Ok(kept)
+
+    newest_first.reverse();
+    Ok(newest_first)
+}
+
+/// Split a reverse-scan block into an incomplete prefix (belongs to earlier
+/// bytes) and complete lines in chronological order, including a final
+/// fragment that has no trailing newline.
+fn split_tail_chunk(chunk: &[u8], has_earlier_bytes: bool) -> io::Result<(Vec<u8>, Vec<String>)> {
+    if chunk.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    if has_earlier_bytes {
+        match chunk.iter().position(|&b| b == b'\n') {
+            None => Ok((chunk.to_vec(), Vec::new())),
+            Some(i) => {
+                let carry = chunk[..i].to_vec();
+                let lines = decode_lines(&chunk[i + 1..])?;
+                Ok((carry, lines))
+            }
+        }
+    } else {
+        Ok((Vec::new(), decode_lines(chunk)?))
+    }
+}
+
+fn decode_lines(bytes: &[u8]) -> io::Result<Vec<String>> {
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut lines = Vec::new();
+    let mut start = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            lines.push(decode_line(&bytes[start..i])?);
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        lines.push(decode_line(&bytes[start..])?);
+    }
+    Ok(lines)
+}
+
+fn decode_line(raw: &[u8]) -> io::Result<String> {
+    let line =
+        std::str::from_utf8(raw).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    Ok(line.strip_suffix('\r').unwrap_or(line).to_string())
 }
 
 pub(crate) fn read_recent_rendered_events(

--- a/crates/orbit-web/src/tests/log_format.rs
+++ b/crates/orbit-web/src/tests/log_format.rs
@@ -1,5 +1,8 @@
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+use std::time::Instant;
+
 use orbit_common::test_fixtures::TEST_CODEX_MODEL;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::super::log_format::*;
 
@@ -40,4 +43,322 @@ fn render_log_event_for_web_uses_shared_labels_and_lowercase_level() {
     assert_eq!(rendered.code, "DENY");
     assert_eq!(rendered.level, "warn");
     assert!(rendered.message_html.contains("<b>path</b>="));
+}
+
+fn event_line(ts: &str, target: &str, message: &str) -> String {
+    json!({
+        "timestamp": ts,
+        "level": "INFO",
+        "target": target,
+        "fields": { "message": message }
+    })
+    .to_string()
+}
+
+fn join_lines(lines: &[String], trailing_newline: bool) -> String {
+    let mut raw = lines.join("\n");
+    if trailing_newline && !raw.is_empty() {
+        raw.push('\n');
+    }
+    raw
+}
+
+fn naive_forward(raw: &str, filters: &Filters, limit: usize) -> Vec<Value> {
+    let mut kept = Vec::new();
+    for line in raw.lines() {
+        if let Some(event) = parse_matching_event(line, filters) {
+            kept.push(event);
+            if kept.len() > limit {
+                kept.remove(0);
+            }
+        }
+    }
+    kept
+}
+
+fn scan(raw: &str, filters: &Filters, limit: usize, block_size: usize) -> Vec<Value> {
+    read_recent_matching_events_from(Cursor::new(raw.as_bytes()), filters, limit, block_size)
+        .expect("scan")
+}
+
+struct CountingReader<R> {
+    inner: R,
+    bytes_read: u64,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes_read += n as u64;
+        Ok(n)
+    }
+}
+
+impl<R: Seek> Seek for CountingReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+#[test]
+fn reverse_scan_keeps_last_matches_in_chronological_order() {
+    let lines = [
+        event_line("2026-04-27T01:00:01Z", "orbit.keep", "a"),
+        event_line("2026-04-27T01:00:02Z", "orbit.keep", "b"),
+        event_line("2026-04-27T01:00:03Z", "orbit.keep", "c"),
+        event_line("2026-04-27T01:00:04Z", "orbit.keep", "d"),
+        event_line("2026-04-27T01:00:05Z", "orbit.keep", "e"),
+    ];
+    let raw = join_lines(&lines, true);
+    let events = scan(&raw, &Filters::default(), 2, 16);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["fields"]["message"], "d");
+    assert_eq!(events[1]["fields"]["message"], "e");
+}
+
+#[test]
+fn reverse_scan_applies_target_level_and_since_filters() {
+    let raw = join_lines(
+        &[
+            json!({
+                "timestamp": "2026-04-27T01:00:01Z",
+                "level": "INFO",
+                "target": "orbit.policy.deny",
+                "fields": {"tool": "proc.spawn", "path": "/tmp/a"}
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-04-27T01:00:03Z",
+                "level": "WARN",
+                "target": "orbit.policy.deny",
+                "fields": {"tool": "fs.write", "path": "/etc/passwd"}
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-04-27T01:00:04Z",
+                "level": "ERROR",
+                "target": "orbit.job.step_finished",
+                "fields": {"step_id": "build", "outcome": "failed", "success": false}
+            })
+            .to_string(),
+        ],
+        true,
+    );
+    let filters = Filters::from_query_parts(
+        Some("orbit.policy".to_string()),
+        Some("warn".to_string()),
+        Some("2026-04-27T01:00:02Z"),
+    )
+    .expect("filters");
+    let events = scan(&raw, &filters, 10, 32);
+    assert_eq!(events, naive_forward(&raw, &filters, 10));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["level"], "WARN");
+    assert_eq!(events[0]["target"], "orbit.policy.deny");
+}
+
+#[test]
+fn reverse_scan_skips_malformed_records() {
+    let raw = format!(
+        "{}\nnot-json\n{}\n{}\n",
+        event_line("2026-04-27T01:00:01Z", "orbit.keep", "first"),
+        "{",
+        event_line("2026-04-27T01:00:02Z", "orbit.keep", "second"),
+    );
+    let events = scan(&raw, &Filters::default(), 10, 8);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["fields"]["message"], "first");
+    assert_eq!(events[1]["fields"]["message"], "second");
+}
+
+#[test]
+fn reverse_scan_reconstructs_lines_that_span_blocks() {
+    let long_message = "m".repeat(40);
+    let lines = [
+        event_line("2026-04-27T01:00:01Z", "orbit.keep", "early"),
+        event_line("2026-04-27T01:00:02Z", "orbit.keep", &long_message),
+        event_line("2026-04-27T01:00:03Z", "orbit.keep", "late"),
+    ];
+    let raw = join_lines(&lines, true);
+    assert!(
+        lines[1].len() > 16,
+        "fixture line must exceed the test block size"
+    );
+    let events = scan(&raw, &Filters::default(), 10, 16);
+    assert_eq!(events, naive_forward(&raw, &Filters::default(), 10));
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[1]["fields"]["message"], long_message);
+}
+
+#[test]
+fn reverse_scan_includes_final_line_without_trailing_newline() {
+    let lines = [
+        event_line("2026-04-27T01:00:01Z", "orbit.keep", "a"),
+        event_line("2026-04-27T01:00:02Z", "orbit.keep", "b"),
+    ];
+    let raw = join_lines(&lines, false);
+    assert!(!raw.ends_with('\n'));
+    let events = scan(&raw, &Filters::default(), 10, 16);
+    assert_eq!(events, naive_forward(&raw, &Filters::default(), 10));
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[1]["fields"]["message"], "b");
+}
+
+#[test]
+fn reverse_scan_zero_limit_returns_empty_without_reading() {
+    let raw = join_lines(
+        &[event_line("2026-04-27T01:00:01Z", "orbit.keep", "a")],
+        true,
+    );
+    let mut reader = CountingReader {
+        inner: Cursor::new(raw.as_bytes()),
+        bytes_read: 0,
+    };
+    let events = read_recent_matching_events_from(&mut reader, &Filters::default(), 0, 16)
+        .expect("zero limit");
+    assert!(events.is_empty());
+    assert_eq!(reader.bytes_read, 0);
+}
+
+#[test]
+fn missing_log_file_returns_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("missing.jsonl");
+    let events = read_recent_matching_events(&path, &Filters::default(), 50).expect("missing");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn dense_tail_does_not_read_or_parse_unnecessary_prefix() {
+    let mut lines = Vec::new();
+    for i in 0..2000 {
+        lines.push(event_line(
+            "2026-04-27T01:00:00Z",
+            "orbit.noise",
+            &format!("n{i:04}"),
+        ));
+    }
+    for i in 0..50 {
+        lines.push(event_line(
+            "2026-04-27T02:00:00Z",
+            "orbit.keep",
+            &format!("k{i:02}"),
+        ));
+    }
+    let raw = join_lines(&lines, true);
+    let prefix_len = {
+        let last_noise = lines[1999].as_str();
+        raw.find(last_noise).expect("prefix") + last_noise.len() + 1
+    };
+    let filters =
+        Filters::from_query_parts(Some("orbit.keep".to_string()), None, None).expect("filters");
+    let mut reader = CountingReader {
+        inner: Cursor::new(raw.as_bytes()),
+        bytes_read: 0,
+    };
+    let events =
+        read_recent_matching_events_from(&mut reader, &filters, 50, TAIL_READ_BLOCK).expect("tail");
+
+    assert_eq!(events.len(), 50);
+    assert_eq!(events[0]["fields"]["message"], "k00");
+    assert_eq!(events[49]["fields"]["message"], "k49");
+    assert_eq!(events, naive_forward(&raw, &filters, 50));
+    assert!(
+        reader.bytes_read < prefix_len as u64,
+        "dense tail must not read the unmatched prefix: read {} of {} prefix bytes (file {})",
+        reader.bytes_read,
+        prefix_len,
+        raw.len()
+    );
+}
+
+#[test]
+fn sparse_filter_scans_to_file_start_and_returns_available_matches() {
+    let mut lines = vec![
+        event_line("2026-04-27T01:00:01Z", "orbit.keep", "early-a"),
+        event_line("2026-04-27T01:00:02Z", "orbit.keep", "early-b"),
+        event_line("2026-04-27T01:00:03Z", "orbit.keep", "early-c"),
+    ];
+    for i in 0..1500 {
+        lines.push(event_line(
+            "2026-04-27T02:00:00Z",
+            "orbit.noise",
+            &format!("n{i:04}"),
+        ));
+    }
+    let raw = join_lines(&lines, true);
+    let filters =
+        Filters::from_query_parts(Some("orbit.keep".to_string()), None, None).expect("filters");
+    let mut reader = CountingReader {
+        inner: Cursor::new(raw.as_bytes()),
+        bytes_read: 0,
+    };
+    let events = read_recent_matching_events_from(&mut reader, &filters, 50, TAIL_READ_BLOCK)
+        .expect("sparse");
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0]["fields"]["message"], "early-a");
+    assert_eq!(events[2]["fields"]["message"], "early-c");
+    assert_eq!(events, naive_forward(&raw, &filters, 50));
+    assert_eq!(
+        reader.bytes_read,
+        raw.len() as u64,
+        "sparse matches at file start must scan the whole fixture"
+    );
+}
+
+#[test]
+#[allow(clippy::print_stdout)]
+fn reverse_scan_measurement_records_work_not_wall_clock() {
+    let noise = 4000usize;
+    let matches = 50usize;
+    let mut lines = Vec::with_capacity(noise + matches);
+    for i in 0..noise {
+        lines.push(event_line(
+            "2026-04-27T01:00:00Z",
+            "orbit.noise",
+            &format!("n{i:04}"),
+        ));
+    }
+    for i in 0..matches {
+        lines.push(event_line(
+            "2026-04-27T02:00:00Z",
+            "orbit.keep",
+            &format!("k{i:02}"),
+        ));
+    }
+    let raw = join_lines(&lines, true);
+    let filters =
+        Filters::from_query_parts(Some("orbit.keep".to_string()), None, None).expect("filters");
+    let density = matches as f64 / lines.len() as f64;
+
+    let naive_start = Instant::now();
+    let naive = naive_forward(&raw, &filters, matches);
+    let naive_ms = naive_start.elapsed().as_secs_f64() * 1000.0;
+
+    let mut reader = CountingReader {
+        inner: Cursor::new(raw.as_bytes()),
+        bytes_read: 0,
+    };
+    let reverse_start = Instant::now();
+    let events = read_recent_matching_events_from(&mut reader, &filters, matches, TAIL_READ_BLOCK)
+        .expect("reverse");
+    let reverse_ms = reverse_start.elapsed().as_secs_f64() * 1000.0;
+
+    assert_eq!(events, naive);
+    assert_eq!(events.len(), matches);
+
+    println!(
+        "log reverse-scan measurement: fixture_bytes={} records={} matches={} density={:.4} block={} bytes_read={} naive_ms={:.3} reverse_ms={:.3} os={} arch={}",
+        raw.len(),
+        lines.len(),
+        matches,
+        density,
+        TAIL_READ_BLOCK,
+        reader.bytes_read,
+        naive_ms,
+        reverse_ms,
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
 }


### PR DESCRIPTION
## Task

[ORB-11614](https://orbit-cli.com/tasks/ORB-11614) — [code-review] Move `/api/log` off the async worker and stop scanning the whole log file

### Description

## Problem and required behavior
`get_log` reads the log synchronously on the async request worker. The shared reader scans and JSON-parses the file from its beginning and shifts a bounded vector for each retained match. HTML rendering already occurs only after retention; it is not performed for every scanned event. Move blocking file work off the async worker and obtain recent matching events without reading an unnecessary file prefix when enough matches are near the end.

## Scope and constraints
Use the existing blocking boundary and one shared tail reader for the log snapshot and diagnostics callers. A bounded reverse scan is suitable, but sparse filters may legitimately require scanning to the file start. Preserve ordering, filter semantics, malformed-line handling and existing response fields. Cover lines spanning read blocks, final lines without newline, zero limit and missing files; preserve or explicitly test the current behavior for each. Coordinate with ORB-11660, which owns snapshot/stream replay cursors and response changes, and ORB-11615, which owns other blocking API work.

## Evidence and validation
At da21eb15 / origin/agent-main 09dec5183, see `crates/orbit-web/src/api/log.rs:82–90` and `crates/orbit-web/src/log_format.rs:145–177`: the forward scan parses each line, removes from the vector front, then renders retained events. The original review was at 7f3a8f5fa. Use deterministic work bounds and correctness tests; record benchmark conditions rather than requiring a universal sub-100ms wall-clock result.

Follow current AGENTS.md and preserve the existing authoritative boundary. Run focused behavior checks plus required make ci-fast and make ci-lint before review; report skipped or environment-dependent verification explicitly.

### Acceptance Criteria

- Existing snapshot fixtures return the same events, fields and ordering, with focused cases for filters, malformed records, block-spanning lines, no trailing newline, zero limit and missing files.
- A large fixture with at least 50 matching records near EOF and limit=50 returns the last 50 in chronological order; a bounded-reader/counting check demonstrates that the unnecessary earlier prefix is not read or parsed.
- A sparse-filter fixture correctly scans farther, including to file start when necessary, and returns all available matches up to the limit.
- The async snapshot handler delegates filesystem scan work through the existing blocking boundary, and diagnostics uses the same reader rather than a second tail implementation.
- A focused benchmark or before/after measurement records fixture size, filter density and execution environment; correctness does not depend on a brittle wall-clock threshold.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the forward JSONL scan in `log_format::read_recent_matching_events` with one bounded reverse block reader (`TAIL_READ_BLOCK` = 64 KiB) shared by `/api/log` and diagnostics.
- `get_log` now runs `read_log_snapshot_from_path` through the existing `api::blocking("log snapshot", ...)` helper instead of scanning on the async request worker.
- Added focused reader tests (filters, malformed records, block-spanning lines, no trailing newline, zero limit, missing file, dense-tail counting bound, sparse scan-to-start, measurement) and snapshot tests for the same edge cases.
- Left snapshot/stream cursor fields and `log-tail.js` unchanged (ORB-11660). Did not wrap other API handlers (ORB-11615).
- Appended `file:crates/orbit-web/src/tests/log_format.rs` and `file:crates/orbit-web/src/api/tests/log.rs` to context_files because those tests were required to prove the criteria.

Assessment: Small, in-boundary change. Ordering, filter semantics, malformed-line skipping, missing-file `[]`, and `{ events, offset }` are preserved. A 421,050-byte / 4,050-record dense-tail fixture (50 matches, density 0.0123) returned k00..k49 in chronological order while reading 65,536 bytes; sparse matches at file start scanned the whole fixture.

Strategic decisions:
- One shared reader rather than a diagnostics-specific tail.
- Deterministic counting-reader work bound instead of a wall-clock gate.
- 16-byte test blocks so spanning-line coverage does not need a huge fixture.

Design weaknesses / risks:
- Severity: low. Invalid UTF-8 in an unread prefix no longer fails the whole snapshot (old `BufRead::lines` did). Scanned lines still error on invalid UTF-8; malformed JSON lines are still skipped. Mitigation: this matches the early-stop goal.
- Severity: low. `make ci-fast` fails on this checkout because `docs/INDEX.md` omits tracked `docs/runbooks/build-budget.md`. Unrelated to this task; index was not regenerated.

Deviations from original plan: none. `log-tail.js` was listed as context but not edited.

Recommended follow-ups: refresh `docs/INDEX.md` on a docs-index task; ORB-11615 for remaining blocking API handlers.

Criteria:
1. Existing snapshot fixtures still return the same events, fields and ordering (`log_snapshot_filters_target_level_and_since` and stream resume tests). Focused cases added for filters, malformed records, block-spanning lines, no trailing newline, zero limit, and missing files.
2. Dense fixture with 50 matching records near EOF and limit=50 returns those 50 in chronological order; CountingReader shows bytes_read=65536, below the unmatched prefix.
3. Sparse-filter fixture with 3 matches at file start and 1500 later non-matches returns all 3 (limit=50) and reads the whole file.
4. `get_log` delegates the scan through `super::blocking`; diagnostics still calls `read_recent_matching_events` (no second tail). Smoke test runs the snapshot function on the blocking pool.
5. Measurement recorded fixture_bytes=421050, records=4050, matches=50, density=0.0123, block=65536, bytes_read=65536, naive_ms=30.145, reverse_ms=1.976, os=linux arch=x86_64. Correctness does not use a wall-clock threshold.

Validation:
- `cargo test -p orbit-web --lib tests::log_format -- --nocapture`: passed (12 tests), including the measurement print.
- `cargo test -p orbit-web --lib api::tests::log`: passed (14 tests).
- `cargo test -p orbit-web --lib api::tests::diagnostics`: passed (10 tests).
- `make ci-fast`: failed at `./scripts/generate-doc-indexes.sh --check` (`docs/INDEX.md` stale: missing `docs/runbooks/build-budget.md`). Pre-existing on this checkout; not caused by this diff. `cargo fmt --all -- --check` and every other ci-fast script passed.
- `make ci-lint`: passed (`cargo clippy --workspace --all-targets -- -D warnings`).
- `git diff --check`: passed.
- `git status --short`: only the four intended files modified; uncommitted as required.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11614-6a9f6f85`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra