### PR TITLE
[code-review] Bound heavyweight Git operations and recover only owned interrupted mutations

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/commit/git_ops.rs
@@ -77,7 +77,8 @@ fn git_success_dynamic_with_identity(
         ("GIT_COMMITTER_EMAIL", committer.email()),
     ];
     let args_ref = args.iter().map(String::as_str).collect::<Vec<_>>();
-    let mut request = git_request(current_dir, &args_ref, 30_000);
+    let timeout_ms = super::super::git::GitTimeoutBudget::current().timeout_for(&args_ref);
+    let mut request = git_request(current_dir, &args_ref, timeout_ms);
     if let EnvironmentMode::ClearAndSet(environment) = &mut request.environment_mode {
         environment.extend(
             env_overrides

--- a/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/freshness.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use orbit_common::{OrbitError, RecoverableVcsConflict};
 use serde_json::{Value, json};
@@ -6,7 +6,10 @@ use serde_json::{Value, json};
 use crate::context::RuntimeHost;
 
 use super::super::input::{input_string_field, required_input_string};
-use super::git::{BaseSyncMode, git_command_success, git_output, resolve_worktree_start_point};
+use super::git::{
+    BaseSyncMode, GitTimeoutBudget, GitTimeoutBudgetGuard, git_command_success, git_failure_error,
+    git_output, git_run, git_success, git_timeout_error, resolve_worktree_start_point,
+};
 use super::handoff::{
     FailedHandoffPhase, HandoffContext, load_handoff_context, rebase_in_progress,
     record_failed_handoff,
@@ -93,6 +96,7 @@ pub(in crate::executor::automation) fn rebase_pr_branch<H: RuntimeHost + ?Sized>
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
+    let _timeout_budget = GitTimeoutBudgetGuard::install(GitTimeoutBudget::from_input(input)?);
     let context = load_handoff_context(host, input, "git_rebase")?;
     match rebase_pr_branch_inner(host, input, &context) {
         Ok(output) => Ok(output),
@@ -136,20 +140,12 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
         &["rev-parse", "--abbrev-ref", "HEAD"],
     )?;
     if rebase_in_progress(&context.workspace_path)? {
-        let conflicting_paths = unmerged_paths(&context.workspace_path)?;
-        if conflicting_paths.is_empty() {
-            return Err(OrbitError::Execution(
-                "git_rebase: rebase remains in progress without unresolved conflict entries"
-                    .to_string(),
-            ));
-        }
-        return Err(rebase_conflict_error(
+        return refuse_or_recover_existing_rebase(
             &context.workspace_path,
+            head,
             head_sha_before,
             base_sha,
-            conflicting_paths,
-            "rebase remains stopped with unresolved conflicts",
-        )?);
+        );
     }
     if current_branch.trim() != head {
         return Err(OrbitError::Execution(format!(
@@ -208,12 +204,24 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
                     .to_string(),
             ));
         }
-        if !git_command_success(&context.workspace_path, &["rebase", base_sha])? {
+        let rebase_outcome = git_run(&context.workspace_path, &["rebase", base_sha])?;
+        if rebase_outcome.timed_out {
+            return recover_started_rebase_timeout(
+                &context.workspace_path,
+                head,
+                head_sha_before,
+                base_sha,
+                &rebase_outcome,
+            );
+        }
+        if !rebase_outcome.success {
             let conflicting_paths = unmerged_paths(&context.workspace_path)?;
             if conflicting_paths.is_empty() {
-                return Err(OrbitError::Execution(format!(
-                    "git_rebase: rebase of '{head}' onto checkpoint '{base_sha}' failed without unresolved conflict entries"
-                )));
+                return Err(git_failure_error(
+                    &context.workspace_path,
+                    &["rebase", base_sha],
+                    &rebase_outcome.stderr,
+                ));
             }
             return Err(rebase_conflict_error(
                 &context.workspace_path,
@@ -249,6 +257,135 @@ fn rebase_pr_branch_inner<H: RuntimeHost + ?Sized>(
         "remote_sha_before": input_string_field(input, "remote_sha"),
         "rewritten": rewritten,
     }))
+}
+
+fn refuse_or_recover_existing_rebase(
+    workspace_path: &Path,
+    head: &str,
+    head_sha_before: &str,
+    base_sha: &str,
+) -> Result<Value, OrbitError> {
+    let conflicting_paths = unmerged_paths(workspace_path)?;
+    if !conflicting_paths.is_empty() {
+        return Err(rebase_conflict_error(
+            workspace_path,
+            head_sha_before,
+            base_sha,
+            conflicting_paths,
+            "rebase remains stopped with unresolved conflicts",
+        )?);
+    }
+    if rebase_belongs_to_attempt(workspace_path, head, head_sha_before, base_sha)? {
+        abort_owned_rebase(workspace_path)?;
+        return Err(OrbitError::Execution(
+            "git_rebase: interrupted rebase started by this attempt was aborted after a Git timeout. Retry can start clean. This is timeout recovery, not a merge conflict and not failure-handoff recovery.".to_string(),
+        ));
+    }
+    let provenance = rebase_provenance_summary(workspace_path);
+    Err(OrbitError::Execution(format!(
+        "git_rebase: a pre-existing rebase is in progress without unresolved conflict entries ({provenance}). Not aborting; foreign or retained candidate state was left intact. Inspect the worktree before retrying. This is not conflict recovery."
+    )))
+}
+
+fn recover_started_rebase_timeout(
+    workspace_path: &Path,
+    head: &str,
+    head_sha_before: &str,
+    base_sha: &str,
+    outcome: &super::git::GitOutcome,
+) -> Result<Value, OrbitError> {
+    let timeout = git_timeout_error(
+        workspace_path,
+        &["rebase", base_sha],
+        outcome.timeout_ms,
+        &outcome.stderr,
+    );
+    if !rebase_in_progress(workspace_path).unwrap_or(false) {
+        return Err(OrbitError::Execution(format!(
+            "{timeout}; git_rebase of '{head}' onto '{base_sha}' timed out. This is timeout recovery, not a merge conflict and not failure-handoff recovery."
+        )));
+    }
+    let conflicting_paths = unmerged_paths(workspace_path).unwrap_or_default();
+    if !conflicting_paths.is_empty() {
+        return Err(rebase_conflict_error(
+            workspace_path,
+            head_sha_before,
+            base_sha,
+            conflicting_paths,
+            &format!(
+                "rebase of '{head}' onto checkpoint '{base_sha}' timed out while stopped with conflicts"
+            ),
+        )?);
+    }
+    abort_owned_rebase(workspace_path)?;
+    Err(OrbitError::Execution(format!(
+        "{timeout}; interrupted rebase started by this attempt was aborted. Retry can start clean. This is timeout recovery, not a merge conflict and not failure-handoff recovery."
+    )))
+}
+
+fn abort_owned_rebase(workspace_path: &Path) -> Result<(), OrbitError> {
+    git_success(workspace_path, &["rebase", "--abort"]).map_err(|error| {
+        OrbitError::Execution(format!(
+            "git_rebase: failed to abort an interrupted rebase started by this attempt: {error}"
+        ))
+    })
+}
+
+fn rebase_belongs_to_attempt(
+    workspace_path: &Path,
+    head: &str,
+    head_sha_before: &str,
+    base_sha: &str,
+) -> Result<bool, OrbitError> {
+    let orig_head = read_rebase_state(workspace_path, "orig-head")?;
+    let onto = read_rebase_state(workspace_path, "onto")?;
+    let head_name = read_rebase_state(workspace_path, "head-name")?;
+    let orig_ok = orig_head.as_deref() == Some(head_sha_before);
+    let onto_ok = onto.as_deref() == Some(base_sha);
+    let head_ok = head_name.as_deref().is_some_and(|name| {
+        name == head || name == format!("refs/heads/{head}") || name.ends_with(&format!("/{head}"))
+    });
+    Ok(orig_ok && onto_ok && head_ok)
+}
+
+fn rebase_provenance_summary(workspace_path: &Path) -> String {
+    let orig_head = read_rebase_state(workspace_path, "orig-head")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "unknown".to_string());
+    let onto = read_rebase_state(workspace_path, "onto")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "unknown".to_string());
+    let head_name = read_rebase_state(workspace_path, "head-name")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("orig-head={orig_head}, onto={onto}, head-name={head_name}")
+}
+
+fn read_rebase_state(workspace_path: &Path, name: &str) -> Result<Option<String>, OrbitError> {
+    for dir in ["rebase-merge", "rebase-apply"] {
+        let rel = match git_output(
+            workspace_path,
+            &["rev-parse", "--git-path", &format!("{dir}/{name}")],
+        ) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let path = if Path::new(&rel).is_absolute() {
+            PathBuf::from(rel)
+        } else {
+            workspace_path.join(rel)
+        };
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            let trimmed = contents.trim();
+            if !trimmed.is_empty() {
+                return Ok(Some(trimmed.to_string()));
+            }
+        }
+    }
+    Ok(None)
 }
 
 fn validate_recovered_rewrite<H: RuntimeHost + ?Sized>(

--- a/crates/orbit-engine/src/executor/automation/vcs/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/git.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::path::Path;
 use std::process::Command;
 
@@ -9,6 +10,173 @@ use orbit_common::fs::git::{
 use orbit_common::security::child_env::AGENT_SUBPROCESS_BASELINE_VARS;
 use orbit_exec::{EnvironmentMode, ExecRequest, NoSandbox, StdinMode, run_process};
 use serde_json::Value;
+
+/// Bounded wall-clock budgets for host Git children.
+///
+/// Heavyweight mutations get their own defaults; every request still carries a
+/// finite `ExecRequest.timeout_ms`. Activity input may overlay these values
+/// through `git_timeout_ms` / `git_timeouts` without changing hook or
+/// environment policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GitTimeoutBudget {
+    pub default_ms: u64,
+    pub fetch_ms: u64,
+    pub worktree_add_ms: u64,
+    pub rebase_ms: u64,
+}
+
+impl GitTimeoutBudget {
+    pub const MIN_MS: u64 = 1;
+    pub const MAX_MS: u64 = 600_000;
+
+    pub const DEFAULT: Self = Self {
+        default_ms: 30_000,
+        fetch_ms: 60_000,
+        worktree_add_ms: 120_000,
+        rebase_ms: 120_000,
+    };
+
+    pub(crate) fn from_input(input: &Value) -> Result<Self, OrbitError> {
+        let mut budget = Self::DEFAULT;
+        if let Some(value) = input.get("git_timeout_ms") {
+            let ms = parse_timeout_ms(value, "git_timeout_ms")?;
+            budget = Self {
+                default_ms: ms,
+                fetch_ms: ms,
+                worktree_add_ms: ms,
+                rebase_ms: ms,
+            };
+        }
+        if let Some(timeouts) = input.get("git_timeouts") {
+            let Some(map) = timeouts.as_object() else {
+                return Err(OrbitError::InvalidInput(
+                    "input.git_timeouts must be an object".to_string(),
+                ));
+            };
+            for (key, value) in map {
+                let field = format!("git_timeouts.{key}");
+                let ms = parse_timeout_ms(value, &field)?;
+                match key.as_str() {
+                    "default" => budget.default_ms = ms,
+                    "fetch" => budget.fetch_ms = ms,
+                    "worktree_add" => budget.worktree_add_ms = ms,
+                    "rebase" => budget.rebase_ms = ms,
+                    other => {
+                        return Err(OrbitError::InvalidInput(format!(
+                            "unknown git_timeouts key '{other}'; expected default, fetch, worktree_add, or rebase"
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(budget)
+    }
+
+    pub(crate) fn current() -> Self {
+        GIT_TIMEOUT_BUDGET.with(Cell::get)
+    }
+
+    pub(crate) fn timeout_for(self, args: &[&str]) -> u64 {
+        match args {
+            ["fetch", ..] => self.fetch_ms,
+            ["worktree", "add", ..] => self.worktree_add_ms,
+            ["rebase", ..] => self.rebase_ms,
+            _ => self.default_ms,
+        }
+    }
+}
+
+thread_local! {
+    static GIT_TIMEOUT_BUDGET: Cell<GitTimeoutBudget> =
+        const { Cell::new(GitTimeoutBudget::DEFAULT) };
+}
+
+/// Restores the previous Git timeout budget when the scope exits.
+pub(crate) struct GitTimeoutBudgetGuard {
+    previous: GitTimeoutBudget,
+}
+
+impl GitTimeoutBudgetGuard {
+    pub(crate) fn install(budget: GitTimeoutBudget) -> Self {
+        let previous = GIT_TIMEOUT_BUDGET.with(|cell| cell.replace(budget));
+        Self { previous }
+    }
+}
+
+impl Drop for GitTimeoutBudgetGuard {
+    fn drop(&mut self) {
+        GIT_TIMEOUT_BUDGET.with(|cell| cell.set(self.previous));
+    }
+}
+
+fn parse_timeout_ms(value: &Value, field: &str) -> Result<u64, OrbitError> {
+    let Some(ms) = value.as_u64() else {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must be an integer number of milliseconds between {} and {}",
+            GitTimeoutBudget::MIN_MS,
+            GitTimeoutBudget::MAX_MS
+        )));
+    };
+    if !(GitTimeoutBudget::MIN_MS..=GitTimeoutBudget::MAX_MS).contains(&ms) {
+        return Err(OrbitError::InvalidInput(format!(
+            "{field} must be between {} and {} ms, got {ms}",
+            GitTimeoutBudget::MIN_MS,
+            GitTimeoutBudget::MAX_MS
+        )));
+    }
+    Ok(ms)
+}
+
+/// Captured Git child result, including timeout vs ordinary failure.
+#[derive(Debug, Clone)]
+pub(crate) struct GitOutcome {
+    pub stdout: String,
+    pub stderr: String,
+    pub success: bool,
+    pub timed_out: bool,
+    pub timeout_ms: u64,
+}
+
+pub(crate) fn git_process_timed_out(stderr: &str) -> bool {
+    stderr.contains("process timed out")
+}
+
+pub(crate) fn git_timeout_error(
+    current_dir: &Path,
+    args: &[&str],
+    timeout_ms: u64,
+    stderr: &str,
+) -> OrbitError {
+    OrbitError::Execution(format!(
+        "git {} timed out after {timeout_ms}ms in '{}': {}",
+        args.join(" "),
+        current_dir.display(),
+        stderr.trim()
+    ))
+}
+
+pub(crate) fn git_failure_error(current_dir: &Path, args: &[&str], stderr: &str) -> OrbitError {
+    OrbitError::Execution(format!(
+        "git {} failed in '{}': {}",
+        args.join(" "),
+        current_dir.display(),
+        stderr.trim()
+    ))
+}
+
+/// Run Git under the current budget. Callers that recover from timeout must
+/// inspect [`GitOutcome::timed_out`] instead of treating it as a Git exit.
+pub(crate) fn git_run(current_dir: &Path, args: &[&str]) -> Result<GitOutcome, OrbitError> {
+    let timeout_ms = GitTimeoutBudget::current().timeout_for(args);
+    let result = run_process(&git_request(current_dir, args, timeout_ms), &NoSandbox)?;
+    Ok(GitOutcome {
+        stdout: result.stdout,
+        stderr: result.stderr.clone(),
+        success: result.success,
+        timed_out: git_process_timed_out(&result.stderr),
+        timeout_ms,
+    })
+}
 
 /// Compose host VCS environments by name. Git needs the SSH agent socket for
 /// authenticated remotes, but never the provider's credentials or ORBIT_* envelope.
@@ -118,18 +286,20 @@ pub(crate) fn git_output(current_dir: &Path, args: &[&str]) -> Result<String, Or
 }
 
 pub(crate) fn git_output_raw(current_dir: &Path, args: &[&str]) -> Result<String, OrbitError> {
-    let result = run_process(&git_request(current_dir, args, 30_000), &NoSandbox)?;
-
-    if !result.success {
-        return Err(OrbitError::Execution(format!(
-            "git {} failed in '{}': {}",
-            args.join(" "),
-            current_dir.display(),
-            result.stderr.trim()
-        )));
+    let outcome = git_run(current_dir, args)?;
+    if outcome.timed_out {
+        return Err(git_timeout_error(
+            current_dir,
+            args,
+            outcome.timeout_ms,
+            &outcome.stderr,
+        ));
+    }
+    if !outcome.success {
+        return Err(git_failure_error(current_dir, args, &outcome.stderr));
     }
 
-    Ok(result.stdout)
+    Ok(outcome.stdout)
 }
 
 pub(crate) fn git_success(current_dir: &Path, args: &[&str]) -> Result<(), OrbitError> {
@@ -137,8 +307,16 @@ pub(crate) fn git_success(current_dir: &Path, args: &[&str]) -> Result<(), Orbit
 }
 
 pub(crate) fn git_command_success(current_dir: &Path, args: &[&str]) -> Result<bool, OrbitError> {
-    let result = run_process(&git_request(current_dir, args, 30_000), &NoSandbox)?;
-    Ok(result.success)
+    let outcome = git_run(current_dir, args)?;
+    if outcome.timed_out {
+        return Err(git_timeout_error(
+            current_dir,
+            args,
+            outcome.timeout_ms,
+            &outcome.stderr,
+        ));
+    }
+    Ok(outcome.success)
 }
 
 /// Fetch `origin/<branch>` into the local remote-tracking ref.
@@ -155,14 +333,19 @@ fn fetch_remote_base_locked(repo_root: &Path, branch: &str) -> Result<(), OrbitE
     let spec = format!("+refs/heads/{branch}:refs/remotes/origin/{branch}");
     let mut last_stderr = String::new();
     for attempt in 0..GIT_FETCH_CAS_ATTEMPTS {
-        let result = run_process(
-            &git_request(repo_root, &["fetch", "origin", &spec], 60_000),
-            &NoSandbox,
-        )?;
-        if result.success {
+        let outcome = git_run(repo_root, &["fetch", "origin", &spec])?;
+        if outcome.timed_out {
+            return Err(git_timeout_error(
+                repo_root,
+                &["fetch", "origin", &spec],
+                outcome.timeout_ms,
+                &outcome.stderr,
+            ));
+        }
+        if outcome.success {
             return Ok(());
         }
-        last_stderr = result.stderr.trim().to_string();
+        last_stderr = outcome.stderr.trim().to_string();
         if should_retry_git_ref_cas(attempt, &last_stderr) {
             tracing::warn!(
                 attempt,

--- a/crates/orbit-engine/src/executor/automation/vcs/handoff.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/handoff.rs
@@ -166,10 +166,17 @@ pub(super) fn record_failed_handoff<H: RuntimeHost + ?Sized>(
     let base_ref = input_string_field(input, "base_ref")
         .map(|value| format!("Base checkpoint: {value}\n"))
         .unwrap_or_default();
+    let timed_out = error.to_string().contains("timed out");
     let recovery = if matches!(phase, FailedHandoffPhase::Rebase)
         && rebase_in_progress(&context.workspace_path).unwrap_or(false)
     {
-        "Worktree state: rebase stopped with unresolved conflicts.\n\nRecovery:\n  Resolve the conflicting paths in this worktree, stage them, run `git rebase --continue`, then resume the same job step. Later handoff phases have not been replayed."
+        if timed_out {
+            "Worktree state: rebase interrupted by a Git timeout.\n\nRecovery:\n  Timeout recovery is not conflict repair. If this attempt started the rebase, Orbit aborts it and a retry can start clean. A pre-existing or foreign rebase is left intact — inspect rebase-merge/rebase-apply before retrying. Ordinary conflict recovery remains pr_conflict_recovery; failure-handoff remains pr_failure_handoff."
+        } else {
+            "Worktree state: rebase stopped with unresolved conflicts.\n\nRecovery:\n  Resolve the conflicting paths in this worktree, stage them, run `git rebase --continue`, then resume the same job step. Later handoff phases have not been replayed. This is conflict recovery, not timeout recovery."
+        }
+    } else if timed_out {
+        "Recovery:\n  This failure is a Git operation timeout, not a merge conflict and not a failure-handoff. Inspect the named checkout, then retry the same job step after timeout recovery has cleaned only owned incomplete state."
     } else {
         "Recovery:\n  Reconcile the recorded phase in this worktree, then resume the same job step. Later handoff phases have not been replayed."
     };

--- a/crates/orbit-engine/src/executor/automation/vcs/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/mod.rs
@@ -31,4 +31,4 @@ pub(crate) fn run_private_operation(
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/mod.rs
@@ -11,7 +11,7 @@ mod open;
 mod promote;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 pub(in crate::executor::automation) use attribution::ship_done_attribution;
 pub(in crate::executor::automation::vcs) use body::meaningful_execution_summary;

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/mod.rs
@@ -9,4 +9,4 @@ mod resume_failure;
 mod resume_preservation;
 mod resume_refresh;
 mod review_gate;
-pub(in crate::executor::automation::vcs::pr) mod test_support;
+pub(in crate::executor::automation::vcs) mod test_support;

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/freshness.rs
@@ -1,0 +1,214 @@
+#![allow(missing_docs)]
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::super::freshness::{prepare_pr_handoff, rebase_pr_branch};
+use super::super::pr::tests::test_support::{
+    PrOpenTestHost, batch_task, pr_workspace, rebase_conflict_pr_workspace,
+};
+#[cfg(unix)]
+use super::with_fake_git;
+use orbit_common::OrbitError;
+
+fn git(current_dir: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn rebase_in_progress(repo: &std::path::Path) -> bool {
+    repo.join(".git/rebase-merge").is_dir() || repo.join(".git/rebase-apply").is_dir()
+}
+
+fn rebase_input(common: &serde_json::Value, prepared: &serde_json::Value) -> serde_json::Value {
+    json!({
+        "workspace_path": common["workspace_path"],
+        "job_run_id": common["job_run_id"],
+        "completed_task_ids": common["completed_task_ids"],
+        "head": prepared["head"],
+        "head_sha": prepared["head_sha"],
+        "base": prepared["base"],
+        "base_ref": prepared["base_ref"],
+        "base_sha": prepared["base_sha"],
+        "remote_sha": prepared["remote_sha"],
+        "commits_behind": prepared["commits_behind"],
+        "sync_required": prepared["sync_required"],
+        "git_timeouts": { "rebase": 400 },
+    })
+}
+
+fn advance_base(workspace_repo: &std::path::Path) {
+    git(workspace_repo, &["checkout", "agent-main"]);
+    fs::write(workspace_repo.join("BASE_ADVANCE.md"), "new base\n").unwrap();
+    git(workspace_repo, &["add", "BASE_ADVANCE.md"]);
+    git(workspace_repo, &["commit", "-m", "advance base"]);
+    git(workspace_repo, &["checkout", "orbit/test-batch"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn owned_rebase_timeout_aborts_and_retry_is_not_permanently_wedged() {
+    let stamp_dir = tempdir().unwrap();
+    let stamp = stamp_dir.path().join("rebase-once");
+    if !with_fake_git(
+        module_path!(),
+        "owned_rebase_timeout_aborts_and_retry_is_not_permanently_wedged",
+        &[("ORBIT_TEST_GIT_REBASE_ONCE", stamp.display().to_string())],
+    ) {
+        return;
+    }
+
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let task_id = "ORB-11606-REBASE-TIMEOUT";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Timeout rebase",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    let first = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("injected rebase timeout");
+    let first_message = first.to_string();
+    assert!(
+        first_message.contains("timed out"),
+        "expected timeout, got {first_message}"
+    );
+    assert!(
+        first_message.contains("timeout recovery") || first_message.contains("Timeout recovery"),
+        "must distinguish timeout recovery: {first_message}"
+    );
+    assert!(
+        !matches!(first, OrbitError::RecoverableVcsConflict(_)),
+        "timeout recovery must not be a conflict: {first}"
+    );
+    assert!(
+        !rebase_in_progress(&workspace.repo),
+        "owned timed-out rebase must be aborted so retry is not wedged"
+    );
+
+    let retried = rebase_pr_branch(&host, &rebase_input(&common, &prepared)).expect("retry");
+    assert_eq!(retried["decision"], json!("performed"));
+    assert!(workspace.repo.join("BASE_ADVANCE.md").exists());
+}
+
+#[test]
+fn pre_existing_rebase_without_conflicts_is_refused_and_left_intact() {
+    let workspace = pr_workspace();
+    advance_base(&workspace.repo);
+    let head_before = git(&workspace.repo, &["rev-parse", "HEAD"]);
+    let onto = git(&workspace.repo, &["rev-parse", "agent-main"]);
+    fs::create_dir_all(workspace.repo.join(".git/rebase-merge")).unwrap();
+    fs::write(
+        workspace.repo.join(".git/rebase-merge/orig-head"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+    )
+    .unwrap();
+    fs::write(
+        workspace.repo.join(".git/rebase-merge/onto"),
+        format!("{onto}\n"),
+    )
+    .unwrap();
+    fs::write(
+        workspace.repo.join(".git/rebase-merge/head-name"),
+        "refs/heads/foreign-branch\n",
+    )
+    .unwrap();
+    fs::write(workspace.repo.join(".git/rebase-merge/git-rebase-todo"), "").unwrap();
+    fs::write(workspace.repo.join(".git/rebase-merge/end"), "1\n").unwrap();
+    fs::write(workspace.repo.join(".git/rebase-merge/msgnum"), "1\n").unwrap();
+    fs::write(workspace.repo.join("retained.txt"), "keep me\n").unwrap();
+
+    let task_id = "ORB-11606-FOREIGN-REBASE";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Foreign rebase",
+            "Outcome: success\nChanges:\n- Candidate remains mergeable.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    let error = rebase_pr_branch(&host, &rebase_input(&common, &prepared))
+        .expect_err("foreign rebase must be refused");
+    let message = error.to_string();
+    assert!(
+        message.contains("pre-existing rebase"),
+        "expected diagnostic refusal, got {message}"
+    );
+    assert!(
+        !matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "foreign rebase is not a conflict: {error}"
+    );
+    assert!(
+        rebase_in_progress(&workspace.repo),
+        "foreign rebase state must remain"
+    );
+    assert_eq!(git(&workspace.repo, &["rev-parse", "HEAD"]), head_before);
+    assert_eq!(
+        fs::read_to_string(workspace.repo.join("retained.txt")).unwrap(),
+        "keep me\n"
+    );
+}
+
+#[test]
+fn conflicting_rebase_still_uses_conflict_recovery_not_timeout_abort() {
+    let workspace = rebase_conflict_pr_workspace();
+    let task_id = "ORB-11606-CONFLICT";
+    let host = PrOpenTestHost::new(
+        vec![batch_task(
+            task_id,
+            "Conflict rebase",
+            "Outcome: success\nChanges:\n- Candidate is complete.",
+        )],
+        workspace.repo.clone(),
+    );
+    let common = json!({
+        "workspace_path": workspace.repo,
+        "job_run_id": "batch-1",
+        "completed_task_ids": [task_id],
+        "base": "agent-main",
+        "base_sync": "local",
+    });
+    let prepared = prepare_pr_handoff(&host, &common).expect("prepare");
+    let error =
+        rebase_pr_branch(&host, &rebase_input(&common, &prepared)).expect_err("fixture conflict");
+    assert!(
+        matches!(error, OrbitError::RecoverableVcsConflict(_)),
+        "conflicts stay typed recovery, got {error}"
+    );
+    assert!(
+        rebase_in_progress(&workspace.repo),
+        "conflicted rebase must not be aborted as a timeout"
+    );
+}

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/git.rs
@@ -6,7 +6,12 @@ use std::process::Command;
 
 use tempfile::tempdir;
 
-use super::super::git::{BaseSyncMode, fetch_remote_base, resolve_worktree_start_point};
+use orbit_exec::EnvironmentMode;
+use serde_json::json;
+
+use super::super::git::{
+    BaseSyncMode, GitTimeoutBudget, fetch_remote_base, git_request, resolve_worktree_start_point,
+};
 
 #[test]
 fn remote_mode_fetches_origin_base_when_local_base_is_stale() {
@@ -180,6 +185,98 @@ fn local_mode_resolves_local_base_without_origin_remote() {
         resolve_worktree_start_point(&repo, "agent-main", BaseSyncMode::Local).unwrap();
 
     assert_eq!(start_point, "agent-main");
+}
+
+#[test]
+fn git_timeout_budget_defaults_are_finite_and_operation_specific() {
+    let budget = GitTimeoutBudget::DEFAULT;
+    assert_eq!(budget.timeout_for(&["status"]), 30_000);
+    assert_eq!(budget.timeout_for(&["rev-parse", "HEAD"]), 30_000);
+    assert_eq!(budget.timeout_for(&["fetch", "origin", "main"]), 60_000);
+    assert_eq!(
+        budget.timeout_for(&["worktree", "add", "/tmp/wt", "main"]),
+        120_000
+    );
+    assert_eq!(budget.timeout_for(&["rebase", "abc"]), 120_000);
+    assert!(budget.default_ms >= GitTimeoutBudget::MIN_MS);
+    assert!(budget.worktree_add_ms <= GitTimeoutBudget::MAX_MS);
+    assert!(budget.rebase_ms <= GitTimeoutBudget::MAX_MS);
+}
+
+#[test]
+fn git_timeout_budget_accepts_valid_overrides() {
+    let blanket = GitTimeoutBudget::from_input(&json!({ "git_timeout_ms": 2_000 })).unwrap();
+    assert_eq!(blanket.timeout_for(&["status"]), 2_000);
+    assert_eq!(blanket.timeout_for(&["fetch", "origin"]), 2_000);
+    assert_eq!(blanket.timeout_for(&["worktree", "add", "p"]), 2_000);
+    assert_eq!(blanket.timeout_for(&["rebase", "abc"]), 2_000);
+
+    let overlay = GitTimeoutBudget::from_input(&json!({
+        "git_timeout_ms": 5_000,
+        "git_timeouts": { "rebase": 8_000, "worktree_add": 7_000 }
+    }))
+    .unwrap();
+    assert_eq!(overlay.timeout_for(&["status"]), 5_000);
+    assert_eq!(overlay.timeout_for(&["rebase", "abc"]), 8_000);
+    assert_eq!(overlay.timeout_for(&["worktree", "add", "p"]), 7_000);
+    assert_eq!(overlay.timeout_for(&["fetch", "origin"]), 5_000);
+}
+
+#[test]
+fn git_timeout_budget_rejects_invalid_and_extreme_values() {
+    for (input, needle) in [
+        (json!({ "git_timeout_ms": 0 }), "between"),
+        (json!({ "git_timeout_ms": 600_001u64 }), "between"),
+        (json!({ "git_timeout_ms": -1 }), "integer"),
+        (json!({ "git_timeout_ms": "unbounded" }), "integer"),
+        (json!({ "git_timeouts": { "rebase": 0 } }), "between"),
+        (
+            json!({ "git_timeouts": { "clone": 1_000 } }),
+            "unknown git_timeouts key",
+        ),
+        (json!({ "git_timeouts": [] }), "must be an object"),
+    ] {
+        let error = GitTimeoutBudget::from_input(&input).expect_err("invalid budget");
+        assert!(
+            error.to_string().contains(needle),
+            "expected '{needle}' in {error} for {input}"
+        );
+    }
+}
+
+#[test]
+fn git_request_always_sets_a_bounded_timeout_and_keeps_hook_policy() {
+    let temp = tempdir().unwrap();
+    let request = git_request(temp.path(), &["status"], 15_000);
+    assert_eq!(request.timeout_ms, Some(15_000));
+    assert_ne!(request.timeout_ms, None);
+    assert!(
+        request
+            .args
+            .windows(2)
+            .any(|pair| pair == ["-c", "core.hooksPath=/dev/null"]),
+        "hooks remain disabled: {:?}",
+        request.args
+    );
+    assert!(
+        request
+            .args
+            .windows(2)
+            .any(|pair| pair == ["-c", "gc.auto=0"]),
+        "gc.auto remains disabled: {:?}",
+        request.args
+    );
+    let EnvironmentMode::ClearAndSet(env) = request.environment_mode else {
+        panic!("git request must clear the environment");
+    };
+    assert!(
+        env.iter()
+            .any(|(key, value)| key == "GIT_OPTIONAL_LOCKS" && value == "0")
+    );
+    assert!(
+        !env.iter()
+            .any(|(key, _)| key.starts_with("ORBIT_") && key.contains("TOKEN"))
+    );
 }
 
 fn init_repo(path: &Path, branch: &str) {

--- a/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/tests/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 mod base_obsolescence;
+mod freshness;
 mod git;
 mod operations;
 
@@ -36,6 +37,143 @@ pub(super) fn with_fake_gh(module: &str, test: &str, script: &str) -> bool {
     assert!(
         output.status.success(),
         "provider test failed:\n{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    false
+}
+
+/// Isolate PATH in a child test process so Git-shim fixtures cannot leak into
+/// concurrent Rust tests. The shim delegates to the real Git binary except for
+/// owned `worktree add` / `rebase` mutations, which hang after the requested
+/// side effect so the parent timeout can fire.
+#[cfg(unix)]
+pub(crate) fn with_fake_git(module: &str, test: &str, extra_env: &[(&str, String)]) -> bool {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let module = module
+        .strip_prefix(concat!(env!("CARGO_CRATE_NAME"), "::"))
+        .unwrap_or(module);
+    let exact_test = format!("{module}::{test}");
+    if std::env::var("ORBIT_TEST_GIT_CHILD").ok().as_deref() == Some(&exact_test) {
+        return true;
+    }
+
+    let real_git = Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("locate Git");
+    assert!(real_git.status.success(), "git must be on PATH");
+    let real_git = String::from_utf8(real_git.stdout)
+        .expect("Git path UTF-8")
+        .trim()
+        .to_string();
+    let quote = |value: &str| format!("'{}'", value.replace('\'', "'\"'\"'"));
+    // Stamp paths are baked into the script: the Git child environment is
+    // cleared and would not see ORBIT_TEST_* variables.
+    let worktree_once = extra_env
+        .iter()
+        .find(|(key, _)| *key == "ORBIT_TEST_GIT_WORKTREE_ONCE")
+        .map(|(_, value)| value.as_str())
+        .unwrap_or("");
+    let rebase_once = extra_env
+        .iter()
+        .find(|(key, _)| *key == "ORBIT_TEST_GIT_REBASE_ONCE")
+        .map(|(_, value)| value.as_str())
+        .unwrap_or("");
+    let script = format!(
+        r#"#!/bin/bash
+set -eu
+real={real}
+worktree_once={worktree_once}
+rebase_once={rebase_once}
+cmd=""
+sub=""
+skip=0
+seen_cmd=0
+for arg in "$@"; do
+  if [ "$skip" -eq 1 ]; then
+    skip=0
+    continue
+  fi
+  if [ "$seen_cmd" -eq 0 ]; then
+    case "$arg" in
+      -c) skip=1; continue ;;
+      -*) continue ;;
+      *) cmd="$arg"; seen_cmd=1; continue ;;
+    esac
+  elif [ -z "$sub" ]; then
+    sub="$arg"
+  fi
+done
+
+if [ "$cmd" = "worktree" ] && [ "$sub" = "add" ]; then
+  if [ -n "$worktree_once" ] && [ ! -f "$worktree_once" ]; then
+    touch "$worktree_once"
+    "$real" "$@"
+    wt=""
+    for arg in "$@"; do
+      if [ -d "$arg" ]; then
+        wt="$arg"
+      fi
+    done
+    if [ -n "$wt" ]; then
+      gitdir="$("$real" -C "$wt" rev-parse --absolute-git-dir 2>/dev/null || true)"
+      if [ -n "$gitdir" ]; then
+        rm -f "$gitdir/HEAD" "$gitdir/index"
+      fi
+    fi
+    sleep 30
+    exit 0
+  fi
+fi
+
+if [ "$cmd" = "rebase" ]; then
+  case "$sub" in
+    --abort|--continue|--skip|--quit) exec "$real" "$@" ;;
+  esac
+  if [ -n "$rebase_once" ] && [ ! -f "$rebase_once" ]; then
+    touch "$rebase_once"
+    rebuilt=()
+    for arg in "$@"; do
+      rebuilt+=("$arg")
+      if [ "$arg" = "rebase" ]; then
+        rebuilt+=(-x "sleep 30")
+      fi
+    done
+    exec "$real" "${{rebuilt[@]}}"
+  fi
+fi
+
+exec "$real" "$@"
+"#,
+        real = quote(&real_git),
+        worktree_once = quote(worktree_once),
+        rebase_once = quote(rebase_once)
+    );
+
+    let bin = tempfile::tempdir().expect("fake git directory");
+    let git = bin.path().join("git");
+    fs::write(&git, script).expect("write fake git");
+    fs::set_permissions(&git, fs::Permissions::from_mode(0o755)).expect("executable git");
+    let mut paths = vec![bin.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let mut command = Command::new(std::env::current_exe().expect("test executable"));
+    command
+        .args(["--exact", &exact_test, "--nocapture"])
+        .env("ORBIT_TEST_GIT_CHILD", &exact_test)
+        .env("PATH", std::env::join_paths(paths).expect("git PATH"));
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    let output = command.output().expect("isolated git shim test");
+    assert!(
+        output.status.success(),
+        "git shim test failed:\n{}\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/merge.rs
@@ -7,9 +7,11 @@ use crate::context::RuntimeHost;
 use crate::executor::automation::input::{canonicalize_existing_dir, input_string_field};
 
 use super::super::git::{
-    BaseSyncMode, base_sync_mode_from_input, git_command_success, git_output, git_success,
+    BaseSyncMode, GitTimeoutBudget, GitTimeoutBudgetGuard, base_sync_mode_from_input,
+    git_command_success, git_failure_error, git_output, git_run, git_success, git_timeout_error,
     resolve_worktree_start_point,
 };
+use super::super::handoff::rebase_in_progress;
 use super::resolve_shared_worktree_path;
 
 const DEFAULT_BASE: &str = "main";
@@ -19,6 +21,7 @@ pub(in crate::executor::automation) fn merge_batch_worktree_into_base<H: Runtime
     host: &H,
     input: &Value,
 ) -> Result<Value, OrbitError> {
+    let _timeout_budget = GitTimeoutBudgetGuard::install(GitTimeoutBudget::from_input(input)?);
     let run_id = super::require_run_id(input, "merge_batch_worktree_into_base")?;
     let repo_root_str = host.repo_root()?;
     let repo_root = canonicalize_existing_dir(&repo_root_str, "repo_root")?;
@@ -135,9 +138,43 @@ fn merge_with_rebase_retry(
         }
 
         let updated_base = resolve_worktree_start_point(repo_root, base, base_sync_mode)?;
-        if let Err(error) = git_success(workspace_path, &["rebase", &updated_base]) {
-            let _ = git_success(workspace_path, &["rebase", "--abort"]);
-            return Err(error);
+        let rebase_already = rebase_in_progress(workspace_path)?;
+        let rebase_outcome = git_run(workspace_path, &["rebase", &updated_base])?;
+        if rebase_outcome.timed_out || !rebase_outcome.success {
+            if !rebase_already {
+                let _ = git_success(workspace_path, &["rebase", "--abort"]);
+            }
+            if rebase_outcome.timed_out {
+                return Err(OrbitError::Execution(format!(
+                    "{}; merge_batch_worktree_into_base: Git rebase timed out. {} This is timeout recovery, not conflict or failure-handoff recovery.",
+                    git_timeout_error(
+                        workspace_path,
+                        &["rebase", &updated_base],
+                        rebase_outcome.timeout_ms,
+                        &rebase_outcome.stderr,
+                    ),
+                    if rebase_already {
+                        "Pre-existing rebase state was left intact."
+                    } else {
+                        "The rebase started by this attempt was aborted."
+                    }
+                )));
+            }
+            if rebase_already {
+                return Err(OrbitError::Execution(format!(
+                    "merge_batch_worktree_into_base: a pre-existing rebase is in progress; not aborting. {}",
+                    git_failure_error(
+                        workspace_path,
+                        &["rebase", &updated_base],
+                        &rebase_outcome.stderr,
+                    )
+                )));
+            }
+            return Err(git_failure_error(
+                workspace_path,
+                &["rebase", &updated_base],
+                &rebase_outcome.stderr,
+            ));
         }
         ensure_clean_checkout(workspace_path, "shared batch worktree")?;
     }

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -8,9 +8,11 @@ use crate::context::{RuntimeHost, TaskAutomationUpdate};
 use crate::executor::automation::input::input_string_field;
 
 use super::super::git::{
-    base_sync_mode_from_input, git_command_success, git_output, git_success,
+    GitOutcome, GitTimeoutBudget, GitTimeoutBudgetGuard, base_sync_mode_from_input,
+    git_command_success, git_failure_error, git_output, git_run, git_success, git_timeout_error,
     resolve_worktree_start_point,
 };
+use super::cleanup::remove_worktree;
 use super::dependency_delivery::{
     DependencyDeliveryMode, dependency_delivery_mode_from_input,
     ensure_dependencies_delivered_into_base,
@@ -54,6 +56,7 @@ pub(in crate::executor::automation) fn setup_worktree<H: RuntimeHost + ?Sized>(
         (None, None) => None,
     };
 
+    let _timeout_budget = GitTimeoutBudgetGuard::install(GitTimeoutBudget::from_input(input)?);
     let repo_root_str = host.repo_root()?;
     let repo_root = Path::new(&repo_root_str);
 
@@ -185,21 +188,26 @@ pub(crate) fn ensure_worktree(
     )?;
 
     if worktree_path.exists() {
-        // Only a worktree this repository registered is ours to reuse and
-        // clean. "Is some git work tree" would also match an unrelated
-        // checkout that happens to sit at the resolved path (a shared
-        // `ORBIT_WORKTREE_ROOT`, a colliding name), and `clean -fd` there
-        // deletes someone else's untracked files.
+        // Only a worktree this repository registered is ours to reuse or
+        // remove. "Is some git work tree" would also match an unrelated
+        // checkout that happens to sit at the resolved path.
         if is_registered_worktree(repo_root, worktree_path)? {
-            let attached_branch = git_output(
-                worktree_path,
-                &["symbolic-ref", "--quiet", "--short", "HEAD"],
-            )?;
-            git_success(worktree_path, &["clean", "-fd"])?;
-            return Ok(attached_branch);
-        }
-
-        if is_empty_dir(worktree_path)? {
+            match inspect_registered_worktree(repo_root, worktree_path, &target, branch_name)? {
+                RegisteredWorktree::Usable { branch } => return Ok(branch),
+                RegisteredWorktree::Incomplete {
+                    retained_work,
+                    evidence,
+                } => {
+                    if retained_work {
+                        return Err(OrbitError::Execution(format!(
+                            "worktree path '{}' is an incomplete checkout of this repository and retains work; refusing to admit or reset it. {evidence}",
+                            worktree_path.display()
+                        )));
+                    }
+                    remove_worktree(repo_root, worktree_path, None, true)?;
+                }
+            }
+        } else if is_empty_dir(worktree_path)? {
             std::fs::remove_dir(worktree_path).map_err(|error| {
                 OrbitError::Execution(format!(
                     "failed to remove empty invalid worktree path '{}': {error}",
@@ -224,27 +232,222 @@ pub(crate) fn ensure_worktree(
     }
 
     git_success(repo_root, &["worktree", "prune"])?;
-    let worktree_path_arg = worktree_path.to_string_lossy();
+    add_worktree(repo_root, worktree_path, &target, branch_name)
+}
+
+enum RegisteredWorktree {
+    Usable {
+        branch: String,
+    },
+    Incomplete {
+        retained_work: bool,
+        evidence: String,
+    },
+}
+
+/// Read-only completeness check. Deleted tracked files, dirty files, and extra
+/// commits are retained work on a usable checkout — they do not prove the
+/// checkout is incomplete and must not be restored or deleted here.
+fn inspect_registered_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    start_point: &str,
+    branch_name: &str,
+) -> Result<RegisteredWorktree, OrbitError> {
+    let inside = git_command_success(worktree_path, &["rev-parse", "--is-inside-work-tree"])?;
+    let head_ok = git_command_success(worktree_path, &["rev-parse", "--verify", "HEAD^{commit}"])?;
+    let git_dir = git_output(worktree_path, &["rev-parse", "--absolute-git-dir"]).ok();
+    let index_ok = git_dir
+        .as_ref()
+        .map(|dir| Path::new(dir).join("index").is_file())
+        .unwrap_or(false);
+    let branch = git_output(
+        worktree_path,
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+    )
+    .ok();
+    let head = git_output(worktree_path, &["rev-parse", "--verify", "HEAD^{commit}"]).ok();
+    let status = git_output(worktree_path, &["status", "--porcelain"]).ok();
+    let unique_commits = branch_has_unique_commits(
+        repo_root,
+        branch.as_deref().unwrap_or(branch_name),
+        start_point,
+    )
+    .unwrap_or(true);
+    let evidence = format!(
+        "HEAD={}, branch={}, gitdir={}, index={}, status={}, unique_commits={unique_commits}. Completeness does not treat deleted tracked files as an incomplete checkout (they may be intended edits). Timeout recovery is not conflict or failure-handoff recovery; stale-branch provenance is owned by ORB-11639.",
+        head.as_deref().unwrap_or("missing"),
+        branch.as_deref().unwrap_or("missing"),
+        git_dir.as_deref().unwrap_or("missing"),
+        if index_ok { "present" } else { "missing" },
+        status
+            .as_deref()
+            .map(|value| if value.trim().is_empty() {
+                "clean"
+            } else {
+                "dirty"
+            })
+            .unwrap_or("unreadable")
+    );
+
+    if inside && head_ok && index_ok {
+        let Some(branch) = branch else {
+            return Ok(RegisteredWorktree::Incomplete {
+                retained_work: true,
+                evidence,
+            });
+        };
+        return Ok(RegisteredWorktree::Usable { branch });
+    }
+
+    let retained_work = unique_commits
+        || status
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+    Ok(RegisteredWorktree::Incomplete {
+        retained_work,
+        evidence,
+    })
+}
+
+fn branch_has_unique_commits(
+    repo_root: &Path,
+    branch_name: &str,
+    start_point: &str,
+) -> Result<bool, OrbitError> {
     let branch_ref = format!("refs/heads/{branch_name}");
-    if git_command_success(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref])? {
-        git_success(
-            repo_root,
-            &["worktree", "add", &worktree_path_arg, branch_name],
-        )?;
+    if !git_command_success(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref])? {
+        return Ok(false);
+    }
+    let tip = git_output(
+        repo_root,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("{branch_name}^{{commit}}"),
+        ],
+    )?;
+    Ok(tip.trim() != start_point.trim())
+}
+
+fn add_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+    target: &str,
+    branch_name: &str,
+) -> Result<String, OrbitError> {
+    let worktree_path_arg = worktree_path.to_string_lossy().into_owned();
+    let branch_ref = format!("refs/heads/{branch_name}");
+    let args = if git_command_success(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref])?
+    {
+        vec![
+            "worktree".to_string(),
+            "add".to_string(),
+            worktree_path_arg,
+            branch_name.to_string(),
+        ]
     } else {
-        git_success(
+        vec![
+            "worktree".to_string(),
+            "add".to_string(),
+            "-b".to_string(),
+            branch_name.to_string(),
+            worktree_path_arg,
+            target.to_string(),
+        ]
+    };
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let outcome = git_run(repo_root, &arg_refs)?;
+    if outcome.timed_out {
+        return Err(recover_worktree_add_timeout(
             repo_root,
-            &[
-                "worktree",
-                "add",
-                "-b",
-                branch_name,
-                &worktree_path_arg,
-                &target,
-            ],
-        )?;
+            worktree_path,
+            branch_name,
+            target,
+            &outcome,
+            &arg_refs,
+        ));
+    }
+    if !outcome.success {
+        return Err(git_failure_error(repo_root, &arg_refs, &outcome.stderr));
     }
     Ok(branch_name.to_string())
+}
+
+fn remove_owned_incomplete_worktree(
+    repo_root: &Path,
+    worktree_path: &Path,
+) -> Result<(), OrbitError> {
+    match remove_worktree(repo_root, worktree_path, None, true) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            if worktree_path.exists() {
+                std::fs::remove_dir_all(worktree_path).map_err(|fs_error| {
+                    OrbitError::Execution(format!(
+                        "{error}; also failed to delete '{}': {fs_error}",
+                        worktree_path.display()
+                    ))
+                })?;
+            }
+            git_success(repo_root, &["worktree", "prune"])?;
+            Ok(())
+        }
+    }
+}
+
+fn recover_worktree_add_timeout(
+    repo_root: &Path,
+    worktree_path: &Path,
+    branch_name: &str,
+    start_point: &str,
+    outcome: &GitOutcome,
+    args: &[&str],
+) -> OrbitError {
+    let timeout = git_timeout_error(repo_root, args, outcome.timeout_ms, &outcome.stderr);
+    let registered = is_registered_worktree(repo_root, worktree_path).unwrap_or(false);
+    if !registered && !worktree_path.exists() {
+        return OrbitError::Execution(format!(
+            "{timeout}; worktree add timed out before registration. This is timeout recovery, not conflict or failure-handoff recovery."
+        ));
+    }
+
+    let inspection = if registered {
+        inspect_registered_worktree(repo_root, worktree_path, start_point, branch_name).ok()
+    } else {
+        None
+    };
+    let can_remove = matches!(
+        &inspection,
+        Some(RegisteredWorktree::Incomplete {
+            retained_work: false,
+            ..
+        })
+    );
+
+    if registered && can_remove {
+        if let Err(error) = remove_owned_incomplete_worktree(repo_root, worktree_path) {
+            return OrbitError::Execution(format!(
+                "{timeout}; failed to remove incomplete owned worktree '{}': {error}. Leave it in place and inspect before retrying. This is timeout recovery, not conflict or failure-handoff recovery.",
+                worktree_path.display()
+            ));
+        }
+        return OrbitError::Execution(format!(
+            "{timeout}; removed incomplete owned worktree '{}'. Retry must create a complete checkout; this is timeout recovery, not conflict or failure-handoff recovery.",
+            worktree_path.display()
+        ));
+    }
+
+    let evidence = match &inspection {
+        Some(RegisteredWorktree::Incomplete { evidence, .. }) => evidence.clone(),
+        Some(RegisteredWorktree::Usable { branch }) => {
+            format!("usable attached branch '{branch}'")
+        }
+        None => format!("registered={registered}, path={}", worktree_path.display()),
+    };
+    OrbitError::Execution(format!(
+        "{timeout}; leaving checkout '{}' in place ({evidence}). Retry will not admit an incomplete checkout. This is timeout recovery, not conflict or failure-handoff recovery.",
+        worktree_path.display()
+    ))
 }
 
 fn is_empty_dir(path: &Path) -> Result<bool, OrbitError> {

--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/tests/setup.rs
@@ -19,6 +19,9 @@ use serde_json::{Value, json};
 
 use crate::context::{RuntimeHost, TaskActivityUpdate, TaskAutomationUpdate};
 
+#[cfg(unix)]
+use crate::executor::automation::vcs::tests::with_fake_git;
+
 use super::super::resolve_worktree_path_from_prefix;
 use super::super::setup::{ensure_worktree, setup_worktree, worktree_setup_output};
 
@@ -182,6 +185,126 @@ fn worktree_setup_publishes_the_resolved_base_commit_alongside_the_moving_ref() 
         output["base_sha"],
         json!("2222222222222222222222222222222222222222")
     );
+}
+
+#[test]
+fn completeness_leaves_deletions_dirty_files_and_retained_commits_intact() {
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let worktree = temp.path().join("worktree");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+    let first_base = commit_file(&repo, "keep.txt", "tracked");
+
+    assert_eq!(
+        ensure_worktree(&repo, &worktree, &first_base, "orbit/test").unwrap(),
+        "orbit/test"
+    );
+    let retained = commit_file(&worktree, "child.txt", "landed");
+    fs::remove_file(worktree.join("keep.txt")).unwrap();
+    fs::write(worktree.join("dirty.txt"), "untracked work").unwrap();
+
+    let second_base = commit_file(&repo, "base.txt", "v2");
+    let reattached = ensure_worktree(&repo, &worktree, &second_base, "orbit/new-name").unwrap();
+
+    assert_eq!(reattached, "orbit/test");
+    assert_eq!(git(&worktree, &["rev-parse", "HEAD"]), retained);
+    assert!(
+        !worktree.join("keep.txt").exists(),
+        "tracked deletion must not be restored by completeness"
+    );
+    assert_eq!(
+        fs::read_to_string(worktree.join("dirty.txt")).unwrap(),
+        "untracked work"
+    );
+    assert_eq!(
+        fs::read_to_string(worktree.join("child.txt")).unwrap(),
+        "landed"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn worktree_add_timeout_after_registration_is_not_admitted_on_retry() {
+    let stamp_dir = tempdir().unwrap();
+    let stamp = stamp_dir.path().join("worktree-once");
+    if !with_fake_git(
+        module_path!(),
+        "worktree_add_timeout_after_registration_is_not_admitted_on_retry",
+        &[("ORBIT_TEST_GIT_WORKTREE_ONCE", stamp.display().to_string())],
+    ) {
+        return;
+    }
+
+    let temp = tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    init_repo(&repo, "agent-main");
+    commit_file(&repo, "base.txt", "v1");
+    let host = FakeHost::new(&repo, &["ORB-11606"]);
+    let run_id = "jrun-timeout-worktree";
+    let input = json!({
+        "task_ids": ["ORB-11606"],
+        "run_id": run_id,
+        "base": "agent-main",
+        "base_sync": "local",
+        "dependency_delivery": "ignore",
+        "git_timeouts": { "worktree_add": 400 },
+    });
+
+    let first = setup_worktree(&host, &input).expect_err("first add must time out");
+    let first_message = first.to_string();
+    assert!(
+        first_message.contains("timed out"),
+        "expected timeout diagnostic, got {first_message}"
+    );
+    assert!(
+        first_message.contains("timeout recovery") || first_message.contains("Timeout recovery"),
+        "timeout recovery must be named: {first_message}"
+    );
+    assert!(
+        !first_message.contains("unresolved conflict"),
+        "timeout must not be labeled a conflict: {first_message}"
+    );
+    assert!(
+        host.admitted().is_empty(),
+        "timed-out setup must not admit the task"
+    );
+
+    let worktree_path = resolve_worktree_path_from_prefix(&repo, "orbit", run_id).unwrap();
+    let second = setup_worktree(&host, &input);
+    match second {
+        Ok(_) => {
+            assert!(
+                git_ok(&worktree_path, &["rev-parse", "--verify", "HEAD^{commit}"]),
+                "retry may admit only a complete checkout"
+            );
+            assert_eq!(host.admitted(), vec!["ORB-11606".to_string()]);
+        }
+        Err(error) => {
+            let message = error.to_string();
+            assert!(
+                host.admitted().is_empty(),
+                "retry must not admit an incomplete checkout"
+            );
+            assert!(
+                message.contains("incomplete") || message.contains("leaving checkout"),
+                "refusal must preserve evidence: {message}"
+            );
+            assert!(
+                worktree_path.exists(),
+                "quarantined checkout must remain for inspection"
+            );
+        }
+    }
+}
+
+fn git_ok(current_dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 fn init_repo(path: &Path, branch: &str) {

--- a/docs/design/activity-job/2_design.md
+++ b/docs/design/activity-job/2_design.md
@@ -3,8 +3,8 @@ summary: "Activity / Job — Design"
 type: design
 title: "Activity / Job — Design"
 owner: codex
-last_updated: 2026-09-07
-last_validated: 2026-09-07
+last_updated: 2026-09-08
+last_validated: 2026-09-08
 status: Draft
 feature: activity-job
 doc_role: design
@@ -297,6 +297,10 @@ completion authorization remain owned by their existing Core and `pr_complete`
 gates; checkpoint refresh cannot grant either.
 
 The provider boundary now admits only worktree-file changes from an implementation provider. Any assigned HEAD or branch movement is a typed `worktree_content_conflict` regardless of commit count, message trailers, or changed paths; Orbit does not try to prove that provider history belongs to the task. `git_commit` stages the task worktree diff, creates exactly one workflow-owned commit, and returns that SHA. It never enumerates or adopts commits above the pinned base, parses `Agent-*` trailers, or validates a commit against `context_files`.
+
+Host Git children always carry a finite `ExecRequest.timeout_ms`. Light commands default to 30s; `fetch` 60s; `worktree add` and `rebase` 120s. Activity input may overlay those values with `git_timeout_ms` or `git_timeouts` (`default`, `fetch`, `worktree_add`, `rebase`); 0, non-integers, unknown keys, and values above 600s are rejected, and the request never uses an unbounded deadline. Hook disabling (`core.hooksPath=/dev/null`, `gc.auto=0`, `--no-verify` on commit/push) and the cleared VCS environment stay in force.
+
+Timeout recovery is not conflict recovery and not failure-handoff recovery. A `worktree add` that times out after this attempt registered the path is removed only when the checkout is owned and nothing unique is retained; otherwise the leftover is refused with path/HEAD/branch evidence and is never admitted incomplete. Deleted tracked files, dirty files, and extra commits are not completeness failures and are not restored or deleted as a shortcut. A rebase this attempt started is aborted on timeout when provenance matches (`orig-head` / `onto` / `head-name`); a pre-existing or foreign rebase is left intact and refused diagnostically. Unmerged paths still produce `RecoverableVcsConflict` for `pr_conflict_recovery`. `pr_failure_handoff` still preserves the candidate. Unexplained stale-branch reuse remains [ORB-11639].
 
 `pr_prepare` is the pre-rewrite authority boundary. It records the exact head SHA, base SHA, and observed remote task-branch SHA before `git_rebase` may rewrite history. `git_push` classifies the remote ref as missing, current, fast-forwardable, remote-ahead, or diverged. Missing and fast-forwardable refs use normal push; current refs are reused; remote-ahead refs fail closed. Divergence may use force-with-lease only when the persisted preparation SHA still exactly matches the observed remote SHA and `git_rebase` reports a performed or recovery-reused rewrite. The engine-private VCS operation emits a branch-scoped `--force-with-lease=refs/heads/<branch>:<expected-sha>`, so a concurrent remote update rejects the push instead of overwriting it. This is [PR handoff recovery follows job checkpoints and exact remote leases](./4_decisions.md#pr-handoff-recovery-follows-job-checkpoints-and-exact-remote-leases).
 
@@ -942,6 +946,7 @@ Read-only history does not need the same dependencies as live execution. [T20260
 
 ## Task References
 
+- **[ORB-11606]** — Bound heavyweight Git operations and recover only owned interrupted mutations ([Timeout recovery is not conflict or failure-handoff recovery](./4_decisions.md#timeout-recovery-is-not-conflict-or-failure-handoff-recovery)).
 - **[ORB-11281]** — Route only typed task-PR rebase conflicts to one system-crew leaf, retry the same checkpoint once, preserve stale-base races, and retain normal review or authorized verified-completion gates.
 - **[ORB-11488]** — Reuse that bounded pinned-rebase recovery when an already-published PR becomes `DIRTY` during authorized completion, with exact branch/PR leases and no protection or auth bypass.
 - **[ORB-11493]** — Refresh one authenticated stale `prepare_branch` checkpoint on preserved-candidate resume, retain source/descendant provenance, and reuse the bounded conflict-recovery and same-PR delivery tail.

--- a/docs/design/activity-job/4_decisions.md
+++ b/docs/design/activity-job/4_decisions.md
@@ -3,8 +3,8 @@ summary: "Activity / Job — Decisions"
 type: design
 title: "Activity / Job — Decisions"
 owner: codex
-last_updated: 2026-08-15
-last_validated: 2026-08-23
+last_updated: 2026-09-08
+last_validated: 2026-09-08
 status: Draft
 feature: activity-job
 doc_role: decisions
@@ -1545,8 +1545,30 @@ which is a broken install and the only artifact fault that escalates
   preserved copy under `.retired-managed/` to reconcile by hand — where
   previously the file would simply have stayed put and kept working.
 
+## Timeout recovery is not conflict or failure-handoff recovery
+
+**Recorded:** 2026-09-08 · [ORB-11606]
+
+### Context
+
+Host Git helpers shared a 30s deadline. A timeout during `worktree add` could leave a registered incomplete checkout that a retry then admitted, and a timeout during `git rebase` could leave rebase-merge without unmerged paths that a retry misclassified as an unexplained wedge. Ordinary conflict recovery (`RecoverableVcsConflict` / `pr_conflict_recovery`) and terminal failure-handoff (`pr_failure_handoff`) already preserve candidates; they must not be reused as a blanket reset/clean/abort.
+
+### Decision
+
+Give heavyweight Git children explicit finite budgets through `ExecRequest.timeout_ms`, with per-operation defaults and optional activity overlays (`git_timeout_ms` / `git_timeouts`). Reject 0, unknown keys, and values above 600s; never omit the deadline. Keep the secured Git environment and hook policy.
+
+On timeout, mutate only state this attempt owns. Remove a newly registered worktree only when ownership and lack of retained work are established; otherwise refuse with evidence and never admit an incomplete checkout. Abort an interrupted rebase only when provenance shows this attempt started it; leave pre-existing or foreign rebase state intact. Deleted tracked files, dirty files, and retained candidate commits are not completeness failures and must not be restored or deleted as a shortcut. Unexplained stale-branch provenance stays with [ORB-11639].
+
+### Consequences
+
+- A retry after an owned worktree-add timeout either recreates a complete checkout or refuses the leftover; it does not silently reuse a broken tree.
+- A retry after an owned rebase timeout is not permanently wedged: the leftover rebase is aborted and documented as timeout recovery.
+- Conflicted rebases still take the typed conflict path; failure-handoff still publishes the candidate.
+- Cost: operators who previously relied on `git clean -fd` during worktree reuse keep dirty files until they reconcile them; that is the intended preservation.
+
 ## Task References
 
+- **[ORB-11606]** — Bound heavyweight Git operations and recover only owned interrupted mutations ([Timeout recovery is not conflict or failure-handoff recovery](#timeout-recovery-is-not-conflict-or-failure-handoff-recovery)).
 - **[ORB-11456]** — Preserve terminal failure-activity evidence and admit only
   its exact Orbit-created candidate across resume
   ([Resumed shipment accepts only its durable Orbit preservation commit](#resumed-shipment-accepts-only-its-durable-orbit-preservation-commit)).


### PR DESCRIPTION
## Task

[ORB-11606](https://orbit-cli.com/tasks/ORB-11606) — [code-review] Bound heavyweight Git operations and recover only owned interrupted mutations

### Description

## Problem
VCS helpers give many mutations a shared 30s deadline. Interrupted worktree creation can leave a registered incomplete checkout, and an interrupted rebase can leave state that later retries cannot classify. Timeout recovery is incomplete. Hooks are already disabled by the shared Git policy, so slow hooks are not a current cause; frequency of large-repo timeouts was not measured.

## Required behavior and constraints
Provide explicit bounded budgets for heavyweight operations through the existing configuration/request boundary, retaining secured environment and hook policy. On timeout, distinguish the operation started by this run from existing candidate/recovery state. Clean up a newly created incomplete worktree only when ownership and lack of retained work are established. Abort an interrupted rebase only when provenance establishes it belongs to this attempt; otherwise preserve evidence and return an actionable refusal. Deleted tracked files alone do not prove an incomplete checkout: they may be intended edits. Preserve failed-handoff data and avoid blanket reset/clean/abort behavior.

## Evidence and validation
Source validation against agent-main 09dec5183 (original review 7f3a8f5fa); re-locate symbols on the implementation revision. crates/orbit-engine/src/executor/automation/vcs/git.rs:34,121,140; freshness.rs:138,214; worktree/setup.rs:193; commit/git_ops.rs and worktree/merge.rs.
These are source-level findings, not measured performance or executed fault-injection results. Use focused deterministic regression tests at the owning boundary. Follow AGENTS.md and pass make ci-fast and make ci-lint before review; no release work is included.

### Acceptance Criteria

- Deterministic temporary Git fixture or shim forces timeout after owned worktree registration; retry never admits the incomplete checkout, and cleanup or quarantine/refusal preserves actionable evidence.
- Injected timeout of a rebase started by this attempt produces documented recovery without an unexplained permanently wedged retry; pre-existing rebase and foreign/retained candidate state remain intact and are refused diagnostically.
- Tests with intentional tracked deletions, dirty files and retained candidate commits show they are not silently restored/deleted by completeness checks.
- Operation budget tests cover defaults, valid overrides and invalid/extreme values while preserving environment/hook restrictions; no unbounded deadline is introduced.
- All process fixtures clean up unconditionally. Tests and docs distinguish timeout recovery from ordinary conflict/failure-handoff recovery; coordinate branch provenance behavior with ORB-11639.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Host Git children now use per-operation finite `ExecRequest.timeout_ms` budgets (light 30s, fetch 60s, worktree add 120s, rebase 120s) with optional `git_timeout_ms` / `git_timeouts` overlays, an RAII budget guard, and no unbounded deadline. Hook/env policy is unchanged.
- `git_run` distinguishes process timeout from ordinary Git failure; `git_command_success` no longer treats a timeout as a falsey Git result.
- `worktree add` timeout recovery removes an owned incomplete checkout only when lack of retained work is established (filesystem fallback if `worktree remove` cannot validate `.git`); otherwise it refuses with evidence. Completeness is read-only: deleted tracked files, dirty files, and extra commits are not restored or cleaned. Retry does not admit an unusable checkout. Complete reuse still keeps attached HEAD (ORB-11639).
- `git_rebase` aborts a timed-out rebase only when this attempt started it (or provenance matches orig-head/onto/head-name). Pre-existing/foreign rebase state is refused diagnostically and left intact. Unmerged paths remain `RecoverableVcsConflict`. Batch merge no longer `rebase --abort`s a pre-existing rebase.
- Docs distinguish timeout recovery from conflict and failure-handoff recovery.
- Unrelated `orbit-search` test Embedder stubs now implement `token_boundaries` so workspace `clippy --all-targets` compiles (pre-existing HEAD gap).

Acceptance criteria:
1. Passed. Unix PATH-isolated Git shim hangs after owned `worktree add` registration; 400ms budget times out; retry never admits the incomplete checkout; cleanup/quarantine diagnostics name timeout recovery.
2. Passed. Injected rebase timeout (`rebase -x sleep`) aborts the owned leftover; retry performs a clean rebase. Pre-existing rebase without conflicts is refused and left intact. Conflicts still use `RecoverableVcsConflict`.
3. Passed. Completeness/reuse test keeps tracked deletions, dirty untracked files, and retained candidate commits.
4. Passed. Budget tests cover defaults, valid overlays, invalid/extreme values; `git_request` always has `Some(timeout)` and keeps hooksPath=/dev/null, gc.auto=0, cleared env.
5. Passed. Shim uses child-process isolation and tempfile Drop. Tests and activity-job docs distinguish timeout recovery from conflict/failure-handoff; stale-branch provenance remains ORB-11639.

Validation:
- `cargo test -p orbit-engine --lib -- executor::automation::vcs::` — passed (231 tests)
- `make ci-fast` — passed (after regenerating `docs/INDEX.md`)
- `make ci-lint` — passed
- `git diff --check` — passed
- `git status --short` — 16 modified + 1 new test file; uncommitted as required

Assessment: Scoped to the VCS Git request boundary. Timeout recovery mutates only owned incomplete state. Remaining risk: live large-repo timeout frequency was not measured; shim-injected faults are deterministic, not production Git hangs.

Deviations from original plan:
- `git worktree remove --force` can fail on a partial `.git` after a mid-add kill; recovery then deletes the owned path and prunes. Justification: otherwise the leftover cannot be cleaned and retry would stay blocked.
- Forwarded `token_boundaries` on two orbit-search test embedders. Justification: workspace clippy --all-targets failed on this HEAD without it.

Friction: none filed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11606-6a9f6c41`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra