### PR TITLE
[code-review] Read each doc once in `search_docs` / related-docs / index instead of re-resolving roots and re-reading every file per record

### DIFF
--- a/crates/orbit-core/src/application/docs/frontmatter.rs
+++ b/crates/orbit-core/src/application/docs/frontmatter.rs
@@ -5,6 +5,28 @@ use orbit_common::OrbitError;
 use super::path_util::component_str;
 use super::types::{DocFrontmatter, DocType, FrontmatterBlock, ParsedDoc, RawDocFrontmatter};
 
+#[cfg(test)]
+thread_local! {
+    static DOC_FILE_READS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_doc_file_read() {
+    DOC_FILE_READS.with(|reads| reads.set(reads.get() + 1));
+}
+
+/// Reset the doc-file read counter (test helper).
+#[cfg(test)]
+pub(super) fn reset_doc_file_reads() {
+    DOC_FILE_READS.with(|reads| reads.set(0));
+}
+
+/// Return how many doc files have been read since the last reset (test helper).
+#[cfg(test)]
+pub(super) fn doc_file_reads() -> usize {
+    DOC_FILE_READS.with(std::cell::Cell::get)
+}
+
 pub(super) fn parse_doc_strict(path: &Path, raw: &str) -> Result<ParsedDoc, OrbitError> {
     let block = split_frontmatter(raw).map_err(|message| {
         OrbitError::InvalidInput(format!(
@@ -57,6 +79,24 @@ pub(super) fn parse_doc_strict(path: &Path, raw: &str) -> Result<ParsedDoc, Orbi
         },
         body: block.body.to_string(),
     })
+}
+
+/// Read a Markdown doc from disk and parse it tolerantly.
+///
+/// This is the one place the docs pipeline opens a doc file: the walk, and the
+/// single-path `docs show` lookup, both come through here. Keeping the read
+/// and the parse together is what lets one docs operation touch each file
+/// exactly once, and `doc_file_reads` makes that observable to tests.
+pub(super) fn read_doc_tolerant(
+    repo_relative: &Path,
+    absolute_path: &Path,
+) -> Result<ParsedDoc, OrbitError> {
+    #[cfg(test)]
+    record_doc_file_read();
+
+    let raw = std::fs::read_to_string(absolute_path)
+        .map_err(|error| OrbitError::Io(format!("read {}: {error}", absolute_path.display())))?;
+    Ok(parse_doc_tolerant(repo_relative, absolute_path, &raw))
 }
 
 pub(super) fn parse_doc_tolerant(

--- a/crates/orbit-core/src/application/docs/mod.rs
+++ b/crates/orbit-core/src/application/docs/mod.rs
@@ -37,6 +37,7 @@ use self::config::{
 };
 use self::migrate::migrate_docs;
 use self::search::{doc_embedding_sources, doc_search_source, related_docs_for_context, show_doc};
+use self::walk::walk_docs_with_bodies;
 
 // The original impl block (291-408) is preserved verbatim except for path adjustments
 // that are mechanical (use of super:: paths). All bodies delegate to submodules.
@@ -90,10 +91,14 @@ impl OrbitRuntime {
         }
         let limit = limit.unwrap_or(20);
         let query_lower = query.to_ascii_lowercase();
+
+        // One roots resolution and one walk for the whole search: every doc is
+        // scored from the body that its single read already produced.
+        let roots = self.docs_roots()?;
         let mut scored = Vec::new();
-        for record in self.list_docs(None, None)? {
-            let body = self.show_doc(&record.path)?.body;
-            if let Some(result) = score_doc_record(doc_search_source(record, body), &query_lower) {
+        for doc in walk_docs_with_bodies(&self.paths().repo_root, &roots)? {
+            let source = doc_search_source(doc.record, doc.body);
+            if let Some(result) = score_doc_record(source, &query_lower) {
                 scored.push(SearchResult::Doc(result));
             }
         }

--- a/crates/orbit-core/src/application/docs/search.rs
+++ b/crates/orbit-core/src/application/docs/search.rs
@@ -7,10 +7,10 @@ use orbit_search::{DocEmbeddingSource, DocSearchSource};
 use orbit_types::policy::{match_glob, normalize_glob_path};
 
 use super::config::DocsRoot;
-use super::frontmatter::parse_doc_tolerant;
+use super::frontmatter::read_doc_tolerant;
 use super::path_util::{path_to_slash_string, repo_relative_path};
-use super::types::{DocRecord, DocShow, TaskRelatedDoc};
-use super::walk::{expand_root, walk_docs_roots};
+use super::types::{DocRecord, DocShow, TaskRelatedDoc, WalkedDoc};
+use super::walk::{expand_root, walk_docs_with_bodies};
 
 const DEFAULT_RELATED_DOC_LIMIT: usize = 5;
 
@@ -41,9 +41,7 @@ pub(super) fn show_doc(
         )));
     }
     let relative = repo_relative_path(repo_root, &absolute)?;
-    let raw = std::fs::read_to_string(&absolute)
-        .map_err(|error| OrbitError::Io(format!("read {}: {error}", absolute.display())))?;
-    let parsed = parse_doc_tolerant(&relative, &absolute, &raw);
+    let parsed = read_doc_tolerant(&relative, &absolute)?;
     Ok(DocShow {
         path: path_to_slash_string(&relative),
         frontmatter: parsed.frontmatter,
@@ -113,22 +111,21 @@ pub(super) fn doc_embedding_sources(
     repo_root: &Path,
     roots: &[DocsRoot],
 ) -> Result<Vec<DocEmbeddingSource>, OrbitError> {
-    let mut sources = Vec::new();
-    for record in walk_docs_roots(repo_root, roots)? {
-        let shown = show_doc(repo_root, roots, &record.path)?;
-        sources.push(DocEmbeddingSource {
-            path: record.path,
-            title: shown.frontmatter.summary,
-            tags: shown.frontmatter.tags,
-            body: shown.body,
-        });
-    }
-    Ok(sources)
+    Ok(walk_docs_with_bodies(repo_root, roots)?
+        .into_iter()
+        .map(|doc| DocEmbeddingSource {
+            path: doc.record.path,
+            title: doc.record.frontmatter.summary,
+            tags: doc.record.frontmatter.tags,
+            body: doc.body,
+        })
+        .collect())
 }
 
 #[derive(Debug)]
 struct RelatedDocCandidate {
     record: DocRecord,
+    body: String,
     score: usize,
     matched_by: BTreeSet<String>,
 }
@@ -159,7 +156,7 @@ pub(super) fn related_docs_for_context(
     }
 
     let mut candidates = BTreeMap::<String, RelatedDocCandidate>::new();
-    for record in walk_docs_roots(repo_root, roots)? {
+    for WalkedDoc { record, body } in walk_docs_with_bodies(repo_root, roots)? {
         let mut score = 0usize;
         let mut matched_by = BTreeSet::new();
 
@@ -196,6 +193,7 @@ pub(super) fn related_docs_for_context(
             })
             .or_insert(RelatedDocCandidate {
                 record,
+                body,
                 score,
                 matched_by,
             });
@@ -210,19 +208,19 @@ pub(super) fn related_docs_for_context(
     });
     ranked.truncate(limit);
 
-    ranked
+    Ok(ranked
         .into_iter()
         .map(|candidate| {
-            let shown = show_doc(repo_root, roots, &candidate.record.path)?;
-            Ok(TaskRelatedDoc {
+            let excerpt = doc_excerpt(&candidate.body, &candidate.record.frontmatter.summary);
+            TaskRelatedDoc {
                 path: candidate.record.path,
                 doc_type: candidate.record.frontmatter.doc_type,
-                summary: candidate.record.frontmatter.summary.clone(),
-                excerpt: doc_excerpt(&shown.body, &candidate.record.frontmatter.summary),
+                summary: candidate.record.frontmatter.summary,
+                excerpt,
                 matched_by: candidate.matched_by.into_iter().collect(),
-            })
+            }
         })
-        .collect()
+        .collect())
 }
 
 fn context_selector_path(repo_root: &Path, selector: &str) -> Option<String> {

--- a/crates/orbit-core/src/application/docs/tests/search.rs
+++ b/crates/orbit-core/src/application/docs/tests/search.rs
@@ -1,12 +1,15 @@
-//! Search result shape and related_docs matching tests migrated for ORB-00250.
+//! Search result shape, doc-read accounting, and related_docs matching tests
+//! (originally migrated for ORB-00250).
 
 use std::fs;
 
 use tempfile::tempdir;
 
 use super::super::config::DocsRoot;
+use super::super::frontmatter::{doc_file_reads, reset_doc_file_reads};
 use super::super::search::related_docs_for_context;
 use super::super::types::DocType;
+use crate::OrbitRuntime;
 
 use orbit_search::{DocSearchResult, DocSearchSource, SearchResult};
 use serde_json::json;
@@ -97,4 +100,37 @@ fn related_docs_match_task_features_against_doc_related_features() {
     assert_eq!(related.len(), 1);
     assert_eq!(related[0].path, "docs/orbit-docs.md");
     assert_eq!(related[0].matched_by, vec!["feature:orbit-docs"]);
+}
+
+#[test]
+fn search_docs_reads_each_doc_once() {
+    const DOC_COUNT: usize = 5;
+
+    let dir = tempdir().expect("tempdir");
+    let global_root = dir.path().join("global");
+    let repo_root = dir.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    fs::create_dir_all(&global_root).expect("global root");
+    fs::create_dir_all(&workspace_root).expect("workspace root");
+    fs::create_dir_all(repo_root.join("docs")).expect("docs dir");
+    for index in 0..DOC_COUNT {
+        fs::write(
+            repo_root.join(format!("docs/doc-{index}.md")),
+            format!("---\ntype: context\nsummary: Doc {index}\n---\nindexable body\n"),
+        )
+        .expect("write doc");
+    }
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+
+    reset_doc_file_reads();
+    let results = runtime
+        .search_docs("indexable", Some(DOC_COUNT), true)
+        .expect("search docs");
+
+    assert_eq!(results.len(), DOC_COUNT, "every doc should match the query");
+    assert_eq!(
+        doc_file_reads(),
+        DOC_COUNT,
+        "search_docs must read each doc exactly once"
+    );
 }

--- a/crates/orbit-core/src/application/docs/types.rs
+++ b/crates/orbit-core/src/application/docs/types.rs
@@ -174,6 +174,15 @@ pub(super) struct RawDocFrontmatter {
     pub(crate) related_artifacts: Vec<ArtifactRef>,
 }
 
+/// One doc as produced by a single walk: its record plus the body parsed out
+/// of the same read. Callers that need the text — search scoring, embeddings,
+/// related-doc excerpts — consume this instead of re-reading the file.
+#[derive(Debug)]
+pub(super) struct WalkedDoc {
+    pub(crate) record: DocRecord,
+    pub(crate) body: String,
+}
+
 #[derive(Debug)]
 pub(super) struct ParsedDoc {
     pub(crate) frontmatter: DocFrontmatter,

--- a/crates/orbit-core/src/application/docs/walk.rs
+++ b/crates/orbit-core/src/application/docs/walk.rs
@@ -7,9 +7,9 @@ use std::process::{Command, Stdio};
 use orbit_common::OrbitError;
 
 use super::config::DocsRoot;
-use super::frontmatter::parse_doc_tolerant;
+use super::frontmatter::read_doc_tolerant;
 use super::path_util::{path_to_slash_string, repo_relative_path};
-use super::types::DocRecord;
+use super::types::{DocRecord, WalkedDoc};
 
 #[cfg(test)]
 thread_local! {
@@ -37,7 +37,22 @@ pub(super) fn git_check_ignore_invocations() -> usize {
     GIT_CHECK_IGNORE_INVOCATIONS.with(std::cell::Cell::get)
 }
 
+/// Walk the configured roots and return one record per doc, dropping the
+/// bodies. Callers that need the text should walk with
+/// [`walk_docs_with_bodies`] rather than re-opening each file.
 pub fn walk_docs_roots(repo_root: &Path, roots: &[DocsRoot]) -> Result<Vec<DocRecord>, OrbitError> {
+    Ok(walk_docs_with_bodies(repo_root, roots)?
+        .into_iter()
+        .map(|doc| doc.record)
+        .collect())
+}
+
+/// Walk the configured roots, keeping each doc's body from the same read that
+/// produced its frontmatter.
+pub(super) fn walk_docs_with_bodies(
+    repo_root: &Path,
+    roots: &[DocsRoot],
+) -> Result<Vec<WalkedDoc>, OrbitError> {
     // A path may be reachable from more than one configured root; if any
     // contributing root names it explicitly (respect_gitignore = false),
     // that override wins over a root that would still filter it.
@@ -71,23 +86,24 @@ pub fn walk_docs_roots(repo_root: &Path, roots: &[DocsRoot]) -> Result<Vec<DocRe
         .collect::<Vec<_>>();
     let ignored = git_ignored_paths(repo_root, &gitignore_checked);
 
-    let mut records = Vec::new();
+    let mut docs = Vec::new();
     for (relative, respect_gitignore) in candidates {
         if respect_gitignore && ignored.contains(&relative) {
             continue;
         }
         let path = repo_root.join(&relative);
-        let raw = fs::read_to_string(&path)
-            .map_err(|error| OrbitError::Io(format!("read {}: {error}", path.display())))?;
-        let parsed = parse_doc_tolerant(&relative, &path, &raw);
-        records.push(DocRecord {
-            path: path_to_slash_string(&relative),
-            frontmatter: parsed.frontmatter,
+        let parsed = read_doc_tolerant(&relative, &path)?;
+        docs.push(WalkedDoc {
+            record: DocRecord {
+                path: path_to_slash_string(&relative),
+                frontmatter: parsed.frontmatter,
+            },
+            body: parsed.body,
         });
     }
-    records.sort_by(|left, right| left.path.cmp(&right.path));
-    records.dedup_by(|left, right| left.path == right.path);
-    Ok(records)
+    docs.sort_by(|left, right| left.record.path.cmp(&right.record.path));
+    docs.dedup_by(|left, right| left.record.path == right.record.path);
+    Ok(docs)
 }
 
 pub(super) fn expand_root(repo_root: &Path, root: &str) -> Result<Vec<PathBuf>, OrbitError> {


### PR DESCRIPTION
## Task

[ORB-11630](https://orbit-cli.com/tasks/ORB-11630) — [code-review] Read each doc once in `search_docs` / related-docs / index instead of re-resolving roots and re-reading every file per record

### Description

## Problem
`walk_docs_roots` already reads every candidate file (`fs::read_to_string`, walk.rs:80) and then discards the body, keeping only frontmatter. `search_docs` then calls `self.show_doc(&record.path)` per record (mod.rs:95), which re-reads `config.toml` to resolve roots (`self.docs_roots()` at mod.rs:76), re-expands every root with filesystem probes and canonicalizes paths in `path_is_under_configured_roots` (search.rs:61-92), and re-reads and re-parses the file. For N docs and R roots a single `orbit search`/`orbit docs search` performs N config reads, N×R root expansions with `canonicalize`, and 2N file reads; `doc_embedding_sources` (search.rs:117-118) and `related_docs_for_context` (search.rs:216) have the same shape, and `global_search` calls `list_docs` again for hybrid ranking (search/mod.rs:486).

## Why It Matters
Docs search is on the agent hot path (MCP `orbit.search`, `task show --with-context`), and cost grows quadratically-ish with roots × docs.

## Proposed Fix
Make the walk return the parsed body alongside the frontmatter (or a `walk_docs_roots_with_bodies`), and have `search_docs`, `doc_embedding_sources` and `related_docs_for_context` consume it directly; resolve `docs_roots()` once per call.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/docs/mod.rs:79-103`, `crates/orbit-core/src/application/docs/walk.rs:74-87`, `crates/orbit-core/src/application/docs/search.rs:17-52`, `crates/orbit-core/src/application/docs/search.rs:112-127`, `crates/orbit-core/src/application/docs/search.rs:213-225`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Existing `application/docs/tests/{walk,search}.rs` pass unchanged; `git_check_ignore_invocations()` stays at one per walk.
- A test counts file opens (e.g. via a temp dir with N docs and a strace-free approach such as a wrapper counter) and asserts each doc is read once per `search_docs`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Implemented: the docs walk now keeps each doc's body from the read that produced its frontmatter, and the search-side consumers use it instead of re-resolving roots and re-reading every file per record.

Changes (all in crates/orbit-core/src/application/docs/):
- frontmatter.rs: new `read_doc_tolerant(repo_relative, absolute)` — the single place the docs pipeline opens a doc file (walk + `show_doc` both route through it). Adds a `#[cfg(test)]` thread-local read counter with `reset_doc_file_reads()` / `doc_file_reads()`, mirroring the existing git-check-ignore counter pattern in walk.rs.
- types.rs: new `pub(super) struct WalkedDoc { record: DocRecord, body: String }`.
- walk.rs: `walk_docs_with_bodies()` is now the walk implementation and returns `Vec<WalkedDoc>`; the public `walk_docs_roots()` stays a record-only projection over it (unchanged signature/behavior, used by `list_docs` and the existing walk tests). Gitignore batching is untouched — still one `git check-ignore` per walk.
- search.rs: `doc_embedding_sources` and `related_docs_for_context` consume the walked bodies; `related_docs_for_context` carries the body on its scored candidates and builds the excerpt from it, so `show_doc` is no longer called per record (removing the per-record config read, per-root re-expansion and `canonicalize` probes). `show_doc` itself is unchanged in behavior and remains the validated single-path lookup for `orbit docs show` / the docs tool host.
- mod.rs: `search_docs` resolves `docs_roots()` once and walks once, scoring each doc from its already-read body (previously `list_docs` + one `show_doc` per record).

Net per `orbit search` / `orbit docs search`: 1 config read + 1 root expansion + N file reads, down from N config reads, N×R root expansions with `canonicalize`, and 2N file reads.

Acceptance criteria:
1. "Existing application/docs/tests/{walk,search}.rs pass unchanged; git_check_ignore_invocations() stays at one per walk" — met. Both test files' pre-existing tests are untouched and pass, including `walker_batches_git_ignore_once_per_walk` (asserts exactly 1 invocation). `cargo test -p orbit-core --lib application::docs` → 22 passed, 0 failed.
2. "A test counts file opens ... and asserts each doc is read once per search_docs" — met by `application::docs::tests::search::search_docs_reads_each_doc_once`: builds a real `OrbitRuntime` over a temp repo with 5 docs, calls `runtime.search_docs(...)`, asserts 5 results and `doc_file_reads() == 5`. Fault-injected the old `show_doc`-per-record read back into `search_docs` and confirmed the test fails (left: 10, right: 5), so it detects the original fault; then reverted.

Validation:
- `cargo test -p orbit-core --lib application::docs` — PASSED (22/22, includes the new test).
- Fault-injection check of the new test — PASSED (test fails on the old re-read shape).
- `make ci-fast` — PASSED (fmt-check + all guardrail scripts, including check-orphan-modules).
- `make ci-lint` — PASSED (workspace clippy, --all-targets, -D warnings, exit 0).
- `git diff --check` clean; `git status --short` shows only the 6 intended files.
- `cargo test -p orbit-core` (full crate) — 1198 passed, 4 failed. All 4 are unrelated to docs and pre-existing/flaky, verified by restoring the pristine sources via `git show HEAD:<path>` and re-running: `dogfood_task_pilot_routine_matches_the_rendered_default_template` (routine cron template drift, */40 vs */15), `concurrent_explicit_edit_preserves_the_newer_status`, and `gate_pipeline_releases_reservation_before_child_success_guard` all fail identically on the unmodified baseline; `claimed_sleeping_worker_does_not_keep_polling_the_run_store` is load-sensitive and passes with these changes when not run under full-suite contention.

Deviations / remaining risk:
- Deliberately out of scope: `application/search/mod.rs::hybrid_doc_hits` still calls `list_docs` a second time (mentioned in the task's problem statement). It needs a path→record map for semantic-only hits, is built lazily (only when doc embeddings exist and hybrid ranking is requested), and is now plain O(N) rather than part of the quadratic shape this task removed. Changing it would require reshaping `search_docs`'s ownership of the walked docs; left alone to keep the change minimal. No context_files were added.
- `walk_docs_with_bodies` materializes all bodies before scoring, so peak memory for one docs operation is now the sum of doc bodies rather than one body at a time. This is what the task's proposed fix asked for; for a corpus in the hundreds of Markdown files it is a few MB.
- Note the read counter is `#[cfg(test)]`-only and thread-local, so it adds nothing to release builds and is safe under parallel test execution.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11630-6a9f724a`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra