### PR TITLE
[code-review] Stop reloading the whole task list on every `reserve_locks` poll

### DIFF
--- a/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
 use orbit_common::OrbitError;
@@ -16,8 +16,8 @@ use serde_json::Value;
 use crate::OrbitRuntime;
 use crate::runtime::task::locks::{
     TaskLockIndex, emit_expired_reservation_events, merge_task_lock_conflicts, parse_task_ids,
-    requested_task_files_indexed, task_lock_conflicts_indexed, workspace_orbit_dir,
-    workspace_task_reservation_id,
+    requested_task_files_indexed, reserve_with_index, task_lock_conflicts_indexed,
+    workspace_orbit_dir, workspace_task_reservation_id,
 };
 
 use super::{
@@ -378,17 +378,24 @@ pub(crate) fn run_deterministic(
                 }));
             }
 
-            let mut output = runtime
-                .run_tool_with_context_and_role(
-                    "orbit.task.locks.reserve",
-                    input.clone(),
-                    Role::Admin,
-                    tool_context,
-                )
-                .map_err(|err| DispatchError::DeterministicActionFailed {
+            let lock_index = TaskLockIndex::load(runtime).map_err(|err| {
+                DispatchError::DeterministicActionFailed {
                     action: action.to_string(),
                     message: format!("{err}"),
-                })?;
+                }
+            })?;
+            let mut output = reserve_with_index(
+                runtime,
+                input.clone(),
+                tool_context.agent_name.clone(),
+                tool_context.model_name.clone(),
+                tool_context.reservation_owner.clone(),
+                &lock_index,
+            )
+            .map_err(|err| DispatchError::DeterministicActionFailed {
+                action: action.to_string(),
+                message: format!("{err}"),
+            })?;
             // Always publish `waiting_on_deps` (empty here) so the gate
             // pipeline can reference `steps.reserve.output.waiting_on_deps`
             // unconditionally, whichever branch produced the output.
@@ -526,24 +533,17 @@ fn dependency_admission_for_input(
         return Ok(BundleDependencyAdmission::default());
     };
     let task_ids = parse_task_ids(&serde_json::json!({ "task_ids": raw_task_ids }))?;
-    let tasks = runtime.stores().tasks().list_tasks()?;
     let status_by_id = runtime.task_status_index()?;
-    let task_by_id = tasks
-        .into_iter()
-        .map(|task| (task.id.clone(), task))
-        .collect::<BTreeMap<_, _>>();
     let mut waiting_on = BTreeSet::new();
     let mut unsatisfiable = Vec::new();
     for task_id in task_ids {
-        let task = task_by_id
-            .get(&task_id)
-            .ok_or_else(|| OrbitError::not_found(crate::NotFoundKind::Task, task_id.clone()))?;
-        let dead_ends = unsatisfiable_task_dependencies(task, &status_by_id);
+        let task = runtime.get_task(&task_id)?;
+        let dead_ends = unsatisfiable_task_dependencies(&task, &status_by_id);
         let dead_end_ids = dead_ends
             .iter()
             .map(|dependency| dependency.dependency_id.clone())
             .collect::<BTreeSet<_>>();
-        for dependency in unmet_task_dependencies(task, &status_by_id) {
+        for dependency in unmet_task_dependencies(&task, &status_by_id) {
             if !dead_end_ids.contains(&dependency.id) {
                 waiting_on.insert(dependency.id);
             }

--- a/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/engine_host/v2_host/tests/dispatch.rs
@@ -5,11 +5,117 @@ use crate::{ShipMode, WorkspaceRuntimeBinding};
 use chrono::Utc;
 use orbit_engine::DispatchError;
 use orbit_engine::RuntimeHost;
+use orbit_store::TaskStoreBackend;
 use orbit_tools::ToolContext;
 use orbit_types::task::{NO_DIFF_EXPECTED_TAG, TaskPriority, TaskStatus, TaskType};
 use orbit_types::workflow::{DeterministicAction, PipelineState};
 use serde_json::json;
 use tempfile::tempdir;
+
+struct CountingTaskStore {
+    inner: std::sync::Arc<dyn TaskStoreBackend>,
+    list_tasks_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl CountingTaskStore {
+    fn new(inner: std::sync::Arc<dyn TaskStoreBackend>) -> Self {
+        Self {
+            inner,
+            list_tasks_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn list_tasks_calls(&self) -> usize {
+        self.list_tasks_calls
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl TaskStoreBackend for CountingTaskStore {
+    fn task_candidates(
+        &self,
+        filter: &orbit_store::contracts::TaskListFilter,
+        limit: usize,
+    ) -> Result<orbit_store::contracts::TaskCandidates, orbit_common::OrbitError> {
+        self.inner.task_candidates(filter, limit)
+    }
+
+    fn query_task_rows(
+        &self,
+        filter: &orbit_store::contracts::TaskListFilter,
+        limit: usize,
+        residual: orbit_store::contracts::TaskResidualFilter<'_>,
+    ) -> Result<orbit_store::contracts::TaskPage, orbit_common::OrbitError> {
+        self.inner.query_task_rows(filter, limit, residual)
+    }
+
+    fn get_task_row(
+        &self,
+        id: &str,
+        list_read: bool,
+    ) -> Result<Option<orbit_store::contracts::TaskRow>, orbit_common::OrbitError> {
+        self.inner.get_task_row(id, list_read)
+    }
+
+    fn create_task(
+        &self,
+        params: orbit_store::TaskCreateParams,
+    ) -> Result<orbit_types::task::Task, orbit_common::OrbitError> {
+        self.inner.create_task(params)
+    }
+
+    fn list_tasks(&self) -> Result<Vec<orbit_types::task::Task>, orbit_common::OrbitError> {
+        self.list_tasks_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.inner.list_tasks()
+    }
+
+    fn task_status_index(
+        &self,
+    ) -> Result<
+        std::collections::BTreeMap<String, orbit_types::task::TaskStatus>,
+        orbit_common::OrbitError,
+    > {
+        self.inner.task_status_index()
+    }
+
+    fn list_tasks_filtered(
+        &self,
+        status: Option<orbit_types::task::TaskStatus>,
+        priority: Option<orbit_types::task::TaskPriority>,
+        parent_id: Option<&str>,
+        job_run_id: Option<&str>,
+        external_ref: Option<&orbit_types::task::ExternalRef>,
+        has_external_ref_system: Option<&str>,
+    ) -> Result<Vec<orbit_types::task::Task>, orbit_common::OrbitError> {
+        self.inner.list_tasks_filtered(
+            status,
+            priority,
+            parent_id,
+            job_run_id,
+            external_ref,
+            has_external_ref_system,
+        )
+    }
+
+    fn get_task(
+        &self,
+        id: &str,
+    ) -> Result<Option<orbit_types::task::Task>, orbit_common::OrbitError> {
+        self.inner.get_task(id)
+    }
+
+    fn search_tasks(
+        &self,
+        query: &str,
+    ) -> Result<Vec<orbit_types::task::Task>, orbit_common::OrbitError> {
+        self.inner.search_tasks(query)
+    }
+
+    fn delete_task(&self, id: &str) -> Result<bool, orbit_common::OrbitError> {
+        self.inner.delete_task(id)
+    }
+}
 
 fn dispatch_declared_action(
     runtime: &OrbitRuntime,
@@ -549,6 +655,28 @@ fn reserve_locks_publishes_empty_waiting_on_deps_when_dependencies_are_met() {
 
     assert_eq!(output["waiting_on_deps"], json!([]));
     assert_eq!(output["reserved"], json!(true));
+}
+
+#[test]
+fn reserve_locks_loads_the_task_store_once_per_poll() {
+    let mut runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let ready = seed_task(&runtime, "Ready", TaskStatus::Backlog, Vec::new());
+    let counting_store = std::sync::Arc::new(CountingTaskStore::new(
+        runtime.context.task_store_for_test(),
+    ));
+    runtime
+        .context
+        .replace_task_store_for_test(counting_store.clone());
+
+    let (_, result) = reserve_locks_for(&runtime, vec![ready]);
+    let output = result.expect("reserve locks");
+
+    assert_eq!(output["reserved"], json!(true));
+    assert_eq!(
+        counting_store.list_tasks_calls(),
+        1,
+        "one ReserveLocks poll must load its lock index once"
+    );
 }
 
 /// ORB-11349: admission loads every task, so one unrelated task's lifecycle

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -394,6 +394,16 @@ impl OrbitContext {
         self.runtime.actor = actor;
     }
 
+    #[cfg(test)]
+    pub(crate) fn replace_task_store_for_test(&mut self, task: Arc<dyn TaskStoreBackend>) {
+        self.stores.task = task;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_store_for_test(&self) -> Arc<dyn TaskStoreBackend> {
+        Arc::clone(&self.stores.task)
+    }
+
     pub(crate) fn scoring_enabled(&self) -> bool {
         self.runtime.scoring_enabled
     }

--- a/crates/orbit-core/src/runtime/task/locks.rs
+++ b/crates/orbit-core/src/runtime/task/locks.rs
@@ -188,6 +188,24 @@ pub(crate) fn reserve(
     model: Option<String>,
     reservation_owner: Option<ReservationOwnerContext>,
 ) -> Result<Value, OrbitError> {
+    let index = TaskLockIndex::load(runtime)?;
+    reserve_with_index(runtime, input, agent, model, reservation_owner, &index)
+}
+
+/// Reserve a task-lock scope using an index loaded by the calling operation.
+///
+/// The v2 `reserve_locks` action needs the same task index for its one-poll
+/// admission path and its reservation check. Keeping the actual reservation
+/// behavior here gives both callers one canonical implementation while letting
+/// that action avoid reloading every task bundle.
+pub(crate) fn reserve_with_index(
+    runtime: &OrbitRuntime,
+    input: Value,
+    agent: Option<String>,
+    model: Option<String>,
+    reservation_owner: Option<ReservationOwnerContext>,
+    index: &TaskLockIndex,
+) -> Result<Value, OrbitError> {
     let reservation_scope = parse_task_lock_reservation_scope(&input)?;
     let ttl_seconds =
         optional_u32_alias(&input, &["ttl_seconds", "ttlSeconds", "ttl-seconds"])?.unwrap_or(1800);
@@ -199,12 +217,11 @@ pub(crate) fn reserve(
 
     let actor = reservation_actor_label(runtime, agent.as_deref(), model.as_deref());
     let workspace_id = workspace_task_reservation_id(runtime)?;
-    let index = TaskLockIndex::load(runtime)?;
     let repo_root = runtime.paths().repo_root.as_path();
     let (task_ids, requested_files) = match &reservation_scope {
         TaskLockReservationScope::TaskIds(task_ids) => (
             task_ids.clone(),
-            requested_task_files_indexed(&index, task_ids, repo_root)?,
+            requested_task_files_indexed(index, task_ids, repo_root)?,
         ),
         TaskLockReservationScope::Files(files) => (
             Vec::new(),
@@ -212,7 +229,7 @@ pub(crate) fn reserve(
         ),
     };
     runtime.reconcile_stale_owned_reservations_for_files(&requested_files, 32)?;
-    let mut conflicts = task_lock_conflicts_indexed(&index, &task_ids, &requested_files, repo_root);
+    let mut conflicts = task_lock_conflicts_indexed(index, &task_ids, &requested_files, repo_root);
 
     record_task_lock_audit_event(
         runtime,


### PR DESCRIPTION
## Task

[ORB-11627](https://orbit-cli.com/tasks/ORB-11627) — [code-review] Stop reloading the whole task list on every `reserve_locks` poll

### Description

## Problem
`dependency_admission_for_input` loads `stores().tasks().list_tasks()` (every bundle from disk, see `repository/task/v2/index.rs:39-52`) **and** `task_status_index()` (line 529-530), builds a `BTreeMap` of all tasks, and then only looks up the handful of bundle ids. The same `ReserveLocks` action then calls `orbit.task.locks.reserve`, whose `TaskLockIndex::load` (`runtime/task/locks.rs:202`, `508-510`) loads the full list again. `task_gate_pipeline` runs this every 30 s for up to 120 iterations per gate run (`assets/jobs/task_gate_pipeline.yaml:81-91`), and the drain admits several gate runs concurrently, so a 1,000-task workspace re-reads 2,000 bundles every 30 s per waiting bundle.

## Why It Matters
The wait loop is designed to be cheap polling; today its cost scales with backlog size × concurrent gates, and it competes for the same task registry the workers are writing to.

## Proposed Fix
In `dependency_admission_for_input`, `get_task` only the requested ids and resolve dependency status from the already-loaded `status_by_id` (drop the full `list_tasks`). Load `TaskLockIndex` once per `ReserveLocks` invocation and pass it into the reserve path (add a `reserve_with_index` entry in `runtime/task/locks.rs`), so one poll does one index load.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs:336-342`, `crates/orbit-core/src/adapter/engine_host/v2_host/dispatch.rs:519-557`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: core-adapter.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test in `v2_host/tests/dispatch.rs` with a counting task-store double asserts one `list_tasks` (or zero, if the index alone suffices) per `ReserveLocks` call.
- Existing unsatisfiable/waiting-on dependency tests in `tests/dispatch.rs` pass unchanged.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced ReserveLocks dependency admission’s full task-list scan with targeted get_task reads plus the existing status index.
- Added reserve_with_index so the deterministic ReserveLocks path loads one TaskLockIndex and reuses it for lock reservation.
- Added a counting TaskStoreBackend regression test for the complete ReserveLocks path.
Criteria:
- Counting-store test asserts exactly one list_tasks call per satisfiable ReserveLocks poll: passed.
- Existing unsatisfiable and waiting-on dependency tests pass unchanged: passed.
Validation:
- cargo fmt --check: passed.
- cargo test -p orbit-core reserve_locks_ --lib: passed (10 tests).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks: direct deterministic reservation now reuses the already-loaded index; direct tool reservations retain their existing index-loading path.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11627-6a9f7219`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra