### PR TITLE
[code-review] Disclose the default field projection of `orbit tool run orbit.task.*`

### DIFF
--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -123,7 +123,7 @@ impl Execute for ToolRunArgs {
         let output = crate::command::task::show::attach_bound_workspace_identity(
             &self.name, &input, runtime, output,
         )?;
-        let output = shape_tool_output(&self.name, &input, output, self.full, &self.fields);
+        let output = shape_tool_output(&self.name, output, self.full, &self.fields);
 
         Ok(Payload::document(output).into())
     }
@@ -181,7 +181,6 @@ const MINIMAL_TASK_FIELDS: &[&str] = &[
 
 pub(super) fn shape_tool_output(
     tool_name: &str,
-    input: &Value,
     output: Value,
     full: bool,
     fields: &[String],
@@ -194,7 +193,7 @@ pub(super) fn shape_tool_output(
         return filter_top_level_fields(output, fields);
     }
 
-    if should_project_minimal_task_output(tool_name, input) {
+    if should_project_minimal_task_output(tool_name) {
         return filter_top_level_fields(
             output,
             &MINIMAL_TASK_FIELDS
@@ -207,21 +206,11 @@ pub(super) fn shape_tool_output(
     output
 }
 
-fn should_project_minimal_task_output(tool_name: &str, input: &Value) -> bool {
+fn should_project_minimal_task_output(tool_name: &str) -> bool {
     if !matches!(
         tool_name,
-        "orbit.task.list"
-            | "orbit.task.show"
-            | "orbit.task.add"
-            | "orbit.task.artifact.put"
-            | "orbit.task.update"
+        "orbit.task.list" | "orbit.task.add" | "orbit.task.artifact.put" | "orbit.task.update"
     ) {
-        return false;
-    }
-
-    if tool_name == "orbit.task.show"
-        && (input.get("field").is_some() || input.get("fields").is_some())
-    {
         return false;
     }
 

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -32,7 +32,6 @@ fn task_show_id_is_read_only_from_orbit_task_show_input() {
 fn list_output_uses_minimal_task_projection() {
     let shaped = shape_tool_output(
         "orbit.task.list",
-        &json!({ "status": "backlog" }),
         json!([{
             "id": "T20260422-0001",
             "title": "Backlog task",
@@ -64,6 +63,29 @@ fn list_output_uses_minimal_task_projection() {
             "created_at": "2026-04-22T00:00:00Z",
             "updated_at": "2026-04-22T00:00:00Z"
         }])
+    );
+}
+
+#[test]
+fn show_output_preserves_task_details_by_default() {
+    let output = json!({
+        "id": "T20260422-0001",
+        "title": "Task details",
+        "status": "backlog",
+        "priority": "medium",
+        "type": "feature",
+        "dependencies": [],
+        "resolved_dependencies": [],
+        "implemented_by": null,
+        "created_at": "2026-04-22T00:00:00Z",
+        "updated_at": "2026-04-22T00:00:00Z",
+        "description": "details must remain available",
+        "acceptance_criteria": ["inspect the complete task"]
+    });
+
+    assert_eq!(
+        shape_tool_output("orbit.task.show", output.clone(), false, &[],),
+        output
     );
 }
 


### PR DESCRIPTION
## Task

[ORB-11619](https://orbit-cli.com/tasks/ORB-11619) — [code-review] Disclose the default field projection of `orbit tool run orbit.task.*`

### Description

## Problem
`shape_tool_output` trims `orbit.task.show`, `orbit.task.list`, `orbit.task.add`, `orbit.task.update`, and `orbit.task.artifact.put` output to `MINIMAL_TASK_FIELDS` (`run.rs:191-203`) unless `--full` or `--fields` is passed. Verified with binary: `orbit tool run orbit.task.show --input '{"id":"DANI-10300"}'` returns exactly `created_at, dependencies, id, implemented_by, priority, resolved_dependencies, status, title, type, updated_at, workspace` — no `description`, `acceptance_criteria`, `tags`, `plan`, `context_files`. `orbit task show` prints all of those, and nothing in `orbit tool run --help` says a projection is applied; `--full` is described as "Return the tool's full unfiltered JSON output", which only makes sense if the reader already knows the default filters. The trimming for `list` is tested (`tool/tests/run.rs:34`) and is a deliberate size control; the gap is that `show` (a single record) is trimmed the same way with no hint.

## Why It Matters
The Orbit skill directs agents to `orbit tool run` as the canonical tool surface; an agent reading a task through it gets a record with no description and no acceptance criteria and has no signal that anything was dropped.

## Proposed Fix
Exempt `orbit.task.show` from the minimal projection (a single record is not a size problem), or at minimum state the default projection in the `--full`/`--fields` help and add a `"_projected": true` marker (or a stderr notice) when fields were dropped.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/tool/run.rs:41-46,191-252`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit tool run orbit.task.show --input '{"id":<id>}'` returns `description` and `acceptance_criteria`, or the help text for `--full` lists the fields kept by default.
- `crates/orbit-cli/src/command/tool/tests/run.rs` asserts the `show` behaviour explicitly.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Removed orbit.task.show from the default MINIMAL_TASK_FIELDS projection so its normal tool output retains the full task record, including description and acceptance_criteria.
- Preserved minimal projection for orbit.task.list, orbit.task.add, orbit.task.update, and orbit.task.artifact.put, plus explicit --fields and --full handling.
- Added show_output_preserves_task_details_by_default in crates/orbit-cli/src/command/tool/tests/run.rs.

Acceptance criteria:
- Passed: built target/debug/orbit and ran orbit tool run orbit.task.show --input '{"id":"ORB-11619"}'; output included description and acceptance_criteria.
- Passed: the required sibling unit test explicitly asserts default orbit.task.show output preserves description and acceptance_criteria.

Validation:
- Passed: cargo test -p orbit-cli --bin orbit command::tool::tests::run (5 passed).
- Passed: cargo fmt --all -- --check after formatting.
- Passed: make ci-fast. Its compiler-cache subcheck reported a bounded environment limitation (cannot create a mount namespace: bwrap lacks permission) but the script handled it as a skip and the overall guard suite passed; this does not validate mount-namespace behavior.
- Passed: make ci-lint (workspace clippy with warnings denied).
- Passed: git diff --check.
- Passed: GIT_OPTIONAL_LOCKS=0 git status --short; only the two scoped source/test files are modified.
- Not a validation failure: the initial command cargo test -p orbit-cli command::tool::tests::run --lib was invalid because orbit-cli has no library target; the corrected bin-target command above passed.

Assessment: Small, direct change at the projection boundary with focused behavioral coverage. No remaining task-scoped risks beyond the documented compiler-cache namespace limitation.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11619-6a9f7497`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra