### PR TITLE
[code-review] Route `orbit docs add` through orbit-config's comment-preserving store and the workspace config

### DIFF
--- a/crates/orbit-config/src/store.rs
+++ b/crates/orbit-config/src/store.rs
@@ -160,12 +160,27 @@ impl ConfigStore {
     /// never touches disk.
     pub fn set_value(&mut self, key: &str, raw_value: &str) -> Result<(), OrbitError> {
         registry::admit_config_key(key)?;
+        self.set_document_value(key, raw_value)
+    }
+
+    /// Set a value in a configuration section that is parsed by a subsystem
+    /// outside the runtime-key registry.
+    ///
+    /// The registry intentionally admits only runtime-owned keys, while the
+    /// same `config.toml` also contains independently owned sections such as
+    /// `[docs]`. Those owners still use this method so their edits preserve
+    /// comments and share [`Self::save`]'s atomic persistence.
+    pub fn set_document_value(&mut self, key: &str, raw_value: &str) -> Result<(), OrbitError> {
+        if key.split('.').any(str::is_empty) {
+            return Err(OrbitError::InvalidInput(
+                "config key must contain non-empty dot-separated segments".to_string(),
+            ));
+        }
         let value = parse_value_literal(raw_value);
         let segments: Vec<&str> = key.split('.').collect();
-        // `admit_config_key` above already rejects `key` unless it is a
-        // dotted registry or crew-field path, so `split_last` is always
-        // `Some` here; handled as an error rather than `expect()` since
-        // this is reachable from user input, not a purely local invariant.
+        // The non-empty segment check above makes `split_last` always `Some`;
+        // still handle it as an error rather than `expect()` because this is
+        // reachable from user input, not a purely local invariant.
         let (last, ancestors) = segments.split_last().ok_or_else(|| {
             OrbitError::InvalidInput(format!("config key '{key}' must not be empty"))
         })?;

--- a/crates/orbit-core/src/application/docs/add_root.rs
+++ b/crates/orbit-core/src/application/docs/add_root.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use orbit_common::OrbitError;
+use orbit_config::{ConfigScope, ConfigStore};
 
 use super::config::{DocsRoot, parse_docs_roots_from_config_toml};
 use super::path_util::path_to_slash_string;
@@ -12,12 +13,7 @@ pub(super) fn add_docs_root(
     path: &str,
 ) -> Result<DocAddOutcome, OrbitError> {
     let normalized = normalize_docs_root_arg(repo_root, path)?;
-    let raw = if config_path.exists() {
-        std::fs::read_to_string(config_path)
-            .map_err(|error| OrbitError::Io(format!("read {}: {error}", config_path.display())))?
-    } else {
-        String::new()
-    };
+    let raw = read_config(config_path)?;
     let mut roots = parse_docs_roots_from_config_toml(&raw)?;
     if roots_equal_contains(&roots, &normalized) {
         return Ok(DocAddOutcome {
@@ -27,7 +23,7 @@ pub(super) fn add_docs_root(
         });
     }
     roots.push(DocsRoot::new(normalized.clone()));
-    write_docs_roots_to_config(config_path, &raw, &roots)?;
+    write_docs_roots_to_config(config_path, &roots)?;
     Ok(DocAddOutcome {
         path: normalized,
         added: true,
@@ -88,38 +84,21 @@ fn comparable_root(raw: &str) -> String {
     raw.trim().trim_end_matches('/').to_ascii_lowercase()
 }
 
-fn write_docs_roots_to_config(
-    config_path: &Path,
-    raw: &str,
-    roots: &[DocsRoot],
-) -> Result<(), OrbitError> {
-    let mut value = if raw.trim().is_empty() {
-        toml::Value::Table(Default::default())
-    } else {
-        raw.parse::<toml::Value>().map_err(|error| {
-            OrbitError::InvalidInput(format!(
-                "invalid config.toml while updating [docs].roots: {error}"
-            ))
-        })?
-    };
-    let table = value
-        .as_table_mut()
-        .ok_or_else(|| OrbitError::InvalidInput("config.toml must be a TOML table".to_string()))?;
-    let docs = table
-        .entry("docs".to_string())
-        .or_insert_with(|| toml::Value::Table(Default::default()));
-    let docs_table = docs.as_table_mut().ok_or_else(|| {
-        OrbitError::InvalidInput("[docs] config must be a TOML table".to_string())
-    })?;
-    docs_table.insert("roots".to_string(), docs_roots_to_toml_value(roots));
-    let rendered = toml::to_string_pretty(&value)
-        .map_err(|error| OrbitError::Execution(format!("serialize config.toml: {error}")))?;
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| OrbitError::Io(format!("create {}: {error}", parent.display())))?;
+fn write_docs_roots_to_config(config_path: &Path, roots: &[DocsRoot]) -> Result<(), OrbitError> {
+    let mut store = ConfigStore::open(ConfigScope::Workspace, config_path)?;
+    store.set_document_value("docs.roots", &docs_roots_to_toml_value(roots).to_string())?;
+    store.save()
+}
+
+fn read_config(config_path: &Path) -> Result<String, OrbitError> {
+    match std::fs::read_to_string(config_path) {
+        Ok(raw) => Ok(raw),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(OrbitError::Io(format!(
+            "read {}: {error}",
+            config_path.display()
+        ))),
     }
-    std::fs::write(config_path, rendered)
-        .map_err(|error| OrbitError::Io(format!("write {}: {error}", config_path.display())))
 }
 
 fn docs_roots_to_toml_value(roots: &[DocsRoot]) -> toml::Value {

--- a/crates/orbit-core/src/application/docs/mod.rs
+++ b/crates/orbit-core/src/application/docs/mod.rs
@@ -129,7 +129,11 @@ impl OrbitRuntime {
     }
 
     pub fn add_docs_root(&self, path: &str) -> Result<DocAddOutcome, OrbitError> {
-        add_docs_root(&self.paths().repo_root, &self.config_path(), path)
+        add_docs_root(
+            &self.paths().repo_root,
+            &self.shared_root().join("config.toml"),
+            path,
+        )
     }
 
     pub fn index_docs(&self, params: DocIndexParams) -> Result<DocIndexResult, OrbitError> {

--- a/crates/orbit-core/src/application/docs/tests/add_root.rs
+++ b/crates/orbit-core/src/application/docs/tests/add_root.rs
@@ -1,2 +1,67 @@
-// No dedicated unit tests for add_root; the add_docs_root integration is exercised
-// via the OrbitRuntime methods and higher-level docs command tests.
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::OrbitRuntime;
+
+#[test]
+fn preserves_comments_and_unrelated_tables_when_adding_a_docs_root() {
+    let root = tempdir().expect("create tempdir");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    let docs_root = repo_root.join("guides");
+    let global_root = root.path().join("global");
+    fs::create_dir_all(&workspace_root).expect("create workspace root");
+    fs::create_dir_all(&docs_root).expect("create docs root");
+    fs::create_dir_all(&global_root).expect("create global root");
+
+    let prefix = "# operator note\n[workflow]\nbase_branch = \"agent-main\"\n\n";
+    let suffix = "\n[search]\nlimit = 20\n";
+    fs::write(
+        workspace_root.join("config.toml"),
+        format!("{prefix}[docs]\nroots = [\"docs/\"]{suffix}"),
+    )
+    .expect("write config");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+
+    runtime.add_docs_root("guides").expect("add docs root");
+
+    let saved = fs::read_to_string(workspace_root.join("config.toml")).expect("read config");
+    assert!(saved.starts_with(prefix), "{saved}");
+    assert!(saved.ends_with(suffix), "{saved}");
+    assert!(
+        saved.contains("roots = [\"docs/\", \"guides/\"]"),
+        "{saved}"
+    );
+}
+
+#[test]
+fn adds_docs_root_to_workspace_config_without_touching_global_config() {
+    let root = tempdir().expect("create tempdir");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    let docs_root = repo_root.join("guides");
+    let global_root = root.path().join("global");
+    let global_config = global_root.join("config.toml");
+    fs::create_dir_all(&workspace_root).expect("create workspace root");
+    fs::create_dir_all(&docs_root).expect("create docs root");
+    fs::create_dir_all(&global_root).expect("create global root");
+    let global_content = "# global-only\n[workflow]\nbase_branch = \"agent-main\"\n";
+    fs::write(&global_config, global_content).expect("write global config");
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root).expect("build runtime");
+
+    runtime.add_docs_root("guides").expect("add docs root");
+
+    assert_eq!(
+        fs::read_to_string(&global_config).expect("read global config"),
+        global_content
+    );
+    assert!(workspace_root.join("config.toml").exists());
+    assert_eq!(
+        runtime.docs_roots().expect("read docs roots"),
+        vec![
+            super::super::DocsRoot::new("docs/"),
+            super::super::DocsRoot::new("guides/")
+        ]
+    );
+}


### PR DESCRIPTION
## Task

[ORB-11629](https://orbit-cli.com/tasks/ORB-11629) — [code-review] Route `orbit docs add` through orbit-config's comment-preserving store and the workspace config

### Description

## Problem
`write_docs_roots_to_config` parses the whole file into `toml::Value`, inserts `[docs].roots`, and rewrites it with `toml::to_string_pretty` followed by a plain `std::fs::write` (lines 99-122). That discards every comment and the key ordering in `config.toml`, and a crash mid-write truncates the file. ARCHITECTURE.md assigns `config.toml` ownership to `orbit-config` with "comment-preserving `ConfigStore` edits with atomic save" (`orbit-config/src/store.rs:60,161,211`); this path bypasses it. The target path comes from `OrbitRuntime::config_path()` (runtime/mod.rs:316-324), which returns the *global* `~/.orbit/config.toml` when the workspace has none, so `orbit docs add docs/` in a workspace without a workspace config writes a repo-relative docs root into the global config that then applies to every workspace on the host.

## Why It Matters
Silent loss of operator comments in the one file operators hand-edit, plus a wrong-scope write that leaks one repo's docs roots into unrelated workspaces.

## Proposed Fix
Write through `orbit_config::ConfigStore` (`set_value` + atomic `save`), and target the workspace root's `config.toml` explicitly (creating it if absent) rather than the effective/global path.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/docs/add_root.rs:91-123`, `crates/orbit-core/src/application/docs/mod.rs:126-128`, `crates/orbit-core/src/runtime/mod.rs:314-324`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test in `application/docs/tests/add_root.rs`: a config with a leading comment and unrelated tables keeps the comment and ordering byte-for-byte outside the `[docs]` table after `add_docs_root`.
- Test: with only a global config present, `add_docs_root` writes `<workspace>/.orbit/config.toml` and leaves `~/.orbit/config.toml` untouched.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Routed docs-root writes through orbit-config ConfigStore, including a narrowly scoped document-section mutation API and atomic save.
- Targeted add_docs_root at the workspace .orbit/config.toml so a missing workspace config is created without changing the global config.
- Added docs add-root regressions for byte-preserved content outside [docs] and global-config isolation.

Criteria evidence:
1. preserves_comments_and_unrelated_tables_when_adding_a_docs_root confirms the leading comment and both unrelated-table regions remain byte-identical while [docs].roots changes.
2. adds_docs_root_to_workspace_config_without_touching_global_config confirms workspace config creation, unchanged global content, and the resulting docs roots.

Validation:
- cargo test -p orbit-core application::docs::tests::add_root --no-fail-fast: passed (2 tests).
- cargo fmt --all -- --check: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.

Assessment: focused four-file change; ConfigStore retains ownership of comment-preserving, atomic config persistence.
Risks: ConfigStore validates only registry-owned runtime keys; the docs extension deliberately uses its document-section API because [docs] is independently parsed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11629-6a9f7587`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra