### PR TITLE
[code-review] Remove the N+1 run-state and audit reads from `orbit.workflow.run.list`

### DIFF
--- a/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/tests/workflow_tools.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use crate::application::job::{AGENT_INVOKE_JOB_ID, JobRunListParams};
 use chrono::Utc;
 use orbit_common::OrbitError;
 use orbit_common::process::identity::{
@@ -10,7 +11,7 @@ use orbit_types::policy::Role;
 use orbit_types::task::TaskStatus;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::{McpCapability, ToolSessionContext};
-use orbit_types::workflow::JobRunState;
+use orbit_types::workflow::{ChildDispatch, JobRunState, PipelineState};
 use serde_json::{Value, json};
 
 use super::super::build_orbit_tool_host;
@@ -939,5 +940,326 @@ fn mcp_run_show_marks_a_missing_trail_unavailable_and_bounds_a_long_history() {
             .collect::<Vec<_>>(),
         (500_005_u64..=500_011).collect::<Vec<_>>(),
         "the newest finished retries fill the rest of the budget"
+    );
+}
+
+fn listed_item<'a>(listed: &'a Value, run_id: &str) -> &'a Value {
+    listed["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .find(|item| item["run_id"] == json!(run_id))
+        .unwrap_or_else(|| panic!("missing listed run {run_id}"))
+}
+
+fn insert_named_run(runtime: &OrbitRuntime, job_id: &str) -> String {
+    runtime
+        .stores()
+        .jobs()
+        .insert_job_run(job_id, 1, Utc::now(), None, None)
+        .expect("insert run")
+        .run_id
+}
+
+fn seed_numbered_recovery(runtime: &OrbitRuntime, run_id: &str, count: u32) {
+    for index in 0..count {
+        seed_v2_event(
+            runtime,
+            run_id,
+            &format!("{run_id}-evt-recovery-{index}"),
+            &format!("2026-09-07T05:25:{index:02}Z"),
+            None,
+            json!({
+                "event_type": "step.recovery_attempted",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "implement_one",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": index % 2 == 1,
+            }),
+        );
+    }
+}
+
+/// [ORB-11625] Default list keeps the enriched contract: lineage, drain
+/// controls, invocation results, and recovery availability/truncation.
+#[test]
+fn mcp_run_list_preserves_enriched_default_projection_across_a_mixed_page() {
+    let (_root, runtime, _repo_root) = test_runtime();
+
+    let legacy_id = insert_named_run(&runtime, "task_auto_pipeline");
+
+    let not_attempted_id = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_v2_event(
+        &runtime,
+        &not_attempted_id,
+        "evt-started",
+        "2026-09-07T05:24:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+
+    let recorded_id = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_numbered_recovery(&runtime, &recorded_id, 2);
+
+    let truncated_id = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_numbered_recovery(&runtime, &truncated_id, 9);
+
+    let drain_id = insert_named_run(&runtime, "workspace_auto_pipeline");
+    let mut drain_state = PipelineState::new(
+        drain_id.clone(),
+        "workspace_auto_pipeline".to_string(),
+        json!({}),
+    );
+    drain_state.record_child_dispatch(
+        ChildDispatch::submitted(
+            "jrun-child-leaves".to_string(),
+            "task_auto_pipeline".to_string(),
+            "invoke_and_wait".to_string(),
+            true,
+            false,
+            Utc::now(),
+        )
+        .with_parent_step_id(Some("ship_leaves".to_string())),
+    );
+    assert!(drain_state.set_drain_worker_limit(
+        7,
+        5,
+        "operator".to_string(),
+        Some("raise".to_string()),
+        None,
+    ));
+    assert!(
+        drain_state
+            .set_drain_admissions_stop("operator".to_string(), Some("window closed".to_string()))
+    );
+    runtime
+        .write_run_state(&drain_id, &drain_state)
+        .expect("seed drain state");
+
+    let invoke_id = insert_named_run(&runtime, AGENT_INVOKE_JOB_ID);
+    let mut invoke_state = PipelineState::new(
+        invoke_id.clone(),
+        AGENT_INVOKE_JOB_ID.to_string(),
+        json!({}),
+    );
+    invoke_state.step_outputs.insert(
+        0,
+        json!({
+            "exit_code": 0,
+            "timed_out": false,
+            "completion_envelope_satisfied": true,
+            "summary": "the clock restarts",
+            "stdout_text": "hello",
+            "stdout_blob_ref": "blob-list",
+        }),
+    );
+    runtime
+        .write_run_state(&invoke_id, &invoke_state)
+        .expect("seed invoke state");
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+    assert_eq!(listed["items"].as_array().expect("items").len(), 6);
+
+    let legacy = listed_item(&listed, &legacy_id);
+    assert_eq!(legacy["child_dispatches"], json!([]));
+    assert_eq!(legacy["drain_worker_limit"], Value::Null);
+    assert_eq!(legacy["drain_admissions_stop"], Value::Null);
+    assert_eq!(legacy["agent_invocation"], Value::Null);
+    assert_eq!(legacy["recovery_attempts"]["state"], json!("unavailable"));
+    assert_eq!(legacy["recovery_attempts"]["limit"], json!(8));
+    assert_eq!(legacy["recovery_attempts"]["truncated"], json!(false));
+    assert_eq!(legacy["execution_progress"], Value::Null);
+
+    let not_attempted = listed_item(&listed, &not_attempted_id);
+    assert_eq!(
+        not_attempted["recovery_attempts"]["state"],
+        json!("not_attempted")
+    );
+    assert_eq!(not_attempted["recovery_attempts"]["items"], json!([]));
+
+    let recorded = listed_item(&listed, &recorded_id);
+    assert_eq!(recorded["recovery_attempts"]["state"], json!("recorded"));
+    assert_eq!(recorded["recovery_attempts"]["truncated"], json!(false));
+    assert_eq!(
+        recorded["recovery_attempts"]["items"][0]["event_id"],
+        json!(format!("{recorded_id}-evt-recovery-0"))
+    );
+    assert_eq!(
+        recorded["recovery_attempts"]["items"][1]["event_id"],
+        json!(format!("{recorded_id}-evt-recovery-1"))
+    );
+    assert_eq!(
+        recorded["recovery_attempts"]["items"][0]["run_id"],
+        json!(recorded_id)
+    );
+
+    let truncated = listed_item(&listed, &truncated_id);
+    assert_eq!(truncated["recovery_attempts"]["truncated"], json!(true));
+    assert_eq!(
+        truncated["recovery_attempts"]["items"]
+            .as_array()
+            .expect("items")
+            .len(),
+        8
+    );
+    assert_eq!(
+        truncated["recovery_attempts"]["items"][0]["event_id"],
+        json!(format!("{truncated_id}-evt-recovery-1"))
+    );
+    assert_eq!(
+        truncated["recovery_attempts"]["items"][7]["event_id"],
+        json!(format!("{truncated_id}-evt-recovery-8"))
+    );
+
+    let drain = listed_item(&listed, &drain_id);
+    assert_eq!(
+        drain["child_dispatches"][0]["child_run_id"],
+        json!("jrun-child-leaves")
+    );
+    assert_eq!(
+        drain["drain_worker_limit"]["max_active_leaf_runs"],
+        json!(7)
+    );
+    assert_eq!(drain["drain_admissions_stop"]["actor"], json!("operator"));
+
+    let invoke = listed_item(&listed, &invoke_id);
+    assert_eq!(
+        invoke["agent_invocation"]["completed_envelope"],
+        json!(true)
+    );
+    assert_eq!(
+        invoke["agent_invocation"]["summary"],
+        json!("the clock restarts")
+    );
+
+    let shown_truncated = run_tool_as_operator(
+        &runtime,
+        "orbit.workflow.run.show",
+        json!({"id": truncated_id}),
+    )
+    .expect("operator run show");
+    assert_eq!(
+        shown_truncated["recovery_attempts"],
+        truncated["recovery_attempts"]
+    );
+    assert_eq!(
+        shown_truncated["execution_progress"]["state"],
+        json!("observed")
+    );
+}
+
+/// [ORB-11625] List enrichment is one state read and two bounded recovery
+/// queries for the page, not one full envelope scan per run. Reconciliation
+/// inside `list_job_runs` is excluded from these counts.
+#[test]
+fn mcp_run_list_projection_batches_state_and_recovery_reads_for_a_page() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let quiet = insert_named_run(&runtime, "task_auto_pipeline");
+    let busy = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_v2_event(
+        &runtime,
+        &quiet,
+        "evt-quiet",
+        "2026-09-07T05:24:00Z",
+        None,
+        json!({"body_kind": "step_started", "step_id": "implement_one"}),
+    );
+    seed_numbered_recovery(&runtime, &busy, 12);
+
+    let runs = runtime
+        .list_job_runs(JobRunListParams::default())
+        .expect("load page");
+    let (items, reads) = super::super::workflow_tools::project_workflow_run_list(&runtime, &runs)
+        .expect("project list");
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(reads.pipeline_state_queries, 1);
+    assert_eq!(reads.recovery_event_queries, 1);
+    assert_eq!(reads.recovery_presence_queries, 1);
+    assert_eq!(reads.per_run_recovery_fetch_limit, 9);
+    assert_eq!(reads.per_run_recovery_projection_limit, 8);
+
+    let empty_reads = super::super::workflow_tools::project_workflow_run_list(&runtime, &[])
+        .expect("empty page")
+        .1;
+    assert_eq!(empty_reads.pipeline_state_queries, 0);
+    assert_eq!(empty_reads.recovery_event_queries, 0);
+    assert_eq!(empty_reads.recovery_presence_queries, 0);
+    assert_eq!(empty_reads.per_run_recovery_fetch_limit, 9);
+}
+
+/// [ORB-11625] A busy earlier run cannot steal a later run's recovery
+/// evidence. Missing and unreadable audit stay `unavailable`.
+#[test]
+fn mcp_run_list_keeps_per_run_recovery_attribution_with_uneven_histories() {
+    let (_root, runtime, _repo_root) = test_runtime();
+    let missing_id = insert_named_run(&runtime, "task_auto_pipeline");
+    let unreadable_id = insert_named_run(&runtime, "task_auto_pipeline");
+    runtime
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: runtime.workspace_id().expect("workspace id"),
+            event_id: "evt-malformed".to_string(),
+            source: "v2_envelope".to_string(),
+            schema_version: 1,
+            event_type: "test.event".to_string(),
+            ts: Utc::now(),
+            run_id: unreadable_id.clone(),
+            agent_identity: "codex".to_string(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: "{not-json".to_string(),
+        })
+        .expect("seed unreadable audit");
+    let quiet_id = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_numbered_recovery(&runtime, &quiet_id, 1);
+    let busy_id = insert_named_run(&runtime, "task_auto_pipeline");
+    seed_numbered_recovery(&runtime, &busy_id, 20);
+
+    let listed = run_tool_as_operator(&runtime, "orbit.workflow.run.list", json!({}))
+        .expect("operator run list");
+
+    let missing = listed_item(&listed, &missing_id);
+    assert_eq!(missing["recovery_attempts"]["state"], json!("unavailable"));
+    assert_eq!(missing["recovery_attempts"]["items"], json!([]));
+
+    let unreadable = listed_item(&listed, &unreadable_id);
+    assert_eq!(
+        unreadable["recovery_attempts"]["state"],
+        json!("unavailable")
+    );
+
+    let quiet = listed_item(&listed, &quiet_id);
+    assert_eq!(quiet["recovery_attempts"]["state"], json!("recorded"));
+    assert_eq!(quiet["recovery_attempts"]["truncated"], json!(false));
+    assert_eq!(
+        quiet["recovery_attempts"]["items"][0]["event_id"],
+        json!(format!("{quiet_id}-evt-recovery-0"))
+    );
+    assert_eq!(
+        quiet["recovery_attempts"]["items"][0]["run_id"],
+        json!(quiet_id)
+    );
+
+    let busy = listed_item(&listed, &busy_id);
+    assert_eq!(busy["recovery_attempts"]["truncated"], json!(true));
+    let busy_ids = busy["recovery_attempts"]["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .map(|item| item["event_id"].as_str().expect("event_id").to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        busy_ids,
+        (12..20)
+            .map(|index| format!("{busy_id}-evt-recovery-{index}"))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        busy["recovery_attempts"]["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .all(|item| item["run_id"] == json!(busy_id))
     );
 }

--- a/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
+++ b/crates/orbit-core/src/adapter/tool_host/workflow_tools.rs
@@ -4,11 +4,14 @@ use std::str::FromStr;
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
 use orbit_types::identity::normalize_optional_attribution_label;
-use orbit_types::workflow::{JobRun, JobRunState};
+use orbit_types::workflow::{JobRun, JobRunState, PipelineState};
 use serde_json::{Value, json};
 
 use crate::application::job::{DrainWorkerLimitRequest, JobRunListParams};
-use crate::runtime::run_audit::{RunExecutionProgress, RunProviderProcess};
+use crate::runtime::run_audit::{
+    MAX_RECOVERY_ATTEMPTS, RECOVERY_FETCH_PER_RUN, RunExecutionProgress, RunProviderProcess,
+    RunRecoveryAttempts,
+};
 use crate::{OrbitRuntime, ShipMode};
 
 use super::input::{parse_optional_string_array_field, parse_string_array_field};
@@ -130,11 +133,58 @@ pub(super) fn list(runtime: &OrbitRuntime, input: Value) -> Result<Value, OrbitE
         limit: Some(parse_limit(&input)?),
         ..Default::default()
     })?;
+    // Default list stays the enriched projection. A summary mode, if added,
+    // must be an explicit opt-in and cannot replace this path [ORB-11625].
+    let (items, _reads) = project_workflow_run_list(runtime, &runs)?;
+    Ok(json!({ "items": items }))
+}
+
+/// Query counts for one list-page projection. Reconciliation reads that happen
+/// inside `list_job_runs` are excluded: they are not this enrichment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RunListProjectionReads {
+    pub pipeline_state_queries: usize,
+    pub recovery_event_queries: usize,
+    pub recovery_presence_queries: usize,
+    pub per_run_recovery_fetch_limit: usize,
+    pub per_run_recovery_projection_limit: usize,
+}
+
+pub(crate) fn project_workflow_run_list(
+    runtime: &OrbitRuntime,
+    runs: &[JobRun],
+) -> Result<(Vec<Value>, RunListProjectionReads), OrbitError> {
+    let reads = RunListProjectionReads {
+        pipeline_state_queries: usize::from(!runs.is_empty()),
+        recovery_event_queries: usize::from(!runs.is_empty()),
+        recovery_presence_queries: usize::from(!runs.is_empty()),
+        per_run_recovery_fetch_limit: RECOVERY_FETCH_PER_RUN,
+        per_run_recovery_projection_limit: MAX_RECOVERY_ATTEMPTS,
+    };
+    if runs.is_empty() {
+        return Ok((Vec::new(), reads));
+    }
+
+    let run_ids = runs
+        .iter()
+        .map(|run| run.run_id.clone())
+        .collect::<Vec<_>>();
+    let states = runtime.read_run_states(&run_ids).unwrap_or_default();
+    let recoveries = runtime
+        .collect_run_recovery_attempts_for_runs(&run_ids)
+        .map(|page| page.by_run_id)
+        .unwrap_or_default();
     let items = runs
         .iter()
-        .map(|run| run_json_with_lineage(runtime, run))
+        .map(|run| {
+            run_json_enriched(
+                run,
+                states.get(&run.run_id).and_then(Option::as_ref),
+                recoveries.get(&run.run_id),
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(json!({ "items": items }))
+    Ok((items, reads))
 }
 
 pub(super) fn resume(
@@ -252,10 +302,18 @@ fn run_json(run: &JobRun) -> Result<Value, OrbitError> {
 /// about lineage instead of each reader seeing a different half of the truth.
 /// An unreadable state degrades to an empty list rather than failing the read.
 fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, OrbitError> {
-    let mut value = run_json(run)?;
     let state = runtime.read_run_state(&run.run_id).ok().flatten();
+    let recovery = runtime.collect_run_recovery_attempts(&run.run_id).ok();
+    run_json_enriched(run, state.as_ref(), recovery.as_ref())
+}
+
+fn run_json_enriched(
+    run: &JobRun,
+    state: Option<&PipelineState>,
+    recovery: Option<&RunRecoveryAttempts>,
+) -> Result<Value, OrbitError> {
+    let mut value = run_json(run)?;
     let dispatches = state
-        .as_ref()
         .map(|state| state.child_dispatches.clone())
         .unwrap_or_default();
     value["child_dispatches"] =
@@ -263,25 +321,19 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
     // [ORB-11253] The effective ceiling and who moved it, from the same read:
     // an operator asking why a drain is admitting five tasks rather than seven
     // is asking about this field, not about the submitted input.
-    value["drain_worker_limit"] = serde_json::to_value(
-        state
-            .as_ref()
-            .and_then(|state| state.drain_worker_limit.as_ref()),
-    )
-    .map_err(serialize_error("serialize drain worker limit"))?;
-    value["drain_admissions_stop"] = serde_json::to_value(
-        state
-            .as_ref()
-            .and_then(|state| state.drain_admissions_stop.as_ref()),
-    )
-    .map_err(serialize_error("serialize drain admissions stop"))?;
+    value["drain_worker_limit"] =
+        serde_json::to_value(state.and_then(|state| state.drain_worker_limit.as_ref()))
+            .map_err(serialize_error("serialize drain worker limit"))?;
+    value["drain_admissions_stop"] =
+        serde_json::to_value(state.and_then(|state| state.drain_admissions_stop.as_ref()))
+            .map_err(serialize_error("serialize drain admissions stop"))?;
     // [ORB-11354] An operator tracking an agent invocation reads it here, from
     // the same show/list surface as any other run: its distinguishable outcome,
     // a bounded preview of the answer, and the durable reference to the full
     // captured output.
     value["agent_invocation"] = serde_json::to_value(crate::application::job::agent_invoke_result(
         run,
-        state.as_ref().map(|state| &state.step_outputs),
+        state.map(|state| &state.step_outputs),
     ))
     .map_err(serialize_error("serialize agent invocation result"))?;
     // Recovery evidence remains separate from the run and step errors above:
@@ -289,13 +341,12 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
     // workflow failure that triggered it. Older/unreadable audit trails remain
     // observable as `unavailable` rather than making existing run-show callers
     // fail their ordinary durable run read.
-    let recovery_attempts = runtime.collect_run_recovery_attempts(&run.run_id).ok();
-    value["recovery_attempts"] = match recovery_attempts {
+    value["recovery_attempts"] = match recovery {
         Some(attempts) => json!({
             "state": attempts.state,
             "limit": attempts.limit,
             "truncated": attempts.truncated,
-            "items": attempts.attempts.into_iter().map(|attempt| json!({
+            "items": attempts.attempts.iter().map(|attempt| json!({
                 "run_id": attempt.run_id,
                 "event_id": attempt.event_id,
                 "attempted_at": attempt.attempted_at.map(|value| value.to_rfc3339()),
@@ -309,7 +360,7 @@ fn run_json_with_lineage(runtime: &OrbitRuntime, run: &JobRun) -> Result<Value, 
         }),
         None => json!({
             "state": "unavailable",
-            "limit": 8,
+            "limit": MAX_RECOVERY_ATTEMPTS,
             "truncated": false,
             "items": [],
         }),

--- a/crates/orbit-core/src/application/job/run/actions.rs
+++ b/crates/orbit-core/src/application/job/run/actions.rs
@@ -1,7 +1,8 @@
 //! Cancellation, archive, delete, and run-state helpers for job runs.
 
+use std::collections::HashMap;
 #[cfg(unix)]
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use chrono::Utc;
 use orbit_common::observability::audit_id::audit_execution_id;
@@ -394,6 +395,14 @@ impl OrbitRuntime {
         run_id: &str,
     ) -> Result<Option<orbit_types::workflow::PipelineState>, OrbitError> {
         self.stores().jobs().read_run_state(run_id)
+    }
+
+    /// Pipeline state for a list page in one store round-trip, not one per run.
+    pub fn read_run_states(
+        &self,
+        run_ids: &[String],
+    ) -> Result<HashMap<String, Option<orbit_types::workflow::PipelineState>>, OrbitError> {
+        self.stores().jobs().read_run_states(run_ids)
     }
 
     /// Persist a run's pipeline state. The write side of [`Self::read_run_state`],

--- a/crates/orbit-core/src/runtime/run_audit.rs
+++ b/crates/orbit-core/src/runtime/run_audit.rs
@@ -75,8 +75,41 @@ pub struct RunRecoveryAttempts {
     pub truncated: bool,
 }
 
-const MAX_RECOVERY_ATTEMPTS: usize = 8;
+impl RunRecoveryAttempts {
+    pub fn unavailable() -> Self {
+        Self {
+            state: "unavailable",
+            attempts: Vec::new(),
+            limit: MAX_RECOVERY_ATTEMPTS,
+            truncated: false,
+        }
+    }
+
+    pub fn not_attempted() -> Self {
+        Self {
+            state: "not_attempted",
+            attempts: Vec::new(),
+            limit: MAX_RECOVERY_ATTEMPTS,
+            truncated: false,
+        }
+    }
+}
+
+pub(crate) const MAX_RECOVERY_ATTEMPTS: usize = 8;
+/// One extra recovery row per run so `truncated` is visible without a
+/// page-wide LIMIT that would starve later runs [ORB-11625].
+pub(crate) const RECOVERY_FETCH_PER_RUN: usize = MAX_RECOVERY_ATTEMPTS + 1;
 const MAX_RECOVERY_DIAGNOSTIC_CHARS: usize = 1024;
+
+/// Recovery evidence for a list page, plus the query counts the list
+/// projection uses to prove it did not scan one full envelope per run.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunRecoveryAttemptsPage {
+    pub by_run_id: HashMap<String, RunRecoveryAttempts>,
+    pub event_queries: usize,
+    pub presence_queries: usize,
+    pub per_run_fetch_limit: usize,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RunCliInvocationRecord {
@@ -353,34 +386,68 @@ impl OrbitRuntime {
         &self,
         run_id: &str,
     ) -> Result<RunRecoveryAttempts, OrbitError> {
-        let events = self.collect_run_audit_events(run_id)?;
-        let audit_state = if events.is_empty() {
-            "unavailable"
-        } else {
-            "not_attempted"
-        };
-        let total = events
-            .iter()
-            .filter(|event| event.body_kind.as_deref() == Some("step_recovery_attempted"))
-            .count();
-        let mut attempts = events
-            .into_iter()
-            .filter(|event| event.body_kind.as_deref() == Some("step_recovery_attempted"))
-            .filter_map(|event| recovery_attempt_from_event(run_id, event))
-            .rev()
-            .take(MAX_RECOVERY_ATTEMPTS)
-            .collect::<Vec<_>>();
-        attempts.reverse();
+        let page = self.collect_run_recovery_attempts_for_runs(&[run_id.to_string()])?;
+        Ok(page
+            .by_run_id
+            .get(run_id)
+            .cloned()
+            .unwrap_or_else(RunRecoveryAttempts::unavailable))
+    }
 
-        Ok(RunRecoveryAttempts {
-            state: if attempts.is_empty() {
-                audit_state
-            } else {
-                "recorded"
-            },
-            attempts,
-            limit: MAX_RECOVERY_ATTEMPTS,
-            truncated: total > MAX_RECOVERY_ATTEMPTS,
+    /// Recovery evidence for a list page from one audit-store handle.
+    ///
+    /// [ORB-11625] The previous list path scanned each run's full v2 envelope
+    /// (`limit: 50_000`) and opened the audit store once per row. This loads
+    /// only `step_recovery_attempted` rows, capped per run at
+    /// [`RECOVERY_FETCH_PER_RUN`], and a presence set for `unavailable` vs
+    /// `not_attempted`. A page-wide LIMIT is not used: it would starve later
+    /// runs with shorter histories. Store-handle reuse is ORB-11632; this
+    /// method must not add a per-run `Store::open`.
+    pub fn collect_run_recovery_attempts_for_runs(
+        &self,
+        run_ids: &[String],
+    ) -> Result<RunRecoveryAttemptsPage, OrbitError> {
+        if run_ids.is_empty() {
+            return Ok(RunRecoveryAttemptsPage {
+                by_run_id: HashMap::new(),
+                event_queries: 0,
+                presence_queries: 0,
+                per_run_fetch_limit: RECOVERY_FETCH_PER_RUN,
+            });
+        }
+
+        let workspace_id = self.workspace_id()?;
+        let store = self.v2_audit_store()?;
+        let rows = store.list_v2_audit_events_for_runs_partitioned(
+            &workspace_id,
+            run_ids,
+            Some("v2_envelope"),
+            Some("step_recovery_attempted"),
+            RECOVERY_FETCH_PER_RUN,
+        )?;
+        let present =
+            store.list_v2_audit_run_ids_with_events(&workspace_id, run_ids, Some("v2_envelope"))?;
+
+        let mut grouped: HashMap<String, Vec<orbit_store::V2AuditEventRow>> = HashMap::new();
+        for row in rows {
+            grouped.entry(row.run_id.clone()).or_default().push(row);
+        }
+
+        let mut by_run_id = HashMap::new();
+        for run_id in run_ids {
+            let attempts = match grouped.get(run_id) {
+                Some(run_rows) => recovery_attempts_from_partitioned_rows(run_id, run_rows),
+                None if present.contains(run_id) => RunRecoveryAttempts::not_attempted(),
+                None => RunRecoveryAttempts::unavailable(),
+            };
+            by_run_id.insert(run_id.clone(), attempts);
+        }
+
+        Ok(RunRecoveryAttemptsPage {
+            by_run_id,
+            event_queries: 1,
+            presence_queries: 1,
+            per_run_fetch_limit: RECOVERY_FETCH_PER_RUN,
         })
     }
 
@@ -771,6 +838,61 @@ fn enclosing_step_id(event: &Value, events: &HashMap<String, Value>) -> Option<S
             .map(str::to_string);
     }
     None
+}
+
+fn recovery_attempts_from_partitioned_rows(
+    run_id: &str,
+    rows: &[orbit_store::V2AuditEventRow],
+) -> RunRecoveryAttempts {
+    let truncated = rows.len() > MAX_RECOVERY_ATTEMPTS;
+    let mut attempts = rows
+        .iter()
+        .filter_map(recovery_event_from_row)
+        .filter_map(|event| recovery_attempt_from_event(run_id, event))
+        .take(MAX_RECOVERY_ATTEMPTS)
+        .collect::<Vec<_>>();
+    attempts.reverse();
+    RunRecoveryAttempts {
+        state: if attempts.is_empty() {
+            "not_attempted"
+        } else {
+            "recorded"
+        },
+        attempts,
+        limit: MAX_RECOVERY_ATTEMPTS,
+        truncated,
+    }
+}
+
+fn recovery_event_from_row(row: &orbit_store::V2AuditEventRow) -> Option<RunAuditEvent> {
+    let raw: Value = serde_json::from_str(&row.payload_json).ok()?;
+    let event_id = raw.get("event_id").and_then(Value::as_str)?.to_string();
+    Some(RunAuditEvent {
+        parent_event_id: raw
+            .get("parent_event_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        event_type: raw
+            .get("event_type")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        body_kind: raw
+            .get("body_kind")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        timestamp: raw
+            .get("ts")
+            .and_then(Value::as_str)
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))
+            .or(Some(row.ts)),
+        step_id: raw
+            .get("step_id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        raw,
+        event_id,
+    })
 }
 
 fn recovery_attempt_from_event(run_id: &str, event: RunAuditEvent) -> Option<RunRecoveryAttempt> {

--- a/crates/orbit-core/src/runtime/tests/run_audit.rs
+++ b/crates/orbit-core/src/runtime/tests/run_audit.rs
@@ -508,6 +508,72 @@ fn recovery_attempt_projection_bounds_history_and_marks_legacy_absence() {
     assert!(not_attempted.attempts.is_empty());
 }
 
+/// [ORB-11625] A page loads recovery evidence in two bounded queries and
+/// keeps per-run attribution when histories are uneven.
+#[test]
+fn recovery_attempts_for_runs_are_partitioned_and_counted_once() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let busy = "jrun-busy";
+    let quiet = "jrun-quiet";
+    let empty = "jrun-empty";
+    seed_v2_audit_events(
+        &runtime,
+        busy,
+        (0..20).map(|index| {
+            json!({
+                "event_id": format!("evt-busy-{index}"),
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": false,
+            })
+        }),
+    );
+    seed_v2_audit_events(
+        &runtime,
+        quiet,
+        [
+            json!({"event_id": "evt-quiet-start", "body_kind": "step_started", "step_id": "sync_base"}),
+            json!({
+                "event_id": "evt-quiet-recovery",
+                "body_kind": "step_recovery_attempted",
+                "step_id": "sync_base",
+                "recovery_activity": "step_failure_recovery",
+                "recovery_succeeded": true,
+            }),
+        ],
+    );
+
+    let page = runtime
+        .collect_run_recovery_attempts_for_runs(&[
+            busy.to_string(),
+            quiet.to_string(),
+            empty.to_string(),
+        ])
+        .expect("batch collect");
+
+    assert_eq!(page.event_queries, 1);
+    assert_eq!(page.presence_queries, 1);
+    assert_eq!(page.per_run_fetch_limit, 9);
+    assert!(page.by_run_id[busy].truncated);
+    assert_eq!(page.by_run_id[busy].attempts.len(), 8);
+    assert_eq!(page.by_run_id[busy].attempts[0].event_id, "evt-busy-12");
+    assert!(
+        page.by_run_id[busy]
+            .attempts
+            .iter()
+            .all(|attempt| attempt.run_id == busy)
+    );
+    assert_eq!(page.by_run_id[quiet].state, "recorded");
+    assert!(!page.by_run_id[quiet].truncated);
+    assert_eq!(
+        page.by_run_id[quiet].attempts[0].event_id,
+        "evt-quiet-recovery"
+    );
+    assert_eq!(page.by_run_id[empty].state, "unavailable");
+    assert!(page.by_run_id[empty].attempts.is_empty());
+}
+
 #[test]
 fn malformed_jsonl_and_missing_blobs_are_tolerated() {
     let runtime = OrbitRuntime::in_memory().expect("build runtime");

--- a/crates/orbit-store/src/contracts/traits.rs
+++ b/crates/orbit-store/src/contracts/traits.rs
@@ -13,7 +13,7 @@ use orbit_types::workflow::{
     RunStateUpdate,
 };
 use serde_json::Value;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use super::friction::{
     FrictionAddParams, FrictionListFilter, FrictionReportedCount, FrictionUpdateParams,
@@ -253,6 +253,24 @@ pub trait V2AuditStoreBackend: Send + Sync {
         filter: &V2AuditEventFilter,
     ) -> Result<Vec<V2AuditEventRow>, OrbitError>;
     fn count_v2_audit_events(&self, filter: &V2AuditEventFilter) -> Result<i64, OrbitError>;
+    /// Newest matching envelope rows for each run, capped independently so a
+    /// busy earlier run cannot consume a page-wide LIMIT.
+    fn list_v2_audit_events_for_runs_partitioned(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+        body_kind: Option<&str>,
+        per_run_limit: usize,
+    ) -> Result<Vec<V2AuditEventRow>, OrbitError>;
+    /// Run ids in `run_ids` that have at least one reconstructable v2 envelope
+    /// row. Used to distinguish `unavailable` from `not_attempted`.
+    fn list_v2_audit_run_ids_with_events(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+    ) -> Result<HashSet<String>, OrbitError>;
 }
 
 pub trait TaskDocumentStoreBackend: Send + Sync {
@@ -473,6 +491,15 @@ pub trait JobRunStoreBackend: Send + Sync {
     fn archive_job_run(&self, run_id: &str) -> Result<String, OrbitError>;
     fn delete_job_run(&self, run_id: &str) -> Result<String, OrbitError>;
     fn read_run_state(&self, run_id: &str) -> Result<Option<PipelineState>, OrbitError>;
+    /// Pipeline state for a list page in one query per chunk, not one per run.
+    ///
+    /// Missing runs and unreadable JSON are omitted / `None` rather than failing
+    /// the page: the MCP list surface degrades those rows the same way a
+    /// per-run `read_run_state` error already does.
+    fn read_run_states(
+        &self,
+        run_ids: &[String],
+    ) -> Result<HashMap<String, Option<PipelineState>>, OrbitError>;
     fn write_run_state(&self, run_id: &str, state: &PipelineState) -> Result<(), OrbitError>;
     /// [ORB-11253] Read-modify-write a run's pipeline state in one immediate
     /// transaction.

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -540,6 +540,14 @@ impl JobRunStoreBackend for SqliteJobRunStore {
             .read_job_run_state_for_workspace(&self.workspace_id, run_id)
     }
 
+    fn read_run_states(
+        &self,
+        run_ids: &[String],
+    ) -> Result<HashMap<String, Option<PipelineState>>, OrbitError> {
+        self.store
+            .read_job_run_states_for_workspace(&self.workspace_id, run_ids)
+    }
+
     fn write_run_state(&self, run_id: &str, state: &PipelineState) -> Result<(), OrbitError> {
         self.store
             .write_job_run_state_for_workspace(&self.workspace_id, run_id, state)
@@ -733,6 +741,56 @@ impl Store {
                 .map_err(|e| OrbitError::Store(format!("invalid pipeline_state_json: {e}")))
         })
         .transpose()
+    }
+
+    /// Pipeline state for a page of runs in one query per chunk.
+    ///
+    /// Unreadable JSON is `None` for that run rather than failing the page:
+    /// list projection already treats a per-run read error as empty lineage.
+    pub fn read_job_run_states_for_workspace(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+    ) -> Result<HashMap<String, Option<PipelineState>>, OrbitError> {
+        let mut states: HashMap<String, Option<PipelineState>> = HashMap::new();
+        if run_ids.is_empty() {
+            return Ok(states);
+        }
+        let conn = self.read()?;
+        for chunk in run_ids.chunks(STEP_RUN_ID_CHUNK) {
+            let placeholders = (0..chunk.len())
+                .map(|index| format!("?{}", index + 2))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT run_id, pipeline_state_json FROM job_runs \
+                     WHERE workspace_id = ?1 AND run_id IN ({placeholders})"
+                ))
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
+                vec![Box::new(workspace_id.to_string())];
+            params.extend(
+                chunk
+                    .iter()
+                    .map(|run_id| Box::new(run_id.clone()) as Box<dyn rusqlite::types::ToSql>),
+            );
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|b| b.as_ref()).collect();
+            let rows = stmt
+                .query_map(param_refs.as_slice(), |row| {
+                    let run_id: String = row.get(0)?;
+                    let raw: Option<String> = row.get(1)?;
+                    Ok((run_id, raw))
+                })
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            for row in rows {
+                let (run_id, raw) = row.map_err(|e| OrbitError::Store(e.to_string()))?;
+                let state = raw.and_then(|raw| serde_json::from_str(&raw).ok());
+                states.insert(run_id, state);
+            }
+        }
+        Ok(states)
     }
 
     pub fn write_job_run_state_for_workspace(

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, TimeZone, Utc};
-use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType};
+use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType, PipelineState};
+use serde_json::json;
 
 use crate::Store;
 use crate::contracts::{JobRunOrder, JobRunQuery};
@@ -87,6 +88,78 @@ fn listing_hydrates_every_runs_steps_across_id_chunks() {
             assert_eq!(step.target_id, format!("step-{position}"), "{}", run.run_id);
         }
     }
+}
+
+/// [ORB-11625] A list page loads pipeline state in one query per id chunk.
+/// Missing runs stay absent; unreadable JSON degrades to `None` rather than
+/// failing the page.
+#[test]
+fn reading_run_states_hydrates_a_page_and_isolates_unreadable_rows() {
+    let store = Store::open_in_memory().expect("open store");
+    let mut expected = Vec::new();
+    for index in 0..4_u32 {
+        let run_id = format!("jrun-state-{index}");
+        let run = run_with_steps(&run_id, JobRunState::Running, at(index), 0);
+        let mut state = PipelineState::new(run_id.clone(), run.job_id.clone(), json!({}));
+        state.record_child_dispatch(
+            orbit_types::workflow::ChildDispatch::submitted(
+                format!("jrun-child-{index}"),
+                "task_auto_pipeline".to_string(),
+                "invoke_and_wait".to_string(),
+                true,
+                false,
+                at(index),
+            )
+            .with_parent_step_id(Some("ship_leaves".to_string())),
+        );
+        store
+            .upsert_job_run_for_workspace("ws", &run, Some(&state))
+            .expect("insert run with state");
+        expected.push(run_id);
+    }
+    let unreadable = run_with_steps("jrun-bad-json", JobRunState::Pending, at(8), 0);
+    store
+        .upsert_job_run_for_workspace("ws", &unreadable, None)
+        .expect("insert run without state");
+    store
+        .with_transaction(|tx| {
+            tx.connection()
+                .execute(
+                    "UPDATE job_runs SET pipeline_state_json = '{not-json' \
+                     WHERE workspace_id = ?1 AND run_id = ?2",
+                    rusqlite::params!["ws", "jrun-bad-json"],
+                )
+                .map_err(|e| orbit_common::OrbitError::Store(e.to_string()))?;
+            Ok(())
+        })
+        .expect("seed unreadable state");
+
+    let mut ids = expected.clone();
+    ids.push("jrun-bad-json".to_string());
+    ids.push("jrun-missing".to_string());
+    let states = store
+        .read_job_run_states_for_workspace("ws", &ids)
+        .expect("batch read");
+
+    assert_eq!(states.len(), 5);
+    for (index, run_id) in expected.iter().enumerate() {
+        let state = states
+            .get(run_id)
+            .expect("run present")
+            .as_ref()
+            .expect("readable state");
+        assert_eq!(
+            state.child_dispatches[0].child_run_id,
+            format!("jrun-child-{index}")
+        );
+    }
+    assert!(
+        states
+            .get("jrun-bad-json")
+            .expect("unreadable row is present")
+            .is_none()
+    );
+    assert!(!states.contains_key("jrun-missing"));
 }
 
 /// Counting and duration reads apply the list filter but ignore its limit.

--- a/crates/orbit-store/src/driver/sqlite/v2_audit_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/v2_audit_store/mod.rs
@@ -1,9 +1,14 @@
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
 
 use crate::{Store, parse_timestamp};
 
 use crate::contracts::{V2AuditEventFilter, V2AuditEventInsertParams, V2AuditEventRow};
+
+/// Run ids per `IN (...)` list, under SQLite's bound-parameter cap.
+const AUDIT_RUN_ID_CHUNK: usize = 500;
 
 impl Store {
     pub fn insert_v2_audit_event(
@@ -78,6 +83,84 @@ impl Store {
             .map_err(|e| OrbitError::Store(e.to_string()))
     }
 
+    /// Newest matching rows for each run, independently capped.
+    ///
+    /// A global `ORDER BY ts DESC LIMIT n` would let a busy earlier run consume
+    /// the whole budget. `ROW_NUMBER()` is partitioned by `run_id` so later
+    /// runs keep their own newest evidence.
+    pub fn list_v2_audit_events_for_runs_partitioned(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+        body_kind: Option<&str>,
+        per_run_limit: usize,
+    ) -> Result<Vec<V2AuditEventRow>, OrbitError> {
+        if run_ids.is_empty() || per_run_limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut rows = Vec::new();
+        let conn = self.read()?;
+        for chunk in run_ids.chunks(AUDIT_RUN_ID_CHUNK) {
+            let (where_clause, mut params) =
+                run_ids_filter_sql(workspace_id, chunk, source, body_kind, false);
+            let limit_idx = params.len() + 1;
+            params.push(Box::new(per_run_limit as i64));
+            let sql = format!(
+                "SELECT id, workspace_id, event_id, source, schema_version, event_type, ts, \
+                 run_id, agent_identity, parent_event_id, workspace_path, payload_json \
+                 FROM ( \
+                    SELECT id, workspace_id, event_id, source, schema_version, event_type, ts, \
+                           run_id, agent_identity, parent_event_id, workspace_path, payload_json, \
+                           ROW_NUMBER() OVER (PARTITION BY run_id ORDER BY ts DESC, id DESC) AS rn \
+                    FROM v2_audit_events {where_clause} \
+                 ) WHERE rn <= ?{limit_idx} \
+                 ORDER BY ts DESC, id DESC"
+            );
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|b| b.as_ref()).collect();
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            let mapped = stmt
+                .query_map(param_refs.as_slice(), row_to_v2_audit_event)
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            rows.extend(collect_rows(mapped)?);
+        }
+        Ok(rows)
+    }
+
+    /// Run ids among `run_ids` that have at least one reconstructable envelope.
+    pub fn list_v2_audit_run_ids_with_events(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+    ) -> Result<HashSet<String>, OrbitError> {
+        let mut present = HashSet::new();
+        if run_ids.is_empty() {
+            return Ok(present);
+        }
+        let conn = self.read()?;
+        for chunk in run_ids.chunks(AUDIT_RUN_ID_CHUNK) {
+            let (where_clause, params) =
+                run_ids_filter_sql(workspace_id, chunk, source, None, true);
+            let sql = format!("SELECT DISTINCT run_id FROM v2_audit_events {where_clause}");
+            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+                params.iter().map(|b| b.as_ref()).collect();
+            let mut stmt = conn
+                .prepare(&sql)
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            let mapped = stmt
+                .query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))
+                .map_err(|e| OrbitError::Store(e.to_string()))?;
+            for run_id in mapped {
+                present.insert(run_id.map_err(|e| OrbitError::Store(e.to_string()))?);
+            }
+        }
+        Ok(present)
+    }
+
     pub fn prune_v2_audit_events_older_than(
         &self,
         workspace_id: &str,
@@ -110,6 +193,73 @@ impl crate::contracts::V2AuditStoreBackend for Store {
     fn count_v2_audit_events(&self, filter: &V2AuditEventFilter) -> Result<i64, OrbitError> {
         Self::count_v2_audit_events(self, filter)
     }
+
+    fn list_v2_audit_events_for_runs_partitioned(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+        body_kind: Option<&str>,
+        per_run_limit: usize,
+    ) -> Result<Vec<V2AuditEventRow>, OrbitError> {
+        Self::list_v2_audit_events_for_runs_partitioned(
+            self,
+            workspace_id,
+            run_ids,
+            source,
+            body_kind,
+            per_run_limit,
+        )
+    }
+
+    fn list_v2_audit_run_ids_with_events(
+        &self,
+        workspace_id: &str,
+        run_ids: &[String],
+        source: Option<&str>,
+    ) -> Result<HashSet<String>, OrbitError> {
+        Self::list_v2_audit_run_ids_with_events(self, workspace_id, run_ids, source)
+    }
+}
+
+fn run_ids_filter_sql(
+    workspace_id: &str,
+    run_ids: &[String],
+    source: Option<&str>,
+    body_kind: Option<&str>,
+    require_event_id: bool,
+) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
+    let mut conditions = vec!["workspace_id = ?1".to_string()];
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = vec![Box::new(workspace_id.to_string())];
+    if let Some(source) = source {
+        conditions.push(format!("source = ?{}", params.len() + 1));
+        params.push(Box::new(source.to_string()));
+    }
+    if body_kind.is_some() || require_event_id {
+        // `json_extract` errors on malformed payloads; skip them the same way
+        // the per-run reconstruction skips unparseable envelope rows.
+        conditions.push("json_valid(payload_json)".to_string());
+    }
+    if let Some(body_kind) = body_kind {
+        conditions.push(format!(
+            "json_extract(payload_json, '$.body_kind') = ?{}",
+            params.len() + 1
+        ));
+        params.push(Box::new(body_kind.to_string()));
+    }
+    if require_event_id {
+        conditions.push("json_extract(payload_json, '$.event_id') IS NOT NULL".to_string());
+    }
+    let start = params.len() + 1;
+    let placeholders = (0..run_ids.len())
+        .map(|index| format!("?{}", start + index))
+        .collect::<Vec<_>>()
+        .join(", ");
+    conditions.push(format!("run_id IN ({placeholders})"));
+    for run_id in run_ids {
+        params.push(Box::new(run_id.clone()));
+    }
+    (format!("WHERE {}", conditions.join(" AND ")), params)
 }
 
 fn v2_filter_sql(filter: &V2AuditEventFilter) -> (String, Vec<Box<dyn rusqlite::types::ToSql>>) {
@@ -202,5 +352,109 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].event_id, "evt-ws_a");
         assert_eq!(store.count_v2_audit_events(&filter).expect("count"), 1);
+    }
+
+    /// [ORB-11625] Per-run partition limits keep a busy earlier run from
+    /// starving a later one. Presence ignores malformed payloads.
+    #[test]
+    fn partitioned_recovery_reads_do_not_starve_later_runs() {
+        let store = Store::open_in_memory().expect("store");
+        let busy = "jrun-busy";
+        let quiet = "jrun-quiet";
+        let empty = "jrun-empty";
+        for index in 0..12_u32 {
+            insert_envelope(
+                &store,
+                busy,
+                &format!("evt-busy-{index}"),
+                index,
+                Some("step_recovery_attempted"),
+            );
+        }
+        insert_envelope(&store, quiet, "evt-quiet-0", 0, Some("step_started"));
+        insert_envelope(
+            &store,
+            quiet,
+            "evt-quiet-1",
+            1,
+            Some("step_recovery_attempted"),
+        );
+        store
+            .insert_v2_audit_event(&V2AuditEventInsertParams {
+                workspace_id: "ws_a".to_string(),
+                event_id: "evt-malformed".to_string(),
+                source: "v2_envelope".to_string(),
+                schema_version: 1,
+                event_type: "test.event".to_string(),
+                ts: Utc::now(),
+                run_id: empty.to_string(),
+                agent_identity: "codex".to_string(),
+                parent_event_id: None,
+                workspace_path: None,
+                payload_json: "{not-json".to_string(),
+            })
+            .expect("insert malformed");
+
+        let run_ids = vec![busy.to_string(), quiet.to_string(), empty.to_string()];
+        let rows = store
+            .list_v2_audit_events_for_runs_partitioned(
+                "ws_a",
+                &run_ids,
+                Some("v2_envelope"),
+                Some("step_recovery_attempted"),
+                9,
+            )
+            .expect("partitioned list");
+        let busy_rows = rows
+            .iter()
+            .filter(|row| row.run_id == busy)
+            .collect::<Vec<_>>();
+        let quiet_rows = rows
+            .iter()
+            .filter(|row| row.run_id == quiet)
+            .collect::<Vec<_>>();
+        assert_eq!(busy_rows.len(), 9);
+        assert_eq!(quiet_rows.len(), 1);
+        assert_eq!(quiet_rows[0].event_id, "evt-quiet-1");
+        assert!(!rows.iter().any(|row| row.run_id == empty));
+
+        let present = store
+            .list_v2_audit_run_ids_with_events("ws_a", &run_ids, Some("v2_envelope"))
+            .expect("presence");
+        assert!(present.contains(busy));
+        assert!(present.contains(quiet));
+        assert!(!present.contains(empty));
+    }
+
+    fn insert_envelope(
+        store: &Store,
+        run_id: &str,
+        event_id: &str,
+        minute: u32,
+        body_kind: Option<&str>,
+    ) {
+        let ts = chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 5, 1, 0, minute, 0)
+            .single()
+            .expect("ts");
+        let payload = serde_json::json!({
+            "event_id": event_id,
+            "body_kind": body_kind,
+            "run_id": run_id,
+        });
+        store
+            .insert_v2_audit_event(&V2AuditEventInsertParams {
+                workspace_id: "ws_a".to_string(),
+                event_id: event_id.to_string(),
+                source: "v2_envelope".to_string(),
+                schema_version: 1,
+                event_type: "test.event".to_string(),
+                ts,
+                run_id: run_id.to_string(),
+                agent_identity: "codex".to_string(),
+                parent_event_id: None,
+                workspace_path: None,
+                payload_json: payload.to_string(),
+            })
+            .expect("insert envelope");
     }
 }


### PR DESCRIPTION
## Task

[ORB-11625](https://orbit-cli.com/tasks/ORB-11625) — [code-review] Remove the N+1 run-state and audit reads from `orbit.workflow.run.list`

### Description

## Problem
`orbit.workflow.run.list` enriches each run separately with pipeline state and recovery audit evidence. A page can therefore perform one state read and a large envelope scan per run. Repeated audit-store construction is tracked in consolidated ORB-11632; this task owns reducing the per-run projection/read amplification.

## Required behavior
Batch or otherwise bound state and recovery-evidence loading for a list page while preserving the existing default list contract: child dispatches, drain controls, agent invocation results, recovery evidence, and unavailable/truncated states remain observable. These fields were deliberately added for operator visibility; do not silently remove them or switch their default off. Preserve show behavior, per-run attribution, ordering, and per-run evidence bounds. A batch-wide limit must not starve later runs or misreport completeness. If a separate summary mode is introduced, it must be explicit and cannot substitute for optimizing the existing default path.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/adapter/tool_host/workflow_tools.rs:92`, `:203`, `:211`, `:247`; `crates/orbit-core/src/runtime/run_audit.rs:376`.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- A multi-run list fixture preserves the previous default enriched output, including child dispatches, controls, invocation results, and available/unavailable/truncated recovery evidence; show regressions remain passing.
- Counting tests demonstrate batched/bounded state and recovery queries for a page rather than one full envelope scan per run; record the intended bound and exclude unrelated reconciliation reads.
- Fixtures with uneven audit histories prove no run loses evidence or receives another run's evidence due to global batch limits; missing/unreadable state and audit behavior is preserved.
- No new per-run store opens are introduced; coordinate handle reuse with ORB-11632. Document any added explicit projection option without changing the default contract.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- `orbit.workflow.run.list` now enriches a page from one `read_run_states` query and one audit-store handle (partitioned recovery events + presence), instead of one `read_run_state` and a 50_000-row envelope scan per run.
- Recovery fetch is bounded per run at 9 (`MAX_RECOVERY_ATTEMPTS + 1`) via `ROW_NUMBER() PARTITION BY run_id`; projection still returns 8 newest attempts. No page-wide LIMIT. No summary mode.
- `run.show` keeps the per-run path and the same enriched fields. Unreadable state/audit still degrades to empty lineage / `unavailable`.
- Store handle reuse: list opens `v2_audit_store()` once per page (ORB-11632 still owns making that open cheap).

Criteria:
1. Mixed-page list fixture preserves child_dispatches, drain controls, agent_invocation, and recorded/unavailable/not_attempted/truncated recovery; show recovery matches list. Passed (`mcp_run_list_preserves_enriched_default_projection_across_a_mixed_page` and existing show tests).
2. Counting tests record 1 state + 1 recovery-event + 1 presence query for a non-empty page (0 for empty), fetch bound 9, projection bound 8; `list_job_runs` reconcile is excluded. Passed (`mcp_run_list_projection_batches_state_and_recovery_reads_for_a_page`, `recovery_attempts_for_runs_are_partitioned_and_counted_once`).
3. Uneven histories: a 20-event run stays truncated without stealing a 1-event run's evidence; missing and malformed audit stay `unavailable`. Passed (`mcp_run_list_keeps_per_run_recovery_attribution_with_uneven_histories`, store partitioned test).
4. No new per-run store opens; one handle per page. No explicit projection option added, so the default contract is unchanged.

Validation:
- `cargo test -p orbit-core --lib adapter::tool_host::tests::workflow_tools` — passed (16)
- `cargo test -p orbit-core --lib runtime::tests::run_audit` — passed (14)
- `cargo test -p orbit-store --lib driver::sqlite::tests::job_run_store` — passed (12)
- `cargo test -p orbit-store --lib partitioned_recovery_reads_do_not_starve_later_runs` — passed
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed; 9 modified files, uncommitted

Assessment: Default list contract preserved; N+1 state/audit reads removed at the list-page boundary.
Remaining risks: Presence/recovery SQL uses `json_valid`/`json_extract` (bundled SQLite). `show` still does a per-run state read plus a 1-run partitioned recovery pair, which is acceptable for a single-run tool.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11625-6a9f7184`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra