### PR TITLE
[code-review] Make generate-doc-indexes.sh --check see untracked docs so index staleness fails before commit

### DIFF
--- a/scripts/generate-doc-indexes.sh
+++ b/scripts/generate-doc-indexes.sh
@@ -118,7 +118,7 @@ is_versioned() {
   local file="$1"
   local relative="${file#"$repo_root/"}"
 
-  git -C "$repo_root" ls-files --error-unmatch -- "$relative" >/dev/null 2>&1
+  git -C "$repo_root" ls-files --cached --others --exclude-standard --error-unmatch -- "$relative" >/dev/null 2>&1
 }
 
 design_entry_doc() {


### PR DESCRIPTION
## Task

[ORB-11682](https://orbit-cli.com/tasks/ORB-11682) — [code-review] Make generate-doc-indexes.sh --check see untracked docs so index staleness fails before commit

### Description

## Problem
`is_versioned` uses `git ls-files --error-unmatch`, and each renderer `continue`s on non-versioned files. A new `docs/runbooks/foo.md` that has not been `git add`ed is invisible, so `make ci-fast` prints "verified docs/INDEX.md"; after the agent commits, CI's `--check` in `ci-guardrails.sh:33` fails and, with no merge gate on agent-main, becomes a remediation task instead of a local fix.

## Why It Matters
The check passes at the only moment the author can cheaply act on it and fails at the moment nobody is looking.

## Proposed Fix
Treat `git ls-files --others --exclude-standard` output as versioned too (skip only ignored files), or print a loud warning listing skipped docs and exit non-zero in `--check` mode when any are skipped.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `scripts/generate-doc-indexes.sh:117-123`, `scripts/generate-doc-indexes.sh:149-151`, `scripts/generate-doc-indexes.sh:179-181`, `scripts/generate-doc-indexes.sh:215-217`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (quality). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Creating an untracked `docs/runbooks/tmp.md` with valid frontmatter makes `./scripts/generate-doc-indexes.sh --check` exit 1 naming the stale index.
- A gitignored scratch file under `docs/` is still ignored.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `is_versioned` in `scripts/generate-doc-indexes.sh` to accept tracked and non-ignored untracked paths using `git ls-files --cached --others --exclude-standard --error-unmatch`.
- Ignored paths remain excluded by Git's standard ignore rules.

Acceptance criteria:
- Passed: a temporary valid untracked `docs/runbooks/tmp.md` caused `./scripts/generate-doc-indexes.sh --check` to exit 1 and report `error: docs/INDEX.md is stale; run scripts/generate-doc-indexes.sh`. The fixture was removed after validation.
- Passed: a temporary `docs/tmp` scratch file was confirmed ignored by `git check-ignore -q`; the same Git listing returned no match. The fixture was removed after validation.

Validation:
- Passed: `bash -n scripts/generate-doc-indexes.sh`.
- Passed: `./scripts/generate-doc-indexes.sh --check` (`verified docs/INDEX.md`) after fixture cleanup.
- Passed: `git diff --check`.
- Passed: `make ci-fast` (the compiler-cache sub-check reported its expected inability to create a bubblewrap mount namespace, then completed with `test-compiler-cache: ok`).
- Passed: `make ci-lint` (`cargo clippy --workspace --all-targets -- -D warnings`, finished successfully).
- Passed: final `GIT_OPTIONAL_LOCKS=0 git status --short` and diff review; only the scoped script is modified.

Assessment: Small, authoritative fix at the Git path-selection boundary; no compatibility or documentation changes were needed. Remaining risk is limited to platform-specific Git behavior outside the Linux environment used here.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11682-6a9f77b0`
- Behind base: 0
- Ahead of base: 1