### PR TITLE
[code-review] Reduce repeated incident inventory work while preserving live admission checks

### DIFF
--- a/crates/orbit-core/src/application/automation/incidents.rs
+++ b/crates/orbit-core/src/application/automation/incidents.rs
@@ -4,16 +4,20 @@ use crate::{
     OrbitRuntime,
     application::job::{RunOwnerLiveness, run_owner_liveness},
 };
+use chrono::{DateTime, Utc};
 use orbit_automation::{
     AutomationError,
     members::incidents::{IncidentFacts, incident_key},
 };
+use orbit_store::contracts::TaskCandidates;
 use orbit_types::{
-    task::{Task, TaskStatus},
-    workflow::{JobRun, JobRunState},
+    task::{Task, TaskEnvelopeV2, TaskStatus},
+    workflow::{JobRun, JobRunState, PipelineState},
 };
 use serde_json::{Value, json};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) type IncidentMembers = BTreeMap<String, Vec<String>>;
 
 pub(crate) fn failure_coupled(
     runtime: &OrbitRuntime,
@@ -51,7 +55,11 @@ fn is_diagnostic_origin(run: &JobRun) -> bool {
 }
 
 /// Walk retry links to the run that started the episode, under a fixed budget.
-fn root(runtime: &OrbitRuntime, run: &JobRun) -> Result<String, AutomationError> {
+fn root(
+    runtime: &OrbitRuntime,
+    run: &JobRun,
+    session: &mut IncidentSession,
+) -> Result<String, AutomationError> {
     let mut current = run.clone();
     let mut seen = BTreeSet::new();
 
@@ -62,8 +70,8 @@ fn root(runtime: &OrbitRuntime, run: &JobRun) -> Result<String, AutomationError>
         let Some(parent) = &current.retry_source_run_id else {
             return Ok(current.run_id);
         };
-        current = runtime
-            .get_job_run_backend(parent)?
+        current = session
+            .backend_run(runtime, parent)?
             .ok_or_else(|| AutomationError::Deferred("incident_lineage_missing".into()))?;
     }
 
@@ -82,19 +90,61 @@ fn observe_with_settlement(
     task: &Task,
     require_settled: bool,
 ) -> Result<(String, Value), AutomationError> {
+    let mut session = IncidentSession::new();
+    let diagnosis = diagnose(runtime, task, &mut session)?;
+    Ok((
+        incident_key(&diagnosis.facts(require_settled))?,
+        diagnosis.evidence,
+    ))
+}
+
+struct Diagnosis {
+    workspace: String,
+    episode: String,
+    cause: Option<String>,
+    failure: bool,
+    recovery_settled: bool,
+    coupled: bool,
+    diagnostic_origin: bool,
+    cancelled: bool,
+    evidence: Value,
+}
+
+impl Diagnosis {
+    fn facts(&self, require_settled: bool) -> IncidentFacts {
+        IncidentFacts {
+            workspace: self.workspace.clone(),
+            episode: Some(self.episode.clone()),
+            cause: self.cause.clone(),
+            failure: self.failure,
+            recovery_settled: !require_settled || self.recovery_settled,
+            current_failure_coupling: self.coupled,
+            diagnostic_origin: self.diagnostic_origin,
+            cancellation: self.cancelled,
+        }
+    }
+}
+
+fn diagnose(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    session: &mut IncidentSession,
+) -> Result<Diagnosis, AutomationError> {
+    session.stats.observes += 1;
+
     let run_id = task
         .job_run_id
         .as_deref()
         .ok_or_else(|| AutomationError::Deferred("human_block".into()))?;
 
-    let mut run = runtime.show_job_run(run_id)?;
+    let mut run = session.show_run(runtime, run_id)?;
     let coupled = failure_coupled(runtime, task, run_id)?;
     let cancelled = run.state == JobRunState::Cancelled;
     let failed = matches!(run.state, JobRunState::Failed | JobRunState::Timeout);
 
     let mut path_settled = true;
     let mut diagnostic_origin = is_diagnostic_origin(&run);
-    let mut episode = root(runtime, &run)?;
+    let mut episode = root(runtime, &run, session)?;
 
     // A blocking dispatch with a typed terminal child result is explicit
     // causality. Multiple failing children need separate obligations; ambiguous
@@ -105,11 +155,12 @@ fn observe_with_settlement(
             return Err(AutomationError::Deferred("incident_lineage_cycle".into()));
         }
 
-        path_settled &=
-            run.state.is_terminal() && run_owner_liveness(&run) == RunOwnerLiveness::Stopped;
+        let liveness = session.probe_liveness(&run);
+        path_settled &= run.state.is_terminal() && liveness == RunOwnerLiveness::Stopped;
         diagnostic_origin |= is_diagnostic_origin(&run);
 
-        let state = runtime.read_run_state(&run.run_id)?;
+        let state = session.run_state(runtime, &run.run_id)?;
+        session.note_run(&run, liveness, &state);
         path_settled &= state
             .as_ref()
             .is_none_or(|state| !state.child_dispatches.iter().any(|d| d.phase.is_open()));
@@ -139,8 +190,8 @@ fn observe_with_settlement(
             break;
         };
 
-        run = runtime.show_job_run(&child.child_run_id)?;
-        episode = root(runtime, &run)?;
+        run = session.show_run(runtime, &child.child_run_id)?;
+        episode = root(runtime, &run, session)?;
     }
 
     if seen.len() == 50 {
@@ -149,8 +200,8 @@ fn observe_with_settlement(
 
     // Collect the whole retry tree under the episode root: an incident is only
     // settled once every run in it has stopped.
-    let root_run = runtime
-        .get_job_run_backend(&episode)?
+    let root_run = session
+        .backend_run(runtime, &episode)?
         .ok_or_else(|| AutomationError::Deferred("incident_lineage_missing".into()))?;
 
     let mut related = vec![root_run];
@@ -158,10 +209,7 @@ fn observe_with_settlement(
     let mut index = 0;
 
     while index < related.len() {
-        let children = runtime
-            .stores()
-            .jobs()
-            .job_run_retries(&related[index].run_id, 51)?;
+        let children = session.retries(runtime, &related[index].run_id)?;
 
         if children.len() > 50 || related.len() + children.len() > 1000 {
             return Err(AutomationError::Deferred("incident_scan_budget".into()));
@@ -176,15 +224,21 @@ fn observe_with_settlement(
         index += 1;
     }
 
-    let settled = related
-        .iter()
-        .filter(|related| lineage.contains(&related.run_id))
-        .all(|related| {
-            related.state.is_terminal() && run_owner_liveness(related) == RunOwnerLiveness::Stopped
-        })
-        && run_owner_liveness(&run) == RunOwnerLiveness::Stopped;
+    let mut settled = true;
+    for related_run in &related {
+        if !lineage.contains(&related_run.run_id) {
+            continue;
+        }
+        let liveness = session.probe_liveness(related_run);
+        let state = session.run_state(runtime, &related_run.run_id)?;
+        session.note_run(related_run, liveness, &state);
+        settled &= related_run.state.is_terminal() && liveness == RunOwnerLiveness::Stopped;
+    }
 
-    let state = runtime.read_run_state(&run.run_id)?;
+    let cause_liveness = session.probe_liveness(&run);
+    let state = session.run_state(runtime, &run.run_id)?;
+    session.note_run(&run, cause_liveness, &state);
+    settled &= cause_liveness == RunOwnerLiveness::Stopped;
     let descendants_settled = state
         .as_ref()
         .is_none_or(|state| !state.child_dispatches.iter().any(|d| d.phase.is_open()));
@@ -196,30 +250,296 @@ fn observe_with_settlement(
         .find(|step| matches!(step.state, JobRunState::Failed | JobRunState::Timeout))
         .map(|step| format!("{}:{}:{}", episode, step.step_index, step.target_id));
 
-    let key = incident_key(&IncidentFacts {
+    Ok(Diagnosis {
         workspace: runtime.workspace_id()?,
-        episode: Some(episode.clone()),
+        episode: episode.clone(),
         cause,
         failure: failed && matches!(run.state, JobRunState::Failed | JobRunState::Timeout),
-        recovery_settled: !require_settled || (path_settled && settled && descendants_settled),
-        current_failure_coupling: coupled,
+        recovery_settled: path_settled && settled && descendants_settled,
+        coupled,
         diagnostic_origin,
-        cancellation: cancelled || run.state == JobRunState::Cancelled,
-    })?;
-
-    Ok((
-        key,
-        json!({"episode":episode,"cause_run_id":run.run_id,"coupled_run_id":run_id,
+        cancelled: cancelled || run.state == JobRunState::Cancelled,
+        evidence: json!({"episode":episode,"cause_run_id":run.run_id,"coupled_run_id":run_id,
         "task_revision":task.updated_at, "task_id":task.id}),
-    ))
+    })
 }
 
 /// Hydrate at most 1,000 blocked task envelopes to find the complete current
 /// cohort, including tasks coupled to different wrappers of the same cause.
 /// An incomplete inventory never certifies partial incident coverage.
-pub(crate) fn members(
-    runtime: &OrbitRuntime,
-) -> Result<std::collections::BTreeMap<String, Vec<String>>, AutomationError> {
+pub(crate) fn members(runtime: &OrbitRuntime) -> Result<IncidentMembers, AutomationError> {
+    IncidentSession::new().inventory(runtime)
+}
+
+/// Bounded reuse of incident inventory work for one `Host` evaluation.
+///
+/// Lifetime: one `members::evaluate` call. `Host::observe` may populate the
+/// session; `Host::admission` reuses that snapshot only after a freshness
+/// check against current blocked-task identities, related-run owner/state,
+/// retry children, child-dispatch tokens, and live liveness probes. Liveness
+/// is never cached by run ID across a changed owner/state observation. A
+/// failed freshness check rebuilds. Candidate fingerprint `observe` stays a
+/// fresh read so `material_changed` does not depend on the session.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct IncidentSession {
+    cached: Option<IncidentMembers>,
+    freshness: Option<FreshnessSnapshot>,
+    stats: IncidentWorkStats,
+    building: FreshnessSnapshot,
+    recording: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct IncidentWorkStats {
+    pub inventory_builds: usize,
+    pub inventory_reuses: usize,
+    pub task_reads: usize,
+    pub run_reads: usize,
+    pub liveness_probes: usize,
+    pub observes: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct FreshnessSnapshot {
+    tasks: Vec<TaskIdentity>,
+    runs: BTreeMap<String, RunIdentity>,
+    retries: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TaskIdentity {
+    id: String,
+    status: TaskStatus,
+    job_run_id: Option<String>,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RunIdentity {
+    state: JobRunState,
+    pid: Option<u32>,
+    pid_start_time: Option<String>,
+    liveness: RunOwnerLiveness,
+    child_dispatches: Vec<(String, String, bool, Option<String>, bool)>,
+}
+
+impl IncidentSession {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stats(&self) -> IncidentWorkStats {
+        self.stats.clone()
+    }
+
+    pub(crate) fn inventory(
+        &mut self,
+        runtime: &OrbitRuntime,
+    ) -> Result<IncidentMembers, AutomationError> {
+        if let Some(cached) = self.cached.clone()
+            && self.fresh(runtime)?
+        {
+            self.stats.inventory_reuses += 1;
+            return Ok(cached);
+        }
+
+        let built = self.rebuild(runtime)?;
+        self.cached = Some(built.clone());
+        Ok(built)
+    }
+
+    fn rebuild(&mut self, runtime: &OrbitRuntime) -> Result<IncidentMembers, AutomationError> {
+        self.stats.inventory_builds += 1;
+        self.recording = true;
+        self.building = FreshnessSnapshot::default();
+
+        let listed = blocked_candidates(runtime)?;
+        self.building.tasks = listed.items.iter().map(envelope_identity).collect();
+
+        let mut members: IncidentMembers = BTreeMap::new();
+        let mut unsettled = BTreeSet::new();
+
+        for candidate in &listed.items {
+            let task = self.read_task(runtime, &candidate.id)?;
+            if let Ok(diagnosis) = diagnose(runtime, &task, self) {
+                if let Ok(key) = incident_key(&diagnosis.facts(true)) {
+                    members.entry(key).or_default().push(task.id);
+                } else if let Ok(key) = incident_key(&diagnosis.facts(false)) {
+                    unsettled.insert(key);
+                }
+            }
+        }
+
+        // An incident with any still-unsettled member is not yet diagnosable at all.
+        members.retain(|key, _| !unsettled.contains(key));
+
+        for ids in members.values_mut() {
+            ids.sort();
+        }
+
+        self.recording = false;
+        self.freshness = Some(std::mem::take(&mut self.building));
+        Ok(members)
+    }
+
+    fn fresh(&mut self, runtime: &OrbitRuntime) -> Result<bool, AutomationError> {
+        let Some(snapshot) = self.freshness.clone() else {
+            return Ok(false);
+        };
+
+        let listed = blocked_candidates(runtime)?;
+        let tasks: Vec<_> = listed.items.iter().map(envelope_identity).collect();
+        if tasks != snapshot.tasks {
+            return Ok(false);
+        }
+
+        for (run_id, expected) in &snapshot.runs {
+            let Some(run) = self.backend_run(runtime, run_id)? else {
+                return Ok(false);
+            };
+            let liveness = self.probe_liveness(&run);
+            if run.state != expected.state
+                || run.pid != expected.pid
+                || run.pid_start_time != expected.pid_start_time
+                || liveness != expected.liveness
+            {
+                return Ok(false);
+            }
+
+            let state = self.run_state(runtime, run_id)?;
+            if child_dispatch_token(state.as_ref()) != expected.child_dispatches {
+                return Ok(false);
+            }
+        }
+
+        for (run_id, expected) in &snapshot.retries {
+            let children = self.retries(runtime, run_id)?;
+            let mut child_ids: Vec<String> =
+                children.iter().map(|child| child.run_id.clone()).collect();
+            child_ids.sort();
+            if &child_ids != expected {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn read_task(&mut self, runtime: &OrbitRuntime, id: &str) -> Result<Task, AutomationError> {
+        self.stats.task_reads += 1;
+        Ok(runtime.get_task(id)?)
+    }
+
+    fn show_run(
+        &mut self,
+        runtime: &OrbitRuntime,
+        run_id: &str,
+    ) -> Result<JobRun, AutomationError> {
+        self.stats.run_reads += 1;
+        Ok(runtime.show_job_run(run_id)?)
+    }
+
+    fn backend_run(
+        &mut self,
+        runtime: &OrbitRuntime,
+        run_id: &str,
+    ) -> Result<Option<JobRun>, AutomationError> {
+        self.stats.run_reads += 1;
+        Ok(runtime.get_job_run_backend(run_id)?)
+    }
+
+    fn run_state(
+        &mut self,
+        runtime: &OrbitRuntime,
+        run_id: &str,
+    ) -> Result<Option<PipelineState>, AutomationError> {
+        self.stats.run_reads += 1;
+        Ok(runtime.read_run_state(run_id)?)
+    }
+
+    fn retries(
+        &mut self,
+        runtime: &OrbitRuntime,
+        run_id: &str,
+    ) -> Result<Vec<JobRun>, AutomationError> {
+        self.stats.run_reads += 1;
+        let children = runtime.stores().jobs().job_run_retries(run_id, 51)?;
+        if self.recording {
+            let mut ids: Vec<String> = children.iter().map(|child| child.run_id.clone()).collect();
+            ids.sort();
+            self.building.retries.insert(run_id.to_string(), ids);
+        }
+        Ok(children)
+    }
+
+    fn probe_liveness(&mut self, run: &JobRun) -> RunOwnerLiveness {
+        self.stats.liveness_probes += 1;
+        run_owner_liveness(run)
+    }
+
+    fn note_run(
+        &mut self,
+        run: &JobRun,
+        liveness: RunOwnerLiveness,
+        state: &Option<PipelineState>,
+    ) {
+        if !self.recording {
+            return;
+        }
+        self.building
+            .runs
+            .entry(run.run_id.clone())
+            .and_modify(|identity| {
+                identity.state = run.state;
+                identity.pid = run.pid;
+                identity.pid_start_time = run.pid_start_time.clone();
+                identity.liveness = liveness;
+                identity.child_dispatches = child_dispatch_token(state.as_ref());
+            })
+            .or_insert(RunIdentity {
+                state: run.state,
+                pid: run.pid,
+                pid_start_time: run.pid_start_time.clone(),
+                liveness,
+                child_dispatches: child_dispatch_token(state.as_ref()),
+            });
+    }
+}
+
+fn envelope_identity(task: &TaskEnvelopeV2) -> TaskIdentity {
+    TaskIdentity {
+        id: task.id.clone(),
+        status: task.status,
+        job_run_id: task.job_run_id.clone(),
+        updated_at: task.updated_at,
+    }
+}
+
+fn child_dispatch_token(
+    state: Option<&PipelineState>,
+) -> Vec<(String, String, bool, Option<String>, bool)> {
+    let Some(state) = state else {
+        return Vec::new();
+    };
+    let mut rows: Vec<_> = state
+        .child_dispatches
+        .iter()
+        .map(|dispatch| {
+            (
+                dispatch.child_run_id.clone(),
+                dispatch.phase.as_str().to_string(),
+                dispatch.blocking,
+                dispatch.child_status.clone(),
+                dispatch.phase.is_open(),
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn blocked_candidates(runtime: &OrbitRuntime) -> Result<TaskCandidates, AutomationError> {
     let candidates = runtime.task_candidates(
         &orbit_store::contracts::TaskListFilter {
             statuses: Some(vec![TaskStatus::Blocked]),
@@ -234,24 +554,5 @@ pub(crate) fn members(
         ));
     }
 
-    let mut members: std::collections::BTreeMap<String, Vec<String>> = Default::default();
-    let mut unsettled = BTreeSet::new();
-
-    for candidate in candidates.items {
-        let task = runtime.get_task(&candidate.id)?;
-        if let Ok((key, _)) = observe(runtime, &task) {
-            members.entry(key).or_default().push(task.id);
-        } else if let Ok((key, _)) = observe_with_settlement(runtime, &task, false) {
-            unsettled.insert(key);
-        }
-    }
-
-    // An incident with any still-unsettled member is not yet diagnosable at all.
-    members.retain(|key, _| !unsettled.contains(key));
-
-    for ids in members.values_mut() {
-        ids.sort();
-    }
-
-    Ok(members)
+    Ok(candidates)
 }

--- a/crates/orbit-core/src/application/automation/members.rs
+++ b/crates/orbit-core/src/application/automation/members.rs
@@ -18,6 +18,7 @@ use orbit_types::{
     },
 };
 use serde_json::{Value, json};
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 pub(crate) fn evaluate(
@@ -55,10 +56,7 @@ pub(crate) fn evaluate(
 
     members::evaluate(
         runtime.automation_store()?.as_ref(),
-        &Host {
-            runtime,
-            trigger: &effective,
-        },
+        &Host::new(runtime, &effective),
         MemberEvaluation {
             consumer: &consumer,
             epoch: &epoch,
@@ -72,9 +70,25 @@ pub(crate) fn evaluate(
     .map_err(automation_error_to_orbit)
 }
 
-struct Host<'a> {
+pub(crate) struct Host<'a> {
     runtime: &'a OrbitRuntime,
     trigger: &'a StateTrigger,
+    incidents: RefCell<super::incidents::IncidentSession>,
+}
+
+impl<'a> Host<'a> {
+    pub(crate) fn new(runtime: &'a OrbitRuntime, trigger: &'a StateTrigger) -> Self {
+        Self {
+            runtime,
+            trigger,
+            incidents: RefCell::new(super::incidents::IncidentSession::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn incident_work_stats(&self) -> super::incidents::IncidentWorkStats {
+        self.incidents.borrow().stats()
+    }
 }
 
 impl MemberHost for Host<'_> {
@@ -160,9 +174,12 @@ impl MemberHost for Host<'_> {
                                 continue;
                             }
 
-                            // The full cohort is hydrated at most once per page.
+                            // The full cohort is hydrated at most once per page
+                            // and reused across later admissions in this Host
+                            // after a freshness check.
                             if incident_inventory.is_none() {
-                                incident_inventory = Some(super::incidents::members(self.runtime)?);
+                                incident_inventory =
+                                    Some(self.incidents.borrow_mut().inventory(self.runtime)?);
                             }
 
                             let task_ids = incident_inventory
@@ -208,7 +225,12 @@ impl MemberHost for Host<'_> {
 
     fn admission(&self, member: &StateMember) -> Result<MemberAdmission, AutomationError> {
         if self.trigger.kind == StateTriggerKind::ExecutionFailed
-            && super::incidents::members(self.runtime)?.get(&member.key) != Some(&member.task_ids)
+            && self
+                .incidents
+                .borrow_mut()
+                .inventory(self.runtime)?
+                .get(&member.key)
+                != Some(&member.task_ids)
         {
             return Ok(MemberAdmission::Retire(
                 "incident_membership_or_recovery_changed".into(),

--- a/crates/orbit-core/src/application/automation/tests/members.rs
+++ b/crates/orbit-core/src/application/automation/tests/members.rs
@@ -1,0 +1,370 @@
+//! Host observe/admission fixtures for incident inventory reuse [ORB-11633].
+
+use super::super::members::Host;
+use crate::OrbitRuntime;
+use chrono::Utc;
+use orbit_automation::members::{MemberAdmission, MemberHost};
+use orbit_engine::{RuntimeHost, TaskAutomationUpdate};
+use orbit_store::{JobRunStepParams, TaskCreateParams, TaskReservationReleaseReason};
+use orbit_types::{
+    task::{TaskPriority, TaskStatus, TaskType},
+    workflow::{
+        ChildDispatch, ChildDispatchPhase, JobRunState, JobTargetType, PipelineState,
+        automation::members::{StateTrigger, StateTriggerKind},
+    },
+};
+use serde_json::json;
+use std::{path::Path, process::Command};
+use tempfile::tempdir;
+
+const PIPELINE_JOB: &str = "task_pr_pipeline";
+const FAILING_STEP: &str = "cli subprocess reported envelope status=\"failed\" despite exit 0";
+
+fn git(root: &Path, args: &[&str]) -> String {
+    let result = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    String::from_utf8(result.stdout).unwrap().trim().into()
+}
+
+fn test_runtime() -> (tempfile::TempDir, OrbitRuntime, std::path::PathBuf) {
+    let root = tempdir().expect("create tempdir");
+    let global_root = root.path().join("global");
+    let repo_root = root.path().join("repo");
+    let workspace_root = repo_root.join(".orbit");
+    std::fs::create_dir_all(&global_root).expect("create global root");
+    std::fs::create_dir_all(&workspace_root).expect("create workspace root");
+    git(&repo_root, &["init", "--initial-branch=agent-main"]);
+    git(&repo_root, &["config", "user.name", "Test"]);
+    git(
+        &repo_root,
+        &["config", "user.email", "test@example.invalid"],
+    );
+    std::fs::write(repo_root.join("sample.txt"), "baseline").unwrap();
+    git(&repo_root, &["add", "sample.txt"]);
+    git(&repo_root, &["commit", "-m", "baseline"]);
+    let runtime = OrbitRuntime::from_roots(&global_root, &workspace_root)
+        .expect("build test runtime")
+        .with_automation_machine_identity(Some("fixture-machine".into()));
+    (root, runtime, repo_root)
+}
+
+fn trigger() -> StateTrigger {
+    StateTrigger {
+        kind: StateTriggerKind::ExecutionFailed,
+        owner_machine: "fixture-machine".into(),
+        branch: "agent-main".into(),
+        debounce_minutes: 1,
+        max_wait_minutes: 10,
+        max_items: 50,
+        retries: 0,
+        deadline_minutes: 30,
+    }
+}
+
+fn create_backlog_task(runtime: &OrbitRuntime, repo_root: &Path, id_hint: &str) -> String {
+    runtime
+        .stores()
+        .task_records()
+        .create(TaskCreateParams {
+            actor: "test".into(),
+            parent_id: None,
+            title: format!("task {id_hint}"),
+            description: "test".into(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            relations: Vec::new(),
+            tags: Vec::new(),
+            required_tools: Vec::new(),
+            plan: "test plan".into(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: Some(repo_root.to_string_lossy().into_owned()),
+            repo_root: None,
+            created_by: Some("test".into()),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Backlog,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
+            orchestrator: None,
+            comments: Vec::new(),
+        })
+        .expect("create task")
+        .id
+}
+
+fn fail_pipeline_attempt(
+    runtime: &OrbitRuntime,
+    task_id: &str,
+    retry: Option<String>,
+    pid: u32,
+) -> String {
+    let run = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(PIPELINE_JOB, 1, Utc::now(), None, retry)
+        .expect("insert pipeline run");
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&run.run_id, Utc::now(), pid)
+        .expect("mark run running");
+    runtime
+        .apply_task_automation_update(
+            task_id,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::InProgress),
+                job_run_id: Some(run.run_id.clone()),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("couple task to run");
+    let now = Utc::now();
+    runtime
+        .stores()
+        .jobs()
+        .complete_job_run_step(
+            &run.run_id,
+            &JobRunStepParams {
+                step_index: 0,
+                target_type: JobTargetType::Activity,
+                target_id: "agent_implement".into(),
+                started_at: now,
+                finished_at: now,
+                duration_ms: Some(1),
+                exit_code: Some(1),
+                agent_response_json: None,
+                state: JobRunState::Failed,
+                error_code: Some("STEP_FAILED".into()),
+                error_message: Some(FAILING_STEP.into()),
+            },
+        )
+        .expect("record failing step");
+    runtime
+        .finalize_job_run_with_reservation_cleanup(
+            &run.run_id,
+            JobRunState::Failed,
+            Utc::now(),
+            Some(1),
+            TaskReservationReleaseReason::RunTerminal,
+        )
+        .expect("finalize failed run");
+    run.run_id
+}
+
+fn dead_pid() -> u32 {
+    i32::MAX as u32
+}
+
+fn assert_retire(admission: MemberAdmission, expected: &str) {
+    match admission {
+        MemberAdmission::Retire(reason) => assert_eq!(reason, expected),
+        MemberAdmission::Admit => panic!("admitted instead of retire {expected}"),
+        MemberAdmission::Withhold(reason) => {
+            panic!("withheld {reason} instead of retire {expected}")
+        }
+    }
+}
+
+fn couple_parent_to_child(
+    runtime: &OrbitRuntime,
+    parent_task: &str,
+    child_run: &str,
+    pid: u32,
+) -> String {
+    let parent = fail_pipeline_attempt(runtime, parent_task, None, pid);
+    let mut state = PipelineState::new(parent.clone(), PIPELINE_JOB.into(), json!({}));
+    let mut dispatch = ChildDispatch::submitted(
+        child_run.into(),
+        PIPELINE_JOB.into(),
+        "invoke".into(),
+        true,
+        false,
+        Utc::now(),
+    );
+    dispatch.phase = ChildDispatchPhase::Terminal;
+    dispatch.child_status = Some("failed".into());
+    state.record_child_dispatch(dispatch);
+    runtime.write_run_state(&parent, &state).unwrap();
+    parent
+}
+
+#[test]
+fn stale_membership_between_observe_and_admission_is_retired() {
+    let (_root, runtime, repo) = test_runtime();
+    let child_task = create_backlog_task(&runtime, &repo, "child");
+    let child = fail_pipeline_attempt(&runtime, &child_task, None, dead_pid());
+    let parent_task = create_backlog_task(&runtime, &repo, "parent");
+    couple_parent_to_child(&runtime, &parent_task, &child, dead_pid());
+
+    let trigger = trigger();
+    let host = Host::new(&runtime, &trigger);
+    let page = host.observe(None, Utc::now()).unwrap();
+    assert_eq!(page.candidates.len(), 1);
+    let member = page.candidates[0].clone();
+    assert_eq!(member.task_ids.len(), 2);
+
+    runtime
+        .apply_task_automation_update(
+            &parent_task,
+            TaskAutomationUpdate {
+                status: Some(TaskStatus::Backlog),
+                ..TaskAutomationUpdate::default()
+            },
+        )
+        .expect("drop parent from the blocked cohort");
+
+    assert_retire(
+        host.admission(&member).unwrap(),
+        "incident_membership_or_recovery_changed",
+    );
+}
+
+#[test]
+fn stale_recovery_cannot_authorize_and_material_changed_still_fires() {
+    let (_root, runtime, repo) = test_runtime();
+    let task = create_backlog_task(&runtime, &repo, "settled");
+    let run_id = fail_pipeline_attempt(&runtime, &task, None, dead_pid());
+
+    let trigger = trigger();
+    let host = Host::new(&runtime, &trigger);
+    let page = host.observe(None, Utc::now()).unwrap();
+    let member = page.candidates[0].clone();
+    assert!(matches!(
+        host.admission(&member).unwrap(),
+        MemberAdmission::Admit
+    ));
+
+    let mut stale_fingerprint = member.clone();
+    stale_fingerprint.fingerprint = "not-the-incident-key".into();
+    assert_retire(
+        host.admission(&stale_fingerprint).unwrap(),
+        "material_changed",
+    );
+
+    let retry = runtime
+        .stores()
+        .jobs()
+        .insert_job_run(PIPELINE_JOB, 2, Utc::now(), None, Some(run_id))
+        .unwrap();
+    runtime
+        .stores()
+        .jobs()
+        .mark_job_run_running(&retry.run_id, Utc::now(), std::process::id())
+        .unwrap();
+
+    match host.admission(&member).unwrap() {
+        MemberAdmission::Admit => panic!("stale recovery evidence authorized the candidate"),
+        MemberAdmission::Retire(_) | MemberAdmission::Withhold(_) => {}
+    }
+}
+
+#[test]
+fn multi_candidate_admission_reuses_inventory_after_freshness_check() {
+    let (_root, runtime, repo) = test_runtime();
+    for hint in ["a", "b", "c"] {
+        let task = create_backlog_task(&runtime, &repo, hint);
+        fail_pipeline_attempt(&runtime, &task, None, dead_pid());
+    }
+
+    let trigger = trigger();
+    let host = Host::new(&runtime, &trigger);
+    let page = host.observe(None, Utc::now()).unwrap();
+    assert_eq!(page.candidates.len(), 3);
+    let after_observe = host.incident_work_stats();
+    assert_eq!(
+        after_observe.inventory_builds, 1,
+        "observe hydrates the blocked cohort once"
+    );
+    assert_eq!(after_observe.inventory_reuses, 0);
+    let observe_observes = after_observe.observes;
+    let observe_task_reads = after_observe.task_reads;
+    let observe_run_reads = after_observe.run_reads;
+    let observe_probes = after_observe.liveness_probes;
+
+    for candidate in &page.candidates {
+        assert!(matches!(
+            host.admission(candidate).unwrap(),
+            MemberAdmission::Admit
+        ));
+    }
+
+    let stats = host.incident_work_stats();
+    // Reuse lifetime: one Host / evaluate. Observe may populate the session.
+    // Admission reuses that snapshot only after re-listing blocked-task
+    // identities and re-probing related-run owner/state, retry children,
+    // child-dispatch tokens, and liveness. A changed token rebuilds.
+    // Fingerprint observe of each candidate's task_ids stays a fresh read
+    // (not counted in session.observes). This is not "exactly one inventory
+    // per evaluation": a freshness miss rebuilds, and a later evaluation
+    // uses a new Host.
+    assert_eq!(
+        stats.inventory_builds, 1,
+        "unchanged world must not rebuild per candidate"
+    );
+    assert!(
+        stats.inventory_reuses >= page.candidates.len(),
+        "each admission should reuse after a freshness check, reuses={}",
+        stats.inventory_reuses
+    );
+    assert_eq!(
+        stats.observes, observe_observes,
+        "inventory diagnose must not rerun per admission"
+    );
+
+    let naive_builds = 1 + page.candidates.len();
+    let naive_inventory_observes = observe_observes * naive_builds;
+    assert!(
+        stats.inventory_builds < naive_builds,
+        "previous path rebuilt inventory on every admission"
+    );
+    assert!(
+        stats.observes < naive_inventory_observes,
+        "previous path re-walked lineage for every blocked task on every admission"
+    );
+    assert!(
+        stats.task_reads < observe_task_reads * naive_builds,
+        "freshness listing is cheaper than hydrating every blocked task again"
+    );
+    assert!(
+        stats.run_reads < observe_run_reads * naive_builds
+            || stats.liveness_probes < observe_probes * naive_builds,
+        "freshness re-reads known runs and re-probes liveness without repeating the full lineage walk"
+    );
+}
+
+#[test]
+fn live_owner_keeps_incomplete_cohort_from_certifying_coverage() {
+    let (_root, runtime, repo) = test_runtime();
+    let child_task = create_backlog_task(&runtime, &repo, "child");
+    let child = fail_pipeline_attempt(&runtime, &child_task, None, dead_pid());
+    let parent_task = create_backlog_task(&runtime, &repo, "live-parent");
+    couple_parent_to_child(&runtime, &parent_task, &child, std::process::id());
+
+    let trigger = trigger();
+    let host = Host::new(&runtime, &trigger);
+    let page = host.observe(None, Utc::now()).unwrap();
+    assert!(
+        page.candidates.is_empty(),
+        "an unsettled member must not certify a partial cohort"
+    );
+    assert!(
+        page.withheld
+            .values()
+            .any(|reason| reason == "incident_recovery_pending"),
+        "incomplete recovery stays withheld: {:?}",
+        page.withheld
+    );
+}

--- a/crates/orbit-core/src/application/automation/tests/mod.rs
+++ b/crates/orbit-core/src/application/automation/tests/mod.rs
@@ -1,1 +1,3 @@
 mod consumer;
+#[cfg(unix)]
+mod members;


### PR DESCRIPTION
## Task

[ORB-11633](https://orbit-cli.com/tasks/ORB-11633) — [code-review] Reduce repeated incident inventory work while preserving live admission checks

### Description

## Problem
`Host::observe` builds an incident inventory once per page, but `Host::admission` rebuilds the complete blocked-task cohort for each candidate. Inventory construction hydrates tasks and traverses related run/recovery evidence, multiplying reads and process probes.

## Required behavior
Reduce repeated inventory and lineage work without weakening admission's current membership/recovery check. An observation-time snapshot must not authorize a cohort that changed before admission. Reuse immutable evidence or introduce bounded reuse with authoritative freshness validation/invalidation; keep fresh checks for mutable membership, recovery settlement, and owner liveness where required. Do not cache run liveness by run ID across changing owner/state observations. If no safe reuse mechanism exists for a portion of the inventory, retain that fresh read and optimize the independent repeated work instead.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/application/automation/members.rs:163`, `:210`, `:216`; `crates/orbit-core/src/application/automation/incidents.rs:224`, `:242`.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- A deterministic fixture changes incident membership between observation and admission; stale membership is retired with the existing incident_membership_or_recovery_changed behavior.
- A fixture changes recovery/settlement or relevant run ownership before admission; stale evidence cannot authorize the candidate. Existing material_changed behavior remains intact.
- A bounded multi-candidate test measures task/run reads or probes and demonstrates reduced repeated work against the previous path; document the reuse lifetime and freshness checks rather than requiring exactly one inventory per evaluation.
- Existing automation consumer and incident tests pass, including incomplete-cohort/budget handling.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a per-Host `IncidentSession` so ExecutionFailed inventory is reused across observe and later admissions in one `members::evaluate` call.
- Admission still authorizes only after a freshness check of blocked-task envelopes, related-run owner/state, retry children, child-dispatch tokens, and live liveness probes. Liveness is re-probed and is never keyed only by run ID. A changed token rebuilds. Candidate fingerprint `observe` stays a fresh read so `material_changed` is unchanged.
- Inventory construction diagnoses each blocked task once (settled then forced-unsettled key) instead of walking lineage twice.
- `incidents::members` remains a one-shot fresh build for triage and other callers.

Criteria:
1. Membership change between observe and admission: `stale_membership_between_observe_and_admission_is_retired` unblocks a parent after observe; admission retires `incident_membership_or_recovery_changed`.
2. Recovery/settlement or live owner before admission: `stale_recovery_cannot_authorize_and_material_changed_still_fires` inserts a live retry and refuses Admit; a wrong fingerprint with matching membership still retires `material_changed`. Live-parent incomplete cohort stays `incident_recovery_pending`.
3. Multi-candidate reuse: three independent incidents, one inventory build at observe, each admission reuses after freshness (`inventory_builds` stays 1, `inventory_reuses` >= 3, inventory `observes` do not grow). Documented on `IncidentSession` and in that test: reuse lasts one Host/evaluate; a freshness miss rebuilds; a later evaluate uses a new Host.
4. Existing consumer, orbit-automation members, and state_incident triage tests passed, including incomplete-cohort handling.

Validation:
- `cargo test -p orbit-core --lib application::automation::tests::members`: passed (4)
- `cargo test -p orbit-core --lib -- application::automation::tests::consumer state_incident`: passed (16)
- `cargo test -p orbit-automation --lib members`: passed (10)
- `make ci-fast`: passed
- `make ci-lint`: passed
- `git diff --check`: passed

Assessment: Scoped to the Core incident adapter. Admission contracts and output reasons are unchanged.
Strategic decisions: Bounded session reuse with fail-closed freshness rather than a single inventory per evaluation or caching liveness by run ID.
Design weaknesses / risks:
- Severity: low. History-only coupling edits that do not change blocked-task envelopes or related-run tokens are not part of the inventory freshness token; they still go through the per-candidate fingerprint observe. Mitigation: fail closed on any envelope/run/liveness/retry/dispatch change.
Deviations from original plan: none material; no separate `tests/incidents.rs` because Host fixtures cover the criteria.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11633-6a9f7389`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra