### PR TITLE
Repair global --workspace collision with search scope after ORB-11598

### DIFF
--- a/crates/orbit-cli/src/command/search.rs
+++ b/crates/orbit-cli/src/command/search.rs
@@ -45,10 +45,10 @@ pub struct SearchCommand {
     /// came from. Accepts a registered name, a `ws_*` ID, or an absolute
     /// checkout path. Distinct from the top-level `orbit --workspace`, which
     /// binds the whole invocation to one checkout.
-    #[arg(long = "workspace", action = ArgAction::Append, value_delimiter = ',', value_name = "SELECTOR")]
+    #[arg(long, action = ArgAction::Append, value_delimiter = ',', value_name = "SELECTOR")]
     pub workspaces: Vec<String>,
     /// Search every active workspace registered on this machine. Overrides
-    /// `--workspace`.
+    /// `--workspaces`.
     #[arg(long)]
     pub all_workspaces: bool,
     /// Output as JSON.

--- a/crates/orbit-cli/src/command/tests/friction_help/add.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/add.txt
@@ -6,6 +6,7 @@ Options:
       --body <BODY>                Markdown body describing what happened and why it caused friction
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --title <TITLE>              One-line record handle, max 120 chars; derived when omitted
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
       --tag <TAGS>                 Friction taxonomy tag; repeat or comma-separate for multiple tags
       --during-task <DURING_TASK>  Optional task ID being worked on when friction occurred
       --model <MODEL>              Agent family to attribute the record to (`codex`, `claude`, `gemini`, or `grok`)

--- a/crates/orbit-cli/src/command/tests/friction_help/list.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/list.txt
@@ -3,15 +3,16 @@ List friction records
 Usage: orbit friction list [OPTIONS]
 
 Options:
-      --model <MODEL>    Optional model filter
-      --root <ROOT>      Override the Orbit root directory (highest precedence)
-      --status <STATUS>  Optional status filter: open, triaged, or resolved
-      --tag <TAG>        Optional tag filter
-      --month <MONTH>    Optional YYYY-MM month filter for reported records
-      --q <Q>            Optional case-insensitive query over id, model, tags, status, task, and body
-      --from <FROM>      Optional RFC3339 lower bound for created_at
-      --to <TO>          Optional RFC3339 upper bound for created_at
-      --limit <LIMIT>    Optional maximum number of records to return
-      --offset <OFFSET>  Optional number of records to skip
-      --json             Output as JSON
-  -h, --help             Print help
+      --model <MODEL>         Optional model filter
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --status <STATUS>       Optional status filter: open, triaged, or resolved
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --tag <TAG>             Optional tag filter
+      --month <MONTH>         Optional YYYY-MM month filter for reported records
+      --q <Q>                 Optional case-insensitive query over id, model, tags, status, task, and body
+      --from <FROM>           Optional RFC3339 lower bound for created_at
+      --to <TO>               Optional RFC3339 upper bound for created_at
+      --limit <LIMIT>         Optional maximum number of records to return
+      --offset <OFFSET>       Optional number of records to skip
+      --json                  Output as JSON
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/resolve.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/resolve.txt
@@ -6,6 +6,7 @@ Arguments:
   <ID>  Friction record ID, e.g. FYYYY-MM-NNN
 
 Options:
-      --json         Output as JSON
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --json                  Output as JSON
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/root.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/root.txt
@@ -12,5 +12,6 @@ Commands:
   resolve  Mark a friction record as resolved
 
 Options:
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/show.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/show.txt
@@ -6,6 +6,7 @@ Arguments:
   <ID>  Friction record ID, e.g. FYYYY-MM-NNN
 
 Options:
-      --json         Output as JSON
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --json                  Output as JSON
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/stats.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/stats.txt
@@ -3,6 +3,7 @@ Compute friction rates
 Usage: orbit friction stats [OPTIONS]
 
 Options:
-      --json         Output as JSON
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --json                  Output as JSON
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/tags.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/tags.txt
@@ -3,6 +3,7 @@ List configured friction taxonomy tags
 Usage: orbit friction tags [OPTIONS]
 
 Options:
-      --json         Output as JSON
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --json                  Output as JSON
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/friction_help/update.txt
+++ b/crates/orbit-cli/src/command/tests/friction_help/update.txt
@@ -6,10 +6,11 @@ Arguments:
   <ID>  Friction record ID, e.g. FYYYY-MM-NNN
 
 Options:
-      --root <ROOT>      Override the Orbit root directory (highest precedence)
-      --status <STATUS>  Optional status: open, triaged, or resolved
-      --tag <TAGS>       Optional replacement taxonomy tag; repeat or comma-separate for multiple tags
-      --body <BODY>      Optional replacement markdown body
-      --title <TITLE>    Optional replacement title, max 120 chars; empty restores derivation
-      --json             Output as JSON
-  -h, --help             Print help
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --status <STATUS>       Optional status: open, triaged, or resolved
+      --tag <TAGS>            Optional replacement taxonomy tag; repeat or comma-separate for multiple tags
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+      --body <BODY>           Optional replacement markdown body
+      --title <TITLE>         Optional replacement title, max 120 chars; empty restores derivation
+      --json                  Output as JSON
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/mod.rs
+++ b/crates/orbit-cli/src/command/tests/mod.rs
@@ -10,6 +10,7 @@ mod locks;
 mod operation;
 mod operation_args;
 mod operation_mode;
+mod search;
 mod sweep;
 
 use std::path::Path;
@@ -70,6 +71,14 @@ fn assert_help_tree_has_no_concrete_artifact_ids(command: &Command) {
 #[test]
 fn recursive_cli_help_uses_only_placeholder_artifact_ids() {
     assert_help_tree_has_no_concrete_artifact_ids(&Cli::command());
+}
+
+#[test]
+fn cli_command_tree_debug_assert_rejects_duplicate_long_flags() {
+    // Clap only panics on colliding long names during command build. Keep an
+    // explicit whole-tree check so a new global/subcommand overlap fails here
+    // instead of in an unrelated parser or help snapshot [ORB-11765].
+    Cli::command().debug_assert();
 }
 
 #[test]

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/enable.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/enable.txt
@@ -9,6 +9,8 @@ Options:
           Task in the finite scope; repeat or comma-separate (at most 50)
       --for <WINDOW>
           Admission window from now, e.g. `30m`, `2h` (at most 24h)
+      --workspace <SELECTOR>
+          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
       --right <RIGHTS>
           Right to grant: prepare, promote, or complete; repeat or comma-separate
       --preset <PRESET>

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/explain.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/explain.txt
@@ -9,6 +9,8 @@ Options:
           Override the Orbit root directory (highest precedence)
       --completion <COMPLETION>
           Run-layer completion preference: review or done (an explicit done past the delivery cap is refused)
+      --workspace <SELECTOR>
+          Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
       --leaf-ceiling <LEAF_CEILING>
           Run-layer ceiling on concurrently live leaf runs
       --recovery-episodes <RECOVERY_EPISODES>

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/list.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/list.txt
@@ -3,7 +3,8 @@ List recent operation-mode grants
 Usage: orbit operation list [OPTIONS]
 
 Options:
-      --limit <LIMIT>  Maximum number of grants to return (default 20)
-      --root <ROOT>    Override the Orbit root directory (highest precedence)
-      --json           Output as JSON
-  -h, --help           Print help
+      --limit <LIMIT>         Maximum number of grants to return (default 20)
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --json                  Output as JSON
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/revoke.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/revoke.txt
@@ -6,6 +6,7 @@ Options:
       --id <ID>                    Grant ID; defaults to the workspace's active grant
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --reason <REASON>            Reason recorded with the revocation
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
       --if-revision <IF_REVISION>  Apply only if the grant is still at this revision
       --claim-token <CLAIM_TOKEN>  Token for this workspace's exclusive claim, when another operator holds one
       --json                       Output as JSON

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/root.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/root.txt
@@ -11,8 +11,9 @@ Commands:
   revoke   Hard-revoke a grant (admitted work loses privileged actions)
 
 Options:
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help
 
 Preferences live under `[operation]` in config.toml and authorize nothing by
 themselves. `orbit operation enable` records the one durable grant: a finite

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/show.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/show.txt
@@ -6,6 +6,7 @@ Arguments:
   <ID>  Grant ID, as printed by `orbit operation list`
 
 Options:
-      --json         Output as JSON
-      --root <ROOT>  Override the Orbit root directory (highest precedence)
-  -h, --help         Print help
+      --json                  Output as JSON
+      --root <ROOT>           Override the Orbit root directory (highest precedence)
+      --workspace <SELECTOR>  Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
+  -h, --help                  Print help

--- a/crates/orbit-cli/src/command/tests/operation_mode_help/stop.txt
+++ b/crates/orbit-cli/src/command/tests/operation_mode_help/stop.txt
@@ -6,6 +6,7 @@ Options:
       --id <ID>                    Grant ID; defaults to the workspace's active grant
       --root <ROOT>                Override the Orbit root directory (highest precedence)
       --reason <REASON>            Reason recorded with the stop
+      --workspace <SELECTOR>       Select a workspace by registered name, logical ID (`ws_*`), or absolute checkout path. Distinct from `--root`, which overrides the Orbit data directory
       --if-revision <IF_REVISION>  Apply only if the grant is still at this revision
       --claim-token <CLAIM_TOKEN>  Token for this workspace's exclusive claim, when another operator holds one
       --json                       Output as JSON

--- a/crates/orbit-cli/src/command/tests/search.rs
+++ b/crates/orbit-cli/src/command/tests/search.rs
@@ -1,0 +1,116 @@
+use clap::{CommandFactory, Parser};
+
+use super::super::{Cli, Commands};
+
+#[test]
+fn search_workspaces_flag_is_repeatable_and_comma_delimited() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "search",
+        "query",
+        "--workspaces",
+        "alpha",
+        "--workspaces",
+        "beta,gamma",
+    ]);
+    assert_eq!(cli.workspace.as_deref(), None);
+    match cli.command {
+        Commands::Search(args) => {
+            assert_eq!(args.query.as_deref(), Some("query"));
+            assert_eq!(
+                args.workspaces,
+                vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
+            );
+            assert!(!args.all_workspaces);
+        }
+        _ => panic!("expected top-level search command"),
+    }
+}
+
+#[test]
+fn global_workspace_and_search_workspaces_are_distinct() {
+    let cli = Cli::parse_from([
+        "orbit",
+        "--workspace",
+        "bound",
+        "search",
+        "query",
+        "--workspaces",
+        "alpha",
+        "--workspaces",
+        "beta",
+    ]);
+    assert_eq!(cli.workspace.as_deref(), Some("bound"));
+    match cli.command {
+        Commands::Search(args) => {
+            assert_eq!(
+                args.workspaces,
+                vec!["alpha".to_string(), "beta".to_string()]
+            );
+            assert!(!args.all_workspaces);
+        }
+        _ => panic!("expected top-level search command"),
+    }
+}
+
+#[test]
+fn post_subcommand_workspace_binds_global_routing_not_search_scope() {
+    let cli = Cli::parse_from(["orbit", "search", "query", "--workspace", "bound"]);
+    assert_eq!(cli.workspace.as_deref(), Some("bound"));
+    match cli.command {
+        Commands::Search(args) => {
+            assert!(
+                args.workspaces.is_empty(),
+                "search scope must not reuse --workspace: {:?}",
+                args.workspaces
+            );
+        }
+        _ => panic!("expected top-level search command"),
+    }
+}
+
+#[test]
+fn search_all_workspaces_parses_without_selectors() {
+    let cli = Cli::parse_from(["orbit", "search", "query", "--all-workspaces"]);
+    assert_eq!(cli.workspace.as_deref(), None);
+    match cli.command {
+        Commands::Search(args) => {
+            assert!(args.all_workspaces);
+            assert!(args.workspaces.is_empty());
+        }
+        _ => panic!("expected top-level search command"),
+    }
+}
+
+#[test]
+fn search_help_distinguishes_global_workspace_from_federated_scope() {
+    let help = match Cli::try_parse_from(["orbit", "search", "--help"]) {
+        Ok(_) => panic!("--help exits before parsing"),
+        Err(error) => error.to_string(),
+    };
+    assert!(
+        help.contains("--workspace <SELECTOR>"),
+        "search --help must still show the global routing selector: {help}"
+    );
+    assert!(
+        help.contains("--workspaces <SELECTOR>"),
+        "search --help must show federated --workspaces scope: {help}"
+    );
+    assert!(
+        help.contains("--all-workspaces"),
+        "search --help must keep --all-workspaces: {help}"
+    );
+    assert!(
+        help.contains("orbit --workspace"),
+        "search --help must distinguish federated scope from global routing: {help}"
+    );
+}
+
+#[test]
+fn search_command_debug_assert_accepts_the_resolved_grammar() {
+    Cli::command()
+        .find_subcommand("search")
+        .expect("search is a top-level command")
+        .clone()
+        .debug_assert();
+}

--- a/docs/design/orbit-search/2_design.md
+++ b/docs/design/orbit-search/2_design.md
@@ -270,7 +270,7 @@ Either retriever alone has a failure mode the other doesn't. RRF resolves both a
 orbit semantic install   [--model bge-small | minilm-l6 | nomic-v1.5] [--force]
 orbit semantic uninstall [--model MODEL] [--all]
 orbit search <query> [--hybrid] [--kind task|doc|friction|all] [--limit N]
-                     [--workspace SELECTOR]... [--all-workspaces]
+                     [--workspaces SELECTOR]... [--all-workspaces]
 orbit search similar <task-id> [--limit N]
 orbit search path <path> [--kind task|doc|friction|all] [--limit N]
 orbit semantic index     [--force] [--model MODEL] [--kind tasks|docs|all]
@@ -286,7 +286,7 @@ orbit semantic stats
 
 If the companion is not installed, `orbit search similar <task-id>`, `orbit semantic index`, and `orbit docs index` exit non-zero with: `"Semantic search not enabled. Run \`orbit semantic install\` to download the inference companion."` Hybrid task and doc search are softer: they emit a warning/note and fall back to lexical results.
 
-`--workspace` and `--all-workspaces` select the federated scope described in [§6.4](#64-cross-workspace-federated-search). They apply to the free-text form only; `similar` and `path` are single-workspace by construction.
+`--workspaces` and `--all-workspaces` select the federated scope described in [§6.4](#64-cross-workspace-federated-search). They apply to the free-text form only; `similar` and `path` are single-workspace by construction. `--workspaces` is deliberately distinct from the global `orbit --workspace` routing selector.
 
 ### 6.2 MCP tools
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -86,7 +86,7 @@ See [Delivery Workflows](../../getting-started/workflows/).
 
 | Command | Purpose |
 |---|---|
-| `orbit search <query>` | Search tasks, docs, and frictions. `--hybrid` adds vector ranking; `orbit search similar <id>` finds task neighbors; `orbit search path <path>` does applicability lookup. |
+| `orbit search <query>` | Search tasks, docs, and frictions. `--hybrid` adds vector ranking; `--workspaces <SELECTOR>` (repeatable) federates across registered checkouts and is distinct from the global `--workspace` routing selector; `orbit search similar <id>` finds task neighbors; `orbit search path <path>` does applicability lookup. |
 | `orbit audit list` \| `show` \| `prune` \| `export` \| `stats` | Query the audit event log. |
 | `orbit run history` | Recent job runs. `-j <job_id>` filters to one job. |
 | `orbit run show [run_id]` | State and step summary for a run; defaults to the most recent. `-s <step_id>`. |


### PR DESCRIPTION
## Task

[ORB-11765](https://orbit-cli.com/tasks/ORB-11765) — Repair global --workspace collision with search scope after ORB-11598

### Description

Hosted Linux CI run 34178689084 now passes the orbit-search embedder compilation failure but fails CLI tests. Both Coverage job101913123379 and Check/Clippy/Test job101913123434 actually checked out 2ddf18c7629dde3d2e91ecabd4a54936fcc979cb (event SHA f6197845ca3f488ce036363d3771d6a2763ca4ab differs). Clap panics: Command search: Long option names must be unique for each argument, but '--workspace' is in use by both 'workspaces' and 'workspace'. Check fails cli_orbit_search_hybrid_doc_json_reports_lexical_fallback_note with this exact panic; Coverage reports 15 CLI failures, including two help snapshots missing the newly global selector. Introducing change 15f5c1217 / ORB-11598 promoted root workspace global while command/search.rs:48 retains repeated search workspace scope. Resolve the CLI grammar coherently while preserving global authoritative workspace selection and federated search scope; update affected help contracts and documented CLI spellings as needed. Do not remove global routing, disable clap assertions, or weaken CI. Confirm current source before edits. Bounded duplicate search covered collision, Long option names and11598; no repair owner found. Evidence https://github.com/constellation-works/orbit/actions/runs/34178689084/job/101913123434 . Use build budget and low compiler concurrency.

### Acceptance Criteria

- CLI command-tree validation and search parser tests pass without duplicate long flags; global workspace routing and repeated multi-workspace search scope have unambiguous tested behavior.
- Affected friction/operation help snapshots accurately reflect shipped options; CLI binary unit tests and failing search integration test pass.
- Run make ci-fast and make ci-lint with captured outcomes, recording any independently attributable remaining CI failure.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Kept global `orbit --workspace` as the authoritative binder (ORB-11598).
- Search federated scope now uses `--workspaces` (repeatable, comma-delimited; field was already `workspaces`). `--all-workspaces` still overrides that flag. This matches MCP `workspaces` and clap uniqueness (global `workspace` vs search `workspaces` previously shared `--workspace`).
- Added whole-command-tree `Cli::command().debug_assert()` regression plus search parser tests for repeated/comma `--workspaces`, mixed global+search flags, and post-subcommand `--workspace` binding the global selector.
- Refreshed all friction and operation `--help` snapshots to include the global `--workspace` option.
- Documented the spelling in `docs/design/orbit-search/2_design.md` and `website/src/content/docs/reference/cli.md`.
Assessment: Narrow CLI grammar repair. Global routing and federated search both remain; clap no longer panics. Breaking for anyone who used `orbit search --workspace` as federated scope — that form now routes the invocation.

Criteria:
1. Command-tree uniqueness and search parser tests: pass. `cli_command_tree_debug_assert_rejects_duplicate_long_flags` and `command::tests::search::*` cover unique longs, repeated `--workspaces`, and unambiguous global vs search scope.
2. Help snapshots and failing tests: pass. All 15 friction/operation snapshots include `--workspace <SELECTOR>`. `cargo test -p orbit-cli --bin orbit`: 477 passed. `cli_orbit_search_hybrid_doc_json_reports_lexical_fallback_note`: passed.
3. `make ci-fast`: passed. `make ci-lint` (ORBIT_CARGO_JOBS=2, CARGO_TARGET_DIR outside worktree): passed. No independently remaining CI failure observed in these gates.

Validation:
- `cargo test -p orbit-cli --bin orbit -- command::tests`: passed (102 tests)
- `cargo test -p orbit-cli --bin orbit`: passed (477 tests)
- `cargo test -p orbit-cli --test docs cli_orbit_search_hybrid_doc_json_reports_lexical_fallback_note -- --exact`: passed
- `make ci-fast`: passed (`test-compiler-cache-namespaces` skipped: bwrap cannot create a user namespace in this sandbox; script still reported ok)
- `make ci-lint`: passed
- `git diff --check`: passed

Strategic decisions: Rename search long flag to `--workspaces` rather than remove global routing or keep a colliding alias. Clap uniqueness is on long names across different arg IDs; a hidden `--workspace` alias would still panic.
Remaining risks: `orbit search <query> --workspace X` now sets global routing (search scope stays current). Same-ID local `workspace` fields on other subcommands (web serve, mcp serve, audit list) merge with the global flag and were out of this CI failure.
Friction: none filed; the tree `debug_assert` is the durable guard.
Uncommitted: pipeline owns commit/PR.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11765-6a9f748f`
- Behind base: 0
- Ahead of base: 1