### PR TITLE
[qa-sweep] First Task local ship still fails when the disposable repo branch is not main

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -31,7 +31,7 @@ pub struct WorkspaceInitArgs {
     /// Workspace name (defaults to directory name)
     #[arg(long)]
     pub name: Option<String>,
-    /// Base branch for this workspace (default: main)
+    /// Base branch for this workspace (default: the checked-out branch, or main)
     ///
     /// Kept optional so re-initializing an existing workspace can distinguish
     /// an omitted value from an explicit request to reset it to `main`.
@@ -159,6 +159,7 @@ impl WorkspaceInitArgs {
         let name = self.name.unwrap_or_else(|| dir_name_or_fallback(cwd));
         let id = canonical_workspace_id(&name);
         let git_remote = detect_git_remote(cwd);
+        let default_base_branch = checked_out_branch(cwd);
         // Every read of the registry below feeds the write at the end; the lock
         // keeps a concurrent sweep or init from saving over this registration.
         let (reconciling_existing, registered_shared_root) =
@@ -276,7 +277,7 @@ impl WorkspaceInitArgs {
                         owner_machine_id: None,
                         git_remote,
                         ship_mode: self.ship_mode,
-                        base_branch: self.base_branch.unwrap_or_else(|| "main".to_string()),
+                        base_branch: self.base_branch.unwrap_or(default_base_branch),
                         status: WorkspaceStatus::Active,
                         created_at: now,
                         updated_at: now,
@@ -365,6 +366,25 @@ impl WorkspaceInitArgs {
             task_prefix,
         })
     }
+}
+
+/// Returns the current local branch for a newly registered checkout.
+///
+/// An explicit `--base-branch` always wins. Repositories without a checked-out
+/// branch retain the long-standing `main` fallback.
+pub(crate) fn checked_out_branch(cwd: &Path) -> String {
+    let output = std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(cwd)
+        .output();
+
+    output
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|branch| branch.trim().to_string())
+        .filter(|branch| !branch.is_empty())
+        .unwrap_or_else(|| "main".to_string())
 }
 
 pub(super) fn render_task_id_start(task_prefix: Option<&str>, next: u32) -> String {

--- a/crates/orbit-cli/src/command/workspace/tests/init.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init.rs
@@ -11,7 +11,7 @@ use orbit_types::workspace::{
 use crate::tests::env_isolation::EnvGuard;
 
 use super::super::init::{
-    ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id,
+    ONBOARDING_FINALIZE_GUIDANCE, WorkspaceInitArgs, canonical_workspace_id, checked_out_branch,
     onboarding_finalize_guidance, render_task_id_start,
 };
 use super::super::list::{format_workspace_list, workspace_list_json};
@@ -22,6 +22,81 @@ use super::super::support::orbit_gitignore_block;
 #[test]
 fn task_id_start_uses_the_host_task_prefix() {
     assert_eq!(render_task_id_start(Some("DANI"), 20_000), "DANI-20000");
+}
+
+#[test]
+fn workspace_init_uses_the_checked_out_branch_when_base_branch_is_omitted() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    std::fs::create_dir_all(&global).expect("create global orbit");
+    std::fs::write(
+        global.join("host.toml"),
+        "schema_version = 2\nmachine_id = \"hm_branch\"\nhost_id = \"branch-host\"\ntask_prefix = \"ORB\"\n",
+    )
+    .expect("write host identity");
+
+    let git_init = std::process::Command::new("git")
+        .args(["init", "--quiet", "--initial-branch", "master"])
+        .arg(workspace.path())
+        .status()
+        .expect("run git init");
+    assert!(git_init.success(), "initialize master branch repository");
+    let git_commit = std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.email=branch@example.test",
+            "-c",
+            "user.name=Branch Test",
+            "commit",
+            "--quiet",
+            "--allow-empty",
+            "-m",
+            "initial commit",
+        ])
+        .current_dir(workspace.path())
+        .status()
+        .expect("create initial commit");
+    assert!(git_commit.success(), "commit master branch fixture");
+
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+    WorkspaceInitArgs {
+        name: Some("checked-out-branch".to_string()),
+        base_branch: None,
+        ship_mode: Some("local".to_string()),
+        role: None,
+        owner: None,
+        task_id_start: None,
+        mcp: false,
+        inject_agent_rules: false,
+        refresh_defaults: false,
+        force: false,
+    }
+    .execute_without_runtime(None)
+    .expect("workspace init");
+
+    let registry = workspace_registry::load_registry_from(&global.join("workspaces.json"))
+        .expect("load workspace registry");
+    let registered = registry.workspaces.first().expect("registered workspace");
+    assert_eq!(registered.base_branch, "master");
+    assert_eq!(registered.ship_mode.as_deref(), Some("local"));
+    assert!(
+        registered.git_remote.is_none(),
+        "fixture must have no remote"
+    );
+}
+
+#[test]
+fn checked_out_branch_keeps_main_as_the_default_for_main_checkouts() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let git_init = std::process::Command::new("git")
+        .args(["init", "--quiet", "--initial-branch", "main"])
+        .arg(workspace.path())
+        .status()
+        .expect("run git init");
+    assert!(git_init.success(), "initialize main branch repository");
+
+    assert_eq!(checked_out_branch(workspace.path()), "main");
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11763](https://orbit-cli.com/tasks/ORB-11763) — [qa-sweep] First Task local ship still fails when the disposable repo branch is not main

### Description

## Problem
ORB-11746 stopped `orbit run ship --mode local` from fetching `origin/<base>` on a disposable repo with no remotes. The next step still fails: `worktree_setup` cannot resolve the hardcoded local base ref `main` when the repo's only branch is `master` (Git's default when `init.defaultBranch` is unset).

First Task tells operators to use a disposable git repository and `orbit run ship --mode local`. It never says the branch must be named `main`, and `orbit workspace init` (no `--base-branch`) records `base_branch: main` regardless of `HEAD`.

## Why It Matters
The first user-facing ship path after install still cannot complete on a throwaway repo. 11746 unblocked origin; this is the remaining First Task worktree failure.

## Evidence (HEAD `2e827933eebb05ae8e6daae9febc73a17facc1ca`, 2026-09-08, jrun-20260908-0154-2)
- Built `orbit` 0.19.2 from this checkout (`CARGO_TARGET_DIR=/tmp/orbit-qa-11757-target`).
- Isolated HOME `/tmp/orb-qa-11757-home` (no `init.defaultBranch`) + scratch root `/tmp/orb-qa-11757-root` + git checkout `/tmp/orb-qa-11757-ws`.
- `git init` created branch `master` (commit `79154d1`). `orbit workspace init --name qa-11757 --ship-mode local` registered `base_branch: "main"`.
- Followed First Task: `task add` → `QASW-00001`, `task update --approve` → `backlog`.
- `orbit run ship QASW-00001 --mode local --format json` submitted `jrun-20260908-0201`.
- Persisted pipeline input has `base_sync: "local"` (11746 holds) and `base_branch: "main"`.
- Child `task_local_pipeline` `jrun-20260908-0201-3` failed in ~1s:
  `worktree_setup` → `unable to resolve local base ref 'main' for task worktree creation`.
- Contrast: `orbit run ship QASW-00004 --mode local --base master` got past `worktree_setup`. It later failed the Bubblewrap capability probe on the default `opus` executor in this sandbox (documented Linux sandbox prerequisite, not this defect).
- Source: `workspace init` defaults `base_branch` to `"main"` (`crates/orbit-cli/src/command/workspace/init.rs`). Ship help says `--base` defaults to `[workflow] base_branch` or `main`. Error string is `crates/orbit-engine/src/executor/automation/vcs/git.rs`.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
HOME=/tmp/orb-qa-base-repro-home
ROOT=/tmp/orb-qa-base-repro-root
WS=/tmp/orb-qa-base-repro-ws
mkdir -p "$HOME" "$WS"
# do not set init.defaultBranch — git init will be master on Git 2.43 without that config
git -C "$WS" init
git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/README.md" && git -C "$WS" add README.md && git -C "$WS" -c commit.gpgsign=false commit -m init
git -C "$WS" rev-parse --abbrev-ref HEAD   # master
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-base --task-prefix QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace init --name qa-base --ship-mode local)
(cd "$WS" && "$BIN" --root "$ROOT" workspace show --format json)  # base_branch=main
cd "$WS"
TASK_ID=$("$BIN" --root "$ROOT" task add --title t --description d --acceptance-criteria a --complexity low --status proposed --format json | jq -r .id)
"$BIN" --root "$ROOT" task update "$TASK_ID" --approve --note ok
"$BIN" --root "$ROOT" run ship "$TASK_ID" --mode local --format json
"$BIN" --root "$ROOT" run show   # failed: unable to resolve local base ref 'main'
```

## Scope
Onboarding / local-ship base branch. Production clones whose base is already `main` (or that pass `--base` / `workspace init --base-branch`) are unaffected. Fix either First Task (require creating `main`, or document `--base $(git branch --show-current)` / `workspace init --base-branch`) or have `workspace init` / local ship default `base_branch` from the checkout's current branch when `--base-branch` is omitted.

### Acceptance Criteria

- Following website First Task on a disposable git repo whose only branch is not named `main`, `orbit run ship --mode local` either completes `worktree_setup` against that branch or the page/`workspace init` names the `main`/`--base-branch` prerequisite before Ship it.
- A repo whose current branch is already `main` still ships against `main` without an extra flag.
- A regression test or documented command covers a non-`main` local branch (for example `master`) with `--mode local` and no remotes.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- New `workspace init` registrations now record the checked-out Git branch when `--base-branch` is omitted; detached, non-Git, and unresolvable checkouts retain the `main` fallback. Explicit base branches and existing registrations remain unchanged.
- Added regression coverage for a committed, remote-free `master` checkout in local ship mode and coverage that a `main` checkout still resolves to `main`.

Acceptance criteria:
1. Met: a disposable local `master` checkout now persists `base_branch: master`, so local ship worktree setup resolves the actual local base rather than an absent `main`.
2. Met: the branch resolver test proves a `main` checkout remains `main` without flags.
3. Met: the focused regression fixture uses `git init --initial-branch master`, creates an initial commit, configures `--ship-mode local`, and asserts no remote plus persisted `master`.

Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-cli workspace_init_uses_the_checked_out_branch_when_base_branch_is_omitted`.
- Passed: `cargo test -p orbit-cli checked_out_branch_keeps_main_as_the_default_for_main_checkouts`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Assessment: focused CLI default change with remote-free fixture coverage. No friction record: no qualifying recurring or non-obvious issue.
Risk: the task does not execute a full local ship pipeline because that pipeline requires sandbox capabilities outside this unit boundary; the persisted base branch is the direct input consumed by worktree setup.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11763-6a9f7838`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra