### PR TITLE
fix: restore native macOS CI validation [ORB-11770]

### DIFF
--- a/crates/orbit-cmd/src/update/tests/stage.rs
+++ b/crates/orbit-cmd/src/update/tests/stage.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use crate::update::stage::{restore_backup, restore_backup_with_rename};
+use crate::update::stage::restore_backup_with_rename;
 
 #[test]
 fn a_failed_atomic_restore_keeps_both_complete_files_and_cleans_staging() {
@@ -58,6 +58,7 @@ fn a_failed_atomic_restore_keeps_both_complete_files_and_cleans_staging() {
 #[cfg(target_os = "linux")]
 #[test]
 fn rollback_replaces_a_running_executable_atomically() {
+    use crate::update::stage::restore_backup;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
     use std::time::{Duration, Instant};

--- a/scripts/test-build-budget.sh
+++ b/scripts/test-build-budget.sh
@@ -6,14 +6,25 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WRAPPER="$ROOT/scripts/build-budget.py"
 TMP="$(mktemp -d)"
 BACKGROUND_PIDS=()
+TEST_COMPLETE=0
+
 cleanup() {
+  local status=$?
   local pid
+
+  # Bash 3.2 can report success after a nounset error inside a function.
+  # Cleanup must not turn an incomplete assertion run into a passing gate.
+  if [[ "$status" == 0 && "$TEST_COMPLETE" != 1 ]]; then
+    status=1
+  fi
+
   if ((${#BACKGROUND_PIDS[@]})); then
     for pid in "${BACKGROUND_PIDS[@]}"; do
       kill "$pid" 2>/dev/null || true
     done
   fi
   rm -rf "$TMP"
+  exit "$status"
 }
 trap cleanup EXIT
 
@@ -31,7 +42,12 @@ forget_pid() {
       remaining+=("$pid")
     fi
   done
-  BACKGROUND_PIDS=("${remaining[@]}")
+
+  BACKGROUND_PIDS=()
+  # Bash 3.2 treats an empty array expansion as unset under nounset.
+  if ((${#remaining[@]})); then
+    BACKGROUND_PIDS=("${remaining[@]}")
+  fi
 }
 
 wait_for() {
@@ -461,4 +477,5 @@ kill "$WATCH_MAKE_PID" 2>/dev/null || true
 wait "$WATCH_MAKE_PID" 2>/dev/null || true
 forget_pid "$WATCH_MAKE_PID"
 
+TEST_COMPLETE=1
 printf 'test-build-budget: ok\n'


### PR DESCRIPTION
Native macOS validation failed Clippy because a Linux-only rollback test imported its helper on every platform. Build-budget tests also stopped early on Apple Bash 3.2 empty-array expansion while incorrectly returning success. Scope the import to its consumer, avoid expanding an empty array, and make incomplete build-budget assertion runs fail during cleanup.

Validation on macOS:
- `CARGO_BUILD_JOBS=2 make ci-fast` passed with the final `test-build-budget: ok` marker.
- `CARGO_BUILD_JOBS=2 make ci-lint` passed the workspace/all-target Clippy gate.
- `cargo test -p orbit-web api::tests --lib`: 243 passed, 1 ignored.
- Injected Bash 3.2 nounset failure exits 1 with no success marker; injected failures in each build-budget/compiler-cache Make recipe propagate as Make exit 2, without running later checks.

The Makefile already propagates nonzero command exits; the false-green defect was in the Bash 3.2 script exit status. No Makefile change is needed. The existing namespace cache test is skipped on macOS because bwrap is unavailable.

Task: ORB-11770. Source regressions: ORB-11345 / PR #1402 and ORB-11760 / PR #1638.
