### PR TITLE
Filter active job runs in SQL before queued-worker admission scans

### DIFF
--- a/crates/orbit-core/src/application/job/run/query.rs
+++ b/crates/orbit-core/src/application/job/run/query.rs
@@ -98,6 +98,7 @@ fn job_run_query(params: JobRunListParams) -> JobRunQuery {
         job_id: params.job_id,
         state: params.state,
         terminal_only: params.terminal_only,
+        active_only: false,
         created_since: params.since,
         limit: params.limit,
         order_by: params.order_by,

--- a/crates/orbit-store/src/contracts/params.rs
+++ b/crates/orbit-store/src/contracts/params.rs
@@ -393,6 +393,11 @@ pub struct JobRunQuery {
     /// Whether to include only states for which `JobRunState::is_terminal()`
     /// returns true. Applied before ordering and limiting.
     pub terminal_only: bool,
+    /// Whether to include only `pending` and `running` rows. Applied before
+    /// ordering, limiting, and step hydration so admission and orphan scans
+    /// never read terminal history [ORB-11762]. Independent of `state` and
+    /// `terminal_only`; combining this with `terminal_only` yields no rows.
+    pub active_only: bool,
     pub created_since: Option<DateTime<Utc>>,
     pub limit: Option<usize>,
     /// Which timestamp `limit` truncates against. Defaults to `CreatedAt` so

--- a/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs
@@ -156,16 +156,14 @@ impl JobRunStoreBackend for SqliteJobRunStore {
 
     fn list_pending_or_running_job_runs(&self, job_id: &str) -> Result<Vec<JobRun>, OrbitError> {
         validate_path_stem(job_id, "job")?;
-        let mut runs = self.store.list_job_runs_for_workspace(
+        self.store.list_job_runs_for_workspace(
             &self.workspace_id,
             &JobRunQuery {
                 job_id: Some(job_id.to_string()),
+                active_only: true,
                 ..Default::default()
             },
-        )?;
-        runs.retain(|run| matches!(run.state, JobRunState::Pending | JobRunState::Running));
-        runs.sort_by_key(|run| std::cmp::Reverse(run.created_at));
-        Ok(runs)
+        )
     }
 
     fn insert_job_run(
@@ -506,15 +504,13 @@ impl JobRunStoreBackend for SqliteJobRunStore {
     }
 
     fn list_all_pending_or_running_runs(&self) -> Result<Vec<JobRun>, OrbitError> {
-        let mut runs = self.store.list_job_runs_for_workspace(
+        self.store.list_job_runs_for_workspace(
             &self.workspace_id,
             &JobRunQuery {
+                active_only: true,
                 ..Default::default()
             },
-        )?;
-        runs.retain(|run| matches!(run.state, JobRunState::Pending | JobRunState::Running));
-        runs.sort_by_key(|run| std::cmp::Reverse(run.created_at));
-        Ok(runs)
+        )
     }
 
     fn archive_job_run(&self, run_id: &str) -> Result<String, OrbitError> {
@@ -1053,6 +1049,9 @@ fn job_run_filter_sql(
         conditions.push(
             "state IN ('success', 'failed', 'timeout', 'cancelled', 'interrupted')".to_string(),
         );
+    }
+    if query.active_only {
+        conditions.push("state IN ('pending', 'running')".to_string());
     }
     if let Some(created_since) = query.created_since {
         conditions.push(format!("created_at >= ?{}", params.len() + 1));

--- a/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs
@@ -1,9 +1,12 @@
+use std::time::{Duration, Instant};
+
 use chrono::{DateTime, TimeZone, Utc};
 use orbit_types::workflow::{JobRun, JobRunState, JobRunStep, JobTargetType, PipelineState};
 use serde_json::json;
 
 use crate::Store;
-use crate::contracts::{JobRunOrder, JobRunQuery};
+use crate::contracts::{JobRunOrder, JobRunQuery, JobRunStoreBackend};
+use crate::driver::sqlite::job_run_store::SqliteJobRunStore;
 
 fn at(minute: u32) -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 5, 1, 0, minute, 0)
@@ -266,6 +269,328 @@ fn recency_order_truncates_by_finish_time_not_creation_time() {
         top_by_recency[0].run_id, "jrun-old-long-running",
         "recency ordering must select the most-recently-finished run before LIMIT applies"
     );
+}
+
+fn insert_named_run(
+    store: &Store,
+    workspace_id: &str,
+    run_id: &str,
+    job_id: &str,
+    state: JobRunState,
+    created: DateTime<Utc>,
+    steps: u32,
+) {
+    let mut run = run_with_steps(run_id, state, created, steps);
+    run.job_id = job_id.to_string();
+    for step in &mut run.steps {
+        step.target_id = format!("{run_id}-{}", step.step_index);
+        if state.is_terminal() {
+            step.agent_response_json = Some(json!({ "payload": "x".repeat(256) }));
+        }
+    }
+    insert_run_with_steps(store, workspace_id, &run);
+}
+
+fn process_cpu_ms() -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/self/stat").ok()?;
+    let after_comm = text.rsplit_once(')')?.1;
+    let mut fields = after_comm.split_whitespace();
+    for _ in 0..11 {
+        fields.next()?;
+    }
+    let utime: u64 = fields.next()?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+    Some((utime.saturating_add(stime)) * 10)
+}
+
+fn elapsed_of(op: impl FnOnce()) -> (Duration, Option<u64>) {
+    let cpu_before = process_cpu_ms();
+    let started = Instant::now();
+    op();
+    let wall = started.elapsed();
+    let cpu = match (cpu_before, process_cpu_ms()) {
+        (Some(before), Some(after)) => Some(after.saturating_sub(before)),
+        _ => None,
+    };
+    (wall, cpu)
+}
+
+fn hydrated_work(runs: &[JobRun]) -> (usize, usize) {
+    (
+        runs.len(),
+        runs.iter().map(|run| run.steps.len()).sum::<usize>(),
+    )
+}
+
+/// [ORB-11762] `list_job_runs_for_workspace` hydrates steps only for the SQL
+/// result set. `active_only` is applied in SQL, so a long terminal history is
+/// never selected and therefore never hydrated. The job-scoped and
+/// workspace-scoped admission helpers must return that same filtered page.
+#[test]
+fn active_only_list_skips_terminal_history_before_hydration() {
+    let store = Store::open_in_memory().expect("open store");
+    let job_id = "task_auto_pipeline";
+    let historical = 800_u32;
+    for index in 0..historical {
+        insert_named_run(
+            &store,
+            "ws",
+            &format!("jrun-term-{index:04}"),
+            job_id,
+            JobRunState::Success,
+            at(index % 50),
+            4,
+        );
+    }
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-active-running",
+        job_id,
+        JobRunState::Running,
+        at(50),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-active-pending-b",
+        job_id,
+        JobRunState::Pending,
+        at(40),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-active-pending-a",
+        job_id,
+        JobRunState::Pending,
+        at(40),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-skipped",
+        job_id,
+        JobRunState::Skipped,
+        at(45),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-retrying",
+        job_id,
+        JobRunState::Retrying,
+        at(46),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "ws",
+        "jrun-other-job",
+        "other_pipeline",
+        JobRunState::Pending,
+        at(51),
+        1,
+    );
+    insert_named_run(
+        &store,
+        "other-ws",
+        "jrun-other-ws",
+        job_id,
+        JobRunState::Pending,
+        at(52),
+        1,
+    );
+
+    let active_query = JobRunQuery {
+        job_id: Some(job_id.to_string()),
+        active_only: true,
+        ..JobRunQuery::default()
+    };
+    let page = store
+        .list_job_runs_for_workspace("ws", &active_query)
+        .expect("active-only page");
+    let ids = page
+        .iter()
+        .map(|run| run.run_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        [
+            "jrun-active-running",
+            "jrun-active-pending-a",
+            "jrun-active-pending-b",
+        ],
+        "SQL must return pending/running for this job in created_at DESC, run_id ASC"
+    );
+    assert!(
+        page.iter().all(|run| {
+            matches!(run.state, JobRunState::Pending | JobRunState::Running)
+                && run.job_id == job_id
+                && run.steps.len() == 1
+                && run.steps[0].target_id.starts_with(&run.run_id)
+        }),
+        "hydrated steps must belong only to the active rows SQL returned"
+    );
+    assert_eq!(
+        page.iter().map(|run| run.steps.len()).sum::<usize>(),
+        3,
+        "terminal history steps must not be hydrated onto the active page"
+    );
+
+    let backend = SqliteJobRunStore::new(store.clone(), "ws");
+    let job_scoped = backend
+        .list_pending_or_running_job_runs(job_id)
+        .expect("job-scoped active list");
+    assert_eq!(
+        job_scoped
+            .iter()
+            .map(|run| run.run_id.as_str())
+            .collect::<Vec<_>>(),
+        ids
+    );
+    let workspace_scoped = backend
+        .list_all_pending_or_running_runs()
+        .expect("workspace-scoped active list");
+    assert_eq!(
+        workspace_scoped
+            .iter()
+            .map(|run| run.run_id.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "jrun-other-job",
+            "jrun-active-running",
+            "jrun-active-pending-a",
+            "jrun-active-pending-b",
+        ]
+    );
+}
+
+/// [ORB-11762] Isolated-store before/after of the queued-worker admission
+/// scan: unfiltered list-then-retain versus SQL `active_only`. Records the
+/// historical/active/queued-worker counts plus CPU and hydration work.
+#[test]
+fn active_lookup_benchmark_records_queued_worker_hydration_cost() {
+    let store = Store::open_in_memory().expect("open store");
+    let job_id = "task_auto_pipeline";
+    let historical = 400_usize;
+    let active = 3_usize;
+    let queued_workers = 8_usize;
+    for index in 0..historical {
+        insert_named_run(
+            &store,
+            "ws",
+            &format!("jrun-hist-{index:04}"),
+            job_id,
+            JobRunState::Failed,
+            at((index % 50) as u32),
+            4,
+        );
+    }
+    for index in 0..active {
+        insert_named_run(
+            &store,
+            "ws",
+            &format!("jrun-live-{index}"),
+            job_id,
+            if index == 0 {
+                JobRunState::Running
+            } else {
+                JobRunState::Pending
+            },
+            at(50 + index as u32),
+            1,
+        );
+    }
+
+    let unfiltered = JobRunQuery {
+        job_id: Some(job_id.to_string()),
+        ..JobRunQuery::default()
+    };
+
+    let mut before_page = Vec::new();
+    let (before_wall, before_cpu_ms) = elapsed_of(|| {
+        before_page = store
+            .list_job_runs_for_workspace("ws", &unfiltered)
+            .expect("unfiltered list");
+    });
+    let (before_rows, before_steps) = hydrated_work(&before_page);
+    before_page.retain(|run| matches!(run.state, JobRunState::Pending | JobRunState::Running));
+
+    let backend = SqliteJobRunStore::new(store.clone(), "ws");
+    let mut after_runs = Vec::new();
+    let (after_wall, after_cpu_ms) = elapsed_of(|| {
+        after_runs = backend
+            .list_pending_or_running_job_runs(job_id)
+            .expect("active list");
+    });
+    let (after_rows, after_steps) = hydrated_work(&after_runs);
+
+    let mut queued_last = Vec::new();
+    let (queued_wall, queued_cpu_ms) = elapsed_of(|| {
+        for _ in 0..queued_workers {
+            queued_last = backend
+                .list_pending_or_running_job_runs(job_id)
+                .expect("queued worker scan");
+        }
+    });
+
+    assert_eq!(after_runs.len(), active);
+    assert_eq!(after_rows, active);
+    assert_eq!(after_steps, active);
+    assert_eq!(queued_last.len(), active);
+    assert_eq!(before_page.len(), active);
+    assert_eq!(before_rows, historical + active);
+    assert_eq!(before_steps, historical * 4 + active);
+    assert!(
+        after_rows < before_rows,
+        "active-only SQL must hydrate fewer run rows than list-then-retain ({after_rows} < {before_rows})"
+    );
+    assert!(
+        after_steps < before_steps,
+        "active-only SQL must hydrate fewer steps than list-then-retain ({after_steps} < {before_steps})"
+    );
+
+    let record = json!({
+        "schema_version": 1,
+        "task_id": "ORB-11762",
+        "historical_row_count": historical,
+        "active_count": active,
+        "queued_worker_count": queued_workers,
+        "before": {
+            "algorithm": "list_job_runs_for_workspace unfiltered then retain pending/running",
+            "rows_read": before_rows,
+            "steps_hydrated": before_steps,
+            "wall_ms": before_wall.as_secs_f64() * 1000.0,
+            "cpu_ms": before_cpu_ms,
+        },
+        "after": {
+            "algorithm": "JobRunQuery.active_only SQL filter before hydration",
+            "rows_read": after_rows,
+            "steps_hydrated": after_steps,
+            "wall_ms": after_wall.as_secs_f64() * 1000.0,
+            "cpu_ms": after_cpu_ms,
+        },
+        "queued_workers": {
+            "scans": queued_workers,
+            "wall_ms": queued_wall.as_secs_f64() * 1000.0,
+            "cpu_ms": queued_cpu_ms,
+        },
+    });
+    if let Ok(path) = std::env::var("ORB_11762_BENCH_PATH") {
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&record).expect("bench json"),
+        )
+        .expect("write bench record");
+    }
+    assert_eq!(record["historical_row_count"], json!(historical));
+    assert_eq!(record["active_count"], json!(active));
+    assert_eq!(record["queued_worker_count"], json!(queued_workers));
 }
 
 /// [ORB-11253] The transactional run-control seam: the run's own state, the


### PR DESCRIPTION
## Task

[ORB-11762](https://orbit-cli.com/tasks/ORB-11762) — Filter active job runs in SQL before queued-worker admission scans

### Description

## Runtime Evidence
On dk-server-1 at 2026-09-08 01:53:56 UTC, `pidstat -u -p 2541204,2628184 1 10` measured 15.60% and 18.30% of one CPU core for pending task_auto_pipeline workers jrun-20260908-0146-5 and jrun-20260908-0151. Both were confirmed pending and sleeping between admission checks; no implementation agent had started. Installed build ada765f77 includes ORB-11602.
## Concrete Code Finding
crates/orbit-store/src/driver/sqlite/job_run_store/mod.rs list_pending_or_running_job_runs currently lists every historical run of a job via JobRunQuery{job_id,..Default}, hydrates them, then filters Pending/Running in Rust. execute_pipeline_run_worker calls reconciliation (which uses this query) and then calls the query again per admission loop. Thus long terminal history is read twice per waiting worker per cycle. CPU sample establishes a queue overhead problem; exact attribution between history hydration and reconciliation should be measured, not assumed.
## Scope
Push active-state filtering into the store query before hydration; preserve ordering, workspace scoping, admission fairness, cancellation, and stale-owner recovery. Add a regression with large terminal history and a few active runs proving history does not hydrate. Inspect nearby active-only query paths for the same exact issue without broad redesign. Benchmark queued workers before/after using isolated stores. Proposed follow-up from CPU investigation; do not launch additional pending processes while capacity is saturated.

### Acceptance Criteria

- Active-only lookup returns precisely pending/running rows in existing order and workspace scope without reading/hydrating terminal historical runs, covered by regression with large terminal history.
- Admission and orphan/cancellation race regressions pass unchanged; no weakened recovery semantics.
- Bounded benchmark records historical row count, active count, queued-worker count, CPU and query/hydration work before/after; make ci-fast and make ci-lint pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added `JobRunQuery.active_only` so pending/running filtering happens in SQL (`state IN ('pending','running')`) before ordering, limiting, and step hydration.
- `list_pending_or_running_job_runs` and the nearby `list_all_pending_or_running_runs` now use that query instead of listing every historical row and retaining in Rust. Workspace scoping and `created_at DESC, run_id ASC` order are unchanged from the shared list path; same-timestamp ties are now deterministic (`run_id ASC`) rather than unstable.
- `job_run_query` in orbit-core sets `active_only: false` so CLI/history listings stay unfiltered.
- Regression seeds 800 terminal runs (4 steps each) plus skipped/retrying/other-job/other-workspace rows and asserts the SQL page is only the three active rows in existing order, with only those three steps hydrated. Isolated-store benchmark compares unfiltered list-then-retain vs SQL active-only.

Assessment: Small, local store-query change. Admission, orphan, and cancellation semantics are unchanged; only the scan no longer hydrates terminal history.

Strategic decisions:
- Reused `JobRunQuery` / `job_run_filter_sql` rather than a one-off SELECT, so list/count/duration stay on one filter.
- Applied the same SQL filter to `list_all_pending_or_running_runs` (identical list-then-retain bug used by orphan reconciliation).

Criteria:
1. Active-only lookup returns precisely pending/running rows in existing order and workspace scope without hydrating terminal history — pass. `active_only_list_skips_terminal_history_before_hydration` (800 terminal + 3 active) asserts job-scoped IDs `running`, `pending-a`, `pending-b` in `created_at DESC, run_id ASC`, excludes skipped/retrying/other-job/other-workspace, and hydrates 3 steps (not 3200+).
2. Admission and orphan/cancellation race regressions pass unchanged — pass. `cargo test -p orbit-core --lib application::job::run::tests`: 74 passed (admissions_stop, cancellation_race, reconcile/orphan, owner, worker_limit).
3. Bounded benchmark records historical/active/queued-worker counts plus CPU and query/hydration work before/after; ci-fast and ci-lint pass — pass. Artifact `active-lookup-benchmark.json`: historical 400, active 3, queued workers 8; before 403 rows / 1603 steps / 124.8 ms wall / 130 ms CPU; after 3 rows / 3 steps / 7.1 ms wall / 10 ms CPU; 8 queued scans 13.7 ms wall / 10 ms CPU.

Validation:
- `cargo test -p orbit-store --lib driver::sqlite::tests::job_run_store` — passed (14 tests, including the two new ones)
- `cargo test -p orbit-core --lib application::job::run::tests` — passed (74 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed (no whitespace errors)

Remaining risks / deviations:
- Same-timestamp order is now `run_id ASC` instead of unstable `created_at`-only sort. Admission fairness still re-sorts by `scheduled_at` then `created_at` then `run_id` in `pipeline_run_is_runnable`.
- Benchmark CPU is `/proc/self/stat` USER_HZ=100 ticks on Linux; wall-clock and row/step counts are the portable evidence.
- Did not launch additional pending pipeline workers.

Unlisted files changed (needed for compile/tests): `file:crates/orbit-core/src/application/job/run/query.rs`, `file:crates/orbit-store/src/driver/sqlite/tests/job_run_store.rs`.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11762-6a9f7858`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: sol