### PR TITLE
[code-review] Bound `pr_complete`'s wait budget and poll interval

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs
@@ -32,6 +32,7 @@ use serde_json::{Value, json};
 
 use crate::context::{ReviewLandingRequest, RuntimeHost};
 
+use super::super::super::ci::bounded_u64;
 use super::super::super::input::input_string_field;
 use super::super::super::task_update::{authorization_note, complete_tasks};
 use super::super::freshness::{
@@ -46,6 +47,9 @@ use super::merge::{MergeCapabilities, MergeStrategy, resolve_merge_capabilities}
 /// Default budget for waiting out required checks before giving up.
 const DEFAULT_MAX_WAIT_SECONDS: u64 = 3600;
 const DEFAULT_POLL_INTERVAL_SECONDS: u64 = 30;
+const MAX_WAIT_SECONDS: u64 = 6 * 60 * 60;
+const MIN_POLL_INTERVAL_SECONDS: u64 = 5;
+const MAX_POLL_INTERVAL_SECONDS: u64 = 10 * 60;
 
 pub(in crate::executor::automation) fn pr_complete<H: RuntimeHost + ?Sized>(
     host: &H,
@@ -131,9 +135,19 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
     workspace_path: &str,
     pr_number: &str,
 ) -> Result<Value, OrbitError> {
-    let max_wait_seconds = input_u64(input, "max_wait_seconds").unwrap_or(DEFAULT_MAX_WAIT_SECONDS);
-    let poll_interval_seconds =
-        input_u64(input, "poll_interval_seconds").unwrap_or(DEFAULT_POLL_INTERVAL_SECONDS);
+    let max_wait_seconds = bounded_u64(
+        input,
+        "max_wait_seconds",
+        DEFAULT_MAX_WAIT_SECONDS,
+        MAX_WAIT_SECONDS,
+    )?;
+    let poll_interval_seconds = bounded_u64(
+        input,
+        "poll_interval_seconds",
+        DEFAULT_POLL_INTERVAL_SECONDS,
+        MAX_POLL_INTERVAL_SECONDS,
+    )?
+    .max(MIN_POLL_INTERVAL_SECONDS);
     let mut waited_seconds = 0_u64;
     let mut auto_merge_requested = false;
     let mut merge_requested = false;
@@ -157,6 +171,8 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                     "strategy": merge_capabilities.map(|capabilities| capabilities.strategy.as_str()),
                     "auto_merge_requested": auto_merge_requested,
                     "waited_seconds": waited_seconds,
+                    "max_wait_seconds": max_wait_seconds,
+                    "poll_interval_seconds": poll_interval_seconds,
                     "landed_commit": landed_commit,
                     "managed_merge": managed_merge,
                     "reviewed_head_sha": reviewed_head_sha,
@@ -271,10 +287,17 @@ fn drive_pr_to_merged<H: RuntimeHost + ?Sized>(
                  #{pr_number} to merge (budget {max_wait_seconds}s); the task stays in review"
             )));
         }
-        if poll_interval_seconds > 0 {
-            sleep(Duration::from_secs(poll_interval_seconds));
+        let remaining_seconds = max_wait_seconds.saturating_sub(waited_seconds);
+        let sleep_seconds = poll_interval_seconds.min(remaining_seconds);
+        sleep(Duration::from_secs(sleep_seconds));
+        waited_seconds = waited_seconds.saturating_add(sleep_seconds);
+
+        if waited_seconds >= max_wait_seconds {
+            return Err(OrbitError::Execution(format!(
+                "pr_complete: timed out after {waited_seconds}s waiting for pull request \
+                 #{pr_number} to merge (budget {max_wait_seconds}s); the task stays in review"
+            )));
         }
-        waited_seconds = waited_seconds.saturating_add(poll_interval_seconds.max(1));
     }
 }
 
@@ -559,8 +582,4 @@ fn ensure_all_tasks_no_diff_expected(tasks: &[Task]) -> Result<(), OrbitError> {
         ));
     }
     Ok(())
-}
-
-fn input_u64(input: &Value, key: &str) -> Option<u64> {
-    input.get(key).and_then(Value::as_u64)
 }

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/complete.rs
@@ -2,8 +2,7 @@
 //!
 //! Every case drives the real `pr_complete` / `task_complete` code against the
 //! shared fake host with a scripted sequence of `pr.status` answers, so the
-//! merge-state machine is exercised without GitHub and without a wall clock:
-//! `poll_interval_seconds: 0` makes the poll loop iterate immediately.
+//! merge-state machine is exercised without GitHub.
 
 use std::fs;
 use std::process::Command;
@@ -36,7 +35,7 @@ fn pending_checks_with_auto_merge_disabled_wait_for_an_ordinary_merge() {
     host.queue_merge_capabilities_with_auto_merge(true, true, true, true, false);
 
     let mut input = complete_input(root.path(), &["T1"]);
-    input["max_wait_seconds"] = json!(1);
+    input["max_wait_seconds"] = json!(10);
     let output = pr_complete(&host, &input).expect("complete after checks settle");
 
     assert_eq!(output["merge"]["merged"], true);
@@ -63,6 +62,41 @@ fn pending_checks_with_auto_merge_disabled_time_out_in_review() {
         "disabled auto-merge is never requested"
     );
     assert_eq!(host.task_status("T1"), TaskStatus::Review);
+}
+
+#[test]
+fn zero_poll_interval_is_clamped_and_does_not_hammer_pr_status() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([state("PENDING")]);
+    host.queue_merge_capabilities_with_auto_merge(true, true, true, true, false);
+
+    let mut input = complete_input(root.path(), &["T1"]);
+    input["poll_interval_seconds"] = json!(0);
+    input["max_wait_seconds"] = json!(5);
+    let error = pr_complete(&host, &input).expect_err("pending checks must time out");
+
+    assert!(error.to_string().contains("timed out"), "{error}");
+    let status_reads = host
+        .vcs_calls()
+        .iter()
+        .filter(|call| call.operation == PR_STATUS_OPERATION)
+        .count();
+    assert!(
+        status_reads <= 1,
+        "a zero input interval must be clamped before polling"
+    );
+}
+
+#[test]
+fn excessive_wait_budget_is_reported_as_the_clamped_ceiling() {
+    let (root, host) = host(vec![review_batch_task("T1", None, None)]);
+    host.queue_pr_status([merged_state()]);
+
+    let mut input = complete_input(root.path(), &["T1"]);
+    input["max_wait_seconds"] = json!(10_000_000);
+    let output = pr_complete(&host, &input).expect("an already merged PR completes");
+
+    assert_eq!(output["merge"]["max_wait_seconds"], json!(6 * 60 * 60));
 }
 
 fn complete_input(workspace_path: &std::path::Path, task_ids: &[&str]) -> Value {
@@ -173,7 +207,7 @@ fn squash_disabled_repository_uses_rebase_for_direct_and_auto_merge() {
         host.queue_pr_status([state(initial), merged_state()]);
         host.queue_merge_capabilities(false, true, true, true);
         let mut input = complete_input(root.path(), &["T1"]);
-        input["max_wait_seconds"] = json!(1);
+        input["max_wait_seconds"] = json!(10);
 
         let output = pr_complete(&host, &input).expect("rebase completion");
 

--- a/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/pr/tests/review_gate.rs
@@ -183,7 +183,7 @@ fn gated_pending_checks_wait_locally_without_enabling_auto_merge() {
     ]);
     host.queue_vcs_result(PR_MERGE_OPERATION, json!({"landed_commit": "landed"}));
     let mut input = complete_input(&workspace.repo, reviewed);
-    input["max_wait_seconds"] = json!(2);
+    input["max_wait_seconds"] = json!(10);
     let output = pr_complete(&host, &input).expect("wait then merge reviewed candidate");
     assert_eq!(output["merge"]["auto_merge_requested"], false);
     let merges: Vec<_> = host


### PR DESCRIPTION
## Task

[ORB-11641](https://orbit-cli.com/tasks/ORB-11641) — [code-review] Bound `pr_complete`'s wait budget and poll interval

### Description

## Problem
`max_wait_seconds` and `poll_interval_seconds` are taken from run input as raw `u64` with no clamp. `poll_interval_seconds: 0` skips the `sleep` and increments `waited_seconds` by 1, so the loop issues up to `max_wait_seconds` back-to-back `gh pr view` calls (3,600 API requests with the default budget, tripping GitHub rate limits and burning the host's `gh` quota). A large `max_wait_seconds` keeps the job thread — and the task in `review` with the run marked running — blocked for as long as the input says, with no upper bound and no cancellation check inside the loop. Compare `ci/mod.rs:66-84` which clamps every input bound.

## Why It Matters
One mis-rendered or malicious template value turns the completion step into an API hammer or an indefinitely running run.

## Proposed Fix
Clamp `poll_interval_seconds` to `[5, 600]` and `max_wait_seconds` to a ceiling (e.g. 6 h) using the same `bounded_u64` helper; log the clamped values in the output.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/executor/automation/vcs/pr/complete.rs:46-48,119-121,253-262`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: `poll_interval_seconds: 0` with a scripted host that reports `PENDING` — the host records at most `max_wait/5` status reads and the step sleeps between them.
- Test: `max_wait_seconds: 10_000_000` is reported in the output as the clamped ceiling.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Bound `pr_complete` max_wait_seconds to 21,600 seconds and poll_interval_seconds to 5–600 seconds using the established bounded input parser.
- Report effective wait and poll values in successful merge output; timeout errors retain the effective budget.
- Stop after the final bounded sleep so a pending PR is not read again after its budget expires.
- Added regression coverage for zero poll input (one status read for a five-second budget) and the 10,000,000-second clamp; updated pending-state fixtures for real five-second polling.
Assessment: The completion boundary now has a single validated limit path and preserves immediate status handling while preventing tight-loop polling.
Criteria evidence:
1. `poll_interval_seconds: 0` is floored to five seconds; the scripted pending-host regression records one PR status read for max_wait_seconds=5 and the implementation sleeps before any subsequent read.
2. A scripted already-merged PR with max_wait_seconds=10,000,000 returns merge.max_wait_seconds=21,600.
Validation:
- `cargo test -p orbit-engine executor::automation::vcs::pr::tests::complete -- --nocapture` — passed (26 tests).
- `cargo test -p orbit-engine executor::automation::vcs::pr::tests::review_gate::gated_pending_checks_wait_locally_without_enabling_auto_merge -- --nocapture` — passed.
- `make ci-fast` — passed.
- `make ci-lint` — passed.
- `git diff --check` — passed.
Risks: Tests use real five-second sleeps to exercise the synchronous wait boundary; no GitHub API call was made.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11641-6a9f79fd`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra