### PR TITLE
[code-review] Load task sidecars and the `--input-file` once per `task show` / `tool run`

### DIFF
--- a/crates/orbit-cli/src/command/mcp/server.rs
+++ b/crates/orbit-cli/src/command/mcp/server.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use orbit_cmd::registry_runtime::{RegisteredRuntimeFactory, ResolvedWorkspaceSelection};
-use orbit_cmd::task_owner;
+use orbit_cmd::task_owner::{self, WorkspaceIdentity};
 use orbit_common::protocol::tool_input::required_string;
 use orbit_common::{NotFoundKind, OrbitError};
 use orbit_core::OrbitRuntime;
@@ -445,7 +445,11 @@ impl ServerMcpHost {
                 .map(|outcome| outcome.value);
         }
 
-        execute_core_tool(&runtime, name, input, context)
+        let owner = WorkspaceIdentity {
+            id: selected.workspace.id.clone(),
+            name: selected.workspace.name.clone(),
+        };
+        execute_core_tool(&runtime, name, input, context, Some(&owner))
     }
 }
 
@@ -490,6 +494,7 @@ fn execute_core_tool(
     name: &str,
     input: Value,
     context: ToolSessionContext,
+    owner: Option<&WorkspaceIdentity>,
 ) -> Result<Value, OrbitError> {
     let output = runtime
         .execute_tool_command_dispatch_with_session_context(
@@ -501,5 +506,5 @@ fn execute_core_tool(
             context,
         )?
         .value;
-    crate::command::task::show::attach_bound_workspace_identity(name, &input, runtime, output)
+    crate::command::task::show::attach_bound_workspace_identity(name, &input, owner, output)
 }

--- a/crates/orbit-cli/src/command/task/output.rs
+++ b/crates/orbit-cli/src/command/task/output.rs
@@ -7,8 +7,8 @@ use orbit_core::{
     resolve_task_relations,
 };
 use orbit_types::task::{
-    ArtifactManifestFileV2, TaskArtifact, task_show_record_field_json,
-    unknown_task_show_field_message,
+    ArtifactManifestFileV2, TaskArtifact, TaskComment, TaskHistoryEntry,
+    task_show_record_field_json, unknown_task_show_field_message,
 };
 use serde_json::{Value, json};
 
@@ -74,27 +74,33 @@ pub(crate) fn task_to_json_for_runtime(
     task: &orbit_core::Task,
 ) -> Result<Value, OrbitError> {
     let status_by_id = runtime.task_status_index()?;
-    task_to_json_with_sidecars(runtime, task, &status_by_id)
+    Ok(task_to_json_with_sidecars(runtime, task, &status_by_id)?.doc)
+}
+
+pub(crate) struct TaskJsonWithSidecars {
+    pub(crate) doc: Value,
+    pub(crate) comments: Vec<TaskComment>,
+    pub(crate) history: Vec<TaskHistoryEntry>,
 }
 
 pub(crate) fn task_to_json_with_sidecars(
     runtime: &OrbitRuntime,
     task: &orbit_core::Task,
     status_by_id: &BTreeMap<String, TaskStatus>,
-) -> Result<Value, OrbitError> {
+) -> Result<TaskJsonWithSidecars, OrbitError> {
     let mut value = task_to_json(task, status_by_id);
     let object = value.as_object_mut().ok_or_else(|| {
         OrbitError::Execution("task JSON projection did not produce an object".to_string())
     })?;
+    let comments = runtime.get_task_comments(&task.id)?;
+    let history = runtime.get_task_history(&task.id)?;
     object.insert(
         "comments".to_string(),
-        serde_json::to_value(runtime.get_task_comments(&task.id)?)
-            .map_err(|e| OrbitError::Io(e.to_string()))?,
+        serde_json::to_value(&comments).map_err(|e| OrbitError::Io(e.to_string()))?,
     );
     object.insert(
         "history".to_string(),
-        serde_json::to_value(runtime.get_task_history(&task.id)?)
-            .map_err(|e| OrbitError::Io(e.to_string()))?,
+        serde_json::to_value(&history).map_err(|e| OrbitError::Io(e.to_string()))?,
     );
     let artifacts = runtime.get_task_artifact_manifest(&task.id)?;
     object.insert(
@@ -133,7 +139,11 @@ pub(crate) fn task_to_json_with_sidecars(
             );
         }
     }
-    Ok(value)
+    Ok(TaskJsonWithSidecars {
+        doc: value,
+        comments,
+        history,
+    })
 }
 
 /// Which columns the caller filtered on, and so must keep even when the filter

--- a/crates/orbit-cli/src/command/task/show.rs
+++ b/crates/orbit-cli/src/command/task/show.rs
@@ -8,7 +8,7 @@ use crate::command::{Block, CommandOut, Execute, Payload};
 
 use super::output::{
     format_task_fields, is_human_visible_history_event, task_fields_to_json,
-    task_to_json_for_runtime,
+    task_to_json_with_sidecars,
 };
 
 #[derive(Args)]
@@ -64,7 +64,8 @@ impl Execute for TaskShowArgs {
         // The task may have been reached through the global registry rather
         // than the cwd, so every full projection names where it was read from.
         let owner = bound_workspace_identity(runtime);
-        let mut doc = task_to_json_for_runtime(runtime, &task)?;
+        let projection = task_to_json_with_sidecars(runtime, &task, &status_by_id)?;
+        let mut doc = projection.doc;
         if let Some(owner) = &owner {
             insert_workspace_identity(&mut doc, owner)?;
         }
@@ -183,10 +184,9 @@ impl Execute for TaskShowArgs {
                     task.execution_summary
                 );
             }
-            let comments = runtime.get_task_comments(&task.id)?;
-            if !comments.is_empty() {
+            if !projection.comments.is_empty() {
                 let _ = writeln!(out, "{}", bold("Comments:"));
-                for comment in &comments {
+                for comment in &projection.comments {
                     let _ = writeln!(
                         out,
                         "  {} {}: {}",
@@ -223,8 +223,8 @@ impl Execute for TaskShowArgs {
             if let Some(ref orchestrator) = task.orchestrator {
                 let _ = writeln!(out, "{} {}", bold("Orchestrator:"), orchestrator);
             }
-            let history = runtime.get_task_history(&task.id)?;
-            let visible_history: Vec<_> = history
+            let visible_history: Vec<_> = projection
+                .history
                 .iter()
                 .filter(|entry| is_human_visible_history_event(&entry.event))
                 .collect();
@@ -299,7 +299,7 @@ fn relation_type_label(relation_type: TaskRelationType) -> &'static str {
 pub(crate) fn attach_bound_workspace_identity(
     tool_name: &str,
     input: &Value,
-    runtime: &OrbitRuntime,
+    owner: Option<&WorkspaceIdentity>,
     mut output: Value,
 ) -> Result<Value, OrbitError> {
     if tool_name != "orbit.task.show" {
@@ -308,8 +308,8 @@ pub(crate) fn attach_bound_workspace_identity(
     if input.get("field").is_some() || input.get("fields").is_some() {
         return Ok(output);
     }
-    if let Some(owner) = bound_workspace_identity(runtime) {
-        insert_workspace_identity(&mut output, &owner)?;
+    if let Some(owner) = owner {
+        insert_workspace_identity(&mut output, owner)?;
     }
     Ok(output)
 }

--- a/crates/orbit-cli/src/command/tool/run.rs
+++ b/crates/orbit-cli/src/command/tool/run.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use clap::Args;
 use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
 use orbit_cmd::task_owner::bound_workspace_identity;
@@ -37,9 +39,35 @@ pub struct ToolRunArgs {
     /// Compatibility alias for pretty-printing JSON error output
     #[arg(long, hide = true)]
     pub pretty: bool,
+    #[arg(skip)]
+    pub(crate) parsed_input: OnceLock<Result<Value, String>>,
 }
 
 impl ToolRunArgs {
+    /// Read and parse tool input once for all pre-dispatch and execution paths
+    /// in this invocation. An unreadable `--input-file` must not be silently
+    /// retried by task-owner bootstrap or audit metadata.
+    pub(crate) fn parsed_input(&self) -> Result<Value, OrbitError> {
+        self.parsed_input
+            .get_or_init(|| self.load_input())
+            .clone()
+            .map_err(OrbitError::InvalidInput)
+    }
+
+    fn load_input(&self) -> Result<Value, String> {
+        if let Some(path) = &self.input_file {
+            let raw = std::fs::read_to_string(path)
+                .map_err(|error| format!("cannot read input file '{path}': {error}"))?;
+            serde_json::from_str(&raw).map_err(|error| format!("invalid JSON in '{path}': {error}"))
+        } else {
+            match &self.input {
+                Some(raw) => serde_json::from_str(raw)
+                    .map_err(|error| format!("invalid JSON input: {error}")),
+                None => Ok(Value::Object(Default::default())),
+            }
+        }
+    }
+
     /// Globally unique task ID from `orbit tool run orbit.task.show` input.
     ///
     /// The CLI bootstraps that one tool through the host task registry rather
@@ -49,12 +77,7 @@ impl ToolRunArgs {
         if self.name != "orbit.task.show" {
             return None;
         }
-        let raw = if let Some(path) = &self.input_file {
-            std::fs::read_to_string(path).ok()?
-        } else {
-            self.input.clone()?
-        };
-        let value: Value = serde_json::from_str(&raw).ok()?;
+        let value = self.parsed_input().ok()?;
         value
             .get("id")
             .and_then(Value::as_str)
@@ -66,19 +89,7 @@ impl ToolRunArgs {
 
 impl Execute for ToolRunArgs {
     fn execute(self, runtime: &OrbitRuntime) -> CommandOut {
-        let mut input: Value = if let Some(path) = &self.input_file {
-            let raw = std::fs::read_to_string(path).map_err(|e| {
-                OrbitError::InvalidInput(format!("cannot read input file '{path}': {e}"))
-            })?;
-            serde_json::from_str(&raw)
-                .map_err(|e| OrbitError::InvalidInput(format!("invalid JSON in '{path}': {e}")))?
-        } else {
-            match &self.input {
-                Some(raw) => serde_json::from_str(raw)
-                    .map_err(|e| OrbitError::InvalidInput(format!("invalid JSON input: {e}")))?,
-                None => Value::Object(Default::default()),
-            }
-        };
+        let mut input = self.parsed_input()?;
 
         // Resolve `workspace` once above local CLI tools, then bind or fail
         // closed. MCP uses its own server-side selector resolution.
@@ -112,7 +123,8 @@ impl Execute for ToolRunArgs {
             return Ok(Payload::detail(doc, text).into());
         }
 
-        let session_context = local_tool_session_context(runtime)?;
+        let owner = bound_workspace_identity(runtime);
+        let session_context = local_tool_session_context(runtime, owner.as_ref())?;
         let output = runtime.execute_tool_command_with_session_context(
             &self.name,
             input.clone(),
@@ -121,7 +133,10 @@ impl Execute for ToolRunArgs {
             session_context,
         )?;
         let output = crate::command::task::show::attach_bound_workspace_identity(
-            &self.name, &input, runtime, output,
+            &self.name,
+            &input,
+            owner.as_ref(),
+            output,
         )?;
         let output = shape_tool_output(&self.name, output, self.full, &self.fields);
 
@@ -133,11 +148,12 @@ pub(super) const LOCAL_MACHINE_ID_FALLBACK: &str = "host/local";
 
 pub(super) fn local_tool_session_context(
     runtime: &OrbitRuntime,
+    owner: Option<&orbit_cmd::task_owner::WorkspaceIdentity>,
 ) -> Result<ToolSessionContext, OrbitError> {
     let (machine_id, host_id) = local_machine_identity(&runtime.global_root())?;
     Ok(ToolSessionContext {
-        workspace_id: bound_workspace_identity(runtime)
-            .map(|owner| owner.id)
+        workspace_id: owner
+            .map(|owner| owner.id.clone())
             .or_else(|| runtime.workspace_id().ok()),
         caller_machine_id: Some(machine_id.clone()),
         caller_host_id: host_id.clone(),

--- a/crates/orbit-cli/src/command/tool/tests/run.rs
+++ b/crates/orbit-cli/src/command/tool/tests/run.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use serde_json::json;
 
 use super::super::run::{
@@ -17,6 +19,7 @@ fn task_show_id_is_read_only_from_orbit_task_show_input() {
         fields: Vec::new(),
         full: false,
         pretty: false,
+        parsed_input: OnceLock::new(),
     };
     assert_eq!(show.task_show_id().as_deref(), Some("ORB-10961"));
 
@@ -93,7 +96,7 @@ fn show_output_preserves_task_details_by_default() {
 fn local_invocation_context_has_trace_and_explicit_identity_fallback() {
     let runtime = orbit_core::OrbitRuntime::in_memory().expect("in-memory runtime");
 
-    let context = local_tool_session_context(&runtime).expect("local invocation context");
+    let context = local_tool_session_context(&runtime, None).expect("local invocation context");
 
     assert!(
         context
@@ -111,6 +114,34 @@ fn local_invocation_context_has_trace_and_explicit_identity_fallback() {
     );
     assert_eq!(context.caller_ip, None);
     assert!(context.effective_capabilities.is_empty());
+}
+
+#[test]
+fn parsed_input_reads_an_input_file_once() {
+    let file = tempfile::NamedTempFile::new().expect("input file");
+    std::fs::write(file.path(), r#"{"id":"first"}"#).expect("write initial input");
+    let show = ToolRunArgs {
+        name: "orbit.task.show".to_string(),
+        input: None,
+        input_file: Some(file.path().to_string_lossy().into_owned()),
+        agent: None,
+        model: None,
+        dry_run: false,
+        fields: Vec::new(),
+        full: false,
+        pretty: false,
+        parsed_input: OnceLock::new(),
+    };
+
+    assert_eq!(
+        show.parsed_input().expect("first parse"),
+        json!({"id":"first"})
+    );
+    std::fs::write(file.path(), r#"{"id":"second"}"#).expect("write replacement input");
+    assert_eq!(
+        show.parsed_input().expect("cached parse"),
+        json!({"id":"first"})
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11620](https://orbit-cli.com/tasks/ORB-11620) — [code-review] Load task sidecars and the `--input-file` once per `task show` / `tool run`

### Description

## Problem
`TaskShowArgs::execute` builds `runtime.task_status_index()` (`show.rs:45`, a full task-registry scan) and then calls `task_to_json_for_runtime` (`show.rs:77`) which builds it again (`output.rs:76`). It then reads `get_task_comments` and `get_task_history` for the human view (`show.rs:166,206`) after `task_to_json_with_sidecars` already read both (`output.rs:91,96`) — four sidecar reads and two registry scans for one record. `bound_workspace_identity` re-parses `workspaces.json` on each call (`task_owner.rs:136-143`) and is invoked from both `local_tool_session_context` and `attach_bound_workspace_identity` in one `tool run`. For `orbit tool run --input-file`, the file is read and JSON-parsed three times before execution: `tool_run_input_identity` (`operation.rs:1105-1116`), `task_show_id` (`run.rs:61-77`), and `execute` (`run.rs:82-87`), with the first two swallowing errors so an unreadable file is only reported on the third read.

## Why It Matters
`task show` and `tool run orbit.task.show` are the hottest agent reads; on large registries the duplicate status-index scan doubles the latency, and the triple file read is a TOCTOU on the one input path recommended for rich content.

## Proposed Fix
Pass the already-built `status_by_id` into `task_to_json_with_sidecars` and reuse its `comments`/`history` for the human view (return them alongside the doc). Parse the tool input once in `ToolRunArgs` (a `parsed_input(&self) -> Result<Value>` cached in a `OnceCell`) and have `operation.rs` use it. Cache the registry identity for the invocation.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-cli/src/command/task/show.rs:44-46,76-77,166,206`, `crates/orbit-cli/src/command/task/output.rs:72-98`, `crates/orbit-cli/src/command/operation.rs:1105-1116`, `crates/orbit-cli/src/command/tool/run.rs:61-77,82-94`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: cli.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `task show` calls `task_status_index`, `get_task_comments`, and `get_task_history` at most once each (assert via a counting test double or by inspection in a sibling test).
- `orbit tool run orbit.task.show --input-file /nonexistent` reports the read error from a single site.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Full `task show` projections now pass one status index into one sidecar load and reuse the loaded comments/history for human rendering.
- `ToolRunArgs` caches input reads/parsing, including failures, across actor metadata, task-owner routing, and execution; local CLI and MCP tool paths reuse one resolved workspace identity.
- Added a sibling regression test proving an input file is read once.
Assessment: The change keeps the existing output shapes and error text while removing duplicate registry, sidecar, input-file, and workspace-identity work.
Acceptance criteria:
- Pass: `TaskShowArgs::execute` calls `task_status_index` once, and `task_to_json_with_sidecars` loads comments/history once; the human renderer consumes the returned sidecars. The focused task-show tests pass.
- Pass: `target/debug/orbit tool run orbit.task.show --input-file /nonexistent` exited 1 and emitted `cannot read input file` exactly once.
Validation:
- Passed: `cargo fmt --all -- --check`.
- Passed: focused CLI tests `cargo test -p orbit-cli --bin orbit command::tool::tests::run` (6 tests) and `command::task::tests::show` (4 tests).
- Passed: `make ci-fast`.
- Passed: `make ci-lint` (`clippy --workspace --all-targets -- -D warnings`).
- Passed: `git diff --check`.
- Informational: `cargo test -p orbit-cli` compiled and ran 479 tests; 464 passed and 15 pre-existing help/audit tests failed because the branch exposes duplicate `--workspace` Clap options in unrelated command surfaces. The focused tests and required gates pass.
Remaining risks / deviations: The full package test failures are unrelated to the changed files and remain for the pipeline/branch owner to reconcile. The compiler-cache namespace probe reported its documented non-privileged-user-namespace skip while `make ci-fast` still passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11620-6a9f7858`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra