### PR TITLE
[code-review] Drive check-dependency-direction.sh from cargo metadata instead of regex-parsing Cargo.toml

### DIFF
--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -71,6 +71,17 @@ allowed_internal_deps() {
   esac
 }
 
+allowed_dev_only_deps() {
+  case "$1" in
+    orbit-core)
+      echo "orbit-exec"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
 contains_word() {
   local haystack="$1"
   local needle="$2"
@@ -101,12 +112,37 @@ for crate, manifest_path in workspace_crates:
 '
 }
 
+load_workspace_dependencies() {
+  cargo metadata --format-version 1 --no-deps --manifest-path "$repo_root/Cargo.toml" |
+    python3 -c '
+import json
+import sys
+
+metadata = json.load(sys.stdin)
+workspace_members = set(metadata["workspace_members"])
+workspace_crates = {
+    package["name"]: package
+    for package in metadata["packages"]
+    if package["id"] in workspace_members
+    and package["name"].startswith("orbit-")
+}
+for crate in sorted(workspace_crates):
+    for dependency in workspace_crates[crate]["dependencies"]:
+        dependency_name = dependency["name"]
+        if dependency_name.startswith("orbit-"):
+            kind = dependency["kind"] or "normal"
+            print(f"{crate}\t{dependency_name}\t{kind}")
+'
+}
+
 workspace_crates=()
 workspace_manifests=()
+declare -A workspace_manifest_by_crate=()
 while IFS=$'\t' read -r crate manifest; do
   if [[ -n "$crate" ]]; then
     workspace_crates+=("$crate")
     workspace_manifests+=("$manifest")
+    workspace_manifest_by_crate["$crate"]="$manifest"
   fi
 done < <(load_workspace_crates)
 
@@ -124,23 +160,27 @@ for index in "${!workspace_crates[@]}"; do
     continue
   fi
 
-  if ! allowed="$(allowed_internal_deps "$crate")"; then
+  if ! allowed_internal_deps "$crate" >/dev/null; then
     echo "missing dependency direction policy for workspace crate '${crate}'"
     fail=1
-    continue
+  fi
+done
+
+while IFS=$'\t' read -r crate dependency kind; do
+  manifest="${workspace_manifest_by_crate[$crate]}"
+  allowed="$(allowed_internal_deps "$crate")"
+
+  if contains_word "$(allowed_dev_only_deps "$crate")" "$dependency" && [[ "$kind" != "dev" ]]; then
+    echo "dependency '${dependency}' in ${manifest} must remain dev-only (kind: ${kind})"
+    fail=1
   fi
 
-  while IFS= read -r dep; do
-    if [[ -n "$dep" ]] && ! contains_word "$allowed" "$dep"; then
-      echo "forbidden dependency '${dep}' found in ${manifest}"
-      echo "  allowed internal deps for ${crate}: ${allowed:-<none>}"
-      fail=1
-    fi
-  done < <(
-    rg -o "^[[:space:]]*orbit-[a-z-]+[[:space:]]*=" "$manifest" |
-      sed -E 's/^[[:space:]]*(orbit-[a-z-]+)[[:space:]]*=.*/\1/'
-  )
-done
+  if [[ -n "$dependency" ]] && ! contains_word "$allowed" "$dependency"; then
+    echo "forbidden dependency '${dependency}' found in ${manifest}"
+    echo "  allowed internal deps for ${crate}: ${allowed:-<none>}"
+    fail=1
+  fi
+done < <(load_workspace_dependencies)
 
 # orbit-core is one crate, but its internal boundaries are directional too.
 # Keep the runtime kernel independent from use cases and protocol adapters;


### PR DESCRIPTION
## Task

[ORB-11646](https://orbit-cli.com/tasks/ORB-11646) — [code-review] Drive check-dependency-direction.sh from cargo metadata instead of regex-parsing Cargo.toml

### Description

## Problem
The script already loads `cargo metadata --no-deps` (lines 86-101) but then discovers internal edges by regexing manifests for `^\s*orbit-[a-z-]+\s*=` (line 140). A renamed dependency — `store = { package = "orbit-store", path = "../orbit-store" }` — matches nothing and passes. The regex also cannot distinguish `[dependencies]` from `[dev-dependencies]`, so the ORB-10617 comment at lines 47-49 ("remains test-only and does not widen Core's production graph") is a policy the script cannot enforce: promoting `orbit-exec` to a production dependency of orbit-core passes.

## Why It Matters
This is the layering guard for ARCHITECTURE.md; a bypass costs one Cargo key rename.

## Proposed Fix
Emit `crate\tdep_name\tkind` from `packages[].dependencies[]` in the existing Python block (use `name`, not `rename`, and `kind` of null/dev/build), and add a separate `allowed_dev_only_deps` case (`orbit-core -> orbit-exec`) enforced against `kind`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `scripts/check-dependency-direction.sh:85-101`, `scripts/check-dependency-direction.sh:133-142`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (quality). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A fixture manifest with `x = { package = "orbit-store", ... }` in a crate that disallows orbit-store fails the guard.
- Moving `orbit-exec` from `[dev-dependencies]` to `[dependencies]` in `crates/orbit-core/Cargo.toml` fails the guard.
- Current tree still prints "dependency direction guard passed".

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced Cargo.toml regex dependency discovery with cargo metadata's workspace package dependency records in scripts/check-dependency-direction.sh.
- Dependency records use the package name (so renamed aliases such as x -> orbit-store are checked) and preserve dependency kind as normal/dev/build.
- Added the orbit-core -> orbit-exec dev-only policy and fail-fast reporting when that edge becomes a normal production dependency.

Acceptance criteria:
- Renamed orbit-store fixture: passed; a metadata fixture equivalent to x = { package = "orbit-store", ... } in orbit-common failed with the forbidden dependency diagnostic.
- Promoted orbit-exec fixture: passed; changing orbit-core -> orbit-exec metadata kind from dev to normal failed with the dev-only diagnostic.
- Current tree: passed; scripts/check-dependency-direction.sh printed "dependency direction guard passed".

Validation:
- bash -n scripts/check-dependency-direction.sh — passed.
- scripts/check-dependency-direction.sh — passed.
- make ci-fast — passed. The compiler-cache namespace subcheck reported its documented environment limitation (bwrap could not create a mount namespace) and returned its skip outcome; the overall target passed.
- make ci-lint — passed.
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — one intended modification: scripts/check-dependency-direction.sh.

Assessment: Scoped one-file change, metadata-driven and preserves the existing allowlist and guard output. No remaining task-specific risks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11646-6a9f7ace`
- Behind base: 0
- Ahead of base: 1