### PR TITLE
fix(ci): isolate compiler cache namespace fixtures [ORB-11767]

### DIFF
--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -69,3 +69,4 @@ fi
 "$repo_root/scripts/smoke-plugin-install.sh"
 "$repo_root/scripts/test-build-budget.sh"
 "$repo_root/scripts/test-compiler-cache.sh"
+"$repo_root/scripts/test-compiler-cache-namespaces.sh"

--- a/scripts/test-compiler-cache-namespaces.sh
+++ b/scripts/test-compiler-cache-namespaces.sh
@@ -25,6 +25,16 @@ fail() {
   exit 1
 }
 
+# Refuse unit-test fixtures before any skip. Nested sandboxes previously
+# skipped at bwrap and never noticed fake HOME/sccache on a real host.
+if [[ -n "${FAKE_RUSTC_LOG-}" || -n "${FAKE_SCCACHE_LOG-}" ]]; then
+  fail "unit-test fixture environment leaked into live namespace test"
+fi
+if [[ -n "${ORBIT_COMPILER_CACHE_BIN-}" && -f "${ORBIT_COMPILER_CACHE_BIN}" ]] \
+  && grep -Fq 'FAKE_SCCACHE_LOG' "$ORBIT_COMPILER_CACHE_BIN" 2>/dev/null; then
+  fail "ORBIT_COMPILER_CACHE_BIN is the unit-test fake sccache"
+fi
+
 if ! command -v bwrap >/dev/null 2>&1; then
   skip "bwrap not on PATH"
 fi

--- a/scripts/test-compiler-cache.sh
+++ b/scripts/test-compiler-cache.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Fallback and enablement tests for scripts/rustc-compiler-cache.sh [ORB-11259] [ORB-11755].
+# Fallback and enablement tests for scripts/rustc-compiler-cache.sh [ORB-11259] [ORB-11755] [ORB-11767].
 # No full crate compile: the wrapper is a rustc argv passthrough.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WRAPPER="$ROOT/scripts/rustc-compiler-cache.sh"
-HOST_PATH="$PATH"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -300,11 +299,30 @@ if [[ -e /tmp/orbit-workspace/Cargo.toml && -e "$ROOT/Cargo.toml" ]] \
   unset CARGO_TARGET_DIR
 fi
 
-# Live mount-namespace regression lives in a sibling script so this file stays
-# a wrapper-argv unit test. Nested sandboxes that cannot create user
-# namespaces skip that script instead of failing ci-fast.
-if [[ -x "$ROOT/scripts/test-compiler-cache-namespaces.sh" ]]; then
-  PATH="$HOST_PATH" "$ROOT/scripts/test-compiler-cache-namespaces.sh"
-fi
+# The live sibling must refuse fixture env before any bwrap skip, so a nested
+# call cannot pass by skipping namespaces.
+set +e
+FAKE_RUSTC_LOG="$TMP/leaked-rustc.log" \
+  "$ROOT/scripts/test-compiler-cache-namespaces.sh" \
+  >"$TMP/guard.out" 2>"$TMP/guard.err"
+guard_status=$?
+set -e
+[[ "$guard_status" -ne 0 ]] || fail "live suite must reject fixture FAKE_* vars"
+grep -F -q 'unit-test fixture environment leaked' "$TMP/guard.err" \
+  || fail "live suite should name the fixture leak, got: $(tr '\n' ' ' <"$TMP/guard.err")"
+
+set +e
+FAKE_RUSTC_LOG= FAKE_SCCACHE_LOG= \
+  ORBIT_COMPILER_CACHE_BIN="$TMP/sccache" \
+  "$ROOT/scripts/test-compiler-cache-namespaces.sh" \
+  >"$TMP/guard-bin.out" 2>"$TMP/guard-bin.err"
+guard_bin_status=$?
+set -e
+[[ "$guard_bin_status" -ne 0 ]] || fail "live suite must reject the fixture sccache binary"
+grep -F -q 'unit-test fake sccache' "$TMP/guard-bin.err" \
+  || fail "live suite should reject fixture sccache, got: $(tr '\n' ' ' <"$TMP/guard-bin.err")"
+
+# Live mount-namespace compile lives in the sibling script and is invoked as
+# a separate CI process after this unit process exits.
 
 printf 'test-compiler-cache: ok\n'


### PR DESCRIPTION
Compiler-cache unit fixtures changed HOME and selected a fake sccache, then launched the live namespace suite with only PATH restored. On namespace-capable hosts this left the live compile without its real Rust toolchain.

Run the live suite as a separate process in the shared CI guardrails, immediately after the unit suite, so it inherits the caller environment. Reject leaked fixtures before capability skips, with regression coverage that fails against the previous namespace entry point.

Validation on macOS:
- Current head 3a9a89ccce7739d8fddd52a9121fc0d5d770b635: Apple Bash syntax checks and compiler-cache unit suite passed. Live Linux namespace compile explicitly skipped because bwrap is unavailable.
- The regression failed against the original namespace script as expected.
- Previous head e7eb3af546d128ae83c7235146bb8f8e6cb5f4ab passed make ci-fast and full workspace/all-target make ci-lint (16.51 seconds). Rebased onto integration refactor 613d4b56f; current head also passed full workspace/all-target make ci-lint. Native ci-fast has an independently tracked Bash 3 compatibility failure (ORB-11775); it is not claimed passing on this head.

Task: ORB-11767.
