### PR TITLE
[code-review] Scan every workspace crate in check-public-artifact-ids.py (a shipped orbit-search string already violates it)

### DIFF
--- a/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
+++ b/crates/orbit-engine/src/executor/automation/vcs/worktree/setup.rs
@@ -275,7 +275,7 @@ fn inspect_registered_worktree(
     )
     .unwrap_or(true);
     let evidence = format!(
-        "HEAD={}, branch={}, gitdir={}, index={}, status={}, unique_commits={unique_commits}. Completeness does not treat deleted tracked files as an incomplete checkout (they may be intended edits). Timeout recovery is not conflict or failure-handoff recovery; stale-branch provenance is owned by ORB-11639.",
+        "HEAD={}, branch={}, gitdir={}, index={}, status={}, unique_commits={unique_commits}. Completeness does not treat deleted tracked files as an incomplete checkout (they may be intended edits). Timeout recovery is not conflict or failure-handoff recovery; stale-branch provenance is recorded separately.",
         head.as_deref().unwrap_or("missing"),
         branch.as_deref().unwrap_or("missing"),
         git_dir.as_deref().unwrap_or("missing"),

--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -521,7 +521,7 @@ pub(crate) fn path_execution_fallback_rationale() -> &'static str {
     // a process with write access to ~/.orbit/embed/bin/ between freshness
     // check and exec can still substitute the binary. Tracked for posix_spawn
     // /dev/fd/N exploration as a follow-up to ORB-00271."
-    "this platform (notably macOS, plus Windows) does not expose fexecve through libc, so the managed companion keeps the pre-existing path execution behavior after descriptor-based freshness validation; the descriptor-vs-path TOCTOU window from ORB-00271 remains open on these targets"
+    "this platform (notably macOS, plus Windows) does not expose fexecve through libc, so the managed companion keeps the pre-existing path execution behavior after descriptor-based freshness validation; the descriptor-vs-path TOCTOU window remains open on these targets"
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/orbit-store/src/repository/token_scoreboard.rs
+++ b/crates/orbit-store/src/repository/token_scoreboard.rs
@@ -12,7 +12,7 @@ use orbit_common::fs::io::{atomic_write_text_volatile as write_atomic, with_excl
 /// Writes `tokens.json` from the invocation store.
 ///
 /// The `known_limitations` payload documents how these totals relate to the
-/// external supervisor worker run store (F2026-08-031 / ORB-10906): they are
+/// external supervisor worker run store: they are
 /// not interchangeable denominators.
 pub fn write_token_scoreboard(
     scoreboard_dir: &Path,
@@ -33,7 +33,7 @@ pub fn write_token_scoreboard(
                 "Legacy agent invocations without a resolved model are omitted from the activities and agents sections.",
                 "Providers without structured usage metadata may emit zero traces.",
                 "Claude CLI result documents repeat the same billed session totals on `usage` and `modelUsage`. Ingest now keeps the `usage` rollup (including the cache-creation TTL split) and does not add sibling `modelUsage`. Already-persisted invocation rows are not rewritten, so historical Claude cache_read is typically ~2x the CLI result.",
-                "The supervisor worker run store (~/.local/share/supervisor/runs/*.json) and this scoreboard's `invocations` table are not one ledger: no shared run id, different populations (all supervisor CLIs vs pipeline activities), and worker top-level `usage` is often absent. The F2026-08-031 10-21x per-run comparison mixed those sets and treated missing worker fields as 0. Do not mix the stores for cost-per-token or tokens-per-minute.",
+                "The supervisor worker run store (~/.local/share/supervisor/runs/*.json) and this scoreboard's `invocations` table are not one ledger: no shared run id, different populations (all supervisor CLIs vs pipeline activities), and worker top-level `usage` is often absent. A historical 10-21x per-run comparison mixed those sets and treated missing worker fields as 0. Do not mix the stores for cost-per-token or tokens-per-minute.",
                 "Use `invocations` / this scoreboard for pipeline activity token accounting (post-fix rows only). Use a worker run's result.usage / result.modelUsage for that CLI process's billed totals. provider_cost_usd and the worker's total_cost_usd agree and are the monthly reconciliation figure."
             ]
         });

--- a/scripts/check-public-artifact-ids.py
+++ b/scripts/check-public-artifact-ids.py
@@ -6,16 +6,7 @@ import re
 import sys
 
 ROOT = Path(__file__).resolve().parent.parent
-SOURCE_ROOTS = [
-    ROOT / "crates/orbit-cli/src",
-    ROOT / "crates/orbit-common/src",
-    ROOT / "crates/orbit-types/src",
-    ROOT / "crates/orbit-core/src",
-    ROOT / "crates/orbit-web/src",
-    ROOT / "crates/orbit-mcp/src",
-    ROOT / "crates/orbit-registry/src",
-    ROOT / "crates/orbit-tools/src",
-]
+SOURCE_ROOTS = sorted((path for path in (ROOT / "crates").glob("*/src") if path.is_dir()))
 CONCRETE_ID = re.compile(
     r"(?<![A-Za-z0-9])(?:ORB-|ADR-|L-)\d+\b|(?<![A-Za-z0-9])F\d{4}-\d{2}-\d{3}\b"
 )


### PR DESCRIPTION
## Task

[ORB-11647](https://orbit-cli.com/tasks/ORB-11647) — [code-review] Scan every workspace crate in check-public-artifact-ids.py (a shipped orbit-search string already violates it)

### Description

## Problem
`SOURCE_ROOTS` hard-codes 8 of the 17 workspace crates, omitting orbit-agent, orbit-automation, orbit-cmd, orbit-config, orbit-engine, orbit-exec, orbit-policy, orbit-search and orbit-store — all compiled into the shipped `orbit` binary. The gap is already live: `crates/orbit-search/src/commands/install.rs:483` embeds "the descriptor-vs-path TOCTOU window from ORB-00271 remains open" in a production string literal, which the guard's own docstring says must never ship.

## Why It Matters
Stale allowlists turn a guardrail into a false assurance; the rule's rationale applies to every crate.

## Proposed Fix
Derive roots from `crates/*/src` (or `cargo metadata` workspace members) instead of a static list; rewrite the install.rs string to describe the limitation without the task ID (keep provenance in a `//` comment).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `scripts/check-public-artifact-ids.py:9-18`, `crates/orbit-search/src/commands/install.rs:483`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (quality). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Before the source fix, `./scripts/check-public-artifact-ids.py` reports `crates/orbit-search/src/commands/install.rs:483`.
- After both fixes the script passes and its root list has no hard-coded crate names.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the hard-coded `SOURCE_ROOTS` crate allowlist with sorted discovery of every existing `crates/*/src` directory.
- Removed concrete artifact IDs from the shipped strings in orbit-search, orbit-engine, and orbit-store while retaining provenance in source comments where applicable.
Assessment: The guard now covers all 17 workspace crate source roots and passes; the production wording preserves the original operational limitations without exposing internal task or finding IDs.

Acceptance criteria:
- Before the root-discovery fix, the baseline guard exited 0 because orbit-search was omitted; this reproduced the reported coverage gap. With dynamic roots enabled, the scan detected the orbit-search violation (plus two additional newly covered violations), which were all removed.
- After both fixes, `./scripts/check-public-artifact-ids.py` passed, and `SOURCE_ROOTS` has no hard-coded crate names; it discovers 17 crate source roots.

Validation:
- `./scripts/check-public-artifact-ids.py`: passed.
- `make ci-fast`: passed. Its compiler-cache namespace subcheck reported the environment-limited namespace skip but the check itself completed successfully.
- `make ci-lint`: passed; workspace clippy completed with `-D warnings`.
- `git diff --check`: passed.
- `git status --short`: passed; only the four task-scoped files are modified.

Remaining risks: The compiler-cache namespace case was not exercised because this environment disallows unprivileged mount namespaces; the repository check handled that bounded limitation as a skip.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11647-6a9f7bb1`
- Behind base: 0
- Ahead of base: 1