### PR TITLE
[code-review] Cache the per-revision instruction listing used by the preparation fingerprint

### DIFF
--- a/crates/orbit-core/src/application/automation/members.rs
+++ b/crates/orbit-core/src/application/automation/members.rs
@@ -1,6 +1,6 @@
 //! Narrow Core adapter for the shared state scheduling domain.
 
-use super::{consumer_key, preparation, source::Source};
+use super::{consumer_key, preparation, preparation::InstructionSnapshot, source::Source};
 use crate::OrbitRuntime;
 use chrono::{DateTime, Utc};
 use orbit_automation::{
@@ -74,6 +74,7 @@ pub(crate) struct Host<'a> {
     runtime: &'a OrbitRuntime,
     trigger: &'a StateTrigger,
     incidents: RefCell<super::incidents::IncidentSession>,
+    instructions: RefCell<BTreeMap<String, InstructionSnapshot>>,
 }
 
 impl<'a> Host<'a> {
@@ -82,7 +83,28 @@ impl<'a> Host<'a> {
             runtime,
             trigger,
             incidents: RefCell::new(super::incidents::IncidentSession::new()),
+            instructions: RefCell::new(BTreeMap::new()),
         }
+    }
+
+    fn fingerprint(
+        &self,
+        task: &orbit_types::task::Task,
+        revision: &str,
+    ) -> Result<String, AutomationError> {
+        let instructions = {
+            let mut cached = self.instructions.borrow_mut();
+            match cached.get(revision) {
+                Some(snapshot) => snapshot.clone(),
+                None => {
+                    let snapshot = preparation::instructions(self.runtime, revision)?;
+                    cached.insert(revision.to_string(), snapshot.clone());
+                    snapshot
+                }
+            }
+        };
+
+        preparation::fingerprint_with_instructions(self.runtime, task, revision, &instructions)
     }
 
     #[cfg(test)]
@@ -146,14 +168,13 @@ impl MemberHost for Host<'_> {
                         withheld.insert(task.id, "task_ineligible".into());
                         continue;
                     }
-                    let fingerprint =
-                        match preparation::fingerprint(self.runtime, &task, &source.commit) {
-                            Ok(fingerprint) => fingerprint,
-                            Err(error) => {
-                                withheld.insert(task.id, error.to_string());
-                                continue;
-                            }
-                        };
+                    let fingerprint = match self.fingerprint(&task, &source.commit) {
+                        Ok(fingerprint) => fingerprint,
+                        Err(error) => {
+                            withheld.insert(task.id, error.to_string());
+                            continue;
+                        }
+                    };
                     candidates.push(StateMember {
                         key: task.id.clone(),
                         task_ids: vec![task.id.clone()],
@@ -246,7 +267,7 @@ impl MemberHost for Host<'_> {
                         return Ok(MemberAdmission::Retire("task_ineligible".into()));
                     }
                     let (_, source) = self.head(&self.trigger.branch)?;
-                    preparation::fingerprint(self.runtime, &task, &source.commit)?
+                    self.fingerprint(&task, &source.commit)?
                 }
                 StateTriggerKind::ExecutionFailed => {
                     match super::incidents::observe(self.runtime, &task) {

--- a/crates/orbit-core/src/application/automation/preparation.rs
+++ b/crates/orbit-core/src/application/automation/preparation.rs
@@ -8,6 +8,13 @@ use orbit_types::task::Task;
 use orbit_types::workflow::automation::members::MemberAssessment;
 use serde_json::{Value, json};
 
+/// Repository instructions captured from one immutable source revision.
+///
+/// The serialized form deliberately remains the fingerprint input used before
+/// this cache existed, so sharing it changes work performed, not evidence.
+#[derive(Clone)]
+pub(crate) struct InstructionSnapshot(String);
+
 /// Bound on the consumer states one lookup reads.
 const MAX_CONSUMER_STATES: usize = 50;
 
@@ -47,26 +54,27 @@ pub(crate) fn fingerprint(
     task: &Task,
     revision: &str,
 ) -> Result<String, AutomationError> {
+    let instructions = instructions(runtime, revision)?;
+    fingerprint_with_instructions(runtime, task, revision, &instructions)
+}
+
+pub(crate) fn instructions(
+    runtime: &OrbitRuntime,
+    revision: &str,
+) -> Result<InstructionSnapshot, AutomationError> {
     let source = Source::new(&runtime.paths().repo_root);
-
-    let mut dependencies = Vec::new();
-
-    for id in task.dependencies().iter().take(51) {
-        if dependencies.len() == 50 {
-            return Err(AutomationError::Deferred("dependency_scan_budget".into()));
-        }
-        let dependency = runtime.get_task(id)?;
-        dependencies.push(json!({"id": id, "status": dependency.status,
-            "relations": dependency.relations, "criteria": dependency.acceptance_criteria,
-            "description": dependency.description, "plan": dependency.plan,
-            "refs": dependency.external_refs, "pr_status": dependency.pr_status}));
-    }
-
-    dependencies.sort_by_key(|value| value["id"].as_str().unwrap_or_default().to_string());
 
     // The pinned tree includes every repository instruction, including nested
     // selectors. Dirty local instructions cannot certify this pinned source.
-    let paths = source.git(&["ls-tree", "-r", "--name-only", revision])?;
+    let paths = source.git(&[
+        "ls-tree",
+        "-r",
+        "--name-only",
+        revision,
+        "--",
+        "**/AGENTS.md",
+        "**/CLAUDE.md",
+    ])?;
 
     let mut instructions = Vec::new();
 
@@ -83,16 +91,37 @@ pub(crate) fn fingerprint(
         ));
     }
 
+    Ok(InstructionSnapshot(
+        serde_json::to_string(&instructions)
+            .map_err(|error| AutomationError::Evidence(error.to_string()))?,
+    ))
+}
+
+pub(crate) fn fingerprint_with_instructions(
+    runtime: &OrbitRuntime,
+    task: &Task,
+    revision: &str,
+    instructions: &InstructionSnapshot,
+) -> Result<String, AutomationError> {
+    let mut dependencies = Vec::new();
+
+    for id in task.dependencies().iter().take(51) {
+        if dependencies.len() == 50 {
+            return Err(AutomationError::Deferred("dependency_scan_budget".into()));
+        }
+        let dependency = runtime.get_task(id)?;
+        dependencies.push(json!({"id": id, "status": dependency.status,
+            "relations": dependency.relations, "criteria": dependency.acceptance_criteria,
+            "description": dependency.description, "plan": dependency.plan,
+            "refs": dependency.external_refs, "pr_status": dependency.pr_status}));
+    }
+
+    dependencies.sort_by_key(|value| value["id"].as_str().unwrap_or_default().to_string());
+
     // The crew a task would actually run under is part of its material input.
     let assignment = runtime.resolve_crew_for_task(None, task.crew.as_deref())?;
     dependencies.push(json!({"effective_assignment": {"crew": assignment.name,
         "model": assignment.assignment.model, "provider": assignment.assignment.provider}}));
 
-    preparation::fingerprint(
-        task,
-        revision,
-        &Value::Array(dependencies),
-        &serde_json::to_string(&instructions)
-            .map_err(|e| AutomationError::Evidence(e.to_string()))?,
-    )
+    preparation::fingerprint(task, revision, &Value::Array(dependencies), &instructions.0)
 }

--- a/crates/orbit-core/src/application/automation/source.rs
+++ b/crates/orbit-core/src/application/automation/source.rs
@@ -11,6 +11,22 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(test)]
+static LS_TREE_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) fn reset_ls_tree_invocations() {
+    LS_TREE_INVOCATIONS.store(0, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(super) fn ls_tree_invocations() -> usize {
+    LS_TREE_INVOCATIONS.load(Ordering::SeqCst)
+}
+
 pub(crate) struct Source<'a> {
     root: &'a Path,
     started: Instant,
@@ -26,6 +42,11 @@ impl<'a> Source<'a> {
 
     /// Run one bounded child process, capturing stdout under a size and time budget.
     fn command(&self, program: &str, args: &[&str]) -> Result<String, AutomationError> {
+        #[cfg(test)]
+        if program == "git" && args.first() == Some(&"ls-tree") {
+            LS_TREE_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
+        }
+
         if self.started.elapsed() > Duration::from_secs(30) {
             return Err(AutomationError::Deferred("source_deadline".into()));
         }

--- a/crates/orbit-core/src/application/automation/tests/members.rs
+++ b/crates/orbit-core/src/application/automation/tests/members.rs
@@ -1,6 +1,10 @@
 //! Host observe/admission fixtures for incident inventory reuse [ORB-11633].
 
-use super::super::members::Host;
+use super::super::{
+    members::Host,
+    preparation,
+    source::{ls_tree_invocations, reset_ls_tree_invocations},
+};
 use crate::OrbitRuntime;
 use chrono::Utc;
 use orbit_automation::members::{MemberAdmission, MemberHost};
@@ -69,6 +73,13 @@ fn trigger() -> StateTrigger {
     }
 }
 
+fn preparation_trigger() -> StateTrigger {
+    StateTrigger {
+        kind: StateTriggerKind::PreparationEligible,
+        ..trigger()
+    }
+}
+
 fn create_backlog_task(runtime: &OrbitRuntime, repo_root: &Path, id_hint: &str) -> String {
     runtime
         .stores()
@@ -102,6 +113,42 @@ fn create_backlog_task(runtime: &OrbitRuntime, repo_root: &Path, id_hint: &str) 
             comments: Vec::new(),
         })
         .expect("create task")
+        .id
+}
+
+fn create_proposed_task(runtime: &OrbitRuntime, repo_root: &Path, id_hint: &str) -> String {
+    runtime
+        .stores()
+        .task_records()
+        .create(TaskCreateParams {
+            actor: "test".into(),
+            parent_id: None,
+            title: format!("task {id_hint}"),
+            description: "test".into(),
+            acceptance_criteria: Vec::new(),
+            dependencies: Vec::new(),
+            relations: Vec::new(),
+            tags: Vec::new(),
+            required_tools: Vec::new(),
+            plan: "test plan".into(),
+            execution_summary: String::new(),
+            context_files: Vec::new(),
+            workspace_path: Some(repo_root.to_string_lossy().into_owned()),
+            repo_root: None,
+            created_by: Some("test".into()),
+            planned_by: None,
+            implemented_by: None,
+            status: TaskStatus::Proposed,
+            priority: TaskPriority::Medium,
+            complexity: None,
+            task_type: TaskType::Chore,
+            external_refs: Vec::new(),
+            source_task_id: None,
+            crew: None,
+            orchestrator: None,
+            comments: Vec::new(),
+        })
+        .expect("create proposed task")
         .id
 }
 
@@ -199,6 +246,48 @@ fn couple_parent_to_child(
     state.record_child_dispatch(dispatch);
     runtime.write_run_state(&parent, &state).unwrap();
     parent
+}
+
+#[test]
+fn preparation_page_lists_instructions_once_for_all_eligible_tasks() {
+    let (_root, runtime, repo) = test_runtime();
+    for hint in ["one", "two", "three"] {
+        create_proposed_task(&runtime, &repo, hint);
+    }
+
+    reset_ls_tree_invocations();
+    let trigger = preparation_trigger();
+    let page = Host::new(&runtime, &trigger)
+        .observe(None, Utc::now())
+        .unwrap();
+
+    assert_eq!(page.candidates.len(), 3);
+    assert_eq!(
+        ls_tree_invocations(),
+        1,
+        "one revision-scoped instruction listing serves the entire page"
+    );
+}
+
+#[test]
+fn cached_instruction_snapshot_preserves_preparation_fingerprint_bytes() {
+    let (_root, runtime, repo) = test_runtime();
+    std::fs::write(repo.join("AGENTS.md"), "Follow the pinned instructions.\n")
+        .expect("write instructions");
+    git(&repo, &["add", "AGENTS.md"]);
+    git(&repo, &["commit", "-m", "add instructions"]);
+
+    let id = create_proposed_task(&runtime, &repo, "fingerprint");
+    let task = runtime.get_task(&id).expect("task");
+    let revision = preparation::head_revision(&runtime, "agent-main").expect("head");
+
+    let before = preparation::fingerprint(&runtime, &task, &revision).expect("fingerprint");
+    let instructions = preparation::instructions(&runtime, &revision).expect("instructions");
+    let after =
+        preparation::fingerprint_with_instructions(&runtime, &task, &revision, &instructions)
+            .expect("fingerprint with cached instructions");
+
+    assert_eq!(before, after);
 }
 
 #[test]

--- a/crates/orbit-core/src/application/operation/promotion.rs
+++ b/crates/orbit-core/src/application/operation/promotion.rs
@@ -22,7 +22,7 @@ use serde_json::json;
 
 use super::{PROMOTION_AUDIT, captured_policy};
 use crate::OrbitRuntime;
-use crate::application::automation::preparation;
+use crate::application::automation::preparation::{self, InstructionSnapshot};
 
 /// History event recorded on a task promoted under a grant.
 pub(crate) const PROMOTION_EVENT: &str = "operation_promoted";
@@ -69,7 +69,7 @@ pub(crate) fn promote_within_grant(
         .map(|task| (task.id, task.status))
         .collect();
     let branch = runtime.workflow_base_branch().to_string();
-    let mut head = None;
+    let mut source: Option<(String, InstructionSnapshot)> = None;
 
     for task_id in &grant.task_ids {
         let task = match runtime.get_task(task_id) {
@@ -113,18 +113,37 @@ pub(crate) fn promote_within_grant(
             decisions.push(PromotionDecision::withheld(task_id, "assessment_unready"));
             continue;
         }
-        let revision = match &head {
-            Some(revision) => revision,
-            None => head.insert(preparation::head_revision(runtime, &branch)?),
+        let (revision, instructions) = match &source {
+            Some(source) => (&source.0, &source.1),
+            None => {
+                let revision = preparation::head_revision(runtime, &branch)?;
+                let instructions = preparation::instructions(runtime, &revision)
+                    .map_err(orbit_automation::automation_error_to_orbit)?;
+                source = Some((revision, instructions));
+                let Some(source) = source.as_ref() else {
+                    return Err(OrbitError::Execution(
+                        "operation promotion did not retain its source snapshot".to_string(),
+                    ));
+                };
+                (&source.0, &source.1)
+            }
         };
-        let fingerprint = preparation::fingerprint(runtime, &task, revision)
-            .map_err(orbit_automation::automation_error_to_orbit)?;
+        let fingerprint =
+            preparation::fingerprint_with_instructions(runtime, &task, revision, instructions)
+                .map_err(orbit_automation::automation_error_to_orbit)?;
         if fingerprint != assessment.resulting_fingerprint {
             decisions.push(PromotionDecision::withheld(task_id, "assessment_stale"));
             continue;
         }
 
-        let decision = promote_locked(runtime, grant, task_id, revision, &fingerprint)?;
+        let decision = promote_locked(
+            runtime,
+            grant,
+            task_id,
+            revision,
+            instructions,
+            &fingerprint,
+        )?;
         runtime.record_pipeline_audit(
             PROMOTION_AUDIT,
             None,
@@ -154,6 +173,7 @@ fn promote_locked(
     grant: &OperationGrant,
     task_id: &str,
     revision: &str,
+    instructions: &InstructionSnapshot,
     expected_fingerprint: &str,
 ) -> Result<PromotionDecision, OrbitError> {
     let mut decision = None;
@@ -163,8 +183,9 @@ fn promote_locked(
             decision = Some(PromotionDecision::withheld(task_id, "status_changed"));
             return Ok(());
         }
-        let fingerprint = preparation::fingerprint(runtime, &current, revision)
-            .map_err(orbit_automation::automation_error_to_orbit)?;
+        let fingerprint =
+            preparation::fingerprint_with_instructions(runtime, &current, revision, instructions)
+                .map_err(orbit_automation::automation_error_to_orbit)?;
         if fingerprint != expected_fingerprint {
             decision = Some(PromotionDecision::withheld(task_id, "assessment_stale"));
             return Ok(());


### PR DESCRIPTION
## Task

[ORB-11634](https://orbit-cli.com/tasks/ORB-11634) — [code-review] Cache the per-revision instruction listing used by the preparation fingerprint

### Description

## Problem
`preparation::fingerprint` runs `git ls-tree -r --name-only <revision>` over the entire tree and then `git show` for every `AGENTS.md`/`CLAUDE.md` (up to 50) per task (preparation.rs:69-84). `Host::observe` calls it for up to 50 tasks per page against the same `source.commit` (members.rs:136), `admission` calls it again per member (members.rs:227), and `promote_within_grant` calls it twice per task — once outside (promotion.rs:120) and once inside the per-task write lock (promotion.rs:166), so the lock is held across up to ~52 git subprocess spawns. `Source::command` also caps output at 1 MiB and fails with `source_budget` (source.rs:60-85), so on a repository whose `ls-tree -r` listing exceeds 1 MiB every preparation candidate is withheld with that opaque reason.

## Why It Matters
The listing and instruction contents are a pure function of the revision; recomputing them per task turns a linear pass into N full-tree listings and keeps a task lock across subprocess I/O.

## Proposed Fix
Compute `(instruction paths, contents)` once per revision (a small cache keyed by commit on the `Source`/`Host` for the duration of the pass) and pass it into `fingerprint`; reuse the outside-lock fingerprint's cached listing inside `promote_locked`; use `git ls-tree -r --name-only <rev> -- ` with a pathspec or `--full-tree` filtering for `*AGENTS.md`/`*CLAUDE.md` so the budget scales with instruction files, not tree size.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-core/src/application/automation/preparation.rs:45-98`, `crates/orbit-core/src/application/automation/members.rs:135-142`, `crates/orbit-core/src/application/operation/promotion.rs:116-127`, `crates/orbit-core/src/application/operation/promotion.rs:152-207`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: core-app.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- A test counting `git` invocations for a page of N eligible tasks shows one `ls-tree` per revision, not per task.
- Fingerprints for the same task/revision are byte-identical before and after the change (regression test on `preparation::fingerprint`).

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added a revision-scoped instruction snapshot that uses filtered git pathspecs and preserves the pre-existing serialized fingerprint evidence.
- Reused snapshots across preparation page observation/admission and across promotion’s outside-lock and locked recheck paths.
- Added regressions proving one ls-tree listing for a multi-task page and byte-identical preparation fingerprints.
Assessment: The cache is bounded to each Host/promotion pass and keyed by commit, avoiding stale cross-revision evidence.
Criteria:
- Page-level invocation count: passed (three eligible tasks produced exactly one ls-tree invocation).
- Fingerprint byte stability: passed (direct fingerprint equals cached-snapshot fingerprint).
Validation:
- cargo test -p orbit-core application::automation::tests::members --lib: passed (6 tests).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks: Git pathspec behavior is covered by fixture instructions; cache lifetime is intentionally limited to a single evaluation or promotion pass.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11634-6a9f79d8`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra