### PR TITLE
[code-review] Reuse runtime-owned SQLite stores for automation, review, operations, and tool audit

### DIFF
--- a/crates/orbit-core/src/adapter/command/tests/dispatch.rs
+++ b/crates/orbit-core/src/adapter/command/tests/dispatch.rs
@@ -1,4 +1,5 @@
 use orbit_common::OrbitError;
+use orbit_store::Store;
 use orbit_tools::ToolExecutionKind;
 use orbit_types::telemetry::AuditEventStatus;
 use orbit_types::tool::{McpCapability, McpTransport, ToolSessionContext};
@@ -49,6 +50,36 @@ fn dispatch_records_success_audit_with_mcp_subcommand_and_clamped_duration() {
         row.duration_ms >= 1,
         "duration_ms clamped to >= 1 (got {})",
         row.duration_ms
+    );
+}
+
+#[test]
+fn runtime_dispatch_reuses_the_open_audit_store() {
+    let _g = env_guard();
+    let runtime = fresh_runtime();
+    let audit_db = runtime.context.persistence().audit_db.clone();
+    let opened = Store::thread_file_open_count_for(&audit_db);
+
+    let outcome = runtime
+        .execute_tool_command_dispatch(
+            "orbit.search",
+            json!({ "query": "reuse", "model": orbit_common::test_fixtures::TEST_CODEX_MODEL }),
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+        )
+        .expect("dispatch ok");
+    assert!(outcome.audit_recorded);
+
+    let events = runtime
+        .list_audit_events(None, Some("orbit.search".to_string()), None, None, 16)
+        .expect("list audit events");
+    assert_eq!(events.len(), 1, "exactly one audit row");
+    assert_eq!(events[0].status, AuditEventStatus::Success);
+    assert_eq!(
+        Store::thread_file_open_count_for(&audit_db),
+        opened,
+        "runtime-backed dispatch must not reopen the audit database"
     );
 }
 

--- a/crates/orbit-core/src/context.rs
+++ b/crates/orbit-core/src/context.rs
@@ -4,10 +4,13 @@ use std::sync::Arc;
 use orbit_engine::PrConfig;
 use orbit_policy::PolicyEngine;
 use orbit_search::{EmbedWorker, VectorStore};
+use orbit_store::Store;
 use orbit_store::contracts::{
-    AuditEventStoreBackend, ExecutorDefStoreBackend, JobRunStoreBackend, PolicyDefStoreBackend,
-    TaskArtifactStoreBackend, TaskDocumentStoreBackend, TaskHistoryStoreBackend,
-    TaskReservationStoreBackend, TaskStoreBackend, ToolStoreBackend,
+    AuditEventStoreBackend, AutomationStoreBackend, ExecutorDefStoreBackend,
+    InvocationStoreBackend, JobRunStoreBackend, OperationStoreBackend, PolicyDefStoreBackend,
+    ReviewStoreBackend, TaskArtifactStoreBackend, TaskDocumentStoreBackend,
+    TaskHistoryStoreBackend, TaskReservationStoreBackend, TaskStoreBackend, ToolStoreBackend,
+    V2AuditStoreBackend,
 };
 use orbit_tools::ToolRegistry;
 use orbit_types::identity::{Crew, normalize_agent_family_for_model};
@@ -92,6 +95,20 @@ pub struct OrbitContext {
     runtime: OrbitRuntimeSettings,
 }
 
+/// Host SQLite handle plus the feature backends composed from it.
+///
+/// These wrap the same writer connection the runtime opened at construction.
+/// Accessors clone the handles; they must not call `Store::open` again.
+#[derive(Clone)]
+pub(crate) struct OrbitHostStore {
+    pub(crate) sqlite: Store,
+    pub(crate) automation: Arc<dyn AutomationStoreBackend>,
+    pub(crate) review: Arc<dyn ReviewStoreBackend>,
+    pub(crate) operation: Arc<dyn OperationStoreBackend>,
+    pub(crate) v2_audit: Arc<dyn V2AuditStoreBackend>,
+    pub(crate) invocation: Arc<dyn InvocationStoreBackend>,
+}
+
 #[derive(Clone)]
 pub(crate) struct OrbitStores {
     pub(crate) task: Arc<dyn TaskStoreBackend>,
@@ -106,6 +123,7 @@ pub(crate) struct OrbitStores {
     pub(crate) audit_event: Arc<dyn AuditEventStoreBackend>,
     pub(crate) executor_def: Arc<dyn ExecutorDefStoreBackend>,
     pub(crate) policy_def: Arc<dyn PolicyDefStoreBackend>,
+    pub(crate) host: OrbitHostStore,
 }
 
 impl OrbitStores {
@@ -123,6 +141,7 @@ impl OrbitStores {
         audit_event: Arc<dyn AuditEventStoreBackend>,
         executor_def: Arc<dyn ExecutorDefStoreBackend>,
         policy_def: Arc<dyn PolicyDefStoreBackend>,
+        host: OrbitHostStore,
     ) -> Self {
         Self {
             task,
@@ -137,6 +156,7 @@ impl OrbitStores {
             audit_event,
             executor_def,
             policy_def,
+            host,
         }
     }
 

--- a/crates/orbit-core/src/runtime/builder.rs
+++ b/crates/orbit-core/src/runtime/builder.rs
@@ -5,9 +5,10 @@ use orbit_policy::PolicyEngine;
 use orbit_search::{EmbedWorker, VectorStore};
 use orbit_store::Store;
 use orbit_store::compose::{
-    WorkspaceTaskBackends, audit_event_store_sqlite, coordination_task_backends,
-    global_executor_def_store, global_policy_def_store, layered_policy_def_store,
-    task_reservation_store_sqlite, tool_store_sqlite, workspace_job_run_store,
+    WorkspaceTaskBackends, audit_event_store_sqlite, automation_store, coordination_task_backends,
+    global_executor_def_store, global_policy_def_store, invocation_store_from_store,
+    layered_policy_def_store, operation_store, review_store, task_reservation_store_sqlite,
+    tool_store_sqlite, v2_audit_store_from_store, workspace_job_run_store,
     workspace_policy_def_store, workspace_task_backends,
 };
 use orbit_store::maintenance::task_registry::{
@@ -25,7 +26,8 @@ use orbit_types::workspace::WorkspacePaths;
 
 use crate::context::OrbitContext;
 use crate::context::{
-    ActorIdentity, OrbitExecutionAssets, OrbitPolicyContext, OrbitRuntimeSettings, OrbitStores,
+    ActorIdentity, OrbitExecutionAssets, OrbitHostStore, OrbitPolicyContext, OrbitRuntimeSettings,
+    OrbitStores,
 };
 use crate::runtime::{HostLifetime, WorkspaceRuntimeBinding};
 use crate::skill_catalog::SkillCatalog;
@@ -117,6 +119,14 @@ pub(crate) fn build_context_from_roots(
     let tool_store = tool_store_sqlite(store.clone());
     let audit_event_store = audit_event_store_sqlite(store.clone());
     let task_reservation_store = task_reservation_store_sqlite(store.clone());
+    let host_store = OrbitHostStore {
+        sqlite: store.clone(),
+        automation: automation_store(store.clone())?,
+        review: review_store(store.clone())?,
+        operation: operation_store(store.clone())?,
+        v2_audit: v2_audit_store_from_store(store.clone()),
+        invocation: invocation_store_from_store(store.clone()),
+    };
     let executor_def_store = global_executor_def_store(persistence.executor_dir.clone());
     let global_policy_store = global_policy_def_store(persistence.policy_dir.clone());
     let workspace_policy_store = workspace_policy_def_store(paths.policies_dir.clone());
@@ -181,6 +191,7 @@ pub(crate) fn build_context_from_roots(
             audit_event_store,
             executor_def_store,
             policy_def_store,
+            host_store,
         ),
         OrbitExecutionAssets::new(Arc::new(registry), skill_catalog),
         OrbitPolicyContext::new(

--- a/crates/orbit-core/src/runtime/engine/invocation.rs
+++ b/crates/orbit-core/src/runtime/engine/invocation.rs
@@ -390,5 +390,5 @@ fn valid_cost(cost: f64) -> bool {
 fn open_invocation_store(
     runtime: &OrbitRuntime,
 ) -> Result<Arc<dyn InvocationStoreBackend>, OrbitError> {
-    orbit_store::compose::invocation_store(&runtime.context.persistence().audit_db)
+    Ok(Arc::clone(&runtime.context.stores().host.invocation))
 }

--- a/crates/orbit-core/src/runtime/friction.rs
+++ b/crates/orbit-core/src/runtime/friction.rs
@@ -1,18 +1,21 @@
 //! Runtime-owned access to the workspace-partitioned friction repository.
 
 use orbit_common::OrbitError;
-use orbit_store::compose::workspace_friction_store_from_path;
+use orbit_store::compose::workspace_friction_store;
 use orbit_store::contracts::FrictionStoreBackend;
 use std::sync::Arc;
 
 use crate::OrbitRuntime;
 
-/// Open the friction repository scoped by this runtime's workspace identity.
+/// Friction repository scoped by this runtime's workspace identity.
+///
+/// Uses the runtime-owned host store rather than opening the audit database
+/// again on every call.
 pub(crate) fn store_for(
     runtime: &OrbitRuntime,
 ) -> Result<Arc<dyn FrictionStoreBackend>, OrbitError> {
-    workspace_friction_store_from_path(
-        &runtime.context.persistence().audit_db,
+    workspace_friction_store(
+        runtime.sqlite_store()?,
         runtime.workspace_id()?,
         runtime.data_root().join("frictions"),
     )

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -392,31 +392,31 @@ impl OrbitRuntime {
     pub fn automation_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::AutomationStoreBackend>, OrbitError> {
-        orbit_store::compose::automation_store(Store::open(&self.context.persistence().audit_db)?)
+        Ok(Arc::clone(&self.context.stores().host.automation))
     }
 
     /// Before-PR review ledgers, certificates, and landings [ORB-11333].
     pub fn review_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::ReviewStoreBackend>, OrbitError> {
-        orbit_store::compose::review_store(Store::open(&self.context.persistence().audit_db)?)
+        Ok(Arc::clone(&self.context.stores().host.review))
     }
 
     /// Operation-mode grants and recovery ledgers in the host store [ORB-11332].
     pub fn operation_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::OperationStoreBackend>, OrbitError> {
-        orbit_store::compose::operation_store(Store::open(&self.context.persistence().audit_db)?)
+        Ok(Arc::clone(&self.context.stores().host.operation))
     }
 
     pub fn sqlite_store(&self) -> Result<Store, OrbitError> {
-        Store::open(&self.context.persistence().audit_db)
+        Ok(self.context.stores().host.sqlite.clone())
     }
 
     pub fn v2_audit_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::V2AuditStoreBackend>, OrbitError> {
-        orbit_store::compose::v2_audit_store(&self.context.persistence().audit_db)
+        Ok(Arc::clone(&self.context.stores().host.v2_audit))
     }
 
     pub fn ensure_persistence_ready(&self) -> Result<(), OrbitError> {

--- a/crates/orbit-core/src/runtime/tests/mod.rs
+++ b/crates/orbit-core/src/runtime/tests/mod.rs
@@ -5,5 +5,6 @@ mod run_audit;
 mod run_input;
 mod runtime;
 mod session_log;
+mod store_reuse;
 mod tool_exec;
 mod workspace_claim;

--- a/crates/orbit-core/src/runtime/tests/store_reuse.rs
+++ b/crates/orbit-core/src/runtime/tests/store_reuse.rs
@@ -1,0 +1,343 @@
+//! Runtime host-store reuse: accessors and dispatch clone the builder-opened
+//! audit database instead of calling `Store::open` again.
+
+use std::time::{Duration, Instant};
+
+use chrono::{Duration as ChronoDuration, Utc};
+use orbit_store::Store;
+use orbit_store::contracts::{
+    GrantInsertOutcome, RecoveryBudget, RecoveryReserveRequest, ReviewReserveRequest,
+    V2AuditEventFilter, V2AuditEventInsertParams,
+};
+use orbit_types::workflow::automation::{AutomationState, SourceRevision};
+use orbit_types::workflow::{
+    GrantLimits, GrantRights, GrantStatus, OperationGrant, RecoveryEpisodeKind, ReviewBudget,
+    ReviewReservation,
+};
+use serde_json::json;
+
+use crate::OrbitRuntime;
+use crate::adapter::command::ToolEntryPoint;
+
+const ACCESS_ITERS: u32 = 32;
+const DISPATCH_ITERS: u32 = 16;
+
+fn runtime() -> OrbitRuntime {
+    OrbitRuntime::in_memory().expect("in-memory runtime")
+}
+
+fn audit_db(runtime: &OrbitRuntime) -> std::path::PathBuf {
+    runtime.context.persistence().audit_db.clone()
+}
+
+fn revision(label: &str) -> SourceRevision {
+    SourceRevision {
+        commit: format!("commit-{label}"),
+        tree: format!("tree-{label}"),
+    }
+}
+
+fn automation_state(consumer: &str) -> AutomationState {
+    let head = revision("head");
+    AutomationState {
+        members: None,
+        consumer: consumer.into(),
+        epoch: "epoch".into(),
+        repository: "repo".into(),
+        branch: "agent-main".into(),
+        generation: 0,
+        baseline: head.clone(),
+        observed: head.clone(),
+        covered: head,
+        pending_commits: vec![],
+        pending: vec![],
+        waived: vec![],
+        excluded: vec![],
+        unresolved: Default::default(),
+        associations: Default::default(),
+        active: None,
+    }
+}
+
+fn grant(workspace_id: &str, id: &str, task_id: &str) -> OperationGrant {
+    let now = Utc::now();
+    OperationGrant {
+        id: id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        actor: "operator".to_string(),
+        source: "test".to_string(),
+        created_at: now,
+        expires_at: now + ChronoDuration::seconds(3_600),
+        revision: 1,
+        task_ids: vec![task_id.to_string()],
+        rights: GrantRights {
+            prepare: true,
+            promote: true,
+            complete: false,
+        },
+        limits: GrantLimits {
+            leaf_ceiling: 2,
+            preparation_due_seconds: 300,
+            recovery_episodes_per_task: 2,
+            recovery_minutes_per_task: 30,
+        },
+        policy: json!({ "version": 1 }),
+        policy_version: 1,
+        status: GrantStatus::Active,
+        stopped: None,
+        revoked: None,
+    }
+}
+
+fn touch_host_accessors(runtime: &OrbitRuntime) {
+    runtime.automation_store().expect("automation");
+    runtime.review_store().expect("review");
+    runtime.operation_store().expect("operation");
+    runtime.v2_audit_store().expect("v2 audit");
+    runtime.sqlite_store().expect("sqlite");
+}
+
+fn dispatch_search(runtime: &OrbitRuntime) {
+    runtime
+        .execute_tool_command_dispatch(
+            "orbit.search",
+            json!({
+                "query": "reuse",
+                "model": orbit_common::test_fixtures::TEST_CODEX_MODEL
+            }),
+            None,
+            None,
+            ToolEntryPoint::Mcp,
+        )
+        .expect("dispatch");
+}
+
+#[test]
+fn repeated_host_access_does_not_reopen_the_audit_database() {
+    let runtime = runtime();
+    let audit_db = audit_db(&runtime);
+    touch_host_accessors(&runtime);
+    dispatch_search(&runtime);
+    let opened = Store::thread_file_open_count_for(&audit_db);
+
+    for _ in 0..ACCESS_ITERS {
+        touch_host_accessors(&runtime);
+    }
+    for _ in 0..DISPATCH_ITERS {
+        dispatch_search(&runtime);
+    }
+
+    assert_eq!(
+        Store::thread_file_open_count_for(&audit_db),
+        opened,
+        "repeated accessor and dispatch use must not call Store::open on the runtime audit database"
+    );
+}
+
+#[test]
+fn worker_preflight_still_reopens_the_audit_database() {
+    let runtime = runtime();
+    let audit_db = audit_db(&runtime);
+    let opened = Store::thread_file_open_count_for(&audit_db);
+    runtime
+        .ensure_persistence_ready()
+        .expect("documented worker preflight");
+    assert!(
+        Store::thread_file_open_count_for(&audit_db) > opened,
+        "ensure_persistence_ready must keep its justified reopen"
+    );
+}
+
+#[test]
+fn reused_handles_keep_partitioned_persistence_and_recovery() {
+    let runtime = runtime();
+    let workspace_id = runtime.workspace_id().expect("workspace id");
+    let other_workspace = "ws_other";
+
+    let first_automation = runtime.automation_store().expect("automation");
+    let first_review = runtime.review_store().expect("review");
+    let first_operation = runtime.operation_store().expect("operation");
+    let first_audit = runtime.v2_audit_store().expect("v2 audit");
+
+    let consumer_a = format!("{workspace_id}/consumer-a");
+    let consumer_b = format!("{workspace_id}/consumer-b");
+    let state_a = automation_state(&consumer_a);
+    let state_b = automation_state(&consumer_b);
+    assert!(
+        first_automation
+            .automation_initialize(&state_a)
+            .expect("init a")
+    );
+    assert!(
+        first_automation
+            .automation_initialize(&state_b)
+            .expect("init b")
+    );
+
+    let task_ids = vec!["ORB-1".to_string()];
+    let ReviewReservation::Reserved { attempt } = first_review
+        .review_reserve(
+            &workspace_id,
+            &ReviewReserveRequest {
+                lineage_key: "ws/ORB-1/agent-main",
+                task_ids: &task_ids,
+                run_id: "jrun-reuse",
+                task_meaning_digest: "meaning",
+                candidate: &revision("impl"),
+                budget: ReviewBudget::default(),
+                now: Utc::now(),
+            },
+        )
+        .expect("reserve review")
+        .0
+    else {
+        panic!("first review start reserves");
+    };
+
+    assert_eq!(
+        first_operation
+            .operation_grant_insert(&grant(&workspace_id, "ogrant-1", "ORB-1"))
+            .expect("insert grant"),
+        GrantInsertOutcome::Inserted
+    );
+    assert_eq!(
+        first_operation
+            .operation_grant_insert(&grant(other_workspace, "ogrant-other", "ORB-2"))
+            .expect("insert other grant"),
+        GrantInsertOutcome::Inserted
+    );
+
+    let (reservation, _) = first_operation
+        .operation_recovery_reserve(
+            &workspace_id,
+            &RecoveryReserveRequest {
+                task_id: "ORB-1",
+                run_id: "jrun-recovery",
+                step_id: Some("sync_base"),
+                kind: RecoveryEpisodeKind::StepRecovery,
+                budget: RecoveryBudget {
+                    episodes: 2,
+                    seconds: 1_800,
+                },
+                now: Utc::now(),
+            },
+        )
+        .expect("reserve recovery");
+    assert!(matches!(
+        reservation,
+        orbit_types::workflow::RecoveryReservation::Reserved { episode: 1, .. }
+    ));
+
+    first_audit
+        .insert_v2_audit_event(&V2AuditEventInsertParams {
+            workspace_id: workspace_id.clone(),
+            event_id: "evt-reuse".into(),
+            source: "test".into(),
+            schema_version: 1,
+            event_type: "reuse.persisted".into(),
+            ts: Utc::now(),
+            run_id: "jrun-reuse".into(),
+            agent_identity: "grok".into(),
+            parent_event_id: None,
+            workspace_path: None,
+            payload_json: json!({ "ok": true }).to_string(),
+        })
+        .expect("insert v2 audit");
+
+    let second_automation = runtime.automation_store().expect("automation reuse");
+    let second_review = runtime.review_store().expect("review reuse");
+    let second_operation = runtime.operation_store().expect("operation reuse");
+    let second_audit = runtime.v2_audit_store().expect("v2 audit reuse");
+
+    assert_eq!(
+        second_automation
+            .automation_state(&consumer_a)
+            .expect("read a"),
+        Some(state_a)
+    );
+    assert_eq!(
+        second_automation
+            .automation_state(&consumer_b)
+            .expect("read b")
+            .map(|state| state.consumer),
+        Some(consumer_b)
+    );
+    assert_eq!(
+        second_review
+            .review_ledger(&workspace_id, "ws/ORB-1/agent-main")
+            .expect("ledger")
+            .expect("present")
+            .attempts[0]
+            .attempt_id,
+        attempt.attempt_id
+    );
+    assert!(
+        second_review
+            .review_ledger(other_workspace, "ws/ORB-1/agent-main")
+            .expect("other ledger")
+            .is_none(),
+        "review ledgers are partitioned by workspace"
+    );
+    assert_eq!(
+        second_operation
+            .operation_active_grant(&workspace_id, Utc::now())
+            .expect("active grant")
+            .map(|grant| grant.id),
+        Some("ogrant-1".into())
+    );
+    assert_eq!(
+        second_operation
+            .operation_active_grant(other_workspace, Utc::now())
+            .expect("other grant")
+            .map(|grant| grant.id),
+        Some("ogrant-other".into())
+    );
+    assert_eq!(
+        second_operation
+            .operation_recovery_ledger(&workspace_id, "ORB-1")
+            .expect("recovery ledger")
+            .expect("present")
+            .episodes_consumed(),
+        1
+    );
+    assert_eq!(
+        second_audit
+            .list_v2_audit_events(&V2AuditEventFilter {
+                workspace_id: workspace_id.clone(),
+                event_type: Some("reuse.persisted".into()),
+                ..V2AuditEventFilter::default()
+            })
+            .expect("list audit")
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn reports_bounded_warm_reuse_versus_reopen_measurements() {
+    let runtime = runtime();
+    let audit_db = audit_db(&runtime);
+    touch_host_accessors(&runtime);
+    dispatch_search(&runtime);
+
+    let reused_access = time_iters(ACCESS_ITERS, || touch_host_accessors(&runtime));
+    let control_open = time_iters(ACCESS_ITERS, || {
+        drop(Store::open(&audit_db).expect("control open"));
+    });
+    let reused_dispatch = time_iters(DISPATCH_ITERS, || dispatch_search(&runtime));
+
+    assert!(
+        reused_access < Duration::from_secs(30)
+            && control_open < Duration::from_secs(30)
+            && reused_dispatch < Duration::from_secs(30),
+        "warm reused accessors {reused_access:?}; same-path Store::open control {control_open:?}; warm dispatch {reused_dispatch:?}"
+    );
+}
+
+fn time_iters(iters: u32, mut body: impl FnMut()) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iters {
+        body();
+    }
+    start.elapsed()
+}

--- a/crates/orbit-store/src/compose/mod.rs
+++ b/crates/orbit-store/src/compose/mod.rs
@@ -134,13 +134,23 @@ pub fn routine_store(
 pub fn invocation_store(
     database: &std::path::Path,
 ) -> Result<Arc<dyn InvocationStoreBackend>, orbit_common::OrbitError> {
-    Ok(Arc::new(Store::open(database)?))
+    Ok(invocation_store_from_store(Store::open(database)?))
+}
+
+/// Compose invocation accounting over an already-opened host store.
+pub fn invocation_store_from_store(store: Store) -> Arc<dyn InvocationStoreBackend> {
+    Arc::new(store)
 }
 
 pub fn v2_audit_store(
     database: &std::path::Path,
 ) -> Result<Arc<dyn V2AuditStoreBackend>, orbit_common::OrbitError> {
-    Ok(Arc::new(Store::open(database)?))
+    Ok(v2_audit_store_from_store(Store::open(database)?))
+}
+
+/// Compose the v2 audit contract over an already-opened host store.
+pub fn v2_audit_store_from_store(store: Store) -> Arc<dyn V2AuditStoreBackend> {
+    Arc::new(store)
 }
 
 pub fn tool_store_sqlite(store: Store) -> Arc<dyn ToolStoreBackend> {

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use orbit_common::OrbitError;
@@ -7,6 +8,14 @@ use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 use crate::driver::sqlite::migration;
 use crate::driver::sqlite::read_pool::{ReadGuard, ReadPool};
+
+thread_local! {
+    static FILE_OPEN_PATHS: RefCell<Vec<PathBuf>> = const { RefCell::new(Vec::new()) };
+}
+
+fn record_file_open(path: &Path) {
+    FILE_OPEN_PATHS.with(|paths| paths.borrow_mut().push(path.to_path_buf()));
+}
 
 /// SQLite store handle: one writer connection behind a mutex (WAL permits a
 /// single writer) plus a read-only connection pool so reads never queue
@@ -70,7 +79,22 @@ impl Store {
         .map_err(|e| OrbitError::Store(e.to_string()))?;
         Ok(())
     }
+    /// Writer-handle constructions of `path` on this thread via [`Store::open`].
+    ///
+    /// Read-pool checkouts use `Connection::open` and are not counted. In-memory
+    /// stores have no file path and are also excluded.
+    pub fn thread_file_open_count_for(path: &Path) -> u64 {
+        FILE_OPEN_PATHS.with(|paths| {
+            paths
+                .borrow()
+                .iter()
+                .filter(|opened| opened.as_path() == path)
+                .count() as u64
+        })
+    }
+
     pub fn open(path: &Path) -> Result<Self, OrbitError> {
+        record_file_open(path);
         let opened = open_private(path)?;
         let conn = opened.connection;
         let read_only = opened.read_only;


### PR DESCRIPTION
## Task

[ORB-11632](https://orbit-cli.com/tasks/ORB-11632) — [code-review] Reuse runtime-owned SQLite stores for automation, review, operations, and tool audit

### Description

## Problem
Runtime automation/review/operation/audit accessors reopen the configured audit database, repeating connection setup and schema checks despite the runtime builder already opening it. Runtime-backed tool dispatch also supplies a factory that calls `sqlite_store()` for each dispatch.

## Required behavior
Compose and reuse these backends from the runtime-owned store, including runtime-backed tool auditing. Consolidated scope includes ORB-11626: preserve mutating-dispatch audit failure semantics and verify the dispatch path does not reopen the database. Use the existing store composition boundary rather than a second resource owner.
Preserve intentional opens where no runtime exists, including global in-process dispatch, and any justified worker preflight reopen. Unrelated task-registry/vector stores are outside the audit-database criterion. Do not prohibit SQLite's managed read-pool connections. Keep touched routine-status code readable without expanding into unrelated formatting.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/runtime/mod.rs:340-368`; `crates/orbit-core/src/runtime/builder.rs:50`; `crates/orbit-core/src/adapter/command/dispatch.rs:124`, `:348`; `crates/orbit-store/src/driver/sqlite/connection.rs:73`.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- Focused instrumentation shows repeated automation/review/operation/audit access and runtime-backed tool dispatch do not repeat Store::open/schema initialization for the runtime audit database after construction; read-pool connections and documented standalone/preflight paths are excluded.
- Automation, review, and operation tests preserve partitioning, persistence, and recovery behavior when handles are reused.
- Command dispatch tests retain audit-row assertions and prove a mutating call still fails closed on audit persistence failure; standalone global dispatch remains functional.
- Report bounded before/after warm dispatch or repeated-access measurements without prescribing an unmeasured improvement threshold; required formatting/lint checks pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Runtime builder keeps the opened host SQLite `Store` on `OrbitHostStore` and composes automation, review, operation, v2-audit, and invocation backends from that handle once.
- Accessors clone those handles instead of `Store::open`/`apply_schema`.
- Runtime-backed dispatch, invocation accounting, and friction compose reuse the same writer; standalone global dispatch and `ensure_persistence_ready` still open.
- `Store::thread_file_open_count_for` counts writer opens by path (read-pool excluded).
Assessment: scoped reuse at the existing compose boundary; no second resource owner.

Criteria:
1. Instrumentation: after construction, 32 accessor sets + 16 `orbit.search` dispatches did not increment `Store::thread_file_open_count_for(audit_db)`. Worker preflight still increments. Read-pool uses `Connection::open` and is uncounted. Standalone global dispatch still opens.
2. Reused handles preserve automation consumer partitioning, review ledger/workspace isolation, operation grants per workspace, and recovery episode persistence; existing automation/review/operation tests passed.
3. Command dispatch tests (35) retain audit-row assertions; mutating `finalize_successful_dispatch` still fails closed; global dispatch still functions including fail-closed on unopenable audit DB.
4. Warm measurements (no threshold): 32 reused accessor sets 15.431µs vs 32 `Store::open` control 69.652ms; 16 warm dispatches 277.187ms. `make ci-fast` passed; `make ci-lint` passed.

Validation:
- `cargo test -p orbit-core --lib runtime::tests::store_reuse` — passed (4)
- `cargo test -p orbit-core --lib adapter::command::tests` — passed (35)
- `cargo test -p orbit-core --lib application::automation::tests` — passed (14)
- `cargo test -p orbit-core --lib application::review::tests` — passed (29)
- `cargo test -p orbit-core --lib application::operation::tests` — passed (15)
- `cargo test -p orbit-store --lib sqlite::automation` — passed (4)
- `cargo test -p orbit-store --lib sqlite::review` — passed (6)
- `cargo test -p orbit-store --lib sqlite::operation` — passed (5)
- `make ci-fast` — passed
- `make ci-lint` — passed
- `git diff --check` — passed

Deviations: also reused invocation and friction compose from the runtime-owned store because those paths reopened the same audit DB on dispatch; not a second owner.
Remaining risks: `ensure_persistence_ready` still reopens by design; registry/vector opens unchanged; friction still runs import on each `store_for` (no `Store::open`).
HEAD at start: b85a8c1070db5ac009f01c26356a700e38ee4c72; changes uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11632-6a9f7825`
- Behind base: 0
- Ahead of base: 1

*authored by: grok*

Orchestrated-By: astra