### PR TITLE
[code-review] Move duplicated path/workspace-id rules to their single owner

### DIFF
--- a/crates/orbit-store/src/driver/file/workspace_binding.rs
+++ b/crates/orbit-store/src/driver/file/workspace_binding.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use orbit_common::OrbitError;
 use serde::{Deserialize, Serialize};
 
+use crate::fs::path_safety::validate_workspace_id;
 use crate::fs::yaml::{parse_yaml_with, write_yaml_atomic_with};
 
 use crate::contracts::WorkspaceConfig;
@@ -90,34 +91,4 @@ fn validate_workspace_config_doc(doc: WorkspaceConfigDoc) -> Result<WorkspaceCon
         schema_version: doc.schema_version,
         workspace_id: validate_workspace_id(&doc.workspace_id)?,
     })
-}
-
-fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
-    let trimmed = raw.trim();
-    let logical = trimmed.strip_prefix("ws_").is_some_and(|name| {
-        !name.is_empty()
-            && name
-                .bytes()
-                .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_'))
-    });
-    let legacy = trimmed.rsplit_once('-').is_some_and(|(slug, suffix)| {
-        !slug.is_empty()
-            && !slug.starts_with('-')
-            && !slug.ends_with('-')
-            && !slug.contains("--")
-            && slug
-                .bytes()
-                .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-'))
-            && suffix.len() == 6
-            && suffix
-                .bytes()
-                .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
-    });
-    if logical || legacy {
-        Ok(trimmed.to_string())
-    } else {
-        Err(OrbitError::InvalidInput(format!(
-            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
-        )))
-    }
 }

--- a/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/store.rs
@@ -19,15 +19,14 @@ use super::queries::{
 use super::schema::{
     apply_schema, assert_registry_user_version, ensure_compatible_schema, registry_user_version,
 };
-use super::util::{
-    normalize_path, now_string, parse_relation_type_name, path_to_string, relation_type_name,
-};
+use super::util::{now_string, parse_relation_type_name, path_to_string, relation_type_name};
 use super::workspace_id::{next_workspace_id_candidate, sanitize_slug, validate_workspace_id};
 use crate::contracts::{
     AllocatorSeedOutcome, BindWorkspaceParams, DanglingRelationTarget, RegisterWorkspaceParams,
     TaskBundleBinding, TaskCompletionByComplexity, TaskIndexFilter, WorkspaceBinding,
     WorkspaceCheckoutBinding,
 };
+use crate::fs::path_safety::normalize_path;
 
 #[derive(Clone)]
 pub struct TaskRegistryStore {

--- a/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/tests/mod.rs
@@ -17,12 +17,13 @@ use tempfile::TempDir;
 
 use super::REGISTRY_SCHEMA_VERSION;
 use super::schema::registry_user_version;
-use super::util::{normalize_path, now_string};
+use super::util::now_string;
 use super::{
     BindWorkspaceParams, ProjectionRebuildResult, RegisterWorkspaceParams, TaskIndexFilter,
     TaskRegistryStore, WorkspaceCheckoutBinding, task_registry_path,
 };
 use crate::contracts::WorkspaceConfig;
+use crate::fs::path_safety::normalize_path;
 use crate::{
     read_workspace_config, read_workspace_config_optional, workspace_config_path,
     workspace_id_for_orbit_dir, write_workspace_config,
@@ -1214,6 +1215,62 @@ fn workspace_config_round_trips_and_validates() {
         read_workspace_config(&orbit_dir),
         Err(OrbitError::InvalidInput(_))
     ));
+}
+
+#[test]
+fn persistence_consumers_share_workspace_id_grammar() {
+    let cases = [
+        ("ws_orbit", Some("ws_orbit")),
+        ("ws_orbit-main_2", Some("ws_orbit-main_2")),
+        ("orbit-test-abcdef", Some("orbit-test-abcdef")),
+        ("  orbit-test-abcdef  ", Some("orbit-test-abcdef")),
+        ("ws_", None),
+        ("ws_Orbit", None),
+        ("-orbit-abcdef", None),
+        ("orbit--test-abcdef", None),
+        ("orbit-ABCDEF", None),
+        ("orbit-abcde", None),
+        ("orbit-abcdef0", None),
+        ("orbit/test-abcdef", None),
+    ];
+
+    for (raw, expected) in cases {
+        let temp = TempDir::new().expect("tempdir");
+        let orbit_dir = temp.path().join(".orbit");
+        let file_result = write_workspace_config(
+            &orbit_dir,
+            &WorkspaceConfig {
+                schema_version: 1,
+                workspace_id: raw.into(),
+            },
+        );
+        let store = store(&temp);
+        let registry_result = store.register_workspace(RegisterWorkspaceParams {
+            workspace_id: raw.into(),
+            slug: "Workspace".into(),
+            repo_fingerprint: None,
+        });
+
+        match expected {
+            Some(expected) => {
+                file_result.expect("file workspace binding accepts id");
+                assert_eq!(
+                    read_workspace_config(&orbit_dir)
+                        .expect("read file workspace binding")
+                        .workspace_id,
+                    expected
+                );
+                assert_eq!(
+                    registry_result.expect("registry accepts id").workspace_id,
+                    expected
+                );
+            }
+            None => {
+                assert!(file_result.is_err(), "file binding accepted {raw:?}");
+                assert!(registry_result.is_err(), "registry accepted {raw:?}");
+            }
+        }
+    }
 }
 
 #[test]

--- a/crates/orbit-store/src/driver/sqlite/task_registry/util.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/util.rs
@@ -1,25 +1,7 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use orbit_types::task::{TaskRelationType, TaskStatus};
-
-pub(super) fn normalize_path(path: &Path) -> PathBuf {
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-}
 
 pub(super) fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()

--- a/crates/orbit-store/src/driver/sqlite/task_registry/workspace_id.rs
+++ b/crates/orbit-store/src/driver/sqlite/task_registry/workspace_id.rs
@@ -4,7 +4,8 @@ use orbit_common::OrbitError;
 use rusqlite::Connection;
 
 use super::queries::{workspace_by_id, workspace_checkout_by_id};
-use super::util::normalize_path;
+use crate::fs::path_safety::normalize_path;
+pub(super) use crate::fs::path_safety::validate_workspace_id;
 
 /// Allocate an unused logical workspace id for `slug` + `path`.
 ///
@@ -58,48 +59,4 @@ pub(super) fn sanitize_slug(raw: &str) -> String {
     } else {
         out
     }
-}
-
-pub(super) fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
-    let trimmed = raw.trim();
-    if is_valid_logical_workspace_id(trimmed) {
-        return Ok(trimmed.to_string());
-    }
-    let Some((slug, suffix)) = trimmed.rsplit_once('-') else {
-        return Err(OrbitError::InvalidInput(format!(
-            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
-        )));
-    };
-    if !is_valid_workspace_slug(slug)
-        || suffix.len() != 6
-        || !suffix
-            .as_bytes()
-            .iter()
-            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
-    {
-        return Err(OrbitError::InvalidInput(format!(
-            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
-        )));
-    }
-    Ok(trimmed.to_string())
-}
-
-fn is_valid_logical_workspace_id(value: &str) -> bool {
-    let Some(name) = value.strip_prefix("ws_") else {
-        return false;
-    };
-    !name.is_empty()
-        && name
-            .as_bytes()
-            .iter()
-            .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_'))
-}
-
-fn is_valid_workspace_slug(slug: &str) -> bool {
-    if slug.is_empty() || slug.starts_with('-') || slug.ends_with('-') || slug.contains("--") {
-        return false;
-    }
-    slug.as_bytes()
-        .iter()
-        .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-'))
 }

--- a/crates/orbit-store/src/fs/path_safety.rs
+++ b/crates/orbit-store/src/fs/path_safety.rs
@@ -12,6 +12,38 @@ pub(crate) fn validate_path_stem(stem: &str, kind: &str) -> Result<(), OrbitErro
     )))
 }
 
+/// Validate persisted logical and legacy workspace identifiers.
+pub(crate) fn validate_workspace_id(raw: &str) -> Result<String, OrbitError> {
+    let trimmed = raw.trim();
+    let logical = trimmed.strip_prefix("ws_").is_some_and(|name| {
+        !name.is_empty()
+            && name
+                .bytes()
+                .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_'))
+    });
+    let legacy = trimmed.rsplit_once('-').is_some_and(|(slug, suffix)| {
+        !slug.is_empty()
+            && !slug.starts_with('-')
+            && !slug.ends_with('-')
+            && !slug.contains("--")
+            && slug
+                .bytes()
+                .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-'))
+            && suffix.len() == 6
+            && suffix
+                .bytes()
+                .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    });
+
+    if logical || legacy {
+        Ok(trimmed.to_string())
+    } else {
+        Err(OrbitError::InvalidInput(format!(
+            "workspace_id '{trimmed}' must use canonical ws_<name> or legacy <slug>-<6char> form"
+        )))
+    }
+}
+
 fn is_safe_path_stem(stem: &str) -> bool {
     let mut components = Path::new(stem).components();
     matches!(


### PR DESCRIPTION
## Task

[ORB-11652](https://orbit-cli.com/tasks/ORB-11652) — [code-review] Move duplicated path/workspace-id rules to their single owner

### Description

## Problem
SQLite task_registry duplicates fs::path_safety path normalization. The file workspace-binding driver and SQLite workspace-id driver separately implement the same logical/legacy workspace-id grammar, allowing future divergence.

## Required behavior and constraints
Reuse the existing filesystem path normalizer and place the shared logical/legacy workspace-id grammar at the lowest existing domain owner both consumers may depend on. Inspect existing identity ownership before selecting a new module. Preserve accepted persisted forms and errors as required; do not combine unrelated same-named validators such as the friction validator merely to satisfy a source-count criterion.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-store/src/driver/sqlite/task_registry/util.rs:6`; `crates/orbit-store/src/fs/path_safety.rs:23`; `crates/orbit-store/src/driver/sqlite/task_registry/workspace_id.rs:63`; `crates/orbit-store/src/driver/file/workspace_binding.rs:95`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A shared table covers canonical ws_ forms, valid legacy slug-six-hex forms, whitespace handling and rejected forms; both persistence consumers agree.
- Existing workspace-binding, task-registry and path-normalization tests pass without changing accepted persisted data.
- The two identified consumers use one grammar implementation and task_registry uses the existing filesystem normalizer; unrelated validators retain their own contracts.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Moved canonical and legacy persisted workspace-id validation and trimming to fs::path_safety; file workspace-binding and SQLite registry now share it.
- Removed task-registry duplicate path normalizer and imported fs::path_safety::normalize_path directly in the SQLite store and ID allocator.
- Added one table-driven persistence-boundary test covering canonical ws_ IDs, valid legacy slug-six-hex IDs, whitespace normalization, and rejected forms through both consumers.

Criteria:
- Shared grammar table and consumer agreement: passed via persistence_consumers_share_workspace_id_grammar.
- Existing workspace-binding, registry, and path-normalization behavior: passed via cargo test -p orbit-store --lib (469 passed, 5 ignored).
- One grammar implementation and filesystem normalizer reuse: confirmed by reviewed diff; friction validator unchanged.

Validation:
- cargo test -p orbit-store persistence_consumers_share_workspace_id_grammar --lib: passed.
- cargo test -p orbit-store workspace_config --lib: passed (2 tests).
- cargo test -p orbit-store task_registry --lib: passed (51 tests).
- cargo test -p orbit-store --lib: passed (469 passed, 5 ignored).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.

Assessment: scoped refactor preserves persisted acceptance and error behavior. No remaining risks or deviations identified; changes are intentionally uncommitted for the pipeline.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11652-6a9f7dbb`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra