### PR TITLE
test: align workflow run-list description snapshots [ORB-11773]

### DIFF
--- a/crates/orbit-cli/tests/output_goldens/tool_list.json
+++ b/crates/orbit-cli/tests/output_goldens/tool_list.json
@@ -1299,7 +1299,7 @@
     "name": "orbit.workflow.run.list",
     "parameters": [
       {
-        "description": "Maximum runs to return (default 25, maximum 200).",
+        "description": "Maximum runs to return (default 25; values above 200 are rejected).",
         "name": "limit",
         "param_type": "integer",
         "required": false

--- a/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
+++ b/crates/orbit-cli/tests/snapshots/mcp_tools_list.json
@@ -1216,7 +1216,7 @@
           "type": "string"
         },
         "limit": {
-          "description": "Maximum runs to return (default 25, maximum 200).",
+          "description": "Maximum runs to return (default 25; values above 200 are rejected).",
           "type": "integer"
         },
         "since": {


### PR DESCRIPTION
Update only the workflow run-list limit description in the production MCP snapshot and CLI tool-list golden to match the existing handler contract: values above 200 are rejected. ORB-11666 changed the description in PR #1631 but left these two expectations stale, failing CI run 34182103247.

Validation on Mac with CARGO_BUILD_JOBS=2:
- Production MCP tools-list snapshot test: passed (1 test).
- CLI plain/JSON output golden test: passed (1 test).
- Workspace/all-target `make ci-lint`: passed.
- Native Bash 3.2 `make ci-fast`: blocked by an unrelated baseline `declare -A` failure in check-dependency-direction.sh introduced by PR #1665. The unchanged gate passed using installed Homebrew Bash 5 on the Mac, including final build-budget/compiler-cache success markers. Namespace probe skipped because bwrap is unavailable.

No broad fixture regeneration or schema/version changes. Task: ORB-11773.
