### PR TITLE
fix: restore non-compiling portable fast guardrails [ORB-11775]

### DIFF
--- a/scripts/check-dependency-direction.sh
+++ b/scripts/check-dependency-direction.sh
@@ -127,22 +127,21 @@ workspace_crates = {
     and package["name"].startswith("orbit-")
 }
 for crate in sorted(workspace_crates):
+    manifest = workspace_crates[crate]["manifest_path"]
     for dependency in workspace_crates[crate]["dependencies"]:
         dependency_name = dependency["name"]
         if dependency_name.startswith("orbit-"):
             kind = dependency["kind"] or "normal"
-            print(f"{crate}\t{dependency_name}\t{kind}")
+            print(f"{crate}\t{manifest}\t{dependency_name}\t{kind}")
 '
 }
 
 workspace_crates=()
 workspace_manifests=()
-declare -A workspace_manifest_by_crate=()
 while IFS=$'\t' read -r crate manifest; do
   if [[ -n "$crate" ]]; then
     workspace_crates+=("$crate")
     workspace_manifests+=("$manifest")
-    workspace_manifest_by_crate["$crate"]="$manifest"
   fi
 done < <(load_workspace_crates)
 
@@ -166,8 +165,7 @@ for index in "${!workspace_crates[@]}"; do
   fi
 done
 
-while IFS=$'\t' read -r crate dependency kind; do
-  manifest="${workspace_manifest_by_crate[$crate]}"
+while IFS=$'\t' read -r crate manifest dependency kind; do
   allowed="$(allowed_internal_deps "$crate")"
 
   if contains_word "$(allowed_dev_only_deps "$crate")" "$dependency" && [[ "$kind" != "dev" ]]; then

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -22,10 +22,10 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
-"$repo_root/scripts/check-ci-macos.sh"
-
 cargo fmt --all -- --check
 if [[ "$fast" == false ]]; then
+  # Enumerating workflow tests compiles their targets; keep it out of ci-fast.
+  "$repo_root/scripts/check-ci-macos.sh"
   cargo clippy --workspace --all-targets -- -D warnings
   if cargo nextest --version >/dev/null 2>&1; then
     cargo nextest run --workspace --lib --bins --tests
@@ -49,6 +49,7 @@ fi
 "$repo_root/scripts/check-installer-pubkey.sh"
 "$repo_root/scripts/test-installer-security.sh"
 "$repo_root/scripts/check-dependency-direction.sh"
+"$repo_root/scripts/test-ci-fast-guards.py"
 "$repo_root/scripts/check-cli-imports.sh"
 "$repo_root/scripts/check-terminal-state-guard.sh"
 "$repo_root/scripts/check-history-note-size.sh"

--- a/scripts/test-ci-fast-guards.py
+++ b/scripts/test-ci-fast-guards.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Exercise guardrail routing and dependency policy with non-compiling fixtures."""
+
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPTS = Path(__file__).resolve().parent
+
+
+class GuardrailTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.scripts = self.root / "scripts"
+        self.scripts.mkdir()
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "cargo.log"
+        self.metadata = self.root / "metadata.json"
+        self.env = dict(os.environ, PATH=f"{self.bin}:{os.environ['PATH']}",
+                        GUARD_TEST_LOG=str(self.log), GUARD_TEST_METADATA=str(self.metadata))
+        self.write_executable(self.bin / "cargo", '''#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ["GUARD_TEST_LOG"], "a") as log:
+    log.write(json.dumps(sys.argv[1:]) + "\\n")
+if sys.argv[1] == "metadata":
+    print(open(os.environ["GUARD_TEST_METADATA"]).read())
+elif sys.argv[1] == "test":
+    print("fixture_test: test")
+''')
+        self.write_executable(self.bin / "rg", "#!/bin/bash\nexit 1\n")
+
+    def write_executable(self, path, content):
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def run_guard(self, name, *arguments):
+        shutil.copy2(SCRIPTS / name, self.scripts / name)
+        return subprocess.run(["/bin/bash", str(self.scripts / name), *arguments],
+                              env=self.env, text=True, capture_output=True)
+
+    def prepare_ci(self):
+        source = (SCRIPTS / "ci-guardrails.sh").read_text()
+        for name in re.findall(r'\$repo_root/scripts/([\w.-]+)', source):
+            self.write_executable(self.scripts / name, "#!/bin/bash\nexit 0\n")
+        shutil.copy2(SCRIPTS / "check-ci-macos.sh", self.scripts / "check-ci-macos.sh")
+        workflows = self.root / ".github/workflows"
+        workflows.mkdir(parents=True)
+        (self.root / "Cargo.toml").touch()
+        (workflows / "ci-macos.yml").write_text('''on:
+  pull_request:
+    paths:
+      - Cargo.toml
+jobs:
+  test:
+    steps:
+      - run: cargo test -p orbit-types fixture_test
+''')
+
+    def test_fast_does_not_enumerate_or_compile_tests(self):
+        self.prepare_ci()
+        result = self.run_guard("ci-guardrails.sh", "--fast")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertEqual(calls, [["fmt", "--all", "--", "--check"]])
+
+    def test_full_still_checks_workflow_test_matches(self):
+        self.prepare_ci()
+        result = self.run_guard("ci-guardrails.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = [json.loads(line) for line in self.log.read_text().splitlines()]
+        self.assertIn(["test", "-p", "orbit-types", "--locked", "fixture_test", "--", "--list"], calls)
+
+    def dependency_result(self, owner, dependency, kind=None):
+        manifests = {}
+        for name in {owner, dependency}:
+            path = self.root / f"{name}.toml"
+            path.touch()
+            manifests[name] = str(path)
+        packages = [dict(id=name, name=name, manifest_path=manifest,
+                         dependencies=([dict(name=dependency, kind=kind)] if name == owner else []))
+                    for name, manifest in manifests.items()]
+        self.metadata.write_text(json.dumps(dict(workspace_members=list(manifests), packages=packages)))
+        return self.run_guard("check-dependency-direction.sh")
+
+    def test_allowed_dependency_on_native_bash(self):
+        result = self.dependency_result("orbit-common", "orbit-types")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("dependency direction guard passed", result.stdout)
+
+    def test_forbidden_dependency_names_owning_manifest(self):
+        result = self.dependency_result("orbit-types", "orbit-common")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"forbidden dependency 'orbit-common' found in {self.root}/orbit-types.toml", result.stdout)
+
+    def test_dev_only_dependency_rejects_production_edge(self):
+        result = self.dependency_result("orbit-core", "orbit-exec")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must remain dev-only", result.stdout)
+
+    def test_dev_only_dependency_accepts_test_edge(self):
+        result = self.dependency_result("orbit-core", "orbit-exec", "dev")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`make ci-fast` started compiling macOS test targets while enumerating workflow filters, and the dependency guard failed on Apple's Bash 3.2 before checking any edges. Keep workflow test enumeration in the full CI path and carry each manifest directly in Cargo metadata dependency rows, removing the Bash 4 associative array.

Add six shell-boundary regression cases covering fast/full routing and allowed, forbidden, and dev-only dependencies. The original scripts fail five cases; the fixed scripts pass all six on native macOS Bash 3.2.57.

Validation: native `make ci-fast`, workspace `make ci-lint`, `/bin/bash scripts/check-dependency-direction.sh`, and `python3 scripts/test-ci-fast-guards.py` passed. Full CI was not run locally; its macOS test-enumeration check remains enabled. Compiler-cache namespace checks explicitly skip on this Mac because Bubblewrap is unavailable.

Task: ORB-11775.
