### PR TITLE
[code-review] Pause polling while the tab is hidden and back off when refreshes fail

### DIFF
--- a/crates/orbit-web/assets/dashboard/app.js
+++ b/crates/orbit-web/assets/dashboard/app.js
@@ -1514,7 +1514,7 @@ async function refreshDashboard() {
   $("conn-status").className = "status-dot orange";
   // Refresh stays available so a slow request never locks navigation or retry.
   const results = await Promise.allSettled(activeRefreshJobs());
-  if (sequence !== refreshSequence || revision !== getWorkspaceRevision()) return;
+  if (sequence !== refreshSequence || revision !== getWorkspaceRevision()) return null;
   const errors = results.filter(result => result.status === "rejected").map(result => result.reason);
   const offline = errors.some(error => error.networkFailure);
   for (const error of errors) console.error(error);
@@ -1522,6 +1522,7 @@ async function refreshDashboard() {
   const label = offline ? "offline" : errors.length ? "panel update failed" : `refreshed ${refreshLabel()}`;
   $("meta-text").textContent = `${label} · ${new Date().toLocaleTimeString()}`;
   if (activeTab === "tasks") fitLogPanelToViewport();
+  return errors.length === 0;
 }
 
 // Invalidate caches at the scope boundary, including programmatic selections.

--- a/crates/orbit-web/assets/dashboard/router.js
+++ b/crates/orbit-web/assets/dashboard/router.js
@@ -13,7 +13,8 @@
 // The public exports (setActiveTab, navigateToRun, initTabs) are thin wrappers over
 // impls that close over the injected ctx (set once via initRouter).
 // No behavior change: every prior hash route, subtab click, back/forward, and the
-// 30s setInterval(refreshDashboard) continue to work identically.
+// dashboard polling is scheduled here so it can pause while a tab is hidden
+// and retry failed refreshes without competing with active dashboard use.
 //
 // Also exports parseHashRoute for symmetry (used only internally today).
 
@@ -50,6 +51,8 @@ const DIAG_FULL_WIDTH_MAINS = {
 };
 const RUN_DETAIL_SUBTABS = ["steps", "events"];
 const KNOWLEDGE_SUBTABS = ["frictions"];
+const REFRESH_INTERVAL_MS = 30_000;
+const MAX_REFRESH_INTERVAL_MS = 5 * 60_000;
 
 function parseHashRoute(raw) {
   const trimmed = String(raw || "").replace(/^#/, "");
@@ -309,6 +312,53 @@ function navigateToRunImpl(ctx, runId, workspaceId = null) {
   setActiveTabImpl(ctx, `runs/${encodeURIComponent(runId)}`);
 }
 
+// A one-shot timer avoids overlapping refreshes: the next poll is scheduled
+// only after the current refresh settles. Hidden tabs have no pending timer;
+// becoming visible starts exactly one refresh and resumes the normal cadence.
+function startDashboardPolling(ctx) {
+  let timer = null;
+  let interval = REFRESH_INTERVAL_MS;
+
+  const clearScheduledRefresh = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const scheduleRefresh = () => {
+    if (document.hidden || timer !== null) return;
+    timer = setTimeout(runRefresh, interval);
+    // Node-based dashboard tests should not be kept alive by a browser poll.
+    // Browsers return a numeric timer handle, so this is a no-op in production.
+    if (typeof timer === "object" && typeof timer.unref === "function") timer.unref();
+  };
+
+  const runRefresh = () => {
+    timer = null;
+    if (document.hidden) return;
+    Promise.resolve(ctx.refreshDashboard())
+      .then((succeeded) => {
+        if (succeeded === true) interval = REFRESH_INTERVAL_MS;
+        if (succeeded === false) interval = Math.min(interval * 2, MAX_REFRESH_INTERVAL_MS);
+      })
+      .catch(() => {
+        interval = Math.min(interval * 2, MAX_REFRESH_INTERVAL_MS);
+      })
+      .finally(scheduleRefresh);
+  };
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      clearScheduledRefresh();
+      return;
+    }
+    runRefresh();
+  });
+
+  runRefresh();
+}
+
 function initTabsImpl(ctx) {
   for (const tab of document.querySelectorAll(".tab")) {
     tab.addEventListener("click", () => setActiveTabImpl(ctx, tab.dataset.tab, { refresh: false }));
@@ -355,8 +405,7 @@ function initTabsImpl(ctx) {
     refresh: false,
     updateHash: false,
   });
-  ctx.refreshDashboard();
-  setInterval(ctx.refreshDashboard, 30000);
+  startDashboardPolling(ctx);
 }
 
 // Public named exports (the stable import surface for app.js and future modules).

--- a/crates/orbit-web/src/tests/dashboard_loading.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading.mjs
@@ -140,6 +140,7 @@ metricsError = false;
 refresh(); await settle();
 check(node('conn-status').className.includes('green'), 'connection recovers');
 const realTimeout = globalThis.setTimeout;
+const realFetch = globalThis.fetch;
 globalThis.setTimeout = (fn, ms, ...args) => realTimeout(fn, ms === 30000 ? 1 : ms, ...args);
 globalThis.fetch = (_path, options) => new Promise((_resolve, reject) => {
   options.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
@@ -148,5 +149,49 @@ refresh(); await settle();
 check(busy('diag-body') === 'false' && text('diag-body').includes('timed out'), 'hung request times out and clears busy state');
 check(!node('refresh-btn').disabled, 'timeout leaves retry available');
 globalThis.setTimeout = realTimeout;
+globalThis.fetch = realFetch;
+const realClearTimeout = globalThis.clearTimeout;
+const scheduledPolls = [];
+globalThis.setTimeout = (fn, ms, ...args) => {
+  if (ms === 0) return realTimeout(fn, ms, ...args);
+  const handle = { cancelled: false, unref: () => {} };
+  scheduledPolls.push({ fn, ms, args, handle });
+  return handle;
+};
+globalThis.clearTimeout = (handle) => {
+  if (typeof handle === 'object') handle.cancelled = true;
+  else realClearTimeout(handle);
+};
+const activePoll = () => scheduledPolls.filter(entry => !entry.handle.cancelled).at(-1);
+const runPoll = async () => {
+  const poll = activePoll();
+  check(poll, 'refresh poll must be scheduled');
+  poll.handle.cancelled = true;
+  poll.fn(...poll.args);
+  await settle();
+};
+
+// Pausing a dashboard removes its pending poll. Returning to it refreshes once,
+// then failed polls double their delay and a successful retry restores 30s.
+document.hidden = true;
+documentListeners.visibilitychange();
+const hiddenSummaryReads = summaryReads;
+await settle();
+check(summaryReads === hiddenSummaryReads, 'hidden dashboard makes no audit-summary request');
+document.hidden = false;
+documentListeners.visibilitychange();
+await settle();
+check(summaryReads === hiddenSummaryReads + 1, 'visible dashboard refreshes exactly once');
+check(activePoll().ms === 30000, 'successful refresh schedules the normal 30s interval');
+networkDown = true;
+await runPoll();
+check(activePoll().ms === 60000, 'first failed refresh doubles the interval');
+await runPoll();
+check(activePoll().ms === 120000, 'consecutive failures continue exponential backoff');
+networkDown = false;
+await runPoll();
+check(activePoll().ms === 30000, 'successful retry restores the 30s interval');
+globalThis.setTimeout = realTimeout;
+globalThis.clearTimeout = realClearTimeout;
 globalThis.loadingTestsPassed = true;
 console.log('Dashboard loading, ordering, empty, error and recovery scenarios passed.');

--- a/crates/orbit-web/src/tests/dashboard_loading_dom.mjs
+++ b/crates/orbit-web/src/tests/dashboard_loading_dom.mjs
@@ -77,6 +77,7 @@ const wrap = get("global-id-wrap");
 wrap.className = "global-id-wrap";
 wrap.appendChild(get("global-task-id"));
 wrap.appendChild(get("global-task-id-error"));
+const documentListeners = {};
 globalThis.document = {
   body: new Node("body"),
   hidden: false,
@@ -98,7 +99,7 @@ globalThis.document = {
     if (tabMatch) return tabs.find((tab) => tab.dataset.tab === tabMatch[1]) || null;
     return new Node();
   },
-  addEventListener: () => {},
+  addEventListener: (name, fn) => { documentListeners[name] = fn; },
 };
 const location = new URL("http://dashboard.test/?workspace=one");
 location.hash = "#tasks";
@@ -132,4 +133,3 @@ Object.defineProperty(globalThis, "navigator", { value: { clipboard: { writeText
 globalThis.requestAnimationFrame = (fn) => fn();
 globalThis.setInterval = () => 0;
 globalThis.EventSource = class { constructor() {} close() {} };
-


### PR DESCRIPTION
## Task

[ORB-11656](https://orbit-cli.com/tasks/ORB-11656) — [code-review] Pause polling while the tab is hidden and back off when refreshes fail

### Description

## Problem
`setInterval(ctx.refreshDashboard, 30000)` runs regardless of `document.hidden`; only the locks fetch checks it (`app.js:1064`). Every tick issues `/api/audit/summary` plus the active tab's fetches; each request re-reads `workspaces.json` and re-resolves every workspace binding (`state.rs:614-666` via the `Ws` extractor), and the summary does roughly a dozen SQLite aggregates plus incident grouping over up to 10 000 rows. A dashboard left in a background tab for a day costs ~2 880 summary computations per tab, and after the server goes away the client keeps polling at the same rate while showing "offline".

## Why It Matters
The API runs on the same host as the pipeline workers; idle tabs should not compete with them for SQLite and the blocking pool.

## Proposed Fix
Skip the tick when `document.hidden` and refresh once on `visibilitychange` to visible; after consecutive failures, double the interval up to ~5 min and reset on success.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/router.js:359`, `crates/orbit-web/assets/dashboard/app.js:1043-1064,1399-1429`, `crates/orbit-web/src/state.rs:593-666`, `crates/orbit-web/src/api/audit.rs:352-514`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (performance). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- With the tab hidden for 5 min the server access log shows no `/api/audit/summary` calls; switching back triggers exactly one refresh.
- Stop the server: the interval between attempts grows (observe in the network tab); restart: the next refresh succeeds and the interval returns to 30 s.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the fixed dashboard interval with a one-shot polling scheduler that cancels pending work while the document is hidden and refreshes exactly once when it becomes visible.
- Made refresh completion report success, failure, or supersession so failed scheduled refreshes exponentially back off from 30 seconds to a five-minute cap and successful ones reset to 30 seconds.
- Added full-dashboard DOM-harness coverage for hidden-tab suppression, one visible refresh, repeated backoff, and recovery.

Assessment: The scheduler owns the canonical polling path, avoids overlapping scheduled refreshes, and leaves manual refresh/navigation behavior intact.

Acceptance criteria:
- Hidden dashboard: the harness verifies no audit-summary request while hidden and exactly one when visible.
- Failure recovery: the harness verifies 30s → 60s → 120s delays under failures and reset to 30s after success.

Validation:
- Passed: `node --check crates/orbit-web/assets/dashboard/router.js`
- Passed: `node --check crates/orbit-web/assets/dashboard/app.js`
- Passed: `node --check crates/orbit-web/src/tests/dashboard_loading_dom.mjs`
- Passed: `node --check crates/orbit-web/src/tests/dashboard_loading.mjs`
- Passed: `cargo test -p orbit-web dashboard_loading_rejects_stale_responses_and_reports_panel_errors --lib`
- Passed: `make ci-fast`
- Passed: `make ci-lint`
- Passed: `git diff --check`

Risks / limits:
- Browser network-tab observation was represented by the existing full-dashboard JavaScript harness; it deterministically counts the audit-summary fixture rather than driving a five-minute real-time browser session.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11656-6a9f7e40`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra