### PR TITLE
[code-review] Avoid redundant managed-asset reconciliation on warm runtime opens

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -243,4 +243,5 @@ parent-authorized admission path. Older binaries ignore both tables.
 | Command Audit   | GlobalOnly         | Single authoritative SQLite event trail          |
 | Semantic Index  | WorkspaceOnly      | Task-derived embeddings stay with the workspace  |
 | Run Traces      | WorkspaceOnly      | Per-repo activity/job JSONL and blob artifacts   |
+| Global Defaults Stamp | GlobalOnly   | `<global root>/resources/.orbit-global-defaults.json` names the embedded default set last reconciled into that root, so a warm runtime open skips re-reading and re-hashing the managed catalogs |
 | ADR/Learning IDs | Shared allocator + worktree-local bodies | ID rows live in shared `.orbit/state/semantic.db`; body files live in the current worktree so they can be staged with code |

--- a/crates/orbit-core/src/application/tests/managed_assets.rs
+++ b/crates/orbit-core/src/application/tests/managed_assets.rs
@@ -13,6 +13,7 @@ use super::super::job::seed_default_jobs;
 use crate::OrbitRuntime;
 use crate::application::job::JobCatalogFilter;
 use crate::bootstrap::activity::seed_default_activities;
+use crate::bootstrap::global_defaults::stamp_path;
 use crate::bootstrap::init::{InitOptions, InitResult, init_workspace_at_root};
 use crate::runtime::OrbitRuntimeRoots;
 use orbit_config::ConfigSeed;
@@ -28,6 +29,13 @@ fn init_global(root: &Path) -> InitResult {
         },
     )
     .expect("initialize global defaults")
+}
+
+/// Make `root` look like it was last reconciled by an earlier release, so an
+/// implicit bootstrap reconciles its managed assets instead of trusting the
+/// stamp this test's own seeding just wrote.
+fn drop_global_defaults_stamp(root: &Path) {
+    std::fs::remove_file(stamp_path(root)).expect("drop the global defaults stamp");
 }
 
 fn sha256(content: &str) -> String {
@@ -227,6 +235,7 @@ fn runtime_bootstrap_refreshes_orbit_written_stale_activity_before_catalog_load(
     assert_ne!(stale, current, "fixture must contain the retired tool");
     std::fs::write(&path, &stale).expect("write stale activity");
     add_managed_manifest_entry(&activities_dir, "agent_implement", &stale);
+    drop_global_defaults_stamp(&global_root);
 
     let runtime = OrbitRuntime::initialize_from_resolved_roots(
         OrbitRuntimeRoots {
@@ -260,6 +269,7 @@ fn runtime_bootstrap_preserves_locally_modified_stale_managed_activity() {
     let locally_modified = format!("{stale}# operator edit\n");
     std::fs::write(&path, &locally_modified).expect("write locally modified stale activity");
     add_managed_manifest_entry(&activities_dir, "agent_implement", &stale);
+    drop_global_defaults_stamp(&global_root);
 
     OrbitRuntime::initialize_from_resolved_roots(
         OrbitRuntimeRoots {

--- a/crates/orbit-core/src/bootstrap/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/global_defaults.rs
@@ -1,0 +1,130 @@
+//! Whether a global Orbit root already carries this binary's managed defaults.
+//!
+//! Reconciling the shipped defaults renders, hashes, and re-reads every managed
+//! skill, activity, job, executor, and policy. That work only changes anything
+//! when the embedded asset set — or the root it renders into — differs from the
+//! last reconciliation, yet implicit bootstrap ran it on every runtime open.
+//!
+//! Each completed global-scope reconciliation therefore records a stamp naming
+//! the asset set it installed. A later open compares that stamp against the
+//! running binary and skips the whole pass when they agree, so a warm open
+//! performs no managed-asset reads or digests at all.
+//!
+//! The stamp answers exactly one question: *did this binary already reconcile
+//! this root?* It deliberately says nothing about what the root looks like now.
+//! Repairing a root whose managed files were edited or deleted by hand belongs
+//! to the explicit paths — `orbit init`, `orbit workspace sync`, and
+//! `orbit doctor` — which never consult the stamp.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use orbit_common::OrbitError;
+use orbit_common::fs::io::atomic_write_text;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::application::executor::DEFAULT_EXECUTOR_FILES;
+use crate::application::job::DEFAULT_JOB_FILES;
+use crate::application::skill::DEFAULT_SKILL_FILES;
+use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
+use crate::bootstrap::policy::DEFAULT_POLICY_FILES;
+
+const GLOBAL_DEFAULTS_STAMP_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GlobalDefaultsStamp {
+    schema_version: u32,
+    defaults_digest: String,
+}
+
+/// Whether `global_root` was already reconciled against the defaults this
+/// binary embeds. An absent, unreadable, or unrecognized stamp reads as stale,
+/// so an unusable stamp costs one reconciliation rather than correctness.
+pub(crate) fn global_defaults_are_current(global_root: &Path) -> bool {
+    let Ok(raw) = fs::read_to_string(stamp_path(global_root)) else {
+        return false;
+    };
+    let Ok(stamp) = serde_json::from_str::<GlobalDefaultsStamp>(&raw) else {
+        return false;
+    };
+
+    stamp.schema_version == GLOBAL_DEFAULTS_STAMP_SCHEMA_VERSION
+        && stamp.defaults_digest == installed_defaults_digest(global_root)
+}
+
+/// Record that a global-scope reconciliation just installed this binary's
+/// defaults into `global_root`. Callers invoke this only after every default
+/// landed, so a partial or failed seed leaves the next open reconciling.
+pub(crate) fn record_global_defaults_reconciled(global_root: &Path) -> Result<(), OrbitError> {
+    let stamp = GlobalDefaultsStamp {
+        schema_version: GLOBAL_DEFAULTS_STAMP_SCHEMA_VERSION,
+        defaults_digest: installed_defaults_digest(global_root),
+    };
+    let mut encoded = serde_json::to_string_pretty(&stamp)
+        .map_err(|error| OrbitError::Store(format!("serialize global defaults stamp: {error}")))?;
+    encoded.push('\n');
+
+    let path = stamp_path(global_root);
+    atomic_write_text(&path, &encoded).map_err(|error| {
+        OrbitError::Io(format!(
+            "write global defaults stamp '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Where a global root records its stamp: beside the resource catalogs it
+/// describes, and never in `state/`, which the layout reserves for workspace
+/// runtime state. Exposed so fixtures can model a root left by another release
+/// without duplicating the path.
+pub(crate) fn stamp_path(global_root: &Path) -> PathBuf {
+    global_root
+        .join("resources")
+        .join(".orbit-global-defaults.json")
+}
+
+/// Identity of the defaults a global-scope bootstrap installs into one root.
+///
+/// The embedded set is the bulk of it, but rendering is root- and
+/// platform-dependent — skill content carries the root path, and the shipped
+/// executors are seeded per host OS — so both join the digest. Two Orbit
+/// binaries sharing one root simply disagree and each reconciles once.
+fn installed_defaults_digest(global_root: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(embedded_defaults_digest());
+    hasher.update([0]);
+    hasher.update(global_root.to_string_lossy().as_bytes());
+    hasher.update([0]);
+    hasher.update(std::env::consts::OS.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Digest of every embedded default a global-scope bootstrap seeds. The inputs
+/// are compile-time constants, so this is computed once per process.
+fn embedded_defaults_digest() -> &'static str {
+    static DIGEST: OnceLock<String> = OnceLock::new();
+
+    DIGEST.get_or_init(|| {
+        let mut hasher = Sha256::new();
+        for (asset_kind, assets) in [
+            ("skill", &DEFAULT_SKILL_FILES[..]),
+            ("activity", DEFAULT_ACTIVITY_FILES),
+            ("job", DEFAULT_JOB_FILES),
+            ("executor", DEFAULT_EXECUTOR_FILES),
+            ("policy", DEFAULT_POLICY_FILES),
+        ] {
+            hasher.update(asset_kind.as_bytes());
+            hasher.update([0]);
+            for (name, content) in assets {
+                hasher.update(name.as_bytes());
+                hasher.update([0]);
+                hasher.update(content.as_bytes());
+                hasher.update([0]);
+            }
+        }
+        format!("{:x}", hasher.finalize())
+    })
+}

--- a/crates/orbit-core/src/bootstrap/init.rs
+++ b/crates/orbit-core/src/bootstrap/init.rs
@@ -18,6 +18,9 @@ use crate::application::workspace_sync::{
     ManagedArtifactOutcome, reconcile_workspace_managed_artifacts,
 };
 use crate::bootstrap::activity::seed_default_activities;
+use crate::bootstrap::global_defaults::{
+    global_defaults_are_current, record_global_defaults_reconciled,
+};
 use crate::bootstrap::policy::seed_default_policies;
 use orbit_common::fs::io::{create_dir_symlink, remove_path_if_exists};
 
@@ -89,18 +92,27 @@ impl OrbitRuntime {
 /// filesystem scan. A config seeded this way carries no `[crews]` table, so it
 /// resolves to the built-in crew registry until an explicit `orbit init`
 /// freezes the host's detected families. [ORB-10885]
+///
+/// Seeding the global defaults renders, hashes, and re-reads every managed
+/// asset, which is worth paying for exactly once per asset set. A warm open
+/// therefore skips it entirely once the root carries this binary's stamp; see
+/// [`crate::bootstrap::global_defaults`] for what that stamp does and does not
+/// claim. The workspace side stays unconditional: it only creates directories
+/// and reaps skill trees that older releases seeded into a workspace root.
 pub(crate) fn ensure_orbit_root_initialized(
     global_root: &Path,
     workspace_root: &Path,
 ) -> Result<(), OrbitError> {
-    let global_init = init_workspace_at_root(
-        global_root,
-        InitOptions {
-            global_only: true,
-            ..Default::default()
-        },
-    );
-    ignore_denied_implicit_bootstrap_write("global defaults", global_root, global_init)?;
+    if !global_defaults_are_current(global_root) {
+        let global_init = init_workspace_at_root(
+            global_root,
+            InitOptions {
+                global_only: true,
+                ..Default::default()
+            },
+        );
+        ignore_denied_implicit_bootstrap_write("global defaults", global_root, global_init)?;
+    }
 
     let workspace_layout = prepare_workspace_root_layout(workspace_root, global_root);
     ignore_denied_implicit_bootstrap_write("workspace layout", workspace_root, workspace_layout)?;
@@ -330,6 +342,15 @@ pub fn init_workspace_at_root(
     }
     if !options.global_only {
         friction_store::ensure_default_tag_taxonomy(&orbit_root.join("frictions"))?;
+    }
+    // Every globally scoped default has now landed, so later runtime opens may
+    // skip the reconciliation pass until this binary's asset set changes. The
+    // stamp is bookkeeping, not a default: an immutable global root that needs
+    // no writes must still complete init, so a denied write only costs the next
+    // open another reconciliation.
+    if options.global_only {
+        let stamp = record_global_defaults_reconciled(&orbit_root);
+        ignore_denied_implicit_bootstrap_write("global defaults stamp", &orbit_root, stamp)?;
     }
 
     Ok(InitResult {

--- a/crates/orbit-core/src/bootstrap/mod.rs
+++ b/crates/orbit-core/src/bootstrap/mod.rs
@@ -1,7 +1,11 @@
 //! Initialization, managed asset seeding, and forward-only startup migrations.
 
 pub(crate) mod activity;
+pub(crate) mod global_defaults;
 pub mod init;
 pub(crate) mod policy;
 pub mod task_migration;
 pub mod task_publication;
+
+#[cfg(test)]
+mod tests;

--- a/crates/orbit-core/src/bootstrap/policy.rs
+++ b/crates/orbit-core/src/bootstrap/policy.rs
@@ -5,7 +5,7 @@ use orbit_store::contracts::PolicyDefStoreBackend;
 use orbit_types::policy::{DEFAULT_POLICY_NAME, PolicyDef};
 use orbit_types::resource::ResourceKind;
 
-const DEFAULT_POLICY_FILES: &[(&str, &str)] = &[(
+pub(crate) const DEFAULT_POLICY_FILES: &[(&str, &str)] = &[(
     DEFAULT_POLICY_NAME,
     include_str!("../../assets/policies/default.yaml"),
 )];

--- a/crates/orbit-core/src/bootstrap/tests/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/tests/global_defaults.rs
@@ -1,0 +1,252 @@
+//! When a runtime open must reconcile the global managed defaults, and what it
+//! must leave untouched when it does not.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::{TempDir, tempdir};
+
+use crate::OrbitRuntime;
+use crate::bootstrap::global_defaults::{global_defaults_are_current, stamp_path};
+use crate::bootstrap::init::ensure_orbit_root_initialized;
+use crate::runtime::OrbitRuntimeRoots;
+
+/// A stamp whose digest belongs to no build of this binary — the shape a root
+/// last reconciled by a different Orbit release has.
+const FOREIGN_RELEASE_STAMP: &str = r#"{
+  "schemaVersion": 1,
+  "defaultsDigest": "0000000000000000000000000000000000000000000000000000000000000000"
+}
+"#;
+
+struct Roots {
+    _temp: TempDir,
+    global: PathBuf,
+    workspace: PathBuf,
+}
+
+fn roots() -> Roots {
+    let temp = tempdir().expect("tempdir");
+    let global = temp.path().join("global");
+    let workspace = temp.path().join("repo/.orbit");
+    Roots {
+        _temp: temp,
+        global,
+        workspace,
+    }
+}
+
+fn activities_dir(global_root: &Path) -> PathBuf {
+    global_root.join("resources/activities")
+}
+
+fn managed_manifest_path(dir: &Path) -> PathBuf {
+    dir.join(crate::application::MANAGED_ASSET_MANIFEST_FILE)
+}
+
+#[test]
+fn first_open_seeds_global_defaults_and_stamps_the_root() {
+    let roots = roots();
+    assert!(
+        !global_defaults_are_current(&roots.global),
+        "an unseeded root cannot be current"
+    );
+
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace).expect("first runtime open");
+
+    assert!(
+        roots
+            .global
+            .join("skills/orbit/SKILL.md")
+            .try_exists()
+            .expect("probe seeded skill router"),
+        "first open must seed the global skill catalog"
+    );
+    assert!(
+        activities_dir(&roots.global)
+            .join("agent_implement.yaml")
+            .try_exists()
+            .expect("probe seeded activity"),
+        "first open must seed the global activity catalog"
+    );
+    assert!(
+        roots
+            .global
+            .join("config.toml")
+            .try_exists()
+            .expect("probe seeded config"),
+        "first open must seed the global config"
+    );
+    assert!(
+        global_defaults_are_current(&roots.global),
+        "a completed first open must stamp the root"
+    );
+}
+
+/// The stamp exists to make the second open cheap: nothing under the managed
+/// catalogs may be read or hashed again. A manifest no reconciliation could
+/// parse stands in as the sentinel — reconciliation loads it before deciding
+/// anything, so an open that still succeeds provably never ran one.
+#[test]
+fn warm_open_does_not_reconcile_managed_asset_digests() {
+    let roots = roots();
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace).expect("first runtime open");
+
+    let activities = activities_dir(&roots.global);
+    let activity_path = activities.join("agent_implement.yaml");
+    let seeded_activity = fs::read_to_string(&activity_path).expect("read seeded activity");
+    fs::write(managed_manifest_path(&activities), "{ not json").expect("corrupt managed manifest");
+
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace)
+        .expect("warm open must not read the managed activity manifest");
+
+    assert_eq!(
+        fs::read_to_string(&activity_path).expect("read activity after warm open"),
+        seeded_activity,
+        "a warm open must leave the managed catalog exactly as it found it"
+    );
+
+    // Control: the corrupt manifest really is load-bearing, so the assertion
+    // above measures the skip rather than a tolerant reconciliation.
+    fs::remove_file(stamp_path(&roots.global)).expect("drop the stamp");
+    let unstamped = ensure_orbit_root_initialized(&roots.global, &roots.workspace);
+    assert!(
+        unstamped.is_err(),
+        "without a stamp the open reconciles and must surface the corrupt manifest"
+    );
+}
+
+/// A root stamped by an earlier release is reconciled again: shipped defaults
+/// this binary needs are restored, and anything the operator edited is kept.
+#[test]
+fn upgraded_root_restores_required_defaults_and_preserves_user_edits() {
+    let roots = roots();
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace).expect("first runtime open");
+
+    let activities = activities_dir(&roots.global);
+    let removed = activities.join("agent_implement.yaml");
+    let shipped_activity = fs::read_to_string(&removed).expect("read seeded activity");
+    fs::remove_file(&removed).expect("remove a required default");
+
+    let edited = activities.join("sleep.yaml");
+    let operator_content = format!(
+        "{}# operator edit\n",
+        fs::read_to_string(&edited).expect("read seeded activity")
+    );
+    fs::write(&edited, &operator_content).expect("hand edit a managed default");
+
+    fs::write(stamp_path(&roots.global), FOREIGN_RELEASE_STAMP).expect("stamp an older release");
+    assert!(!global_defaults_are_current(&roots.global));
+
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace).expect("upgraded runtime open");
+
+    assert_eq!(
+        fs::read_to_string(&removed).expect("read restored activity"),
+        shipped_activity,
+        "an upgraded root must restore the defaults this binary requires"
+    );
+    assert_eq!(
+        fs::read_to_string(&edited).expect("read preserved activity"),
+        operator_content,
+        "reconciliation must preserve a locally modified managed asset"
+    );
+    assert!(
+        global_defaults_are_current(&roots.global),
+        "the reconciled root must carry this binary's stamp"
+    );
+}
+
+/// An immutable global root cannot record the stamp, which is bookkeeping and
+/// never a precondition for reading the catalog it describes.
+#[cfg(unix)]
+#[test]
+fn denied_stamp_write_keeps_the_open_and_its_reads_working() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let roots = roots();
+    ensure_orbit_root_initialized(&roots.global, &roots.workspace).expect("first runtime open");
+    fs::remove_file(stamp_path(&roots.global)).expect("drop the stamp");
+
+    let resources_dir = roots.global.join("resources");
+    fs::set_permissions(&resources_dir, fs::Permissions::from_mode(0o555))
+        .expect("make the resources directory read-only");
+    // A privileged test process ignores the mode bits, so there is no denial
+    // left to observe; the readable-catalog assertions below still hold.
+    let denial_is_observable = fs::write(resources_dir.join(".probe"), "").is_err();
+
+    let opened = ensure_orbit_root_initialized(&roots.global, &roots.workspace);
+    fs::set_permissions(&resources_dir, fs::Permissions::from_mode(0o755))
+        .expect("restore the resources directory");
+
+    opened.expect("a denied stamp write must not fail the open");
+    assert!(
+        fs::read_to_string(activities_dir(&roots.global).join("agent_implement.yaml")).is_ok(),
+        "the managed catalog stays readable after a denied stamp write"
+    );
+    if denial_is_observable {
+        assert!(
+            !global_defaults_are_current(&roots.global),
+            "an unrecorded stamp must leave the next open reconciling"
+        );
+    }
+}
+
+/// Bootstrap and composition read config at different scopes on purpose: the
+/// scoreboard seed is a global-root decision, while everything the runtime
+/// resolves layers the workspace over the global file. Skipping reconciliation
+/// must not blur the two.
+#[test]
+fn global_bootstrap_scope_survives_a_workspace_config_override() {
+    let roots = roots();
+    fs::create_dir_all(&roots.global).expect("create global root");
+    fs::create_dir_all(&roots.workspace).expect("create workspace root");
+    fs::write(
+        roots.global.join("config.toml"),
+        "[scoring]\nenabled = false\n",
+    )
+    .expect("write global config");
+    fs::write(
+        roots.workspace.join("config.toml"),
+        "[scoring]\nenabled = true\n",
+    )
+    .expect("write workspace config");
+
+    let _env = orbit_common::test_env::scoped(
+        orbit_common::test_env::INHERITED_AUTHORITY_ENV
+            .iter()
+            .copied()
+            .map(|name| (name, None)),
+    );
+
+    for open in ["first", "warm"] {
+        let runtime = OrbitRuntime::initialize_from_resolved_roots(
+            OrbitRuntimeRoots {
+                global_root: roots.global.clone(),
+                shared_root: roots.workspace.clone(),
+                local_root: roots.workspace.clone(),
+            },
+            None,
+        )
+        .unwrap_or_else(|error| panic!("{open} runtime open: {error}"));
+
+        assert!(
+            runtime.scoring_enabled(),
+            "{open} open must resolve the workspace override over the global file"
+        );
+        drop(runtime);
+
+        assert!(
+            !roots
+                .workspace
+                .join("state/scoreboard/pr.json")
+                .try_exists()
+                .expect("probe scoreboard template"),
+            "{open} open must decide scoreboard seeding from the global config alone"
+        );
+    }
+
+    assert!(
+        global_defaults_are_current(&roots.global),
+        "the first open stamps the root the warm open then skips"
+    );
+}

--- a/crates/orbit-core/src/bootstrap/tests/mod.rs
+++ b/crates/orbit-core/src/bootstrap/tests/mod.rs
@@ -1,0 +1,1 @@
+mod global_defaults;

--- a/crates/orbit-core/src/composition.rs
+++ b/crates/orbit-core/src/composition.rs
@@ -6,6 +6,7 @@ use orbit_common::OrbitError;
 use orbit_config::{ConfigRoots, ResolvedConfig};
 use orbit_store::compose::global_policy_def_store;
 
+use crate::bootstrap::global_defaults::global_defaults_are_current;
 use crate::bootstrap::init::ensure_orbit_root_initialized;
 use crate::bootstrap::policy::seed_default_policies;
 use crate::bootstrap::task_migration::apply_configured_id_start;
@@ -263,17 +264,25 @@ fn prepare_resolved_config(
             return Err(error);
         }
     }
-    let global_policy_store = global_policy_def_store(resolved.persistence.policy_dir.clone());
-    if let Err(error) = seed_default_policies(global_policy_store.as_ref(), false) {
-        if error.is_readonly_or_access_failure() {
-            tracing::warn!(
-                target: "orbit.core.bootstrap",
-                root = %global_root.display(),
-                error = %error,
-                "skipped incidental default-policy persistence"
-            );
-        } else {
-            return Err(error);
+    // Not every runtime open bootstraps its global root: opening a registered
+    // checkout or an observation-only runtime goes straight to composition, so
+    // the shipped default policy is seeded here. `policy_dir` is derived from
+    // the global root and cannot be relocated by config, so the same stamp that
+    // lets bootstrap skip reconciliation settles this seed too — a root already
+    // reconciled by this binary carries the policy.
+    if !global_defaults_are_current(global_root) {
+        let global_policy_store = global_policy_def_store(resolved.persistence.policy_dir.clone());
+        if let Err(error) = seed_default_policies(global_policy_store.as_ref(), false) {
+            if error.is_readonly_or_access_failure() {
+                tracing::warn!(
+                    target: "orbit.core.bootstrap",
+                    root = %global_root.display(),
+                    error = %error,
+                    "skipped incidental default-policy persistence"
+                );
+            } else {
+                return Err(error);
+            }
         }
     }
     Ok(resolved)

--- a/docs/runbooks/state-and-backup.md
+++ b/docs/runbooks/state-and-backup.md
@@ -52,7 +52,7 @@ precedence). Path layout is defined in
 | `tasks/workspaces/<ws-id>/<task-id>/` | canonical task bundles (survive repo moves) | **authoritative** |
 | `frictions/workspaces/<ws-id>/` | live tag taxonomy plus the published legacy record tree used for one-time import/rollback | mixed: taxonomy is authoritative configuration; record files are legacy evidence after SQLite import |
 | `resources/activities/`, `resources/jobs/` | managed defaults plus operator-authored activity/job YAML; hidden manifests retain managed content provenance | mixed: current defaults are regenerable, but untracked YAML and `resources/.retired-managed/` backups are **authoritative until reviewed** |
-| other `resources/`, `skills/` | default executor/policy defs and skills | regenerable (`orbit init` reseeds) |
+| other `resources/`, `skills/` | default executor/policy defs and skills; `resources/.orbit-global-defaults.json` records which embedded default set was last reconciled here | regenerable (`orbit init` reseeds) |
 | `state/logs/orbit.jsonl` (+ rotated archives) | unified JSONL log sink for all Orbit processes | disposable |
 | `state/task-publication/` | private Git object/work-tree caches plus pending-push reconciliation records | regenerable after a cleanly recorded success; retain during push-success/local-record recovery |
 | `embed/` | semantic-search companion binary + models | regenerable (`orbit semantic install`) |
@@ -89,6 +89,11 @@ precedence). Path layout is defined in
 > with no manifest, non-matching YAML stays in place and init names it in a
 > warning. Move or delete only the named stale file after confirming it came
 > from an older release, then rerun `orbit init` and the affected list command.
+> A runtime open reconciles the managed catalogs only when the root does not
+> already carry the running binary's `resources/.orbit-global-defaults.json` stamp — a
+> fresh root, an upgrade, or a different Orbit build. Restoring a managed file
+> removed or corrupted by hand is therefore an explicit `orbit init` /
+> `orbit workspace sync` step rather than a side effect of the next command.
 
 ### Retired graph state and task selectors
 


### PR DESCRIPTION
## Task

[ORB-11638](https://orbit-cli.com/tasks/ORB-11638) — [code-review] Avoid redundant managed-asset reconciliation on warm runtime opens

### Description

## Problem
Implicit runtime opening calls global initialization, which reconciles managed skills, executors, policies, activities and jobs even on an already initialized root. Tracked assets are read and hashed again. Policy seeding is also repeated during composition.

## Required behavior
Avoid unnecessary digest reconciliation on unchanged warm opens while preserving first-open bootstrap, required default asset availability after upgrades, explicit init/sync behavior, user-modified asset preservation, and denied incidental-write handling. Define when reconciliation is required and make that decision at the bootstrap/composition boundary; do not silently require manual initialization for previously supported runtime opens.
The config read inside initialization is global-only; composition loads layered global/workspace configuration. These reads are not interchangeable. Any consolidation must preserve workspace overrides and the intended scope of bootstrap decisions. The performance target is redundant reconciliation reads/hashes, not legitimate managed-asset loads needed to execute the runtime.

## Evidence and validation
Originally reviewed at `7f3a8f5fa` (2026-09-07); concern revalidated at `da21eb15`, with inspected files unchanged at fetched `agent-main` `09dec5183`. Re-locate symbols if source has moved. `crates/orbit-core/src/composition.rs:34`, `:189`, `:205`; `crates/orbit-core/src/bootstrap/init.rs:96`, `:107`, `:190`, `:236`; `crates/orbit-core/src/application/mod.rs` reconciliation implementation.
Follow current AGENTS.md and owning module conventions. Run focused tests below and required `make ci-fast` / `make ci-lint` checks before review.

### Acceptance Criteria

- A focused warm-open test demonstrates no redundant managed-asset digest reconciliation on the second unchanged open, while allowing legitimate execution-time asset reads.
- First-open and upgraded-root tests demonstrate required defaults remain available, user modifications are preserved, and incidental write denial retains supported read behavior.
- Layered config tests show workspace overrides still apply and global bootstrap uses the intended scope.
- Explicit init/workspace sync tests retain applicable Refreshed/Retired/Preserved outcomes; run bootstrap and managed-assets tests.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What changed

Reconciliation of the global managed defaults is now a decision made at the bootstrap/composition boundary instead of unconditional work on every runtime open.

- **New `crates/orbit-core/src/bootstrap/global_defaults.rs`** — a stamp at `<global root>/resources/.orbit-global-defaults.json` (`{schemaVersion, defaultsDigest}`) recording the SHA-256 of the embedded default set (28 skills, 49 activities, 14 jobs, 10 executors, 1 policy) joined with the root path and host OS, because skill rendering injects the root and executors are seeded per OS. The digest of the compile-time constants is computed once per process (`OnceLock`). An absent, unreadable, or foreign stamp reads as stale, so an unusable stamp costs one reconciliation, never correctness.
- **`bootstrap/init.rs`** — `ensure_orbit_root_initialized` skips the global-scope seed when the stamp is current; the workspace side (layout dirs, legacy skill reaping, scoreboard) stays unconditional. `init_workspace_at_root` records the stamp only after every global-scope default landed, routed through the existing `ignore_denied_implicit_bootstrap_write` so an immutable root still opens.
- **`composition.rs`** — the duplicate default-policy seed in `prepare_resolved_config` is gated on the same stamp. It stays for the open paths that never bootstrap (registered checkout, read-only open); `persistence.policy_dir` is derived from the global root and cannot be relocated by config, so the stamp is the right authority. Config loading is untouched: bootstrap still reads global-only, composition still layers workspace over global.
- Explicit `orbit init`, `orbit workspace sync`, and `orbit doctor` never consult the stamp, so their Created/Refreshed/Retired/Migrated/Preserved outcomes are unchanged by construction.
- Docs: new `ARCHITECTURE.md` scoping-rules row for the stamp, and `docs/runbooks/state-and-backup.md` inventory row plus an operator note that restoring a hand-removed managed file is now an explicit `orbit init` / `orbit workspace sync` step.

Measured on this host (debug build, 20 iterations, temp roots): a warm `ensure_orbit_root_initialized` drops from **54.1 ms to 0.75 ms**.

## Criteria → evidence

1. *No redundant digest reconciliation on the second unchanged open* — `bootstrap::tests::global_defaults::warm_open_does_not_reconcile_managed_asset_digests`: after the first open the activity manifest is replaced with unparseable JSON; the warm open still succeeds (reconciliation loads that manifest before deciding anything, so it provably never ran) and leaves the catalog byte-identical. A two-sided control drops the stamp and asserts the same call now fails on the corrupt manifest. Execution-time reads are untouched — the catalogs stay present and readable, exercised by `runtime_bootstrap_reads_seeded_global_assets_without_write_access` and the doctor/catalog tests.
2. *First open, upgraded root, user edits, denied write* — `first_open_seeds_global_defaults_and_stamps_the_root` (skills, activities, config seeded; root stamped); `upgraded_root_restores_required_defaults_and_preserves_user_edits` (a foreign-release stamp forces reconciliation: a deleted default is restored to shipped content, a hand-edited default is preserved verbatim, the root is re-stamped); `denied_stamp_write_keeps_the_open_and_its_reads_working` (read-only `resources/`: the open succeeds, the catalog stays readable, and the unrecorded stamp leaves the next open reconciling — the denial assertion self-skips if the process is privileged enough to ignore the mode bits).
3. *Layered config vs. global bootstrap scope* — `global_bootstrap_scope_survives_a_workspace_config_override`: global `scoring.enabled = false` with workspace `true`; across both the first and the warm open the composed runtime reports `scoring_enabled() == true` (layered override) while no scoreboard template is seeded (global-only bootstrap decision).
4. *Explicit init/sync outcomes retained* — the existing `application::tests::managed_assets` and `bootstrap::init::tests` suites pass unchanged, including retirement, refresh, preservation, provenance-migration, and artifact-health cases. Two fixtures gained one line: `runtime_bootstrap_refreshes_orbit_written_stale_activity_before_catalog_load` and `runtime_bootstrap_preserves_locally_modified_stale_managed_activity` now drop the stamp their own `init_global` wrote, because a root carrying an older release's manifest digest but this binary's stamp is a state no release can produce; the assertions themselves are unchanged.

## Validation

- `cargo test -p orbit-core --lib` — **1209 passed, 3 failed**. All three fail identically at HEAD (`cbd924de0`) in a clean export of the same tree, so they are pre-existing and unrelated: `application::job::tests::catalog::gate_pipeline_releases_reservation_before_child_success_guard` and `application::routine::tests::dogfood_task_pilot_routine_matches_the_rendered_default_template` (this repo's own `.orbit/` copies have drifted from the shipped assets: `max_active_runs` 15 vs 10, cron `*/15` vs `*/40`), and `application::task::tests::update::concurrent_explicit_edit_preserves_the_newer_status`. A fourth, `application::tests::job_pipeline::claimed_sleeping_worker_does_not_keep_polling_the_run_store`, failed once under full parallel load and passes in isolation and on re-run.
- `cargo test -p orbit-core --lib -- bootstrap:: application::tests::managed_assets` — 43 passed, 0 failed (the focused suites this task names).
- `cargo test -p orbit-cmd --lib` — passed (includes the doctor artifact-health suite).
- `cargo test -p orbit-cli` — 454 passed, 15 failed, all pre-existing clap `debug_assert` panics from a duplicate `--workspace` long flag on `orbit search` (`Long option names must be unique … '--workspace' is in use by both 'workspaces' and 'workspace'`), plus the two help-surface tests that render the same command. One CLI failure *was* mine and is fixed: `workspace_init_under_home_with_global_orbit_creates_repo_orbit` asserts a global root never grows workspace-only layout, which the stamp violated when it lived under `state/`; it now lives beside the catalogs it describes in `resources/`.
- `cargo test -p orbit-web --lib` — 366 passed, 1 failed: `dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close`, a node-run dashboard JS assertion (`expected one retry timer, got 2`) with no Rust bootstrap involvement, traceable to the `/api/log` change in `725fc8834`.
- `make ci-fast` — exit 0. `make ci-lint` — exit 0.
- `git diff --check` clean; `git status --short` shows only the intended files plus the new `bootstrap/global_defaults.rs` and `bootstrap/tests/`. No caches or temporary artifacts left behind (the throwaway timing harness was removed).

## Deviation and risk

Deliberate, documented behavior change: a warm open no longer restores a managed default that was deleted or corrupted **by hand** on a root already stamped by the running binary. Upgrades, fresh roots, and a different Orbit build all still reconcile, because the stamp is keyed to the embedded asset set. Repair of a hand-damaged root moves to the explicit paths (`orbit init`, `orbit workspace sync`, `orbit doctor`), which never consult the stamp; this is stated in the module docs and in the state-and-backup runbook. Two Orbit builds sharing one `~/.orbit` disagree and each reconciles on its own opens — the same rewriting they already did before this change, with no added cost.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11638-6a9f7686`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra