### PR TITLE
[code-review] Collect failures across selected tests within each CI suite invocation

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -73,7 +73,7 @@ jobs:
       # runner forbids `sandbox-exec`, `sandbox_exec_can_apply()` self-skips the
       # apply-time tests rather than failing — never worse than the Linux gate.
       - name: Run orbit-exec sandbox tests (real sandbox-exec)
-        run: cargo test -p orbit-exec --locked
+        run: cargo test --no-fail-fast -p orbit-exec --locked
 
       # [ORB-11055] The nested `orbit.task.update` regression needs the CLI
       # binary; the child-runtime inventory test lives in orbit-core.
@@ -81,12 +81,12 @@ jobs:
         run: cargo build -p orbit-cli --locked --bin orbit
 
       - name: Run orbit-core sandbox tests
-        run: cargo test -p orbit-core --locked sandbox
+        run: cargo test --no-fail-fast -p orbit-core --locked sandbox
 
       # Linux cannot exercise Darwin's libproc zombie/group semantics. Keep
       # these filters aligned with the owner/liveness path triggers above.
       - name: Run process identity and job-run owner tests
         run: |
-          cargo test -p orbit-common --locked process::tests::identity -- --nocapture
-          cargo test -p orbit-core --locked application::job::run::tests::owner -- --nocapture
-          cargo test -p orbit-core --locked application::job::run::tests::actions -- --nocapture
+          cargo test --no-fail-fast -p orbit-common --locked process::tests::identity -- --nocapture
+          cargo test --no-fail-fast -p orbit-core --locked application::job::run::tests::owner -- --nocapture
+          cargo test --no-fail-fast -p orbit-core --locked application::job::run::tests::actions -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run Linux sandbox/policy enforcement tests
-        run: cargo test -p orbit-exec -p orbit-policy -p orbit-tools --locked
+        run: cargo test --no-fail-fast -p orbit-exec -p orbit-policy -p orbit-tools --locked
 
   # [ORB-10010] MSRV floor: `rust-version` in [workspace.package] (Cargo.toml).
   # Evidence for 1.89: edition 2024 requires >= 1.85, the highest

--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -28,12 +28,12 @@ if [[ "$fast" == false ]]; then
   "$repo_root/scripts/check-ci-macos.sh"
   cargo clippy --workspace --all-targets -- -D warnings
   if cargo nextest --version >/dev/null 2>&1; then
-    cargo nextest run --workspace --lib --bins --tests
+    cargo nextest run --no-fail-fast --workspace --lib --bins --tests
   else
     echo "cargo-nextest not found; falling back to cargo test" >&2
-    cargo test --workspace --lib --bins --tests
+    cargo test --no-fail-fast --workspace --lib --bins --tests
   fi
-  cargo test --workspace --doc
+  cargo test --no-fail-fast --workspace --doc
   RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
   # Supply-chain gate: dependency advisories + license allow-list (deny.toml).
   # [ORB-00416] Soft-presence like nextest above — CI installs a pinned version;


### PR DESCRIPTION
## Task

[ORB-11644](https://orbit-cli.com/tasks/ORB-11644) — [code-review] Collect failures across selected tests within each CI suite invocation

### Description

## Problem and required behavior
Suite invocations in CI stop after an initial failing test target, hiding other failures that could be reported in the same invocation. Configure the actual Cargo/nextest test-suite invocations to continue running their selected tests after a test failure and still return failure overall.

## Scope and constraints
This task covers failure collection within each test-suite invocation. It does not promise that later shell commands, documentation checks or separate CI steps run after an earlier command fails: `scripts/ci-guardrails.sh` uses `set -e`, and macOS has multiple sequential commands. Preserve that shell failure behavior. Inventory `scripts/ci-guardrails.sh`, `.github/workflows/ci.yml`, `.github/workflows/ci-macos.yml` and `.config/nextest.toml`, and use the supported no-fail-fast option or one authoritative profile setting for the relevant invocations. Do not duplicate settings without need or modify build, discovery and test-list commands merely to satisfy a text search.

## Evidence and validation
At da21eb15 / origin/agent-main 09dec5183, ci-guardrails.sh lines 18, 21 and 23 omit no-fail-fast; the script exits on failure at line 2. The original review was at 7f3a8f5fa. Validate failure collection with a tiny isolated fixture workspace or existing focused harness, never by introducing failures into the live repository or running a known hazardous broad suite.

Follow current AGENTS.md and preserve the existing authoritative boundary. Run focused behavior checks plus required make ci-fast and make ci-lint before review; report skipped or environment-dependent verification explicitly.

### Acceptance Criteria

- An isolated fixture with two failing test targets shows both target failures from one supported Cargo suite invocation and returns nonzero.
- When nextest is available, the equivalent fixture confirms all selected failures are reported with a nonzero result under the configured nextest invocation.
- The relevant CI suite invocations use the verified failure-collection setting, while subsequent-command shell fail-fast behavior remains explicit and unchanged.
- Passing fixture runs still succeed; syntax/configuration checks pass for the changed workflow, script or nextest settings.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Added the supported `--no-fail-fast` option to the CI guardrail nextest invocation, Cargo fallback, and documentation-test invocation in `scripts/ci-guardrails.sh`.
- Added `--no-fail-fast` to the Linux enforcement suite and every macOS Cargo test-suite invocation in the scoped workflows.
- Kept `.config/nextest.toml` unchanged because the installed nextest version supports the explicit invocation flag; preserved `set -euo pipefail` and macOS's separate sequential commands.

Acceptance criteria:
- Isolated Cargo fixture with two failing integration-test targets: passed; one `cargo test --no-fail-fast --workspace --tests` invocation reported both failures and returned 101.
- Equivalent isolated nextest fixture: passed; `cargo nextest run --no-fail-fast --workspace --tests` reported both failures and returned 100.
- CI invocation and shell behavior: passed by diff inspection and repository guardrails; all scoped suite commands carry the flag, shell fail-fast anchors remain present, and no later-command behavior was changed.
- Passing/configuration checks: passed; both fixture suites passed with the flag, `bash -n scripts/ci-guardrails.sh`, PyYAML parsing of both workflows, `cargo nextest list --workspace --tests --locked`, and `git diff --check` succeeded.

Validation:
- `make ci-fast`: passed. The compiler-cache namespace subcheck reported an environment-dependent skip because bubblewrap cannot create an unprivileged mount namespace; the target completed successfully.
- `make ci-lint`: passed; workspace all-target clippy with `-D warnings` completed successfully.
- `actionlint`, `yamllint`, and Ruby YAML parsing: not run because unavailable; equivalent PyYAML workflow parsing and repository CI guardrails passed.
- macOS runtime execution: not run on this Linux host; workflow syntax/path/filter checks passed locally.

Assessment: The change is minimal and uses the tool-supported option at each actual CI suite boundary while preserving command-level fail-fast semantics. No unrelated files changed; changes remain uncommitted for pipeline delivery.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11644-6a9f7ee7`
- Behind base: 0
- Ahead of base: 1