### PR TITLE
fix: diagnose the database path through a fresh read-only probe [ORB-11787]

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -211,7 +211,7 @@ fn doctor_check_config(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
 
 /// `PRAGMA quick_check` plus migration-ledger schema version vs binary.
 fn doctor_check_database(runtime: &OrbitRuntime) -> WorkspaceDoctorResult {
-    let store = match runtime.sqlite_store() {
+    let store = match runtime.sqlite_store_for_diagnostics() {
         Ok(store) => store,
         Err(error) => {
             return check(

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -283,6 +283,27 @@ fn unopenable_store_database_fails_the_database_check() {
     );
 }
 
+#[test]
+fn missing_store_database_is_reported_without_recreating_it() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let runtime = workspace_runtime(&temp);
+    let db_path = temp.path().join("global").join("orbit.db");
+    fs::remove_file(&db_path).expect("remove store db");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let database = status_of(&results, "database");
+    assert_eq!(
+        database.status,
+        WorkspaceDoctorStatus::Error,
+        "{database:?}"
+    );
+    assert!(database.message.contains("cannot open store database"));
+    assert!(
+        !db_path.exists(),
+        "doctor must not recreate a missing database"
+    );
+}
+
 #[cfg(unix)]
 fn reaped_child_pid() -> u32 {
     let mut child = std::process::Command::new("true")

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -413,6 +413,13 @@ impl OrbitRuntime {
         Ok(self.context.stores().host.sqlite.clone())
     }
 
+    /// Probe the configured database path independently of cached runtime
+    /// handles. Diagnostics must observe missing or replaced files and must
+    /// not repair or migrate them as a side effect.
+    pub fn sqlite_store_for_diagnostics(&self) -> Result<Store, OrbitError> {
+        Store::open_read_only(&self.context.persistence().audit_db)
+    }
+
     pub fn v2_audit_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::V2AuditStoreBackend>, OrbitError> {

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use orbit_common::OrbitError;
 use orbit_common::storage::sqlite::{apply_default_pragmas, open_private};
-use rusqlite::{Connection, Transaction, TransactionBehavior};
+use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
 
 use crate::driver::sqlite::migration;
 use crate::driver::sqlite::read_pool::{ReadGuard, ReadPool};
@@ -114,6 +114,18 @@ impl Store {
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             readers: (!read_only).then(|| Arc::new(ReadPool::new(path.to_path_buf()))),
+        })
+    }
+
+    /// Open an existing database for an observational probe, without creating
+    /// the database, applying migrations, or changing database pragmas. Use a fresh
+    /// connection so a cached runtime handle cannot hide a replaced path.
+    pub fn open_read_only(path: &Path) -> Result<Self, OrbitError> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            readers: None,
         })
     }
 

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -207,3 +207,51 @@ fn file_store_is_private_under_permissive_umask() {
         assert_eq!(mode, 0o600, "private SQLite file {}", file.display());
     }
 }
+
+#[test]
+fn read_only_probe_does_not_create_a_missing_database() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("missing.db");
+    assert!(Store::open_read_only(&path).is_err());
+    assert!(!path.exists(), "diagnosis must not create the database");
+}
+
+#[test]
+fn read_only_probe_preserves_unmigrated_database_and_rejects_writes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    let connection = rusqlite::Connection::open(&path).expect("fixture database");
+    connection
+        .execute_batch("CREATE TABLE fixture (id INTEGER)")
+        .expect("fixture table");
+    drop(connection);
+    let before = std::fs::read(&path).expect("database before probe");
+
+    let probe = Store::open_read_only(&path).expect("read-only probe");
+    probe.quick_check().expect("valid database");
+    assert_eq!(probe.schema_version().expect("version"), 0);
+    assert!(
+        probe
+            .with_transaction(|tx| {
+                tx.connection()
+                    .execute("INSERT INTO fixture VALUES (1)", [])
+                    .map_err(|error| OrbitError::Store(error.to_string()))?;
+                Ok(())
+            })
+            .is_err(),
+        "probe must reject writes"
+    );
+    drop(probe);
+    assert_eq!(std::fs::read(&path).expect("database after probe"), before);
+}
+
+#[test]
+fn read_only_probe_reports_malformed_database_without_repair() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("store.db");
+    let content = b"not a SQLite database";
+    std::fs::write(&path, content).expect("malformed fixture");
+    let probe = Store::open_read_only(&path).expect("open existing file");
+    assert!(probe.quick_check().is_err());
+    assert_eq!(std::fs::read(&path).expect("unchanged file"), content);
+}


### PR DESCRIPTION
Doctor reported a healthy database after its configured file was deleted or replaced by a directory because runtime store reuse kept an already-open connection alive. Add a fresh read-only diagnostic open of the configured path while ordinary runtime operations keep sharing their cached store. The probe neither creates the database nor applies migrations.

The original failing unopenable-path test remains intact. Added coverage checks that missing files remain missing, malformed contents remain unchanged, and probing an unmigrated database preserves its bytes and rejects writes.

Validation on native macOS:
- `cargo test -p orbit-store --lib driver::sqlite::tests::connection::`: 11 passed.
- `cargo test -p orbit-cmd --lib tests::doctor::`: 24 passed.
- `make ci-fast` and `make ci-lint`: passed. Namespace compiler-cache coverage explicitly skips without Bubblewrap.

Repairs the regression introduced by ORB-11632 / PR #1670. Task: ORB-11787. Full hosted CI was not run locally.
