### PR TITLE
fix: import default activities from the runtime owner [ORB-11788]

### DIFF
--- a/crates/orbit-core/src/bootstrap/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/global_defaults.rs
@@ -28,8 +28,8 @@ use sha2::{Digest, Sha256};
 use crate::application::executor::DEFAULT_EXECUTOR_FILES;
 use crate::application::job::DEFAULT_JOB_FILES;
 use crate::application::skill::DEFAULT_SKILL_FILES;
-use crate::bootstrap::activity::DEFAULT_ACTIVITY_FILES;
 use crate::bootstrap::policy::DEFAULT_POLICY_FILES;
+use crate::runtime::assets::DEFAULT_ACTIVITY_FILES;
 
 const GLOBAL_DEFAULTS_STAMP_SCHEMA_VERSION: u32 = 1;
 


### PR DESCRIPTION
Fix the remaining global-defaults consumer after ORB-11631 relocated DEFAULT_ACTIVITY_FILES into runtime::assets. The newer bootstrap/global_defaults.rs still imported the constant through bootstrap::activity, whose import is private, breaking orbit-core compilation with E0603.

The change imports the same constant directly from its runtime owner. This is a one-file integration repair for ORB-11631 / PR #1677 and the consumer added by ORB-11638 / PR #1676.

Validation on Mac with CARGO_BUILD_JOBS=2: native `make ci-fast` passed; full workspace/all-target `make ci-lint` passed; focused global-defaults bootstrap tests passed (5 tests); `git diff --check` passed. The Linux namespace probe is explicitly skipped on Mac because bwrap is unavailable. Task: ORB-11788.
