### PR TITLE
[code-review] Make expandable rows and filter pills keyboard-operable

### DIFF
--- a/crates/orbit-web/assets/dashboard/audit.js
+++ b/crates/orbit-web/assets/dashboard/audit.js
@@ -1,7 +1,7 @@
 // Orbit dashboard audit-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { el, fetchJson, syncNodes, positiveIntParam, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, getWorkspace, setWorkspace, persistScopeToUrl, DEFAULT_DASHBOARD_WINDOW } from './common.js';
+import { el, fetchJson, syncNodes, makeToggleRow, positiveIntParam, isAggregateView, renderPanelPlaceholder, getWindow, setWindow, getWorkspace, setWorkspace, persistScopeToUrl, DEFAULT_DASHBOARD_WINDOW } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -906,7 +906,10 @@ function renderAudit(events, ctx) {
     const cmd = ev.subcommand ? `${ev.command} ${ev.subcommand}` : ev.command;
     const tr = el("tr", { class: "audit-row", title: `event ${ev.id}` });
     tr.dataset.key = `audit-${ev.id}`;
-    tr.dataset.hash = `${ev.id}-${ev.status}-${exit}`;
+    // Expansion is part of the row's identity: without it the keyed diff reuses
+    // the collapsed node and drops the `expanded` class and `aria-expanded`
+    // the toggle just set.
+    tr.dataset.hash = `${ev.id}-${ev.status}-${exit}-${expandedAuditIds.has(ev.id)}`;
     tr.appendChild(el("td", { text: fmtTimestampValue(ctx, ev.timestamp) }));
     tr.appendChild(el("td", { text: ev.role || "-" }));
     tr.appendChild(el("td", { text: tool }));
@@ -918,10 +921,16 @@ function renderAudit(events, ctx) {
     tr.appendChild(el("td", { class: exitClass, text: exit == null ? "-" : String(exit) }));
     tr.appendChild(el("td", { class: "num", text: fmtDurationValue(ctx, ev.duration_ms) }));
     if (expandedAuditIds.has(ev.id)) tr.classList.add("expanded");
-    tr.addEventListener("click", () => {
-      if (expandedAuditIds.has(ev.id)) expandedAuditIds.delete(ev.id);
-      else expandedAuditIds.add(ev.id);
-      renderAudit(lastAudit, ctx);
+    makeToggleRow(tr, {
+      expanded: expandedAuditIds.has(ev.id),
+      // The detail row only exists while the event is open, so the IDREF is
+      // only published while it actually resolves.
+      controls: expandedAuditIds.has(ev.id) ? `audit-detail-${ev.id}` : null,
+      onToggle: () => {
+        if (expandedAuditIds.has(ev.id)) expandedAuditIds.delete(ev.id);
+        else expandedAuditIds.add(ev.id);
+        renderAudit(lastAudit, ctx);
+      },
     });
     frag.appendChild(tr);
 
@@ -935,6 +944,8 @@ function renderAudit(events, ctx) {
 function buildAuditDetailRow(ev, ctx) {
   const tr = el("tr", { class: "audit-detail-row" });
   tr.dataset.key = `audit-detail-${ev.id}`;
+  // The event row's `aria-controls` points here, so the detail needs a real id.
+  tr.id = `audit-detail-${ev.id}`;
   tr.dataset.hash = JSON.stringify(ev);
   const td = el("td");
   td.colSpan = AUDIT_COLUMNS.length;

--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -305,6 +305,34 @@ export function el(tag, opts = {}, children = []) {
   return node;
 }
 
+// ORB-11658: expanding a row is the dashboard's primary interaction, so it has
+// to be operable without a mouse. The row itself carries the button semantics —
+// wrapping the cells in a real <button> would break the CSS grid every row type
+// lays out in — so this is the one place that grants the tab stop, the ARIA
+// role and state, and the Enter/Space binding, and it binds `click` from the
+// same handler so pointer and keyboard can never drift apart.
+//
+// `expanded` is omitted for rows that navigate instead of disclosing; those get
+// button semantics with no expansion state. `controls` names the detail node
+// when the row renders one with a stable id.
+export function makeToggleRow(node, { expanded, onToggle, controls } = {}) {
+  node.tabIndex = 0;
+  node.setAttribute("role", "button");
+  if (expanded != null) node.setAttribute("aria-expanded", String(!!expanded));
+  if (controls) node.setAttribute("aria-controls", controls);
+  node.addEventListener("click", onToggle);
+  node.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    // Key events target whatever holds focus. A nested select or button is its
+    // own tab stop and owns its keys; only the row's own activation belongs to
+    // the row, so a bubbled key press must not toggle it.
+    if (event.target !== node) return;
+    event.preventDefault();
+    onToggle(event);
+  });
+  return node;
+}
+
 // ORB-11655: a panel refresh rebuilds its nodes every 30 s, but disclosure is
 // operator state, not payload state — a <details> the operator opened has to
 // come back open. Keyed in one store so every rebuilt panel restores the same

--- a/crates/orbit-web/assets/dashboard/dashboard.css
+++ b/crates/orbit-web/assets/dashboard/dashboard.css
@@ -980,6 +980,20 @@
         outline-offset: 2px;
       }
 
+      /* ORB-11658: expandable rows and the collapsible field headers are
+         keyboard-operable (role="button" plus Enter/Space), so focus has to be
+         visible on them as well. The ring is inset because an outward one on a
+         full-bleed row is clipped by the panel's scroll container. */
+      .row:focus-visible,
+      .artifact-row:focus-visible,
+      .audit-row:focus-visible,
+      .step-row:focus-visible,
+      .runs-row:focus-visible,
+      .field-block.collapsible h4:focus-visible {
+        outline: 2px solid var(--accent-hover);
+        outline-offset: -2px;
+      }
+
       .filter-summary {
         padding: 6px 16px;
         font-family: var(--font-mono);
@@ -4215,6 +4229,16 @@
         background: var(--bg);
         display: flex; align-items: center; gap: 12px;
         font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim);
+      }
+      /* ORB-11658: the log-foot controls are real <button>s so they are
+         focusable and announced as toggles; strip the user-agent chrome the
+         <span>s they replaced never carried. */
+      .log-foot button { font: inherit; background: none; border: none; color: inherit; padding: 0; }
+      .log-foot .filter-pill:focus-visible,
+      .log-foot .seg.right:focus-visible,
+      .log-foot .count:focus-visible {
+        outline: 2px solid var(--accent-hover);
+        outline-offset: 2px;
       }
       .log-foot .seg { display: inline-flex; align-items: center; gap: 6px; }
       .log-foot .seg b { color: var(--fg); font-weight: 500; }

--- a/crates/orbit-web/assets/dashboard/index.html
+++ b/crates/orbit-web/assets/dashboard/index.html
@@ -124,12 +124,12 @@
           <div class="dock-pane" data-pane="log">
             <section class="panel" id="log-panel">
               <div class="log-foot log-filters">
-                <span class="filter-pill on" data-filter="all">all</span>
-                <span class="filter-pill" data-filter="err">err</span>
-                <span class="filter-pill" data-filter="deny">deny</span>
-                <span class="filter-pill" data-filter="warn">warn</span>
-                <span class="seg right on" id="log-follow-tail" title="Follow the tail"><b>&#8595;</b> follow</span>
-                <span class="count" id="log-buffered-count" style="display: none;">0 buffered</span>
+                <button type="button" class="filter-pill on" data-filter="all" aria-pressed="true">all</button>
+                <button type="button" class="filter-pill" data-filter="err" aria-pressed="false">err</button>
+                <button type="button" class="filter-pill" data-filter="deny" aria-pressed="false">deny</button>
+                <button type="button" class="filter-pill" data-filter="warn" aria-pressed="false">warn</button>
+                <button type="button" class="seg right on" id="log-follow-tail" title="Follow the tail" aria-pressed="true"><b>&#8595;</b> follow</button>
+                <button type="button" class="count" id="log-buffered-count" style="display: none;">0 buffered</button>
               </div>
               <div class="log-stream">
                 <div class="inner" id="logInner"></div>

--- a/crates/orbit-web/assets/dashboard/log-tail.js
+++ b/crates/orbit-web/assets/dashboard/log-tail.js
@@ -204,9 +204,10 @@ export function initLogTail() {
   
   const followBtn = $("log-follow-tail");
   if (followBtn) {
-    followBtn.addEventListener("click", (e) => {
+    followBtn.addEventListener("click", () => {
       logFollowTail = !logFollowTail;
-      e.currentTarget.classList.toggle("on", logFollowTail);
+      followBtn.classList.toggle("on", logFollowTail);
+      followBtn.setAttribute("aria-pressed", String(logFollowTail));
       if (logFollowTail) {
         flushBufferedLogs();
       }
@@ -221,8 +222,8 @@ export function initLogTail() {
   }
 
   document.querySelectorAll("#side-dock .filter-pill").forEach(pill => {
-    pill.addEventListener("click", (e) => {
-      const filter = e.currentTarget.dataset.filter;
+    pill.addEventListener("click", () => {
+      const filter = pill.dataset.filter;
       if (filter === "all") {
         activeLogFilters.clear();
         activeLogFilters.add("all");
@@ -237,10 +238,8 @@ export function initLogTail() {
           activeLogFilters.add(filter);
         }
       }
-      
-      document.querySelectorAll("#side-dock .filter-pill").forEach(p => {
-        p.classList.toggle("on", activeLogFilters.has(p.dataset.filter));
-      });
+
+      syncLogFilterPills();
       applyLogFilters();
     });
   });
@@ -269,6 +268,17 @@ function enforceLogBounds() {
     for (const row of toRemove) {
       row.remove();
     }
+  }
+}
+
+// The pills are toggle buttons: `on` carries the visual state and `aria-pressed`
+// carries the same fact for assistive tech, so both are written from the one
+// active-filter set rather than from the click target.
+function syncLogFilterPills() {
+  for (const pill of document.querySelectorAll("#side-dock .filter-pill")) {
+    const on = activeLogFilters.has(pill.dataset.filter);
+    pill.classList.toggle("on", on);
+    pill.setAttribute("aria-pressed", String(on));
   }
 }
 

--- a/crates/orbit-web/assets/dashboard/run-detail.js
+++ b/crates/orbit-web/assets/dashboard/run-detail.js
@@ -15,7 +15,7 @@
 // No behavior change: identical rendering, expand/collapse, tooltips, routing, subtab
 // activation, and scroll-to-step.
 
-import { el, syncNodes, stateCell, positiveIntParam } from './common.js';
+import { el, syncNodes, stateCell, positiveIntParam, makeToggleRow } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -262,12 +262,18 @@ export function renderRunSteps() {
       el("span", { class: exitClass, text: exit == null ? "-" : String(exit) }),
     ]);
     row.dataset.key = `step-${step.step_index}`;
-    row.dataset.hash = `${step.step_index}-${step.state}-${exit}`;
+    // Expansion is part of the row's identity: without it the keyed diff reuses
+    // the collapsed node and drops the `expanded` class and `aria-expanded`
+    // the toggle just set.
+    row.dataset.hash = `${step.step_index}-${step.state}-${exit}-${expandedStepIndices.has(step.step_index)}`;
     if (expandedStepIndices.has(step.step_index)) row.classList.add("expanded");
-    row.addEventListener("click", () => {
-      if (expandedStepIndices.has(step.step_index)) expandedStepIndices.delete(step.step_index);
-      else expandedStepIndices.add(step.step_index);
-      renderRunSteps();
+    makeToggleRow(row, {
+      expanded: expandedStepIndices.has(step.step_index),
+      onToggle: () => {
+        if (expandedStepIndices.has(step.step_index)) expandedStepIndices.delete(step.step_index);
+        else expandedStepIndices.add(step.step_index);
+        renderRunSteps();
+      },
     });
     frag.appendChild(row);
     if (expandedStepIndices.has(step.step_index)) {

--- a/crates/orbit-web/assets/dashboard/runs.js
+++ b/crates/orbit-web/assets/dashboard/runs.js
@@ -11,7 +11,7 @@
 // callbacks (fetchAndRender*, navigateToRun) and getters (activeRunId, lastRuns,
 // formatters) that the actions and render depend on. No direct import from app.js.
 
-import { panelCanRender, el, stateCell, syncNodes, postJson } from './common.js';
+import { panelCanRender, el, stateCell, syncNodes, postJson, makeToggleRow } from './common.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -675,7 +675,9 @@ export function renderRuns(runs) {
     row.dataset.key = `run-${runIdentity(r)}`;
     row.dataset.hash = `${runIdentity(r)}-${ts}-${r.duration_ms}-${r.state}-${r.retry_source_run_id || ""}-${resumedAsId || ""}-${friction.denials}-${friction.toolFails}-${friction.durationMs}-${friction.longRun}`;
     row.style.cursor = "pointer";
-    row.addEventListener("click", () => doNavigateToRun(r.run_id, r.workspace_id));
+    // A run row opens the run detail view rather than disclosing inline, so it
+    // gets button semantics with no expansion state.
+    makeToggleRow(row, { onToggle: () => doNavigateToRun(r.run_id, r.workspace_id) });
     frag.appendChild(row);
   }
   syncNodes(body, Array.from(frag.children));

--- a/crates/orbit-web/assets/dashboard/tasks.js
+++ b/crates/orbit-web/assets/dashboard/tasks.js
@@ -1,7 +1,7 @@
 // Orbit dashboard task-domain rendering and actions.
 // Pure vanilla JS, split into ES modules with no build step.
 
-import { onWorkspaceChange, panelCanRender, el, statusPill, patchJson, postJson, syncNodes, isAggregateView, withWorkspace } from './common.js';
+import { onWorkspaceChange, panelCanRender, el, statusPill, patchJson, postJson, syncNodes, isAggregateView, withWorkspace, makeToggleRow } from './common.js';
 import { renderMarkdown, renderMarkdownInline } from './markdown.js';
 
 const $ = (id) => document.getElementById(id);
@@ -654,7 +654,7 @@ function buildArtifactPreview(artifact, response) {
 
 export function buildArtifacts(task) {
   const wrap = el("div", { class: "artifacts" });
-  for (const artifact of task.artifacts) {
+  for (const [index, artifact] of task.artifacts.entries()) {
     const path = String(artifact.path || "");
     const mediaType = String(artifact.media_type || "application/octet-stream");
     const row = el("div", {
@@ -662,27 +662,38 @@ export function buildArtifacts(task) {
       text: `${path} · ${mediaType} · ${fmtSize(artifact.size_bytes)}`,
     });
     const preview = el("div", { class: "artifact-preview" });
+    // Artifact paths are free-form, so the position in the list is what makes a
+    // stable id the row's `aria-controls` can point at.
+    preview.id = `artifact-preview-${task.id}-${index}`;
     preview.hidden = true;
-    row.addEventListener("click", async (e) => {
-      e.stopPropagation();
-      if (preview.dataset.loaded === "true" && !preview.hidden) {
-        preview.hidden = true;
-        return;
-      }
-      if (preview.dataset.loaded === "true") {
-        preview.hidden = false;
-        return;
-      }
-      preview.hidden = false;
-      preview.textContent = "loading...";
-      try {
-        const response = await fetch(artifactUrl(task.id, path));
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        preview.replaceChildren(await buildArtifactPreview(artifact, response));
-        preview.dataset.loaded = "true";
-      } catch (error) {
-        preview.textContent = `Unable to load ${path}: ${error.message}`;
-      }
+
+    // Disclosure lives on the preview's `hidden` flag; keeping the two in one
+    // setter is what stops the announced state from drifting from the visible one.
+    const revealPreview = (visible) => {
+      preview.hidden = !visible;
+      row.setAttribute("aria-expanded", String(visible));
+    };
+
+    makeToggleRow(row, {
+      expanded: false,
+      controls: preview.id,
+      onToggle: async (e) => {
+        e.stopPropagation();
+        if (preview.dataset.loaded === "true") {
+          revealPreview(preview.hidden);
+          return;
+        }
+        revealPreview(true);
+        preview.textContent = "loading...";
+        try {
+          const response = await fetch(artifactUrl(task.id, path));
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          preview.replaceChildren(await buildArtifactPreview(artifact, response));
+          preview.dataset.loaded = "true";
+        } catch (error) {
+          preview.textContent = `Unable to load ${path}: ${error.message}`;
+        }
+      },
     });
     wrap.appendChild(row);
     wrap.appendChild(preview);
@@ -704,9 +715,13 @@ function buildTaskDetail(task, context) {
     const block = el("div", { class: classes });
     const h4 = el("h4", { text: title });
     if (collapsible) {
-      h4.addEventListener("click", (e) => {
-        e.stopPropagation();
-        block.classList.toggle("collapsed");
+      makeToggleRow(h4, {
+        expanded: !collapsed,
+        onToggle: (e) => {
+          e.stopPropagation();
+          const nowCollapsed = block.classList.toggle("collapsed");
+          h4.setAttribute("aria-expanded", String(!nowCollapsed));
+        },
       });
     }
     block.appendChild(h4);
@@ -1264,9 +1279,13 @@ function buildPinnedTask(ptask, context) {
     buildStatusUpdateControl(ptask, context),
     buildCrewUpdateControl(ptask, context),
   ]);
-  row.addEventListener("click", (e) => {
-    e.stopPropagation();
-    if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
+  // The pinned row's detail is always open, so the row is a plain copy-the-id
+  // action rather than a disclosure.
+  makeToggleRow(row, {
+    onToggle: (e) => {
+      e.stopPropagation();
+      if (navigator.clipboard) navigator.clipboard.writeText(ptask.id).catch(() => {});
+    },
   });
   row.dataset.hash = `${ptask.id}-${ptask.title}-${ptask.status}-${ptask.crew || ""}-${ptask.resolved_crew || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, ptask.id)}-${feedbackSignature(crewFeedback, ptask.id)}`;
 
@@ -1414,20 +1433,26 @@ export function renderTasks(tasks, context) {
       row.dataset.key = `task-${t.id}`;
       // Basic hash based on row presentation parameters + expanded state
       row.dataset.hash = `${t.id}-${t.title}-${t.status}-${t.crew || ""}-${t.resolved_crew || ""}-${t.workspace_id || ""}-${crewOptionsSignature()}-${feedbackSignature(statusFeedback, t.id)}-${feedbackSignature(crewFeedback, t.id)}-${expandedTaskIds.has(t.id)}`;
-      row.addEventListener("click", () => {
-        const toggle = () => {
-          if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
-          else expandedTaskIds.add(t.id);
-          renderTasks(taskList(context), context);
-        };
-        if (document.startViewTransition) {
-          row.style.viewTransitionName = `task-row-${t.id}`;
-          document.startViewTransition(toggle).finished.then(() => {
-            row.style.viewTransitionName = "";
-          });
-        } else {
-          toggle();
-        }
+      makeToggleRow(row, {
+        expanded: expandedTaskIds.has(t.id),
+        // The detail node only exists while the row is open, so the IDREF is
+        // only published while it actually resolves.
+        controls: expandedTaskIds.has(t.id) ? `detail-${t.id}` : null,
+        onToggle: () => {
+          const toggle = () => {
+            if (expandedTaskIds.has(t.id)) expandedTaskIds.delete(t.id);
+            else expandedTaskIds.add(t.id);
+            renderTasks(taskList(context), context);
+          };
+          if (document.startViewTransition) {
+            row.style.viewTransitionName = `task-row-${t.id}`;
+            document.startViewTransition(toggle).finished.then(() => {
+              row.style.viewTransitionName = "";
+            });
+          } else {
+            toggle();
+          }
+        },
       });
       if (expandedTaskIds.has(t.id)) row.classList.add("expanded");
       nodes.push(row);
@@ -1439,6 +1464,8 @@ export function renderTasks(tasks, context) {
         } else {
           const detail = buildTaskDetail(t, context);
           detail.dataset.key = key;
+          // The row's `aria-controls` points here, so the detail needs a real id.
+          detail.id = key;
           // Diff by full task object stringified
           detail.dataset.hash = JSON.stringify(t);
           nodes.push(detail);

--- a/crates/orbit-web/src/tests/dashboard_assets.rs
+++ b/crates/orbit-web/src/tests/dashboard_assets.rs
@@ -214,7 +214,9 @@ fn dashboard_task_actions_route_to_selected_workspace() {
         "withWorkspace must be exported from common.js so other modules can reuse it"
     );
     assert!(
-        tasks.contains("withWorkspace } from './common.js'"),
+        tasks
+            .lines()
+            .any(|line| line.contains("from './common.js'") && line.contains("withWorkspace")),
         "tasks.js must import withWorkspace from common.js"
     );
     assert!(
@@ -1669,13 +1671,21 @@ globalThis.document = {
 };
 const location = new URL("http://dashboard.test/");
 globalThis.window = { location, innerHeight: 900, addEventListener: () => {}, localStorage: { getItem: () => null, setItem: () => {} } };
-const retryFns = [];
+// Long timers are held rather than run so the retry can be driven by hand.
+// clearTimeout has to actually clear: fetchJson arms a 30s abort timer and
+// cancels it in its `finally`, and a no-op stub would leave that behind and
+// make it look like a pending stream retry.
+const pendingTimers = new Map();
+let nextTimerId = 1;
 const nativeSetTimeout = setTimeout;
 globalThis.setTimeout = (fn, ms = 0) => {
-  if (ms >= 250) { retryFns.push(fn); return retryFns.length; }
-  return nativeSetTimeout(fn, ms);
+  if (ms < 250) return nativeSetTimeout(fn, ms);
+  const id = nextTimerId++;
+  pendingTimers.set(id, fn);
+  return id;
 };
-globalThis.clearTimeout = () => {};
+globalThis.clearTimeout = (id) => { pendingTimers.delete(id); };
+const retryFns = () => [...pendingTimers.values()];
 const sources = [];
 class MockEventSource {
   static CONNECTING = 0;
@@ -1710,8 +1720,8 @@ if (label.textContent !== "log stream unavailable, retrying") {
 }
 if (!bar.classList.contains("disconnected")) throw new Error("status bar did not mark disconnected");
 if (!get("side-dock").classList.contains("disconnected")) throw new Error("dock did not mark disconnected");
-if (retryFns.length !== 1) throw new Error(`expected one retry timer, got ${retryFns.length}`);
-retryFns[0]();
+if (retryFns().length !== 1) throw new Error(`expected one retry timer, got ${retryFns().length}`);
+retryFns()[0]();
 if (sources.length !== 2) throw new Error(`retry did not open a new EventSource, got ${sources.length}`);
 if (!sources[1].url.includes("from=42")) throw new Error(`retry lost resume offset: ${sources[1].url}`);
 sources[1].readyState = EventSource.OPEN;
@@ -3456,4 +3466,78 @@ fn dashboard_loading_rejects_stale_responses_and_reports_panel_errors() {
         include_str!("dashboard_loading_dom.mjs"),
         include_str!("dashboard_loading.mjs")
     ));
+}
+
+// ORB-11658: the dashboard's primary interaction is expanding a row, and the
+// log dock's level filters gate what the operator can even see. Both were
+// pointer-only. Two things carry the fix and are asserted separately: the
+// shipped markup (a real <button> is what makes Space activate a pill, and
+// document order is what makes Tab reach a row from the search box), and the
+// shipped modules (role, tab stop, aria state, and the key handlers), which the
+// Node scenario drives directly.
+#[test]
+fn dashboard_log_dock_controls_are_real_toggle_buttons() {
+    let index = include_str!("../../assets/dashboard/index.html");
+
+    for control in [
+        r#"<button type="button" class="filter-pill on" data-filter="all" aria-pressed="true">all</button>"#,
+        r#"<button type="button" class="filter-pill" data-filter="err" aria-pressed="false">err</button>"#,
+        r#"<button type="button" class="filter-pill" data-filter="deny" aria-pressed="false">deny</button>"#,
+        r#"<button type="button" class="filter-pill" data-filter="warn" aria-pressed="false">warn</button>"#,
+        r#"<button type="button" class="seg right on" id="log-follow-tail" title="Follow the tail" aria-pressed="true">"#,
+        r#"<button type="button" class="count" id="log-buffered-count""#,
+    ] {
+        assert!(
+            index.contains(control),
+            "the log dock must ship this control as a pressable button: {control}"
+        );
+    }
+    assert!(
+        !index.contains(r#"<span class="filter-pill"#),
+        "no log filter may remain a <span>"
+    );
+
+    // Tab order is document order: the search box has to come before the rows
+    // it filters for "Tab from the search box reaches the first task row".
+    let search = index
+        .find(r#"id="task-search""#)
+        .expect("task search input must exist");
+    let rows = index
+        .find(r#"id="tasks-body""#)
+        .expect("task list body must exist");
+    assert!(
+        search < rows,
+        "the task search box must precede the task rows in document order"
+    );
+}
+
+#[test]
+fn dashboard_rows_are_keyboard_operable_without_changing_click_behaviour() {
+    run_dashboard_javascript_test(&format!(
+        "{}\n{}",
+        include_str!("dashboard_keyboard_dom.mjs"),
+        include_str!("dashboard_keyboard.mjs")
+    ));
+}
+
+// The focus ring is the other half of keyboard operability: a row that can be
+// focused but shows nothing is not usable.
+#[test]
+fn dashboard_css_shows_focus_on_every_operable_row() {
+    let css = include_str!("../../assets/dashboard/dashboard.css");
+
+    for selector in [
+        ".row:focus-visible",
+        ".artifact-row:focus-visible",
+        ".audit-row:focus-visible",
+        ".step-row:focus-visible",
+        ".runs-row:focus-visible",
+        ".field-block.collapsible h4:focus-visible",
+        ".log-foot .filter-pill:focus-visible",
+    ] {
+        assert!(
+            css.contains(selector),
+            "{selector} must have a visible focus ring"
+        );
+    }
 }

--- a/crates/orbit-web/src/tests/dashboard_keyboard.mjs
+++ b/crates/orbit-web/src/tests/dashboard_keyboard.mjs
@@ -1,0 +1,147 @@
+// ORB-11658: every expandable row must be operable from the keyboard, and the
+// pointer path it shares must keep behaving exactly as before.
+//
+// These scenarios drive the shipped modules through the DOM adapter, so they
+// observe what the modules actually set on each row. Focus order itself and the
+// browser's native Space-activates-a-button rule are properties of the shipped
+// markup, asserted against index.html in dashboard_assets.rs.
+import assert from "node:assert/strict";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// --- Task rows: Enter expands, and the pointer path is untouched -------------
+
+const { renderTasks } = await import("./tasks.js");
+
+const task = { id: "ORB-1", title: "keyboard operable", status: "review", artifacts: [] };
+const context = {
+  getTasks: () => [task],
+  getSearchQuery: () => "",
+  getActiveStatuses: () => new Set(["review"]),
+  statusOrder: ["review"],
+  statusUpdateTargets: [],
+  fmtAbsTime: (value) => value,
+  refreshDashboard: () => Promise.resolve(),
+};
+
+const tasksBody = document.getElementById("tasks-body");
+const taskRow = () => tasksBody.children.find((node) => node.dataset.key === "task-ORB-1");
+const taskDetail = () => tasksBody.children.find((node) => node.dataset.key === "detail-ORB-1");
+
+// The view transition is part of the existing click behaviour: record that it
+// still wraps the toggle, and that the row is named before the transition runs.
+let transitions = 0;
+let namedDuringTransition = null;
+document.startViewTransition = (callback) => {
+  transitions += 1;
+  namedDuringTransition = taskRow().style.viewTransitionName;
+  callback();
+  return { finished: Promise.resolve() };
+};
+
+renderTasks([task], context);
+
+assert.equal(taskRow().getAttribute("role"), "button", "a task row must expose button semantics");
+assert.equal(taskRow().tabIndex, 0, "a task row must be a tab stop");
+assert.equal(taskRow().getAttribute("aria-expanded"), "false");
+assert.equal(taskDetail(), undefined, "the detail is not rendered while collapsed");
+assert.equal(
+  taskRow().getAttribute("aria-controls"),
+  null,
+  "a collapsed row must not point at a detail that is not in the document",
+);
+
+taskRow().dispatch("keydown", { key: "Enter" });
+
+assert.equal(taskRow().getAttribute("aria-expanded"), "true", "Enter must expand the row");
+assert.equal(taskRow().getAttribute("aria-controls"), "detail-ORB-1");
+assert.equal(taskDetail().id, "detail-ORB-1", "the detail the row points at must carry that id");
+assert.equal(transitions, 1, "Enter must take the same view-transition path a click takes");
+assert.equal(namedDuringTransition, "task-row-ORB-1");
+assert.ok(
+  taskRow().className.includes("data-changed"),
+  "the keyed diff must still highlight the re-rendered row",
+);
+
+// A key press that started on a nested control (a status or crew select) bubbles
+// to the row; the row must leave it to the control that owns it.
+const nestedSelect = document.createElement("select");
+taskRow().dispatch("keydown", { key: " ", target: nestedSelect });
+assert.equal(taskRow().getAttribute("aria-expanded"), "true", "a bubbled key press must not toggle the row");
+
+// Space on the row itself is an activation.
+taskRow().dispatch("keydown", { key: " " });
+assert.equal(taskRow().getAttribute("aria-expanded"), "false");
+
+// Clicking still collapses and expands exactly as it did before.
+taskRow().dispatch("click");
+assert.equal(taskRow().getAttribute("aria-expanded"), "true", "clicking must still expand the row");
+// Enter, Space and the click each ran one transition; the bubbled key press ran none.
+assert.equal(transitions, 3, "only real activations take the view-transition path");
+
+// --- Audit rows and run-step rows share the same helper ----------------------
+
+const auditEvent = { id: 7, timestamp: "t", role: "agent", tool_name: "orbit", command: "task", target_id: "ORB-1", status: "success", exit_code: 0, duration_ms: 12 };
+const logPayload = {
+  offset: 0,
+  events: [
+    { ts: "t", source: "orbit", level: "info", code: "OK", message_html: "started" },
+    { ts: "t", source: "orbit", level: "error", code: "ERR", message_html: "failed" },
+  ],
+};
+globalThis.fetch = async (path) => {
+  const payload = String(path).startsWith("/api/audit") ? [auditEvent] : logPayload;
+  return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+};
+
+const { fetchAndRenderAudit } = await import("./audit.js");
+await fetchAndRenderAudit({});
+const auditRow = () => document.getElementById("audit-body").querySelector("table.scoreboard-table").querySelector("tbody").children.find((node) => node.dataset.key === "audit-7");
+
+assert.equal(auditRow().getAttribute("role"), "button");
+assert.equal(auditRow().tabIndex, 0);
+assert.equal(auditRow().getAttribute("aria-expanded"), "false");
+auditRow().dispatch("keydown", { key: "Enter" });
+assert.equal(auditRow().getAttribute("aria-expanded"), "true", "Enter must expand an audit event");
+assert.equal(auditRow().getAttribute("aria-controls"), "audit-detail-7");
+assert.ok(auditRow().classList.contains("expanded"), "the expanded row must keep its class through the keyed diff");
+
+const { setActiveRunDetail, renderRunSteps } = await import("./run-detail.js");
+
+setActiveRunDetail({ run: {}, steps: [{ step_index: 0, target_type: "task", target_id: "ORB-1", state: "success", duration_ms: 5, exit_code: 0 }] });
+renderRunSteps();
+const stepRow = () => document.getElementById("run-steps-body").children.find((node) => node.dataset.key === "step-0");
+
+assert.equal(stepRow().getAttribute("role"), "button");
+assert.equal(stepRow().tabIndex, 0);
+assert.equal(stepRow().getAttribute("aria-expanded"), "false");
+stepRow().dispatch("keydown", { key: " " });
+assert.equal(stepRow().getAttribute("aria-expanded"), "true", "Space must expand a run step");
+assert.ok(stepRow().classList.contains("expanded"));
+
+// --- Log filter pills: pressing a pill filters and reports its own state -----
+
+const { initLogTail } = await import("./log-tail.js");
+initLogTail();
+await tick();
+
+const pills = document.querySelectorAll("#side-dock .filter-pill");
+const pill = (filter) => pills.find((node) => node.dataset.filter === filter);
+const visibleLogCount = () => document.getElementById("log-count").textContent;
+
+assert.equal(visibleLogCount(), "2", "the unfiltered dock shows both lines");
+assert.equal(pill("all").getAttribute("aria-pressed"), "true");
+
+// A real <button> turns Space into a click, which is the handler under test.
+pill("err").dispatch("click");
+
+assert.equal(pill("err").getAttribute("aria-pressed"), "true", "the pressed pill must report itself pressed");
+assert.equal(pill("all").getAttribute("aria-pressed"), "false", "selecting a level must release `all`");
+assert.ok(pill("err").classList.contains("on"), "the visual state must track the announced state");
+assert.equal(visibleLogCount(), "1", "filtering to err must drop the info line");
+
+pill("err").dispatch("click");
+
+assert.equal(pill("err").getAttribute("aria-pressed"), "false");
+assert.equal(pill("all").getAttribute("aria-pressed"), "true", "clearing the last level falls back to `all`");
+assert.equal(visibleLogCount(), "2");

--- a/crates/orbit-web/src/tests/dashboard_keyboard_dom.mjs
+++ b/crates/orbit-web/src/tests/dashboard_keyboard_dom.mjs
@@ -1,0 +1,167 @@
+// DOM adapter for the keyboard-operability scenarios.
+//
+// Unlike the other adapters here this one keeps attributes in a real map and
+// dispatches to every registered listener, because the behaviour under test is
+// exactly "which attributes did the row set" and "does a keydown reach the row
+// handler".
+class Node {
+  constructor(tag = "div") {
+    this.tagName = String(tag).toUpperCase();
+    this.id = "";
+    this.children = [];
+    this.dataset = {};
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this.style = { setProperty: () => {}, display: "" };
+    this.className = "";
+    this.title = "";
+    this.value = "";
+    this.hidden = false;
+    this.disabled = false;
+    this.tabIndex = -1;
+    this._text = "";
+    this.parentNode = null;
+  }
+
+  appendChild(child) {
+    if (child == null) return child;
+    if (child.parentNode) child.parentNode.removeChild(child);
+    this.children.push(child);
+    child.parentNode = this;
+    return child;
+  }
+  insertBefore(child, before) {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const index = this.children.indexOf(before);
+    if (index < 0) return this.appendChild(child);
+    this.children.splice(index, 0, child);
+    child.parentNode = this;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((candidate) => candidate !== child);
+    child.parentNode = null;
+    return child;
+  }
+  replaceChildren(...children) {
+    this._text = "";
+    this.children = [];
+    for (const child of children) this.appendChild(child);
+  }
+  remove() { if (this.parentNode) this.parentNode.removeChild(this); }
+
+  addEventListener(name, fn) {
+    const bound = this.listeners.get(name) || [];
+    bound.push(fn);
+    this.listeners.set(name, bound);
+  }
+  // Test-only dispatcher. `overrides` can set `target` to model a key press
+  // that started on a nested control and bubbled up to the row.
+  dispatch(name, overrides = {}) {
+    const event = { target: this, currentTarget: this, preventDefault() {}, stopPropagation() {}, ...overrides };
+    for (const fn of this.listeners.get(name) || []) fn(event);
+  }
+
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.has(name) ? this.attributes.get(name) : null; }
+
+  get textContent() { return this._text + this.children.map((child) => child.textContent || "").join(""); }
+  set textContent(value) { this._text = String(value); this.children = []; }
+  set innerHTML(value) { this.textContent = value; }
+  get innerHTML() { return this.textContent; }
+  get firstChild() { return this.children[0] || null; }
+  get lastElementChild() { return this.children[this.children.length - 1] || null; }
+
+  get classList() {
+    const self = this;
+    const tokens = () => new Set(self.className.split(/\s+/).filter(Boolean));
+    const write = (set) => { self.className = [...set].join(" "); };
+    return {
+      add: (...names) => { const set = tokens(); for (const name of names) set.add(name); write(set); },
+      remove: (...names) => { const set = tokens(); for (const name of names) set.delete(name); write(set); },
+      contains: (name) => tokens().has(name),
+      toggle: (name, on) => {
+        const set = tokens();
+        const next = on === undefined ? !set.has(name) : !!on;
+        if (next) set.add(name); else set.delete(name);
+        write(set);
+        return next;
+      },
+    };
+  }
+
+  // Supports the `tag`, `.class` and `tag.class` selectors the dashboard
+  // modules actually use to re-find nodes they rendered earlier.
+  matches(selector) {
+    const [tag, ...classes] = String(selector).split(".");
+    if (tag && this.tagName !== tag.toUpperCase()) return false;
+    return classes.every((name) => this.classList.contains(name));
+  }
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (child.matches(selector)) return child;
+      const found = child.querySelector(selector);
+      if (found) return found;
+    }
+    return null;
+  }
+  querySelectorAll(selector) {
+    const found = [];
+    for (const child of this.children) {
+      if (child.matches(selector)) found.push(child);
+      found.push(...child.querySelectorAll(selector));
+    }
+    return found;
+  }
+  contains(node) { return this === node || this.children.some((child) => child.contains(node)); }
+  focus() { globalThis.document.activeElement = this; }
+  closest() { return null; }
+  scrollIntoView() {}
+}
+
+const byId = new Map();
+const get = (id) => byId.get(id) || (byId.set(id, Object.assign(new Node(), { id })), byId.get(id));
+
+// The log dock's filter pills live in index.html, so the harness stands in the
+// same markup the page ships: real buttons carrying `data-filter`.
+const sideDock = get("side-dock");
+for (const filter of ["all", "err", "deny", "warn"]) {
+  const pill = new Node("button");
+  pill.className = filter === "all" ? "filter-pill on" : "filter-pill";
+  pill.dataset.filter = filter;
+  pill.setAttribute("aria-pressed", filter === "all" ? "true" : "false");
+  sideDock.appendChild(pill);
+}
+
+globalThis.document = {
+  body: new Node("body"),
+  hidden: false,
+  activeElement: null,
+  getElementById: get,
+  createElement: (tag) => new Node(tag),
+  createElementNS: (_ns, tag) => new Node(tag),
+  createTextNode: (text) => Object.assign(new Node("#text"), { textContent: text }),
+  createDocumentFragment: () => new Node("#fragment"),
+  querySelectorAll: (selector) => {
+    if (selector === "#side-dock .filter-pill") return sideDock.querySelectorAll(".filter-pill");
+    return [];
+  },
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+
+globalThis.window = {
+  location: new URL("http://dashboard.test/"),
+  innerHeight: 900,
+  addEventListener: () => {},
+  matchMedia: () => ({ addEventListener: () => {}, matches: false }),
+  localStorage: { getItem: () => null, setItem: () => {} },
+};
+globalThis.history = { replaceState: () => {} };
+Object.defineProperty(globalThis, "navigator", {
+  value: { clipboard: { writeText: () => Promise.resolve() } },
+  configurable: true,
+});
+globalThis.requestAnimationFrame = (fn) => fn();
+globalThis.setInterval = () => 0;
+globalThis.EventSource = class { constructor() {} close() {} };


### PR DESCRIPTION
## Task

[ORB-11658](https://orbit-cli.com/tasks/ORB-11658) — [code-review] Make expandable rows and filter pills keyboard-operable

### Description

## Problem
Task rows (`div.row`), audit rows (`tr`), run-step rows, run rows, artifact rows, and the collapsible `h4` section headers toggle on `click` only — no `tabindex`, `role`, `aria-expanded`, or key handler. The log filter pills and "follow" toggle are `<span>`s. A keyboard or screen-reader user cannot open a task detail, expand an audit event, or filter the log. Only the friction accordion (`app.js:498-508`) and incident rows (`diagnostics.js:353-374`, a real `<button>`) are operable; `focus-visible` styles exist only for selects, chips, rail tabs and dock segments (`dashboard.css:870-875`).

## Why It Matters
The dashboard's primary interaction (expand a row to see detail and act on it) is unreachable without a mouse.

## Proposed Fix
Add a small helper in `common.js` (`makeToggleRow(node, {expanded, onToggle})`) that sets `tabindex=0`, `role="button"`, `aria-expanded`, and handles Enter/Space; apply it to the listed rows and headers; render the log pills as `<button aria-pressed>`; extend the `:focus-visible` rule to `.row`, `.audit-row`, `.step-row`, `.runs-row`, `.filter-pill`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/tasks.js:657-677,696-702,1367-1392`, `crates/orbit-web/assets/dashboard/audit.js:882-908`, `crates/orbit-web/assets/dashboard/run-detail.js:251-266`, `crates/orbit-web/assets/dashboard/runs.js:606-611`, `crates/orbit-web/assets/dashboard/log-tail.js:190-231`, `crates/orbit-web/assets/dashboard/index.html:130-135`, `crates/orbit-web/assets/dashboard/common.js:205-216`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Tab from the task search box reaches the first task row; Enter expands it and `aria-expanded` flips.
- Tab reaches the log filter pills; Space toggles `err` and the row count updates.
- Existing click behaviour is unchanged (the `data-changed` highlight, view transitions).

## Execution Summary

<details>
<summary>Click to expand</summary>

Made the dashboard's expandable rows and log filter controls keyboard-operable.

## Change

`common.js` gains `makeToggleRow(node, { expanded, onToggle, controls })` — the one
place that grants a row its tab stop, `role="button"`, `aria-expanded`/`aria-controls`,
and the Enter/Space binding. It binds `click` from the same handler so pointer and
keyboard cannot drift apart. Its keydown path ignores events whose `target` is not the
row itself, so a nested status/crew select or action button keeps its own key semantics.
`aria-controls` is published only while the detail node it names is actually in the
document.

Applied to every row type the review enumerates:
- `tasks.js` — task rows (view-transition toggle preserved), the pinned-task row
  (copy-id action, no expansion state), artifact rows, and the collapsible `h4`
  field headers.
- `audit.js` — audit event rows.
- `run-detail.js` — run-step rows.
- `runs.js` — run rows (navigate, so button semantics with no `aria-expanded`).

`index.html`: the six `log-foot` controls (four filter pills, follow toggle, buffered
count) are now real `<button type="button">`s; the pills and follow toggle carry
`aria-pressed`. `log-tail.js` writes `on` + `aria-pressed` from the one
`activeLogFilters` set via a new `syncLogFilterPills()`.

`dashboard.css`: `:focus-visible` extended to `.row`, `.artifact-row`, `.audit-row`,
`.step-row`, `.runs-row`, the collapsible field header (inset ring — an outward one on
a full-bleed row is clipped by the panel's scroll container), and the log-foot controls;
plus a UA-chrome reset for `.log-foot button`.

Two latent bugs fixed because the new ARIA state depends on them: the audit-row and
run-step-row `dataset.hash` omitted expansion state, so the keyed `syncNodes` diff
reused the collapsed node and dropped both the `expanded` class and `aria-expanded`
that the toggle had just set.

## Acceptance criteria

1. **Tab from the task search box reaches the first task row; Enter expands it and
   `aria-expanded` flips** — met. Behavior test asserts the row carries `role="button"`
   and `tabIndex === 0`, starts `aria-expanded="false"` with no dangling
   `aria-controls`, and after Enter reports `aria-expanded="true"` with
   `aria-controls="detail-ORB-1"` resolving to the rendered detail. Tab *order* itself
   is document order, asserted against `index.html` (`#task-search` precedes
   `#tasks-body`); the browser's own focus traversal is not exercised by the Node
   harness — see limits below.
2. **Tab reaches the log filter pills; Space toggles `err` and the row count updates**
   — met. The pills ship as real `<button>`s (asserted against `index.html`), which is
   what makes them tab stops and makes Space fire `click`. The behavior test drives that
   click and asserts `err` flips to `aria-pressed="true"` and `.on`, `all` releases, and
   `#log-count` goes 2 → 1; clicking again restores `all` and 2.
3. **Existing click behaviour unchanged** — met. Same test asserts a click still
   expands, the re-rendered row still picks up the `data-changed` highlight from the
   keyed diff, and each real activation (Enter, Space, click) runs exactly one
   `document.startViewTransition` with `viewTransitionName` set to `task-row-<id>`
   beforehand — while a key press bubbled from a nested control runs none.

## Validation

| Command | Outcome |
| --- | --- |
| `make ci-fast` | passed (exit 0). One sandbox skip: `test-compiler-cache-namespaces` — bwrap cannot create a mount namespace here; unrelated to this change. |
| `make ci-lint` | passed (exit 0). |
| `cargo test -p orbit-web --lib dashboard` | passed — 65/65, including the three new tests. |
| `cargo test -p orbit-web` | 370 passed, 1 pre-existing failure (below). |
| `git diff --check` | clean. |

Regression evidence: running the new scenario against `git show HEAD:` copies of the
dashboard assets fails at the first assertion (`role` is `null`, not `"button"`), so the
test detects the original fault.

New tests live in `crates/orbit-web/src/tests/dashboard_keyboard{,_dom}.mjs`, following
the existing `dashboard_loading{,_dom}.mjs` sidecar convention rather than growing
`dashboard_assets.rs` (already ~3.5k lines).

## Pre-existing failures, not caused by this change

- `tests::health::detailed_healthz_fails_when_store_db_is_broken` — expects 503, gets
  200. Replaces `orbit.db` with a directory and expects the SQLite write probe to fail;
  environment-dependent and structurally uncoupled from dashboard assets. Deterministic
  on re-run. Left as-is (out of scope).
- `dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close` — failed with
  `expected one retry timer, got 2`, and reproduces on pristine HEAD assets. Its Node
  harness stubbed `clearTimeout` as a no-op, so `fetchJson`'s cancelled 30 s abort timer
  counted as a pending stream retry. **Fixed** (timers keyed in a `Map`; `clearTimeout`
  now clears) because this task's own validation could not otherwise be demonstrated
  green. Assertion strength is unchanged. Filed as friction F2026-09-075.

## Deviations and remaining risk

- **Out-of-scope file touched:** `crates/orbit-web/src/tests/dashboard_assets.rs` (added
  to `context_files`) — needed for the acceptance-criteria tests. It also required
  relaxing one assertion in `dashboard_task_actions_route_to_selected_workspace` that
  matched the literal string `"withWorkspace } from './common.js'"`, i.e. it pinned
  `withWorkspace` to be *last* in the import list; adding `makeToggleRow` broke it. Now
  asserts the contract (the `./common.js` import line mentions `withWorkspace`) rather
  than import order. `dashboard.css` was likewise added to scope — the review's proposed
  fix names the `:focus-visible` extension but did not list the file.
- **Known ARIA tradeoff:** a task row with `role="button"` contains interactive
  descendants (status/crew selects, action buttons), which is not strictly valid ARIA;
  some assistive tech may prune them from the row's subtree. This follows the fix the
  review specified and is what the acceptance criteria require; avoiding it would mean
  restructuring rows around a separate per-row disclosure affordance, a materially larger
  UI change. The nested controls remain individually focusable and operable.
- **Limits of the evidence:** the Node harness observes what the shipped modules set on
  each node and drives their handlers directly. It does not exercise real browser focus
  traversal or the native Space-activates-a-button rule — those rest on the shipped
  markup (`tabindex=0` in document order; real `<button>` elements), asserted separately
  against `index.html`. The repo has a Playwright convention (`*_browser.mjs`) that could
  verify both in Chromium, but Playwright is not installed here and I did not install it;
  no such harness was written since I could not run it. The CSS focus rings are asserted
  as selectors present, not as rendered pixels.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11658-6a9f801b`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra