### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -409,7 +409,7 @@ fn workspace_auto_preserves_concrete_workspace_step_failure() {
 /// job declares, not a Rust helper.
 #[test]
 fn workspace_auto_forwards_its_crew_allowlist_to_every_detached_child() {
-    let (_root, runtime, repo_root, global_root) = test_runtime();
+    let (root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
     let host = ScriptedWorkspaceAutoHost::new(&runtime, WorkspaceAutoScenario::LeafAndEpic);
     let input = json!({
@@ -419,16 +419,19 @@ fn workspace_auto_forwards_its_crew_allowlist_to_every_detached_child() {
         "idle_sleep_seconds": 0,
         "allowed_crews": ["opus", "sonnet"],
     });
+    // Keep the fixture's persisted job id unique. The engine uses the run id
+    // as retry-jitter salt, and a hard-coded job id can reach that seed through
+    // the run-id collision fallback.
+    let fixture_job_id = root
+        .path()
+        .file_name()
+        .expect("test tempdir has a final path component")
+        .to_string_lossy()
+        .into_owned();
     let run = runtime
         .stores()
         .jobs()
-        .insert_job_run(
-            "workspace_auto_pipeline",
-            1,
-            Utc::now(),
-            Some(input.clone()),
-            None,
-        )
+        .insert_job_run(&fixture_job_id, 1, Utc::now(), Some(input.clone()), None)
         .expect("insert workspace auto run");
     runtime
         .write_run_state(


### PR DESCRIPTION
## Task

[ORB-11779](https://orbit-cli.com/tasks/ORB-11779) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#165`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `a93caa13890764380e184d996fa709b1bcbe278c`
- Location: `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 426
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/165

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 426 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` so the allowlist forwarding fixture uses the test runtime's unique temporary-root name as its persisted job ID.
- Removed the hard-coded `"workspace_auto_pipeline"` value from the `insert_job_run` argument that can flow through run-ID collision fallback into retry-jitter seeding.
- Preserved the pipeline name passed to `try_execute_named_job`, the fixture input, assertions, and intended behavior.

Acceptance criteria:
1. Passed by source review: the affected `insert_job_run` call no longer receives a hard-coded value; no suppression, dismissal, or exclusion was added.
2. Passed by code-path review: only the fixture job identifier changed; the named pipeline execution, runtime state, child dispatches, allowlist forwarding, and assertions remain unchanged.
3. Repository checks passed where available: `make ci-fast` and `cargo fmt --all -- --check`; the source-level scan confirms the affected call now uses `&fixture_job_id`. The focused Rust test and `make ci-lint` were attempted but are blocked by the pre-existing unrelated compile error `E0603` in `crates/orbit-core/src/bootstrap/global_defaults.rs:31` (private `DEFAULT_ACTIVITY_FILES` import). CodeQL is not installed in this checkout and agent-side GitHub access is explicitly out of scope, so the hosted alert rerun remains deferred.

Validation:
- PASSED: `cargo fmt --all -- --check`.
- PASSED: `make ci-fast` (guardrails completed successfully; its compiler-cache namespace probe reported the documented non-privileged-user-namespace skip).
- PASSED: `git diff --check`.
- PASSED: `git status --short`/diff review: only the authorized context file is modified.
- FAILED/BLOCKED: `cargo test -p orbit-core workspace_auto --lib` — compilation stopped at pre-existing `E0603` in `crates/orbit-core/src/bootstrap/global_defaults.rs:31`.
- FAILED/BLOCKED: `make ci-lint` — same pre-existing `E0603`; no lint result was produced.
- NOT RUN: CodeQL — unavailable locally; no agent-side GitHub access by task scope.

Assessment: The hard-coded value at the reported data-flow source is replaced with a per-fixture runtime-derived identifier, matching the established remediation pattern in the neighboring job tests. Remaining risk is limited to the unavailable hosted CodeQL rerun and the unrelated baseline compile failure.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11779-6a9f8425`
- Behind base: 0
- Ahead of base: 1