### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/run/reconcile.rs

### DIFF
--- a/crates/orbit-core/src/application/job/run/reconcile.rs
+++ b/crates/orbit-core/src/application/job/run/reconcile.rs
@@ -1,7 +1,6 @@
 //! Stale-run reconciliation, terminal timing repair, and audit helpers.
 
 use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, Utc};
 use orbit_common::OrbitError;
@@ -27,21 +26,12 @@ pub(super) struct ReconcilePass {
     healthy: HashSet<OwnerSnapshotKey>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct OwnerSnapshotKey {
     run_id: String,
     state: JobRunState,
     pid: Option<u32>,
     pid_start_time: Option<String>,
-}
-
-impl Hash for OwnerSnapshotKey {
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.run_id.hash(hasher);
-        std::mem::discriminant(&self.state).hash(hasher);
-        self.pid.hash(hasher);
-        self.pid_start_time.hash(hasher);
-    }
 }
 
 impl ReconcilePass {

--- a/crates/orbit-types/src/workflow/job.rs
+++ b/crates/orbit-types/src/workflow/job.rs
@@ -81,7 +81,7 @@ impl FromStr for JobScheduleState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[serde(rename_all = "snake_case")]
 pub enum JobRunState {


### PR DESCRIPTION
## Merge conflict handoff

Orbit preserved and pushed this task's candidate after a merge conflict stopped delivery. This PR is intentionally blocked; reconcile the named paths before retrying delivery.

- Task: `ORB-11776`
- Run: `jrun-20260908-0329-5`
- Failed step: `sync_base`
- Error code: `recoverable_vcs_conflict`
- Original base: `9d18943b3fe142339d78a9b00c678cf2f4056690`
- Target base: `5abc05ae419cdc6d43fe9a094fca812878b42bfd`

## Conflicting paths

- `crates/orbit-core/src/application/job/run/reconcile.rs`

## Failure

```text
recoverable VCS conflict during 'git_rebase': original base '9d18943b3fe142339d78a9b00c678cf2f4056690', target base '5abc05ae419cdc6d43fe9a094fca812878b42bfd'; rebase of 'orbit/ORB-11776-6a9f8117' onto checkpoint '5abc05ae419cdc6d43fe9a094fca812878b42bfd' stopped with conflicts; conflicting paths: crates/orbit-core/src/application/job/run/reconcile.rs
```