### PR TITLE
[code-review] Route task-bundle locking through one bounded, diagnosable lock implementation

### DIFF
--- a/crates/orbit-common/src/error.rs
+++ b/crates/orbit-common/src/error.rs
@@ -246,6 +246,11 @@ pub enum OrbitError {
         path: String,
         reason: String,
     },
+    /// A bounded advisory file-lock acquisition exhausted its deadline.
+    /// Structured lock and holder fields let callers diagnose contention
+    /// without parsing the display message.
+    #[error("{0}")]
+    FileLockTimeout(Box<crate::fs::io::FileLockTimeout>),
     #[error("store error: {0}")]
     Store(String),
     #[error("invalid task status transition: {0}")]
@@ -428,6 +433,13 @@ impl OrbitError {
         }
     }
 
+    pub fn file_lock_timeout(&self) -> Option<&crate::fs::io::FileLockTimeout> {
+        match self {
+            Self::FileLockTimeout(timeout) => Some(timeout),
+            _ => None,
+        }
+    }
+
     /// Translate a filesystem write failure.
     ///
     /// EROFS/EACCES name `path` and hint that this is likely a sandbox or
@@ -462,6 +474,12 @@ impl OrbitError {
 
 impl From<std::io::Error> for OrbitError {
     fn from(err: std::io::Error) -> Self {
+        if let Some(timeout) = err
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<crate::fs::io::FileLockTimeout>())
+        {
+            return OrbitError::FileLockTimeout(Box::new(timeout.clone()));
+        }
         OrbitError::Io(err.to_string())
     }
 }

--- a/crates/orbit-common/src/fs/file_lock.rs
+++ b/crates/orbit-common/src/fs/file_lock.rs
@@ -1,0 +1,274 @@
+//! Bounded advisory file-lock acquisition and holder diagnostics.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use super::io::{
+    classify_lock_io, classify_or_wrap_lock_io, create_private_dir_all, open_private_file,
+};
+
+/// Default upper bound for an advisory file-lock acquisition.
+pub const DEFAULT_FILE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+const DEFAULT_FILE_LOCK_WARN_AFTER: Duration = Duration::from_secs(3);
+const FILE_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Deadline and warning policy for one advisory file-lock acquisition.
+#[derive(Debug, Clone, Copy)]
+pub struct FileLockOptions {
+    /// Fail acquisition after this duration.
+    pub timeout: Duration,
+    /// Emit one contention warning after this duration.
+    pub warn_after: Duration,
+}
+
+impl Default for FileLockOptions {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_FILE_LOCK_TIMEOUT,
+            warn_after: DEFAULT_FILE_LOCK_WARN_AFTER,
+        }
+    }
+}
+
+/// Advisory metadata recorded by an exclusive lock holder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileLockHolderInfo {
+    /// Process ID of the exclusive holder that wrote this metadata.
+    pub pid: u32,
+    /// RFC 3339 acquisition timestamp.
+    pub acquired_at: String,
+    /// Human-readable operation label.
+    pub label: String,
+}
+
+/// Structured details for an advisory lock acquisition that exceeded its deadline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileLockTimeout {
+    /// Exact, stable lock file that could not be acquired.
+    pub lock_path: PathBuf,
+    /// Human-readable label of the waiting operation.
+    pub label: String,
+    /// Injected acquisition deadline in milliseconds.
+    pub timeout_ms: u64,
+    /// Advisory exclusive-holder metadata, when a complete record was readable.
+    pub holder: Option<FileLockHolderInfo>,
+}
+
+impl std::fmt::Display for FileLockTimeout {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "timed out after {}ms acquiring {} lock '{}'",
+            self.timeout_ms,
+            self.label,
+            self.lock_path.display()
+        )?;
+        if let Some(holder) = &self.holder {
+            write!(
+                formatter,
+                " (held by pid {} since {}, op: {})",
+                holder.pid, holder.acquired_at, holder.label
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for FileLockTimeout {}
+
+/// RAII guard for a directly acquired advisory lock.
+#[derive(Debug)]
+#[must_use = "the advisory lock is released as soon as the guard is dropped"]
+pub struct FileLockGuard {
+    file: File,
+    clear_holder_on_drop: bool,
+}
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        if self.clear_holder_on_drop {
+            let _ = clear_file_lock_holder(&self.file);
+        }
+    }
+}
+
+/// Acquire an exclusive advisory lock at the exact `lock_path`.
+///
+/// This is the common mechanism behind target-derived locks and store locks.
+/// It preserves the lock file and only clears holder metadata on clean drop,
+/// so queued descriptors never switch to a replacement inode.
+pub fn acquire_exclusive_file_lock(
+    lock_path: &Path,
+    label: &str,
+    options: FileLockOptions,
+) -> io::Result<FileLockGuard> {
+    let parent = lock_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("cannot determine lock parent for '{}'", lock_path.display()),
+        )
+    })?;
+    create_private_dir_all(parent).map_err(|error| classify_lock_io(parent, error))?;
+
+    let lock_file = open_lock_file(lock_path, label)?;
+    acquire_file_lock(lock_file, lock_path, label, options, true)
+}
+
+/// Attempt one exclusive acquisition at the exact `lock_path` without waiting.
+pub fn try_acquire_exclusive_file_lock(
+    lock_path: &Path,
+    label: &str,
+) -> io::Result<Option<FileLockGuard>> {
+    let parent = lock_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("cannot determine lock parent for '{}'", lock_path.display()),
+        )
+    })?;
+    create_private_dir_all(parent).map_err(|error| classify_lock_io(parent, error))?;
+
+    let lock_file = open_lock_file(lock_path, label)?;
+    match FileExt::try_lock_exclusive(&lock_file) {
+        Ok(()) => {
+            write_file_lock_holder(&lock_file, label);
+            Ok(Some(FileLockGuard {
+                file: lock_file,
+                clear_holder_on_drop: true,
+            }))
+        }
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+        Err(error) => Err(classify_or_wrap_lock_io(lock_path, error, |error| {
+            format!("lock {label} '{}': {error}", lock_path.display())
+        })),
+    }
+}
+
+pub(crate) fn acquire_shared_file_lock(
+    lock_path: &Path,
+    label: &str,
+    options: FileLockOptions,
+) -> io::Result<FileLockGuard> {
+    let lock_file = open_lock_file(lock_path, label)?;
+    acquire_file_lock(lock_file, lock_path, label, options, false)
+}
+
+/// Read advisory holder metadata. Missing, empty, torn, and legacy files are
+/// intentionally reported as no metadata because the OS lock is authoritative.
+pub fn read_file_lock_holder(lock_path: &Path) -> Option<FileLockHolderInfo> {
+    let mut raw = String::new();
+    File::open(lock_path).ok()?.read_to_string(&mut raw).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn open_lock_file(lock_path: &Path, label: &str) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    open_private_file(lock_path, &mut options).map_err(|error| {
+        classify_or_wrap_lock_io(lock_path, error, |error| {
+            format!("open {label} lock '{}': {error}", lock_path.display())
+        })
+    })
+}
+
+fn acquire_file_lock(
+    lock_file: File,
+    lock_path: &Path,
+    label: &str,
+    options: FileLockOptions,
+    exclusive: bool,
+) -> io::Result<FileLockGuard> {
+    let started = Instant::now();
+    let mut warned = false;
+
+    loop {
+        let acquisition = if exclusive {
+            FileExt::try_lock_exclusive(&lock_file)
+        } else {
+            FileExt::try_lock_shared(&lock_file)
+        };
+        match acquisition {
+            Ok(()) => {
+                if exclusive {
+                    write_file_lock_holder(&lock_file, label);
+                }
+                return Ok(FileLockGuard {
+                    file: lock_file,
+                    clear_holder_on_drop: exclusive,
+                });
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                let elapsed = started.elapsed();
+                if elapsed >= options.timeout {
+                    let timeout = FileLockTimeout {
+                        lock_path: lock_path.to_path_buf(),
+                        label: label.to_string(),
+                        timeout_ms: duration_millis(options.timeout),
+                        holder: read_file_lock_holder(lock_path),
+                    };
+                    return Err(io::Error::new(io::ErrorKind::TimedOut, timeout));
+                }
+                if !warned && elapsed >= options.warn_after {
+                    warned = true;
+                    warn_for_contention(lock_path, label, elapsed);
+                }
+                std::thread::sleep(FILE_LOCK_RETRY_INTERVAL.min(options.timeout - elapsed));
+            }
+            Err(error) => {
+                return Err(classify_or_wrap_lock_io(lock_path, error, |error| {
+                    format!("lock {label} '{}': {error}", lock_path.display())
+                }));
+            }
+        }
+    }
+}
+
+fn warn_for_contention(lock_path: &Path, label: &str, elapsed: Duration) {
+    let holder = read_file_lock_holder(lock_path)
+        .map(|holder| {
+            format!(
+                "pid {} since {} ({})",
+                holder.pid, holder.acquired_at, holder.label
+            )
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    crate::tracing::warn!(
+        target: "orbit.common.fs.file_lock",
+        lock_path = %lock_path.display(),
+        label,
+        waited_ms = duration_millis(elapsed),
+        holder,
+        "still waiting for advisory file lock; a holder may be hung",
+    );
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn write_file_lock_holder(file: &File, label: &str) {
+    let holder = FileLockHolderInfo {
+        pid: std::process::id(),
+        acquired_at: chrono::Utc::now().to_rfc3339(),
+        label: label.to_string(),
+    };
+    let _ = write_file_lock_holder_inner(file, &holder);
+}
+
+fn write_file_lock_holder_inner(mut file: &File, holder: &FileLockHolderInfo) -> io::Result<()> {
+    let encoded = serde_json::to_vec(holder).map_err(io::Error::other)?;
+    file.seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
+    file.write_all(&encoded)?;
+    file.flush()
+}
+
+fn clear_file_lock_holder(mut file: &File) -> io::Result<()> {
+    file.set_len(0)?;
+    file.flush()
+}

--- a/crates/orbit-common/src/fs/io.rs
+++ b/crates/orbit-common/src/fs/io.rs
@@ -22,7 +22,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use fs2::FileExt;
+use super::file_lock::acquire_shared_file_lock;
+pub use super::file_lock::{
+    DEFAULT_FILE_LOCK_TIMEOUT, FileLockGuard, FileLockHolderInfo, FileLockOptions, FileLockTimeout,
+    acquire_exclusive_file_lock, read_file_lock_holder, try_acquire_exclusive_file_lock,
+};
 
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -342,8 +346,8 @@ fn claim_lock_path(path: &Path) -> Option<HeldLockPath> {
 ///
 /// The lock is re-entrant per thread: a nested call for the same lock path
 /// runs `op` directly under the outermost acquisition instead of deadlocking
-/// on a second descriptor. Cross-thread and cross-process callers still block
-/// on the flock as before, including readers holding
+/// on a second descriptor. Cross-thread and cross-process callers wait up to
+/// [`DEFAULT_FILE_LOCK_TIMEOUT`] on the flock, including readers holding
 /// [`with_shared_file_lock`] on the same target.
 ///
 /// The closure returns `Result<T, E>` where any filesystem error hit while
@@ -354,6 +358,20 @@ fn claim_lock_path(path: &Path) -> Option<HeldLockPath> {
 /// `label` prefixes error messages for diagnosability when the lock path
 /// alone isn't enough context.
 pub fn with_exclusive_file_lock<T, E, F>(target_path: &Path, label: &str, op: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
+    with_exclusive_file_lock_options(target_path, label, FileLockOptions::default(), op)
+}
+
+/// [`with_exclusive_file_lock`] with an explicit, testable acquisition policy.
+pub fn with_exclusive_file_lock_options<T, E, F>(
+    target_path: &Path,
+    label: &str,
+    options: FileLockOptions,
+    op: F,
+) -> Result<T, E>
 where
     F: FnOnce() -> Result<T, E>,
     E: From<io::Error>,
@@ -381,24 +399,7 @@ where
     let Some(_held) = claim_lock_path(&lock_path) else {
         return op();
     };
-    let mut options = OpenOptions::new();
-    options.create(true).read(true).write(true).truncate(false);
-    apply_private_file_mode(&mut options);
-    let lock_file = options.open(&lock_path).map_err(|e| {
-        classify_or_wrap_lock_io(&lock_path, e, |e| {
-            format!("open {label} lock '{}': {e}", lock_path.display())
-        })
-    })?;
-    set_private_file_permissions(&lock_path).map_err(|e| {
-        classify_or_wrap_lock_io(&lock_path, e, |e| {
-            format!("chmod {label} lock '{}': {e}", lock_path.display())
-        })
-    })?;
-    lock_file.lock_exclusive().map_err(|e| {
-        classify_or_wrap_lock_io(&lock_path, e, |e| {
-            format!("lock {label} '{}': {e}", lock_path.display())
-        })
-    })?;
+    let _lock = acquire_exclusive_file_lock(&lock_path, label, options)?;
 
     op()
 }
@@ -420,6 +421,8 @@ where
 /// - Acquisition is best effort. A store on a read-only mount, or any
 ///   filesystem that refuses the lock file, still serves the read unlocked
 ///   rather than failing it — the same exposure as before this lock existed.
+///   Active contention waits up to the configured deadline and returns a typed
+///   timeout instead of reading through a live writer.
 /// - Re-entrancy is shared with the exclusive variant, so a read nested inside
 ///   a writer's own critical section runs directly instead of deadlocking on a
 ///   second descriptor.
@@ -428,6 +431,20 @@ where
 /// target. A nested request never upgrades the outer acquisition, so the
 /// mutation would run under a shared lock that concurrent readers also hold.
 pub fn with_shared_file_lock<T, E, F>(target_path: &Path, label: &str, op: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E>,
+    E: From<io::Error>,
+{
+    with_shared_file_lock_options(target_path, label, FileLockOptions::default(), op)
+}
+
+/// [`with_shared_file_lock`] with an explicit, testable acquisition policy.
+pub fn with_shared_file_lock_options<T, E, F>(
+    target_path: &Path,
+    label: &str,
+    options: FileLockOptions,
+    op: F,
+) -> Result<T, E>
 where
     F: FnOnce() -> Result<T, E>,
     E: From<io::Error>,
@@ -442,8 +459,9 @@ where
     let Some(_held) = claim_lock_path(&lock_path) else {
         return op();
     };
-    let _lock_file = match acquire_shared_lock(&lock_path) {
+    let _lock_file = match acquire_shared_file_lock(&lock_path, label, options) {
         Ok(file) => Some(file),
+        Err(error) if error.kind() == io::ErrorKind::TimedOut => return Err(E::from(error)),
         Err(error) => {
             crate::tracing::debug!(
                 target: "orbit.common.fs",
@@ -457,14 +475,6 @@ where
     };
 
     op()
-}
-
-fn acquire_shared_lock(lock_path: &Path) -> io::Result<File> {
-    let mut options = OpenOptions::new();
-    options.create(true).read(true).write(true).truncate(false);
-    let lock_file = open_private_file(lock_path, &mut options)?;
-    lock_file.lock_shared()?;
-    Ok(lock_file)
 }
 
 /// The lock path to open and to key re-entrancy on, resolved through symlinks
@@ -497,7 +507,7 @@ fn lock_path_for(path: &Path) -> io::Result<PathBuf> {
     Ok(path.with_file_name(format!(".{file_name}.lock")))
 }
 
-fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::Result<File> {
+pub(crate) fn open_private_file(path: &Path, options: &mut OpenOptions) -> io::Result<File> {
     apply_private_file_mode(options);
     let file = options.open(path)?;
     set_private_file_permissions(path)?;
@@ -587,14 +597,14 @@ pub(crate) fn write_access_error_message(path: &Path, err: &io::Error) -> Option
     })
 }
 
-fn classify_lock_io(path: &Path, err: io::Error) -> io::Error {
+pub(crate) fn classify_lock_io(path: &Path, err: io::Error) -> io::Error {
     match write_access_error_message(path, &err) {
         Some(message) => io::Error::new(err.kind(), message),
         None => err,
     }
 }
 
-fn classify_or_wrap_lock_io(
+pub(crate) fn classify_or_wrap_lock_io(
     path: &Path,
     err: io::Error,
     fallback: impl FnOnce(&io::Error) -> String,

--- a/crates/orbit-common/src/fs/mod.rs
+++ b/crates/orbit-common/src/fs/mod.rs
@@ -1,3 +1,4 @@
+pub mod file_lock;
 pub mod git;
 pub mod io;
 pub mod path;

--- a/crates/orbit-common/src/security/redaction.rs
+++ b/crates/orbit-common/src/security/redaction.rs
@@ -248,6 +248,9 @@ pub fn redact_sensitive_env_error(error: OrbitError) -> OrbitError {
             path: redact_sensitive_env_text(&path),
             reason: redact_sensitive_env_text(&reason),
         },
+        OrbitError::FileLockTimeout(timeout) => OrbitError::FileLockTimeout(
+            redact_file_lock_timeout(*timeout, redact_sensitive_env_text),
+        ),
         OrbitError::Store(m) => OrbitError::Store(redact_sensitive_env_text(&m)),
         OrbitError::TaskStatusTransition(m) => {
             OrbitError::TaskStatusTransition(redact_sensitive_env_text(&m))
@@ -391,6 +394,9 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
             path: redact_all(&path),
             reason: redact_all(&reason),
         },
+        OrbitError::FileLockTimeout(timeout) => {
+            OrbitError::FileLockTimeout(redact_file_lock_timeout(*timeout, redact_all))
+        }
         OrbitError::Store(m) => OrbitError::Store(redact_all(&m)),
         OrbitError::TaskStatusTransition(m) => OrbitError::TaskStatusTransition(redact_all(&m)),
         OrbitError::DependencyNotDelivered(diagnostic) => OrbitError::DependencyNotDelivered(
@@ -410,6 +416,19 @@ pub fn redact_all_error(error: OrbitError) -> OrbitError {
         OrbitError::WorkspaceError(m) => OrbitError::WorkspaceError(redact_all(&m)),
         OrbitError::Migration(m) => OrbitError::Migration(redact_all(&m)),
     }
+}
+
+fn redact_file_lock_timeout(
+    mut timeout: crate::fs::io::FileLockTimeout,
+    redact: fn(&str) -> String,
+) -> Box<crate::fs::io::FileLockTimeout> {
+    timeout.lock_path = redact(&timeout.lock_path.to_string_lossy()).into();
+    timeout.label = redact(&timeout.label);
+    if let Some(holder) = &mut timeout.holder {
+        holder.acquired_at = redact(&holder.acquired_at);
+        holder.label = redact(&holder.label);
+    }
+    Box::new(timeout)
 }
 
 fn redact_friction_not_local(

--- a/crates/orbit-store/src/fs/lock/mod.rs
+++ b/crates/orbit-store/src/fs/lock/mod.rs
@@ -1,126 +1,21 @@
-//! Bounded, diagnostic advisory file locking shared by the SQLite ID allocator
-//! and file-backed stores. [ORB-00412]
+//! Store-facing adapters for Orbit's common bounded advisory lock.
 //!
-//! Record mutation serializes through `fs2`
-//! advisory (`flock(2)`) locks. A bare [`fs2::FileExt::lock_exclusive`] blocks
-//! *indefinitely*: if a holder hangs — as opposed to crashing, since the OS
-//! releases advisory locks on process death — every other agent stalls forever
-//! with no signal about who holds the lock or why. Under concurrent
-//! multi-agent use (parallel worktrees, unattended
-//! ship-sweep) that silent stall is a whole-workspace availability risk.
-//!
-//! This module bounds the wait with a configurable deadline, records holder
-//! metadata (PID + acquisition timestamp) into the lock file for diagnostics,
-//! and emits a `tracing::warn!` once a waiter has been blocked past a
-//! threshold. Holder metadata is advisory only — the OS `flock` is the source
-//! of truth; the metadata is read solely to enrich the error/warning a blocked
-//! waiter reports. A clean guard drop clears the metadata while still holding
-//! the flock, while an abrupt process death leaves it behind as a crash signal.
-//!
-//! The returned [`FileLockGuard`] follows the RAII-guard pattern
-//! (`docs/design-patterns/raii_guard.md`): the OS lock is released when the
-//! guard is dropped, including on `?`-return and unwind.
+//! Task bundles and independent store locks use the same deadline, holder
+//! metadata, and stable-file behavior. The implementation lives in
+//! `orbit-common` so lower-level persistence helpers never depend upward on
+//! the store crate.
 
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
-use std::time::{Duration, Instant};
-
-use fs2::FileExt;
 use orbit_common::OrbitError;
-use serde::{Deserialize, Serialize};
+use std::path::Path;
 
-/// Default upper bound on how long an exclusive acquisition blocks before
-/// failing with a typed error. Deliberately generous: contention is normal
-/// under concurrent multi-agent use, but a hung holder should not stall the
-/// workspace forever.
-pub(crate) const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+pub use orbit_common::fs::io::FileLockHolderInfo as LockHolderInfo;
+pub(crate) use orbit_common::fs::io::{FileLockGuard, FileLockOptions as LockOptions};
+use orbit_common::fs::io::{
+    acquire_exclusive_file_lock, read_file_lock_holder, try_acquire_exclusive_file_lock,
+};
 
-/// Emit a diagnostic warning once a waiter has been blocked at least this long.
-const DEFAULT_WARN_AFTER: Duration = Duration::from_secs(3);
-
-/// Poll interval for the try-lock retry loop.
-const RETRY_INTERVAL: Duration = Duration::from_millis(50);
-
-/// Tunables for a single lock acquisition. Use [`LockOptions::default`] for
-/// production defaults; tests override the durations to stay fast and
-/// deterministic.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct LockOptions {
-    /// Fail the acquisition once the waiter has blocked this long.
-    pub(crate) timeout: Duration,
-    /// Warn (once) once the waiter has blocked this long.
-    pub(crate) warn_after: Duration,
-}
-
-impl Default for LockOptions {
-    fn default() -> Self {
-        Self {
-            timeout: DEFAULT_LOCK_TIMEOUT,
-            warn_after: DEFAULT_WARN_AFTER,
-        }
-    }
-}
-
-/// RAII guard over an exclusive advisory file lock. A clean drop clears the
-/// diagnostic holder metadata before the wrapped [`File`] is dropped (and
-/// `fs2` unlocks on close), while a process crash leaves the metadata behind
-/// for `orbit doctor` to report.
-#[derive(Debug)]
-#[must_use = "the advisory lock is released as soon as the guard is dropped"]
-pub(crate) struct FileLockGuard {
-    // Held purely for its Drop side effect: closing the file releases the
-    // `flock`. Named with a leading underscore so dead-code analysis does not
-    // flag the never-read field.
-    _file: File,
-}
-
-impl Drop for FileLockGuard {
-    fn drop(&mut self) {
-        // Clear the diagnostic marker before closing the descriptor. The flock
-        // is therefore held throughout the metadata transition, so a waiter
-        // cannot observe a clean release as a stale holder or race a path
-        // replacement. Best-effort matches acquisition metadata handling:
-        // advisory diagnostics must never turn a successful release into an
-        // application failure.
-        let _ = clear_holder(&self._file);
-    }
-}
-
-/// Metadata written into a lock file by its current holder. Advisory and
-/// diagnostic only — never load-bearing for correctness.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct LockHolder {
-    pid: u32,
-    /// RFC 3339 acquisition timestamp.
-    acquired_at: String,
-    /// Human label of the operation holding the lock.
-    label: String,
-}
-
-/// Public, read-only view of the holder metadata recorded in a lock file.
-/// Advisory and diagnostic only (the OS `flock` is the source of truth, and
-/// the OS releases advisory locks on process death) — consumers such as
-/// `orbit doctor` use it to spot leftover metadata from crashed holders.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LockHolderInfo {
-    /// PID recorded by the holder at acquisition time.
-    pub pid: u32,
-    /// RFC 3339 acquisition timestamp.
-    pub acquired_at: String,
-    /// Human label of the operation that acquired the lock.
-    pub label: String,
-}
-
-/// Read the holder metadata recorded in a lock file, if any. Lenient like
-/// [`read_holder`]: missing file, torn write, or legacy empty lock files
-/// yield `None` rather than an error.
 pub fn read_lock_holder(path: &Path) -> Option<LockHolderInfo> {
-    read_holder(path).map(|holder| LockHolderInfo {
-        pid: holder.pid,
-        acquired_at: holder.acquired_at,
-        label: holder.label,
-    })
+    read_file_lock_holder(path)
 }
 
 /// Acquire an exclusive advisory lock on `path` using production defaults,
@@ -140,155 +35,15 @@ pub(crate) fn try_acquire_exclusive(
     path: &Path,
     label: &str,
 ) -> Result<Option<FileLockGuard>, OrbitError> {
-    let parent = path.parent().ok_or_else(|| {
-        OrbitError::Store(format!(
-            "cannot determine lock parent for '{}'",
-            path.display()
-        ))
-    })?;
-    fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
-
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(path)
-        .map_err(|error| OrbitError::Io(error.to_string()))?;
-
-    match file.try_lock_exclusive() {
-        Ok(()) => {
-            write_holder(&file, label);
-            Ok(Some(FileLockGuard { _file: file }))
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-        Err(error) => Err(OrbitError::Store(format!(
-            "failed to acquire {label} lock '{}': {error}",
-            path.display()
-        ))),
-    }
+    try_acquire_exclusive_file_lock(path, label).map_err(OrbitError::from)
 }
 
-/// Acquire an exclusive advisory lock with explicit [`LockOptions`]. On timeout
-/// returns [`OrbitError::Store`] whose message names the lock path and any
-/// holder metadata, so a stalled waiter is observable rather than silent.
 pub(crate) fn acquire_exclusive_with(
     path: &Path,
     label: &str,
     options: LockOptions,
 ) -> Result<FileLockGuard, OrbitError> {
-    let parent = path.parent().ok_or_else(|| {
-        OrbitError::Store(format!(
-            "cannot determine lock parent for '{}'",
-            path.display()
-        ))
-    })?;
-    fs::create_dir_all(parent).map_err(|error| OrbitError::Io(error.to_string()))?;
-
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .read(true)
-        .write(true)
-        .open(path)
-        .map_err(|error| OrbitError::Io(error.to_string()))?;
-
-    let started = Instant::now();
-    let mut warned = false;
-    loop {
-        match file.try_lock_exclusive() {
-            Ok(()) => {
-                // Best-effort holder metadata; advisory/diagnostic only.
-                write_holder(&file, label);
-                return Ok(FileLockGuard { _file: file });
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                let elapsed = started.elapsed();
-                if elapsed >= options.timeout {
-                    return Err(OrbitError::Store(format!(
-                        "timed out after {:?} acquiring {label} lock '{}'{}",
-                        options.timeout,
-                        path.display(),
-                        holder_suffix(path),
-                    )));
-                }
-                if !warned && elapsed >= options.warn_after {
-                    warned = true;
-                    orbit_common::tracing::warn!(
-                        target: "orbit.store.file_lock",
-                        lock_path = %path.display(),
-                        label,
-                        waited_ms = elapsed.as_millis() as u64,
-                        holder = %holder_description(path),
-                        "still waiting for advisory file lock; a holder may be hung",
-                    );
-                }
-                std::thread::sleep(RETRY_INTERVAL);
-            }
-            Err(error) => {
-                return Err(OrbitError::Store(format!(
-                    "failed to acquire {label} lock '{}': {error}",
-                    path.display()
-                )));
-            }
-        }
-    }
-}
-
-/// Overwrite the lock file with the current holder's metadata. Best-effort: a
-/// failure here never fails the acquisition, and a concurrent reader tolerating
-/// a torn write is expected (see [`read_holder`]).
-fn write_holder(file: &File, label: &str) {
-    let holder = LockHolder {
-        pid: std::process::id(),
-        acquired_at: chrono::Utc::now().to_rfc3339(),
-        label: label.to_string(),
-    };
-    let _ = write_holder_inner(file, &holder);
-}
-
-fn write_holder_inner(mut file: &File, holder: &LockHolder) -> std::io::Result<()> {
-    let json = serde_json::to_string(holder).unwrap_or_default();
-    file.seek(SeekFrom::Start(0))?;
-    file.set_len(0)?;
-    file.write_all(json.as_bytes())?;
-    file.flush()?;
-    Ok(())
-}
-
-fn clear_holder(mut file: &File) -> std::io::Result<()> {
-    file.set_len(0)?;
-    file.flush()?;
-    Ok(())
-}
-
-/// Read the holder metadata a blocked waiter can report. Lenient: any read or
-/// parse failure (missing file, torn write, legacy empty lock file) yields
-/// `None` rather than an error, because this is diagnostic-only.
-fn read_holder(path: &Path) -> Option<LockHolder> {
-    let mut raw = String::new();
-    File::open(path).ok()?.read_to_string(&mut raw).ok()?;
-    serde_json::from_str(&raw).ok()
-}
-
-fn holder_suffix(path: &Path) -> String {
-    match read_holder(path) {
-        Some(holder) => format!(
-            " (held by pid {} since {}, op: {})",
-            holder.pid, holder.acquired_at, holder.label
-        ),
-        None => String::new(),
-    }
-}
-
-fn holder_description(path: &Path) -> String {
-    match read_holder(path) {
-        Some(holder) => format!(
-            "pid {} since {} ({})",
-            holder.pid, holder.acquired_at, holder.label
-        ),
-        None => "unknown".to_string(),
-    }
+    acquire_exclusive_file_lock(path, label, options).map_err(OrbitError::from)
 }
 
 #[cfg(test)]

--- a/crates/orbit-store/src/fs/lock/tests/file_lock.rs
+++ b/crates/orbit-store/src/fs/lock/tests/file_lock.rs
@@ -57,6 +57,15 @@ fn times_out_naming_lock_path_and_holder() {
     // (flock(2) treats separate opens independently), so this must time out.
     let error = acquire_exclusive_with(&path, "waiter", short_options(150))
         .expect_err("acquisition should time out while the lock is held");
+    let timeout = error
+        .file_lock_timeout()
+        .expect("timeout must be a structured OrbitError variant");
+    assert_eq!(timeout.lock_path, path);
+    assert_eq!(timeout.label, "waiter");
+    assert_eq!(
+        timeout.holder.as_ref().map(|holder| holder.label.as_str()),
+        Some("holder")
+    );
     let message = error.to_string();
 
     assert!(
@@ -146,6 +155,8 @@ fn read_lock_holder_is_lenient_on_missing_or_garbage_files() {
 #[cfg(unix)]
 #[test]
 fn sigkilled_holder_releases_lock() {
+    use std::os::unix::fs::MetadataExt;
+
     let dir = TempDir::new().expect("tempdir");
     let lock_path = dir.path().join("crash.lock");
     let ready_path = dir.path().join("ready");
@@ -170,6 +181,8 @@ fn sigkilled_holder_releases_lock() {
         }
         std::thread::sleep(Duration::from_millis(20));
     }
+    let child_pid = child.id();
+    let inode = std::fs::metadata(&lock_path).expect("lock metadata").ino();
 
     // While the child holds it, the parent cannot acquire within a short budget.
     let held = acquire_exclusive_with(&lock_path, "parent-probe", short_options(200));
@@ -178,6 +191,9 @@ fn sigkilled_holder_releases_lock() {
     // Crash the holder: Child::kill() sends SIGKILL on Unix.
     child.kill().expect("SIGKILL child");
     child.wait().expect("reap child");
+    let stale = read_lock_holder(&lock_path).expect("crash leaves diagnostic metadata");
+    assert_eq!(stale.pid, child_pid);
+    assert_eq!(stale.label, "crash-holder");
 
     // The advisory lock is released on process death: acquisition now succeeds.
     let guard = acquire_exclusive_with(
@@ -188,10 +204,16 @@ fn sigkilled_holder_releases_lock() {
             warn_after: Duration::from_secs(3600),
         },
     );
+    let guard = guard.expect("lock released after holder was SIGKILLed");
+    assert_eq!(
+        std::fs::metadata(&lock_path).expect("lock retained").ino(),
+        inode,
+        "recovery must acquire the existing lock file"
+    );
+    drop(guard);
     assert!(
-        guard.is_ok(),
-        "lock not released after holder was SIGKILLed: {:?}",
-        guard.err()
+        read_lock_holder(&lock_path).is_none(),
+        "clean reacquisition clears the stale crash metadata"
     );
 }
 

--- a/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/concurrency.rs
@@ -12,6 +12,10 @@ use std::time::Duration;
 
 use super::*;
 
+#[cfg(unix)]
+const TASK_LOCK_HOLDER_CHILD_TEST: &str =
+    "repository::task::v2::tests::concurrency::task_lock_holder_child";
+
 fn create_tasks(store: &TaskV2Store, count: usize) -> Vec<String> {
     (0..count)
         .map(|index| {
@@ -29,6 +33,112 @@ fn document_update(actor: &str, summary: &str) -> TaskDocumentUpdateParams {
         execution_summary: Some(summary.to_string()),
         ..Default::default()
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn task_update_times_out_with_live_process_holder_diagnostics_then_recovers() {
+    use std::os::unix::fs::MetadataExt;
+
+    use orbit_common::fs::io::{FileLockOptions, with_exclusive_file_lock_options};
+
+    use crate::driver::file::task_bundle::bundle_lock_target;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = store(&temp);
+    let id = create_tasks(&store, 1).remove(0);
+    let bundle_dir = store.bundle_store.bundle_path(&id).expect("bundle path");
+    let lock_target = bundle_lock_target(&bundle_dir);
+    let lock_path = lock_target.with_file_name(format!(".{id}.bundle.lock"));
+    let ready_path = temp.path().join("holder-ready");
+
+    let exe = std::env::current_exe().expect("current test exe");
+    let mut child = std::process::Command::new(exe)
+        .args(["--exact", TASK_LOCK_HOLDER_CHILD_TEST, "--ignored"])
+        .env("ORBIT_TASK_LOCK_HOLDER_PATH", &lock_path)
+        .env("ORBIT_TASK_LOCK_HOLDER_READY", &ready_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn task-lock holder");
+    let child_pid = child.id();
+
+    let started = std::time::Instant::now();
+    while !ready_path.exists() {
+        if started.elapsed() > Duration::from_secs(20) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("child never acquired task lock");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let inode = std::fs::metadata(&lock_path).expect("lock metadata").ino();
+    let result = with_exclusive_file_lock_options(
+        &lock_target,
+        "competing task update",
+        FileLockOptions {
+            timeout: Duration::from_millis(150),
+            warn_after: Duration::from_secs(60),
+        },
+        || {
+            store
+                .update_task_document(&id, &document_update("codex", "after contention"))
+                .map(|_| ())
+        },
+    );
+
+    child.kill().expect("kill task-lock holder");
+    child.wait().expect("reap task-lock holder");
+
+    let error: OrbitError = result.expect_err("live holder must force the short deadline");
+    let timeout = error
+        .file_lock_timeout()
+        .expect("timeout must retain its structured type");
+    assert_eq!(timeout.lock_path, lock_path);
+    let holder = timeout.holder.as_ref().expect("holder metadata");
+    assert_eq!(holder.pid, child_pid);
+    assert_eq!(holder.label, "task update test holder");
+
+    let stale = crate::fs::lock::read_lock_holder(&lock_path)
+        .expect("killed holder metadata remains for doctor");
+    assert_eq!(stale.pid, child_pid);
+
+    store
+        .update_task_document(&id, &document_update("codex", "after contention"))
+        .expect("killing the holder releases the advisory lock");
+    assert_eq!(
+        std::fs::metadata(&lock_path).expect("lock retained").ino(),
+        inode,
+        "recovery must preserve the stable lock-file identity"
+    );
+    assert!(
+        crate::fs::lock::read_lock_holder(&lock_path).is_none(),
+        "the successful update must clear holder metadata on release"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+#[ignore = "helper process for task_update_times_out_with_live_process_holder_diagnostics_then_recovers"]
+fn task_lock_holder_child() {
+    use orbit_common::fs::io::{FileLockOptions, acquire_exclusive_file_lock};
+
+    let (Ok(lock_path), Ok(ready_path)) = (
+        std::env::var("ORBIT_TASK_LOCK_HOLDER_PATH"),
+        std::env::var("ORBIT_TASK_LOCK_HOLDER_READY"),
+    ) else {
+        return;
+    };
+
+    let _guard = acquire_exclusive_file_lock(
+        std::path::Path::new(&lock_path),
+        "task update test holder",
+        FileLockOptions::default(),
+    )
+    .expect("child acquires task lock");
+    std::fs::write(ready_path, b"ready").expect("write ready sentinel");
+    std::thread::sleep(Duration::from_secs(60));
 }
 
 /// A bundle removed between the registry snapshot and the read — the window


### PR DESCRIPTION
## Task

[ORB-11651](https://orbit-cli.com/tasks/ORB-11651) — [code-review] Route task-bundle locking through one bounded, diagnosable lock implementation

### Description

## Problem
Task bundle creation, mutation, deletion and JSONL append paths use the common unbounded file-lock helper, whereas orbit-store also has bounded locking with holder diagnostics. A stalled holder can leave competing task writers waiting indefinitely.

## Required behavior and constraints
Provide one bounded, diagnosable acquisition policy for the task-bundle lock family with configurable/testable deadlines, actionable timeout errors and holder information when available. Preserve per-thread reentrancy, shared/exclusive reader compatibility and stable lock identity. Keep dependency direction valid: common cannot call upward into store. Scope consolidation to shared mechanics and affected consumers, not every independent lock in the repository. Integrate existing doctor diagnostics rather than inventing a parallel diagnostic system.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-common/src/fs/io.rs:328`; `crates/orbit-store/src/repository/task/v2_bundle.rs:96`; `crates/orbit-store/src/fs/lock/mod.rs:159,199`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- With a separate process holding a task write lock, a competing update reaches a short injected deadline and returns a typed timeout identifying the lock and available holder metadata.
- Nested same-thread access, shared reads under the writer contract, and ordinary concurrent task updates retain their current non-deadlocking behavior.
- Holder diagnostics distinguish active contention from stale metadata after a killed process; releasing/killing a holder permits subsequent acquisition without unsafe lock-file replacement.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Moved bounded advisory acquisition, holder metadata, warnings, stable-file cleanup, and one-shot locking into orbit-common; orbit-store now delegates to that single lower-level implementation.
- Added FileLockTimeout as a structured OrbitError carrying the lock path, waiter label, deadline, and optional holder metadata; preserved error redaction.
- Routed existing common exclusive and shared target locks through the 30-second bounded policy while preserving per-thread reentrancy and read-only shared-lock fallback. Task creation, mutation, deletion, recovery, reads, and JSONL append consumers keep their existing stable targets and now inherit the bounded implementation.
- Added process-level regression coverage for a held task-bundle lock, short injected timeout, live holder metadata, killed-holder stale diagnostics, subsequent update recovery, and unchanged lock inode. Extended store lock tests for typed timeout and crash metadata cleanup.
Criteria evidence:
1. The new child-process task update regression holds the canonical bundle lock in a separate process, injects a 150ms waiter deadline, and asserts FileLockTimeout fields including the exact lock path and child PID/label.
2. Existing nested full-read/write, shared reader/writer, same-task update, distinct-task update, deletion, and settled-corruption concurrency tests all pass under the bounded implementation; common symlink and panic reentrancy tests also pass.
3. SIGKILL tests distinguish live timeout metadata from dead-holder metadata, then reacquire the same inode and verify clean release clears metadata. The existing orbit doctor dead-holder diagnostic test passes through the common metadata reader.
Validation:
- PASSED: cargo test -p orbit-common fs::tests::io -- --test-threads=1 (11 passed).
- PASSED: cargo test -p orbit-store fs::lock::tests::file_lock -- --test-threads=1 (6 passed, 1 intentionally ignored child helper).
- PASSED: cargo test -p orbit-store repository::task::v2::tests::concurrency -- --test-threads=1 (14 passed, 1 intentionally ignored child helper).
- PASSED: cargo test -p orbit-store repository::task::v2::tests::concurrency::task_update_times_out_with_live_process_holder_diagnostics_then_recovers -- --exact --test-threads=1 (1 passed after final status recheck).
- PASSED: cargo test -p orbit-cmd tests::doctor::dead_holder_lock_file_is_reported_stale -- --test-threads=1 (1 passed).
- PASSED: make ci-fast. Its compiler-cache namespace probe reported the documented bwrap user-namespace skip, and the enclosing check passed.
- PASSED: make ci-lint.
- PASSED: git diff --check.
Assessment: One canonical lock implementation now owns timeout and diagnostics without a new dependency edge; task consumers retain their established lock identity and orchestration.
Deviations from original plan: Added file:crates/orbit-common/src/fs/file_lock.rs and its module registration to keep io.rs below the repository size warning; task context was updated before those edits.
Remaining risk: Process and inode recovery behavior was exercised on Linux. The platform-neutral implementation compiles workspace-wide, but macOS runtime behavior was not directly exercised in this Linux runner.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11651-6a9f7d96`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra