### PR TITLE
[BLOCKED] [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -1083,6 +1083,9 @@ fn task_gate_noops_done_task_and_releases_reservation() {
     seed_default_catalogs(&global_root);
     let task_id = seed_gate_task(&runtime, &repo_root, TaskStatus::Done);
 
+    // The production retry path uses the run ID as a jitter salt. Reuse the
+    // store-generated fixture task ID here so the test does not feed a
+    // hard-coded value into that cryptographic data flow.
     let outcome = execute_gate_job(
         &runtime,
         &repo_root,
@@ -1091,7 +1094,7 @@ fn task_gate_noops_done_task_and_releases_reservation() {
             "task_ids": [task_id.clone()],
             "mode": "pr",
         }),
-        "jrun-gate-done-stale",
+        task_id.as_str(),
     );
 
     assert!(outcome.success);


### PR DESCRIPTION
The stale-done-task gate fixture now uses its store-generated task ID as the execution run ID instead of a fixed string reaching retry jitter. Its done-task no-op and reservation-release assertions are unchanged; no production behavior or scanning suppression was added.

Recovered on Mac from preserved head 76adf6e20606c9738176b1f26a8e2bd8e43837c1, integrating agent-main 68ca3011d and the already-landed compile repair. Original history and failed-run evidence are preserved; no Linux process was restarted.

Validation on Mac with CARGO_BUILD_JOBS=2: native make ci-fast passed; workspace/all-target make ci-lint passed; exact task_gate_noops_done_task_and_releases_reservation test passed (1 test); git diff --check passed. Linux namespace probe skipped because bwrap is unavailable. CodeQL rescan/alert closure has not been verified.

<details>
<summary>Preserved failure-handoff evidence</summary>

## Delivery failure handoff

Orbit preserved and pushed this task's candidate after the shipment pipeline failed. This PR is intentionally blocked; inspect the recorded failure before retrying delivery.

- Task: `ORB-11782`
- Run: `jrun-20260908-0343-3`
- Failed step: `implement_bundle`
- Error code: `pipeline_step_failed`
- Original base: `b8ada6e836e0cefcd69008954faa72725ee11e82`
- Target base: `216bd3d542202a3429a58a172ce37350a85a6886`

## Conflicting paths

- None reported; inspect the failed pipeline step before merging.

## Failure

```text
job executor: step `implement_one`: cli subprocess reported declared envelope status="failed" despite exit 0: error.code=validation_blocked; error.message=orbit-core cannot compile because bootstrap/global_defaults.rs imports private DEFAULT_ACTIVITY_FILES.
```

</details>
