### PR TITLE
test: use generated identity for completion recovery fixture [ORB-11778]

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec/completion.rs
+++ b/crates/orbit-core/src/application/job/tests/exec/completion.rs
@@ -19,7 +19,6 @@ use crate::application::task::{TaskAddParams, TaskUpdateParams};
 fn completion_merge_failure_routes_to_review_recovery_without_republishing() {
     let (_root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
-    let run_id = "jrun-completion-merge-failure";
     let task = runtime
         .add_task(TaskAddParams {
             title: "Published completion candidate".to_string(),
@@ -40,6 +39,9 @@ fn completion_merge_failure_routes_to_review_recovery_without_republishing() {
             ..Default::default()
         })
         .expect("seed published task");
+    // The executor uses the run ID as retry-jitter salt. Reuse the
+    // store-generated fixture task ID instead of a hard-coded salt.
+    let run_id = task.id.clone();
     runtime
         .update_task(
             &task.id,
@@ -76,7 +78,7 @@ fn completion_merge_failure_routes_to_review_recovery_without_republishing() {
         &host,
         job,
         json!({ "task_ids": [task.id] }),
-        run_id,
+        &run_id,
     )
     .expect_err("private merge denial must fail the pipeline");
 


### PR DESCRIPTION
The completion recovery fixture used a fixed run ID as retry-jitter salt. Reuse its store-generated task ID and borrow that value when invoking the executor, preserving the recovery assertions.

Recovered the existing candidate onto current `agent-main`, including the shared activity import repair from PR #1682. The original worker stopped on that unrelated old-base compilation error; no pipeline restart was needed.

Validation on native macOS: focused completion recovery test passed (1 test); `make ci-fast` and `make ci-lint` passed. Compiler-cache namespace checks explicitly skip without Bubblewrap.

Task: ORB-11778. This PR does not establish a new CodeQL scan result.
