### PR TITLE
[code-review] Avoid reparsing unchanged envelopes during indexed task selection

### DIFF
--- a/crates/orbit-store/src/repository/task/v2/envelope_cache.rs
+++ b/crates/orbit-store/src/repository/task/v2/envelope_cache.rs
@@ -1,0 +1,145 @@
+//! Freshness-stamped reuse of parsed task envelopes.
+//!
+//! Indexed selection needs every registered task's envelope metadata on every
+//! listing — filters, ordering, and the candidate rows themselves are answered
+//! from envelope fields — so the freshness scan used to re-read and re-parse
+//! one `task.yaml` per registered task even when nothing had changed. This
+//! cache keeps each parse and re-validates it against the envelope file's
+//! stamp before every reuse, turning the steady-state scan into one metadata
+//! probe per task.
+//!
+//! # Freshness policy
+//!
+//! An entry is reused only when the envelope file still reports the same
+//! [`EnvelopeStamp`]: filesystem identity (device and inode), byte length, and
+//! modification time. The store never rewrites `task.yaml` in place — every
+//! publish stages a sibling file and renames it over the target — so a write
+//! from this process or any other one lands on a new inode and invalidates the
+//! entry. The stamp is taken *before* the parse it labels, so a write that
+//! races the read can only cost an extra parse on the next scan; superseded
+//! content is never reused.
+//!
+//! # What a stamp does not prove
+//!
+//! A stamp is evidence that a file was not rewritten, not proof that its bytes
+//! are identical. An in-place overwrite that preserved identity, length, and
+//! timestamp would go unnoticed, and a filesystem with coarse timestamps or no
+//! inode numbers narrows the evidence further. Reuse therefore never stands
+//! alone: the caller still compares every reused envelope's `updated_at`
+//! against the generated index, and `reindex_workspace` re-reads and
+//! re-validates every bundle from disk with no reference to this cache.
+//!
+//! Entries are bounded by the tasks registered to the workspace, which the
+//! freshness scan already materializes in full; a deleted task's entry is
+//! dropped by a later scan and can never be served in the meantime, because
+//! task IDs are not reused.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs::{self, Metadata};
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::time::SystemTime;
+
+use orbit_types::task::TaskEnvelopeV2;
+
+use crate::contracts::TaskBundleBinding;
+
+/// Filesystem evidence that an envelope file is the one a cached parse came
+/// from. See the module docs for the guarantees this does and does not carry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct EnvelopeStamp {
+    len: u64,
+    modified: Option<SystemTime>,
+    /// Device and inode on Unix; `None` where the platform reports neither.
+    identity: Option<(u64, u64)>,
+}
+
+#[derive(Default)]
+pub(super) struct EnvelopeCache {
+    entries: Mutex<HashMap<String, (EnvelopeStamp, TaskEnvelopeV2)>>,
+    /// Metadata probes taken so far. Listing tests assert that a warm scan
+    /// pays exactly one per registered task and no envelope parses at all.
+    #[cfg(test)]
+    stat_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl EnvelopeCache {
+    /// Stamp `path`, or `None` when it cannot be stamped — a bundle a
+    /// concurrent writer is publishing or removing, or a metadata call that
+    /// failed. Both cases fall through to the strict envelope read, which
+    /// decides between "skip this task" and a reported error.
+    pub(super) fn stamp(&self, path: &Path) -> Option<EnvelopeStamp> {
+        #[cfg(test)]
+        self.stat_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let metadata = fs::metadata(path).ok()?;
+        Some(EnvelopeStamp {
+            len: metadata.len(),
+            modified: metadata.modified().ok(),
+            identity: file_identity(&metadata),
+        })
+    }
+
+    /// The envelope parsed from the file this stamp describes, if it is still
+    /// the file the entry was taken from.
+    pub(super) fn reuse(&self, task_id: &str, stamp: &EnvelopeStamp) -> Option<TaskEnvelopeV2> {
+        let entries = self.entries();
+        let (cached, envelope) = entries.get(task_id)?;
+        (cached == stamp).then(|| envelope.clone())
+    }
+
+    pub(super) fn remember(&self, task_id: &str, stamp: EnvelopeStamp, envelope: &TaskEnvelopeV2) {
+        self.entries()
+            .insert(task_id.to_string(), (stamp, envelope.clone()));
+    }
+
+    pub(super) fn forget(&self, task_id: &str) {
+        self.entries().remove(task_id);
+    }
+
+    /// Drop entries for tasks the workspace no longer registers. Deletion
+    /// removes the binding, so holding more entries than bindings is the
+    /// signal that orphans have accumulated; entries below that threshold are
+    /// left alone rather than paying a set build on every scan.
+    pub(super) fn retain_registered(&self, registered: &[TaskBundleBinding]) {
+        let mut entries = self.entries();
+        if entries.len() <= registered.len() {
+            return;
+        }
+        let live = registered
+            .iter()
+            .map(|binding| binding.task_id.as_str())
+            .collect::<BTreeSet<_>>();
+        entries.retain(|task_id, _| live.contains(task_id.as_str()));
+    }
+
+    /// A poisoned lock only means some thread panicked while holding it. Every
+    /// entry is re-proved against the filesystem before it is reused, so the
+    /// cache keeps serving rather than failing an unrelated read.
+    fn entries(&self) -> MutexGuard<'_, HashMap<String, (EnvelopeStamp, TaskEnvelopeV2)>> {
+        self.entries.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    #[cfg(test)]
+    pub(super) fn take_stat_calls(&self) -> usize {
+        self.stat_calls
+            .swap(0, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(super) fn entry_count(&self) -> usize {
+        self.entries().len()
+    }
+}
+
+#[cfg(unix)]
+fn file_identity(metadata: &Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn file_identity(_metadata: &Metadata) -> Option<(u64, u64)> {
+    None
+}

--- a/crates/orbit-store/src/repository/task/v2/index.rs
+++ b/crates/orbit-store/src/repository/task/v2/index.rs
@@ -83,6 +83,12 @@ impl TaskV2Store {
     }
 
     /// Reuse the freshness scan for bounded selection, without reading bodies.
+    ///
+    /// Each registered task costs one metadata probe; its envelope is parsed
+    /// again only when the [`EnvelopeCache`] stamp policy cannot prove the file
+    /// is the one already parsed. Reuse never replaces the index comparison
+    /// below — a cached envelope whose `updated_at` disagrees with its index
+    /// row still sends the caller to a rebuild.
     pub(super) fn validated_envelopes(&self) -> Result<Option<Vec<TaskEnvelopeV2>>, OrbitError> {
         let registered = self.registry.tasks_for_workspace(&self.workspace_id)?;
         let indexed = self
@@ -91,15 +97,14 @@ impl TaskV2Store {
         if registered.len() != indexed.len() {
             return Ok(None);
         }
+        self.envelope_cache.retain_registered(&registered);
+
         let mut envelopes = Vec::with_capacity(registered.len());
-        for binding in registered {
+        for binding in &registered {
             let Some(version) = indexed.get(&binding.task_id) else {
                 return Ok(None);
             };
-            let Some(envelope) = self
-                .bundle_store
-                .read_envelope_if_settled(&binding.task_id)?
-            else {
+            let Some(envelope) = self.settled_envelope(&binding.task_id)? else {
                 continue;
             };
             if envelope.updated_at.to_rfc3339() != *version {
@@ -108,6 +113,32 @@ impl TaskV2Store {
             envelopes.push(envelope);
         }
         Ok(Some(envelopes))
+    }
+
+    /// One registered task's envelope, reusing the previous parse while the
+    /// envelope file is unchanged. `None` carries the same meaning as
+    /// [`TaskBundleStoreV2::read_envelope_if_settled`]: a concurrent writer
+    /// holds this bundle, so the scan skips it rather than failing.
+    fn settled_envelope(&self, task_id: &str) -> Result<Option<TaskEnvelopeV2>, OrbitError> {
+        // Stamped before the parse it labels, so a write that races this read
+        // costs one extra parse next scan instead of pinning stale content.
+        let stamp = self
+            .envelope_cache
+            .stamp(&self.bundle_store.envelope_path(task_id)?);
+        if let Some(stamp) = stamp
+            && let Some(envelope) = self.envelope_cache.reuse(task_id, &stamp)
+        {
+            return Ok(Some(envelope));
+        }
+
+        let Some(envelope) = self.bundle_store.read_envelope_if_settled(task_id)? else {
+            self.envelope_cache.forget(task_id);
+            return Ok(None);
+        };
+        if let Some(stamp) = stamp {
+            self.envelope_cache.remember(task_id, stamp, &envelope);
+        }
+        Ok(Some(envelope))
     }
 
     /// Rebuild the generated index from the bundles, degrading to `false` (use

--- a/crates/orbit-store/src/repository/task/v2/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/mod.rs
@@ -4,6 +4,7 @@
 //! The `artifacts` module owns task artifact reads, manifests, and upserts.
 //! The `sidecars` module owns comments and history row reads.
 //! The `index` module owns generated index reads, rebuilds, bundle translation, and task locking helpers.
+//! The `envelope_cache` module owns freshness-stamped reuse of parsed envelopes.
 //! The `query` module owns in-memory, sidecar, and artifact query matching.
 //! The `relations` module owns relation construction and replacement helpers.
 //! The `sequencing` module owns monotonic event and comment sequence calculations.
@@ -37,6 +38,7 @@ mod acceptance;
 mod artifact_paths;
 mod artifacts;
 mod crud;
+mod envelope_cache;
 mod index;
 mod listing;
 mod query;
@@ -50,6 +52,7 @@ mod tests;
 
 use acceptance::{parse_acceptance, render_acceptance};
 use artifact_paths::{normalize_v2_artifact_path, resolve_v2_artifact_file_path};
+use envelope_cache::EnvelopeCache;
 use relations::{relations_from_create_params, replace_relations};
 use sequencing::{next_event_id, next_sequence};
 
@@ -57,6 +60,8 @@ pub(crate) struct TaskV2Store {
     registry: TaskRegistryStore,
     bundle_store: TaskBundleStoreV2,
     workspace_id: String,
+    /// Envelope parses reused across listings; see [`envelope_cache`].
+    envelope_cache: EnvelopeCache,
 }
 
 impl TaskV2Store {
@@ -75,6 +80,7 @@ impl TaskV2Store {
             ),
             registry,
             workspace_id,
+            envelope_cache: EnvelopeCache::default(),
         }
     }
 
@@ -86,6 +92,7 @@ impl TaskV2Store {
             ),
             registry,
             workspace_id,
+            envelope_cache: EnvelopeCache::default(),
         }
     }
 }

--- a/crates/orbit-store/src/repository/task/v2/tests/envelope_cache.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/envelope_cache.rs
@@ -1,0 +1,494 @@
+//! ORB-11648: indexed selection reuses parsed envelopes for unchanged files.
+//!
+//! Every test here pins one half of the freshness policy documented on
+//! [`super::super::envelope_cache`]: a warm scan must parse nothing, and any
+//! change on disk — a store write, an out-of-band rewrite, a deletion, or a
+//! corrupt file — must still be observed exactly as it was before the cache.
+
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use super::listing::{corpus, probes, reads};
+use super::listing_bench::seed;
+use super::*;
+use crate::contracts::{TaskCandidates, TaskListFilter};
+use crate::workflow::task::reindex_workspace;
+
+const CORPUS: usize = 200;
+
+fn filters() -> Vec<TaskListFilter> {
+    vec![
+        TaskListFilter::default(),
+        TaskListFilter {
+            tags: vec!["selective".to_string()],
+            ..Default::default()
+        },
+        TaskListFilter {
+            statuses: Some(vec![TaskStatus::Backlog]),
+            ..Default::default()
+        },
+        TaskListFilter {
+            statuses: Some(vec![TaskStatus::Review]),
+            ..Default::default()
+        },
+        TaskListFilter {
+            priority: Some(TaskPriority::High),
+            ..Default::default()
+        },
+    ]
+}
+
+/// Selection order, filtering and totals recomputed from a strict scan of the
+/// bundles on disk, with neither the generated index nor the cache in the path.
+fn strict_reference(
+    store: &TaskV2Store,
+    filter: &TaskListFilter,
+    limit: usize,
+) -> (Vec<String>, usize) {
+    let filter = filter.normalized();
+    let mut envelopes = store
+        .bundle_store
+        .list_bundles()
+        .expect("strict bundle scan")
+        .into_iter()
+        .map(|bundle| bundle.envelope)
+        .filter(|envelope| filter.matches(envelope))
+        .collect::<Vec<_>>();
+    sort_by_created_desc_id_asc(
+        &mut envelopes,
+        |envelope| &envelope.created_at,
+        |envelope| &envelope.id,
+    );
+    let total = envelopes.len();
+    let mut ids = envelopes
+        .into_iter()
+        .map(|envelope| envelope.id)
+        .collect::<Vec<_>>();
+    ids.truncate(limit);
+    (ids, total)
+}
+
+fn selected_ids(candidates: &TaskCandidates) -> Vec<String> {
+    candidates
+        .items
+        .iter()
+        .map(|envelope| envelope.id.clone())
+        .collect()
+}
+
+/// Metadata probes and envelope parses charged since the previous call.
+fn scan_cost(store: &TaskV2Store) -> (usize, usize) {
+    (probes(store), reads(store).1)
+}
+
+#[test]
+fn a_warm_candidate_selection_parses_no_envelopes_and_matches_the_strict_reference() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, CORPUS);
+    let filters = filters();
+    let expected = filters
+        .iter()
+        .map(|filter| strict_reference(&store, filter, 50))
+        .collect::<Vec<_>>();
+    scan_cost(&store);
+
+    // Cold: one metadata probe and one envelope parse per registered task.
+    store
+        .task_candidates(&filters[0], 50)
+        .expect("cold selection");
+    assert_eq!(scan_cost(&store), (CORPUS, CORPUS));
+
+    // Warm: the same metadata work, and no envelope parse at all.
+    for (filter, (expected_ids, expected_total)) in filters.iter().zip(expected) {
+        let candidates = store.task_candidates(filter, 50).expect("warm selection");
+        assert_eq!(
+            scan_cost(&store),
+            (CORPUS, 0),
+            "a warm scan must stat every task and parse none"
+        );
+        assert_eq!(candidates.total, expected_total);
+        assert_eq!(selected_ids(&candidates), expected_ids);
+    }
+}
+
+#[test]
+fn a_status_transition_reparses_only_the_task_it_rewrote() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 8);
+    store
+        .task_candidates(&TaskListFilter::default(), 8)
+        .expect("warm the cache");
+    let moved = store
+        .task_candidates(&TaskListFilter::default(), 1)
+        .expect("select one")
+        .items
+        .remove(0);
+    scan_cost(&store);
+
+    store
+        .update_task_history(
+            &moved.id,
+            &TaskHistoryUpdateParams {
+                actor: "codex".to_string(),
+                status: Some(TaskStatus::Review),
+                ..Default::default()
+            },
+        )
+        .expect("transition");
+    reads(&store);
+
+    let review = TaskListFilter {
+        statuses: Some(vec![TaskStatus::Review]),
+        ..Default::default()
+    };
+    let candidates = store.task_candidates(&review, 8).expect("selection");
+    assert_eq!(
+        scan_cost(&store),
+        (8, 1),
+        "only the rewritten envelope reparses"
+    );
+    assert_eq!(selected_ids(&candidates), vec![moved.id.clone()]);
+    // The transition kept the generated index in step, so the indexed status
+    // filter agrees with the freshly parsed envelope.
+    assert_eq!(
+        store
+            .list_tasks_filtered(Some(TaskStatus::Review), None, None, None, None, None)
+            .expect("indexed status filter")
+            .into_iter()
+            .map(|task| task.id)
+            .collect::<Vec<_>>(),
+        vec![moved.id.clone()]
+    );
+
+    scan_cost(&store);
+    let candidates = store.task_candidates(&review, 8).expect("selection");
+    assert_eq!(scan_cost(&store), (8, 0), "the new parse is reused in turn");
+    assert_eq!(selected_ids(&candidates), vec![moved.id]);
+}
+
+#[test]
+fn an_out_of_band_atomic_replacement_invalidates_the_cache_and_the_index() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 4);
+    let mut envelope = store
+        .task_candidates(&TaskListFilter::default(), 4)
+        .expect("warm the cache")
+        .items
+        .remove(0);
+    scan_cost(&store);
+
+    // Republished exactly as the store publishes an envelope — staged, then
+    // renamed over the target — but without the matching index write.
+    envelope.priority = TaskPriority::Low;
+    envelope.tags = vec!["re-tagged".to_string()];
+    envelope.updated_at += chrono::Duration::seconds(1);
+    store
+        .bundle_store
+        .rewrite_envelope(&envelope.id, &envelope)
+        .expect("republish envelope");
+
+    let low = TaskListFilter {
+        priority: Some(TaskPriority::Low),
+        tags: vec!["re-tagged".to_string()],
+        ..Default::default()
+    };
+    let (expected_ids, expected_total) = strict_reference(&store, &low, 4);
+    reads(&store);
+    let candidates = store.task_candidates(&low, 4).expect("selection");
+    assert_eq!(selected_ids(&candidates), expected_ids);
+    assert_eq!(candidates.total, expected_total);
+    assert_eq!(expected_ids, vec![envelope.id.clone()]);
+
+    // `updated_at` no longer matches the index row, so the whole index is
+    // rebuilt from the bundles and the indexed filters refresh with it.
+    assert_eq!(
+        store
+            .list_tasks_by_tags(&["re-tagged".to_string()])
+            .expect("indexed tag filter")
+            .into_iter()
+            .map(|task| task.id)
+            .collect::<Vec<_>>(),
+        vec![envelope.id.clone()]
+    );
+
+    scan_cost(&store);
+    let candidates = store.task_candidates(&low, 4).expect("selection");
+    assert_eq!(
+        scan_cost(&store),
+        (4, 0),
+        "the republished envelope is cached in turn"
+    );
+    assert_eq!(selected_ids(&candidates), vec![envelope.id]);
+}
+
+/// An editor that truncates and rewrites `task.yaml` keeps the file's identity,
+/// so only its length and timestamp witness the change. The scan must still
+/// re-read it, even though the unchanged `updated_at` leaves the index valid.
+#[cfg(unix)]
+#[test]
+fn an_in_place_rewrite_that_keeps_updated_at_still_refreshes_filter_fields() {
+    use std::os::unix::fs::MetadataExt;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 4);
+    let mut envelope = store
+        .task_candidates(&TaskListFilter::default(), 4)
+        .expect("warm the cache")
+        .items
+        .remove(0);
+    let path = store
+        .bundle_store
+        .envelope_path(&envelope.id)
+        .expect("envelope path");
+    let identity_before = fs::metadata(&path).expect("metadata").ino();
+
+    envelope.title = "Edited outside the store by hand".to_string();
+    envelope.tags = vec!["hand-edited".to_string()];
+    fs::write(
+        &path,
+        serde_yaml::to_string(&envelope).expect("serialize envelope"),
+    )
+    .expect("in-place rewrite");
+    assert_eq!(
+        fs::metadata(&path).expect("metadata").ino(),
+        identity_before,
+        "the rewrite must reuse the file to exercise the length/timestamp stamp"
+    );
+
+    let hand_edited = TaskListFilter {
+        tags: vec!["hand-edited".to_string()],
+        ..Default::default()
+    };
+    let (expected_ids, expected_total) = strict_reference(&store, &hand_edited, 4);
+    scan_cost(&store);
+    let candidates = store.task_candidates(&hand_edited, 4).expect("selection");
+    assert_eq!(
+        scan_cost(&store),
+        (4, 1),
+        "only the edited envelope reparses"
+    );
+    assert_eq!(candidates.total, expected_total);
+    assert_eq!(selected_ids(&candidates), expected_ids);
+    assert_eq!(
+        candidates.items[0].title,
+        "Edited outside the store by hand"
+    );
+}
+
+#[test]
+fn deleted_and_in_flight_bundles_drop_their_cached_parses() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 4);
+    let selected = store
+        .task_candidates(&TaskListFilter::default(), 4)
+        .expect("warm the cache")
+        .items;
+    assert_eq!(store.envelope_cache.entry_count(), 4);
+
+    assert!(store.delete_task(&selected[0].id).expect("delete task"));
+    let candidates = store
+        .task_candidates(&TaskListFilter::default(), 4)
+        .expect("selection after deletion");
+    assert_eq!(candidates.total, 3);
+    assert!(!selected_ids(&candidates).contains(&selected[0].id));
+    assert_eq!(
+        store.envelope_cache.entry_count(),
+        3,
+        "an unregistered task must not keep a cached parse"
+    );
+
+    // A bundle removed under a live binding is a concurrent deletion the scan
+    // skips; its cached parse must go with it rather than resurrect the task.
+    let path = store
+        .bundle_store
+        .bundle_path(&selected[1].id)
+        .expect("bundle path");
+    fs::remove_dir_all(&path).expect("remove bundle");
+    let candidates = store
+        .task_candidates(&TaskListFilter::default(), 4)
+        .expect("selection with an in-flight bundle");
+    assert_eq!(candidates.total, 2);
+    assert!(!selected_ids(&candidates).contains(&selected[1].id));
+    assert_eq!(store.envelope_cache.entry_count(), 2);
+}
+
+#[test]
+fn missing_and_legacy_index_metadata_fall_back_to_the_strict_scan() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 6);
+    let (expected_ids, expected_total) = strict_reference(&store, &TaskListFilter::default(), 6);
+    store
+        .task_candidates(&TaskListFilter::default(), 6)
+        .expect("warm the cache");
+
+    let conn = rusqlite::Connection::open(task_registry_path(temp.path())).expect("open registry");
+    for sql in [
+        "DELETE FROM task_bundle_index",
+        "UPDATE task_bundle_index SET updated_at = 'stale'",
+        "UPDATE task_bundle_index SET complexity = NULL",
+    ] {
+        conn.execute(sql, []).expect("degrade the index");
+        let candidates = store
+            .task_candidates(&TaskListFilter::default(), 6)
+            .expect("selection over a degraded index");
+        assert_eq!(candidates.total, expected_total, "{sql}");
+        assert_eq!(selected_ids(&candidates), expected_ids, "{sql}");
+        assert_eq!(
+            store.task_complexity_by_id().expect("complexity").len(),
+            expected_total,
+            "{sql}"
+        );
+    }
+}
+
+#[test]
+fn a_corrupt_envelope_is_reported_by_selection_and_by_explicit_reindex() {
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, 3);
+    let selected = store
+        .task_candidates(&TaskListFilter::default(), 3)
+        .expect("warm the cache")
+        .items;
+    assert!(reindex_workspace(&store.registry, &store.workspace_id).is_ok());
+
+    let path = store
+        .bundle_store
+        .envelope_path(&selected[0].id)
+        .expect("envelope path");
+    fs::write(&path, "not: [a valid, envelope").expect("corrupt the envelope");
+
+    let error = store
+        .task_candidates(&TaskListFilter::default(), 3)
+        .expect_err("a cached parse must not hide a corrupt envelope");
+    assert!(
+        error.to_string().contains(&selected[0].id),
+        "expected the corrupt task id in `{error}`"
+    );
+    let error = reindex_workspace(&store.registry, &store.workspace_id)
+        .expect_err("explicit reindex must diagnose the corrupt envelope");
+    assert!(
+        error.to_string().contains(&selected[0].id),
+        "expected the corrupt task id in `{error}`"
+    );
+}
+
+/// Writers rewriting envelopes while readers select must never see a parse
+/// that outlived its file: every listing agrees with the durable state.
+#[test]
+fn concurrent_updates_never_serve_a_superseded_cached_envelope() {
+    const TASKS: usize = 6;
+    const ROUNDS: usize = 25;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = corpus(&temp, TASKS);
+    let listings = std::sync::atomic::AtomicUsize::new(0);
+
+    let ids = store
+        .task_candidates(&TaskListFilter::default(), TASKS)
+        .expect("select ids")
+        .items
+        .into_iter()
+        .map(|envelope| envelope.id)
+        .collect::<Vec<_>>();
+
+    std::thread::scope(|scope| {
+        for (index, id) in ids.iter().enumerate() {
+            let store = &store;
+            scope.spawn(move || {
+                for round in 0..ROUNDS {
+                    store
+                        .update_task_document(
+                            id,
+                            &TaskDocumentUpdateParams {
+                                actor: "codex".to_string(),
+                                title: Some(format!("writer {index} @{round}")),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap_or_else(|err| panic!("update of {id} failed: {err}"));
+                }
+            });
+        }
+        for _ in 0..3 {
+            let store = &store;
+            let listings = &listings;
+            scope.spawn(move || {
+                for _ in 0..(ROUNDS * TASKS) {
+                    let candidates = store
+                        .task_candidates(&TaskListFilter::default(), TASKS)
+                        .unwrap_or_else(|err| panic!("selection failed: {err}"));
+                    assert_eq!(candidates.total, TASKS, "no task may drop out");
+                    listings.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+        }
+    });
+
+    assert!(listings.load(Ordering::Relaxed) > 0);
+    let candidates = store
+        .task_candidates(&TaskListFilter::default(), TASKS)
+        .expect("final selection");
+    for envelope in candidates.items {
+        let durable = store
+            .get_task(&envelope.id)
+            .expect("read task")
+            .expect("task exists");
+        assert_eq!(
+            envelope.title, durable.title,
+            "a cached parse outlived its file"
+        );
+        assert_eq!(envelope.updated_at, durable.updated_at);
+    }
+}
+
+/// Acceptance-scale evidence: at 3000 registered tasks a warm selection parses
+/// nothing, pays one metadata probe per task, and still agrees with a strict
+/// bundle scan on filtering, ordering and totals. Ignored by default because
+/// generating the corpus dominates the run.
+#[test]
+#[ignore = "generated 3000-task corpus"]
+#[allow(clippy::print_stdout)]
+fn a_warm_three_thousand_task_selection_parses_no_envelopes() {
+    const TASKS: usize = 3000;
+
+    let temp = TempDir::new().expect("tempdir");
+    let store = seed(&temp.path().join("global"), "ws_warm_3000", TASKS);
+    let filters = filters();
+    let expected = filters
+        .iter()
+        .map(|filter| strict_reference(&store, filter, 50))
+        .collect::<Vec<_>>();
+    scan_cost(&store);
+
+    let cold_started = Instant::now();
+    let cold = store
+        .task_candidates(&filters[0], 50)
+        .expect("cold selection");
+    let cold_ms = cold_started.elapsed().as_secs_f64() * 1000.0;
+    let cold_cost = scan_cost(&store);
+    assert_eq!(cold_cost, (TASKS, TASKS));
+    assert_eq!(cold.total, TASKS);
+
+    let mut warm_ms = Vec::new();
+    for (filter, (expected_ids, expected_total)) in filters.iter().zip(expected) {
+        let started = Instant::now();
+        let candidates = store.task_candidates(filter, 50).expect("warm selection");
+        warm_ms.push(started.elapsed().as_secs_f64() * 1000.0);
+        assert_eq!(
+            scan_cost(&store),
+            (TASKS, 0),
+            "a warm scan must stat every task and parse none"
+        );
+        assert_eq!(candidates.total, expected_total);
+        assert_eq!(selected_ids(&candidates), expected_ids);
+    }
+    warm_ms.sort_by(f64::total_cmp);
+
+    println!(
+        "{}",
+        serde_json::json!({"tasks": TASKS, "filters": warm_ms.len(),
+        "cold_ms": cold_ms, "cold_envelope_parses": cold_cost.1,
+        "cold_stat_calls": cold_cost.0, "warm_median_ms": warm_ms[warm_ms.len() / 2],
+        "warm_envelope_parses": 0, "warm_stat_calls": TASKS})
+    );
+}

--- a/crates/orbit-store/src/repository/task/v2/tests/listing.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing.rs
@@ -6,6 +6,13 @@ use crate::contracts::TaskListFilter;
 use crate::driver::file::task_bundle::take_artifact_payload_reads;
 use crate::workflow::task::reindex_workspace;
 
+/// Metadata probes charged to the envelope freshness scan since the previous
+/// call. Paired with [`reads`], this separates stamping an envelope file from
+/// parsing it.
+pub(super) fn probes(store: &TaskV2Store) -> usize {
+    store.envelope_cache.take_stat_calls()
+}
+
 pub(super) fn reads(store: &TaskV2Store) -> (usize, usize) {
     (
         store.bundle_store.bundle_reads.swap(0, Ordering::Relaxed),
@@ -50,9 +57,11 @@ fn bounded_queries_load_only_selected_bundles_as_the_corpus_grows() {
             tags: vec!["selective".to_string()],
             ..Default::default()
         };
+        // The freshness scan already parsed every envelope above, so the
+        // second query pays metadata probes and no envelope parse.
         let page = store.query_task_rows(&filter, 50, None).unwrap();
         assert_eq!(page.total, count / 10);
-        assert_eq!(reads(&store), ((count / 10).min(50), count));
+        assert_eq!(reads(&store), ((count / 10).min(50), 0));
         assert!(
             page.items
                 .iter()
@@ -141,6 +150,12 @@ fn bounded_integrity_is_selected_only_but_direct_unbounded_and_fallback_reads_ar
 fn missing_and_stale_indexes_rebuild_then_return_to_bounded_reads() {
     let temp = TempDir::new().unwrap();
     let store = corpus(&temp, 10);
+    // Parse every envelope once up front, so each iteration below measures the
+    // rebuild itself rather than the first freshness scan's parses.
+    store
+        .query_task_rows(&TaskListFilter::default(), 2, None)
+        .unwrap();
+    reads(&store);
     let conn = rusqlite::Connection::open(task_registry_path(temp.path())).unwrap();
     for sql in [
         "DELETE FROM task_bundle_index",
@@ -156,7 +171,7 @@ fn missing_and_stale_indexes_rebuild_then_return_to_bounded_reads() {
         store
             .query_task_rows(&TaskListFilter::default(), 2, None)
             .unwrap();
-        assert_eq!(reads(&store), (2, 10));
+        assert_eq!(reads(&store), (2, 0));
     }
 }
 

--- a/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/listing_bench.rs
@@ -5,7 +5,7 @@
 
 use std::time::Instant;
 
-use super::listing::reads;
+use super::listing::{probes, reads};
 use super::*;
 use crate::contracts::{RegisterWorkspaceParams, TaskListFilter, TaskRow};
 
@@ -56,7 +56,10 @@ fn baseline_row(store: &TaskV2Store, task: Task) -> TaskRow {
     }
 }
 
-fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store {
+/// Generate `count` registered, indexed bundles for `workspace`. Shared with
+/// the envelope-cache tests, which need a corpus far larger than `create_task`
+/// can produce in test time.
+pub(super) fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store {
     let registry = TaskRegistryStore::open(&task_registry_path(global)).unwrap();
     registry
         .register_workspace(RegisterWorkspaceParams {
@@ -181,6 +184,7 @@ fn seed(global: &Path, workspace: &str, count: usize) -> TaskV2Store {
         }
     }
     reads(&store);
+    probes(&store);
     store
 }
 
@@ -297,6 +301,7 @@ fn task_list_io_benchmark() {
         std::hint::black_box(operation(&stores, &mode, name, &detail_id));
         stores.iter().for_each(|store| {
             reads(store);
+            probes(store);
         });
         let mut latencies = Vec::new();
         let mut counts = Vec::new();
@@ -307,8 +312,11 @@ fn task_list_io_benchmark() {
             counts.push(
                 stores
                     .iter()
-                    .map(reads)
-                    .fold((0, 0), |a, b| (a.0 + b.0, a.1 + b.1)),
+                    .map(|store| {
+                        let (bundles, envelopes) = reads(store);
+                        (bundles, envelopes, probes(store))
+                    })
+                    .fold((0, 0, 0), |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2)),
             );
         }
         latencies.sort_by(f64::total_cmp);
@@ -319,7 +327,8 @@ fn task_list_io_benchmark() {
             "{}",
             serde_json::json!({"mode": mode, "per_workspace": size, "workspaces": 3,
             "operation": name, "median_ms": latencies[5], "p95_ms": latencies[10],
-            "full_bundle_loads": counts[0].0, "envelope_only_reads": counts[0].1,
+            "full_bundle_loads": counts[0].0, "envelope_parses": counts[0].1,
+            "envelope_stat_calls": counts[0].2,
             "peak_rss_setup_inclusive": hwm, "samples": 11, "cache": "warm tmpfs; no cold-cache control"})
         );
     }

--- a/crates/orbit-store/src/repository/task/v2/tests/mod.rs
+++ b/crates/orbit-store/src/repository/task/v2/tests/mod.rs
@@ -127,6 +127,7 @@ pub(super) fn assert_sandbox_write_io(err: &OrbitError, path_substr: &str) {
 
 mod concurrency;
 mod crud;
+mod envelope_cache;
 mod update;
 
 mod listing;

--- a/crates/orbit-store/src/repository/task/v2_bundle.rs
+++ b/crates/orbit-store/src/repository/task/v2_bundle.rs
@@ -83,6 +83,12 @@ impl TaskBundleStoreV2 {
             .canonical_task_bundle_path(&self.workspace_id, task_id)
     }
 
+    /// The single file [`Self::read_envelope_if_settled`] parses, for callers
+    /// that decide whether that parse is still needed.
+    pub(crate) fn envelope_path(&self, task_id: &str) -> Result<PathBuf, OrbitError> {
+        Ok(self.bundle_path(task_id)?.join(TASK_ENVELOPE_FILE_NAME))
+    }
+
     /// Run `op` while holding this task's exclusive bundle lock.
     ///
     /// A lifecycle write spans more than one file — a transition appends to
@@ -397,10 +403,7 @@ impl TaskBundleStoreV2 {
             )));
         }
         envelope.validate()?;
-        publish_envelope(
-            &self.bundle_path(task_id)?.join(TASK_ENVELOPE_FILE_NAME),
-            envelope,
-        )
+        publish_envelope(&self.envelope_path(task_id)?, envelope)
     }
 
     pub(crate) fn rewrite_artifact_manifest(

--- a/docs/design/task-artifacts/2_design.md
+++ b/docs/design/task-artifacts/2_design.md
@@ -245,6 +245,8 @@ The bundle remains canonical. The registry maintains generated projections from 
 
 Task mutations rewrite the generated rows after the envelope write. The index row `updated_at` is a version stamp for the canonical envelope. V2 list and filter paths may use the index only when every registered task has an index row and every indexed `updated_at` matches the bundle envelope. Count or version mismatches trigger a lazy rebuild from registered bundles; if rebuild fails, queries fall back to reading bundles directly. Full-text search still scans task content until the Phase 5 lexical/semantic indexes land.
 
+That comparison also supplies the metadata candidate selection filters and orders by, so it runs against every registered envelope. To keep it from re-parsing unchanged files, each process holds the parsed envelopes in memory and re-proves one against its file's stamp — filesystem identity, length, and modification time — before reusing it; anything the stamp cannot vouch for is read and parsed again. A stamp is evidence that a file was not rewritten rather than proof that its bytes are unchanged, so it never stands alone: the `updated_at` comparison above still runs on every reused envelope, and explicit reindex re-reads and re-validates every bundle from disk.
+
 ## 8. Crash Consistency
 
 The v2 bundle is local and file-backed, so multi-file mutations are not fully transactional. The implementation keeps the envelope canonical and makes generated data rebuildable, but the following interrupted states are expected repair cases:


### PR DESCRIPTION
## Task

[ORB-11648](https://orbit-cli.com/tasks/ORB-11648) — [code-review] Avoid reparsing unchanged envelopes during indexed task selection

### Description

## Problem
validated_envelopes reads and YAML-parses every registered task envelope before indexed selection. task_candidates also consumes those envelopes for filtering, so merely checking file stamps would not supply its required metadata.

## Required behavior and constraints
Avoid reparsing unchanged envelopes by combining an explicit freshness policy with complete indexed or cached metadata for filtering and candidate output. Account for atomic replacement, deletion, legacy index rows and concurrent updates. File mtime/length alone is a heuristic, not proof of identical content; define its limitations and retain strict rebuild/reindex verification. Preserve visible corruption reporting and current selection semantics. Coordinate with artifact-read optimization without conflating the two costs.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-store/src/repository/task/v2/index.rs:86,99`; `crates/orbit-store/src/repository/task/v2/listing.rs:10,31`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- A warm 3000-task candidate selection demonstrates zero envelope YAML parses for unchanged files and records filesystem/metadata work; filters, ordering and total counts match strict reference results.
- Out-of-band content edits and atomic replacement invalidate cached/indexed metadata under the defined policy; status and other filter fields refresh correctly.
- Missing or legacy metadata, deleted tasks and concurrent writes take a tested fallback; explicit reindex still diagnoses malformed/corrupt envelopes.

## Execution Summary

<details>
<summary>Click to expand</summary>

## What changed

`validated_envelopes` (the freshness scan that also supplies every candidate's filter/order metadata) no longer re-parses envelopes that did not change.

- New `crates/orbit-store/src/repository/task/v2/envelope_cache.rs`: an `EnvelopeCache` owned by `TaskV2Store`, keyed by task ID, holding the parsed `TaskEnvelopeV2` beside an `EnvelopeStamp` of its `task.yaml` (device+inode, byte length, mtime). Module docs state the policy and its limits: a stamp is evidence a file was not rewritten, not proof its bytes are identical; the store only publishes envelopes by staging + rename, so every store write lands on a new inode.
- `index.rs`: `validated_envelopes` calls a new `settled_envelope` per registered task — stamp the file, reuse the cached parse on an exact stamp match, otherwise fall through to the existing `read_envelope_if_settled`. The stamp is taken **before** the parse it labels, so a racing write can only cost an extra parse next scan; superseded content is never reused. Unchanged: the indexed `updated_at` comparison on every envelope (cached or not), the count check, skip-if-in-flight, the rebuild fallback, and corruption reporting. Entries for deleted tasks are dropped; the rebuild/fallback scan and `reindex_workspace` stay strict and cache-free (reindex builds its own bundle store).
- `v2_bundle.rs`: added `envelope_path()` (used by the stamp and by `rewrite_envelope`).
- `docs/design/task-artifacts/2_design.md` §7 documents the reuse rule next to the existing index-freshness rule (unlisted file; added to `context_files` — the design doc describes this exact freshness contract, so leaving it stale would be a review blocker).
- `queries.rs` (listed context) needed no change: no index schema or query change was required.

## Criteria

1. **Warm 3000-task selection, zero parses, metadata work recorded.** `a_warm_three_thousand_task_selection_parses_no_envelopes` (ignored; generated corpus) on 3000 registered tasks: cold pass 3000 parses / 3000 stats / 535 ms; each warm pass 0 parses / 3000 stats / 34 ms median (debug build). Five filter shapes (none, tag, two status sets, priority) match a strict `list_bundles` reference on selected IDs, order and totals. The always-on `a_warm_candidate_selection_parses_no_envelopes_and_matches_the_strict_reference` asserts the same invariants at 200 tasks. The ORB-11205 bench now reports `envelope_parses` / `envelope_stat_calls`; at 3x1000 tasks steady state it reports 0 parses for list/selective/aggregate.
2. **Out-of-band edits and atomic replacement.** `an_out_of_band_atomic_replacement_invalidates_the_cache_and_the_index` republishes an envelope (staged + renamed) with new priority/tags/`updated_at` and no index write: the cache is invalidated, the `updated_at` mismatch rebuilds the index, and both the candidate path and the indexed tag filter refresh. `an_in_place_rewrite_that_keeps_updated_at_still_refreshes_filter_fields` (unix) truncates and rewrites `task.yaml` on the same inode with an unchanged `updated_at` — the length/mtime stamp still forces the re-parse and the title/tag filters refresh. `a_status_transition_reparses_only_the_task_it_rewrote` shows a real transition re-parsing exactly one envelope, with candidate and indexed status filters agreeing.
3. **Fallbacks and diagnosis.** `deleted_and_in_flight_bundles_drop_their_cached_parses` (deleted task, and a bundle removed under a live binding), `missing_and_legacy_index_metadata_fall_back_to_the_strict_scan` (missing rows, stale `updated_at`, `NULL` legacy complexity), `concurrent_updates_never_serve_a_superseded_cached_envelope` (6 writers x 25 rounds against 3 concurrent selectors; every final candidate matches the durable strict read), and `a_corrupt_envelope_is_reported_by_selection_and_by_explicit_reindex` (a cached parse does not hide corruption; selection and `reindex_workspace` both name the task).

Two existing listing tests were updated because their assertions encoded the old cost model (`bounded_queries_load_only_selected_bundles_as_the_corpus_grows`, `missing_and_stale_indexes_rebuild_then_return_to_bounded_reads`); both still assert the same behavior, now with the warm-scan parse counts.

## Validation

- PASSED `cargo test -p orbit-store` — 476 passed, 0 failed, 6 ignored.
- PASSED `cargo test -p orbit-store --lib repository::task::v2::tests::envelope_cache::a_warm_three_thousand_task_selection_parses_no_envelopes -- --ignored` (evidence above).
- PASSED `ORBIT_TASK_BENCH_MODE=candidate ORBIT_TASK_BENCH_SIZE=1000 cargo test -p orbit-store --lib ...listing_bench -- --ignored`.
- PASSED `make ci-fast` (exit 0) and `make ci-lint` (exit 0, no warnings).
- FAILED, PRE-EXISTING, UNRELATED `cargo test -p orbit-core` — 1214 passed, 3 failed: `catalog::gate_pipeline_releases_reservation_before_child_success_guard` and `routine::dogfood_task_pilot_routine_matches_the_rendered_default_template` compare shipped resources against this machine's gitignored `.orbit/` workspace files (`max_active_runs` 10 vs 15, cron `*/40` vs `*/15`); `task::tests::update::concurrent_explicit_edit_preserves_the_newer_status` was reproduced with the cache lookup bypassed (identical `Proposed` vs `Archived` failure), so it does not involve this change.
- FAILED, PRE-EXISTING, UNRELATED `cargo test -p orbit-web` — 367 passed, 1 failed: `dashboard_assets::dashboard_log_tail_resumes_from_snapshot_offset_and_retries_on_close`, a Node dashboard-behavior harness assertion ("expected one retry timer, got 2") touching no Rust store code.
- NOT RUN: full `make ci` (per AGENTS.md, the merge gate runs it in CI). macOS behavior is not exercised here; the unix stamp path is identical on macOS, and the one inode assertion is `#[cfg(unix)]`.

## Risk

The cache is per process and per `TaskV2Store`, bounded by the workspace's registered tasks — the same set the scan already materializes per call, so peak memory is unchanged in kind (~3 MB resident for 3000 tasks) though now retained between calls. Correctness rests on the stamp plus the unchanged `updated_at` comparison; an in-place overwrite preserving inode, length and mtime would be missed, which the module doc states and which `reindex_workspace` remains the strict answer to.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11648-6a9f7d2c`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra