### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -355,9 +355,15 @@ fn workspace_auto_keeps_dispatching_while_earlier_leaves_are_still_running() {
 /// detached leaf.
 #[test]
 fn workspace_auto_fails_promptly_when_leaf_dispatch_has_no_durable_child() {
-    let (_root, runtime, repo_root, global_root) = test_runtime();
+    let (root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
     let host = ScriptedWorkspaceAutoHost::new(&runtime, WorkspaceAutoScenario::DispatchFailure);
+    let run_id = root
+        .path()
+        .file_name()
+        .expect("test tempdir has a final path component")
+        .to_string_lossy()
+        .into_owned();
 
     let err = try_execute_named_job(
         &runtime,
@@ -365,7 +371,7 @@ fn workspace_auto_fails_promptly_when_leaf_dispatch_has_no_durable_child() {
         &host,
         "workspace_auto_pipeline",
         json!({"max_tasks": 50, "for_seconds": 0, "idle_sleep_seconds": 0}),
-        "jrun-workspace-auto-dispatch-failure",
+        &run_id,
     )
     .expect_err("pre-link dispatch failure must fail the workspace drain");
 


### PR DESCRIPTION
## Task

[ORB-11780](https://orbit-cli.com/tasks/ORB-11780) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#167`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `a93caa13890764380e184d996fa709b1bcbe278c`
- Location: `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 368
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/167

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 368 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the dispatch-failure test in `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` to derive its engine run ID from the unique temporary test directory.
- Removed the hard-coded run ID that CodeQL identified as a cryptographic salt input; the test still exercises the same pre-link dispatch failure and assertion path.

Assessment: The change is minimal, preserves the intended failure behavior, and removes the flagged hard-coded salt data flow without suppressions or exclusions.

Acceptance criteria:
- Code scanning remediation: satisfied; the literal at the reported location is gone and the run ID is dynamically derived from the test fixture.
- Intended behavior: satisfied; the focused regression test and all six workspace-auto module tests pass.
- Validation/security checks: repository checks passed. A live GitHub CodeQL alert re-scan was not run because the task evidence states agent-side GitHub access is unavailable; source-level confirmation found no occurrence of the flagged hard-coded run ID.

Validation:
- `cargo test -p orbit-core workspace_auto_fails_promptly_when_leaf_dispatch_has_no_durable_child --lib`: passed (1 test).
- `cargo test -p orbit-core application::job::tests::workspace_auto_pipeline --lib`: passed (6 tests).
- `make ci-fast`: passed. Its compiler-cache namespace subcheck reported a bounded skip because this environment cannot create a bubblewrap mount namespace; the remaining guardrails passed.
- `make ci-lint`: passed (workspace all-targets clippy with warnings denied).
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Source check for `jrun-workspace-auto-dispatch-failure`: passed; no occurrence remains.
- `git status --short`: only `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` is modified.

Remaining risk: CodeQL's remote alert state requires the normal GitHub scan after delivery; no agent-side re-scan was available.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11780-6a9f874c`
- Behind base: 0
- Ahead of base: 1