### PR TITLE
[code-review] Wire `test-mcp-registry-publish-workflow.sh` into a gate and make it run on macOS

### DIFF
--- a/scripts/ci-guardrails.sh
+++ b/scripts/ci-guardrails.sh
@@ -48,6 +48,7 @@ fi
 "$repo_root/scripts/generate-doc-indexes.sh" --check
 "$repo_root/scripts/check-installer-pubkey.sh"
 "$repo_root/scripts/test-installer-security.sh"
+"$repo_root/scripts/test-mcp-registry-publish-workflow.sh"
 "$repo_root/scripts/check-dependency-direction.sh"
 "$repo_root/scripts/test-ci-fast-guards.py"
 "$repo_root/scripts/check-cli-imports.sh"

--- a/scripts/test-mcp-registry-publish-workflow.sh
+++ b/scripts/test-mcp-registry-publish-workflow.sh
@@ -58,8 +58,8 @@ if ! grep --fixed-strings --quiet -- '"$role" != "admin"' "$preflight"; then
   exit 1
 fi
 
-preflight_line="$(grep --line-number --fixed-strings -- 'Require an active constellation-works administrator membership' "$workflow" | cut --delimiter=: --fields=1)"
-publisher_login_line="$(grep --line-number --fixed-strings -- './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"' "$workflow" | cut --delimiter=: --fields=1)"
+preflight_line="$(grep --line-number --fixed-strings -- 'Require an active constellation-works administrator membership' "$workflow" | cut -d: -f1)"
+publisher_login_line="$(grep --line-number --fixed-strings -- './mcp-publisher login github --token "$MCP_REGISTRY_PAT_TOKEN"' "$workflow" | cut -d: -f1)"
 if [[ "$preflight_line" -ge "$publisher_login_line" ]]; then
   echo "membership preflight must run before publisher login" >&2
   exit 1


### PR DESCRIPTION
## Task

[ORB-11645](https://orbit-cli.com/tasks/ORB-11645) — [code-review] Wire `test-mcp-registry-publish-workflow.sh` into a gate and make it run on macOS

### Description

## Problem
This script is the regression suite for the registry-publication security boundary (admin-membership preflight, pagination, token non-disclosure, pinned publisher checksum) but it is referenced by no Makefile target, no workflow and no other script — it never runs. It also cannot run locally on macOS: lines 61-62 use `cut --delimiter=: --fields=1`, which BSD `cut` rejects, so the preflight-ordering assertion aborts under `set -e`. Concrete scenario: someone removes the `"$role" != "admin"` check from `publish-mcp-registry.yml`; nothing fails.

## Why It Matters
The workflow holds a PAT that can publish the public MCP registry record; its only automated safety net is currently dead code.

## Proposed Fix
Replace the two `cut --delimiter=: --fields=1` with `cut -d: -f1`, and add the script to both `ci-guardrails.sh` and `make ci-fast`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `scripts/test-mcp-registry-publish-workflow.sh:61-62`, `scripts/ci-guardrails.sh:33-52`, `Makefile:117-140`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (security). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `./scripts/test-mcp-registry-publish-workflow.sh` passes on macOS (BSD cut) and ubuntu.
- Deleting the admin-role line from `publish-mcp-registry.yml` makes `make ci-fast` and `ci-guardrails.sh` fail.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced GNU-only cut long options with BSD/POSIX-compatible `cut -d: -f1` in the MCP Registry workflow regression script.
- Added `test-mcp-registry-publish-workflow.sh` to `scripts/ci-guardrails.sh`; `make ci-fast` reaches it through the canonical `ci-guardrails.sh --fast` target, so no duplicate Makefile invocation was added.

Assessment: The registry publication security regression suite now runs in the fast/full guardrail path and retains its admin-membership, ordering, pagination, redaction, and publisher-pin assertions.

Criteria evidence:
- `./scripts/test-mcp-registry-publish-workflow.sh` passed on this Ubuntu/Linux host. The changed `cut -d: -f1` form is supported by BSD cut; an actual macOS host was unavailable, so macOS execution remains indirectly evidenced.
- A temporary fixture with the admin-role condition removed failed the focused script with `missing administrator-role check`, failed `./scripts/ci-guardrails.sh --fast`, and failed `make ci-fast`, demonstrating the security gate is active.

Validation:
- PASSED: `./scripts/test-mcp-registry-publish-workflow.sh`
- PASSED: `bash -n scripts/test-mcp-registry-publish-workflow.sh scripts/ci-guardrails.sh`
- PASSED: tampered fixture focused script, guardrails, and `make ci-fast` expected-failure checks
- PASSED: `make ci-fast`; `test-compiler-cache-namespaces.sh` self-skipped because this sandbox cannot create a bubblewrap namespace
- PASSED: `make ci-lint`
- PASSED: `git diff --check`
- PASSED: final status shows only the two task-scoped script changes

Deviations from original plan:
- No Makefile edit was needed because `ci-fast` delegates to `scripts/ci-guardrails.sh --fast`; adding a second direct invocation would duplicate the gate.

Remaining risks:
- macOS execution was not available in this Linux worktree; the portability fix uses the BSD/POSIX option form.
- The exact temporary tamper fixture and six temporary log files could not be removed because the sandbox rejected the cleanup command; they are outside the worktree and bounded.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11645-6a9f878b`
- Behind base: 0
- Ahead of base: 1