### PR TITLE
[qa-sweep] `workspace init --task-id-start` bricks a custom task prefix before any task is minted

### DIFF
--- a/crates/orbit-cli/src/command/workspace/init.rs
+++ b/crates/orbit-cli/src/command/workspace/init.rs
@@ -638,8 +638,11 @@ fn collect_init_report(
 
     let allocator = match task_id_start {
         Some(start) => {
-            let outcome =
-                orbit_core::bootstrap::task_migration::seed_task_id_start(global_root, start)?;
+            let outcome = orbit_core::bootstrap::task_migration::seed_task_id_start(
+                global_root,
+                init_result.task_prefix.as_deref(),
+                start,
+            )?;
             AllocatorOutcome::Ran {
                 next: render_task_id_start(init_result.task_prefix.as_deref(), outcome.next),
                 changed: outcome.changed,

--- a/crates/orbit-cli/src/command/workspace/tests/init_report.rs
+++ b/crates/orbit-cli/src/command/workspace/tests/init_report.rs
@@ -3,10 +3,16 @@ use std::path::Path;
 use serde_json::Value;
 use tempfile::tempdir;
 
-use crate::command::CommandOutput;
+use orbit_cmd::registry_runtime::RegisteredRuntimeFactory;
+use orbit_core::TaskComplexity;
+use orbit_core::application::task::TaskAddParams;
+
+use crate::InitCommand;
+use crate::command::{CommandOutput, Execute};
 use crate::tests::env_isolation::EnvGuard;
 
 use super::super::init::WorkspaceInitArgs;
+use super::super::show::WorkspaceShowArgs;
 
 struct IsolatedWorkspace {
     workspace: tempfile::TempDir,
@@ -171,6 +177,90 @@ fn requested_allocator_uses_the_host_task_prefix_and_records_unchanged_reseeds()
         second_text.contains("id_start:  allocator already at DANI-20000 (unchanged)"),
         "{second_text}"
     );
+}
+
+#[test]
+fn task_id_start_adopts_custom_prefix_before_a_runtime_opens() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    InitCommand {
+        force: false,
+        non_interactive: true,
+        host_name: Some("prefix-host".to_string()),
+        task_prefix: Some("QASW".to_string()),
+    }
+    .execute_without_runtime(Some(&global))
+    .expect("initialize host identity");
+
+    let mut args = report_args();
+    args.task_id_start = Some(100);
+    args.execute_without_runtime(Some(&global))
+        .expect("initialize workspace and seed allocator");
+
+    let connection =
+        rusqlite::Connection::open(global.join("tasks/index.sqlite")).expect("open task registry");
+    let allocator: (String, u32) = connection
+        .query_row(
+            "SELECT task_prefix, next_number FROM allocator_state WHERE authority = 'local'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read allocator state");
+    assert_eq!(allocator, ("QASW".to_string(), 100));
+
+    let runtime = RegisteredRuntimeFactory::initialize_with_root_override(Some(&global))
+        .expect("open runtime for workspace show");
+    WorkspaceShowArgs {}
+        .execute(&runtime)
+        .expect("workspace show after seeded init");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "seeded prefix task".to_string(),
+            complexity: TaskComplexity::Low,
+            ..TaskAddParams::default()
+        })
+        .expect("add task after seeded init");
+    assert_eq!(task.id, "QASW-00100");
+}
+
+#[test]
+fn custom_prefix_without_task_id_start_still_mints_tasks() {
+    let workspace = tempdir().expect("workspace tempdir");
+    let home = tempdir().expect("home tempdir");
+    let global = home.path().join(".orbit");
+    let _env = EnvGuard::acquire().home(home.path()).cwd(workspace.path());
+
+    InitCommand {
+        force: false,
+        non_interactive: true,
+        host_name: Some("unseeded-prefix-host".to_string()),
+        task_prefix: Some("QASB".to_string()),
+    }
+    .execute_without_runtime(Some(&global))
+    .expect("initialize host identity");
+
+    report_args()
+        .execute_without_runtime(Some(&global))
+        .expect("initialize workspace without an allocator seed");
+
+    let runtime = RegisteredRuntimeFactory::initialize_with_root_override(Some(&global))
+        .expect("open runtime after unseeded init");
+    WorkspaceShowArgs {}
+        .execute(&runtime)
+        .expect("workspace show after unseeded init");
+
+    let task = runtime
+        .add_task(TaskAddParams {
+            title: "unseeded prefix task".to_string(),
+            complexity: TaskComplexity::Low,
+            ..TaskAddParams::default()
+        })
+        .expect("add task after unseeded init");
+    assert_eq!(task.id, "QASB-00000");
 }
 
 #[test]

--- a/crates/orbit-core/src/bootstrap/task_migration.rs
+++ b/crates/orbit-core/src/bootstrap/task_migration.rs
@@ -89,13 +89,20 @@ impl OrbitRuntime {
 }
 
 /// Seed the task-id allocator so the next allocated id is `start`. Used by
-/// `orbit workspace init --task-id-start N` before a runtime exists; the counter
-/// only moves forward, so a value below the current position is refused.
+/// `orbit workspace init --task-id-start N` before a runtime exists. When a
+/// host identity supplies a prefix, adopt it before advancing the counter; the
+/// counter only moves forward, so a value below the current position is refused.
 pub fn seed_task_id_start(
     global_root: &Path,
+    task_prefix: Option<&str>,
     start: u32,
 ) -> Result<AllocatorSeedOutcome, OrbitError> {
     let registry = TaskRegistryStore::open(&task_registry_path(global_root))?;
+
+    if let Some(task_prefix) = task_prefix {
+        registry.set_task_prefix(task_prefix)?;
+    }
+
     registry.seed_allocator_start(start)
 }
 


### PR DESCRIPTION
## Task

[ORB-11771](https://orbit-cli.com/tasks/ORB-11771) — [qa-sweep] `workspace init --task-id-start` bricks a custom task prefix before any task is minted

### Description

## Problem
`orbit init --task-prefix QASW` writes `host.toml` with that prefix, but the SQLite allocator is created with the historical default `task_prefix=ORB`, `next_number=0`. Prefix adoption (`TaskRegistryStore::set_task_prefix`) is allowed only while `current == "ORB" && next == 0 && no tasks`.

`orbit workspace init --task-id-start N` calls `seed_task_id_start` **before** any runtime `sync_task_prefix`. That advances `next_number` to N while leaving `task_prefix=ORB`. ORB-11617 then prints `allocator seeded to QASW-00NNN` from the host identity, not from SQLite.

The next command that opens a runtime (`workspace show`, `task add`, …) calls `sync_task_prefix`, sees `ORB` with `next != 0`, and fails:
`task prefix is immutable after allocation begins (registry uses 'ORB', host identity requests 'QASW')`.

## Why It Matters
`--task-id-start` is the documented way to hand a second machine a disjoint id range ([setup/first-run.md] / [setup/multi-host.md]). Using it together with a non-`ORB` prefix — the normal multi-host setup — leaves the host unable to show the workspace or mint tasks, even though init reported success and printed the custom prefix.

Without `--task-id-start`, adoption still works: `workspace show` syncs `ORB`/`next=0` → `QASB` and `task add` mints `QASB-00000`.

## Evidence (HEAD `b85a8c1070db5ac009f01c26356a700e38ee4c72`, 2026-09-08, jrun-20260908-0251-3)
Built `/tmp/orbit-qa-11768-target/debug/orbit` 0.19.2. Isolated HOME `/tmp/orb-qa-11768-home`, `--root /tmp/orb-qa-11768-root`, git checkout `/tmp/orb-qa-11768-ws` (`main`).

```
$ orbit --root $ROOT init --non-interactive --host-name qa-11768 --task-prefix QASW
host identity (created): … task_prefix=QASW
$ (cd $WS && orbit --root $ROOT workspace init --name qa-11768 --ship-mode local --task-id-start 100)
workspace 'qa-11768' initialized
  id_start:  allocator seeded to QASW-00100
$ sqlite3 $ROOT/tasks/index.sqlite 'SELECT next_number, task_prefix FROM allocator_state;'
100|ORB
$ (cd $WS && orbit --root $ROOT workspace show --format json)
{"code":"invalid_input","error":"invalid input: task prefix is immutable after allocation begins (registry uses 'ORB', host identity requests 'QASW')"}
```

Contrast (second scratch, no `--task-id-start`, prefix `QASB`): allocator becomes `0|QASB` after `workspace show`; `task add` succeeds as `QASB-00000`.

Source: `seed_task_id_start` in `crates/orbit-core/src/bootstrap/task_migration.rs` is invoked from `collect_init_report` in `crates/orbit-cli/src/command/workspace/init.rs` without `sync_task_prefix`. Adoption gate is `crates/orbit-store/src/driver/sqlite/task_registry/store.rs` (`set_task_prefix`). Display-only coverage: `requested_allocator_uses_the_host_task_prefix_and_records_unchanged_reseeds` asserts `DANI-20000` text and never opens a runtime afterward.

Related commit: `9e40b66e8` Print the host's real task prefix in `workspace init --task-id-start` output [ORB-11617] (#1646) — the printed id is QASW, the stored prefix is still ORB.

## Validation impact vs production impact
- **Validation impact:** does not block `make ci-fast` (passed at this HEAD). Existing workspace-init unit tests only check the rendered report, so they stay green.
- **Production impact:** yes. A documented first-run / multi-host command sequence (`init --task-prefix` + `workspace init --task-id-start`) leaves the host unable to run subsequent workspace/task commands until the allocator row is repaired by hand.

## Reproduction
```bash
cargo build -p orbit-cli --bin orbit
BIN=$(pwd)/target/debug/orbit
HOME=/tmp/orb-qa-prefix-repro-home
ROOT=/tmp/orb-qa-prefix-repro-root
WS=/tmp/orb-qa-prefix-repro-ws
mkdir -p "$HOME" "$WS"
git -C "$WS" init -b main
git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/README.md" && git -C "$WS" add README.md && git -C "$WS" -c commit.gpgsign=false commit -m init
"$BIN" --root "$ROOT" init --non-interactive --host-name qa-prefix --task-prefix QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace init --name qa-prefix --ship-mode local --task-id-start 100)
sqlite3 "$ROOT/tasks/index.sqlite" 'SELECT next_number, task_prefix FROM allocator_state;'
# expect 100|ORB  (bug) rather than 100|QASW
(cd "$WS" && "$BIN" --root "$ROOT" workspace show --format json)
# invalid input: task prefix is immutable … registry uses 'ORB', host identity requests 'QASW'
```

## Scope
Adopt the host prefix (or seed it at allocator create) **before** `--task-id-start` advances `next_number`. Keep the QASW-00NNN display only after SQLite matches. Production hosts that never pass `--task-id-start`, or that use prefix `ORB`, are unaffected.

Not a duplicate of ORB-11763 (local-ship `main` vs `master`).

### Acceptance Criteria

- After `orbit init --task-prefix QASW` and `workspace init --task-id-start 100`, `allocator_state` is `task_prefix=QASW` and `next_number=100` (not `ORB`).
- `orbit workspace show` and `orbit task add` succeed on that root and mint `QASW-00100` as the first id.
- A host that inits with a custom prefix and omits `--task-id-start` still adopts the prefix and can mint tasks.
- A regression covers init + `--task-id-start` + a subsequent runtime command (`workspace show` or `task add`), not only the rendered `QASW-00100` string.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Updated bootstrap seeding so a supplied host task prefix is adopted by SQLite before `--task-id-start` advances the allocator.
- Added regressions covering `orbit init` with QASW/QASB, workspace initialization, seeded allocator state, a subsequent workspace-show runtime operation, and the first minted task ID.

Criteria evidence:
1. Seeded QASW allocator state is asserted as `(QASW, 100)`.
2. The seeded regression opens the runtime, executes workspace show, and mints `QASW-00100`.
3. The unseeded QASB regression opens the runtime, executes workspace show, and mints `QASB-00000`.
4. The seeded regression exercises host init, workspace init with `--task-id-start`, runtime opening/show, and task creation.

Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-cli task_id_start_adopts_custom_prefix_before_a_runtime_opens`.
- Passed: `cargo test -p orbit-cli custom_prefix_without_task_id_start_still_mints_tasks`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.

Assessment: focused bootstrap ordering fix; no remaining known risks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11771-6a9f86af`
- Behind base: 0
- Ahead of base: 1