### PR TITLE
[code-review] Push the `field` filter into the retrievers instead of post-filtering the over-fetched top-K

### DIFF
--- a/crates/orbit-search/src/commands/doc_search.rs
+++ b/crates/orbit-search/src/commands/doc_search.rs
@@ -78,6 +78,7 @@ pub(crate) fn run_with_embedder(
         &model_id,
         retriever_limit,
         Some(SOURCE_KIND_DOC),
+        None,
     )?;
     let hits = rollup_doc_hits(vector_store, cosine, limit)?;
 

--- a/crates/orbit-search/src/commands/related.rs
+++ b/crates/orbit-search/src/commands/related.rs
@@ -75,6 +75,7 @@ pub(crate) fn run_with_embedder(
         embedder.model_id(),
         retriever_limit,
         Some("task"),
+        None,
     )?;
     let candidates = cosine
         .into_iter()

--- a/crates/orbit-search/src/commands/search.rs
+++ b/crates/orbit-search/src/commands/search.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::commands::resolve_query_model;
 use crate::vector::VectorStore;
-use crate::vector::query::{
-    FusedCandidate, bm25_top_k, reciprocal_rank_fusion, rollup_to_tasks, snippet_for_hit,
-};
+use crate::vector::query::{bm25_top_k, reciprocal_rank_fusion, rollup_to_tasks, snippet_for_hit};
 use crate::{Embedder, SubprocessEmbedder};
 
 const DEFAULT_LIMIT: usize = 10;
@@ -93,6 +91,8 @@ pub(crate) fn run_with_embedder(
     let bm25_store = vector_store.clone();
     let cosine_model_id = model_id.clone();
     let cosine_kind = kind.map(ToOwned::to_owned);
+    let field = params.field.as_deref();
+    let cosine_field = field.map(ToOwned::to_owned);
 
     let (cosine, bm25) = thread::scope(|scope| {
         let cosine_handle = scope.spawn(|| {
@@ -102,10 +102,11 @@ pub(crate) fn run_with_embedder(
                 &cosine_model_id,
                 retriever_limit,
                 cosine_kind.as_deref(),
+                cosine_field.as_deref(),
             )
         });
         let bm25_handle =
-            scope.spawn(|| bm25_top_k(&bm25_store, &query_for_bm25, kind, retriever_limit));
+            scope.spawn(|| bm25_top_k(&bm25_store, &query_for_bm25, kind, field, retriever_limit));
         let cosine = cosine_handle
             .join()
             .map_err(|_| OrbitError::Execution("cosine retriever panicked".to_string()))?;
@@ -115,8 +116,7 @@ pub(crate) fn run_with_embedder(
         Ok::<_, OrbitError>((cosine?, bm25?))
     })?;
 
-    let mut candidates = reciprocal_rank_fusion(&cosine, &bm25);
-    apply_candidate_filters(&mut candidates, params.field.as_deref(), kind);
+    let candidates = reciprocal_rank_fusion(&cosine, &bm25);
     let task_hits = rollup_to_tasks(candidates, limit);
     let results = task_hits
         .into_iter()
@@ -146,17 +146,6 @@ pub(crate) fn run_with_embedder(
         .collect::<Result<Vec<_>, OrbitError>>()?;
 
     Ok(SemanticSearchResult { results, model_id })
-}
-
-pub(crate) fn apply_candidate_filters(
-    candidates: &mut Vec<FusedCandidate>,
-    field: Option<&str>,
-    kind: Option<&str>,
-) {
-    candidates.retain(|candidate| {
-        field.is_none_or(|field| candidate.field == field)
-            && kind.is_none_or(|kind| candidate.source_kind == kind)
-    });
 }
 
 pub(crate) fn truncate_snippet(snippet: &str) -> String {

--- a/crates/orbit-search/src/commands/tests/search.rs
+++ b/crates/orbit-search/src/commands/tests/search.rs
@@ -130,3 +130,48 @@ fn search_runs_both_retrievers_and_rolls_up_fields() {
     assert!(breakdown.bm25_rank.is_some());
     assert!(breakdown.cosine_rank.is_some());
 }
+
+#[test]
+fn field_filter_retrieves_title_hits_before_fusion() {
+    let store = VectorStore::open_in_memory().unwrap();
+    let embedder = KeywordEmbedder;
+
+    store
+        .index_task(
+            &task("BEST", "semantic design", "unrelated", "unrelated"),
+            &embedder,
+            false,
+        )
+        .unwrap();
+    for index in 0..50 {
+        store
+            .index_task(
+                &task(
+                    &format!("WEAK-{index}"),
+                    "semantic notes",
+                    "semantic design",
+                    "unrelated",
+                ),
+                &embedder,
+                false,
+            )
+            .unwrap();
+    }
+
+    let result = run_with_embedder(
+        &store,
+        &embedder,
+        SemanticSearchParams {
+            query: "semantic design".to_string(),
+            limit: 1,
+            field: Some("title".to_string()),
+            kind: Some("task".to_string()),
+            model: None,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.results.len(), 1);
+    assert_eq!(result.results[0].source_id, "BEST");
+    assert_eq!(result.results[0].best_field, "title");
+}

--- a/crates/orbit-search/src/vector/query/bm25.rs
+++ b/crates/orbit-search/src/vector/query/bm25.rs
@@ -18,6 +18,7 @@ pub fn bm25_top_k(
     store: &VectorStore,
     query: &str,
     kind: Option<&str>,
+    field: Option<&str>,
     limit: usize,
 ) -> Result<Vec<Bm25Hit>, OrbitError> {
     if query.trim().is_empty() || limit == 0 {
@@ -32,51 +33,29 @@ pub fn bm25_top_k(
     let fts_err =
         |error| crate::vector::store::schema::translate_corpus_fts_sql_error(&conn, error);
     let mut hits = Vec::new();
-    if let Some(kind) = kind {
-        let mut stmt = conn
-            .prepare(
-                r#"
-                    SELECT
-                        chunks.source_kind,
-                        chunks.source_id,
-                        chunks.field,
-                        chunks.id,
-                        bm25(corpus_fts) AS rank
-                    FROM corpus_fts
-                    JOIN chunks ON chunks.id = corpus_fts.rowid
-                    WHERE corpus_fts MATCH ?1 AND chunks.source_kind = ?2
-                    ORDER BY rank
-                    LIMIT ?3
-                "#,
-            )
-            .map_err(fts_err)?;
-        let mut rows = stmt
-            .query(params![match_query, kind, limit as i64])
-            .map_err(fts_err)?;
-        collect_hits(&mut rows, &mut hits)?;
-    } else {
-        let mut stmt = conn
-            .prepare(
-                r#"
-                    SELECT
-                        chunks.source_kind,
-                        chunks.source_id,
-                        chunks.field,
-                        chunks.id,
-                        bm25(corpus_fts) AS rank
-                    FROM corpus_fts
-                    JOIN chunks ON chunks.id = corpus_fts.rowid
-                    WHERE corpus_fts MATCH ?1
-                    ORDER BY rank
-                    LIMIT ?2
-                "#,
-            )
-            .map_err(fts_err)?;
-        let mut rows = stmt
-            .query(params![match_query, limit as i64])
-            .map_err(fts_err)?;
-        collect_hits(&mut rows, &mut hits)?;
-    }
+    let mut stmt = conn
+        .prepare(
+            r#"
+                SELECT
+                    chunks.source_kind,
+                    chunks.source_id,
+                    chunks.field,
+                    chunks.id,
+                    bm25(corpus_fts) AS rank
+                FROM corpus_fts
+                JOIN chunks ON chunks.id = corpus_fts.rowid
+                WHERE corpus_fts MATCH ?1
+                    AND (?2 IS NULL OR chunks.source_kind = ?2)
+                    AND (?3 IS NULL OR chunks.field = ?3)
+                ORDER BY rank
+                LIMIT ?4
+            "#,
+        )
+        .map_err(fts_err)?;
+    let mut rows = stmt
+        .query(params![match_query, kind, field, limit as i64])
+        .map_err(fts_err)?;
+    collect_hits(&mut rows, &mut hits)?;
     Ok(hits)
 }
 

--- a/crates/orbit-search/src/vector/query/cosine.rs
+++ b/crates/orbit-search/src/vector/query/cosine.rs
@@ -20,6 +20,7 @@ pub fn cosine_top_k(
     model_id: &str,
     limit: usize,
     kind: Option<&str>,
+    field: Option<&str>,
 ) -> Result<Vec<CosineHit>, OrbitError> {
     if query.is_empty() || limit == 0 {
         return Ok(Vec::new());
@@ -31,44 +32,25 @@ pub fn cosine_top_k(
         .map_err(|error| OrbitError::Store(format!("mutex poisoned: {error}")))?;
 
     let mut candidates = Vec::new();
-    if let Some(kind) = kind {
-        let mut stmt = conn
-            .prepare(
-                r#"
-                    SELECT source_kind, source_id, field, chunk_idx, embedding
-                    FROM embeddings
-                    WHERE model_id = ?1 AND source_kind = ?2
-                "#,
-            )
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
-        let mut rows = stmt
-            .query(params![model_id, kind])
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
-        while let Some(row) = rows
-            .next()
-            .map_err(|error| OrbitError::Store(error.to_string()))?
-        {
-            candidates.push(row_to_hit(row, query)?);
-        }
-    } else {
-        let mut stmt = conn
-            .prepare(
-                r#"
-                    SELECT source_kind, source_id, field, chunk_idx, embedding
-                    FROM embeddings
-                    WHERE model_id = ?1
-                "#,
-            )
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
-        let mut rows = stmt
-            .query(params![model_id])
-            .map_err(|error| OrbitError::Store(error.to_string()))?;
-        while let Some(row) = rows
-            .next()
-            .map_err(|error| OrbitError::Store(error.to_string()))?
-        {
-            candidates.push(row_to_hit(row, query)?);
-        }
+    let mut stmt = conn
+        .prepare(
+            r#"
+                SELECT source_kind, source_id, field, chunk_idx, embedding
+                FROM embeddings
+                WHERE model_id = ?1
+                    AND (?2 IS NULL OR source_kind = ?2)
+                    AND (?3 IS NULL OR field = ?3)
+            "#,
+        )
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    let mut rows = stmt
+        .query(params![model_id, kind, field])
+        .map_err(|error| OrbitError::Store(error.to_string()))?;
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| OrbitError::Store(error.to_string()))?
+    {
+        candidates.push(row_to_hit(row, query)?);
     }
 
     candidates.sort_by(compare_cosine_hits);

--- a/crates/orbit-search/src/vector/query/tests/bm25.rs
+++ b/crates/orbit-search/src/vector/query/tests/bm25.rs
@@ -28,7 +28,7 @@ fn bm25_top_k_ranks_lexical_matches() {
             .unwrap();
     }
 
-    let hits = bm25_top_k(&store, "neutrino", Some("task"), 3).unwrap();
+    let hits = bm25_top_k(&store, "neutrino", Some("task"), None, 3).unwrap();
 
     assert_eq!(hits[0].source_id, "T2");
     assert_eq!(hits[0].field, "purpose");
@@ -58,8 +58,8 @@ fn bm25_top_k_filters_by_source_kind() {
         )
         .unwrap();
 
-    let task_hits = bm25_top_k(&store, "neutrino", Some("task"), 10).unwrap();
-    let all_hits = bm25_top_k(&store, "neutrino", None, 10).unwrap();
+    let task_hits = bm25_top_k(&store, "neutrino", Some("task"), None, 10).unwrap();
+    let all_hits = bm25_top_k(&store, "neutrino", None, None, 10).unwrap();
 
     assert_eq!(task_hits.len(), 1);
     assert_eq!(task_hits[0].source_kind, "task");
@@ -101,7 +101,7 @@ fn bm25_multi_word_query_matches_non_adjacent_terms() {
             .unwrap();
     }
 
-    let hits = bm25_top_k(&store, "neutrino decay", Some("task"), 5).unwrap();
+    let hits = bm25_top_k(&store, "neutrino decay", Some("task"), None, 5).unwrap();
     assert_eq!(hits.len(), 1, "{hits:?}");
     assert_eq!(hits[0].source_id, "T1");
 }
@@ -156,7 +156,7 @@ fn bm25_and_snippets_survive_inline_to_external_content_migration() {
     }
 
     let store = VectorStore::open(&path).expect("open migrates layout");
-    let hits = bm25_top_k(&store, "neutrino", Some("task"), 5).expect("current bm25");
+    let hits = bm25_top_k(&store, "neutrino", Some("task"), None, 5).expect("current bm25");
     assert_eq!(hits.len(), 1, "{hits:?}");
     assert_eq!(hits[0].source_kind, "task");
     assert_eq!(hits[0].source_id, "T1");

--- a/crates/orbit-search/src/vector/query/tests/cosine.rs
+++ b/crates/orbit-search/src/vector/query/tests/cosine.rs
@@ -38,7 +38,7 @@ fn cosine_top_k_returns_expected_ordering_with_noop_vectors() {
         .unwrap();
 
     let query = embedder.embed(&["beta"]).unwrap().remove(0);
-    let hits = cosine_top_k(&store, &query, embedder.model_id(), 3, Some("task")).unwrap();
+    let hits = cosine_top_k(&store, &query, embedder.model_id(), 3, Some("task"), None).unwrap();
 
     assert_eq!(hits.len(), 3);
     assert_eq!(hits[0].source_id, "T2");

--- a/crates/orbit-search/src/vector/store/tests/upsert.rs
+++ b/crates/orbit-search/src/vector/store/tests/upsert.rs
@@ -160,7 +160,14 @@ fn inference_does_not_hold_store_mutex_or_sqlite_write_lock() {
     let query = noop.embed(&["beta"]).unwrap().remove(0);
     let store_for_query = store.clone();
     let hits = run_unblocked("query on shared store", move || {
-        cosine_top_k(&store_for_query, &query, noop.model_id(), 3, Some("task"))
+        cosine_top_k(
+            &store_for_query,
+            &query,
+            noop.model_id(),
+            3,
+            Some("task"),
+            None,
+        )
     });
     assert!(
         hits.iter().any(|hit| hit.source_id == "VISIBLE"),


### PR DESCRIPTION
## Task

[ORB-11706](https://orbit-cli.com/tasks/ORB-11706) — [code-review] Push the `field` filter into the retrievers instead of post-filtering the over-fetched top-K

### Description

## Problem
`run_with_embedder` fetches `limit × 4` cosine and BM25 hits across all fields, fuses them, and only then `apply_candidate_filters` drops candidates whose `field != params.field`. Both retrievers already accept `kind`, so the `kind` half of the post-filter is redundant, but the `field` half is lossy: with `--field title --limit 10`, the 40 fetched chunks are dominated by `description`/`body`/`plan` rows for any query that matches bodies well, and the title rows that would have ranked 41st+ are never seen, so the command returns fewer results than exist — or none — while an unfiltered search shows the same tasks. The result also depends on how many chunks the other fields have, so it is not stable across reindexes.

## Why It Matters
`--field` is a documented CLI/MCP parameter and silently returns wrong (incomplete) results.

## Proposed Fix
Add an optional `field` predicate to `cosine_top_k` and `bm25_top_k` (`AND field = ?`), pass `params.field` through from `run_with_embedder`, and delete `apply_candidate_filters` (or reduce it to a debug assertion).

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/commands/search.rs:88-120`, `crates/orbit-search/src/commands/search.rs:151-160`, `crates/orbit-search/src/vector/query/cosine.rs:17-80`, `crates/orbit-search/src/vector/query/bm25.rs:15-65`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (bug). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- Test: index 50 tasks whose descriptions match the query strongly and whose titles match weakly; `semantic_search(field="title", limit=1)` returns the best-title task rather than an empty list.
- Existing `commands/tests/search.rs` tests pass; `apply_candidate_filters` is removed or no longer reachable with `field`.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added optional `field` predicates to cosine and BM25 retrieval SQL, so candidate limits apply within the requested field.
- Passed the semantic-search field parameter into both retrievers and removed post-fusion `apply_candidate_filters`.
- Preserved other cosine consumers with an explicit unfiltered field argument and updated direct retriever tests/callers.
- Added a regression test indexing 50 strong-description/weak-title tasks and asserting title-filtered limit-one search returns the best title.
Assessment: Retrieval filtering now occurs at the authoritative query boundary, preventing cross-field top-K starvation.
Criteria evidence:
1. `field_filter_retrieves_title_hits_before_fusion` indexes 50 weak-title/strong-description tasks plus BEST and verifies a title-filtered limit-one query returns BEST.
2. `cargo test -p orbit-search commands::tests::search` passed (2 tests); `apply_candidate_filters` is removed.
Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-search commands::tests::search`.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `git diff --check`.
- Not passed (unrelated existing failure): full `cargo test -p orbit-search` ran 82 tests successfully and failed `commands::tests::install::companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout` twice with a localhost download request error; this test is outside the changed search path.
Risks: The full crate suite has the documented unrelated installer-test failure; required fast CI and workspace lint checks passed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11706-6a9f88c6`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra