### PR TITLE
[code-review] Return JSON `{error}` for every rejection and never surface a JSON parse error to the user

### DIFF
--- a/crates/orbit-web/assets/dashboard/common.js
+++ b/crates/orbit-web/assets/dashboard/common.js
@@ -419,7 +419,14 @@ export function requestJson(path, method, body) {
   }
   return fetch(withWorkspace(path), opts).then(async (res) => {
     const text = await res.text();
-    const body = text ? JSON.parse(text) : {};
+    let body = {};
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = { error: text };
+      }
+    }
     if (!res.ok) {
       throw new Error(body.error || `${path}: HTTP ${res.status}`);
     }

--- a/crates/orbit-web/src/api/automation.rs
+++ b/crates/orbit-web/src/api/automation.rs
@@ -1,10 +1,9 @@
 //! Immutable coverage evidence, scoped to the selected owner workspace.
 
-use super::{map_runtime_error, routines::OperationsQuery};
+use super::{bad_request, map_runtime_error, not_found, routines::OperationsQuery};
 use crate::state::DashboardState;
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
     response::{IntoResponse, Response},
 };
 
@@ -14,14 +13,14 @@ pub(super) async fn accepted_evidence(
     Path((kind, name, batch)): Path<(String, String, String)>,
 ) -> Response {
     let Some(workspace) = query.workspace.as_deref() else {
-        return (StatusCode::BAD_REQUEST, "select a workspace").into_response();
+        return bad_request("select a workspace".to_string());
     };
     if !matches!(kind.as_str(), "auto-task" | "routine") {
-        return StatusCode::NOT_FOUND.into_response();
+        return not_found("coverage evidence not found".to_string());
     }
     let runtime = match super::auto_tasks::resolve_workspace(&state, workspace) {
         Ok((_, runtime)) => runtime,
-        Err(reason) => return (StatusCode::NOT_FOUND, reason).into_response(),
+        Err(reason) => return not_found(reason),
     };
     let result = (|| {
         let consumer = orbit_core::application::automation::consumer_key(&runtime, &kind, &name)?;
@@ -35,7 +34,7 @@ pub(super) async fn accepted_evidence(
             receipt.evidence,
         )
             .into_response(),
-        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Ok(None) => not_found("coverage evidence not found".to_string()),
         Err(error) => map_runtime_error(error),
     }
 }

--- a/crates/orbit-web/src/api/mod.rs
+++ b/crates/orbit-web/src/api/mod.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 use axum::Router;
-use axum::body::Body;
+use axum::body::{Body, to_bytes};
 use axum::http::uri::Authority;
 use axum::http::{Method, Request, StatusCode, header};
 use axum::middleware::{self, Next};
@@ -371,6 +371,35 @@ pub(super) fn server_error(e: orbit_core::OrbitError) -> Response {
         .into_response()
 }
 
+/// Normalize framework-generated client errors to the dashboard's JSON error
+/// contract. Extractor rejections occur before handlers run, so this boundary
+/// covers every route without repeating rejection handling in each handler.
+async fn json_client_error(response: Response) -> Response {
+    if !response.status().is_client_error()
+        || response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .is_some_and(|value| value.as_bytes().starts_with(b"application/json"))
+    {
+        return response;
+    }
+
+    let (parts, body) = response.into_parts();
+    let message = match to_bytes(body, 64 * 1024).await {
+        Ok(body) => String::from_utf8_lossy(&body).into_owned(),
+        Err(error) => format!("failed to read error response: {error}"),
+    };
+    let mut json_response = (parts.status, Json(json!({ "error": message }))).into_response();
+
+    for (name, value) in &parts.headers {
+        if name != header::CONTENT_TYPE {
+            json_response.headers_mut().insert(name, value.clone());
+        }
+    }
+
+    json_response
+}
+
 /// Run a blocking runtime call on the blocking pool instead of the async
 /// worker that is serving the request.
 ///
@@ -557,6 +586,7 @@ pub(super) fn router() -> Router<crate::state::DashboardState> {
             get(diagnostics::diagnostics_implement_one),
         )
         .route("/diagnostics/denials", get(denials::list_denials))
+        .layer(middleware::map_response(json_client_error))
         .layer(middleware::from_fn(require_localhost_origin))
 }
 

--- a/crates/orbit-web/src/api/tests/handlers.rs
+++ b/crates/orbit-web/src/api/tests/handlers.rs
@@ -393,6 +393,36 @@ async fn patch_task_crew_null_clears_stale_explicit_crew_to_default() {
 }
 
 #[tokio::test]
+async fn extractor_rejections_return_json_errors() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+
+    let response =
+        patch_task_body(runtime.clone(), "ORB-invalid", r#"{"crew":5}"#.to_string()).await;
+    assert!(response.status().is_client_error());
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/json")
+    );
+    assert!(body_json(response).await["error"].is_string());
+
+    let response = router()
+        .with_state(crate::state::DashboardState::single(Arc::new(runtime)))
+        .oneshot(
+            Request::builder()
+                .uri("/log?limit=abc")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert!(response.status().is_client_error());
+    assert!(body_json(response).await["error"].is_string());
+}
+
+#[tokio::test]
 async fn crews_endpoint_returns_sorted_runtime_registry() {
     let (_root, runtime) = runtime_with_custom_crews();
 


### PR DESCRIPTION
## Task

[ORB-11659](https://orbit-cli.com/tasks/ORB-11659) — [code-review] Return JSON `{error}` for every rejection and never surface a JSON parse error to the user

### Description

## Problem
`requestJson` does `JSON.parse(text)` on every response. Axum's built-in extractor rejections (`Json<T>` body errors -> 400/415/422, `Query<T>` -> 400, `Path` -> 400) return `text/plain` bodies, and `automation::accepted_evidence` returns plain-text 400/404 too; only `create_friction_action` maps `JsonRejection` to `{error}`. So a dashboard PATCH that trips deserialisation (e.g. `crew` set to a number by a client, or `?limit=abc`) shows `Unexpected token 'F', "Failed to d"... is not valid JSON` next to the control instead of the server's message, and API consumers get two error shapes.

## Why It Matters
The error contract is documented as `{ "error": ... }` and the dashboard and bridge both key on it.

## Proposed Fix
Client: fall back to the raw text (`body = { error: text }`) when parsing fails. Server: add a crate-local `Json`/`Query` wrapper (or `axum::extract::WithRejection`) that maps rejections through `bad_request`, and convert the plain-text responses in `automation.rs` to `bad_request`/`not_found`.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-web/assets/dashboard/common.js:256-274`, `crates/orbit-web/src/api/automation.rs:19,31,35`, `crates/orbit-web/src/api/frictions.rs:196-203`, `crates/orbit-web/src/api/mod.rs:401-535`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: medium (ux). Review area: web.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `curl -X PATCH -H 'content-type: application/json' -d '{"crew":5}' /api/tasks/<id>` returns a JSON `{error: ...}` body with status 4xx.
- `GET /api/log?limit=abc` returns JSON `{error}`.
- A test in `api/tests/handlers.rs` asserts `content-type: application/json` on an extractor rejection.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Normalized non-JSON 4xx responses at the API router boundary to the documented JSON `{error}` contract, covering Axum extractor rejections without per-handler duplication.
- Converted automation coverage-evidence 400/404 branches to the shared JSON error helpers.
- Made dashboard `requestJson` expose raw non-JSON error text instead of a JSON parsing exception.
- Added handler coverage for malformed PATCH JSON (`crew: 5`) and malformed `/log?limit=abc`, including `content-type: application/json`.

Criteria evidence:
1. The malformed PATCH handler test receives a client-error response, JSON content type, and string `error`.
2. The malformed log query in the same test receives a client-error JSON `error`.
3. The handler test explicitly asserts `content-type` is `application/json` for the extractor rejection.

Validation:
- `cargo fmt --check`: passed.
- `cargo test -p orbit-web extractor_rejections_return_json_errors --lib`: passed (1 test).
- `cargo test -p orbit-web --lib`: failed: 371 passed, 1 unrelated existing health test failed (`tests::health::detailed_healthz_fails_when_store_db_is_broken` expected 503, got 200); the new extractor test passed.
- `make ci-fast`: passed.
- `make ci-lint`: passed.
- `git diff --check`: passed.

Assessment: focused shared-boundary implementation; no known task-specific risk. The full orbit-web lib suite has the unrelated health-test failure noted above.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11659-6a9f882e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra