### PR TITLE
test: isolate worker read counters by owning database [ORB-11797]

### DIFF
--- a/crates/orbit-core/src/application/job/pipeline.rs
+++ b/crates/orbit-core/src/application/job/pipeline.rs
@@ -1442,7 +1442,7 @@ impl OrbitRuntime {
         let mut claimed = false;
         loop {
             #[cfg(test)]
-            worker_observer_read_counter::record(run_id);
+            worker_observer_read_counter::record(self, run_id);
             let run = self
                 .get_job_run_backend(run_id)?
                 .ok_or_else(|| OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string()))?;
@@ -1488,7 +1488,7 @@ impl OrbitRuntime {
                 // ownership, cancellation, and terminal outcomes stay
                 // authoritative.
                 #[cfg(test)]
-                worker_observer_read_counter::record(run_id);
+                worker_observer_read_counter::record(self, run_id);
                 let run = self.get_job_run_backend(run_id)?.ok_or_else(|| {
                     OrbitError::not_found(NotFoundKind::JobRun, run_id.to_string())
                 })?;
@@ -2144,30 +2144,43 @@ pub(crate) mod worker_command_override {
 #[cfg(test)]
 pub(crate) mod worker_observer_read_counter {
     use std::collections::HashMap;
+    use std::path::PathBuf;
     use std::sync::{LazyLock, Mutex};
 
-    static COUNTS: LazyLock<Mutex<HashMap<String, usize>>> =
+    use crate::OrbitRuntime;
+
+    type StoreRun = (PathBuf, String);
+
+    static COUNTS: LazyLock<Mutex<HashMap<StoreRun, usize>>> =
         LazyLock::new(|| Mutex::new(HashMap::new()));
 
     pub(crate) struct Counter {
-        run_id: String,
+        key: StoreRun,
     }
 
-    pub(crate) fn track(run_id: &str) -> Counter {
+    fn key(runtime: &OrbitRuntime, run_id: &str) -> StoreRun {
+        // Run IDs are local to a database. Its resolved path remains stable
+        // across runtime clones while isolating independent temporary stores.
+        (
+            runtime.context.persistence().audit_db.clone(),
+            run_id.to_string(),
+        )
+    }
+
+    pub(crate) fn track(runtime: &OrbitRuntime, run_id: &str) -> Counter {
+        let key = key(runtime, run_id);
         COUNTS
             .lock()
             .expect("test observer counters are not poisoned")
-            .insert(run_id.to_string(), 0);
-        Counter {
-            run_id: run_id.to_string(),
-        }
+            .insert(key.clone(), 0);
+        Counter { key }
     }
 
-    pub(crate) fn record(run_id: &str) {
+    pub(crate) fn record(runtime: &OrbitRuntime, run_id: &str) {
         if let Some(count) = COUNTS
             .lock()
             .expect("test observer counters are not poisoned")
-            .get_mut(run_id)
+            .get_mut(&key(runtime, run_id))
         {
             *count += 1;
         }
@@ -2178,7 +2191,7 @@ pub(crate) mod worker_observer_read_counter {
             *COUNTS
                 .lock()
                 .expect("test observer counters are not poisoned")
-                .get(&self.run_id)
+                .get(&self.key)
                 .expect("tracked observer counter exists")
         }
     }
@@ -2188,7 +2201,7 @@ pub(crate) mod worker_observer_read_counter {
             COUNTS
                 .lock()
                 .expect("test observer counters are not poisoned")
-                .remove(&self.run_id);
+                .remove(&self.key);
         }
     }
 }

--- a/crates/orbit-core/src/application/tests/job_pipeline.rs
+++ b/crates/orbit-core/src/application/tests/job_pipeline.rs
@@ -320,6 +320,36 @@ fn routine_style_detached_worker_is_claimed_within_ownership_window() {
     assert_child_reaped(worker_pid);
 }
 
+#[test]
+fn observer_read_counts_isolate_identical_run_ids_in_independent_stores() {
+    let (_first_root, first) = test_runtime();
+    let (_second_root, second) = test_runtime();
+    let run = first
+        .stores()
+        .jobs()
+        .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
+        .expect("insert fixture run");
+    // Deliberately use the same ID for both stores, independent of allocator
+    // timing, to reproduce cross-test counter collisions deterministically.
+    let first_count = worker_observer_read_counter::track(&first, &run.run_id);
+    let second_count = worker_observer_read_counter::track(&second, &run.run_id);
+
+    worker_observer_read_counter::record(&first.clone(), &run.run_id);
+    assert_eq!(first_count.reads(), 1, "runtime clones share the counter");
+    assert_eq!(second_count.reads(), 0, "another database is isolated");
+
+    worker_observer_read_counter::record(&second, &run.run_id);
+    assert_eq!(first_count.reads(), 1);
+    assert_eq!(second_count.reads(), 1);
+    drop(first_count);
+    worker_observer_read_counter::record(&second, &run.run_id);
+    assert_eq!(
+        second_count.reads(),
+        2,
+        "dropping another store keeps this counter"
+    );
+}
+
 /// Once a worker has claimed the run, the startup observer waits for its exit
 /// instead of polling the run row for the rest of the worker lifetime.
 #[cfg(unix)]
@@ -332,7 +362,7 @@ fn claimed_sleeping_worker_does_not_keep_polling_the_run_store() {
         .jobs()
         .insert_job_run("task_gate_pipeline", 1, Utc::now(), None, None)
         .expect("insert pending run");
-    let observer_reads = worker_observer_read_counter::track(&run.run_id);
+    let observer_reads = worker_observer_read_counter::track(&runtime, &run.run_id);
     let command = worker_command_override::command(&runtime.paths().repo_root, &run.run_id)
         .expect("build sleeping worker command");
     let log_path = pipeline_worker_log_path(&runtime.paths().logs_dir, &run.run_id);


### PR DESCRIPTION
The worker polling regression test counted reads globally by run ID. Independent temporary databases can allocate the same ID, so another parallel test's observer inflated the measured reads and failed the existing one-read bound.

Scope the test-only counter to the resolved owning database path and run ID. Runtime clones keep sharing their counter, while independent stores and counter lifetimes are isolated. Add a deterministic two-store/same-ID regression. Production polling and ID generation are unchanged, and the existing read bound is preserved.

Validation on native macOS: worker pipeline suite passed all 21 tests, including the original bounded-read test and deterministic store-isolation regression; `make ci-fast` and full `make ci-lint` passed. Logs confirm compilation and lint of this worktree, with changed source mtimes refreshed before using the shared target. Compiler-cache namespace coverage explicitly skips without Bubblewrap.

Task: ORB-11797. Repairs the counter isolation introduced by ORB-11602 / PR #1603.
