### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### DIFF
--- a/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
+++ b/crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs
@@ -385,9 +385,15 @@ fn workspace_auto_fails_promptly_when_leaf_dispatch_has_no_durable_child() {
 
 #[test]
 fn workspace_auto_preserves_concrete_workspace_step_failure() {
-    let (_root, runtime, repo_root, global_root) = test_runtime();
+    let (root, runtime, repo_root, global_root) = test_runtime();
     seed_default_catalogs(&global_root);
     let host = ScriptedWorkspaceAutoHost::new(&runtime, WorkspaceAutoScenario::ClassifierFailure);
+    let run_id = root
+        .path()
+        .file_name()
+        .expect("test tempdir has a final path component")
+        .to_string_lossy()
+        .into_owned();
 
     let err = try_execute_named_job(
         &runtime,
@@ -395,7 +401,7 @@ fn workspace_auto_preserves_concrete_workspace_step_failure() {
         &host,
         "workspace_auto_pipeline",
         json!({"max_tasks": 50, "for_seconds": 0, "idle_sleep_seconds": 0}),
-        "jrun-workspace-auto-classifier-failure",
+        &run_id,
     )
     .expect_err("workspace-level deterministic failure must fail the drain");
 


### PR DESCRIPTION
## Task

[ORB-11781](https://orbit-cli.com/tasks/ORB-11781) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/workspace_a…

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#168`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `a93caa13890764380e184d996fa709b1bcbe278c`
- Location: `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 392
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/168

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/workspace_auto_pipeline.rs` line 392 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated `workspace_auto_preserves_concrete_workspace_step_failure` to derive its run ID from the test runtime's unique temporary root instead of passing the fixed `jrun-workspace-auto-classifier-failure` string.
- The classifier-failure scenario and assertions remain unchanged; only the run-ID source changed to remove the hard-coded value used by the engine's retry-jitter salt path.

Assessment: Minimal, task-scoped fix matching the neighboring test fixture pattern. The test still exercises and preserves the concrete workspace-step failure behavior.

Criteria evidence:
1. Remediated the CodeQL hard-coded cryptographic value finding with a real code change in the affected file; no suppression, dismissal, or exclusion was added.
2. The test still invokes `workspace_auto_pipeline`, expects the classifier failure, verifies the failure message and single classifier call, and verifies no detached child dispatch.
3. `cargo test -p orbit-core application::job::tests::workspace_auto_pipeline::workspace_auto_preserves_concrete_workspace_step_failure -- --exact` passed (1 test). `make ci-fast` passed, including formatting and repository guardrails; its compiler-cache namespace subcheck reported an environment skip because unprivileged namespaces are unavailable. `make ci-lint` passed (workspace clippy with `-D warnings`). `make audit` initially failed because the shared advisory database lock was on a read-only path; the equivalent full `cargo deny check --disable-fetch` passed using a writable task-scoped Cargo home, with advisories, bans, licenses, and sources all OK. A final source scan confirmed the fixed run-ID literal is absent. Direct GitHub CodeQL alert recheck was not run because the task bounds state that agent-side GitHub access is not required and no local `codeql` executable is available.
Validation:
- Passed: targeted Orbit Core regression test.
- Passed: `make ci-fast`.
- Passed: `make ci-lint`.
- Passed: `cargo deny check --disable-fetch` with a writable task-scoped Cargo home.
- Passed: `git diff --check`; final status contains only the intended source file.
- Not run: direct remote CodeQL rescan; unavailable within the stated collection bounds.
Risks / deviations:
- The remote alert's post-rescan state remains for CI/GitHub CodeQL to verify; local evidence shows the flagged fixed literal/data flow is removed.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11781-6a9f8991`
- Behind base: 0
- Ahead of base: 1