### PR TITLE
[code-review] Bound stalled companion downloads without restoring a whole-request deadline

### DIFF
--- a/crates/orbit-search/src/commands/install.rs
+++ b/crates/orbit-search/src/commands/install.rs
@@ -37,6 +37,9 @@ use crate::{CompanionPaths, platform_companion_filename};
 const COMPANION_URL_ENV: &str = "ORBIT_SEARCH_COMPANION_URL";
 const COMPANION_SHA256_ENV: &str = "ORBIT_SEARCH_COMPANION_SHA256";
 const COMPANION_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Longest silence tolerated on an accepted companion connection. This is an
+/// idle bound, not a transfer deadline: see [`companion_download_client`].
+pub(crate) const COMPANION_STALLED_READ_TIMEOUT: Duration = Duration::from_secs(30);
 const CHECKSUM_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
@@ -238,12 +241,20 @@ fn validate_download_url(url: &str) -> Result<(), OrbitError> {
     Ok(())
 }
 
-fn companion_download_client() -> Result<Client, OrbitError> {
+/// Builds the companion download client.
+///
+/// Companion assets are large enough that a whole-request deadline rejects
+/// healthy slow links, so the client carries no transfer deadline. reqwest's
+/// blocking client re-arms `timeout` for every individual operation — the send
+/// phase, then each [`std::io::Read::read`] on the streamed response — so the
+/// bound below only fires when a connection goes silent, and resets after each
+/// chunk that arrives. Reading a companion body must therefore stay on the
+/// streaming loop in [`download_companion_to_temp`]; the buffering accessors
+/// (`Response::bytes`, `text`, `json`) apply the same value once to the whole
+/// body, which is exactly the total deadline this must not reintroduce.
+pub(crate) fn companion_download_client() -> Result<Client, OrbitError> {
     Client::builder()
-        // Companion assets are large enough that a whole-request deadline
-        // rejects healthy slow links. A bounded connection phase still avoids
-        // waiting indefinitely for an unreachable server.
-        .timeout(None)
+        .timeout(COMPANION_STALLED_READ_TIMEOUT)
         .connect_timeout(COMPANION_CONNECT_TIMEOUT)
         .build()
         .map_err(|error| {
@@ -251,7 +262,7 @@ fn companion_download_client() -> Result<Client, OrbitError> {
         })
 }
 
-fn download_companion_to_temp(
+pub(crate) fn download_companion_to_temp(
     client: &Client,
     url: &str,
     temp_path: &Path,

--- a/crates/orbit-search/src/commands/tests/install.rs
+++ b/crates/orbit-search/src/commands/tests/install.rs
@@ -8,8 +8,9 @@
 )))]
 use super::super::install::path_execution_fallback_rationale;
 use super::super::install::{
-    CompanionIntegrity, CompanionLaunchMode, ManagedCompanion, SemanticInstallParams,
-    checksum_from_manifest, companion_launch_mode, default_release_download_source,
+    COMPANION_STALLED_READ_TIMEOUT, CompanionIntegrity, CompanionLaunchMode, ManagedCompanion,
+    SemanticInstallParams, checksum_from_manifest, companion_download_client,
+    companion_launch_mode, default_release_download_source, download_companion_to_temp,
     install_companion_to_temp, run, sha256_hex,
 };
 
@@ -19,7 +20,7 @@ use crate::companion::{
     ensure_semantic_search_supported_for_platform, unsafe_companion_overrides_enabled,
 };
 use crate::{CompanionPaths, locate_companion, platform_companion_filename};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::thread;
@@ -49,7 +50,7 @@ fn companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeou
 
     assert!(
         started.elapsed() > Duration::from_secs(35),
-        "the fixture must exceed reqwest's former 30-second whole-request timeout"
+        "the fixture must outlast the idle bound so only a total deadline could reject it"
     );
     assert_eq!(actual_checksum, checksum);
     assert_eq!(
@@ -57,6 +58,37 @@ fn companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeou
             .expect("download metadata")
             .len(),
         1024 * 1024
+    );
+}
+
+#[test]
+fn companion_download_bounds_a_stalled_response_after_partial_progress() {
+    let _guard = EnvGuard::new();
+    let temp = tempdir().expect("tempdir");
+    let url = serve_stalled_response();
+
+    set_env("NO_PROXY", "127.0.0.1,localhost");
+    set_env("no_proxy", "127.0.0.1,localhost");
+
+    let client = companion_download_client().expect("configure companion download");
+    let started = Instant::now();
+    let error = download_companion_to_temp(&client, &url, &temp.path().join("companion"))
+        .expect_err("a response that stops sending body bytes must not block forever");
+    let elapsed = started.elapsed();
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to read companion download"),
+        "{error}"
+    );
+    assert!(
+        elapsed >= COMPANION_STALLED_READ_TIMEOUT,
+        "the reads that did succeed must not count against the idle bound; failed after {elapsed:?}"
+    );
+    assert!(
+        elapsed < COMPANION_STALLED_READ_TIMEOUT * 3,
+        "the stalled read must fail near {COMPANION_STALLED_READ_TIMEOUT:?}; took {elapsed:?}"
     );
 }
 
@@ -85,12 +117,15 @@ fn companion_install_reports_a_dead_connection() {
     );
 }
 
+/// Serves `body` in 64 KiB chunks separated by `delay_between_chunks`, so the
+/// whole transfer takes far longer than any single quiet period.
 fn serve_throttled_response(body: Vec<u8>, delay_between_chunks: Duration) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind throttled HTTP server");
     let address = listener.local_addr().expect("throttled server address");
 
     thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("accept companion download");
+        consume_request_head(&mut stream);
         std::io::Write::write_all(
             &mut stream,
             format!(
@@ -110,6 +145,55 @@ fn serve_throttled_response(body: Vec<u8>, delay_between_chunks: Duration) -> St
     });
 
     format!("http://{address}/companion")
+}
+
+/// Serves response headers and one 64 KiB chunk of a body that promises one
+/// more byte, then holds the socket open without ever sending it. The client
+/// must therefore observe a stalled read rather than a premature EOF.
+fn serve_stalled_response() -> String {
+    const DELIVERED_PREFIX: usize = 64 * 1024;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalled HTTP server");
+    let address = listener.local_addr().expect("stalled server address");
+
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept companion download");
+        consume_request_head(&mut stream);
+        std::io::Write::write_all(
+            &mut stream,
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                DELIVERED_PREFIX + 1
+            )
+            .as_bytes(),
+        )
+        .expect("write response headers");
+        std::io::Write::write_all(&mut stream, &vec![b'x'; DELIVERED_PREFIX])
+            .expect("write partial response body");
+
+        // Outlast the assertion window by a wide margin: an unbounded client
+        // must be seen hanging, not rescued by the fixture closing the socket.
+        thread::sleep(COMPANION_STALLED_READ_TIMEOUT * 6);
+    });
+
+    format!("http://{address}/companion")
+}
+
+/// Reads and discards the request head so a fixture responds only after the
+/// client has finished sending its request. hyper rejects a response that
+/// overlaps the request it is still writing (`UnexpectedMessage`), which makes
+/// an eager fixture fail the exchange at random (ORB-11761).
+fn consume_request_head(stream: &mut TcpStream) {
+    let mut head = Vec::new();
+    let mut byte = [0; 1];
+
+    while !head.ends_with(b"\r\n\r\n") {
+        match std::io::Read::read(stream, &mut byte) {
+            Ok(0) => break,
+            Ok(_) => head.push(byte[0]),
+            Err(error) => panic!("read companion request head: {error}"),
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Task

[ORB-11761](https://orbit-cli.com/tasks/ORB-11761) — [code-review] Bound stalled companion downloads without restoring a whole-request deadline

### Description

## Problem

The companion download client disables the total request timeout and configures only a connect timeout. Once a server accepts the connection, a response that stops producing body bytes can block `response.read` forever. The slow-link fix correctly removed the 30-second whole-request deadline, but it also removed the only bound on an already-connected, stalled transfer.

## Evidence

- `crates/orbit-search/src/commands/install.rs:241-248` builds the shared client with `.timeout(None)` and `.connect_timeout(...)`, but no per-read timeout.
- `crates/orbit-search/src/commands/install.rs:259-280` synchronously loops over `response.read` until EOF, so a server that sends headers or a partial body and then stalls never returns from semantic installation.
- The vendored reqwest 0.12.28 `ClientBuilder::read_timeout` contract states that the timeout applies to each read and resets after every successful read, which preserves arbitrarily slow progressing downloads while bounding stalled connections.

## Impact

`orbit semantic install` can hang indefinitely against a broken proxy, CDN, or accepted connection that stops responding. This is an availability and first-run UX regression introduced while fixing the former total-download timeout.

## Constraints

Keep the streamed constant-memory path and do not restore a total request deadline. Apply the idle bound only where it preserves the intentionally short checksum metadata deadlines.

### Acceptance Criteria

- The companion asset request has a bounded idle/read timeout that resets after successful reads while retaining no whole-request deadline.
- A local HTTP regression proves that a continuously progressing transfer may exceed the old 30-second total deadline, while a response that sends headers or a partial body and then stalls fails within the configured idle bound.
- `make ci-fast` and `make ci-lint` pass.

## Execution Summary

<details>
<summary>Click to expand</summary>

## Outcome

Restored a bounded idle timeout on the companion download client and fixed the flaky
local HTTP fixture that produced the hosted failure in CI 34181888819.

## Root cause of the hosted failure (comment 3)

The panic in `companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout`
was **not** caused by the missing idle bound. Reproduced locally (~50% of isolated runs, and
2/2 on a clean checkout of HEAD with the full crate suite). Printing `{error:?}` instead of
`{error}` exposed the real source:

    reqwest::Error { kind: Request, url: "http://127.0.0.1:.../companion",
      source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(UnexpectedMessage)) }

`serve_throttled_response` wrote response headers immediately on `accept()` without reading the
request. hyper's h1 client rejects a response that overlaps the request it is still writing, so
the exchange failed at random. It is a test-fixture race in request/setup, not body idle
behaviour. Fixed by draining the request head (`consume_request_head`) before responding.

## Implementation

`crates/orbit-search/src/commands/install.rs`
- New `COMPANION_STALLED_READ_TIMEOUT` (30s); `companion_download_client()` sets
  `.timeout(COMPANION_STALLED_READ_TIMEOUT)` in place of `.timeout(None)`.
- The task description proposed `ClientBuilder::read_timeout`. That method does **not** exist on
  reqwest's *blocking* builder (async only). It is not needed: reqwest 0.12.28's blocking client
  re-arms `timeout` per operation — `ClientHandle::execute_request` for the send phase and
  `impl Read for blocking::Response` (`src/blocking/response.rs:439`) for **each** `read()` call,
  passing the duration freshly every time. On the existing streaming `Read` loop that is exactly
  an idle bound that resets after every successful read, with no whole-request deadline. The
  30s value only becomes a total deadline via the buffering accessors (`bytes`/`text`/`json`);
  the doc comment on `companion_download_client` records that constraint next to the code.
- Checksum manifest/signature requests keep their per-request `CHECKSUM_METADATA_TIMEOUT`, which
  overrides the client value, so those short metadata deadlines are unchanged.
- `companion_download_client` / `download_companion_to_temp` widened to `pub(crate)` so the
  regression test can drive the real production client directly.

`crates/orbit-search/src/commands/tests/install.rs`
- `consume_request_head()` helper; `serve_throttled_response` now uses it.
- New `serve_stalled_response()`: sends headers plus 64 KiB of a body that promises one more
  byte, then holds the socket open for 3 minutes without sending it.
- New test `companion_download_bounds_a_stalled_response_after_partial_progress`: asserts the
  download fails with `failed to read companion download` after >= 30s (proving earlier
  successful reads did not count against the bound) and well under 90s.

## Acceptance criteria

1. **Bounded idle/read timeout that resets after successful reads, no whole-request deadline** —
   met. `.timeout(COMPANION_STALLED_READ_TIMEOUT)` is applied per operation by the blocking
   client, and the streamed `Read` loop is preserved, so total transfer time stays unbounded.
2. **Local HTTP regression proving both behaviours** — met.
   - Continuously progressing transfer exceeding 30s:
     `companion_install_streams_a_slow_one_mebibyte_download_without_a_total_timeout` still
     asserts elapsed > 35s and now passes 10/10 isolated repeats (was flaky before the fixture
     fix) and 5/5 full-suite runs.
   - Stalled transfer: the new test fails in 30s. Negative control — reverting the client to
     `.timeout(None)` makes it fail with `took 180.00898964s`, i.e. it only unblocked when the
     fixture closed the socket.
3. **`make ci-fast` and `make ci-lint`** — both exit 0.

## Validation (all commands run in this worktree)

| Command | Outcome |
| --- | --- |
| `make ci-fast` | passed (exit 0) |
| `make ci-lint` | passed (exit 0) |
| `cargo test -p orbit-search --lib` x3 | passed, 83/83 each |
| `cargo test -p orbit-search` (all targets) x2 | passed, 83 + 1 + 2 each |
| isolated repeat: slow-download test x10 | passed 10/10 |
| baseline control: HEAD content, `cargo test -p orbit-search` x2 | slow-download test FAILED 2/2 with the hosted error, confirming the pre-existing fixture race |
| negative control: `.timeout(None)` + new stall test | FAILED after 180s, confirming the test detects a missing idle bound |

Not run: `make ci` (workspace policy defers the full gate to CI); macOS/Windows behaviour is not
exercised — the fixture and client paths are OS-independent, but that is indirect evidence only.

## Risks / notes

- One transient full-suite run showed 3 unrelated `tests::subprocess::fake_companion` failures
  (millisecond-budget subprocess timing tests) on this shared, loaded box. They passed in
  isolation and in all 5 subsequent full runs, and did not appear in the HEAD baseline runs
  either; treated as ambient load flake, not a regression from this change.
- Cost: the new stall test adds ~30s to the `orbit-search` lib binary, serialized behind the
  existing `EnvGuard` with the 36s slow-download test (binary goes ~36s -> ~66s). It takes the
  guard only to pin `NO_PROXY`, matching the existing test. Kept deliberately so the shipped
  30s constant itself is exercised rather than a shorter test-only bound.
- Friction filed: F2026-09-078 (reqwest blocking `timeout` is per-operation; eager test HTTP
  fixtures trigger hyper `UnexpectedMessage`).
- Scope: only the two declared `context_files` were changed; no selectors added.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11761-6a9f7f28`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra