### PR TITLE
fix: probe current database write readiness without repair [ORB-11798]

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -183,8 +183,7 @@ impl DoctorCommands for OrbitRuntime {
     }
 
     fn health_check_store_writable(&self) -> Result<String, OrbitError> {
-        let store = self.sqlite_store()?;
-        store.check_writable()?;
+        self.check_sqlite_store_writable()?;
         Ok("store database accepts writes".to_string())
     }
 }

--- a/crates/orbit-core/src/runtime/mod.rs
+++ b/crates/orbit-core/src/runtime/mod.rs
@@ -421,6 +421,12 @@ impl OrbitRuntime {
         Store::open_read_only(&self.context.persistence().audit_db)
     }
 
+    /// Check write readiness at the configured path without recreating or
+    /// migrating the database, independently of cached runtime connections.
+    pub fn check_sqlite_store_writable(&self) -> Result<(), OrbitError> {
+        Store::check_path_writable(&self.context.persistence().audit_db)
+    }
+
     pub fn v2_audit_store(
         &self,
     ) -> Result<Arc<dyn orbit_store::contracts::V2AuditStoreBackend>, OrbitError> {

--- a/crates/orbit-store/src/driver/sqlite/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/connection.rs
@@ -254,6 +254,17 @@ impl Store {
         )))
     }
 
+    /// Probe the current database path without creating or migrating it.
+    /// A fresh read-write connection detects replaced paths and must acquire
+    /// the write lock; cached handles and read-only opens cannot prove readiness.
+    pub fn check_path_writable(path: &Path) -> Result<(), OrbitError> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        conn.busy_timeout(std::time::Duration::from_secs(1))
+            .map_err(|error| OrbitError::Store(error.to_string()))?;
+        check_connection_writable(&conn)
+    }
+
     /// Prove the database accepts writes without mutating it: acquire the
     /// write lock via `BEGIN IMMEDIATE`, then roll back. Fails when the
     /// database file (or its WAL sidecars) is not writable, or when the
@@ -263,7 +274,11 @@ impl Store {
             .conn
             .lock()
             .map_err(|e| OrbitError::Store(format!("mutex poisoned: {e}")))?;
-        conn.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
-            .map_err(|e| OrbitError::Store(format!("write probe failed: {e}")))
+        check_connection_writable(&conn)
     }
+}
+
+fn check_connection_writable(conn: &Connection) -> Result<(), OrbitError> {
+    conn.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
+        .map_err(|error| OrbitError::Store(format!("write probe failed: {error}")))
 }

--- a/crates/orbit-store/src/driver/sqlite/tests/connection.rs
+++ b/crates/orbit-store/src/driver/sqlite/tests/connection.rs
@@ -35,6 +35,40 @@ fn check_writable_acquires_and_releases_write_lock() {
 }
 
 #[test]
+fn path_write_probe_does_not_create_or_migrate_databases() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("probe.db");
+    assert!(Store::check_path_writable(&path).is_err());
+    assert!(!path.exists(), "probe must not create a missing database");
+
+    let conn = rusqlite::Connection::open(&path).expect("create plain database");
+    conn.execute_batch("CREATE TABLE sentinel(value INTEGER); INSERT INTO sentinel VALUES (7);")
+        .expect("create existing data");
+    Store::check_path_writable(&path).expect("existing writable database passes");
+    let tables: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count tables after probe");
+    assert_eq!(tables, 1, "probe must not apply Orbit migrations");
+    let value: i64 = conn
+        .query_row("SELECT value FROM sentinel", [], |row| row.get(0))
+        .expect("read unchanged data");
+    assert_eq!(value, 7);
+
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .expect("hold write lock");
+    assert!(
+        Store::check_path_writable(&path).is_err(),
+        "probe must acquire actual write access"
+    );
+    conn.execute_batch("ROLLBACK").expect("release write lock");
+    Store::check_path_writable(&path).expect("probe succeeds after write lock release");
+}
+
+#[test]
 fn transaction_and_read_callbacks_expose_scoped_sql_connections() {
     let store = Store::open_in_memory().expect("open in-memory store");
     store

--- a/crates/orbit-web/src/tests/health.rs
+++ b/crates/orbit-web/src/tests/health.rs
@@ -87,6 +87,26 @@ async fn detailed_healthz_fails_when_store_db_is_broken() {
 }
 
 #[tokio::test]
+async fn detailed_healthz_does_not_recreate_a_missing_store_db() {
+    let runtime = OrbitRuntime::in_memory().expect("build runtime");
+    let db_path = runtime.global_root().join("orbit.db");
+    std::fs::remove_file(&db_path).expect("remove store db");
+    let state = DashboardState::single(Arc::new(runtime));
+    let log_dir = tempfile::tempdir().expect("tempdir");
+
+    let response = detailed_response(&state, Ok(log_dir.path().join("orbit.jsonl"))).await;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        check(&body_json(response).await, "sqlite_writable")["status"],
+        "fail"
+    );
+    assert!(
+        !db_path.exists(),
+        "readiness must not recreate the database"
+    );
+}
+
+#[tokio::test]
 async fn detailed_healthz_fails_when_log_sink_is_unwritable() {
     let state = single_state();
     // A path whose parent is a regular file can never accept appends.


### PR DESCRIPTION
Detailed health returned 200 after the configured database path was removed or replaced because it checked an older cached SQLite handle.

Probe write readiness through a fresh existing-database connection, without creating a missing database or applying migrations. The store owns the read-write open and bounded write-lock/rollback check; the runtime supplies the configured path. Ordinary cached operations and the read-only doctor probe retain their existing behavior.

Tests cover healthy readiness, a replaced database path, a missing database remaining absent, preservation of an existing schema/data, refusal while another connection holds the write lock, and success after release.

Task: ORB-11798. Regression introduced by cached store reuse in 613d4b56f (ORB-11632 / PR #1670).

Mac validation: forced current-source compilation of store/core/cmd/web before tests; all 6 web health tests and all 12 SQLite connection tests passed, including the new cases. Native make ci-fast passed.
Full workspace/all-target make ci-lint passed in 52.50 seconds.
