### PR TITLE
[code-review] Cancel escaped-pipe readers and stop output after supervisor completion

### DIFF
--- a/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/orchestrator.rs
@@ -458,6 +458,7 @@ pub fn run_cli_backend(
         output_capture_limit: None,
         on_spawn: Some(&on_spawn),
         wait: None,
+        live_readers: None,
     });
 
     let (stdout, stderr, exit_code, duration, timed_out) = match spawn_result {

--- a/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs
@@ -1,13 +1,50 @@
 // Existing expect calls in this module document local invariants; keep the allow scoped while the workspace lint is ratcheted.
 #![allow(clippy::expect_used)]
 
+//! CLI subprocess supervisor.
+//!
+//! # Output drain / truncation contract
+//!
+//! stdout/stderr readers belong to the supervisor until it returns. After the
+//! child exits, times out, or `wait` fails, the supervisor kills the process
+//! tree and then:
+//!
+//! 1. **Bounded drain.** Readers keep consuming readable bytes and emitting
+//!    tracing line events until EOF or [`OUTPUT_READER_JOIN_TIMEOUT`].
+//! 2. **Cancel.** If a writer still holds the pipe (an escaped session), the
+//!    supervisor wakes each reader through an owned pollable cancel fd. The
+//!    reader then nonblocking-drains whatever is already readable and stops
+//!    capturing and emitting. The supervisor joins the reader thread before
+//!    returning. It does not close another thread's pipe descriptor and does
+//!    not treat a duplicate close as cancellation.
+//! 3. **Capture finish.** Bytes collected before cancel/EOF are frozen by
+//!    [`RollingOutputCapture::finish`]: under the limit they are kept in full;
+//!    over the limit the prefix plus a complete-line tail are kept and
+//!    `truncated` is set. Writes that arrive after cancel are discarded and
+//!    must not be logged for the completed invocation.
+//! 4. **Wait error.** Readers are finalized the same way; the function then
+//!    returns [`SpawnError`] and drops the finished capture because the error
+//!    type has no output payload.
+//!
+//! Unix implements wakeup with `poll` on the reader fd plus a `UnixStream`
+//! pair. Non-Unix platforms keep a blocking `Read` and cannot interrupt an
+//! escaped holder; that path is not tested here.
+
 use std::collections::VecDeque;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::path::Path;
 use std::process::{Child, ExitStatus};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 
 use super::super::dispatcher::ResolvedSandbox;
 use super::spawn::{SpawnError, SpawnedChild, spawn_child_with_optional_sandbox};
@@ -163,6 +200,10 @@ pub(super) struct SpawnWithTimeoutRequest<'a> {
     /// Test seam for exercising wait failures without depending on another
     /// thread reaping the child between `try_wait` calls.
     pub(super) wait: Option<WaitHook<'a>>,
+    /// Test seam: each live output reader increments this counter for the
+    /// lifetime of its thread so tests can observe finalization without
+    /// sampling process-wide thread counts.
+    pub(super) live_readers: Option<Arc<AtomicUsize>>,
 }
 
 struct OutputReaderContext {
@@ -177,6 +218,29 @@ struct OutputReaderContext {
 struct OutputReaderHandle {
     finished: mpsc::Receiver<()>,
     join: thread::JoinHandle<()>,
+    #[cfg(unix)]
+    cancel: Option<UnixStream>,
+}
+
+struct LiveReaderGuard {
+    counter: Option<Arc<AtomicUsize>>,
+}
+
+impl LiveReaderGuard {
+    fn enter(counter: Option<Arc<AtomicUsize>>) -> Self {
+        if let Some(counter) = counter.as_ref() {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+        Self { counter }
+    }
+}
+
+impl Drop for LiveReaderGuard {
+    fn drop(&mut self) {
+        if let Some(counter) = self.counter.as_ref() {
+            counter.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
 }
 
 pub(super) fn spawn_with_timeout(
@@ -194,6 +258,7 @@ pub(super) fn spawn_with_timeout(
         output_capture_limit,
         on_spawn,
         wait,
+        live_readers,
     } = request;
 
     let started = Instant::now();
@@ -237,6 +302,7 @@ pub(super) fn spawn_with_timeout(
                 cwd: trace.cwd.map(ToString::to_string),
                 dispatch: dispatch.clone(),
             },
+            live_readers.clone(),
         )
     });
     let stderr_reader = child.stderr.take().map(|handle| {
@@ -251,6 +317,7 @@ pub(super) fn spawn_with_timeout(
                 cwd: trace.cwd.map(ToString::to_string),
                 dispatch,
             },
+            live_readers,
         )
     });
 
@@ -301,33 +368,29 @@ pub(super) fn spawn_with_timeout(
         join_output_reader(h, reader_join_deadline);
     }
 
+    let stdout = finish_captured_output(&stdout_buf, output_limit);
+    let stderr = finish_captured_output(&stderr_buf, output_limit);
+
     if let Some(err) = wait_error {
+        drop((stdout, stderr));
         return Err(SpawnError::transient(format!("wait {program}: {err}")));
     }
 
-    let stdout = stdout_buf
-        .lock()
-        .map(|buf| buf.finish())
-        .unwrap_or_else(|_| CapturedOutput {
-            bytes: Vec::new(),
-            protocol_offset: 0,
-            observed_bytes: 0,
-            capture_limit_bytes: output_limit,
-            truncated: false,
-        });
-    let stderr = stderr_buf
-        .lock()
-        .map(|buf| buf.finish())
-        .unwrap_or_else(|_| CapturedOutput {
-            bytes: Vec::new(),
-            protocol_offset: 0,
-            observed_bytes: 0,
-            capture_limit_bytes: output_limit,
-            truncated: false,
-        });
     let exit_code = exit_status.as_ref().and_then(|s| s.code());
     let duration = started.elapsed();
     Ok((stdout, stderr, exit_code, duration, timed_out))
+}
+
+fn finish_captured_output(buf: &SharedOutputCapture, output_limit: usize) -> CapturedOutput {
+    buf.lock()
+        .map(|buf| buf.finish())
+        .unwrap_or_else(|_| CapturedOutput {
+            bytes: Vec::new(),
+            protocol_offset: 0,
+            observed_bytes: 0,
+            capture_limit_bytes: output_limit,
+            truncated: false,
+        })
 }
 
 fn default_output_capture_limit() -> usize {
@@ -337,60 +400,59 @@ fn default_output_capture_limit() -> usize {
     )
 }
 
+#[cfg(unix)]
 fn spawn_output_reader<R>(
     handle: R,
     buf: SharedOutputCapture,
     context: OutputReaderContext,
+    live_readers: Option<Arc<AtomicUsize>>,
+) -> OutputReaderHandle
+where
+    R: Read + IntoRawFd + Send + 'static,
+{
+    let fd = handle.into_raw_fd();
+    // SAFETY: `into_raw_fd` transferred ownership of a valid pipe descriptor.
+    let mut reader = unsafe { File::from_raw_fd(fd) };
+    let _ = set_nonblocking(reader.as_raw_fd());
+    let (wakeup, cancel) = match UnixStream::pair() {
+        Ok((wakeup, cancel)) => {
+            let _ = wakeup.set_nonblocking(true);
+            let _ = cancel.set_nonblocking(true);
+            (Some(wakeup), Some(cancel))
+        }
+        Err(_) => (None, None),
+    };
+
+    let (finished_tx, finished) = mpsc::channel();
+    let join = thread::spawn(move || {
+        let _live = LiveReaderGuard::enter(live_readers);
+        tracing::dispatcher::with_default(&context.dispatch, || {
+            read_cancelable_output(&mut reader, wakeup.as_ref(), &buf, &context);
+        });
+        let _ = finished_tx.send(());
+    });
+    OutputReaderHandle {
+        finished,
+        join,
+        cancel,
+    }
+}
+
+#[cfg(not(unix))]
+fn spawn_output_reader<R>(
+    handle: R,
+    buf: SharedOutputCapture,
+    context: OutputReaderContext,
+    live_readers: Option<Arc<AtomicUsize>>,
 ) -> OutputReaderHandle
 where
     R: Read + Send + 'static,
 {
-    let OutputReaderContext {
-        provider,
-        stream,
-        job_run_id,
-        task_id,
-        cwd,
-        dispatch,
-    } = context;
-
     let (finished_tx, finished) = mpsc::channel();
     let join = thread::spawn(move || {
-        tracing::dispatcher::with_default(&dispatch, || {
-            let mut reader = handle;
-            let mut chunk = [0u8; 4096];
-            let mut line_buf = Vec::new();
-            loop {
-                match reader.read(&mut chunk) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let raw = &chunk[..n];
-                        buf.lock()
-                            .expect("subprocess output buf poisoned")
-                            .push(raw);
-                        emit_output_chunk(
-                            &provider,
-                            stream,
-                            &job_run_id,
-                            task_id.as_deref(),
-                            cwd.as_deref(),
-                            raw,
-                            &mut line_buf,
-                        );
-                    }
-                    Err(_) => break,
-                }
-            }
-            if !line_buf.is_empty() {
-                emit_output_line(
-                    &provider,
-                    stream,
-                    &job_run_id,
-                    task_id.as_deref(),
-                    cwd.as_deref(),
-                    &line_buf,
-                );
-            }
+        let _live = LiveReaderGuard::enter(live_readers);
+        tracing::dispatcher::with_default(&context.dispatch, || {
+            read_blocking_output(handle, &buf, &context);
         });
         let _ = finished_tx.send(());
     });
@@ -398,15 +460,206 @@ where
 }
 
 fn join_output_reader(reader: OutputReaderHandle, deadline: Instant) {
-    let OutputReaderHandle { finished, join } = reader;
+    let OutputReaderHandle {
+        finished,
+        join,
+        #[cfg(unix)]
+        cancel,
+    } = reader;
     let timeout = deadline.saturating_duration_since(Instant::now());
     match finished.recv_timeout(timeout) {
         Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
             let _ = join.join();
         }
-        // The reader is still blocked on a pipe some escaped process holds;
-        // the captured bytes so far are what the run gets.
-        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            #[cfg(unix)]
+            {
+                drop(cancel);
+                let _ = join.join();
+            }
+            #[cfg(not(unix))]
+            drop(join);
+        }
+    }
+}
+
+fn read_blocking_output<R: Read>(
+    mut reader: R,
+    buf: &SharedOutputCapture,
+    context: &OutputReaderContext,
+) {
+    let mut chunk = [0u8; 4096];
+    let mut line_buf = Vec::new();
+    loop {
+        match reader.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => append_output_chunk(buf, context, &chunk[..n], &mut line_buf),
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => break,
+        }
+    }
+    flush_line_buf(context, &line_buf);
+}
+
+#[cfg(unix)]
+fn read_cancelable_output(
+    reader: &mut File,
+    wakeup: Option<&UnixStream>,
+    buf: &SharedOutputCapture,
+    context: &OutputReaderContext,
+) {
+    let Some(wakeup) = wakeup else {
+        read_blocking_output(reader, buf, context);
+        return;
+    };
+
+    let mut chunk = [0u8; 4096];
+    let mut line_buf = Vec::new();
+    let mut cancelled = false;
+    loop {
+        match poll_reader_or_cancel(reader.as_raw_fd(), wakeup.as_raw_fd()) {
+            PollOutcome::Failed => break,
+            PollOutcome::Cancelled => {
+                cancelled = true;
+                break;
+            }
+            PollOutcome::Readable => match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => append_output_chunk(buf, context, &chunk[..n], &mut line_buf),
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(_) => break,
+            },
+        }
+    }
+    if cancelled {
+        drain_readable_output(reader, buf, context, &mut line_buf);
+    }
+    flush_line_buf(context, &line_buf);
+}
+
+fn append_output_chunk(
+    buf: &SharedOutputCapture,
+    context: &OutputReaderContext,
+    raw: &[u8],
+    line_buf: &mut Vec<u8>,
+) {
+    buf.lock()
+        .expect("subprocess output buf poisoned")
+        .push(raw);
+    emit_output_chunk(
+        &context.provider,
+        context.stream,
+        &context.job_run_id,
+        context.task_id.as_deref(),
+        context.cwd.as_deref(),
+        raw,
+        line_buf,
+    );
+}
+
+fn flush_line_buf(context: &OutputReaderContext, line_buf: &[u8]) {
+    if line_buf.is_empty() {
+        return;
+    }
+    emit_output_line(
+        &context.provider,
+        context.stream,
+        &context.job_run_id,
+        context.task_id.as_deref(),
+        context.cwd.as_deref(),
+        line_buf,
+    );
+}
+
+#[cfg(unix)]
+fn drain_readable_output(
+    reader: &mut File,
+    buf: &SharedOutputCapture,
+    context: &OutputReaderContext,
+    line_buf: &mut Vec<u8>,
+) {
+    let mut chunk = [0u8; 4096];
+    loop {
+        if !fd_is_readable(reader.as_raw_fd()) {
+            return;
+        }
+        match reader.read(&mut chunk) {
+            Ok(0) => return,
+            Ok(n) => append_output_chunk(buf, context, &chunk[..n], line_buf),
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => return,
+            Err(_) => return,
+        }
+    }
+}
+
+#[cfg(unix)]
+enum PollOutcome {
+    Readable,
+    Cancelled,
+    Failed,
+}
+
+#[cfg(unix)]
+fn poll_reader_or_cancel(reader_fd: RawFd, wakeup_fd: RawFd) -> PollOutcome {
+    let mut fds = [
+        libc::pollfd {
+            fd: reader_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: wakeup_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+    ];
+    loop {
+        // SAFETY: `fds` is a valid two-element pollfd array we own for the
+        // duration of the call; both descriptors are owned by this thread.
+        let rc = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, -1) };
+        if rc < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return PollOutcome::Failed;
+        }
+        if fds[1].revents != 0 {
+            return PollOutcome::Cancelled;
+        }
+        if fds[0].revents != 0 {
+            return PollOutcome::Readable;
+        }
+    }
+}
+
+#[cfg(unix)]
+fn fd_is_readable(fd: RawFd) -> bool {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: `pfd` is a valid pollfd we own; `fd` is the reader thread's pipe.
+    let rc = unsafe { libc::poll(&mut pfd, 1, 0) };
+    rc > 0 && pfd.revents != 0
+}
+
+#[cfg(unix)]
+fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: `fd` is an owned descriptor; F_GETFL reads flags only.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is still owned; F_SETFL only adds O_NONBLOCK.
+    let rc = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if rc < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/supervisor.rs
@@ -4,12 +4,16 @@ use std::path::Path;
 
 #[cfg(unix)]
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tempfile::tempdir;
 
 use super::super::supervisor::{SpawnTraceContext, SpawnWithTimeoutRequest, spawn_with_timeout};
-use super::test_support::{assert_event, capture_events, capture_redacted_tracing_output, sh_args};
+use super::test_support::{
+    assert_event, capture_events, capture_events_live, capture_redacted_tracing_output, sh_args,
+};
 
 fn spawn_test_request<'a>(
     program: &'a str,
@@ -30,6 +34,7 @@ fn spawn_test_request<'a>(
         output_capture_limit: None,
         on_spawn: None,
         wait: None,
+        live_readers: None,
     }
 }
 
@@ -173,12 +178,19 @@ fn spawn_with_timeout_cleans_process_group_when_wait_fails() {
             cwd: None,
         },
     );
+    let live_readers = Arc::new(AtomicUsize::new(0));
     request.on_spawn = Some(&on_spawn);
     request.wait = Some(&wait);
+    request.live_readers = Some(Arc::clone(&live_readers));
 
     let error = spawn_with_timeout(request).expect_err("injected wait failure");
     assert!(!error.permanent);
     assert!(error.message.contains("injected wait failure"));
+    assert_eq!(
+        live_readers.load(Ordering::SeqCst),
+        0,
+        "wait-error must join output readers before returning"
+    );
 
     let pid = child_pid.get();
     assert_ne!(pid, 0);
@@ -220,8 +232,9 @@ fn spawn_with_timeout_redacts_tracing_line_without_redacting_raw_stdout() {
 #[test]
 fn spawn_with_timeout_kills_timed_out_process_and_keeps_partial_output() {
     let args = sh_args("printf '%s\\n' 'before timeout'; sleep 1; printf '%s\\n' after");
+    let live_readers = Arc::new(AtomicUsize::new(0));
     let (result, events) = capture_events(|| {
-        spawn_with_timeout(spawn_test_request(
+        let mut request = spawn_test_request(
             "/bin/sh",
             &args,
             None,
@@ -232,7 +245,9 @@ fn spawn_with_timeout_kills_timed_out_process_and_keeps_partial_output() {
                 task_id: Some("TTIME"),
                 cwd: None,
             },
-        ))
+        );
+        request.live_readers = Some(Arc::clone(&live_readers));
+        spawn_with_timeout(request)
     });
     let (stdout, stderr, exit_code, _duration, timed_out) = result.expect("spawn succeeds");
 
@@ -240,6 +255,11 @@ fn spawn_with_timeout_kills_timed_out_process_and_keeps_partial_output() {
     assert!(stderr.bytes().is_empty());
     assert_eq!(exit_code, None);
     assert!(timed_out);
+    assert_eq!(
+        live_readers.load(Ordering::SeqCst),
+        0,
+        "timeout must join output readers before returning"
+    );
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].field("stream"), Some("stdout"));
     assert_eq!(events[0].field("line"), Some("before timeout"));
@@ -329,7 +349,11 @@ fn spawn_with_timeout_kills_grandchild_holding_output_pipes() {
 
 /// A helper the agent detached into its own session outlives the child and
 /// the group kill, and keeps the stdout pipe open. The child exited normally,
-/// so the run must still finish promptly with the output it produced.
+/// so the run must still finish promptly with the output it produced, join
+/// its readers, and ignore later helper writes.
+///
+/// Cancellation uses Unix `poll` + a wakeup socketpair. Non-Unix platforms
+/// keep blocking reads and are not tested here.
 #[cfg(unix)]
 #[test]
 fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder() {
@@ -344,22 +368,27 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
     let pid_dir = tempdir().expect("pid tempdir");
     let pid_file = pid_dir.path().join("escaped.pid");
     let ready_file = pid_dir.path().join("escaped.ready");
+    let write_now_file = pid_dir.path().join("escaped.write-now");
+    let wrote_file = pid_dir.path().join("escaped.wrote");
     let escaped_helper = EscapedProcessGuard::new(pid_file.clone());
     // The delayed helper establishes its detached session and records its PID
     // before telling the parent it may exit. That makes the parent wait for a
     // verified escaped pipe holder instead of racing the supervisor's group
-    // cleanup against helper startup.
+    // cleanup against helper startup. After the supervisor returns, the test
+    // signals the helper to write again so post-return emission can be checked.
     let script = format!(
-        "perl -MPOSIX -e 'select(undef, undef, undef, 0.2); POSIX::setsid(); open(my $pid, \">\", $ARGV[0]); print $pid $$; close $pid; open(my $ready, \">\", $ARGV[1]); print $ready \"ready\"; close $ready; exec \"sleep\", \"30\"' {} {} & while [ ! -s {} ]; do sleep 0.01; done; printf '%s\n' 'done'",
-        shell_quote(pid_file.to_string_lossy().as_ref()),
-        shell_quote(ready_file.to_string_lossy().as_ref()),
-        shell_quote(ready_file.to_string_lossy().as_ref()),
+        "perl -MPOSIX -e '$SIG{{PIPE}}=\"IGNORE\"; $| = 1; select(undef, undef, undef, 0.2); POSIX::setsid(); open(my $pid, \">\", $ARGV[0]); print $pid $$; close $pid; open(my $ready, \">\", $ARGV[1]); print $ready \"ready\"; close $ready; while (!-s $ARGV[2]) {{ select(undef, undef, undef, 0.05); }} print STDOUT \"after-return\\n\"; open(my $wrote, \">\", $ARGV[3]); print $wrote \"wrote\"; close $wrote; sleep 30' {pid} {ready} {write_now} {wrote} & while [ ! -s {ready} ]; do sleep 0.01; done; printf '%s\n' 'done'",
+        pid = shell_quote(pid_file.to_string_lossy().as_ref()),
+        ready = shell_quote(ready_file.to_string_lossy().as_ref()),
+        write_now = shell_quote(write_now_file.to_string_lossy().as_ref()),
+        wrote = shell_quote(wrote_file.to_string_lossy().as_ref()),
     );
     let args = sh_args(&script);
+    let live_readers = Arc::new(AtomicUsize::new(0));
 
     let started = std::time::Instant::now();
-    let (stdout, _stderr, exit_code, _duration, timed_out) =
-        spawn_with_timeout(spawn_test_request(
+    let (result, log) = capture_events_live(|| {
+        let mut request = spawn_test_request(
             "/bin/sh",
             &args,
             None,
@@ -370,13 +399,21 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
                 task_id: Some("TESC"),
                 cwd: None,
             },
-        ))
-        .expect("spawn succeeds");
+        );
+        request.live_readers = Some(Arc::clone(&live_readers));
+        spawn_with_timeout(request)
+    });
+    let (stdout, _stderr, exit_code, _duration, timed_out) = result.expect("spawn succeeds");
 
     let escaped_pid = read_pid(&pid_file);
     assert!(
         process_is_live(escaped_pid),
         "the escaped helper must remain live after the parent exits"
+    );
+    assert_eq!(
+        live_readers.load(Ordering::SeqCst),
+        0,
+        "escaped-pipe readers must join before the supervisor returns"
     );
 
     assert!(!timed_out);
@@ -386,6 +423,30 @@ fn spawn_with_timeout_returns_after_a_normal_exit_despite_an_escaped_pipe_holder
         started.elapsed() < Duration::from_secs(5),
         "a normal exit must not wait on the escaped pipe holder"
     );
+
+    let events = log.snapshot();
+    assert_event(&events, "stdout", "done");
+    assert!(
+        events
+            .iter()
+            .all(|event| event.field("line") != Some("after-return")),
+        "pre-return events must not include helper output written later; events={events:?}"
+    );
+
+    std::fs::write(&write_now_file, "now").expect("signal helper to write");
+    assert!(
+        wait_until(Duration::from_secs(2), || wrote_file.exists()),
+        "escaped helper should write after the supervisor returns"
+    );
+    let events_after = log.snapshot();
+    assert!(
+        events_after
+            .iter()
+            .all(|event| event.field("line") != Some("after-return")),
+        "escaped helper output after return must not be emitted; events={events_after:?}"
+    );
+    assert_eq!(events_after.len(), events.len());
+
     drop(escaped_helper);
     assert!(
         wait_until(Duration::from_secs(2), || !process_is_live(escaped_pid)),
@@ -419,6 +480,7 @@ impl Drop for EscapedProcessGuard {
             unsafe {
                 libc::kill(pid as libc::pid_t, libc::SIGKILL);
             }
+            let _ = wait_until(Duration::from_secs(2), || !process_is_live(pid));
         }
     }
 }

--- a/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
+++ b/crates/orbit-engine/src/activity_job/cli_runner/tests/test_support.rs
@@ -52,6 +52,16 @@ pub(in crate::activity_job::cli_runner) fn capture_events<F, T>(f: F) -> (T, Vec
 where
     F: FnOnce() -> T,
 {
+    let (result, log) = capture_events_live(f);
+    (result, log.snapshot())
+}
+
+/// Captures tracing events and keeps the subscriber alive so a test can
+/// observe emissions after the producing call returns.
+pub(in crate::activity_job::cli_runner) fn capture_events_live<F, T>(f: F) -> (T, EventLog)
+where
+    F: FnOnce() -> T,
+{
     let events = Arc::new(Mutex::new(Vec::new()));
     let subscriber = CaptureSubscriber {
         events: Arc::clone(&events),
@@ -59,8 +69,24 @@ where
     };
     let dispatch = tracing::Dispatch::new(subscriber);
     let result = tracing::dispatcher::with_default(&dispatch, f);
-    let events = events.lock().expect("events lock").clone();
-    (result, events)
+    (
+        result,
+        EventLog {
+            events,
+            _dispatch: dispatch,
+        },
+    )
+}
+
+pub(in crate::activity_job::cli_runner) struct EventLog {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+    _dispatch: tracing::Dispatch,
+}
+
+impl EventLog {
+    pub(in crate::activity_job::cli_runner) fn snapshot(&self) -> Vec<CapturedEvent> {
+        self.events.lock().expect("events lock").clone()
+    }
 }
 
 pub(in crate::activity_job::cli_runner) fn capture_redacted_tracing_output<F>(


### PR DESCRIPTION
## Task

[ORB-11672](https://orbit-cli.com/tasks/ORB-11672) — [code-review] Cancel escaped-pipe readers and stop output after supervisor completion

### Description

## Problem
The bounded join returns while an escaped descendant can still hold stdout/stderr open. Dropping a JoinHandle leaves its reader blocked, retaining capture state and potentially logging under a finished run. The previous suggestion to close a duplicate fd does not cancel the original reader; closing another thread's owned fd is not a safe portable cancellation contract.

## Required behavior and constraints
Give output readers a bounded, explicit cancellation/wakeup path, such as owned nonblocking/pollable IO, and terminate/join them before the supervisor finishes. Preserve normal output draining within the budget and prevent emissions after return. Do not close another thread's owned raw descriptor or assume duplicate close interrupts read. Coordinate with ORB-11671's all-exit cleanup so normal exit, timeout and wait failure share correct reader finalization. Keep fixtures temporary and unconditionally kill/reap escaped helpers.

## Evidence and validation
Source validation against agent-main 09dec5183 (original review 7f3a8f5fa); re-locate symbols on the implementation revision. crates/orbit-engine/src/activity_job/cli_runner/supervisor.rs:279,325,385; existing escaped-holder test; related ORB-11671.
These are source-level findings, not measured performance or executed fault-injection results. Use focused deterministic regression tests at the owning boundary. Follow AGENTS.md and pass make ci-fast and make ci-lint before review; no release work is included.

### Acceptance Criteria

- An escaped-pipe-holder regression proves supervisor return is bounded while the helper remains alive and reader resources have returned to baseline; use synchronization/counters, not global process thread counts.
- A test subscriber confirms no output emission for the completed invocation after the supervisor returns, even when the escaped helper writes afterward.
- Normal exit, timeout and injected wait-error paths all finalize readers and preserve captured pre-completion output according to a documented drain/truncation contract.
- Every process fixture has unconditional cleanup; exercise actual supported platform IO behavior and report any platform not tested.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Gave CLI supervisor output readers an owned Unix pollable cancellation path: nonblocking pipe File plus a UnixStream wakeup pair. The reader thread owns the pipe fd and poll()s it with the wakeup fd; the supervisor signals cancel by dropping its wakeup end and then joins. It never closes another thread's descriptor.
- After child exit, timeout, or wait failure the supervisor still kills the process tree, drains for OUTPUT_READER_JOIN_TIMEOUT, cancels any escaped-pipe reader, finishes capture, and only then returns. Wait-error drops the finished capture because SpawnError has no output payload.
- Added a per-invocation Arc<AtomicUsize> live-reader RAII seam. Extended the Unix escaped-holder fixture so the helper stays alive, writes after return (SIGPIPE ignored), and is killed/reaped by Drop. A live tracing subscriber proves no post-return emission.
- Documented the drain/truncation contract on the supervisor module, including that non-Unix keeps blocking reads and is not tested here.

Acceptance criteria:
- Criterion 1: met. Escaped-holder test returns in <5s while the helper is still live and live_readers is 0 (not process thread counts).
- Criterion 2: met. After return the helper writes "after-return"; the kept subscriber records no new events for that invocation.
- Criterion 3: met. Normal exit, timeout, and injected wait-error all join readers (live_readers==0) and preserve pre-completion capture per the module contract (timeout keeps "before timeout"; wait-error finishes then drops capture with the error).
- Criterion 4: met. EscapedProcessGuard unconditionally SIGKILLs and waits for death. Tests exercise Linux poll/pipe IO. Non-Unix cancellation is documented as untested.

Validation:
- cargo test -p orbit-engine --lib activity_job::cli_runner::tests::supervisor -- --nocapture — passed, 8 tests (Linux).
- make ci-fast — passed (exit 0). Internal test-compiler-cache-namespaces skipped: bwrap cannot create a user namespace in this sandbox; that skip is not treated as proof of the reader fix.
- make ci-lint — passed.
- git diff --check — passed.
- GIT_OPTIONAL_LOCKS=0 git status --short — passed; only the four scoped files are modified.

Assessment: Cancellation is explicit and join-before-return is shared with ORB-11671's all-exit cleanup. Windows/non-Unix still cannot wake a blocking read; that is documented and untested.

Strategic decisions: UnixStream pair wakeup instead of closing another thread's pipe fd; per-invocation counter instead of /proc thread counts.
Design weaknesses / risks: Severity low — non-Unix still detaches on join timeout. Mitigation: documented, no Windows CI in this suite.
Deviations from original plan: none.
Friction checkpoint: none filed.
Starting HEAD: 36599c128f8795ef8bafa4910b32a1484c91fcfb (clean). Changes left uncommitted.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11672-6a9f8a7f`
- Behind base: 0
- Ahead of base: 1