### PR TITLE
[code-review] Correct the deny.toml rationale for RUSTSEC-2023-0071 (rsa) to reflect its real call sites

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,10 +26,10 @@ ignore = [
     # tokenizers -> fastembed (embeddings). No maintained drop-in; low risk.
     # Re-review by 2027-01-04.
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; transitive via fastembed/tokenizers; no vuln. Re-review 2027-01-04." },
-    # rsa Marvin timing sidechannel. No constant-time release yet. Reachable
-    # only via local embedding/search paths where request timing is not
-    # network-observable. Re-review by 2027-01-04.
-    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing sidechannel; no fixed release; local non-network-observable use. Re-review 2027-01-04." },
+    # rsa Marvin timing sidechannel. No constant-time release yet. Orbit uses
+    # rsa only for public-key release verification; Marvin concerns private-key
+    # decryption/signing, which the binary never performs. Re-review by 2027-01-04.
+    { id = "RUSTSEC-2023-0071", reason = "rsa used only for PKCS#1 v1.5 public-key verification of release checksums (orbit-common::security::release); Marvin concerns private-key decryption/signing, which the binary never performs. Re-review 2027-01-04." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Task

[ORB-11684](https://orbit-cli.com/tasks/ORB-11684) — [code-review] Correct the deny.toml rationale for RUSTSEC-2023-0071 (rsa) to reflect its real call sites

### Description

## Problem
The advisory exception says the rsa Marvin side channel is "Reachable only via local embedding/search paths". `rsa` is not a dependency of orbit-search; its workspace consumers are `crates/orbit-common` (release-signature verification in `src/security/release.rs`) and `crates/orbit-cmd` (update tests). The risk conclusion still holds — the binary performs public-key verification only, and Marvin affects private-key operations — but the recorded justification points at the wrong code, so the 2027-01-04 re-review starts from a false premise.

## Why It Matters
CONTRIBUTING.md requires a justification for every advisory exception; an inaccurate one undermines the audit trail of the release-trust path.

## Proposed Fix
Reword the `reason` to "rsa used only for PKCS#1 v1.5 public-key verification of release checksums (orbit-common::security::release); Marvin concerns private-key decryption/signing, which the binary never performs. Re-review 2027-01-04."

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `deny.toml:29-32`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (security). Review area: scripts-ci.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `cargo deny check` still passes.
- `grep -n "RUSTSEC-2023-0071" deny.toml` shows the rationale naming `orbit-common` release verification and public-key-only use.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated the RUSTSEC-2023-0071 exception in deny.toml to identify orbit-common::security::release as the release-checksum verification call site and to document public-key-only use.
- Updated the adjacent comment so it no longer claims the advisory is reachable through embedding/search paths.

Acceptance criteria:
- cargo deny check: passed with an isolated temporary CARGO_HOME. The first run against the shared cache was blocked before checking by a read-only advisory database lock at ~/.cargo/advisory-dbs/db.lock; the isolated run reported advisories ok, bans ok, licenses ok, sources ok.
- grep -n "RUSTSEC-2023-0071" deny.toml: passed; line 32 contains the orbit-common release-verification and public-key-only rationale.

Validation:
- make ci-fast: passed. Its compiler-cache mount-namespace subcheck reported an environment limitation (unprivileged namespaces unavailable) and skipped that subcheck; the overall command exited 0.
- make ci-lint: passed; workspace clippy completed with -D warnings.
- git diff --check: passed.
- git status --short: only deny.toml is modified.

Assessment: The scoped audit rationale is corrected with no code or dependency changes. Remaining deviation is limited to the shared cargo-deny cache being read-only; the same check passed using an isolated cache outside the worktree.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11684-6a9f8cb8`
- Behind base: 0
- Ahead of base: 1