### PR TITLE
[code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### DIFF
--- a/crates/orbit-core/src/application/job/tests/exec.rs
+++ b/crates/orbit-core/src/application/job/tests/exec.rs
@@ -1398,13 +1398,17 @@ fn epic_pipeline_local_mode_merges_once_into_the_workspace_base() {
     seed_default_catalogs(&global_root);
     stub_epic_finisher(&global_root);
     let host = ScriptedEpicHost::new(&runtime, vec!["ORB-CHILD-1".to_string()]).local_mode();
+    let run_id = Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_default()
+        .to_string();
 
     let outcome = try_execute_full_epic_job(
         &runtime,
         &repo_root,
         &host,
         json!({ "epic_task_id": "ORB-EPIC" }),
-        "jrun-scripted-epic-local",
+        &run_id,
     )
     .expect("execute epic local delivery");
 


### PR DESCRIPTION
## Task

[ORB-11785](https://orbit-cli.com/tasks/ORB-11785) — [code-scanning-sweep] Fix rust/hard-coded-cryptographic-value in crates/orbit-core/src/application/job/tests/exec.rs

### Description

This task was filed from bounded Code scanning evidence collected on the engine-private host boundary. It does not require agent-side GitHub access.

## Alert evidence

- Repository: `constellation-works/orbit`
- Alert: `#173`
- Rule: `rust/hard-coded-cryptographic-value` (rust/hard-coded-cryptographic-value)
- Security severity: `critical`
- Tool: `CodeQL` (version `2.26.4`, guid `unknown`)
- Message: This hard-coded value is used as a salt.
- Ref: `refs/heads/main`
- Commit: `a93caa13890764380e184d996fa709b1bcbe278c`
- Location: `crates/orbit-core/src/application/job/tests/exec.rs` line 1405
- Created: `2026-09-07T01:20:40Z`
- Updated: `2026-09-07T01:20:40Z`
- Alert URL: https://github.com/constellation-works/orbit/security/code-scanning/173

## Collection bounds

```json
{
  "alerts_at_cap": true,
  "alerts_limit": 100,
  "notes": [
    "open Code scanning alerts were listed at the 100-alert cap; further alerts may exist"
  ]
}
```

Remediate the identified rule at the affected location without suppressing or dismissing the finding, then run the repository's normal validation.


### Acceptance Criteria

- Remediate Code scanning rule `rust/hard-coded-cryptographic-value` at `crates/orbit-core/src/application/job/tests/exec.rs` line 1405 with a real code or configuration fix; do not suppress, dismiss, or exclude the finding.
- Preserve the intended behavior while removing the data flow or unsafe construct identified in the inline alert evidence.
- Run the repository's documented validation and security checks and confirm the identified rule no longer reports at the affected location.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Replaced the hard-coded `jrun-scripted-epic-local` run ID in `crates/orbit-core/src/application/job/tests/exec.rs` with a runtime-generated nanosecond timestamp before passing it to the executor.
- Preserved the local-mode epic delivery assertions and the production retry-jitter salt data flow now receives a per-run value.

Assessment: The affected test no longer supplies a hard-coded value to the executor's jitter salt path; the change is minimal and keeps the intended behavior.

Criteria:
- Code scanning remediation: satisfied at the affected fixture; the literal is absent and the run ID is generated at runtime.
- Intended behavior: satisfied; the targeted local-mode epic test passes unchanged in its behavioral assertions.
- Validation/security: repository gates and cargo-deny passed; direct CodeQL confirmation was unavailable because the `codeql` CLI is not installed. Source-level verification found no remaining `jrun-scripted-epic-local` literal.

Validation:
- `cargo test -p orbit-core epic_pipeline_local_mode_merges_once_into_the_workspace_base -- --nocapture` — passed (1 test).
- `make ci-fast` — passed; its compiler-cache namespace subcheck reported the host's unavailable unprivileged mount namespace and skipped that subcheck.
- `make ci-lint` — passed.
- `make audit` — failed to acquire the read-only shared advisory DB lock; rerun as `CARGO_HOME=<temporary writable directory> cargo deny check` — passed (advisories, bans, licenses, and sources).
- `git diff --check` — passed.
- `GIT_OPTIONAL_LOCKS=0 git status --short` — only the scoped test file is modified.

Remaining risk: CodeQL itself was not runnable locally; the next repository CodeQL analysis should verify alert #173 is cleared.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11785-6a9f8cb3`
- Behind base: 0
- Ahead of base: 1