### PR TITLE
[code-review] Keep only an event counter in `V2AuditWriter` instead of a full in-memory event copy

### DIFF
--- a/crates/orbit-cmd/src/activity_v2.rs
+++ b/crates/orbit-cmd/src/activity_v2.rs
@@ -29,7 +29,7 @@ pub struct V2ActivityRunResult {
     pub output: Value,
     pub message: Option<String>,
     pub run_id: String,
-    pub events_emitted: usize,
+    pub events_emitted: u64,
 }
 
 /// Direct v2 activity execution surface for [`OrbitRuntime`] (extension
@@ -127,10 +127,7 @@ impl ActivityV2Commands for OrbitRuntime {
             state: outcome_str.to_string(),
         })?;
 
-        let events_count = writer
-            .events_snapshot()
-            .map(|s| s.len())
-            .unwrap_or_default();
+        let events_count = writer.emitted_event_count();
 
         match dispatch {
             Ok(o) => Ok(V2ActivityRunResult {

--- a/crates/orbit-core/Cargo.toml
+++ b/crates/orbit-core/Cargo.toml
@@ -44,4 +44,5 @@ libc.workspace = true
 
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
+orbit-engine = { path = "../orbit-engine", features = ["test-support"] }
 orbit-exec = { path = "../orbit-exec" }

--- a/crates/orbit-core/src/application/job/exec.rs
+++ b/crates/orbit-core/src/application/job/exec.rs
@@ -35,7 +35,7 @@ pub struct V2JobRunResult {
     pub success: bool,
     pub pipeline: Value,
     pub message: Option<String>,
-    pub events_emitted: usize,
+    pub events_emitted: u64,
 }
 
 /// Path-specific durable records retained while finalizing a v2 run.
@@ -308,10 +308,7 @@ impl OrbitRuntime {
             state: outcome_str.to_string(),
         })?;
 
-        let events_count = writer
-            .events_snapshot()
-            .map(|s| s.len())
-            .unwrap_or_default();
+        let events_count = writer.emitted_event_count();
 
         match outcome_res {
             Ok(o) => Ok(V2JobRunResult {

--- a/crates/orbit-engine/Cargo.toml
+++ b/crates/orbit-engine/Cargo.toml
@@ -11,6 +11,9 @@ stability = "internal"
 [lints]
 workspace = true
 
+[features]
+test-support = []
+
 [dependencies]
 chrono.workspace = true
 libc = { workspace = true }
@@ -34,3 +37,7 @@ tracing.workspace = true
 [dev-dependencies]
 orbit-common = { path = "../orbit-common", features = ["test-util"] }
 tracing-subscriber.workspace = true
+
+[[test]]
+name = "v2_cli_agent"
+required-features = ["test-support"]

--- a/crates/orbit-engine/src/activity_job/audit_writer.rs
+++ b/crates/orbit-engine/src/activity_job/audit_writer.rs
@@ -45,7 +45,9 @@ pub struct V2AuditWriter {
     workspace_path: Option<String>,
     inner: Arc<dyn AuditSink>,
     envelope_sink: Option<Arc<dyn EnvelopeSink>>,
+    #[cfg(any(test, feature = "test-support"))]
     events: Mutex<Vec<V2AuditEvent>>,
+    emitted_event_count: AtomicU64,
     event_counter: Mutex<u64>,
     parent_stacks: Mutex<HashMap<ThreadId, Vec<String>>>,
     /// [ORB-00414] Count of audit-write failures observed this run. Non-fatal
@@ -82,7 +84,9 @@ impl V2AuditWriter {
             workspace_path: None,
             inner,
             envelope_sink: None,
+            #[cfg(any(test, feature = "test-support"))]
             events: Mutex::new(Vec::new()),
+            emitted_event_count: AtomicU64::new(0),
             event_counter: Mutex::new(0),
             parent_stacks: Mutex::new(HashMap::new()),
             audit_failures: AtomicU64::new(0),
@@ -176,13 +180,17 @@ impl V2AuditWriter {
             // [ORB-00414] SQLite persistence failures should not crash the run,
             // but must be observable: record the failure (counter + tracing
             // error) instead of swallowing it. Emitting the event to the
-            // in-memory snapshot below is still the load-bearing path.
+            // Event emission is still counted below, so run results reflect
+            // the complete set of attempted envelope writes.
             self.note_audit_failure(event.envelope.event_type.as_str(), &error);
         }
+        #[cfg(any(test, feature = "test-support"))]
         self.events
             .lock()
             .map_err(|_| WriteError::Poisoned)?
             .push(event);
+
+        self.emitted_event_count.fetch_add(1, Ordering::Relaxed);
         Ok(event_id)
     }
 
@@ -342,7 +350,14 @@ impl V2AuditWriter {
         })
     }
 
-    /// Snapshot of emitted events (for smoke verification).
+    /// Number of envelope events emitted during this run.
+    pub fn emitted_event_count(&self) -> u64 {
+        self.emitted_event_count.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot of emitted events, retained only for tests that inspect
+    /// envelope contents.
+    #[cfg(any(test, feature = "test-support"))]
     pub fn events_snapshot(&self) -> Result<Vec<V2AuditEvent>, WriteError> {
         Ok(self
             .events


### PR DESCRIPTION
## Task

[ORB-11674](https://orbit-cli.com/tasks/ORB-11674) — [code-review] Keep only an event counter in `V2AuditWriter` instead of a full in-memory event copy

### Description

## Problem
Every envelope event is persisted to SQLite and *also* pushed into `events: Mutex<Vec<V2AuditEvent>>` for the whole run. The only production readers are `orbit-core/src/application/job/exec.rs:311-314` and `orbit-cmd/src/activity_v2.rs:130-133`, which call `events_snapshot()` (a full clone of the vector) just to take `.len()`. Long fan-out/loop runs with many CLI invocations keep every event (with its payload strings) alive until the run ends, and the snapshot clones the lot once more at the end.

## Why It Matters
Unbounded per-run memory growth in a long-lived service for data that is already durable, plus a needless O(n) clone at run completion.

## Proposed Fix
Replace the vector with an `AtomicU64` count exposed as `emitted_event_count()`; keep `events_snapshot()` behind `#[cfg(any(test, feature = "test-support"))]` for the integration tests that inspect events.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-engine/src/activity_job/audit_writer.rs:48,182-186,346-352`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (performance). Review area: engine.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `orbit-core` and `orbit-cmd` compile against `emitted_event_count()` and report the same `events_emitted` value as before.
- `crates/orbit-engine/tests/v2_cli_agent.rs` still passes using the test-only snapshot.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced production V2AuditWriter event retention with an AtomicU64 emitted-event counter; the event vector and events_snapshot() are compiled only for unit/test-support builds.
- Updated orbit-core and orbit-cmd result paths to read emitted_event_count(), retaining the reported event total as u64.
- Added the engine test-support feature and activated it only for orbit-core dev builds so external tests that inspect envelopes remain supported; v2_cli_agent explicitly requires that test feature.
Assessment: Production runs no longer retain or clone envelope payloads solely to compute the final count.
Criteria evidence:
1. orbit-core and orbit-cmd compile against emitted_event_count() and retain the final event count; make ci-lint passed with all targets and warnings denied.
2. crates/orbit-engine/tests/v2_cli_agent.rs passed with the test-only snapshot enabled: cargo test -p orbit-engine --features test-support --test v2_cli_agent.
Validation:
- cargo fmt --all --check: passed.
- cargo test -p orbit-engine --features test-support --test v2_cli_agent: passed (1 test).
- cargo test -p orbit-core --test sandbox_off: passed (1 test; verifies the dev-only snapshot feature for external engine consumers).
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks/deviations: events_emitted is now u64, matching the AtomicU64 counter; serialized JSON numeric values remain equivalent for ordinary counts. No remaining known risks.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11674-6a9f8a96`
- Behind base: 0
- Ahead of base: 1