### PR TITLE
[code-review] Drop the fake parallelism in `semantic_search` (both retrievers serialise on one connection mutex)

### DIFF
--- a/crates/orbit-search/src/commands/search.rs
+++ b/crates/orbit-search/src/commands/search.rs
@@ -1,5 +1,3 @@
-use std::thread;
-
 use orbit_common::OrbitError;
 use serde::{Deserialize, Serialize};
 
@@ -86,35 +84,16 @@ pub(crate) fn run_with_embedder(
     let retriever_limit = limit.saturating_mul(RETRIEVER_OVERFETCH).max(limit);
     let kind = params.kind.as_deref();
     let model_id = embedder.model_id().to_string();
-    let query_for_bm25 = query.to_string();
-    let cosine_store = vector_store.clone();
-    let bm25_store = vector_store.clone();
-    let cosine_model_id = model_id.clone();
-    let cosine_kind = kind.map(ToOwned::to_owned);
     let field = params.field.as_deref();
-    let cosine_field = field.map(ToOwned::to_owned);
-
-    let (cosine, bm25) = thread::scope(|scope| {
-        let cosine_handle = scope.spawn(|| {
-            crate::vector::query::cosine_top_k(
-                &cosine_store,
-                &query_vector,
-                &cosine_model_id,
-                retriever_limit,
-                cosine_kind.as_deref(),
-                cosine_field.as_deref(),
-            )
-        });
-        let bm25_handle =
-            scope.spawn(|| bm25_top_k(&bm25_store, &query_for_bm25, kind, field, retriever_limit));
-        let cosine = cosine_handle
-            .join()
-            .map_err(|_| OrbitError::Execution("cosine retriever panicked".to_string()))?;
-        let bm25 = bm25_handle
-            .join()
-            .map_err(|_| OrbitError::Execution("bm25 retriever panicked".to_string()))?;
-        Ok::<_, OrbitError>((cosine?, bm25?))
-    })?;
+    let cosine = crate::vector::query::cosine_top_k(
+        vector_store,
+        &query_vector,
+        &model_id,
+        retriever_limit,
+        kind,
+        field,
+    )?;
+    let bm25 = bm25_top_k(vector_store, query, kind, field, retriever_limit)?;
 
     let candidates = reciprocal_rank_fusion(&cosine, &bm25);
     let task_hits = rollup_to_tasks(candidates, limit);


### PR DESCRIPTION
## Task

[ORB-11717](https://orbit-cli.com/tasks/ORB-11717) — [code-review] Drop the fake parallelism in `semantic_search` (both retrievers serialise on one connection mutex)

### Description

## Problem
`run_with_embedder` clones the `VectorStore` twice and runs `cosine_top_k` and `bm25_top_k` in a `thread::scope`, but `VectorStore::clone` shares the same `Arc<Mutex<Connection>>`, and each retriever locks it for its entire duration, so the two threads execute strictly one after the other. The scope buys two thread spawns, two joins, panic mapping and extra clones (`query_for_bm25`, `cosine_kind`, `cosine_model_id`) with zero overlap; `related.rs` and `doc_search.rs` run sequentially for the same work and are simpler.

## Why It Matters
Misleading structure (a reader assumes the retrievers overlap) and extra moving parts on the hot query path, contrary to AGENTS.md "fewest moving parts".

## Proposed Fix
Call the two retrievers sequentially, or if overlap is genuinely wanted, give queries their own read connection (open a second `Connection` for reads in `VectorStore`) so the scope actually parallelises.

## Constraints / Notes
- Found in a full code/UX/quality/performance review of `agent-main` at `7f3a8f5fa` (2026-09-07). File references: `crates/orbit-search/src/commands/search.rs:92-116`, `crates/orbit-search/src/vector/store/mod.rs:33-36`. Line numbers refer to that revision; re-locate by symbol if the file has moved.
- Severity as reviewed: low (design). Review area: search-registry.
- Follow AGENTS.md: single canonical path, rules at their authoritative boundary, no compatibility shims without a stated contract, keep files under ~800 lines. `make ci-fast` and `make ci-lint` must pass before review.

### Acceptance Criteria

- `search.rs` has no `thread::scope`, or `VectorStore` exposes a separate read connection and a test asserts both retrievers can hold their connection simultaneously.
- `commands/tests/search.rs` passes with identical ranking output.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Replaced the scoped cosine/BM25 worker threads in `run_with_embedder` with direct sequential calls against the same `VectorStore`.
- Removed now-unnecessary store/input/model clones and thread panic translation while preserving retriever order, inputs, reciprocal-rank fusion, and result rollup.

Criteria:
1. Passed: `crates/orbit-search/src/commands/search.rs` no longer imports threading or calls `thread::scope`; the canonical serial path is used.
2. Passed: `cargo test -p orbit-search commands::tests::search` ran both search tests successfully, including the ranking/rollup behavior tests.

Validation:
- Passed: `cargo fmt --check`.
- Passed: `cargo test -p orbit-search commands::tests::search` (2 passed).
- Passed: `make ci-fast` (one non-failing environment skip: compiler-cache namespace test could not create a bubblewrap namespace).
- Passed: `make ci-lint` (workspace all-target Clippy with warnings denied).
- Passed: `git diff --check`.

Assessment: The implementation now matches the single-connection ownership model with a smaller, readable canonical execution path. No remaining task-specific risks identified.
Diff: `crates/orbit-search/src/commands/search.rs` only.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11717-6a9f8ef7`
- Behind base: 0
- Ahead of base: 1