### PR TITLE
[code-review] Export bundles under the shared read lock and exclude lock/staging sidecars from the archive

### DIFF
--- a/crates/orbit-store/src/driver/file/task_bundle/mod.rs
+++ b/crates/orbit-store/src/driver/file/task_bundle/mod.rs
@@ -8,14 +8,13 @@ mod migrations;
 mod types;
 
 pub(crate) use bundle_io::{
-    BundleWriteFault, PendingWriteGuard, append_jsonl_row, cleanup_partial_bundle_best_effort,
-    fail_if_injected, publish_envelope, read_bundle_at, read_bundle_lightweight_at,
-    read_envelope_at, recover_pending_bundle_at, write_bundle_at, write_bundle_with_artifacts_at,
+    BundleWriteFault, PENDING_WRITE_FILE_NAME, PendingWriteGuard, append_jsonl_row,
+    cleanup_partial_bundle_best_effort, fail_if_injected, publish_envelope, read_bundle_at,
+    read_bundle_lightweight_at, read_envelope_at, recover_pending_bundle_at, write_bundle_at,
+    write_bundle_with_artifacts_at,
 };
 
 #[cfg(test)]
-pub(crate) use bundle_io::{
-    PENDING_WRITE_FILE_NAME, inject_bundle_write_faults, take_artifact_payload_reads,
-};
+pub(crate) use bundle_io::{inject_bundle_write_faults, take_artifact_payload_reads};
 pub(crate) use lock::bundle_lock_target;
 pub(crate) use types::{TaskBundleV2, TaskDocumentV2};

--- a/crates/orbit-store/src/workflow/task/archive.rs
+++ b/crates/orbit-store/src/workflow/task/archive.rs
@@ -9,6 +9,9 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use orbit_common::OrbitError;
+use orbit_common::fs::io::with_shared_file_lock;
+
+use crate::driver::file::task_bundle::{PENDING_WRITE_FILE_NAME, bundle_lock_target};
 
 /// Compression level for the zstd frame. Task bundles are small text; a moderate
 /// level keeps archives compact without a slow compress path.
@@ -55,13 +58,61 @@ pub(super) fn write_archive(
 
     for (task_id, dir) in bundle_dirs {
         let arcname = format!("{BUNDLES_DIR}/{task_id}");
-        builder
-            .append_dir_all(&arcname, dir)
-            .map_err(map_io("append bundle"))?;
+        with_shared_file_lock(&bundle_lock_target(dir), "task migration export", || {
+            if !dir.is_dir() {
+                return Err(OrbitError::Store(format!(
+                    "canonical bundle for '{task_id}' disappeared while exporting at {}",
+                    dir.display()
+                )));
+            }
+            append_bundle_tree(&mut builder, &arcname, dir)
+        })?;
     }
 
     let encoder = builder.into_inner().map_err(map_io("finalize tar"))?;
     encoder.finish().map_err(map_io("finalize zstd"))?;
+    Ok(())
+}
+
+/// Append one canonical bundle while its shared lock is held. The pending-write
+/// record is recovery machinery, not bundle content; all other dotfiles remain
+/// eligible payloads and must round-trip unchanged.
+fn append_bundle_tree<W: std::io::Write>(
+    builder: &mut tar::Builder<W>,
+    archive_dir: &str,
+    source_dir: &Path,
+) -> Result<(), OrbitError> {
+    builder
+        .append_dir(archive_dir, source_dir)
+        .map_err(map_io("append bundle directory"))?;
+
+    let mut entries = std::fs::read_dir(source_dir)
+        .map_err(map_io("read bundle directory"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_io("read bundle directory"))?;
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        let name = entry.file_name();
+        if name == PENDING_WRITE_FILE_NAME {
+            continue;
+        }
+
+        let source = entry.path();
+        let archive_path = format!("{archive_dir}/{}", name.to_string_lossy());
+        if entry
+            .file_type()
+            .map_err(map_io("inspect bundle entry"))?
+            .is_dir()
+        {
+            append_bundle_tree(builder, &archive_path, &source)?;
+        } else {
+            builder
+                .append_path_with_name(&source, archive_path)
+                .map_err(map_io("append bundle entry"))?;
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/orbit-store/src/workflow/task/tests/mod.rs
+++ b/crates/orbit-store/src/workflow/task/tests/mod.rs
@@ -634,6 +634,205 @@ fn export_ids_subset_and_rejects_unknown() {
 }
 
 #[test]
+fn export_waits_for_a_transition_and_imports_the_settled_bundle() {
+    use std::sync::Barrier;
+    use std::time::Duration;
+
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive = src.path().join("tasks.tar.zst");
+    let ws = "export-transition-abcdef";
+    let registry = open_registry(src.path());
+    let binding = bind(&registry, src.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    let bundle = make_bundle("ORB-00000", "transition", Vec::new());
+    seed(&store, &registry, ws, &bundle);
+
+    let event_appended = Barrier::new(2);
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .with_bundle_write_lock("ORB-00000", || {
+                    let current = store.read_bundle("ORB-00000")?;
+                    let event = TaskEventRowV2 {
+                        schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                        event_id: "EV-0002".to_string(),
+                        at: Utc::now(),
+                        by: "codex".to_string(),
+                        event_type: "status_changed".to_string(),
+                        note: None,
+                        from_status: Some(TaskStatus::Backlog),
+                        to_status: Some(TaskStatus::InProgress),
+                    };
+                    store.append_event("ORB-00000", &event)?;
+                    event_appended.wait();
+                    std::thread::sleep(Duration::from_millis(100));
+
+                    let mut envelope = current.envelope;
+                    envelope.status = TaskStatus::InProgress;
+                    envelope.updated_at = Utc::now();
+                    store.rewrite_envelope("ORB-00000", &envelope)
+                })
+                .expect("finish transition");
+        });
+
+        event_appended.wait();
+        export_tasks(&registry, ws, ExportSelection::All, &archive, exported_at())
+            .expect("export waits for the settled transition");
+    });
+
+    let target = open_registry(dst.path());
+    let outcome =
+        import_tasks(&target, &archive, None, ImportConflictPolicy::Fail).expect("import");
+    assert_eq!(outcome.tasks[0].action, ImportAction::Kept);
+    let imported = read_bundle_at(
+        &target
+            .canonical_task_bundle_path(ws, "ORB-00000")
+            .expect("canonical path"),
+    )
+    .expect("read imported bundle");
+    assert_eq!(imported.envelope.status, TaskStatus::InProgress);
+    assert_eq!(
+        imported.events.last().and_then(|event| event.to_status),
+        Some(TaskStatus::InProgress)
+    );
+}
+
+#[test]
+fn export_excludes_pending_sidecar_but_keeps_dotfile_artifacts() {
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive = src.path().join("tasks.tar.zst");
+    let ws = "export-sidecars-abcdef";
+    let registry = open_registry(src.path());
+    let binding = bind(&registry, src.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        ws,
+        &make_bundle("ORB-00000", "dotfile artifact", Vec::new()),
+    );
+
+    let dotfile = seed_artifact_blob(&store, "ORB-00000", ".payload", b"dotfile", "codex");
+    store
+        .rewrite_artifact_manifest(
+            "ORB-00000",
+            &ArtifactManifestV2 {
+                schema_version: TASK_ARTIFACT_SCHEMA_VERSION,
+                files: vec![dotfile],
+            },
+        )
+        .expect("write artifact manifest");
+    let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+    fs::write(
+        bundle_dir.join(crate::driver::file::task_bundle::PENDING_WRITE_FILE_NAME),
+        "internal recovery state",
+    )
+    .expect("write pending sidecar");
+
+    export_tasks(&registry, ws, ExportSelection::All, &archive, exported_at()).expect("export");
+
+    let extracted = TempDir::new().unwrap();
+    super::archive::extract_archive(&archive, extracted.path()).expect("extract");
+    let archived_bundle = extracted.path().join("bundles/ORB-00000");
+    assert!(
+        !archived_bundle
+            .join(crate::driver::file::task_bundle::PENDING_WRITE_FILE_NAME)
+            .exists()
+    );
+    assert_eq!(
+        fs::read(archived_bundle.join("artifacts/files/.payload")).expect("dotfile payload"),
+        b"dotfile"
+    );
+
+    let target = open_registry(dst.path());
+    import_tasks(&target, &archive, None, ImportConflictPolicy::Fail).expect("import");
+    let imported = read_bundle_at(
+        &target
+            .canonical_task_bundle_path(ws, "ORB-00000")
+            .expect("canonical path"),
+    )
+    .expect("dotfile artifact round trips");
+    assert_eq!(imported.artifact_manifest.expect("manifest").files.len(), 1);
+}
+
+#[test]
+fn export_racing_a_deletion_is_valid_or_reports_the_disappeared_bundle() {
+    use std::sync::Barrier;
+    use std::time::Duration;
+
+    let src = TempDir::new().unwrap();
+    let dst = TempDir::new().unwrap();
+    let archive = src.path().join("tasks.tar.zst");
+    let ws = "export-deleted-abcdef";
+    let registry = open_registry(src.path());
+    let binding = bind(&registry, src.path(), ws);
+    let store = bundle_store(&registry, &binding);
+    seed(
+        &store,
+        &registry,
+        ws,
+        &make_bundle("ORB-00000", "deleted", Vec::new()),
+    );
+
+    let bundle_dir = store.bundle_path("ORB-00000").expect("bundle path");
+    let holding = Barrier::new(2);
+    let release = Barrier::new(2);
+    let (export_sent, export_received) = std::sync::mpsc::sync_channel(1);
+
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            store
+                .with_bundle_write_lock("ORB-00000", || {
+                    holding.wait();
+                    release.wait();
+                    Ok(())
+                })
+                .expect("hold bundle lock");
+        });
+        holding.wait();
+
+        scope.spawn(|| {
+            store
+                .with_bundle_write_lock("ORB-00000", || {
+                    fs::remove_dir_all(&bundle_dir).map_err(|error| {
+                        orbit_common::OrbitError::Io(format!("delete bundle: {error}"))
+                    })
+                })
+                .expect("delete bundle");
+        });
+        scope.spawn(|| {
+            export_sent
+                .send(export_tasks(
+                    &registry,
+                    ws,
+                    ExportSelection::All,
+                    &archive,
+                    exported_at(),
+                ))
+                .expect("send export result");
+        });
+        release.wait();
+
+        match export_received
+            .recv_timeout(Duration::from_secs(10))
+            .expect("export must finish")
+        {
+            Ok(_) => {
+                let target = open_registry(dst.path());
+                import_tasks(&target, &archive, None, ImportConflictPolicy::Fail)
+                    .expect("a completed export must import cleanly");
+            }
+            Err(error) => assert!(
+                error.to_string().contains("disappeared"),
+                "concurrent deletion must be actionable: {error}"
+            ),
+        }
+    });
+}
+
+#[test]
 fn corrupt_archive_fails_before_mutation() {
     let dst = TempDir::new().unwrap();
     let bogus = dst.path().join("bogus.tar.zst");


### PR DESCRIPTION
## Task

[ORB-11686](https://orbit-cli.com/tasks/ORB-11686) — [code-review] Export bundles under the shared read lock and exclude lock/staging sidecars from the archive

### Description

## Problem
Export copies a canonical bundle directory with append_dir_all without holding its shared bundle lock. A concurrent transition can therefore produce an archive containing an event and envelope from different states. Internal lock sidecars inside the bundle are also copied.

## Required behavior and constraints
Hold the canonical shared lock for the actual snapshot/copy, or create a consistent immutable snapshot while holding it and archive that snapshot. Export canonical content and artifact payloads while excluding known internal lock/staging sidecars; do not discard legitimate dotfiles by name alone. Sibling staging directories outside the bundle are not copied by the current append_dir_all and are not evidence of this defect. Preserve import integrity checks and handle concurrent disappearance explicitly.

## Evidence and validation
Validated against local da21eb15; affected implementation files were unchanged at fetched origin/agent-main 09dec5183. `crates/orbit-store/src/workflow/task/archive.rs:56`; shared writer boundary in `crates/orbit-store/src/repository/task/v2_bundle.rs:96`. Re-locate by symbol if lines move. Follow current AGENTS.md; preserve authoritative ownership and existing contracts. Run focused regression tests plus `make ci-fast` and `make ci-lint` before review.

### Acceptance Criteria

- Pause a transition between event append and envelope rewrite, export concurrently, then finish the transition; the archive imports successfully with a consistent settled state.
- Archive inspection confirms known internal lock/staging sidecars are absent while valid artifact content, including any supported dotfile payload, round-trips.
- Concurrent deletion yields a documented result or actionable error rather than a successful corrupt archive.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Export now acquires each canonical bundle shared lock for the archive copy, rechecks a bundle after lock acquisition, and reports a disappeared bundle explicitly.
- Archive traversal excludes only the internal .pending-write.yaml recovery sidecar; legitimate dotfiles, including artifact payloads, remain intact.
- Added regressions for a paused transition, sidecar/dotfile round-trip, and deletion racing export.
Assessment: The archive snapshot now observes the writer lock boundary used by lifecycle transitions and cannot return success after a vanished bundle.
Criteria evidence:
1. The paused-transition regression exports concurrently, imports the archive, and verifies the settled InProgress envelope/event state.
2. Archive extraction proves .pending-write.yaml is absent while a .payload artifact imports and verifies successfully.
3. The deletion-race regression requires either a cleanly importable archive or an actionable disappeared-bundle error.
Validation:
- cargo fmt --check: passed.
- cargo test -p orbit-store workflow::task::tests::export_ -- --nocapture: passed (4 tests).
- cargo test -p orbit-store workflow::task::tests::round_trip_keeps_ids_and_content -- --nocapture: passed.
- make ci-fast: passed.
- make ci-lint: passed.
- git diff --check: passed.
Risks: The archive still writes directly to the requested output path, so an export that fails after earlier bundles may leave a partial file; the API returns an error and never reports that file as a successful archive.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11686-6a9f8c8e`
- Behind base: 0
- Ahead of base: 1

Orchestrated-By: astra