### PR TITLE
[qa-sweep] After the ORB-11638 defaults stamp, a deleted managed default never self-heals and `orbit doctor` still reports "Workspace healthy"

### DIFF
--- a/crates/orbit-cmd/src/doctor.rs
+++ b/crates/orbit-cmd/src/doctor.rs
@@ -611,8 +611,9 @@ fn doctor_check_task_relations(runtime: &OrbitRuntime) -> WorkspaceDoctorResult 
 /// fails to parse is the operator's own in-progress edit, and classifying it
 /// as `Error` would silently start failing `orbit doctor` in cron and CI for
 /// workspaces that were passing yesterday. Only an *unloadable shipped
-/// default* — provably Orbit-written content that no longer parses, i.e. a
-/// broken install — escalates to `Error`. Everything else warns.
+/// default* — a broken install: Orbit-written content that no longer parses,
+/// or a primary shipped default that is simply gone — escalates to `Error`.
+/// Everything else warns.
 fn doctor_check_definition_artifacts(runtime: &OrbitRuntime) -> Vec<WorkspaceDoctorResult> {
     let report = match runtime.inspect_definition_artifacts() {
         Ok(report) => report,
@@ -635,7 +636,7 @@ fn doctor_check_definition_artifacts(runtime: &OrbitRuntime) -> Vec<WorkspaceDoc
                     format!("no {} on disk yet", health.kind.as_str())
                 } else {
                     format!(
-                        "{} {} loaded, none residual, stale, deprecated, or faulty",
+                        "{} {} loaded, none residual, stale, deprecated, faulty, or missing",
                         health.scanned,
                         health.kind.as_str()
                     )

--- a/crates/orbit-cmd/src/tests/doctor.rs
+++ b/crates/orbit-cmd/src/tests/doctor.rs
@@ -830,3 +830,34 @@ fn stale_shipped_activity_default_names_the_refresh_remediation() {
     assert!(row.message.contains("older release"), "{}", row.message);
     assert_eq!(row.remediation.as_deref(), Some("Run `orbit init`."));
 }
+
+#[test]
+fn missing_shipped_activity_default_is_an_error_not_healthy() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_root = temp.path().join("global");
+    let workspace_root = temp.path().join("repo/.orbit");
+    let runtime = OrbitRuntime::initialize_from_resolved_roots(
+        OrbitRuntimeRoots {
+            global_root: global_root.clone(),
+            shared_root: workspace_root.clone(),
+            local_root: workspace_root,
+        },
+        None,
+    )
+    .expect("initialize runtime with defaults");
+    let path = global_root.join("resources/activities/git_merge.yaml");
+    std::fs::remove_file(&path).expect("delete shipped default");
+
+    let results = runtime.doctor_workspace().expect("doctor");
+    let row = status_of(&results, "artifacts-activities");
+    assert_eq!(row.status, WorkspaceDoctorStatus::Error, "{row:?}");
+    assert!(row.message.contains("missing"), "{}", row.message);
+    assert!(row.message.contains("git_merge"), "{}", row.message);
+    assert_eq!(row.remediation.as_deref(), Some("Run `orbit init`."));
+    assert!(
+        results
+            .iter()
+            .any(|row| row.status == WorkspaceDoctorStatus::Error),
+        "a missing shipped default must not leave the workspace looking healthy: {results:?}"
+    );
+}

--- a/crates/orbit-core/src/application/artifact_health.rs
+++ b/crates/orbit-core/src/application/artifact_health.rs
@@ -14,6 +14,10 @@
 //! - **Stale** — the file is a managed copy of an *older* release of a default
 //!   this binary still ships, or an untracked file colliding with a bundled
 //!   default name.
+//! - **Missing** — the managed catalog was previously reconciled, and a primary
+//!   shipped default this binary still embeds is absent from disk. Warm opens
+//!   skip reconciliation when the defaults stamp matches, so this state can
+//!   persist until `orbit init` or `orbit workspace sync` restores the file.
 //!
 //! Provenance judgements are made from the per-kind managed manifest written by
 //! [`super::reconcile_managed_assets`]. Residual skill directories are the one
@@ -132,6 +136,8 @@ pub enum ArtifactCondition {
     Deprecated,
     /// Drifted from the current release, or colliding with a bundled name.
     Stale,
+    /// A primary shipped default this binary still embeds is not on disk.
+    Missing,
 }
 
 impl ArtifactCondition {
@@ -141,6 +147,7 @@ impl ArtifactCondition {
             Self::Residual => "residual",
             Self::Deprecated => "deprecated",
             Self::Stale => "stale",
+            Self::Missing => "missing",
         }
     }
 }
@@ -182,10 +189,16 @@ pub struct ArtifactFinding {
 impl ArtifactFinding {
     /// A shipped default that no longer loads is a broken install rather than
     /// a workspace authoring mistake, and is the only artifact fault that
-    /// escalates `orbit doctor` to a nonzero exit.
+    /// escalates `orbit doctor` to a nonzero exit. That includes a managed
+    /// file that is simply gone: dispatch cannot load what is not on disk.
     pub fn is_unloadable_shipped_default(&self) -> bool {
-        self.condition == ArtifactCondition::Faulty
-            && self.provenance != ArtifactProvenance::UserAuthored
+        match self.condition {
+            ArtifactCondition::Faulty => self.provenance != ArtifactProvenance::UserAuthored,
+            ArtifactCondition::Missing => true,
+            ArtifactCondition::Residual
+            | ArtifactCondition::Deprecated
+            | ArtifactCondition::Stale => false,
+        }
     }
 }
 
@@ -487,7 +500,51 @@ fn diagnose_catalog(runtime: &OrbitRuntime, catalog: &ManagedCatalog) -> Artifac
         }
     }
 
+    // Missing: a previously reconciled catalog no longer has a primary shipped
+    // default on disk. The stale loop above skips absent files, and loaders
+    // only inspect what remains, so without this check a deleted default is
+    // invisible — including after a warm open that trusted the defaults stamp.
+    if manifest.is_some() {
+        for name in &catalog.shipped {
+            if !is_primary_shipped_asset(kind, name) {
+                continue;
+            }
+            let path = catalog.path_of(name);
+            if path.is_file() {
+                continue;
+            }
+            findings.push(ArtifactFinding {
+                kind,
+                name: name.clone(),
+                path,
+                condition: ArtifactCondition::Missing,
+                provenance: ArtifactProvenance::OrbitWritten,
+                detail: format!(
+                    "`{name}` is a shipped {} default this Orbit still embeds, but the managed \
+                     file is absent",
+                    kind.singular()
+                ),
+                remediation: format!("Run `{}`.", init_command(kind)),
+            });
+        }
+    }
+
     finish_catalog_health(runtime, catalog, findings, &tracked)
+}
+
+/// The catalog entry dispatch actually loads: a YAML stem, or a skill's
+/// `SKILL.md`. Reference files under a skill tree are not independent
+/// definitions, so a missing one is not reported here.
+fn is_primary_shipped_asset(kind: ArtifactKind, name: &str) -> bool {
+    match kind {
+        ArtifactKind::Skill => Path::new(name)
+            .file_name()
+            .is_some_and(|file_name| file_name == "SKILL.md"),
+        ArtifactKind::Job
+        | ArtifactKind::Activity
+        | ArtifactKind::AutoTask
+        | ArtifactKind::Routine => true,
+    }
 }
 
 fn finish_catalog_health(

--- a/crates/orbit-core/src/application/tests/artifact_health.rs
+++ b/crates/orbit-core/src/application/tests/artifact_health.rs
@@ -5,8 +5,10 @@ use tempfile::tempdir;
 use crate::OrbitRuntime;
 use crate::application::activity_catalog_health::remove_spec_backend_key;
 use crate::application::artifact_health::{
-    ArtifactCondition, ArtifactHealth, ArtifactKind, FIX_RETIRED_ACTIVITY_BACKENDS_CMD,
+    ArtifactCondition, ArtifactHealth, ArtifactKind, ArtifactProvenance,
+    FIX_RETIRED_ACTIVITY_BACKENDS_CMD,
 };
+use crate::runtime::OrbitRuntimeRoots;
 
 fn workspace_runtime(root: &Path) -> (OrbitRuntime, PathBuf, PathBuf) {
     let global_root = root.join("global");
@@ -30,6 +32,21 @@ fn health_of(report: &[ArtifactHealth], kind: ArtifactKind) -> &ArtifactHealth {
         .iter()
         .find(|health| health.kind == kind)
         .unwrap_or_else(|| panic!("missing artifact health for {kind:?}"))
+}
+
+fn seeded_runtime(root: &Path) -> (OrbitRuntime, PathBuf, PathBuf) {
+    let global_root = root.join("global");
+    let workspace_root = root.join("repo/.orbit");
+    let runtime = OrbitRuntime::initialize_from_resolved_roots(
+        OrbitRuntimeRoots {
+            global_root: global_root.clone(),
+            shared_root: workspace_root.clone(),
+            local_root: workspace_root.clone(),
+        },
+        None,
+    )
+    .expect("initialize runtime with defaults");
+    (runtime, global_root, workspace_root)
 }
 
 #[test]
@@ -248,5 +265,109 @@ fn remove_spec_backend_key_refuses_flow_style() {
     assert!(
         error.contains("flow-style") || error.contains("block-style"),
         "{error}"
+    );
+}
+
+#[test]
+fn missing_shipped_activity_is_reported_and_not_restored_by_the_fix_flag() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, global_root, _workspace) = seeded_runtime(root.path());
+    let path = global_root.join("resources/activities/git_merge.yaml");
+    assert!(path.is_file(), "seeded catalog must include git_merge");
+    std::fs::remove_file(&path).expect("delete shipped default");
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    let finding = health_of(&report, ArtifactKind::Activity)
+        .findings
+        .iter()
+        .find(|finding| finding.name == "git_merge")
+        .expect("missing shipped activity must be reported");
+    assert_eq!(finding.condition, ArtifactCondition::Missing);
+    assert_eq!(finding.provenance, ArtifactProvenance::OrbitWritten);
+    assert_eq!(finding.path, path);
+    assert!(finding.is_unloadable_shipped_default());
+    assert!(
+        finding.remediation.contains("orbit init"),
+        "{}",
+        finding.remediation
+    );
+
+    assert_eq!(
+        runtime
+            .remove_stale_definition_artifacts()
+            .expect("fix flag retires deprecated artifacts only"),
+        0
+    );
+    assert!(
+        !path.exists(),
+        "missing defaults are restored by init/sync, not --fix-stale-artifacts"
+    );
+}
+
+#[test]
+fn locally_modified_shipped_activity_is_not_reported_missing() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, global_root, _workspace) = seeded_runtime(root.path());
+    let path = global_root.join("resources/activities/git_merge.yaml");
+    let current = std::fs::read_to_string(&path).expect("read shipped activity");
+    std::fs::write(&path, format!("{current}# operator edit\n")).expect("keep a custom override");
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    assert!(
+        health_of(&report, ArtifactKind::Activity)
+            .findings
+            .iter()
+            .all(|finding| finding.name != "git_merge"),
+        "an on-disk custom override must not look missing: {:?}",
+        health_of(&report, ArtifactKind::Activity).findings
+    );
+}
+
+#[test]
+fn missing_shipped_job_is_reported() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, global_root, _workspace) = seeded_runtime(root.path());
+    let path = global_root.join("resources/jobs/task_gate_pipeline.yaml");
+    std::fs::remove_file(&path).expect("delete shipped job");
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    let finding = health_of(&report, ArtifactKind::Job)
+        .findings
+        .iter()
+        .find(|finding| finding.name == "task_gate_pipeline")
+        .expect("missing shipped job must be reported");
+    assert_eq!(finding.condition, ArtifactCondition::Missing);
+    assert!(finding.is_unloadable_shipped_default());
+}
+
+#[test]
+fn catalog_without_a_managed_manifest_does_not_report_missing_shipped_defaults() {
+    let root = tempdir().expect("tempdir");
+    let (runtime, _workspace, activities) = workspace_runtime(root.path());
+    std::fs::write(
+        activities.join("custom_loop.yaml"),
+        agent_loop_yaml("custom_loop", ""),
+    )
+    .expect("write workspace-only activity");
+
+    let report = runtime
+        .inspect_definition_artifacts()
+        .expect("inspect artifacts");
+    let missing = health_of(&report, ArtifactKind::Activity)
+        .findings
+        .iter()
+        .filter(|finding| finding.condition == ArtifactCondition::Missing)
+        .count();
+    assert_eq!(
+        missing,
+        0,
+        "custom catalogs without a managed manifest are not missing shipped defaults: {:?}",
+        health_of(&report, ArtifactKind::Activity).findings
     );
 }

--- a/crates/orbit-core/src/bootstrap/global_defaults.rs
+++ b/crates/orbit-core/src/bootstrap/global_defaults.rs
@@ -13,8 +13,11 @@
 //! The stamp answers exactly one question: *did this binary already reconcile
 //! this root?* It deliberately says nothing about what the root looks like now.
 //! Repairing a root whose managed files were edited or deleted by hand belongs
-//! to the explicit paths — `orbit init`, `orbit workspace sync`, and
-//! `orbit doctor` — which never consult the stamp.
+//! to the explicit paths — `orbit init` and `orbit workspace sync` — which
+//! never consult the stamp. `orbit doctor` also never consults the stamp: it
+//! compares each previously reconciled managed catalog against the embedded
+//! default set and reports a missing shipped default instead of calling the
+//! root healthy. Restoration remains `orbit init` / `orbit workspace sync`.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/docs/runbooks/health-checks.md
+++ b/docs/runbooks/health-checks.md
@@ -4,8 +4,8 @@ summary: Check Orbit workspace, database, dashboard, log-sink, job-run, and rout
 tags: [operations, health, doctor, dashboard, routines]
 paths: ["crates/orbit-cmd/src/doctor.rs", "crates/orbit-core/src/application/job/run/reconcile.rs"]
 related_features: [orbit-core, activity-job, routines]
-related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986]
-last_validated: 2026-08-31
+related_artifacts: [ORB-10005, ORB-10070, ORB-10473, ORB-10501, ORB-10558, ORB-10986, ORB-11791]
+last_validated: 2026-09-08
 ---
 
 # Check Orbit Health
@@ -28,7 +28,7 @@ Every check degrades to a row rather than aborting unless the store itself canno
 | `job-runs` | orphaned `pending` or `running` runs with no live worker process |
 | `task-reservations` | active reservations whose owner run or terminal task association proves the reservation stale |
 | `task-relations` | unresolved relation/dependency targets that would block a task-index rebuild |
-| `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, or catalog-invalid |
+| `artifacts-*` | skills, jobs, activities, auto-tasks, and routines on disk: stale, deprecated, residual, catalog-invalid, or a previously reconciled shipped default that is missing |
 
 Example:
 
@@ -83,13 +83,15 @@ recovery, job cancellation, graph cleanup, id-allocation retirement, filesystem 
 task-reservation release, and retired activity-backend cleanup have different evidence and
 safety gates, so each repair remains explicit and safety-scoped.
 
-For definition convergence after installing a new Orbit binary, use `orbit workspace sync`
-rather than a doctor repair. Sync uses managed manifests to create newly shipped definitions,
-refresh or retire only provably unedited Orbit-written instances, migrate legacy routine
-provenance, and preserve operator content. `orbit workspace sync --check` is the read-only fleet
-inspection form. Doctor continues to diagnose invalid/stale artifacts and perform only the
-specific repair named by an individual flag; neither command upgrades the binary or pulls a
-remote repository.
+For definition convergence after installing a new Orbit binary, or to restore a shipped
+default that was deleted by hand, use `orbit workspace sync` rather than a doctor repair.
+Sync uses managed manifests to create newly shipped definitions, refresh or retire only
+provably unedited Orbit-written instances, migrate legacy routine provenance, and preserve
+operator content. `orbit workspace sync --check` is the read-only fleet inspection form.
+Doctor reports a missing shipped default as an `artifacts-*` error (it does not consult the
+warm-open defaults stamp, and it does not rewrite the file); run `orbit init` or
+`orbit workspace sync` to restore it. Doctor performs only the specific repair named by an
+individual flag; neither command upgrades the binary or pulls a remote repository.
 
 ### Repair retired activity backends
 


### PR DESCRIPTION
## Task

[ORB-11791](https://orbit-cli.com/tasks/ORB-11791) — [qa-sweep] After the ORB-11638 defaults stamp, a deleted managed default never self-heals and `orbit doctor` still reports "Workspace healthy"

### Description

## Problem

`9d18943b3` ([code-review] Avoid redundant managed-asset reconciliation on warm runtime opens [ORB-11638], #1676) makes a warm runtime open skip managed-asset reconciliation once `<orbit_root>/resources/.orbit-global-defaults.json` matches the running binary. That is the intended optimization, and its module doc states the recovery contract:

> Repairing a root whose managed files were edited or deleted by hand belongs to the explicit paths — `orbit init`, `orbit workspace sync`, and `orbit doctor` — which never consult the stamp.
> — `crates/orbit-core/src/bootstrap/global_defaults.rs`

Two of those three hold. **`orbit doctor` does not.** It neither repairs the missing default nor reports it, and exits 0 with `Workspace healthy.` So the previously self-healing failure mode is now silent and persistent, and the diagnostic named in the contract as a repair path gives the root a clean bill of health.

## Evidence (worktree `orbit-jrun-20260908-0342-3`, HEAD `724cadc07` + the one-line ORB-11790 import repair, Linux, 2026-09-08, jrun-20260908-0342-3)

Isolated `HOME=/tmp/qa11769/home`, `--root /tmp/qa11769/root`, scratch git checkout `/tmp/qa11769/repo`, inherited `ORBIT_*` cleared.

```
$ orbit --root $ROOT init --non-interactive --host-name qa11769 --task-prefix QSWP
... default_activities_refreshed=45 ...
$ cat $ROOT/resources/.orbit-global-defaults.json
{ "schemaVersion": 1, "defaultsDigest": "2f6285a8bcf4092b25469a8b33f01e06c6607f88665a0639d006aa1708a6654e" }

$ rm $ROOT/resources/activities/git_merge.yaml     # a shipped default a shipped workflow targets

$ orbit --root $ROOT task list --limit 2           # ordinary warm open, exit 0
$ test -f $ROOT/resources/activities/git_merge.yaml && echo RESTORED || echo NOT_RESTORED
NOT_RESTORED

$ orbit --root $ROOT activity list | grep git_merge     # no match; git_commit is still listed
$ orbit --root $ROOT doctor
artifacts-activities	ok	44 activities loaded, none residual, stale, deprecated, or faulty
Workspace healthy.
doctor exit=0
$ test -f $ROOT/resources/activities/git_merge.yaml && echo RESTORED || echo NOT_RESTORED
NOT_RESTORED
```

`orbit workspace sync` **does** repair it, as documented:

```
$ orbit --root $ROOT workspace sync
managed artifacts converged
$ test -f $ROOT/resources/activities/git_merge.yaml && echo RESTORED
RESTORED
```

The stamp is provably the thing that suppresses the old self-heal:

```
$ rm $ROOT/resources/activities/git_merge.yaml
$ rm $ROOT/resources/.orbit-global-defaults.json      # simulate the pre-ORB-11638 unconditional path
$ orbit --root $ROOT task list --limit 1              # same ordinary warm open, exit 0
$ test -f $ROOT/resources/activities/git_merge.yaml && echo RESTORED_WITHOUT_STAMP
RESTORED_WITHOUT_STAMP
```

So: stamp present → no repair on any warm open; stamp absent → the next warm open repairs. Before ORB-11638 every open took the second path.

## Why it matters

- `git_merge` is not a decorative asset. `crates/orbit-core/src/runtime/assets.rs` documents that every `target: activity:<name>` in a shipped workflow must resolve to an entry in `DEFAULT_ACTIVITY_FILES`. A root missing it has a shipped workflow that cannot resolve its step, and nothing in the normal command path reports that.
- `orbit doctor` is the command an operator runs when something is wrong. Its `artifacts-activities` check counts what loaded (44) and validates residual/stale/deprecated/faulty entries, but never compares against the shipped default set, so a *missing* default is invisible to it. Before ORB-11638 that blind spot did not matter, because the state could not persist; now it can.
- The failure is silent: exit 0, `Workspace healthy.`, no warning anywhere.

## Validation impact vs production impact

- **Validation impact:** none. `make ci-fast` passes (exit 0) at this HEAD. `make ci-lint` fails for the unrelated build break filed as ORB-11790. This defect blocks no gate.
- **Production impact:** yes, but bounded — it requires a managed default to go missing (hand edit, partial/interrupted write, external cleanup, a restore that misses `resources/`). When it happens, the root stays broken indefinitely and the documented diagnostic reports it healthy. Roots whose managed files are never disturbed are unaffected.

## Reproduction

```bash
export HOME=/tmp/orb-stamp-home && mkdir -p "$HOME"
ROOT=/tmp/orb-stamp-root; WS=/tmp/orb-stamp-ws; mkdir -p "$WS"
git -C "$WS" init -q -b main && git -C "$WS" config user.email q@e && git -C "$WS" config user.name q
echo x > "$WS/R.md" && git -C "$WS" add R.md && git -C "$WS" -c commit.gpgsign=false commit -qm init
orbit --root "$ROOT" init --non-interactive --host-name st --task-prefix STMP
(cd "$WS" && orbit --root "$ROOT" workspace init --name stws --ship-mode local)
rm "$ROOT/resources/activities/git_merge.yaml"
(cd "$WS" && orbit --root "$ROOT" task list --limit 1)          # no repair
(cd "$WS" && orbit --root "$ROOT" activity list | grep -c git_merge)   # 0
(cd "$WS" && orbit --root "$ROOT" doctor | tail -3)             # "Workspace healthy."
```

## Scope

Pick one and make the code and the module doc agree:

1. **Preferred — make `orbit doctor` honour the contract it is named in.** Have the `artifacts-activities` / `artifacts-jobs` / `artifacts-skills` checks compare the loaded set against the embedded default set and report (or repair) a missing shipped default. This keeps the ORB-11638 warm-open optimization intact and closes the observability gap the stamp opened.
2. Or, if doctor is to stay purely diagnostic, correct the `global_defaults.rs` module doc to name only `orbit init` and `orbit workspace sync`, and make doctor at least *report* the missing default rather than printing `Workspace healthy.`

Do not revert the stamp; the optimization is sound and `workspace sync` already recovers correctly.

Not a duplicate: no open task covers the defaults stamp, doctor's artifact checks, or managed-asset self-healing. Distinct from ORB-11790 (a compile error in the same file, unrelated cause).

### Acceptance Criteria

- Deleting a shipped managed default from an initialized catalog (manifest present, stamp current) makes inspect_definition_artifacts report ArtifactCondition::Missing for that primary asset.
- doctor_workspace maps a missing shipped default to artifacts-* Error with a non-empty remediation naming the matching init command, and does not treat the catalog as healthy.
- A locally modified shipped file that is still on disk is not reported as missing; --fix-stale-artifacts does not restore missing files.
- Warm-open stamp skip is unchanged: doctor never consults the stamp, and implicit bootstrap still skips reconciliation when the stamp matches.
- Partial catalogs without a managed manifest (custom-only test fixtures) do not get a flood of missing-shipped findings.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success
Changes:
- Added `ArtifactCondition::Missing` and a diagnose loop that, when a managed catalog has a provenance manifest, reports each absent primary shipped default (YAML stems; skill `SKILL.md` entry points).
- Missing shipped defaults escalate `artifacts-*` to Error via `is_unloadable_shipped_default`, with remediation `orbit init` / `orbit workspace init`.
- `--fix-stale-artifacts` still only retires deprecated files; restore remains `orbit init` / `orbit workspace sync`.
- `global_defaults.rs` module doc now names init/sync as the repair paths and doctor as the diagnostic that never consults the stamp.
- Runbook `docs/runbooks/health-checks.md` documents the missing-default error.

Assessment: Matches the preferred diagnostic path without reverting the ORB-11638 stamp. Custom overrides that are still on disk are unchanged. Partial catalogs without a managed manifest do not flood missing findings.

Criteria:
- Missing finding after deleting a shipped default from an initialized catalog: met (`git_merge` activity, `task_gate_pipeline` job).
- doctor_workspace Error + `Run \`orbit init\`.` + not healthy: met.
- Locally modified on-disk file not missing; fix flag does not restore: met.
- Stamp skip unchanged: met (existing `bootstrap::tests::global_defaults` still pass; doctor inspects files, never the stamp).
- No missing-shipped flood without a managed manifest: met.

Validation:
- `cargo test -p orbit-core --lib application::tests::artifact_health` — passed (9 tests)
- `cargo test -p orbit-core --lib application::tests::managed_assets` — passed (16 tests)
- `cargo test -p orbit-core --lib bootstrap::tests::global_defaults` — passed (5 tests)
- `cargo test -p orbit-cmd --lib tests::doctor` — passed (25 tests)
- `make ci-fast` — passed
- `make ci-lint` — passed (`cargo clippy --workspace --all-targets -- -D warnings`)
- `git diff --check` — passed
- CLI `orbit doctor` against a live `--root` was not run; Error mapping is covered at `doctor_workspace`.

Deviations: Doctor reports rather than auto-repairs missing files, so the stamp module doc now names only init/sync as repair paths. Justified by existing doctor design (no blanket `--fix`) and the health-checks runbook.
Remaining risk: a missing skill *reference* file (not `SKILL.md`) is not reported; dispatch still loads the skill.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11791-6a9f8c32`
- Behind base: 0
- Ahead of base: 1