### PR TITLE
[code-review] Ignore commented-out `mod` lines in check-orphan-modules.sh

### DIFF
--- a/scripts/check-orphan-modules.sh
+++ b/scripts/check-orphan-modules.sh
@@ -23,7 +23,152 @@ if ! command -v rg >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v perl >/dev/null 2>&1; then
+  echo "check-orphan-modules: Perl is required; install it before running" >&2
+  exit 1
+fi
+
 fail=0
+
+# Replace comments and string/character literal contents with whitespace while
+# preserving newlines, so declaration matching only sees Rust tokens. This is
+# intentionally limited to the lexical forms relevant to the guard; it avoids
+# treating examples in comments and literals as module registrations without
+# adding a Rust parser dependency to this shell-only check.
+strip_rust_non_code() {
+  perl - "$1" <<'PERL'
+use strict;
+use warnings;
+
+my $source = do { local $/; <> };
+my $output = '';
+my $index = 0;
+my $length = length $source;
+my $state = 'code';
+my $block_depth = 0;
+my $raw_hashes = 0;
+
+sub mask {
+  my ($text) = @_;
+  $text =~ s/[^\r\n]/ /g;
+  return $text;
+}
+
+while ($index < $length) {
+  my $character = substr($source, $index, 1);
+
+  if ($state eq 'code') {
+    if (substr($source, $index, 2) eq '//') {
+      $output .= '  ';
+      $index += 2;
+      $state = 'line_comment';
+      next;
+    }
+
+    if (substr($source, $index, 2) eq '/*') {
+      $output .= '  ';
+      $index += 2;
+      $block_depth = 1;
+      $state = 'block_comment';
+      next;
+    }
+
+    my $remaining = substr($source, $index);
+    if ($remaining =~ /\Ar(#+)?"/) {
+      my $prefix = $&;
+      $raw_hashes = defined($1) ? length($1) : 0;
+      $output .= mask($prefix);
+      $index += length($prefix);
+      $state = 'raw_string';
+      next;
+    }
+
+    if ($character eq '"') {
+      $output .= ' ';
+      $index++;
+      $state = 'string';
+      next;
+    }
+
+    # Mask short character literals, including escaped characters, so a
+    # quote inside one cannot change how the remainder of the owner is read.
+    if ($character eq "'" && $remaining =~ /\A'(?:\\[\s\S]|[^\\\r\n']){1,4}'/) {
+      my $literal = $&;
+      $output .= mask($literal);
+      $index += length($literal);
+      next;
+    }
+
+    $output .= $character;
+    $index++;
+    next;
+  }
+
+  if ($state eq 'line_comment') {
+    $output .= $character eq "\n" ? "\n" : ' ';
+    $index++;
+    $state = 'code' if $character eq "\n";
+    next;
+  }
+
+  if ($state eq 'block_comment') {
+    if (substr($source, $index, 2) eq '/*') {
+      $output .= '  ';
+      $index += 2;
+      $block_depth++;
+      next;
+    }
+
+    if (substr($source, $index, 2) eq '*/') {
+      $output .= '  ';
+      $index += 2;
+      $block_depth--;
+      if ($block_depth == 0) {
+        $state = 'code';
+      }
+      next;
+    }
+
+    $output .= $character eq "\n" ? "\n" : ' ';
+    $index++;
+    next;
+  }
+
+  if ($state eq 'string') {
+    if ($character eq '\\') {
+      $output .= ' ';
+      $index++;
+      if ($index < $length) {
+        my $escaped = substr($source, $index, 1);
+        $output .= $escaped eq "\n" ? "\n" : ' ';
+        $index++;
+      }
+      next;
+    }
+
+    $output .= $character eq "\n" ? "\n" : ' ';
+    $index++;
+    if ($character eq '"') {
+      $state = 'code';
+    }
+    next;
+  }
+
+  my $terminator = '"' . ('#' x $raw_hashes);
+  if (substr($source, $index, length($terminator)) eq $terminator) {
+    $output .= mask($terminator);
+    $index += length($terminator);
+    $state = 'code';
+    next;
+  }
+
+  $output .= $character eq "\n" ? "\n" : ' ';
+  $index++;
+}
+
+print $output;
+PERL
+}
 
 is_declared() {
   local stem="$1"
@@ -36,7 +181,7 @@ is_declared() {
     "$dir/lib.rs" \
     "$dir/main.rs" \
     "$(dirname "$dir")/$(basename "$dir").rs"; do
-    if [[ -f "$owner" ]] && rg -q "\\bmod[[:space:]]+(r#)?${stem}\\b[[:space:]]*[;{]" "$owner"; then
+    if [[ -f "$owner" ]] && rg -q "\\bmod[[:space:]]+(r#)?${stem}\\b[[:space:]]*[;{]" < <(strip_rust_non_code "$owner"); then
       return 0
     fi
   done


### PR DESCRIPTION
## Task

[ORB-11681](https://orbit-cli.com/tasks/ORB-11681) — [code-review] Ignore commented-out `mod` lines in check-orphan-modules.sh

### Description

## Problem and required behavior
The orphan-module guard treats commented-out module declarations as registrations. `is_declared` searches raw owner text, so an owner containing only `// mod foo;` incorrectly registers sibling `foo.rs`. Exclude declarations appearing in comments or string literals while recognizing actual supported Rust declarations, including attributes on the same line, visibility qualifiers, raw identifiers and existing path attributes.

## Constraints and evidence
Do not prescribe start-of-line anchoring that rejects `#[cfg(test)] mod tests;`, or simple line-comment stripping that leaves block comments and string examples. Choose the smallest reliable approach for the guard's supported syntax; preserve existing path-attribute handling and current source-tree coverage. Inspect `scripts/check-orphan-modules.sh`, especially `is_declared` (lines 28–48 at da21eb15, unchanged in origin/agent-main 09dec5183). The original finding was recorded at 7f3a8f5fa.

Follow current AGENTS.md and preserve the existing authoritative boundary. Run focused behavior checks plus required make ci-fast and make ci-lint before review; report skipped or environment-dependent verification explicitly.

### Acceptance Criteria

- A bounded fixture with sibling foo.rs and only a line-comment or block-comment mod foo declaration fails with foo.rs reported as orphaned.
- A fixture containing mod foo text only in ordinary or raw string literals does not register foo.rs.
- Actual declarations with same-line #[cfg(test)] attributes, pub(crate), raw identifiers and supported #[path] forms retain their existing registration behavior; the current tree passes the guard.
- Focused fixtures exercise the guard entry point and would detect the original commented-declaration false negative without changing the working repository.

## Execution Summary

<details>
<summary>Click to expand</summary>

Outcome: success

Changes:
- Updated scripts/check-orphan-modules.sh so owner-file module matching masks line comments, nested block comments, ordinary strings, raw strings, and short character literals before applying the existing declaration regex.
- Preserved the existing declaration forms and #[path] scan; added an explicit Perl prerequisite check for the new lexical masking helper.

Acceptance criteria:
1. Passed. A temporary fixture with sibling foo.rs and only line/block-comment mod foo text reported foo.rs as orphaned with the fixed script. The same fixture passed with the baseline script, demonstrating the original false negative.
2. Passed. A separate temporary fixture containing mod foo only in ordinary and raw string literals reported foo.rs as orphaned.
3. Passed. A temporary fixture using same-line #[cfg(test)] mod foo, pub(crate) mod bar, mod r#baz, and #[path = "qux.rs"] retained registration; the repository guard also passed.
4. Passed. Focused fixtures exercised the actual guard entry point from temporary directories outside the worktree; final git status contains only the scoped script change.

Validation:
- Passed: bash -n scripts/check-orphan-modules.sh.
- Passed: scripts/check-orphan-modules.sh.
- Passed: focused baseline/fixed comment fixture comparison.
- Passed: focused string-literal fixture.
- Passed: focused supported-declaration and #[path] fixture.
- Passed: make ci-fast (final run). Its compiler-cache namespace subcheck reported an environment-dependent skip because bwrap could not create a mount namespace; the overall command exited 0.
- Passed: make ci-lint (workspace clippy with -D warnings).
- Passed: git diff --check.
- Passed: git status --short; only scripts/check-orphan-modules.sh is modified.
- Not run: shellcheck; executable unavailable in the environment.

Assessment: The scoped guard now distinguishes Rust code from comments and literals while retaining current module and path-attribute behavior. Remaining risk is limited to lexical edge cases outside the guard's supported syntax; the helper handles nested block comments and raw-string delimiters.

</details>

## Validation

- Not reported

## Branch Freshness

- Base ref: `origin/agent-main`
- Head ref: `orbit/ORB-11681-6a9f8d98`
- Behind base: 0
- Ahead of base: 1